### PR TITLE
fix(web): keep AMR selected after onboarding picks it

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -960,8 +960,18 @@ function AppInner() {
   // avoids racing the local-config initial value against a slow agents
   // probe — by the time this runs, daemonConfig has already overlaid the
   // user's previous choice, so we only fill an empty slot.
+  //
+  // First-run onboarding is the one time we must NOT do this: the onboarding
+  // flow is the sole authority for the initial agent pick (AMR is the
+  // recommended default there), and AMR (vela) detection is asynchronous. If
+  // this fallback fires during onboarding while AMR is still being detected it
+  // snaps the slot to the registry-first *detected* agent (Claude) and
+  // persists it to the daemon, which then races and clobbers the user's AMR
+  // selection on the next launch. Gate on onboardingCompleted so this only
+  // backfills an empty slot for returning users.
   useEffect(() => {
     if (!daemonConfigLoaded || agentsLoading) return;
+    if (config.onboardingCompleted !== true) return;
     if (config.agentId) return;
     const firstAvailable = agents.find((a) => a.available);
     if (!firstAvailable) return;
@@ -972,7 +982,13 @@ function AppInner() {
       void syncConfigToDaemon(next);
       return next;
     });
-  }, [daemonConfigLoaded, agentsLoading, agents, config.agentId]);
+  }, [
+    daemonConfigLoaded,
+    agentsLoading,
+    agents,
+    config.agentId,
+    config.onboardingCompleted,
+  ]);
 
   // Auto-pick the default design system the same way — only after daemon
   // config has merged so we never overwrite a daemon-stored selection.

