### PR TITLE
fix(postinstall): skip build targets whose sources are absent so the Docker image build survives

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,6 +43,15 @@ function resolvePackageManagerInvocation() {
 const packageManager = resolvePackageManagerInvocation();
 
 for (const target of buildTargets) {
+  // Partial install contexts (e.g. deploy/Dockerfile copies only
+  // apps/daemon/package.json before `pnpm install`) lack the target's sources;
+  // building there fails `tsc -p tsconfig.json` with TS5058. Skip instead —
+  // such contexts run the real build later, once sources are in place.
+  if (!existsSync(resolve(repoRoot, target, "tsconfig.json"))) {
+    process.stdout.write(`postinstall: skipping ${target} (no tsconfig.json in this context)\n`);
+    continue;
+  }
+
   const result = spawnSync(
     packageManager.command,
     [...packageManager.argsPrefix, "-C", target, "run", "build"],

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -156,4 +158,65 @@ test("postinstall builds workspace packages whose linkable bins delegate to dist
     .filter((directory) => !postinstallBuildTargets().has(directory));
 
   assert.deepEqual(missingBuildTargets, []);
+});
+
+test("every postinstall build target has a checked-in tsconfig.json", () => {
+  // postinstall.mjs skips targets without a tsconfig.json so partial install
+  // contexts (deploy/Dockerfile) survive; this invariant keeps that skip a
+  // no-op for full checkouts instead of silently masking a broken target.
+  // postinstallBuildTargets() over-extracts other quoted workspace paths from
+  // the script (e.g. apps/daemon/package.json), so narrow to package roots.
+  const missingTsconfigs = [...postinstallBuildTargets()]
+    .filter((target) => existsSync(join(repoRoot, target, "package.json")))
+    .filter((target) => !existsSync(join(repoRoot, target, "tsconfig.json")));
+  assert.deepEqual(missingTsconfigs, []);
+});
+
+test("postinstall skips build targets whose tsconfig.json is absent from the install context", () => {
+  // deploy/Dockerfile runs `pnpm install` (and thus this postinstall) at a stage
+  // where only apps/daemon/package.json has been copied — no tsconfig.json or
+  // src/. Building such a target fails `tsc -p tsconfig.json` with TS5058 and
+  // aborts the image build, so postinstall must skip it instead.
+  const sandbox = mkdtempSync(join(tmpdir(), "postinstall-test-"));
+  try {
+    // repoRoot inside postinstall.mjs resolves to the script's parent directory,
+    // so a copy of the script in <sandbox>/scripts exercises the sandbox layout.
+    mkdirSync(join(sandbox, "scripts"));
+    writeFileSync(
+      join(sandbox, "scripts", "postinstall.mjs"),
+      readFileSync(join(repoRoot, "scripts/postinstall.mjs")),
+    );
+
+    // Buildable target: package.json + tsconfig.json present.
+    mkdirSync(join(sandbox, "packages/contracts"), { recursive: true });
+    writeFileSync(join(sandbox, "packages/contracts/package.json"), "{}");
+    writeFileSync(join(sandbox, "packages/contracts/tsconfig.json"), "{}");
+
+    // Docker install-stage state: manifest only, no tsconfig.json.
+    mkdirSync(join(sandbox, "apps/daemon"), { recursive: true });
+    writeFileSync(join(sandbox, "apps/daemon/package.json"), "{}");
+
+    // Stub package manager: postinstall.mjs treats a JS npm_execpath as the pnpm
+    // entry point, so every build invocation lands here and gets logged.
+    const invocationLog = join(sandbox, "invocations.log");
+    writeFileSync(
+      join(sandbox, "pnpm-stub.mjs"),
+      [
+        'import { appendFileSync } from "node:fs";',
+        `appendFileSync(${JSON.stringify(invocationLog)}, process.argv.slice(2).join(" ") + "\\n");`,
+      ].join("\n"),
+    );
+
+    const result = spawnSync(process.execPath, [join(sandbox, "scripts", "postinstall.mjs")], {
+      encoding: "utf8",
+      env: { ...process.env, npm_execpath: join(sandbox, "pnpm-stub.mjs") },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const invocations = existsSync(invocationLog) ? readFileSync(invocationLog, "utf8") : "";
+    assert.match(invocations, /-C packages\/contracts run build/);
+    assert.doesNotMatch(invocations, /-C apps\/daemon run build/);
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Part of #4012 (the **docker compose build failure**; the primary 401 `API_TOKEN_REQUIRED` behavior is an auth-design question left to maintainers — see my claim comment on the issue).

## Why

`docker compose build` (and any `docker build -f deploy/Dockerfile .`) is currently broken on `main`: the Dockerfile runs `pnpm install --frozen-lockfile` at a stage where only `apps/daemon/package.json` has been copied (no `tsconfig.json` / `src/` — the full `COPY apps ./apps` happens after install). The root `postinstall` (`scripts/postinstall.mjs`) unconditionally builds every entry in `buildTargets`, so `apps/daemon`'s `tsc -p tsconfig.json` aborts the whole image build:

```text
#17 91.72 . postinstall: > @open-design/daemon@0.10.0 build /app/apps/daemon
#17 91.72 . postinstall: > tsc -p tsconfig.json
#17 91.75 . postinstall: error TS5058: The specified path does not exist: 'tsconfig.json'.
#17 91.82  ELIFECYCLE  Command failed with exit code 1.
```

This regressed when `apps/daemon` was added to `buildTargets`; the `docker-image` workflow only fires on version tags (last run 2026-05-16), so CI never exercised the Dockerfile since.

## What users will see

`docker compose up -d` / `docker build -f deploy/Dockerfile .` builds the image again. Normal `pnpm install` is unaffected: every build target ships a checked-in `tsconfig.json` (now enforced by a test), so the new skip is a no-op outside partial install contexts.

## Surface area

- [x] **None** — internal build-script fix plus tests

## Screenshots

N/A (no UI).

## Bug fix verification

- Test path that reproduces the bug: `scripts/postinstall.test.ts` → *"postinstall skips build targets whose tsconfig.json is absent from the install context"*. It copies `postinstall.mjs` into a tmp sandbox shaped like the Dockerfile's install stage (`apps/daemon/package.json` only, no tsconfig) with a stub `npm_execpath` package manager that logs invocations, and asserts `apps/daemon` is not built while a fully-present target is.
- Did the test go red on `main` and green on this branch? **yes** (red on main: the log contains `-C apps/daemon run build`; green with the fix).
- End-to-end: `docker build -f deploy/Dockerfile .` on `main` fails with the TS5058 log above; on this branch the full image builds and `docker run --rm <image> node apps/daemon/dist/cli.js` answers (the daemon is still really built — by the Dockerfile's explicit `pnpm --filter @open-design/daemon build` after `COPY apps`).
- A second new test pins the invariant that every `buildTargets` entry has a checked-in `tsconfig.json`, so the skip can't silently mask a genuinely broken target in a full checkout.

## Validation

- `pnpm guard` — 42/42 passing (was 40; +2 new)
- `pnpm typecheck` — clean
- `docker build -f deploy/Dockerfile .` — red on `main`, green on this branch (full image, both stages)