### PR TITLE
fix(desktop): prevent zero-delay idle updater polling

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -98,6 +98,7 @@ const STABLE_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const DEFAULT_POLL_INITIAL_DELAY_MS = 5000;
 const DEFAULT_POLL_BACKOFF_INITIAL_MS = 60 * 1000;
 const DEFAULT_POLL_BACKOFF_MAX_MS = 30 * 60 * 1000;
+const MIN_SCHEDULED_POLL_DELAY_MS = 1000;
 const MAC_DEFERRED_INSTALLER_TIMEOUT_MS = 10 * 60 * 1000;
 const WINDOWS_DEFERRED_INSTALLER_TIMEOUT_MS = 10 * 60 * 1000;
 const ARTIFACT_DOWNLOAD_MAX_ATTEMPTS = 3;
@@ -373,6 +374,12 @@ function durationEnv(value: string | undefined, fallback: number, name: string):
   return parsed;
 }
 
+function positiveDurationEnv(value: string | undefined, fallback: number, name: string): number {
+  const parsed = durationEnv(value, fallback, name);
+  if (parsed === 0) throw new Error(`${name} must be greater than 0 milliseconds`);
+  return parsed;
+}
+
 function defaultPollIntervalMs(channel: DesktopUpdateChannel): number {
   return channel === DESKTOP_UPDATE_CHANNELS.STABLE ? STABLE_POLL_INTERVAL_MS : BETA_POLL_INTERVAL_MS;
 }
@@ -406,12 +413,12 @@ export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): D
     autoCheck: isTruthyEnv(env[DESKTOP_UPDATE_ENV.AUTO_CHECK]) ?? enabled,
     autoDownload: isTruthyEnv(env[DESKTOP_UPDATE_ENV.AUTO_DOWNLOAD]) ?? true,
     autoOpen: isTruthyEnv(env[DESKTOP_UPDATE_ENV.AUTO_OPEN]) ?? false,
