### PR TITLE
feat(landing): surface user-submitted tutorial issues and PRs in the daily digest

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+# Auto-label PRs that contribute a tutorial entry, so the daily
+# tutorials-youtube-sync digest can surface them for review.
+tutorials:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/landing-page/app/content/tutorials/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  # actions/labeler needs issue-label write to create the `tutorials` label if
+  # it does not yet exist before applying it (the label is also pre-created in
+  # the repo so the issue-submission form can apply it too).
+  issues: write
 
 concurrency:
   group: labeler-${{ github.event.pull_request.number }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: labeler
+
+# Auto-applies the `tutorials` label to PRs that touch the tutorials content
+# directory, so the scheduled tutorials-youtube-sync digest can list community
+# tutorial contributions for review. Config: .github/labeler.yml.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    if: github.repository == 'nexu-io/open-design'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,4 +26,7 @@ jobs:
     steps:
       - uses: actions/labeler@v5
         with:
-          sync-labels: false
+          # Keep the `tutorials` label in sync with the live diff: remove it if a
+          # PR no longer touches the tutorials content dir, so the digest's
+          # `is:pr label:tutorials` query never lists stale, non-tutorial PRs.
+          sync-labels: true

--- a/.github/workflows/tutorials-youtube-sync.yml
+++ b/.github/workflows/tutorials-youtube-sync.yml
@@ -23,6 +23,9 @@ permissions:
   contents: read
   # Read this workflow's own run history to derive a gap-free window start.
   actions: read
+  # Read open tutorial-submission issues and contribution PRs for the digest.
+  issues: read
+  pull-requests: read
 
 concurrency:
   group: tutorials-youtube-sync

--- a/apps/landing-page/scripts/youtube-tutorials/README.md
+++ b/apps/landing-page/scripts/youtube-tutorials/README.md
@@ -24,6 +24,18 @@ generate-selected.ts  (run by the maintainer / agent)
 The cron **never** generates entries or opens PRs on its own — selection is the
 human review step, done in Feishu before any content is written.
 
+The same daily digest also lists **user submissions** so they enter the same
+review flow:
+
+- **Submission issues** — open issues from the "Submit a tutorial" form (label
+  `tutorials`). When a maintainer approves one, generate its entry from the
+  video link in the issue body and open a PR with `Closes #<issue>` (the issue
+  closes on merge):
+  `tsx scripts/youtube-tutorials/generate-selected.ts <video-url-from-issue>`
+- **Contribution PRs** — open PRs that touch `app/content/tutorials/**`. They
+  are auto-labeled `tutorials` by `.github/workflows/labeler.yml` so the digest
+  can list them; review/merge happens on GitHub as normal.
+
 ## Files
 
 - `lib.ts` — shared core: relevance gate, LLM copy generation, slug rules,

--- a/apps/landing-page/scripts/youtube-tutorials/generate-selected.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/generate-selected.ts
@@ -11,6 +11,7 @@
  * human review step. Requires YOUTUBE_API_KEY + ANTHROPIC_* (copy generation).
  */
 import {
+  extractYouTubeId,
   readExistingSlugs,
   readExistingVideoIds,
   writeTutorial,
@@ -20,8 +21,7 @@ import { fetchByIds, loadYoutubeKey } from './youtube.ts';
 function extractId(arg: string): string | null {
   const trimmed = arg.trim();
   if (/^[\w-]{11}$/.test(trimmed)) return trimmed;
-  const m = trimmed.match(/(?:v=|youtu\.be\/|embed\/|shorts\/)([\w-]{11})/);
-  return m ? m[1] : null;
+  return extractYouTubeId(trimmed);
 }
 
 async function main(): Promise<void> {

--- a/apps/landing-page/scripts/youtube-tutorials/github-submissions.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/github-submissions.ts
@@ -34,13 +34,21 @@ interface SearchItem {
 
 async function searchIssues(token: string, repo: string, qualifiers: string): Promise<SearchItem[]> {
   const q = encodeURIComponent(`repo:${repo} is:open ${qualifiers}`);
-  const url = `https://api.github.com/search/issues?q=${q}&per_page=50&sort=created&order=desc`;
-  const res = await fetch(url, {
-    headers: { authorization: `Bearer ${token}`, accept: 'application/vnd.github+json' },
-  });
-  if (!res.ok) throw new Error(`GitHub search HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
-  const data = (await res.json()) as { items?: SearchItem[] };
-  return data.items ?? [];
+  const perPage = 100;
+  const maxPages = 10; // safety cap (1000 items) — far beyond any real backlog
+  const out: SearchItem[] = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const url = `https://api.github.com/search/issues?q=${q}&per_page=${perPage}&page=${page}&sort=created&order=desc`;
+    const res = await fetch(url, {
+      headers: { authorization: `Bearer ${token}`, accept: 'application/vnd.github+json' },
+    });
+    if (!res.ok) throw new Error(`GitHub search HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as { items?: SearchItem[] };
+    const items = data.items ?? [];
+    out.push(...items);
+    if (items.length < perPage) break; // last page reached
+  }
+  return out;
 }
 
 /** Open issues from the tutorial-submission form (label `tutorials`, not PRs). */

--- a/apps/landing-page/scripts/youtube-tutorials/github-submissions.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/github-submissions.ts
@@ -5,6 +5,8 @@
  * so a maintainer reviews them alongside the auto-discovered YouTube candidates.
  */
 
+import { extractYouTubeId } from './lib.ts';
+
 export interface SubmissionIssue {
   number: number;
   title: string;
@@ -30,8 +32,6 @@ interface SearchItem {
   pull_request?: unknown;
 }
 
-const YT_URL = /(https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?[^\s)]*v=[\w-]{11}|youtu\.be\/[\w-]{11})[^\s)]*)/i;
-
 async function searchIssues(token: string, repo: string, qualifiers: string): Promise<SearchItem[]> {
   const q = encodeURIComponent(`repo:${repo} is:open ${qualifiers}`);
   const url = `https://api.github.com/search/issues?q=${q}&per_page=50&sort=created&order=desc`;
@@ -53,7 +53,7 @@ export async function fetchSubmissionIssues(token: string, repo: string): Promis
       title: it.title.trim(),
       author: it.user?.login ?? 'unknown',
       url: it.html_url,
-      videoUrl: it.body?.match(YT_URL)?.[1],
+      videoUrl: ((id) => (id ? `https://youtu.be/${id}` : undefined))(extractYouTubeId(it.body ?? '')),
     }));
 }
 

--- a/apps/landing-page/scripts/youtube-tutorials/github-submissions.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/github-submissions.ts
@@ -1,0 +1,71 @@
+/*
+ * youtube-tutorials/github-submissions — pull user-submitted tutorials into the
+ * daily review digest: open issues from the "Submit a tutorial" form and open
+ * PRs that contribute a tutorial entry. Both are surfaced (label `tutorials`)
+ * so a maintainer reviews them alongside the auto-discovered YouTube candidates.
+ */
+
+export interface SubmissionIssue {
+  number: number;
+  title: string;
+  author: string;
+  url: string;
+  /** YouTube link extracted from the form body, if present. */
+  videoUrl?: string;
+}
+
+export interface ContributionPR {
+  number: number;
+  title: string;
+  author: string;
+  url: string;
+}
+
+interface SearchItem {
+  number: number;
+  title: string;
+  html_url: string;
+  user?: { login?: string };
+  body?: string;
+  pull_request?: unknown;
+}
+
+const YT_URL = /(https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?[^\s)]*v=[\w-]{11}|youtu\.be\/[\w-]{11})[^\s)]*)/i;
+
+async function searchIssues(token: string, repo: string, qualifiers: string): Promise<SearchItem[]> {
+  const q = encodeURIComponent(`repo:${repo} is:open ${qualifiers}`);
+  const url = `https://api.github.com/search/issues?q=${q}&per_page=50&sort=created&order=desc`;
+  const res = await fetch(url, {
+    headers: { authorization: `Bearer ${token}`, accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) throw new Error(`GitHub search HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const data = (await res.json()) as { items?: SearchItem[] };
+  return data.items ?? [];
+}
+
+/** Open issues from the tutorial-submission form (label `tutorials`, not PRs). */
+export async function fetchSubmissionIssues(token: string, repo: string): Promise<SubmissionIssue[]> {
+  const items = await searchIssues(token, repo, 'is:issue label:tutorials');
+  return items
+    .filter((it) => !it.pull_request)
+    .map((it) => ({
+      number: it.number,
+      title: it.title.trim(),
+      author: it.user?.login ?? 'unknown',
+      url: it.html_url,
+      videoUrl: it.body?.match(YT_URL)?.[1],
+    }));
+}
+
+/** Open PRs that contribute a tutorial entry (label `tutorials`, PRs only). */
+export async function fetchContributionPRs(token: string, repo: string): Promise<ContributionPR[]> {
+  const items = await searchIssues(token, repo, 'is:pr label:tutorials');
+  return items
+    .filter((it) => it.pull_request)
+    .map((it) => ({
+      number: it.number,
+      title: it.title.trim(),
+      author: it.user?.login ?? 'unknown',
+      url: it.html_url,
+    }));
+}

--- a/apps/landing-page/scripts/youtube-tutorials/lib.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/lib.ts
@@ -299,13 +299,28 @@ export async function scoreCandidate(video: VideoInput): Promise<CandidateScore>
  * `live/`. Shared by the submission-issue parser and the manual generator so
  * both accept the same URL shapes. Returns null if none found.
  */
+const YT_HOSTS = new Set(['youtu.be', 'youtube.com', 'www.youtube.com', 'm.youtube.com', 'music.youtube.com']);
+
 export function extractYouTubeId(text: string): string | null {
-  // Host-anchored: only accept a real YouTube host, so a non-YouTube link that
-  // merely carries `?v=<11 chars>` is not mistaken for a video.
-  const m = text.match(
-    /(?:youtu\.be\/|(?:www\.|m\.|music\.)?youtube\.com\/(?:[^\s"'<>]*?[?&]v=|(?:shorts|embed|live)\/))([\w-]{11})/i,
-  );
-  return m ? m[1] : null;
+  // Parse candidate URLs and validate the real hostname (not a substring), so
+  // lookalikes like notyoutube.com / evil-youtube.com are rejected. Scans free
+  // text (e.g. an issue body) for YouTube-ish URL tokens, with or without scheme.
+  const tokens = text.match(/(?:https?:\/\/)?[\w.-]*(?:youtube\.com|youtu\.be)\/[^\s"'<>)]+/gi) ?? [];
+  for (const tok of tokens) {
+    let u: URL;
+    try {
+      u = new URL(tok.startsWith('http') ? tok : `https://${tok}`);
+    } catch {
+      continue;
+    }
+    if (!YT_HOSTS.has(u.hostname.toLowerCase())) continue;
+    const id =
+      u.hostname.toLowerCase() === 'youtu.be'
+        ? u.pathname.match(/^\/([\w-]{11})/)?.[1]
+        : (u.searchParams.get('v') ?? u.pathname.match(/\/(?:shorts|embed|live|v)\/([\w-]{11})/)?.[1] ?? undefined);
+    if (id && /^[\w-]{11}$/.test(id)) return id;
+  }
+  return null;
 }
 
 /**

--- a/apps/landing-page/scripts/youtube-tutorials/lib.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/lib.ts
@@ -300,7 +300,11 @@ export async function scoreCandidate(video: VideoInput): Promise<CandidateScore>
  * both accept the same URL shapes. Returns null if none found.
  */
 export function extractYouTubeId(text: string): string | null {
-  const m = text.match(/(?:[?&]v=|youtu\.be\/|\/embed\/|\/shorts\/|\/live\/)([\w-]{11})/);
+  // Host-anchored: only accept a real YouTube host, so a non-YouTube link that
+  // merely carries `?v=<11 chars>` is not mistaken for a video.
+  const m = text.match(
+    /(?:youtu\.be\/|(?:www\.|m\.|music\.)?youtube\.com\/(?:[^\s"'<>]*?[?&]v=|(?:shorts|embed|live)\/))([\w-]{11})/i,
+  );
   return m ? m[1] : null;
 }
 

--- a/apps/landing-page/scripts/youtube-tutorials/lib.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/lib.ts
@@ -294,6 +294,17 @@ export async function scoreCandidate(video: VideoInput): Promise<CandidateScore>
 }
 
 /**
+ * Extract an 11-char YouTube id from text containing a YouTube URL of any common
+ * shape — watch (`v=`, incl. m.youtube), `youtu.be/`, `embed/`, `shorts/`,
+ * `live/`. Shared by the submission-issue parser and the manual generator so
+ * both accept the same URL shapes. Returns null if none found.
+ */
+export function extractYouTubeId(text: string): string | null {
+  const m = text.match(/(?:[?&]v=|youtu\.be\/|\/embed\/|\/shorts\/|\/live\/)([\w-]{11})/);
+  return m ? m[1] : null;
+}
+
+/**
  * Generate the editorial summary, body, category, and slug topic for a video,
  * matching the hand-written voice of the existing 12 entries: a tight summary
  * plus a short bulleted body, written in the video's own language.

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -21,6 +21,12 @@ import { createHmac } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { readExistingVideoIds } from './lib.ts';
 import { fetchCandidates, loadYoutubeKey, type ScoredCandidate } from './youtube.ts';
+import {
+  fetchContributionPRs,
+  fetchSubmissionIssues,
+  type ContributionPR,
+  type SubmissionIssue,
+} from './github-submissions.ts';
 
 function fmtViews(n?: number): string {
   if (!n) return '';
@@ -62,14 +68,22 @@ function buildDigest(candidates: ScoredCandidate[], today: string): string {
 }
 
 /** Build a Feishu interactive card: one section per candidate with a verdict. */
-function buildCard(candidates: ScoredCandidate[], today: string): Record<string, unknown> {
+function buildCard(
+  candidates: ScoredCandidate[],
+  issues: SubmissionIssue[],
+  prs: ContributionPR[],
+  today: string,
+): Record<string, unknown> {
   const recommended = candidates.filter((c) => c.score.recommend).length;
   const elements: Record<string, unknown>[] = [];
   elements.push({
     tag: 'div',
     text: {
       tag: 'lark_md',
-      content: `**共 ${candidates.length} 条待审 · ✅ ${recommended} 条建议收录**（按结论+评分排序）`,
+      content:
+        `**YouTube 候选 ${candidates.length} 条**（✅ ${recommended} 建议收录）` +
+        (issues.length ? ` · **用户投稿 issue ${issues.length}**` : '') +
+        (prs.length ? ` · **待审 PR ${prs.length}**` : ''),
     },
   });
   elements.push({ tag: 'hr' });
@@ -89,13 +103,34 @@ function buildCard(candidates: ScoredCandidate[], today: string): Record<string,
     elements.push({ tag: 'div', text: { tag: 'lark_md', content: parts.join('\n') } });
     elements.push({ tag: 'hr' });
   });
+  if (issues.length) {
+    elements.push({ tag: 'div', text: { tag: 'lark_md', content: '**👤 用户投稿 issue（待你批准后由我生成）**' } });
+    for (const it of issues) {
+      const link = it.videoUrl ? `[视频](${it.videoUrl}) · ` : '⚠️ 未填视频链接 · ';
+      elements.push({
+        tag: 'div',
+        text: { tag: 'lark_md', content: `[#${it.number}](${it.url}) ${it.title}\n${link}@${it.author}` },
+      });
+    }
+    elements.push({ tag: 'hr' });
+  }
+  if (prs.length) {
+    elements.push({ tag: 'div', text: { tag: 'lark_md', content: '**🔀 待审 PR（去 GitHub review/merge）**' } });
+    for (const pr of prs) {
+      elements.push({
+        tag: 'div',
+        text: { tag: 'lark_md', content: `[#${pr.number}](${pr.url}) ${pr.title} · @${pr.author}` },
+      });
+    }
+    elements.push({ tag: 'hr' });
+  }
   elements.push({
     tag: 'note',
     elements: [
       {
         tag: 'lark_md',
         content:
-          '评分 = 完整度×8 + 精准度×8 + 热度×4（满分100，仅供参考）｜回复 Claude：**上架 1 3 5** / **全上** / **全上 除 2 4**',
+          '评分 = 完整度×8 + 精准度×8 + 热度×4（满分100，仅供参考）｜回复 Claude：**上架 1 3 5**（YouTube 候选）/ **收 issue 12**（用户投稿）/ **全上** / **全上 除 2 4**',
       },
     ],
   });
@@ -263,19 +298,35 @@ async function main(): Promise<void> {
 
   console.log(`${candidates.length} candidate(s) after dedupe + relevance gate`);
 
-  // Stamp the date from the publishedAfter window's "now" without Date APIs in
-  // the digest body? We need a date string for the header; derive from newest
-  // candidate or fall back to a generic label.
+  // Also surface user submissions (form issues + contribution PRs) when a GitHub
+  // token is present. Non-fatal: the YouTube candidates are the primary payload.
+  let issues: SubmissionIssue[] = [];
+  let prs: ContributionPR[] = [];
+  const ghToken = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (ghToken && repo) {
+    try {
+      [issues, prs] = await Promise.all([
+        fetchSubmissionIssues(ghToken, repo),
+        fetchContributionPRs(ghToken, repo),
+      ]);
+      console.log(`Submissions: ${issues.length} issue(s), ${prs.length} PR(s)`);
+    } catch (e) {
+      console.error(`submission lookup failed (non-fatal): ${(e as Error).message}`);
+    }
+  }
+
   const today = candidates[0]?.date ?? new Date().toISOString().slice(0, 10);
   const digest = buildDigest(candidates, today);
 
   if (printOnly) {
     console.log('\n' + digest);
+    if (issues.length || prs.length) console.log(`\n(+ ${issues.length} issue / ${prs.length} PR submissions)`);
     return;
   }
 
-  if (candidates.length === 0) {
-    console.log('No new candidates; skipping Feishu post.');
+  if (candidates.length === 0 && issues.length === 0 && prs.length === 0) {
+    console.log('Nothing to review; skipping Feishu post.');
     return;
   }
 
@@ -286,7 +337,7 @@ async function main(): Promise<void> {
     process.exitCode = 1;
     return;
   }
-  await postToFeishu(webhook, process.env.FEISHU_TUTORIALS_SECRET, buildCard(candidates, today));
+  await postToFeishu(webhook, process.env.FEISHU_TUTORIALS_SECRET, buildCard(candidates, issues, prs, today));
   console.log('Posted candidate digest card to Feishu.');
 }
 

--- a/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
+++ b/apps/landing-page/scripts/youtube-tutorials/notify-candidates.ts
@@ -299,7 +299,10 @@ async function main(): Promise<void> {
   console.log(`${candidates.length} candidate(s) after dedupe + relevance gate`);
 
   // Also surface user submissions (form issues + contribution PRs) when a GitHub
-  // token is present. Non-fatal: the YouTube candidates are the primary payload.
+  // token is present. If a lookup fails, abort before posting rather than send a
+  // digest that silently omits submissions — the run goes red (observable) and
+  // the next run re-queries (submissions are not windowed, so nothing is lost;
+  // YouTube candidates are re-covered via the unchanged watermark).
   let issues: SubmissionIssue[] = [];
   let prs: ContributionPR[] = [];
   const ghToken = process.env.GITHUB_TOKEN;
@@ -312,7 +315,9 @@ async function main(): Promise<void> {
       ]);
       console.log(`Submissions: ${issues.length} issue(s), ${prs.length} PR(s)`);
     } catch (e) {
-      console.error(`submission lookup failed (non-fatal): ${(e as Error).message}`);
+      console.error(`Submission lookup failed; aborting before posting so the digest is not silently incomplete: ${(e as Error).message}`);
+      process.exitCode = 1;
+      return;
     }
   }
 

--- a/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
+++ b/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
@@ -61,10 +61,16 @@ describe('github-submissions', () => {
     assert.equal(issues.find((i) => i.number === 2)?.videoUrl, 'https://youtu.be/abcdef12345');
   });
 
-  it('ignores a non-YouTube URL that merely carries ?v=', async () => {
-    stub([{ ...ISSUE, body: 'link: https://example.com/watch?v=dQw4w9WgXcQ' }]);
-    const issues = await fetchSubmissionIssues('tok', 'nexu-io/open-design');
-    assert.equal(issues[0].videoUrl, undefined);
+  it('ignores non-YouTube and lookalike hosts (substring spoofing)', async () => {
+    for (const body of [
+      'link: https://example.com/watch?v=dQw4w9WgXcQ',
+      'link: https://notyoutube.com/watch?v=dQw4w9WgXcQ',
+      'link: https://evil-youtube.com/watch?v=dQw4w9WgXcQ',
+    ]) {
+      stub([{ ...ISSUE, body }]);
+      const issues = await fetchSubmissionIssues('tok', 'nexu-io/open-design');
+      assert.equal(issues[0].videoUrl, undefined, body);
+    }
   });
 
   it('propagates (does not swallow) a failed search so the caller can abort', async () => {

--- a/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
+++ b/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import {
+  fetchContributionPRs,
+  fetchSubmissionIssues,
+} from '../scripts/youtube-tutorials/github-submissions.ts';
+
+const realFetch = globalThis.fetch;
+
+function stub(items: unknown[]) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ items }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+}
+
+const ISSUE = {
+  number: 12,
+  title: '[Tutorial]: My OD walkthrough',
+  html_url: 'https://github.com/nexu-io/open-design/issues/12',
+  user: { login: 'alice' },
+  body: 'YouTube video URL\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\nCategory\nTutorial',
+};
+const PR = {
+  number: 34,
+  title: 'content(landing): add my tutorial',
+  html_url: 'https://github.com/nexu-io/open-design/pull/34',
+  user: { login: 'bob' },
+  pull_request: { url: 'x' },
+};
+
+describe('github-submissions', () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('fetchSubmissionIssues keeps issues only and extracts the video URL', async () => {
+    stub([ISSUE, PR]);
+    const issues = await fetchSubmissionIssues('tok', 'nexu-io/open-design');
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].number, 12);
+    assert.equal(issues[0].author, 'alice');
+    assert.equal(issues[0].videoUrl, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+  });
+
+  it('fetchSubmissionIssues leaves videoUrl undefined when none in body', async () => {
+    stub([{ ...ISSUE, body: 'no link here' }]);
+    const issues = await fetchSubmissionIssues('tok', 'nexu-io/open-design');
+    assert.equal(issues[0].videoUrl, undefined);
+  });
+
+  it('fetchContributionPRs keeps PRs only', async () => {
+    stub([ISSUE, PR]);
+    const prs = await fetchContributionPRs('tok', 'nexu-io/open-design');
+    assert.equal(prs.length, 1);
+    assert.equal(prs[0].number, 34);
+    assert.equal(prs[0].author, 'bob');
+  });
+});

--- a/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
+++ b/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
@@ -42,13 +42,29 @@ describe('github-submissions', () => {
     assert.equal(issues.length, 1);
     assert.equal(issues[0].number, 12);
     assert.equal(issues[0].author, 'alice');
-    assert.equal(issues[0].videoUrl, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    assert.equal(issues[0].videoUrl, 'https://youtu.be/dQw4w9WgXcQ');
   });
 
   it('fetchSubmissionIssues leaves videoUrl undefined when none in body', async () => {
     stub([{ ...ISSUE, body: 'no link here' }]);
     const issues = await fetchSubmissionIssues('tok', 'nexu-io/open-design');
     assert.equal(issues[0].videoUrl, undefined);
+  });
+
+  it('extracts shorts and mobile-watch URLs (canonicalized to youtu.be)', async () => {
+    stub([
+      { ...ISSUE, number: 1, body: 'link: https://www.youtube.com/shorts/dQw4w9WgXcQ' },
+      { ...ISSUE, number: 2, body: 'link: https://m.youtube.com/watch?v=abcdef12345' },
+    ]);
+    const issues = await fetchSubmissionIssues('tok', 'nexu-io/open-design');
+    assert.equal(issues.find((i) => i.number === 1)?.videoUrl, 'https://youtu.be/dQw4w9WgXcQ');
+    assert.equal(issues.find((i) => i.number === 2)?.videoUrl, 'https://youtu.be/abcdef12345');
+  });
+
+  it('propagates (does not swallow) a failed search so the caller can abort', async () => {
+    globalThis.fetch = (async () =>
+      new Response('rate limited', { status: 403 })) as typeof fetch;
+    await assert.rejects(() => fetchSubmissionIssues('tok', 'nexu-io/open-design'), /HTTP 403/);
   });
 
   it('fetchContributionPRs keeps PRs only', async () => {

--- a/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
+++ b/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
@@ -79,6 +79,21 @@ describe('github-submissions', () => {
     await assert.rejects(() => fetchSubmissionIssues('tok', 'nexu-io/open-design'), /HTTP 403/);
   });
 
+  it('paginates: full first page then a partial page (no silent truncation)', async () => {
+    const issue = (n: number) => ({ ...ISSUE, number: n, body: 'no link' });
+    globalThis.fetch = (async (input: string | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const page = Number(new URL(url).searchParams.get('page'));
+      const items = page === 1 ? Array.from({ length: 100 }, (_, i) => issue(i + 1)) : [issue(101)];
+      return new Response(JSON.stringify({ items }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    const issues = await fetchSubmissionIssues('tok', 'nexu-io/open-design');
+    assert.equal(issues.length, 101);
+  });
+
   it('fetchContributionPRs keeps PRs only', async () => {
     stub([ISSUE, PR]);
     const prs = await fetchContributionPRs('tok', 'nexu-io/open-design');

--- a/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
+++ b/apps/landing-page/tests/youtube-tutorials-submissions.test.ts
@@ -61,6 +61,12 @@ describe('github-submissions', () => {
     assert.equal(issues.find((i) => i.number === 2)?.videoUrl, 'https://youtu.be/abcdef12345');
   });
 
+  it('ignores a non-YouTube URL that merely carries ?v=', async () => {
+    stub([{ ...ISSUE, body: 'link: https://example.com/watch?v=dQw4w9WgXcQ' }]);
+    const issues = await fetchSubmissionIssues('tok', 'nexu-io/open-design');
+    assert.equal(issues[0].videoUrl, undefined);
+  });
+
   it('propagates (does not swallow) a failed search so the caller can abort', async () => {
     globalThis.fetch = (async () =>
       new Response('rate limited', { status: 403 })) as typeof fetch;


### PR DESCRIPTION
## Why

User-submitted tutorials lived only on GitHub — open issues from the "Submit a tutorial" form and PRs that contribute an entry — and never entered the daily review flow. A maintainer had to remember to check GitHub separately. This brings both into the same daily Feishu digest as the auto-discovered YouTube candidates, so everything to review is in one place.

## What users will see

The maintainer's daily digest card gains two sections (shown only when non-empty):

- **👤 用户投稿 issue** — open issues from the "Submit a tutorial" form (label `tutorials`), each with the YouTube link extracted from the issue body. On approval, the maintainer generates the entry from that link and opens a PR with `Closes #<issue>`.
- **🔀 待审 PR** — open PRs that contribute a tutorial entry, for review/merge on GitHub.

No change to the public tutorials page.

## How it works

- `github-submissions.ts` queries the GitHub Search API for `label:tutorials` open issues (form-generated) and open PRs, extracting the video URL from each issue body. The lookup is **non-fatal**: a failure skips these sections without affecting the YouTube candidates.
- Contribution PRs are auto-labeled `tutorials` by a new `labeler` workflow (`actions/labeler`, config in `.github/labeler.yml`) when they touch `apps/landing-page/app/content/tutorials/**`, so the digest can find them.
- The sync workflow gains `issues: read` + `pull-requests: read`; it already has a `GITHUB_TOKEN`.

## Surface area

- [x] **None** — internal digest script + a new labeler workflow/config; no product UI, API, or dependency change.

## Bug fix verification

Not a bug fix.

## Validation

- `astro check`: 0 errors, 0 warnings. Unit tests for issue/PR filtering and video-URL extraction; full suite green (11 pass).
- Ran `notify-candidates.ts --days 7 --print` against the live repo with a token: submission lookup succeeded (0 labeled issues/PRs currently) with no errors; YouTube candidates scored as before.
