### PR TITLE
fix(release): restore nightly stableVersion + github attribution so 0.10.0 can promote to stable

### DIFF
--- a/.github/workflow/scripts/release/storage/publish-metadata.ts
+++ b/.github/workflow/scripts/release/storage/publish-metadata.ts
@@ -123,6 +123,11 @@ function releaseMetadataFields(): Record<string, unknown> {
       nightlyNumber: parsed.number,
       nightlyVersion: releaseVersion,
       releaseVersion,
+      // Stable promotion gates the validated nightly on metadata.stableVersion
+      // (scripts/release-stable.ts). A nightly is a candidate for its own base
+      // version, so stamp it here; the unified-publisher refactor (#3995)
+      // dropped this field for nightlies and blocked stable promotion.
+      stableVersion: optional("STABLE_VERSION", parsed.baseVersion),
     };
   }
   const parsed = parseStableReleaseVersion(releaseVersion);

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1171,11 +1171,16 @@ jobs:
           MAC_ARM64_RESULT: ${{ needs.build_mac.result }}
           MAC_X64_RESULT: ${{ needs.build_mac_intel.result }}
           RELEASE_ASSET_SUFFIX: ""
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_METADATA_DIR: ${{ runner.temp }}/release-metadata
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-metadata/outputs.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          RELEASE_RUN_ID: ${{ github.run_id }}
           RELEASE_SIGNED: "true"
           RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
           RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
@@ -1183,6 +1188,7 @@ jobs:
           RELEASE_STORAGE_REGION: auto
           RELEASE_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
           RELEASE_VERSION: ${{ needs.metadata.outputs.release_version }}
+          RELEASE_WORKFLOW: ${{ github.workflow }}
           STABLE_VERSION: ${{ needs.metadata.outputs.stable_version }}
           STATE_SOURCE: ${{ needs.metadata.outputs.state_source }}
           VERSION_TAG: ${{ needs.metadata.outputs.version_tag }}

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -150,6 +150,15 @@ describe("release workflows", () => {
     expect(stable).toContain(".github\\workflow\\scripts\\release\\prepare-platform-assets.ps1");
     expect(countOccurrences(stable, ".github/workflow/scripts/release/storage/publish-platform.ts")).toBeGreaterThanOrEqual(4);
     expect(stable).toContain(".github/workflow/scripts/release/storage/publish-metadata.ts");
+    // The stable promotion gate (scripts/release-stable.ts) validates the
+    // nightly's metadata.github.{commit,branch,repository,workflow}; the publish
+    // step must therefore pass the RELEASE_* attribution env. #3995 unified the
+    // publisher but left these unset for release-stable, so github.* shipped
+    // empty and no nightly could be promoted.
+    expect(stable).toContain("RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}");
+    expect(stable).toContain("RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}");
+    expect(stable).toContain("RELEASE_REPOSITORY: ${{ github.repository }}");
+    expect(stable).toContain("RELEASE_WORKFLOW: ${{ github.workflow }}");
     expect(stable).toContain(".github/workflow/scripts/release/storage/verify-metadata.ts");
     expect(stable).toContain(".github/workflow/scripts/release/storage/summary-metadata.ts");
     expect(stable).toContain("open-design-release-mac-arm64-publish-manifest");

--- a/tools/serve/tests/release-metadata-publish.test.ts
+++ b/tools/serve/tests/release-metadata-publish.test.ts
@@ -131,6 +131,8 @@ describe("shared release metadata publisher", () => {
           };
           allReadyTargetsSigned?: boolean;
           signed?: boolean;
+          stableVersion?: string;
+          github?: { commit?: string };
         };
         expect(metadata.channel).toBe(channel);
         expect(metadata.releaseState).toBe("complete");
@@ -138,6 +140,15 @@ describe("shared release metadata publisher", () => {
         expect(metadata.allReadyTargetsSigned).toBe(false);
         expect(metadata.releaseTargets?.mac_arm64?.artifacts?.payload?.url).toBe("https://example.test/mac-payload");
         expect(metadata.releaseTargets?.win_x64?.artifacts?.payload?.url).toBe("https://example.test/win-payload");
+        // github attribution must round-trip from the RELEASE_* env the workflow
+        // passes; the stable promotion gate checks metadata.github.commit.
+        expect(metadata.github?.commit).toBe("abc123");
+        // Nightlies are stable candidates for their own base version. The stable
+        // promotion gate requires metadata.stableVersion on the validated
+        // nightly; the unified-publisher refactor (#3995) dropped it.
+        if (channel === "nightly") {
+          expect(metadata.stableVersion).toBe("1.2.3");
+        }
         expect(server.getObject(`${channel}/latest/metadata.json`)).not.toBeNull();
       }
     } finally {


### PR DESCRIPTION
## Why

Promoting 0.10.0 to stable is blocked. `release-stable.yml channel=stable` dry-runs fail at "Prepare release metadata" with:

```
[release-stable] R2 stable-channel nightly metadata.stableVersion must be 0.10.0; got (missing)
```

Root cause is the unified-publisher refactor in #3995 ("Unify release metadata publishing"). When it consolidated the four channels' metadata publishing into the shared `publish-metadata.ts`, it dropped two things the stable promotion gate (`scripts/release-stable.ts` → `validateStableNightlyMetadata`) requires on a validated nightly:

1. **`stableVersion`** — the nightly branch of `releaseMetadataFields()` stopped emitting it (only the stable branch keeps it). Old nightlies had it (e.g. `0.9.0.nightly.1` metadata carries `stableVersion: 0.9.0`); current 0.10.0 nightlies don't.
2. **`github.commit` / `branch` / `workflow`** — `githubInfo()` reads `RELEASE_COMMIT` / `RELEASE_BRANCH` / `RELEASE_REPOSITORY` / `RELEASE_WORKFLOW` / `RELEASE_RUN_*`, but `release-stable.yml` never passes them to the publish step (`release-beta.yml` does). So `metadata.github.*` shipped empty, which the gate also rejects.

Either alone makes **every** 0.10.0 nightly un-promotable. Confirmed by content-checking the published `0.10.0.nightly.36/.37` metadata (no `stableVersion`, empty `github.commit`) and a `dry_run=true` stable promotion that fails the gate.

## What users will see

Nothing in the product. Internally: the next nightly built from `release/v0.10.0` carries `stableVersion` + correct `github` attribution again, so `release-stable channel=stable` can validate and promote it — i.e. 0.10.0 can ship.

## Surface area

- [x] **None** — CI release tooling only: `release-stable.yml` (passes the `RELEASE_*` attribution env to the publish step) and `publish-metadata.ts` (restores `stableVersion` on the nightly channel), mirroring the existing `release-beta.yml` wiring. No product code.

## Bug fix verification

Red specs added (both go red on `release/v0.10.0`, green on this branch):

- `tools/serve/tests/release-metadata-publish.test.ts` — asserts nightly metadata carries `stableVersion` and that `github.commit` round-trips from `RELEASE_COMMIT`. Red on base: `AssertionError: expected undefined to be '1.2.3'`.
- `tools/pack/tests/release-workflows.test.ts` — asserts `release-stable.yml` passes `RELEASE_BRANCH/COMMIT/REPOSITORY/WORKFLOW` to the publish-metadata step. Red on base: `RELEASE_COMMIT` not found.

Local validation: both suites green on branch, `pnpm guard` (fail 0), `pnpm typecheck` (0 errors).

> This fix also belongs on `main` (same regression). Targeting `release/v0.10.0` first to unblock the in-flight 0.10.0 release; will forward to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
