### PR TITLE
add cross-app import boundary check to pnpm guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tools-pack": "pnpm exec tools-pack",
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
-    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/postinstall.test.ts",
+    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/check-cross-app-imports.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/postinstall.test.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",
     "sync:community-pets": "node --experimental-strip-types scripts/sync-community-pets.ts",

--- a/scripts/check-cross-app-imports.test.ts
+++ b/scripts/check-cross-app-imports.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
   type AppDirectoryRegistry,
   collectCrossAppImportViolationsFromSource,
   isCrossAppImportSourceFile,
+  loadAppDirectoryRegistry,
 } from "./check-cross-app-imports.ts";
 
 const registry: AppDirectoryRegistry = {
@@ -137,4 +141,23 @@ test("cross-app import check ignores files outside apps/", () => {
   );
 
   assert.deepEqual(violations, []);
+});
+
+test("app registry loading fails loudly when an app manifest is malformed", async () => {
+  const appsRoot = await mkdtemp(path.join(os.tmpdir(), "open-design-apps-"));
+  const appRoot = path.join(appsRoot, "web");
+  const manifestPath = path.join(appRoot, "package.json");
+
+  await mkdir(appRoot);
+  await writeFile(manifestPath, "{ invalid json", "utf8");
+
+  await assert.rejects(
+    loadAppDirectoryRegistry(appsRoot),
+    (error) =>
+      error instanceof Error &&
+      error.message.includes(`Failed to load app package manifest at ${manifestPath}:`) &&
+      error.message.includes("JSON"),
+  );
+
+  await rm(appsRoot, { force: true, recursive: true });
 });

--- a/scripts/check-cross-app-imports.test.ts
+++ b/scripts/check-cross-app-imports.test.ts
@@ -48,6 +48,19 @@ test("cross-app import check rejects another app's package name", () => {
   assert.ok(violations.every((violation) => violation.targetApp === "daemon"));
 });
 
