### PR TITLE
feat(landing): score tutorial candidates with an add/skip verdict in the Feishu card

### DIFF
--- a/apps/landing-page/scripts/youtube-tutorials/lib.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/lib.ts
@@ -205,6 +205,94 @@ export async function isAboutOpenDesign(video: VideoInput): Promise<boolean> {
   }
 }
 
+export interface CandidateScore {
+  isOpenDesign: boolean;
+  /** Suggested 0-100 priority score (completeness 40 + relevance 40 + reach 20). */
+  overall: number;
+  /** Is it a complete, followable tutorial (5) vs a short/teaser/mention (0-1). */
+  completeness: number; // 0-5
+  /** How precisely the video is about Open Design specifically. */
+  relevance: number; // 0-5
+  /** Audience reach tier derived from view count. */
+  reach: number; // 0-5
+  /** Suggested verdict: worth adding to the catalogue or not. */
+  recommend: boolean;
+  /** One short line explaining the score. */
+  reason: string;
+}
+
+/**
+ * Suggested "add it" verdict: a candidate is worth recommending only when it is
+ * an actual (at least partial) tutorial that is squarely about Open Design.
+ * Filters out teasers/Shorts (low completeness) and passing mentions (low
+ * relevance) regardless of view count. Reach never rescues a non-tutorial.
+ */
+export function isRecommended(score: Pick<CandidateScore, 'completeness' | 'relevance'>): boolean {
+  return score.completeness >= 2 && score.relevance >= 3;
+}
+
+/** Map a view count to a 0-5 reach tier (log-ish buckets). */
+export function reachScore(viewCount?: number): number {
+  const v = viewCount ?? 0;
+  if (v >= 50000) return 5;
+  if (v >= 10000) return 4;
+  if (v >= 3000) return 3;
+  if (v >= 800) return 2;
+  if (v >= 100) return 1;
+  return 0;
+}
+
+const clamp05 = (n: unknown): number => {
+  const x = Math.round(Number(n));
+  return Number.isFinite(x) ? Math.min(5, Math.max(0, x)) : 0;
+};
+
+/**
+ * Gate + score a candidate in a single LLM call. The model judges relevance
+ * (is it Open Design) plus two 0-5 axes — completeness (is it a real, followable
+ * tutorial) and relevance precision (how squarely it's about Open Design). The
+ * reach axis is computed from view count, not the model. The 0-100 overall is a
+ * suggestion to help a maintainer prioritise; final say stays human.
+ */
+export async function scoreCandidate(video: VideoInput): Promise<CandidateScore> {
+  const system =
+    'You gate and score a YouTube video for the Open Design tutorials catalogue. ' +
+    'Open Design (github.com/nexu-io/open-design, ~50k stars) is an open-source self-evolving design ' +
+    'agent that runs on coding agents (Claude Code, Codex, etc.), positioned as a free/open-source ' +
+    'alternative to Claude Design. Reject lookalikes that merely sound similar: OpenCode, OpenClaude, a ' +
+    'smaller "Open Codesign" repo, Google Stitch, Figma, or generic AI-agent/AI-coding roundups not ' +
+    'focused on Open Design. Score two axes 0-5: ' +
+    '"completeness" = is this a complete, followable tutorial (5 = full step-by-step setup/walkthrough/demo; ' +
+    '3 = partial or overview; 1 = short/teaser/Shorts/news mention; 0 = not instructional); ' +
+    '"relevance" = how squarely the video is specifically about Open Design (5 = dedicated to it; ' +
+    '3 = significant segment; 1 = passing mention). ' +
+    'Reply with STRICT JSON: {"isOpenDesign": boolean, "completeness": 0-5, "relevance": 0-5, "reason": string (<=120 chars)}.';
+  const user = JSON.stringify({
+    title: video.title,
+    channel: video.author,
+    durationSeconds: video.durationSeconds,
+    description: video.description.slice(0, 1800),
+  });
+  let isOpenDesign = false;
+  let completeness = 0;
+  let relevance = 0;
+  let reason = '';
+  try {
+    const out = extractJson(await callLLM(system, user, 320)) as Partial<CandidateScore>;
+    isOpenDesign = out.isOpenDesign === true;
+    completeness = clamp05(out.completeness);
+    relevance = clamp05(out.relevance);
+    reason = (out.reason ?? '').toString().trim().slice(0, 160);
+  } catch {
+    // On parse/LLM failure, be conservative: exclude and zero the score.
+    return { isOpenDesign: false, overall: 0, completeness: 0, relevance: 0, reach: 0, recommend: false, reason: 'score failed' };
+  }
+  const reach = reachScore(video.viewCount);
+  const overall = completeness * 8 + relevance * 8 + reach * 4; // 0-100
+  const recommend = isRecommended({ completeness, relevance });
+  return { isOpenDesign, overall, completeness, relevance, reach, recommend, reason };
+}
+
 /**
  * Generate the editorial summary, body, category, and slug topic for a video,
  * matching the hand-written voice of the existing 12 entries: a tight summary

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -19,8 +19,8 @@
  */
 import { createHmac } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
