### PR TITLE
fix(daemon): suppress AMR DSML artifact echoes

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -3,7 +3,6 @@ import type { Writable } from 'node:stream';
 import path from 'node:path';
 import {
   createDsmlArtifactTextSuppressor,
-  emitWithTextSuppressor,
   type ArtifactTextSuppressor,
 } from './artifact-text-suppression.js';
 
@@ -340,13 +339,29 @@ function isAcpCompletedStatus(update: JsonObject): boolean {
   return status === 'completed' || status === 'complete' || status === 'succeeded' || status === 'success';
 }
 
-function isAcpArtifactWriteUpdate(update: JsonObject): boolean {
-  if (!isAcpCompletedStatus(update)) return false;
+function isAcpTerminalFailureStatus(update: JsonObject): boolean {
+  const status = acpUpdateStatus(update);
+  return status === 'failed' || status === 'failure' || status === 'error' || status === 'cancelled' || status === 'canceled';
+}
+
+function acpToolCallId(update: JsonObject): string | null {
+  return typeof update.toolCallId === 'string' && update.toolCallId.trim()
+    ? update.toolCallId.trim()
+    : null;
+}
+
+function isAcpArtifactWriteLabel(update: JsonObject): boolean {
   const label = [
     typeof update.title === 'string' ? update.title : '',
     typeof update.name === 'string' ? update.name : '',
   ].join(' ');
   return /\b(?:edit|write|create|update|save|patch|replace)\b/i.test(label);
+}
+
+function isAcpArtifactWriteUpdate(update: JsonObject, writeToolCallIds: Set<string>): boolean {
+  if (!isAcpCompletedStatus(update)) return false;
+  const toolCallId = acpToolCallId(update);
+  return isAcpArtifactWriteLabel(update) || (toolCallId ? writeToolCallIds.has(toolCallId) : false);
 }
 
 export function createJsonLineStream(onMessage: (message: unknown, rawLine: string) => void) {
@@ -763,6 +778,7 @@ export function attachAcpSession({
   let aborted = false;
   let stageTimer: TimerHandle | null = null;
   let dsmlArtifactSuppressor: ArtifactTextSuppressor | null = null;
+  const acpArtifactWriteToolCallIds = new Set<string>();
 
   const stageWatchdogDisabled = stageTimeoutMs <= 0;
   const resetStageTimer = (label: string) => {
@@ -1005,14 +1021,18 @@ export function attachAcpSession({
               });
             }
             if (dsmlArtifactSuppressor) {
-              const emitted = emitWithTextSuppressor(
-                dsmlArtifactSuppressor,
-                (event) => send('agent', event),
-                delta,
-              );
-              if (emitted) emittedVisibleTextChunk = true;
-              if (emittedVisibleTextChunk && dsmlArtifactSuppressor.isSuppressing()) {
-                finishCleanPrompt();
+              const wasSuppressingArtifact = dsmlArtifactSuppressor.isSuppressing();
+              const strippedDelta = dsmlArtifactSuppressor.strip(delta);
+              if (strippedDelta) {
+                emittedVisibleTextChunk = true;
+                send('agent', { type: 'text_delta', delta: strippedDelta });
+              }
+              if (
+                !dsmlArtifactSuppressor.isSuppressing() &&
+                !dsmlArtifactSuppressor.hasPendingCandidate() &&
+                (wasSuppressingArtifact || strippedDelta !== delta)
+              ) {
+                dsmlArtifactSuppressor = null;
               }
             } else {
               emittedVisibleTextChunk = true;
@@ -1030,8 +1050,16 @@ export function attachAcpSession({
         // when the model emits no closing assistant text. Track it so the prompt-complete
         // handler does not misreport such a turn as "no output / model unavailable".
         emittedToolCall = true;
-        if (isAcpArtifactWriteUpdate(update)) {
+        const toolCallId = acpToolCallId(update);
+        if (toolCallId && isAcpArtifactWriteLabel(update)) {
+          acpArtifactWriteToolCallIds.add(toolCallId);
+        }
+        if (isAcpArtifactWriteUpdate(update, acpArtifactWriteToolCallIds)) {
           dsmlArtifactSuppressor = createDsmlArtifactTextSuppressor();
+          if (toolCallId) acpArtifactWriteToolCallIds.delete(toolCallId);
+        } else if (toolCallId && isAcpTerminalFailureStatus(update)) {
+          acpArtifactWriteToolCallIds.delete(toolCallId);
+          dsmlArtifactSuppressor = null;
         }
         return;
       }

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -364,8 +364,6 @@ function isAcpArtifactWriteUpdate(update: JsonObject, writeToolCallIds: Set<stri
   return isAcpArtifactWriteLabel(update) || (toolCallId ? writeToolCallIds.has(toolCallId) : false);
 }
 
-const ACP_ARTIFACT_ECHO_PREFIX_RE = /^\s*(?:<\s*\|?\s*DSML[\s,]+artifact\b|<\s*artifact\b)/i;
-
 export function createJsonLineStream(onMessage: (message: unknown, rawLine: string) => void) {
   let buffer = '';
   let pendingJson = '';
@@ -780,6 +778,7 @@ export function attachAcpSession({
   let aborted = false;
   let stageTimer: TimerHandle | null = null;
   let dsmlArtifactSuppressor: ArtifactTextSuppressor | null = null;
+  let dsmlArtifactSuppressorArmedAfterText = false;
   const acpArtifactWriteToolCallIds = new Set<string>();
 
   const stageWatchdogDisabled = stageTimeoutMs <= 0;
@@ -1024,18 +1023,21 @@ export function attachAcpSession({
               });
             }
             if (dsmlArtifactSuppressor) {
+              const wasSuppressingArtifact = dsmlArtifactSuppressor.isSuppressing();
+              const hadPendingArtifactCandidate = dsmlArtifactSuppressor.hasPendingCandidate();
+              const strippedDelta = dsmlArtifactSuppressor.strip(delta);
+              const hasOpenArtifactCandidate =
+                dsmlArtifactSuppressor.isSuppressing() || dsmlArtifactSuppressor.hasPendingCandidate();
               const shouldPreserveIncrementalProse =
                 !isCumulativeSnapshot &&
-                !dsmlArtifactSuppressor.isSuppressing() &&
-                !dsmlArtifactSuppressor.hasPendingCandidate() &&
-                !ACP_ARTIFACT_ECHO_PREFIX_RE.test(delta);
-              const wasSuppressingArtifact = dsmlArtifactSuppressor.isSuppressing();
-              const strippedDelta = shouldPreserveIncrementalProse
-                ? delta
-                : dsmlArtifactSuppressor.strip(delta);
-              if (strippedDelta) {
+                !wasSuppressingArtifact &&
+                !hadPendingArtifactCandidate &&
+                !hasOpenArtifactCandidate &&
+                (strippedDelta === delta || !dsmlArtifactSuppressorArmedAfterText);
+              const outputDelta = shouldPreserveIncrementalProse ? delta : strippedDelta;
+              if (outputDelta) {
                 emittedVisibleTextChunk = true;
-                send('agent', { type: 'text_delta', delta: strippedDelta });
+                send('agent', { type: 'text_delta', delta: outputDelta });
               }
               const consumedArtifactText =
                 !shouldPreserveIncrementalProse && (wasSuppressingArtifact || strippedDelta !== delta);
@@ -1043,11 +1045,11 @@ export function attachAcpSession({
                 shouldPreserveIncrementalProse ||
                 (
                   consumedArtifactText &&
-                  !dsmlArtifactSuppressor.isSuppressing() &&
-                  !dsmlArtifactSuppressor.hasPendingCandidate()
+                  !hasOpenArtifactCandidate
                 )
               ) {
                 dsmlArtifactSuppressor = null;
+                dsmlArtifactSuppressorArmedAfterText = false;
               }
             } else {
               emittedVisibleTextChunk = true;
@@ -1071,10 +1073,12 @@ export function attachAcpSession({
         }
         if (isAcpArtifactWriteUpdate(update, acpArtifactWriteToolCallIds)) {
           dsmlArtifactSuppressor = createDsmlArtifactTextSuppressor();
+          dsmlArtifactSuppressorArmedAfterText = emittedTextBuffer.length > 0;
           if (toolCallId) acpArtifactWriteToolCallIds.delete(toolCallId);
         } else if (toolCallId && isAcpTerminalFailureStatus(update)) {
           acpArtifactWriteToolCallIds.delete(toolCallId);
           dsmlArtifactSuppressor = null;
+          dsmlArtifactSuppressorArmedAfterText = false;
         }
         return;
       }

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -779,6 +779,7 @@ export function attachAcpSession({
   let aborted = false;
   let stageTimer: TimerHandle | null = null;
   let dsmlArtifactSuppressor: ArtifactTextSuppressor | null = null;
+  let dsmlArtifactSuppressorToolCallId: string | null = null;
   let dsmlArtifactSuppressorArmedAfterText = false;
   let dsmlArtifactSuppressorSawIncrementalProse = false;
   const acpArtifactWriteToolCallIds = new Set<string>();
@@ -1059,6 +1060,7 @@ export function attachAcpSession({
               }
               if (consumedArtifactText && !hasOpenArtifactCandidate) {
                 dsmlArtifactSuppressor = null;
+                dsmlArtifactSuppressorToolCallId = null;
                 dsmlArtifactSuppressorArmedAfterText = false;
                 dsmlArtifactSuppressorSawIncrementalProse = false;
               }
@@ -1084,14 +1086,20 @@ export function attachAcpSession({
         }
         if (isAcpArtifactWriteUpdate(update, acpArtifactWriteToolCallIds)) {
           dsmlArtifactSuppressor = createDsmlArtifactTextSuppressor();
+          dsmlArtifactSuppressorToolCallId = toolCallId;
           dsmlArtifactSuppressorArmedAfterText = emittedTextBuffer.length > 0;
           dsmlArtifactSuppressorSawIncrementalProse = false;
           if (toolCallId) acpArtifactWriteToolCallIds.delete(toolCallId);
         } else if (toolCallId && isAcpTerminalFailureStatus(update)) {
+          const ownsPendingWriteSuppression = toolCallId === dsmlArtifactSuppressorToolCallId;
+          const ownsPendingWriteCall = acpArtifactWriteToolCallIds.has(toolCallId);
           acpArtifactWriteToolCallIds.delete(toolCallId);
-          dsmlArtifactSuppressor = null;
-          dsmlArtifactSuppressorArmedAfterText = false;
-          dsmlArtifactSuppressorSawIncrementalProse = false;
+          if (ownsPendingWriteSuppression || ownsPendingWriteCall) {
+            dsmlArtifactSuppressor = null;
+            dsmlArtifactSuppressorToolCallId = null;
+            dsmlArtifactSuppressorArmedAfterText = false;
+            dsmlArtifactSuppressorSawIncrementalProse = false;
+          }
         }
         return;
       }

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -1,6 +1,10 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import type { Writable } from 'node:stream';
 import path from 'node:path';
+import {
+  createDsmlArtifactTextSuppressor,
+  emitWithTextSuppressor,
+} from './artifact-text-suppression.js';
 
 const ACP_PROTOCOL_VERSION = 1;
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -730,12 +734,14 @@ export function attachAcpSession({
   let emittedThinkingStart = false;
   let emittedFirstTokenStatus = false;
   let emittedTextChunk = false;
+  let emittedVisibleTextChunk = false;
   let emittedToolCall = false;
   let emittedTextBuffer = '';
   let finished = false;
   let fatal = false;
   let aborted = false;
   let stageTimer: TimerHandle | null = null;
+  const dsmlArtifactSuppressor = createDsmlArtifactTextSuppressor();
 
   const stageWatchdogDisabled = stageTimeoutMs <= 0;
   const resetStageTimer = (label: string) => {
@@ -844,6 +850,33 @@ export function attachAcpSession({
     nextId += 1;
   };
 
+  const finishCleanPrompt = (usageSource?: unknown) => {
+    if (finished) return;
+    const flushedText = dsmlArtifactSuppressor.flush();
+    if (flushedText) {
+      emittedVisibleTextChunk = true;
+      send('agent', { type: 'text_delta', delta: flushedText });
+    }
+    const usage = formatUsage(usageSource);
+    if (usage) {
+      send('agent', {
+        type: 'usage',
+        usage,
+        durationMs: Date.now() - runStartedAt,
+      });
+    }
+    finished = true;
+    clearStageTimer();
+    stdin.end();
+    // Some ACP agents keep the child process alive after stdin closes,
+    // waiting for another prompt. Each Open Design run owns one process per
+    // turn, so close it once this prompt is cleanly complete.
+    const cleanExitTimer = setTimeout(() => {
+      if (!child.killed) child.kill('SIGTERM');
+    }, 500);
+    child.once('close', () => clearTimeout(cleanExitTimer));
+  };
+
   const replyPermission = (raw: JsonObject) => {
     const params = asObject(raw.params);
     const optionId = choosePermissionOutcome(params?.options);
@@ -869,7 +902,7 @@ export function attachAcpSession({
   };
 
   const parser = createJsonLineStream((raw, rawLine) => {
-    if (aborted) return;
+    if (aborted || finished) return;
     resetStageTimer('response');
     const obj = asObject(raw);
     if (!obj) return;
@@ -950,7 +983,15 @@ export function attachAcpSession({
                 ttftMs: Date.now() - runStartedAt,
               });
             }
-            send('agent', { type: 'text_delta', delta });
+            const emitted = emitWithTextSuppressor(
+              dsmlArtifactSuppressor,
+              (event) => send('agent', event),
+              delta,
+            );
+            if (emitted) emittedVisibleTextChunk = true;
+            if (emittedVisibleTextChunk && dsmlArtifactSuppressor.isSuppressing()) {
+              finishCleanPrompt();
+            }
           }
         }
         return;
@@ -1023,30 +1064,7 @@ export function attachAcpSession({
         );
         return;
       }
-      const usage = formatUsage(result.usage);
-      if (usage) {
-        send('agent', {
-          type: 'usage',
-          usage,
-          durationMs: Date.now() - runStartedAt,
-        });
-      }
-      finished = true;
-      clearStageTimer();
-      stdin.end();
-      // Some ACP agents (e.g. Devin for Terminal) keep the child process
-      // alive after stdin closes, waiting for the next prompt. Each Open
-      // Design run spawns its own agent process per turn, so the child must
-      // terminate for `child.on('close')` to fire and the chat run to
-      // finalize — otherwise the chat stays stuck in the "working" state.
-      // Give the child a short grace period to exit on its own first; if it
-      // doesn't, SIGTERM forces it. This mirrors the pattern in
-      // detectAcpModels() which already kills the child after a clean
-      // model-discovery probe completes (see line ~270 in this file).
-      const cleanExitTimer = setTimeout(() => {
-        if (!child.killed) child.kill('SIGTERM');
-      }, 500);
-      child.once('close', () => clearTimeout(cleanExitTimer));
+      finishCleanPrompt(result.usage);
       return;
     }
     if (sessionId && model && model !== 'default' && obj.id === expectedId) {

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -21,6 +21,7 @@ const MAX_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // `OD_ACP_STAGE_TIMEOUT_MS=0` would call `setTimeout(..., 0)` and fail every
 // ACP session on the next tick instead of disabling the watchdog.
 const DEFAULT_STAGE_TIMEOUT_MS = 600_000;
+const ACP_ARTIFACT_ECHO_START_RE = /^\s*<\s*(?:\|?\s*DSML[\s,]+artifact\b|artifact\b)/i;
 
 type JsonRpcId = string | number;
 type JsonObject = Record<string, unknown>;
@@ -779,6 +780,7 @@ export function attachAcpSession({
   let stageTimer: TimerHandle | null = null;
   let dsmlArtifactSuppressor: ArtifactTextSuppressor | null = null;
   let dsmlArtifactSuppressorArmedAfterText = false;
+  let dsmlArtifactSuppressorSawIncrementalProse = false;
   const acpArtifactWriteToolCallIds = new Set<string>();
 
   const stageWatchdogDisabled = stageTimeoutMs <= 0;
@@ -1028,28 +1030,37 @@ export function attachAcpSession({
               const strippedDelta = dsmlArtifactSuppressor.strip(delta);
               const hasOpenArtifactCandidate =
                 dsmlArtifactSuppressor.isSuppressing() || dsmlArtifactSuppressor.hasPendingCandidate();
+              const consumedArtifactText = wasSuppressingArtifact || strippedDelta !== delta;
               const shouldPreserveIncrementalProse =
                 !isCumulativeSnapshot &&
                 !wasSuppressingArtifact &&
                 !hadPendingArtifactCandidate &&
                 !hasOpenArtifactCandidate &&
-                (strippedDelta === delta || !dsmlArtifactSuppressorArmedAfterText);
+                (
+                  strippedDelta === delta ||
+                  (
+                    !dsmlArtifactSuppressorArmedAfterText &&
+                    dsmlArtifactSuppressorSawIncrementalProse &&
+                    !ACP_ARTIFACT_ECHO_START_RE.test(delta)
+                  )
+                );
               const outputDelta = shouldPreserveIncrementalProse ? delta : strippedDelta;
               if (outputDelta) {
                 emittedVisibleTextChunk = true;
                 send('agent', { type: 'text_delta', delta: outputDelta });
               }
-              const consumedArtifactText =
-                !shouldPreserveIncrementalProse && (wasSuppressingArtifact || strippedDelta !== delta);
               if (
-                shouldPreserveIncrementalProse ||
-                (
-                  consumedArtifactText &&
-                  !hasOpenArtifactCandidate
-                )
+                strippedDelta === delta &&
+                !wasSuppressingArtifact &&
+                !hadPendingArtifactCandidate &&
+                !hasOpenArtifactCandidate
               ) {
+                dsmlArtifactSuppressorSawIncrementalProse = true;
+              }
+              if (consumedArtifactText && !hasOpenArtifactCandidate) {
                 dsmlArtifactSuppressor = null;
                 dsmlArtifactSuppressorArmedAfterText = false;
+                dsmlArtifactSuppressorSawIncrementalProse = false;
               }
             } else {
               emittedVisibleTextChunk = true;
@@ -1074,11 +1085,13 @@ export function attachAcpSession({
         if (isAcpArtifactWriteUpdate(update, acpArtifactWriteToolCallIds)) {
           dsmlArtifactSuppressor = createDsmlArtifactTextSuppressor();
           dsmlArtifactSuppressorArmedAfterText = emittedTextBuffer.length > 0;
+          dsmlArtifactSuppressorSawIncrementalProse = false;
           if (toolCallId) acpArtifactWriteToolCallIds.delete(toolCallId);
         } else if (toolCallId && isAcpTerminalFailureStatus(update)) {
           acpArtifactWriteToolCallIds.delete(toolCallId);
           dsmlArtifactSuppressor = null;
           dsmlArtifactSuppressorArmedAfterText = false;
+          dsmlArtifactSuppressorSawIncrementalProse = false;
         }
         return;
       }

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -1021,17 +1021,12 @@ export function attachAcpSession({
               });
             }
             if (dsmlArtifactSuppressor) {
-              const wasSuppressingArtifact = dsmlArtifactSuppressor.isSuppressing();
               const strippedDelta = dsmlArtifactSuppressor.strip(delta);
               if (strippedDelta) {
                 emittedVisibleTextChunk = true;
                 send('agent', { type: 'text_delta', delta: strippedDelta });
               }
-              if (
-                !dsmlArtifactSuppressor.isSuppressing() &&
-                !dsmlArtifactSuppressor.hasPendingCandidate() &&
-                (wasSuppressingArtifact || strippedDelta !== delta)
-              ) {
+              if (!dsmlArtifactSuppressor.isSuppressing() && !dsmlArtifactSuppressor.hasPendingCandidate()) {
                 dsmlArtifactSuppressor = null;
               }
             } else {

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {
   createDsmlArtifactTextSuppressor,
   emitWithTextSuppressor,
+  type ArtifactTextSuppressor,
 } from './artifact-text-suppression.js';
 
 const ACP_PROTOCOL_VERSION = 1;
@@ -326,6 +327,26 @@ function currentModelFromSessionResult(result: JsonObject): string | null {
   return typeof models?.currentModelId === 'string' && models.currentModelId.trim()
     ? models.currentModelId.trim()
     : null;
+}
+
+function acpUpdateStatus(update: JsonObject): string {
+  return typeof update.status === 'string'
+    ? update.status.trim().toLowerCase().replace(/[\s_-]+/g, '')
+    : '';
+}
+
+function isAcpCompletedStatus(update: JsonObject): boolean {
+  const status = acpUpdateStatus(update);
+  return status === 'completed' || status === 'complete' || status === 'succeeded' || status === 'success';
+}
+
+function isAcpArtifactWriteUpdate(update: JsonObject): boolean {
+  if (!isAcpCompletedStatus(update)) return false;
+  const label = [
+    typeof update.title === 'string' ? update.title : '',
+    typeof update.name === 'string' ? update.name : '',
+  ].join(' ');
+  return /\b(?:edit|write|create|update|save|patch|replace)\b/i.test(label);
 }
 
 export function createJsonLineStream(onMessage: (message: unknown, rawLine: string) => void) {
@@ -741,7 +762,7 @@ export function attachAcpSession({
   let fatal = false;
   let aborted = false;
   let stageTimer: TimerHandle | null = null;
-  const dsmlArtifactSuppressor = createDsmlArtifactTextSuppressor();
+  let dsmlArtifactSuppressor: ArtifactTextSuppressor | null = null;
 
   const stageWatchdogDisabled = stageTimeoutMs <= 0;
   const resetStageTimer = (label: string) => {
@@ -852,7 +873,7 @@ export function attachAcpSession({
 
   const finishCleanPrompt = (usageSource?: unknown) => {
     if (finished) return;
-    const flushedText = dsmlArtifactSuppressor.flush();
+    const flushedText = dsmlArtifactSuppressor?.flush() ?? '';
     if (flushedText) {
       emittedVisibleTextChunk = true;
       send('agent', { type: 'text_delta', delta: flushedText });
@@ -983,14 +1004,19 @@ export function attachAcpSession({
                 ttftMs: Date.now() - runStartedAt,
               });
             }
-            const emitted = emitWithTextSuppressor(
-              dsmlArtifactSuppressor,
-              (event) => send('agent', event),
-              delta,
-            );
-            if (emitted) emittedVisibleTextChunk = true;
-            if (emittedVisibleTextChunk && dsmlArtifactSuppressor.isSuppressing()) {
-              finishCleanPrompt();
+            if (dsmlArtifactSuppressor) {
+              const emitted = emitWithTextSuppressor(
+                dsmlArtifactSuppressor,
+                (event) => send('agent', event),
+                delta,
+              );
+              if (emitted) emittedVisibleTextChunk = true;
+              if (emittedVisibleTextChunk && dsmlArtifactSuppressor.isSuppressing()) {
+                finishCleanPrompt();
+              }
+            } else {
+              emittedVisibleTextChunk = true;
+              send('agent', { type: 'text_delta', delta });
             }
           }
         }
@@ -1004,6 +1030,9 @@ export function attachAcpSession({
         // when the model emits no closing assistant text. Track it so the prompt-complete
         // handler does not misreport such a turn as "no output / model unavailable".
         emittedToolCall = true;
+        if (isAcpArtifactWriteUpdate(update)) {
+          dsmlArtifactSuppressor = createDsmlArtifactTextSuppressor();
+        }
         return;
       }
       return;

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -364,6 +364,8 @@ function isAcpArtifactWriteUpdate(update: JsonObject, writeToolCallIds: Set<stri
   return isAcpArtifactWriteLabel(update) || (toolCallId ? writeToolCallIds.has(toolCallId) : false);
 }
 
+const ACP_ARTIFACT_ECHO_PREFIX_RE = /^\s*(?:<\s*\|?\s*DSML[\s,]+artifact\b|<\s*artifact\b)/i;
+
 export function createJsonLineStream(onMessage: (message: unknown, rawLine: string) => void) {
   let buffer = '';
   let pendingJson = '';
@@ -1006,7 +1008,8 @@ export function attachAcpSession({
       if (update.sessionUpdate === 'agent_message_chunk') {
         const text = asObject(update.content)?.text;
         if (typeof text === 'string' && text.length > 0) {
-          const delta = text.startsWith(emittedTextBuffer)
+          const isCumulativeSnapshot = text.startsWith(emittedTextBuffer);
+          const delta = isCumulativeSnapshot
             ? text.slice(emittedTextBuffer.length)
             : text;
           if (delta.length > 0) {
@@ -1021,12 +1024,29 @@ export function attachAcpSession({
               });
             }
             if (dsmlArtifactSuppressor) {
-              const strippedDelta = dsmlArtifactSuppressor.strip(delta);
+              const shouldPreserveIncrementalProse =
+                !isCumulativeSnapshot &&
+                !dsmlArtifactSuppressor.isSuppressing() &&
+                !dsmlArtifactSuppressor.hasPendingCandidate() &&
+                !ACP_ARTIFACT_ECHO_PREFIX_RE.test(delta);
+              const wasSuppressingArtifact = dsmlArtifactSuppressor.isSuppressing();
+              const strippedDelta = shouldPreserveIncrementalProse
+                ? delta
+                : dsmlArtifactSuppressor.strip(delta);
               if (strippedDelta) {
                 emittedVisibleTextChunk = true;
                 send('agent', { type: 'text_delta', delta: strippedDelta });
               }
-              if (!dsmlArtifactSuppressor.isSuppressing() && !dsmlArtifactSuppressor.hasPendingCandidate()) {
+              const consumedArtifactText =
+                !shouldPreserveIncrementalProse && (wasSuppressingArtifact || strippedDelta !== delta);
+              if (
+                shouldPreserveIncrementalProse ||
+                (
+                  consumedArtifactText &&
+                  !dsmlArtifactSuppressor.isSuppressing() &&
+                  !dsmlArtifactSuppressor.hasPendingCandidate()
+                )
+              ) {
                 dsmlArtifactSuppressor = null;
               }
             } else {

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -21,7 +21,13 @@ const MAX_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // `OD_ACP_STAGE_TIMEOUT_MS=0` would call `setTimeout(..., 0)` and fail every
 // ACP session on the next tick instead of disabling the watchdog.
 const DEFAULT_STAGE_TIMEOUT_MS = 600_000;
-const ACP_ARTIFACT_ECHO_START_RE = /^\s*<\s*(?:\|?\s*DSML[\s,]+artifact\b|artifact\b)/i;
+const ACP_ARTIFACT_OPEN_PATTERN = String.raw`<\s*(?:\|?\s*DSML[\s,]+artifact\b|artifact\b)`;
+const ACP_GENERATED_FILE_PREFIX_PATTERN =
+  String.raw`(?:here\s+is|here'?s)\s+the\s+generated\s+file\s*:?\s*(?:\r?\n|\s)*`;
+const ACP_ARTIFACT_ECHO_START_RE = new RegExp(
+  String.raw`^\s*(?:${ACP_ARTIFACT_OPEN_PATTERN}|${ACP_GENERATED_FILE_PREFIX_PATTERN}${ACP_ARTIFACT_OPEN_PATTERN})`,
+  'i',
+);
 
 type JsonRpcId = string | number;
 type JsonObject = Record<string, unknown>;

--- a/apps/daemon/src/artifact-text-suppression.ts
+++ b/apps/daemon/src/artifact-text-suppression.ts
@@ -4,12 +4,14 @@ const ARTIFACT_OPEN_RE = /(?:<\s*\|?\s*DSML[\s,]+artifact\b[^>]*>|<\s*artifact\b
 const DSML_ARTIFACT_CLOSE_RE = /(?:<\/artifact>|<\/\s*\|?\s*DSML\s*>|<\s*\|?\s*\/\s*DSML\s*\|?\s*>)/i;
 const DSML_OPEN_CANONICAL = 'dsmlartifact';
 const ARTIFACT_OPEN_CANONICAL = 'artifact';
+const ARTIFACT_CLOSE_CANONICALS = ['artifact', 'dsml'];
 const MAX_CANDIDATE_LENGTH = 512;
 
 export interface ArtifactTextSuppressor {
   strip(text: string): string;
   flush(): string;
   isSuppressing(): boolean;
+  hasPendingCandidate(): boolean;
 }
 
 export function createDsmlArtifactTextSuppressor(): ArtifactTextSuppressor {
@@ -22,7 +24,11 @@ export function createDsmlArtifactTextSuppressor(): ArtifactTextSuppressor {
 
     if (suppressing) {
       const close = DSML_ARTIFACT_CLOSE_RE.exec(current);
-      if (!close || close.index === undefined) return '';
+      if (!close || close.index === undefined) {
+        const closeCandidateStart = possibleArtifactCloseStart(current);
+        if (closeCandidateStart !== -1) candidate = current.slice(closeCandidateStart);
+        return '';
+      }
       suppressing = false;
       const end = close.index + close[0].length;
       return strip(current.slice(end));
@@ -53,7 +59,11 @@ export function createDsmlArtifactTextSuppressor(): ArtifactTextSuppressor {
     return suppressing;
   }
 
-  return { strip, flush, isSuppressing };
+  function hasPendingCandidate(): boolean {
+    return candidate.length > 0;
+  }
+
+  return { strip, flush, isSuppressing, hasPendingCandidate };
 }
 
 export function emitWithTextSuppressor(
@@ -87,4 +97,25 @@ function isPossibleDsmlArtifactOpen(text: string): boolean {
     compact.startsWith(DSML_OPEN_CANONICAL) ||
     ARTIFACT_OPEN_CANONICAL.startsWith(compact) ||
     compact.startsWith(ARTIFACT_OPEN_CANONICAL);
+}
+
+function possibleArtifactCloseStart(text: string): number {
+  const min = Math.max(0, text.length - MAX_CANDIDATE_LENGTH);
+  let index = text.lastIndexOf('<');
+  while (index >= min) {
+    const tail = text.slice(index);
+    if (isPossibleArtifactClose(tail)) return index;
+    if (index === 0) break;
+    index = text.lastIndexOf('<', index - 1);
+  }
+  return -1;
+}
+
+function isPossibleArtifactClose(text: string): boolean {
+  if (!text.startsWith('<') || text.includes('>')) return false;
+  const compact = text.toLowerCase().replace(/[<|/\s]/g, '');
+  return compact.length === 0 ||
+    ARTIFACT_CLOSE_CANONICALS.some((canonical) =>
+      canonical.startsWith(compact) || compact.startsWith(canonical),
+    );
 }

--- a/apps/daemon/src/artifact-text-suppression.ts
+++ b/apps/daemon/src/artifact-text-suppression.ts
@@ -1,0 +1,90 @@
+type EventSink = (event: { type: 'text_delta'; delta: string }) => void;
+
+const ARTIFACT_OPEN_RE = /(?:<\s*\|?\s*DSML[\s,]+artifact\b[^>]*>|<\s*artifact\b[^>]*>)/i;
+const DSML_ARTIFACT_CLOSE_RE = /(?:<\/artifact>|<\/\s*\|?\s*DSML\s*>|<\s*\|?\s*\/\s*DSML\s*\|?\s*>)/i;
+const DSML_OPEN_CANONICAL = 'dsmlartifact';
+const ARTIFACT_OPEN_CANONICAL = 'artifact';
+const MAX_CANDIDATE_LENGTH = 512;
+
+export interface ArtifactTextSuppressor {
+  strip(text: string): string;
+  flush(): string;
+  isSuppressing(): boolean;
+}
+
+export function createDsmlArtifactTextSuppressor(): ArtifactTextSuppressor {
+  let suppressing = false;
+  let candidate = '';
+
+  function strip(text: string): string {
+    const current = `${candidate}${text}`;
+    candidate = '';
+
+    if (suppressing) {
+      const close = DSML_ARTIFACT_CLOSE_RE.exec(current);
+      if (!close || close.index === undefined) return '';
+      suppressing = false;
+      const end = close.index + close[0].length;
+      return strip(current.slice(end));
+    }
+
+    const open = ARTIFACT_OPEN_RE.exec(current);
+    if (open && open.index !== undefined) {
+      suppressing = true;
+      const prefix = current.slice(0, open.index);
+      const tail = current.slice(open.index + open[0].length);
+      return `${prefix}${strip(tail)}`;
+    }
+
+    const candidateStart = possibleDsmlArtifactOpenStart(current);
+    if (candidateStart === -1) return current;
+
+    candidate = current.slice(candidateStart);
+    return current.slice(0, candidateStart);
+  }
+
+  function flush(): string {
+    const text = candidate;
+    candidate = '';
+    return suppressing ? '' : text;
+  }
+
+  function isSuppressing(): boolean {
+    return suppressing;
+  }
+
+  return { strip, flush, isSuppressing };
+}
+
+export function emitWithTextSuppressor(
+  suppressor: ArtifactTextSuppressor,
+  onEvent: EventSink,
+  text: string,
+): boolean {
+  const delta = suppressor.strip(text);
+  if (!delta) return false;
+  onEvent({ type: 'text_delta', delta });
+  return true;
+}
+
+function possibleDsmlArtifactOpenStart(text: string): number {
+  const min = Math.max(0, text.length - MAX_CANDIDATE_LENGTH);
+  let index = text.lastIndexOf('<');
+  while (index >= min) {
+    const tail = text.slice(index);
+    if (isPossibleDsmlArtifactOpen(tail)) return index;
+    if (index === 0) break;
+    index = text.lastIndexOf('<', index - 1);
+  }
+  return -1;
+}
+
+function isPossibleDsmlArtifactOpen(text: string): boolean {
+  if (!text.startsWith('<') || text.includes('>')) return false;
+  const compact = text.toLowerCase().replace(/[<|,\s]/g, '');
+  return compact.length === 0 ||
+    DSML_OPEN_CANONICAL.startsWith(compact) ||
+    compact.startsWith(DSML_OPEN_CANONICAL) ||
+    ARTIFACT_OPEN_CANONICAL.startsWith(compact) ||
+    compact.startsWith(ARTIFACT_OPEN_CANONICAL);
+}

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2033,26 +2033,28 @@ async function testAgentConnectionInternal(
 
       const latencyMs = Date.now() - start;
       const buffered = sink.getText().trim();
-      // ACP agents that don't shut down on stdin.end() (e.g. Devin for
-      // Terminal) are now SIGTERM'd from attachAcpSession after a clean
-      // prompt completion, which sets `winner.signal === 'SIGTERM'`. For
-      // that exact forced-shutdown shape we trust the ACP-level success
-      // signal so connection tests don't report `agent_spawn_failed`
-      // despite a healthy assistant response (see #1265 / #1286).
+      // ACP agents that don't shut down on stdin.end() are terminated after a
+      // clean prompt completion. Depending on the ACP bridge, this can surface
+      // either as SIGTERM or as a normal code 130 teardown. For those exact
+      // forced-shutdown shapes we trust the ACP-level success signal so
+      // connection tests don't report `agent_spawn_failed` despite a healthy
+      // assistant response (see #1265 / #1286).
       //
-      // Scope the override narrowly: only `code === null` AND
-      // `signal === 'SIGTERM'` AND `acpCleanCompletion` count as a clean
-      // forced shutdown. Any other post-response process failure (non-zero
-      // exit code, SIGKILL, SIGSEGV, etc.) still falls through to
-      // `agent_spawn_failed`, preserving the existing connection-test
-      // failure behavior for genuine post-response problems.
+      // Scope the override narrowly: only the known daemon-triggered ACP
+      // teardown shapes plus `acpCleanCompletion` count as a clean forced
+      // shutdown. Any other post-response process failure (code 1, SIGKILL,
+      // SIGSEGV, etc.) still falls through to `agent_spawn_failed`, preserving
+      // the existing connection-test failure behavior for genuine
+      // post-response problems.
       const acpCleanCompletion =
         typeof acpSession?.completedSuccessfully === 'function' &&
         acpSession.completedSuccessfully();
       const acpForcedShutdown =
-        winner.code === null &&
-        winner.signal === 'SIGTERM' &&
-        acpCleanCompletion;
+        acpCleanCompletion &&
+        (
+          (winner.code === null && winner.signal === 'SIGTERM') ||
+          (winner.code === 130 && winner.signal === null)
+        );
       const exitedCleanly =
         (winner.code === 0 && !winner.signal) || acpForcedShutdown;
       if (buffered) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4500,7 +4500,15 @@ export function classifyChatRunCloseStatus(params: {
   if (params.cancelRequested) return 'canceled';
   if (params.code === 0) return 'succeeded';
   const acpForcedShutdown =
-    params.code === null && params.signal === 'SIGTERM' && params.acpCleanCompletion;
+    params.acpCleanCompletion &&
+    (
+      (params.code === null && params.signal === 'SIGTERM') ||
+      // Vela's ACP bridge can surface the daemon-triggered post-completion
+      // teardown as a normal exit code 130 instead of a SIGTERM signal. Once
+      // the ACP prompt already resolved cleanly, that is shutdown noise rather
+      // than an agent execution failure.
+      (params.code === 130 && params.signal === null)
+    );
   if (acpForcedShutdown) return 'succeeded';
   const artifactQuietShutdown =
     params.artifactQuietShutdownRequested &&

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -305,7 +305,7 @@ test('attachAcpSession keeps incremental ACP message chunks unchanged', () => {
   assert.deepEqual(textDeltas, ['Agent Haven', ' — managed AI agents']);
 });
 
-test('attachAcpSession stops after duplicate DSML artifact text starts', () => {
+test('attachAcpSession suppresses split duplicate DSML artifact text and preserves trailing prose', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];
 
@@ -330,10 +330,14 @@ test('attachAcpSession stops after duplicate DSML artifact text starts', () => {
     sessionUpdate: 'agent_message_chunk',
     content: { text: 'Build passes. No AI slop detected.\n\n< | DSML artifact identifier="page" type="text/html">' },
   });
-  assert.equal(child.stdin.writableEnded, true);
+  assert.equal(child.stdin.writableEnded, false);
   writeAcpUpdate(child, {
     sessionUpdate: 'agent_message_chunk',
-    content: { text: '\n<!doctype html><html><body>raw html</body></html>\n</artifact>Tail' },
+    content: { text: '\n<!doctype html><html><body>raw html</body></html>\n</art' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'ifact>Tail' },
   });
   writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
 
@@ -341,14 +345,14 @@ test('attachAcpSession stops after duplicate DSML artifact text starts', () => {
     .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
     .map((entry) => (entry.payload as { delta?: unknown }).delta);
 
-  assert.deepEqual(textDeltas, ['Build passes. No AI slop detected.\n\n']);
+  assert.deepEqual(textDeltas, ['Build passes. No AI slop detected.\n\n', 'Tail']);
   assert.equal(
     events.some((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'usage'),
-    false,
+    true,
   );
 });
 
-test('attachAcpSession stops after duplicate legacy artifact text starts', () => {
+test('attachAcpSession suppresses split duplicate legacy artifact text', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];
 
@@ -376,9 +380,9 @@ test('attachAcpSession stops after duplicate legacy artifact text starts', () =>
   assert.equal(child.stdin.writableEnded, false);
   writeAcpUpdate(child, {
     sessionUpdate: 'agent_message_chunk',
-    content: { text: 'ifact identifier="page" type="text/html">\n<!doctype html><html></html>' },
+    content: { text: 'ifact identifier="page" type="text/html">\n<!doctype html><html></html></artifact>' },
   });
-  assert.equal(child.stdin.writableEnded, true);
+  assert.equal(child.stdin.writableEnded, false);
   writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
 
   const textDeltas = events
@@ -386,6 +390,52 @@ test('attachAcpSession stops after duplicate legacy artifact text starts', () =>
     .map((entry) => (entry.payload as { delta?: unknown }).delta);
 
   assert.deepEqual(textDeltas, ['Ready to output.\n\n']);
+});
+
+test('attachAcpSession suppresses DSML echo after opaque completed write update', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'tc-opaque',
+    title: 'edit',
+    status: 'pending',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'tc-opaque',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Done\n\n<artifact identifier="page">raw html</artifact>Tail' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: ' Later docs mention <artifact identifier="example">literal</artifact> syntax.' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, [
+    'Done\n\nTail',
+    ' Later docs mention <artifact identifier="example">literal</artifact> syntax.',
+  ]);
 });
 
 test('attachAcpSession preserves literal artifact prose before any write echo is expected', () => {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -438,6 +438,44 @@ test('attachAcpSession suppresses DSML echo after opaque completed write update'
   ]);
 });
 
+test('attachAcpSession suppresses incremental artifact echo after earlier assistant text', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Planning changes.\n' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'call-1',
+    title: 'edit',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Done.\n\n<artifact identifier="page">raw html</artifact>Tail' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, ['Planning changes.\n', 'Done.\n\nTail']);
+});
+
 test('attachAcpSession clears ACP suppression after plain prose before later literal artifact text', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -555,6 +555,46 @@ test('attachAcpSession keeps ACP suppression after plain incremental prose befor
   assert.deepEqual(textDeltas, ['Build passes.\n\n', 'Tail']);
 });
 
+test('attachAcpSession keeps ACP suppression after unrelated failed tool before echo chunk', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'write-1',
+    title: 'edit',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'grep-1',
+    title: 'grep',
+    status: 'failed',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Build passes.\n\n<artifact identifier="page">raw html</artifact>Tail' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, ['Build passes.\n\nTail']);
+});
+
 test('attachAcpSession keeps ACP suppression across plain cumulative snapshots', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -305,6 +305,77 @@ test('attachAcpSession keeps incremental ACP message chunks unchanged', () => {
   assert.deepEqual(textDeltas, ['Agent Haven', ' — managed AI agents']);
 });
 
+test('attachAcpSession stops after duplicate DSML artifact text starts', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Build passes. No AI slop detected.\n\n< | DSML artifact identifier="page" type="text/html">' },
+  });
+  assert.equal(child.stdin.writableEnded, true);
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: '\n<!doctype html><html><body>raw html</body></html>\n</artifact>Tail' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, ['Build passes. No AI slop detected.\n\n']);
+  assert.equal(
+    events.some((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'usage'),
+    false,
+  );
+});
+
+test('attachAcpSession stops after duplicate legacy artifact text starts', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Ready to output.\n\n<art' },
+  });
+  assert.equal(child.stdin.writableEnded, false);
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'ifact identifier="page" type="text/html">\n<!doctype html><html></html>' },
+  });
+  assert.equal(child.stdin.writableEnded, true);
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, ['Ready to output.\n\n']);
+});
+
 test('attachAcpSession exposes abort and sends session cancel after session creation', () => {
   const child = new FakeAcpChild();
   const writes: string[] = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -517,6 +517,44 @@ test('attachAcpSession clears ACP suppression after plain prose before later lit
   ]);
 });
 
+test('attachAcpSession keeps ACP suppression after plain incremental prose before echo chunk', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'call-1',
+    title: 'edit',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Build passes.\n\n' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: '<artifact identifier="page">raw html</artifact>Tail' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, ['Build passes.\n\n', 'Tail']);
+});
+
 test('attachAcpSession keeps ACP suppression across plain cumulative snapshots', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -321,6 +321,12 @@ test('attachAcpSession stops after duplicate DSML artifact text starts', () => {
   writeAcpResult(child, 1, {});
   writeAcpResult(child, 2, { sessionId: 'session-1' });
   writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'call-1',
+    title: 'edit',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
     sessionUpdate: 'agent_message_chunk',
     content: { text: 'Build passes. No AI slop detected.\n\n< | DSML artifact identifier="page" type="text/html">' },
   });
@@ -358,6 +364,12 @@ test('attachAcpSession stops after duplicate legacy artifact text starts', () =>
   writeAcpResult(child, 1, {});
   writeAcpResult(child, 2, { sessionId: 'session-1' });
   writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'call-1',
+    title: 'edit',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
     sessionUpdate: 'agent_message_chunk',
     content: { text: 'Ready to output.\n\n<art' },
   });
@@ -374,6 +386,36 @@ test('attachAcpSession stops after duplicate legacy artifact text starts', () =>
     .map((entry) => (entry.payload as { delta?: unknown }).delta);
 
   assert.deepEqual(textDeltas, ['Ready to output.\n\n']);
+});
+
+test('attachAcpSession preserves literal artifact prose before any write echo is expected', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'document artifact syntax',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  const literal = 'To show the syntax, write <artifact identifier="page">literal</artifact> in docs.';
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: literal },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, [literal]);
 });
 
 test('attachAcpSession exposes abort and sends session cancel after session creation', () => {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -438,6 +438,47 @@ test('attachAcpSession suppresses DSML echo after opaque completed write update'
   ]);
 });
 
+test('attachAcpSession clears ACP suppression after plain prose before later literal artifact text', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'call-1',
+    title: 'edit',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Build passes.\n\n' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Later docs mention <artifact identifier="example">literal</artifact> syntax.' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, [
+    'Build passes.\n\n',
+    'Later docs mention <artifact identifier="example">literal</artifact> syntax.',
+  ]);
+});
+
 test('attachAcpSession preserves literal artifact prose before any write echo is expected', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -479,6 +479,44 @@ test('attachAcpSession clears ACP suppression after plain prose before later lit
   ]);
 });
 
+test('attachAcpSession keeps ACP suppression across plain cumulative snapshots', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'call-1',
+    title: 'edit',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Build passes.\n\n' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Build passes.\n\n<artifact identifier="page">raw html</artifact>Tail' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, ['Build passes.\n\n', 'Tail']);
+});
+
 test('attachAcpSession preserves literal artifact prose before any write echo is expected', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -555,6 +555,44 @@ test('attachAcpSession keeps ACP suppression after plain incremental prose befor
   assert.deepEqual(textDeltas, ['Build passes.\n\n', 'Tail']);
 });
 
+test('attachAcpSession suppresses prose-prefixed delayed artifact echo after plain prose', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'build landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'call-1',
+    title: 'edit',
+    status: 'completed',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Build passes.\n\n' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Here is the generated file:\n<artifact identifier="page">raw html</artifact>Tail' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, ['Build passes.\n\n', 'Here is the generated file:\nTail']);
+});
+
 test('attachAcpSession keeps ACP suppression after unrelated failed tool before echo chunk', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/artifact-text-suppression.test.ts
+++ b/apps/daemon/tests/artifact-text-suppression.test.ts
@@ -45,6 +45,17 @@ test('DSML artifact suppressor strips legacy artifact blocks', () => {
   );
 });
 
+test('DSML artifact suppressor strips split legacy artifact close tags', () => {
+  const suppressor = createDsmlArtifactTextSuppressor();
+
+  assert.equal(
+    suppressor.strip('Done\n\n<artifact identifier="page" type="text/html" title="Page">raw'),
+    'Done\n\n',
+  );
+  assert.equal(suppressor.strip('</art'), '');
+  assert.equal(suppressor.strip('ifact>Tail'), 'Tail');
+});
+
 test('DSML artifact suppressor strips split legacy artifact open tags', () => {
   const suppressor = createDsmlArtifactTextSuppressor();
 

--- a/apps/daemon/tests/artifact-text-suppression.test.ts
+++ b/apps/daemon/tests/artifact-text-suppression.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { createDsmlArtifactTextSuppressor } from '../src/artifact-text-suppression.js';
+
+test('DSML artifact suppressor preserves non-DSML tags at the start of a chunk', () => {
+  const suppressor = createDsmlArtifactTextSuppressor();
+
+  assert.equal(
+    suppressor.strip('<question-form id="task-type">'),
+    '<question-form id="task-type">',
+  );
+  assert.equal(suppressor.flush(), '');
+});
+
+test('DSML artifact suppressor preserves partial non-DSML tags at the start of a chunk', () => {
+  const suppressor = createDsmlArtifactTextSuppressor();
+
+  assert.equal(suppressor.strip('<question'), '<question');
+  assert.equal(suppressor.flush(), '');
+});
+
+test('DSML artifact suppressor strips DSML artifact blocks', () => {
+  const suppressor = createDsmlArtifactTextSuppressor();
+
+  assert.equal(
+    suppressor.strip('Done\n\n< | DSML artifact identifier="page" type="text/html">'),
+    'Done\n\n',
+  );
+  assert.equal(
+    suppressor.strip('\n<!doctype html><html></html>\n</artifact>Tail'),
+    'Tail',
+  );
+});
+
+test('DSML artifact suppressor strips legacy artifact blocks', () => {
+  const suppressor = createDsmlArtifactTextSuppressor();
+
+  assert.equal(
+    suppressor.strip('Done\n\n<artifact identifier="page" type="text/html" title="Page">'),
+    'Done\n\n',
+  );
+  assert.equal(
+    suppressor.strip('\n<!doctype html><html></html>\n</artifact>Tail'),
+    'Tail',
+  );
+});
+
+test('DSML artifact suppressor strips split legacy artifact open tags', () => {
+  const suppressor = createDsmlArtifactTextSuppressor();
+
+  assert.equal(suppressor.strip('Done\n\n<art'), 'Done\n\n');
+  assert.equal(
+    suppressor.strip('ifact identifier="page" type="text/html">\n<html></html>'),
+    '',
+  );
+  assert.equal(suppressor.strip('</artifact>Tail'), 'Tail');
+});

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -274,6 +274,28 @@ describe('classifyChatRunCloseStatus (#1451 close-handler classification)', () =
     ).toBe('succeeded');
   });
 
+  it('returns succeeded on Vela ACP code 130 after clean ACP completion', () => {
+    expect(
+      classifyChatRunCloseStatus({
+        ...base,
+        code: 130,
+        signal: null,
+        acpCleanCompletion: true,
+      }),
+    ).toBe('succeeded');
+  });
+
+  it('returns failed on Vela ACP code 130 before clean ACP completion', () => {
+    expect(
+      classifyChatRunCloseStatus({
+        ...base,
+        code: 130,
+        signal: null,
+        acpCleanCompletion: false,
+      }),
+    ).toBe('failed');
+  });
+
   it('returns failed when ACP shutdown was via SIGKILL (not the narrow override)', () => {
     expect(
       classifyChatRunCloseStatus({


### PR DESCRIPTION
## Why

AMR/Vela runs can emit DeepSeek DSML artifact text after the real file has already been written. In the chat this shows up as raw `<!doctype html>`/HTML at the end of the assistant message: the code block card is gone, but the plain text still leaks into the transcript.

The previous artifact-echo fix covered Claude stream and JSON event stream runtimes. AMR uses the ACP JSON-RPC path, so its `agent_message_chunk` text bypassed that suppression.

## What users will see

When using AMR/Vela models such as DeepSeek v4, completed artifact runs no longer append the DSML-wrapped HTML source into the assistant message after the generated file is already available.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; daemon stream filtering only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/acp.test.ts`, `attachAcpSession suppresses DSML artifact HTML emitted as ACP message text`
- Did the test go red on `main` and green on this branch? Yes: the ACP path previously forwarded the DSML HTML as `text_delta`; the new regression is green on this branch.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/acp.test.ts` from `apps/daemon`
- `pnpm exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts tests/structured-streams.test.ts tests/acp.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
