### PR TITLE
Preserve structured daemon stream errors

### DIFF
--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -868,6 +868,7 @@ async function consumeDaemonRun({
   let exitCode: number | null = null;
   let exitSignal: string | null = null;
   let endStatus: ChatRunStatus | null = null;
+  let pendingStructuredError: Error | null = null;
   // Tracks whether the server explicitly declared `status: 'succeeded'` in
   // the SSE end payload (or via the fallback run-status fetch). Distinct
   // from `endStatus === 'succeeded'`, which can be a local fallback when
@@ -994,6 +995,8 @@ async function consumeDaemonRun({
 
           if (event.event === 'error') {
             const data = event.data as SseErrorPayload;
+            const structuredError = daemonSseError(data);
+            pendingStructuredError = structuredError;
             // The daemon emits this error frame from the child-close handler
             // BEFORE `finishWithRetryDecision()` runs, so a transient failure it
             // can recover via a same-run retry is reported here first and only
@@ -1014,13 +1017,13 @@ async function consumeDaemonRun({
             if (status && (status.status === 'failed' || status.status === 'canceled')) {
               onRunStatus?.('failed');
               handlers.onError(
-                markErrorResumable(daemonSseError(data), status.resumable === true),
+                markErrorResumable(structuredError, status.resumable === true),
               );
               return;
             }
             if (!status) {
               onRunStatus?.('failed');
-              handlers.onError(daemonSseError(data));
+              handlers.onError(structuredError);
               return;
             }
             continue;
@@ -1086,6 +1089,10 @@ async function consumeDaemonRun({
       (!serverDeclaredSuccess &&
         (exitSignal || (exitCode !== null && exitCode !== 0)));
     if (looksLikeFailure) {
+      if (pendingStructuredError) {
+        handlers.onError(markErrorResumable(pendingStructuredError, endResumable));
+        return;
+      }
       if (shouldSuppressLifecycleExitFallback(agentId, exitCode, exitSignal, stderrBuf)) {
         handlers.onDone(acc);
         return;

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -105,6 +105,46 @@ describe('streamViaDaemon', () => {
     expect(handlers.onDone).toHaveBeenCalledTimes(1);
   });
 
+  it('prefers a structured daemon error over the lifecycle exit fallback when the run later fails', async () => {
+    const handlers = createDaemonHandlers();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-1' });
+      if (url === '/api/runs/run-1/events') {
+        return sseResponse(
+          [
+            'event: error',
+            'data: {"code":"AGENT_EXECUTION_FAILED","message":"intentional fake codex failure","retryable":false}',
+            '',
+            'event: end',
+            'data: {"code":1,"status":"failed"}',
+            '',
+            '',
+          ].join('\n'),
+        );
+      }
+      if (url === '/api/runs/run-1') {
+        return jsonResponse({ id: 'run-1', status: 'running' });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'do the thing' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'intentional fake codex failure' }),
+    );
+    expect(handlers.onError).not.toHaveBeenCalledWith(new Error('agent exited with code 1'));
+    expect(handlers.onDone).not.toHaveBeenCalled();
+  });
+
   it('surfaces a terminal failure with the finalized resumable flag', async () => {
     const handlers = createDaemonHandlers();
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary
- preserve daemon SSE error frames when the run later ends failed/non-zero
- keep the lifecycle exit-code fallback only for failures without a structured error
- add a provider regression test for the Codex turn.failed case

## Verification
- pnpm -C apps/web exec vitest run tests/providers/sse.test.ts
- pnpm -C e2e exec playwright test -c playwright.config.ts ui/real-daemon-run.test.ts --grep "real daemon run surfaces process/parser errors in chat"