+test("cross-app import check rejects another app's package name in require.resolve", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/web/src/setup-runtime.ts",
+    "const daemonManifest = require.resolve('@open-design/daemon/package.json');",
+    registry,
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0]?.specifier, "@open-design/daemon/package.json");
+  assert.equal(violations[0]?.targetApp, "daemon");
+  assert.equal(violations[0]?.lineNumber, 1);
+});
+
 test("cross-app import check rejects cross-app imports from app-owned mjs entrypoints", () => {
   assert.equal(isCrossAppImportSourceFile("entry.js"), true);
   assert.equal(isCrossAppImportSourceFile("entry.cjs"), true);

--- a/scripts/check-cross-app-imports.test.ts
+++ b/scripts/check-cross-app-imports.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type AppDirectoryRegistry,
+  collectCrossAppImportViolationsFromSource,
+} from "./check-cross-app-imports.ts";
+
+const registry: AppDirectoryRegistry = {
+  packageNameByDirectory: new Map([
+    ["daemon", "@open-design/daemon"],
+    ["web", "@open-design/web"],
+  ]),
+};
+
+test("cross-app import check rejects web importing daemon src via relative path", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/web/src/providers/daemon.ts",
+    "import { spawnAgent } from '../../../daemon/src/server.ts';",
+    registry,
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0]?.targetApp, "daemon");
+  assert.equal(violations[0]?.lineNumber, 1);
+});
+
+test("cross-app import check rejects another app's package name", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/web/src/runtime/todos.ts",
+    [
+      "import type { RunRecord } from '@open-design/daemon/src/server.ts';",
+      "const mod = await import('@open-design/daemon');",
+      "const legacy = require('@open-design/daemon/dist/cli.js');",
+    ].join("\n"),
+    registry,
+  );
+
+  assert.deepEqual(
+    violations.map((violation) => violation.lineNumber),
+    [1, 2, 3],
+  );
+  assert.ok(violations.every((violation) => violation.targetApp === "daemon"));
+});
+
+test("cross-app import check rejects export-from and apps/ rooted specifiers", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/daemon/src/index.ts",
+    ["export { FileViewer } from 'apps/web/src/components/FileViewer.tsx';", "import 'apps/web/src/index.css';"].join(
+      "\n",
+    ),
+    registry,
+  );
+
+  assert.deepEqual(
+    violations.map((violation) => violation.targetApp),
+    ["web", "web"],
+  );
+});
+
+test("cross-app import check allows packages, same-app relatives, and externals", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/web/src/components/ChatPane.tsx",
+    [
+      "import { Button } from '@open-design/components';",
+      "import type { ChatRunEvent } from '@open-design/contracts';",
+      "import { latestTodoWriteInputFromMessages } from '../runtime/todos.ts';",
+      "import path from 'node:path';",
+      "import React from 'react';",
+    ].join("\n"),
+    registry,
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("cross-app import check ignores relatives that escape apps/ without hitting a registered app", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/daemon/tests/mcp-extract-refs.test.ts",
+    "const refs = extractRelativeRefs('@import \"../../shared.css\";', 'a/b/c/file.css', 'text/css');",
+    registry,
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("cross-app import check allows allowlisted packaged -> desktop main export", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/packaged/src/index.ts",
+    "import { applyOsLocaleSwitch, createSplashWindow } from '@open-design/desktop/main';",
+    { packageNameByDirectory: new Map([["packaged", "@open-design/packaged"], ["desktop", "@open-design/desktop"]]) },
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("cross-app import check ignores files outside apps/", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "e2e/tests/dialog/stop-reconciles-message.test.ts",
+    "import { something } from '../../../apps/daemon/src/server.ts';",
+    registry,
+  );
+
+  assert.deepEqual(violations, []);
+});

--- a/scripts/check-cross-app-imports.test.ts
+++ b/scripts/check-cross-app-imports.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   type AppDirectoryRegistry,
   collectCrossAppImportViolationsFromSource,
+  isCrossAppImportSourceFile,
 } from "./check-cross-app-imports.ts";
 
 const registry: AppDirectoryRegistry = {
@@ -43,6 +44,24 @@ test("cross-app import check rejects another app's package name", () => {
   assert.ok(violations.every((violation) => violation.targetApp === "daemon"));
 });
 
+test("cross-app import check rejects cross-app imports from app-owned mjs entrypoints", () => {
+  assert.equal(isCrossAppImportSourceFile("entry.js"), true);
+  assert.equal(isCrossAppImportSourceFile("entry.cjs"), true);
+  assert.equal(isCrossAppImportSourceFile("postcss.config.mjs"), true);
+  assert.equal(isCrossAppImportSourceFile("types.d.ts"), true);
+  assert.equal(isCrossAppImportSourceFile("package.json"), false);
+
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/web/postcss.config.mjs",
+    "import { startDaemon } from '@open-design/daemon/src/server.ts';",
+    registry,
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0]?.targetApp, "daemon");
+  assert.equal(violations[0]?.lineNumber, 1);
+});
+
 test("cross-app import check rejects export-from and apps/ rooted specifiers", () => {
   const violations = collectCrossAppImportViolationsFromSource(
     "apps/daemon/src/index.ts",
@@ -67,6 +86,22 @@ test("cross-app import check allows packages, same-app relatives, and externals"
       "import { latestTodoWriteInputFromMessages } from '../runtime/todos.ts';",
       "import path from 'node:path';",
       "import React from 'react';",
+    ].join("\n"),
+    registry,
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("cross-app import check ignores quoted snippets and comments", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/web/tests/import-boundary-fixture.test.ts",
+    [
+      "const snippet = \"import { x } from '@open-design/daemon/src/server.ts';\";",
+      "// import { y } from '@open-design/daemon/src/server.ts';",
+      "/*",
+      "require('@open-design/daemon/dist/cli.js');",
+      "*/",
     ].join("\n"),
     registry,
   );

--- a/scripts/check-cross-app-imports.test.ts
+++ b/scripts/check-cross-app-imports.test.ts
@@ -161,3 +161,21 @@ test("app registry loading fails loudly when an app manifest is malformed", asyn
 
   await rm(appsRoot, { force: true, recursive: true });
 });
+
+test("app registry loading rejects parseable app manifests without a package name", async () => {
+  const appsRoot = await mkdtemp(path.join(os.tmpdir(), "open-design-apps-"));
+  const appRoot = path.join(appsRoot, "web");
+  const manifestPath = path.join(appRoot, "package.json");
+
+  await mkdir(appRoot);
+  await writeFile(manifestPath, "{}", "utf8");
+
+  await assert.rejects(
+    loadAppDirectoryRegistry(appsRoot),
+    (error) =>
+      error instanceof Error &&
+      error.message === `Failed to load app package manifest at ${manifestPath}: package name must be a non-empty string`,
+  );
+
+  await rm(appsRoot, { force: true, recursive: true });
+});

--- a/scripts/check-cross-app-imports.test.ts
+++ b/scripts/check-cross-app-imports.test.ts
@@ -92,6 +92,23 @@ test("cross-app import check rejects createRequire-based cross-app resolution", 
   assert.ok(violations.every((violation) => violation.targetApp === "daemon"));
 });
 
+test("cross-app import check rejects CommonJS node:module namespace createRequire resolution", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/web/src/setup-runtime.cjs",
+    [
+      'const moduleApi = require("node:module");',
+      "const nodeRequire = moduleApi.createRequire(__filename);",
+      'nodeRequire.resolve("@open-design/daemon/package.json");',
+    ].join("\n"),
+    registry,
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0]?.specifier, "@open-design/daemon/package.json");
+  assert.equal(violations[0]?.targetApp, "daemon");
+  assert.equal(violations[0]?.lineNumber, 3);
+});
+
 test("cross-app import check rejects cross-app imports from app-owned mjs entrypoints", () => {
   assert.equal(isCrossAppImportSourceFile("entry.js"), true);
   assert.equal(isCrossAppImportSourceFile("entry.cjs"), true);

--- a/scripts/check-cross-app-imports.test.ts
+++ b/scripts/check-cross-app-imports.test.ts
@@ -61,6 +61,37 @@ test("cross-app import check rejects another app's package name in require.resol
   assert.equal(violations[0]?.lineNumber, 1);
 });
 
+test("cross-app import check rejects createRequire-based cross-app resolution", () => {
+  const violations = collectCrossAppImportViolationsFromSource(
+    "apps/web/src/setup-runtime.ts",
+    [
+      "import { createRequire, createRequire as makeRequire } from 'node:module';",
+      "import * as nodeModule from 'node:module';",
+      "const directDaemonManifest = createRequire(import.meta.url).resolve('@open-design/daemon/package.json');",
+      "const aliasDaemonManifest = makeRequire(import.meta.url).resolve('@open-design/daemon/package.json');",
+      "const nodeRequire = nodeModule.createRequire(import.meta.url);",
+      "const daemonCli = nodeRequire('@open-design/daemon/dist/cli.js');",
+      "const daemonPackageJson = nodeRequire.resolve('@open-design/daemon/package.json');",
+    ].join("\n"),
+    registry,
+  );
+
+  assert.deepEqual(
+    violations.map((violation) => violation.specifier),
+    [
+      "@open-design/daemon/package.json",
+      "@open-design/daemon/package.json",
+      "@open-design/daemon/dist/cli.js",
+      "@open-design/daemon/package.json",
+    ],
+  );
+  assert.deepEqual(
+    violations.map((violation) => violation.lineNumber),
+    [3, 4, 6, 7],
+  );
+  assert.ok(violations.every((violation) => violation.targetApp === "daemon"));
+});
+
 test("cross-app import check rejects cross-app imports from app-owned mjs entrypoints", () => {
   assert.equal(isCrossAppImportSourceFile("entry.js"), true);
   assert.equal(isCrossAppImportSourceFile("entry.cjs"), true);

--- a/scripts/check-cross-app-imports.ts
+++ b/scripts/check-cross-app-imports.ts
@@ -129,6 +129,15 @@ function stringLiteralReference(node: ts.Node, sourceFile: ts.SourceFile): Impor
   return { index: node.getStart(sourceFile), specifier: node.text };
 }
 
+function isRequireResolveExpression(expression: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === "require" &&
+    expression.name.text === "resolve"
+  );
+}
+
 function collectImportSpecifierReferences(repositoryPath: string, source: string): ImportSpecifierReference[] {
   const sourceFile = ts.createSourceFile(
     repositoryPath,
@@ -161,6 +170,8 @@ function collectImportSpecifierReferences(repositoryPath: string, source: string
       if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
         pushStringLiteral(firstArgument);
       } else if (ts.isIdentifier(node.expression) && node.expression.text === "require") {
+        pushStringLiteral(firstArgument);
+      } else if (isRequireResolveExpression(node.expression)) {
         pushStringLiteral(firstArgument);
       }
     }

--- a/scripts/check-cross-app-imports.ts
+++ b/scripts/check-cross-app-imports.ts
@@ -207,8 +207,9 @@ export function collectCrossAppImportViolationsFromSource(
   return violations.sort((left, right) => left.lineNumber - right.lineNumber);
 }
 
-async function loadAppDirectoryRegistry(): Promise<AppDirectoryRegistry> {
-  const appsRoot = path.join(repoRoot, "apps");
+export async function loadAppDirectoryRegistry(
+  appsRoot = path.join(repoRoot, "apps"),
+): Promise<AppDirectoryRegistry> {
   const packageNameByDirectory = new Map<string, string>();
 
   for (const entry of await readdir(appsRoot, { withFileTypes: true })) {
@@ -218,8 +219,9 @@ async function loadAppDirectoryRegistry(): Promise<AppDirectoryRegistry> {
     let manifest: { name?: unknown };
     try {
       manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { name?: unknown };
-    } catch {
-      continue;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to load app package manifest at ${manifestPath}: ${reason}`);
     }
 
     if (typeof manifest.name === "string" && manifest.name.length > 0) {

--- a/scripts/check-cross-app-imports.ts
+++ b/scripts/check-cross-app-imports.ts
@@ -1,0 +1,214 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+// Apps integrate through HTTP APIs, `packages/contracts`, and app-local
+// provider boundaries. Reaching into another app's directory (src/, tests/,
+// or even dist/) couples two runtimes through private implementation and is
+// a repository boundary violation; `apps/web/**` importing
+// `apps/daemon/src/**` is the canonical example.
+const crossAppImportSkippedDirectories = new Set([
+  ".next",
+  ".od-data",
+  "dist",
+  "node_modules",
+  "out",
+  "reports",
+  "test-results",
+]);
+
+const crossAppImportSourceExtensions = new Set([".ts", ".tsx", ".mts", ".cts"]);
+
+export type AppDirectoryRegistry = {
+  // app directory name under apps/ (e.g. "daemon") -> package name (e.g. "@open-design/daemon")
+  packageNameByDirectory: Map<string, string>;
+};
+
+export type CrossAppImportViolation = {
+  filePath: string;
+  lineNumber: number;
+  specifier: string;
+  targetApp: string;
+  reason: string;
+};
+
+type CrossAppImportAllowlistEntry = {
+  pathPattern: RegExp;
+  specifierPattern: RegExp;
+  reason: string;
+};
+
+// Only deliberate, documented exceptions belong here. Prefer promoting the
+// shared logic to packages/ instead.
+const crossAppImportAllowlist: CrossAppImportAllowlistEntry[] = [
+  {
+    pathPattern: /^apps\/packaged\/(?:src|tests)\//,
+    specifierPattern: /^@open-design\/desktop\/main$/,
+    reason:
+      "apps/packaged is the thin packaged Electron entry that wraps the desktop shell through its declared ./main package export",
+  },
+];
+
+const importSpecifierPatterns = [
+  // import defaultExport, { named as alias } from '...' / import type { T } from '...'
+  /\bimport\s+(?:type\s+)?[\w$*{},\s]*?\bfrom\s*['"]([^'"\n]+)['"]/g,
+  // side-effect import '...' (not CSS @import, which can appear in fixture strings)
+  /(?<!@)\bimport\s*['"]([^'"\n]+)['"]/g,
+  // export { x } from '...' / export * from '...' / export type { T } from '...'
+  /\bexport\s+(?:type\s+)?[\w$*{},\s]*?\bfrom\s*['"]([^'"\n]+)['"]/g,
+  // dynamic import('...')
+  /\bimport\s*\(\s*['"]([^'"\n]+)['"]\s*\)/g,
+  // require('...')
+  /\brequire\s*\(\s*['"]([^'"\n]+)['"]\s*\)/g,
+];
+
+function lineNumberForIndex(source: string, index: number): number {
+  return source.slice(0, index).split("\n").length;
+}
+
+function appDirectoryForRepositoryPath(repositoryPath: string): string | null {
+  const [scope, appDirectory] = repositoryPath.split("/");
+  return scope === "apps" && appDirectory ? appDirectory : null;
+}
+
+function isCrossAppImportAllowlisted(repositoryPath: string, specifier: string): boolean {
+  return crossAppImportAllowlist.some(
+    (entry) => entry.pathPattern.test(repositoryPath) && entry.specifierPattern.test(specifier),
+  );
+}
+
+function targetAppForSpecifier(
+  repositoryPath: string,
+  specifier: string,
+  registry: AppDirectoryRegistry,
+): string | null {
+  const importingApp = appDirectoryForRepositoryPath(repositoryPath);
+  if (importingApp == null) return null;
+
+  const isForeignAppDirectory = (targetApp: string | null): targetApp is string =>
+    targetApp != null && targetApp !== importingApp && registry.packageNameByDirectory.has(targetApp);
+
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(repositoryPath), specifier));
+    const targetApp = appDirectoryForRepositoryPath(resolved);
+    return isForeignAppDirectory(targetApp) ? targetApp : null;
+  }
+
+  if (specifier.startsWith("apps/")) {
+    const targetApp = appDirectoryForRepositoryPath(specifier);
+    return isForeignAppDirectory(targetApp) ? targetApp : null;
+  }
+
+  for (const [appDirectory, packageName] of registry.packageNameByDirectory) {
+    if (appDirectory === importingApp) continue;
+    if (specifier === packageName || specifier.startsWith(`${packageName}/`)) {
+      return appDirectory;
+    }
+  }
+
+  return null;
+}
+
+export function collectCrossAppImportViolationsFromSource(
+  repositoryPath: string,
+  source: string,
+  registry: AppDirectoryRegistry,
+): CrossAppImportViolation[] {
+  const violations: CrossAppImportViolation[] = [];
+  const seen = new Set<string>();
+
+  for (const pattern of importSpecifierPatterns) {
+    for (const match of source.matchAll(pattern)) {
+      const specifier = match[1];
+      if (specifier === undefined) continue;
+
+      const dedupeKey = `${match.index}\0${specifier}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+
+      const targetApp = targetAppForSpecifier(repositoryPath, specifier, registry);
+      if (targetApp == null || isCrossAppImportAllowlisted(repositoryPath, specifier)) continue;
+
+      violations.push({
+        filePath: repositoryPath,
+        lineNumber: lineNumberForIndex(source, match.index ?? 0),
+        specifier,
+        targetApp,
+        reason: `apps must not import another app's private implementation (apps/${targetApp}); integrate via HTTP APIs and packages/contracts`,
+      });
+    }
+  }
+
+  return violations.sort((left, right) => left.lineNumber - right.lineNumber);
+}
+
+async function loadAppDirectoryRegistry(): Promise<AppDirectoryRegistry> {
+  const appsRoot = path.join(repoRoot, "apps");
+  const packageNameByDirectory = new Map<string, string>();
+
+  for (const entry of await readdir(appsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const manifestPath = path.join(appsRoot, entry.name, "package.json");
+    let manifest: { name?: unknown };
+    try {
+      manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { name?: unknown };
+    } catch {
+      continue;
+    }
+
+    if (typeof manifest.name === "string" && manifest.name.length > 0) {
+      packageNameByDirectory.set(entry.name, manifest.name);
+    }
+  }
+
+  return { packageNameByDirectory };
+}
+
+async function collectAppSourceFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (crossAppImportSkippedDirectories.has(entry.name)) continue;
+      files.push(...(await collectAppSourceFiles(fullPath)));
+      continue;
+    }
+
+    if (entry.isFile() && crossAppImportSourceExtensions.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+export async function checkCrossAppImports(): Promise<boolean> {
+  const registry = await loadAppDirectoryRegistry();
+  const violations: CrossAppImportViolation[] = [];
+
+  for (const appDirectory of [...registry.packageNameByDirectory.keys()].sort()) {
+    for (const fullPath of await collectAppSourceFiles(path.join(repoRoot, "apps", appDirectory))) {
+      const repositoryPath = path.relative(repoRoot, fullPath).split(path.sep).join("/");
+      const source = await readFile(fullPath, "utf8");
+      violations.push(...collectCrossAppImportViolationsFromSource(repositoryPath, source, registry));
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error("Cross-app import boundary violations found:");
+    for (const violation of violations) {
+      console.error(`- ${violation.filePath}:${violation.lineNumber} \`${violation.specifier}\` -> ${violation.reason}`);
+    }
+    console.error(
+      "Move shared logic to packages/ (DTOs belong in packages/contracts) or call the owning app's HTTP API instead.",
+    );
+    return false;
+  }
+
+  console.log("Cross-app import check passed: apps do not import another app's private implementation.");
+  return true;
+}

--- a/scripts/check-cross-app-imports.ts
+++ b/scripts/check-cross-app-imports.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
+import ts from "typescript";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -18,7 +19,7 @@ const crossAppImportSkippedDirectories = new Set([
   "test-results",
 ]);
 
-const crossAppImportSourceExtensions = new Set([".ts", ".tsx", ".mts", ".cts"]);
+const crossAppImportSourceExtensions = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"]);
 
 export type AppDirectoryRegistry = {
   // app directory name under apps/ (e.g. "daemon") -> package name (e.g. "@open-design/daemon")
@@ -50,26 +51,13 @@ const crossAppImportAllowlist: CrossAppImportAllowlistEntry[] = [
   },
 ];
 
-const importSpecifierPatterns = [
-  // import defaultExport, { named as alias } from '...' / import type { T } from '...'
-  /\bimport\s+(?:type\s+)?[\w$*{},\s]*?\bfrom\s*['"]([^'"\n]+)['"]/g,
-  // side-effect import '...' (not CSS @import, which can appear in fixture strings)
-  /(?<!@)\bimport\s*['"]([^'"\n]+)['"]/g,
-  // export { x } from '...' / export * from '...' / export type { T } from '...'
-  /\bexport\s+(?:type\s+)?[\w$*{},\s]*?\bfrom\s*['"]([^'"\n]+)['"]/g,
-  // dynamic import('...')
-  /\bimport\s*\(\s*['"]([^'"\n]+)['"]\s*\)/g,
-  // require('...')
-  /\brequire\s*\(\s*['"]([^'"\n]+)['"]\s*\)/g,
-];
-
-function lineNumberForIndex(source: string, index: number): number {
-  return source.slice(0, index).split("\n").length;
-}
-
 function appDirectoryForRepositoryPath(repositoryPath: string): string | null {
   const [scope, appDirectory] = repositoryPath.split("/");
   return scope === "apps" && appDirectory ? appDirectory : null;
+}
+
+export function isCrossAppImportSourceFile(fileName: string): boolean {
+  return crossAppImportSourceExtensions.has(path.extname(fileName));
 }
 
 function isCrossAppImportAllowlisted(repositoryPath: string, specifier: string): boolean {
@@ -110,6 +98,80 @@ function targetAppForSpecifier(
   return null;
 }
 
+type ImportSpecifierReference = {
+  index: number;
+  specifier: string;
+};
+
+function scriptKindForRepositoryPath(repositoryPath: string): ts.ScriptKind {
+  switch (path.extname(repositoryPath)) {
+    case ".js":
+      return ts.ScriptKind.JS;
+    case ".jsx":
+      return ts.ScriptKind.JSX;
+    case ".mjs":
+      return ts.ScriptKind.JS;
+    case ".cjs":
+      return ts.ScriptKind.JS;
+    case ".tsx":
+      return ts.ScriptKind.TSX;
+    case ".mts":
+      return ts.ScriptKind.TS;
+    case ".cts":
+      return ts.ScriptKind.TS;
+    default:
+      return ts.ScriptKind.TS;
+  }
+}
+
+function stringLiteralReference(node: ts.Node, sourceFile: ts.SourceFile): ImportSpecifierReference | null {
+  if (!ts.isStringLiteralLike(node)) return null;
+  return { index: node.getStart(sourceFile), specifier: node.text };
+}
+
+function collectImportSpecifierReferences(repositoryPath: string, source: string): ImportSpecifierReference[] {
+  const sourceFile = ts.createSourceFile(
+    repositoryPath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindForRepositoryPath(repositoryPath),
+  );
+  const references: ImportSpecifierReference[] = [];
+
+  const pushStringLiteral = (node: ts.Node | undefined): void => {
+    if (node == null) return;
+    const reference = stringLiteralReference(node, sourceFile);
+    if (reference != null) references.push(reference);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      pushStringLiteral(node.moduleSpecifier);
+    } else if (ts.isExportDeclaration(node)) {
+      pushStringLiteral(node.moduleSpecifier);
+    } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+      pushStringLiteral(node.moduleReference.expression);
+    } else if (ts.isImportTypeNode(node)) {
+      if (ts.isLiteralTypeNode(node.argument)) {
+        pushStringLiteral(node.argument.literal);
+      }
+    } else if (ts.isCallExpression(node)) {
+      const firstArgument = node.arguments[0];
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        pushStringLiteral(firstArgument);
+      } else if (ts.isIdentifier(node.expression) && node.expression.text === "require") {
+        pushStringLiteral(firstArgument);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return references;
+}
+
 export function collectCrossAppImportViolationsFromSource(
   repositoryPath: string,
   source: string,
@@ -117,27 +179,29 @@ export function collectCrossAppImportViolationsFromSource(
 ): CrossAppImportViolation[] {
   const violations: CrossAppImportViolation[] = [];
   const seen = new Set<string>();
+  const sourceFile = ts.createSourceFile(
+    repositoryPath,
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    scriptKindForRepositoryPath(repositoryPath),
+  );
 
-  for (const pattern of importSpecifierPatterns) {
-    for (const match of source.matchAll(pattern)) {
-      const specifier = match[1];
-      if (specifier === undefined) continue;
+  for (const reference of collectImportSpecifierReferences(repositoryPath, source)) {
+    const dedupeKey = `${reference.index}\0${reference.specifier}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
 
-      const dedupeKey = `${match.index}\0${specifier}`;
-      if (seen.has(dedupeKey)) continue;
-      seen.add(dedupeKey);
+    const targetApp = targetAppForSpecifier(repositoryPath, reference.specifier, registry);
+    if (targetApp == null || isCrossAppImportAllowlisted(repositoryPath, reference.specifier)) continue;
 
-      const targetApp = targetAppForSpecifier(repositoryPath, specifier, registry);
-      if (targetApp == null || isCrossAppImportAllowlisted(repositoryPath, specifier)) continue;
-
-      violations.push({
-        filePath: repositoryPath,
-        lineNumber: lineNumberForIndex(source, match.index ?? 0),
-        specifier,
-        targetApp,
-        reason: `apps must not import another app's private implementation (apps/${targetApp}); integrate via HTTP APIs and packages/contracts`,
-      });
-    }
+    violations.push({
+      filePath: repositoryPath,
+      lineNumber: sourceFile.getLineAndCharacterOfPosition(reference.index).line + 1,
+      specifier: reference.specifier,
+      targetApp,
+      reason: `apps must not import another app's private implementation (apps/${targetApp}); integrate via HTTP APIs and packages/contracts`,
+    });
   }
 
   return violations.sort((left, right) => left.lineNumber - right.lineNumber);
@@ -178,7 +242,7 @@ async function collectAppSourceFiles(directory: string): Promise<string[]> {
       continue;
     }
 
-    if (entry.isFile() && crossAppImportSourceExtensions.has(path.extname(entry.name))) {
+    if (entry.isFile() && isCrossAppImportSourceFile(entry.name)) {
       files.push(fullPath);
     }
   }

--- a/scripts/check-cross-app-imports.ts
+++ b/scripts/check-cross-app-imports.ts
@@ -224,9 +224,11 @@ export async function loadAppDirectoryRegistry(
       throw new Error(`Failed to load app package manifest at ${manifestPath}: ${reason}`);
     }
 
-    if (typeof manifest.name === "string" && manifest.name.length > 0) {
-      packageNameByDirectory.set(entry.name, manifest.name);
+    if (typeof manifest.name !== "string" || manifest.name.trim().length === 0) {
+      throw new Error(`Failed to load app package manifest at ${manifestPath}: package name must be a non-empty string`);
     }
+
+    packageNameByDirectory.set(entry.name, manifest.name);
   }
 
   return { packageNameByDirectory };

--- a/scripts/check-cross-app-imports.ts
+++ b/scripts/check-cross-app-imports.ts
@@ -139,6 +139,12 @@ function isNodeModuleSpecifier(node: ts.Node | undefined): boolean {
   return node != null && ts.isStringLiteralLike(node) && (node.text === "node:module" || node.text === "module");
 }
 
+function isRequireNodeModuleCall(expression: ts.Expression): boolean {
+  if (!ts.isCallExpression(expression) || !ts.isIdentifier(expression.expression)) return false;
+  const [moduleSpecifier] = expression.arguments;
+  return expression.expression.text === "require" && isNodeModuleSpecifier(moduleSpecifier);
+}
+
 function collectCreateRequireBindings(sourceFile: ts.SourceFile): CreateRequireBindings {
   const bindings: CreateRequireBindings = {
     createRequireIdentifiers: new Set(),
@@ -164,25 +170,25 @@ function collectCreateRequireBindings(sourceFile: ts.SourceFile): CreateRequireB
         bindings.createRequireNamespaces.add(namedBindings.name.text);
       }
     } else if (ts.isVariableDeclaration(node) && ts.isObjectBindingPattern(node.name)) {
-      if (
-        node.initializer != null &&
-        ts.isCallExpression(node.initializer) &&
-        ts.isIdentifier(node.initializer.expression)
-      ) {
-        const [moduleSpecifier] = node.initializer.arguments;
-        if (node.initializer.expression.text === "require" && isNodeModuleSpecifier(moduleSpecifier)) {
-          for (const element of node.name.elements) {
-            const propertyName = element.propertyName != null && ts.isIdentifier(element.propertyName)
-              ? element.propertyName.text
-              : ts.isIdentifier(element.name)
-                ? element.name.text
-                : null;
-            if (propertyName === "createRequire" && ts.isIdentifier(element.name)) {
-              bindings.createRequireIdentifiers.add(element.name.text);
-            }
+      if (node.initializer != null && isRequireNodeModuleCall(node.initializer)) {
+        for (const element of node.name.elements) {
+          const propertyName = element.propertyName != null && ts.isIdentifier(element.propertyName)
+            ? element.propertyName.text
+            : ts.isIdentifier(element.name)
+              ? element.name.text
+              : null;
+          if (propertyName === "createRequire" && ts.isIdentifier(element.name)) {
+            bindings.createRequireIdentifiers.add(element.name.text);
           }
         }
       }
+    } else if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer != null &&
+      isRequireNodeModuleCall(node.initializer)
+    ) {
+      bindings.createRequireNamespaces.add(node.name.text);
     }
 
     ts.forEachChild(node, collectCreateRequireImports);

--- a/scripts/check-cross-app-imports.ts
+++ b/scripts/check-cross-app-imports.ts
@@ -103,6 +103,12 @@ type ImportSpecifierReference = {
   specifier: string;
 };
 
+type CreateRequireBindings = {
+  createRequireIdentifiers: Set<string>;
+  createRequireNamespaces: Set<string>;
+  requireLikeIdentifiers: Set<string>;
+};
+
 function scriptKindForRepositoryPath(repositoryPath: string): ts.ScriptKind {
   switch (path.extname(repositoryPath)) {
     case ".js":
@@ -129,12 +135,94 @@ function stringLiteralReference(node: ts.Node, sourceFile: ts.SourceFile): Impor
   return { index: node.getStart(sourceFile), specifier: node.text };
 }
 
-function isRequireResolveExpression(expression: ts.Expression): boolean {
+function isNodeModuleSpecifier(node: ts.Node | undefined): boolean {
+  return node != null && ts.isStringLiteralLike(node) && (node.text === "node:module" || node.text === "module");
+}
+
+function collectCreateRequireBindings(sourceFile: ts.SourceFile): CreateRequireBindings {
+  const bindings: CreateRequireBindings = {
+    createRequireIdentifiers: new Set(),
+    createRequireNamespaces: new Set(),
+    requireLikeIdentifiers: new Set(["require"]),
+  };
+
+  const collectCreateRequireImports = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node) &&
+      isNodeModuleSpecifier(node.moduleSpecifier) &&
+      node.importClause?.namedBindings != null
+    ) {
+      const { namedBindings } = node.importClause;
+      if (ts.isNamedImports(namedBindings)) {
+        for (const element of namedBindings.elements) {
+          const importedName = element.propertyName?.text ?? element.name.text;
+          if (importedName === "createRequire") {
+            bindings.createRequireIdentifiers.add(element.name.text);
+          }
+        }
+      } else if (ts.isNamespaceImport(namedBindings)) {
+        bindings.createRequireNamespaces.add(namedBindings.name.text);
+      }
+    } else if (ts.isVariableDeclaration(node) && ts.isObjectBindingPattern(node.name)) {
+      if (
+        node.initializer != null &&
+        ts.isCallExpression(node.initializer) &&
+        ts.isIdentifier(node.initializer.expression)
+      ) {
+        const [moduleSpecifier] = node.initializer.arguments;
+        if (node.initializer.expression.text === "require" && isNodeModuleSpecifier(moduleSpecifier)) {
+          for (const element of node.name.elements) {
+            const propertyName = element.propertyName != null && ts.isIdentifier(element.propertyName)
+              ? element.propertyName.text
+              : ts.isIdentifier(element.name)
+                ? element.name.text
+                : null;
+            if (propertyName === "createRequire" && ts.isIdentifier(element.name)) {
+              bindings.createRequireIdentifiers.add(element.name.text);
+            }
+          }
+        }
+      }
+    }
+
+    ts.forEachChild(node, collectCreateRequireImports);
+  };
+
+  const collectRequireLikeIdentifiers = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer != null &&
+      isCreateRequireCall(node.initializer, bindings)
+    ) {
+      bindings.requireLikeIdentifiers.add(node.name.text);
+    }
+
+    ts.forEachChild(node, collectRequireLikeIdentifiers);
+  };
+
+  collectCreateRequireImports(sourceFile);
+  collectRequireLikeIdentifiers(sourceFile);
+  return bindings;
+}
+
+function isCreateRequireCall(expression: ts.Expression, bindings: CreateRequireBindings): boolean {
+  return (
+    ts.isCallExpression(expression) &&
+    ((ts.isIdentifier(expression.expression) && bindings.createRequireIdentifiers.has(expression.expression.text)) ||
+      (ts.isPropertyAccessExpression(expression.expression) &&
+        ts.isIdentifier(expression.expression.expression) &&
+        bindings.createRequireNamespaces.has(expression.expression.expression.text) &&
+        expression.expression.name.text === "createRequire"))
+  );
+}
+
+function isRequireResolveExpression(expression: ts.Expression, bindings: CreateRequireBindings): boolean {
   return (
     ts.isPropertyAccessExpression(expression) &&
-    ts.isIdentifier(expression.expression) &&
-    expression.expression.text === "require" &&
-    expression.name.text === "resolve"
+    expression.name.text === "resolve" &&
+    ((ts.isIdentifier(expression.expression) && bindings.requireLikeIdentifiers.has(expression.expression.text)) ||
+      isCreateRequireCall(expression.expression, bindings))
   );
 }
 
@@ -147,6 +235,7 @@ function collectImportSpecifierReferences(repositoryPath: string, source: string
     scriptKindForRepositoryPath(repositoryPath),
   );
   const references: ImportSpecifierReference[] = [];
+  const createRequireBindings = collectCreateRequireBindings(sourceFile);
 
   const pushStringLiteral = (node: ts.Node | undefined): void => {
     if (node == null) return;
@@ -169,9 +258,12 @@ function collectImportSpecifierReferences(repositoryPath: string, source: string
       const firstArgument = node.arguments[0];
       if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
         pushStringLiteral(firstArgument);
-      } else if (ts.isIdentifier(node.expression) && node.expression.text === "require") {
+      } else if (
+        ts.isIdentifier(node.expression) &&
+        createRequireBindings.requireLikeIdentifiers.has(node.expression.text)
+      ) {
         pushStringLiteral(firstArgument);
-      } else if (isRequireResolveExpression(node.expression)) {
+      } else if (isRequireResolveExpression(node.expression, createRequireBindings)) {
         pushStringLiteral(firstArgument);
       }
     }

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -2,6 +2,7 @@ import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { checkCrossAppImports } from "./check-cross-app-imports.ts";
 import { checkDesignSystemManifests } from "./check-design-system-manifests.ts";
 import { checkDesignSystemPackageQuality } from "./check-design-system-package-quality.ts";
 import { checkDesignSystemComponentFixtureReport } from "./check-components-fixtures.ts";
@@ -1052,6 +1053,7 @@ const checks: GuardCheck[] = [
   { name: "residual JavaScript", run: checkResidualJavaScript },
   { name: "package dependency specs", run: checkPackageDependencySpecs },
   { name: "product neutrality", run: checkProductNeutrality },
+  { name: "cross-app imports", run: checkCrossAppImports },
   { name: "test layout", run: checkTestLayout },
   { name: "e2e layout", run: checkE2eLayout },
   { name: "web test layout", run: checkWebTestLayout },


### PR DESCRIPTION
## Why

- **Use case:** while auditing this repo's acceptance gates we found the cross-app import boundary (root `AGENTS.md` → Boundary constraints: app packages must not import another app's private `src/`/`tests/`; in particular `apps/web/**` must not import `apps/daemon/src/**`) is documented in `AGENTS.md` and `docs/code-review-guidelines.md` (forbidden surfaces) but enforced only by human review. Nothing in `pnpm guard` or CI catches a violating import today.
- **Pain:** every PR currently relies on a reviewer remembering to scan imports for boundary violations. With the current external-PR volume this is review bandwidth spent on a mechanically checkable rule, and a missed violation couples the web and daemon runtimes at compile time, bypasses `packages/contracts` as the single review point for shared shapes, and breaks the separately-packaged sidecar assumption. Moving the rule into `pnpm guard` makes violating PRs fail preflight before a maintainer ever looks at them.

## What users will see

No end-user-visible change. Contributors who add a cross-app import now get a failing `pnpm guard` (locally and in CI preflight) with the offending `file:line`, the import specifier, and a pointer to the sanctioned integration paths (HTTP APIs + `packages/contracts`):

```
Cross-app import boundary violations found:
- apps/web/src/providers/daemon.ts:3 `../../daemon/src/server.ts` -> apps must not import another app's private implementation (apps/daemon); integrate via HTTP APIs and packages/contracts
Move shared logic to packages/ (DTOs belong in packages/contracts) or call the owning app's HTTP API instead.
```

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — repo-level guard check + its unit tests only (`scripts/`, root `package.json` guard script)

## Screenshots

Not applicable (no UI surface).

## Bug fix verification

Not a bug fix. Effectiveness was still verified red-first: the first run of the new check against the workspace flagged real hits, which were triaged into (a) a false positive (CSS `@import` string inside a daemon test fixture) — fixed in the matcher and covered by a regression test, and (b) the deliberate `apps/packaged` → `@open-design/desktop/main` wrapper relationship — `apps/desktop` declares `./main` in its `package.json#exports` and `apps/packaged` is documented as the thin packaged Electron entry around the desktop shell, so it is allowlisted with a documented reason. The allowlist requires a `reason` per entry, so future exceptions surface in review diffs.

## Validation

- `pnpm guard` — all checks green, including the new `cross-app imports` check; 47 unit tests pass (7 new in `scripts/check-cross-app-imports.test.ts` covering relative-path escapes, package-name specifiers, `export … from`, dynamic `import()`/`require()`, the allowlisted packaged→desktop export, and non-app paths).
- `pnpm typecheck` — full workspace + `scripts/tsconfig.json`, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)