### PR TITLE
fix(release): pass RELEASE_COMMIT/RUN_ID to every publish step (follow-up to #4144)

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -114,12 +114,14 @@ env:
   # and the helper still strips .map to keep source out of the installer.
   POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
   POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
-  # github attribution for the published metadata + per-platform manifests, set
-  # workflow-wide (as release-beta.yml does) so the platform build jobs and the
-  # publish-metadata step agree on github.runId. publish-metadata.ts refuses a
-  # platform manifest whose github.{runId,commit} disagree with the publish
-  # step's, so these must stay consistent across every publish step.
-  RELEASE_BRANCH: ${{ github.ref_name }}
+  # Run/repo attribution for the published metadata + per-platform manifests,
+  # set workflow-wide so the platform build jobs and the publish-metadata step
+  # agree on github.runId — publish-metadata.ts refuses a platform manifest
+  # whose github.{runId,commit} disagree with the publish step's. These are the
+  # same for caller and callee under workflow_call, so they're safe here. Branch
+  # is NOT: under workflow_call (or inputs.ref) github.ref_name is the caller's
+  # ref, so RELEASE_BRANCH is passed per publish step as the resolved
+  # needs.metadata.outputs.branch instead, matching what the metadata job built.
   RELEASE_REPOSITORY: ${{ github.repository }}
   RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
   RELEASE_RUN_ID: ${{ github.run_id }}
@@ -467,6 +469,7 @@ jobs:
           RELEASE_ARTIFACT_MODE: all
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_NAMESPACE: ${{ needs.metadata.outputs.namespace }}
           RELEASE_NOTES: Open Design ${{ needs.metadata.outputs.release_version }}
@@ -481,6 +484,7 @@ jobs:
           RELEASE_ARTIFACT_MODE: all
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
@@ -579,6 +583,7 @@ jobs:
           RELEASE_ARTIFACT_MODE: all
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_NAMESPACE: ${{ needs.metadata.outputs.mac_intel_namespace }}
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -592,6 +597,7 @@ jobs:
           RELEASE_ARTIFACT_MODE: all
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
@@ -813,6 +819,7 @@ jobs:
         env:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}\release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}\release-platform-manifests
@@ -948,6 +955,7 @@ jobs:
         env:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_NAMESPACE: ${{ needs.metadata.outputs.linux_namespace }}
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -960,6 +968,7 @@ jobs:
         env:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
+          RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -114,6 +114,16 @@ env:
   # and the helper still strips .map to keep source out of the installer.
   POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
   POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
+  # github attribution for the published metadata + per-platform manifests, set
+  # workflow-wide (as release-beta.yml does) so the platform build jobs and the
+  # publish-metadata step agree on github.runId. publish-metadata.ts refuses a
+  # platform manifest whose github.{runId,commit} disagree with the publish
+  # step's, so these must stay consistent across every publish step.
+  RELEASE_BRANCH: ${{ github.ref_name }}
+  RELEASE_REPOSITORY: ${{ github.repository }}
+  RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+  RELEASE_RUN_ID: ${{ github.run_id }}
+  RELEASE_WORKFLOW: ${{ github.workflow }}
 
 jobs:
   metadata:
