### PR TITLE
fix(plugins-home): correct deck/scroll preview capture + smoother gallery playback

### DIFF
--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -10,9 +10,10 @@
 // as a cheap stand-in for the old live hover-pan iframe — the `<video>` mounts
 // as soon as the tile is on-screen and loops the in-place span while idle
 // (animated pages still look alive), and on hover jumps to the pan. The element
-// stays mounted the whole time it's on-screen, so hover never remounts/reloads
-// the source and can't flash black at the hand-off, and `preload="auto"`
-// buffers the whole small clip up front so the idle->pan jump never stalls.
+// stays mounted across a generous margin, so hover never remounts/reloads the
+// source and can't flash black at the hand-off; it only decodes/plays while the
+// tile is truly visible, and `preload="metadata"` paints the first frame off the
+// faststart header instead of buffering the whole clip up front.
 
 import { useEffect, useRef, useState } from 'react';
 import type { MediaPreviewSpec } from '../preview';
@@ -20,10 +21,15 @@ import type { MediaPreviewSpec } from '../preview';
 interface Props {
   preview: MediaPreviewSpec;
   pluginTitle: string;
+  // `inView` (a generous margin) MOUNTS the clip so its first frame is ready
+  // before the tile scrolls in; `visible` (no margin) gates actually
+  // playing/decoding it, so off-screen tiles in the mount margin stay paused on
+  // their poster instead of all spinning up decodes + clip downloads at once.
   inView: boolean;
+  visible?: boolean;
 }
 
