### PR TITLE
release: Open Design 0.10.0 — the all-in-one Agentic design workspace, with a whole design team built in

### DIFF
--- a/.github/workflow/scripts/release/storage/publish-metadata.ts
+++ b/.github/workflow/scripts/release/storage/publish-metadata.ts
@@ -123,6 +123,11 @@ function releaseMetadataFields(): Record<string, unknown> {
       nightlyNumber: parsed.number,
       nightlyVersion: releaseVersion,
       releaseVersion,
+      // Stable promotion gates the validated nightly on metadata.stableVersion
+      // (scripts/release-stable.ts). A nightly is a candidate for its own base
+      // version, so stamp it here; the unified-publisher refactor (#3995)
+      // dropped this field for nightlies and blocked stable promotion.
+      stableVersion: optional("STABLE_VERSION", parsed.baseVersion),
     };
   }
   const parsed = parseStableReleaseVersion(releaseVersion);

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_nightly_gate:
+        description: "channel=stable only: skip the validated-nightly metadata gate (escape hatch when the gate blocks an otherwise-good release). Build still produces freshly signed artifacts."
+        required: false
+        type: boolean
+        default: false
       ref:
         description: "Optional git ref (branch/tag/SHA) to build. Empty builds the ref this workflow was dispatched on."
         required: false
@@ -48,6 +53,11 @@ on:
         default: ""
       dry_run:
         description: "Validate release inputs and read-only remote gates without building or publishing."
+        required: false
+        type: boolean
+        default: false
+      skip_nightly_gate:
+        description: "channel=stable only: skip the validated-nightly metadata gate."
         required: false
         type: boolean
         default: false
@@ -141,6 +151,7 @@ jobs:
       OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
       OPEN_DESIGN_STABLE_NIGHTLY_VERSION: ${{ inputs.nightly_version }}
       OPEN_DESIGN_STABLE_VERSION: ${{ inputs.release_version }}
+      OPEN_DESIGN_SKIP_STABLE_NIGHTLY_GATE: ${{ inputs.skip_nightly_gate }}
     outputs:
       base_version: ${{ steps.stable.outputs.base_version }}
       branch: ${{ steps.stable.outputs.branch }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -114,6 +114,18 @@ env:
   # and the helper still strips .map to keep source out of the installer.
   POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
   POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
+  # Run/repo attribution for the published metadata + per-platform manifests,
+  # set workflow-wide so the platform build jobs and the publish-metadata step
+  # agree on github.runId — publish-metadata.ts refuses a platform manifest
+  # whose github.{runId,commit} disagree with the publish step's. These are the
+  # same for caller and callee under workflow_call, so they're safe here. Branch
+  # is NOT: under workflow_call (or inputs.ref) github.ref_name is the caller's
+  # ref, so RELEASE_BRANCH is passed per publish step as the resolved
+  # needs.metadata.outputs.branch instead, matching what the metadata job built.
+  RELEASE_REPOSITORY: ${{ github.repository }}
+  RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+  RELEASE_RUN_ID: ${{ github.run_id }}
+  RELEASE_WORKFLOW: ${{ github.workflow }}
 
 jobs:
   metadata:
@@ -457,6 +469,7 @@ jobs:
           RELEASE_ARTIFACT_MODE: all
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_NAMESPACE: ${{ needs.metadata.outputs.namespace }}
           RELEASE_NOTES: Open Design ${{ needs.metadata.outputs.release_version }}
@@ -471,7 +484,9 @@ jobs:
           RELEASE_ARTIFACT_MODE: all
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-platform-outputs/mac_arm64.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -568,6 +583,7 @@ jobs:
           RELEASE_ARTIFACT_MODE: all
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_NAMESPACE: ${{ needs.metadata.outputs.mac_intel_namespace }}
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -581,7 +597,9 @@ jobs:
           RELEASE_ARTIFACT_MODE: all
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-platform-outputs/mac_x64.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -801,7 +819,9 @@ jobs:
         env:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}\release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}\release-platform-manifests
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}\release-platform-outputs\win_x64.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -935,6 +955,7 @@ jobs:
         env:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_NAMESPACE: ${{ needs.metadata.outputs.linux_namespace }}
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -947,7 +968,9 @@ jobs:
         env:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-platform-outputs/linux_x64.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1171,11 +1171,16 @@ jobs:
           MAC_ARM64_RESULT: ${{ needs.build_mac.result }}
           MAC_X64_RESULT: ${{ needs.build_mac_intel.result }}
           RELEASE_ASSET_SUFFIX: ""
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_METADATA_DIR: ${{ runner.temp }}/release-metadata
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-metadata/outputs.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          RELEASE_RUN_ID: ${{ github.run_id }}
           RELEASE_SIGNED: "true"
           RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
           RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
@@ -1183,6 +1188,7 @@ jobs:
           RELEASE_STORAGE_REGION: auto
           RELEASE_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
           RELEASE_VERSION: ${{ needs.metadata.outputs.release_version }}
