### PR TITLE
chore(amr): bump bundled vela CLI to 0.0.16

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-bPYV6FtDZcUNnCpFbaT3cz07kAqy+2LEiHiwmCU7Qy8=";
-  webHash = "sha256-yT6dcsP6xPE+5ErNXOPZagj5+4gZVtX9DBcBilKZAm4=";
+  daemonHash = "sha256-Ov4ES82qQ1GeCPk1iWMdifwh8T/Xl3AKCsUKsiheruw=";
+  webHash = "sha256-Y9hspnCl3NGO7yTIIfqu2yBN0hYvfLEjiWRKxjasGmg=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,8 +706,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.15
-        version: 0.0.15
+        specifier: 0.0.16
+        version: 0.0.16
 
   tools/serve:
     dependencies:
@@ -1845,33 +1845,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.15':
-    resolution: {integrity: sha512-rMRKBVIn/MESkWSYjTvJirSMVgwrvVswf0TV0ZZOQCYP3lzKto8fmAmzYXYPOXMNZ+b9cFVI+YdapDeaMBF1cA==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.16':
+    resolution: {integrity: sha512-LlJwirtSa8RbN14+YGgT2/LzjGaS2J1sxpoBLVF/bAPWB2LUYH1Eg9lxLMGOSEVIOU3ySmcHbeSkhAaz7oXlUw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.15':
-    resolution: {integrity: sha512-ff1I3dcj/+7mIPCtUY2BzGZiydiqyzWEA2Izn4t9mFEmM1SiM5rsyWfXpsJEaHMEUBSxXyjlaSCwhOcRx2t/tQ==}
+  '@powerformer/vela-cli-darwin-x64@0.0.16':
+    resolution: {integrity: sha512-41q8UuxGADtxhnj7fbq/hta/0rG1O60jFHLEOhoTlVfXeWG3DwvBeuQg5/R677g9WViHMlHqnq3N6Kq/gKJ9BQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.15':
-    resolution: {integrity: sha512-344QP1gS7hXWLKbIkBPciwB9JmiJ8YOI+VyD1RbaBES4ZhkY/yUdCPQiGD2d5LeWwErk11gtRMAK0zS3Fa+Zxw==}
+  '@powerformer/vela-cli-linux-arm64@0.0.16':
+    resolution: {integrity: sha512-69c5M9da56x1Fy6dNdLcBj36LVrbc2N8QissOmd0nOeze2M2YKyauQ86rEB6Kx7Ez72hyBfAX8uz6jkq8IX4Xg==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.15':
-    resolution: {integrity: sha512-BogFlbWRIHsCdyBQUq4KSF2oF4S10XLfp94nk2+cGn2cHvmyPFxlyTa7kp0X7h50IS+tg6uVfdcPLCb7+p0HJg==}
+  '@powerformer/vela-cli-linux-x64@0.0.16':
+    resolution: {integrity: sha512-b+sw+OBiv6Ll20OcPnU9hKu29WGGSGgvFQS6YLf/xLHSrO0Qk5Vj5fAJb/q04jwCYD9sJBemsRiZZPj2UfZpZA==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.15':
-    resolution: {integrity: sha512-+x91P30Ae9drrWe8GvehKXbW29rbBIf+FtuCAq6tH/3gwQs5I6OZbQLibIoOVXfz5ObBQBd/onNXY7M6+K1Rkg==}
+  '@powerformer/vela-cli-win32-x64@0.0.16':
+    resolution: {integrity: sha512-2vIoW/HX9Z0cwnYTtG5AxK9EdNXPi28fxeXUjd46EJ8XmcdXPIRbMi4WGUPNxr04Ld248wAdwut7gD2PwcfHpw==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.15':
-    resolution: {integrity: sha512-wosX3yF+XmCqEHEvMGH8XDahVcMCA1ZcT4Sa7ti/FuyfwnuTOO8mfXXBbauVOXb1glAX1HU2perAkfykTQ8/Wg==}
+  '@powerformer/vela-cli@0.0.16':
+    resolution: {integrity: sha512-07VuABihm7XLoNkGNTFQj/aAcVE9KZNIdZrwmjk7JqOuFj1tSp9YgXNpSuXwDM729K26z7cDgEurAGmzADLdtw==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -6560,28 +6560,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.15':
+  '@powerformer/vela-cli-darwin-arm64@0.0.16':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.15':
+  '@powerformer/vela-cli-darwin-x64@0.0.16':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.15':
+  '@powerformer/vela-cli-linux-arm64@0.0.16':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.15':
+  '@powerformer/vela-cli-linux-x64@0.0.16':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.15':
+  '@powerformer/vela-cli-win32-x64@0.0.16':
     optional: true
 
-  '@powerformer/vela-cli@0.0.15':
+  '@powerformer/vela-cli@0.0.16':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.15
-      '@powerformer/vela-cli-darwin-x64': 0.0.15
-      '@powerformer/vela-cli-linux-arm64': 0.0.15
-      '@powerformer/vela-cli-linux-x64': 0.0.15
-      '@powerformer/vela-cli-win32-x64': 0.0.15
+      '@powerformer/vela-cli-darwin-arm64': 0.0.16
+      '@powerformer/vela-cli-darwin-x64': 0.0.16
+      '@powerformer/vela-cli-linux-arm64': 0.0.16
+      '@powerformer/vela-cli-linux-x64': 0.0.16
+      '@powerformer/vela-cli-win32-x64': 0.0.16
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -24,7 +24,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.15"
+    "@powerformer/vela-cli": "0.0.16"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

`tools/pack` bundles a pinned `@powerformer/vela-cli` into packaged builds, currently `0.0.15`. That CLI is the one packaged Open Design spawns for AMR runs. `0.0.15` predates [powerformer/vela#277](https://github.com/powerformer/vela/pull/277), which makes the vela ACP bridge forward OpenCode token usage on the `session/prompt` result. Without it, every AMR run reports `token_count_source: "unknown"` in analytics even on success, because the daemon's `formatUsage(result.usage)` had nothing to read.

vela `0.0.16` (npm `@powerformer/vela-cli@0.0.16`, all platform packages published) ships that fix: the daemon now receives real `inputTokens/outputTokens/totalTokens` and attributes `provider_usage`.

## What users will see

No visible UI change. Packaged builds that bundle the vela CLI will, after this bump, report accurate provider token counts for AMR runs in product analytics instead of `unknown`. Dev/PATH users who bring their own vela are unaffected by the pin and just need their own `vela` updated.

## Changes

- `tools/pack/package.json` optionalDependency `@powerformer/vela-cli`: `0.0.15` → `0.0.16`
- `pnpm-lock.yaml` regenerated (`--lockfile-only`); all five platform packages resolve to `0.0.16`.
- `nix/pnpm-deps.nix` daemon/web fixed-output hashes refreshed for the new lockfile.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

<!-- This is a bundled-binary version bump in the tools/pack workspace package (not the root package.json, not a new dependency). It touches no UI/CLI/contract/i18n surface; the only behavior delta is internal analytics accuracy (token_count_source: unknown -> provider_usage for AMR runs). -->

## Validation

- `@powerformer/vela-cli@0.0.16` + all five platform packages confirmed published on npm.
- `pnpm install --lockfile-only` clean; no residual `0.0.15` in the lockfile.
- `Validate Nix flake` hash mismatch fixed by refreshing `nix/pnpm-deps.nix` (daemon + web FOD hashes) from the CI `nix-hash-refresh` artifact.
- No source/code changes; the daemon already reads the camelCase usage keys vela 0.0.16 emits.

## Related

Supersedes #4015 (@alchemistklk), which bumps the same `tools/pack` vela pin to `0.0.14` and currently has merge conflicts on `main`. A maintainer may want to close #4015 in favor of this.