### PR TITLE
[codex] Add PR UI P0 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       tools_dev_tests_required: ${{ steps.detect.outputs.tools_dev_tests_required }}
       tools_pack_tests_required: ${{ steps.detect.outputs.tools_pack_tests_required }}
       nix_validation_required: ${{ steps.detect.outputs.nix_validation_required }}
+      ui_p0_pr_required: ${{ steps.detect.outputs.ui_p0_pr_required }}
       workspace_validation_required: ${{ steps.detect.outputs.workspace_validation_required }}
 
     steps:
@@ -52,6 +53,7 @@ jobs:
           tools_dev_tests_required=false
           tools_pack_tests_required=false
           nix_validation_required=false
+          ui_p0_pr_required=false
           workspace_validation_required=false
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             gh api --paginate \
@@ -80,6 +82,9 @@ jobs:
                 tools_dev_tests_required=true
                 tools_pack_tests_required=true
               fi
+              if [[ "$file" == "apps/web/"* || "$file" == "apps/daemon/"* || "$file" == "packages/components/"* || "$file" == "packages/contracts/"* || "$file" == "packages/host/"* || "$file" == "packages/platform/"* || "$file" == "packages/sidecar/"* || "$file" == "packages/sidecar-proto/"* || "$file" == "e2e/ui/"* || "$file" == "e2e/lib/"* || "$file" == "e2e/resources/"* || "$file" == "e2e/scripts/"* || "$file" == "e2e/package.json" || "$file" == "e2e/playwright.config.ts" || "$file" == "package.json" || "$file" == "pnpm-lock.yaml" || "$file" == "pnpm-workspace.yaml" || "$file" == ".github/actions/setup-playwright/"* || "$file" == ".github/actions/setup-workspace/"* || "$file" == ".github/workflows/ci.yml" || "$file" == ".github/workflows/ui-extended-main.yml" || "$file" == ".github/workflows/ui-p0-pr.yml" ]]; then
+                ui_p0_pr_required=true
+              fi
               # Keep this filter in sync with flake.nix daemonWorkspacePaths / webWorkspacePaths.
               if [[ "$file" == "package.json" || "$file" == "pnpm-lock.yaml" || "$file" == "pnpm-workspace.yaml" || "$file" == "flake.nix" || "$file" == "flake.lock" || "$file" == "nix/"* || "$file" == ".github/workflows/ci.yml" || "$file" == ".github/workflows/nix-check.yml" || "$file" == ".github/workflows/nix-hash-autofix.yml" || "$file" == "apps/daemon/"* || "$file" == "apps/web/"* || "$file" == "packages/components/"* || "$file" == "packages/contracts/"* || "$file" == "packages/registry-protocol/"* || "$file" == "packages/agui-adapter/"* || "$file" == "packages/plugin-runtime/"* || "$file" == "packages/sidecar-proto/"* || "$file" == "packages/sidecar/"* || "$file" == "packages/platform/"* || "$file" == "packages/diagnostics/"* || "$file" == "packages/host/"* || "$file" == "assets/"* || "$file" == "plugins/"* || "$file" == "skills/"* || "$file" == "design-systems/"* || "$file" == "design-templates/"* || "$file" == "craft/"* || "$file" == "prompt-templates/"* || "$file" == "scripts/update-nix-pnpm-deps-hash.ts" ]]; then
                 nix_validation_required=true
@@ -98,6 +103,7 @@ jobs:
                 && [ "$tools_dev_tests_required" = "true" ] \
                 && [ "$tools_pack_tests_required" = "true" ] \
                 && [ "$nix_validation_required" = "true" ] \
+                && [ "$ui_p0_pr_required" = "true" ] \
                 && [ "$workspace_validation_required" = "true" ]; then
                 break
               fi
@@ -131,6 +137,7 @@ jobs:
             echo "tools_dev_tests_required=$tools_dev_tests_required"
             echo "tools_pack_tests_required=$tools_pack_tests_required"
             echo "nix_validation_required=$nix_validation_required"
+            echo "ui_p0_pr_required=$ui_p0_pr_required"
             echo "workspace_validation_required=$workspace_validation_required"
           } >> "$GITHUB_OUTPUT"
 
@@ -478,6 +485,7 @@ jobs:
         run: pnpm --filter @open-design/e2e test
 
       - name: Playwright critical
+        if: ${{ github.event_name != 'pull_request' || needs.change_scopes.outputs.ui_p0_pr_required != 'true' }}
         run: |
           pnpm -C e2e exec tsx scripts/playwright.ts clean
           pnpm -C e2e run test:ui:critical

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,6 @@ jobs:
         run: pnpm --filter @open-design/e2e test
 
       - name: Playwright critical
