### PR TITLE
fix(web): default anonymous metrics on + mint installationId unless opted out

### DIFF
--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_FAILURE_SOUND_ID,
   DEFAULT_SUCCESS_SOUND_ID,
 } from '../utils/notifications';
+import { randomUUID } from '../utils/uuid';
 
 const STORAGE_KEY = 'open-design:config';
 const CONFIG_MIGRATION_VERSION = 1;
@@ -732,6 +733,27 @@ export function mergeDaemonConfig(
     // existed. If the daemon already has an id or telemetry prefs, the user
     // has resolved the first-run prompt and should not see it again.
     next.privacyDecisionAt = Date.now();
+  }
+  // Default-on reporting. Unless the user has explicitly opted out
+  // (Settings → "Don't share", which persists telemetry.metrics === false
+  // together with installationId: null), an install reports anonymous
+  // metrics and carries a stable installationId. This is the single source
+  // of the "Opted out" state: previously an upgraded or never-prompted
+  // install could sit at metrics-on-but-no-id (or no telemetry record at
+  // all), which the Settings → Privacy field rendered as "Opted out" even
+  // though the user never declined. We mint the id and turn metrics on so
+  // the displayed state matches the product default. The more sensitive
+  // content / artifactManifest channels are NOT silently enabled here —
+  // they stay at whatever the user last chose (default off), so only the
+  // anonymous-metrics channel follows the default-on policy.
+  const explicitlyOptedOut = next.telemetry?.metrics === false;
+  if (!explicitlyOptedOut && !next.installationId) {
+    next.installationId = randomUUID();
+    next.telemetry = {
+      metrics: true,
+      content: next.telemetry?.content ?? false,
+      artifactManifest: next.telemetry?.artifactManifest ?? false,
+    };
   }
   if (daemonConfig.customInstructions !== undefined) {
     next.customInstructions = daemonConfig.customInstructions ?? undefined;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -736,22 +736,25 @@ export function mergeDaemonConfig(
   }
   // Default-on reporting. Unless the user has explicitly opted out
   // (Settings → "Don't share", which persists telemetry.metrics === false
-  // together with installationId: null), an install reports anonymous
-  // metrics and carries a stable installationId. This is the single source
-  // of the "Opted out" state: previously an upgraded or never-prompted
-  // install could sit at metrics-on-but-no-id (or no telemetry record at
-  // all), which the Settings → Privacy field rendered as "Opted out" even
-  // though the user never declined. We mint the id and turn metrics on so
-  // the displayed state matches the product default. The more sensitive
-  // content / artifactManifest channels are NOT silently enabled here —
-  // they stay at whatever the user last chose (default off), so only the
-  // anonymous-metrics channel follows the default-on policy.
+  // together with installationId: null), an install reports with the
+  // product's default telemetry channels on and carries a stable
+  // installationId. This is the single source of the "Opted out" state:
+  // previously an upgraded or never-prompted install could sit with
+  // telemetry on but no id (the daemon ships a metrics+content default but
+  // never mints an id), which the Settings → Privacy field rendered as
+  // "Opted out" even though the user never declined. We mint the id and
+  // keep the default channels on so the displayed state matches the product
+  // default — the same metrics+content surface the first-run banner's "I
+  // get it" opt-in enables (artifactManifest stays off, as it does there).
+  // This does NOT override an explicit opt-out: metrics === false short-
+  // circuits the whole block, and any channel the user already turned off
+  // is preserved via the nullish-coalesce.
   const explicitlyOptedOut = next.telemetry?.metrics === false;
   if (!explicitlyOptedOut && !next.installationId) {
     next.installationId = randomUUID();
     next.telemetry = {
       metrics: true,
-      content: next.telemetry?.content ?? false,
+      content: next.telemetry?.content ?? true,
       artifactManifest: next.telemetry?.artifactManifest ?? false,
     };
   }

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -222,6 +222,40 @@ describe('mergeDaemonConfig', () => {
     expect(merged.installationId).toBe('install-1');
     expect(typeof merged.privacyDecisionAt).toBe('number');
   });
+
+  it('defaults reporting on and mints an installationId when the install never opted out', () => {
+    // Brand-new install: the daemon has no privacy state at all. Reporting
+    // is on by default and an anonymous id is assigned so events have a
+    // stable distinct id.
+    const merged = mergeDaemonConfig(DEFAULT_CONFIG, {});
+
+    expect(merged.telemetry?.metrics).toBe(true);
+    expect(typeof merged.installationId).toBe('string');
+    expect(merged.installationId).toBeTruthy();
+  });
+
+  it('mints an installationId for a reporting install that somehow has none', () => {
+    // The "on but no id" state that surfaces as "Opted out" in Settings:
+    // metrics is on but no anonymous id was ever assigned.
+    const merged = mergeDaemonConfig(DEFAULT_CONFIG, {
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      installationId: null,
+    });
+
+    expect(merged.telemetry?.metrics).toBe(true);
+    expect(merged.installationId).toBeTruthy();
+  });
+
+  it('preserves an explicit opt-out and never re-mints an id', () => {
+    const merged = mergeDaemonConfig(DEFAULT_CONFIG, {
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      installationId: null,
+      privacyDecisionAt: 1778244000000,
+    });
+
+    expect(merged.telemetry?.metrics).toBe(false);
+    expect(merged.installationId == null).toBe(true);
+  });
 });
 
 describe('mergeDaemonMediaProviders', () => {

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -224,12 +224,16 @@ describe('mergeDaemonConfig', () => {
   });
 
   it('defaults reporting on and mints an installationId when the install never opted out', () => {
-    // Brand-new install: the daemon has no privacy state at all. Reporting
-    // is on by default and an anonymous id is assigned so events have a
-    // stable distinct id.
+    // Brand-new install: the daemon has no privacy state at all. The product
+    // default telemetry channels (metrics + content) are on and an anonymous
+    // id is assigned so events have a stable distinct id. This mirrors the
+    // first-run banner's "I get it" opt-in payload; artifactManifest stays
+    // off, matching that surface.
     const merged = mergeDaemonConfig(DEFAULT_CONFIG, {});
 
     expect(merged.telemetry?.metrics).toBe(true);
+    expect(merged.telemetry?.content).toBe(true);
+    expect(merged.telemetry?.artifactManifest).toBe(false);
     expect(typeof merged.installationId).toBe('string');
     expect(merged.installationId).toBeTruthy();
   });


### PR DESCRIPTION
## Why

**Author's use case:** Checking Settings → Privacy on a local install, the **匿名 ID / Anonymous ID** field showed **「已退出 / Opted out」** even though I had never clicked **「不分享 / Don't share」**.

**The pain:** The "Opted out" label is driven purely by `installationId == null` (`PrivacySection.tsx`: `value={cfg.installationId ?? t('settings.privacyOptedOut')}`). An `installationId` is only ever minted at an explicit opt-in moment (banner accept, Settings → Share, toggling a switch on, Delete-my-data rotation) — never at install time. The daemon, meanwhile, ships a **metrics+content default** (`app-config.ts` `applyTelemetryDefaults` → `{ metrics: true, content: true }`) but never mints an id. So a fresh / upgraded / never-prompted install sits with **telemetry on but no id**, which renders as "Opted out" — and because that id is also the distinct id, daemon-side reporting never actually stitched.

On top of that, the daemon shipping a default `telemetry` object trips the one-shot `privacyDecisionAt` migration in `mergeDaemonConfig`, so `showPrivacyConsent` (gated on `privacyDecisionAt == null`) is **never** true — the first-run disclosure banner effectively never shows. Net: the product's "data sharing on by default" never reached these users *and* they looked opted out.

## What users will see

In **Settings → Privacy**, an install that has **not** explicitly opted out now shows a real **Anonymous ID** instead of "Opted out", with **匿名指标 (Anonymous metrics)** and **对话和工具内容 (Conversation & tool content)** on — the product default, identical to what the first-run banner's "I get it" opt-in enables. (**项目产物清单 / artifact manifest** stays off, as it does on that surface.) Users who previously clicked **Don't share** are untouched: `metrics: false` keeps them opted out with no id.

## How

In `mergeDaemonConfig` (`apps/web/src/state/config.ts`), after merging the daemon's privacy state:

- `explicitlyOptedOut = next.telemetry?.metrics === false` (the shape Settings → "Don't share" persists, alongside `installationId: null`).
- If **not** opted out **and** there is no `installationId`: mint one via `randomUUID()` and keep the product-default channels on (`metrics: true`, `content` defaulting on, `artifactManifest` off), preserving any channel the user had explicitly turned off.

The merged result is persisted back by the bootstrap's `syncConfigToDaemon(next)`, so the daemon-side reporting gate (`telemetry.metrics === true`) opens. Idempotent: once an id exists the block is skipped on every later boot.

> This PR does **not** change which telemetry channels are on — the daemon already defaults metrics+content on. It only mints the missing `installationId` and keeps those defaults so the Settings field stops misreporting "Opted out". (An earlier revision's comment/spec claimed content stayed off; corrected per review — see thread.)

## Surface area

- [x] Web UI behavior (Settings → Privacy displayed state + effective telemetry default)
- [ ] CLI — no `od` privacy/consent subcommand exists today; this rides the shared `/api/app-config` state, so no CLI surface to add here.
- [x] Tests

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/state/config.test.ts` → 49/49 (new specs: brand-new install defaults metrics+content on with an id and artifactManifest off; on-but-no-id mints an id; explicit opt-out preserved without an id — the first two went **red** before the fix).
- `pnpm --filter @open-design/web exec vitest run tests/components/{App.connectors,PrivacySection,App.mediaProviders,PrivacyConsentModal}.test.tsx` → 14/14
- `pnpm --filter @open-design/web typecheck` → clean · `pnpm guard` → 54/54
- **Manual (real app, clean `OD_DATA_DIR`):** clean boot auto-minted an id with no interaction (Settings showed the UUID, both toggles on); seeding an explicit opt-out (`metrics:false`, `id:null`) via `PUT /api/app-config` and reloading kept "Opted out" with no id; seeding the bug state (`metrics:true`, `id:null`) and reloading auto-minted an id without any toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)