### PR TITLE
perf(plugins-home): prefetch the next rows' baked clips for instant scroll-in

### DIFF
--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -27,9 +27,20 @@ interface Props {
   // their poster instead of all spinning up decodes + clip downloads at once.
   inView: boolean;
   visible?: boolean;
+  // `approaching` (a margin tighter than `inView`, wider than `visible`) warms
+  // the FULL clip into the HTTP cache before the tile is visible, so playback
+  // starts instantly on scroll-in instead of buffering from the +faststart
+  // header at the moment it appears. Decoding still waits for `visible`.
+  approaching?: boolean;
 }
 
-export function MediaSurface({ preview, pluginTitle, inView, visible = inView }: Props) {
+export function MediaSurface({
+  preview,
+  pluginTitle,
+  inView,
+  visible = inView,
+  approaching = false,
+}: Props) {
   const [hovering, setHovering] = useState(false);
   // Track per-URL poster load failure so a 404 / decode error / dead
   // host swaps in the typographic fallback instead of leaving the
@@ -153,11 +164,13 @@ export function MediaSurface({ preview, pluginTitle, inView, visible = inView }:
           muted
           playsInline
           loop
-          // `metadata` paints the first frame off the +faststart header (moov +
-          // a few frames) instead of waiting on the whole file, so tiles show
-          // fast and don't all saturate the network buffering full clips up
-          // front; the idle hold buffers the pan span before hover.
-          preload={idlePlays ? 'metadata' : 'none'}
+          // Tiered preload so scroll-in is instant without saturating the
+          // network on first paint. In the wide mount margin: `metadata` (moov +
+          // first frame off the +faststart header). Once `approaching` (or
+          // hovering): `auto`, warming the whole clip into the HTTP cache a row
+          // or two ahead so it plays without a buffering beat. Hover-only video
+          // templates stay `none` until hovered.
+          preload={approaching || hovering ? 'auto' : idlePlays ? 'metadata' : 'none'}
           // Look like an inert iframe thumbnail: no native controls or PiP, and
           // clicks fall through to the card (open detail) instead of the video.
           disablePictureInPicture

--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import type { MediaPreviewSpec } from '../preview';
+import { useInView } from '../useInView';
 
 interface Props {
   preview: MediaPreviewSpec;
@@ -27,20 +28,9 @@ interface Props {
   // their poster instead of all spinning up decodes + clip downloads at once.
   inView: boolean;
   visible?: boolean;
-  // `approaching` (a margin tighter than `inView`, wider than `visible`) warms
-  // the FULL clip into the HTTP cache before the tile is visible, so playback
-  // starts instantly on scroll-in instead of buffering from the +faststart
-  // header at the moment it appears. Decoding still waits for `visible`.
-  approaching?: boolean;
 }
 
-export function MediaSurface({
-  preview,
-  pluginTitle,
-  inView,
-  visible = inView,
-  approaching = false,
-}: Props) {
+export function MediaSurface({ preview, pluginTitle, inView, visible = inView }: Props) {
   const [hovering, setHovering] = useState(false);
   // Track per-URL poster load failure so a 404 / decode error / dead
   // host swaps in the typographic fallback instead of leaving the
@@ -60,6 +50,17 @@ export function MediaSurface({
   // in-place span can loop while idle; plain video-template plugins keep the
   // cheaper poster-until-hover behaviour.
   const idlePlays = isVideo && holdMs != null;
+  // Prefetch zone: warm the full clip into the HTTP cache a row or two ahead so
+  // playback starts instantly on scroll-in instead of buffering from the
+  // +faststart header at the moment the tile appears. Only baked clips can
+  // upgrade `preload`, so the observer's ref is attached only when `idlePlays`;
+  // for every other media card useInView never sees a node and creates no
+  // observer — no extra threshold rerenders on a scroll-heavy gallery.
+  const { ref: approachRef, inView: approachingRaw } = useInView<HTMLDivElement>({
+    rootMargin: '1000px',
+    once: false,
+  });
+  const approaching = idlePlays && approachingRaw;
   // Mount across the wider `inView` margin so hover/scroll-in never remounts +
   // reloads the source, but only decode/buffer when truly `visible` (or
   // hovering) — otherwise every tile in the margin runs a simultaneous decode +
@@ -132,6 +133,7 @@ export function MediaSurface({
 
   return (
     <div
+      ref={idlePlays ? approachRef : undefined}
       className="plugins-home__media"
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}

--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -17,7 +17,6 @@
 
 import { useEffect, useRef, useState } from 'react';
 import type { MediaPreviewSpec } from '../preview';
-import { useInView } from '../useInView';
 
 interface Props {
   preview: MediaPreviewSpec;
@@ -52,15 +51,37 @@ export function MediaSurface({ preview, pluginTitle, inView, visible = inView }:
   const idlePlays = isVideo && holdMs != null;
   // Prefetch zone: warm the full clip into the HTTP cache a row or two ahead so
   // playback starts instantly on scroll-in instead of buffering from the
-  // +faststart header at the moment the tile appears. Only baked clips can
-  // upgrade `preload`, so the observer's ref is attached only when `idlePlays`;
-  // for every other media card useInView never sees a node and creates no
-  // observer — no extra threshold rerenders on a scroll-heavy gallery.
-  const { ref: approachRef, inView: approachingRaw } = useInView<HTMLDivElement>({
-    rootMargin: '1000px',
-    once: false,
-  });
-  const approaching = idlePlays && approachingRaw;
+  // +faststart header at the moment the tile appears. Keep the root ref stable
+  // across card reuse, and gate observer creation on `idlePlays` inside the
+  // effect: non-baked media cards pay no observer/rerender cost, while a reused
+  // card that flips from non-baked -> baked still subscribes correctly.
+  const approachRef = useRef<HTMLDivElement>(null);
+  const [approaching, setApproaching] = useState(false);
+  useEffect(() => {
+    if (!idlePlays) {
+      setApproaching(false);
+      return;
+    }
+
+    const node = approachRef.current;
+    if (!node) return;
+
+    if (typeof IntersectionObserver === 'undefined') {
+      setApproaching(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          setApproaching(entry.isIntersecting);
+        }
+      },
+      { rootMargin: '1000px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [idlePlays]);
   // Mount across the wider `inView` margin so hover/scroll-in never remounts +
   // reloads the source, but only decode/buffer when truly `visible` (or
   // hovering) — otherwise every tile in the margin runs a simultaneous decode +
@@ -133,7 +154,7 @@ export function MediaSurface({ preview, pluginTitle, inView, visible = inView }:
 
   return (
     <div
-      ref={idlePlays ? approachRef : undefined}
+      ref={approachRef}
       className="plugins-home__media"
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}

--- a/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
@@ -42,6 +42,14 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
     rootMargin: eager ? '1800px' : '1500px',
     once: false,
   });
+  //  - `approaching` (a row or two out): warm the FULL clip into the HTTP cache
+  //    so it plays instantly on scroll-in. Tighter than `keep` so a fast scroll
+  //    over the whole gallery doesn't prefetch every clip's bytes at once — only
+  //    the next rows in front of the viewport.
+  const { ref: approachingRef, inView: approaching } = useInView<HTMLDivElement>({
+    rootMargin: eager ? '1200px' : '1000px',
+    once: false,
+  });
   const { ref: visibleRef, inView: visible } = useInView<HTMLDivElement>({
     rootMargin: '0px',
     once: false,
@@ -50,9 +58,10 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
     (node: HTMLDivElement | null) => {
       nearRef.current = node;
       keepRef.current = node;
+      approachingRef.current = node;
       visibleRef.current = node;
     },
-    [nearRef, keepRef, visibleRef],
+    [nearRef, keepRef, approachingRef, visibleRef],
   );
 
   return (
@@ -66,6 +75,7 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
           preview={preview}
           pluginTitle={pluginTitle}
           inView={keep}
+          approaching={approaching}
           visible={visible}
         />
       ) : preview.kind === 'html' ? (

--- a/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
@@ -26,9 +26,11 @@ interface Props {
 export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }: Props) {
   const usesBakedClipKeepalive =
     preview.kind === 'media' && preview.mediaType === 'video' && preview.loopHoldMs != null;
-  // Three nested visibility zones for a baked clip:
+  // Visibility zones:
   //  - `inView` (tight): mount cheap-but-live content — iframes, design surfaces.
   //    Kept tight so a 350-plugin gallery never spins up dozens of live iframes.
+  //  - `mediaReady` (medium): fetch cheap media posters a little earlier than
+  //    live content, without widening iframe/design-system work.
   //  - `keep` (wide): keep the <video> + poster MOUNTED across a few screens, so
   //    scrolling away and back doesn't remount + reload the clip. The bytes are
   //    HTTP-cached (immutable), but a fresh <video> still re-fetches metadata and
@@ -38,6 +40,10 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
   //    running simultaneous decodes.
   const { ref: nearRef, inView } = useInView<HTMLDivElement>({
     rootMargin: eager ? '480px' : '120px',
+    once: false,
+  });
+  const { ref: mediaRef, inView: mediaReady } = useInView<HTMLDivElement>({
+    rootMargin: eager ? '720px' : '360px',
     once: false,
   });
   const { ref: keepRef, inView: keep } = useInView<HTMLDivElement>({
@@ -54,10 +60,11 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
   const setRef = useCallback(
     (node: HTMLDivElement | null) => {
       nearRef.current = node;
+      mediaRef.current = node;
       keepRef.current = node;
       visibleRef.current = node;
     },
-    [nearRef, keepRef, visibleRef],
+    [nearRef, mediaRef, keepRef, visibleRef],
   );
 
   return (
@@ -70,7 +77,7 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
         <MediaSurface
           preview={preview}
           pluginTitle={pluginTitle}
-          inView={usesBakedClipKeepalive ? keep : inView}
+          inView={usesBakedClipKeepalive ? keep : mediaReady}
           visible={visible}
         />
       ) : preview.kind === 'html' ? (

--- a/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
@@ -42,26 +42,20 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
     rootMargin: eager ? '1800px' : '1500px',
     once: false,
   });
-  //  - `approaching` (a row or two out): warm the FULL clip into the HTTP cache
-  //    so it plays instantly on scroll-in. Tighter than `keep` so a fast scroll
-  //    over the whole gallery doesn't prefetch every clip's bytes at once — only
-  //    the next rows in front of the viewport.
-  const { ref: approachingRef, inView: approaching } = useInView<HTMLDivElement>({
-    rootMargin: eager ? '1200px' : '1000px',
-    once: false,
-  });
   const { ref: visibleRef, inView: visible } = useInView<HTMLDivElement>({
     rootMargin: '0px',
     once: false,
   });
+  // The prefetch zone (warm the full clip a row ahead) lives inside MediaSurface
+  // so only baked-clip cards pay for that observer — html/design/text/plain-video
+  // tiles can never upgrade `preload`, so they must not rerender on its threshold.
   const setRef = useCallback(
     (node: HTMLDivElement | null) => {
       nearRef.current = node;
       keepRef.current = node;
-      approachingRef.current = node;
       visibleRef.current = node;
     },
-    [nearRef, keepRef, approachingRef, visibleRef],
+    [nearRef, keepRef, visibleRef],
   );
 
   return (
@@ -75,7 +69,6 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
           preview={preview}
           pluginTitle={pluginTitle}
           inView={keep}
-          approaching={approaching}
           visible={visible}
         />
       ) : preview.kind === 'html' ? (

--- a/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/PreviewSurface.tsx
@@ -24,6 +24,8 @@ interface Props {
 }
 
 export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }: Props) {
+  const usesBakedClipKeepalive =
+    preview.kind === 'media' && preview.mediaType === 'video' && preview.loopHoldMs != null;
   // Three nested visibility zones for a baked clip:
   //  - `inView` (tight): mount cheap-but-live content — iframes, design surfaces.
   //    Kept tight so a 350-plugin gallery never spins up dozens of live iframes.
@@ -68,7 +70,7 @@ export function PreviewSurface({ pluginId, pluginTitle, preview, eager = false }
         <MediaSurface
           preview={preview}
           pluginTitle={pluginTitle}
-          inView={keep}
+          inView={usesBakedClipKeepalive ? keep : inView}
           visible={visible}
         />
       ) : preview.kind === 'html' ? (

--- a/apps/web/tests/components/plugins-home-media-surface.test.tsx
+++ b/apps/web/tests/components/plugins-home-media-surface.test.tsx
@@ -37,6 +37,14 @@ const VIDEO_POSTER: MediaPreviewSpec = {
   imageOnly: false,
 };
 
+// A baked hover-pan clip: `loopHoldMs` set => idlePlays, so the <video> mounts
+// across the wide margin and we can assert its tiered preload.
+const BAKED_CLIP: MediaPreviewSpec = {
+  ...VIDEO_POSTER,
+  videoUrl: 'https://example.invalid/clip.mp4',
+  loopHoldMs: 2500,
+};
+
 afterEach(() => {
   cleanup();
 });
@@ -112,5 +120,39 @@ describe('MediaSurface broken-poster fallback (#2955)', () => {
       <MediaSurface preview={VIDEO_POSTER} pluginTitle="Video example" inView={true} />,
     );
     expect(container.querySelector('.plugins-home__media-badge')).toBeNull();
+  });
+});
+
+describe('MediaSurface tiered clip preload (scroll-in prefetch)', () => {
+  it('preloads only metadata while mounted in the wide margin but not yet approaching', () => {
+    const { container } = render(
+      <MediaSurface
+        preview={BAKED_CLIP}
+        pluginTitle="Clip"
+        inView={true}
+        approaching={false}
+        visible={false}
+      />,
+    );
+    const video = container.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video!.getAttribute('preload')).toBe('metadata');
+  });
+
+  it('warms the full clip (preload=auto) once approaching, before it becomes visible', () => {
+    // The whole point of the prefetch tier: the bytes are in the HTTP cache a
+    // row or two ahead, so playback starts instantly on scroll-in instead of
+    // buffering from the +faststart header at the moment the tile appears.
+    const { container } = render(
+      <MediaSurface
+        preview={BAKED_CLIP}
+        pluginTitle="Clip"
+        inView={true}
+        approaching={true}
+        visible={false}
+      />,
+    );
+    const video = container.querySelector('video');
+    expect(video!.getAttribute('preload')).toBe('auto');
   });
 });

--- a/apps/web/tests/components/plugins-home-media-surface.test.tsx
+++ b/apps/web/tests/components/plugins-home-media-surface.test.tsx
@@ -124,33 +124,36 @@ describe('MediaSurface broken-poster fallback (#2955)', () => {
 });
 
 describe('MediaSurface tiered clip preload (scroll-in prefetch)', () => {
-  it('preloads only metadata while mounted in the wide margin but not yet approaching', () => {
-    const { container } = render(
-      <MediaSurface
-        preview={BAKED_CLIP}
-        pluginTitle="Clip"
-        inView={true}
-        approaching={false}
-        visible={false}
-      />,
-    );
-    const video = container.querySelector('video');
-    expect(video).not.toBeNull();
-    expect(video!.getAttribute('preload')).toBe('metadata');
+  it('keeps preload at metadata while mounted but before the prefetch zone is reached', () => {
+    // A non-firing IntersectionObserver models the tile being mounted in the
+    // wide margin but not yet in the prefetch zone: useInView never reports
+    // in-view, so the internal `approaching` signal stays false.
+    const orig = globalThis.IntersectionObserver;
+    globalThis.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof IntersectionObserver;
+    try {
+      const { container } = render(
+        <MediaSurface preview={BAKED_CLIP} pluginTitle="Clip" inView={true} visible={false} />,
+      );
+      const video = container.querySelector('video');
+      expect(video).not.toBeNull();
+      expect(video!.getAttribute('preload')).toBe('metadata');
+    } finally {
+      globalThis.IntersectionObserver = orig;
+    }
   });
 
-  it('warms the full clip (preload=auto) once approaching, before it becomes visible', () => {
-    // The whole point of the prefetch tier: the bytes are in the HTTP cache a
-    // row or two ahead, so playback starts instantly on scroll-in instead of
-    // buffering from the +faststart header at the moment the tile appears.
+  it('warms the full clip (preload=auto) once the prefetch zone is reached', () => {
+    // jsdom ships no IntersectionObserver, so useInView reports in-view
+    // immediately — i.e. the prefetch zone is reached. The whole point of the
+    // tier: the bytes are warmed into the HTTP cache a row or two ahead, so
+    // playback starts instantly on scroll-in instead of buffering from the
+    // +faststart header at the moment the tile appears.
     const { container } = render(
-      <MediaSurface
-        preview={BAKED_CLIP}
-        pluginTitle="Clip"
-        inView={true}
-        approaching={true}
-        visible={false}
-      />,
+      <MediaSurface preview={BAKED_CLIP} pluginTitle="Clip" inView={true} visible={false} />,
     );
     const video = container.querySelector('video');
     expect(video!.getAttribute('preload')).toBe('auto');

--- a/apps/web/tests/components/plugins-home-media-surface.test.tsx
+++ b/apps/web/tests/components/plugins-home-media-surface.test.tsx
@@ -126,7 +126,7 @@ describe('MediaSurface broken-poster fallback (#2955)', () => {
 describe('MediaSurface tiered clip preload (scroll-in prefetch)', () => {
   it('keeps preload at metadata while mounted but before the prefetch zone is reached', () => {
     // A non-firing IntersectionObserver models the tile being mounted in the
-    // wide margin but not yet in the prefetch zone: useInView never reports
+    // wide margin but not yet in the prefetch zone: the observer never reports
     // in-view, so the internal `approaching` signal stays false.
     const orig = globalThis.IntersectionObserver;
     globalThis.IntersectionObserver = class {
@@ -147,8 +147,8 @@ describe('MediaSurface tiered clip preload (scroll-in prefetch)', () => {
   });
 
   it('warms the full clip (preload=auto) once the prefetch zone is reached', () => {
-    // jsdom ships no IntersectionObserver, so useInView reports in-view
-    // immediately — i.e. the prefetch zone is reached. The whole point of the
+    // jsdom ships no IntersectionObserver, so MediaSurface treats the prefetch
+    // zone as reached immediately. The whole point of the
     // tier: the bytes are warmed into the HTTP cache a row or two ahead, so
     // playback starts instantly on scroll-in instead of buffering from the
     // +faststart header at the moment the tile appears.
@@ -157,5 +157,33 @@ describe('MediaSurface tiered clip preload (scroll-in prefetch)', () => {
     );
     const video = container.querySelector('video');
     expect(video!.getAttribute('preload')).toBe('auto');
+  });
+
+  it('starts observing when a reused media card becomes a baked clip', () => {
+    // React can reuse the same MediaSurface instance while filters/feeds rotate
+    // cards. A plain video card should not pay for the prefetch observer, but if
+    // that same instance later receives a baked clip, the stable ref + idlePlays
+    // effect dependency must subscribe then; otherwise it would stay stuck at
+    // preload=metadata forever.
+    const orig = globalThis.IntersectionObserver;
+    const observed: Element[] = [];
+    globalThis.IntersectionObserver = class {
+      observe(node: Element) {
+        observed.push(node);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof IntersectionObserver;
+    try {
+      const { rerender } = render(
+        <MediaSurface preview={VIDEO_POSTER} pluginTitle="Video" inView={true} visible={false} />,
+      );
+      expect(observed).toHaveLength(0);
+
+      rerender(<MediaSurface preview={BAKED_CLIP} pluginTitle="Clip" inView={true} visible={false} />);
+      expect(observed).toHaveLength(1);
+    } finally {
+      globalThis.IntersectionObserver = orig;
+    }
   });
 });

--- a/apps/web/tests/components/plugins-home-preview-surface.test.tsx
+++ b/apps/web/tests/components/plugins-home-preview-surface.test.tsx
@@ -21,11 +21,15 @@ vi.mock('../../src/components/plugins-home/cards/MediaSurface', () => ({
 }));
 
 vi.mock('../../src/components/plugins-home/cards/HtmlSurface', () => ({
-  HtmlSurface: () => <div data-testid="html-surface" />,
+  HtmlSurface: ({ inView }: { inView: boolean }) => (
+    <div data-testid="html-surface" data-in-view={String(inView)} />
+  ),
 }));
 
 vi.mock('../../src/components/plugins-home/cards/DesignSystemSurface', () => ({
-  DesignSystemSurface: () => <div data-testid="design-surface" />,
+  DesignSystemSurface: ({ inView }: { inView: boolean }) => (
+    <div data-testid="design-surface" data-in-view={String(inView)} />
+  ),
 }));
 
 vi.mock('../../src/components/plugins-home/cards/TextSurface', () => ({
@@ -55,10 +59,10 @@ const BAKED_CLIP_PREVIEW: MediaPreviewSpec = {
 };
 
 function renderWithVisibility(preview: MediaPreviewSpec) {
-  // PreviewSurface calls useInView in this order: near, keep, visible. Make the
+  // PreviewSurface calls useInView in this order: near, media, keep, visible. Make the
   // values intentionally disagree so the gate passed to MediaSurface proves
   // which zone each media subtype uses.
-  visibilityQueue.splice(0, visibilityQueue.length, true, false, true);
+  visibilityQueue.splice(0, visibilityQueue.length, false, true, false, true);
   render(
     <PreviewSurface pluginId="sample" pluginTitle="Sample" preview={preview} />,
   );
@@ -75,15 +79,38 @@ describe('PreviewSurface media visibility gates', () => {
     visibilityQueue.splice(0, visibilityQueue.length);
   });
 
-  it('keeps image media on the tight near margin', () => {
+  it('warms image media on the medium media margin', () => {
     expect(renderWithVisibility(IMAGE_PREVIEW).dataset.inView).toBe('true');
   });
 
-  it('keeps plain video media on the tight near margin', () => {
+  it('warms plain video media on the medium media margin', () => {
     expect(renderWithVisibility(PLAIN_VIDEO_PREVIEW).dataset.inView).toBe('true');
   });
 
   it('uses the wide keepalive margin only for baked hover-pan clips', () => {
     expect(renderWithVisibility(BAKED_CLIP_PREVIEW).dataset.inView).toBe('false');
+  });
+
+  it('keeps html and design surfaces on the tight near margin', () => {
+    visibilityQueue.splice(0, visibilityQueue.length, false, true, true, true);
+    render(
+      <PreviewSurface
+        pluginId="sample"
+        pluginTitle="Sample"
+        preview={{ kind: 'html', src: '/preview', label: 'preview', source: 'preview' }}
+      />,
+    );
+    expect(screen.getByTestId('html-surface').dataset.inView).toBe('false');
+    cleanup();
+
+    visibilityQueue.splice(0, visibilityQueue.length, false, true, true, true);
+    render(
+      <PreviewSurface
+        pluginId="sample"
+        pluginTitle="Sample"
+        preview={{ kind: 'design', brand: 'Sample', designSystemId: null, swatches: [] }}
+      />,
+    );
+    expect(screen.getByTestId('design-surface').dataset.inView).toBe('false');
   });
 });

--- a/apps/web/tests/components/plugins-home-preview-surface.test.tsx
+++ b/apps/web/tests/components/plugins-home-preview-surface.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PreviewSurface } from '../../src/components/plugins-home/cards/PreviewSurface';
+import type { MediaPreviewSpec } from '../../src/components/plugins-home/preview';
+
+const visibilityQueue: boolean[] = [];
+
+vi.mock('../../src/components/plugins-home/useInView', () => ({
+  useInView: () => ({
+    ref: { current: null },
+    inView: visibilityQueue.shift() ?? false,
+  }),
+}));
+
+vi.mock('../../src/components/plugins-home/cards/MediaSurface', () => ({
+  MediaSurface: ({ inView, visible }: { inView: boolean; visible?: boolean }) => (
+    <div data-testid="media-surface" data-in-view={String(inView)} data-visible={String(visible)} />
+  ),
+}));
+
+vi.mock('../../src/components/plugins-home/cards/HtmlSurface', () => ({
+  HtmlSurface: () => <div data-testid="html-surface" />,
+}));
+
+vi.mock('../../src/components/plugins-home/cards/DesignSystemSurface', () => ({
+  DesignSystemSurface: () => <div data-testid="design-surface" />,
+}));
+
+vi.mock('../../src/components/plugins-home/cards/TextSurface', () => ({
+  TextSurface: () => <div data-testid="text-surface" />,
+}));
+
+const IMAGE_PREVIEW: MediaPreviewSpec = {
+  kind: 'media',
+  mediaType: 'image',
+  poster: 'https://example.invalid/poster.jpg',
+  videoUrl: null,
+  audioUrl: null,
+  imageOnly: true,
+};
+
+const PLAIN_VIDEO_PREVIEW: MediaPreviewSpec = {
+  ...IMAGE_PREVIEW,
+  mediaType: 'video',
+  videoUrl: 'https://example.invalid/plain.mp4',
+  imageOnly: false,
+};
+
+const BAKED_CLIP_PREVIEW: MediaPreviewSpec = {
+  ...PLAIN_VIDEO_PREVIEW,
+  videoUrl: 'https://example.invalid/baked.mp4',
+  loopHoldMs: 2500,
+};
+
+function renderWithVisibility(preview: MediaPreviewSpec) {
+  // PreviewSurface calls useInView in this order: near, keep, visible. Make the
+  // values intentionally disagree so the gate passed to MediaSurface proves
+  // which zone each media subtype uses.
+  visibilityQueue.splice(0, visibilityQueue.length, true, false, true);
+  render(
+    <PreviewSurface pluginId="sample" pluginTitle="Sample" preview={preview} />,
+  );
+  return screen.getByTestId('media-surface');
+}
+
+afterEach(() => {
+  cleanup();
+  visibilityQueue.splice(0, visibilityQueue.length);
+});
+
+describe('PreviewSurface media visibility gates', () => {
+  beforeEach(() => {
+    visibilityQueue.splice(0, visibilityQueue.length);
+  });
+
+  it('keeps image media on the tight near margin', () => {
+    expect(renderWithVisibility(IMAGE_PREVIEW).dataset.inView).toBe('true');
+  });
+
+  it('keeps plain video media on the tight near margin', () => {
+    expect(renderWithVisibility(PLAIN_VIDEO_PREVIEW).dataset.inView).toBe('true');
+  });
+
+  it('uses the wide keepalive margin only for baked hover-pan clips', () => {
+    expect(renderWithVisibility(BAKED_CLIP_PREVIEW).dataset.inView).toBe('false');
+  });
+});


### PR DESCRIPTION
## Why

Reviewing the just-merged baked-gallery work, I noticed the home gallery already mounts baked clips across a wide margin (so scrolling never remounts them), but the `<video>` stayed at `preload="metadata"` until the tile became visible. The full clip only started downloading the moment it entered the viewport — a short buffering beat on every scroll-in. The gallery should feel 丝滑 while scrolling, not "load as it appears".

## What users will see

Scrolling the home plugin gallery, baked hover-pan clips a row or two ahead of the viewport are warmed into the HTTP cache before they arrive, so they start playing instantly on scroll-in instead of buffering. Media posters also get a modest poster-only warmup before the viewport. No visible UI change — purely smoother scrolling.

## How it works

- HTML/design surfaces keep the tight live-content margin: 120px normally, 480px in eager gallery mode.
- Ordinary media posters use a medium poster warmup margin: 360px normally, 720px in eager gallery mode.
- Baked hover-pan clips keep the wide keepalive margin: 1500px normally, 1800px in eager gallery mode, so scroll-away/scroll-back does not remount and reload the clip.
- Baked hover-pan clips also get an internal prefetch zone in `MediaSurface` (~1000px) that flips `<video preload>` from `metadata` to `auto`, warming full clip bytes ahead of viewport entry.
- Playback/decoding still waits for true visibility (0px), so off-screen tiles can prefetch bytes without all spinning up simultaneous decodes.

Posters are cheap (~8–35KB JPEG, around 20KB typical). The heavier layer is the ~278KB baked video bytes, so the full-clip prefetch is scoped only to baked clips.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

No CLI / HTTP API / contract / i18n / dependency / env changes — this is a client-side rendering refinement of an existing UI surface (no new user-facing capability, so the UI/CLI dual-track does not apply).

## Screenshots

No visual UI change; behavior is smoother video startup while scrolling the existing home plugin gallery.

## Bug fix verification

- Not a bug fix; perf/UX refinement.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run tests/components/plugins-home-media-surface.test.tsx tests/components/plugins-home-preview-surface.test.tsx` — 12 passed
- `pnpm guard`
- Live dev validation before PR: clips a row ahead carry `preload=auto`, further baked clips stay `metadata`; scroll-in plays without a buffering beat.
