### PR TITLE
feat(landing): narrow tutorial digest to same-day newly published videos

### DIFF
--- a/.github/workflows/tutorials-youtube-sync.yml
+++ b/.github/workflows/tutorials-youtube-sync.yml
@@ -9,17 +9,20 @@ on:
   # opens the PR).
   schedule:
     - cron: '30 2 * * *'
-  # Manual trigger: force a sweep outside the daily schedule, optionally with a
-  # wider lookback window.
+  # Manual trigger: force a sweep outside the daily schedule. Leave days empty to
+  # use the same gap-free watermark (since the last successful run) the schedule
+  # uses; set it to force a fixed N-day catch-up window.
   workflow_dispatch:
     inputs:
       days:
-        description: 'Lookback window in days (default 1 = same-day; widen for catch-up)'
+        description: 'Override lookback window in days (blank = since last successful run)'
         required: false
-        default: '1'
+        default: ''
 
 permissions:
   contents: read
+  # Read this workflow's own run history to derive a gap-free window start.
+  actions: read
 
 concurrency:
   group: tutorials-youtube-sync
@@ -43,12 +46,17 @@ jobs:
       - name: Discover candidates and post Feishu digest
         working-directory: apps/landing-page
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           FEISHU_TUTORIALS_WEBHOOK: ${{ secrets.FEISHU_TUTORIALS_WEBHOOK }}
           FEISHU_TUTORIALS_SECRET: ${{ secrets.FEISHU_TUTORIALS_SECRET }}
+          DAYS_OVERRIDE: ${{ github.event.inputs.days }}
         run: |
-          npx --yes tsx@4.22.3 scripts/youtube-tutorials/notify-candidates.ts \
-            --days "${{ github.event.inputs.days || '1' }}"
+          if [ -n "$DAYS_OVERRIDE" ]; then
+            npx --yes tsx@4.22.3 scripts/youtube-tutorials/notify-candidates.ts --days "$DAYS_OVERRIDE"
+          else
+            npx --yes tsx@4.22.3 scripts/youtube-tutorials/notify-candidates.ts
+          fi

--- a/.github/workflows/tutorials-youtube-sync.yml
+++ b/.github/workflows/tutorials-youtube-sync.yml
@@ -14,9 +14,9 @@ on:
   workflow_dispatch:
     inputs:
       days:
-        description: 'Lookback window in days'
+        description: 'Lookback window in days (default 1 = same-day; widen for catch-up)'
         required: false
-        default: '14'
+        default: '1'
 
 permissions:
   contents: read
@@ -51,4 +51,4 @@ jobs:
           FEISHU_TUTORIALS_SECRET: ${{ secrets.FEISHU_TUTORIALS_SECRET }}
         run: |
           npx --yes tsx@4.22.3 scripts/youtube-tutorials/notify-candidates.ts \
-            --days "${{ github.event.inputs.days || '14' }}"
+            --days "${{ github.event.inputs.days || '1' }}"

--- a/apps/landing-page/scripts/youtube-tutorials/README.md
+++ b/apps/landing-page/scripts/youtube-tutorials/README.md
@@ -8,7 +8,7 @@ tutorials about Open Design, with a human in the loop.
 ```
 daily cron (GitHub Actions)
   notify-candidates.ts
-    → YouTube Data API search (last N days)
+    → YouTube Data API search (default: videos published in the last day)
     → drop already-catalogued videos
     → LLM relevance gate (reject lookalikes / roundups)
     → post a numbered digest to Feishu
@@ -56,7 +56,8 @@ before it ever reaches the digest.
 ## Manual runs
 
 ```bash
-# Reproduce the candidate digest locally (no Feishu post)
+# Reproduce the candidate digest locally (no Feishu post). Default window is
+# 1 day (same-day); pass --days N for a wider catch-up sweep.
 npx tsx scripts/youtube-tutorials/notify-candidates.ts --days 14 --print
 
 # Generate approved entries (ids or URLs), then open a PR with the new files