-    checkBackoffInitialMs: durationEnv(
+    checkBackoffInitialMs: positiveDurationEnv(
       env[DESKTOP_UPDATE_ENV.CHECK_BACKOFF_INITIAL_MS],
       DEFAULT_POLL_BACKOFF_INITIAL_MS,
       DESKTOP_UPDATE_ENV.CHECK_BACKOFF_INITIAL_MS,
     ),
-    checkBackoffMaxMs: durationEnv(
+    checkBackoffMaxMs: positiveDurationEnv(
       env[DESKTOP_UPDATE_ENV.CHECK_BACKOFF_MAX_MS],
       DEFAULT_POLL_BACKOFF_MAX_MS,
       DESKTOP_UPDATE_ENV.CHECK_BACKOFF_MAX_MS,
@@ -421,7 +428,7 @@ export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): D
       DEFAULT_POLL_INITIAL_DELAY_MS,
       DESKTOP_UPDATE_ENV.CHECK_INITIAL_DELAY_MS,
     ),
-    checkIntervalMs: durationEnv(
+    checkIntervalMs: positiveDurationEnv(
       env[DESKTOP_UPDATE_ENV.CHECK_INTERVAL_MS],
       defaultPollIntervalMs(channel),
       DESKTOP_UPDATE_ENV.CHECK_INTERVAL_MS,
@@ -3008,6 +3015,7 @@ export function createDesktopUpdaterScheduler(
   let failureCount = 0;
   let tickRunning = false;
   let unsubscribe: (() => void) | null = null;
+  let warnedZeroDelay = false;
 
   const clearTimer = () => {
     if (timer == null) return;
@@ -3023,6 +3031,18 @@ export function createDesktopUpdaterScheduler(
     unsubscribe = null;
   };
 
+  const normalizeScheduledDelay = (delayMs: number): number => {
+    if (delayMs > 0) return delayMs;
+    if (!warnedZeroDelay) {
+      warnedZeroDelay = true;
+      logger.warn(
+        `[open-design updater] refusing non-positive scheduled poll delay (${delayMs}ms); `
+          + `using ${MIN_SCHEDULED_POLL_DELAY_MS}ms floor`,
+      );
+    }
+    return MIN_SCHEDULED_POLL_DELAY_MS;
+  };
+
   const nextDelay = (status: DesktopUpdateStatusSnapshot | null): number => {
     if (status != null && status.state !== DESKTOP_UPDATE_STATES.ERROR) {
       failureCount = 0;
@@ -3035,10 +3055,11 @@ export function createDesktopUpdaterScheduler(
 
   const schedule = (delayMs: number) => {
     if (!running || timer != null) return;
+    const boundedDelayMs = normalizeScheduledDelay(delayMs);
     timer = setTimeout(() => {
       timer = null;
       void tick();
-    }, delayMs);
+    }, boundedDelayMs);
     timer.unref?.();
   };
 

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -2015,6 +2015,95 @@ describe("desktop updater", () => {
     }
   });
 
+  it("floors non-positive scheduled delays instead of spinning a zero-ms loop", async () => {
+    vi.useFakeTimers();
+    const warn = vi.fn();
+    const updater = {
+      checkForUpdates: vi.fn(async () => ({
+        arch: "arm64",
+        capabilities: {
+          canApplyInPlace: false,
+          canDownload: true,
+          canOpenInstaller: true,
+          requiresManualInstall: true,
+        },
+        channel: DESKTOP_UPDATE_CHANNELS.BETA,
+        currentVersion: "1.0.0",
+        enabled: true,
+        mode: "package-launcher" as const,
+        platform: "darwin",
+        state: DESKTOP_UPDATE_STATES.NOT_AVAILABLE,
+        supported: true,
+      })),
+      config: {
+        arch: "arm64",
+        autoCheck: true,
+        autoDownload: true,
+        autoOpen: false,
+        channel: DESKTOP_UPDATE_CHANNELS.BETA,
+        checkBackoffInitialMs: 60_000,
+        checkBackoffMaxMs: 300_000,
+        checkInitialDelayMs: 5_000,
+        checkIntervalMs: 15 * 60 * 1000,
+        currentVersion: "1.0.0",
+        downloadRoot: "/tmp/open-design-updates",
+        enabled: true,
+        metadataUrl: "https://example.invalid/metadata.json",
+        mode: "package-launcher" as const,
+        platform: "darwin",
+      },
+      downloadUpdate: vi.fn(),
+      handle: vi.fn(),
+      installUpdate: vi.fn(),
+      shouldAutoCheck: vi.fn(() => true),
+      snapshot: vi.fn(() => ({
+        arch: "arm64",
+        capabilities: {
+          canApplyInPlace: false,
+          canDownload: true,
+          canOpenInstaller: true,
+          requiresManualInstall: true,
+        },
+        channel: DESKTOP_UPDATE_CHANNELS.BETA,
+        currentVersion: "1.0.0",
+        enabled: true,
+        mode: "package-launcher" as const,
+        platform: "darwin",
+        state: DESKTOP_UPDATE_STATES.IDLE,
+        supported: true,
+      })),
+      status: vi.fn(),
+      subscribe: vi.fn(() => () => undefined),
+    };
+
+    try {
+      const scheduler = createDesktopUpdaterScheduler(updater as any, {
+        backoffInitialMs: 0,
+        backoffMaxMs: 1000,
+        initialDelayMs: 0,
+        intervalMs: 0,
+        logger: { warn } as any,
+      });
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(999);
+      expect(updater.checkForUpdates).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(updater.checkForUpdates).toHaveBeenCalledTimes(2);
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      scheduler.stop("test");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stops scheduled polling after the installer has been opened", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture();
@@ -2363,6 +2452,25 @@ describe("desktop updater", () => {
 
       expect(config.channel).toBe(DESKTOP_UPDATE_CHANNELS.BETA);
       expect(config.metadataUrl).toContain("/beta/latest/metadata.json");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a zero recurring update interval", () => {
+    const root = makeRoot();
+    try {
+      expect(() =>
+        resolveDesktopUpdaterConfig({
+          currentVersion: "1.2.3-beta.4",
+          downloadRoot: root,
+          env: {
+            [DESKTOP_UPDATE_ENV.CHECK_INTERVAL_MS]: "0",
+            [DESKTOP_UPDATE_ENV.ENABLED]: "1",
+          },
+          source: SIDECAR_SOURCES.PACKAGED,
+        }),
+      ).toThrow(`${DESKTOP_UPDATE_ENV.CHECK_INTERVAL_MS} must be greater than 0 milliseconds`);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
Closes #3533

## Why

Packaged desktop builds should sit near idle after startup, but the desktop updater scheduler accepted `0ms` recurring delays from config/env and would happily re-arm itself as a zero-delay timeout loop. That creates exactly the kind of uncapped idle polling path that can pin the Electron main process and drag the renderer down with it.

## What users will see

Desktop builds no longer spin an uncapped updater poll loop if a bad packaged config or env resolves to a zero recurring delay. The updater now rejects zero recurring intervals up front and floors any non-positive scheduled delay at runtime instead of hot-looping.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the scheduler/config bug: `apps/desktop/tests/main/updater.test.ts`
- Did the test go red on `main` and green on this branch? no — I added focused regression coverage for the zero-delay scheduler path and validated it on this branch only.
- Additional verification: `pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/updater.test.ts`

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/updater.test.ts`
- `pnpm --filter @open-design/desktop test -- apps/desktop/tests/main/updater.test.ts` currently pulls an unrelated pre-existing failure in `apps/desktop/tests/main/window-chrome.test.ts`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>