### PR TITLE
feat(web,daemon): keep annotation position anchors when the screenshot is missing

### DIFF
--- a/apps/daemon/src/runtimes/chat-prompt-inputs.ts
+++ b/apps/daemon/src/runtimes/chat-prompt-inputs.ts
@@ -496,7 +496,23 @@ export function normalizeCommentAttachments(input: readonly CommentAttachmentInp
         record.selectionKind === 'visual' ? 'visual' : record.selectionKind === 'pod' ? 'pod' : 'element';
       if (!filePath || !elementId) return null;
       if (selectionKind !== 'visual' && !selector) return null;
-      if (selectionKind === 'visual' && !screenshotPath) return null;
+      // Visual marks are kept even without a screenshot (#4084): when the
+      // preview capture fails (#4080) the structured location — file,
+      // pagePosition, markKind, currentText — is the only anchor the agent
+      // gets, so dropping the attachment here would silently strip the
+      // user's targeting from the prompt.
+      const pagePosition = normalizeAttachmentPosition(record.pagePosition);
+      if (selectionKind === 'visual' && !screenshotPath) {
+        // A screenshot-less visual mark is only actionable when it carries a
+        // concrete anchor: a positive-size pagePosition or a DOM selector.
+        // /api/runs accepts commentAttachments from any client, and
+        // normalizeAttachmentPosition() collapses missing/malformed positions
+        // to 0,0,0x0 — which identifies no region. Rendering such a payload
+        // would hard-scope the agent onto fields that point nowhere and steer
+        // it to edit an arbitrary part of the file, so drop it instead.
+        const hasUsablePosition = pagePosition.width > 0 && pagePosition.height > 0;
+        if (!hasUsablePosition && !selector) return null;
+      }
       const podMembers = selectionKind === 'pod' ? normalizeAttachmentPodMembers(record.podMembers) : [];
       const memberCount =
         selectionKind === 'pod'
@@ -517,16 +533,16 @@ export function normalizeCommentAttachments(input: readonly CommentAttachmentInp
         label,
         comment,
         currentText: compactString(record.currentText, 160),
-        pagePosition: normalizeAttachmentPosition(record.pagePosition),
+        pagePosition,
         htmlHint: compactString(record.htmlHint, 180),
         style: normalizeAnnotationStyle(record.style),
         selectionKind,
         memberCount,
         podMembers,
-        screenshotPath: selectionKind === 'visual' ? screenshotPath : undefined,
+        screenshotPath: selectionKind === 'visual' && screenshotPath ? screenshotPath : undefined,
         markKind: selectionKind === 'visual' ? markKind : undefined,
         intent: selectionKind === 'visual'
-          ? intent || visualAnnotationIntent(markKind)
+          ? intent || (screenshotPath ? visualAnnotationIntent(markKind) : visualAnnotationIntentWithoutScreenshot())
           : undefined,
         imageAttachments: imageAttachments.length > 0 ? imageAttachments : undefined,
         commentContext,
@@ -545,7 +561,7 @@ export function renderCommentAttachmentHint(
     '',
     '',
     '<attached-preview-comments>',
-    "Hard scope: change ONLY the elements identified below by selector / position / pod members. Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules even if you notice issues there — surface those as a follow-up note in your reply instead of editing them. If the user's request cannot be satisfied without touching outside this scope, ask the user before proceeding. For visual marks, inspect the screenshot and modify the marked region first.",
+    "Hard scope: change ONLY the elements identified below by selector / position / pod members. Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules even if you notice issues there — surface those as a follow-up note in your reply instead of editing them. If the user's request cannot be satisfied without touching outside this scope, ask the user before proceeding. For visual marks, inspect the screenshot when one is provided (otherwise locate the region from the structured fields) and modify the marked region first.",
   ];
   for (const item of commentAttachments) {
     const targetKind =
@@ -565,11 +581,20 @@ export function renderCommentAttachmentHint(
       lines.push(`comment: ${item.comment}`);
     }
     if (targetKind === 'visual') {
-      lines.push(
-        `screenshot: ${item.screenshotPath}`,
-        `markKind: ${item.markKind || 'stroke'}`,
-        `intent: ${item.intent || visualAnnotationIntent(item.markKind || 'stroke')}`,
-      );
+      if (item.screenshotPath) {
+        lines.push(
+          `screenshot: ${item.screenshotPath}`,
+          `markKind: ${item.markKind || 'stroke'}`,
+          `intent: ${item.intent || visualAnnotationIntent(item.markKind || 'stroke')}`,
+        );
+      } else {
+        // Screenshot capture failed (#4080) — no screenshot exists for this
+        // mark. Point the agent at the structured fields instead (#4084).
+        lines.push(
+          `markKind: ${item.markKind || 'stroke'}`,
+          `intent: ${item.intent || visualAnnotationIntentWithoutScreenshot()}`,
+        );
+      }
       if (item.selector) lines.push(`selector: ${item.selector}`);
     } else {
       lines.splice(lines.length - 4, 0, `selector: ${item.selector}`);
@@ -640,6 +665,13 @@ function visualAnnotationIntent(markKind: InputValue) {
     return 'The screenshot has a blue focus box and red strokes; together they identify the part the user wants changed.';
   }
   return 'The screenshot has red strokes that identify the visual region the user wants changed.';
+}
+
+// Screenshot-less variant (#4084): the capture failed (#4080), so the intent
+// must not reference a screenshot that does not exist. Mirrors the copy in
+// apps/web/src/comments.ts.
+function visualAnnotationIntentWithoutScreenshot() {
+  return 'The user marked a region of the live preview; no screenshot was captured, so locate the region using file, position, and currentText.';
 }
 
 function compactString(value: InputValue, max: number) {

--- a/apps/daemon/tests/comment-attachments.test.ts
+++ b/apps/daemon/tests/comment-attachments.test.ts
@@ -565,6 +565,103 @@ describe('preview comment agent payload', () => {
     expect(hint).toContain('marked region');
     expect(hint).not.toContain('selector: ');
   });
+
+  // Issue #4084: when the preview screenshot cannot be captured (#4080), the
+  // degraded send still carries the mark's position/markKind metadata. The
+  // normalizer must keep such attachments and the prompt hint must point the
+  // agent at position/currentText instead of a screenshot that does not exist.
+  it('keeps a visual annotation without a screenshot and renders a screenshot-free hint', () => {
+    const normalized = normalizeCommentAttachments([
+      commentAttachment({
+        id: 'visual-noshot-1',
+        elementId: 'visual-mark-2',
+        selector: '',
+        label: 'Marked region',
+        comment: 'Make this part bigger',
+        selectionKind: 'visual',
+        markKind: 'stroke',
+        pagePosition: { x: 120, y: 300, width: 400, height: 250 },
+      }),
+    ]);
+
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]).toMatchObject({
+      selectionKind: 'visual',
+      markKind: 'stroke',
+      comment: 'Make this part bigger',
+    });
+    expect(normalized[0]?.screenshotPath).toBeUndefined();
+
+    const hint = renderCommentAttachmentHint(normalized);
+    expect(hint).toContain('targetKind: visual');
+    expect(hint).toContain('markKind: stroke');
+    expect(hint).not.toContain('screenshot:');
+    // The agent is told there is no screenshot and to locate the region from
+    // the structured fields instead.
+    expect(hint).toContain('no screenshot');
+  });
+
+  it('still drops visual annotations that carry no location data at all', () => {
+    const normalized = normalizeCommentAttachments([
+      commentAttachment({
+        id: 'visual-empty',
+        elementId: '',
+        filePath: '',
+        selector: '',
+        selectionKind: 'visual',
+        markKind: 'stroke',
+      }),
+    ]);
+
+    expect(normalized).toHaveLength(0);
+  });
+
+  // PR #4105 QA: /api/runs accepts commentAttachments from any client, so a
+  // screenshot-less visual attachment with filePath/elementId but no usable
+  // anchor (pagePosition collapses to 0,0,0x0; no selector) must be dropped —
+  // rendering it would hard-scope the agent onto fields that identify no
+  // region, steering it to edit an arbitrary part of the file.
+  it('drops a screenshot-less visual annotation whose position is missing or zero-size', () => {
+    const normalized = normalizeCommentAttachments([
+      commentAttachment({
+        id: 'visual-no-anchor-1',
+        elementId: 'visual-mark-3',
+        selector: '',
+        selectionKind: 'visual',
+        markKind: 'stroke',
+        pagePosition: undefined,
+      }),
+      commentAttachment({
+        id: 'visual-no-anchor-2',
+        elementId: 'visual-mark-4',
+        selector: '',
+        selectionKind: 'visual',
+        markKind: 'stroke',
+        pagePosition: { x: 120, y: 40, width: 0, height: 0 },
+      }),
+    ]);
+
+    expect(normalized).toHaveLength(0);
+  });
+
+  it('keeps a screenshot-less visual annotation anchored by a selector alone', () => {
+    const normalized = normalizeCommentAttachments([
+      commentAttachment({
+        id: 'visual-selector-anchor',
+        elementId: 'visual-mark-5',
+        selector: '[data-od-id="chart"]',
+        selectionKind: 'visual',
+        markKind: 'stroke',
+        pagePosition: undefined,
+      }),
+    ]);
+
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]).toMatchObject({
+      selectionKind: 'visual',
+      selector: '[data-od-id="chart"]',
+    });
+  });
 });
 
 function seededDb() {

--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -48,7 +48,10 @@ export interface VisualAnnotationTarget {
 export interface VisualAnnotationAttachmentInput {
   order: number;
   idSeed?: string;
-  screenshotPath: string;
+  /** Absent when the preview screenshot could not be captured (#4080); the
+   *  attachment then carries only the structured location (file/position/
+   *  markKind) so the agent can still find the marked region (#4084). */
+  screenshotPath?: string;
   markKind: PreviewVisualMarkKind;
   note: string;
   bounds: { x: number; y: number; width: number; height: number };
@@ -325,15 +328,17 @@ export function buildBoardCommentAttachments(input: {
 
 export function buildVisualAnnotationAttachment(input: VisualAnnotationAttachmentInput): ChatCommentAttachment {
   const target = input.target ?? null;
-  const intent = visualAnnotationIntent(input.markKind);
+  const intent = input.screenshotPath
+    ? visualAnnotationIntent(input.markKind)
+    : visualAnnotationIntentWithoutScreenshot();
   const visualId = sanitizeVisualAttachmentId(input.idSeed || input.screenshotPath || String(input.order));
   const elementId = target?.elementId?.trim() || `visual-mark-${visualId}`;
-  const label = target?.label?.trim() || 'Marked screenshot region';
+  const label = target?.label?.trim() || (input.screenshotPath ? 'Marked screenshot region' : 'Marked preview region');
   const comment = input.note.trim() || intent;
   return {
     id: `${elementId}-visual-${visualId}`,
     order: input.order,
-    filePath: target?.filePath?.trim() || input.screenshotPath,
+    filePath: target?.filePath?.trim() || input.screenshotPath || '',
     elementId,
     selector: target?.selector?.trim() || '',
     label,
@@ -441,7 +446,7 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
     '',
     '',
     '<attached-preview-comments>',
-    "Hard scope: change ONLY the elements identified below by selector / position / pod members. Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules even if you notice issues there — surface those as a follow-up note in your reply instead of editing them. If the user's request cannot be satisfied without touching outside this scope, ask the user before proceeding. For visual marks, inspect the screenshot and modify the marked region first.",
+    "Hard scope: change ONLY the elements identified below by selector / position / pod members. Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules even if you notice issues there — surface those as a follow-up note in your reply instead of editing them. If the user's request cannot be satisfied without touching outside this scope, ask the user before proceeding. For visual marks, inspect the screenshot when one is provided (otherwise locate the region from the structured fields) and modify the marked region first.",
   ];
   commentAttachments.forEach((item) => {
     const position = normalizePosition(item.pagePosition);
@@ -462,11 +467,18 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
       lines.push(`comment: ${item.comment}`);
     }
     if (selectionKind === 'visual') {
-      lines.push(
-        `screenshot: ${item.screenshotPath || '(missing)'}`,
-        `markKind: ${item.markKind || 'stroke'}`,
-        `intent: ${item.intent || visualAnnotationIntent(item.markKind || 'stroke')}`,
-      );
+      if (item.screenshotPath) {
+        lines.push(
+          `screenshot: ${item.screenshotPath}`,
+          `markKind: ${item.markKind || 'stroke'}`,
+          `intent: ${item.intent || visualAnnotationIntent(item.markKind || 'stroke')}`,
+        );
+      } else {
+        lines.push(
+          `markKind: ${item.markKind || 'stroke'}`,
+          `intent: ${item.intent || visualAnnotationIntentWithoutScreenshot()}`,
+        );
+      }
       if (item.selector) lines.push(`selector: ${item.selector}`);
     } else {
       lines.splice(lines.length - 4, 0, `selector: ${item.selector}`);
@@ -508,6 +520,13 @@ function visualAnnotationIntent(markKind: PreviewVisualMarkKind): string {
     return 'The screenshot has a blue focus box and red strokes; together they identify the part the user wants changed.';
   }
   return 'The screenshot has red strokes that identify the visual region the user wants changed.';
+}
+
+// Screenshot-less variant (#4084): the capture failed (#4080), so pointing the
+// agent at a screenshot would point at nothing. The structured fields are the
+// only anchor.
+function visualAnnotationIntentWithoutScreenshot(): string {
+  return 'The user marked a region of the live preview; no screenshot was captured, so locate the region using file, position, and currentText.';
 }
 
 function normalizePosition(input: PreviewComment['position']): PreviewComment['position'] {

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1844,31 +1844,6 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               const result = await uploadProjectFiles(id, annotationFiles);
               if (result.uploaded.length > 0) {
                 uploaded = assignChatAttachmentOrders(result.uploaded, orderStart);
-                const screenshot = detail.file ? uploaded[0] : null;
-                if (screenshot && detail.markKind && detail.bounds) {
-                  visualAttachmentInput = {
-                    order: isFiniteAttachmentOrder(screenshot.order) ? screenshot.order : orderStart,
-                    idSeed: screenshot.path,
-                    screenshotPath: screenshot.path,
-                    markKind: detail.markKind,
-                    note: detail.note,
-                    bounds: detail.bounds,
-                    target: detail.target
-                      ? {
-                          filePath: detail.target.filePath || detail.filePath || screenshot.path,
-                          elementId: detail.target.elementId,
-                          selector: detail.target.selector,
-                          label: detail.target.label,
-                          text: detail.target.text,
-                          position: detail.target.position,
-                          htmlHint: detail.target.htmlHint,
-                        }
-                      : {
-                          filePath: detail.filePath || screenshot.path,
-                          position: detail.bounds,
-                        },
-                  };
-                }
               }
               if (result.failed.length > 0) {
                 const detailText = result.error ? ` (${result.error})` : '';
@@ -1878,6 +1853,38 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   return;
                 }
               }
+            }
+            // The structured visual comment is built whenever the mark has a
+            // location, with or without the screenshot upload. When the
+            // preview capture failed (#4080) the screenshot is absent, but
+            // file/bounds/markKind still anchor the marked region for the
+            // agent (#4084) — dropping them would reduce the send to bare
+            // prose and force the agent to guess what "this part" means.
+            if (detail.markKind && detail.bounds) {
+              const screenshot = detail.file && uploaded.length > 0 ? uploaded[0] : null;
+              visualAttachmentInput = {
+                order: screenshot && isFiniteAttachmentOrder(screenshot.order) ? screenshot.order : 1,
+                idSeed: screenshot?.path
+                  ?? `${detail.filePath || 'preview'}-${detail.markKind}-${Math.round(detail.bounds.x * 1000)}-${Math.round(detail.bounds.y * 1000)}`,
+                ...(screenshot ? { screenshotPath: screenshot.path } : {}),
+                markKind: detail.markKind,
+                note: detail.note,
+                bounds: detail.bounds,
+                target: detail.target
+                  ? {
+                      filePath: detail.target.filePath || detail.filePath || screenshot?.path || '',
+                      elementId: detail.target.elementId,
+                      selector: detail.target.selector,
+                      label: detail.target.label,
+                      text: detail.target.text,
+                      position: detail.target.position,
+                      htmlHint: detail.target.htmlHint,
+                    }
+                  : {
+                      filePath: detail.filePath || screenshot?.path || '',
+                      position: detail.bounds,
+                    },
+              };
             }
             setUploading(false);
 

--- a/apps/web/tests/comments.test.ts
+++ b/apps/web/tests/comments.test.ts
@@ -224,6 +224,40 @@ describe('preview comment attachment helpers', () => {
     expect(messageContentWithCommentAttachments('', [attachment])).not.toContain('selector: ');
   });
 
+  // Issue #4084: a failed screenshot capture (#4080) must not strip the mark's
+  // structured location. The payload still carries bounds/markKind/filePath so
+  // the agent can locate the region without pixels.
+  it('builds visual annotation payloads without a screenshot', () => {
+    const attachment = buildVisualAnnotationAttachment({
+      order: 1,
+      idSeed: 'box-1',
+      markKind: 'stroke',
+      note: 'Make this part bigger',
+      bounds: { x: 120, y: 60, width: 300, height: 200 },
+      target: {
+        filePath: 'index.html',
+        position: { x: 120, y: 60, width: 300, height: 200 },
+      },
+    });
+
+    expect(attachment).toMatchObject({
+      selectionKind: 'visual',
+      markKind: 'stroke',
+      filePath: 'index.html',
+      comment: 'Make this part bigger',
+    });
+    expect(attachment.screenshotPath).toBeUndefined();
+    expect(attachment.pagePosition).toMatchObject({ x: 120, y: 60, width: 300, height: 200 });
+    expect(attachment.id).toContain('box-1');
+    // The prompt context must not point the agent at a screenshot that does
+    // not exist — it renders the structured location instead.
+    const content = messageContentWithCommentAttachments('', [attachment]);
+    expect(content).toContain('targetKind: visual');
+    expect(content).not.toContain('screenshot:');
+    expect(content).toContain('no screenshot');
+    expect(content).toContain('position: x120 y60 300x200');
+  });
+
   it('keeps large queued board-note batches ordered in one send payload', () => {
     const notes = Array.from({ length: 8 }, (_, index) => `Note ${index + 1}`);
     const attachments = buildBoardCommentAttachments({


### PR DESCRIPTION
Fixes #4084

> **Stacked on #4080** — this branch includes #4080's commit because the screenshot-less annotation event only exists once #4080's degraded send lands. After #4080 merges, this PR's diff collapses to the single `feat` commit (`ef7b3e71b`).

## Why

Follow-up declared in #4080's "Adjacent issues". #4080 stopped a failed preview capture from dead-ending annotation sends, but the degraded send silently lost **all structured targeting**: the composer only built the visual comment when the screenshot upload existed, and the daemon normalizer dropped any visual attachment without `screenshotPath`. The agent received bare prose — a deictic note like "这块加一个红色边框" ("add a red border to this part") resolved to nothing, so the agent had to scan files and guess the region, burning tokens and risking edits to the wrong element. The metadata that fixes this (bounds, markKind, filePath, optional DOM target) was already collected by the draw overlay and already supported by the contract (`ChatCommentAttachment.screenshotPath` is optional) and by the daemon's prompt renderer — it was just gated on the screenshot at three points.

## What users will see

No new UI. When an annotation goes out without its screenshot (capture failed, #4080's degraded path), the agent now receives the marked region's structured anchors — file, pixel position, mark kind, current text — in the same `<attached-preview-comments>` block used by screenshot-backed marks, with the prompt hint telling it to locate the region from those fields instead of a screenshot that does not exist. In practice: a box drawn over one card plus a note that only says "this part" gets the right element changed, instead of a guess.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract** — no contract change: `screenshotPath` was already optional in `packages/contracts`; this PR only aligns web/daemon behavior with the existing shape
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — screenshot-less visual annotations now reach the agent with their location metadata (previously stripped); the prompt's hard-scope instruction now reads "inspect the screenshot when one is provided (otherwise locate the region from the structured fields)"
- [ ] **None**

## Screenshots

Blind-instruction verification (real browser, real `claude` run): box drawn over the **right** card, note is only「这块加一个红色边框」— zero content words. The agent located the region purely from the forwarded `pagePosition` and put the red border on exactly the boxed `#chart` element, and its reply even respects the hard-scope instruction (declines to fix an adjacent issue it noticed outside the mark):

![blind-instruction verify — red border lands on the boxed region](https://raw.githubusercontent.com/fancyboi999/open-design/assets-4064/4084-blind-instruction-verify.png)

Persisted send payload (sqlite, `comment_attachments_json`) for that turn — no `screenshotPath`, location intact:

```json
{
  "filePath": "index.html",
  "label": "Marked preview region",
  "comment": "这块加一个红色边框",
  "pagePosition": { "x": 438, "y": 30, "width": 341, "height": 150 },
  "selectionKind": "visual",
  "markKind": "stroke",
  "intent": "The user marked a region of the live preview; no screenshot was captured, so locate the region using file, position, and currentText."
}
```

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/comment-attachments.test.ts` — "keeps a visual annotation without a screenshot and renders a screenshot-free hint" (red on the base branch: the normalizer dropped the attachment), plus "still drops visual annotations that carry no location data at all" pinning the discard invariant.
  - `apps/web/tests/comments.test.ts` — "builds visual annotation payloads without a screenshot" (red on the base branch: `screenshotPath` was required and the build was gated on it).
- Red on base, green on this branch: **yes** for both.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web test` — 322 files / 3171 tests pass
- `pnpm --filter @open-design/daemon test` — changed-domain suites green; 5 environment-sensitive files (proxy-dispatcher, connection-test, langfuse-bridge, project-design-system-routes, env-and-detection) fail identically with the working tree stashed on the base commit, i.e. pre-existing local-env failures (proxy/network), not introduced here
- Real-browser end-to-end (above): send → daemon run `succeeded` → correct element edited from a deictic note with no screenshot

## Adjacent issues (not in this PR)

- Level 2 from #4084: resolve free-drawn boxes to DOM anchors (selector/text of elements intersecting the box) via the srcDoc bridge's healthy postMessage channel, so screenshot-less sends carry element-level anchors rather than page coordinates.
