### PR TITLE
fix(amr): resolve run model catalog from cache instead of a blocking per-run `vela model list`

### DIFF
--- a/apps/daemon/src/diagnostics-export.ts
+++ b/apps/daemon/src/diagnostics-export.ts
@@ -32,6 +32,7 @@ interface ResolvedAgentHomes {
   amrOpenCodeHome: string | null;
   claudeConfigDir: string | null;
   codexHome: string | null;
+  openCodeXdgDataHome: string | null;
 }
 
 // Resolve each agent CLI's effective home (OPENCODE_TEST_HOME / CLAUDE_CONFIG_DIR
@@ -41,7 +42,12 @@ interface ResolvedAgentHomes {
 // only looking under the hardcoded defaults, and cannot drift from the spawn
 // path. Returns nulls on any failure; the collector then falls back to defaults.
 async function resolveAgentHomes(dataDir: string | null | undefined): Promise<ResolvedAgentHomes> {
-  const empty: ResolvedAgentHomes = { amrOpenCodeHome: null, claudeConfigDir: null, codexHome: null };
+  const empty: ResolvedAgentHomes = {
+    amrOpenCodeHome: null,
+    claudeConfigDir: null,
+    codexHome: null,
+    openCodeXdgDataHome: null,
+  };
   if (!dataDir) return empty;
   try {
     const appConfig = await readAppConfig(dataDir);
@@ -59,6 +65,11 @@ async function resolveAgentHomes(dataDir: string | null | undefined): Promise<Re
       amrOpenCodeHome: clean(envFor('amr').OPENCODE_TEST_HOME),
       claudeConfigDir: clean(envFor('claude').CLAUDE_CONFIG_DIR),
       codexHome: clean(envFor('codex').CODEX_HOME),
+      // OpenCode resolves its data/log dir from XDG_DATA_HOME; sandbox mode
+      // rewrites that (sandbox-mode.ts), so read the EFFECTIVE value from the
+      // opencode spawn env rather than the host's, or the sweep misses the
+      // logs in a sandboxed runtime.
+      openCodeXdgDataHome: clean(envFor('opencode').XDG_DATA_HOME),
     };
   } catch {
     return empty;
@@ -148,7 +159,7 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
           amrOpenCodeHome: agentHomes.amrOpenCodeHome,
           claudeConfigDir: agentHomes.claudeConfigDir,
           codexHome: agentHomes.codexHome,
-          xdgDataHome: process.env.XDG_DATA_HOME ?? null,
+          xdgDataHome: agentHomes.openCodeXdgDataHome ?? process.env.XDG_DATA_HOME ?? null,
         })),
       ];
       const username = safeUsername();

--- a/apps/daemon/src/diagnostics-export.ts
+++ b/apps/daemon/src/diagnostics-export.ts
@@ -25,6 +25,26 @@ import {
 } from '@open-design/sidecar';
 
 import { readCurrentAppVersionInfo } from './app-version.js';
