### PR TITLE
Fix Langfuse completion telemetry fallback

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -111,6 +111,7 @@ function migrate(db: SqliteDb): void {
       session_mode TEXT,
       run_context_json TEXT,
       applied_plugin_snapshot_json TEXT,
+      telemetry_finalized_at INTEGER,
       started_at INTEGER,
       ended_at INTEGER,
       position INTEGER NOT NULL,
@@ -284,6 +285,9 @@ function migrate(db: SqliteDb): void {
   }
   if (!messageCols.some((c: DbRow) => c.name === 'applied_plugin_snapshot_json')) {
     db.exec(`ALTER TABLE messages ADD COLUMN applied_plugin_snapshot_json TEXT`);
+  }
+  if (!messageCols.some((c: DbRow) => c.name === 'telemetry_finalized_at')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN telemetry_finalized_at INTEGER`);
   }
   const routineRunCols = db.prepare(`PRAGMA table_info(routine_runs)`).all() as DbRow[];
   if (!routineRunCols.some((c: DbRow) => c.name === 'error_code')) {
@@ -1201,6 +1205,10 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
               produced_files_json = ?, feedback_json = ?,
               pre_turn_file_names_json = ?,
               session_mode = ?, run_context_json = ?, applied_plugin_snapshot_json = ?,
+              telemetry_finalized_at = CASE
+                WHEN ? THEN COALESCE(telemetry_finalized_at, ?)
+                ELSE telemetry_finalized_at
+              END,
               started_at = ?, ended_at = ?
         WHERE id = ?`,
     ).run(
@@ -1220,6 +1228,8 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       normalizeMessageSessionModeForStorage(m.sessionMode),
       m.runContext ? JSON.stringify(m.runContext) : null,
       m.appliedPluginSnapshot ? JSON.stringify(m.appliedPluginSnapshot) : null,
+      m.telemetryFinalized === true ? 1 : 0,
+      now,
       m.startedAt ?? null,
       m.endedAt ?? null,
       m.id,
@@ -1231,11 +1241,12 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       )
       .get(conversationId) as DbRow | undefined;
     const position = (max?.m ?? -1) + 1;
-    // 22 values: id, conversation_id, role, content, agent_id, agent_name,
+    // 23 values: id, conversation_id, role, content, agent_id, agent_name,
     // run_id, run_status, last_run_event_id, events_json, attachments_json,
     // comment_attachments_json, produced_files_json, feedback_json,
     // pre_turn_file_names_json, session_mode, run_context_json,
-    // applied_plugin_snapshot_json, started_at, ended_at, position, created_at.
+    // applied_plugin_snapshot_json, telemetry_finalized_at, started_at,
+    // ended_at, position, created_at.
     db.prepare(
       `INSERT INTO messages
          (id, conversation_id, role, content, agent_id, agent_name,
@@ -1243,8 +1254,8 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
           attachments_json, comment_attachments_json, produced_files_json,
           feedback_json, pre_turn_file_names_json,
           session_mode, run_context_json, applied_plugin_snapshot_json,
-          started_at, ended_at, position, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          telemetry_finalized_at, started_at, ended_at, position, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       m.id,
       conversationId,
@@ -1264,6 +1275,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       normalizeMessageSessionModeForStorage(m.sessionMode),
       m.runContext ? JSON.stringify(m.runContext) : null,
       m.appliedPluginSnapshot ? JSON.stringify(m.appliedPluginSnapshot) : null,
+      m.telemetryFinalized === true ? now : null,
       m.startedAt ?? null,
       m.endedAt ?? null,
       position,
@@ -1295,6 +1307,38 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
     )
     .get(m.id) as DbRow | undefined;
   return row ? normalizeMessage(row) : null;
+}
+
+export function getMessageTelemetryFinalizationState(db: SqliteDb, messageId: string) {
+  const row = db
+    .prepare(
+      `SELECT telemetry_finalized_at AS telemetryFinalizedAt,
+              content,
+              attachments_json AS attachmentsJson,
+              comment_attachments_json AS commentAttachmentsJson,
+              produced_files_json AS producedFilesJson
+         FROM messages
+        WHERE id = ?`,
+    )
+    .get(messageId) as DbRow | undefined;
+  if (!row) {
+    return {
+      exists: false,
+      finalizedAt: null,
+      hasBufferedPayload: false,
+    };
+  }
+  const hasBufferedPayload =
+    (typeof row.content === 'string' && row.content.trim().length > 0)
+    || jsonArrayHasItems(row.attachmentsJson)
+    || jsonArrayHasItems(row.commentAttachmentsJson)
+    || jsonArrayHasItems(row.producedFilesJson);
+  return {
+    exists: true,
+    finalizedAt:
+      typeof row.telemetryFinalizedAt === 'number' ? row.telemetryFinalizedAt : null,
+    hasBufferedPayload,
+  };
 }
 
 export function appendMessageStatusEvent(db: SqliteDb, messageId: string, event: DbRow) {
@@ -1667,6 +1711,11 @@ function parseJsonOrUndef(s: unknown): any {
   } catch {
     return undefined;
   }
+}
+
+function jsonArrayHasItems(s: unknown): boolean {
+  const parsed = parseJsonOrUndef(s);
+  return Array.isArray(parsed) && parsed.length > 0;
 }
 
 // ---------- routines ----------

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1312,11 +1312,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
 export function getMessageTelemetryFinalizationState(db: SqliteDb, messageId: string) {
   const row = db
     .prepare(
-      `SELECT telemetry_finalized_at AS telemetryFinalizedAt,
-              content,
-              attachments_json AS attachmentsJson,
-              comment_attachments_json AS commentAttachmentsJson,
-              produced_files_json AS producedFilesJson
+      `SELECT telemetry_finalized_at AS telemetryFinalizedAt
          FROM messages
         WHERE id = ?`,
     )
@@ -1325,19 +1321,12 @@ export function getMessageTelemetryFinalizationState(db: SqliteDb, messageId: st
     return {
       exists: false,
       finalizedAt: null,
-      hasBufferedPayload: false,
     };
   }
-  const hasBufferedPayload =
-    (typeof row.content === 'string' && row.content.trim().length > 0)
-    || jsonArrayHasItems(row.attachmentsJson)
-    || jsonArrayHasItems(row.commentAttachmentsJson)
-    || jsonArrayHasItems(row.producedFilesJson);
   return {
     exists: true,
     finalizedAt:
       typeof row.telemetryFinalizedAt === 'number' ? row.telemetryFinalizedAt : null,
-    hasBufferedPayload,
   };
 }
 