-        if: ${{ github.event_name != 'pull_request' || needs.change_scopes.outputs.ui_p0_pr_required != 'true' }}
         run: |
           pnpm -C e2e exec tsx scripts/playwright.ts clean
           pnpm -C e2e run test:ui:critical

--- a/.github/workflows/notify-main-ci-feishu.yml
+++ b/.github/workflows/notify-main-ci-feishu.yml
@@ -14,7 +14,6 @@ on:
   workflow_run:
     workflows:
       - ci
-      - ui-extended-main
     types:
       - completed
 

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -1,9 +1,6 @@
 name: ui-extended-main
 
 on:
-  push:
-    branches:
-      - main
   schedule:
     # 02:00 UTC = 10:00 Asia/Shanghai
     - cron: "0 2 * * *"
@@ -29,7 +26,7 @@ concurrency:
 jobs:
   ui_p0:
     name: UI P0 (${{ matrix.name }})
-    if: ${{ github.repository == 'nexu-io/open-design' && (github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite != 'full')) }}
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -37,55 +34,17 @@ jobs:
       matrix:
         include:
           - name: entry-onboarding
-            smoke_command: >-
-              pnpm -C e2e exec playwright test -c playwright.config.ts
-              ui/critical-smoke.test.ts
-              --grep '\[P0\]'
-            command: >-
-              pnpm -C e2e exec playwright test -c playwright.config.ts
-              ui/critical-smoke.test.ts
-              ui/entry-chrome-flows.test.ts
-              ui/entry-configuration-flows.test.ts
-              ui/amr-onboarding.test.ts
-              ui/api-empty-response.test.ts
-              --grep '\[P0\]'
+            smoke_shard: smoke
+            shard: entry-onboarding
           - name: project-workspace
-            smoke_command: >-
-              pnpm -C e2e exec playwright test -c playwright.config.ts
-              ui/critical-smoke.test.ts
-              --grep '\[P0\]'
-            command: >-
-              pnpm -C e2e exec playwright test -c playwright.config.ts
-              ui/app.test.ts
-              ui/app-restoration.test.ts
-              ui/app-design-files.test.ts
-              ui/app-manual-edit.test.ts
-              ui/project-management-flows.test.ts
-              ui/workspace-keyboard-flows.test.ts
-              --grep '\[P0\]'
+            smoke_shard: smoke
+            shard: project-workspace
           - name: runtime-recovery
-            smoke_command: >-
-              pnpm -C e2e exec playwright test -c playwright.config.ts
-              ui/critical-smoke.test.ts
-              --grep '\[P0\]'
-            command: >-
-              pnpm -C e2e exec playwright test -c playwright.config.ts
-              ui/real-daemon-run.test.ts
-              ui/amr-run-failure-recovery.test.ts
-              ui/amr-logout-requires-relogin.test.ts
-              ui/settings-local-cli-codex-fallback.test.ts
-              --grep '\[P0\]'
+            smoke_shard: smoke
+            shard: runtime-recovery
           - name: settings-connectors
-            smoke_command: >-
-              pnpm -C e2e exec playwright test -c playwright.config.ts
-              ui/critical-smoke.test.ts
-              --grep '\[P0\].*settings dialog'
-            command: >-
-              pnpm -C e2e exec playwright test -c playwright.config.ts
-              ui/settings-api-protocol.test.ts
-              ui/settings-connectors-auth-happy-path.test.ts
-              ui/settings-connectors-auth-recovery.test.ts
-              --grep '\[P0\]'
+            smoke_shard: settings-smoke
+            shard: settings-connectors
 
     steps:
       - name: Checkout
@@ -110,10 +69,10 @@ jobs:
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
       - name: Run UI shell smoke
-        run: ${{ matrix.smoke_command }}
+        run: pnpm -C e2e exec tsx scripts/ui-p0-shards.ts ${{ matrix.smoke_shard }}
 
       - name: Run UI P0 domain
-        run: ${{ matrix.command }}
+        run: pnpm -C e2e exec tsx scripts/ui-p0-shards.ts ${{ matrix.shard }}
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
@@ -130,7 +89,7 @@ jobs:
 
   ui_extended:
     name: UI P1 (${{ matrix.name }})
-    if: ${{ github.repository == 'nexu-io/open-design' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite == 'p0p1')) }}
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite == 'p0p1' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -182,9 +141,9 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  ui_full_manual:
+  ui_full:
     name: Full UI regression