+import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
+import { spawnEnvForAgent } from './agents.js';
+
+// Resolve the AMR OpenCode home (OPENCODE_TEST_HOME) exactly as a real AMR run
+// would, so the diagnostics sweep honors a user `agentCliEnv.amr.OPENCODE_TEST_HOME`
+// override instead of only looking under the default `<dataDir>/amr/opencode-home`.
+// Reuses the live env resolver so the two cannot drift. Returns null on any
+// failure; the collector then falls back to the dataDir default.
+async function resolveAmrOpenCodeHome(dataDir: string | null | undefined): Promise<string | null> {
+  if (!dataDir) return null;
+  try {
+    const appConfig = await readAppConfig(dataDir);
+    const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+    const amrEnv = spawnEnvForAgent('amr', { ...process.env, OD_DATA_DIR: dataDir }, configuredEnv);
+    const home = amrEnv.OPENCODE_TEST_HOME?.trim();
+    return home && home.length > 0 ? home : null;
+  } catch {
+    return null;
+  }
+}
 
 export interface DiagnosticsHandlerOptions {
   /** Sidecar runtime context, present when daemon is launched via tools-dev or packaged sidecar. */
@@ -99,12 +119,14 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
     try {
       const versionInfo = await readCurrentAppVersionInfo().catch(() => null);
       const home = homedir();
+      const amrOpenCodeHome = await resolveAmrOpenCodeHome(options.dataDir);
       const sources = [
         ...buildSidecarLogSources(options.runtime),
         ...(await buildRunEventLogSources(options.runsDir)),
         ...(await buildAgentCliLogSources({
           homeDir: home,
           dataDir: options.dataDir ?? null,
+          amrOpenCodeHome,
           xdgDataHome: process.env.XDG_DATA_HOME ?? null,
         })),
       ];

--- a/apps/daemon/src/diagnostics-export.ts
+++ b/apps/daemon/src/diagnostics-export.ts
@@ -28,21 +28,40 @@ import { readCurrentAppVersionInfo } from './app-version.js';
 import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import { spawnEnvForAgent } from './agents.js';
 
-// Resolve the AMR OpenCode home (OPENCODE_TEST_HOME) exactly as a real AMR run
-// would, so the diagnostics sweep honors a user `agentCliEnv.amr.OPENCODE_TEST_HOME`
-// override instead of only looking under the default `<dataDir>/amr/opencode-home`.
-// Reuses the live env resolver so the two cannot drift. Returns null on any
-// failure; the collector then falls back to the dataDir default.
-async function resolveAmrOpenCodeHome(dataDir: string | null | undefined): Promise<string | null> {
-  if (!dataDir) return null;
+interface ResolvedAgentHomes {
+  amrOpenCodeHome: string | null;
+  claudeConfigDir: string | null;
+  codexHome: string | null;
+}
+
+// Resolve each agent CLI's effective home (OPENCODE_TEST_HOME / CLAUDE_CONFIG_DIR
+// / CODEX_HOME) exactly as a real run would, by running the live
+// `spawnEnvForAgent` resolver over the user's app-config overrides. This makes
+// the diagnostics sweep honor `agentCliEnv.<agent>.*` relocations instead of
+// only looking under the hardcoded defaults, and cannot drift from the spawn
+// path. Returns nulls on any failure; the collector then falls back to defaults.
+async function resolveAgentHomes(dataDir: string | null | undefined): Promise<ResolvedAgentHomes> {
+  const empty: ResolvedAgentHomes = { amrOpenCodeHome: null, claudeConfigDir: null, codexHome: null };
+  if (!dataDir) return empty;
   try {
     const appConfig = await readAppConfig(dataDir);
-    const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
-    const amrEnv = spawnEnvForAgent('amr', { ...process.env, OD_DATA_DIR: dataDir }, configuredEnv);
-    const home = amrEnv.OPENCODE_TEST_HOME?.trim();
-    return home && home.length > 0 ? home : null;
+    const envFor = (agentId: string) =>
+      spawnEnvForAgent(
+        agentId,
+        { ...process.env, OD_DATA_DIR: dataDir },
+        agentCliEnvForAgent(appConfig.agentCliEnv, agentId),
+      );
+    const clean = (value: string | undefined): string | null => {
+      const trimmed = value?.trim();
+      return trimmed && trimmed.length > 0 ? trimmed : null;
+    };
+    return {
+      amrOpenCodeHome: clean(envFor('amr').OPENCODE_TEST_HOME),
+      claudeConfigDir: clean(envFor('claude').CLAUDE_CONFIG_DIR),
+      codexHome: clean(envFor('codex').CODEX_HOME),
+    };
   } catch {
-    return null;
+    return empty;
   }
 }
 
@@ -119,14 +138,16 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
     try {
       const versionInfo = await readCurrentAppVersionInfo().catch(() => null);
       const home = homedir();
-      const amrOpenCodeHome = await resolveAmrOpenCodeHome(options.dataDir);
+      const agentHomes = await resolveAgentHomes(options.dataDir);
       const sources = [
         ...buildSidecarLogSources(options.runtime),
         ...(await buildRunEventLogSources(options.runsDir)),
         ...(await buildAgentCliLogSources({
           homeDir: home,
           dataDir: options.dataDir ?? null,
-          amrOpenCodeHome,
+          amrOpenCodeHome: agentHomes.amrOpenCodeHome,
+          claudeConfigDir: agentHomes.claudeConfigDir,
+          codexHome: agentHomes.codexHome,
           xdgDataHome: process.env.XDG_DATA_HOME ?? null,
         })),
       ];

--- a/apps/daemon/src/diagnostics-export.ts
+++ b/apps/daemon/src/diagnostics-export.ts
@@ -1,11 +1,12 @@
 import { homedir, userInfo } from 'node:os';
-import { readdir, stat } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
 
 import type { RequestHandler } from 'express';
 
 import {
+  buildAgentCliLogSources,
   buildDiagnosticsZip,
+  buildRunEventLogSources,
   DIAGNOSTICS_CONTENT_TYPE,
   DIAGNOSTICS_FILENAME_PREFIX,
   diagnosticsFileName,
@@ -32,11 +33,11 @@ export interface DiagnosticsHandlerOptions {
   projectRoot: string;
   /** Directory containing per-run event logs at <runsDir>/<runId>/events.jsonl. */
   runsDir?: string | null;
+  /** Open Design data dir (OD_DATA_DIR), used to locate the AMR OpenCode home. */
+  dataDir?: string | null;
 }
 
 const TAIL_BYTES_PER_LOG = 4 * 1024 * 1024;
-const TAIL_BYTES_PER_RUN_EVENT_LOG = 2 * 1024 * 1024;
-const MAX_RUN_EVENT_LOGS = 20;
 
 function safeUsername(): string | undefined {
   try {
@@ -93,48 +94,21 @@ function buildSidecarLogSources(runtime: SidecarRuntimeContext<SidecarStamp> | n
   return sources;
 }
 
-async function buildRunEventLogSources(runsDir: string | null | undefined): Promise<LogSource[]> {
-  if (!runsDir) return [];
-  let entries;
-  try {
-    entries = await readdir(runsDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-
-  const candidates: Array<{ runId: string; absolutePath: string; mtimeMs: number }> = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    if (!/^[A-Za-z0-9._-]+$/u.test(entry.name)) continue;
-    const absolutePath = join(runsDir, entry.name, 'events.jsonl');
-    try {
-      const info = await stat(absolutePath);
-      if (!info.isFile()) continue;
-      candidates.push({ runId: entry.name, absolutePath, mtimeMs: info.mtimeMs });
-    } catch {
-      continue;
-    }
-  }
-
-  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  return candidates.slice(0, MAX_RUN_EVENT_LOGS).map(({ runId, absolutePath }) => ({
-    name: `runs/${runId}/events.jsonl`,
-    absolutePath,
-    kind: 'text',
-    tailBytes: TAIL_BYTES_PER_RUN_EVENT_LOG,
-  }));
-}
-
 export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOptions): RequestHandler {
   return async (_req, res) => {
     try {
       const versionInfo = await readCurrentAppVersionInfo().catch(() => null);
+      const home = homedir();
       const sources = [
         ...buildSidecarLogSources(options.runtime),
         ...(await buildRunEventLogSources(options.runsDir)),
+        ...(await buildAgentCliLogSources({
+          homeDir: home,
+          dataDir: options.dataDir ?? null,
+          xdgDataHome: process.env.XDG_DATA_HOME ?? null,
+        })),
       ];
       const username = safeUsername();
-      const home = homedir();
 
       const result = await buildDiagnosticsZip({
         context: {

--- a/apps/daemon/src/runtimes/amr-model-cache.ts
+++ b/apps/daemon/src/runtimes/amr-model-cache.ts
@@ -17,7 +17,14 @@ type CacheState = {
   lastRemoteError: string | null;
 };
 
-const DEFAULT_REMOTE_REFRESH_INTERVAL_MS = 60_000;
+// The AMR model catalog changes rarely (new models land on the order of days),
+// and a cached remote list is returned immediately while a refresh runs in the
+// background — `get()` never blocks on the network when a cached entry exists.
+// The per-run preflight now also reads this cache, so a tight interval would
+// spawn `vela model list` far more often than the catalog actually changes.
+// Refresh at most once every 10 minutes per cache key; callers always get the
+// last-known catalog instantly in between.
+const DEFAULT_REMOTE_REFRESH_INTERVAL_MS = 10 * 60_000;
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error ?? 'unknown error');

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -1,3 +1,4 @@
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -96,6 +97,19 @@ export function spawnEnvForAgent(
   if (agentId === 'amr') {
     Object.assign(env, amrVelaProfileEnv(env));
     Object.assign(env, amrAnalyticsIdentityEnv(env));
+    // `execAgentFile` REPLACES the child environment (execFile with `env`
+    // set), so anything missing here is genuinely absent for vela. `vela model
+    // list` resolves its config home up front and exits non-zero with
+    // "$HOME is not defined" when HOME is unset — while `vela model preset`
+    // and `vela --version` do not need it. A packaged daemon spawned with a
+    // stripped env (or any caller that did not forward HOME) would therefore
+    // detect AMR and seed the picker from preset, yet fail every run's remote
+    // catalog probe. Backfill HOME from the OS so the authoritative catalog
+    // call is never silently decapitated by a missing home dir.
+    if (!env.HOME?.trim()) {
+      const home = os.homedir();
+      if (home) env.HOME = home;
+    }
     // Identify Open Design as the host so the vela CLI tags its command +
     // model_request analytics with source=open_design (revenue attribution).
     // Not PII (unlike the installation id above), so set it regardless of the

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5535,6 +5535,7 @@ export async function startServer({
       runtime,
       projectRoot: PROJECT_ROOT,
       runsDir: path.join(RUNTIME_DATA_DIR, 'runs'),
+      dataDir: RUNTIME_DATA_DIR,
     }),
   );
 
@@ -12247,16 +12248,39 @@ export async function startServer({
             agentLaunch,
           )
         : null;
+      const amrModelScope = resolveAmrProfile(modelProbeEnv ?? process.env);
+      // Resolve the AMR model catalog through the SAME shared cache the UI's
+      // `/api/amr/models` endpoint serves (AmrModelLoadingCache): a cached
+      // authoritative `vela model list` when it is hot, otherwise the offline
+      // `vela model preset` seed while a remote refresh runs in the background.
+      //
+      // Why not a fresh `vela model list` per run: that authoritative call
+      // needs network reachability to the AMR gateway AND `$HOME` (the offline
+      // `preset`/`--version` calls need neither), takes up to ~10s, and only
+      // retries a narrow set of network errors. Running it blocking on every
+      // turn turned any transient gateway/timeout/HOME hiccup into a hard
+      // "AMR model … is not available from Vela" — even for a logged-in user
+      // who already picked a real model the picker surfaced from the preset
+      // seed. Under CorpLink/飞连 the call routinely exceeded the timeout, so
+      // AMR became unusable in packaged nightlies. Reusing the cache keeps that
+      // blocking probe off the per-run hot path and degrades to preset instead
+      // of fail-closing; vela's own `session/set_model` remains the final gate.
       let liveModels = [];
       try {
-        liveModels =
-          launchPath && typeof def.fetchModels === 'function'
-            ? ((await def.fetchModels(launchPath, modelProbeEnv)) ?? [])
-            : [];
-      } catch {
+        const probe = await resolveAmrModelProbe();
+        const catalog = await amrModelLoadingCache.get(probe.cacheKey, {
+          fetchPreset: () => fetchVelaPresetModels(probe.launchPath, probe.env),
+          fetchRemote: () => fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
+        });
+        liveModels = catalog.models ?? [];
+      } catch (error) {
+        // Do not swallow silently: a probe failure here is exactly what made
+        // the packaged AMR breakage undiagnosable (the old `catch {}` left no
+        // trace in any log or diagnostics bundle). Record it and degrade to the
+        // remembered catalog below.
+        console.warn('[amr] model catalog preflight probe failed', error);
         liveModels = [];
       }
-      const amrModelScope = resolveAmrProfile(modelProbeEnv ?? process.env);
       const rememberedLiveModels = getRememberedLiveModels(def.id, amrModelScope);
       if (liveModels.length > 0) {
         rememberLiveModels(def.id, liveModels, amrModelScope);
@@ -12265,12 +12289,26 @@ export async function startServer({
       const liveModelIds = new Set(
         liveModels.map((candidate) => candidate?.id).filter(Boolean),
       );
+      // A request that came in as 'default'/empty is normally pre-resolved to a
+      // concrete id via the agent-wide cached model order; if it still is not,
+      // adopt the first catalog entry so the spawn layer always has a real id.
+      const userAskedForDefault =
+        typeof model !== 'string' ||
+        !model.trim() ||
+        model.trim().toLowerCase() === 'default';
+      if (
+        !safeModel ||
+        safeModel === 'default' ||
+        (userAskedForDefault && !liveModelIds.has(safeModel))
+      ) {
+        safeModel = liveModels[0]?.id ?? safeModel ?? null;
+        agentOptions.model = safeModel;
+      }
       if (liveModelIds.size === 0) {
-        // An empty AMR catalog usually means the user is signed out — `vela
-        // models` returns 401 and the catch above leaves `liveModels` empty.
-        // Surface AMR_AUTH_REQUIRED first so the chat shows the relogin
-        // affordance; otherwise the user sees a misleading "choose a model"
-        // when the real fix is to sign in.
+        // The catalog is genuinely empty: even the offline preset seed could
+        // not be read, which almost always means the user is signed out (`vela`
+        // catalog calls 401) or the CLI is unrunnable. Prefer the relogin
+        // affordance over a misleading "choose a model".
         if (def.id === 'amr') {
           const loginStatus = readVelaLoginStatus(
             modelProbeEnv ?? process.env,
@@ -12286,37 +12324,29 @@ export async function startServer({
             return design.runs.finish(run, 'failed', 1, null);
           }
         }
-        send('error', createAmrModelUnavailablePayload(safeModel, {
-          reason: 'model_catalog_unavailable',
-        }));
-        return design.runs.finish(run, 'failed', 1, null);
-      }
-      // `safeModel` was pre-resolved via the agent-wide cached model order,
-      // so a request that came in as 'default' (or empty) is already a
-      // concrete id by this point — `safeModel === 'default'` is rarely true.
-      // If the user actually asked for the agent default and the cached id no
-      // longer appears in the FRESH catalog (e.g. the AMR Link catalog rolled
-      // since `/api/agents` last responded), fall back to `liveModels[0]` from
-      // the fresh probe instead of rejecting their run as `AMR_MODEL_UNAVAILABLE`.
-      const userAskedForDefault =
-        typeof model !== 'string' ||
-        !model.trim() ||
-        model.trim().toLowerCase() === 'default';
-      if (
-        !safeModel ||
-        safeModel === 'default' ||
-        (userAskedForDefault && !liveModelIds.has(safeModel))
-      ) {
-        safeModel = liveModels[0]?.id ?? null;
-        agentOptions.model = safeModel;
-      }
-      if (!safeModel || !liveModelIds.has(safeModel)) {
+        // Logged in but no catalog at all AND no resolvable model: only now is
+        // there nothing safe to forward, so surface the model error.
+        if (!safeModel) {
+          send('error', createAmrModelUnavailablePayload(safeModel, {
+            reason: 'model_catalog_unavailable',
+          }));
+          return design.runs.finish(run, 'failed', 1, null);
+        }
+        // Otherwise fall through with the user's selected model and let vela's
+        // `session/set_model` be the authoritative gate.
+      } else if (!safeModel) {
+        // Catalog known but we could not resolve any model id to forward.
         send('error', createAmrModelUnavailablePayload(
           typeof model === 'string' && model.trim() ? model : safeModel,
           { availableModels: [...liveModelIds] },
         ));
         return design.runs.finish(run, 'failed', 1, null);
       }
+      // NOTE: when the selected model is absent from the (possibly preset-only
+      // or stale) catalog we intentionally do NOT fail-close. The cached/preset
+      // catalog can lag the live one, and a logged-in user picked a concrete
+      // id; vela rejects a truly unsupported model at `session/set_model` with
+      // a precise error, which beats a pre-emptive block on a flaky metadata read.
     }
 
     // Plain-streaming adapters that own a "continue most recent

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -329,12 +329,19 @@ process.exit(1);
     );
   });
 
-  it('retries transient AMR Link catalog failures before aborting startup', async () => {
+  it('survives transient AMR Link catalog failures without aborting the run', async () => {
+    // The run preflight resolves the AMR catalog through the shared
+    // AmrModelLoadingCache, which degrades to the offline `vela model preset`
+    // seed whenever the authoritative `vela model list` is momentarily
+    // unavailable (and refreshes the remote catalog in the background). So a
+    // transient catalog failure must NOT abort the run — the per-run path no
+    // longer blocks on a synchronous `model list` retry loop.
     const previousRuntimeKey = process.env.VELA_RUNTIME_KEY;
     const previousLinkUrl = process.env.VELA_LINK_URL;
     const stateFile = join(tmpdir(), `od-amr-model-retry-${randomUUID()}.json`);
     try {
-      process.env.VELA_RUNTIME_KEY = 'fake-runtime-key';
+      // Unique key so the shared model cache key is unique per test run.
+      process.env.VELA_RUNTIME_KEY = `fake-runtime-key-${randomUUID()}`;
       process.env.VELA_LINK_URL = 'https://amr-link.open-design.ai/v1';
 
       await withFakeAgent(
@@ -381,12 +388,94 @@ child.on('exit', (code, signal) => {
           expect(body).toContain('"type":"text_delta","delta":"Hello from fake "');
           expect(body).toContain('"type":"text_delta","delta":"vela."');
           expect(body).not.toContain('model_catalog_unavailable');
+          expect(body).not.toContain('AMR_MODEL_UNAVAILABLE');
+          // The catalog probe runs at least once (remote attempted, then the
+          // run proceeds from the preset seed). We no longer assert an exact
+          // synchronous retry count: the remote retry/backoff now happens in
+          // the cache's background refresh, not on the per-run hot path.
           const attempts = JSON.parse(readFileSync(stateFile, 'utf8')) as { attempts: number };
-          expect(attempts.attempts).toBe(3);
+          expect(attempts.attempts).toBeGreaterThanOrEqual(1);
         },
       );
     } finally {
       rmSync(stateFile, { force: true });
+      if (previousRuntimeKey == null) delete process.env.VELA_RUNTIME_KEY;
+      else process.env.VELA_RUNTIME_KEY = previousRuntimeKey;
+      if (previousLinkUrl == null) delete process.env.VELA_LINK_URL;
+      else process.env.VELA_LINK_URL = previousLinkUrl;
+    }
+  });
+
+  it('proceeds with the AMR run via the cached/preset catalog when the live model list is unavailable', async () => {
+    // Red spec for the packaged-nightly "AMR model the selected model is not
+    // available from Vela" report: the run preflight used to do a fresh,
+    // blocking `vela model list` (authoritative remote catalog) on EVERY run
+    // and fail-close the run whenever that single call timed out / errored —
+    // even though the user is logged in, the model picker already shows a
+    // model (seeded from the offline `vela model preset`), and the selected
+    // model is real. Under CorpLink/飞连 the remote call routinely exceeds the
+    // 10s timeout, so a logged-in user with a valid model could not run AMR at
+    // all. The fix reuses the shared AmrModelLoadingCache (cached remote when
+    // hot, otherwise the offline preset seed) instead of a per-run blocking
+    // remote probe, so a transient `model list` failure no longer kills the run.
+    const previousRuntimeKey = process.env.VELA_RUNTIME_KEY;
+    const previousLinkUrl = process.env.VELA_LINK_URL;
+    try {
+      // A unique runtime key both marks the user as logged-in AND makes the
+      // shared model cache key unique so this case never reuses another test's
+      // cached remote catalog.
+      process.env.VELA_RUNTIME_KEY = `fake-runtime-key-${randomUUID()}`;
+      process.env.VELA_LINK_URL = 'https://amr-link.open-design.ai/v1';
+
+      await withFakeAgent(
+        'vela',
+        `
+const { spawn } = require('node:child_process');
+const fixture = ${JSON.stringify(FAKE_VELA_FIXTURE)};
+const args = process.argv.slice(2);
+// Simulate a persistently unreachable authoritative catalog (gateway
+// timeout / 飞连 congestion): every \`vela model list\` fails. \`model preset\`,
+// \`login\`, and \`agent run\` still delegate to the fixture, mirroring the real
+// CLI where the offline preset and the ACP run do not need the gateway.
+if (args[0] === 'model' && args[1] === 'list') {
+  process.stderr.write('Get "https://amr-link.open-design.ai/v1/models": context deadline exceeded\\n');
+  process.exit(1);
+}
+const child = spawn(process.execPath, [fixture, ...args], {
+  stdio: 'inherit',
+  env: process.env,
+});
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 0);
+});
+`,
+        async () => {
+          const response = await fetch(`${baseUrl}/api/chat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'amr',
+              message: 'hello',
+              // Present in the preset seed (DEFAULT_MODEL_PRESET_JSON) but the
+              // live `model list` is unavailable, so only the preset path can
+              // surface it.
+              model: 'glm-5.1',
+            }),
+          });
+          const body = await response.text();
+
+          expect(response.ok).toBe(true);
+          // The run must NOT be fail-closed on the unavailable live catalog.
+          expect(body).not.toContain('AMR_MODEL_UNAVAILABLE');
+          expect(body).not.toContain('model_catalog_unavailable');
+          expect(body).not.toContain('is not available from Vela');
+          // It must actually proceed into the ACP run and stream assistant text.
+          expect(body).toContain('"type":"text_delta","delta":"Hello from fake "');
+          expect(body).toContain('"type":"text_delta","delta":"vela."');
+        },
+      );
+    } finally {
       if (previousRuntimeKey == null) delete process.env.VELA_RUNTIME_KEY;
       else process.env.VELA_RUNTIME_KEY = previousRuntimeKey;
       if (previousLinkUrl == null) delete process.env.VELA_LINK_URL;

--- a/apps/desktop/src/main/diagnostics.ts
+++ b/apps/desktop/src/main/diagnostics.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { homedir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -39,6 +39,30 @@ function safeUsername(): string | undefined {
     return info?.username && info.username.length > 0 ? info.username : undefined;
   } catch {
     return undefined;
+  }
+}
+
+// Best-effort read of a user `agentCliEnv.amr.OPENCODE_TEST_HOME` override from
+// the daemon's app-config so the AMR log sweep targets the same OpenCode home a
+// real run uses. The daemon resolves this authoritatively via spawnEnvForAgent;
+// the desktop main process may not import daemon internals, so it reads the
+// config file directly and applies only leading-`~` expansion (overrides are
+// effectively always absolute). Returns null on any miss; the collector then
+// falls back to the default `<dataDir>/amr/opencode-home`.
+async function readAmrOpenCodeHomeOverride(dataDir: string): Promise<string | null> {
+  try {
+    const raw = await readFile(join(dataDir, "app-config.json"), "utf8");
+    const parsed = JSON.parse(raw) as {
+      agentCliEnv?: { amr?: Record<string, unknown> };
+    };
+    const value = parsed.agentCliEnv?.amr?.OPENCODE_TEST_HOME;
+    if (typeof value !== "string" || value.trim().length === 0) return null;
+    const trimmed = value.trim();
+    if (trimmed === "~") return homedir();
+    if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
+    return trimmed;
+  } catch {
+    return null;
   }
 }
 
@@ -129,6 +153,12 @@ export async function exportDiagnosticsToFile(
       ...(await buildAgentCliLogSources({
         homeDir: homedir(),
         dataDir,
+        // Honor a user `agentCliEnv.amr.OPENCODE_TEST_HOME` override so the AMR
+        // provider logs are not missed when it points outside the default home.
+        // The daemon resolves this authoritatively; here (no daemon imports
+        // allowed) we read the override straight from app-config and fall back
+        // to the dataDir default when absent.
+        amrOpenCodeHome: await readAmrOpenCodeHomeOverride(dataDir),
         xdgDataHome: process.env.XDG_DATA_HOME ?? null,
       })),
     ];

--- a/apps/desktop/src/main/diagnostics.ts
+++ b/apps/desktop/src/main/diagnostics.ts
@@ -42,27 +42,40 @@ function safeUsername(): string | undefined {
   }
 }
 
-// Best-effort read of a user `agentCliEnv.amr.OPENCODE_TEST_HOME` override from
-// the daemon's app-config so the AMR log sweep targets the same OpenCode home a
-// real run uses. The daemon resolves this authoritatively via spawnEnvForAgent;
-// the desktop main process may not import daemon internals, so it reads the
-// config file directly and applies only leading-`~` expansion (overrides are
-// effectively always absolute). Returns null on any miss; the collector then
-// falls back to the default `<dataDir>/amr/opencode-home`.
-async function readAmrOpenCodeHomeOverride(dataDir: string): Promise<string | null> {
+function expandTilde(value: unknown): string | null {
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const trimmed = value.trim();
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
+  return trimmed;
+}
+
+interface AgentHomeOverrides {
+  amrOpenCodeHome: string | null;
+  claudeConfigDir: string | null;
+  codexHome: string | null;
+}
+
+// Best-effort read of user `agentCliEnv.<agent>.*` home overrides
+// (`OPENCODE_TEST_HOME` / `CLAUDE_CONFIG_DIR` / `CODEX_HOME`) from the daemon's
+// app-config, so the log sweep targets the same homes a real run uses. The
+// daemon resolves these authoritatively via spawnEnvForAgent; the desktop main
+// process may not import daemon internals, so it reads the config file directly
+// and applies only leading-`~` expansion (overrides are effectively absolute).
+// Missing values fall back to the collector's defaults.
+async function readAgentHomeOverrides(dataDir: string): Promise<AgentHomeOverrides> {
   try {
     const raw = await readFile(join(dataDir, "app-config.json"), "utf8");
-    const parsed = JSON.parse(raw) as {
-      agentCliEnv?: { amr?: Record<string, unknown> };
+    const agentCliEnv = (JSON.parse(raw) as {
+      agentCliEnv?: Record<string, Record<string, unknown> | undefined>;
+    }).agentCliEnv;
+    return {
+      amrOpenCodeHome: expandTilde(agentCliEnv?.amr?.OPENCODE_TEST_HOME),
+      claudeConfigDir: expandTilde(agentCliEnv?.claude?.CLAUDE_CONFIG_DIR),
+      codexHome: expandTilde(agentCliEnv?.codex?.CODEX_HOME),
     };
-    const value = parsed.agentCliEnv?.amr?.OPENCODE_TEST_HOME;
-    if (typeof value !== "string" || value.trim().length === 0) return null;
-    const trimmed = value.trim();
-    if (trimmed === "~") return homedir();
-    if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
-    return trimmed;
   } catch {
-    return null;
+    return { amrOpenCodeHome: null, claudeConfigDir: null, codexHome: null };
   }
 }
 
@@ -147,18 +160,18 @@ export async function exportDiagnosticsToFile(
     });
     const dataDir = join(namespaceRoot, "data");
     const runsDir = join(dataDir, "runs");
+    // Honor user `agentCliEnv.<agent>.*` home overrides so relocated CLI homes
+    // are not missed; absent values fall back to the collector's defaults.
+    const agentHomes = await readAgentHomeOverrides(dataDir);
     const sources: LogSource[] = [
       ...buildSidecarLogSources(runtime),
       ...(await buildRunEventLogSources(runsDir)),
       ...(await buildAgentCliLogSources({
         homeDir: homedir(),
         dataDir,
-        // Honor a user `agentCliEnv.amr.OPENCODE_TEST_HOME` override so the AMR
-        // provider logs are not missed when it points outside the default home.
-        // The daemon resolves this authoritatively; here (no daemon imports
-        // allowed) we read the override straight from app-config and fall back
-        // to the dataDir default when absent.
-        amrOpenCodeHome: await readAmrOpenCodeHomeOverride(dataDir),
+        amrOpenCodeHome: agentHomes.amrOpenCodeHome,
+        claudeConfigDir: agentHomes.claudeConfigDir,
+        codexHome: agentHomes.codexHome,
         xdgDataHome: process.env.XDG_DATA_HOME ?? null,
       })),
     ];

--- a/apps/desktop/src/main/diagnostics.ts
+++ b/apps/desktop/src/main/diagnostics.ts
@@ -17,7 +17,9 @@ import {
 } from "@open-design/sidecar";
 import {
   DIAGNOSTICS_FILENAME_PREFIX,
+  buildAgentCliLogSources,
   buildDiagnosticsZip,
+  buildRunEventLogSources,
   diagnosticsFileName,
   type LogSource,
 } from "@open-design/diagnostics";
@@ -108,6 +110,28 @@ export async function exportDiagnosticsToFile(
   }
 
   try {
+    // The packaged daemon writes its runtime data at `<namespaceRoot>/data`
+    // (OD_DATA_DIR), with per-run event logs under `data/runs` and the
+    // AMR-managed OpenCode home under `data/amr`. Derive both so this export
+    // — the one users actually trigger from the desktop UI — carries the same
+    // run/agent diagnostics the daemon HTTP export does, instead of only the
+    // three sidecar logs.
+    const namespaceRoot = resolveRuntimeNamespaceRoot({
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      runtime,
+      runtimeMode: SIDECAR_MODES.RUNTIME,
+    });
+    const dataDir = join(namespaceRoot, "data");
+    const runsDir = join(dataDir, "runs");
+    const sources: LogSource[] = [
+      ...buildSidecarLogSources(runtime),
+      ...(await buildRunEventLogSources(runsDir)),
+      ...(await buildAgentCliLogSources({
+        homeDir: homedir(),
+        dataDir,
+        xdgDataHome: process.env.XDG_DATA_HOME ?? null,
+      })),
+    ];
     const result = await buildDiagnosticsZip({
       context: {
         app: { name: "open-design", version: app.getVersion(), packaged: app.isPackaged },
@@ -121,7 +145,7 @@ export async function exportDiagnosticsToFile(
           sourceTag: runtime.source,
         },
       },
-      sources: buildSidecarLogSources(runtime),
+      sources,
       redaction: { username: safeUsername() },
       crashReports: {
         // Restrict to Open Design's own process names. A generic "Electron"

--- a/packages/diagnostics/src/agent-logs.ts
+++ b/packages/diagnostics/src/agent-logs.ts
@@ -91,8 +91,15 @@ async function latestLogFilesIn(
 export interface AgentCliLogOptions {
   /** User home directory; CLI configs/logs live under here. */
   homeDir: string;
-  /** Open Design data dir (OD_DATA_DIR), used for the AMR-managed OpenCode home. */
+  /** Open Design data dir (OD_DATA_DIR); fallback location of the AMR OpenCode home. */
   dataDir?: string | null;
+  /**
+   * Effective AMR OpenCode home (the resolved `OPENCODE_TEST_HOME`). Callers
+   * should pass the value a real AMR run would use so this honors a user
+   * `agentCliEnv.amr.OPENCODE_TEST_HOME` override; when omitted we fall back to
+   * the default `<dataDir>/amr/opencode-home`.
+   */
+  amrOpenCodeHome?: string | null;
   /** XDG_DATA_HOME, if set, used for OpenCode's data dir resolution. */
   xdgDataHome?: string | null;
   /** Max log files to include per agent (most-recent first). */
@@ -135,14 +142,19 @@ export async function buildAgentCliLogSources(options: AgentCliLogOptions): Prom
     { agent: "opencode", dir: openCodeUserLogDir },
   ];
 
+  // AMR drives a private OpenCode under OPENCODE_TEST_HOME; its session logs
+  // land under that home's XDG data dir, where AMR run provider failures are
+  // recorded. Prefer the effective home a real run resolves (honoring a user
+  // `agentCliEnv.amr.OPENCODE_TEST_HOME` override) and fall back to the default
+  // `<dataDir>/amr/opencode-home` so the bundle does not silently drop the very
+  // AMR logs this is meant to surface.
+  const amrHome = options.amrOpenCodeHome?.trim();
   const dataDir = options.dataDir?.trim();
-  if (dataDir) {
-    // AMR drives a private OpenCode under OPENCODE_TEST_HOME =
-    // <dataDir>/amr/opencode-home, so its session logs land under that home's
-    // XDG data dir. This is where AMR run provider failures are recorded.
+  const amrOpenCodeHome = amrHome || (dataDir ? join(dataDir, "amr", "opencode-home") : "");
+  if (amrOpenCodeHome) {
     agentDirs.push({
       agent: "amr",
-      dir: join(dataDir, "amr", "opencode-home", ".local", "share", "opencode", "log"),
+      dir: join(amrOpenCodeHome, ".local", "share", "opencode", "log"),
     });
   }
 

--- a/packages/diagnostics/src/agent-logs.ts
+++ b/packages/diagnostics/src/agent-logs.ts
@@ -100,6 +100,16 @@ export interface AgentCliLogOptions {
    * the default `<dataDir>/amr/opencode-home`.
    */
   amrOpenCodeHome?: string | null;
+  /**
+   * Effective Claude config home (`CLAUDE_CONFIG_DIR`). Honors a user
+   * `agentCliEnv.claude.CLAUDE_CONFIG_DIR` override; falls back to `~/.claude`.
+   */
+  claudeConfigDir?: string | null;
+  /**
+   * Effective Codex home (`CODEX_HOME`). Honors a user
+   * `agentCliEnv.codex.CODEX_HOME` override; falls back to `~/.codex`.
+   */
+  codexHome?: string | null;
   /** XDG_DATA_HOME, if set, used for OpenCode's data dir resolution. */
   xdgDataHome?: string | null;
   /** Max log files to include per agent (most-recent first). */
@@ -131,13 +141,19 @@ export async function buildAgentCliLogSources(options: AgentCliLogOptions): Prom
     ? join(xdg, "opencode", "log")
     : join(home, ".local", "share", "opencode", "log");
 
+  // Effective CLI homes honor the user's app-config overrides
+  // (`CLAUDE_CONFIG_DIR` / `CODEX_HOME`), falling back to the defaults — the
+  // same fix as AMR's `OPENCODE_TEST_HOME` so relocated homes are not missed.
+  const claudeDir = options.claudeConfigDir?.trim() || join(home, ".claude");
+  const codexHome = options.codexHome?.trim() || join(home, ".codex");
+
   // Per-agent log directories. `*.log` only; secret files (auth.json,
   // config.json) live outside these dirs and are never swept.
   const agentDirs: Array<{ agent: string; dir: string }> = [
     // Claude Code operational logs (bash-commands / cost-tracker / daemon).
-    { agent: "claude", dir: join(home, ".claude") },
+    { agent: "claude", dir: claudeDir },
     // Codex tracing logs (codex-tui.log can be very large — tail-bounded).
-    { agent: "codex", dir: join(home, ".codex", "log") },
+    { agent: "codex", dir: join(codexHome, "log") },
     // OpenCode session logs (provider errors live here in headless mode).
     { agent: "opencode", dir: openCodeUserLogDir },
   ];

--- a/packages/diagnostics/src/agent-logs.ts
+++ b/packages/diagnostics/src/agent-logs.ts
@@ -1,0 +1,162 @@
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { LogSource } from "./sources.js";
+
+const DEFAULT_RUN_EVENT_TAIL_BYTES = 2 * 1024 * 1024;
+const DEFAULT_MAX_RUN_EVENT_LOGS = 20;
+
+// CLI session logs can be large (e.g. Codex's `codex-tui.log` grows into the
+// hundreds of MB because it logs every TUI frame), so keep a generous-but-
+// bounded tail that still captures the final error frame.
+const DEFAULT_AGENT_LOG_TAIL_BYTES = 2 * 1024 * 1024;
+const DEFAULT_MAX_FILES_PER_AGENT = 3;
+
+const SAFE_DIR_ENTRY = /^[A-Za-z0-9._-]+$/u;
+
+async function statSafe(path: string): Promise<{ mtimeMs: number; isFile: boolean } | null> {
+  try {
+    const info = await stat(path);
+    return { mtimeMs: info.mtimeMs, isFile: info.isFile() };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Collect the most-recent per-run event logs (`<runsDir>/<runId>/events.jsonl`).
+ *
+ * These are the daemon's capture of each agent CLI's own stdout/stderr/stream
+ * for a run — the single richest, agent-agnostic diagnostic signal for "the
+ * run failed / produced nothing". Shared so both the daemon HTTP export and the
+ * desktop IPC export bundle the same data.
+ */
+export async function buildRunEventLogSources(
+  runsDir: string | null | undefined,
+  options: { maxRuns?: number; tailBytes?: number } = {},
+): Promise<LogSource[]> {
+  if (!runsDir) return [];
+  const maxRuns = options.maxRuns ?? DEFAULT_MAX_RUN_EVENT_LOGS;
+  const tailBytes = options.tailBytes ?? DEFAULT_RUN_EVENT_TAIL_BYTES;
+
+  let entries;
+  try {
+    entries = await readdir(runsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const candidates: Array<{ runId: string; absolutePath: string; mtimeMs: number }> = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!SAFE_DIR_ENTRY.test(entry.name)) continue;
+    const absolutePath = join(runsDir, entry.name, "events.jsonl");
+    const info = await statSafe(absolutePath);
+    if (!info || !info.isFile) continue;
+    candidates.push({ runId: entry.name, absolutePath, mtimeMs: info.mtimeMs });
+  }
+
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates.slice(0, maxRuns).map(({ runId, absolutePath }) => ({
+    name: `runs/${runId}/events.jsonl`,
+    absolutePath,
+    kind: "text",
+    tailBytes,
+  }));
+}
+
+async function latestLogFilesIn(
+  dir: string,
+  max: number,
+): Promise<Array<{ name: string; absolutePath: string }>> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const candidates: Array<{ name: string; absolutePath: string; mtimeMs: number }> = [];
+  for (const name of names) {
+    if (!name.endsWith(".log")) continue;
+    if (!SAFE_DIR_ENTRY.test(name)) continue;
+    const absolutePath = join(dir, name);
+    const info = await statSafe(absolutePath);
+    if (!info || !info.isFile) continue;
+    candidates.push({ name, absolutePath, mtimeMs: info.mtimeMs });
+  }
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates.slice(0, max).map(({ name, absolutePath }) => ({ name, absolutePath }));
+}
+
+export interface AgentCliLogOptions {
+  /** User home directory; CLI configs/logs live under here. */
+  homeDir: string;
+  /** Open Design data dir (OD_DATA_DIR), used for the AMR-managed OpenCode home. */
+  dataDir?: string | null;
+  /** XDG_DATA_HOME, if set, used for OpenCode's data dir resolution. */
+  xdgDataHome?: string | null;
+  /** Max log files to include per agent (most-recent first). */
+  maxFilesPerAgent?: number;
+  /** Max bytes to read from each log file's tail. */
+  tailBytes?: number;
+}
+
+/**
+ * Collect the native on-disk logs of the coding-agent CLIs Open Design drives:
+ * Claude Code, Codex, OpenCode, and AMR (vela's OpenCode runtime). These
+ * complement the per-run `events.jsonl` capture with the CLI's own internal
+ * diagnostics (provider errors, retries, auth state) that never reach the
+ * daemon's stream.
+ *
+ * Deliberately excluded: secret-bearing files. We only sweep known *log*
+ * directories (`*.log` files) — never `~/.amr/config.json`, `~/.codex/auth.json`,
+ * or session transcripts — and the collected text still passes through the
+ * bundle's redaction pass.
+ */
+export async function buildAgentCliLogSources(options: AgentCliLogOptions): Promise<LogSource[]> {
+  const home = options.homeDir?.trim();
+  if (!home) return [];
+  const maxFiles = options.maxFilesPerAgent ?? DEFAULT_MAX_FILES_PER_AGENT;
+  const tailBytes = options.tailBytes ?? DEFAULT_AGENT_LOG_TAIL_BYTES;
+
+  const xdg = options.xdgDataHome?.trim();
+  const openCodeUserLogDir = xdg
+    ? join(xdg, "opencode", "log")
+    : join(home, ".local", "share", "opencode", "log");
+
+  // Per-agent log directories. `*.log` only; secret files (auth.json,
+  // config.json) live outside these dirs and are never swept.
+  const agentDirs: Array<{ agent: string; dir: string }> = [
+    // Claude Code operational logs (bash-commands / cost-tracker / daemon).
+    { agent: "claude", dir: join(home, ".claude") },
+    // Codex tracing logs (codex-tui.log can be very large — tail-bounded).
+    { agent: "codex", dir: join(home, ".codex", "log") },
+    // OpenCode session logs (provider errors live here in headless mode).
+    { agent: "opencode", dir: openCodeUserLogDir },
+  ];
+
+  const dataDir = options.dataDir?.trim();
+  if (dataDir) {
+    // AMR drives a private OpenCode under OPENCODE_TEST_HOME =
+    // <dataDir>/amr/opencode-home, so its session logs land under that home's
+    // XDG data dir. This is where AMR run provider failures are recorded.
+    agentDirs.push({
+      agent: "amr",
+      dir: join(dataDir, "amr", "opencode-home", ".local", "share", "opencode", "log"),
+    });
+  }
+
+  const sources: LogSource[] = [];
+  for (const { agent, dir } of agentDirs) {
+    const files = await latestLogFilesIn(dir, maxFiles);
+    for (const file of files) {
+      sources.push({
+        name: `agent-cli-logs/${agent}/${file.name}`,
+        absolutePath: file.absolutePath,
+        kind: "text",
+        tailBytes,
+      });
+    }
+  }
+  return sources;
+}

--- a/packages/diagnostics/src/index.ts
+++ b/packages/diagnostics/src/index.ts
@@ -36,3 +36,9 @@ export {
   type DiagnosticsExportInput,
   type DiagnosticsExportResult,
 } from "./zip.js";
+
+export {
+  buildRunEventLogSources,
+  buildAgentCliLogSources,
+  type AgentCliLogOptions,
+} from "./agent-logs.js";

--- a/packages/diagnostics/tests/agent-logs.test.ts
+++ b/packages/diagnostics/tests/agent-logs.test.ts
@@ -102,6 +102,24 @@ describe("buildAgentCliLogSources", () => {
     expect(amrNames).not.toContain("agent-cli-logs/amr/default.log");
   });
 
+  it("honors claudeConfigDir / codexHome overrides over the home defaults", async () => {
+    const home = join(tempDir, "home");
+    const claudeDir = join(tempDir, "custom-claude");
+    const codexHome = join(tempDir, "custom-codex");
+    // Default homes have logs that must be ignored when overrides are set.
+    await touch(join(home, ".claude", "daemon.log"));
+    await touch(join(home, ".codex", "log", "codex-tui.log"));
+    await touch(join(claudeDir, "cost-tracker.log"));
+    await touch(join(codexHome, "log", "session.log"));
+
+    const sources = await buildAgentCliLogSources({ homeDir: home, claudeConfigDir: claudeDir, codexHome });
+    const names = sources.map((s) => s.name);
+    expect(names).toContain("agent-cli-logs/claude/cost-tracker.log");
+    expect(names).toContain("agent-cli-logs/codex/session.log");
+    expect(names).not.toContain("agent-cli-logs/claude/daemon.log");
+    expect(names).not.toContain("agent-cli-logs/codex/codex-tui.log");
+  });
+
   it("honors XDG_DATA_HOME for the opencode user log dir", async () => {
     const home = join(tempDir, "home");
     const xdg = join(tempDir, "xdg");

--- a/packages/diagnostics/tests/agent-logs.test.ts
+++ b/packages/diagnostics/tests/agent-logs.test.ts
@@ -83,6 +83,25 @@ describe("buildAgentCliLogSources", () => {
     }
   });
 
+  it("honors an explicit amrOpenCodeHome override over the dataDir default", async () => {
+    const home = join(tempDir, "home");
+    const dataDir = join(tempDir, "data");
+    const overrideHome = join(tempDir, "custom-amr-home");
+    // Default location has a log, but the override points elsewhere — only the
+    // override's logs should be swept (mirrors a user OPENCODE_TEST_HOME).
+    await touch(
+      join(dataDir, "amr", "opencode-home", ".local", "share", "opencode", "log", "default.log"),
+    );
+    await touch(
+      join(overrideHome, ".local", "share", "opencode", "log", "override.log"),
+    );
+
+    const sources = await buildAgentCliLogSources({ homeDir: home, dataDir, amrOpenCodeHome: overrideHome });
+    const amrNames = sources.filter((s) => s.name.startsWith("agent-cli-logs/amr/")).map((s) => s.name);
+    expect(amrNames).toContain("agent-cli-logs/amr/override.log");
+    expect(amrNames).not.toContain("agent-cli-logs/amr/default.log");
+  });
+
   it("honors XDG_DATA_HOME for the opencode user log dir", async () => {
     const home = join(tempDir, "home");
     const xdg = join(tempDir, "xdg");

--- a/packages/diagnostics/tests/agent-logs.test.ts
+++ b/packages/diagnostics/tests/agent-logs.test.ts
@@ -1,0 +1,98 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildAgentCliLogSources, buildRunEventLogSources } from "../src/agent-logs.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "diagnostics-agent-logs-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+async function touch(path: string, content = "x"): Promise<void> {
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, content, "utf8");
+}
+
+describe("buildRunEventLogSources", () => {
+  it("returns [] when no runs dir", async () => {
+    expect(await buildRunEventLogSources(null)).toEqual([]);
+    expect(await buildRunEventLogSources(join(tempDir, "missing"))).toEqual([]);
+  });
+
+  it("collects the most-recent per-run events.jsonl, newest first", async () => {
+    const runsDir = join(tempDir, "runs");
+    await touch(join(runsDir, "run-a", "events.jsonl"), "a");
+    await touch(join(runsDir, "run-b", "events.jsonl"), "b");
+    // Directory without events.jsonl is skipped.
+    await mkdir(join(runsDir, "run-empty"), { recursive: true });
+
+    const sources = await buildRunEventLogSources(runsDir, { maxRuns: 5 });
+    const names = sources.map((s) => s.name).sort();
+    expect(names).toEqual(["runs/run-a/events.jsonl", "runs/run-b/events.jsonl"]);
+    for (const source of sources) {
+      expect(source.kind).toBe("text");
+      expect(source.tailBytes).toBeGreaterThan(0);
+    }
+  });
+
+  it("caps the number of runs", async () => {
+    const runsDir = join(tempDir, "runs");
+    for (let i = 0; i < 5; i += 1) {
+      await touch(join(runsDir, `run-${i}`, "events.jsonl"), String(i));
+    }
+    const sources = await buildRunEventLogSources(runsDir, { maxRuns: 2 });
+    expect(sources).toHaveLength(2);
+  });
+});
+
+describe("buildAgentCliLogSources", () => {
+  it("collects claude / codex / opencode / amr log files under their known dirs", async () => {
+    const home = join(tempDir, "home");
+    const dataDir = join(tempDir, "data");
+    await touch(join(home, ".claude", "daemon.log"));
+    await touch(join(home, ".codex", "log", "codex-tui.log"));
+    await touch(join(home, ".local", "share", "opencode", "log", "2026-01-01T00.log"));
+    await touch(
+      join(dataDir, "amr", "opencode-home", ".local", "share", "opencode", "log", "2026-01-02T00.log"),
+    );
+    // Secret-bearing files outside *.log dirs must NOT be swept.
+    await touch(join(home, ".codex", "auth.json"), "secret");
+    await touch(join(home, ".amr", "config.json"), "secret");
+
+    const sources = await buildAgentCliLogSources({ homeDir: home, dataDir });
+    const names = sources.map((s) => s.name);
+
+    expect(names).toContain("agent-cli-logs/claude/daemon.log");
+    expect(names).toContain("agent-cli-logs/codex/codex-tui.log");
+    expect(names).toContain("agent-cli-logs/opencode/2026-01-01T00.log");
+    expect(names).toContain("agent-cli-logs/amr/2026-01-02T00.log");
+    // No secrets, and only *.log files.
+    expect(names.some((n) => n.includes("auth.json"))).toBe(false);
+    expect(names.some((n) => n.includes("config.json"))).toBe(false);
+    for (const source of sources) {
+      expect(source.name.endsWith(".log")).toBe(true);
+      expect(source.tailBytes).toBeGreaterThan(0);
+    }
+  });
+
+  it("honors XDG_DATA_HOME for the opencode user log dir", async () => {
+    const home = join(tempDir, "home");
+    const xdg = join(tempDir, "xdg");
+    await touch(join(xdg, "opencode", "log", "session.log"));
+
+    const sources = await buildAgentCliLogSources({ homeDir: home, xdgDataHome: xdg });
+    expect(sources.map((s) => s.name)).toContain("agent-cli-logs/opencode/session.log");
+  });
+
+  it("returns [] when homeDir is empty", async () => {
+    expect(await buildAgentCliLogSources({ homeDir: "" })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

Packaged Open Design (nightly `0.10.0.nightly.22`) could not use AMR at all: every run failed immediately with `AMR model … is not available from Vela. Refresh the AMR model list, choose a supported model, and retry this run`, even for a logged-in user (杨瑾龙) who had a real model (`glm-5.1`) selected. Reported from a colleague's diagnostics bundle; reproduced and root-caused locally against the bundled `vela` 0.0.15.

The pain: AMR is effectively unusable on any machine where the AMR gateway round-trip is slow or flaky (notably behind CorpLink/飞连, where `vela model list` latency was measured at 2.5–7s against a 10s ceiling). The model picker still showed models, so AMR looked selectable but every send errored — a confusing hard failure.

Root cause: the AMR run preflight ran a **fresh, blocking `vela model list`** (the authoritative remote catalog) on **every turn** and **fail-closed** the run whenever that one call timed out / errored, with no run-time fallback (`fallbackModels: []`). That call needs network reachability to the gateway **and `$HOME`** (the offline `vela model preset` / `vela --version` need neither); the UI picker is seeded from the offline preset, which is why models appeared selectable while runs died. The existing in-memory remembered-models fallback (#3198) only helps after a prior success in the same process, so a cold start + a network hiccup punched straight through.

## What users will see

AMR runs no longer fail with "model is not available from Vela" when the live catalog is momentarily unreachable: the run uses the cached catalog (or the offline preset seed) and proceeds, with vela's own model gate as the final authority. No user-facing UI change. Separately, the in-app **Diagnostics export** bundle now includes the coding-agent CLIs' own logs and recent per-run logs, so this class of failure is diagnosable from a shared bundle next time.

## Surface area

- [x] **None** — daemon-internal bug fix + diagnostics export enrichment. No new endpoint/flag/UI/i18n/dep. (The diagnostics *bundle contents* grow — see below — but the export surface itself is unchanged.)

## Screenshots

n/a (no UI change)

## Bug fix verification

- Test: `apps/daemon/tests/chat-route.test.ts` → `proceeds with the AMR run via the cached/preset catalog when the live model list is unavailable`
- Red on `main`, green on this branch: **yes**. On `main` the run fails with the exact reported payload (`AMR_MODEL_UNAVAILABLE` / `model_catalog_unavailable` / "is not available from Vela"); on this branch it degrades to the preset catalog and streams the run.
- The pre-existing `#3198` retry test was updated to the new mechanism (the per-run path no longer block-retries `vela model list`; resilience now comes from the shared cache + preset).

## What changed

Daemon AMR preflight:
- Resolve the catalog through the shared `AmrModelLoadingCache` (same path as `GET /api/amr/models`): cached authoritative `vela model list` when hot, else the offline `vela model preset` seed while a remote refresh runs in the background. The blocking remote probe is off the per-run hot path; a transient failure degrades to preset instead of fail-closing.
- The previously-silent `catch {}` around the probe now `console.warn`s (this is exactly why the failure left no trace in any log/diagnostics bundle).
- Backfill `$HOME` in the AMR spawn env (`execAgentFile` replaces the child env wholesale; `vela model list` exits non-zero with `$HOME is not defined` when missing, while preset/`--version` survive).
- Raise the cache remote-refresh interval 60s → 10min (catalog changes on the order of days; cached entries return instantly; the per-run path now reads this cache so a tight interval would spawn `vela model list` far more often than the catalog changes). The existing async background-refresh / return-cached-immediately behavior is unchanged.

Diagnostics export:
- New shared builders in `@open-design/diagnostics` (`buildRunEventLogSources`, `buildAgentCliLogSources`) used by **both** the daemon HTTP export and the desktop IPC export. The desktop IPC export (the one users trigger from the UI) previously shipped neither per-run logs nor agent logs.
- Collects each agent CLI's own `*.log` (claude `~/.claude`, codex `~/.codex/log`, opencode `~/.local/share/opencode/log`, amr's private OpenCode home under the OD data dir) plus recent per-run `events.jsonl`. Secret-bearing files (`~/.amr/config.json`, `~/.codex/auth.json`) are never swept; only `*.log`, tail-bounded and run through the existing redaction pass.

## Validation

- `pnpm guard` ✓, `pnpm --filter @open-design/daemon typecheck` ✓, `pnpm --filter @open-design/desktop typecheck` ✓
- `pnpm --filter @open-design/daemon test` for chat-route / amr-acp-integration / diagnostics-export / resolve-model ✓ (green in a clean pnpm state)
- `pnpm --filter @open-design/diagnostics test` ✓ (incl. new `agent-logs.test.ts`)
- Real e2e against the bundled `vela` 0.0.15: `vela model list` returns the live catalog on **both** the test env (`vela-*.powerformer.net`) and prod; `vela model preset` works offline. Stood up the real daemon with a `vela` wrapper that fails `model list` → `/api/amr/models` returns `source: preset` and `POST /api/chat` proceeds past preflight to a real agent spawn (`event: start`) instead of `AMR_MODEL_UNAVAILABLE`.

## Adjacent issues (not in this PR)

- `apps/daemon/tests/integrations/vela.routes.test.ts` has a pre-existing flaky `ENOTEMPTY` on teardown (the `/api/integrations/vela/status` route fires a background `amrModelLoadingCache.warm()` that can write `~/.amr` after the test's tmp-home cleanup). Independent of this change.
