### PR TITLE
fix(web): update .present-exit styles for improved accessibility and …

### DIFF
--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -324,19 +324,37 @@
 }
 .present-exit {
   position: absolute;
-  top: calc(env(safe-area-inset-top, 0px) + 20px);
-  right: calc(env(safe-area-inset-right, 0px) + 20px);
+  top: calc(env(safe-area-inset-top, 0px) + 12px);
+  right: calc(env(safe-area-inset-right, 0px) + 12px);
   z-index: 1001;
   display: inline-flex;
   align-items: center;
-  padding: 6px 12px;
+  gap: 6px;
+  min-height: 30px;
+  padding: 0 10px;
   font-size: 12px;
-  background: rgba(255, 255, 255, 0.92);
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-muted);
+  background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-pill);
   cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: background var(--dur-quick) var(--ease-out), border-color var(--dur-quick) var(--ease-out), color var(--dur-quick) var(--ease-out), transform var(--dur-quick) var(--ease-out);
 }
-.present-exit:hover { background: white; }
+.present-exit:hover {
+  background: var(--bg-subtle);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+.present-exit:active {
+  transform: translateY(1px);
+}
+.present-exit:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--selected) 72%, transparent);
+  outline-offset: 2px;
+}
 
 /* Picker (legacy in some surfaces) */
 .picker {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -5133,14 +5133,15 @@ describe('LiveArtifactViewer', () => {
     expect(rule).toContain('display: none;');
   });
 
-  it('keeps the presentation exit button aligned with preview chrome spacing', () => {
+  it('keeps the presentation exit button compact and aligned with preview chrome spacing', () => {
     const css = readExpandedIndexCss();
     const rule = css.match(/\.present-exit\s*\{[^}]+\}/)?.[0] ?? '';
 
-    expect(rule).toContain('top: calc(env(safe-area-inset-top, 0px) + 20px);');
-    expect(rule).toContain('right: calc(env(safe-area-inset-right, 0px) + 20px);');
+    expect(rule).toContain('top: calc(env(safe-area-inset-top, 0px) + 12px);');
+    expect(rule).toContain('right: calc(env(safe-area-inset-right, 0px) + 12px);');
     expect(rule).toContain('display: inline-flex;');
     expect(rule).toContain('align-items: center;');
+    expect(rule).toContain('border-radius: var(--radius-pill);');
   });
 
   it('keeps in-tab presentation overlays anchored to the inherited workspace tab height', () => {


### PR DESCRIPTION

Fixes #4118 

## Why

The HTML `In this tab` preview close button used a hardcoded light background, so it did not adapt when the app switched to dark mode. That made it look like a bright chip floating over the preview content instead of part of the viewer chrome.

This also made the control feel heavier than necessary and more likely to visually compete with page content underneath.

## What users will see

In dark mode, the close button now uses theme colors, has clearer hover/focus/pressed states, and appears as a smaller, less intrusive control in the top-right corner.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new root dependency
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

before
<img width="710" height="472" alt="image" src="https://github.com/user-attachments/assets/742296e2-5839-41cb-bf2e-317a483a8ea9" />

after
<img width="710" height="487" alt="image" src="https://github.com/user-attachments/assets/9775c131-85f0-4327-99dd-12bec0d30aeb" />


## Bug fix verification

No red spec; this is a visual styling bug. Verified that the existing preview DOM/layout is unchanged and the close control now uses theme tokens instead of hardcoded light colors.

## Validation

- `pnpm --filter @open-design/web test -- FileViewer.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`