@@ -472,6 +482,7 @@ jobs:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-platform-outputs/mac_arm64.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -582,6 +593,7 @@ jobs:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-platform-outputs/mac_x64.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -802,6 +814,7 @@ jobs:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}\release-assets
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}\release-platform-manifests
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}\release-platform-outputs\win_x64.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
@@ -948,6 +961,7 @@ jobs:
           RELEASE_ASSET_SUFFIX: ""
           RELEASE_ASSETS_DIR: ${{ runner.temp }}/release-assets
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-platform-outputs/linux_x64.json
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -159,6 +159,14 @@ describe("release workflows", () => {
     expect(stable).toContain("RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}");
     expect(stable).toContain("RELEASE_REPOSITORY: ${{ github.repository }}");
     expect(stable).toContain("RELEASE_WORKFLOW: ${{ github.workflow }}");
+    // publish-metadata.ts refuses a platform manifest whose github.{runId,commit}
+    // disagree with the publish step's. RELEASE_COMMIT must therefore reach every
+    // publish step (4 platforms + the metadata step), and RELEASE_RUN_ID must be
+    // workflow-wide so the platform build jobs stamp the same runId the metadata
+    // step validates against — otherwise publish fails with
+    // "refusing stale <target> platform manifest ...: github.runId=0".
+    expect(countOccurrences(stable, "RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}")).toBeGreaterThanOrEqual(5);
+    expect(stable).toContain("RELEASE_RUN_ID: ${{ github.run_id }}");
     expect(stable).toContain(".github/workflow/scripts/release/storage/verify-metadata.ts");
     expect(stable).toContain(".github/workflow/scripts/release/storage/summary-metadata.ts");
     expect(stable).toContain("open-design-release-mac-arm64-publish-manifest");

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -155,7 +155,6 @@ describe("release workflows", () => {
     // step must therefore pass the RELEASE_* attribution env. #3995 unified the
     // publisher but left these unset for release-stable, so github.* shipped
     // empty and no nightly could be promoted.
-    expect(stable).toContain("RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}");
     expect(stable).toContain("RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}");
     expect(stable).toContain("RELEASE_REPOSITORY: ${{ github.repository }}");
     expect(stable).toContain("RELEASE_WORKFLOW: ${{ github.workflow }}");
@@ -167,6 +166,13 @@ describe("release workflows", () => {
     // "refusing stale <target> platform manifest ...: github.runId=0".
     expect(countOccurrences(stable, "RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}")).toBeGreaterThanOrEqual(5);
     expect(stable).toContain("RELEASE_RUN_ID: ${{ github.run_id }}");
+    // RELEASE_BRANCH must be the resolved needs.metadata.outputs.branch on every
+    // publish step (not github.ref_name): under workflow_call / inputs.ref the
+    // caller ref differs from the built ref, so a workflow-wide github.ref_name
+    // would make the per-platform manifests' github.branch disagree with the
+    // aggregate metadata the metadata job stamps.
+    expect(countOccurrences(stable, "RELEASE_BRANCH: ${{ needs.metadata.outputs.branch }}")).toBeGreaterThanOrEqual(5);
+    expect(stable).not.toContain("RELEASE_BRANCH: ${{ github.ref_name }}");
     expect(stable).toContain(".github/workflow/scripts/release/storage/verify-metadata.ts");
     expect(stable).toContain(".github/workflow/scripts/release/storage/summary-metadata.ts");
     expect(stable).toContain("open-design-release-mac-arm64-publish-manifest");


### PR DESCRIPTION
## Why

Follow-up to #4144. That PR restored the stable-promotion attribution env, but only on the **publish-metadata** step. Building a nightly from `release/v0.10.0` then failed at "Publish release metadata to R2":

```
Error: refusing stale mac_arm64 platform manifest for 0.10.0.nightly.39: github.runId=0
```

`publish-metadata.ts → validateManifest()` rejects any per-platform manifest whose `github.runId` / `github.commit` disagree with the publish step's `currentRunId` / `currentCommit`. The platform build jobs write those manifests but never received the `RELEASE_*` env, so they stamped `runId=0` — while the metadata step (after #4144) now expected the real run id. Before #4144 everything was `0`, so the guard passed by accident; #4144 set it on one side only.

## What users will see

Nothing in the product. Internally: a nightly built from `release/v0.10.0` via a direct `release-stable channel=nightly` dispatch now publishes cleanly with consistent `github.{runId,commit,branch}` across the aggregate metadata and every platform manifest, and carries `stableVersion` — so `release-stable channel=stable` can finally validate and promote it.

## Surface area

- [x] **None** — CI release tooling only (`release-stable.yml`), mirroring `release-beta.yml`'s wiring: `RELEASE_REPOSITORY/RUN_ATTEMPT/RUN_ID/WORKFLOW` are workflow-wide (identical for caller and callee under `workflow_call`), and `RELEASE_COMMIT` + `RELEASE_BRANCH` are passed to every publish step (4 platforms + metadata) using the resolved `needs.metadata.outputs.{commit,branch}` — never `github.ref_name`, which would be the caller's ref under `workflow_call` / `inputs.ref`.

## Validation

- `pnpm --filter @open-design/tools-pack test` — 194 passed (includes the new `release-workflows` assertions).
- `pnpm guard` — 54/54, 0 fail.
- Red spec (`tools/pack/tests/release-workflows.test.ts`): `RELEASE_COMMIT` and `RELEASE_BRANCH` must each reach all 5 publish steps (`countOccurrences(...) >= 5`), `RELEASE_RUN_ID` is workflow-wide, and `RELEASE_BRANCH: ${{ github.ref_name }}` must NOT appear. Red on base (only the metadata step carried these → count 1), green on this branch.

## Bug fix verification

Same as above — workflow-text regression assertions in `tools/pack/tests/release-workflows.test.ts` lock the per-step `RELEASE_COMMIT` / `RELEASE_BRANCH` coverage and forbid the caller-ref `github.ref_name` form.

> Same as #4144, this also belongs on `main`; targeting `release/v0.10.0` to finish unblocking the 0.10.0 promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
