### PR TITLE
[codex] Reduce PR CI wall time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ["1/2", "2/2"]
+        shard: ["1/3", "2/3", "3/3"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,11 +415,15 @@ jobs:
         run: pnpm --filter @open-design/tools-pack exec vitest run tests/launcher-payload.test.ts
 
   daemon_workspace_tests:
-    name: Daemon workspace tests
+    name: Daemon workspace tests (${{ matrix.shard }})
     needs: [change_scopes]
     if: ${{ needs.change_scopes.outputs.daemon_tests_required == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ["1/2", "2/2"]
 
     steps:
       - name: Checkout
@@ -432,7 +436,33 @@ jobs:
         run: pnpm --filter @open-design/daemon build
 
       - name: Daemon workspace tests
-        run: pnpm --filter @open-design/daemon test
+        run: pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts --shard ${{ matrix.shard }}
+
+  daemon_workspace_gate:
+    name: Daemon workspace tests
+    needs:
+      - change_scopes
+      - daemon_workspace_tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check daemon workspace test shards
+        env:
+          DAEMON_REQUIRED: ${{ needs.change_scopes.outputs.daemon_tests_required }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS_JSON" | jq .
+          shard_result="$(echo "$NEEDS_JSON" | jq -r '.daemon_workspace_tests.result')"
+          if [ "$DAEMON_REQUIRED" != "true" ] && [ "$shard_result" = "skipped" ]; then
+            exit 0
+          fi
+          if [ "$shard_result" != "success" ]; then
+            echo "Daemon workspace test shards failed: $shard_result"
+            exit 1
+          fi
 
   web_workspace_tests:
     name: Web workspace tests
@@ -526,7 +556,7 @@ jobs:
       - nix_validation
       - workspace_unit_tests
       - windows_tools_pack_payload_tests
-      - daemon_workspace_tests
+      - daemon_workspace_gate
       - web_workspace_tests
       - browser_tests
       - build_workspaces

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,7 @@ jobs:
         run: pnpm --filter @open-design/e2e test
 
       - name: Playwright critical
+        if: ${{ github.event_name != 'pull_request' || needs.change_scopes.outputs.ui_p0_pr_required != 'true' }}
         run: |
           pnpm -C e2e exec tsx scripts/playwright.ts clean
           pnpm -C e2e run test:ui:critical

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -39,6 +39,9 @@ jobs:
           - name: project-workspace
             smoke_shard: smoke
             shard: project-workspace
+          - name: workspace-restoration
+            smoke_shard: smoke
+            shard: workspace-restoration
           - name: runtime-recovery
             smoke_shard: smoke
             shard: runtime-recovery

--- a/.github/workflows/ui-p0-pr.yml
+++ b/.github/workflows/ui-p0-pr.yml
@@ -93,6 +93,8 @@ jobs:
             shard: entry-onboarding
           - name: project-workspace
             shard: project-workspace
+          - name: workspace-restoration
+            shard: workspace-restoration
           - name: runtime-recovery
             shard: runtime-recovery
           - name: settings-connectors

--- a/.github/workflows/visual-pr-verify.yml
+++ b/.github/workflows/visual-pr-verify.yml
@@ -46,25 +46,6 @@ jobs:
         if: ${{ steps.changes.outputs.should_run == 'true' }}
         uses: ./.github/actions/visual-screenshot
 
-      - name: Run Playwright critical gate
-        if: ${{ steps.changes.outputs.should_run == 'true' }}
-        run: |
-          pnpm -C e2e exec tsx scripts/playwright.ts clean
-          pnpm -C e2e run test:ui:critical
-
-      - name: Upload critical gate debug artifact
-        if: ${{ always() && steps.changes.outputs.should_run == 'true' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: visual-pr-critical-gate-${{ github.event.pull_request.number }}-${{ github.run_id }}
-          path: |
-            e2e/ui/reports/playwright-html-report
-            e2e/ui/reports/results.json
-            e2e/ui/reports/test-results
-            e2e/ui/test-results
-          if-no-files-found: ignore
-          retention-days: 7
-
       - name: Run strict visual Playwright suite
         if: ${{ steps.changes.outputs.should_run == 'true' }}
         env:

--- a/e2e/scripts/ui-p0-shards.ts
+++ b/e2e/scripts/ui-p0-shards.ts
@@ -27,12 +27,15 @@ const shards: Record<string, Shard> = {
     grep: String.raw`\[P0\]`,
     files: [
       'ui/app.test.ts',
-      'ui/app-restoration.test.ts',
       'ui/app-design-files.test.ts',
       'ui/app-manual-edit.test.ts',
       'ui/project-management-flows.test.ts',
       'ui/workspace-keyboard-flows.test.ts',
     ],
+  },
+  'workspace-restoration': {
+    grep: String.raw`\[P0\]`,
+    files: ['ui/app-restoration.test.ts'],
   },
   'runtime-recovery': {
     grep: String.raw`\[P0\]`,


### PR DESCRIPTION
## Summary
- split the UI P0 project workspace shard so restoration coverage runs independently
- remove duplicate critical UI runs from visual verification and PR Browser tests when ui-p0-pr already covers the gate
- shard daemon workspace tests across three Vitest shards with a stable aggregate gate

## Expected impact
- targets sub-10-minute PR CI wall time by reducing the longest workflow tails
- keeps critical UI coverage on PRs through ui-p0-pr while preserving the Browser critical step for non-PR events

## Validation
- `pnpm -C e2e exec tsx scripts/ui-p0-shards.ts list`
- `pnpm exec tsx scripts/check-ui-p0-path-parity.ts`
- `git diff --check`
- Ruby YAML parse for changed workflow files
- confirmed Vitest supports `--shard <index>/<count>`

Base is currently stacked on #4142 because that PR has not merged yet. Retarget to `main` after #4142 lands.