### PR TITLE
fix(web): gate the next-step card on having a previewable artifact

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -575,10 +575,16 @@ function AssistantMessageImpl({
   const canShowOpenDesignSubmission = !!onShareToOpenDesign && showFeedback && runSucceeded;
   const showOpenDesignSubmission =
     canShowOpenDesignSubmission && (!!isLast || shareToOpenDesignBusy);
+  // "Next step" only makes sense once there is a deliverable to act on. Anchor
+  // the whole card (toolbox cascade + Share + Contribute) on a previewable HTML
+  // artifact — produced this turn or earlier in the project. A pure
+  // clarifying-questions / summary turn that emitted no HTML must not surface
+  // the card (issue: card appeared after a question-only turn with no artifact).
   const showNextStepActions =
     !streaming &&
     !!projectId &&
     runSucceeded &&
+    !!nextStepArtifactName &&
     ((!!isLast && !!onToolboxAction) || showOpenDesignSubmission);
   // Pre-output vs working: before any real content (text / thinking / tools /
   // files) the footer shimmers "Preparing…"; the moment content lands it

--- a/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
@@ -2,9 +2,10 @@
 
 /**
  * Gate coverage for the "next step" affordance under the last assistant
- * message. The featured design-toolbox rows should appear for the last
- * successful turn even without a previewable artifact; the Share action still
- * needs HTML.
+ * message. The card anchors on a deliverable: it appears only once the turn
+ * (or the project) has a previewable HTML artifact to take a next step on. A
+ * pure clarifying-questions / summary turn that produced no HTML must not
+ * surface the card.
  */
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
@@ -115,13 +116,27 @@ describe('AssistantMessage next-step affordance', () => {
     expect(onShareToOpenDesign).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the featured toolbox rows even when the turn produced no previewable HTML artifact', () => {
+  it('does not render the card when the turn produced no previewable HTML artifact', () => {
     render(
       <AssistantMessage
         message={baseMessage({ producedFiles: [producedFile('notes.md', 'text')] })}
         streaming={false}
         projectId="proj-1"
         isLast
+        {...handlers()}
+      />,
+    );
+    expect(screen.queryByTestId('next-step-actions')).toBeNull();
+  });
+
+  it('renders once the project has a previewable HTML artifact from an earlier turn', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({ producedFiles: [] })}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        projectFiles={[producedFile('landing.html')]}
         {...handlers()}
       />,
     );

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -123,7 +123,7 @@ describe('AssistantMessage feedback gate', () => {
 
     render(
       <AssistantMessage
-        message={baseMessage()}
+        message={baseMessage({ producedFiles: [producedFile('landing.html')] })}
         streaming={false}
         projectId="proj-1"
         isLast


### PR DESCRIPTION
## Why

**Author's use case:** While exercising a fresh deck project, the assistant's first turn was a clarifying-questions turn — AMR opened a `Quick brief` question form in the Questions panel and was *waiting on the user to answer it*. Nothing had been generated yet, yet the "NEXT STEP" card (the design-toolbox cascade: `Match next step` / `Design polish / ready to ship` / `More`) was already sitting under the message.

**Pain being addressed:** "Next step" only makes sense once there is a *current step* — a deliverable to iterate on / polish / share. Showing it after a question-only (or pure summary) turn is premature and confusing: it offers `Design polish` / `ready to ship` / `Share` when there is nothing to polish or ship, and it does so while the agent is still blocking on a question form.

Root cause: `showNextStepActions` in `AssistantMessage.tsx` gated on `!streaming && projectId && runSucceeded && ((isLast && onToolboxAction) || showOpenDesignSubmission)` — it never checked whether the turn (or project) actually produced a deliverable. `onToolboxAction` is wired on every last message, so the card showed after *any* successful last turn.

## What users will see

The "NEXT STEP" card no longer appears after a turn that produced no previewable HTML deliverable (e.g. a clarifying-questions turn, or a plain text/summary reply). It surfaces once there is a previewable artifact to act on — produced this turn, or already present in the project from an earlier turn. Share / Download / Contribute (which already required an artifact) are unchanged.

> Note: this intentionally reverses the explicit `#4023` decision that the toolbox rows should show "even without a previewable artifact". The toolbox remains reachable from the composer's `+` menu when there is no deliverable yet.

## How verified

Red spec first (went red on the release base, green on this branch):
- `apps/web/tests/components/AssistantMessage.nextStep.test.tsx` — *"does not render the card when the turn produced no previewable HTML artifact"* (flips the old assertion) + *"renders once the project has a previewable HTML artifact from an earlier turn"*.
- Updated `apps/web/tests/components/AssistantMessage.test.tsx` Contribute test to ship a real HTML deliverable (Contribute is a deliverable action).

`pnpm --filter @open-design/web exec vitest` (next-step + NextStepActions suites, 40 passed), `pnpm --filter @open-design/web typecheck`, `pnpm guard` all green.

## Surface area

- [x] Web UI (`apps/web`)
- [ ] CLI — N/A: the next-step card is a chat-UI affordance with no CLI surface.

## Screenshots

Bug repro (before): the "NEXT STEP" card appears under a question-only AMR turn with no artifact. _After_ screenshot to be attached from a local run.
