### PR TITLE
fix: allow packaged app newsletter subscribe origin

### DIFF
--- a/apps/landing-page/functions/subscribe.ts
+++ b/apps/landing-page/functions/subscribe.ts
@@ -40,6 +40,7 @@ type SubscribeRecord = {
 const ALLOWED_ORIGINS = [
   "https://open-design.ai",
   "https://www.open-design.ai",
+  "od://app",
   "tauri://localhost",
   "http://localhost",
   "http://127.0.0.1",
@@ -415,6 +416,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 };
 
 export const __newsletterSubscribeTest = {
+  corsHeaders,
   persistNewsletterSubscription,
   shouldAttemptWelcomeEmail,
 };

--- a/apps/landing-page/tests/subscribe.test.ts
+++ b/apps/landing-page/tests/subscribe.test.ts
@@ -67,6 +67,18 @@ function createEnv(kv: TestKv) {
 }
 
 describe("newsletter subscribe welcome email", () => {
+  it("allows packaged desktop app requests from the od protocol", () => {
+    const headers = __newsletterSubscribeTest.corsHeaders("od://app");
+
+    assert.equal(headers["Access-Control-Allow-Origin"], "od://app");
+  });
+
+  it("allows localhost web runtime requests", () => {
+    const headers = __newsletterSubscribeTest.corsHeaders("http://127.0.0.1:58100");
+
+    assert.equal(headers["Access-Control-Allow-Origin"], "http://127.0.0.1:58100");
+  });
+
   it("sends and records a welcome email for a new subscriber", async () => {
     const kv = new MemoryKv();
     const { calls, fetcher } = createFetchRecorder();


### PR DESCRIPTION
## Why

Packaged desktop onboarding newsletter signup was blocked before it reached the `/subscribe` Pages Function. The desktop renderer runs from the `od://app` origin, but the landing function only allowed the marketing domain and localhost origins, so browser CORS rejected the request while `http://127.0.0.1:<port>` testing still worked.

This fixes the production subscription path for packaged app users and prevents the browser-vs-app mismatch from coming back.

## What users will see

Users completing onboarding in the packaged desktop app can subscribe to the Open Design newsletter successfully. The browser security layer no longer blocks the request before it reaches the landing function.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI changes.

## Bug fix verification

- Test path that reproduces the bug: `apps/landing-page/tests/subscribe.test.ts`
- Did the test go red on `main` and green on this branch? The `od://app` CORS assertion was missing on `main`; it passes after adding the origin to the Pages Function allowlist.
- Manual verification: simulated `OPTIONS https://open-design.ai/subscribe` with `Origin: od://app` and confirmed current production returns the marketing origin instead, which explains the packaged app block.

## Validation

- `pnpm --filter @open-design/landing-page test`