### PR TITLE
feat(web): make Composio API key gate clickable

### DIFF
--- a/apps/web/src/components/ConnectorsBrowser.tsx
+++ b/apps/web/src/components/ConnectorsBrowser.tsx
@@ -262,7 +262,7 @@ interface ConnectorsBrowserProps {
    *  (SettingsDialog uses the settings page family instead), no event
    *  is fired. */
   onConnectorsTabClick?: (
-    element: 'provider_chip' | 'search_connectors',
+    element: 'provider_chip' | 'search_connectors' | 'gate_card',
   ) => void;
   /** Analytics hook for the per-connector authorization result. The
    *  daemon emits its own server-side telemetry but the click→outcome
@@ -1004,13 +1004,23 @@ export function ConnectorsBrowser({
               aria-label={t('connectors.gateTitle')}
               data-testid="connector-gate"
             >
-              <div className="connector-gate-card">
+              <a
+                className="connector-gate-card"
+                href="https://app.composio.dev"
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => onConnectorsTabClick?.('gate_card')}
+              >
                 <div className="connector-gate-icon" aria-hidden>
                   <Icon name="settings" size={20} />
                 </div>
                 <h3 className="connector-gate-title">{t('connectors.gateTitle')}</h3>
                 <p className="connector-gate-body">{t('connectors.gateBody')}</p>
-              </div>
+                <span className="connector-gate-cta">
+                  {t('settings.connectorsGetApiKey')}
+                  <Icon name="external-link" size={12} />
+                </span>
+              </a>
             </div>
           ) : null}
         </div>

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4708,6 +4708,7 @@ export function ConnectorSection({
       | 'save_key'
       | 'clear'
       | 'get_api_key'
+      | 'gate_card'
       | 'provider_chip'
       | 'search_connectors',
   ) => void;

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -1723,10 +1723,14 @@ button.connector-action.is-loading {
   max-width: 420px;
   padding: 28px 28px 24px;
   text-align: center;
+  text-decoration: none;
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow-md, 0 10px 30px rgba(0, 0, 0, 0.18));
+}
+.connector-gate-card:visited {
+  color: inherit;
 }
 .connector-gate-icon {
   display: inline-flex;
@@ -1752,6 +1756,16 @@ button.connector-action.is-loading {
   color: var(--text-muted);
   font-size: 13px;
   line-height: 1.5;
+}
+.connector-gate-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 10px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
 }
 /* ------------------------------------------------------------------ */
 /* Connector detail drawer                                             */

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -1762,7 +1762,6 @@ button.connector-action.is-loading {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  margin-top: 10px;
   color: var(--text);
   font-size: 12px;
   font-weight: 600;

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -1428,6 +1428,7 @@ export interface IntegrationsConnectorsTabClickProps {
     | 'save_key'
     | 'clear'
     | 'get_api_key'
+    | 'gate_card'
     | 'provider_chip'
     | 'search_connectors';
 }


### PR DESCRIPTION
Fixes #4033

## Why

I picked this up because the main Composio empty-state card looked like the next step, but it wasn’t clickable. Users had to notice the smaller “Get API key” link near the input instead.

## What users will see

When a Composio API key is required on Integrations → Connectors, the centered empty-state card is now clickable and opens Composio. The card also shows a small “Get API key” CTA.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots
<img width="1792" height="1096" alt="20260610131113" src="https://github.com/user-attachments/assets/7ad21406-1fac-4ad6-a26c-16e0e30f1f23" />

<!-- Add before/after screenshots here. -->

## Bug fix verification

This is an enhancement, so I didn’t add a red-spec bug test. I verified the clickable gate behavior manually.

## Validation

- `corepack pnpm --filter @open-design/contracts build`
- `corepack pnpm typecheck`
- `corepack pnpm guard`
- `corepack pnpm --filter @open-design/web test`