### PR TITLE
fix(web): unify entry topbar tooltips

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -713,10 +713,11 @@ export function EntryShell({
             <div className="entry-main__topbar-chips entry-main__topbar-chips--icon-only">
               <GithubStarBadge />
               <a
-                className="entry-discord-badge"
+                className="entry-discord-badge od-tooltip"
                 href={DISCORD_URL}
                 aria-label={discordAriaLabel}
                 data-tooltip={discordAriaLabel}
+                data-tooltip-placement="bottom"
                 data-testid="entry-discord-badge"
               >
                 <Icon name="discord" size={14} className="entry-discord-badge__icon" />
@@ -735,7 +736,7 @@ export function EntryShell({
               {executionSwitcher}
               <button
                 type="button"
-                className="use-everywhere-chip"
+                className="use-everywhere-chip od-tooltip"
                 onClick={() => {
                   trackHomeToolbarClick(analytics.track, {
                     page_name: 'home',
@@ -745,6 +746,7 @@ export function EntryShell({
                   openIntegrationTab('use-everywhere');
                 }}
                 data-tooltip={t('entry.useEverywhereTitle')}
+                data-tooltip-placement="bottom"
                 aria-label={t('entry.useEverywhereAria')}
                 data-testid="entry-use-everywhere-button"
               >

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -716,7 +716,6 @@ export function EntryShell({
                 className="entry-discord-badge"
                 href={DISCORD_URL}
                 aria-label={discordAriaLabel}
-                title={discordAriaLabel}
                 data-tooltip={discordAriaLabel}
                 data-testid="entry-discord-badge"
               >

--- a/apps/web/src/components/GithubStarBadge.tsx
+++ b/apps/web/src/components/GithubStarBadge.tsx
@@ -22,12 +22,13 @@ export function GithubStarBadge() {
 
   return (
     <a
-      className="entry-star-badge"
+      className="entry-star-badge od-tooltip"
       href={GITHUB_REPO_URL}
       target="_blank"
       rel="noreferrer noopener"
       aria-label={t('entry.githubStarAria')}
-      title={t('entry.githubStarTitle')}
+      data-tooltip={t('entry.githubStarTitle')}
+      data-tooltip-placement="bottom"
       data-testid="entry-star-badge"
     >
       <Icon name="github-filled" size={16} className="entry-star-badge__icon" />

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -550,7 +550,6 @@ export function InlineModelSwitcher({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={`${chipMode} · ${chipPrimary} · ${chipModel}`}
-        title={`${chipMode} · ${chipPrimary} · ${chipModel}`}
         data-tooltip={`${chipMode} · ${chipPrimary} · ${chipModel}`}
       >
         {showAmrReminder ? (

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -542,7 +542,7 @@ export function InlineModelSwitcher({
       <button
         type="button"
         className={
-          'inline-switcher__chip' +
+          'inline-switcher__chip od-tooltip' +
           (showAmrReminder ? ' has-amr-reminder' : '')
         }
         data-testid="inline-model-switcher-chip"
@@ -551,6 +551,7 @@ export function InlineModelSwitcher({
         aria-expanded={open}
         aria-label={`${chipMode} · ${chipPrimary} · ${chipModel}`}
         data-tooltip={`${chipMode} · ${chipPrimary} · ${chipModel}`}
+        data-tooltip-placement="bottom"
       >
         {showAmrReminder ? (
           <span

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -808,10 +808,10 @@
 }
 
 /* Downward hover tooltip for the collapsed chips. */
-.entry-main__topbar-chips--icon-only [data-tooltip] {
+.entry-main__topbar-chips--icon-only [data-tooltip]:not(.od-tooltip) {
   position: relative;
 }
-.entry-main__topbar-chips--icon-only [data-tooltip]::after {
+.entry-main__topbar-chips--icon-only [data-tooltip]:not(.od-tooltip)::after {
   content: attr(data-tooltip);
   position: absolute;
   top: calc(100% + 8px);
@@ -830,14 +830,14 @@
   transition: opacity 120ms var(--ease-out), transform 120ms var(--ease-out);
   z-index: 60;
 }
-.entry-main__topbar-chips--icon-only [data-tooltip]:hover::after,
-.entry-main__topbar-chips--icon-only [data-tooltip]:focus-visible::after {
+.entry-main__topbar-chips--icon-only [data-tooltip]:not(.od-tooltip):hover::after,
+.entry-main__topbar-chips--icon-only [data-tooltip]:not(.od-tooltip):focus-visible::after {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
 /* While the model-switcher popover is open, suppress its tooltip so the
    bubble doesn't collide with the menu. */
-.entry-main__topbar-chips--icon-only [data-tooltip][aria-expanded='true']::after {
+.entry-main__topbar-chips--icon-only [data-tooltip]:not(.od-tooltip)[aria-expanded='true']::after {
   display: none;
 }
 


### PR DESCRIPTION
Fixes #4053

## Why

The entry topbar could show duplicate or inconsistent tooltips because some chips mixed native `title` attributes with local `[data-tooltip]::after` CSS, while the settings button used the shared `.od-tooltip` / `TooltipLayer` path.

## What users will see

Entry topbar tooltips now appear as a single, consistent shared tooltip for the GitHub, Discord, model switcher, Use Everywhere, and settings controls.


## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<img width="319" height="99" alt="image" src="https://github.com/user-attachments/assets/ce25d2f2-5847-40b9-a41d-6f29d69a67a7" />
<img width="315" height="100" alt="image" src="https://github.com/user-attachments/assets/3c100d05-dea5-43b8-a851-d3a2cbaee3f1" />


## Bug fix verification

No red spec added; this is a visual browser tooltip collision. Verified by removing native `title` usage from affected chips, moving them to `.od-tooltip`, and guarding the legacy CSS tooltip with `:not(.od-tooltip)`.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm guard `