### PR TITLE
fix: trim passive address URL trailing slash

### DIFF
--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -2842,7 +2842,7 @@ export function formatAddressDisplayParts(url: string, title?: string): AddressD
   if (!cleanTitle) return { url };
   const fallback = labelFromUrl(url);
   if (cleanTitle === fallback || cleanTitle === url) return { url };
-  return { url, title: cleanTitle };
+  return { url: url.replace(/\/+$/, ''), title: cleanTitle };
 }
 
 export function formatAddressDisplay(url: string, title?: string): string {

--- a/apps/web/tests/components/DesignBrowserPanel.test.tsx
+++ b/apps/web/tests/components/DesignBrowserPanel.test.tsx
@@ -231,13 +231,13 @@ describe('formatAddressDisplay', () => {
 
   it('appends a real page title for the passive address display', () => {
     expect(formatAddressDisplay('https://www.baidu.com/', '百度一下，你就知道')).toBe(
-      'https://www.baidu.com/ / 百度一下，你就知道',
+      'https://www.baidu.com / 百度一下，你就知道',
     );
   });
 
   it('exposes URL and title as separate passive display parts', () => {
     expect(formatAddressDisplayParts('https://brandfetch.com/', 'Just a moment...')).toEqual({
-      url: 'https://brandfetch.com/',
+      url: 'https://brandfetch.com',
       title: 'Just a moment...',
     });
   });

--- a/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
+++ b/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
@@ -291,7 +291,7 @@ describe('DesignBrowserPanel <webview> navigation', () => {
 
     expect(getAddressDisplay(container)).toMatchObject({
       title: '百度一下，你就知道',
-      url: 'https://www.baidu.com/',
+      url: 'https://www.baidu.com',
     });
 
     fireEvent.focus(input);


### PR DESCRIPTION
## Summary\n- Trim trailing slashes from the passive address URL when a page title is displayed\n- Keep navigation/current URL untouched; only the display parts are normalized\n- Update address display tests for root URLs with titles\n\nCloses #4051\n\n## Validation\n- corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/DesignBrowserPanel.test.tsx tests/components/DesignBrowserPanel.webview.test.tsx\n- corepack pnpm --filter @open-design/web typecheck

## Surface area
- [x] UI
- [ ] API
- [ ] Data model
- [ ] Build/tooling
- [ ] Documentation