### PR TITLE
[codex] Keep question forms editable after banner reopen

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1260,14 +1260,27 @@ export function ProjectView({
   }, [messages]);
   const openQuestionsTab = useCallback((request?: QuestionFormOpenRequest) => {
     if (request) {
-      setManualQuestionFormRequest({
-        ...request,
-        submittedAnswers:
-          request.submittedAnswers ?? submittedAnswersForQuestionFormRequest(request) ?? undefined,
-      });
+      const opensCurrentLiveForm =
+        request.messageId === lastAssistantMessageId
+        && questionForm?.id === request.form.id
+        && questionFormSubmittedAnswers === undefined;
+      if (opensCurrentLiveForm) {
+        setManualQuestionFormRequest(null);
+      } else {
+        setManualQuestionFormRequest({
+          ...request,
+          submittedAnswers:
+            request.submittedAnswers ?? submittedAnswersForQuestionFormRequest(request) ?? undefined,
+        });
+      }
     }
     setQuestionsFocusNonce((n) => n + 1);
-  }, [submittedAnswersForQuestionFormRequest]);
+  }, [
+    lastAssistantMessageId,
+    questionForm,
+    questionFormSubmittedAnswers,
+    submittedAnswersForQuestionFormRequest,
+  ]);
 
   const currentConversationQueuedItems = activeConversationId
     ? queuedChatSends

--- a/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
+++ b/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
@@ -3,6 +3,8 @@
 import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectView } from '../../src/components/ProjectView';
+import type { QuestionFormOpenRequest } from '../../src/components/AssistantMessage';
+import type { QuestionForm } from '../../src/artifacts/question-form';
 
 const listConversations = vi.fn();
 const listMessages = vi.fn();
@@ -31,8 +33,14 @@ const saveTabs = vi.fn();
 // regression we want to pin).
 const chatPaneProps: {
   onDeleteConversation?: (id: string) => Promise<void> | void;
+  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
   activeConversationId?: string | null;
   conversations?: Array<{ id: string; title?: string | null }>;
+} = {};
+
+const fileWorkspaceProps: {
+  questionFormInteractive?: boolean;
+  questionFormSubmittedAnswers?: Record<string, string | string[]>;
 } = {};
 
 vi.mock('../../src/i18n', () => ({
@@ -96,10 +104,12 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 vi.mock('../../src/components/ChatPane', () => ({
   ChatPane: (props: {
     onDeleteConversation?: (id: string) => Promise<void> | void;
+    onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
     activeConversationId?: string | null;
     conversations?: Array<{ id: string; title?: string | null }>;
   }) => {
     chatPaneProps.onDeleteConversation = props.onDeleteConversation;
+    chatPaneProps.onOpenQuestions = props.onOpenQuestions;
     chatPaneProps.activeConversationId = props.activeConversationId;
     chatPaneProps.conversations = props.conversations;
     return null;
@@ -107,7 +117,14 @@ vi.mock('../../src/components/ChatPane', () => ({
 }));
 
 vi.mock('../../src/components/FileWorkspace', () => ({
-  FileWorkspace: () => null,
+  FileWorkspace: (props: {
+    questionFormInteractive?: boolean;
+    questionFormSubmittedAnswers?: Record<string, string | string[]>;
+  }) => {
+    fileWorkspaceProps.questionFormInteractive = props.questionFormInteractive;
+    fileWorkspaceProps.questionFormSubmittedAnswers = props.questionFormSubmittedAnswers;
+    return null;
+  },
 }));
 
 vi.mock('../../src/components/Loading', () => ({
@@ -148,8 +165,11 @@ describe('ProjectView conversation delete', () => {
     cleanup();
     vi.clearAllMocks();
     chatPaneProps.onDeleteConversation = undefined;
+    chatPaneProps.onOpenQuestions = undefined;
     chatPaneProps.activeConversationId = undefined;
     chatPaneProps.conversations = undefined;
+    fileWorkspaceProps.questionFormInteractive = undefined;
+    fileWorkspaceProps.questionFormSubmittedAnswers = undefined;
   });
 
   // Issue #1202: the home `Needs input` badge is rendered from the
@@ -287,5 +307,69 @@ describe('ProjectView conversation delete', () => {
     await waitFor(() => expect(createConversation).toHaveBeenCalledWith('project-1'));
     await waitFor(() => expect(chatPaneProps.activeConversationId).toBe('conv-fresh'));
     expect(chatPaneProps.conversations?.map((conversation) => conversation.id)).toEqual(['conv-fresh']);
+  });
+
+  it('keeps the latest unanswered question form editable after opening it from the chat banner', async () => {
+    const form: QuestionForm = {
+      id: 'task-type',
+      title: 'Choose the task type',
+      questions: [
+        {
+          id: 'taskType',
+          label: 'What should we make?',
+          type: 'radio',
+          required: true,
+          options: [
+            { label: 'Prototype', value: 'prototype' },
+            { label: 'Image', value: 'image' },
+          ],
+        },
+      ],
+    };
+    const assistantMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: [
+        '<question-form id="task-type" title="Choose the task type">',
+        JSON.stringify({ questions: form.questions }),
+        '</question-form>',
+      ].join('\n'),
+      runStatus: 'succeeded',
+      events: [],
+      producedFiles: [],
+    };
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation 1' }]);
+    listMessages.mockResolvedValue([assistantMessage]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockResolvedValue(undefined);
+
+    renderProjectView(vi.fn());
+
+    await waitFor(() => expect(fileWorkspaceProps.questionFormInteractive).toBe(true));
+    expect(fileWorkspaceProps.questionFormSubmittedAnswers).toBeUndefined();
+    await waitFor(() => expect(chatPaneProps.onOpenQuestions).toBeDefined());
+
+    act(() => {
+      chatPaneProps.onOpenQuestions?.({
+        form: {
+          id: form.id,
+          title: form.title,
+          questions: [...form.questions],
+        },
+        messageId: assistantMessage.id,
+      });
+    });
+
+    expect(fileWorkspaceProps.questionFormSubmittedAnswers).toBeUndefined();
+    expect(fileWorkspaceProps.questionFormInteractive).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

While testing the discovery question form, clicking the chat-side Questions banner after the form had already auto-opened moved the right-hand Questions panel into a locked state. The form still represented the latest unanswered assistant turn, so users should be able to keep selecting chips and typing answers after reopening it from the banner.

Root cause: the banner path always pinned a manual question-form request, and `ProjectView` treated all manual requests as historical read-only forms.

## What users will see

Users can click the left chat Questions banner for the current unanswered form and the right Questions panel remains editable. Historical answered forms still reopen as read-only answered previews.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is an interaction-state bug on an existing form surface. The regression is covered by the component test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.deleteConversation.test.tsx`
- Did the test go red on `main` and green on this branch? yes. The new test failed before the fix with `questionFormInteractive` becoming `false`, then passed after the fix.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/components/ProjectView.deleteConversation.test.tsx` from `apps/web`
- `pnpm guard`
- `pnpm typecheck`