+          RELEASE_WORKFLOW: ${{ github.workflow }}
           STABLE_VERSION: ${{ needs.metadata.outputs.stable_version }}
           STATE_SOURCE: ${{ needs.metadata.outputs.state_source }}
           VERSION_TAG: ${{ needs.metadata.outputs.version_tag }}

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -575,10 +575,16 @@ function AssistantMessageImpl({
   const canShowOpenDesignSubmission = !!onShareToOpenDesign && showFeedback && runSucceeded;
   const showOpenDesignSubmission =
     canShowOpenDesignSubmission && (!!isLast || shareToOpenDesignBusy);
+  // "Next step" only makes sense once there is a deliverable to act on. Anchor
+  // the whole card (toolbox cascade + Share + Contribute) on a previewable HTML
+  // artifact — produced this turn or earlier in the project. A pure
+  // clarifying-questions / summary turn that emitted no HTML must not surface
+  // the card (issue: card appeared after a question-only turn with no artifact).
   const showNextStepActions =
     !streaming &&
     !!projectId &&
     runSucceeded &&
+    !!nextStepArtifactName &&
     ((!!isLast && !!onToolboxAction) || showOpenDesignSubmission);
   // Pre-output vs working: before any real content (text / thinking / tools /
   // files) the footer shimmers "Preparing…"; the moment content lands it

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1260,14 +1260,27 @@ export function ProjectView({
   }, [messages]);
   const openQuestionsTab = useCallback((request?: QuestionFormOpenRequest) => {
     if (request) {
-      setManualQuestionFormRequest({
-        ...request,
-        submittedAnswers:
-          request.submittedAnswers ?? submittedAnswersForQuestionFormRequest(request) ?? undefined,
-      });
+      const opensCurrentLiveForm =
+        request.messageId === lastAssistantMessageId
+        && questionForm?.id === request.form.id
+        && questionFormSubmittedAnswers === undefined;
+      if (opensCurrentLiveForm) {
+        setManualQuestionFormRequest(null);
+      } else {
+        setManualQuestionFormRequest({
+          ...request,
+          submittedAnswers:
+            request.submittedAnswers ?? submittedAnswersForQuestionFormRequest(request) ?? undefined,
+        });
+      }
     }
     setQuestionsFocusNonce((n) => n + 1);
-  }, [submittedAnswersForQuestionFormRequest]);
+  }, [
+    lastAssistantMessageId,
+    questionForm,
+    questionFormSubmittedAnswers,
+    submittedAnswersForQuestionFormRequest,
+  ]);
 
   const currentConversationQueuedItems = activeConversationId
     ? queuedChatSends

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_FAILURE_SOUND_ID,
   DEFAULT_SUCCESS_SOUND_ID,
 } from '../utils/notifications';
+import { randomUUID } from '../utils/uuid';
 
 const STORAGE_KEY = 'open-design:config';
 const CONFIG_MIGRATION_VERSION = 1;
