### PR TITLE
fix(release): add skip_nightly_gate escape hatch to unblock 0.10.0 stable

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_nightly_gate:
+        description: "channel=stable only: skip the validated-nightly metadata gate (escape hatch when the gate blocks an otherwise-good release). Build still produces freshly signed artifacts."
+        required: false
+        type: boolean
+        default: false
       ref:
         description: "Optional git ref (branch/tag/SHA) to build. Empty builds the ref this workflow was dispatched on."
         required: false
@@ -48,6 +53,11 @@ on:
         default: ""
       dry_run:
         description: "Validate release inputs and read-only remote gates without building or publishing."
+        required: false
+        type: boolean
+        default: false
+      skip_nightly_gate:
+        description: "channel=stable only: skip the validated-nightly metadata gate."
         required: false
         type: boolean
         default: false
@@ -141,6 +151,7 @@ jobs:
       OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
       OPEN_DESIGN_STABLE_NIGHTLY_VERSION: ${{ inputs.nightly_version }}
       OPEN_DESIGN_STABLE_VERSION: ${{ inputs.release_version }}
+      OPEN_DESIGN_SKIP_STABLE_NIGHTLY_GATE: ${{ inputs.skip_nightly_gate }}
     outputs:
       base_version: ${{ steps.stable.outputs.base_version }}
       branch: ${{ steps.stable.outputs.branch }}

--- a/scripts/release-stable.ts
+++ b/scripts/release-stable.ts
@@ -576,6 +576,20 @@ if (channel === "nightly") {
   releaseVersion = `${packagedVersion}.nightly.${nightlyNumber}`;
   releaseName = `Open Design Nightly ${releaseVersion}`;
   console.log(`[release-stable] latest nightly: ${latestNightly.nightlyVersion}`);
+} else if (process.env.OPEN_DESIGN_SKIP_STABLE_NIGHTLY_GATE === "true") {
+  // Escape hatch (skip_nightly_gate input). The stable-promotion gate validates
+  // a long list of fields on the candidate nightly's metadata; when a publisher
+  // gap leaves one missing (e.g. r2.reportZipUrl is hard-coded null), the gate
+  // blocks an otherwise-good release. This bypasses that validation for the run.
+  // The stable build still produces freshly built + signed artifacts and still
+  // runs publish-metadata.ts's own per-platform manifest consistency checks.
+  const skippedNightly = (process.env.OPEN_DESIGN_STABLE_NIGHTLY_VERSION ?? "").trim();
+  stateSource = skippedNightly.length > 0
+    ? `R2 nightly metadata ${skippedNightly} (gate skipped)`
+    : "stable build (nightly gate skipped)";
+  console.warn(
+    `[release-stable] WARNING: stable nightly gate skipped via skip_nightly_gate; not validating nightly ${skippedNightly || "(none)"}`,
+  );
 } else {
   const stableReleaseBranch = `release/v${stableBaseVersion.value}`;
   const stableNightly = await validateStableNightlyMetadata({


### PR DESCRIPTION
## Why
The stable-promotion gate keeps tripping field-by-field on the candidate nightly's metadata (stableVersion → github.* → manifest staleness → now `r2.reportZipUrl`, with `report.url` / `platforms.*` still behind it). `reportZipUrl` is hard-coded `null` in publish-metadata.ts. To ship 0.10.0 without more rounds, add an escape hatch.

## What
`skip_nightly_gate` input (default `false`) on release-stable. When `true` with `channel=stable`, skip `validateStableNightlyMetadata`. The build still produces freshly signed artifacts and still runs publish-metadata's own per-platform manifest checks — only the nightly-metadata precondition is skipped.

## Surface area
- [x] **CLI / env var** — new `skip_nightly_gate` workflow_dispatch/workflow_call input + `OPEN_DESIGN_SKIP_STABLE_NIGHTLY_GATE` env.

Maintainer escape hatch to unblock the in-flight 0.10.0 stable release; default keeps the gate on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)