### PR TITLE
ci: harden the structured ci-gate workflow stack

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,12 +17,18 @@ jobs:
   actionlint:
     name: Lint GitHub Actions workflows
     runs-on: ubuntu-latest
+    env:
+      ACTIONLINT_VERSION: 1.7.12
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
+      - name: Install actionlint
+        run: |
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz actionlint
+          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:1.7.12
-        with:
-          args: -color
+        run: actionlint -color

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,162 +1,63 @@
 name: ci-gate
 
 on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
+      target_sha:
+        description: Optional SHA to aggregate. Empty uses the triggering SHA.
+        required: false
+        type: string
+        default: ""
+      target_event:
+        description: Optional event to aggregate. Empty uses the triggering event.
+        required: false
+        type: string
+        default: ""
       runner_run_id:
-        description: ci-runner workflow run id to accept as the common path
+        description: Optional ci-runner run id override
         required: false
         type: string
+        default: ""
       hosted_run_id:
-        description: ci-hosted workflow run id to accept as the backup path
+        description: Optional ci-hosted run id override
         required: false
         type: string
-      policy:
-        description: Gate policy for provided run ids
-        required: true
-        type: choice
-        default: any-success
-        options:
-          - any-success
-          - both-success
+        default: ""
 
 permissions:
   actions: read
   contents: read
 
+concurrency:
+  group: ci-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  gate:
-    name: CI gate
+  validate:
+    name: Validate workspace
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 90
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      TARGET_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || (github.event_name != 'workflow_dispatch' && github.sha || '') }}
+      TARGET_EVENT: ${{ github.event_name == 'workflow_dispatch' && inputs.target_event || (github.event_name != 'workflow_dispatch' && github.event_name || '') }}
+      RUNNER_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.runner_run_id || '' }}
+      HOSTED_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.hosted_run_id || '' }}
+      RUNNER_WORKFLOW: ci-runner
+      HOSTED_WORKFLOW: ci-hosted
     steps:
-      - name: Evaluate CI run ids
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          HOSTED_RUN_ID: ${{ inputs.hosted_run_id }}
-          POLICY: ${{ inputs.policy }}
-          RUNNER_RUN_ID: ${{ inputs.runner_run_id }}
-        run: |
-          set -euo pipefail
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
 
-          require_numeric_id() {
-            local label="$1"
-            local value="$2"
-            if [ -z "$value" ]; then
-              return 0
-            fi
-            if ! [[ "$value" =~ ^[0-9]+$ ]]; then
-              echo "$label must be a numeric GitHub Actions run id: $value" >&2
-              exit 2
-            fi
-          }
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
 
-          fetch_run() {
-            local label="$1"
-            local id="$2"
-            local out="$RUNNER_TEMP/$label.json"
-            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id" > "$out"
-            jq -r --arg label "$label" '{
-              label: $label,
-              id: .id,
-              name: .name,
-              event: .event,
-              headBranch: .head_branch,
-              headSha: .head_sha,
-              status: .status,
-              conclusion: .conclusion,
-              url: .html_url
-            }' "$out"
-          }
-
-          require_numeric_id runner_run_id "$RUNNER_RUN_ID"
-          require_numeric_id hosted_run_id "$HOSTED_RUN_ID"
-
-          if [ -z "$RUNNER_RUN_ID" ] && [ -z "$HOSTED_RUN_ID" ]; then
-            echo "Provide at least one of runner_run_id or hosted_run_id." >&2
-            exit 2
-          fi
-
-          results="$RUNNER_TEMP/ci-gate-results.jsonl"
-          : > "$results"
-
-          if [ -n "$RUNNER_RUN_ID" ]; then
-            fetch_run runner "$RUNNER_RUN_ID" >> "$results"
-          fi
-          if [ -n "$HOSTED_RUN_ID" ]; then
-            fetch_run hosted "$HOSTED_RUN_ID" >> "$results"
-          fi
-
-          jq -s . "$results"
-
-          unexpected_workflows="$(jq -r '
-            select((.label == "runner" and .name != "ci-runner") or (.label == "hosted" and .name != "ci-hosted"))
-            | "\(.label) run \(.id) is workflow \(.name // "<missing>")"
-          ' "$results")"
-          if [ -n "$unexpected_workflows" ]; then
-            echo "CI run id(s) do not match the expected workflow:"
-            echo "$unexpected_workflows"
-            exit 1
-          fi
-
-          missing_identity="$(jq -r '
-            select((.headSha == null or .headSha == "") or (.headBranch == null or .headBranch == "") or (.event == null or .event == ""))
-            | "\(.label) run \(.id) is missing headSha/headBranch/event"
-          ' "$results")"
-          if [ -n "$missing_identity" ]; then
-            echo "CI run id(s) are missing required identity fields:"
-            echo "$missing_identity"
-            exit 1
-          fi
-
-          mismatched_identity="$(jq -s -r '
-            def unique_values($key): [.[] | .[$key] | select(. != null and . != "")] | unique;
-            [
-              if (unique_values("headSha") | length) == 1 then empty else "headSha" end,
-              if (unique_values("headBranch") | length) == 1 then empty else "headBranch" end,
-              if (unique_values("event") | length) == 1 then empty else "event" end
-            ] | .[]
-          ' "$results")"
-          if [ -n "$mismatched_identity" ]; then
-            echo "CI run id(s) do not share the same identity field(s):"
-            echo "$mismatched_identity"
-            exit 1
-          fi
-
-          unfinished="$(jq -r 'select(.status != "completed") | "\(.label)=\(.status)"' "$results")"
-          if [ -n "$unfinished" ]; then
-            echo "CI run(s) are not completed:"
-            echo "$unfinished"
-            exit 1
-          fi
-
-          success_count="$(jq -s '[.[] | select(.conclusion == "success")] | length' "$results")"
-          provided_count="$(jq -s 'length' "$results")"
-
-          if [ "$POLICY" = "any-success" ]; then
-            echo "OD_CI_GATE_RESULT policy=$POLICY provided=$provided_count success=$success_count"
-            if [ "$success_count" -ge 1 ]; then
-              echo "CI gate accepted: at least one provided path succeeded."
-              exit 0
-            fi
-            echo "CI gate rejected: no provided path succeeded." >&2
-            exit 1
-          fi
-
-          if [ "$POLICY" = "both-success" ]; then
-            echo "OD_CI_GATE_RESULT policy=$POLICY provided=$provided_count success=$success_count"
-            if [ -z "$RUNNER_RUN_ID" ] || [ -z "$HOSTED_RUN_ID" ]; then
-              echo "CI gate rejected: policy=both-success requires both runner_run_id and hosted_run_id." >&2
-              exit 2
-            fi
-            if [ "$success_count" -eq "$provided_count" ]; then
-              echo "CI gate accepted: all provided paths succeeded."
-              exit 0
-            fi
-            echo "CI gate rejected: at least one provided path did not succeed." >&2
-            exit 1
-          fi
-
-          echo "Unknown policy: $POLICY" >&2
-          exit 2
+      - name: Aggregate CI results
+        run: node --experimental-strip-types .github/workflows/scripts/ci/aggregate-results.ts

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 90
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      TARGET_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || (github.event_name != 'workflow_dispatch' && github.sha || '') }}
+      TARGET_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || (github.event_name != 'workflow_dispatch' && (github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha) || '') }}
       TARGET_EVENT: ${{ github.event_name == 'workflow_dispatch' && inputs.target_event || (github.event_name != 'workflow_dispatch' && github.event_name || '') }}
       RUNNER_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.runner_run_id || '' }}
       HOSTED_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.hosted_run_id || '' }}

