### PR TITLE
fix(web): show seven recent projects on wide home layouts

### DIFF
--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -32,6 +32,10 @@ const EMPTY_DESIGN_SYSTEMS: DesignSystemSummary[] = [];
 
 const DECK_PREVIEW_WIDTH = 1280;
 const DECK_PREVIEW_HEIGHT = 720;
+const DEFAULT_RECENT_PROJECT_LIMIT = 6;
+const WIDE_RECENT_PROJECT_LIMIT = 7;
+// 7 * 180px cards + 6 * 12px gaps, matching recent-projects.css.
+const WIDE_RECENT_PROJECT_MIN_ROW_WIDTH = 1332;
 const deckCoverCache = new Map<string, string>();
 const deckCoverInflight = new Map<string, Promise<string>>();
 
@@ -40,14 +44,44 @@ export function RecentProjectsStrip({
   designSystems = EMPTY_DESIGN_SYSTEMS,
   onOpen,
   onViewAll,
-  limit = 6,
+  limit,
 }: Props) {
   const t = useT();
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const [responsiveLimit, setResponsiveLimit] = useState(DEFAULT_RECENT_PROJECT_LIMIT);
+  const resolvedLimit = limit ?? responsiveLimit;
+
+  useEffect(() => {
+    if (limit !== undefined) return;
+
+    const node = rowRef.current;
+    const update = () => {
+      const rowWidth =
+        node?.getBoundingClientRect().width ??
+        (typeof window === 'undefined' ? 0 : window.innerWidth);
+      setResponsiveLimit(
+        rowWidth >= WIDE_RECENT_PROJECT_MIN_ROW_WIDTH
+          ? WIDE_RECENT_PROJECT_LIMIT
+          : DEFAULT_RECENT_PROJECT_LIMIT,
+      );
+    };
+
+    update();
+    if (node && typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(update);
+      observer.observe(node);
+      return () => observer.disconnect();
+    }
+
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [limit]);
+
   const recent = useMemo(
     () => [...projects]
       .sort((a, b) => b.updatedAt - a.updatedAt)
-      .slice(0, limit),
-    [projects, limit],
+      .slice(0, resolvedLimit),
+    [projects, resolvedLimit],
   );
   const [coverByProject, setCoverByProject] = useState<
     Record<string, { kind: 'html' | 'image' | 'video' | 'logo'; name: string } | null>
@@ -144,7 +178,7 @@ export function RecentProjectsStrip({
           <Icon name="chevron-right" size={12} />
         </button>
       </header>
-      <div className="recent-projects__row" role="list">
+      <div ref={rowRef} className="recent-projects__row" role="list">
         {recent.map((project) => {
           const cover = projectCover(project, coverByProject[project.id] ?? null);
           const designSystemProject = isDesignSystemProject(project);

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../../src/providers/registry', () => ({
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -41,7 +42,71 @@ function project(overrides: Partial<Project>): Project {
   };
 }
 
+function projects(count: number): Project[] {
+  return Array.from({ length: count }, (_, index) =>
+    project({
+      id: `project-${index + 1}`,
+      name: `Project ${index + 1}`,
+      updatedAt: count - index,
+    }),
+  );
+}
+
 describe('RecentProjectsStrip', () => {
+  it('shows seven projects when the row has room for a seventh card', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getRect(this: HTMLElement) {
+      return {
+        x: 0,
+        y: 0,
+        width: this.classList.contains('recent-projects__row') ? 1332 : 180,
+        height: 100,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      };
+    });
+
+    const { container } = render(
+      <RecentProjectsStrip
+        projects={projects(8)}
+        onOpen={() => {}}
+        onViewAll={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.recent-projects__card')).toHaveLength(7);
+    });
+  });
+
+  it('keeps six projects when the row is below the wide-card threshold', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getRect(this: HTMLElement) {
+      return {
+        x: 0,
+        y: 0,
+        width: this.classList.contains('recent-projects__row') ? 1331 : 180,
+        height: 100,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      };
+    });
+
+    const { container } = render(
+      <RecentProjectsStrip
+        projects={projects(8)}
+        onOpen={() => {}}
+        onViewAll={() => {}}
+      />,
+    );
+
+    expect(container.querySelectorAll('.recent-projects__card')).toHaveLength(6);
+  });
+
   it('matches project cards with previews and design-system tags', async () => {
     const { container } = render(
       <RecentProjectsStrip


### PR DESCRIPTION
Fixes #4076

## Why

I hit the Home `Recent Projects` row looking under-filled on wide fullscreen layouts. The grid had enough room for a seventh card, but the strip still rendered six, leaving an empty slot on the right.

This keeps the common smaller layout compact while using the extra space when the row is actually wide enough.

## What users will see

On wide Home layouts, can show seven project cards in the first row.

Below the seven-card width threshold, it still shows six cards so most layouts do not gain an extra row.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

<img width="3480" height="1740" alt="image" src="https://github.com/user-attachments/assets/f90607e4-477c-46c2-a78c-062d355154ba" />


## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/RecentProjectsStrip.test.tsx`
- Red/green: yes. With the old fixed-six behavior restored temporarily, the wide-row test failed with `expected length 7 but got 6`; restoring this change made it pass.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/RecentProjectsStrip.test.tsx`