--- a/apps/web/tests/components/App.onboarding-agent-autoselect.test.tsx
+++ b/apps/web/tests/components/App.onboarding-agent-autoselect.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { App } from '../../src/App';
+import type { AppConfig } from '../../src/types';
+import { loadConfig, mergeDaemonConfig, fetchDaemonConfig } from '../../src/state/config';
+import {
+  daemonIsLive,
+  fetchAgentsStream,
+  fetchAppVersionInfo,
+  fetchDesignSystems,
+  fetchPromptTemplates,
+  fetchSkills,
+} from '../../src/providers/registry';
+import { fetchAmrModels } from '../../src/providers/daemon';
+import { listProjects, listTemplates } from '../../src/state/projects';
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+  useRoute: () => ({ kind: 'home' as const, view: 'home' as const }),
+}));
+
+// Minimal EntryView that surfaces the agent selection + onboarding state so
+// the test can observe whether the App-level auto-select fired.
+vi.mock('../../src/components/EntryView', () => ({
+  EntryView: ({ config }: { config: AppConfig }) => (
+    <>
+      <div data-testid="agent-id">{config.agentId ?? 'none'}</div>
+      <div data-testid="onboarding-completed">
+        {String(config.onboardingCompleted)}
+      </div>
+    </>
+  ),
+}));
+
+vi.mock('../../src/components/ProjectView', () => ({
+  ProjectView: () => <div>Project view</div>,
+}));
+
+vi.mock('../../src/components/pet/PetOverlay', () => ({
+  PetOverlay: () => null,
+}));
+
+vi.mock('../../src/components/pet/pets', () => ({
+  migrateCustomPetAtlas: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/components/SettingsDialog', () => ({
+  SettingsDialog: () => null,
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    daemonIsLive: vi.fn(),
+    fetchAgentsStream: vi.fn(),
+    fetchAppVersionInfo: vi.fn(),
+    fetchDesignSystems: vi.fn(),
+    fetchPromptTemplates: vi.fn(),
+    fetchSkills: vi.fn(),
+  };
+});
+
+vi.mock('../../src/providers/daemon', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/daemon')>(
+    '../../src/providers/daemon',
+  );
+  return {
+    ...actual,
+    fetchAmrModels: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return {
+    ...actual,
+    listProjects: vi.fn(),
+    listTemplates: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/config')>(
+    '../../src/state/config',
+  );
+  return {
+    ...actual,
+    fetchComposioConfigFromDaemon: vi.fn().mockResolvedValue(null),
+    loadConfig: vi.fn(),
+    // Use the real merge so onboardingCompleted / agentId flow exactly as in
+    // production from the daemon config.
+    mergeDaemonConfig: vi.fn(actual.mergeDaemonConfig),
+    saveConfig: vi.fn(),
+    fetchDaemonConfig: vi.fn(),
+    fetchMediaProvidersFromDaemon: vi.fn().mockResolvedValue({
+      status: 'ok',
+      providers: null,
+    }),
+    syncComposioConfigToDaemon: vi.fn().mockResolvedValue(true),
+    syncConfigToDaemon: vi.fn().mockResolvedValue(undefined),
+    syncMediaProvidersToDaemon: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const mockedDaemonIsLive = vi.mocked(daemonIsLive);
+const mockedFetchAgentsStream = vi.mocked(fetchAgentsStream);
+const mockedFetchAppVersionInfo = vi.mocked(fetchAppVersionInfo);
+const mockedFetchDesignSystems = vi.mocked(fetchDesignSystems);
+const mockedFetchPromptTemplates = vi.mocked(fetchPromptTemplates);
+const mockedFetchSkills = vi.mocked(fetchSkills);
+const mockedFetchAmrModels = vi.mocked(fetchAmrModels);
+const mockedListProjects = vi.mocked(listProjects);
+const mockedListTemplates = vi.mocked(listTemplates);
+const mockedLoadConfig = vi.mocked(loadConfig);
+const mockedFetchDaemonConfig = vi.mocked(fetchDaemonConfig);
+
+function firstRunConfig(): AppConfig {
+  return {
+    mode: 'daemon',
+    apiKey: '',
+    apiProtocol: 'anthropic',
+    apiVersion: '',
+    baseUrl: 'https://api.anthropic.com',
+    model: 'claude-sonnet-4-5',
+    apiProviderBaseUrl: 'https://api.anthropic.com',
+    apiProtocolConfigs: {},
+    agentId: null,
+    skillId: null,
+    designSystemId: null,
+    // First run: the user has NOT finished onboarding yet. Onboarding owns
+    // the agent pick (AMR is the recommended default).
+    onboardingCompleted: false,
+    mediaProviders: {},
+    composio: {},
+    agentModels: {},
+    agentCliEnv: {},
+  };
+}
+
+// Only Claude is detected on the first agent probe. AMR (vela) detection is
+// asynchronous and can lag behind the initial bootstrap — this is the window
+// in which the App-level fallback is tempted to snap the agent to Claude.
+const claudeOnly = [
+  {
+    id: 'claude',
+    name: 'Claude Code',
+    bin: 'claude',
+    available: true,
+    version: '1.0.0',
+    models: [{ id: 'sonnet', label: 'Sonnet' }],
+  },
+];
+
+describe('App first-run agent auto-select', () => {
+  beforeEach(() => {
+    mockedDaemonIsLive.mockResolvedValue(true);
+    mockedFetchAgentsStream.mockResolvedValue([...claudeOnly]);
+    mockedFetchSkills.mockResolvedValue([]);
+    mockedFetchDesignSystems.mockResolvedValue([]);
+    mockedFetchPromptTemplates.mockResolvedValue([]);
+    mockedFetchAppVersionInfo.mockResolvedValue(null);
+    mockedListProjects.mockResolvedValue([]);
+    mockedListTemplates.mockResolvedValue([]);
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'preset',
+      refreshing: false,
+      models: [{ id: 'amr-model', label: 'AMR Model' }],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('does not auto-pick a default agent while first-run onboarding is in progress', async () => {
+    const { syncConfigToDaemon } = await import('../../src/state/config');
+    const mockedSync = vi.mocked(syncConfigToDaemon);
+    mockedLoadConfig.mockReturnValue(firstRunConfig());
+    // Daemon has nothing persisted yet (fresh install): no agentId, onboarding
+    // not completed.
+    mockedFetchDaemonConfig.mockResolvedValue({});
+
+    render(<App />);
+
+    // Once the daemon config + the (Claude-only, AMR-still-detecting) agent
+    // list have both landed, the App-level auto-select effect is eligible to
+    // run. During first-run onboarding it must stay its hand — the onboarding
+    // flow owns the first agent pick (AMR is the recommended default) — so the
+    // agent slot stays empty rather than snapping to Claude and racing the
+    // onboarding's own AMR selection.
+    await waitFor(() => {
+      expect(screen.getByTestId('onboarding-completed').textContent).toBe('false');
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(screen.getByTestId('agent-id').textContent).toBe('none');
+    // And it must not have persisted a Claude default to the daemon, which is
+    // what later clobbers the user's AMR pick on the next launch.
+    const wroteClaude = mockedSync.mock.calls.some(
+      ([cfg]) => (cfg as AppConfig | undefined)?.agentId === 'claude',
+    );
+    expect(wroteClaude).toBe(false);
+  });
+
+  it('auto-picks the first available agent once onboarding is complete', async () => {
+    mockedLoadConfig.mockReturnValue({
+      ...firstRunConfig(),
+      onboardingCompleted: true,
+    });
+    mockedFetchDaemonConfig.mockResolvedValue({ onboardingCompleted: true });
+
+    render(<App />);
+
+    // Returning user with an empty agent slot: the fallback should still fill
+    // it with the first available agent.
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-id').textContent).toBe('claude');
+    });
+  });
+});

--- a/apps/web/tests/components/App.onboarding-amr-e2e.test.tsx
+++ b/apps/web/tests/components/App.onboarding-amr-e2e.test.tsx
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+//
+// High-fidelity integration test for the onboarding -> home agent-selection
+// bug: the user picks (or accepts the recommended default) Open Design AMR
+// during first-run onboarding, but the home agent picker comes back showing
+// Claude Code. Unlike the component-level EntryShell tests (which mock
+// `onAgentChange` so it never updates config), this mounts the REAL `App`
+// with the REAL router and REAL EntryView/onboarding UI, so the App-level
+// config lifecycle + auto-select interact exactly as in production. Only the
+// daemon/provider boundary is mocked, and AMR (vela) detection is made to lag
+// the first agent probe — the exact window in which the bug surfaces.
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { App } from '../../src/App';
+import type { AppConfig } from '../../src/types';
+import { loadConfig, fetchDaemonConfig } from '../../src/state/config';
+import {
+  daemonIsLive,
+  fetchAgentsStream,
+  fetchAppVersionInfo,
+  fetchDesignSystems,
+  fetchDesignTemplates,
+  fetchPromptTemplates,
+  fetchSkills,
+} from '../../src/providers/registry';
+import { fetchAmrModels } from '../../src/providers/daemon';
+import { listProjects, listTemplates } from '../../src/state/projects';
+
+const analyticsMocks = vi.hoisted(() => ({ track: vi.fn() }));
+
+vi.mock('../../src/analytics/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
+  return {
+    ...actual,
+    useAnalytics: () => ({
+      newRequestId: vi.fn(() => 'request-1'),
+      setConfigureGlobals: vi.fn(),
+      setConsent: vi.fn(),
+      setIdentity: vi.fn(),
+      setUserId: vi.fn(),
+      track: analyticsMocks.track,
+    }),
+    useAppVersion: () => null,
+  };
+});
+
+vi.mock('../../src/components/pet/PetOverlay', () => ({
+  PetOverlay: () => null,
+}));
+vi.mock('../../src/components/pet/pets', () => ({
+  migrateCustomPetAtlas: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    daemonIsLive: vi.fn(),
+    fetchAgentsStream: vi.fn(),
+    fetchAppVersionInfo: vi.fn(),
+    fetchDesignSystems: vi.fn(),
+    fetchDesignTemplates: vi.fn(),
+    fetchPromptTemplates: vi.fn(),
+    fetchSkills: vi.fn(),
+  };
+});
+
+vi.mock('../../src/providers/daemon', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/daemon')>(
+    '../../src/providers/daemon',
+  );
+  return { ...actual, fetchAmrModels: vi.fn() };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return { ...actual, listProjects: vi.fn(), listTemplates: vi.fn() };
+});
+
+// Keep the REAL mergeDaemonConfig/loadConfig logic; only stub the network
+// writes and the daemon GET so we can drive a deterministic first-run.
+vi.mock('../../src/state/config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/config')>(
+    '../../src/state/config',
+  );
+  return {
+    ...actual,
+    fetchComposioConfigFromDaemon: vi.fn().mockResolvedValue(null),
+    loadConfig: vi.fn(),
+    fetchDaemonConfig: vi.fn(),
+    fetchMediaProvidersFromDaemon: vi.fn().mockResolvedValue({ status: 'ok', providers: null }),
+    syncComposioConfigToDaemon: vi.fn().mockResolvedValue(true),
+    syncConfigToDaemon: vi.fn().mockResolvedValue(undefined),
+    syncMediaProvidersToDaemon: vi.fn().mockResolvedValue(undefined),
+    saveConfig: vi.fn(),
+  };
+});
+
+const mockedDaemonIsLive = vi.mocked(daemonIsLive);
+const mockedFetchAgentsStream = vi.mocked(fetchAgentsStream);
+const mockedFetchAppVersionInfo = vi.mocked(fetchAppVersionInfo);
+const mockedFetchDesignSystems = vi.mocked(fetchDesignSystems);
+const mockedFetchDesignTemplates = vi.mocked(fetchDesignTemplates);
+const mockedFetchPromptTemplates = vi.mocked(fetchPromptTemplates);
+const mockedFetchSkills = vi.mocked(fetchSkills);
+const mockedFetchAmrModels = vi.mocked(fetchAmrModels);
+const mockedListProjects = vi.mocked(listProjects);
+const mockedListTemplates = vi.mocked(listTemplates);
+const mockedLoadConfig = vi.mocked(loadConfig);
+const mockedFetchDaemonConfig = vi.mocked(fetchDaemonConfig);
+
+const claudeAgent = {
+  id: 'claude',
+  name: 'Claude Code',
+  bin: 'claude',
+  available: true,
+  version: '1.0.0',
+  models: [{ id: 'sonnet', label: 'Sonnet' }],
+};
+const amrAgent = {
+  id: 'amr',
+  name: 'AMR',
+  bin: 'vela',
+  available: true,
+  version: '1.0.0',
+  models: [{ id: 'amr-model', label: 'AMR Model' }],
+};
+
+function firstRunConfig(): AppConfig {
+  return {
+    mode: 'daemon',
+    apiKey: '',
+    apiProtocol: 'anthropic',
+    apiVersion: '',
+    baseUrl: 'https://api.anthropic.com',
+    model: 'claude-sonnet-4-5',
+    apiProviderBaseUrl: 'https://api.anthropic.com',
+    apiProtocolConfigs: {},
+    agentId: null,
+    skillId: null,
+    designSystemId: null,
+    onboardingCompleted: false,
+    privacyDecisionAt: 1,
+    mediaProviders: {},
+    composio: {},
+    agentModels: {},
+    agentCliEnv: {},
+  } as AppConfig;
+}
+
+beforeEach(() => {
+  // jsdom polyfills the full EntryView tree expects.
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+  const win = window as unknown as Record<string, unknown>;
+  win.ResizeObserver ||= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  win.IntersectionObserver ||= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  };
+  window.scrollTo = window.scrollTo || (() => {});
+  window.history.replaceState(null, '', '/');
+
+  mockedDaemonIsLive.mockResolvedValue(true);
+  // AMR (vela) detection LAGS: the first probe only sees Claude. Every
+  // subsequent probe (the onboarding shell re-scans when it finds no AMR)
+  // returns AMR as well.
+  mockedFetchAgentsStream
+    .mockResolvedValueOnce([{ ...claudeAgent }])
+    .mockResolvedValue([{ ...amrAgent }, { ...claudeAgent }]);
+  mockedFetchSkills.mockResolvedValue([]);
+  mockedFetchDesignSystems.mockResolvedValue([]);
+  mockedFetchDesignTemplates.mockResolvedValue([]);
+  mockedFetchPromptTemplates.mockResolvedValue([]);
+  mockedFetchAppVersionInfo.mockResolvedValue(null);
+  mockedListProjects.mockResolvedValue([]);
+  mockedListTemplates.mockResolvedValue([]);
+  mockedFetchAmrModels.mockResolvedValue({
+    source: 'preset',
+    refreshing: false,
+    models: [{ id: 'amr-model', label: 'AMR Model' }],
+  });
+  mockedLoadConfig.mockReturnValue(firstRunConfig());
+  mockedFetchDaemonConfig.mockResolvedValue({});
+
+  // The onboarding + inline switcher poll the vela login status; report a
+  // signed-in account so the AMR runtime is fully selectable.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const json = url.includes('/api/integrations/vela/status')
+        ? {
+            loggedIn: true,
+            profile: 'prod',
+            user: { id: 'u', email: 'user@example.com' },
+            configPath: '/x',
+          }
+        : {};
+      return new Response(JSON.stringify(json), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  analyticsMocks.track.mockReset();
+});
+
+describe('onboarding -> home AMR selection (end to end)', () => {
+  it('lands on the home agent picker with AMR selected after accepting the AMR default', async () => {
+    render(<App />);
+
+    // Bootstrap routes a first-run user into onboarding; the AMR runtime is
+    // the recommended default and the mocked status reports it signed in.
+    const continueButton = await screen.findByRole(
+      'button',
+      { name: /^Continue$/i },
+      { timeout: 5000 },
+    );
+    fireEvent.click(continueButton);
+
+    // About-you step -> finish.
+    const finish = await screen.findByRole('button', { name: /Finish setup/i });
+    fireEvent.click(finish);
+
+    // Now on home: the inline model switcher chip must reflect AMR, not the
+    // Claude default the App-level auto-select used to snap to while AMR was
+    // still being detected.
+    const chip = await screen.findByTestId('inline-model-switcher-chip');
+    await waitFor(() => {
+      expect(chip.getAttribute('aria-label') ?? '').toContain('AMR');
+    });
+    expect(chip.getAttribute('aria-label') ?? '').not.toContain('Claude');
+  });
+});