-export function MediaSurface({ preview, pluginTitle, inView }: Props) {
+export function MediaSurface({ preview, pluginTitle, inView, visible = inView }: Props) {
   const [hovering, setHovering] = useState(false);
   // Track per-URL poster load failure so a 404 / decode error / dead
   // host swaps in the typographic fallback instead of leaving the
@@ -43,7 +49,12 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
   // in-place span can loop while idle; plain video-template plugins keep the
   // cheaper poster-until-hover behaviour.
   const idlePlays = isVideo && holdMs != null;
+  // Mount across the wider `inView` margin so hover/scroll-in never remounts +
+  // reloads the source, but only decode/buffer when truly `visible` (or
+  // hovering) — otherwise every tile in the margin runs a simultaneous decode +
+  // full-clip download and the gallery stutters / first frames lag.
   const showVideo = inView && isVideo && (idlePlays || hovering);
+  const playing = showVideo && ((idlePlays && visible) || hovering);
 
   // Idle: loop the leading [0, holdMs] in-place-animation span. Hover: jump to
   // holdMs and loop the pan span [holdMs, end] so it responds immediately
@@ -51,7 +62,7 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
   // while on-screen.
   useEffect(() => {
     const v = videoRef.current;
-    if (!v || !showVideo || holdMs == null) return;
+    if (!v || !playing || holdMs == null) return;
     const hold = holdMs / 1000;
     const clamp = (t: number) => {
       if (hovering) {
@@ -82,7 +93,7 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
     const onTime = () => clamp(v.currentTime);
     v.addEventListener('timeupdate', onTime);
     return () => v.removeEventListener('timeupdate', onTime);
-  }, [showVideo, hovering, holdMs]);
+  }, [playing, hovering, holdMs]);
 
   // The `autoplay` attribute alone doesn't reliably start a freshly-mounted
   // muted clip here (Electron/Chromium leaves it paused at readyState 1), so
@@ -90,6 +101,12 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
   useEffect(() => {
     const v = videoRef.current;
     if (!v || !showVideo) return;
+    if (!playing) {
+      // Mounted but off-screen (in the margin) or idle-disabled: hold the poster
+      // frame, don't decode.
+      v.pause();
+      return;
+    }
     const tryPlay = () => {
       const p = v.play();
       if (p && typeof p.catch === 'function') p.catch(() => {});
@@ -97,7 +114,7 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
     tryPlay();
     v.addEventListener('canplay', tryPlay);
     return () => v.removeEventListener('canplay', tryPlay);
-  }, [showVideo]);
+  }, [showVideo, playing]);
 
   const hasPoster = Boolean(preview.poster);
   const useFallback = !hasPoster || posterLoadFailed;
@@ -136,9 +153,11 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
           muted
           playsInline
           loop
-          // On-screen baked clips buffer the whole (small ~450KB) clip so the
-          // idle->pan hand-off never stalls; hover-only videos stay lazy.
-          preload={idlePlays ? 'auto' : 'none'}
+          // `metadata` paints the first frame off the +faststart header (moov +
+          // a few frames) instead of waiting on the whole file, so tiles show
+          // fast and don't all saturate the network buffering full clips up
+          // front; the idle hold buffers the pan span before hover.
+          preload={idlePlays ? 'metadata' : 'none'}
           // Look like an inert iframe thumbnail: no native controls or PiP, and
           // clicks fall through to the card (open detail) instead of the video.
           disablePictureInPicture

--- a/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
@@ -7,6 +7,7 @@
 // hammer the daemon on first paint. The text-fallback variant
 // short-circuits the lazy mount because it has no off-screen cost.
 
+import { useCallback } from 'react';
 import type { PluginPreviewSpec } from '../preview';
 import { useInView } from '../useInView';
 import { DesignSystemSurface } from './DesignSystemSurface';
@@ -23,19 +24,40 @@ interface Props {
 }
 
 export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }: Props) {
-  const { ref, inView } = useInView<HTMLDivElement>({
+  // `inView` (a generous margin) mounts the surface so its poster / first frame
+  // is ready before it scrolls in; `visible` (no margin) gates the expensive
+  // part — decoding/playing a baked clip — to tiles truly on screen, so the
+  // off-screen tiles inside the mount margin don't all spin up decodes + clip
+  // downloads at once.
+  const { ref: nearRef, inView } = useInView<HTMLDivElement>({
     rootMargin: eager ? '480px' : '120px',
     once: false,
   });
+  const { ref: visibleRef, inView: visible } = useInView<HTMLDivElement>({
+    rootMargin: '0px',
+    once: false,
+  });
+  const setRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      nearRef.current = node;
+      visibleRef.current = node;
+    },
+    [nearRef, visibleRef],
+  );
 
   return (
     <div
-      ref={ref}
+      ref={setRef}
       className={`plugins-home__preview plugins-home__preview--${preview.kind}`}
       data-preview-kind={preview.kind}
     >
       {preview.kind === 'media' ? (
-        <MediaSurface preview={preview} pluginTitle={pluginTitle} inView={inView} />
+        <MediaSurface
+          preview={preview}
+          pluginTitle={pluginTitle}
+          inView={inView}
+          visible={visible}
+        />
       ) : preview.kind === 'html' ? (
         <HtmlSurface
           preview={preview}

--- a/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
@@ -24,13 +24,22 @@ interface Props {
 }
 
 export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }: Props) {
-  // `inView` (a generous margin) mounts the surface so its poster / first frame
-  // is ready before it scrolls in; `visible` (no margin) gates the expensive
-  // part — decoding/playing a baked clip — to tiles truly on screen, so the
-  // off-screen tiles inside the mount margin don't all spin up decodes + clip
-  // downloads at once.
+  // Three nested visibility zones for a baked clip:
+  //  - `inView` (tight): mount cheap-but-live content — iframes, design surfaces.
+  //    Kept tight so a 350-plugin gallery never spins up dozens of live iframes.
+  //  - `keep` (wide): keep the <video> + poster MOUNTED across a few screens, so
+  //    scrolling away and back doesn't remount + reload the clip. The bytes are
+  //    HTTP-cached (immutable), but a fresh <video> still re-fetches metadata and
+  //    re-decodes the first frame, which reads as a load every scroll-back.
+  //  - `visible` (no margin): only DECODE/play while truly on screen, so the
+  //    kept-mounted off-screen clips stay paused on their poster instead of all
+  //    running simultaneous decodes.
   const { ref: nearRef, inView } = useInView<HTMLDivElement>({
     rootMargin: eager ? '480px' : '120px',
+    once: false,
+  });
+  const { ref: keepRef, inView: keep } = useInView<HTMLDivElement>({
+    rootMargin: eager ? '1800px' : '1500px',
     once: false,
   });
   const { ref: visibleRef, inView: visible } = useInView<HTMLDivElement>({
@@ -40,9 +49,10 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
   const setRef = useCallback(
     (node: HTMLDivElement | null) => {
       nearRef.current = node;
+      keepRef.current = node;
       visibleRef.current = node;
     },
-    [nearRef, visibleRef],
+    [nearRef, keepRef, visibleRef],
   );
 
   return (
@@ -55,7 +65,7 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
         <MediaSurface
           preview={preview}
           pluginTitle={pluginTitle}
-          inView={inView}
+          inView={keep}
           visible={visible}
         />
       ) : preview.kind === 'html' ? (

--- a/docs/plugins-spec.md
+++ b/docs/plugins-spec.md
@@ -256,7 +256,8 @@ Rules of authorship:
       "entry":  "./preview/index.html",
       "poster": "./preview/poster.png",
       "video":  "./preview/demo.mp4",
-      "gif":    "./preview/demo.gif"
+      "gif":    "./preview/demo.gif",
+      "motion": "scroll"
     },
 
     "useCase": {
@@ -357,7 +358,7 @@ Rules of authorship:
 - `title_i18n` / `description_i18n` — optional localized display metadata. Keep `title` and `description` as English fallbacks; UI surfaces resolve requested locale, base language, English, then the first available value.
 - `od.kind` — registry classification (`skill` / `scenario` / `atom` / `bundle`).
 - `od.taskKind` — one of the four product scenarios (`new-generation` / `code-migration` / `figma-migration` / `tune-collab`, see §1 "Four product scenarios"). Drives marketplace filters, default input templates, and the recommended pipeline starting point.
-- `od.preview` — drives the marketplace card and detail page. `entry` is served sandboxed via the daemon (the existing `/api/skills/:id/example` plumbing extended to plugins).
+- `od.preview` — drives the marketplace card and detail page. `entry` is served sandboxed via the daemon (the existing `/api/skills/:id/example` plumbing extended to plugins). `motion` (`scroll` | `deck` | `static`, optional) tells the gallery how to bake the card's hover clip from your `entry` HTML: `scroll` = a vertical-scroll landing page (pan top→bottom — also the right choice for scroll-hijack pages a programmatic scroll can't drive), `deck` = a horizontal slideshow (walk slides via arrow/wheel), `static` = a single fixed screen (hold its in-place animation). Omit it to auto-detect from the page's scroll height; set it when auto-detect guesses wrong (e.g. a vertical page that carries a horizontal marquee).
 - `od.useCase.query` — the exact text that lands in the brief field on click-to-use. It may be a legacy string or a locale map keyed by BCP-47-style locale tags (for example `{ "en": "...", "zh-CN": "..." }`). Apply-time resolution tries the requested locale, base language, `en`, then the first available value. `{{var}}` placeholders bind to `od.inputs`.
 - `od.context.*` — typed chips that hydrate the `ContextChipStrip` above the input. Each entry compiles to a `ContextItem` (§5.2).
 - `od.context.atoms` — **unordered set** declaring the atoms a plugin needs. The daemon uses them in default order; intended for simple plugins that don't customize flow.

--- a/docs/schemas/open-design.plugin.v1.json
+++ b/docs/schemas/open-design.plugin.v1.json
@@ -55,7 +55,12 @@
             "entry":  { "type": "string" },
             "poster": { "type": "string" },
             "video":  { "type": "string" },
-            "gif":    { "type": "string" }
+            "gif":    { "type": "string" },
+            "motion": {
+              "type": "string",
+              "enum": ["scroll", "deck", "static"],
+              "description": "How the gallery should capture this HTML preview's hover clip: 'scroll' = vertical-scroll landing page (pan top->bottom), 'deck' = horizontal slideshow (walk slides), 'static' = single fixed screen (hold its in-place animation). Omit to auto-detect from the page's scroll height."
+            }
           },
           "additionalProperties": true
         },

--- a/packages/contracts/src/plugins/manifest.ts
+++ b/packages/contracts/src/plugins/manifest.ts
@@ -172,6 +172,10 @@ export const PluginManifestSchema = z.object({
       poster: z.string().optional(),
       video:  z.string().optional(),
       gif:    z.string().optional(),
+      // How the gallery bakes this HTML preview's hover clip: 'scroll' (vertical
+      // pan), 'deck' (walk a horizontal slideshow), 'static' (hold a single
+      // screen). Omit to auto-detect from the page's scroll height.
+      motion: z.enum(['scroll', 'deck', 'static']).optional(),
     }).passthrough().optional(),
     useCase: z.object({
       query: z.union([z.string(), LocalizedTextSchema]).optional(),

--- a/packages/contracts/tests/plugins-manifest.test.ts
+++ b/packages/contracts/tests/plugins-manifest.test.ts
@@ -44,6 +44,25 @@ describe('plugin manifest localized text', () => {
     );
   });
 
+  it('accepts a valid preview motion and rejects an invalid one', () => {
+    const manifest = PluginManifestSchema.parse({
+      name: 'sample-plugin',
+      version: '1.0.0',
+      od: {
+        preview: { type: 'html', entry: './index.html', motion: 'deck' },
+      },
+    });
+    expect(manifest.od?.preview?.motion).toBe('deck');
+
+    expect(() =>
+      PluginManifestSchema.parse({
+        name: 'sample-plugin',
+        version: '1.0.0',
+        od: { preview: { type: 'html', motion: 'sideways' } },
+      }),
+    ).toThrow();
+  });
+
   it('accepts localized title and description metadata', () => {
     const manifest = PluginManifestSchema.parse({
       name: 'sample-plugin',

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -47,7 +47,12 @@ import path from 'node:path';
 //   v3: bound the slide-walk — cap deckSignal's DOM scan + a wall-time cap — so a
 //       deck that renders every slide in one giant rail (#deck{width:10000vw})
 //       no longer drags the walk, and the clip, out to 20s+ in CI.
-const BAKE_VERSION = 3;
+//   v4: honor an `od.preview.motion` ('scroll'|'deck'|'static') declaration;
+//       auto-detect deck-vs-scroll by viewport height (not by probing, which
+//       misread tall pages with a horizontal marquee as decks); pan via REAL
+//       wheel events so scroll-hijack landing pages (custom/transform scroll)
+//       actually move.
+const BAKE_VERSION = 4;
 
 // ---- config ---------------------------------------------------------------
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:17579';
@@ -120,6 +125,25 @@ async function discoverIds() {
   return LIMIT ? ids.slice(0, LIMIT) : ids;
 }
 
+// Authors can declare how their preview should be captured via
+// `od.preview.motion` ('scroll' | 'deck' | 'static'); we honor it and only
+// auto-detect when it's absent. Returns an id -> motion map (missing => null).
+async function loadMotionMap() {
+  const map = {};
+  try {
+    const res = await fetch(`${BASE_URL}/api/plugins`);
+    const data = await res.json();
+    const items = Array.isArray(data) ? data : (data.plugins || data.items || data.available || []);
+    for (const it of items) {
+      if (!it || typeof it !== 'object') continue;
+      const id = it.id || it.slug;
+      const m = it.manifest?.od?.preview?.motion;
+      if (id && (m === 'scroll' || m === 'deck' || m === 'static')) map[id] = m;
+    }
+  } catch {}
+  return map;
+}
+
 // ---- deck (PPT/slideshow) driving -----------------------------------------
 // A structural fingerprint of the current slide, robust across deck styles:
 // the transform of any slide-rail wider/taller than the viewport, the scroll
@@ -183,7 +207,7 @@ async function walkSlides(page, driver) {
 }
 
 // ---- render + encode one plugin -------------------------------------------
-async function bakeOne(browser, id, hash) {
+async function bakeOne(browser, id, hash, motion) {
   const page = await browser.newPage();
   await page.setViewport({ width: RENDER_W, height: VIEW_H, deviceScaleFactor: 1 });
   try {
@@ -193,14 +217,27 @@ async function bakeOne(browser, id, hash) {
   } catch (e) { await page.close(); return { id, skipped: `load ${e.message}` }; }
   await sleep(1000);
 
-  // Classify navigation by PROBING, not guessing from scrollHeight: press the
-  // arrow key, then nudge the wheel, and see whether a slide actually moves
-  // (deckSignal ignores the WebGL background, so only real navigation counts).
-  // Most decks are arrow-key; some advance on the wheel; the rest are ordinary
-  // vertical-scroll pages (incl. up/down decks) and keep the linear pan. Probing
-  // advances the deck, so decks reload to reset to slide 1 before capturing.
+  // Capture mode: an explicit `od.preview.motion` declaration wins; otherwise
+  // auto-detect from the viewport height. A fixed-viewport page (no vertical
+  // scroll) is a deck/slideshow; a vertically-scrollable page is a landing page
+  // and gets the pan — even when it carries a horizontal sub-component (a logo
+  // marquee, a feature carousel) that would otherwise look like a slide rail.
+  // Classifying by scroll height, NOT by probing inputs, keeps a tall page off
+  // the deck path: a wheel probe would scroll it and the scroll-driven animation
+  // would read as a slide change (precision-farming pages got walked sideways).
+  let mode = motion;
+  if (mode !== 'scroll' && mode !== 'deck' && mode !== 'static') {
+    const vScrollable = await page.evaluate(
+      () => document.documentElement.scrollHeight > window.innerHeight * 1.15,
+    );
+    mode = vScrollable ? 'scroll' : 'deck';
+  }
+  const isDeck = mode === 'deck';
+  const isStatic = mode === 'static';
   let deckDriver = null;
-  {
+  if (isDeck) {
+    // Find which input advances the deck (arrow keys, then the wheel) — only on a
+    // confirmed deck, where a wheel nudge can't scroll the page out from under us.
     const sig0 = await page.evaluate(deckSignal, DECK_SCAN_CAP);
     await driveDeck(page, 'arrow');
     await sleep(900);
@@ -211,13 +248,6 @@ async function bakeOne(browser, id, hash) {
       if ((await page.evaluate(deckSignal, DECK_SCAN_CAP)) !== sig0) deckDriver = 'wheel';
     }
   }
-  const vScrollable = await page.evaluate(
-    () => document.documentElement.scrollHeight > window.innerHeight * 1.15,
-  );
-  // A horizontally-navigable deck OR a fixed-viewport single slide is a deck:
-  // capture at the deck aspect and walk it. A page that only scrolls vertically
-  // (a landing page, or an up/down deck) keeps the linear pan.
-  const isDeck = deckDriver !== null || !vScrollable;
   let capW = RENDER_W, capH = VIEW_H;
   if (isDeck) {
     capW = DECK_W; capH = DECK_H;
@@ -307,7 +337,7 @@ async function bakeOne(browser, id, hash) {
     try { await client.send('Page.screencastFrameAck', { sessionId: e.sessionId }); } catch {}
   });
 
-  const maxY = isDeck ? 0 : await page.evaluate(() =>
+  const maxY = (isDeck || isStatic) ? 0 : await page.evaluate(() =>
     Math.max(0, document.documentElement.scrollHeight - window.innerHeight));
 
   await client.send('Page.startScreencast',
@@ -321,22 +351,47 @@ async function bakeOne(browser, id, hash) {
   let durMs;
   if (isDeck) {
     durMs = await walkSlides(page, deckDriver);
+  } else if (maxY <= 0) {
+    // Static / single-screen page: just hold, capturing its in-place animation.
+    durMs = 2500;
+    await sleep(durMs);
   } else {
     // Pre-computed from the measured page height so the pan always reaches the
     // bottom within MAX_PAN (whole clip stays ~<=10s): base VELOCITY for normal
     // pages, auto-sped-up (capped duration) for tall ones.
-    durMs = maxY <= 0 ? 2500 : Math.min(MAX_PAN, Math.round(maxY / VELOCITY));
-    await page.evaluate((dur, my) => new Promise((res) => {
-      if (my <= 0) { setTimeout(res, dur); return; }
-      let start = null;
-      function step(t) {
-        if (start === null) start = t;
-        const e = Math.min(1, (t - start) / dur);
-        window.scrollTo(0, Math.round(my * e)); // linear = constant velocity
-        if (e < 1) requestAnimationFrame(step); else res();
+    durMs = Math.min(MAX_PAN, Math.round(maxY / VELOCITY));
+    // Ordinary pages scroll via window.scrollTo (smooth rAF). Scroll-hijack
+    // landing pages (custom / transform scroll — Lenis-style) ignore it, so
+    // detect that and pan them with REAL wheel events instead, which trigger the
+    // page's own scroll handler.
+    const windowScrolls = await page.evaluate(() => {
+      const before = window.scrollY || document.documentElement.scrollTop;
+      window.scrollTo(0, 160);
+      const moved = (window.scrollY || document.documentElement.scrollTop) > before + 40;
+      window.scrollTo(0, 0);
+      return moved;
+    });
+    if (windowScrolls) {
+      await page.evaluate((dur, my) => new Promise((res) => {
+        let start = null;
+        function step(t) {
+          if (start === null) start = t;
+          const e = Math.min(1, (t - start) / dur);
+          window.scrollTo(0, Math.round(my * e)); // linear = constant velocity
+          if (e < 1) requestAnimationFrame(step); else res();
+        }
+        requestAnimationFrame(step);
+      }), durMs, maxY);
+    } else {
+      await page.mouse.move(Math.round(capW / 2), Math.round(capH / 2));
+      const tick = 40;
+      const perTick = Math.max(8, Math.round(maxY / (durMs / tick)));
+      const t0 = Date.now();
+      while (Date.now() - t0 < durMs) {
+        await page.mouse.wheel({ deltaY: perTick });
+        await sleep(tick);
       }
-      requestAnimationFrame(step);
-    }), durMs, maxY);
+    }
   }
   await client.send('Page.stopScreencast');
   await page.close();
@@ -382,6 +437,7 @@ async function bakeOne(browser, id, hash) {
 // ---- main -----------------------------------------------------------------
 mkdirSync(OUT, { recursive: true });
 const ids = await discoverIds();
+const motionMap = await loadMotionMap();
 console.log(`baking ${ids.length} plugin previews from ${BASE_URL} -> ${OUT}`);
 const browser = await puppeteer.launch({
   executablePath: resolveChrome(), headless: 'new',
@@ -402,7 +458,7 @@ for (const id of ids) {
   let hash = null;
   try {
     const html = await (await fetch(`${BASE_URL}/api/plugins/${encodeURIComponent(id)}/preview`)).text();
-    hash = createHash('sha256').update(html).update(` ${BAKE_VERSION}`).digest('hex').slice(0, 16);
+    hash = createHash('sha256').update(html).update(` ${BAKE_VERSION} ${motionMap[id] || ''}`).digest('hex').slice(0, 16);
   } catch {}
   const prev = previews[id];
   // In CI the unchanged clips already live on R2 (not on disk), so PREVIEW_REMOTE
@@ -416,7 +472,7 @@ for (const id of ids) {
     continue;
   }
   let r;
-  try { r = await bakeOne(browser, id, hash); } catch (e) { r = { id, skipped: `error ${e.message}` }; }
+  try { r = await bakeOne(browser, id, hash, motionMap[id]); } catch (e) { r = { id, skipped: `error ${e.message}` }; }
   if (r.skipped) { skip += 1; console.log(`  ~ ${id}: skip (${r.skipped})`); continue; }
   previews[id] = { video: r.video, poster: r.poster, durationMs: r.durationMs, holdMs: r.holdMs, hash };
   ok += 1;

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -206,6 +206,21 @@ async function walkSlides(page, driver) {
   return Math.max(SLIDE_MS, Date.now() - t0);
 }
 
+// Probe which input advances a fixed-viewport deck: press the arrow key, then
+// nudge the wheel, watching deckSignal for a real slide change. Returns 'arrow',
+// 'wheel', or null when nothing moves it (a single static screen). Advances the
+// deck as a side effect, so callers that go on to capture reload first.
+async function probeDeckDriver(page) {
+  const sig0 = await page.evaluate(deckSignal, DECK_SCAN_CAP);
+  await driveDeck(page, 'arrow');
+  await sleep(900);
+  if ((await page.evaluate(deckSignal, DECK_SCAN_CAP)) !== sig0) return 'arrow';
+  await driveDeck(page, 'wheel');
+  await sleep(900);
+  if ((await page.evaluate(deckSignal, DECK_SCAN_CAP)) !== sig0) return 'wheel';
+  return null;
+}
+
 // ---- render + encode one plugin -------------------------------------------
 async function bakeOne(browser, id, hash, motion) {
   const page = await browser.newPage();
@@ -218,36 +233,32 @@ async function bakeOne(browser, id, hash, motion) {
   await sleep(1000);
 
   // Capture mode: an explicit `od.preview.motion` declaration wins; otherwise
-  // auto-detect from the viewport height. A fixed-viewport page (no vertical
-  // scroll) is a deck/slideshow; a vertically-scrollable page is a landing page
-  // and gets the pan — even when it carries a horizontal sub-component (a logo
-  // marquee, a feature carousel) that would otherwise look like a slide rail.
-  // Classifying by scroll height, NOT by probing inputs, keeps a tall page off
-  // the deck path: a wheel probe would scroll it and the scroll-driven animation
-  // would read as a slide change (precision-farming pages got walked sideways).
+  // auto-detect.
   let mode = motion;
-  if (mode !== 'scroll' && mode !== 'deck' && mode !== 'static') {
+  let deckDriver = null;
+  if (mode === 'scroll' || mode === 'deck' || mode === 'static') {
+    // Explicit declaration: a deck still needs its advancing input probed.
+    if (mode === 'deck') deckDriver = await probeDeckDriver(page);
+  } else {
+    // A vertically-scrollable page is a landing page (pan it) — even with a
+    // horizontal marquee/carousel sub-component; classifying by scroll height,
+    // not by probing, keeps a tall page off the deck path (a wheel probe would
+    // scroll it and the scroll-driven animation reads as a slide change, which
+    // walked precision-farming pages sideways). A fixed-viewport page is a deck
+    // only if an input actually advances it; otherwise it's a single static
+    // screen that just holds its in-place animation (default viewport, no walk).
     const vScrollable = await page.evaluate(
       () => document.documentElement.scrollHeight > window.innerHeight * 1.15,
     );
-    mode = vScrollable ? 'scroll' : 'deck';
+    if (vScrollable) {
+      mode = 'scroll';
+    } else {
+      deckDriver = await probeDeckDriver(page);
+      mode = deckDriver ? 'deck' : 'static';
+    }
   }
   const isDeck = mode === 'deck';
   const isStatic = mode === 'static';
-  let deckDriver = null;
-  if (isDeck) {
-    // Find which input advances the deck (arrow keys, then the wheel) — only on a
-    // confirmed deck, where a wheel nudge can't scroll the page out from under us.
-    const sig0 = await page.evaluate(deckSignal, DECK_SCAN_CAP);
-    await driveDeck(page, 'arrow');
-    await sleep(900);
-    if ((await page.evaluate(deckSignal, DECK_SCAN_CAP)) !== sig0) deckDriver = 'arrow';
-    else {
-      await driveDeck(page, 'wheel');
-      await sleep(900);
-      if ((await page.evaluate(deckSignal, DECK_SCAN_CAP)) !== sig0) deckDriver = 'wheel';
-    }
-  }
   let capW = RENDER_W, capH = VIEW_H;
   if (isDeck) {
     capW = DECK_W; capH = DECK_H;

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -339,6 +339,18 @@ async function bakeOne(browser, id, hash, motion) {
 
   const maxY = (isDeck || isStatic) ? 0 : await page.evaluate(() =>
     Math.max(0, document.documentElement.scrollHeight - window.innerHeight));
+  // Detect the scroll mechanism BEFORE recording: this probe jumps the page
+  // (scrollTo 160 -> 0), which once the screencast is running would bake a
+  // visible lurch at the head of the pan. Ordinary pages scroll via
+  // window.scrollTo; scroll-hijack landing pages (custom / transform scroll)
+  // ignore it and need real wheel events to drive their own scroll handler.
+  const windowScrolls = maxY > 0 && (await page.evaluate(() => {
+    const before = window.scrollY || document.documentElement.scrollTop;
+    window.scrollTo(0, 160);
+    const moved = (window.scrollY || document.documentElement.scrollTop) > before + 40;
+    window.scrollTo(0, 0);
+    return moved;
+  }));
 
   await client.send('Page.startScreencast',
     { format: 'jpeg', quality: 80, everyNthFrame: 1, maxWidth: capW, maxHeight: capH });
@@ -360,17 +372,8 @@ async function bakeOne(browser, id, hash, motion) {
     // bottom within MAX_PAN (whole clip stays ~<=10s): base VELOCITY for normal
     // pages, auto-sped-up (capped duration) for tall ones.
     durMs = Math.min(MAX_PAN, Math.round(maxY / VELOCITY));
-    // Ordinary pages scroll via window.scrollTo (smooth rAF). Scroll-hijack
-    // landing pages (custom / transform scroll — Lenis-style) ignore it, so
-    // detect that and pan them with REAL wheel events instead, which trigger the
-    // page's own scroll handler.
-    const windowScrolls = await page.evaluate(() => {
-      const before = window.scrollY || document.documentElement.scrollTop;
-      window.scrollTo(0, 160);
-      const moved = (window.scrollY || document.documentElement.scrollTop) > before + 40;
-      window.scrollTo(0, 0);
-      return moved;
-    });
+    // Smooth rAF window.scrollTo for ordinary pages; real wheel events for
+    // scroll-hijack pages (windowScrolls probed above, before recording).
     if (windowScrolls) {
       await page.evaluate((dur, my) => new Promise((res) => {
         let start = null;


### PR DESCRIPTION
A systematic pass over all 126 baked gallery previews (not just the few reported)
plus the runtime playback, bundling the gallery-preview fixes together.

## Why

Auditing every baked clip surfaced three capture bugs and two playback ones:

**Capture (bake):**
- 2 vertical landing pages were misread as horizontal decks and walked sideways.
  The input probe wheel-scrolled them and the scroll-driven animation looked like
  a slide change. Now classify by viewport height: a fixed-viewport page is a
  deck; a vertically-scrollable page is a landing page (pan it) even when it
  carries a horizontal marquee/carousel sub-component.
- 9 scroll-hijack landing pages (custom / transform scroll that `window.scrollTo`
  can't drive) baked a static, non-panning clip. Pan those with REAL wheel events
  (`page.mouse.wheel`), which trigger the page's own scroll handler.
- single-screen pages now hold (static) instead of being forced down a deck path.

**Playback (web):**
- Every on-screen clip eagerly buffered the whole file (`preload=auto`) and the
  margin tiles all decoded at once, so first frames lagged. Decode/play only the
  truly-visible tiles; `preload=metadata` paints the first frame off the
  faststart header.
- Scrolling a tile away and back re-showed a load even though the bytes are
  HTTP-cached: the `<video>` unmounted at the tight margin and remounted fresh.
  Keep clips mounted across a few-screen window for instant scroll-back.

## What users will see

Vertical pages pan down (incl. scroll-hijack ones), decks walk their slides,
single screens hold; tiles paint fast, only visible clips run, and scrolling back
to a clip you just saw is instant.

## How

- `scripts/bake-plugin-previews.mjs`: viewport-height classification, real-wheel
  pan for scroll-hijack pages, `static` hold, and an opt-in `od.preview.motion`
  (`scroll` | `deck` | `static`) override the bake honors before auto-detecting.
  `BAKE_VERSION -> 4` re-bakes everything. (Also strips a stray NUL byte from the
  hash line.)
- `docs/schemas/open-design.plugin.v1.json` + `docs/plugins-spec.md`: document the
  new `od.preview.motion` field for plugin authors.
- `MediaSurface` / `PreviewSurface`: three visibility zones — tight (mount
  iframes), wide (keep clips mounted for scroll-back), zero (decode/play) — plus
  `preload=metadata`.

## Surface area

- [x] Build/repo scripts (`scripts/bake-plugin-previews.mjs`)
- [x] Plugin contract (`od.preview.motion` — schema + spec)
- [x] UI (gallery preview playback)
