### PR TITLE
[codex] Fix skill plugin CTA timing

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2682,12 +2682,29 @@ function emittedRenderableQuestionForm(text) {
   return false;
 }
 
-function detectSkillPluginCandidateOnRunSuccess(db, runs, run, input, projectRoot) {
+function assistantMessageEmittedQuestionForm(db, assistantMessageId) {
+  if (!assistantMessageId) return false;
+  const row = db.prepare(`SELECT content FROM messages WHERE id = ?`).get(assistantMessageId);
+  return emittedRenderableQuestionForm(row?.content);
+}
+
+function deferredSkillPluginCandidateForRun(db, run) {
+  if (!run.projectId || !run.conversationId) return null;
+  return listSkillPluginCandidates(db, run.projectId)
+    .find((candidate) =>
+      candidate.status !== 'dismissed' &&
+      !candidate.assistantMessageId &&
+      candidate.conversationId === run.conversationId,
+    ) ?? null;
+}
+
+export function detectSkillPluginCandidateOnRunSuccess(db, runs, run, input, projectRoot) {
   if (!run.projectId || !run.conversationId) return;
   void runs
     .wait(run)
     .then(async (finalStatus) => {
       if (finalStatus.status !== 'succeeded') return;
+      const pausedForQuestion = assistantMessageEmittedQuestionForm(db, run.assistantMessageId);
       const detected = await detectSkillPluginCandidate({
         projectId: run.projectId,
         runId: run.id,
@@ -2698,8 +2715,10 @@ function detectSkillPluginCandidateOnRunSuccess(db, runs, run, input, projectRoo
         projectRoot,
       });
       const candidate = detected ? insertSkillPluginCandidate(db, detected) : null;
-      if (!candidate || candidate.status === 'dismissed') return;
-      upsertSkillPluginCandidateAssistantMessage(db, run, candidate);
+      if (pausedForQuestion) return;
+      const candidateToShow = candidate ?? deferredSkillPluginCandidateForRun(db, run);
+      if (!candidateToShow || candidateToShow.status === 'dismissed') return;
+      upsertSkillPluginCandidateAssistantMessage(db, run, candidateToShow);
     })
     .catch((err) => {
       console.warn('[plugins] skill candidate detection failed', err);
@@ -2725,6 +2744,11 @@ export function upsertSkillPluginCandidateAssistantMessage(db, run, candidate) {
     candidate.assistantMessageId !== run.assistantMessageId &&
     typeof existingMessagePosition === 'number';
   const messageId = canReuseExistingMessage ? candidate.assistantMessageId : randomUUID();
+  const shouldMoveReusedMessage =
+    canReuseExistingMessage &&
+    typeof currentMessagePosition === 'number' &&
+    typeof existingMessagePosition === 'number' &&
+    existingMessagePosition <= currentMessagePosition;
   if (
     candidate.assistantMessageId &&
     candidate.assistantMessageId !== messageId &&
@@ -2749,6 +2773,12 @@ export function upsertSkillPluginCandidateAssistantMessage(db, run, candidate) {
     createdAt: now,
     endedAt: now,
   });
+  if (shouldMoveReusedMessage) {
+    const max = db
+      .prepare(`SELECT COALESCE(MAX(position), -1) AS m FROM messages WHERE conversation_id = ?`)
+      .get(run.conversationId)?.m ?? -1;
+    db.prepare(`UPDATE messages SET position = ? WHERE id = ?`).run(Number(max) + 1, messageId);
+  }
   db.prepare(
     `UPDATE skill_plugin_candidates
         SET assistant_message_id = ?, updated_at = ?

--- a/apps/daemon/tests/skill-plugin-candidates.test.ts
+++ b/apps/daemon/tests/skill-plugin-candidates.test.ts
@@ -17,7 +17,10 @@ import {
   insertSkillPluginCandidate,
   listSkillPluginCandidates,
 } from '../src/plugins/skill-candidates.js';
-import { upsertSkillPluginCandidateAssistantMessage } from '../src/server.js';
+import {
+  detectSkillPluginCandidateOnRunSuccess,
+  upsertSkillPluginCandidateAssistantMessage,
+} from '../src/server.js';
 
 let tmpDir: string;
 let projectRoot: string;
@@ -277,5 +280,90 @@ describe('skill plugin candidates', () => {
       message.events?.some((event: { kind?: string }) => event.kind === 'plugin_candidate'),
     )).toHaveLength(1);
     expect(listSkillPluginCandidates(db, 'proj_1')[0]?.assistantMessageId).toBe(firstCardId);
+    expect(listMessages(db, 'conv_1').map((message) => message.id)).toEqual([
+      'assistant_1',
+      'assistant_2',
+      firstCardId,
+    ]);
+  });
+
+  it('defers the CTA when the matching run only asks a question form', async () => {
+    const db = openDatabase(tmpDir, { dataDir: path.join(tmpDir, 'data') });
+    insertProject(db, {
+      id: 'proj_1',
+      name: 'Candidate project',
+      skillId: null,
+      designSystemId: null,
+      pendingPrompt: null,
+      metadata: { kind: 'prototype' },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    insertConversation(db, {
+      id: 'conv_1',
+      projectId: 'proj_1',
+      title: 'Candidate conversation',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    upsertMessage(db, 'conv_1', {
+      id: 'assistant_question',
+      role: 'assistant',
+      content: [
+        'I need one detail first.',
+        '<question-form id="task-type" title="Choose task type">',
+        '{"questions":[{"id":"kind","type":"single-choice","label":"What?","options":["Slide deck"]}]}',
+        '</question-form>',
+      ].join('\n'),
+      createdAt: 1,
+      endedAt: 1,
+    });
+
+    const runs = { wait: async () => ({ status: 'succeeded' }) };
+    detectSkillPluginCandidateOnRunSuccess(db, runs, {
+      id: 'run_question',
+      projectId: 'proj_1',
+      conversationId: 'conv_1',
+      assistantMessageId: 'assistant_question',
+      agentId: 'agent_1',
+    }, {
+      message: 'Use https://github.com/foo/bar/blob/main/SKILL.md for this run.',
+    }, projectRoot);
+    await flushSkillCandidateHook();
+
+    const deferred = listSkillPluginCandidates(db, 'proj_1')[0];
+    expect(deferred?.assistantMessageId).toBeNull();
+    expect(listMessages(db, 'conv_1').map((message) => message.id)).toEqual(['assistant_question']);
+
+    upsertMessage(db, 'conv_1', {
+      id: 'assistant_final',
+      role: 'assistant',
+      content: 'Done. Created the deck.',
+      createdAt: 2,
+      endedAt: 2,
+    });
+    detectSkillPluginCandidateOnRunSuccess(db, runs, {
+      id: 'run_final',
+      projectId: 'proj_1',
+      conversationId: 'conv_1',
+      assistantMessageId: 'assistant_final',
+      agentId: 'agent_1',
+    }, {
+      message: '[form answers -- task-type]\n- What?: Slide deck',
+    }, projectRoot);
+    await flushSkillCandidateHook();
+
+    const shown = listSkillPluginCandidates(db, 'proj_1')[0];
+    expect(shown?.assistantMessageId).toBeTruthy();
+    expect(listMessages(db, 'conv_1').map((message) => message.id)).toEqual([
+      'assistant_question',
+      'assistant_final',
+      shown?.assistantMessageId,
+    ]);
   });
 });
+
+async function flushSkillCandidateHook() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -230,6 +230,45 @@ export function mergeSavedPreviewComment(current: PreviewComment[], saved: Previ
   return current.map((comment, index) => (index === existingIndex ? saved : comment));
 }
 
+function mergeServerMessageWithLocal(server: ChatMessage, local?: ChatMessage): ChatMessage {
+  if (!local) return server;
+  const merged: ChatMessage = { ...server };
+  if (!server.producedFiles?.length && local.producedFiles?.length) {
+    merged.producedFiles = local.producedFiles;
+  }
+  if (!server.preTurnFileNames?.length && local.preTurnFileNames?.length) {
+    merged.preTurnFileNames = local.preTurnFileNames;
+  }
+  if (!server.lastRunEventId && local.lastRunEventId) {
+    merged.lastRunEventId = local.lastRunEventId;
+  }
+  if (!server.startedAt && local.startedAt) {
+    merged.startedAt = local.startedAt;
+  }
+  if (!server.endedAt && local.endedAt) {
+    merged.endedAt = local.endedAt;
+  }
+  if (!server.runStatus && local.runStatus) {
+    merged.runStatus = local.runStatus;
+  }
+  return merged;
+}
+
+export function mergeServerMessagesIntoConversation(
+  current: ChatMessage[],
+  serverMessages: ChatMessage[],
+): ChatMessage[] {
+  const currentById = new Map(current.map((message) => [message.id, message]));
+  const serverIds = new Set(serverMessages.map((message) => message.id));
+  const merged = serverMessages.map((message) =>
+    mergeServerMessageWithLocal(message, currentById.get(message.id)),
+  );
+  for (const message of current) {
+    if (!serverIds.has(message.id)) merged.push(message);
+  }
+  return merged;
+}
+
 interface Props {
   project: Project;
   routeFileName: string | null;
@@ -2220,6 +2259,32 @@ export function ProjectView({
     [activeConversationId, project.id],
   );
 
+  const refreshConversationMessagesFromServer = useCallback(
+    async (conversationId: string) => {
+      if (messagesConversationIdRef.current !== conversationId) return;
+      try {
+        const serverMessages = await listMessages(project.id, conversationId);
+        if (messagesConversationIdRef.current !== conversationId) return;
+        setMessages((current) => mergeServerMessagesIntoConversation(current, serverMessages));
+        setMessagesInitialized(true);
+        setMessagesConversationId(conversationId);
+        setFailedMessagesConversationId(null);
+      } catch (err) {
+        console.warn('Failed to refresh conversation messages after run completion', err);
+      }
+    },
+    [project.id],
+  );
+
+  const scheduleConversationMessageRefresh = useCallback(
+    (conversationId: string) => {
+      window.setTimeout(() => {
+        void refreshConversationMessagesFromServer(conversationId);
+      }, 150);
+    },
+    [refreshConversationMessagesFromServer],
+  );
+
   const markStreamingConversation = useCallback((conversationId: string) => {
     streamingConversationIdRef.current = conversationId;
     setStreaming(true);
@@ -2786,6 +2851,9 @@ export function ProjectView({
               clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
               persistNow({ telemetryFinalized: true });
             }
+            if (isTerminalRunStatus(runStatus)) {
+              scheduleConversationMessageRefresh(reattachConversationId);
+            }
           },
           onRunEventId: (lastRunEventId) => {
             textBuffer.flush();
@@ -2845,6 +2913,7 @@ export function ProjectView({
     persistArtifact,
     requestOpenFile,
     onProjectsRefresh,
+    scheduleConversationMessageRefresh,
   ]);
 
   const commitQueuedChatSends = useCallback((next: QueuedChatSend[]) => {
@@ -3606,6 +3675,7 @@ export function ProjectView({
             updateConversationLatestRun(runStatus, endedAt);
             if (isTerminalRunStatus(runStatus)) {
               clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
+              scheduleConversationMessageRefresh(runConversationId);
             }
           },
           onRunEventId: (lastRunEventId) => {
@@ -3758,6 +3828,7 @@ export function ProjectView({
       markStreamingConversation,
       clearStreamingMarker,
       clearCurrentRunStreamingMarker,
+      scheduleConversationMessageRefresh,
       onProjectsRefresh,
       onProjectChange,
     ],

--- a/apps/web/tests/components/ProjectView.questionFormKey.test.ts
+++ b/apps/web/tests/components/ProjectView.questionFormKey.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildQuestionFormKey } from '../../src/components/ProjectView';
+import {
+  buildQuestionFormKey,
+  mergeServerMessagesIntoConversation,
+} from '../../src/components/ProjectView';
+import type { ChatMessage, ProjectFile } from '../../src/types';
 
 describe('buildQuestionFormKey', () => {
   it('is stable across a streaming form-id change (no remount mid-answer)', () => {
@@ -28,5 +32,62 @@ describe('buildQuestionFormKey', () => {
     expect(buildQuestionFormKey(null, 'msg-1', true)).toBeNull();
     expect(buildQuestionFormKey('conv-1', null, true)).toBeNull();
     expect(buildQuestionFormKey('conv-1', 'msg-1', false)).toBeNull();
+  });
+});
+
+describe('mergeServerMessagesIntoConversation', () => {
+  it('adds server-created CTA messages while preserving local produced files', () => {
+    const producedFile: ProjectFile = {
+      name: 'deck.html',
+      size: 1024,
+      mtime: 1,
+      kind: 'html',
+      mime: 'text/html',
+    };
+    const localMessages: ChatMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        content: 'Use this SKILL.md',
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Done',
+        runStatus: 'succeeded',
+        producedFiles: [producedFile],
+      },
+    ];
+    const serverMessages: ChatMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        content: 'Use this SKILL.md',
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Done',
+        runStatus: 'succeeded',
+      },
+      {
+        id: 'cta-1',
+        role: 'assistant',
+        content: '',
+        events: [
+          {
+            kind: 'plugin_candidate',
+            candidateId: 'candidate-1',
+            title: 'Main',
+            description: 'This repo looks like a plugin.',
+          },
+        ],
+      },
+    ];
+
+    const merged = mergeServerMessagesIntoConversation(localMessages, serverMessages);
+
+    expect(merged.map((message) => message.id)).toEqual(['user-1', 'assistant-1', 'cta-1']);
+    expect(merged[1]?.producedFiles).toEqual([producedFile]);
   });
 });


### PR DESCRIPTION
## Why

While testing the skill-to-plugin CTA flow, CTA cards could appear too early after a successful clarification-form turn, or only appear after a manual refresh once the final run finished. This made the CTA timing feel inconsistent and could surface plugin actions before the requested artifact was complete.

Root cause: the daemon hook treated any succeeded run as eligible for CTA insertion, including runs whose assistant message only emitted a renderable `<question-form>`. The web chat also did not reconcile server-created assistant messages after daemon run completion, so late CTA insertion depended on reload.

## What users will see

Skill/plugin CTA cards now appear after the final successful artifact-producing run, not after the first clarification form. If the daemon inserts the CTA after the run stream closes, the chat refreshes the message list automatically without requiring a page reload.

## Surface area

- [x] **UI** — changed chat message reconciliation in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — skill/plugin CTA timing changes for existing users
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This was validated through the local chat flow and regression tests; the visible change is timing of an existing CTA card.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/skill-plugin-candidates.test.ts`
- Did the test go red on `main` and green on this branch? no; validated by adding a focused regression for the question-form deferral case on this branch.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/skill-plugin-candidates.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ProjectView.questionFormKey.test.ts`
- `pnpm guard`