--- a/.github/workflows/ci-hosted.yml
+++ b/.github/workflows/ci-hosted.yml
@@ -1,141 +1,61 @@
 name: ci-hosted
 
 on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       mode:
-        description: Shared CI script mode to run on GitHub-hosted runners
+        description: Hosted CI mode
         required: true
         type: choice
-        default: all
+        default: nix
         options:
-          - all
-          - probe
-          - setup
-          - core
-          - policy
-          - unit
-          - typecheck
-          - daemon
-          - web
-          - build
-          - browser
+          - nix
+          - full
 
 permissions:
   contents: read
 
-env:
-  COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
-  COREPACK_HOME: /home/runner/.cache/open-design-ci/corepack
-  OD_CI_ALLOW_DOCKER: "1"
-  OD_CI_DAEMON_MAX_WORKERS: "4"
-  OD_CI_INSTALL_TIMEOUT_SECONDS: "1500"
-  OD_CI_LANE: hosted
-  OD_CI_PNPM_FETCH_RETRIES: "6"
-  OD_CI_PNPM_FETCH_RETRY_MAXTIMEOUT: "120000"
-  OD_CI_PNPM_FETCH_RETRY_MINTIMEOUT: "20000"
-  OD_CI_PNPM_INSTALL_FLAGS: "--frozen-lockfile --prefer-offline --network-concurrency=8"
-  OD_CI_PNPM_NETWORK_TIMEOUT: "180000"
-  OD_CI_PNPM_STORE_DIR: /home/runner/.cache/open-design-ci/pnpm-store
-  OD_CI_PLAYWRIGHT_INSTALL_FLAGS: "--with-deps chromium"
-  OD_CI_STEP_TIMEOUT_SECONDS: "600"
+concurrency:
+  group: ci-hosted-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'nix' }}
+  cancel-in-progress: true
 
 jobs:
-  plan:
-    name: Hosted CI plan
+  hosted:
+    name: Hosted CI
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      modes: ${{ steps.plan.outputs.modes }}
-    steps:
-      - name: Select hosted CI modes
-        id: plan
-        env:
-          MODE: ${{ inputs.mode }}
-        run: |
-          set -euo pipefail
-          case "$MODE" in
-            all)
-              modes='["core","typecheck","daemon","web","build","browser"]'
-              ;;
-            probe | setup | core | policy | unit | typecheck | daemon | web | build | browser)
-              modes="$(jq -nc --arg mode "$MODE" '[$mode]')"
-              ;;
-            *)
-              echo "Unsupported mode: $MODE" >&2
-              exit 2
-              ;;
-          esac
-          echo "modes=$modes" >> "$GITHUB_OUTPUT"
-          echo "$modes" | jq .
-
-  checks:
-    name: Hosted CI ${{ matrix.mode }}
-    needs:
-      - plan
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        mode: ${{ fromJSON(needs.plan.outputs.modes) }}
+    timeout-minutes: 120
+    env:
+      CI_GATE_HOSTED_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'nix' }}
+      CI_GATE_PLAYWRIGHT_INSTALL_FLAGS: --with-deps chromium
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
-      - name: Prepare package manager
-        run: |
-          set -euo pipefail
-          node --version
-          package_manager="$(node -p "require('./package.json').packageManager")"
-          corepack enable
-          corepack prepare "$package_manager" --activate
-          pnpm --version
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
 
-      - name: Run CI script
-        env:
-          MATRIX_MODE: ${{ matrix.mode }}
-        run: |
-          set -euo pipefail
-          script_mode="$MATRIX_MODE"
-          if [ "$script_mode" = "daemon" ]; then
-            script_mode="daemon-parallel"
-          fi
-          .github/workflows/scripts/ci.sh "$script_mode"
+      - name: Run hosted CI protocol
+        run: .github/workflows/scripts/ci-gate.sh --provider hosted --mode "$CI_GATE_HOSTED_MODE" --results-path .od/ci-gate/ci-results.json
 
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
+      - name: Upload hosted CI results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ci-hosted-${{ matrix.mode }}-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
+          name: ci-results-hosted
+          path: .od/ci-gate/ci-results.json
+          if-no-files-found: error
           retention-days: 7
-
-  gate:
-    name: Hosted CI gate
-    needs:
-      - plan
-      - checks
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Check hosted CI jobs
-        env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
-        run: |
-          set -euo pipefail
-          echo "$NEEDS_JSON" | jq .
-          failures="$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key)=\(.value.result)"')"
-          if [ -n "$failures" ]; then
-            echo "Hosted CI failed:"
-            echo "$failures"
-            exit 1
-          fi

--- a/.github/workflows/ci-hosted.yml
+++ b/.github/workflows/ci-hosted.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 120
     env:
       CI_GATE_HOSTED_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'nix' }}
+      CI_GATE_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       CI_GATE_PLAYWRIGHT_INSTALL_FLAGS: --with-deps chromium
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
       COREPACK_HOME: /home/runner/.cache/open-design-ci/corepack

--- a/.github/workflows/ci-hosted.yml
+++ b/.github/workflows/ci-hosted.yml
@@ -32,6 +32,8 @@ jobs:
     env:
       CI_GATE_HOSTED_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'nix' }}
       CI_GATE_PLAYWRIGHT_INSTALL_FLAGS: --with-deps chromium
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+      COREPACK_HOME: /home/runner/.cache/open-design-ci/corepack
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -53,6 +55,7 @@ jobs:
 
       - name: Upload hosted CI results
         if: ${{ always() }}
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: ci-results-hosted

--- a/.github/workflows/ci-runner.yml
+++ b/.github/workflows/ci-runner.yml
@@ -1,386 +1,44 @@
 name: ci-runner
 
 on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
   workflow_dispatch:
-    inputs:
-      mode:
-        description: Shared CI script mode to run
-        required: true
-        type: choice
-        default: all
-        options:
-          - all
-          - probe
-          - setup
-          - core
-          - policy
-          - unit
-          - typecheck
-          - daemon
-          - daemon-parallel
-          - web
-          - build
-          - browser
 
 permissions:
   contents: read
 
-env:
-  COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
-  COREPACK_HOME: /home/runner/.cache/open-design-ci/corepack
-  OD_CI_ALLOW_DOCKER: "1"
-  OD_CI_INSTALL_TIMEOUT_SECONDS: "1500"
-  OD_CI_LANE: runner
-  OD_CI_PNPM_FETCH_RETRIES: "6"
-  OD_CI_PNPM_FETCH_RETRY_MAXTIMEOUT: "120000"
-  OD_CI_PNPM_FETCH_RETRY_MINTIMEOUT: "20000"
-  OD_CI_PNPM_INSTALL_FLAGS: "--frozen-lockfile --prefer-offline --network-concurrency=8"
-  OD_CI_PNPM_NETWORK_TIMEOUT: "180000"
-  OD_CI_PNPM_STORE_DIR: /home/runner/.cache/open-design-ci/pnpm-store
-  OD_CI_PLAYWRIGHT_INSTALL_FLAGS: "chromium"
-  OD_CI_STEP_TIMEOUT_SECONDS: "600"
+concurrency:
+  group: ci-runner-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  all_daemon:
-    name: Runner CI all daemon
-    if: ${{ inputs.mode == 'all' }}
+  runner:
+    name: Runner CI
     runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
