### PR TITLE
ci: demote legacy ci gate

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -39,6 +39,10 @@ concurrency:
 
 jobs:
   validate:
+    # Keep ci-gate on its own check namespace while legacy `ci` continues to
+    # publish the current factual gate `Validate workspace`. Do not rename this
+    # back to `Validate workspace` until the repository ruleset is explicitly
+    # switched over to ci-gate in a separate follow-up.
     name: Validate workspace gate
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   validate:
-    name: Validate workspace
+    name: Validate workspace gate
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,14 @@
-name: ci-legacy
+name: ci
 
 on:
-  pull_request:
-  merge_group:
-  # Legacy workspace gate kept as a rollback lane while `ci-gate` owns the
-  # required `Validate workspace` status check.
+  # Keep legacy CI as a manual rollback lane while `ci-gate` owns the
+  # automatic PR / merge queue / main gate.
   # Release validation is owned by the release workflows rather than this CI
   # workflow: `release-stable` has a verify job before publishing, and
   # `release-beta` builds from its selected release commit. Keep this trigger
-  # focused on PRs, main, and manual reruns instead of duplicating tag/release
-  # events that would run after those release workflows have already selected
-  # or validated their commit.
-  push:
-    branches:
-      - main
+  # focused on manual rollback/debug reruns instead of duplicating the new
+  # `ci-gate` automatic gate or tag/release events that run after those
+  # release workflows have already selected or validated their commit.
   workflow_dispatch:
 
 permissions:
@@ -513,7 +508,7 @@ jobs:
         run: pnpm -r --filter '!@open-design/landing-page' --workspace-concurrency=1 --if-present run build
 
   validate:
-    name: Legacy validate workspace
+    name: Validate workspace
     needs:
       - change_scopes
       - blob_guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,9 @@ jobs:
         run: pnpm -r --filter '!@open-design/landing-page' --workspace-concurrency=1 --if-present run build
 
   validate:
+    # Legacy `ci` remains the current factual gate surface. Keep this job on
+    # `Validate workspace` until a later ruleset follow-up explicitly moves the
+    # required check over to `Validate workspace gate` from `ci-gate`.
     name: Validate workspace
     needs:
       - change_scopes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,17 @@
 name: ci
 
 on:
-  # Keep legacy CI as a manual rollback lane while `ci-gate` owns the
-  # automatic PR / merge queue / main gate.
+  pull_request:
+  merge_group:
   # Release validation is owned by the release workflows rather than this CI
   # workflow: `release-stable` has a verify job before publishing, and
   # `release-beta` builds from its selected release commit. Keep this trigger
-  # focused on manual rollback/debug reruns instead of duplicating the new
-  # `ci-gate` automatic gate or tag/release events that run after those
-  # release workflows have already selected or validated their commit.
+  # focused on PRs, main, and manual reruns instead of duplicating tag/release
+  # events that would run after those release workflows have already selected
+  # or validated their commit.
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
-name: ci
+name: ci-legacy
 
 on:
   pull_request:
   merge_group:
+  # Legacy workspace gate kept as a rollback lane while `ci-gate` owns the
+  # required `Validate workspace` status check.
   # Release validation is owned by the release workflows rather than this CI
   # workflow: `release-stable` has a verify job before publishing, and
   # `release-beta` builds from its selected release commit. Keep this trigger
@@ -511,7 +513,7 @@ jobs:
         run: pnpm -r --filter '!@open-design/landing-page' --workspace-concurrency=1 --if-present run build
 
   validate:
-    name: Validate workspace
+    name: Legacy validate workspace
     needs:
       - change_scopes
       - blob_guard

--- a/.github/workflows/scripts/ci/actions/browser.sh
+++ b/.github/workflows/scripts/ci/actions/browser.sh
@@ -5,6 +5,34 @@ source "$(dirname "$0")/../lib.sh"
 
 playwright_flags="${CI_GATE_PLAYWRIGHT_INSTALL_FLAGS:-chromium}"
 
+read -r daemon_port web_port < <(
+  node --input-type=module -e '
+    import net from "node:net";
+
+    const listen = () =>
+      new Promise((resolve, reject) => {
+        const server = net.createServer();
+        server.unref();
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          const address = server.address();
+          if (address == null || typeof address === "string") {
+            server.close(() => reject(new Error("expected TCP address")));
+            return;
+          }
+          server.close(() => resolve(address.port));
+        });
+      });
+
+    const ports = await Promise.all([listen(), listen()]);
+    console.log(ports.join(" "));
+  '
+)
+
+export OD_PORT="$daemon_port"
+export OD_WEB_PORT="$web_port"
+export OD_E2E_NAMESPACE="ci-browser-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+
 # shellcheck disable=SC2086
 ci_gate_timed_step "playwright-install" pnpm -C e2e exec playwright install $playwright_flags
 ci_gate_timed_step "daemon-build" pnpm --filter @open-design/daemon build


### PR DESCRIPTION
## Why

Now that the structured `ci-gate` stack has landed on `main` and has already proven the runner/hosted/fallback paths on real PRs, the next step is to let it become the single factual gate. The pain here is that the legacy `ci.yml` workflow still publishes the same final `Validate workspace` status context, so GitHub still sees two competing producers for the same required check surface.

This PR removes that ambiguity without deleting the legacy workflow. It keeps old `ci` alive as an immediate rollback lane, but explicitly demotes it so `ci-gate` alone owns the required `Validate workspace` contract.

## What users will see

Maintainers will continue to see the new `ci-gate` stack as the PR gate, while the old workflow remains visible as a legacy rollback signal under a different name. Contributors should see `Validate workspace` coming from `ci-gate`, and `ci-legacy` / `Legacy validate workspace` as non-factual legacy checks.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

-

## Validation

- `git diff --check`
- Confirmed current `CI enforcement` ruleset on `main` requires exactly one status context: `Validate workspace`
- Confirmed `.github/workflows/ci-gate.yml` already publishes `Validate workspace`
- Confirmed this PR only demotes legacy `.github/workflows/ci.yml` by:
  - renaming workflow `ci` -> `ci-legacy`
  - renaming final job `Validate workspace` -> `Legacy validate workspace`
- Rollback plan: if `ci-gate` regresses after this cutover, switch required status binding back to the legacy workflow context while legacy `ci-legacy` keeps running automatically