@@ -1711,11 +1700,6 @@ function parseJsonOrUndef(s: unknown): any {
   } catch {
     return undefined;
   }
-}
-
-function jsonArrayHasItems(s: unknown): boolean {
-  const parsed = parseJsonOrUndef(s);
-  return Array.isArray(parsed) && parsed.length > 0;
 }
 
 // ---------- routines ----------

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -19,6 +19,7 @@ import {
 } from './plugins/index.js';
 import { connectorService } from './connectors/service.js';
 import type { RouteDeps } from './server-context.js';
+import { readAnalyticsContext } from './analytics.js';
 import { listSkills } from './skills.js';
 import { isSafeId } from './projects.js';
 import {
@@ -1626,7 +1627,11 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     });
     // Bump the parent project's updatedAt so the project list re-orders.
     updateProject(db, req.params.id, {});
-    ctx.telemetry?.reportFinalizedMessage(saved, m);
+    ctx.telemetry?.reportFinalizedMessage(saved, m, {
+      analyticsContext: readAnalyticsContext(req),
+      projectId: req.params.id,
+      conversationId: req.params.cid,
+    });
     res.json({ message: saved });
   });
 

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -59,7 +59,16 @@ export interface ProjectPreviewScopeDeps {
 }
 
 export interface TelemetryDeps {
-  reportFinalizedMessage: (saved: any, body?: any) => void;
+  reportFinalizedMessage: (
+    saved: any,
+    body?: any,
+    options?: {
+      analyticsContext?: any;
+      projectId?: string;
+      conversationId?: string;
+      reportTrigger?: 'final_message' | 'terminal_fallback';
+    },
+  ) => void;
   /**
    * Best-effort Langfuse score emission for assistant-turn user ratings.
    * Returns the categorical outcome so the API surface in chat-routes can

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3185,6 +3185,10 @@ export function createFinalizedMessageTelemetryReporter({
   };
 }
 
+export function shouldReportRunCompletionTelemetryFallbackStatus(status: unknown): boolean {
+  return status === 'failed' || status === 'canceled';
+}
+
 const CLOUDFLARE_PAGES_PROJECT_METADATA_KEY = 'cloudflarePagesProjectName';
 
 function cloudflarePagesDeploymentMetadata(projectName) {
@@ -5864,6 +5868,7 @@ export async function startServer({
     run: any;
     status: string;
   }) => {
+    if (!shouldReportRunCompletionTelemetryFallbackStatus(status)) return;
     const timer = setTimeout(() => {
       if (reportedRuns.has(run.id)) return;
       reportFinalizedMessage(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -406,6 +406,7 @@ import {
   getConversation,
   getDeployment,
   getDeploymentById,
+  getMessageTelemetryFinalizationState,
   getProject,
   getTemplate,
   insertConversation,
@@ -3128,6 +3129,7 @@ export function createFinalizedMessageTelemetryReporter({
       });
       return;
     }
+    const reportTrigger = options.reportTrigger ?? 'final_message';
     if (reportedRuns.has(run.id)) {
       captureResult({
         analyticsContext: options.analyticsContext,
@@ -3147,7 +3149,9 @@ export function createFinalizedMessageTelemetryReporter({
       });
       return;
     }
-    reportedRuns.add(run.id);
+    if (reportTrigger !== 'terminal_fallback') {
+      reportedRuns.add(run.id);
+    }
     void (async () => {
       const start = Date.now();
       const delivery = await report({
@@ -3168,7 +3172,7 @@ export function createFinalizedMessageTelemetryReporter({
         delivery: state,
         durationMs: Date.now() - start,
         projectId: options.projectId,
-        reportTrigger: options.reportTrigger,
+        reportTrigger,
         reportResult: state.langfuse_expected === false
           ? 'skipped'
           : state.langfuse_delivery_status === 'accepted'
@@ -5829,8 +5833,10 @@ export async function startServer({
     });
   });
 
-  // Tracks runs whose completion has already been forwarded to Langfuse so
-  // repeated message updates only emit one trace per run.
+  // Tracks runs whose finalized assistant message has already been forwarded
+  // to Langfuse so repeated message updates only emit one final trace per run.
+  // Terminal fallback reports intentionally do not claim this set; a delayed
+  // telemetry-finalized message can still replace the synthetic fallback.
   const reportedRuns = new Set();
 
   // App-version snapshot read once at server start for Langfuse trace metadata.
@@ -5871,6 +5877,11 @@ export async function startServer({
     if (!shouldReportRunCompletionTelemetryFallbackStatus(status)) return;
     const timer = setTimeout(() => {
       if (reportedRuns.has(run.id)) return;
+      if (run.assistantMessageId) {
+        const messageTelemetry = getMessageTelemetryFinalizationState(db, run.assistantMessageId);
+        if (messageTelemetry.finalizedAt !== null) return;
+        if (messageTelemetry.exists && messageTelemetry.hasBufferedPayload) return;
+      }
       reportFinalizedMessage(
         {
           id: run.assistantMessageId ?? `${run.id}-terminal`,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5880,7 +5880,6 @@ export async function startServer({
       if (run.assistantMessageId) {
         const messageTelemetry = getMessageTelemetryFinalizationState(db, run.assistantMessageId);
         if (messageTelemetry.finalizedAt !== null) return;
-        if (messageTelemetry.exists && messageTelemetry.hasBufferedPayload) return;
       }
       reportFinalizedMessage(
         {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2566,6 +2566,7 @@ async function ensureGhReady() {
 }
 
 const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
+const LANGFUSE_TERMINAL_FALLBACK_DELAY_MS = 15_000;
 
 function reconcileAssistantMessageOnRunEnd(db, runs, run) {
   if (!run.assistantMessageId) return;
@@ -3069,6 +3070,7 @@ export function createFinalizedMessageTelemetryReporter({
     durationMs,
     projectId,
     reportResult,
+    reportTrigger = 'final_message',
     run,
     runId,
     skipReason,
@@ -3093,7 +3095,7 @@ export function createFinalizedMessageTelemetryReporter({
           ? { langfuse_drop_reason: delivery.langfuse_drop_reason }
           : {}),
         langfuse_report_result: reportResult,
-        langfuse_report_trigger: 'final_message',
+        langfuse_report_trigger: reportTrigger,
         ...(skipReason ? { langfuse_report_skip_reason: skipReason } : {}),
         ...(durationMs !== undefined ? { report_duration_ms: durationMs } : {}),
         ...(terminalResult ? { result: terminalResult } : {}),
@@ -3118,6 +3120,7 @@ export function createFinalizedMessageTelemetryReporter({
           langfuse_drop_reason: 'network_error',
         },
         projectId: options.projectId,
+        reportTrigger: options.reportTrigger,
         reportResult: 'skipped',
         runId,
         skipReason: 'run_not_found',
@@ -3135,6 +3138,7 @@ export function createFinalizedMessageTelemetryReporter({
           langfuse_drop_reason: 'network_error',
         },
         projectId: options.projectId,
+        reportTrigger: options.reportTrigger,
         reportResult: 'skipped',
         run,
         runId: run.id,
@@ -3164,6 +3168,7 @@ export function createFinalizedMessageTelemetryReporter({
         delivery: state,
         durationMs: Date.now() - start,
         projectId: options.projectId,
+        reportTrigger: options.reportTrigger,
         reportResult: state.langfuse_expected === false
           ? 'skipped'
           : state.langfuse_delivery_status === 'accepted'
@@ -5850,6 +5855,37 @@ export async function startServer({
     reportedRuns,
     getAppVersion: () => cachedAppVersion,
   });
+  const reportRunCompletionTelemetryFallback = ({
+    analyticsContext,
+    run,
+    status,
+  }: {
+    analyticsContext: any;
+    run: any;
+    status: string;
+  }) => {
+    const timer = setTimeout(() => {
+      if (reportedRuns.has(run.id)) return;
+      reportFinalizedMessage(
+        {
+          id: run.assistantMessageId ?? `${run.id}-terminal`,
+          conversationId: run.conversationId,
+          endedAt: run.updatedAt,
+          role: 'assistant',
+          runId: run.id,
+          runStatus: status,
+        },
+        { telemetryFinalized: true },
+        {
+          analyticsContext,
+          conversationId: run.conversationId,
+          projectId: run.projectId,
+          reportTrigger: 'terminal_fallback',
+        },
+      );
+    }, LANGFUSE_TERMINAL_FALLBACK_DELAY_MS);
+    timer.unref?.();
+  };
 
   const reportFeedback = (req: {
     runId: string;
@@ -14830,6 +14866,11 @@ export async function startServer({
             token_count_source: usageAnalytics.token_count_source,
           },
           insertId: `${runInsertId}-finish`,
+        });
+        reportRunCompletionTelemetryFallback({
+          analyticsContext,
+          run,
+          status: status.status,
         });
       }).catch(() => {
         // wait() can't reject in current runs.ts impl, but guard anyway.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3104,7 +3104,7 @@ export function createFinalizedMessageTelemetryReporter({
         ...(run?.agentId ? { agent_provider_id: agentIdToTracking(run.agentId) } : {}),
         ...(run?.model !== undefined ? { model_id: modelIdForTracking(run.model) } : {}),
       },
-      insertId: `${runId}-langfuse-report-${reportResult}${skipReason ? `-${skipReason}` : ''}`,
+      insertId: `${runId}-langfuse-report-${reportTrigger}-${reportResult}${skipReason ? `-${skipReason}` : ''}`,
     });
   };
   return (saved, body = {}, options = {}) => {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -14457,6 +14457,15 @@ export async function startServer({
     // here so PostHog actually receives the event. Both fire under the
     // same insert_id prefix so any web-side mirror dedupes by $insert_id.
     const analyticsContext = readAnalyticsContext(req);
+    design.runs.wait(run).then((status: { status: string }) => {
+      reportRunCompletionTelemetryFallback({
+        analyticsContext: analyticsContext ?? null,
+        run,
+        status: status.status,
+      });
+    }).catch(() => {
+      // wait() can't reject in current runs.ts impl, but guard anyway.
+    });
     if (analyticsContext) {
       const reqBody = (req.body || {}) as Record<string, unknown>;
       const runInsertId = newInsertId();
@@ -14866,11 +14875,6 @@ export async function startServer({
             token_count_source: usageAnalytics.token_count_source,
           },
           insertId: `${runInsertId}-finish`,
-        });
-        reportRunCompletionTelemetryFallback({
-          analyticsContext,
-          run,
-          status: status.status,
         });
       }).catch(() => {
         // wait() can't reject in current runs.ts impl, but guard anyway.

--- a/apps/daemon/tests/run-failure-telemetry-smoke.test.ts
+++ b/apps/daemon/tests/run-failure-telemetry-smoke.test.ts
@@ -219,6 +219,48 @@ describe('run failure telemetry smoke', () => {
     expect(trace.body.id).toBe(run.id);
     expect(trace.body.metadata.error_code).toBe(deriveRunErrorCode(run));
   });
+
+  it('lets a delayed failed-run final message report win over terminal fallback', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-failure-late-final-bin-'));
+    await writeFakeClaude(binDir, 'claude-late-final', 'late finalization smoke failure');
+
+    ingestion = await startLangfuseIngestion();
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_BASE_URL = ingestion.url;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.POSTHOG_KEY;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    restoreSetTimeout = accelerateLangfuseTerminalFallbackDelay(1000);
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: path.join(binDir, 'claude-late-final') } },
+      telemetry: { metrics: true, content: true, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const run = await createAndWaitForRun(started.url, {
+      caseId: 'late_finalized_failed_message',
+      agentId: 'claude',
+      message: 'od-failure-smoke-late-finalized-message',
+    });
+    const finalContent = 'late finalized failed assistant content';
+
+    await saveAssistantMessage(started.url, run, {
+      content: finalContent,
+      producedFiles: [{ name: 'late-final.html', kind: 'html', size: 42 }],
+    });
+    await delay(1200);
+    expect(ingestion.traces.some((trace) => trace.body.id === run.id)).toBe(false);
+
+    await finalizeAssistantMessage(started.url, run, {
+      content: finalContent,
+      producedFiles: [{ name: 'late-final.html', kind: 'html', size: 42 }],
+    });
+    const trace = await ingestion.waitForTrace(run.id);
+    expect(trace.body.output).toBe(finalContent);
+  });
 });
 
 function snapshotEnv(): Record<string, string | undefined> {
@@ -239,7 +281,7 @@ function restoreEnv(env: Record<string, string | undefined>): void {
   }
 }
 
-function accelerateLangfuseTerminalFallbackDelay(): () => void {
+function accelerateLangfuseTerminalFallbackDelay(delayMs = 0): () => void {
   const originalSetTimeout = globalThis.setTimeout;
   const spy = vi.spyOn(globalThis, 'setTimeout');
   spy.mockImplementation(((
@@ -247,7 +289,7 @@ function accelerateLangfuseTerminalFallbackDelay(): () => void {
     timeout: Parameters<typeof globalThis.setTimeout>[1],
     ...args: any[]
   ) => {
-    const delay = timeout === 15_000 ? 0 : timeout;
+    const delay = timeout === 15_000 ? delayMs : timeout;
     return originalSetTimeout(handler, delay, ...args);
   }) as typeof globalThis.setTimeout);
   return () => spy.mockRestore();
@@ -400,7 +442,12 @@ async function readRunEvents(file: string): Promise<RunEvent[]> {
     .map((line) => JSON.parse(line) as RunEvent);
 }
 
-async function finalizeAssistantMessage(url: string, run: RunStatus): Promise<void> {
+async function saveAssistantMessage(
+  url: string,
+  run: RunStatus,
+  patch: Record<string, unknown> = {},
+  telemetryFinalized = false,
+): Promise<void> {
   const response = await fetch(
     `${url}/api/projects/${encodeURIComponent(run.projectId)}/conversations/${encodeURIComponent(run.conversationId)}/messages/${encodeURIComponent(run.assistantMessageId)}`,
     {
@@ -415,11 +462,20 @@ async function finalizeAssistantMessage(url: string, run: RunStatus): Promise<vo
         runStatus: run.status,
         startedAt: run.createdAt,
         endedAt: run.updatedAt,
-        telemetryFinalized: true,
+        ...patch,
+        ...(telemetryFinalized ? { telemetryFinalized: true } : {}),
       }),
     },
   );
   expect(response.status).toBe(200);
+}
+
+async function finalizeAssistantMessage(
+  url: string,
+  run: RunStatus,
+  patch: Record<string, unknown> = {},
+): Promise<void> {
+  await saveAssistantMessage(url, run, patch, true);
 }
 
 function delay(ms: number): Promise<void> {

--- a/apps/daemon/tests/run-failure-telemetry-smoke.test.ts
+++ b/apps/daemon/tests/run-failure-telemetry-smoke.test.ts
@@ -220,9 +220,9 @@ describe('run failure telemetry smoke', () => {
     expect(trace.body.metadata.error_code).toBe(deriveRunErrorCode(run));
   });
 
-  it('lets a delayed failed-run final message report win over terminal fallback', async () => {
-    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-failure-late-final-bin-'));
-    await writeFakeClaude(binDir, 'claude-late-final', 'late finalization smoke failure');
+  it('reports terminal fallback with buffered content when final telemetry never arrives', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-failure-buffered-fallback-bin-'));
+    await writeFakeClaude(binDir, 'claude-buffered-fallback', 'buffered fallback smoke failure');
 
     ingestion = await startLangfuseIngestion();
     process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
@@ -235,31 +235,24 @@ describe('run failure telemetry smoke', () => {
     restoreSetTimeout = accelerateLangfuseTerminalFallbackDelay(1000);
     await putConfig(started.url, {
       agentId: 'claude',
-      agentCliEnv: { claude: { CLAUDE_BIN: path.join(binDir, 'claude-late-final') } },
+      agentCliEnv: { claude: { CLAUDE_BIN: path.join(binDir, 'claude-buffered-fallback') } },
       telemetry: { metrics: true, content: true, artifactManifest: false },
       privacyDecisionAt: Date.now(),
     });
 
     const run = await createAndWaitForRun(started.url, {
-      caseId: 'late_finalized_failed_message',
+      caseId: 'buffered_unfinalized_failed_message',
       agentId: 'claude',
-      message: 'od-failure-smoke-late-finalized-message',
+      message: 'od-failure-smoke-buffered-unfinalized-message',
     });
-    const finalContent = 'late finalized failed assistant content';
+    const bufferedContent = 'buffered unfinalized failed assistant content';
 
     await saveAssistantMessage(started.url, run, {
-      content: finalContent,
-      producedFiles: [{ name: 'late-final.html', kind: 'html', size: 42 }],
-    });
-    await delay(1200);
-    expect(ingestion.traces.some((trace) => trace.body.id === run.id)).toBe(false);
-
-    await finalizeAssistantMessage(started.url, run, {
-      content: finalContent,
-      producedFiles: [{ name: 'late-final.html', kind: 'html', size: 42 }],
+      content: bufferedContent,
+      producedFiles: [{ name: 'buffered-fallback.html', kind: 'html', size: 42 }],
     });
     const trace = await ingestion.waitForTrace(run.id);
-    expect(trace.body.output).toBe(finalContent);
+    expect(trace.body.output).toBe(bufferedContent);
   });
 });
 

--- a/apps/daemon/tests/run-failure-telemetry-smoke.test.ts
+++ b/apps/daemon/tests/run-failure-telemetry-smoke.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { startServer } from '../src/server.js';
 import { classifyRunFailure } from '../src/run-failure-classification.js';
@@ -42,8 +42,11 @@ describe('run failure telemetry smoke', () => {
   let started: StartedServer | null = null;
   let binDir: string | null = null;
   let ingestion: Awaited<ReturnType<typeof startLangfuseIngestion>> | null = null;
+  let restoreSetTimeout: (() => void) | null = null;
 
   afterEach(async () => {
+    restoreSetTimeout?.();
+    restoreSetTimeout = null;
     await Promise.resolve(started?.shutdown?.());
     if (started?.server) {
       await new Promise<void>((resolve) => started?.server.close(() => resolve()));
@@ -185,6 +188,37 @@ describe('run failure telemetry smoke', () => {
       }
     }
   });
+
+  it('reports the terminal Langfuse fallback for headerless run requests', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-failure-fallback-bin-'));
+    await writeFakeClaude(binDir, 'claude-terminal-failure', 'terminal fallback smoke failure');
+
+    ingestion = await startLangfuseIngestion();
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_BASE_URL = ingestion.url;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.POSTHOG_KEY;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    restoreSetTimeout = accelerateLangfuseTerminalFallbackDelay();
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: path.join(binDir, 'claude-terminal-failure') } },
+      telemetry: { metrics: true, content: true, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const run = await createAndWaitForRun(started.url, {
+      caseId: 'headerless_terminal_fallback',
+      agentId: 'claude',
+      message: 'od-failure-smoke-headerless-terminal-fallback',
+    });
+
+    const trace = await ingestion.waitForTrace(run.id);
+    expect(trace.body.id).toBe(run.id);
+    expect(trace.body.metadata.error_code).toBe(deriveRunErrorCode(run));
+  });
 });
 
 function snapshotEnv(): Record<string, string | undefined> {
@@ -203,6 +237,20 @@ function restoreEnv(env: Record<string, string | undefined>): void {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   }
+}
+
+function accelerateLangfuseTerminalFallbackDelay(): () => void {
+  const originalSetTimeout = globalThis.setTimeout;
+  const spy = vi.spyOn(globalThis, 'setTimeout');
+  spy.mockImplementation(((
+    handler: Parameters<typeof globalThis.setTimeout>[0],
+    timeout: Parameters<typeof globalThis.setTimeout>[1],
+    ...args: any[]
+  ) => {
+    const delay = timeout === 15_000 ? 0 : timeout;
+    return originalSetTimeout(handler, delay, ...args);
+  }) as typeof globalThis.setTimeout);
+  return () => spy.mockRestore();
 }
 
 async function writeFakeClaude(dir: string, name: string, stderr: string | null): Promise<void> {

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -5,6 +5,7 @@ import {
   composeChatUserRequestForAgent,
   createFinalizedMessageTelemetryReporter,
   shouldReportRunCompletedFromMessage,
+  shouldReportRunCompletionTelemetryFallbackStatus,
   telemetryPromptFromRunRequest,
 } from '../src/server.js';
 
@@ -42,6 +43,13 @@ describe('Langfuse message finalization gate', () => {
         { telemetryFinalized: true },
       ),
     ).toBe(false);
+  });
+
+  it('schedules terminal fallback only for failed and canceled runs', () => {
+    expect(shouldReportRunCompletionTelemetryFallbackStatus('failed')).toBe(true);
+    expect(shouldReportRunCompletionTelemetryFallbackStatus('canceled')).toBe(true);
+    expect(shouldReportRunCompletionTelemetryFallbackStatus('succeeded')).toBe(false);
+    expect(shouldReportRunCompletionTelemetryFallbackStatus('running')).toBe(false);
   });
 
   it('uses the explicit current prompt for telemetry instead of the full transcript', () => {

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -272,6 +272,49 @@ describe('Langfuse message finalization gate', () => {
     });
   });
 
+  it('allows a real final message report after a terminal fallback report', () => {
+    const run = {
+      id: 'run-failed-late-final',
+      projectId: 'project-1',
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      status: 'failed',
+      createdAt: 1,
+      updatedAt: 2,
+      events: [],
+    };
+    const report = vi.fn();
+    const reporter = createFinalizedMessageTelemetryReporter({
+      design: { runs: { get: vi.fn(() => run) } },
+      db: 'db',
+      dataDir: '/tmp/od-data',
+      reportedRuns: new Set<string>(),
+      report,
+    });
+
+    reporter(
+      { ...terminalMessage, runId: run.id, runStatus: 'failed', endedAt: 1234 },
+      { telemetryFinalized: true },
+      { reportTrigger: 'terminal_fallback' },
+    );
+    reporter(
+      { ...terminalMessage, runId: run.id, runStatus: 'failed', endedAt: 1235 },
+      { telemetryFinalized: true },
+      { reportTrigger: 'final_message' },
+    );
+    reporter(
+      { ...terminalMessage, runId: run.id, runStatus: 'failed', endedAt: 1236 },
+      { telemetryFinalized: true },
+      { reportTrigger: 'final_message' },
+    );
+
+    expect(report).toHaveBeenCalledTimes(2);
+    expect(report.mock.calls.map(([call]) => call.persistedEndedAt)).toEqual([
+      1234,
+      1235,
+    ]);
+  });
+
   it('captures Langfuse report acceptance after final message reporting resolves', async () => {
     const run = {
       id: 'run-accepted',

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -308,6 +308,7 @@ describe('Langfuse message finalization gate', () => {
         },
         projectId: 'project-1',
         conversationId: 'conv-1',
+        reportTrigger: 'terminal_fallback',
       },
     );
     await Promise.resolve();
@@ -322,7 +323,7 @@ describe('Langfuse message finalization gate', () => {
           langfuse_expected: true,
           langfuse_delivery_status: 'accepted',
           langfuse_report_result: 'accepted',
-          langfuse_report_trigger: 'final_message',
+          langfuse_report_trigger: 'terminal_fallback',
         }),
       }),
     );

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -272,7 +272,7 @@ describe('Langfuse message finalization gate', () => {
     });
   });
 
-  it('allows a real final message report after a terminal fallback report', () => {
+  it('allows a real final message report after a terminal fallback report', async () => {
     const run = {
       id: 'run-failed-late-final',
       projectId: 'project-1',
@@ -283,9 +283,17 @@ describe('Langfuse message finalization gate', () => {
       updatedAt: 2,
       events: [],
     };
-    const report = vi.fn();
+    const capture = vi.fn<(event: { insertId?: string }) => void>();
+    const report = vi.fn(async (_args: any) => ({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted' as const,
+    }));
     const reporter = createFinalizedMessageTelemetryReporter({
-      design: { runs: { get: vi.fn(() => run) } },
+      design: {
+        analytics: { capture },
+        getAppVersion: () => '0.7.0',
+        runs: { get: vi.fn(() => run) },
+      },
       db: 'db',
       dataDir: '/tmp/od-data',
       reportedRuns: new Set<string>(),
@@ -295,24 +303,58 @@ describe('Langfuse message finalization gate', () => {
     reporter(
       { ...terminalMessage, runId: run.id, runStatus: 'failed', endedAt: 1234 },
       { telemetryFinalized: true },
-      { reportTrigger: 'terminal_fallback' },
+      {
+        analyticsContext: {
+          deviceId: 'device-1',
+          sessionId: 'session-1',
+          clientType: 'desktop',
+          locale: 'zh-CN',
+          requestId: 'request-1',
+        },
+        reportTrigger: 'terminal_fallback',
+      },
     );
     reporter(
       { ...terminalMessage, runId: run.id, runStatus: 'failed', endedAt: 1235 },
       { telemetryFinalized: true },
-      { reportTrigger: 'final_message' },
+      {
+        analyticsContext: {
+          deviceId: 'device-1',
+          sessionId: 'session-1',
+          clientType: 'desktop',
+          locale: 'zh-CN',
+          requestId: 'request-1',
+        },
+        reportTrigger: 'final_message',
+      },
     );
     reporter(
       { ...terminalMessage, runId: run.id, runStatus: 'failed', endedAt: 1236 },
       { telemetryFinalized: true },
-      { reportTrigger: 'final_message' },
+      {
+        analyticsContext: {
+          deviceId: 'device-1',
+          sessionId: 'session-1',
+          clientType: 'desktop',
+          locale: 'zh-CN',
+          requestId: 'request-1',
+        },
+        reportTrigger: 'final_message',
+      },
     );
+    await Promise.resolve();
 
     expect(report).toHaveBeenCalledTimes(2);
     expect(report.mock.calls.map(([call]) => call.persistedEndedAt)).toEqual([
       1234,
       1235,
     ]);
+    expect(capture).toHaveBeenCalledTimes(3);
+    expect(capture.mock.calls.map(([call]) => call.insertId)).toEqual(expect.arrayContaining([
+      'run-failed-late-final-langfuse-report-terminal_fallback-accepted',
+      'run-failed-late-final-langfuse-report-final_message-accepted',
+      'run-failed-late-final-langfuse-report-final_message-skipped-duplicate_run',
+    ]));
   });
 
   it('captures Langfuse report acceptance after final message reporting resolves', async () => {
@@ -367,7 +409,7 @@ describe('Langfuse message finalization gate', () => {
     expect(capture).toHaveBeenCalledWith(
       expect.objectContaining({
         eventName: 'langfuse_report_result',
-        insertId: 'run-accepted-langfuse-report-accepted',
+        insertId: 'run-accepted-langfuse-report-terminal_fallback-accepted',
         properties: expect.objectContaining({
           run_id: 'run-accepted',
           langfuse_trace_id: 'run-accepted',
@@ -414,7 +456,7 @@ describe('Langfuse message finalization gate', () => {
     expect(capture).toHaveBeenCalledWith(
       expect.objectContaining({
         eventName: 'langfuse_report_result',
-        insertId: 'run-missing-langfuse-report-skipped-run_not_found',
+        insertId: 'run-missing-langfuse-report-final_message-skipped-run_not_found',
         properties: expect.objectContaining({
           project_id: 'project-1',
           conversation_id: 'conv-1',

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -2352,7 +2352,7 @@ export interface LangfuseReportResultProps {
   langfuse_delivery_status: TrackingLangfuseDeliveryStatus;
   langfuse_drop_reason?: TrackingLangfuseDropReason;
   langfuse_report_result: TrackingLangfuseReportResult;
-  langfuse_report_trigger: 'final_message';
+  langfuse_report_trigger: 'final_message' | 'terminal_fallback';
   langfuse_report_skip_reason?: TrackingLangfuseReportSkipReason;
   report_duration_ms?: number;
   result?: TrackingRunResult;

--- a/packages/contracts/tests/analytics-run-finished-contract.test.ts
+++ b/packages/contracts/tests/analytics-run-finished-contract.test.ts
@@ -156,7 +156,7 @@ describe('analytics run_finished contract', () => {
         langfuse_delivery_status: 'failed',
         langfuse_drop_reason: 'network_error',
         langfuse_report_result: 'failed',
-        langfuse_report_trigger: 'final_message',
+        langfuse_report_trigger: 'terminal_fallback',
         report_duration_ms: 123,
         result: 'failed',
         error_code: 'AGENT_EXECUTION_FAILED',


### PR DESCRIPTION
## Why

Hourly 0.10.x stability monitoring showed `run_finished.langfuse_delivery_status=queued` for recent runs, but Langfuse trace lookup only found 5 of 8 failed sample traces. The missing traces were early terminal failures such as model selection failure and first-token timeout, where the web client may never save a telemetry-finalized assistant message.

Langfuse credentials and ingestion are healthy: a direct Open Design `reportRunCompleted` smoke returned `accepted` and the trace was readable through the Langfuse traces API. The gap is the Open Design trigger path, not Langfuse itself.

## What users will see

No UI change. Langfuse observability should now receive traces for terminal runs even when no final assistant message is saved. PostHog `langfuse_report_result` can also distinguish normal `final_message` reports from `terminal_fallback` reports.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — changed analytics contract shape for `langfuse_report_trigger`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — terminal runs can now emit Langfuse via delayed fallback when final-message reporting never arrives
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/telemetry-message-finalization.test.ts`; `packages/contracts/tests/analytics-run-finished-contract.test.ts`
- Did the test go red on `main` and green on this branch? no. The production symptom required external Langfuse/PostHog data and early-failure timing; I used the existing pure reporter tests instead of adding a route server test.
- Additional evidence: Langfuse trace API found 5/8 recent failed traces; missing traces were the early failures that may not persist a final assistant message.

## Validation

- `pnpm --filter @open-design/contracts test -- analytics-run-finished-contract.test.ts`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/telemetry-message-finalization.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- Langfuse smoke: Open Design `reportRunCompleted` returned `accepted`; trace `codex-smoke-1781083318492` was readable through `/api/public/traces/:id`.