-    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite == 'full' }}
+    if: ${{ github.repository == 'nexu-io/open-design' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite == 'full')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -217,7 +176,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-full-manual-${{ github.run_id }}
+          name: ui-full-${{ github.run_id }}
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-p0-pr.yml
+++ b/.github/workflows/ui-p0-pr.yml
@@ -1,0 +1,205 @@
+name: ui-p0-pr
+
+on:
+  pull_request:
+    paths:
+      - apps/web/**
+      - apps/daemon/**
+      - packages/components/**
+      - packages/contracts/**
+      - packages/host/**
+      - packages/platform/**
+      - packages/sidecar/**
+      - packages/sidecar-proto/**
+      - e2e/ui/**
+      - e2e/lib/**
+      - e2e/resources/**
+      - e2e/scripts/**
+      - e2e/package.json
+      - e2e/playwright.config.ts
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - .github/actions/setup-playwright/**
+      - .github/actions/setup-workspace/**
+      - .github/workflows/ci.yml
+      - .github/workflows/ui-extended-main.yml
+      - .github/workflows/ui-p0-pr.yml
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: ui-p0-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ui_smoke:
+    name: UI P0 smoke
+    if: ${{ github.repository == 'nexu-io/open-design' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        with:
+          package-json-path: e2e/package.json
+          install-command: pnpm -C e2e exec playwright install --with-deps chromium
+
+      - name: Prebuild workspace type declarations
+        run: |
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/desktop build
+          pnpm --filter @open-design/web build:sidecar
+
+      - name: Clean Playwright state
+        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
+
+      - name: Run UI shell smoke
+        run: pnpm -C e2e exec tsx scripts/ui-p0-shards.ts smoke
+
+      - name: Upload Playwright debug artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-p0-pr-${{ github.run_id }}-smoke
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ui_p0:
+    name: UI P0 (${{ matrix.name }})
+    if: ${{ github.repository == 'nexu-io/open-design' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: entry-onboarding
+            shard: entry-onboarding
+          - name: project-workspace
+            shard: project-workspace
+          - name: runtime-recovery
+            shard: runtime-recovery
+          - name: settings-connectors
+            shard: settings-connectors
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        with:
+          package-json-path: e2e/package.json
+          install-command: pnpm -C e2e exec playwright install --with-deps chromium
+
+      - name: Prebuild workspace type declarations
+        run: |
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/desktop build
+          pnpm --filter @open-design/web build:sidecar
+
+      - name: Clean Playwright state
+        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
+
+      - name: Run UI P0 domain
+        run: pnpm -C e2e exec tsx scripts/ui-p0-shards.ts ${{ matrix.shard }}
+
+      - name: Upload Playwright debug artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-p0-pr-${{ github.run_id }}-${{ matrix.name }}
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ui_p0_gate:
+    name: UI P0 PR gate
+    needs:
+      - ui_smoke
+      - ui_p0
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Summarize UI P0 jobs
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          jobs_json="$RUNNER_TEMP/ui-p0-jobs.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?per_page=100" > "$jobs_json"
+          {
+            echo "## UI P0 PR summary"
+            echo
+            echo "| Job | Result | Duration | Slowest step |"
+            echo "| --- | --- | ---: | --- |"
+            jq -r '
+              def parse_ts: sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601;
+              def seconds($start; $end):
+                if ($start and $end) then (($end | parse_ts) - ($start | parse_ts)) else null end;
+              def fmt($seconds):
+                if $seconds == null then "n/a"
+                elif $seconds >= 60 then "\(((($seconds / 60) * 10 | round) / 10))m"
+                else "\(($seconds | round))s"
+                end;
+              def row($cells): "| \($cells | join(" | ")) |";
+
+              .jobs
+              | map(select(.name | startswith("UI P0")))
+              | sort_by(.name)
+              | .[]
+              | (
+                  [(.steps // [])[] | select(.started_at and .completed_at and .conclusion != "skipped") | {
+                    name,
+                    duration: seconds(.started_at; .completed_at)
+                  }]
+                  | max_by(.duration // 0)
+                ) as $slow
+              | row([
+                  .name,
+                  (.conclusion // .status),
+                  fmt(seconds(.started_at; .completed_at)),
+                  "\($slow.name // "n/a") (\(fmt($slow.duration)))"
+                ])
+            ' "$jobs_json"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check UI P0 jobs
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS_JSON" | jq .
+          failures="$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key)=\(.value.result)"')"
+          if [ -n "$failures" ]; then
+            echo "UI P0 PR validation failed:"
+            echo "$failures"
+            exit 1
+          fi

--- a/e2e/scripts/ui-p0-shards.ts
+++ b/e2e/scripts/ui-p0-shards.ts
@@ -1,0 +1,99 @@
+import { spawn } from 'node:child_process';
+
+type Shard = {
+  grep: string;
+  files: string[];
+};
+
+const shards: Record<string, Shard> = {
+  smoke: {
+    grep: String.raw`\[P0\]`,
+    files: ['ui/critical-smoke.test.ts'],
+  },
+  'settings-smoke': {
+    grep: String.raw`\[P0\].*settings dialog`,
+    files: ['ui/critical-smoke.test.ts'],
+  },
+  'entry-onboarding': {
+    grep: String.raw`\[P0\]`,
+    files: [
+      'ui/entry-chrome-flows.test.ts',
+      'ui/entry-configuration-flows.test.ts',
+      'ui/amr-onboarding.test.ts',
+      'ui/api-empty-response.test.ts',
+    ],
+  },
+  'project-workspace': {
+    grep: String.raw`\[P0\]`,
+    files: [
+      'ui/app.test.ts',
+      'ui/app-restoration.test.ts',
+      'ui/app-design-files.test.ts',
+      'ui/app-manual-edit.test.ts',
+      'ui/project-management-flows.test.ts',
+      'ui/workspace-keyboard-flows.test.ts',
+    ],
+  },
+  'runtime-recovery': {
+    grep: String.raw`\[P0\]`,
+    files: [
+      'ui/real-daemon-run.test.ts',
+      'ui/amr-run-failure-recovery.test.ts',
+      'ui/amr-logout-requires-relogin.test.ts',
+      'ui/settings-local-cli-codex-fallback.test.ts',
+    ],
+  },
+  'settings-connectors': {
+    grep: String.raw`\[P0\]`,
+    files: [
+      'ui/settings-api-protocol.test.ts',
+      'ui/settings-connectors-auth-happy-path.test.ts',
+      'ui/settings-connectors-auth-recovery.test.ts',
+    ],
+  },
+};
+
+const commandName = process.argv[2] ?? 'help';
+
+if (commandName === 'help') {
+  printUsage();
+} else if (commandName === 'list') {
+  console.log(Object.keys(shards).join('\n'));
+} else {
+  const shard = shards[commandName];
+  if (shard == null) {
+    console.error(`Unknown UI P0 shard: ${commandName}`);
+    printUsage();
+    process.exitCode = 1;
+  } else {
+    await runPlaywright(shard);
+  }
+}
+
+async function runPlaywright(shard: Shard): Promise<void> {
+  const args = ['test', '-c', 'playwright.config.ts', ...shard.files, '--grep', shard.grep];
+  const child = spawn('playwright', args, {
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code) => resolve(code));
+  });
+  process.exitCode = exitCode ?? 1;
+}
+
+function printUsage(): void {
+  console.log(`Usage: tsx scripts/ui-p0-shards.ts <shard>
+
+Shards:
+${Object.keys(shards)
+  .map((name) => `  ${name}`)
+  .join('\n')}
+
+Commands:
+  list    Print shard names
+  help    Show this help
+`);
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tools-pack": "pnpm exec tools-pack",
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
-    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/check-cross-app-imports.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/postinstall.test.ts",
+    "guard": "tsx ./scripts/guard.ts && tsx ./scripts/check-ui-p0-path-parity.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/check-cross-app-imports.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/postinstall.test.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",
     "sync:community-pets": "node --experimental-strip-types scripts/sync-community-pets.ts",

--- a/scripts/check-ui-p0-path-parity.ts
+++ b/scripts/check-ui-p0-path-parity.ts
@@ -1,0 +1,87 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const uiP0WorkflowPath = ".github/workflows/ui-p0-pr.yml";
+const ciWorkflowPath = ".github/workflows/ci.yml";
+
+type NormalizedPathRule = {
+  kind: "exact" | "prefix";
+  value: string;
+};
+
+async function main(): Promise<void> {
+  const [uiP0Workflow, ciWorkflow] = await Promise.all([
+    readFile(path.join(repoRoot, uiP0WorkflowPath), "utf8"),
+    readFile(path.join(repoRoot, ciWorkflowPath), "utf8"),
+  ]);
+
+  const uiP0Rules = normalizeRules(extractUiP0WorkflowPaths(uiP0Workflow));
+  const ciRules = normalizeRules(extractCiUiP0Rules(ciWorkflow));
+
+  const missingFromCi = difference(uiP0Rules, ciRules);
+  const missingFromWorkflow = difference(ciRules, uiP0Rules);
+
+  if (missingFromCi.length || missingFromWorkflow.length) {
+    console.error("UI P0 PR path rules drifted between ui-p0-pr.yml and ci.yml.");
+    if (missingFromCi.length) {
+      console.error(`\nRules present in ${uiP0WorkflowPath} but missing from ${ciWorkflowPath}:`);
+      for (const rule of missingFromCi) console.error(`- ${rule}`);
+    }
+    if (missingFromWorkflow.length) {
+      console.error(`\nRules present in ${ciWorkflowPath} but missing from ${uiP0WorkflowPath}:`);
+      for (const rule of missingFromWorkflow) console.error(`- ${rule}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`UI P0 PR path parity passed (${uiP0Rules.length} rules).`);
+}
+
+function extractUiP0WorkflowPaths(source: string): string[] {
+  const blockMatch = source.match(/pull_request:\n\s+paths:\n(?<block>(?:\s+- .+\n)+)/u);
+  const block = blockMatch?.groups?.block;
+  if (!block) {
+    throw new Error(`Unable to find pull_request.paths in ${uiP0WorkflowPath}.`);
+  }
+
+  return block
+    .split("\n")
+    .map((line) => line.trim().match(/^-\s+(.+)$/u)?.[1]?.trim())
+    .filter((value): value is string => Boolean(value));
+}
+
+function extractCiUiP0Rules(source: string): string[] {
+  const blockMatch = source.match(/^\s*if \[\[ (?<condition>[^\n]+) \]\]; then\n\s+ui_p0_pr_required=true$/mu);
+  const condition = blockMatch?.groups?.condition;
+  if (!condition) {
+    throw new Error(`Unable to find ui_p0_pr_required path condition in ${ciWorkflowPath}.`);
+  }
+
+  return [...condition.matchAll(/\$file"\s+==\s+"([^"]+)"(\*)?/gu)].map((match) => `${match[1]}${match[2] ?? ""}`);
+}
+
+function normalizeRules(paths: string[]): string[] {
+  return paths
+    .map(normalizeRule)
+    .map((rule) => `${rule.kind}:${rule.value}`)
+    .sort();
+}
+
+function normalizeRule(value: string): NormalizedPathRule {
+  if (value.endsWith("/**")) {
+    return { kind: "prefix", value: value.slice(0, -2) };
+  }
+  if (value.endsWith("*")) {
+    return { kind: "prefix", value: value.slice(0, -1) };
+  }
+  return { kind: "exact", value };
+}
+
+function difference(left: string[], right: string[]): string[] {
+  const rightSet = new Set(right);
+  return left.filter((value) => !rightSet.has(value));
+}
+
+await main();

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -22,6 +22,7 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 const allowedE2eScripts = new Set([
   "e2e/scripts/playwright.ts",
   "e2e/scripts/release-smoke.ts",
+  "e2e/scripts/ui-p0-shards.ts",
   "e2e/scripts/visual-report.ts",
 ]);
 


### PR DESCRIPTION
## Summary

Adds a PR-facing UI P0 workflow that runs the P0 shards in parallel and reports per-shard timing in the run summary.

Also reduces duplicated CI work by skipping `ci`'s `test:ui:critical` step when the PR P0 workflow covers the change, moves `ui-extended-main` off main pushes and into daily full UI regression, and removes `ui-extended-main` from the main CI Feishu alert workflow.

## Details

- Adds `.github/workflows/ui-p0-pr.yml` with smoke, parallel P0 shards, and a final gate job.
- Centralizes P0 shard commands in `e2e/scripts/ui-p0-shards.ts`.
- Adds `scripts/check-ui-p0-path-parity.ts` and wires it into `pnpm guard` so `ci.yml` and `ui-p0-pr.yml` path rules cannot drift silently.
- Keeps existing user e2e file edits out of this PR.

## Validation

- `pnpm guard`
- `pnpm exec tsx scripts/check-ui-p0-path-parity.ts`
- `pnpm exec tsc -p scripts/tsconfig.json --noEmit`
- `pnpm -C e2e exec tsc -p tsconfig.json --noEmit`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color .github/workflows/ci.yml .github/workflows/ui-p0-pr.yml .github/workflows/ui-extended-main.yml .github/workflows/notify-main-ci-feishu.yml`
