### PR TITLE
fix(release): retry R2 uploads on transient network errors

### DIFF
--- a/.github/workflow/scripts/release/storage/s3-upload.ts
+++ b/.github/workflow/scripts/release/storage/s3-upload.ts
@@ -66,6 +66,82 @@ function authorizationHeader(config: StorageConfig, method: "GET" | "PUT", canon
   return `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
 }
 
+// R2/S3 uploads run from CI over the public internet and occasionally hit
+// transient TLS/socket failures (observed: `fetch failed` → `ECONNRESET` mid
+// PUT) or throttling. A single such blip used to fail the whole platform build,
+// which gated the publish step and produced a download-less release. Retry the
+// signed request on transient network errors and retryable status codes with
+// bounded exponential backoff + jitter. Each attempt is RE-SIGNED with a fresh
+// timestamp because the SigV4 signature covers `x-amz-date`.
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+const MAX_ATTEMPTS = 5;
+const BASE_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 8000;
+
+function isRetryableNetworkError(error: unknown): boolean {
+  const retryableCodes = new Set([
+    "ECONNRESET",
+    "ETIMEDOUT",
+    "ECONNREFUSED",
+    "EPIPE",
+    "EAI_AGAIN",
+    "ENOTFOUND",
+    "UND_ERR_SOCKET",
+    "UND_ERR_CONNECT_TIMEOUT",
+    "UND_ERR_HEADERS_TIMEOUT",
+    "UND_ERR_BODY_TIMEOUT",
+  ]);
+  const visited = new Set<unknown>();
+  let current: unknown = error;
+  while (current != null && !visited.has(current)) {
+    visited.add(current);
+    const candidate = current as { cause?: unknown; code?: unknown; message?: unknown };
+    if (typeof candidate.code === "string" && retryableCodes.has(candidate.code)) return true;
+    if (typeof candidate.message === "string" && /fetch failed|socket hang up|network|terminated|other side closed/i.test(candidate.message)) return true;
+    current = candidate.cause;
+  }
+  return false;
+}
+
+function backoffDelayMs(attempt: number): number {
+  const exponential = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** (attempt - 1));
+  // Full-jitter over the lower half so retries spread out without a thundering herd.
+  return Math.floor(exponential / 2 + Math.random() * (exponential / 2));
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function fetchSignedWithRetry(label: string, buildRequest: () => { init: RequestInit; url: URL }): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const { init, url } = buildRequest();
+    try {
+      const response = await fetch(url, init);
+      if (RETRYABLE_STATUS.has(response.status) && attempt < MAX_ATTEMPTS) {
+        try {
+          await response.body?.cancel();
+        } catch {
+          // ignore: draining the discarded body is best-effort
+        }
+        console.log(`[s3-upload] ${label} returned HTTP ${response.status}; retrying (attempt ${attempt}/${MAX_ATTEMPTS})`);
+        await sleep(backoffDelayMs(attempt));
+        continue;
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableNetworkError(error) || attempt >= MAX_ATTEMPTS) throw error;
+      console.log(`[s3-upload] ${label} failed with a transient network error; retrying (attempt ${attempt}/${MAX_ATTEMPTS})`);
+      await sleep(backoffDelayMs(attempt));
+    }
+  }
+  throw lastError;
+}
+
 export async function putStorageObject(options: PutObjectOptions): Promise<void> {
   const result = await putStorageObjectWithStatus(options);
   if (!result.ok) {
@@ -76,27 +152,32 @@ export async function putStorageObject(options: PutObjectOptions): Promise<void>
 export async function putStorageObjectWithStatus(options: PutObjectOptions): Promise<{ body: string; ok: boolean; status: number; url: string }> {
   const body = readFileSync(options.bodyPath);
   const payloadHash = hash(body);
-  const { amzDate, dateStamp } = amzTimestamp(new Date());
   const { canonicalUri, url } = objectUrl(options, options.objectKey);
-  const headers: Record<string, string> = {
-    "cache-control": options.cacheControl,
-    "content-type": options.contentType,
-    host: url.host,
-    "x-amz-content-sha256": payloadHash,
-    "x-amz-date": amzDate,
-    ...(options.headers ?? {}),
-  };
-  if (options.sessionToken != null && options.sessionToken.length > 0) {
-    headers["x-amz-security-token"] = options.sessionToken;
-  }
 
-  const response = await fetch(url, {
-    body,
-    headers: {
-      ...headers,
-      Authorization: authorizationHeader(options, "PUT", canonicalUri, headers, payloadHash, dateStamp),
-    },
-    method: "PUT",
+  const response = await fetchSignedWithRetry(`PUT ${url}`, () => {
+    const { amzDate, dateStamp } = amzTimestamp(new Date());
+    const headers: Record<string, string> = {
+      "cache-control": options.cacheControl,
+      "content-type": options.contentType,
+      host: url.host,
+      "x-amz-content-sha256": payloadHash,
+      "x-amz-date": amzDate,
+      ...(options.headers ?? {}),
+    };
+    if (options.sessionToken != null && options.sessionToken.length > 0) {
+      headers["x-amz-security-token"] = options.sessionToken;
+    }
+    return {
+      init: {
+        body,
+        headers: {
+          ...headers,
+          Authorization: authorizationHeader(options, "PUT", canonicalUri, headers, payloadHash, dateStamp),
+        },
+        method: "PUT",
+      },
+      url,
+    };
   });
   return {
     body: await response.text().catch(() => ""),
@@ -108,23 +189,28 @@ export async function putStorageObjectWithStatus(options: PutObjectOptions): Pro
 
 export async function getStorageObject(options: GetObjectOptions): Promise<{ etag: string; text: string } | null> {
   const payloadHash = hash("");
-  const { amzDate, dateStamp } = amzTimestamp(new Date());
   const { canonicalUri, url } = objectUrl(options, options.objectKey);
-  const headers: Record<string, string> = {
-    host: url.host,
-    "x-amz-content-sha256": payloadHash,
-    "x-amz-date": amzDate,
-  };
-  if (options.sessionToken != null && options.sessionToken.length > 0) {
-    headers["x-amz-security-token"] = options.sessionToken;
-  }
 
-  const response = await fetch(url, {
-    headers: {
-      ...headers,
-      Authorization: authorizationHeader(options, "GET", canonicalUri, headers, payloadHash, dateStamp),
-    },
-    method: "GET",
+  const response = await fetchSignedWithRetry(`GET ${url}`, () => {
+    const { amzDate, dateStamp } = amzTimestamp(new Date());
+    const headers: Record<string, string> = {
+      host: url.host,
+      "x-amz-content-sha256": payloadHash,
+      "x-amz-date": amzDate,
+    };
+    if (options.sessionToken != null && options.sessionToken.length > 0) {
+      headers["x-amz-security-token"] = options.sessionToken;
+    }
+    return {
+      init: {
+        headers: {
+          ...headers,
+          Authorization: authorizationHeader(options, "GET", canonicalUri, headers, payloadHash, dateStamp),
+        },
+        method: "GET",
+      },
+      url,
+    };
   });
   if (response.status === 404) return null;
   if (!response.ok) {


### PR DESCRIPTION
## Why

While running on-demand nightlies off `main`, the mac Intel x64 platform build kept failing — and when it did, the `Publish` job (gated on every platform succeeding) was skipped, so the nightly shipped with **no download links** and the Feishu card came through empty.

Root cause, from the failing run's log:

```
publish-platform.ts
[TypeError: fetch failed] { [cause]: Error: read ECONNRESET, code: 'ECONNRESET' }
##[error]Process completed with exit code 1.
```

`s3-upload.ts` uploads every release/nightly asset to R2 with a single `fetch` and **zero retries**. R2 PUTs run from CI over the public internet, so an occasional transient TLS/socket reset (`ECONNRESET`) or throttle is expected — but today any one blip fails the entire platform build. It's flaky, not deterministic: adjacent runs with the same inputs published fine.

## What users will see

No app-facing change. Maintainers get reliable release/nightly builds: a single transient upload failure no longer fails the whole platform build or gates the publish step, so nightlies stop shipping download-less / empty-card.

## Surface area

- [x] **None** — internal CI release script (`.github/workflow/scripts/release/storage/s3-upload.ts`); no app, API, CLI, i18n, or dependency surface.

## Bug fix verification

There is no test harness for `.github/workflow/scripts/**` — these scripts run via `node --experimental-strip-types` and sit in no `tsconfig`/`vitest` project, so a committed in-repo red spec isn't cheap to add without standing up new infra (out of scope for a one-file CI fix).

Instead, a standalone harness (mocks `globalThis.fetch`) was run against **both** the `origin/main` file and this branch's file:

| Case | origin/main (no retry) | this branch |
|------|------------------------|-------------|
| ECONNRESET once, then 200 | ❌ throws (1 fetch) — *the exact prod failure* | ✅ succeeds (2 fetches) |
| constant 403 | ✅ throws, no retry (1 fetch) | ✅ throws, no retry (1 fetch) |
| 503 twice, then 200 | ❌ throws (1 fetch) | ✅ succeeds (3 fetches) |
| persistent ECONNRESET | ❌ throws (1 fetch) | ✅ gives up after 5 attempts |

So the change goes red→green on exactly the observed failure mode while leaving non-retryable outcomes (403/404/success) untouched.

## Validation

- Standalone strict `tsc --noEmit` on the changed file (scripts/tsconfig.json options): clean
- Red/green `node --experimental-strip-types` harness above: red on `main`, green on branch

## Adjacent issues (separate follow-ups, not in this PR)

1. **Nightly `metadata.json` writes an empty `github` block** (`commit`/`branch`/`repository` all blank), so the "changelog since last nightly" always reads `首个 Nightly 包,无上个版本可对比` even at `.nightly.24+`. The `previous_commit` baseline can never resolve.
2. **The `notify` Feishu job fires even when `Publish` was skipped/failed** (it only checks `release_version != ''`), so a failed build still posts a download-less card. Gating notify on publish success would suppress the empty cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
