### PR TITLE
fix(packaging): serve baked plugin previews in the packaged app

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1354,8 +1354,20 @@ const DAEMON_RESOURCE_ROOT = resolveDaemonResourceRoot();
 const STATIC_DIR = path.join(PROJECT_ROOT, 'apps', 'web', 'out');
 // Baked plugin preview clips (scripts/bake-plugin-previews.mjs). Served at
 // PLUGIN_PREVIEWS_ROUTE; their manifest rewrites html plugins' previews to a
-// cheap poster + hover-play video in the home gallery.
-const PLUGIN_PREVIEWS_DIR = resolvePluginPreviewsDir(PROJECT_ROOT);
+// cheap poster + hover-play video in the home gallery. In packaged builds the
+// bundled manifest lives under OD_RESOURCE_ROOT (Resources/open-design) like
+// every other resource tree — NOT under PROJECT_ROOT, which for the prebundled
+// daemon resolves to Resources/app (two levels up from the sidecar) and has no
+// data/. Resolve against the resource root so the packaged gallery actually gets
+// baked previews instead of falling back to live iframes; an explicit
+// OD_PLUGIN_PREVIEWS_DIR override and the dev layout still win.
+const PLUGIN_PREVIEWS_DIR = process.env.OD_PLUGIN_PREVIEWS_DIR
+  ? resolvePluginPreviewsDir(PROJECT_ROOT)
+  : resolveDaemonResourceDir(
+      DAEMON_RESOURCE_ROOT,
+      path.join('data', 'plugin-previews'),
+      path.join(PROJECT_ROOT, 'data', 'plugin-previews'),
+    );
 const OD_BIN = resolveDaemonCliPath();
 const OD_NODE_BIN = process.execPath;
 const SKILLS_DIR = resolveDaemonResourceDir(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1346,6 +1346,21 @@ function resolveDaemonResourceDir(resourceRoot, segment, fallback) {
   return resourceRoot ? path.join(resourceRoot, segment) : fallback;
 }
 
+// Where the daemon reads the baked plugin-preview manifest from. In a packaged
+// build the bundled manifest lives under the resource root (OD_RESOURCE_ROOT,
+// Resources/open-design) like every other resource tree — NOT under PROJECT_ROOT,
+// which for the prebundled daemon resolves to Resources/app (two levels up from
+// the sidecar) and has no data/. An explicit OD_PLUGIN_PREVIEWS_DIR override and
+// the dev PROJECT_ROOT layout still win. Exported for regression coverage.
+export function resolveDaemonPluginPreviewsDir({ env = process.env, resourceRoot, projectRoot }) {
+  if (env.OD_PLUGIN_PREVIEWS_DIR) return resolvePluginPreviewsDir(projectRoot);
+  return resolveDaemonResourceDir(
+    resourceRoot,
+    path.join('data', 'plugin-previews'),
+    path.join(projectRoot, 'data', 'plugin-previews'),
+  );
+}
+
 const DAEMON_RESOURCE_ROOT = resolveDaemonResourceRoot();
 // Built web app lives in `out/` — that's where Next.js writes the static
 // export configured in next.config.ts. The folder name used to be `dist/`
@@ -1354,20 +1369,11 @@ const DAEMON_RESOURCE_ROOT = resolveDaemonResourceRoot();
 const STATIC_DIR = path.join(PROJECT_ROOT, 'apps', 'web', 'out');
 // Baked plugin preview clips (scripts/bake-plugin-previews.mjs). Served at
 // PLUGIN_PREVIEWS_ROUTE; their manifest rewrites html plugins' previews to a
-// cheap poster + hover-play video in the home gallery. In packaged builds the
-// bundled manifest lives under OD_RESOURCE_ROOT (Resources/open-design) like
-// every other resource tree — NOT under PROJECT_ROOT, which for the prebundled
-// daemon resolves to Resources/app (two levels up from the sidecar) and has no
-// data/. Resolve against the resource root so the packaged gallery actually gets
-// baked previews instead of falling back to live iframes; an explicit
-// OD_PLUGIN_PREVIEWS_DIR override and the dev layout still win.
-const PLUGIN_PREVIEWS_DIR = process.env.OD_PLUGIN_PREVIEWS_DIR
-  ? resolvePluginPreviewsDir(PROJECT_ROOT)
-  : resolveDaemonResourceDir(
-      DAEMON_RESOURCE_ROOT,
-      path.join('data', 'plugin-previews'),
-      path.join(PROJECT_ROOT, 'data', 'plugin-previews'),
-    );
+// cheap poster + hover-play video in the home gallery.
+const PLUGIN_PREVIEWS_DIR = resolveDaemonPluginPreviewsDir({
+  resourceRoot: DAEMON_RESOURCE_ROOT,
+  projectRoot: PROJECT_ROOT,
+});
 const OD_BIN = resolveDaemonCliPath();
 const OD_NODE_BIN = process.execPath;
 const SKILLS_DIR = resolveDaemonResourceDir(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1353,7 +1353,13 @@ function resolveDaemonResourceDir(resourceRoot, segment, fallback) {
 // the sidecar) and has no data/. An explicit OD_PLUGIN_PREVIEWS_DIR override and
 // the dev PROJECT_ROOT layout still win. Exported for regression coverage.
 export function resolveDaemonPluginPreviewsDir({ env = process.env, resourceRoot, projectRoot }) {
-  if (env.OD_PLUGIN_PREVIEWS_DIR) return resolvePluginPreviewsDir(projectRoot);
+  // Resolve the override from the injected `env` (absolute passthrough, relative
+  // against projectRoot) rather than re-reading process.env, so the helper is
+  // pure and the override path is actually testable.
+  const override = env.OD_PLUGIN_PREVIEWS_DIR;
+  if (override) {
+    return path.isAbsolute(override) ? override : path.resolve(projectRoot, override);
+  }
   return resolveDaemonResourceDir(
     resourceRoot,
     path.join('data', 'plugin-previews'),

--- a/apps/daemon/tests/server-paths.test.ts
+++ b/apps/daemon/tests/server-paths.test.ts
@@ -117,4 +117,24 @@ describe('resolveDaemonPluginPreviewsDir', () => {
       resolveDaemonPluginPreviewsDir({ env: {}, resourceRoot: undefined, projectRoot }),
     ).toBe(path.join(projectRoot, 'data', 'plugin-previews'));
   });
+
+  it('honors an OD_PLUGIN_PREVIEWS_DIR override from the injected env', () => {
+    const projectRoot = '/repo';
+
+    // Absolute override passes through; a relative one resolves against projectRoot.
+    expect(
+      resolveDaemonPluginPreviewsDir({
+        env: { OD_PLUGIN_PREVIEWS_DIR: '/abs/previews' },
+        resourceRoot: '/res/open-design',
+        projectRoot,
+      }),
+    ).toBe('/abs/previews');
+    expect(
+      resolveDaemonPluginPreviewsDir({
+        env: { OD_PLUGIN_PREVIEWS_DIR: 'rel/previews' },
+        resourceRoot: '/res/open-design',
+        projectRoot,
+      }),
+    ).toBe(path.join(projectRoot, 'rel', 'previews'));
+  });
 });

--- a/apps/daemon/tests/server-paths.test.ts
+++ b/apps/daemon/tests/server-paths.test.ts
@@ -1,6 +1,11 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { resolveDaemonCliPath, resolveDaemonResourceRoot, resolveProjectRoot } from '../src/server.js';
+import {
+  resolveDaemonCliPath,
+  resolveDaemonPluginPreviewsDir,
+  resolveDaemonResourceRoot,
+  resolveProjectRoot,
+} from '../src/server.js';
 
 describe('resolveProjectRoot', () => {
   it('resolves the repository root from the source daemon directory', () => {
@@ -90,5 +95,26 @@ describe('resolveDaemonResourceRoot', () => {
     expect(() => resolveDaemonResourceRoot({ configured, safeBases: [safeBase] })).toThrow(
       /OD_RESOURCE_ROOT must be under/,
     );
+  });
+});
+
+describe('resolveDaemonPluginPreviewsDir', () => {
+  it('resolves under the resource root in the packaged layout', () => {
+    // Packaged: the prebundled daemon's PROJECT_ROOT is Resources/app (no data/),
+    // but the bundled manifest lives under OD_RESOURCE_ROOT (Resources/open-design).
+    const resourceRoot = '/Applications/Open Design.app/Contents/Resources/open-design';
+    const projectRoot = '/Applications/Open Design.app/Contents/Resources/app';
+
+    expect(
+      resolveDaemonPluginPreviewsDir({ env: {}, resourceRoot, projectRoot }),
+    ).toBe(path.join(resourceRoot, 'data', 'plugin-previews'));
+  });
+
+  it('falls back to the project root in the dev layout (no resource root)', () => {
+    const projectRoot = path.resolve(import.meta.dirname, '../../..');
+
+    expect(
+      resolveDaemonPluginPreviewsDir({ env: {}, resourceRoot: undefined, projectRoot }),
+    ).toBe(path.join(projectRoot, 'data', 'plugin-previews'));
   });
 });

--- a/tools/pack/src/resources.ts
+++ b/tools/pack/src/resources.ts
@@ -64,6 +64,12 @@ const BUNDLED_RESOURCE_TREES = [
   { from: join("assets", "frames"), to: "frames" },
   { from: join("assets", "community-pets"), to: "community-pets" },
   { from: "prompt-templates", to: "prompt-templates" },
+  // Baked plugin-preview manifest. The gallery's pre-rendered hover-pan clips
+  // live on R2; the daemon needs this checked-in manifest to map each plugin to
+  // its clip (it serves clips from R2 when the files aren't on disk, which is the
+  // packaged case). Without it the packaged daemon reads an empty manifest and the
+  // gallery falls back to live, GPU-expensive iframes instead of the baked clips.
+  { from: join("data", "plugin-previews"), to: join("data", "plugin-previews") },
 ] as const;
 
 export async function copyBundledResourceTrees({

--- a/tools/pack/src/win/resources.ts
+++ b/tools/pack/src/win/resources.ts
@@ -11,7 +11,7 @@ import {
 } from "../vela-cli.js";
 import type { WinPaths, ResourceTreeCacheMetadata } from "./types.js";
 
-const RESOURCE_TREE_CACHE_SCHEMA_VERSION = 5;
+const RESOURCE_TREE_CACHE_SCHEMA_VERSION = 6;
 
 async function createResourceTreeCacheKey(config: ToolPackConfig): Promise<string> {
   const velaCliBin = await resolveOptionalVelaCliBinary({
@@ -29,6 +29,7 @@ async function createResourceTreeCacheKey(config: ToolPackConfig): Promise<strin
     designTemplates: await hashPath(join(config.workspaceRoot, "design-templates")),
     node: "win.resource-tree",
     pluginOfficial: await hashPath(join(config.workspaceRoot, "plugins", "_official")),
+    pluginPreviews: await hashPath(join(config.workspaceRoot, "data", "plugin-previews")),
     pluginRegistry: await hashPath(join(config.workspaceRoot, "plugins", "registry")),
     promptTemplates: await hashPath(join(config.workspaceRoot, "prompt-templates")),
     schemaVersion: RESOURCE_TREE_CACHE_SCHEMA_VERSION,

--- a/tools/pack/tests/mac.test.ts
+++ b/tools/pack/tests/mac.test.ts
@@ -168,6 +168,7 @@ describe("copyResourceTree", () => {
         "assets/frames",
         "assets/community-pets",
         "prompt-templates",
+        "data/plugin-previews",
       ];
 
       for (const name of resourceNames) {

--- a/tools/pack/tests/resources.test.ts
+++ b/tools/pack/tests/resources.test.ts
@@ -87,7 +87,15 @@ describe("copyBundledResourceTrees", () => {
       await mkdir(join(workspaceRoot, "prompt-templates", "image"), {
         recursive: true,
       });
+      await mkdir(join(workspaceRoot, "data", "plugin-previews"), {
+        recursive: true,
+      });
       await writeFile(promptTemplatePath, "{\"id\":\"sample\"}\n", "utf8");
+      await writeFile(
+        join(workspaceRoot, "data", "plugin-previews", "manifest.json"),
+        "{\"previews\":{}}\n",
+        "utf8",
+      );
       await writeFile(designTemplatePath, "# Orbit General\n", "utf8");
       await writeFile(communityPetPath, "{\"name\":\"sample\"}\n", "utf8");
       await writeFile(
@@ -105,6 +113,15 @@ describe("copyBundledResourceTrees", () => {
           "utf8",
         ),
       ).resolves.toBe("{\"id\":\"sample\"}\n");
+      // The baked plugin-preview manifest must land under data/plugin-previews so
+      // the packaged daemon can map plugins to their R2 clips; without it the
+      // gallery silently falls back to live iframes.
+      await expect(
+        readFile(
+          join(resourceRoot, "data", "plugin-previews", "manifest.json"),
+          "utf8",
+        ),
+      ).resolves.toBe("{\"previews\":{}}\n");
       await expect(
         readFile(
           join(resourceRoot, "design-templates", "orbit-general", "SKILL.md"),

--- a/tools/pack/tests/win-resources.test.ts
+++ b/tools/pack/tests/win-resources.test.ts
@@ -52,6 +52,14 @@ async function createWorkspaceFixture(workspaceRoot: string): Promise<void> {
   await mkdir(join(workspaceRoot, "prompt-templates", "image"), {
     recursive: true,
   });
+  await mkdir(join(workspaceRoot, "data", "plugin-previews"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(workspaceRoot, "data", "plugin-previews", "manifest.json"),
+    "{\"previews\":{}}\n",
+    "utf8",
+  );
   await mkdir(join(workspaceRoot, "plugins", "registry", "official"), {
     recursive: true,
   });

--- a/tools/pack/tests/win-resources.test.ts
+++ b/tools/pack/tests/win-resources.test.ts
@@ -112,6 +112,52 @@ describe("prepareResourceTree", () => {
     }
   });
 
+  it("invalidates the Windows resource tree cache when the plugin-preview manifest changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-previews-"));
+    const workspaceRoot = join(root, "workspace");
+    const resourceRoot = join(root, "materialized", "open-design");
+    const cache = new ToolPackCache(join(root, "cache"));
+    const config = { workspaceRoot } as ToolPackConfig;
+    const paths = { resourceRoot } as WinPaths;
+    const manifestPath = join(
+      workspaceRoot,
+      "data",
+      "plugin-previews",
+      "manifest.json",
+    );
+    const materializedManifestPath = join(
+      resourceRoot,
+      "data",
+      "plugin-previews",
+      "manifest.json",
+    );
+
+    try {
+      await createWorkspaceFixture(workspaceRoot);
+      await writeFile(manifestPath, "{\"previews\":{\"a\":1}}\n", "utf8");
+
+      await prepareResourceTree(config, paths, cache, { materialize: true });
+
+      await expect(readFile(materializedManifestPath, "utf8")).resolves.toBe(
+        "{\"previews\":{\"a\":1}}\n",
+      );
+
+      await writeFile(manifestPath, "{\"previews\":{\"a\":2}}\n", "utf8");
+
+      await prepareResourceTree(config, paths, cache, { materialize: true });
+
+      await expect(readFile(materializedManifestPath, "utf8")).resolves.toBe(
+        "{\"previews\":{\"a\":2}}\n",
+      );
+      expect(cache.report().entries.map((entry) => entry.status)).toEqual([
+        "miss",
+        "miss",
+      ]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("copies a configured Vela CLI binary into the Windows resource tree", async () => {
     const root = await mkdtemp(join(tmpdir(), "open-design-win-vela-"));
     const workspaceRoot = join(root, "workspace");


### PR DESCRIPTION
## Why

The packaged desktop app showed the home gallery with live, GPU-expensive
iframes instead of the baked hover-pan clips from #4020 — even though the bake
pipeline and R2 clips were live. Two gaps that only bite the packaged layout:

1. **The manifest wasn't bundled.** `data/plugin-previews/manifest.json` is
   absent from the packaged resource trees. The clips live on R2, but without the
   checked-in manifest the daemon has no plugin → clip mapping, so every plugin
   falls back to the live iframe.
2. **The daemon looked in the wrong place.** Even bundled, `PLUGIN_PREVIEWS_DIR`
   resolved from `PROJECT_ROOT`. For the prebundled sidecar
   (`Resources/app/prebundled/daemon/daemon-sidecar.mjs`) `resolveProjectRoot`
   returns `Resources/app` — two levels up — which has no `data/`. The bundled
   resources actually live under `OD_RESOURCE_ROOT` (`Resources/open-design`),
   where every other tree (skills, plugins, design-systems…) is resolved from.

## What users will see

Packaged builds now show the cheap baked poster + hover-play clips in the
Community gallery, exactly like the web/dev app — no more per-tile live iframes.

## How

- `tools/pack/src/resources.ts`: add `data/plugin-previews` to
  `BUNDLED_RESOURCE_TREES` (just the manifest — the clips stay on R2).
- `apps/daemon/src/server.ts`: resolve `PLUGIN_PREVIEWS_DIR` against
  `DAEMON_RESOURCE_ROOT` like the other resource dirs, keeping the explicit
  `OD_PLUGIN_PREVIEWS_DIR` override and the dev `PROJECT_ROOT` fallback.

Verified end-to-end: built + installed a mac app locally; the packaged daemon's
`/api/plugins` now returns `od.bakedPreview` blocks for 126 plugins (R2 URLs)
where it previously returned none.

## Surface area

- [x] Packaging (`tools/pack`)
- [x] Daemon resource resolution (`apps/daemon`)