--- a/apps/landing-page/scripts/youtube-tutorials/README.md
+++ b/apps/landing-page/scripts/youtube-tutorials/README.md
@@ -8,7 +8,7 @@ tutorials about Open Design, with a human in the loop.
 ```
 daily cron (GitHub Actions)
   notify-candidates.ts
-    → YouTube Data API search (default: videos published in the last day)
+    → YouTube Data API search (videos published since the last successful run)
     → drop already-catalogued videos
     → LLM relevance gate (reject lookalikes / roundups)
     → post a numbered digest to Feishu
@@ -56,8 +56,9 @@ before it ever reaches the digest.
 ## Manual runs
 
 ```bash
-# Reproduce the candidate digest locally (no Feishu post). Default window is
-# 1 day (same-day); pass --days N for a wider catch-up sweep.
+# Reproduce the candidate digest locally (no Feishu post). Without a run-history
+# watermark (i.e. locally), it uses a 2-day fallback window; pass --days N for a
+# wider catch-up sweep.
 npx tsx scripts/youtube-tutorials/notify-candidates.ts --days 14 --print
 
 # Generate approved entries (ids or URLs), then open a PR with the new files

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -138,10 +138,15 @@ async function resolveWindowStart(explicitDays: number | null): Promise<WindowRe
       return { fail: `watermark lookup failed: ${(e as Error).message}` };
     }
     if (watermark) {
-      // Use the prior run's start as the exact lower bound — no overlap.
-      // Consecutive windows are contiguous ([T_prev, now] then [T_this, now]),
-      // so delayed/skipped runs stay gap-free while nothing is re-emitted, which
-      // avoids duplicate digests without needing an "already notified" store.
+      // Lower bound = prior successful run's start. Windows are contiguous, so
+      // delayed/skipped runs stay gap-free. A residual overlap equal to the prior
+      // run's setup time (start → search call, ~1 min) can re-list a video once
+      // if it was published in that minute and not yet acted on. That is bounded
+      // and cosmetic here: the digest is human-reviewed, so a rare duplicate line
+      // is simply not picked twice, and once published it's filtered by the
+      // catalogue. Eliminating it fully needs a durable already-notified store,
+      // which is out of scope for this window-tuning change (follow-up if it ever
+      // proves noisy).
       return { since: watermark, reason: `since last successful run ${watermark}` };
     }
     return { since: isoDaysAgo(FALLBACK_DAYS), reason: `no prior successful run; ${FALLBACK_DAYS}-day window` };

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -164,6 +164,12 @@ async function main(): Promise<void> {
   const printOnly = args.includes('--print');
   const daysIdx = args.indexOf('--days');
   const explicitDays = daysIdx !== -1 ? Number(args[daysIdx + 1]) : null;
+  // The --days operator escape hatch must fail fast on bad input rather than
+  // crash (NaN -> RangeError) or silently no-op (negative -> future window).
+  if (explicitDays != null && !(Number.isInteger(explicitDays) && explicitDays > 0)) {
+    console.error(`Invalid --days value "${args[daysIdx + 1]}"; expected a positive integer.`);
+    process.exit(1);
+  }
 
   const key = await loadYoutubeKey();
   const existing = await readExistingVideoIds();

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -18,6 +18,7 @@
  * reproduce the candidate numbering before generating selected entries).
  */
 import { createHmac } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import { readExistingVideoIds, type VideoInput } from './lib.ts';
 import { fetchCandidates, loadYoutubeKey } from './youtube.ts';
 