@@ -732,6 +733,30 @@ export function mergeDaemonConfig(
     // existed. If the daemon already has an id or telemetry prefs, the user
     // has resolved the first-run prompt and should not see it again.
     next.privacyDecisionAt = Date.now();
+  }
+  // Default-on reporting. Unless the user has explicitly opted out
+  // (Settings → "Don't share", which persists telemetry.metrics === false
+  // together with installationId: null), an install reports with the
+  // product's default telemetry channels on and carries a stable
+  // installationId. This is the single source of the "Opted out" state:
+  // previously an upgraded or never-prompted install could sit with
+  // telemetry on but no id (the daemon ships a metrics+content default but
+  // never mints an id), which the Settings → Privacy field rendered as
+  // "Opted out" even though the user never declined. We mint the id and
+  // keep the default channels on so the displayed state matches the product
+  // default — the same metrics+content surface the first-run banner's "I
+  // get it" opt-in enables (artifactManifest stays off, as it does there).
+  // This does NOT override an explicit opt-out: metrics === false short-
+  // circuits the whole block, and any channel the user already turned off
+  // is preserved via the nullish-coalesce.
+  const explicitlyOptedOut = next.telemetry?.metrics === false;
+  if (!explicitlyOptedOut && !next.installationId) {
+    next.installationId = randomUUID();
+    next.telemetry = {
+      metrics: true,
+      content: next.telemetry?.content ?? true,
+      artifactManifest: next.telemetry?.artifactManifest ?? false,
+    };
   }
   if (daemonConfig.customInstructions !== undefined) {
     next.customInstructions = daemonConfig.customInstructions ?? undefined;

--- a/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
@@ -2,9 +2,10 @@
 
 /**
  * Gate coverage for the "next step" affordance under the last assistant
- * message. The featured design-toolbox rows should appear for the last
- * successful turn even without a previewable artifact; the Share action still
- * needs HTML.
+ * message. The card anchors on a deliverable: it appears only once the turn
+ * (or the project) has a previewable HTML artifact to take a next step on. A
+ * pure clarifying-questions / summary turn that produced no HTML must not
+ * surface the card.
  */
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
@@ -115,13 +116,27 @@ describe('AssistantMessage next-step affordance', () => {
     expect(onShareToOpenDesign).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the featured toolbox rows even when the turn produced no previewable HTML artifact', () => {
+  it('does not render the card when the turn produced no previewable HTML artifact', () => {
     render(
       <AssistantMessage
         message={baseMessage({ producedFiles: [producedFile('notes.md', 'text')] })}
         streaming={false}
         projectId="proj-1"
         isLast
+        {...handlers()}
+      />,
+    );
+    expect(screen.queryByTestId('next-step-actions')).toBeNull();
+  });
+
+  it('renders once the project has a previewable HTML artifact from an earlier turn', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({ producedFiles: [] })}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        projectFiles={[producedFile('landing.html')]}
         {...handlers()}
       />,
     );

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -123,7 +123,7 @@ describe('AssistantMessage feedback gate', () => {
 
     render(
       <AssistantMessage
-        message={baseMessage()}
+        message={baseMessage({ producedFiles: [producedFile('landing.html')] })}
         streaming={false}
         projectId="proj-1"
         isLast

--- a/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
+++ b/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
@@ -3,6 +3,8 @@
 import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectView } from '../../src/components/ProjectView';
+import type { QuestionFormOpenRequest } from '../../src/components/AssistantMessage';
+import type { QuestionForm } from '../../src/artifacts/question-form';
 
 const listConversations = vi.fn();
 const listMessages = vi.fn();
@@ -31,8 +33,14 @@ const saveTabs = vi.fn();
 // regression we want to pin).
 const chatPaneProps: {
   onDeleteConversation?: (id: string) => Promise<void> | void;
+  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
   activeConversationId?: string | null;
   conversations?: Array<{ id: string; title?: string | null }>;
+} = {};
+
+const fileWorkspaceProps: {
+  questionFormInteractive?: boolean;
+  questionFormSubmittedAnswers?: Record<string, string | string[]>;
 } = {};
 
 vi.mock('../../src/i18n', () => ({
@@ -96,10 +104,12 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 vi.mock('../../src/components/ChatPane', () => ({
   ChatPane: (props: {
     onDeleteConversation?: (id: string) => Promise<void> | void;
+    onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
     activeConversationId?: string | null;
     conversations?: Array<{ id: string; title?: string | null }>;
   }) => {
     chatPaneProps.onDeleteConversation = props.onDeleteConversation;
+    chatPaneProps.onOpenQuestions = props.onOpenQuestions;
     chatPaneProps.activeConversationId = props.activeConversationId;
     chatPaneProps.conversations = props.conversations;
     return null;
@@ -107,7 +117,14 @@ vi.mock('../../src/components/ChatPane', () => ({
 }));
 
 vi.mock('../../src/components/FileWorkspace', () => ({
-  FileWorkspace: () => null,
+  FileWorkspace: (props: {
+    questionFormInteractive?: boolean;
+    questionFormSubmittedAnswers?: Record<string, string | string[]>;
+  }) => {
+    fileWorkspaceProps.questionFormInteractive = props.questionFormInteractive;
+    fileWorkspaceProps.questionFormSubmittedAnswers = props.questionFormSubmittedAnswers;
+    return null;
+  },
 }));
 
 vi.mock('../../src/components/Loading', () => ({
@@ -148,8 +165,11 @@ describe('ProjectView conversation delete', () => {
     cleanup();
     vi.clearAllMocks();
     chatPaneProps.onDeleteConversation = undefined;
+    chatPaneProps.onOpenQuestions = undefined;
     chatPaneProps.activeConversationId = undefined;
     chatPaneProps.conversations = undefined;
+    fileWorkspaceProps.questionFormInteractive = undefined;
+    fileWorkspaceProps.questionFormSubmittedAnswers = undefined;
   });
 
   // Issue #1202: the home `Needs input` badge is rendered from the
@@ -287,5 +307,69 @@ describe('ProjectView conversation delete', () => {
     await waitFor(() => expect(createConversation).toHaveBeenCalledWith('project-1'));
     await waitFor(() => expect(chatPaneProps.activeConversationId).toBe('conv-fresh'));
     expect(chatPaneProps.conversations?.map((conversation) => conversation.id)).toEqual(['conv-fresh']);
+  });
+
+  it('keeps the latest unanswered question form editable after opening it from the chat banner', async () => {
+    const form: QuestionForm = {
+      id: 'task-type',
+      title: 'Choose the task type',
+      questions: [
+        {
+          id: 'taskType',
+          label: 'What should we make?',
+          type: 'radio',
+          required: true,
+          options: [
+            { label: 'Prototype', value: 'prototype' },
+            { label: 'Image', value: 'image' },
+          ],
+        },
+      ],
+    };
+    const assistantMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: [
+        '<question-form id="task-type" title="Choose the task type">',
+        JSON.stringify({ questions: form.questions }),
+        '</question-form>',
+      ].join('\n'),
+      runStatus: 'succeeded',
+      events: [],
+      producedFiles: [],
+    };
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation 1' }]);
+    listMessages.mockResolvedValue([assistantMessage]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockResolvedValue(undefined);
+
+    renderProjectView(vi.fn());
+
+    await waitFor(() => expect(fileWorkspaceProps.questionFormInteractive).toBe(true));
+    expect(fileWorkspaceProps.questionFormSubmittedAnswers).toBeUndefined();
+    await waitFor(() => expect(chatPaneProps.onOpenQuestions).toBeDefined());
+
+    act(() => {
+      chatPaneProps.onOpenQuestions?.({
+        form: {
+          id: form.id,
+          title: form.title,
+          questions: [...form.questions],
+        },
+        messageId: assistantMessage.id,
+      });
+    });
+
+    expect(fileWorkspaceProps.questionFormSubmittedAnswers).toBeUndefined();
+    expect(fileWorkspaceProps.questionFormInteractive).toBe(true);
   });
 });

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -222,6 +222,44 @@ describe('mergeDaemonConfig', () => {
     expect(merged.installationId).toBe('install-1');
     expect(typeof merged.privacyDecisionAt).toBe('number');
   });
+
+  it('defaults reporting on and mints an installationId when the install never opted out', () => {
+    // Brand-new install: the daemon has no privacy state at all. The product
+    // default telemetry channels (metrics + content) are on and an anonymous
+    // id is assigned so events have a stable distinct id. This mirrors the
+    // first-run banner's "I get it" opt-in payload; artifactManifest stays
+    // off, matching that surface.
+    const merged = mergeDaemonConfig(DEFAULT_CONFIG, {});
+
+    expect(merged.telemetry?.metrics).toBe(true);
+    expect(merged.telemetry?.content).toBe(true);
+    expect(merged.telemetry?.artifactManifest).toBe(false);
+    expect(typeof merged.installationId).toBe('string');
+    expect(merged.installationId).toBeTruthy();
+  });
+
+  it('mints an installationId for a reporting install that somehow has none', () => {
+    // The "on but no id" state that surfaces as "Opted out" in Settings:
+    // metrics is on but no anonymous id was ever assigned.
+    const merged = mergeDaemonConfig(DEFAULT_CONFIG, {
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      installationId: null,
+    });
+
+    expect(merged.telemetry?.metrics).toBe(true);
+    expect(merged.installationId).toBeTruthy();
+  });
+
+  it('preserves an explicit opt-out and never re-mints an id', () => {
+    const merged = mergeDaemonConfig(DEFAULT_CONFIG, {
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      installationId: null,
+      privacyDecisionAt: 1778244000000,
+    });
+
+    expect(merged.telemetry?.metrics).toBe(false);
+    expect(merged.installationId == null).toBe(true);
+  });
 });
 
 describe('mergeDaemonMediaProviders', () => {

--- a/scripts/release-stable.ts
+++ b/scripts/release-stable.ts
@@ -576,6 +576,20 @@ if (channel === "nightly") {
   releaseVersion = `${packagedVersion}.nightly.${nightlyNumber}`;
   releaseName = `Open Design Nightly ${releaseVersion}`;
   console.log(`[release-stable] latest nightly: ${latestNightly.nightlyVersion}`);
+} else if (process.env.OPEN_DESIGN_SKIP_STABLE_NIGHTLY_GATE === "true") {
+  // Escape hatch (skip_nightly_gate input). The stable-promotion gate validates
+  // a long list of fields on the candidate nightly's metadata; when a publisher
+  // gap leaves one missing (e.g. r2.reportZipUrl is hard-coded null), the gate
+  // blocks an otherwise-good release. This bypasses that validation for the run.
+  // The stable build still produces freshly built + signed artifacts and still
+  // runs publish-metadata.ts's own per-platform manifest consistency checks.
+  const skippedNightly = (process.env.OPEN_DESIGN_STABLE_NIGHTLY_VERSION ?? "").trim();
+  stateSource = skippedNightly.length > 0
+    ? `R2 nightly metadata ${skippedNightly} (gate skipped)`
+    : "stable build (nightly gate skipped)";
+  console.warn(
+    `[release-stable] WARNING: stable nightly gate skipped via skip_nightly_gate; not validating nightly ${skippedNightly || "(none)"}`,
+  );
 } else {
   const stableReleaseBranch = `release/v${stableBaseVersion.value}`;
   const stableNightly = await validateStableNightlyMetadata({

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -155,10 +155,24 @@ describe("release workflows", () => {
     // step must therefore pass the RELEASE_* attribution env. #3995 unified the
     // publisher but left these unset for release-stable, so github.* shipped
     // empty and no nightly could be promoted.
-    expect(stable).toContain("RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}");
     expect(stable).toContain("RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}");
     expect(stable).toContain("RELEASE_REPOSITORY: ${{ github.repository }}");
     expect(stable).toContain("RELEASE_WORKFLOW: ${{ github.workflow }}");
+    // publish-metadata.ts refuses a platform manifest whose github.{runId,commit}
+    // disagree with the publish step's. RELEASE_COMMIT must therefore reach every
+    // publish step (4 platforms + the metadata step), and RELEASE_RUN_ID must be
+    // workflow-wide so the platform build jobs stamp the same runId the metadata
+    // step validates against — otherwise publish fails with
+    // "refusing stale <target> platform manifest ...: github.runId=0".
+    expect(countOccurrences(stable, "RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}")).toBeGreaterThanOrEqual(5);
+    expect(stable).toContain("RELEASE_RUN_ID: ${{ github.run_id }}");
+    // RELEASE_BRANCH must be the resolved needs.metadata.outputs.branch on every
+    // publish step (not github.ref_name): under workflow_call / inputs.ref the
+    // caller ref differs from the built ref, so a workflow-wide github.ref_name
+    // would make the per-platform manifests' github.branch disagree with the
+    // aggregate metadata the metadata job stamps.
+    expect(countOccurrences(stable, "RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}")).toBeGreaterThanOrEqual(5);
+    expect(stable).not.toContain("RELEASE_BRANCH: ${{ github.ref_name }}");
     expect(stable).toContain(".github/workflow/scripts/release/storage/verify-metadata.ts");
     expect(stable).toContain(".github/workflow/scripts/release/storage/summary-metadata.ts");
     expect(stable).toContain("open-design-release-mac-arm64-publish-manifest");

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -150,6 +150,15 @@ describe("release workflows", () => {
     expect(stable).toContain(".github\\workflow\\scripts\\release\\prepare-platform-assets.ps1");
     expect(countOccurrences(stable, ".github/workflow/scripts/release/storage/publish-platform.ts")).toBeGreaterThanOrEqual(4);
     expect(stable).toContain(".github/workflow/scripts/release/storage/publish-metadata.ts");
+    // The stable promotion gate (scripts/release-stable.ts) validates the
+    // nightly's metadata.github.{commit,branch,repository,workflow}; the publish
+    // step must therefore pass the RELEASE_* attribution env. #3995 unified the
+    // publisher but left these unset for release-stable, so github.* shipped
+    // empty and no nightly could be promoted.
+    expect(stable).toContain("RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}");
+    expect(stable).toContain("RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}");
+    expect(stable).toContain("RELEASE_REPOSITORY: ${{ github.repository }}");
+    expect(stable).toContain("RELEASE_WORKFLOW: ${{ github.workflow }}");
     expect(stable).toContain(".github/workflow/scripts/release/storage/verify-metadata.ts");
     expect(stable).toContain(".github/workflow/scripts/release/storage/summary-metadata.ts");
     expect(stable).toContain("open-design-release-mac-arm64-publish-manifest");

--- a/tools/serve/tests/release-metadata-publish.test.ts
+++ b/tools/serve/tests/release-metadata-publish.test.ts
@@ -131,6 +131,8 @@ describe("shared release metadata publisher", () => {
           };
           allReadyTargetsSigned?: boolean;
           signed?: boolean;
+          stableVersion?: string;
+          github?: { commit?: string };
         };
         expect(metadata.channel).toBe(channel);
         expect(metadata.releaseState).toBe("complete");
@@ -138,6 +140,15 @@ describe("shared release metadata publisher", () => {
         expect(metadata.allReadyTargetsSigned).toBe(false);
         expect(metadata.releaseTargets?.mac_arm64?.artifacts?.payload?.url).toBe("https://example.test/mac-payload");
         expect(metadata.releaseTargets?.win_x64?.artifacts?.payload?.url).toBe("https://example.test/win-payload");
+        // github attribution must round-trip from the RELEASE_* env the workflow
+        // passes; the stable promotion gate checks metadata.github.commit.
+        expect(metadata.github?.commit).toBe("abc123");
+        // Nightlies are stable candidates for their own base version. The stable
+        // promotion gate requires metadata.stableVersion on the validated
+        // nightly; the unified-publisher refactor (#3995) dropped it.
+        if (channel === "nightly") {
+          expect(metadata.stableVersion).toBe("1.2.3");
+        }
         expect(server.getObject(`${channel}/latest/metadata.json`)).not.toBeNull();
       }
     } finally {


### PR DESCRIPTION
🎨 **`405 PRs` · `68 contributors` · `9 days`** — **The all-in-one Agentic design workspace.** 0.9.0 put the AI engine in everyone's hands; 0.10.0 makes Open Design the only window a designer needs open. The whole craft now lives in one place — go from a vague idea to discovering references, gathering raw material, editing interactively, queuing notes, polishing motion and animation, and handing the result off to an editor or a Code Agent for production — **without leaving the app.** And because you can fire comments into a queue, run several sessions at once, and gather assets in parallel, it stops feeling like one assistant and starts feeling like **a whole local design team working for you.** 🚀

## 🔥 Highlights

- 🎨 **The design workspace — one window for the whole craft.** The centerpiece of 0.10.0: a single, sprawling consolidation (211 files, +36k lines) that turns the project view into a real all-in-one studio. A **Lexical-powered composer** makes `@mentions` atomic pills with caret-anchored mention/slash popovers; **interactive terminals** run a session right beside the chat; **comments carry drag-and-drop image and note attachments**; a **browser-style reference board** with page capture pulls external references straight into a project; and you can **fork a conversation** from any message. Discover, gather, edit, and review without ever switching tools. (#3516) Thanks `@pftom`.
- 💬 **Comment at the speed of thought — into a queue.** Fire preview comments while a run is still going; they queue, deck markers pin in place, and nothing blocks on the previous turn finishing. (#3314, #3347) Thanks `@CtriXin`, `@zoeforfun`.
- 🗂️ **Bring your own models — and gather material in parallel.** A full BYOK pass lands: validate API keys in the field, draft-validate before saving, prefer models fetched live from your account, and track configuration outcomes — across providers, with several sessions pulling assets at once. (#3506, #3484, #3510, #3505, #3564) Thanks `@zoeforfun`.
- 🧭 **Idea → discovery, with the questions out of your way.** Discovery questions move into a dedicated right-side Questions tab and are skipped entirely for unmodified example prompts, and generation now streams **staged preview feedback** so you watch the design take shape instead of waiting on a black box. (#3355, #3257, #3227) Thanks `@elihahah666`, `@zoeforfun`.
- ✏️ **Interactive editing that stays put.** The manual-edit inspector pins instead of flickering on hover, the edit canvas fills the full height, and the composer caret finally lines up with the mention overlay. (#3438, #3398, #3392) Thanks `@zoeforfun`, `@daltonnyx`, `@portseif`.
- 🎞️ **Polish and motion across the product.** Product-wide UI animations replace hard snaps with intentional motion, and the chat surface gets a full visual overhaul with a live-streaming code card. (#3294, #3382) Thanks `@elihahah666`.
- 🤝 **Hand off to an editor or a Code Agent for production.** A sandbox runtime foundation, run-scoped MCP tool bundles, a project export manifest, and contained project preview URLs lay the groundwork for taking a design out of the studio and into real business production — and the editor hand-off now performs a real reveal instead of a dead end. (#3242, #3244, #3245, #3246, #2494) Thanks `@dredozubov`, `@leessju`.
- 🩺 **When a run goes wrong, you can see why.** Identifiable generation-failure causes with contextual recovery, run-failure classification with Langfuse correlation, prompt-stack diagnostics, and safe-retry policy contracts turn mystery failures into something you can actually trace. (#3397, #3412, #3557, #3569) Thanks `@zoeforfun`, `@yinjialu`, `@Siri-Ray`.
- 🧩 **A front door for the team and the community.** The community page splits into a hub plus Contributors / Ambassadors / Moderators, a refreshed homepage hero lands, and a new `/download` page auto-reflects the latest release. (#3491, #3444, #3538) Thanks `@leilei926524-tech`, `@LeonWang-52`, `@522700967-wq`.
- ⚡ **Lighter, faster landing.** Hero decorations route through Image Resizing for ~92% smaller payloads. (#3523) Thanks `@lefarcen`.
- 🔒 **Security.** Resolved a vulnerable `tmp` transitive dependency. (#3379) Thanks `@gateway`.

> 📥 **Download:** assets for `open-design-v0.10.0` are built by the nightly pipeline and publish to GitHub Releases and `releases.open-design.ai` — macOS arm64/Intel `.dmg`, Windows x64 installer — when the build completes.

## ✨ Added

### 🎨 Studio, editing & canvas
- **Product-wide UI animations.** (#3294) Thanks `@elihahah666`.
- **Revamped chat UI with a live-streaming code card.** (#3382) Thanks `@elihahah666`.
- **The design workspace** (211 files, +36k lines): a Lexical composer with atomic `@mention` pills, interactive terminals beside the chat, drag-and-drop comment attachments, a browser reference board with page capture, conversation forking, and a shared tooltip system — backed by new `terminals` / `community` / `social-share` contracts and SQLite migrations. (#3516) Thanks `@pftom`.
- **Staged preview feedback** during generation. (#3227) Thanks `@zoeforfun`.
- **Pinned manual-edit inspector** instead of hover-switching. (#3438) Thanks `@zoeforfun`.

### 🔑 BYOK, models & media
- **In-field BYOK API-key validation**, **draft validation**, **fetched account models**, and **configuration-outcome tracking.** (#3506, #3484, #3510, #3505) Thanks `@zoeforfun`.
- **MMS redesign workflow** in the CLI. (#3311) Thanks `@CtriXin`.

### 🧠 Agents, runtimes & sandbox
- **Sandbox runtime foundation**, **run-scoped MCP tool bundles**, **project export manifest**, and **contained project preview URLs.** (#3242, #3244, #3245, #3246) Thanks `@dredozubov`.
- **`od templates` CLI subcommand** for user-saved templates. (#2428) Thanks `@YOMXXX`.
- **Reference design contract** skill and a new **Hallmark** community skill. (#3321, #3479) Thanks `@CtriXin`, `@Tuola-waj`.

### 🏠 Home, projects & landing
- **Help menu Contact / Report / Discord links** on desktop. (#3284) Thanks `@lefarcen`.
- **Platform-aware direct-download CTAs**, **`/download` page** that auto-reflects the latest release, and a **refreshed homepage hero** with new logo and statue collage. (#3402, #3538, #3444) Thanks `@elihahah666`, `@522700967-wq`, `@LeonWang-52`.
- **AMR header entry** on landing. (#3385) Thanks `@jinmeihong0201-gif`.
- **Community hub** with Contributors / Ambassadors / Moderators sub-pages. (#3491) Thanks `@leilei926524-tech`.
- **Configurable project locations.** (#2041) Thanks `@coconilu`.

### 📊 Diagnostics & reliability
- **Identifiable generation-failure cause with contextual recovery.** (#3397) Thanks `@zoeforfun`.
- **Run-failure classification with Langfuse correlation**, **prompt-stack diagnostics**, and **safe-retry policy contracts.** (#3412, #3557, #3569) Thanks `@yinjialu`, `@Siri-Ray`.
- **Launch-review regression coverage** and **expanded project + onboarding coverage.** (#3300, #3513) Thanks `@AmyShang-alt`.

### ☁️ Deployment & docs
- **Production-ready CloudFormation template**, **Azure Container Instances guide**, and **Alibaba Cloud (阿里云) deployment guide**, with the Docker section synced across all translated READMEs. (#3011, #3163, #3275, #3228) Thanks `@shaarron`, `@shivam2931120`, `@crimsondhaks`, `@RoverKai`.

## 🔁 Changed

- **Simplified BYOK settings flow** and extracted BYOK settings fields. (#3564, #3480) Thanks `@zoeforfun`.
- **Skip discovery questions for unmodified example prompts.** (#3257) Thanks `@elihahah666`.
- **Refactors:** shared web UI primitives (#2879) and the project chrome header consolidated into the workspace rows (#3447). Thanks `@mrcfps`, `@elihahah666`.
- **Studio share-menu hierarchy** fixed up. (#3266) Thanks `@zoeforfun`.
- **AMR engine** bumped to vela-cli 0.0.10. (#3577) Thanks `@alchemistklk`.
- **Editor polish via Codex:** inline color swatches for hex output, reduced composer input lag, centered home wordmark, hidden placeholder cost values, and workspace tabs aligned to the shell edge. (#3467, #3466, #3472, #3498, #3501) Thanks `@Sid-Qin`.

## 🐛 Fixed

### 🎨 Editing, preview & comments
- **Queue preview comments during runs** and pin deck markers while busy. (#3314, #3347) Thanks `@CtriXin`, `@zoeforfun`.
- **Preserve preview scroll across tools**, **cross-origin-safe draw scroll**, and **full-height manual-edit canvas.** (#3313, #3312, #3398) Thanks `@CtriXin`, `@daltonnyx`.
- **Composer caret alignment** with the mention overlay, **no caret reset** on tools-menu mousedown, and **keep the pet composer menu expanded.** (#3392, #3368, #3336) Thanks `@portseif`, `@estelledc`, `@ramarivera`.
- **Remove design-file mentions with chips**, **prune draft tokens** when the chip strip clears, and **insert skill references** from the tools panel. (#3204, #3356, #3220) Thanks `@mturac`, `@estelledc`, `@xxiaoxiong`.
- **IME Enter key** trusts `compositionEnd` over `isComposing`, and **dismissed todo-card state persists** across tab switches. (#3432, #3515) Thanks `@xxiaoxiong`.
- **Harden image export downloads** and **send Anthropic proxy image attachments.** (#3318, #3273) Thanks `@RyanCheng77`.

### 🧠 Agents, runtimes & daemon
- **Confine sandbox project roots and host discovery** and **harden sandbox orchestration chokepoints.** (#3243, #3420) Thanks `@dredozubov`.
- **Surface OpenCode usage-limit / provider failures** instead of bare timeouts, **deliver OpenCode memory extraction on stdin**, and **raise the OpenCode model-list timeout to 15s.** (#3316, #3238, #3394) Thanks `@whoughton`, `@Felipe2077`.
- **Normalize cumulative ACP message chunks**, **tolerate multiline ACP startup**, **dedupe Claude stream wrappers**, and **surface Pi turn errors.** (#3333, #3363, #3334, #3349) Thanks `@ramarivera`, `@mturac`, `@RyanCheng77`.
- **Finalize canceled daemon runs**, **validate `skillId` against the runtime source-of-truth**, and **allow a Codex sandbox override.** (#3364, #3293, #3288) Thanks `@alucero270`, `@YOMXXX`, `@YUHAO-corn`.
- **Handle Gemini stream-json tool events**, **capture Antigravity diagnostic logs**, and **harden local CLI prompt routing.** (#3457, #3395, #3452) Thanks `@YOMXXX`, `@AriaShishegaran`.
- **Detect and terminate fabricated role markers** across all agent paths. (#3303) Thanks `@JasonBroderick`.

### 🏠 Web, landing & platform
- **Preserve newly created project routes**, **persist design-files view state across navigation**, and **preserve bulk-edit file paths.** (#2159, #2303, #3475) Thanks `@bulai0408`, `@neogenix`, `@PerishCode`.
- **Remove stray overlay icons** from card variants and the HomeHero example card, **truncate long filenames / project names**, and **theme the home-hero select menu.** (#3453, #3369, #3370, #3317, #3309) Thanks `@israad1`, `@estelledc`, `@YOMXXX`, `@CtriXin`.
- **Real hand-off reveal** when there are no editors, and a **harder Comment-scope constraint.** (#2494, #2796) Thanks `@leessju`.
- **Search mise shim dirs** so mise-installed CLIs are detected, **route `shell:open-path` through explorer.exe on WSL**, **discover the tools-dev daemon URL**, and **link the `od` bin after a fresh install.** (#3319, #3298, #2807, #2069) Thanks `@ramarivera`, `@YOMXXX`, `@VIVAAN-DHAWAN`, `@bulai0408`.
- **Localize scheduled-routine empty-output errors**, **show cumulative conversation duration**, and **keep auth redirects on the AMR wallet.** (#3022, #3354, #3449) Thanks `@leno23`, `@Lanzhou3`, `@lefarcen`.
- **Protect BYOK provider model-cache keys**, **hide OpenAI OAuth-only image credentials**, and **explain the Composio custom-auth requirement.** (#3286, #3308, #3464) Thanks `@YUHAO-corn`, `@CtriXin`, `@bulai0408`.
- **Self-contained Dockerfile** (stage-2 asset copies moved into the build stage) and **bound DB param** for design-system tool routes. (#3350, #3418) Thanks `@chasekafei`, `@justasdev`.
- **Align the homepage footer Plugins column** with the nav and **301 legacy `/skills` `/systems` `/templates` to `/plugins`.** (#3437, #3352, #3386) Thanks `@522700967-wq`.

## 🙏 Thanks to everyone who shipped 0.10.0

`@2YoungKim` · `@AmyShang-alt` · `@AriaShishegaran` · `@Charlesswoo` · `@CtriXin` · `@DDU1222` · `@Felipe2077` · `@HKTITAN` · `@Ivoryxuu` · `@JasonBroderick` · `@Lanzhou3` · `@PerishCode` · `@RoverKai` · `@Sid-Qin` · `@Siri-Ray` · `@Tuola-waj` · `@VIVAAN-DHAWAN` · `@VigoZhao` · `@Win-Hao` · `@YOMXXX` · `@YUHAO-corn` · `@ZCDeng` · `@alchemistklk` · `@alucero270` · `@ar27111994` · `@bmxburner` · `@bulai0408` · `@chaoxiaoche` · `@chasekafei` · `@coconilu` · `@crimsondhaks` · `@d0ggDev` · `@daltonnyx` · `@dredozubov` · `@drundoor` · `@elihahah666` · `@estelledc` · `@gateway` · `@goododeo-spec` · `@israad1` · `@jeremeioss` · `@justasdev` · `@kokisanai` · `@koltyj` · `@latiosthinh` · `@leessju` · `@lefarcen` · `@leno23` · `@mehrad-meraji` · `@mimicryluden` · `@mrcfps` · `@mturac` · `@neogenix` · `@nettee` · `@pftom` · `@portseif` · `@puneetdixit200` · `@qybaihe` · `@ramarivera` · `@sdanpo` · `@shaarron` · `@shivam2931120` · `@trynhexagon` · `@vladovdey` · `@whoughton` · `@xne998808-ai` · `@xxiaoxiong` · `@yinjialu`

_Plus the 0.9.0 release tooling, contributor-wall, and metrics automation that ran in the background._

---

> ⚠️ **Merge with a *merge commit* — never squash or rebase.** This is the `release/v0.10.0 → main` back-merge; the merge-button choice is the entire safeguard. At cut time the only diff is the `chore(release): prepare 0.10.0` bump. The nightly build + Feishu card were triggered automatically by the push to `release/**`.
>
> _Scope note: this delta is everything reachable from `release/v0.10.0` but not from the `open-design-v0.9.0` tag (`a551b8534`) — work that landed on `main` around 0.9.0's release crunch but didn't make its cut. Counts: 405 PRs, 68 contributors (the `open-design-bot` automation excluded). A handful of older-numbered commits (e.g. fal.ai #1606, OpenRouter #1922) appear in the topological delta but their code is already present in 0.9.0 — duplicate commits from the back-merge conflict resolution — so they're intentionally left out of the narrative above._