### PR DESCRIPTION
## Why

I hit this while testing onboarding: I picked **Open Design AMR** as my runtime on the first-run onboarding screen, but when I landed on the home screen the agent picker had quietly reverted to **Claude Code**. The AMR pick didn't stick.

Root cause is a race against the App-level "auto-pick first available agent" fallback. AMR (vela) detection is asynchronous, so during the brief window where AMR isn't detected yet, that fallback fires *during onboarding*, snaps the empty agent slot to the registry-first *detected* agent (Claude), and persists it to both localStorage and the daemon. That premature Claude write is the only thing that ever competes with onboarding's own AMR selection — and because the daemon config writes are fire-and-forget PUTs (last-write-wins) and the post-sign-in app-config refetch overlays the daemon's `agentId`, the stray Claude value can win and clobber the user's AMR pick on the next launch.

The onboarding flow already owns the first-run agent pick (AMR is the recommended default there), so the App-level fallback has no business firing while onboarding is still in progress.

## What users will see

No visible new UI. Behavior fix: when you choose Open Design AMR (or accept it as the recommended default) during first-run onboarding, the home agent picker now stays on AMR instead of silently reverting to Claude Code. Returning users with no agent selected are unaffected — the app still backfills the first available agent for them.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the first-run agent auto-pick no longer runs while onboarding is in progress (it now waits until `onboardingCompleted`); for returning users with an empty agent slot the fallback is unchanged.
- [ ] **None**

