### PR TITLE
[codex] add Kimi affiliate docs link

### DIFF
--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -37,7 +37,7 @@ const AGENT_INSTALL_LINKS: Record<
   },
   kimi: {
     installUrl: 'https://github.com/MoonshotAI/kimi-cli',
-    docsUrl: 'https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html',
+    docsUrl: 'https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html?aff=open-design',
   },
   'cursor-agent': {
     installUrl: 'https://cursor.com/docs/cli/overview',

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -460,6 +460,7 @@ test('detectAgents includes sanitized install and docs metadata from split runti
       const agents = await detectAgents();
       const qoder = agents.find((agent) => agent.id === 'qoder');
       const deepseek = agents.find((agent) => agent.id === 'deepseek');
+      const kimi = agents.find((agent) => agent.id === 'kimi');
 
       assert.ok(qoder);
       assert.equal(qoder.available, false);
@@ -469,6 +470,11 @@ test('detectAgents includes sanitized install and docs metadata from split runti
       assert.equal(
         deepseek.docsUrl,
         'https://github.com/Hmbown/CodeWhale/blob/main/README.md',
+      );
+      assert.ok(kimi);
+      assert.equal(
+        kimi.docsUrl,
+        'https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html?aff=open-design',
       );
     });
   } finally {


### PR DESCRIPTION
## Summary
- Add the Open Design affiliate query string to the Kimi CLI docs link exposed through runtime metadata.
- Leave the Kimi CLI install URL, API behavior, and agent registration unchanged.

## Validation
- `git diff --check origin/main...HEAD`
- `node --import tsx -e "import { installMetaForAgent } from './apps/daemon/src/runtimes/metadata.ts'; const expected = 'https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html?aff=open-design'; if (installMetaForAgent('kimi').docsUrl !== expected) throw new Error('unexpected docsUrl');"`
- `pnpm --filter @open-design/daemon typecheck`
