### PR TITLE
[codex] Fix onboarding dropdown styling

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -135,7 +135,6 @@ import {
 import { closeAmrActivationWindowBestEffort } from './AmrLoginPill';
 import { AnimatePresence } from 'motion/react';
 import { smoothScrollToTop } from '../utils/smoothScrollToTop';
-import { renderModelOptions } from './modelOptions';
 import {
   providerModelsCacheKey,
   type ProviderModelsCache,
@@ -167,6 +166,7 @@ function writeStoredRailOpen(open: boolean): void {
 
 const DISCORD_URL = 'https://discord.gg/mHAjSMV6gz';
 const X_URL = 'https://x.com/nexudotio';
+const ONBOARDING_DROPDOWN_OPEN_EVENT = 'open-design:onboarding-dropdown-open';
 
 // The topbar chips (GitHub star, model switcher, Use everywhere)
 // collapse into the settings dropdown when the viewport gets
@@ -1108,14 +1108,10 @@ function OnboardingView({
       area = 'runtime';
       stepIndex = '1';
       stepName = 'connect';
-    } else if (step === 1) {
+    } else {
       area = 'about_you';
       stepIndex = '2';
       stepName = 'about_you';
-    } else {
-      area = 'newsletter';
-      stepIndex = '3';
-      stepName = 'newsletter';
     }
     trackPageView(analytics.track, {
       page_name: 'onboarding',
@@ -1147,8 +1143,7 @@ function OnboardingView({
     stepName: TrackingOnboardingStepName;
   } {
     if (stepIdx === 0) return { area: 'runtime', stepIndex: '1', stepName: 'connect' };
-    if (stepIdx === 1) return { area: 'about_you', stepIndex: '2', stepName: 'about_you' };
-    return { area: 'newsletter', stepIndex: '3', stepName: 'newsletter' };
+    return { area: 'about_you', stepIndex: '2', stepName: 'about_you' };
   }
   function emitOnboardingClick(
     element: TrackingOnboardingClickElement,
@@ -1242,7 +1237,6 @@ function OnboardingView({
   const steps = [
     t('settings.onboardingStepConnect'),
     t('settings.onboardingStepProfile'),
-    t('settings.onboardingStepNewsletter'),
   ];
   const isLastStep = step === steps.length - 1;
 
@@ -1757,8 +1751,6 @@ function OnboardingView({
     ? t('settings.amrSigningIn')
     : step === 0 && amrSelectedAndSignedOut
       ? t('settings.amrSignInToContinue')
-    : step === 1
-      ? t('settings.onboardingContinue')
     : isLastStep
       ? t('settings.onboardingFinish')
       : t('settings.onboardingContinue');
@@ -1990,31 +1982,28 @@ function OnboardingView({
                   }}
                 />
               </div>
-            </div>
-          ) : null}
-
-          {step === 2 ? (
-            <div className="onboarding-view__panel">
-              <OnboardingPanelHeader
-                title={t('settings.onboardingNewsletterTitle')}
-                body={t('settings.onboardingNewsletterBody')}
-              />
-              <label className="onboarding-view__email-field">
-                <span className="onboarding-view__email-label">
-                  {t('newsletter.label')}
-                </span>
-                <input
-                  className="onboarding-view__email-input"
-                  type="email"
-                  autoComplete="email"
-                  inputMode="email"
-                  placeholder={t('newsletter.placeholder')}
-                  value={profile.email}
-                  onChange={(event) =>
-                    setProfile((current) => ({ ...current, email: event.target.value }))
-                  }
+              <div className="onboarding-view__newsletter-inline">
+                <OnboardingPanelHeader
+                  title={t('settings.onboardingNewsletterTitle')}
+                  body={t('settings.onboardingNewsletterBody')}
                 />
-              </label>
+                <label className="onboarding-view__email-field">
+                  <span className="onboarding-view__email-label">
+                    {t('newsletter.label')}
+                  </span>
+                  <input
+                    className="onboarding-view__email-input"
+                    type="email"
+                    autoComplete="email"
+                    inputMode="email"
+                    placeholder={t('newsletter.placeholder')}
+                    value={profile.email}
+                    onChange={(event) =>
+                      setProfile((current) => ({ ...current, email: event.target.value }))
+                    }
+                  />
+                </label>
+              </div>
             </div>
           ) : null}
 
@@ -2145,6 +2134,8 @@ function OnboardingCliSetupPanel({
           value={selectedModel}
           options={modelOptions}
           onChange={onSelectModel}
+          searchable
+          searchPlaceholder={t('newproj.modelSearch')}
         />
       ) : null}
     </div>
@@ -2165,35 +2156,26 @@ function OnboardingAmrModelSelect({
   const t = useT();
   const modelSource = modelsSource ?? 'fallback';
   const displayModels = models.map((model) => ({
-    ...model,
+    value: model.id,
     label: formatOnboardingAmrModelLabel(model),
   }));
   const modelSourceLabel = t('settings.onboardingAmrModelSourceLabel');
   return (
-    <label
+    <div
       className="onboarding-view__model-picker"
       onClick={(event) => event.stopPropagation()}
     >
-      <span className="onboarding-view__model-label">
-        {t('settings.modelPicker')}
-        <span className={`onboarding-view__model-source ${modelSource}`}>
-          {modelSourceLabel}
-        </span>
-      </span>
-      <span className="onboarding-view__model-select-wrap">
-        <select
-          value={selectedModel}
-          onChange={(event) => onSelectModel(event.target.value)}
-        >
-          {renderModelOptions(displayModels)}
-        </select>
-        <Icon
-          name="chevron-down"
-          size={12}
-          className="onboarding-view__model-select-chevron"
-        />
-      </span>
-    </label>
+      <OnboardingDropdown
+        label={`${t('settings.modelPicker')} · ${modelSourceLabel}`}
+        placeholder={t('settings.modelSourceFallback')}
+        value={selectedModel}
+        options={displayModels}
+        onChange={onSelectModel}
+        searchable
+        searchPlaceholder={t('newproj.modelSearch')}
+        sourceTone={modelSource}
+      />
+    </div>
   );
 }
 
@@ -2340,6 +2322,8 @@ function OnboardingByokSetupPanel({
         value={selectedProvider?.baseUrl ?? ''}
         options={providerOptions}
         onChange={onProviderChange}
+        searchable
+        searchPlaceholder={t('settings.quickFillProvider')}
       />
       <label className="onboarding-view__inline-field">
         <span>{t('settings.apiKey')}</span>
@@ -2374,6 +2358,8 @@ function OnboardingByokSetupPanel({
             options={modelOptions}
             onChange={onModelChange}
             placement="top"
+            searchable
+            searchPlaceholder={t('newproj.modelSearch')}
           />
         ) : (
           <label className="onboarding-view__inline-field">
@@ -2550,6 +2536,9 @@ type OnboardingDropdownBaseProps = {
   placeholder: string;
   options: Array<{ value: string; label: string }>;
   placement?: 'bottom' | 'top';
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  sourceTone?: string;
 };
 
 type OnboardingDropdownProps =
@@ -2565,6 +2554,7 @@ type OnboardingDropdownProps =
     });
 
 export function OnboardingDropdown(props: OnboardingDropdownProps) {
+  const t = useT();
   const {
     label,
     placeholder,
@@ -2572,11 +2562,16 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
     options,
     placement = 'bottom',
     multiple = false,
+    searchable = false,
+    searchPlaceholder,
+    sourceTone,
   } = props;
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
   const [resolvedPlacement, setResolvedPlacement] = useState(placement);
   const [menuMaxHeight, setMenuMaxHeight] = useState(240);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const dropdownIdRef = useRef(`onboarding-dropdown-${Math.random().toString(36).slice(2)}`);
   const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
   const selectedOptions = options.filter((option) => selectedValues.includes(option.value));
   const selectedOption = selectedOptions[0];
@@ -2585,6 +2580,13 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
     ? selectedOptions.map((option) => option.label).join(', ')
     : selectedOption?.label;
   const triggerLabel = selectedLabel || placeholder;
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleOptions =
+    searchable && normalizedQuery
+      ? options.filter((option) =>
+          `${option.label} ${option.value}`.toLowerCase().includes(normalizedQuery),
+        )
+      : options;
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -2638,6 +2640,39 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
     };
   }, [open]);
 
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+    }
+  }, [open]);
+
+  useEffect(() => {
+    function handlePeerOpen(event: Event) {
+      if ((event as CustomEvent<string>).detail !== dropdownIdRef.current) {
+        setOpen(false);
+      }
+    }
+
+    window.addEventListener(ONBOARDING_DROPDOWN_OPEN_EVENT, handlePeerOpen);
+    return () => {
+      window.removeEventListener(ONBOARDING_DROPDOWN_OPEN_EVENT, handlePeerOpen);
+    };
+  }, []);
+
+  function toggleOpen() {
+    setOpen((current) => {
+      const nextOpen = !current;
+      if (nextOpen) {
+        window.dispatchEvent(
+          new CustomEvent(ONBOARDING_DROPDOWN_OPEN_EVENT, {
+            detail: dropdownIdRef.current,
+          }),
+        );
+      }
+      return nextOpen;
+    });
+  }
+
   return (
     <div
       className="onboarding-view__select-field"
@@ -2645,7 +2680,12 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
       data-open={open || undefined}
       ref={rootRef}
     >
-      <span className="onboarding-view__select-label">{label}</span>
+      <span
+        className="onboarding-view__select-label"
+        data-source-tone={sourceTone || undefined}
+      >
+        {label}
+      </span>
       <button
         type="button"
         className={`onboarding-view__select-trigger${open ? ' is-open' : ''}${
@@ -2654,7 +2694,7 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
         aria-haspopup="listbox"
         aria-expanded={open}
         title={triggerLabel}
-        onClick={() => setOpen((current) => !current)}
+        onClick={toggleOpen}
       >
         <span>{triggerLabel}</span>
         <Icon name="chevron-down" size={16} />
@@ -2662,38 +2702,65 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
       {open ? (
         <div
           className="onboarding-view__select-menu"
-          role="listbox"
-          aria-label={label}
-          aria-multiselectable={multiple || undefined}
+          data-searchable={searchable || undefined}
           style={{ '--onboarding-select-menu-max-height': `${menuMaxHeight}px` } as CSSProperties}
         >
-          {options.map((option) => {
-            const selected = selectedValues.includes(option.value);
-            return (
-              <button
-                key={option.value}
-                type="button"
-                className={`onboarding-view__select-option${selected ? ' is-selected' : ''}`}
-                role="option"
-                aria-selected={selected}
-                onClick={() => {
-                  if (props.multiple) {
-                    props.onChange(
-                      selected
-                        ? selectedValues.filter((selectedValue) => selectedValue !== option.value)
-                        : [...selectedValues, option.value],
-                    );
-                    return;
-                  }
-                  props.onChange(option.value);
-                  setOpen(false);
-                }}
-              >
-                <span>{option.label}</span>
-                {selected ? <Icon name="check" size={15} /> : null}
-              </button>
-            );
-          })}
+          {searchable ? (
+            <label
+              className="onboarding-view__select-search"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Icon name="search" size={14} />
+              <input
+                type="search"
+                value={query}
+                placeholder={searchPlaceholder || placeholder}
+                aria-label={searchPlaceholder || label}
+                autoFocus
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => event.stopPropagation()}
+              />
+            </label>
+          ) : null}
+          <div
+            className="onboarding-view__select-options"
+            role="listbox"
+            aria-label={label}
+            aria-multiselectable={multiple || undefined}
+          >
+            {visibleOptions.map((option) => {
+              const selected = selectedValues.includes(option.value);
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`onboarding-view__select-option${selected ? ' is-selected' : ''}`}
+                  role="option"
+                  aria-selected={selected}
+                  onClick={() => {
+                    if (props.multiple) {
+                      props.onChange(
+                        selected
+                          ? selectedValues.filter((selectedValue) => selectedValue !== option.value)
+                          : [...selectedValues, option.value],
+                      );
+                      return;
+                    }
+                    props.onChange(option.value);
+                    setOpen(false);
+                  }}
+                >
+                  <span>{option.label}</span>
+                  {selected ? <Icon name="check" size={15} /> : null}
+                </button>
+              );
+            })}
+            {visibleOptions.length === 0 ? (
+              <div className="onboarding-view__select-empty">
+                {t('settings.fetchModelsEmpty')}
+              </div>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2587,6 +2587,7 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
           `${option.label} ${option.value}`.toLowerCase().includes(normalizedQuery),
         )
       : options;
+  const emptyMessage = searchable ? t('homeHero.footer.noMatches') : t('settings.fetchModelsEmpty');
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -2718,7 +2719,11 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
                 aria-label={searchPlaceholder || label}
                 autoFocus
                 onChange={(event) => setQuery(event.target.value)}
-                onKeyDown={(event) => event.stopPropagation()}
+                onKeyDown={(event) => {
+                  if (event.key !== 'Escape') {
+                    event.stopPropagation();
+                  }
+                }}
               />
             </label>
           ) : null}
@@ -2756,9 +2761,7 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
               );
             })}
             {visibleOptions.length === 0 ? (
-              <div className="onboarding-view__select-empty">
-                {t('settings.fetchModelsEmpty')}
-              </div>
+              <div className="onboarding-view__select-empty">{emptyMessage}</div>
             ) : null}
           </div>
         </div>

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1681,7 +1681,7 @@
 .onboarding-view__hero h1 {
   margin: 0;
   color: var(--text-strong);
-  font-size: 56px;
+  font-size: 64px;
   line-height: 0.98;
   letter-spacing: 0;
 }
@@ -1696,8 +1696,8 @@
 
 .onboarding-view__steps {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
   width: min(860px, 100%);
   margin: 0;
   padding: 0;
@@ -1708,10 +1708,10 @@
 .onboarding-view__steps li {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   min-width: 0;
-  min-height: 46px;
-  padding: 10px 12px;
+  min-height: 64px;
+  padding: 14px 18px;
   border-radius: var(--radius);
   border: 1px solid var(--border);
   color: var(--text-muted);
@@ -1724,10 +1724,10 @@
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  width: 26px;
-  height: 26px;
+  width: 32px;
+  height: 32px;
   border-radius: var(--radius-pill);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
   color: var(--text-muted);
   background: var(--bg-subtle);
@@ -1741,7 +1741,7 @@
   background: transparent;
   color: inherit;
   font: inherit;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 650;
   text-align: left;
   cursor: pointer;
@@ -1879,7 +1879,7 @@
 .onboarding-view__panel-head h2 {
   margin: 0;
   color: var(--text-strong);
-  font-size: 25px;
+  font-size: 32px;
   line-height: 1.2;
   letter-spacing: 0;
 }
@@ -2010,7 +2010,7 @@
 
 .onboarding-view__runtime-stack {
   display: grid;
-  gap: 12px;
+  gap: 18px;
 }
 
 .onboarding-view__alternatives {
@@ -2364,12 +2364,14 @@
 .onboarding-view__card--featured.onboarding-view__card--amr {
   grid-template-columns: max-content minmax(0, 1fr);
   grid-template-rows: auto auto;
-  column-gap: 16px;
-  row-gap: 12px;
+  column-gap: 22px;
+  row-gap: 18px;
   align-items: center;
-  min-height: 184px;
-  padding: 34px 30px;
-  overflow: hidden;
+  min-height: 246px;
+  padding: 40px 34px 36px;
+  overflow: visible;
+  position: relative;
+  z-index: 3;
 }
 
 .onboarding-view__card.is-selected {
@@ -2470,10 +2472,10 @@
   grid-row: 1;
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   min-width: 0;
   width: fit-content;
-  padding: 9px 12px 9px 9px;
+  padding: 10px 16px 10px 10px;
   border: 1px solid color-mix(in srgb, var(--border) 88%, var(--text-muted) 12%);
   border-radius: var(--radius);
   background: color-mix(in srgb, var(--bg-panel) 98%, var(--text-muted) 2%);
@@ -2487,7 +2489,7 @@
 
 .onboarding-view__identity .onboarding-view__card-copy {
   align-self: center;
-  gap: 3px;
+  gap: 4px;
   padding-right: 0;
 }
 
@@ -2506,13 +2508,13 @@
 }
 
 .onboarding-view__card--featured strong {
-  font-size: 20px;
+  font-size: 22px;
 }
 
 .onboarding-view__card-meta {
   display: block;
   color: var(--text-muted);
-  font-size: 11.5px;
+  font-size: 13px;
   font-weight: 620;
   line-height: 1.2;
 }
@@ -2547,7 +2549,7 @@
 }
 
 .onboarding-view__benefit-aside .onboarding-view__benefit-stack {
-  gap: 7px;
+  gap: 10px;
 }
 
 .onboarding-view__model-picker {
@@ -2580,7 +2582,7 @@
   gap: 0;
   min-width: 0;
   color: var(--text-strong);
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 700;
   line-height: 1.2;
 }
@@ -2615,28 +2617,41 @@
   display: block;
 }
 
-.onboarding-view__model-select-wrap .onboarding-view__model-select {
+.onboarding-view__model-select-wrap select {
+  appearance: none;
+  -webkit-appearance: none;
   width: 100%;
-  min-height: 42px;
-  padding: 0 34px 0 13px;
+  min-height: 54px;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, var(--text-muted) 12%);
   border-radius: var(--radius);
   background-color: var(--bg-panel);
   color: var(--text-strong);
-  font-size: 13px;
+  padding: 0 44px 0 16px;
+  font: inherit;
+  font-size: 16px;
   font-weight: 500;
   line-height: 1.2;
   box-shadow: var(--shadow-xs);
   transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1), border-color 160ms cubic-bezier(0.23, 1, 0.32, 1), color 160ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 160ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
-.onboarding-view__model-select-wrap .onboarding-view__model-select:hover {
+.onboarding-view__model-select-wrap select:hover {
   border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
   background-color: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
 }
 
-.onboarding-view__model-select-wrap .onboarding-view__model-select:focus-visible {
+.onboarding-view__model-select-wrap select:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 42%, transparent);
   outline-offset: 2px;
+}
+
+.onboarding-view__model-select-chevron {
+  position: absolute;
+  top: 50%;
+  right: 14px;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
 }
 
 .onboarding-view__benefits {
@@ -2658,8 +2673,8 @@
 .onboarding-view__benefit-aside
   .onboarding-view__benefits
   > .onboarding-view__benefit {
-  min-height: 24px;
-  padding: 0 9px;
+  min-height: 28px;
+  padding: 0 12px;
   border-color: color-mix(in srgb, var(--accent) 32%, transparent);
   color: var(--accent-strong);
   background:
@@ -2671,7 +2686,7 @@
   box-shadow:
     inset 0 1px 0 color-mix(in srgb, #fff 10%, transparent),
     0 6px 16px color-mix(in srgb, var(--accent) 7%, transparent);
-  font-size: 11.5px;
+  font-size: 13px;
   font-weight: 760;
 }
 
@@ -2743,13 +2758,13 @@
 }
 
 .onboarding-view__benefit--upcoming {
-  min-height: 18px;
-  padding: 0 6px;
+  min-height: 22px;
+  padding: 0 8px;
   border-color: color-mix(in srgb, var(--text-muted) 8%, transparent);
   color: color-mix(in srgb, var(--text-muted) 68%, var(--text));
   background: color-mix(in srgb, var(--text-muted) 4%, transparent);
   box-shadow: none;
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 600;
 }
 
@@ -2859,6 +2874,14 @@
   gap: 16px;
 }
 
+.onboarding-view__newsletter-inline {
+  display: grid;
+  gap: 14px;
+  margin-top: 8px;
+  padding-top: 18px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+}
+
 .onboarding-view__email-field {
   display: grid;
   gap: 8px;
@@ -2901,6 +2924,10 @@
   display: grid;
   gap: 8px;
   min-width: 0;
+}
+
+.onboarding-view__select-field[data-open='true'] {
+  z-index: 60;
 }
 
 .onboarding-view__select-label {
@@ -2962,15 +2989,16 @@
 
 .onboarding-view__select-menu {
   position: absolute;
-  z-index: 20;
+  z-index: 70;
   top: calc(100% + 6px);
   left: 0;
   right: 0;
   display: grid;
-  gap: 1px;
-  max-height: min(224px, 36vh);
-  overflow-y: auto;
-  overflow-x: hidden;
+  gap: 4px;
+  --onboarding-select-menu-height: min(var(--onboarding-select-menu-max-height, 224px), 36vh);
+  --onboarding-select-search-height: 0px;
+  max-height: var(--onboarding-select-menu-height);
+  overflow: hidden;
   overscroll-behavior: contain;
   padding: 4px;
   border: 1px solid color-mix(in srgb, var(--border) 88%, var(--accent) 12%);
@@ -2982,15 +3010,68 @@
   scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent) transparent;
 }
 
-.onboarding-view__select-menu::-webkit-scrollbar {
+.onboarding-view__select-menu[data-searchable='true'] {
+  --onboarding-select-search-height: 42px;
+}
+
+.onboarding-view__select-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 0 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-elevated) 94%, var(--bg-panel) 6%);
+  color: var(--text-muted);
+}
+
+.onboarding-view__select-search input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--text-strong);
+  font: inherit;
+  font-size: 13px;
+}
+
+.onboarding-view__select-search input::placeholder {
+  color: color-mix(in srgb, var(--text-muted) 78%, transparent);
+}
+
+.onboarding-view__select-options {
+  display: grid;
+  gap: 1px;
+  max-height: calc(var(--onboarding-select-menu-height) - var(--onboarding-select-search-height));
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent) transparent;
+}
+
+.onboarding-view__select-empty {
+  display: flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 7px 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.onboarding-view__select-options::-webkit-scrollbar {
   width: 8px;
 }
 
-.onboarding-view__select-menu::-webkit-scrollbar-track {
+.onboarding-view__select-options::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.onboarding-view__select-menu::-webkit-scrollbar-thumb {
+.onboarding-view__select-options::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--text-muted) 28%, transparent);
   border: 2px solid transparent;
   border-radius: var(--radius-pill);
@@ -3180,734 +3261,6 @@
     display: none;
   }
   .entry-discord-badge__sep {
-    display: none;
-  }
-}
-
-.onboarding-view__primary:focus-visible,
-.onboarding-view__secondary:focus-visible,
-.onboarding-view__ghost:focus-visible,
-.onboarding-view__steps li button:focus-visible,
-.onboarding-view__card:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.onboarding-view__grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 10px;
-}
-
-.onboarding-view__runtime-stack {
-  display: grid;
-  gap: 12px;
-}
-
-.onboarding-view__alternatives {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.onboarding-view__alternatives .onboarding-view__card {
-  grid-template-columns: 34px minmax(0, 1fr);
-  min-height: 96px;
-  padding: 13px 14px;
-  gap: 11px;
-}
-
-.onboarding-view__alternatives .onboarding-view__icon {
-  width: 34px;
-  height: 34px;
-}
-
-.onboarding-view__alternatives .onboarding-view__card-top {
-  display: flex;
-  min-height: 0;
-}
-
-.onboarding-view__alternatives .onboarding-view__card strong {
-  font-size: 14px;
-  line-height: 1.2;
-}
-
-.onboarding-view__alternatives .onboarding-view__card small {
-  font-size: 11.5px;
-  line-height: 1.4;
-}
-
-.onboarding-view__alternatives .onboarding-view__card-action {
-  margin-top: 2px;
-  font-size: 11.5px;
-}
-
-.onboarding-view__setup-panel {
-  display: grid;
-  gap: 14px;
-  min-width: 0;
-  padding: 14px;
-  border: 1px solid color-mix(in srgb, var(--border) 82%, var(--accent) 18%);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
-  box-shadow: var(--shadow-xs);
-  overflow: visible;
-}
-
-.onboarding-view__setup-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 14px;
-  min-width: 0;
-}
-
-.onboarding-view__setup-head > div:first-child {
-  min-width: 0;
-}
-
-.onboarding-view__setup-head strong {
-  display: block;
-  color: var(--text-strong);
-  font-size: 13px;
-  line-height: 1.3;
-}
-
-.onboarding-view__setup-head p {
-  margin: 4px 0 0;
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-.onboarding-view__setup-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: -2px;
-}
-
-.onboarding-view__setup-head-actions {
-  display: inline-flex;
-  flex: 0 0 auto;
-  flex-wrap: wrap;
-  gap: 8px;
-  justify-content: flex-end;
-}
-
-.onboarding-view__mini-button,
-.onboarding-view__field-row button,
-.onboarding-view__protocol-strip button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 32px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0 11px;
-  color: var(--text);
-  background: var(--bg-panel);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 650;
-  cursor: pointer;
-  box-shadow: var(--shadow-xs);
-}
-
-.onboarding-view__mini-button:hover,
-.onboarding-view__field-row button:hover,
-.onboarding-view__protocol-strip button:hover {
-  color: var(--text-strong);
-  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
-}
-
-.onboarding-view__mini-button:disabled {
-  cursor: default;
-  opacity: 0.58;
-}
-
-.onboarding-view__mini-button.is-loading {
-  color: var(--text-muted);
-}
-
-.onboarding-view__agent-strip {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
-
-.onboarding-view__agent-chip {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  min-width: 0;
-  min-height: 48px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 8px 10px;
-  color: var(--text);
-  background: var(--bg-panel);
-  text-align: left;
-  cursor: pointer;
-  animation: onboarding-agent-pop 220ms cubic-bezier(0.23, 1, 0.32, 1) both;
-}
-
-.onboarding-view__agent-chip.is-selected {
-  border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
-  background: color-mix(in srgb, var(--bg-panel) 92%, var(--accent) 8%);
-}
-
-.onboarding-view__agent-chip .agent-icon {
-  flex: 0 0 auto;
-}
-
-.onboarding-view__agent-chip span {
-  display: grid;
-  min-width: 0;
-  gap: 2px;
-}
-
-.onboarding-view__agent-chip strong,
-.onboarding-view__agent-chip small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.onboarding-view__agent-chip strong {
-  color: var(--text-strong);
-  font-size: 12.5px;
-  line-height: 1.2;
-}
-
-.onboarding-view__agent-chip small {
-  color: var(--text-muted);
-  font-size: 11px;
-}
-
-.onboarding-view__empty-slice {
-  border: 1px dashed var(--border);
-  border-radius: var(--radius);
-  padding: 13px;
-  color: var(--text-muted);
-  background: var(--bg-panel);
-  font-size: 12px;
-}
-
-.onboarding-view__scan-copy {
-  display: grid;
-  gap: 6px;
-  justify-items: start;
-}
-
-.onboarding-view__scan-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  width: fit-content;
-  margin: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 8px 10px;
-  color: var(--text-muted);
-  background: var(--bg-panel);
-  font-size: 12px;
-  line-height: 1.3;
-}
-
-.onboarding-view__scan-hint {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-.onboarding-view__protocol-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.onboarding-view__protocol-strip button.is-selected {
-  color: var(--text-strong);
-  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
-  background: color-mix(in srgb, var(--bg-panel) 90%, var(--accent) 10%);
-}
-
-.onboarding-view__inline-field {
-  display: grid;
-  gap: 8px;
-  min-width: 0;
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 650;
-}
-
-.onboarding-view__inline-field input {
-  width: 100%;
-  min-width: 0;
-  min-height: 42px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0 12px;
-  color: var(--text-strong);
-  background: var(--bg-panel);
-  font: inherit;
-  font-size: 13px;
-  font-weight: 500;
-  box-shadow: var(--shadow-xs);
-}
-
-.onboarding-view__inline-field input:focus,
-.onboarding-view__inline-field input:focus-visible,
-.onboarding-view__agent-chip:focus-visible,
-.onboarding-view__mini-button:focus-visible,
-.onboarding-view__field-row button:focus-visible,
-.onboarding-view__protocol-strip button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.onboarding-view__field-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px;
-  min-width: 0;
-}
-
-.onboarding-view__field-row button {
-  min-height: 42px;
-}
-
-.onboarding-view__compact-fields {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 10px;
-}
-
-.onboarding-view__test-status {
-  margin: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 10px 12px;
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-.onboarding-view__test-status.is-running {
-  color: var(--text-muted);
-  background: var(--bg-panel);
-}
-
-.onboarding-view__test-status.is-success {
-  color: var(--success-text, #166534);
-  border-color: color-mix(in srgb, var(--success, #22c55e) 34%, var(--border));
-  background: color-mix(in srgb, var(--success, #22c55e) 9%, var(--bg-panel));
-}
-
-.onboarding-view__test-status.is-warn {
-  color: var(--warning-text, #92400e);
-  border-color: color-mix(in srgb, var(--warning, #f59e0b) 34%, var(--border));
-  background: color-mix(in srgb, var(--warning, #f59e0b) 10%, var(--bg-panel));
-}
-
-.onboarding-view__test-status.is-error {
-  color: var(--danger-text, #991b1b);
-  border-color: color-mix(in srgb, var(--danger, #ef4444) 34%, var(--border));
-  background: color-mix(in srgb, var(--danger, #ef4444) 9%, var(--bg-panel));
-}
-
-@keyframes onboarding-agent-pop {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.onboarding-view__card {
-  display: grid;
-  grid-template-columns: 44px minmax(0, 1fr);
-  gap: 14px;
-  align-items: center;
-  min-height: 112px;
-  padding: 16px 18px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--bg-panel);
-  color: var(--text);
-  text-align: left;
-  cursor: pointer;
-  position: relative;
-  box-shadow: var(--shadow-xs);
-  transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1), border-color 160ms cubic-bezier(0.23, 1, 0.32, 1), transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-.onboarding-view__card--featured {
-  grid-template-columns: 56px minmax(0, 1fr) auto;
-  min-height: 168px;
-  padding: 22px 24px;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--accent) 13%, var(--bg-panel)) 0%,
-      var(--bg-panel) 54%
-    );
-  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
-  box-shadow: 0 18px 40px color-mix(in srgb, var(--accent) 10%, transparent);
-}
-
-.onboarding-view__card.is-selected {
-  border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
-  background: color-mix(in srgb, var(--bg-panel) 94%, var(--accent) 6%);
-}
-
-.onboarding-view__card--featured.is-selected {
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--accent) 16%, var(--bg-panel)) 0%,
-      color-mix(in srgb, var(--bg-panel) 96%, var(--accent) 4%) 54%
-    );
-}
-
-.onboarding-view__card:hover {
-  border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
-  background: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
-  transform: translateY(-1px);
-}
-
-.onboarding-view__card-top {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 26px;
-  margin-bottom: 0;
-}
-
-.onboarding-view__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: var(--radius);
-  color: var(--accent-strong);
-  background: color-mix(in srgb, var(--accent) 9%, var(--bg-panel));
-  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
-}
-
-.onboarding-view__card--featured .onboarding-view__icon {
-  width: 52px;
-  height: 52px;
-  background: color-mix(in srgb, var(--accent) 12%, var(--bg-panel));
-}
-
-.onboarding-view__badge {
-  display: inline-flex;
-  align-items: center;
-  flex: 0 0 auto;
-  min-height: 22px;
-  padding: 0 8px;
-  border-radius: var(--radius-pill);
-  font-size: 11px;
-  font-weight: 650;
-}
-
-.onboarding-view__badge {
-  color: var(--accent-strong);
-  background: color-mix(in srgb, var(--accent) 10%, var(--bg-panel));
-}
-
-.onboarding-view__card-copy {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
-}
-
-.onboarding-view__card strong {
-  display: block;
-  color: var(--text-strong);
-  font-size: 16px;
-  line-height: 1.25;
-}
-
-.onboarding-view__card--featured strong {
-  font-size: 20px;
-}
-
-.onboarding-view__card small {
-  display: block;
-  margin-top: 0;
-  color: var(--text-muted);
-  font-size: 12.5px;
-  line-height: 1.45;
-  white-space: pre-line;
-}
-
-.onboarding-view__card--featured small {
-  max-width: none;
-  font-size: 13px;
-}
-
-.onboarding-view__card-action {
-  grid-column: 2;
-  justify-self: start;
-  color: var(--accent-strong);
-  font-size: 12px;
-  font-weight: 700;
-  white-space: nowrap;
-  opacity: 0.92;
-}
-
-.onboarding-view__card--featured .onboarding-view__card-action {
-  grid-column: auto;
-  justify-self: end;
-}
-
-.onboarding-view__check {
-  position: absolute;
-  top: 14px;
-  right: 14px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: var(--radius-pill);
-  color: var(--accent-contrast, #fff);
-  background: var(--accent);
-  box-shadow: 0 8px 18px color-mix(in srgb, var(--accent) 24%, transparent);
-}
-
-.onboarding-view__form-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 16px;
-}
-
-.onboarding-view__select-field {
-  position: relative;
-  display: grid;
-  gap: 8px;
-  min-width: 0;
-}
-
-.onboarding-view__select-field[data-open='true'] {
-  z-index: 45;
-}
-
-.onboarding-view__select-label {
-  color: var(--text-strong);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.onboarding-view__select-trigger {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  width: 100%;
-  min-height: 42px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0 12px 0 13px;
-  color: var(--text-muted);
-  background: var(--bg-panel);
-  font: inherit;
-  font-size: 13px;
-  text-align: left;
-  cursor: pointer;
-  box-shadow: var(--shadow-xs);
-  transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1), border-color 160ms cubic-bezier(0.23, 1, 0.32, 1), color 160ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 160ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-.onboarding-view__select-trigger > span {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.onboarding-view__select-trigger svg {
-  flex: 0 0 auto;
-  color: var(--text-muted);
-  transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1), color 160ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-.onboarding-view__select-trigger.has-value {
-  color: var(--text-strong);
-}
-
-.onboarding-view__select-trigger:hover,
-.onboarding-view__select-trigger.is-open {
-  color: var(--text-strong);
-  border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
-  background: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
-}
-
-.onboarding-view__select-trigger.is-open {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
-}
-
-.onboarding-view__select-trigger.is-open svg {
-  color: var(--accent-strong);
-  transform: rotate(180deg);
-}
-
-.onboarding-view__select-trigger:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.onboarding-view__select-menu {
-  position: absolute;
-  z-index: 50;
-  top: calc(100% + 6px);
-  left: 0;
-  right: 0;
-  display: grid;
-  gap: 2px;
-  max-height: min(
-    var(--onboarding-select-menu-max-height, 240px),
-    max(48px, min(240px, calc(100vh - 120px)))
-  );
-  overflow-y: auto;
-  overflow-x: hidden;
-  overscroll-behavior: contain;
-  padding: 6px;
-  border: 1px solid color-mix(in srgb, var(--border) 82%, var(--accent) 18%);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--bg-panel) 96%, var(--bg-subtle) 4%);
-  box-shadow: 0 14px 34px color-mix(in srgb, var(--shadow-color, #000) 12%, transparent);
-  scrollbar-gutter: stable;
-}
-
-.onboarding-view__select-field[data-placement='top'] .onboarding-view__select-menu {
-  top: auto;
-  bottom: calc(100% + 6px);
-}
-
-.onboarding-view__select-option {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: 32px;
-  width: 100%;
-  border: 0;
-  border-radius: var(--radius-sm);
-  padding: 0 10px;
-  color: var(--text);
-  background: transparent;
-  font: inherit;
-  font-size: 13px;
-  text-align: left;
-  cursor: pointer;
-}
-
-.onboarding-view__select-option > span {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.onboarding-view__select-option:hover {
-  color: var(--text-strong);
-  background: color-mix(in srgb, var(--accent) 7%, var(--bg-panel));
-}
-
-.onboarding-view__select-option.is-selected {
-  color: var(--accent-strong);
-  background: color-mix(in srgb, var(--accent) 10%, var(--bg-panel));
-  font-weight: 650;
-}
-
-.onboarding-view__select-option svg {
-  flex: 0 0 auto;
-}
-
-.onboarding-view__select-option:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -1px;
-}
-
-/* ============================================================
-   GitHub star pill — sticky top-bar CTA.
-
-   Mirrors the marketing landing-page "Star · <count>" affordance:
-   small chrome, low-emphasis, sits next to the model switcher and
-   settings cog. Hover swaps to the panel-strong palette so the call-
-   to-action still reads as clickable when the topbar is otherwise
-   sparse. The count slot animates in via `data-loading` so the
-   pill never visibly jumps when the API response arrives.
-   ============================================================ */
-.entry-star-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: 32px;
-  padding: 0 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-pill);
-  background: var(--bg-panel);
-  color: var(--text);
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1;
-  text-decoration: none;
-  cursor: pointer;
-  box-shadow: var(--shadow-xs);
-  transition: background-color 120ms var(--ease-out), border-color 120ms var(--ease-out),
-    color 120ms var(--ease-out), transform 120ms var(--ease-out);
-  white-space: nowrap;
-}
-.entry-star-badge:hover {
-  background: var(--bg-subtle);
-  border-color: var(--border-strong);
-  color: var(--text-strong);
-}
-.entry-star-badge:active {
-  transform: scale(0.98);
-}
-.entry-star-badge:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
-}
-.entry-star-badge__icon {
-  color: var(--text-muted);
-  flex: 0 0 auto;
-}
-.entry-star-badge:hover .entry-star-badge__icon {
-  color: var(--text-strong);
-}
-.entry-star-badge__label {
-  color: var(--text-strong);
-  font-weight: 600;
-}
-.entry-star-badge__sep {
-  color: var(--text-faint);
-}
-.entry-star-badge__count {
-  color: var(--text);
-  font-variant-numeric: tabular-nums;
-  transition: opacity 160ms var(--ease-out);
-}
-.entry-star-badge__count[data-loading='true'] {
-  opacity: 0.55;
-}
-
-@media (max-width: 700px) {
-  .entry-star-badge__label {
-    display: none;
-  }
-  .entry-star-badge__sep {
     display: none;
   }
 }

--- a/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
@@ -87,7 +87,9 @@ describe('OnboardingDropdown', () => {
     fireEvent.click(screen.getByRole('button', { name: /Very long Windows model option 1/ }));
 
     const listbox = screen.getByRole('listbox', { name: 'Model' });
-    expect(listbox.parentElement?.getAttribute('data-placement')).toBe('top');
-    expect(listbox.style.getPropertyValue('--onboarding-select-menu-max-height')).toBe('240px');
+    const field = listbox.closest('.onboarding-view__select-field');
+    const menu = listbox.closest('.onboarding-view__select-menu') as HTMLElement | null;
+    expect(field?.getAttribute('data-placement')).toBe('top');
+    expect(menu?.style.getPropertyValue('--onboarding-select-menu-max-height')).toBe('240px');
   });
 });

--- a/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
@@ -92,4 +92,54 @@ describe('OnboardingDropdown', () => {
     expect(field?.getAttribute('data-placement')).toBe('top');
     expect(menu?.style.getPropertyValue('--onboarding-select-menu-max-height')).toBe('240px');
   });
+
+  it('lets Escape close the searchable menu', () => {
+    render(
+      <OnboardingDropdown
+        label="Model"
+        placeholder="Select a model"
+        value="model-1"
+        options={[
+          { value: 'model-1', label: 'Claude Sonnet 4.5' },
+          { value: 'model-2', label: 'GPT-5' },
+        ]}
+        onChange={vi.fn()}
+        searchable
+        searchPlaceholder="Search models"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Claude Sonnet 4.5/ }));
+    const search = screen.getByRole('searchbox', { name: 'Search models' });
+    expect(screen.getByRole('listbox', { name: 'Model' })).toBeTruthy();
+
+    fireEvent.keyDown(search, { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox', { name: 'Model' })).toBeNull();
+  });
+
+  it('uses generic no-match copy for searchable dropdown filters', () => {
+    render(
+      <OnboardingDropdown
+        label="Provider"
+        placeholder="Custom provider"
+        value=""
+        options={[
+          { value: 'anthropic', label: 'Anthropic' },
+          { value: 'openai', label: 'OpenAI' },
+        ]}
+        onChange={vi.fn()}
+        searchable
+        searchPlaceholder="Provider"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Custom provider/ }));
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Provider' }), {
+      target: { value: 'missing provider' },
+    });
+
+    expect(screen.getByText('No matches')).toBeTruthy();
+    expect(screen.queryByText('No compatible text models were returned.')).toBeNull();
+  });
 });

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -620,12 +620,9 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     chooseDropdownOption('Organization size', /Growth company/i);
     chooseDropdownOption('Use case', /Product design/i);
     chooseDropdownOption('Where did you hear about us?', /Search/i);
-    // About you is no longer the last step — advance to the newsletter step.
-    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
     await waitFor(() => {
       expect(document.querySelector('.onboarding-view__email-input')).toBeTruthy();
     });
-    // Finish from the newsletter step.
     fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
 
     expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
@@ -645,22 +642,14 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
           step_index: '2',
           step_name: 'about_you',
         }),
-        expect.objectContaining({
-          page_name: 'onboarding',
-          area: 'newsletter',
-          step_index: '3',
-          step_name: 'newsletter',
-        }),
       ]),
     );
 
-    // The About-you survey snapshot now fires on Finish from the newsletter
-    // step (the new last step), so it carries area: 'newsletter'. The payload
-    // — the user's role/org/use-case/source picks — is what matters and is
-    // still intact.
+    // The About-you survey snapshot fires from the final step and carries
+    // the user's role/org/use-case/source picks.
     expect(findTrackedEvent('ui_click', (payload) => payload.element === 'about_you_submit')).toMatchObject({
       page_name: 'onboarding',
-      area: 'newsletter',
+      area: 'about_you',
       element: 'about_you_submit',
       action: 'continue',
       role: 'engineer',
@@ -709,8 +698,6 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
     });
-    // About you -> newsletter step (where the email field now lives)
-    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
     await waitFor(() => {
       expect(document.querySelector('.onboarding-view__email-input')).toBeTruthy();
     });
@@ -759,8 +746,6 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
     });
-    // Advance to the newsletter step, then finish without typing an email.
-    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
     await waitFor(() => {
       expect(document.querySelector('.onboarding-view__email-input')).toBeTruthy();
     });
@@ -816,8 +801,6 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
     });
-    // About you -> newsletter step
-    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
     await waitFor(() => {
       expect(document.querySelector('.onboarding-view__email-input')).toBeTruthy();
     });

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 import { dismissPrivacyDialog, STORAGE_KEY, waitForLoadingToClear } from '@/playwright/amr';
 import { fulfillAgentsRoute } from '@/playwright/mock-factory';
@@ -43,9 +43,11 @@ test('[P0] @critical onboarding lets AMR Cloud sign in and complete setup after 
   await expect(continueButton).toBeVisible();
   await continueButton.click();
 
-  await expect(page.getByRole('button', { name: /Continue/i })).toBeVisible({ timeout: 10_000 });
-  await page.getByRole('button', { name: /Continue/i }).click();
-
+  await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(1);
+  await expect
+    .poll(() => page.evaluate(() => window.__amrOnboardingStatusCalls ?? 0))
+    .toBeGreaterThanOrEqual(2);
+  await expect(page.getByRole('button', { name: /Finish setup/i })).toBeVisible({ timeout: 10_000 });
   await expectOnboardingFinished(page);
   await pollStoredConfig(page).toMatchObject({
     agentId: 'amr',
@@ -113,7 +115,7 @@ test('[P0] onboarding recovers from a transient AMR status failure and still con
 
   await page.getByRole('button', { name: /sign in to continue/i }).click();
 
-  await expect(page.getByRole('button', { name: /Continue/i })).toBeVisible({ timeout: 12_000 });
+  await expect(page.getByRole('button', { name: /Finish setup/i })).toBeVisible({ timeout: 12_000 });
 });
 
 test('[P0] onboarding lets the user cancel an incomplete AMR sign-in and retry', async ({ page }) => {
@@ -195,31 +197,9 @@ test('[P0] onboarding AMR card lets the user pick a live runtime model before co
 
   const amrCard = page.locator('.onboarding-view__amr-cloud-card');
   await expect(amrCard.getByRole('button', { name: /Open Design AMR/i })).toBeVisible();
-  let selectedModel = 'deepseek-v4-flash';
-  const modelSelect = page.locator('.onboarding-view__model-picker select');
-  if ((await modelSelect.count()) > 0) {
-    const optionValues = await modelSelect.locator('option').evaluateAll((options) =>
-      options.map((option) => (option as HTMLOptionElement).value).filter(Boolean),
-    );
-    expect(optionValues.length).toBeGreaterThan(0);
-    selectedModel = optionValues.includes(selectedModel)
-      ? selectedModel
-      : optionValues[0]!;
-    await modelSelect.selectOption(selectedModel);
-    await expect(modelSelect).toHaveValue(selectedModel);
-  } else {
-    selectedModel = 'glm-5.1';
-    const modelPicker = amrCard.getByRole('combobox', { name: /Model.*AMR CLI/i });
-    await modelPicker.click();
-    const popover = page.getByTestId('onboarding-amr-model-popover');
-    await expect(popover).toBeVisible();
-    const search = page.getByTestId('onboarding-amr-model-search');
-    if ((await search.count()) > 0) {
-      await expect(search).toBeVisible();
-      await search.fill('glm');
-    }
-    await popover.getByRole('option', { name: 'GLM 5.1' }).click();
-  }
+  const selectedModel = 'glm-5.1';
+  await selectOnboardingOption(amrCard, 'Model', 'GLM 5.1');
+  await expect(expectOnboardingTrigger(amrCard, 'Model')).toContainText('GLM 5.1');
   await expect
     .poll(() => page.evaluate((key) => JSON.parse(window.localStorage.getItem(key) || '{}'), STORAGE_KEY))
     .toMatchObject({
@@ -246,7 +226,7 @@ test('[P0] onboarding AMR card lets the user pick a live runtime model before co
 test('[P0] onboarding skip exits to home and marks onboarding completed', async ({ page }) => {
   const config = await wireOnboardingMocks(page, {
     amrAvailable: true,
-    initialLoggedIn: false,
+    initialLoggedIn: true,
   });
 
   await seedOnboardingConfig(page, config);
@@ -285,7 +265,7 @@ test('[P0] onboarding about-you step accepts profile selections and completes se
   await expect(expectOnboardingTrigger(page, 'Use case')).toContainText('Prototype / app UI');
   await expect(expectOnboardingTrigger(page, 'Where did you hear about us?')).toContainText('Search');
 
-  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await page.getByRole('button', { name: /Finish setup/i }).click();
 
   await expectOnboardingFinished(page);
   await pollStoredConfig(page).toMatchObject({
@@ -329,18 +309,20 @@ test('[P0] @critical onboarding BYOK path can fetch models, test the provider, a
 
   await page.getByRole('button', { name: /Bring your own key/i }).click();
   await expect(page.getByText('BYOK')).toBeVisible();
+  const byokPanel = page.locator('.onboarding-view__setup-panel').filter({ hasText: /BYOK/ });
 
   await fillInlineField(page, 'API key', 'test-api-key');
   await fillInlineField(page, 'Base URL', 'https://api.anthropic.com');
   await page.getByRole('button', { name: /Fetch models/i }).click();
   await expect(page.getByRole('status')).toContainText('Fetched 2 models.');
-  await selectOnboardingOption(page, 'Model', 'claude-opus-4-8');
+  await selectOnboardingOption(byokPanel, 'Model', 'claude-opus-4-8');
 
   await page.getByRole('button', { name: /^Test$/i }).click();
   await expect(page.getByText('Connected. Replied in 27 ms')).toBeVisible();
 
   await page.getByRole('button', { name: /^Continue$/i }).click();
-  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await expect(page.getByText(/Optional details for better defaults/i)).toBeVisible();
+  await page.getByRole('button', { name: /Finish setup/i }).click();
 
   await expectOnboardingFinished(page);
   await pollStoredConfig(page).toMatchObject({
@@ -548,18 +530,20 @@ function pollStoredConfig(page: Page) {
   );
 }
 
-function onboardingField(page: Page, label: string) {
-  return page.locator('.onboarding-view__select-field, .onboarding-view__inline-field').filter({
+type OnboardingLocatorRoot = Page | Locator;
+
+function onboardingField(root: OnboardingLocatorRoot, label: string) {
+  return root.locator('.onboarding-view__select-field, .onboarding-view__inline-field').filter({
     hasText: new RegExp(label, 'i'),
   }).first();
 }
 
-function expectOnboardingTrigger(page: Page, label: string) {
-  return onboardingField(page, label).getByRole('button');
+function expectOnboardingTrigger(root: OnboardingLocatorRoot, label: string) {
+  return onboardingField(root, label).getByRole('button');
 }
 
-async function selectOnboardingOption(page: Page, label: string, option: string) {
-  const field = onboardingField(page, label);
+async function selectOnboardingOption(root: OnboardingLocatorRoot, label: string, option: string) {
+  const field = onboardingField(root, label);
   const listbox = field.getByRole('listbox', { name: new RegExp(label, 'i') });
   if (!(await listbox.isVisible().catch(() => false))) {
     await field.getByRole('button').click();

--- a/e2e/ui/visual-home.test.ts
+++ b/e2e/ui/visual-home.test.ts
@@ -71,8 +71,12 @@ test('[P2] captures the onboarding runtime selection surface', async ({ page }) 
   await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
   await expect(page.getByRole('heading', { name: /Welcome|欢迎/i })).toBeVisible();
   await expect(page.getByText(/Open Design AMR/i)).toBeVisible();
-  await expect(page.locator('.onboarding-view__amr-cloud-card .onboarding-view__model-picker select')).toHaveValue(
-    'deepseek-v4-flash',
+  await expect(
+    page
+      .locator('.onboarding-view__amr-cloud-card .onboarding-view__model-picker')
+      .getByRole('button'),
+  ).toContainText(
+    'DeepSeek V4 Flash',
   );
   await waitForVisualFonts(page);
 


### PR DESCRIPTION
## Summary
- Restore the onboarding flow to the intended two-step layout with the newsletter field inline on the profile step.
- Replace AMR's native model select with the shared onboarding dropdown and enable searchable dropdowns for AMR, local CLI, and BYOK model/provider selectors.
- Fix dropdown layering and scrolling so the search input does not cover model options while the list scrolls.
- Update onboarding e2e coverage for the AMR first-run sign-in path and the custom dropdown interactions.

## Why
The onboarding page regressed visually: AMR used a native system select while the other runtime panels used custom dropdowns, and searchable dropdowns could obscure list content while scrolling. The duplicate legacy onboarding CSS also overrode the intended layout.

## Visual regression review
- Checked the onboarding runtime selection surface in Electron against the expected two-step layout.
- Verified AMR, Local CLI, and BYOK model/provider dropdowns render as in-app searchable menus instead of native selects.
- Verified the dropdown search input no longer overlays model rows while the options list scrolls.
- Updated `visual-home` onboarding coverage so the visual regression path asserts the AMR custom dropdown trigger instead of the removed native select.

## Validation
- `pnpm -C apps/web exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding.test.tsx`
- `pnpm -C e2e exec playwright test -c playwright.config.ts ui/amr-onboarding.test.ts ui/visual-home.test.ts --grep "onboarding"`
- `pnpm -C e2e exec playwright test -c playwright.config.ts ui/amr-onboarding.test.ts --grep "AMR Cloud sign in"`
- `git diff --check`
- Manual Electron verification of AMR, local CLI, and BYOK onboarding dropdowns.

Note: `pnpm -C apps/web exec tsc --noEmit --pretty false` still fails on existing AMR analytics contract mismatches unrelated to this change.