## Screenshots

No UI surface changed; this is a state/persistence fix. (The reported symptom: home agent picker showing Claude Code selected with AMR available + signed in, after choosing AMR in onboarding.)

## Bug fix verification

- **Red spec (reproduces the root cause):** `apps/web/tests/components/App.onboarding-agent-autoselect.test.tsx` → *"does not auto-pick a default agent while first-run onboarding is in progress"*. With a first-run config and only Claude detected (AMR still being probed), it asserts the App does not auto-select/persist a default agent. **Red on `main`** (`expected 'none', received 'claude'` + a `syncConfigToDaemon({agentId:'claude'})` write), **green on this branch**. The companion case *"auto-picks the first available agent once onboarding is complete"* stays green to prove the returning-user fallback is preserved.
- **End-to-end integration test:** `apps/web/tests/components/App.onboarding-amr-e2e.test.tsx` mounts the real `App` + real router + real onboarding UI (only the daemon/provider boundary is mocked, with AMR detection lagging the first probe), drives `bootstrap → onboarding → home`, and asserts the home inline switcher chip shows **AMR**, not Claude.
- **Honest scope note:** the *full* user-visible symptom ("after restart the picker shows Claude") is a write-ordering race — in a single deterministic session the AMR write self-heals, so the e2e test passes on `main` too. It is kept as a forward behavioral guard. The deterministic regression guard is the red spec above, which pins the actual contaminant (the premature Claude write) that the fix removes.

## Validation

- `pnpm --filter @open-design/web typecheck` ✅
- `pnpm guard` ✅ (54/54)
- `pnpm --filter @open-design/web test` ✅ — 325 files, 3186 passed, 1 skipped, 0 failed (Node 24)