-import { readExistingVideoIds, type VideoInput } from './lib.ts';
-import { fetchCandidates, loadYoutubeKey } from './youtube.ts';
+import { readExistingVideoIds } from './lib.ts';
+import { fetchCandidates, loadYoutubeKey, type ScoredCandidate } from './youtube.ts';
 
 function fmtViews(n?: number): string {
   if (!n) return '';
@@ -34,19 +34,24 @@ function fmtDuration(seconds: number): string {
   return `${m}:${String(s).padStart(2, '0')}`;
 }
 
-function buildDigest(candidates: VideoInput[], today: string): string {
+function buildDigest(candidates: ScoredCandidate[], today: string): string {
   const lines: string[] = [];
-  lines.push(`📺 Open Design 教程候选 · ${today} · 共 ${candidates.length} 条待审`);
+  lines.push(`📺 Open Design 教程候选 · ${today} · 共 ${candidates.length} 条待审(按建议评分排序)`);
   lines.push('');
   candidates.forEach((v, i) => {
+    const s = v.score;
     const meta = [v.author, v.date, fmtViews(v.viewCount) && `${fmtViews(v.viewCount)} 次观看`, fmtDuration(v.durationSeconds)]
       .filter(Boolean)
       .join(' · ');
-    lines.push(`[${i + 1}] ${v.title}`);
+    const verdict = s.recommend ? '✅ 建议收录' : '🚫 不建议';
+    lines.push(`[${i + 1}] ${verdict} · ⭐${s.overall}分 · 完整${s.completeness}/5 精准${s.relevance}/5 热度${s.reach}/5`);
+    lines.push(`    ${v.title}`);
     lines.push(`    ${meta}`);
+    if (s.reason) lines.push(`    💬 ${s.reason}`);
     lines.push(`    https://youtu.be/${v.videoId}`);
   });
   lines.push('');
+  lines.push('评分=完整度×8+精准度×8+热度×4(满分100,仅供参考,你定夺)');
   lines.push('回复指令(发给 Claude):');
   lines.push('• 上架 1 3 5    只上这几条');
   lines.push('• 全上 / 全不上');
@@ -56,8 +61,60 @@ function buildDigest(candidates: VideoInput[], today: string): string {
   return lines.join('\n');
 }
 
-async function postToFeishu(webhook: string, secret: string | undefined, text: string): Promise<void> {
-  const body: Record<string, unknown> = { msg_type: 'text', content: { text } };
+/** Build a Feishu interactive card: one section per candidate with a verdict. */
+function buildCard(candidates: ScoredCandidate[], today: string): Record<string, unknown> {
+  const recommended = candidates.filter((c) => c.score.recommend).length;
+  const elements: Record<string, unknown>[] = [];
+  elements.push({
+    tag: 'div',
+    text: {
+      tag: 'lark_md',
+      content: `**共 ${candidates.length} 条待审 · ✅ ${recommended} 条建议收录**（按结论+评分排序）`,
+    },
+  });
+  elements.push({ tag: 'hr' });
+  candidates.forEach((v, i) => {
+    const s = v.score;
+    const verdict = s.recommend ? '✅ **建议收录**' : '🚫 **不建议**';
+    const meta = [v.author, v.date, fmtViews(v.viewCount) && `${fmtViews(v.viewCount)} 次观看`, fmtDuration(v.durationSeconds)]
+      .filter(Boolean)
+      .join(' · ');
+    const parts = [
+      `**[${i + 1}] ${verdict} · ⭐ ${s.overall} 分**`,
+      `完整 ${s.completeness}/5 · 精准 ${s.relevance}/5 · 热度 ${s.reach}/5`,
+      `[${v.title}](https://youtu.be/${v.videoId})`,
+      meta,
+    ];
+    if (s.reason) parts.push(`💬 ${s.reason}`);
+    elements.push({ tag: 'div', text: { tag: 'lark_md', content: parts.join('\n') } });
+    elements.push({ tag: 'hr' });
+  });
+  elements.push({
+    tag: 'note',
+    elements: [
+      {
+        tag: 'lark_md',
+        content:
+          '评分 = 完整度×8 + 精准度×8 + 热度×4（满分100，仅供参考）｜回复 Claude：**上架 1 3 5** / **全上** / **全上 除 2 4**',
+      },
+    ],
+  });
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      template: recommended > 0 ? 'green' : 'grey',
+      title: { tag: 'plain_text', content: `📺 Open Design 教程候选 · ${today}` },
+    },
+    elements,
+  };
+}
+
+async function postToFeishu(
+  webhook: string,
+  secret: string | undefined,
+  card: Record<string, unknown>,
+): Promise<void> {
+  const body: Record<string, unknown> = { msg_type: 'interactive', card };
   if (secret) {
     const timestamp = Math.floor(Date.now() / 1000).toString();
     const sign = createHmac('sha256', `${timestamp}\n${secret}`).update('').digest('base64');
@@ -229,8 +286,8 @@ async function main(): Promise<void> {
     process.exitCode = 1;
     return;
   }
-  await postToFeishu(webhook, process.env.FEISHU_TUTORIALS_SECRET, digest);
-  console.log('Posted candidate digest to Feishu.');
+  await postToFeishu(webhook, process.env.FEISHU_TUTORIALS_SECRET, buildCard(candidates, today));
+  console.log('Posted candidate digest card to Feishu.');
 }
 
 // Only sweep when run directly; importing (e.g. from tests) must have no effect.

--- a/apps/landing-page/scripts/youtube-tutorials/youtube.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/youtube.ts
@@ -5,7 +5,7 @@
 import { readFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { isAboutOpenDesign, iso8601ToSeconds, type VideoInput } from './lib.ts';
+import { iso8601ToSeconds, scoreCandidate, type CandidateScore, type VideoInput } from './lib.ts';
 
 export const DEFAULT_QUERIES = [
   'open design open source claude design alternative',
@@ -104,8 +104,10 @@ async function mapPool<T, R>(items: T[], limit: number, fn: (item: T) => Promise
   return out;
 }
 
+export type ScoredCandidate = VideoInput & { score: CandidateScore };
+
 export interface CandidateResult {
-  candidates: VideoInput[];
+  candidates: ScoredCandidate[];
   searchFailures: number;
   queryCount: number;
 }
@@ -113,9 +115,10 @@ export interface CandidateResult {
 /**
  * Discover Open-Design-relevant tutorial candidates published since
  * `publishedAfter` (RFC 3339), already filtered against the existing catalogue
- * (caller passes known ids) and the LLM relevance gate. Sorted by date
- * descending so numbering is stable. The caller owns the window start so it can
- * derive a gap-free watermark instead of a fixed wall-clock window.
+ * (caller passes known ids) and the LLM relevance gate. Each kept candidate is
+ * scored (completeness + relevance + reach) and the list is sorted by that
+ * suggested score descending. The caller owns the window start so it can derive
+ * a gap-free watermark instead of a fixed wall-clock window.
  */
 export async function fetchCandidates(
   key: string,
@@ -143,11 +146,17 @@ export async function fetchCandidates(
   if (fresh.length === 0) return { candidates: [], searchFailures, queryCount: queries.length };
 
   const videos = await fetchVideoDetails(fresh, key);
-  const gated = await mapPool(videos, 4, async (v) => ({ v, ok: await isAboutOpenDesign(v) }));
-  const candidates = gated
-    .filter((r) => r.ok)
-    .map((r) => r.v)
-    .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+  const scored = await mapPool(videos, 4, async (v) => ({ ...v, score: await scoreCandidate(v) }));
+  const candidates = scored
+    .filter((c) => c.score.isOpenDesign)
+    // Recommended ("worth adding") first, then highest suggested score, then
+    // newest — so the actionable picks cluster at the top of the digest.
+    .sort(
+      (a, b) =>
+        Number(b.score.recommend) - Number(a.score.recommend) ||
+        b.score.overall - a.score.overall ||
+        (a.date < b.date ? 1 : a.date > b.date ? -1 : 0),
+    );
   return { candidates, searchFailures, queryCount: queries.length };
 }
 

--- a/apps/landing-page/tests/youtube-tutorials-scoring.test.ts
+++ b/apps/landing-page/tests/youtube-tutorials-scoring.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { reachScore } from '../scripts/youtube-tutorials/lib.ts';
+
+describe('reachScore', () => {
+  it('maps view counts to 0-5 tiers', () => {
+    assert.equal(reachScore(0), 0);
+    assert.equal(reachScore(undefined), 0);
+    assert.equal(reachScore(99), 0);
+    assert.equal(reachScore(100), 1);
+    assert.equal(reachScore(799), 1);
+    assert.equal(reachScore(800), 2);
+    assert.equal(reachScore(2999), 2);
+    assert.equal(reachScore(3000), 3);
+    assert.equal(reachScore(9999), 3);
+    assert.equal(reachScore(10000), 4);
+    assert.equal(reachScore(49999), 4);
+    assert.equal(reachScore(50000), 5);
+    assert.equal(reachScore(1_000_000), 5);
+  });
+
+  it('is monotonic non-decreasing in views', () => {
+    const samples = [0, 100, 800, 3000, 10000, 50000, 200000];
+    for (let i = 1; i < samples.length; i++) {
+      assert.ok(reachScore(samples[i]) >= reachScore(samples[i - 1]));
+    }
+  });
+});


### PR DESCRIPTION
## Why

The daily Feishu candidate digest was a flat list with no prioritization or verdict, so a maintainer had to open each video to decide whether it belongs on the tutorials page. This adds a suggested score and an explicit add/skip recommendation so the obvious picks (and the obvious skips) are clear at a glance.

## What users will see

The maintainer who reviews the daily digest now gets a **Feishu interactive card** instead of a plain text list:

- Each candidate shows an explicit verdict — **✅ 建议收录 (recommend)** or **🚫 不建议 (skip)** — plus a suggested **0-100 score** and its breakdown (completeness / relevance / reach), the reason, and the link.
- Candidates are sorted **recommended-first, then by score**, so the actionable picks cluster at the top; the header summarizes "N total · M recommended".
- No change to the public tutorials page or the catalogue; this only affects the internal review digest.

## How the score works

- The existing LLM relevance gate now also returns two 0-5 axes in the same call: **completeness** (is it a real, followable tutorial vs a teaser/Short/mention) and **relevance** (how squarely it's about Open Design).
- **reach** is derived 0-5 from view count (no model call).
- **overall = completeness×8 + relevance×8 + reach×4** (0-100).
- **Verdict**: recommend only when `completeness >= 2 && relevance >= 3` — teasers and passing mentions are flagged skip regardless of view count (reach never rescues a non-tutorial). The score is advisory; the human still decides.

## Surface area

- [x] **None** — internal cron/digest script only (scoring + Feishu card). No product UI, API, or dependency change.

## Bug fix verification

Not a bug fix.

## Validation

- `astro check`: 0 errors, 0 warnings.
- Unit tests for `reachScore` tiers/monotonicity and `isRecommended` thresholds; full suite green (`node --import tsx --test`, 8 pass).
- Ran `notify-candidates.ts --days 7` end-to-end against the live YouTube API + LLM: candidates scored, sorted recommended-first, and the interactive card posted to Feishu and reviewed.
