### PR TITLE
fix(web): show sending state on home composer submit

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -584,7 +584,10 @@ export function EntryShell({
   // submits now arrive with the hidden od-default router plugin and
   // projectKind='other', so the agent asks for the exact task type
   // before continuing.
-  function handlePluginLoopSubmit(payload: PluginLoopSubmit) {
+  // Forwards onCreateProject's result so HomeView can hold its sending
+  // state until the creation roundtrip settles, and recover on failure
+  // (#4082).
+  function handlePluginLoopSubmit(payload: PluginLoopSubmit): Promise<boolean> | boolean | void {
     const summarizedName = summarizeProjectNameFromPrompt(payload.prompt);
     const head = payload.prompt.trim().split(/\s+/).slice(0, 8).join(' ');
     const firstAttachmentName = payload.attachments?.[0]?.name ?? '';
@@ -620,7 +623,7 @@ export function EntryShell({
         examplePromptBrief: payload.examplePromptContext.brief,
       } : {}),
     };
-    onCreateProject({
+    return onCreateProject({
       name,
       skillId: payload.skillId ?? null,
       designSystemId: payload.designSystemId ?? null,

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -167,6 +167,10 @@ interface Props {
   pendingPluginId: string | null;
   pendingChipId: string | null;
   submitDisabled?: boolean;
+  // True while the submitted run is still creating its project/conversation
+  // (#4082). Distinct from `submitDisabled`: it swaps the send button into a
+  // visible Sending… state instead of leaving it silently idle.
+  submitting?: boolean;
   onPickPlugin: (record: InstalledPluginRecord, nextPrompt: string | null) => void;
   onPickExamplePlugin?: (record: InstalledPluginRecord, chipId: string, promptText: string) => void;
   onPickSkill?: (skill: SkillSummary, nextPrompt: string | null) => void;
@@ -275,6 +279,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     pendingPluginId,
     pendingChipId,
     submitDisabled = false,
+    submitting = false,
     onPickPlugin,
     onPickExamplePlugin = () => undefined,
     onPickSkill = () => undefined,
@@ -324,7 +329,8 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
   const mentionPickerRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const shortcutsMenuRef = useRef<HTMLDivElement>(null);
-  const canSubmit = (prompt.trim().length > 0 || stagedFiles.length > 0) && !submitDisabled;
+  const canSubmit =
+    (prompt.trim().length > 0 || stagedFiles.length > 0) && !submitDisabled && !submitting;
   const previewHomeFile = useMemo(() => {
     if (!previewHomeFileKey) return null;
     return stagedFiles.find((file, index) => homeFileKey(file, index) === previewHomeFileKey) ?? null;
@@ -1479,17 +1485,18 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
             ) : null}
             <button
               type="button"
-              className={`home-hero__submit od-tooltip${sendAttention ? ' home-hero__attention-sheen' : ''}`}
+              className={`home-hero__submit od-tooltip${sendAttention ? ' home-hero__attention-sheen' : ''}${submitting ? ' is-sending' : ''}`}
               data-testid="home-hero-submit"
               onClick={onSubmit}
               onAnimationEnd={() => setSendAttention(false)}
               disabled={!canSubmit}
-              title={canSubmit ? t('homeHero.run') : t('homeHero.typeSomethingToRun')}
-              data-tooltip={canSubmit ? t('homeHero.run') : t('homeHero.typeSomethingToRun')}
-              aria-label={t('homeHero.run')}
+              title={submitting ? t('chat.comments.sending') : canSubmit ? t('homeHero.run') : t('homeHero.typeSomethingToRun')}
+              data-tooltip={submitting ? t('chat.comments.sending') : canSubmit ? t('homeHero.run') : t('homeHero.typeSomethingToRun')}
+              aria-label={submitting ? t('chat.comments.sending') : t('homeHero.run')}
+              aria-busy={submitting}
             >
               <Icon name="send" size={13} />
-              <span>{t('chat.send')}</span>
+              <span>{submitting ? t('chat.comments.sending') : t('chat.send')}</span>
             </button>
           </div>
         </div>

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1546,6 +1546,14 @@ export function HomeView({
         sessionMode === 'design'
           ? submittedActive?.record.id ?? DEFAULT_UNSELECTED_SCENARIO_PLUGIN_ID
           : submittedActive?.record.id ?? null;
+      // The example-prompt override is a one-shot marker. Decide whether to
+      // send it now, but defer spending the marker until the create is
+      // accepted — a rejected attempt stays retryable and must resend it.
+      const examplePromptKey = 'od:example-prompt-used';
+      const examplePromptToSend =
+        examplePromptInfoRef.current != null && localStorage.getItem(examplePromptKey) == null
+          ? examplePromptInfoRef.current
+          : null;
       const accepted = await onSubmit({
         prompt: trimmed,
         pluginId: routedPluginId,
@@ -1565,18 +1573,14 @@ export function HomeView({
         ...(workingDir ? { workingDir } : {}),
         ...(workingDirToken ? { workingDirToken } : {}),
         conversationMode: sessionMode,
-        ...(() => {
-          if (!examplePromptInfoRef.current) return {};
-          const key = 'od:example-prompt-used';
-          if (localStorage.getItem(key)) return {};
-          localStorage.setItem(key, '1');
-          return { examplePromptContext: examplePromptInfoRef.current };
-        })(),
+        ...(examplePromptToSend ? { examplePromptContext: examplePromptToSend } : {}),
       });
       if (accepted === false) {
         setError('Failed to start the run. Make sure the daemon is reachable, then try again.');
         return;
       }
+      // Create accepted — now it is safe to spend the one-shot marker.
+      if (examplePromptToSend) localStorage.setItem(examplePromptKey, '1');
       // Only drop the staged contexts once the run actually started — a
       // rejected creation keeps them so the retry sends the same payload.
       setSelectedPluginContexts([]);

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -196,7 +196,10 @@ interface Props {
   projectsLoading?: boolean;
   designSystems?: DesignSystemSummary[];
   defaultDesignSystemId?: string | null;
-  onSubmit: (payload: PluginLoopSubmit) => void;
+  // Resolves false when the project/conversation creation was rejected —
+  // the composer uses that to leave the sending state and let the user
+  // retry (#4082). Plain-void handlers keep working (treated as accepted).
+  onSubmit: (payload: PluginLoopSubmit) => Promise<boolean> | boolean | void;
   onOpenProject: (id: string) => void;
   onViewAllProjects: () => void;
   onBrowseRegistry?: () => void;
@@ -304,6 +307,10 @@ export function HomeView({
     examplePromptInfoRef.current = info;
   }, []);
   const [error, setError] = useState<string | null>(null);
+  // In-flight window between Send and the run starting (or failing) — the
+  // project-creation roundtrip happens upstream of this component, so the
+  // submit handler's promise is the only signal that it settled (#4082).
+  const [sending, setSending] = useState(false);
   const [elevenLabsVoices, setElevenLabsVoices] = useState<AudioVoiceOption[]>([]);
   const [elevenLabsVoicesLoading, setElevenLabsVoicesLoading] = useState(false);
   // Live AIHubMix image catalogue merged into the home media composer's model
@@ -1420,6 +1427,9 @@ export function HomeView({
   }
 
   async function submit() {
+    // The send button disables itself while sending, but the Enter-to-send
+    // path lands here directly — swallow re-entry during the in-flight window.
+    if (sending) return;
     const trimmed = prompt.trim();
     if (!trimmed && stagedFiles.length === 0) return;
     // P0 ui_click area=chat_composer element=send_button. Fires before the
@@ -1444,122 +1454,142 @@ export function HomeView({
       );
       return;
     }
-    const defaultInputs = { prompt: trimmed };
-    const submittedDesignSystemId = homeDesignSystemSelectionForInputs(
-      submittedActive?.inputs ?? null,
-      designSystemPickerSystems,
-      t('designSystemPicker.noneTitle'),
-    );
-    // Composer inputs are forwarded as-is; the deferred footer/media fields are
-    // stripped from this set just below to form the run-facing inputs.
-    const submittedApplyInputs = submittedActive ? submittedActive.inputs : defaultInputs;
-    // Inputs forwarded to the run AND used to build the run-facing snapshot:
-    // drop every now-hidden footer/media setting so the first-turn
-    // question-form flow collects them instead of inheriting a baked-in
-    // default (`ratio: 16:9`, `duration: 5`, `audioType: speech`, …). The
-    // snapshot is resolved from these stripped inputs too — the daemon renders
-    // `## Plugin inputs` from `snapshot.inputs` and tells the agent not to
-    // re-ask about anything listed there, so leaving the deferred defaults in
-    // the snapshot would suppress the discovery flow even though
-    // `onSubmit.pluginInputs` was stripped. Stripping only removes non-required
-    // fields (`subject`/`style`/`aspect`/`mediaKind` stay), so the
-    // od-media-generation apply still validates.
-    const submittedPluginInputs = submittedActive
-      ? stripArtifactFooterInputs(submittedApplyInputs)
-      : defaultInputs;
-    const activeInputsChangedForSubmit = submittedActive
-      ? !inputsEqual(submittedActive.result?.appliedPlugin?.inputs ?? submittedActive.inputs, submittedPluginInputs)
-      : false;
-    if (submittedActive && (!submittedActive.result || activeInputsChangedForSubmit)) {
-      const result = await resolveActivePlugin(submittedActive.record, submittedPluginInputs);
-      if (!result) {
-        setError(`Failed to apply ${submittedActive.record.title}. Check the plugin parameters and try again.`);
+    setError(null);
+    // Sending covers the whole async tail — a pending plugin apply (when one
+    // must resolve first) and the project-creation roundtrip are both windows
+    // a second click could otherwise re-enter.
+    setSending(true);
+    try {
+      const defaultInputs = { prompt: trimmed };
+      const submittedDesignSystemId = homeDesignSystemSelectionForInputs(
+        submittedActive?.inputs ?? null,
+        designSystemPickerSystems,
+        t('designSystemPicker.noneTitle'),
+      );
+      // Composer inputs are forwarded as-is; the deferred footer/media fields are
+      // stripped from this set just below to form the run-facing inputs.
+      const submittedApplyInputs = submittedActive ? submittedActive.inputs : defaultInputs;
+      // Inputs forwarded to the run AND used to build the run-facing snapshot:
+      // drop every now-hidden footer/media setting so the first-turn
+      // question-form flow collects them instead of inheriting a baked-in
+      // default (`ratio: 16:9`, `duration: 5`, `audioType: speech`, …). The
+      // snapshot is resolved from these stripped inputs too — the daemon renders
+      // `## Plugin inputs` from `snapshot.inputs` and tells the agent not to
+      // re-ask about anything listed there, so leaving the deferred defaults in
+      // the snapshot would suppress the discovery flow even though
+      // `onSubmit.pluginInputs` was stripped. Stripping only removes non-required
+      // fields (`subject`/`style`/`aspect`/`mediaKind` stay), so the
+      // od-media-generation apply still validates.
+      const submittedPluginInputs = submittedActive
+        ? stripArtifactFooterInputs(submittedApplyInputs)
+        : defaultInputs;
+      const activeInputsChangedForSubmit = submittedActive
+        ? !inputsEqual(submittedActive.result?.appliedPlugin?.inputs ?? submittedActive.inputs, submittedPluginInputs)
+        : false;
+      if (submittedActive && (!submittedActive.result || activeInputsChangedForSubmit)) {
+        const result = await resolveActivePlugin(submittedActive.record, submittedPluginInputs);
+        if (!result) {
+          setError(`Failed to apply ${submittedActive.record.title}. Check the plugin parameters and try again.`);
+          return;
+        }
+        submittedActive = { ...submittedActive, result, inputs: submittedPluginInputs };
+        setActive(submittedActive);
+      }
+      // Reconcile each selected context against the serialized prompt text before
+      // forwarding it. Inline-backed contexts (inserted as `@mention` pills) are
+      // only sent while their token survives in the prompt — the Lexical composer
+      // lets users delete a mention pill (backspace, edit), and when they do that
+      // plugin/MCP/connector should stop being sent. Context-only `Use`
+      // selections never carry a token, so they stay in the payload until the
+      // user explicitly clears them.
+      const contextPlugins = selectedPluginContexts
+        .filter((item) => !item.inlineBacked || mentionTokenPresent(trimmed, item.record.title))
+        .map((item) => ({
+          id: item.record.id,
+          title: item.record.title,
+          ...(item.record.manifest?.description
+            ? { description: item.record.manifest.description }
+            : {}),
+        }));
+      const contextMcpServers = selectedMcpContexts
+        .filter((item) => !item.inlineBacked || mentionTokenPresent(trimmed, item.server.label || item.server.id))
+        .map((item) => ({
+          id: item.server.id,
+          ...(item.server.label ? { label: item.server.label } : {}),
+          ...(item.server.transport ? { transport: item.server.transport } : {}),
+          ...(item.server.url ? { url: item.server.url } : {}),
+          ...(item.server.command ? { command: item.server.command } : {}),
+        }));
+      const contextConnectors = selectedConnectorContexts
+        .filter((item) => !item.inlineBacked || mentionTokenPresent(trimmed, item.connector.name))
+        .map((item) => ({
+          id: item.connector.id,
+          name: item.connector.name,
+          provider: item.connector.provider,
+          category: item.connector.category,
+          status: item.connector.status,
+          ...(item.connector.accountLabel ? { accountLabel: item.connector.accountLabel } : {}),
+        }));
+      const submittedProjectKind =
+        submittedActive?.projectKind ?? fallbackProjectKind ?? projectKindForSkill(activeSkill) ?? 'other';
+      const submittedProjectMetadata = submittedActive?.mediaSurface
+        ? metadataForHomeMediaComposer(submittedActive.mediaSurface, submittedActive.inputs, promptTemplates)
+        : homeCreateProjectMetadata(
+            submittedProjectKind,
+            submittedActive?.inputs ?? null,
+            submittedActive?.projectMetadata ?? fallbackProjectMetadata ?? null,
+          );
+      // Scenario plugins (chips / preset cards) and explicit skill picks are
+      // mutually exclusive routing sources — never send both (#2972).
+      const resolvedSkillId = submittedActive ? null : activeSkill?.id ?? null;
+      const routedPluginId =
+        sessionMode === 'design'
+          ? submittedActive?.record.id ?? DEFAULT_UNSELECTED_SCENARIO_PLUGIN_ID
+          : submittedActive?.record.id ?? null;
+      const accepted = await onSubmit({
+        prompt: trimmed,
+        pluginId: routedPluginId,
+        pluginType: submittedActive?.record.marketplaceTrust ?? (routedPluginId ? 'official' : null),
+        skillId: resolvedSkillId,
+        appliedPluginSnapshotId: submittedActive?.result?.appliedPlugin?.snapshotId ?? null,
+        pluginTitle: submittedActive?.record.title ?? null,
+        taskKind: submittedActive?.result?.appliedPlugin?.taskKind ?? null,
+        pluginInputs: submittedPluginInputs,
+        projectKind: submittedProjectKind,
+        projectMetadata: submittedProjectMetadata,
+        designSystemId: submittedDesignSystemId,
+        contextPlugins,
+        contextMcpServers,
+        contextConnectors,
+        attachments: stagedFiles,
+        ...(workingDir ? { workingDir } : {}),
+        ...(workingDirToken ? { workingDirToken } : {}),
+        conversationMode: sessionMode,
+        ...(() => {
+          if (!examplePromptInfoRef.current) return {};
+          const key = 'od:example-prompt-used';
+          if (localStorage.getItem(key)) return {};
+          localStorage.setItem(key, '1');
+          return { examplePromptContext: examplePromptInfoRef.current };
+        })(),
+      });
+      if (accepted === false) {
+        setError('Failed to start the run. Make sure the daemon is reachable, then try again.');
         return;
       }
-      submittedActive = { ...submittedActive, result, inputs: submittedPluginInputs };
-      setActive(submittedActive);
+      // Only drop the staged contexts once the run actually started — a
+      // rejected creation keeps them so the retry sends the same payload.
+      setSelectedPluginContexts([]);
+      setSelectedMcpContexts([]);
+      setSelectedConnectorContexts([]);
+    } catch (err) {
+      // A submit handler that throws (instead of resolving false) lands on
+      // the same recovery path as a rejected creation.
+      console.warn('Home composer submit failed', err);
+      setError('Failed to start the run. Make sure the daemon is reachable, then try again.');
+    } finally {
+      setSending(false);
     }
-    // Reconcile each selected context against the serialized prompt text before
-    // forwarding it. Inline-backed contexts (inserted as `@mention` pills) are
-    // only sent while their token survives in the prompt — the Lexical composer
-    // lets users delete a mention pill (backspace, edit), and when they do that
-    // plugin/MCP/connector should stop being sent. Context-only `Use`
-    // selections never carry a token, so they stay in the payload until the
-    // user explicitly clears them.
-    const contextPlugins = selectedPluginContexts
-      .filter((item) => !item.inlineBacked || mentionTokenPresent(trimmed, item.record.title))
-      .map((item) => ({
-        id: item.record.id,
-        title: item.record.title,
-        ...(item.record.manifest?.description
-          ? { description: item.record.manifest.description }
-          : {}),
-      }));
-    const contextMcpServers = selectedMcpContexts
-      .filter((item) => !item.inlineBacked || mentionTokenPresent(trimmed, item.server.label || item.server.id))
-      .map((item) => ({
-        id: item.server.id,
-        ...(item.server.label ? { label: item.server.label } : {}),
-        ...(item.server.transport ? { transport: item.server.transport } : {}),
-        ...(item.server.url ? { url: item.server.url } : {}),
-        ...(item.server.command ? { command: item.server.command } : {}),
-      }));
-    const contextConnectors = selectedConnectorContexts
-      .filter((item) => !item.inlineBacked || mentionTokenPresent(trimmed, item.connector.name))
-      .map((item) => ({
-        id: item.connector.id,
-        name: item.connector.name,
-        provider: item.connector.provider,
-        category: item.connector.category,
-        status: item.connector.status,
-        ...(item.connector.accountLabel ? { accountLabel: item.connector.accountLabel } : {}),
-      }));
-    const submittedProjectKind =
-      submittedActive?.projectKind ?? fallbackProjectKind ?? projectKindForSkill(activeSkill) ?? 'other';
-    const submittedProjectMetadata = submittedActive?.mediaSurface
-      ? metadataForHomeMediaComposer(submittedActive.mediaSurface, submittedActive.inputs, promptTemplates)
-      : homeCreateProjectMetadata(
-          submittedProjectKind,
-          submittedActive?.inputs ?? null,
-          submittedActive?.projectMetadata ?? fallbackProjectMetadata ?? null,
-        );
-    // Scenario plugins (chips / preset cards) and explicit skill picks are
-    // mutually exclusive routing sources — never send both (#2972).
-    const resolvedSkillId = submittedActive ? null : activeSkill?.id ?? null;
-    const routedPluginId =
-      sessionMode === 'design'
-        ? submittedActive?.record.id ?? DEFAULT_UNSELECTED_SCENARIO_PLUGIN_ID
-        : submittedActive?.record.id ?? null;
-    onSubmit({
-      prompt: trimmed,
-      pluginId: routedPluginId,
-      pluginType: submittedActive?.record.marketplaceTrust ?? (routedPluginId ? 'official' : null),
-      skillId: resolvedSkillId,
-      appliedPluginSnapshotId: submittedActive?.result?.appliedPlugin?.snapshotId ?? null,
-      pluginTitle: submittedActive?.record.title ?? null,
-      taskKind: submittedActive?.result?.appliedPlugin?.taskKind ?? null,
-      pluginInputs: submittedPluginInputs,
-      projectKind: submittedProjectKind,
-      projectMetadata: submittedProjectMetadata,
-      designSystemId: submittedDesignSystemId,
-      contextPlugins,
-      contextMcpServers,
-      contextConnectors,
-      attachments: stagedFiles,
-      ...(workingDir ? { workingDir } : {}),
-      ...(workingDirToken ? { workingDirToken } : {}),
-      conversationMode: sessionMode,
-      ...(() => {
-        if (!examplePromptInfoRef.current) return {};
-        const key = 'od:example-prompt-used';
-        if (localStorage.getItem(key)) return {};
-        localStorage.setItem(key, '1');
-        return { examplePromptContext: examplePromptInfoRef.current };
-      })(),
-    });
-    setSelectedPluginContexts([]);
-    setSelectedMcpContexts([]);
-    setSelectedConnectorContexts([]);
   }
 
   return (
@@ -1622,6 +1652,7 @@ export function HomeView({
           Boolean(pendingAuthoringChipId) ||
           Boolean(active && !active.inputsValid)
         }
+        submitting={sending}
         onPickPlugin={(record, nextPrompt) => addPluginContext(record, nextPrompt)}
         onPickExamplePlugin={useExamplePlugin}
         onPickSkill={useSkill}

--- a/apps/web/tests/components/HomeView.composer-sending-state.test.tsx
+++ b/apps/web/tests/components/HomeView.composer-sending-state.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+// Home composer send must show an in-flight state (#4082).
+//
+// Submitting from Home kicks off an async project-creation /
+// conversation-creation roundtrip before navigation unmounts the screen.
+// Without a sending state the button stays idle through that window, so
+// the app "looks frozen" and accepts duplicate sends. These tests pin the
+// contract: while the submit promise is pending the button is disabled and
+// labelled Sending…, repeat clicks are swallowed, and a failed creation
+// re-enables the composer with a visible error so the user can retry.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { HomeView } from '../../src/components/HomeView';
+import { I18nProvider } from '../../src/i18n';
+import { writeHomeGuideStage } from '../../src/components/home-hero/firstRunGuide';
+import { setHomeHeroPrompt } from '../helpers/home-hero-lexical';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+  window.localStorage.clear();
+});
+
+function stubPluginsFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (url: RequestInfo | URL) => {
+    if (typeof url === 'string' && url === '/api/plugins') {
+      return new Response(JSON.stringify({ plugins: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }));
+}
+
+function renderHome(onSubmit: (payload: unknown) => Promise<boolean> | void) {
+  // Keep the first-run guide quiet so sheen classes never race the
+  // sending-state classes asserted below.
+  writeHomeGuideStage('done');
+  stubPluginsFetch();
+  return render(
+    <I18nProvider initial="en">
+      <HomeView
+        projects={[]}
+        onSubmit={onSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe('home composer sending state', () => {
+  it('shows Sending… and swallows repeat clicks while creation is in flight', async () => {
+    let resolveSubmit: (accepted: boolean) => void = () => undefined;
+    const onSubmit = vi.fn(
+      () => new Promise<boolean>((resolve) => { resolveSubmit = resolve; }),
+    );
+    renderHome(onSubmit);
+
+    await screen.findByTestId('home-hero-input');
+    setHomeHeroPrompt('Build a landing page');
+    const submit = (await screen.findByTestId('home-hero-submit')) as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+
+    fireEvent.click(submit);
+    await waitFor(() => {
+      expect(submit.disabled).toBe(true);
+    });
+    expect(submit.textContent).toContain('Sending…');
+    expect(submit.className).toContain('is-sending');
+
+    // A second click during the in-flight window must not start a second run.
+    fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // Flush the resolution so the trailing state update lands inside the test.
+    resolveSubmit(true);
+    await waitFor(() => {
+      expect(submit.disabled).toBe(false);
+    });
+  });
+
+  it('re-enables the composer and surfaces an error when creation fails', async () => {
+    let resolveSubmit: (accepted: boolean) => void = () => undefined;
+    const onSubmit = vi.fn(
+      () => new Promise<boolean>((resolve) => { resolveSubmit = resolve; }),
+    );
+    renderHome(onSubmit);
+
+    await screen.findByTestId('home-hero-input');
+    setHomeHeroPrompt('Build a landing page');
+    const submit = (await screen.findByTestId('home-hero-submit')) as HTMLButtonElement;
+
+    fireEvent.click(submit);
+    await waitFor(() => {
+      expect(submit.disabled).toBe(true);
+    });
+
+    resolveSubmit(false);
+    await waitFor(() => {
+      expect(submit.disabled).toBe(false);
+    });
+    expect(submit.textContent).toContain('Send');
+    expect(submit.className).not.toContain('is-sending');
+    expect((await screen.findByRole('alert')).textContent).toMatch(/try again/i);
+
+    // The failure path must leave the composer retryable.
+    fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/tests/components/HomeView.composer-sending-state.test.tsx
+++ b/apps/web/tests/components/HomeView.composer-sending-state.test.tsx
@@ -23,10 +23,10 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
-function stubPluginsFetch() {
+function stubPluginsFetch(plugins: unknown[] = []) {
   vi.stubGlobal('fetch', vi.fn(async (url: RequestInfo | URL) => {
     if (typeof url === 'string' && url === '/api/plugins') {
-      return new Response(JSON.stringify({ plugins: [] }), {
+      return new Response(JSON.stringify({ plugins }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -34,6 +34,26 @@ function stubPluginsFetch() {
     throw new Error(`unexpected fetch ${url}`);
   }));
 }
+
+const WEB_PROTOTYPE_PLUGIN = {
+  id: 'example-web-prototype',
+  title: 'Web Prototype',
+  version: '0.1.0',
+  trust: 'bundled' as const,
+  sourceKind: 'bundled' as const,
+  source: '/tmp/web-prototype',
+  capabilitiesGranted: ['prompt:inject'],
+  fsPath: '/tmp/web-prototype',
+  installedAt: 0,
+  updatedAt: 0,
+  manifest: {
+    name: 'example-web-prototype',
+    title: 'Web Prototype',
+    version: '0.1.0',
+    description: 'General-purpose desktop web prototype.',
+    od: { kind: 'scenario', taskKind: 'new-generation' },
+  },
+};
 
 function renderHome(onSubmit: (payload: unknown) => Promise<boolean> | void) {
   // Keep the first-run guide quiet so sheen classes never race the
@@ -110,5 +130,71 @@ describe('home composer sending state', () => {
     // The failure path must leave the composer retryable.
     fireEvent.click(submit);
     expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not spend the one-shot example-prompt marker on a failed create', async () => {
+    // The example-prompt override is a one-shot localStorage marker. A
+    // rejected create keeps the composer retryable, so the marker must not
+    // be consumed until the create is accepted — otherwise the retry drops
+    // examplePromptContext and the user loses the example flow they picked.
+    const onSubmit = vi
+      .fn<(payload: unknown) => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    writeHomeGuideStage('done');
+    // The prototype rail binds the example plugin, so its apply roundtrip
+    // must succeed for submit() to reach onSubmit.
+    vi.stubGlobal('fetch', vi.fn(async (url: RequestInfo | URL) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [WEB_PROTOTYPE_PLUGIN] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (typeof url === 'string' && url.includes('/apply')) {
+        return new Response(JSON.stringify({ ok: true, appliedPlugin: { snapshotId: 'snap-1' } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+    render(
+      <I18nProvider initial="en">
+        <HomeView
+          projects={[]}
+          onSubmit={onSubmit}
+          onOpenProject={() => undefined}
+          onViewAllProjects={() => undefined}
+        />
+      </I18nProvider>,
+    );
+
+    // Seeding through a fallback prompt-example card is what arms the
+    // examplePromptContext marker.
+    fireEvent.click(await screen.findByTestId('home-hero-rail-prototype'));
+    const exampleCards = await screen.findAllByTestId('home-hero-prompt-example');
+    fireEvent.click(exampleCards[0]!);
+
+    const submit = (await screen.findByTestId('home-hero-submit')) as HTMLButtonElement;
+    await waitFor(() => expect(submit.disabled).toBe(false));
+
+    fireEvent.click(submit);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect((onSubmit.mock.calls[0]![0] as { examplePromptContext?: unknown }).examplePromptContext).toBeTruthy();
+
+    // Create was rejected: the marker stays unspent so the retry resends it.
+    await waitFor(() => expect(submit.disabled).toBe(false));
+    expect(window.localStorage.getItem('od:example-prompt-used')).toBeNull();
+
+    fireEvent.click(submit);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2));
+    expect((onSubmit.mock.calls[1]![0] as { examplePromptContext?: unknown }).examplePromptContext).toBeTruthy();
+
+    // Only now — after an accepted create — is the one-shot marker spent.
+    await waitFor(() => {
+      expect(window.localStorage.getItem('od:example-prompt-used')).toBe('1');
+    });
   });
 });


### PR DESCRIPTION
Fixes #4082

## Why

On the Home composer, clicking `Send` kicks off the async project/conversation-creation roundtrip (`POST /api/projects` + working-dir handoff + staged-file upload + auto-send wiring), but the submit button stayed in its idle state for that whole window — no spinner, no disabled feedback, workspace still empty. Intermittently (slow daemon, big attachments) that reads as the app being frozen, and repeat clicks could fire duplicate creations. Reported in #4082 with a screen recording; triage in that thread traced the gap to `HomeHero`'s submit button never learning about the in-flight window (`streaming` only flips inside ProjectView's `handleSend`, which Home never reaches).

## What users will see

- After clicking `Send` on Home, the button immediately flips to a disabled `Sending…` state until the run starts (navigation into the project) or fails.
- Repeat clicks (and Enter-to-send) during that window are ignored — no more duplicate sends.
- If project creation fails, the composer comes back: the button returns to `Send` and an error line ("Failed to start the run. Make sure the daemon is reachable, then try again.") appears, with the prompt and staged contexts kept for retry.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

No new i18n keys: the label reuses the existing `chat.comments.sending` / `chat.send` strings (same pair the comment composer's send button already swaps between), so every locale is covered.

## Screenshots

Captured through the repo's own Playwright e2e harness against `pnpm tools-dev run web`; to make the in-flight window long enough to photograph, the demo run intercepted `POST /api/projects` with a 5s delay and a 500 response (route mock in a throwaway spec, not committed — same technique as `entry-chrome-flows.test.ts`).

**Before — 1.5s after clicking Send, request in flight: button still idle, nothing indicates progress**

![before: idle Send while request is in flight](https://raw.githubusercontent.com/maxmilian/open-design/assets-4082/before-inflight.png)

**After — same moment: button disabled and showing `Sending…`**

![after: disabled Sending state](https://raw.githubusercontent.com/maxmilian/open-design/assets-4082/after-inflight.png)

**After — creation failed: button restored, error surfaced, composer retryable**

![after: failure recovery with error banner](https://raw.githubusercontent.com/maxmilian/open-design/assets-4082/after-after-failure.png)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeView.composer-sending-state.test.tsx` — (1) while the submit handler's promise is pending the button must be disabled, labelled `Sending…`, and swallow repeat clicks; (2) a rejected creation must re-enable the composer, surface an error, and leave it retryable.
- Did the test go red on `main` and green on this branch? **yes** (both specs fail on main: the button never leaves its idle state).

## Validation

- `pnpm typecheck` — all packages pass (re-run after rebasing onto current `main`).
- `pnpm --filter @open-design/web test` — 325 files / 3186 tests pass (includes the 2 new specs).
- `pnpm guard` — passes.

## Notes for review

- The mechanism: `EntryShell.handlePluginLoopSubmit` now returns `onCreateProject`'s `Promise<boolean>`, `HomeView.submit()` holds a `sending` flag until it settles, and `HomeHero` renders the flag (`submitting` prop folded into `canSubmit`, so the click and Enter-to-send paths are gated by the same window). Existing void-returning `onSubmit` handlers (tests, future callers) are still accepted and treated as fire-and-forget.
- The `sending` window deliberately starts *before* the deferred plugin-apply roundtrip (`resolveActivePlugin`) — when a scenario plugin still needs a fresh apply, that network wait was a second re-entrable gap with the same frozen look. A submit handler that throws (instead of resolving `false`) lands on the same recovery path via the `catch`.
- Staged contexts are now only cleared after the run actually starts — a rejected creation keeps them so the retry sends the same payload.
- Coordination with #4059 (send-button attention pulse, merged): the pulse fires *before* the click to direct users to Send; this state fires *after* it. The `is-sending` class coexists with `home-hero__attention-sheen`, and since `Sending…` only appears post-click, the two never animate at once.
- Timeout/stall messaging from the issue's "suggested fix direction" is intentionally not included — once creation succeeds, navigation unmounts Home, and a timeout policy for a hung daemon feels like a product decision beyond this fix. Happy to follow up if wanted.
