### PR TITLE
fix(daemon): expose bundled Playwright to agents

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -51,6 +51,7 @@
     "jszip": "3.10.1",
     "multer": "2.1.1",
     "node-pty": "1.1.0",
+    "playwright": "1.60.0",
     "posthog-node": "5.34.6",
     "prom-client": "15.1.3",
     "tar": "7.5.15",

--- a/apps/daemon/src/prompts/official-system.ts
+++ b/apps/daemon/src/prompts/official-system.ts
@@ -62,6 +62,7 @@ PDFs, PPTX, DOCX: you can extract them via Bash (\`unzip\`, \`pdftotext\`, etc.)
 - Match the visual vocabulary of any provided codebase or design system: copywriting tone, color palette, hover/click states, animation, shadow, density. Think out loud about what you observe before you start writing.
 - **Color usage**: choose the product background and palette from the user's brand, domain, screenshots, selected design system, or active skill direction. Do not inherit Open Design app chrome colors. Do not default to warm beige/cream/peach/pink/orange-brown canvas treatments unless those colors are explicitly justified by the product brand or user-provided reference.
 - Don't use \`scrollIntoView\` — it can break the embedded preview. Use other DOM scroll methods.
+- **Browser validation**: when you need a real browser pass for local HTML/prototypes, use the Playwright runtime advertised by \`OD_PLAYWRIGHT_CLI\` / \`OD_PLAYWRIGHT_PACKAGE\` with \`OD_NODE_BIN\`; do not assume Playwright is installed in the project folder. Prefer Playwright's isolated Chromium profile for screenshots and responsive checks. Do not launch the user's normal Chrome/Safari profile just to validate an artifact.
 
 ## Content guidelines
 - **No filler.** Never pad with placeholder text, dummy sections, or stat-slop just to fill space. If a section feels empty, that's a design problem to solve with composition, not by inventing words.
@@ -116,7 +117,7 @@ When the user attaches an image, it arrives as an absolute path you can read. Us
 At the start of new work, ask focused questions in plain text. Skip questions for small tweaks or follow-ups. Always confirm: starting context (UI kit, design system, codebase, brand assets), audience and tone, output format (single page vs deck vs prototype), variation count, and any specific constraints. If the user hasn't provided a starting point, **ask** — designing without context produces generic output.
 
 ## Verification
-Before emitting your final artifact, sanity-check the file you wrote. If you used Bash, you can grep your own output for obvious issues (broken tag, missing closing brace). For prototypes with JS, mentally trace the main interaction. The user lands on whatever you ship — make sure it doesn't crash on load.
+Before emitting your final artifact, sanity-check the file you wrote. If you used Bash, you can grep your own output for obvious issues (broken tag, missing closing brace). For prototypes with JS, mentally trace the main interaction. When a browser/runtime pass is useful, use bundled Playwright via \`"$OD_NODE_BIN" "$OD_PLAYWRIGHT_CLI"\` or a CommonJS script that starts with \`const { chromium } = require(process.env.OD_PLAYWRIGHT_PACKAGE);\`; capture desktop and mobile screenshots with an isolated Playwright context rather than opening the user's normal browser profile. The user lands on whatever you ship — make sure it doesn't crash on load.
 
 ## What you don't do
 - Don't recreate copyrighted designs (other companies' distinctive UI patterns, branded visual elements). Help the user build something original instead.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -539,12 +539,28 @@ function cleanOptionalPath(value: string | undefined): string | null {
     : null;
 }
 
+export type PlaywrightRuntimePaths = {
+  cli: string;
+  package: string;
+};
+
 export function resolveDaemonCliPath(env: NodeJS.ProcessEnv = process.env): string {
   const configured = cleanOptionalPath(env[DAEMON_CLI_PATH_ENV]) ?? cleanOptionalPath(env.OD_BIN);
   if (configured) return configured;
 
   const packageJsonPath = require.resolve('@open-design/daemon/package.json');
   return path.join(path.dirname(packageJsonPath), 'dist', 'cli.js');
+}
+
+export function resolvePlaywrightRuntimePaths(): PlaywrightRuntimePaths | null {
+  try {
+    return {
+      cli: require.resolve('playwright/cli'),
+      package: require.resolve('playwright'),
+    };
+  } catch {
+    return null;
+  }
 }
 
 const PROJECT_ROOT = resolveProjectRoot(__dirname);
@@ -1850,6 +1866,7 @@ export function createAgentRuntimeEnv(
   daemonUrl: string,
   toolTokenGrant: { token?: string } | null = null,
   nodeBin: string = process.execPath,
+  playwrightRuntime: PlaywrightRuntimePaths | null = resolvePlaywrightRuntimePaths(),
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = applySandboxRuntimeEnv(
     {
@@ -1857,6 +1874,12 @@ export function createAgentRuntimeEnv(
       OD_DATA_DIR: RUNTIME_DATA_DIR,
       OD_DAEMON_URL: daemonUrl,
       OD_NODE_BIN: nodeBin,
+      ...(playwrightRuntime
+        ? {
+            OD_PLAYWRIGHT_CLI: playwrightRuntime.cli,
+            OD_PLAYWRIGHT_PACKAGE: playwrightRuntime.package,
+          }
+        : {}),
     },
     SANDBOX_RUNTIME,
   );
@@ -1923,6 +1946,7 @@ export function createAgentRuntimeToolPrompt(
     `- Daemon URL: \`${daemonUrl}\` (also available as \`OD_DAEMON_URL\`).`,
     '- `OD_NODE_BIN` is the absolute path to the Node-compatible runtime that started the daemon; packaged desktop installs provide this even when the user has no system `node` on PATH.',
     '- `OD_BIN` is the absolute path to the Open Design CLI script. On POSIX shells run wrappers with `"$OD_NODE_BIN" "$OD_BIN" tools ...`; do not call bare `od`, which may resolve to the system octal-dump command on Unix-like systems.',
+    '- `OD_PLAYWRIGHT_CLI` and `OD_PLAYWRIGHT_PACKAGE` point at Open Design\'s bundled Playwright runtime when available. For browser validation, prefer `"$OD_NODE_BIN" "$OD_PLAYWRIGHT_CLI" ...` or a small CommonJS script that uses `require(process.env.OD_PLAYWRIGHT_PACKAGE)`. Do not assume Playwright is installed in the project you are editing.',
     '- On PowerShell use `& $env:OD_NODE_BIN $env:OD_BIN tools ...`; on cmd.exe use `"%OD_NODE_BIN%" "%OD_BIN%" tools ...`.',
     tokenLine,
     '- Prefer project wrapper commands through `OD_NODE_BIN` + `OD_BIN` over raw HTTP. The wrappers read these environment values automatically.',

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -554,8 +554,15 @@ export function resolveDaemonCliPath(env: NodeJS.ProcessEnv = process.env): stri
 
 export function resolvePlaywrightRuntimePaths(): PlaywrightRuntimePaths | null {
   try {
+    const packageJsonPath = require.resolve('playwright/package.json');
+    const packageJson = require(packageJsonPath);
+    const cliBin = packageJson?.bin?.playwright;
+    if (typeof cliBin !== 'string' || cliBin.trim().length === 0) {
+      return null;
+    }
+
     return {
-      cli: require.resolve('playwright/cli'),
+      cli: path.resolve(path.dirname(packageJsonPath), cliBin),
       package: require.resolve('playwright'),
     };
   } catch {

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -13,14 +13,33 @@ describe('agent runtime tool environment', () => {
       'http://127.0.0.1:7456',
       { token: 'fresh-token' },
       '/opt/open-design/bin/node',
+      {
+        cli: '/opt/open-design/node_modules/playwright/cli.js',
+        package: '/opt/open-design/node_modules/playwright/index.js',
+      },
     );
 
     expect(env).toMatchObject({
       PATH: `/opt/open-design/bin${path.delimiter}/bin`,
       OD_DAEMON_URL: 'http://127.0.0.1:7456',
       OD_NODE_BIN: '/opt/open-design/bin/node',
+      OD_PLAYWRIGHT_CLI: '/opt/open-design/node_modules/playwright/cli.js',
+      OD_PLAYWRIGHT_PACKAGE: '/opt/open-design/node_modules/playwright/index.js',
       OD_TOOL_TOKEN: 'fresh-token',
     });
+  });
+
+  it('omits Playwright env paths when the bundled runtime cannot be resolved', () => {
+    const env = createAgentRuntimeEnv(
+      { PATH: '/bin' },
+      'http://127.0.0.1:7456',
+      null,
+      '/opt/open-design/bin/node',
+      null,
+    );
+
+    expect(env.OD_PLAYWRIGHT_CLI).toBeUndefined();
+    expect(env.OD_PLAYWRIGHT_PACKAGE).toBeUndefined();
   });
 
   it('prepends node binary directory to PATH when not already present', () => {
@@ -135,6 +154,8 @@ describe('agent runtime tool environment', () => {
     expect(prompt).toContain('Daemon URL: `http://127.0.0.1:7456`');
     expect(prompt).toContain('`OD_DAEMON_URL`');
     expect(prompt).toContain('`OD_NODE_BIN`');
+    expect(prompt).toContain('`OD_PLAYWRIGHT_CLI`');
+    expect(prompt).toContain('bundled Playwright runtime');
     expect(prompt).toContain('`"$OD_NODE_BIN" "$OD_BIN" tools ...`');
     expect(prompt).toContain('& $env:OD_NODE_BIN $env:OD_BIN tools ...');
     expect(prompt).toContain('`OD_TOOL_TOKEN` is available');

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -1,12 +1,36 @@
 import path from 'node:path';
+import { createRequire } from 'node:module';
 
 import { describe, expect, it, vi } from 'vitest';
 import { SIDECAR_ENV } from '@open-design/sidecar-proto';
 
-import { createAgentRuntimeEnv, createAgentRuntimeToolPrompt } from '../src/server.js';
+import {
+  createAgentRuntimeEnv,
+  createAgentRuntimeToolPrompt,
+  resolvePlaywrightRuntimePaths,
+} from '../src/server.js';
 import { applyAgentLaunchEnv } from '../src/runtimes/launch.js';
 
+const require = createRequire(import.meta.url);
+
 describe('agent runtime tool environment', () => {
+  it('resolves the bundled Playwright CLI from package bin metadata', () => {
+    const runtimePaths = resolvePlaywrightRuntimePaths();
+    const packageJsonPath = require.resolve('playwright/package.json');
+    const packageJson = require(packageJsonPath);
+    const cliBin = packageJson?.bin?.playwright;
+
+    expect(typeof cliBin).toBe('string');
+    if (typeof cliBin !== 'string') {
+      throw new Error('playwright package.json does not declare bin.playwright');
+    }
+
+    expect(runtimePaths).toEqual({
+      cli: path.resolve(path.dirname(packageJsonPath), cliBin),
+      package: require.resolve('playwright'),
+    });
+  });
+
   it('injects daemon URL and run-scoped tool token into agent sessions', () => {
     const env = createAgentRuntimeEnv(
       { PATH: '/bin', OD_TOOL_TOKEN: 'stale-token' },

--- a/apps/daemon/tests/skills.test.ts
+++ b/apps/daemon/tests/skills.test.ts
@@ -150,7 +150,7 @@ describe('listSkills', () => {
     expect(skill.body).toContain('`OD_TOOL_TOKEN`');
   });
 
-  it('includes the agent-browser skill as an external CLI integration', async () => {
+  it('includes the agent-browser skill with bundled Playwright as the default validation path', async () => {
     const skills = await listSkills(skillsRoot);
     const skill = skills.find((entry: { id: string }) => entry.id === 'agent-browser');
 
@@ -164,12 +164,18 @@ describe('listSkills', () => {
       upstream: 'https://github.com/vercel-labs/agent-browser/blob/main/skills/agent-browser/SKILL.md',
     });
     expect(skill.triggers).toContain('test this web app');
+    expect(skill.body).toContain('Use Open Design\'s bundled Playwright runtime first');
+    expect(skill.body).toContain('`OD_PLAYWRIGHT_CLI`');
+    expect(skill.body).toContain('`OD_PLAYWRIGHT_PACKAGE`');
+    expect(skill.body).toContain('Do not report "Playwright is not installed"');
+    expect(skill.body).toContain('Do not open the user\'s normal Chrome, Safari, or browser profile');
+    expect(skill.body).toContain('const { chromium } = require(process.env.OD_PLAYWRIGHT_PACKAGE);');
     expect(skill.body).toContain('agent-browser skills get core');
     expect(skill.body).toContain('Never print full upstream guides into chat or tool output');
-    expect(skill.body).toContain('`agent-browser` must attach to an existing CDP endpoint');
+    expect(skill.body).toContain('agent-browser` must attach to an\nexisting CDP endpoint');
     expect(skill.body).toContain('curl -fsS http://127.0.0.1:9223/json/version');
-    expect(skill.body).toContain('open -na "Google Chrome" --args');
-    expect(skill.body).toContain('for i in {1..20}');
+    expect(skill.body).not.toContain('open -na "Google Chrome" --args');
+    expect(skill.body).not.toContain('for i in {1..20}');
     expect(skill.body).toContain('agent-browser connect http://127.0.0.1:9223');
     expect(skill.body).toContain('Never run\n`agent-browser open` before `agent-browser connect`');
     expect(skill.body).toContain('--remote-debugging-port=9223');
@@ -178,8 +184,10 @@ describe('listSkills', () => {
     expect(skill.body).toContain('Open Design Smoke Path');
     expect(skill.body).toContain('`daemon-cli.mjs browser snapshot`');
     expect(skill.body).toContain('misinterpreted as daemon startup');
-    expect(skill.body).toContain('trap cleanup_agent_browser EXIT INT TERM');
-    expect(skill.body).toContain('pkill -f -- "--user-data-dir=${CHROME_USER_DATA_DIR}"');
+    expect(skill.body).not.toContain('trap cleanup_agent_browser EXIT INT TERM');
+    expect(skill.body).not.toContain('pkill -f -- "--user-data-dir=${CHROME_USER_DATA_DIR}"');
+    expect(skill.body).toContain('/tmp/od-playwright-desktop.png');
+    expect(skill.body).toContain('/tmp/od-playwright-mobile.png');
   });
 
   it('includes the DCF valuation, X research, and Last30Days research skills', async () => {

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-Ov4ES82qQ1GeCPk1iWMdifwh8T/Xl3AKCsUKsiheruw=";
+  daemonHash = "sha256-T0Ag/zKoSiusc72evEV7HcdrJPRah0esmSu6WVHbjac=";
   webHash = "sha256-Y9hspnCl3NGO7yTIIfqu2yBN0hYvfLEjiWRKxjasGmg=";
 }

--- a/packages/contracts/src/prompts/official-system.ts
+++ b/packages/contracts/src/prompts/official-system.ts
@@ -58,6 +58,7 @@ PDFs, PPTX, DOCX: you can extract them via Bash (\`unzip\`, \`pdftotext\`, etc.)
 - Match the visual vocabulary of any provided codebase or design system: copywriting tone, color palette, hover/click states, animation, shadow, density. Think out loud about what you observe before you start writing.
 - **Color usage**: choose the product background and palette from the user's brand, domain, screenshots, selected design system, or active skill direction. Do not inherit Open Design app chrome colors. Do not default to warm beige/cream/peach/pink/orange-brown canvas treatments unless those colors are explicitly justified by the product brand or user-provided reference.
 - Don't use \`scrollIntoView\` — it can break the embedded preview. Use other DOM scroll methods.
+- **Browser validation**: when you need a real browser pass for local HTML/prototypes, use the Playwright runtime advertised by \`OD_PLAYWRIGHT_CLI\` / \`OD_PLAYWRIGHT_PACKAGE\` with \`OD_NODE_BIN\`; do not assume Playwright is installed in the project folder. Prefer Playwright's isolated Chromium profile for screenshots and responsive checks. Do not launch the user's normal Chrome/Safari profile just to validate an artifact.
 
 ## Content guidelines
 - **No filler.** Never pad with placeholder text, dummy sections, or stat-slop just to fill space. If a section feels empty, that's a design problem to solve with composition, not by inventing words.
@@ -112,7 +113,7 @@ When the user attaches an image, it arrives as an absolute path you can read. Us
 At the start of new work, ask focused questions in plain text. Skip questions for small tweaks or follow-ups. Always confirm: starting context (UI kit, design system, codebase, brand assets), audience and tone, output format (single page vs deck vs prototype), variation count, and any specific constraints. If the user hasn't provided a starting point, **ask** — designing without context produces generic output.
 
 ## Verification
-Before emitting your final artifact, sanity-check the file you wrote. If you used Bash, you can grep your own output for obvious issues (broken tag, missing closing brace). For prototypes with JS, mentally trace the main interaction. The user lands on whatever you ship — make sure it doesn't crash on load.
+Before emitting your final artifact, sanity-check the file you wrote. If you used Bash, you can grep your own output for obvious issues (broken tag, missing closing brace). For prototypes with JS, mentally trace the main interaction. When a browser/runtime pass is useful, use bundled Playwright via \`"$OD_NODE_BIN" "$OD_PLAYWRIGHT_CLI"\` or a CommonJS script that starts with \`const { chromium } = require(process.env.OD_PLAYWRIGHT_PACKAGE);\`; capture desktop and mobile screenshots with an isolated Playwright context rather than opening the user's normal browser profile. The user lands on whatever you ship — make sure it doesn't crash on load.
 
 ## What you don't do
 - Don't recreate copyrighted designs (other companies' distinctive UI patterns, branded visual elements). Help the user build something original instead.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       node-pty:
         specifier: 1.1.0
         version: 1.1.0
+      playwright:
+        specifier: 1.60.0
+        version: 1.60.0
       posthog-node:
         specifier: 5.34.6
         version: 5.34.6

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -58,20 +58,33 @@ tab unless the user names another target.
 
 ## Requirements
 
-Verify the CLI before doing any browser work:
+Use Open Design's bundled Playwright runtime first. It is exposed to agent
+runs through the runtime tool environment:
+
+```bash
+test -n "${OD_PLAYWRIGHT_CLI:-}" && test -n "${OD_PLAYWRIGHT_PACKAGE:-}"
+"$OD_NODE_BIN" "$OD_PLAYWRIGHT_CLI" --version
+```
+
+For custom inspection, write a small CommonJS script and load Playwright from
+the env path so it works even when the generated project has no package
+dependencies:
+
+```js
+const { chromium } = require(process.env.OD_PLAYWRIGHT_PACKAGE);
+```
+
+Do not report "Playwright is not installed" just because the project folder has
+no local dependency. If `OD_PLAYWRIGHT_CLI` or `OD_PLAYWRIGHT_PACKAGE` is
+missing, say that the Open Design bundled Playwright runtime is unavailable.
+
+The external `agent-browser` CLI is optional. Use it only when it is already
+installed and you specifically need to attach to an existing user-controlled CDP
+browser session:
 
 ```bash
 command -v agent-browser
 ```
-
-If missing, stop and tell the user to install it:
-
-```bash
-npm i -g agent-browser
-agent-browser install
-```
-
-Do not replace the CLI with ad hoc browser scripts.
 
 ## Context Hygiene
 
@@ -109,9 +122,40 @@ the user is building from the reference. Do not paste full page HTML or large
 asset dumps into chat; summarize the relevant selectors, tokens, URLs, and
 screenshots.
 
+## Playwright Startup Contract
+
+For artifact and local preview validation, prefer isolated Playwright Chromium
+over the user's normal browser profile. Start local static servers on loopback
+only, then drive the page with a temporary browser context:
+
+```js
+const { chromium } = require(process.env.OD_PLAYWRIGHT_PACKAGE);
+
+async function main() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  await page.goto(process.env.TARGET_URL, { waitUntil: 'domcontentloaded' });
+  await page.screenshot({ path: '/tmp/od-playwright-desktop.png', fullPage: true });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.screenshot({ path: '/tmp/od-playwright-mobile.png', fullPage: true });
+  await browser.close();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+```
+
+Do not open the user's normal Chrome, Safari, or browser profile just to inspect
+an Open Design artifact. This avoids macOS privacy prompts for Documents,
+Desktop, cloud-drive folders, media libraries, and unrelated user data.
+
 ## CDP Startup Contract
 
-`agent-browser` must attach to an existing CDP endpoint. Never run
+Use this section only when the task explicitly requires an existing browser
+session and `agent-browser` is installed. `agent-browser` must attach to an
+existing CDP endpoint. Never run
 `agent-browser open` before `agent-browser connect`; doing so can make the CLI
 auto-launch Chrome and re-enter the crash path.
 
@@ -122,30 +166,15 @@ misinterpreted as daemon startup and open an internal `127.0.0.1:<port>` service
 in the system browser. Use the external `agent-browser` CLI attached to CDP
 instead.
 
-Use this sequence:
+Use this sequence only for that optional CDP path:
 
 ```bash
-if ! curl -fsS http://127.0.0.1:9223/json/version | rg -q webSocketDebuggerUrl; then
-  open -na "Google Chrome" --args \
-    --remote-debugging-port=9223 \
-    --user-data-dir=/tmp/od-agent-browser-chrome \
-    --no-first-run \
-    --no-default-browser-check
-
-  for i in {1..20}; do
-    if curl -fsS http://127.0.0.1:9223/json/version | rg -q webSocketDebuggerUrl; then
-      break
-    fi
-    sleep 0.5
-  done
-fi
-
 curl -fsS http://127.0.0.1:9223/json/version | rg webSocketDebuggerUrl
 agent-browser connect http://127.0.0.1:9223
 ```
 
-If CDP is still unavailable after polling, stop and ask the user to launch
-Chrome manually from Terminal:
+If CDP is unavailable, stop and ask the user to launch Chrome manually from
+Terminal before you attach:
 
 ```bash
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
@@ -164,61 +193,56 @@ Lightpanda is optional. Do not try `--engine lightpanda` unless
 
 ## Open Design Smoke Path
 
-Use a temp home and stable session:
+Use bundled Playwright and write screenshots to `/tmp` unless the user asks for
+project artifacts:
 
 ```bash
-export HOME=/tmp/agent-browser-home
-export AGENT_BROWSER_SESSION=od-local-preview
-```
+cat > /tmp/od-playwright-smoke.cjs <<'EOF'
+const { chromium } = require(process.env.OD_PLAYWRIGHT_PACKAGE);
 
-When you start a temporary Chrome profile for this smoke path, close it before
-finishing the task. Prefer a shell trap around the whole smoke script:
+const url = process.env.TARGET_URL || 'http://127.0.0.1:17573/';
+const desktopPath = process.env.DESKTOP_SCREENSHOT || '/tmp/od-playwright-desktop.png';
+const mobilePath = process.env.MOBILE_SCREENSHOT || '/tmp/od-playwright-mobile.png';
 
-```bash
-CHROME_USER_DATA_DIR=/tmp/od-agent-browser-chrome
-cleanup_agent_browser() {
-  pkill -f -- "--user-data-dir=${CHROME_USER_DATA_DIR}" 2>/dev/null || true
+async function main() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  const title = await page.title();
+  const currentUrl = page.url();
+  const bodyText = await page.locator('body').innerText({ timeout: 3000 }).catch(() => '');
+  await page.screenshot({ path: desktopPath, fullPage: true });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.screenshot({ path: mobilePath, fullPage: true });
+  await browser.close();
+  console.log(JSON.stringify({
+    ok: true,
+    title,
+    url: currentUrl,
+    visibleText: bodyText.slice(0, 500),
+    screenshots: { desktop: desktopPath, mobile: mobilePath }
+  }, null, 2));
 }
-trap cleanup_agent_browser EXIT INT TERM
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+EOF
+
+TARGET_URL=http://127.0.0.1:17573/ "$OD_NODE_BIN" /tmp/od-playwright-smoke.cjs
 ```
 
-With the Open Design preview at `http://127.0.0.1:17573/`, run:
-
-```bash
-if ! curl -fsS http://127.0.0.1:9223/json/version | rg -q webSocketDebuggerUrl; then
-  open -na "Google Chrome" --args \
-    --remote-debugging-port=9223 \
-    --user-data-dir="$CHROME_USER_DATA_DIR" \
-    --no-first-run \
-    --no-default-browser-check
-
-  for i in {1..20}; do
-    if curl -fsS http://127.0.0.1:9223/json/version | rg -q webSocketDebuggerUrl; then
-      break
-    fi
-    sleep 0.5
-  done
-fi
-
-curl -fsS http://127.0.0.1:9223/json/version | rg webSocketDebuggerUrl
-agent-browser connect http://127.0.0.1:9223
-agent-browser open http://127.0.0.1:17573/
-agent-browser get title
-agent-browser get url
-agent-browser snapshot
-agent-browser screenshot /tmp/od-agent-browser.png
-```
-
-Expected success: title `Open Design`, current URL under `127.0.0.1:17573`,
-visible Open Design UI text in the snapshot, and a screenshot at
-`/tmp/od-agent-browser.png`.
+Expected success: JSON with title `Open Design`, current URL under
+`127.0.0.1:17573`, visible Open Design UI text, and screenshots at
+`/tmp/od-playwright-desktop.png` and `/tmp/od-playwright-mobile.png`.
 
 ## Workflow
 
-1. Verify `agent-browser` is installed.
-2. Redirect upstream docs to temp files; quote only relevant lines.
-3. Ensure CDP is reachable, starting Chrome with `open -na` if needed.
-4. Connect with `agent-browser connect http://127.0.0.1:9223`.
+1. Verify bundled Playwright is available through `OD_PLAYWRIGHT_CLI` and `OD_PLAYWRIGHT_PACKAGE`.
+2. Use an isolated Playwright Chromium context for local preview validation.
+3. Redirect upstream `agent-browser` docs to temp files only when using the optional external CLI.
+4. For optional CDP sessions, connect with `agent-browser connect http://127.0.0.1:9223`.
 5. Open the local preview URL.
 6. If the run prompt includes a selected browser workspace item, open or focus
    that URL before inspecting.


### PR DESCRIPTION
Closes #3184

## Why

This bug report came from plugin/prototype authoring in 0.8.0: agents wanted to do a browser viewport pass, but checked the generated project for Playwright, found no local dependency, and fell back to static checks. On macOS, the alternate browser path could also try to launch the user's normal Chrome profile, causing unexpected privacy permission prompts for unrelated folders.

This PR makes browser validation part of the Open Design agent runtime instead of an accidental project-local/global dependency.

## What users will see

Agents should prefer Open Design's bundled Playwright runtime for local HTML/prototype validation and responsive screenshots. They should no longer say Playwright is missing just because the generated project has no Playwright dependency, and the built-in browser skill now avoids launching the user's normal browser profile for default artifact checks.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `OD_PLAYWRIGHT_CLI` and `OD_PLAYWRIGHT_PACKAGE` env vars exposed to agent runs
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — changes the built-in `agent-browser` skill instructions
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — agents are prompted to use bundled Playwright for browser validation by default
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/agent-runtime-env.test.ts`, `apps/daemon/tests/skills.test.ts`
- Did the test go red on `main` and green on this branch? no — this container has no Node/package-manager binary on `PATH`, so I could not execute the Vitest red/green loop locally.
- Added focused coverage for exposing bundled Playwright env paths, omitting them when unavailable, and keeping the browser skill on the bundled Playwright path instead of the previous global `agent-browser`/system Chrome default.

## Validation

- `git diff --check` — passed
- Not run: `pnpm guard`, `pnpm typecheck`, package-scoped Vitest suites — `node`, `npm`, `pnpm`, and `corepack` are unavailable on `PATH` in this execution environment.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>