### PR TITLE
fix(web): clamp oversized run-error payloads behind a details toggle

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -954,9 +954,12 @@ export function ChatPane({
   const errorNeedsClamp =
     !!displayError && (displayError.length > 160 || displayError.includes('\n'));
   const [errorDetailsExpanded, setErrorDetailsExpanded] = useState(false);
+  // Key the reset on the failure identity too: distinct failed runs often
+  // render the identical string (same upstream 400 on retry, shared
+  // runFailureUi translation), and a new failure must start collapsed.
   useEffect(() => {
     setErrorDetailsExpanded(false);
-  }, [displayError]);
+  }, [displayError, retryAssistant?.id, retryAssistant?.runId]);
   // The failed run whose error this top-level card represents. AssistantMessage
   // suppresses only THIS message's per-message error pill (to avoid the
   // duplicate); other failed turns — older history, or once a follow-up makes

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -947,6 +947,16 @@ export function ChatPane({
       errorDiagnosticCopyTimerRef.current = null;
     }
   }, []);
+  // Unclassified failures fall through to the raw upstream payload, which can
+  // be a multi-KB JSON/HTML blob (#3907). Clamp the card to a short summary
+  // and keep the full payload behind an explicit details toggle. Anything
+  // multiline or longer than a sentence-ish line gets the toggle.
+  const errorNeedsClamp =
+    !!displayError && (displayError.length > 160 || displayError.includes('\n'));
+  const [errorDetailsExpanded, setErrorDetailsExpanded] = useState(false);
+  useEffect(() => {
+    setErrorDetailsExpanded(false);
+  }, [displayError]);
   // The failed run whose error this top-level card represents. AssistantMessage
   // suppresses only THIS message's per-message error pill (to avoid the
   // duplicate); other failed turns — older history, or once a follow-up makes
