### PR TITLE
ci(release): allow manual nightly+Feishu dispatch off any ref

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -9,11 +9,33 @@ name: notify-release-feishu
 # during it coalesce into a single trailing build of the latest commit. With
 # cancel-in-progress the previous behavior starved — pushes spaced closer than
 # the build duration kept cancelling each other and no package was ever cut.
+#
+# Also dispatchable by hand (workflow_dispatch) so a nightly + Feishu card can be
+# cut without an actual push. The normal manual path is to dispatch ON a
+# release/vX.Y.Z branch with `ref`/`release_version` empty — release-stable then
+# derives the version from the branch name exactly like the push trigger does.
+# Building from a non-release ref such as main is also possible but requires
+# `release_version` (e.g. 0.10.0, matching apps/packaged/package.json), because
+# the branch name carries no version; the resulting package is labelled
+# X.Y.Z.nightly.N on that same version line. Either way the build's actual commit
+# (not the dispatch ref) anchors the changelog and the card.
 
 on:
   push:
     branches:
       - "release/**"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to build a nightly from. Empty builds the ref this workflow is dispatched on. Dispatch on release/vX.Y.Z and leave empty for the normal path."
+        required: false
+        type: string
+        default: ""
+      release_version:
+        description: "Base version (x.y.z) — ONLY needed to build from a non-release ref such as main, where the branch name carries no version. Must equal apps/packaged/package.json. Leave empty on a release/vX.Y.Z branch."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -36,6 +58,14 @@ jobs:
     secrets: inherit
     with:
       channel: nightly
+      # Empty on push events (inputs context is unset there), so release-stable
+      # falls back to building the pushed commit. On workflow_dispatch this
+      # carries the operator-chosen ref (or empty = the dispatch ref).
+      ref: ${{ inputs.ref }}
+      # Empty on push and on release/vX.Y.Z dispatches (branch name carries the
+      # version). Only set when building from a non-release ref like main, where
+      # release-stable cannot derive the base version from the branch name.
+      release_version: ${{ inputs.release_version }}
 
   notify:
     name: Notify Feishu (release)
@@ -46,7 +76,11 @@ jobs:
       - name: Checkout built ref
         uses: actions/checkout@v6.0.2
         with:
-          ref: ${{ github.sha }}
+          # The commit release-stable actually built, not github.sha. On push
+          # the two coincide, but on workflow_dispatch with an explicit ref they
+          # can differ — anchoring on the built commit keeps the changelog range
+          # (previous_commit..commit) correct for manual nightly runs.
+          ref: ${{ needs.build.outputs.commit }}
           fetch-depth: 0
 
       - name: Compute changelog since last nightly


### PR DESCRIPTION
## Why

I wanted to cut a nightly package + Feishu card without first pushing to a `release/**` branch — handy when I just want to hand a fresh build to the group for a quick look, or build a nightly off `main` on demand. Today `notify-release-feishu.yml` only fires on `push: branches: release/**`; there is no manual entry point, so the only way to trigger the nightly+Feishu stream is an actual release-branch push. That makes ad-hoc nightlies awkward and tempts people into dummy commits.

This adds a `workflow_dispatch` trigger to the same workflow so the nightly build + Feishu group notification can be kicked off by hand, while leaving the existing push behavior byte-for-byte unchanged (`inputs.*` is empty on push events).

## What users will see

Maintainers get a **Run workflow** button on `notify-release-feishu` in the Actions tab (visible once this lands on `main`, as GitHub only exposes `workflow_dispatch` from the default branch). Two optional inputs:

- `ref` — git ref to build. Leave empty to build the dispatch ref. The intended path is to dispatch **on** a `release/vX.Y.Z` branch with both inputs empty, which behaves exactly like a push to that branch.
- `release_version` — only needed to build from a **non-release** ref such as `main`, where the branch name carries no version. Must equal `apps/packaged/package.json` (currently `0.10.0`); the resulting package is labelled `X.Y.Z.nightly.N` on that same version line.

Either way it builds a nightly via `release-stable` (channel=nightly) and posts the same "Nightly" Feishu card to `FEISHU_RELEASE_WEBHOOK`.

It also fixes a latent bug that only surfaces under manual dispatch: the `notify` job's changelog step checked out `github.sha`, which equals the built commit on push but can differ on a `workflow_dispatch` with an explicit `ref`. It now checks out `needs.build.outputs.commit` (the commit `release-stable` actually built), keeping the `previous_commit..commit` changelog range correct.

## Surface area

- [x] **CLI / env var** — adds `workflow_dispatch` inputs (`ref`, `release_version`) to a GitHub Actions workflow; no `od`/`tools-*` change
- [ ] **None**

(Closest applicable box — this is a CI workflow trigger change, not app code. No UI, API/contract, i18n, or dependency surface touched.)

## Bug fix verification

Partly a bug fix (the `github.sha` → `needs.build.outputs.commit` correction), but the failure only manifests inside GitHub Actions on a `workflow_dispatch` with a non-HEAD `ref`, which has no cheap local red-spec harness. The fix is an invariant: anchor the changelog on the commit the build job reports it built, not on the dispatch ref. Verified by reading the `release-stable` `workflow_call` output contract (`commit`, `previous_commit`) and confirming the changelog range consumes both.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/notify-release-feishu.yml'))"` — YAML parses
- Cross-checked that `release-stable.yml`'s `workflow_call` block accepts `channel` / `ref` / `release_version` and exposes the `commit` / `previous_commit` / `branch` / `*_url` / `release_version` outputs the `notify` job consumes
- Traced `release-stable.ts`: `resolveStableBaseVersion(branch=inputs.ref||github.ref_name, OPEN_DESIGN_STABLE_VERSION=inputs.release_version)` confirms why a non-release ref needs `release_version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