+    timeout-minutes: 120
     env:
-      OD_CI_DAEMON_MAX_WORKERS: "4"
+      CI_GATE_PLAYWRIGHT_INSTALL_FLAGS: chromium
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Run daemon
-        run: .github/workflows/scripts/ci.sh daemon-parallel
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
 
-      - name: Upload CI manifests
-        if: always()
-        continue-on-error: true
+      - name: Run runner CI protocol
+        run: .github/workflows/scripts/ci-gate.sh --provider runner --mode default --results-path .od/ci-gate/ci-results.json
+
+      - name: Upload runner CI results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ci-runner-all-daemon-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
+          name: ci-results-runner
+          path: .od/ci-gate/ci-results.json
+          if-no-files-found: error
           retention-days: 7
-
-  all_browser:
-    name: Runner CI all browser
-    if: ${{ inputs.mode == 'all' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 45
-    env:
-      OD_PLAYWRIGHT_TIMEOUT: "60000"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run browser
-        run: .github/workflows/scripts/ci.sh browser
-
-      - name: Upload CI manifests
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-all-browser-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  all_core_typecheck_web_build:
-    name: Runner CI all core + typecheck + web + build
-    if: ${{ inputs.mode == 'all' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 45
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run core
-        run: .github/workflows/scripts/ci.sh core
-
-      - name: Run typecheck
-        run: .github/workflows/scripts/ci.sh typecheck
-
-      - name: Run web
-        run: .github/workflows/scripts/ci.sh web
-
-      - name: Run build
-        run: .github/workflows/scripts/ci.sh build
-
-      - name: Upload CI manifests
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-all-core-typecheck-web-build-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  probe:
-    name: Runner CI probe
-    if: ${{ inputs.mode == 'probe' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh probe
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-probe-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  setup:
-    name: Runner CI setup
-    if: ${{ inputs.mode == 'setup' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh setup
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-setup-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  core:
-    name: Runner CI core
-    if: ${{ inputs.mode == 'core' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh core
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-core-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  policy:
-    name: Runner CI policy
-    if: ${{ inputs.mode == 'policy' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh policy
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-policy-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  unit:
-    name: Runner CI unit
-    if: ${{ inputs.mode == 'unit' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh unit
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-unit-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  typecheck:
-    name: Runner CI typecheck
-    if: ${{ inputs.mode == 'typecheck' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh typecheck
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-typecheck-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  daemon:
-    name: Runner CI daemon
-    if: ${{ inputs.mode == 'daemon' || inputs.mode == 'daemon-parallel' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
-    env:
-      OD_CI_DAEMON_MAX_WORKERS: "4"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        env:
-          INPUT_MODE: ${{ inputs.mode }}
-        run: |
-          set -euo pipefail
-          script_mode=daemon
-          if [ "$INPUT_MODE" = "daemon-parallel" ]; then
-            script_mode=daemon-parallel
-          fi
-          .github/workflows/scripts/ci.sh "$script_mode"
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-daemon-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  web:
-    name: Runner CI web
-    if: ${{ inputs.mode == 'web' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh web
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-web-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  build:
-    name: Runner CI build
-    if: ${{ inputs.mode == 'build' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh build
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-build-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  browser:
-    name: Runner CI browser
-    if: ${{ inputs.mode == 'browser' }}
-    runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
-    timeout-minutes: 45
-    env:
-      OD_PLAYWRIGHT_TIMEOUT: "60000"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Run CI script
-        run: .github/workflows/scripts/ci.sh browser
-
-      - name: Upload CI manifest
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-runner-browser-${{ github.run_id }}
-          path: .od/ci/*-manifest.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  gate:
-    name: Runner CI gate
-    needs:
-      - all_daemon
-      - all_browser
-      - all_core_typecheck_web_build
-      - probe
-      - setup
-      - core
-      - policy
-      - unit
-      - typecheck
-      - daemon
-      - web
-      - build
-      - browser
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Check runner CI jobs
-        env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
-        run: |
-          set -euo pipefail
-          echo "$NEEDS_JSON" | jq .
-          failures="$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key)=\(.value.result)"')"
-          if [ -n "$failures" ]; then
-            echo "Runner CI failed:"
-            echo "$failures"
-            exit 1
-          fi

--- a/.github/workflows/ci-runner.yml
+++ b/.github/workflows/ci-runner.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 120
     env:
       CI_GATE_PLAYWRIGHT_INSTALL_FLAGS: chromium
+      CI_GATE_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
       COREPACK_HOME: /home/runner/.cache/open-design-ci/corepack
     steps:

--- a/.github/workflows/ci-runner.yml
+++ b/.github/workflows/ci-runner.yml
@@ -26,11 +26,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
       - name: Run runner CI protocol
         run: .github/workflows/scripts/ci-gate.sh --provider runner --mode default --results-path .od/ci-gate/ci-results.json
 

--- a/.github/workflows/ci-runner.yml
+++ b/.github/workflows/ci-runner.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 120
     env:
       CI_GATE_PLAYWRIGHT_INSTALL_FLAGS: chromium
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+      COREPACK_HOME: /home/runner/.cache/open-design-ci/corepack
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -31,6 +33,7 @@ jobs:
 
       - name: Upload runner CI results
         if: ${{ always() }}
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: ci-results-runner

--- a/.github/workflows/scripts/ci-gate.sh
+++ b/.github/workflows/scripts/ci-gate.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+provider=""
+mode=""
+results_path=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --provider)
+      provider="${2:-}"
+      shift 2
+      ;;
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    --results-path)
+      results_path="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$provider" ] || [ -z "$mode" ]; then
+  echo "usage: $0 --provider <runner|hosted> --mode <default|nix|full> [--results-path <path>]" >&2
+  exit 2
+fi
+
+case "$provider" in
+  runner)
+    if [ "$mode" != "default" ]; then
+      echo "runner only supports --mode default" >&2
+      exit 2
+    fi
+    ;;
+  hosted)
+    if [ "$mode" != "nix" ] && [ "$mode" != "full" ]; then
+      echo "hosted only supports --mode nix|full" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "unknown provider: $provider" >&2
+    exit 2
+    ;;
+esac
+
+ci_root="${GITHUB_WORKSPACE:-$(pwd)}"
+results_path="${results_path:-$ci_root/.od/ci-gate/ci-results.json}"
+results_dir="$(dirname "$results_path")"
+actions_jsonl="$results_dir/actions.jsonl"
+
+mkdir -p "$results_dir"
+: > "$actions_jsonl"
+
+event_name="${GITHUB_EVENT_NAME:-unknown}"
+head_sha="${GITHUB_SHA:-unknown}"
+run_id="${GITHUB_RUN_ID:-unknown}"
+run_attempt="${GITHUB_RUN_ATTEMPT:-unknown}"
+
+actions=(
+  nix
+  guard
+  i18n
+  unit
+  typecheck
+  daemon
+  web
+  build
+  browser
+)
+
+append_result() {
+  local action="$1"
+  local kind="$2"
+  local status="$3"
+  jq -nc \
+    --arg action "$action" \
+    --arg kind "$kind" \
+    --arg status "$status" \
+    '{
+      action: $action,
+      kind: $kind,
+      status: $status
+    }' >> "$actions_jsonl"
+}
+
+is_real_action() {
+  local action="$1"
+  case "$provider:$mode:$action" in
+    runner:default:nix)
+      return 1
+      ;;
+    hosted:nix:nix)
+      return 0
+      ;;
+    hosted:nix:*)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+has_real_non_nix=false
+for action in "${actions[@]}"; do
+  if is_real_action "$action" && [ "$action" != "nix" ]; then
+    has_real_non_nix=true
+    break
+  fi
+done
+
+setup_status="success"
+if [ "$has_real_non_nix" = "true" ]; then
+  package_manager="$(node -p "require('./package.json').packageManager")"
+  echo "preparing workspace with $package_manager"
+  set +e
+  timeout 180s bash -lc 'corepack enable && corepack prepare "$1" --activate' _ "$package_manager"
+  corepack_exit="$?"
+  set -e
+  if [ "$corepack_exit" != "0" ]; then
+    setup_status="failure"
+  else
+    set +e
+    timeout 1800s pnpm install --frozen-lockfile --prefer-offline --network-concurrency=8
+    install_exit="$?"
+    set -e
+    if [ "$install_exit" != "0" ]; then
+      setup_status="failure"
+    fi
+  fi
+fi
+
+overall_exit=0
+for action in "${actions[@]}"; do
+  if ! is_real_action "$action"; then
+    append_result "$action" "placeholder" "not-run"
+    continue
+  fi
+
+  if [ "$action" != "nix" ] && [ "$setup_status" != "success" ]; then
+    append_result "$action" "real" "failure"
+    overall_exit=1
+    continue
+  fi
+
+  echo "running action: $action"
+  set +e
+  "$ci_root/.github/workflows/scripts/ci/actions/$action.sh"
+  action_exit="$?"
+  set -e
+  if [ "$action_exit" = "0" ]; then
+    append_result "$action" "real" "success"
+  else
+    append_result "$action" "real" "failure"
+    overall_exit=1
+  fi
+done
+
+jq -sc \
+  --arg provider "$provider" \
+  --arg mode "$mode" \
+  --arg eventName "$event_name" \
+  --arg headSha "$head_sha" \
+  --arg runId "$run_id" \
+  --arg runAttempt "$run_attempt" \
+  '{
+    schemaVersion: 1,
+    provider: $provider,
+    mode: $mode,
+    eventName: $eventName,
+    headSha: $headSha,
+    runId: $runId,
+    runAttempt: $runAttempt,
+    actions: .
+  }' "$actions_jsonl" > "$results_path"
+
+echo "ci results: $results_path"
+exit "$overall_exit"

--- a/.github/workflows/scripts/ci-gate.sh
+++ b/.github/workflows/scripts/ci-gate.sh
@@ -69,7 +69,7 @@ mkdir -p "$npm_config_store_dir"
 : > "$actions_jsonl"
 
 event_name="${GITHUB_EVENT_NAME:-unknown}"
-head_sha="${GITHUB_SHA:-unknown}"
+head_sha="${CI_GATE_HEAD_SHA:-${GITHUB_SHA:-unknown}}"
 run_id="${GITHUB_RUN_ID:-unknown}"
 run_attempt="${GITHUB_RUN_ATTEMPT:-unknown}"
 

--- a/.github/workflows/scripts/ci-gate.sh
+++ b/.github/workflows/scripts/ci-gate.sh
@@ -89,6 +89,22 @@ append_result() {
   local action="$1"
   local kind="$2"
   local status="$3"
+  local steps_path="${4:-}"
+  if [ -n "$steps_path" ] && [ -s "$steps_path" ]; then
+    jq -nc \
+      --arg action "$action" \
+      --arg kind "$kind" \
+      --arg status "$status" \
+      --slurpfile steps "$steps_path" \
+      '{
+        action: $action,
+        kind: $kind,
+        status: $status,
+        steps: $steps
+      }' >> "$actions_jsonl"
+    return 0
+  fi
+
   jq -nc \
     --arg action "$action" \
     --arg kind "$kind" \
@@ -149,6 +165,10 @@ fi
 
 overall_exit=0
 for action in "${actions[@]}"; do
+  action_steps_jsonl="$results_dir/${action}-steps.jsonl"
+  : > "$action_steps_jsonl"
+  export CI_GATE_ACTION_TIMINGS_PATH="$action_steps_jsonl"
+
   if ! is_real_action "$action"; then
     append_result "$action" "placeholder" "not-run"
     continue
@@ -166,9 +186,9 @@ for action in "${actions[@]}"; do
   action_exit="$?"
   set -e
   if [ "$action_exit" = "0" ]; then
-    append_result "$action" "real" "success"
+    append_result "$action" "real" "success" "$action_steps_jsonl"
   else
-    append_result "$action" "real" "failure"
+    append_result "$action" "real" "failure" "$action_steps_jsonl"
     overall_exit=1
   fi
 done

--- a/.github/workflows/scripts/ci-gate.sh
+++ b/.github/workflows/scripts/ci-gate.sh
@@ -55,7 +55,17 @@ results_path="${results_path:-$ci_root/.od/ci-gate/ci-results.json}"
 results_dir="$(dirname "$results_path")"
 actions_jsonl="$results_dir/actions.jsonl"
 
+export COREPACK_ENABLE_DOWNLOAD_PROMPT="${COREPACK_ENABLE_DOWNLOAD_PROMPT:-0}"
+export COREPACK_HOME="${COREPACK_HOME:-$HOME/.cache/open-design-ci/corepack}"
+export npm_config_store_dir="${npm_config_store_dir:-$HOME/.cache/open-design-ci/pnpm-store}"
+export npm_config_fetch_retries="${npm_config_fetch_retries:-6}"
+export npm_config_fetch_retry_maxtimeout="${npm_config_fetch_retry_maxtimeout:-120000}"
+export npm_config_fetch_retry_mintimeout="${npm_config_fetch_retry_mintimeout:-20000}"
+export npm_config_network_timeout="${npm_config_network_timeout:-180000}"
+
 mkdir -p "$results_dir"
+mkdir -p "$COREPACK_HOME"
+mkdir -p "$npm_config_store_dir"
 : > "$actions_jsonl"
 
 event_name="${GITHUB_EVENT_NAME:-unknown}"
@@ -182,4 +192,5 @@ jq -sc \
   }' "$actions_jsonl" > "$results_path"
 
 echo "ci results: $results_path"
+echo "OD_CI_RESULTS_JSON $(base64 < "$results_path" | tr -d '\n')"
 exit "$overall_exit"

--- a/.github/workflows/scripts/ci/actions/browser.sh
+++ b/.github/workflows/scripts/ci/actions/browser.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+playwright_flags="${CI_GATE_PLAYWRIGHT_INSTALL_FLAGS:-chromium}"
+
+# shellcheck disable=SC2086
+pnpm -C e2e exec playwright install $playwright_flags
+pnpm --filter @open-design/daemon build
+pnpm --filter @open-design/desktop build
+pnpm --filter @open-design/web build:sidecar
+pnpm --filter @open-design/e2e test
+pnpm -C e2e exec tsx scripts/playwright.ts clean
+pnpm -C e2e run test:ui:critical

--- a/.github/workflows/scripts/ci/actions/browser.sh
+++ b/.github/workflows/scripts/ci/actions/browser.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+source "$(dirname "$0")/../lib.sh"
+
 playwright_flags="${CI_GATE_PLAYWRIGHT_INSTALL_FLAGS:-chromium}"
 
 # shellcheck disable=SC2086
-pnpm -C e2e exec playwright install $playwright_flags
-pnpm --filter @open-design/daemon build
-pnpm --filter @open-design/desktop build
-pnpm --filter @open-design/web build:sidecar
-pnpm --filter @open-design/e2e test
-pnpm -C e2e exec tsx scripts/playwright.ts clean
-pnpm -C e2e run test:ui:critical
+ci_gate_timed_step "playwright-install" pnpm -C e2e exec playwright install $playwright_flags
+ci_gate_timed_step "daemon-build" pnpm --filter @open-design/daemon build
+ci_gate_timed_step "desktop-build" pnpm --filter @open-design/desktop build
+ci_gate_timed_step "web-build-sidecar" pnpm --filter @open-design/web build:sidecar
+ci_gate_timed_step "e2e-vitest" pnpm --filter @open-design/e2e test
+ci_gate_timed_step "playwright-clean" pnpm -C e2e exec tsx scripts/playwright.ts clean
+ci_gate_timed_step "playwright-critical" pnpm -C e2e run test:ui:critical

--- a/.github/workflows/scripts/ci/actions/build.sh
+++ b/.github/workflows/scripts/ci/actions/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+pnpm --filter @open-design/daemon build
+pnpm --filter @open-design/desktop build
+pnpm --filter @open-design/web build:sidecar
+pnpm -r --filter '!@open-design/landing-page' --workspace-concurrency=1 --if-present run build

--- a/.github/workflows/scripts/ci/actions/build.sh
+++ b/.github/workflows/scripts/ci/actions/build.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-pnpm --filter @open-design/daemon build
-pnpm --filter @open-design/desktop build
-pnpm --filter @open-design/web build:sidecar
-pnpm -r --filter '!@open-design/landing-page' --workspace-concurrency=1 --if-present run build
+source "$(dirname "$0")/../lib.sh"
+
+ci_gate_timed_step "daemon-build" pnpm --filter @open-design/daemon build
+ci_gate_timed_step "desktop-build" pnpm --filter @open-design/desktop build
+ci_gate_timed_step "web-build-sidecar" pnpm --filter @open-design/web build:sidecar
+ci_gate_timed_step "workspace-build" pnpm -r --filter '!@open-design/landing-page' --workspace-concurrency=1 --if-present run build

--- a/.github/workflows/scripts/ci/actions/daemon.sh
+++ b/.github/workflows/scripts/ci/actions/daemon.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+pnpm --filter @open-design/daemon build
+pnpm --filter @open-design/daemon test

--- a/.github/workflows/scripts/ci/actions/daemon.sh
+++ b/.github/workflows/scripts/ci/actions/daemon.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-pnpm --filter @open-design/daemon build
-pnpm --filter @open-design/daemon test
+source "$(dirname "$0")/../lib.sh"
+
+ci_gate_timed_step "daemon-build" pnpm --filter @open-design/daemon build
+ci_gate_timed_step "daemon-test" pnpm --filter @open-design/daemon test

--- a/.github/workflows/scripts/ci/actions/guard.sh
+++ b/.github/workflows/scripts/ci/actions/guard.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+pnpm guard

--- a/.github/workflows/scripts/ci/actions/guard.sh
+++ b/.github/workflows/scripts/ci/actions/guard.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-pnpm guard
+source "$(dirname "$0")/../lib.sh"
+
+ci_gate_timed_step "guard" pnpm guard

--- a/.github/workflows/scripts/ci/actions/i18n.sh
+++ b/.github/workflows/scripts/ci/actions/i18n.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+pnpm i18n:check

--- a/.github/workflows/scripts/ci/actions/i18n.sh
+++ b/.github/workflows/scripts/ci/actions/i18n.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-pnpm i18n:check
+source "$(dirname "$0")/../lib.sh"
+
+ci_gate_timed_step "i18n-check" pnpm i18n:check

--- a/.github/workflows/scripts/ci/actions/nix.sh
+++ b/.github/workflows/scripts/ci/actions/nix.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+nix flake check --print-build-logs --keep-going

--- a/.github/workflows/scripts/ci/actions/nix.sh
+++ b/.github/workflows/scripts/ci/actions/nix.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-nix flake check --print-build-logs --keep-going
+source "$(dirname "$0")/../lib.sh"
+
+ci_gate_timed_step "flake-check" nix flake check --print-build-logs --keep-going

--- a/.github/workflows/scripts/ci/actions/typecheck.sh
+++ b/.github/workflows/scripts/ci/actions/typecheck.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+pnpm --filter @open-design/daemon build
+pnpm --filter @open-design/desktop build
+pnpm --filter @open-design/web build:sidecar
+pnpm -r --filter '!open-design' --filter '!@open-design/landing-page' --workspace-concurrency=4 --if-present run typecheck
+pnpm exec tsc -p scripts/tsconfig.json --noEmit

--- a/.github/workflows/scripts/ci/actions/typecheck.sh
+++ b/.github/workflows/scripts/ci/actions/typecheck.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-pnpm --filter @open-design/daemon build
-pnpm --filter @open-design/desktop build
-pnpm --filter @open-design/web build:sidecar
-pnpm -r --filter '!open-design' --filter '!@open-design/landing-page' --workspace-concurrency=4 --if-present run typecheck
-pnpm exec tsc -p scripts/tsconfig.json --noEmit
+source "$(dirname "$0")/../lib.sh"
+
+ci_gate_timed_step "daemon-build" pnpm --filter @open-design/daemon build
+ci_gate_timed_step "desktop-build" pnpm --filter @open-design/desktop build
+ci_gate_timed_step "web-build-sidecar" pnpm --filter @open-design/web build:sidecar
+ci_gate_timed_step "workspace-typecheck" pnpm -r --filter '!open-design' --filter '!@open-design/landing-page' --workspace-concurrency=4 --if-present run typecheck
+ci_gate_timed_step "scripts-tsc" pnpm exec tsc -p scripts/tsconfig.json --noEmit

--- a/.github/workflows/scripts/ci/actions/unit.sh
+++ b/.github/workflows/scripts/ci/actions/unit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+pnpm --filter @open-design/contracts test
+pnpm --filter @open-design/host test
+pnpm --filter @open-design/platform test
+pnpm --filter @open-design/sidecar test
+pnpm --filter @open-design/sidecar-proto test
+pnpm --filter @open-design/tools-dev test
+pnpm --filter @open-design/tools-pack test

--- a/.github/workflows/scripts/ci/actions/unit.sh
+++ b/.github/workflows/scripts/ci/actions/unit.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-pnpm --filter @open-design/contracts test
-pnpm --filter @open-design/host test
-pnpm --filter @open-design/platform test
-pnpm --filter @open-design/sidecar test
-pnpm --filter @open-design/sidecar-proto test
-pnpm --filter @open-design/tools-dev test
-pnpm --filter @open-design/tools-pack test
+source "$(dirname "$0")/../lib.sh"
+
+ci_gate_timed_step "contracts-test" pnpm --filter @open-design/contracts test
+ci_gate_timed_step "host-test" pnpm --filter @open-design/host test
+ci_gate_timed_step "platform-test" pnpm --filter @open-design/platform test
+ci_gate_timed_step "sidecar-test" pnpm --filter @open-design/sidecar test
+ci_gate_timed_step "sidecar-proto-test" pnpm --filter @open-design/sidecar-proto test
+ci_gate_timed_step "tools-dev-test" pnpm --filter @open-design/tools-dev test
+ci_gate_timed_step "tools-pack-test" pnpm --filter @open-design/tools-pack test

--- a/.github/workflows/scripts/ci/actions/web.sh
+++ b/.github/workflows/scripts/ci/actions/web.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+pnpm --filter @open-design/web build:sidecar
+pnpm --filter @open-design/web test

--- a/.github/workflows/scripts/ci/actions/web.sh
+++ b/.github/workflows/scripts/ci/actions/web.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-pnpm --filter @open-design/web build:sidecar
-pnpm --filter @open-design/web test
+source "$(dirname "$0")/../lib.sh"
+
+ci_gate_timed_step "web-build-sidecar" pnpm --filter @open-design/web build:sidecar
+ci_gate_timed_step "web-test" pnpm --filter @open-design/web test

--- a/.github/workflows/scripts/ci/aggregate-results.ts
+++ b/.github/workflows/scripts/ci/aggregate-results.ts
@@ -1,0 +1,307 @@
+import { execFile } from "node:child_process";
+import { appendFile, mkdtemp, readdir, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+type Provider = "runner" | "hosted";
+type ActionName =
+  | "nix"
+  | "guard"
+  | "i18n"
+  | "unit"
+  | "typecheck"
+  | "daemon"
+  | "web"
+  | "build"
+  | "browser";
+type ActionKind = "real" | "placeholder";
+type ActionStatus = "success" | "failure" | "not-run";
+
+type ActionResult = {
+  action: ActionName;
+  kind: ActionKind;
+  status: ActionStatus;
+};
+
+type WorkflowResult = {
+  schemaVersion: number;
+  provider: Provider;
+  mode: string;
+  eventName: string;
+  headSha: string;
+  runId: string;
+  runAttempt: string;
+  actions: ActionResult[];
+};
+
+type WorkflowRun = {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  head_sha: string;
+  event: string;
+  html_url: string;
+  created_at: string;
+};
+
+const ACTIONS: ActionName[] = [
+  "nix",
+  "guard",
+  "i18n",
+  "unit",
+  "typecheck",
+  "daemon",
+  "web",
+  "build",
+  "browser",
+];
+
+const token = process.env.GITHUB_TOKEN ?? "";
+const repository = process.env.GITHUB_REPOSITORY ?? "";
+let targetSha = process.env.TARGET_SHA ?? "";
+let targetEvent = process.env.TARGET_EVENT ?? "";
+const runnerWorkflow = process.env.RUNNER_WORKFLOW ?? "ci-runner";
+const hostedWorkflow = process.env.HOSTED_WORKFLOW ?? "ci-hosted";
+const runnerRunId = process.env.RUNNER_RUN_ID ?? "";
+const hostedRunId = process.env.HOSTED_RUN_ID ?? "";
+const timeoutSeconds = Number(process.env.POLL_TIMEOUT_SECONDS ?? "3600");
+const pollIntervalSeconds = Number(process.env.POLL_INTERVAL_SECONDS ?? "20");
+const summaryPath = process.env.GITHUB_STEP_SUMMARY ?? "";
+
+if (!token || !repository) {
+  throw new Error("GITHUB_TOKEN and GITHUB_REPOSITORY are required");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function github<T>(path: string): Promise<T> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "open-design-ci-gate",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${path} failed: ${response.status} ${await response.text()}`);
+  }
+  return (await response.json()) as T;
+}
+
+function sortNewest(runs: WorkflowRun[]): WorkflowRun[] {
+  return [...runs].sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at));
+}
+
+async function fetchRunById(id: string): Promise<WorkflowRun> {
+  return await github<WorkflowRun>(`/repos/${repository}/actions/runs/${id}`);
+}
+
+async function findRunByWorkflowName(workflowName: string): Promise<WorkflowRun | null> {
+  const payload = await github<{ workflow_runs: WorkflowRun[] }>(
+    `/repos/${repository}/actions/runs?head_sha=${encodeURIComponent(targetSha)}&event=${encodeURIComponent(targetEvent)}&per_page=100`,
+  );
+  const matches = sortNewest(payload.workflow_runs).filter((run) => run.name === workflowName);
+  return matches[0] ?? null;
+}
+
+async function waitForRun(workflowName: string, explicitRunId: string): Promise<WorkflowRun> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (true) {
+    const run = explicitRunId ? await fetchRunById(explicitRunId) : await findRunByWorkflowName(workflowName);
+    if (run != null) {
+      if (run.head_sha !== targetSha) {
+        throw new Error(`${workflowName} run ${run.id} head_sha ${run.head_sha} does not match target ${targetSha}`);
+      }
+      if (run.status === "completed") {
+        return run;
+      }
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${workflowName} to complete for ${targetSha}`);
+    }
+    await sleep(pollIntervalSeconds * 1000);
+  }
+}
+
+async function downloadResultArtifact(provider: Provider, runId: number): Promise<WorkflowResult> {
+  const dir = await mkdtemp(join(tmpdir(), `od-ci-${provider}-`));
+  await execFileAsync(
+    "gh",
+    ["run", "download", String(runId), "--repo", repository, "--name", `ci-results-${provider}`, "--dir", dir],
+    {
+      env: { ...process.env, GH_TOKEN: token },
+    },
+  );
+  const resultPath = await findResultFile(dir);
+  const raw = await readFile(resultPath, "utf8");
+  return parseWorkflowResult(JSON.parse(raw));
+}
+
+async function findResultFile(root: string): Promise<string> {
+  const entries = await readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isFile() && entry.name === "ci-results.json") {
+      return path;
+    }
+    if (entry.isDirectory()) {
+      try {
+        return await findResultFile(path);
+      } catch {
+        // Keep walking until a matching result file is found.
+      }
+    }
+  }
+  throw new Error(`ci-results.json not found under ${root}`);
+}
+
+function parseWorkflowResult(raw: unknown): WorkflowResult {
+  if (typeof raw !== "object" || raw == null) {
+    throw new Error("workflow result must be an object");
+  }
+  const data = raw as Record<string, unknown>;
+  if (data.schemaVersion !== 1) {
+    throw new Error(`unsupported schemaVersion: ${String(data.schemaVersion)}`);
+  }
+  if (data.provider !== "runner" && data.provider !== "hosted") {
+    throw new Error(`unsupported provider: ${String(data.provider)}`);
+  }
+  if (!Array.isArray(data.actions)) {
+    throw new Error("workflow result actions must be an array");
+  }
+  const actions = data.actions.map((entry) => {
+    if (typeof entry !== "object" || entry == null) {
+      throw new Error("workflow result action must be an object");
+    }
+    const action = entry as Record<string, unknown>;
+    const actionName = String(action.action);
+    const kind = String(action.kind);
+    const status = String(action.status);
+    if (!ACTIONS.includes(actionName as ActionName)) {
+      throw new Error(`unknown action: ${actionName}`);
+    }
+    if (kind !== "real" && kind !== "placeholder") {
+      throw new Error(`unknown action kind: ${kind}`);
+    }
+    if (status !== "success" && status !== "failure" && status !== "not-run") {
+      throw new Error(`unknown action status: ${status}`);
+    }
+    return {
+      action: actionName as ActionName,
+      kind: kind as ActionKind,
+      status: status as ActionStatus,
+    };
+  });
+
+  return {
+    schemaVersion: 1,
+    provider: data.provider as Provider,
+    mode: String(data.mode ?? ""),
+    eventName: String(data.eventName ?? ""),
+    headSha: String(data.headSha ?? ""),
+    runId: String(data.runId ?? ""),
+    runAttempt: String(data.runAttempt ?? ""),
+    actions,
+  };
+}
+
+function validateIdentity(result: WorkflowResult, provider: Provider): void {
+  if (result.provider !== provider) {
+    throw new Error(`expected provider ${provider}, got ${result.provider}`);
+  }
+  if (result.headSha !== targetSha) {
+    throw new Error(`${provider} result headSha ${result.headSha} does not match target ${targetSha}`);
+  }
+  const explicitRunId = provider === "runner" ? runnerRunId : hostedRunId;
+  const skipStrictEventMatch = targetEvent === "workflow_dispatch" && explicitRunId !== "";
+  if (!skipStrictEventMatch && result.eventName !== targetEvent && result.eventName !== "workflow_dispatch") {
+    throw new Error(`${provider} result event ${result.eventName} does not match target ${targetEvent}`);
+  }
+  const actionNames = new Set(result.actions.map((action) => action.action));
+  if (actionNames.size !== ACTIONS.length) {
+    throw new Error(`${provider} result does not contain exactly one entry for each action`);
+  }
+}
+
+function summarizeAction(action: ActionName, runner: WorkflowResult, hosted: WorkflowResult): {
+  passed: boolean;
+  reason: string;
+} {
+  const candidates = [runner, hosted]
+    .flatMap((result) => result.actions.filter((entry) => entry.action === action).map((entry) => ({ ...entry, provider: result.provider })));
+  const realCandidates = candidates.filter((entry) => entry.kind === "real");
+  if (realCandidates.some((entry) => entry.status === "success")) {
+    const providers = realCandidates.filter((entry) => entry.status === "success").map((entry) => entry.provider).join(", ");
+    return { passed: true, reason: `success via ${providers}` };
+  }
+  if (realCandidates.length > 0) {
+    const providers = realCandidates.map((entry) => `${entry.provider}:${entry.status}`).join(", ");
+    return { passed: false, reason: `real results but no success (${providers})` };
+  }
+  return { passed: false, reason: "no real result available" };
+}
+
+async function appendSummary(lines: string[]): Promise<void> {
+  if (!summaryPath) return;
+  await appendFile(summaryPath, `${lines.join("\n")}\n`, "utf8");
+}
+
+async function main(): Promise<void> {
+  if (!targetSha || !targetEvent) {
+    const seedRunId = runnerRunId || hostedRunId;
+    if (!seedRunId) {
+      throw new Error("TARGET_SHA and TARGET_EVENT are required unless a runner_run_id or hosted_run_id is provided");
+    }
+    const seedRun = await fetchRunById(seedRunId);
+    targetSha ||= seedRun.head_sha;
+    targetEvent ||= seedRun.event;
+  }
+
+  const runnerRun = await waitForRun(runnerWorkflow, runnerRunId);
+  const hostedRun = await waitForRun(hostedWorkflow, hostedRunId);
+
+  const runnerResult = await downloadResultArtifact("runner", runnerRun.id);
+  const hostedResult = await downloadResultArtifact("hosted", hostedRun.id);
+
+  validateIdentity(runnerResult, "runner");
+  validateIdentity(hostedResult, "hosted");
+
+  const failures: string[] = [];
+  const summaryLines = [
+    "## CI Gate",
+    "",
+    `Target SHA: \`${targetSha}\``,
+    `Target event: \`${targetEvent}\``,
+    `Runner run: [${runnerRun.id}](${runnerRun.html_url}) conclusion=\`${runnerRun.conclusion ?? "null"}\``,
+    `Hosted run: [${hostedRun.id}](${hostedRun.html_url}) conclusion=\`${hostedRun.conclusion ?? "null"}\` mode=\`${hostedResult.mode}\``,
+    "",
+    "| Action | Result | Reason |",
+    "| --- | --- | --- |",
+  ];
+
+  for (const action of ACTIONS) {
+    const outcome = summarizeAction(action, runnerResult, hostedResult);
+    summaryLines.push(`| \`${action}\` | ${outcome.passed ? "pass" : "fail"} | ${outcome.reason} |`);
+    if (!outcome.passed) {
+      failures.push(`${action}: ${outcome.reason}`);
+    }
+  }
+
+  await appendSummary(summaryLines);
+  for (const line of summaryLines) {
+    console.log(line);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`ci-gate failed\n${failures.join("\n")}`);
+  }
+}
+
+await main();

--- a/.github/workflows/scripts/ci/aggregate-results.ts
+++ b/.github/workflows/scripts/ci/aggregate-results.ts
@@ -19,11 +19,19 @@ type ActionName =
   | "browser";
 type ActionKind = "real" | "placeholder";
 type ActionStatus = "success" | "failure" | "not-run";
+type StepStatus = "success" | "failure";
+
+type ActionStepTiming = {
+  name: string;
+  durationMs: number;
+  status: StepStatus;
+};
 
 type ActionResult = {
   action: ActionName;
   kind: ActionKind;
   status: ActionStatus;
+  steps?: ActionStepTiming[];
 };
 
 type WorkflowResult = {
@@ -219,10 +227,41 @@ function parseWorkflowResult(raw: unknown): WorkflowResult {
     if (status !== "success" && status !== "failure" && status !== "not-run") {
       throw new Error(`unknown action status: ${status}`);
     }
+    let steps: ActionStepTiming[] | undefined;
+    if (action.steps != null) {
+      if (!Array.isArray(action.steps)) {
+        throw new Error(`action ${actionName} steps must be an array`);
+      }
+      steps = action.steps.map((stepEntry) => {
+        if (typeof stepEntry !== "object" || stepEntry == null) {
+          throw new Error(`action ${actionName} step must be an object`);
+        }
+        const step = stepEntry as Record<string, unknown>;
+        const name = String(step.name ?? "");
+        const durationMs = Number(step.durationMs);
+        const stepStatus = String(step.status);
+        if (!name) {
+          throw new Error(`action ${actionName} step name is required`);
+        }
+        if (!Number.isFinite(durationMs) || durationMs < 0) {
+          throw new Error(`action ${actionName} step ${name} has invalid durationMs`);
+        }
+        if (stepStatus !== "success" && stepStatus !== "failure") {
+          throw new Error(`action ${actionName} step ${name} has invalid status ${stepStatus}`);
+        }
+        return {
+          name,
+          durationMs,
+          status: stepStatus as StepStatus,
+        };
+      });
+    }
+
     return {
       action: actionName as ActionName,
       kind: kind as ActionKind,
       status: status as ActionStatus,
+      steps,
     };
   });
 

--- a/.github/workflows/scripts/ci/aggregate-results.ts
+++ b/.github/workflows/scripts/ci/aggregate-results.ts
@@ -132,16 +132,21 @@ async function waitForRun(workflowName: string, explicitRunId: string): Promise<
 
 async function downloadResultArtifact(provider: Provider, runId: number): Promise<WorkflowResult> {
   const dir = await mkdtemp(join(tmpdir(), `od-ci-${provider}-`));
-  await execFileAsync(
-    "gh",
-    ["run", "download", String(runId), "--repo", repository, "--name", `ci-results-${provider}`, "--dir", dir],
-    {
-      env: { ...process.env, GH_TOKEN: token },
-    },
-  );
-  const resultPath = await findResultFile(dir);
-  const raw = await readFile(resultPath, "utf8");
-  return parseWorkflowResult(JSON.parse(raw));
+  try {
+    await execFileAsync(
+      "gh",
+      ["run", "download", String(runId), "--repo", repository, "--name", `ci-results-${provider}`, "--dir", dir],
+      {
+        env: { ...process.env, GH_TOKEN: token },
+      },
+    );
+    const resultPath = await findResultFile(dir);
+    const raw = await readFile(resultPath, "utf8");
+    return parseWorkflowResult(JSON.parse(raw));
+  } catch (error) {
+    console.warn(`artifact download failed for ${provider} run ${runId}; falling back to structured log payload`);
+    return await downloadResultFromLog(runId);
+  }
 }
 
 async function findResultFile(root: string): Promise<string> {
@@ -160,6 +165,27 @@ async function findResultFile(root: string): Promise<string> {
     }
   }
   throw new Error(`ci-results.json not found under ${root}`);
+}
+
+async function downloadResultFromLog(runId: number): Promise<WorkflowResult> {
+  const { stdout } = await execFileAsync("gh", ["run", "view", String(runId), "--repo", repository, "--log"], {
+    env: { ...process.env, GH_TOKEN: token },
+    maxBuffer: 1024 * 1024 * 32,
+  });
+  const marker = "OD_CI_RESULTS_JSON ";
+  const payload = stdout
+    .split("\n")
+    .map((line) => {
+      const index = line.indexOf(marker);
+      return index >= 0 ? line.slice(index + marker.length).trim() : "";
+    })
+    .filter((line) => line.length > 0)
+    .at(-1);
+  if (!payload) {
+    throw new Error(`OD_CI_RESULTS_JSON marker not found in run ${runId} logs`);
+  }
+  const raw = Buffer.from(payload, "base64").toString("utf8");
+  return parseWorkflowResult(JSON.parse(raw));
 }
 
 function parseWorkflowResult(raw: unknown): WorkflowResult {

--- a/.github/workflows/scripts/ci/lib.sh
+++ b/.github/workflows/scripts/ci/lib.sh
@@ -34,10 +34,11 @@ ci_gate_timed_step() {
   local finished_at
   local duration_ms
   local step_exit
+  local step_timeout_seconds="${CI_GATE_STEP_TIMEOUT_SECONDS:-600}"
 
   started_at="$(ci_gate_now_ms)"
   set +e
-  "$@"
+  timeout "${step_timeout_seconds}s" "$@"
   step_exit="$?"
   set -e
   finished_at="$(ci_gate_now_ms)"

--- a/.github/workflows/scripts/ci/lib.sh
+++ b/.github/workflows/scripts/ci/lib.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ci_gate_now_ms() {
+  python3 -c 'import time; print(int(time.time() * 1000))'
+}
+
+ci_gate_append_step_timing() {
+  local step_name="$1"
+  local duration_ms="$2"
+  local step_status="$3"
+  local timings_path="${CI_GATE_ACTION_TIMINGS_PATH:-}"
+
+  if [ -z "$timings_path" ]; then
+    return 0
+  fi
+
+  jq -nc \
+    --arg name "$step_name" \
+    --argjson durationMs "$duration_ms" \
+    --arg status "$step_status" \
+    '{
+      name: $name,
+      durationMs: $durationMs,
+      status: $status
+    }' >> "$timings_path"
+}
+
+ci_gate_timed_step() {
+  local step_name="$1"
+  shift
+
+  local started_at
+  local finished_at
+  local duration_ms
+  local step_exit
+
+  started_at="$(ci_gate_now_ms)"
+  set +e
+  "$@"
+  step_exit="$?"
+  set -e
+  finished_at="$(ci_gate_now_ms)"
+  duration_ms="$((finished_at - started_at))"
+
+  if [ "$step_exit" = "0" ]; then
+    ci_gate_append_step_timing "$step_name" "$duration_ms" "success"
+  else
+    ci_gate_append_step_timing "$step_name" "$duration_ms" "failure"
+  fi
+
+  return "$step_exit"
+}


### PR DESCRIPTION
## Why

I needed to turn the new `ci-gate` stack into something the repository can actually trust as the future PR check entrypoint, instead of leaving it at design-only status. The immediate pain here was that the new `ci-*` workflows still needed real proof that they could absorb the old gate semantics, survive self-hosted runner transport issues, and support the intended hosted fallback path before we can switch repository rules over.

This PR hardens that new stack so the CI gate itself is no longer the risky part of the migration. It gives us a structured result contract, a thin aggregator, verified fallback behavior, and enough runtime timing detail to understand hotspots later without coupling gate correctness to workflow logs.

## What users will see

There is no end-user product surface change. For maintainers and contributors, the repository gains a new `ci-gate` workflow stack that can serve as the future PR check entrypoint, with a self-hosted default path, a hosted `nix|full` path, structured aggregation, and a verified hosted fallback flow.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

-

## Validation

- `bash -n .github/workflows/scripts/ci-gate.sh .github/workflows/scripts/ci/lib.sh .github/workflows/scripts/ci/actions/*.sh`
- `git diff --check`
- Manual GitHub Actions validation on `codex/ci-gate-hardening`:
  - `ci-runner` `27261360550` verified structured-log fallback behavior when self-hosted artifact upload hit `ECONNRESET`
  - `ci-hosted mode=nix` `27261360728` verified the default hosted nix lane and structured result artifact
  - `ci-gate` `27261371310` verified action-level aggregation and runner log fallback
  - `ci-hosted mode=full` `27262247348` verified hosted full fallback on the current head
  - `ci-gate` `27263628637` verified explicit fallback aggregation with failed runner + successful hosted full
  - `ci-gate` `27263701318` verified workflow_dispatch run-id inference without explicit `target_sha` / `target_event`
  - `ci-hosted mode=nix` `27266573824` verified timing-enabled structured results with per-step `steps[]`
  - `ci-runner` `27267280361` and `ci-hosted mode=full` `27267280362` verified comparative timing output across runner and hosted