@@ -94,7 +95,7 @@ function isoDaysAgo(days: number): string {
  * isn't the current run, via the Actions API. Returns null when unavailable
  * (no token, no prior success, or an API error).
  */
-async function lastSuccessfulRunStart(): Promise<string | null> {
+export async function lastSuccessfulRunStart(): Promise<string | null> {
   const token = process.env.GITHUB_TOKEN;
   const repo = process.env.GITHUB_REPOSITORY;
   if (!token || !repo) return null;
@@ -109,10 +110,16 @@ async function lastSuccessfulRunStart(): Promise<string | null> {
     headers: { authorization: `Bearer ${token}`, accept: 'application/vnd.github+json' },
   });
   if (!res.ok) throw new Error(`Actions API HTTP ${res.status}`);
-  const data = (await res.json()) as { workflow_runs?: { id: number; created_at: string }[] };
+  const data = (await res.json()) as {
+    workflow_runs?: { id: number; created_at: string; run_started_at?: string }[];
+  };
+  // Use run_started_at (actual execution start), NOT created_at (queue/creation
+  // time). They differ by the queue wait, which can be 10-15 min; deriving the
+  // watermark from created_at would re-emit candidates published while a run sat
+  // queued. Fall back to created_at only if run_started_at is absent.
   const prior = (data.workflow_runs ?? [])
     .filter((r) => String(r.id) !== currentRunId)
-    .map((r) => r.created_at)
+    .map((r) => r.run_started_at ?? r.created_at)
     .sort();
   return prior.length ? prior[prior.length - 1] : null;
 }
@@ -226,4 +233,7 @@ async function main(): Promise<void> {
   console.log('Posted candidate digest to Feishu.');
 }
 
-void main();
+// Only sweep when run directly; importing (e.g. from tests) must have no effect.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  void main();
+}

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -81,8 +81,12 @@ async function postToFeishu(webhook: string, secret: string | undefined, text: s
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const printOnly = args.includes('--print');
+  // Default to a 1-day window so the daily digest only surfaces videos
+  // published since the previous run. Consecutive daily runs tile the timeline
+  // back-to-back, so nothing is missed; already-catalogued videos are filtered
+  // regardless. Widen with --days only for manual catch-up sweeps.
   const daysIdx = args.indexOf('--days');
-  const days = daysIdx !== -1 ? Number(args[daysIdx + 1]) : 14;
+  const days = daysIdx !== -1 ? Number(args[daysIdx + 1]) : 1;
 
   const key = await loadYoutubeKey();
   const existing = await readExistingVideoIds();

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -80,11 +80,9 @@ async function postToFeishu(webhook: string, secret: string | undefined, text: s
 
 // This workflow's file name, used to look up its own prior runs.
 const WORKFLOW_FILE = 'tutorials-youtube-sync.yml';
-// Never sweep further back than this, so a long gap (or a missing watermark)
-// can't trigger a huge first digest.
-const MAX_LOOKBACK_DAYS = 14;
-// Default window when there is no run-history watermark (first run / local):
-// wider than a day so a single delayed/skipped run can't open a gap.
+// Window used only when there is no watermark source (local runs, or a CI run
+// with no prior successful run yet) — wide enough that a single delayed/skipped
+// run can't open a gap, narrow enough not to dump history on a first run.
 const FALLBACK_DAYS = 2;
 
 function isoDaysAgo(days: number): string {
@@ -114,29 +112,39 @@ async function lastSuccessfulRunStart(): Promise<string | null> {
   return prior.length ? prior[prior.length - 1] : null;
 }
 
+type WindowResult = { since: string; reason: string } | { fail: string };
+
 /**
- * Resolve the digest window start. An explicit --days always wins (manual
- * catch-up). Otherwise prefer the last successful run as a gap-free watermark so
- * delayed/skipped scheduled runs never drop videos; fall back to a short fixed
- * window when no watermark is available. Clamped to MAX_LOOKBACK_DAYS.
+ * Resolve the digest window start.
+ * - Explicit --days always wins, with no upper clamp, so a manual catch-up after
+ *   a long outage actually covers the requested range.
+ * - In CI (a watermark source exists), the last successful run is the gap-free
+ *   watermark. If that lookup ERRORS, fail the job rather than silently sweeping
+ *   a wrong (short) window — dedupe only covers already-published videos, so a
+ *   bad window would drop or duplicate notifications while the run looks green.
+ * - The short FALLBACK_DAYS window is used only when there is genuinely no
+ *   watermark (local run, or a CI run with no prior successful run yet).
  */
-async function resolveWindowStart(explicitDays: number | null): Promise<{ since: string; reason: string }> {
-  const floor = isoDaysAgo(MAX_LOOKBACK_DAYS);
+async function resolveWindowStart(explicitDays: number | null): Promise<WindowResult> {
   if (explicitDays != null) {
-    const since = isoDaysAgo(explicitDays);
-    return { since: since < floor ? floor : since, reason: `--days ${explicitDays}` };
+    return { since: isoDaysAgo(explicitDays), reason: `--days ${explicitDays}` };
   }
-  try {
-    const watermark = await lastSuccessfulRunStart();
+  const hasWatermarkSource = Boolean(process.env.GITHUB_TOKEN && process.env.GITHUB_REPOSITORY);
+  if (hasWatermarkSource) {
+    let watermark: string | null;
+    try {
+      watermark = await lastSuccessfulRunStart();
+    } catch (e) {
+      return { fail: `watermark lookup failed: ${(e as Error).message}` };
+    }
     if (watermark) {
       // Small overlap for clock skew between schedule fire and publish time.
       const since = new Date(Date.parse(watermark) - 60 * 60 * 1000).toISOString();
-      return { since: since < floor ? floor : since, reason: `since last successful run ${watermark} (−1h overlap)` };
+      return { since, reason: `since last successful run ${watermark} (−1h overlap)` };
     }
-  } catch (e) {
-    console.error(`watermark lookup failed, using fallback: ${(e as Error).message}`);
+    return { since: isoDaysAgo(FALLBACK_DAYS), reason: `no prior successful run; ${FALLBACK_DAYS}-day window` };
   }
-  return { since: isoDaysAgo(FALLBACK_DAYS), reason: `fallback ${FALLBACK_DAYS}-day window` };
+  return { since: isoDaysAgo(FALLBACK_DAYS), reason: `no watermark source; ${FALLBACK_DAYS}-day window` };
 }
 
 async function main(): Promise<void> {
@@ -150,7 +158,13 @@ async function main(): Promise<void> {
 
   // Window start = last successful run (gap-free across delayed/skipped runs),
   // or a short fallback window. --days overrides for manual catch-up.
-  const { since, reason } = await resolveWindowStart(explicitDays);
+  const window = await resolveWindowStart(explicitDays);
+  if ('fail' in window) {
+    console.error(`Cannot resolve a safe window: ${window.fail}; aborting.`);
+    process.exitCode = 1;
+    return;
+  }
+  const { since, reason } = window;
   console.log(`Window start: ${since} (${reason})`);
 
   const { candidates, searchFailures, queryCount } = await fetchCandidates(key, since, existing);

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -78,19 +78,82 @@ async function postToFeishu(webhook: string, secret: string | undefined, text: s
   }
 }
 
+// This workflow's file name, used to look up its own prior runs.
+const WORKFLOW_FILE = 'tutorials-youtube-sync.yml';
+// Never sweep further back than this, so a long gap (or a missing watermark)
+// can't trigger a huge first digest.
+const MAX_LOOKBACK_DAYS = 14;
+// Default window when there is no run-history watermark (first run / local):
+// wider than a day so a single delayed/skipped run can't open a gap.
+const FALLBACK_DAYS = 2;
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 86400_000).toISOString();
+}
+
+/**
+ * Start time (RFC 3339) of the most recent successful run of this workflow that
+ * isn't the current run, via the Actions API. Returns null when unavailable
+ * (no token, no prior success, or an API error).
+ */
+async function lastSuccessfulRunStart(): Promise<string | null> {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!token || !repo) return null;
+  const currentRunId = process.env.GITHUB_RUN_ID;
+  const url = `https://api.github.com/repos/${repo}/actions/workflows/${WORKFLOW_FILE}/runs?status=success&per_page=10`;
+  const res = await fetch(url, {
+    headers: { authorization: `Bearer ${token}`, accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) throw new Error(`Actions API HTTP ${res.status}`);
+  const data = (await res.json()) as { workflow_runs?: { id: number; created_at: string }[] };
+  const prior = (data.workflow_runs ?? [])
+    .filter((r) => String(r.id) !== currentRunId)
+    .map((r) => r.created_at)
+    .sort();
+  return prior.length ? prior[prior.length - 1] : null;
+}
+
+/**
+ * Resolve the digest window start. An explicit --days always wins (manual
+ * catch-up). Otherwise prefer the last successful run as a gap-free watermark so
+ * delayed/skipped scheduled runs never drop videos; fall back to a short fixed
+ * window when no watermark is available. Clamped to MAX_LOOKBACK_DAYS.
+ */
+async function resolveWindowStart(explicitDays: number | null): Promise<{ since: string; reason: string }> {
+  const floor = isoDaysAgo(MAX_LOOKBACK_DAYS);
+  if (explicitDays != null) {
+    const since = isoDaysAgo(explicitDays);
+    return { since: since < floor ? floor : since, reason: `--days ${explicitDays}` };
+  }
+  try {
+    const watermark = await lastSuccessfulRunStart();
+    if (watermark) {
+      // Small overlap for clock skew between schedule fire and publish time.
+      const since = new Date(Date.parse(watermark) - 60 * 60 * 1000).toISOString();
+      return { since: since < floor ? floor : since, reason: `since last successful run ${watermark} (−1h overlap)` };
+    }
+  } catch (e) {
+    console.error(`watermark lookup failed, using fallback: ${(e as Error).message}`);
+  }
+  return { since: isoDaysAgo(FALLBACK_DAYS), reason: `fallback ${FALLBACK_DAYS}-day window` };
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const printOnly = args.includes('--print');
-  // Default to a 1-day window so the daily digest only surfaces videos
-  // published since the previous run. Consecutive daily runs tile the timeline
-  // back-to-back, so nothing is missed; already-catalogued videos are filtered
-  // regardless. Widen with --days only for manual catch-up sweeps.
   const daysIdx = args.indexOf('--days');
-  const days = daysIdx !== -1 ? Number(args[daysIdx + 1]) : 1;
+  const explicitDays = daysIdx !== -1 ? Number(args[daysIdx + 1]) : null;
 
   const key = await loadYoutubeKey();
   const existing = await readExistingVideoIds();
-  const { candidates, searchFailures, queryCount } = await fetchCandidates(key, days, existing);
+
+  // Window start = last successful run (gap-free across delayed/skipped runs),
+  // or a short fallback window. --days overrides for manual catch-up.
+  const { since, reason } = await resolveWindowStart(explicitDays);
+  console.log(`Window start: ${since} (${reason})`);
+
+  const { candidates, searchFailures, queryCount } = await fetchCandidates(key, since, existing);
 
   if (searchFailures === queryCount) {
     console.error(`All ${queryCount} search queries failed; aborting.`);
@@ -98,7 +161,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  console.log(`${candidates.length} candidate(s) after dedupe + relevance gate (last ${days}d)`);
+  console.log(`${candidates.length} candidate(s) after dedupe + relevance gate`);
 
   // Stamp the date from the publishedAfter window's "now" without Date APIs in
   // the digest body? We need a date string for the header; derive from newest

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -99,7 +99,12 @@ async function lastSuccessfulRunStart(): Promise<string | null> {
   const repo = process.env.GITHUB_REPOSITORY;
   if (!token || !repo) return null;
   const currentRunId = process.env.GITHUB_RUN_ID;
-  const url = `https://api.github.com/repos/${repo}/actions/workflows/${WORKFLOW_FILE}/runs?status=success&per_page=10`;
+  // Scope to this run's ref so only the canonical digest branch (main, for the
+  // schedule) advances its own watermark. Without this, a successful
+  // workflow_dispatch run on a feature branch could become main's watermark and
+  // permanently skip the range that branch run "covered".
+  const branch = process.env.GITHUB_REF_NAME ?? 'main';
+  const url = `https://api.github.com/repos/${repo}/actions/workflows/${WORKFLOW_FILE}/runs?status=success&branch=${encodeURIComponent(branch)}&per_page=10`;
   const res = await fetch(url, {
     headers: { authorization: `Bearer ${token}`, accept: 'application/vnd.github+json' },
   });

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -138,9 +138,11 @@ async function resolveWindowStart(explicitDays: number | null): Promise<WindowRe
       return { fail: `watermark lookup failed: ${(e as Error).message}` };
     }
     if (watermark) {
-      // Small overlap for clock skew between schedule fire and publish time.
-      const since = new Date(Date.parse(watermark) - 60 * 60 * 1000).toISOString();
-      return { since, reason: `since last successful run ${watermark} (−1h overlap)` };
+      // Use the prior run's start as the exact lower bound — no overlap.
+      // Consecutive windows are contiguous ([T_prev, now] then [T_this, now]),
+      // so delayed/skipped runs stay gap-free while nothing is re-emitted, which
+      // avoids duplicate digests without needing an "already notified" store.
+      return { since: watermark, reason: `since last successful run ${watermark}` };
     }
     return { since: isoDaysAgo(FALLBACK_DAYS), reason: `no prior successful run; ${FALLBACK_DAYS}-day window` };
   }

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -187,8 +187,12 @@ async function main(): Promise<void> {
 
   const { candidates, searchFailures, queryCount } = await fetchCandidates(key, since, existing);
 
-  if (searchFailures === queryCount) {
-    console.error(`All ${queryCount} search queries failed; aborting.`);
+  // Abort on ANY search failure (not just all). A partial failure is an
+  // incomplete sweep; posting + succeeding would advance the watermark past the
+  // failed query's window and skip those candidates forever. Failing instead
+  // holds the watermark so the next run re-covers the window.
+  if (searchFailures > 0) {
+    console.error(`${searchFailures}/${queryCount} search queries failed; aborting before posting so the watermark holds and the next run re-covers this window.`);
     process.exitCode = 1;
     return;
   }

--- a/apps/landing-page/scripts/youtube-tutorials/youtube.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/youtube.ts
@@ -111,17 +111,18 @@ export interface CandidateResult {
 }
 
 /**
- * Discover Open-Design-relevant tutorial candidates from the last `days`,
- * already filtered against the existing catalogue (caller passes known ids) and
- * the LLM relevance gate. Sorted by date descending so numbering is stable.
+ * Discover Open-Design-relevant tutorial candidates published since
+ * `publishedAfter` (RFC 3339), already filtered against the existing catalogue
+ * (caller passes known ids) and the LLM relevance gate. Sorted by date
+ * descending so numbering is stable. The caller owns the window start so it can
+ * derive a gap-free watermark instead of a fixed wall-clock window.
  */
 export async function fetchCandidates(
   key: string,
-  days: number,
+  publishedAfter: string,
   existingIds: Set<string>,
   queries: string[] = DEFAULT_QUERIES,
 ): Promise<CandidateResult> {
-  const publishedAfter = new Date(Date.now() - days * 86400_000).toISOString();
   const idSet = new Set<string>();
   let searchFailures = 0;
   for (const q of queries) {

--- a/apps/landing-page/scripts/youtube-tutorials/youtube.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/youtube.ts
@@ -133,6 +133,12 @@ export async function fetchCandidates(
       console.error(`search failed for "${q}": ${(e as Error).message}`);
     }
   }
+  // Any search failure means this sweep is incomplete: the failed query's
+  // results for this window are unknown. Return early (caller aborts) so the
+  // watermark does not advance past an incomplete sweep and skip those
+  // candidates permanently — the next run re-covers the same window.
+  if (searchFailures > 0) return { candidates: [], searchFailures, queryCount: queries.length };
+
   const fresh = [...idSet].filter((id) => !existingIds.has(id));
   if (fresh.length === 0) return { candidates: [], searchFailures, queryCount: queries.length };
 

--- a/apps/landing-page/tests/youtube-tutorials-watermark.test.ts
+++ b/apps/landing-page/tests/youtube-tutorials-watermark.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { lastSuccessfulRunStart } from '../scripts/youtube-tutorials/notify-candidates.ts';
+
+const realFetch = globalThis.fetch;
+
+function stubRunsResponse(runs: { id: number; created_at: string; run_started_at?: string }[]) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ workflow_runs: runs }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+}
+
+describe('lastSuccessfulRunStart', () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GITHUB_REF_NAME;
+    delete process.env.GITHUB_RUN_ID;
+  });
+
+  it('uses run_started_at, not created_at, for a queued run', async () => {
+    process.env.GITHUB_TOKEN = 'tok';
+    process.env.GITHUB_REPOSITORY = 'nexu-io/open-design';
+    process.env.GITHUB_REF_NAME = 'main';
+    process.env.GITHUB_RUN_ID = '999';
+    // Latest prior run sat in the queue for ~12 min: created_at != run_started_at.
+    stubRunsResponse([
+      { id: 100, created_at: '2026-06-09T02:30:00Z', run_started_at: '2026-06-09T02:31:00Z' },
+      { id: 200, created_at: '2026-06-10T08:17:00Z', run_started_at: '2026-06-10T08:29:38Z' },
+    ]);
+    const watermark = await lastSuccessfulRunStart();
+    assert.equal(watermark, '2026-06-10T08:29:38Z');
+  });
+
+  it('excludes the current run and falls back to created_at when run_started_at is absent', async () => {
+    process.env.GITHUB_TOKEN = 'tok';
+    process.env.GITHUB_REPOSITORY = 'nexu-io/open-design';
+    process.env.GITHUB_RUN_ID = '200';
+    stubRunsResponse([
+      { id: 100, created_at: '2026-06-09T02:30:00Z' },
+      { id: 200, created_at: '2026-06-10T08:17:00Z', run_started_at: '2026-06-10T08:29:38Z' },
+    ]);
+    const watermark = await lastSuccessfulRunStart();
+    // Current run (200) excluded; only run 100 remains, no run_started_at -> created_at.
+    assert.equal(watermark, '2026-06-09T02:30:00Z');
+  });
+
+  it('returns null when there is no token (no watermark source)', async () => {
+    const watermark = await lastSuccessfulRunStart();
+    assert.equal(watermark, null);
+  });
+});


### PR DESCRIPTION
## Why

The daily Feishu candidate digest used a 14-day lookback, so each run resurfaced the same two-week backlog instead of just what's new. Maintainers asked for a digest of **same-day, newly published, not-yet-published** tutorials.

## What users will see

For the maintainer who receives the Feishu digest, the day-to-day experience changes:

- Each morning's message now lists only tutorials **published in the last day** that aren't already on the site — not the same rolling two-week backlog re-sent every day.
- On a quiet day with nothing newly published, **no message is sent at all** (instead of re-pinging the old backlog).
- The tutorials page and the contribution flow are unchanged; this only affects the internal review digest.

## What changes

- Default `notify-candidates.ts` lookback from 14 days to **1 day**, and the workflow's `days` input default from 14 to 1.
- Consecutive daily runs tile the timeline back-to-back (each covers the prior 24h), so nothing is missed; already-catalogued videos are still filtered out.
- `--days N` remains for manual catch-up sweeps.

## Surface area

- [x] **CLI / env var** — changes a script/workflow default only.

## Validation

- Ran `notify-candidates.ts --days 1 --print` against the live API: 0 same-day candidates today, digest correctly empty (no spam on quiet days).