@@ -2016,10 +2026,30 @@ export function ChatPane({
                 scrollContainerRef={logRef}
               />
               {displayError ? (
-                <div className="msg error">
-                  <span className="chat-error-text">{displayError}</span>
+                <div className="msg error" data-error-expanded={errorDetailsExpanded ? 'true' : 'false'}>
+                  <span
+                    className="chat-error-text"
+                    data-clamped={errorNeedsClamp && !errorDetailsExpanded ? 'true' : 'false'}
+                  >
+                    {displayError}
+                  </span>
+                  {/* errorDiagnosticText is non-null whenever displayError is,
+                      so this container — and the details toggle inside it —
+                      always renders for a clamped error. If diagnostics ever
+                      become conditional, the toggle must move out of this gate
+                      or long errors would clamp with no way to expand. */}
                   {errorDiagnosticText || showErrorActions || (retryAssistant && onRetry && runFailureUi) ? (
                     <div className="chat-error-actions">
+                      {errorNeedsClamp ? (
+                        <button
+                          type="button"
+                          className="ghost chat-error-details-toggle"
+                          aria-expanded={errorDetailsExpanded}
+                          onClick={() => setErrorDetailsExpanded((prev) => !prev)}
+                        >
+                          {errorDetailsExpanded ? t('chat.errorHideDetails') : t('chat.errorShowDetails')}
+                        </button>
+                      ) : null}
                       {showByokRecoveryCta ? (
                         <button
                           type="button"

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -948,11 +949,27 @@ export function ChatPane({
     }
   }, []);
   // Unclassified failures fall through to the raw upstream payload, which can
-  // be a multi-KB JSON/HTML blob (#3907). Clamp the card to a short summary
+  // be a multi-KB JSON/HTML blob (#3907). Collapse the card to a short summary
   // and keep the full payload behind an explicit details toggle. Anything
   // multiline or longer than a sentence-ish line gets the toggle.
+  const ERROR_SUMMARY_MAX = 160;
   const errorNeedsClamp =
-    !!displayError && (displayError.length > 160 || displayError.includes('\n'));
+    !!displayError && (displayError.length > ERROR_SUMMARY_MAX || displayError.includes('\n'));
+  // The collapsed card renders only this summary — never the raw blob — so
+  // assistive tech, selection, and copy paths don't hit a multi-KB payload
+  // before the user opens details (#4028 design review). The full text lives in
+  // the expanded scroll region; full diagnostics stay one click away via copy.
+  // Summarize the first non-blank line (payloads sometimes lead with blank
+  // lines) and cap by code point so a multibyte char never splits mid-pair.
+  const errorFirstLine = displayError
+    ? (displayError.split('\n').find((line) => line.trim() !== '') ?? displayError).trim()
+    : '';
+  const errorSummaryChars = Array.from(errorFirstLine);
+  const errorSummary =
+    errorSummaryChars.length > ERROR_SUMMARY_MAX
+      ? `${errorSummaryChars.slice(0, ERROR_SUMMARY_MAX).join('').trimEnd()}…`
+      : errorFirstLine;
+  const errorDetailsId = useId();
   const [errorDetailsExpanded, setErrorDetailsExpanded] = useState(false);
   // Key the reset on the failure identity too: distinct failed runs often
   // render the identical string (same upstream 400 on retry, shared
@@ -2030,11 +2047,18 @@ export function ChatPane({
               />
               {displayError ? (
                 <div className="msg error" data-error-expanded={errorDetailsExpanded ? 'true' : 'false'}>
+                  {/* Collapsed renders only errorSummary (not the raw blob); the
+                      expanded span owns a bounded scroll, so it's keyboard-
+                      focusable and named for assistive tech (#4028 design review). */}
                   <span
+                    id={errorDetailsId}
                     className="chat-error-text"
-                    data-clamped={errorNeedsClamp && !errorDetailsExpanded ? 'true' : 'false'}
+                    tabIndex={errorNeedsClamp && errorDetailsExpanded ? 0 : undefined}
+                    aria-label={
+                      errorNeedsClamp && errorDetailsExpanded ? t('chat.errorDetailsLabel') : undefined
+                    }
                   >
-                    {displayError}
+                    {errorNeedsClamp && !errorDetailsExpanded ? errorSummary : displayError}
                   </span>
                   {/* errorDiagnosticText is non-null whenever displayError is,
                       so this container — and the details toggle inside it —
@@ -2048,6 +2072,7 @@ export function ChatPane({
                           type="button"
                           className="ghost chat-error-details-toggle"
                           aria-expanded={errorDetailsExpanded}
+                          aria-controls={errorDetailsId}
                           onClick={() => setErrorDetailsExpanded((prev) => !prev)}
                         >
                           {errorDetailsExpanded ? t('chat.errorHideDetails') : t('chat.errorShowDetails')}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1510,6 +1510,8 @@ export const ar: Dict = {
   'chat.openFile': 'فتح {name}',
   'chat.copyPrompt': 'نسخ الأمر',
   'chat.copyErrorDiagnostic': 'نسخ تشخيصات الخطأ',
+  'chat.errorShowDetails': 'عرض التفاصيل',
+  'chat.errorHideDetails': 'إخفاء التفاصيل',
   'chat.copyDone': 'تم النسخ!',
   'chat.inspect.noEditableTargets': 'لم يُعثر على نصوص قابلة للتحرير أو أهداف نمط.',
   'chat.inspect.noCommentTargets': 'لم يُعثر على نصوص قابلة للتعليق أو أهداف مرئية.',

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1512,6 +1512,7 @@ export const ar: Dict = {
   'chat.copyErrorDiagnostic': 'نسخ تشخيصات الخطأ',
   'chat.errorShowDetails': 'عرض التفاصيل',
   'chat.errorHideDetails': 'إخفاء التفاصيل',
+  'chat.errorDetailsLabel': 'تفاصيل الخطأ',
   'chat.copyDone': 'تم النسخ!',
   'chat.inspect.noEditableTargets': 'لم يُعثر على نصوص قابلة للتحرير أو أهداف نمط.',
   'chat.inspect.noCommentTargets': 'لم يُعثر على نصوص قابلة للتعليق أو أهداف مرئية.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1510,6 +1510,8 @@ export const de: Dict = {
   'chat.openFile': '{name} öffnen',
   'chat.copyPrompt': 'Prompt kopieren',
   'chat.copyErrorDiagnostic': 'Fehlerdiagnose kopieren',
+  'chat.errorShowDetails': 'Details anzeigen',
+  'chat.errorHideDetails': 'Details ausblenden',
   'chat.copyDone': 'Kopiert!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1512,6 +1512,7 @@ export const de: Dict = {
   'chat.copyErrorDiagnostic': 'Fehlerdiagnose kopieren',
   'chat.errorShowDetails': 'Details anzeigen',
   'chat.errorHideDetails': 'Details ausblenden',
+  'chat.errorDetailsLabel': 'Fehlerdetails',
   'chat.copyDone': 'Kopiert!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1510,6 +1510,8 @@ export const en: Dict = {
   'chat.openFile': 'Open {name}',
   'chat.copyPrompt': 'Copy prompt',
   'chat.copyErrorDiagnostic': 'Copy error diagnostics',
+  'chat.errorShowDetails': 'Show details',
+  'chat.errorHideDetails': 'Hide details',
   'chat.copyDone': 'Copied!',
   'chat.inspect.noEditableTargets': 'No editable text or style targets found.',
   'chat.inspect.noCommentTargets': 'No commentable text or visual targets found.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1512,6 +1512,7 @@ export const en: Dict = {
   'chat.copyErrorDiagnostic': 'Copy error diagnostics',
   'chat.errorShowDetails': 'Show details',
   'chat.errorHideDetails': 'Hide details',
+  'chat.errorDetailsLabel': 'Error details',
   'chat.copyDone': 'Copied!',
   'chat.inspect.noEditableTargets': 'No editable text or style targets found.',
   'chat.inspect.noCommentTargets': 'No commentable text or visual targets found.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1510,6 +1510,8 @@ export const esES: Dict = {
   'chat.openFile': 'Abrir {name}',
   'chat.copyPrompt': 'Copiar prompt',
   'chat.copyErrorDiagnostic': 'Copiar diagnóstico del error',
+  'chat.errorShowDetails': 'Mostrar detalles',
+  'chat.errorHideDetails': 'Ocultar detalles',
   'chat.copyDone': '¡Copiado!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1512,6 +1512,7 @@ export const esES: Dict = {
   'chat.copyErrorDiagnostic': 'Copiar diagnóstico del error',
   'chat.errorShowDetails': 'Mostrar detalles',
   'chat.errorHideDetails': 'Ocultar detalles',
+  'chat.errorDetailsLabel': 'Detalles del error',
   'chat.copyDone': '¡Copiado!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1510,6 +1510,8 @@ export const fa: Dict = {
   'chat.openFile': 'باز کردن {name}',
   'chat.copyPrompt': 'کپی پرامپت',
   'chat.copyErrorDiagnostic': 'کپی اطلاعات عیب‌یابی خطا',
+  'chat.errorShowDetails': 'نمایش جزئیات',
+  'chat.errorHideDetails': 'پنهان کردن جزئیات',
   'chat.copyDone': 'کپی شد!',
   'chat.inspect.noEditableTargets': 'هیچ متن قابل‌ویرایش یا هدف استایلی یافت نشد.',
   'chat.inspect.noCommentTargets': 'هیچ متن قابل‌نظردهی یا هدف بصری یافت نشد.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1512,6 +1512,7 @@ export const fa: Dict = {
   'chat.copyErrorDiagnostic': 'کپی اطلاعات عیب‌یابی خطا',
   'chat.errorShowDetails': 'نمایش جزئیات',
   'chat.errorHideDetails': 'پنهان کردن جزئیات',
+  'chat.errorDetailsLabel': 'جزئیات خطا',
   'chat.copyDone': 'کپی شد!',
   'chat.inspect.noEditableTargets': 'هیچ متن قابل‌ویرایش یا هدف استایلی یافت نشد.',
   'chat.inspect.noCommentTargets': 'هیچ متن قابل‌نظردهی یا هدف بصری یافت نشد.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1510,6 +1510,8 @@ export const fr: Dict = {
   'chat.openFile': 'Ouvrir {name}',
   'chat.copyPrompt': 'Copier le prompt',
   'chat.copyErrorDiagnostic': 'Copier le diagnostic d’erreur',
+  'chat.errorShowDetails': 'Afficher les détails',
+  'chat.errorHideDetails': 'Masquer les détails',
   'chat.copyDone': 'Copié !',
   'chat.inspect.noEditableTargets': 'Aucune cible de texte ou de style modifiable trouvée.',
   'chat.inspect.noCommentTargets': 'Aucune cible de texte ou visuelle pouvant recevoir un commentaire n’a été trouvée.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1512,6 +1512,7 @@ export const fr: Dict = {
   'chat.copyErrorDiagnostic': 'Copier le diagnostic d’erreur',
   'chat.errorShowDetails': 'Afficher les détails',
   'chat.errorHideDetails': 'Masquer les détails',
+  'chat.errorDetailsLabel': 'Détails de l’erreur',
   'chat.copyDone': 'Copié !',
   'chat.inspect.noEditableTargets': 'Aucune cible de texte ou de style modifiable trouvée.',
   'chat.inspect.noCommentTargets': 'Aucune cible de texte ou visuelle pouvant recevoir un commentaire n’a été trouvée.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1510,6 +1510,8 @@ export const hu: Dict = {
   'chat.openFile': '{name} megnyitása',
   'chat.copyPrompt': 'Prompt másolása',
   'chat.copyErrorDiagnostic': 'Hibadiagnosztika másolása',
+  'chat.errorShowDetails': 'Részletek megjelenítése',
+  'chat.errorHideDetails': 'Részletek elrejtése',
   'chat.copyDone': 'Másolva!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1512,6 +1512,7 @@ export const hu: Dict = {
   'chat.copyErrorDiagnostic': 'Hibadiagnosztika másolása',
   'chat.errorShowDetails': 'Részletek megjelenítése',
   'chat.errorHideDetails': 'Részletek elrejtése',
+  'chat.errorDetailsLabel': 'Hibarészletek',
   'chat.copyDone': 'Másolva!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1510,6 +1510,8 @@ export const id: Dict = {
   'chat.openFile': 'Buka {name}',
   'chat.copyPrompt': 'Salin prompt',
   'chat.copyErrorDiagnostic': 'Salin diagnostik error',
+  'chat.errorShowDetails': 'Tampilkan detail',
+  'chat.errorHideDetails': 'Sembunyikan detail',
   'chat.copyDone': 'Disalin!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1512,6 +1512,7 @@ export const id: Dict = {
   'chat.copyErrorDiagnostic': 'Salin diagnostik error',
   'chat.errorShowDetails': 'Tampilkan detail',
   'chat.errorHideDetails': 'Sembunyikan detail',
+  'chat.errorDetailsLabel': 'Detail kesalahan',
   'chat.copyDone': 'Disalin!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1510,6 +1510,8 @@ export const it: Dict = {
   'chat.openFile': 'Apri {name}',
   'chat.copyPrompt': 'Copia prompt',
   'chat.copyErrorDiagnostic': 'Copy error diagnostics',
+  'chat.errorShowDetails': 'Mostra dettagli',
+  'chat.errorHideDetails': 'Nascondi dettagli',
   'chat.copyDone': 'Copiato!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1512,6 +1512,7 @@ export const it: Dict = {
   'chat.copyErrorDiagnostic': 'Copy error diagnostics',
   'chat.errorShowDetails': 'Mostra dettagli',
   'chat.errorHideDetails': 'Nascondi dettagli',
+  'chat.errorDetailsLabel': 'Dettagli errore',
   'chat.copyDone': 'Copiato!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1510,6 +1510,8 @@ export const ja: Dict = {
   'chat.openFile': '{name} を開く',
   'chat.copyPrompt': 'プロンプトをコピー',
   'chat.copyErrorDiagnostic': 'エラー診断をコピー',
+  'chat.errorShowDetails': '詳細を表示',
+  'chat.errorHideDetails': '詳細を隠す',
   'chat.copyDone': 'コピーしました！',
   'chat.inspect.noEditableTargets': '編集可能なテキストまたはスタイルの対象が見つかりません。',
   'chat.inspect.noCommentTargets': 'コメント可能なテキストまたはビジュアルの対象が見つかりません。',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1512,6 +1512,7 @@ export const ja: Dict = {
   'chat.copyErrorDiagnostic': 'エラー診断をコピー',
   'chat.errorShowDetails': '詳細を表示',
   'chat.errorHideDetails': '詳細を隠す',
+  'chat.errorDetailsLabel': 'エラーの詳細',
   'chat.copyDone': 'コピーしました！',
   'chat.inspect.noEditableTargets': '編集可能なテキストまたはスタイルの対象が見つかりません。',
   'chat.inspect.noCommentTargets': 'コメント可能なテキストまたはビジュアルの対象が見つかりません。',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1510,6 +1510,8 @@ export const ko: Dict = {
   'chat.openFile': '{name} 열기',
   'chat.copyPrompt': '프롬프트 복사',
   'chat.copyErrorDiagnostic': '오류 진단 복사',
+  'chat.errorShowDetails': '세부 정보 표시',
+  'chat.errorHideDetails': '세부 정보 숨기기',
   'chat.copyDone': '복사됨!',
   'chat.inspect.noEditableTargets': '편집 가능한 텍스트 또는 스타일 대상을 찾을 수 없습니다.',
   'chat.inspect.noCommentTargets': '댓글을 달 수 있는 텍스트 또는 시각적 대상을 찾을 수 없습니다.',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1512,6 +1512,7 @@ export const ko: Dict = {
   'chat.copyErrorDiagnostic': '오류 진단 복사',
   'chat.errorShowDetails': '세부 정보 표시',
   'chat.errorHideDetails': '세부 정보 숨기기',
+  'chat.errorDetailsLabel': '오류 세부 정보',
   'chat.copyDone': '복사됨!',
   'chat.inspect.noEditableTargets': '편집 가능한 텍스트 또는 스타일 대상을 찾을 수 없습니다.',
   'chat.inspect.noCommentTargets': '댓글을 달 수 있는 텍스트 또는 시각적 대상을 찾을 수 없습니다.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1510,6 +1510,8 @@ export const pl: Dict = {
   'chat.openFile': 'Otwórz {name}',
   'chat.copyPrompt': 'Kopiuj prompt',
   'chat.copyErrorDiagnostic': 'Kopiuj diagnostykę błędu',
+  'chat.errorShowDetails': 'Pokaż szczegóły',
+  'chat.errorHideDetails': 'Ukryj szczegóły',
   'chat.copyDone': 'Skopiowano!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1512,6 +1512,7 @@ export const pl: Dict = {
   'chat.copyErrorDiagnostic': 'Kopiuj diagnostykę błędu',
   'chat.errorShowDetails': 'Pokaż szczegóły',
   'chat.errorHideDetails': 'Ukryj szczegóły',
+  'chat.errorDetailsLabel': 'Szczegóły błędu',
   'chat.copyDone': 'Skopiowano!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1510,6 +1510,8 @@ export const ptBR: Dict = {
   'chat.openFile': 'Abrir {name}',
   'chat.copyPrompt': 'Copiar prompt',
   'chat.copyErrorDiagnostic': 'Copiar diagnóstico do erro',
+  'chat.errorShowDetails': 'Mostrar detalhes',
+  'chat.errorHideDetails': 'Ocultar detalhes',
   'chat.copyDone': 'Copiado!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1512,6 +1512,7 @@ export const ptBR: Dict = {
   'chat.copyErrorDiagnostic': 'Copiar diagnóstico do erro',
   'chat.errorShowDetails': 'Mostrar detalhes',
   'chat.errorHideDetails': 'Ocultar detalhes',
+  'chat.errorDetailsLabel': 'Detalhes do erro',
   'chat.copyDone': 'Copiado!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1510,6 +1510,8 @@ export const ru: Dict = {
   'chat.openFile': 'Открыть {name}',
   'chat.copyPrompt': 'Скопировать запрос',
   'chat.copyErrorDiagnostic': 'Скопировать диагностику ошибки',
+  'chat.errorShowDetails': 'Показать подробности',
+  'chat.errorHideDetails': 'Скрыть подробности',
   'chat.copyDone': 'Скопировано!',
   'chat.inspect.noEditableTargets': 'Редактируемый текст или объекты стиля не найдены.',
   'chat.inspect.noCommentTargets': 'Текст или визуальные объекты для комментирования не найдены.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1512,6 +1512,7 @@ export const ru: Dict = {
   'chat.copyErrorDiagnostic': 'Скопировать диагностику ошибки',
   'chat.errorShowDetails': 'Показать подробности',
   'chat.errorHideDetails': 'Скрыть подробности',
+  'chat.errorDetailsLabel': 'Сведения об ошибке',
   'chat.copyDone': 'Скопировано!',
   'chat.inspect.noEditableTargets': 'Редактируемый текст или объекты стиля не найдены.',
   'chat.inspect.noCommentTargets': 'Текст или визуальные объекты для комментирования не найдены.',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1510,6 +1510,8 @@ export const th: Dict = {
   'chat.openFile': 'เปิด {name}',
   'chat.copyPrompt': 'คัดลอกพรอมต์',
   'chat.copyErrorDiagnostic': 'คัดลอกข้อมูลวิเคราะห์ข้อผิดพลาด',
+  'chat.errorShowDetails': 'แสดงรายละเอียด',
+  'chat.errorHideDetails': 'ซ่อนรายละเอียด',
   'chat.copyDone': 'คัดลอกแล้ว!',
   'chat.inspect.noEditableTargets': 'ไม่พบข้อความหรือเป้าหมายสไตล์ที่แก้ไขได้',
   'chat.inspect.noCommentTargets': 'ไม่พบข้อความหรือเป้าหมายภาพที่แสดงความคิดเห็นได้',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1512,6 +1512,7 @@ export const th: Dict = {
   'chat.copyErrorDiagnostic': 'คัดลอกข้อมูลวิเคราะห์ข้อผิดพลาด',
   'chat.errorShowDetails': 'แสดงรายละเอียด',
   'chat.errorHideDetails': 'ซ่อนรายละเอียด',
+  'chat.errorDetailsLabel': 'รายละเอียดข้อผิดพลาด',
   'chat.copyDone': 'คัดลอกแล้ว!',
   'chat.inspect.noEditableTargets': 'ไม่พบข้อความหรือเป้าหมายสไตล์ที่แก้ไขได้',
   'chat.inspect.noCommentTargets': 'ไม่พบข้อความหรือเป้าหมายภาพที่แสดงความคิดเห็นได้',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1510,6 +1510,8 @@ export const tr: Dict = {
   'chat.openFile': '{name}’ı aç',
   'chat.copyPrompt': 'Promptu kopyala',
   'chat.copyErrorDiagnostic': 'Hata tanısını kopyala',
+  'chat.errorShowDetails': 'Ayrıntıları göster',
+  'chat.errorHideDetails': 'Ayrıntıları gizle',
   'chat.copyDone': 'Kopyalandı!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1512,6 +1512,7 @@ export const tr: Dict = {
   'chat.copyErrorDiagnostic': 'Hata tanısını kopyala',
   'chat.errorShowDetails': 'Ayrıntıları göster',
   'chat.errorHideDetails': 'Ayrıntıları gizle',
+  'chat.errorDetailsLabel': 'Hata ayrıntıları',
   'chat.copyDone': 'Kopyalandı!',
   'chat.inspect.noEditableTargets': 'This page has no editable elements yet.',
   'chat.inspect.noCommentTargets': 'This page has no commentable elements yet.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1510,6 +1510,8 @@ export const uk: Dict = {
   'chat.openFile': 'Відкрити {name}',
   'chat.copyPrompt': 'Копіювати запит',
   'chat.copyErrorDiagnostic': 'Скопіювати діагностику помилки',
+  'chat.errorShowDetails': 'Показати деталі',
+  'chat.errorHideDetails': 'Приховати деталі',
   'chat.copyDone': 'Скопійовано!',
   'chat.inspect.noEditableTargets': 'Не знайдено редагованого тексту чи цілей стилю.',
   'chat.inspect.noCommentTargets': 'Не знайдено тексту чи візуальних цілей для коментування.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1512,6 +1512,7 @@ export const uk: Dict = {
   'chat.copyErrorDiagnostic': 'Скопіювати діагностику помилки',
   'chat.errorShowDetails': 'Показати деталі',
   'chat.errorHideDetails': 'Приховати деталі',
+  'chat.errorDetailsLabel': 'Деталі помилки',
   'chat.copyDone': 'Скопійовано!',
   'chat.inspect.noEditableTargets': 'Не знайдено редагованого тексту чи цілей стилю.',
   'chat.inspect.noCommentTargets': 'Не знайдено тексту чи візуальних цілей для коментування.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1510,6 +1510,8 @@ export const zhCN: Dict = {
   'chat.openFile': '打开 {name}',
   'chat.copyPrompt': '复制提示词',
   'chat.copyErrorDiagnostic': '复制错误诊断信息',
+  'chat.errorShowDetails': '显示详情',
+  'chat.errorHideDetails': '收起详情',
   'chat.copyDone': '已复制！',
   'chat.inspect.noEditableTargets': '未找到可编辑的文本或样式目标。',
   'chat.inspect.noCommentTargets': '未找到可评论的文本或视觉目标。',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1512,6 +1512,7 @@ export const zhCN: Dict = {
   'chat.copyErrorDiagnostic': '复制错误诊断信息',
   'chat.errorShowDetails': '显示详情',
   'chat.errorHideDetails': '收起详情',
+  'chat.errorDetailsLabel': '错误详情',
   'chat.copyDone': '已复制！',
   'chat.inspect.noEditableTargets': '未找到可编辑的文本或样式目标。',
   'chat.inspect.noCommentTargets': '未找到可评论的文本或视觉目标。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1510,6 +1510,8 @@ export const zhTW: Dict = {
   'chat.openFile': '開啟 {name}',
   'chat.copyPrompt': '複製提示詞',
   'chat.copyErrorDiagnostic': '複製錯誤診斷資訊',
+  'chat.errorShowDetails': '顯示詳情',
+  'chat.errorHideDetails': '收起詳情',
   'chat.copyDone': '已複製！',
   'chat.inspect.noEditableTargets': '未找到可編輯的文字或樣式目標。',
   'chat.inspect.noCommentTargets': '未找到可評論的文字或視覺目標。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1512,6 +1512,7 @@ export const zhTW: Dict = {
   'chat.copyErrorDiagnostic': '複製錯誤診斷資訊',
   'chat.errorShowDetails': '顯示詳情',
   'chat.errorHideDetails': '收起詳情',
+  'chat.errorDetailsLabel': '錯誤詳情',
   'chat.copyDone': '已複製！',
   'chat.inspect.noEditableTargets': '未找到可編輯的文字或樣式目標。',
   'chat.inspect.noCommentTargets': '未找到可評論的文字或視覺目標。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2061,6 +2061,8 @@ export interface Dict {
   'chat.openFile': string;
   'chat.copyPrompt': string;
   'chat.copyErrorDiagnostic': string;
+  'chat.errorShowDetails': string;
+  'chat.errorHideDetails': string;
   'chat.copyDone': string;
   'chat.composerPlaceholder': string;
   'chat.activeFileEditingLabel': string;

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2063,6 +2063,7 @@ export interface Dict {
   'chat.copyErrorDiagnostic': string;
   'chat.errorShowDetails': string;
   'chat.errorHideDetails': string;
+  'chat.errorDetailsLabel': string;
   'chat.copyDone': string;
   'chat.composerPlaceholder': string;
   'chat.activeFileEditingLabel': string;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -740,7 +740,31 @@
   justify-content: space-between;
   gap: 10px;
 }
-.chat-error-text { min-width: 0; }
+.chat-error-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+/* Collapsed: show a summary-sized slice of the payload (#3907). The full
+   text stays in the DOM so selection/copy keep working. */
+.chat-error-text[data-clamped='true'] {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+/* Expanded: bounded, scrollable details instead of flooding the column. */
+.msg.error[data-error-expanded='true'] {
+  align-items: flex-start;
+}
+.msg.error[data-error-expanded='true'] .chat-error-text {
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+.chat-error-details-toggle {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
 .chat-error-actions {
   flex: 0 0 auto;
   display: flex;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -757,6 +757,9 @@
   align-items: flex-start;
 }
 .msg.error[data-error-expanded='true'] .chat-error-text {
+  /* The span is already blockified as a flex item of .msg.error; keep the
+     scroll container explicit so the 240px cap survives layout refactors. */
+  display: block;
   max-height: 240px;
   overflow: auto;
   white-space: pre-wrap;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -744,15 +744,9 @@
   min-width: 0;
   overflow-wrap: anywhere;
 }
-/* Collapsed: show a summary-sized slice of the payload (#3907). The full
-   text stays in the DOM so selection/copy keep working. */
-.chat-error-text[data-clamped='true'] {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
-}
-/* Expanded: bounded, scrollable details instead of flooding the column. */
+/* Expanded: bounded, scrollable details instead of flooding the column. The
+   collapsed card renders a short summary directly (#4028 design review), so
+   there is no raw payload to visually clamp here. */
 .msg.error[data-error-expanded='true'] {
   align-items: flex-start;
 }
@@ -763,6 +757,12 @@
   max-height: 240px;
   overflow: auto;
   white-space: pre-wrap;
+}
+/* The expanded region is keyboard-focusable (it owns scrolling), so surface a
+   focus ring matching the rest of the app. */
+.msg.error[data-error-expanded='true'] .chat-error-text:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .chat-error-details-toggle {
   flex: 0 0 auto;

--- a/apps/web/tests/components/ChatPane.error-card.test.tsx
+++ b/apps/web/tests/components/ChatPane.error-card.test.tsx
@@ -5,7 +5,7 @@ import { forwardRef, useImperativeHandle } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatPane } from '../../src/components/ChatPane';
-import type { Conversation, ProjectMetadata } from '../../src/types';
+import type { ChatMessage, Conversation, ProjectMetadata } from '../../src/types';
 
 const composerMocks = vi.hoisted(() => ({
   focus: vi.fn(),
@@ -133,6 +133,29 @@ describe('ChatPane error card payload discipline (#3907)', () => {
     expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('true');
 
     rerender(paneElement({ error: `${LONG_RAW_ERROR} (second attempt)` }));
+
+    expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('false');
+    expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');
+  });
+
+  it('collapses the expanded view when a new failed run repeats the same payload', () => {
+    // Distinct failed runs frequently render the identical string (same
+    // upstream 400 on retry, or a shared runFailureUi translation), so the
+    // reset must key off the failure identity, not the display text.
+    const failedRunMessage = (id: string, runId: string): ChatMessage => ({
+      id,
+      role: 'assistant',
+      content: '',
+      runId,
+      runStatus: 'failed',
+      events: [{ kind: 'status', label: 'error', detail: LONG_RAW_ERROR }],
+    });
+    const { container, rerender } = renderPane({ messages: [failedRunMessage('a1', 'run-1')] });
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.errorShowDetails' }));
+    expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('true');
+
+    rerender(paneElement({ messages: [failedRunMessage('a2', 'run-2')] }));
 
     expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('false');
     expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');

--- a/apps/web/tests/components/ChatPane.error-card.test.tsx
+++ b/apps/web/tests/components/ChatPane.error-card.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { forwardRef, useImperativeHandle } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import type { Conversation, ProjectMetadata } from '../../src/types';
+
+const composerMocks = vi.hoisted(() => ({
+  focus: vi.fn(),
+  restoreDraft: vi.fn(),
+  setDraft: vi.fn(),
+}));
+
+vi.mock('../../src/i18n', () => ({
+  useI18n: () => ({ locale: 'en', setLocale: () => undefined, t: (key: string) => key }),
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, ref) => {
+    useImperativeHandle(ref, () => ({
+      focus: composerMocks.focus,
+      restoreDraft: composerMocks.restoreDraft,
+      setDraft: composerMocks.setDraft,
+    }));
+    return <output data-testid="composer" />;
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const conversations: Conversation[] = [
+  { id: 'conv-1', projectId: 'project-1', title: 'Conversation 1', createdAt: 1, updatedAt: 1 },
+];
+
+const projectMetadata: ProjectMetadata = { kind: 'prototype' };
+
+// Mirrors the raw payload class from #3907: an opencode session error whose
+// JSON body (headers + HTML response) lands in the card unclassified.
+const LONG_RAW_ERROR =
+  'json-rpc id 4: opencode event stream: opencode session error: '
+  + JSON.stringify({
+    sessionID: 'ses_16a0d242cffe0',
+    name: 'APIError',
+    data: {
+      message: 'Bad Request',
+      statusCode: 400,
+      isRetryable: false,
+      responseHeaders: { 'alt-svc': 'h3=":443"', 'content-type': 'text/html' },
+      responseBody: '<html><head><title>400 Bad Request</title></head><body><center>400 Bad Request</center></body></html>',
+    },
+  });
+
+const SHORT_ERROR = 'Conversation failed to load.';
+
+function paneElement(extra: Partial<React.ComponentProps<typeof ChatPane>>) {
+  return (
+    <ChatPane
+      projectKindForTracking="prototype"
+      messages={[]}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      conversations={conversations}
+      activeConversationId="conv-1"
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      projectMetadata={projectMetadata}
+      {...extra}
+    />
+  );
+}
+
+function renderPane(extra: Partial<React.ComponentProps<typeof ChatPane>>) {
+  return render(paneElement(extra));
+}
+
+describe('ChatPane error card payload discipline (#3907)', () => {
+  it('clamps an oversized raw payload and offers a details toggle', () => {
+    const { container } = renderPane({ error: LONG_RAW_ERROR });
+
+    const text = container.querySelector('.chat-error-text');
+    expect(text).not.toBeNull();
+    // Full payload stays in the DOM (clamp is visual), so copy/inspect still works.
+    expect(text!.textContent).toBe(LONG_RAW_ERROR);
+    expect(text!.getAttribute('data-clamped')).toBe('true');
+
+    const toggle = screen.getByRole('button', { name: 'chat.errorShowDetails' });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('expands to a scrollable details view and collapses back', () => {
+    const { container } = renderPane({ error: LONG_RAW_ERROR });
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.errorShowDetails' }));
+
+    const card = container.querySelector('.msg.error');
+    const text = container.querySelector('.chat-error-text');
+    expect(card!.getAttribute('data-error-expanded')).toBe('true');
+    expect(text!.getAttribute('data-clamped')).toBe('false');
+    expect(text!.textContent).toBe(LONG_RAW_ERROR);
+
+    const hideToggle = screen.getByRole('button', { name: 'chat.errorHideDetails' });
+    expect(hideToggle.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(hideToggle);
+    expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('false');
+    expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');
+  });
+
+  it('renders short errors as-is without a toggle', () => {
+    const { container } = renderPane({ error: SHORT_ERROR });
+
+    const text = container.querySelector('.chat-error-text');
+    expect(text!.textContent).toBe(SHORT_ERROR);
+    expect(text!.getAttribute('data-clamped')).toBe('false');
+    expect(screen.queryByRole('button', { name: 'chat.errorShowDetails' })).toBeNull();
+  });
+
+  it('collapses the expanded view when a different error arrives', () => {
+    const { container, rerender } = renderPane({ error: LONG_RAW_ERROR });
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.errorShowDetails' }));
+    expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('true');
+
+    rerender(paneElement({ error: `${LONG_RAW_ERROR} (second attempt)` }));
+
+    expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('false');
+    expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');
+  });
+
+  it('treats short multiline payloads as clampable', () => {
+    const { container } = renderPane({ error: 'line one\nline two\nline three' });
+
+    expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');
+    expect(screen.getByRole('button', { name: 'chat.errorShowDetails' })).not.toBeNull();
+  });
+});

--- a/apps/web/tests/components/ChatPane.error-card.test.tsx
+++ b/apps/web/tests/components/ChatPane.error-card.test.tsx
@@ -85,20 +85,29 @@ function renderPane(extra: Partial<React.ComponentProps<typeof ChatPane>>) {
 }
 
 describe('ChatPane error card payload discipline (#3907)', () => {
-  it('clamps an oversized raw payload and offers a details toggle', () => {
+  it('collapses an oversized raw payload to a summary and offers a details toggle', () => {
     const { container } = renderPane({ error: LONG_RAW_ERROR });
 
     const text = container.querySelector('.chat-error-text');
     expect(text).not.toBeNull();
-    // Full payload stays in the DOM (clamp is visual), so copy/inspect still works.
-    expect(text!.textContent).toBe(LONG_RAW_ERROR);
-    expect(text!.getAttribute('data-clamped')).toBe('true');
+    // Collapsed cards must NOT carry the raw blob in the DOM (#4028 design
+    // review): only a short summary, so assistive tech / selection / copy don't
+    // trip over a multi-KB payload before the user opens details.
+    expect(text!.textContent).not.toBe(LONG_RAW_ERROR);
+    expect(text!.textContent).not.toContain('<html>');
+    expect(text!.textContent).not.toContain('responseBody');
+    expect(text!.textContent!.endsWith('…')).toBe(true);
+    // Collapsed text is not a scroll container, so it is not focusable.
+    expect(text!.hasAttribute('tabindex')).toBe(false);
 
     const toggle = screen.getByRole('button', { name: 'chat.errorShowDetails' });
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    // Disclosure pattern: the toggle points at the details region by id.
+    expect(text!.id).not.toBe('');
+    expect(toggle.getAttribute('aria-controls')).toBe(text!.id);
   });
 
-  it('expands to a scrollable details view and collapses back', () => {
+  it('expands to a focusable scrollable details view and collapses back', () => {
     const { container } = renderPane({ error: LONG_RAW_ERROR });
 
     fireEvent.click(screen.getByRole('button', { name: 'chat.errorShowDetails' }));
@@ -106,15 +115,20 @@ describe('ChatPane error card payload discipline (#3907)', () => {
     const card = container.querySelector('.msg.error');
     const text = container.querySelector('.chat-error-text');
     expect(card!.getAttribute('data-error-expanded')).toBe('true');
-    expect(text!.getAttribute('data-clamped')).toBe('false');
+    // Expanded: the full payload is now in the DOM, inside the bounded scroll area.
     expect(text!.textContent).toBe(LONG_RAW_ERROR);
+    // The scroll region owns scrolling, so it is keyboard-focusable and named.
+    expect(text!.getAttribute('tabindex')).toBe('0');
+    expect(text!.getAttribute('aria-label')).toBe('chat.errorDetailsLabel');
 
     const hideToggle = screen.getByRole('button', { name: 'chat.errorHideDetails' });
     expect(hideToggle.getAttribute('aria-expanded')).toBe('true');
 
     fireEvent.click(hideToggle);
     expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('false');
-    expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');
+    const collapsedText = container.querySelector('.chat-error-text');
+    expect(collapsedText!.textContent).not.toBe(LONG_RAW_ERROR);
+    expect(collapsedText!.hasAttribute('tabindex')).toBe(false);
   });
 
   it('renders short errors as-is without a toggle', () => {
@@ -122,7 +136,7 @@ describe('ChatPane error card payload discipline (#3907)', () => {
 
     const text = container.querySelector('.chat-error-text');
     expect(text!.textContent).toBe(SHORT_ERROR);
-    expect(text!.getAttribute('data-clamped')).toBe('false');
+    expect(text!.hasAttribute('tabindex')).toBe(false);
     expect(screen.queryByRole('button', { name: 'chat.errorShowDetails' })).toBeNull();
   });
 
@@ -135,7 +149,7 @@ describe('ChatPane error card payload discipline (#3907)', () => {
     rerender(paneElement({ error: `${LONG_RAW_ERROR} (second attempt)` }));
 
     expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('false');
-    expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');
+    expect(container.querySelector('.chat-error-text')!.textContent).not.toContain('<html>');
   });
 
   it('collapses the expanded view when a new failed run repeats the same payload', () => {
@@ -158,13 +172,26 @@ describe('ChatPane error card payload discipline (#3907)', () => {
     rerender(paneElement({ messages: [failedRunMessage('a2', 'run-2')] }));
 
     expect(container.querySelector('.msg.error')!.getAttribute('data-error-expanded')).toBe('false');
-    expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');
+    expect(container.querySelector('.chat-error-text')!.textContent).not.toBe(LONG_RAW_ERROR);
   });
 
-  it('treats short multiline payloads as clampable', () => {
+  it('summarizes a short multiline payload to its first line', () => {
     const { container } = renderPane({ error: 'line one\nline two\nline three' });
 
-    expect(container.querySelector('.chat-error-text')!.getAttribute('data-clamped')).toBe('true');
+    const text = container.querySelector('.chat-error-text');
+    // Collapsed multiline shows only the first line, not the later lines.
+    expect(text!.textContent).toBe('line one');
+    expect(text!.textContent).not.toContain('line two');
+    expect(screen.getByRole('button', { name: 'chat.errorShowDetails' })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.errorShowDetails' }));
+    expect(container.querySelector('.chat-error-text')!.textContent).toBe('line one\nline two\nline three');
+  });
+
+  it('summarizes the first non-blank line when the payload leads with blank lines', () => {
+    const { container } = renderPane({ error: '   \n\nActual failure detail' });
+
+    expect(container.querySelector('.chat-error-text')!.textContent).toBe('Actual failure detail');
     expect(screen.getByRole('button', { name: 'chat.errorShowDetails' })).not.toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #3907

## Why

When a run fails with an error the web client can't classify, `ChatPane` renders the full raw upstream payload (`displayError = runFailureUi?.messageKey ? t(...) : rawError`) into `.chat-error-text`, which had no payload-size discipline — a multi-KB JSON/HTML blob (e.g. an AMR relay 400 wrapped in a session error) flooded the entire chat column while still being unreadable (#3907, screenshots there and below). The dedicated right-pane failure surface was removed by #3986, so per the maintainer re-scope confirmed in the issue, this applies the summary-plus-details split to the surviving surface: the chat error card.

## What users will see

When a run fails with a long/multiline error, the chat error card now shows a short summary (the first non-blank line of the payload) with a **Show details** button next to Retry. Expanding reveals the full payload in a bounded, scrollable, wrap-safe block; **Hide details** collapses it back. Short errors render exactly as before — no toggle. The copy-diagnostics button is unchanged and remains the copy path for the full text.

Per @chaoxiaoche's design review, the collapsed card now renders **only the summary** — the raw payload is no longer placed in the DOM until you expand, so assistive tech / selection / copy never hit the multi-KB blob first. The expanded details region owns its own scroll, so it is keyboard-focusable with an accessible name, and the toggle is wired to it via `aria-controls` / `aria-expanded` for a proper disclosure pattern.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)

Three keys (`chat.errorShowDetails` / `chat.errorHideDetails` / `chat.errorDetailsLabel`) added to `Dict`, `en`, and all 18 other locales.

## Screenshots

Captured from the real app (playwright harness + a fake agent emitting an unclassifiable multi-KB payload on stderr; error injected via the repo's own fake-agent e2e harness).

**Before — raw blob floods the chat column:**

<img width="1280" height="720" alt="before-flood" src="https://github.com/user-attachments/assets/5b5e750a-1a54-4daa-ad9d-3051ca74de56" />

**After — collapsed: summary only, with Show details + Retry (raw payload not in the DOM):**

<img width="424" height="102" alt="od4028-collapsed" src="https://github.com/user-attachments/assets/f9f2b873-074b-4685-9c7f-bf9601d59fbd" />

**After — expanded: full payload in a bounded, scrollable, keyboard-focusable details region:**

<img width="424" height="261" alt="od4028-expanded" src="https://github.com/user-attachments/assets/2209fd89-781b-4042-a147-c178906385aa" />

## Bug fix verification

- Test path: `apps/web/tests/components/ChatPane.error-card.test.tsx` (7 tests: collapsed summary excludes the raw payload + offers a toggle, expand→focusable scroll region→collapse round-trip, expanded-state reset when a different error / a new failed run with identical text arrives, short errors render with no toggle, short multiline summarizes to its first line, blank-leading-line payloads summarize to the first non-blank line)
- Red on `main`, green on this branch? **yes** — the feature does not exist on `main` (no toggle, no summary discipline), so the suite fails there and passes with this change.

## Validation

- `pnpm guard` — pass (fail 0)
- `pnpm typecheck` — pass (all packages; verifies the 19-locale `Dict` parity for the new keys)
- `pnpm --filter @open-design/web vitest run tests/components/ChatPane.error-card.test.tsx` — 7/7 pass
- `pnpm --filter @open-design/web test` — full web suite green (319 files / 3147 tests)
- Manual: drove the real app via the e2e harness with a fake agent dumping an unclassifiable multi-KB blob — collapsed/expanded states shown above; also verified the classified-failure paths (AMR balance/auth short messages) render without a toggle
