### PR TITLE
[codex] Fix landing download release metadata

### DIFF
--- a/apps/landing-page/app/_lib/github.ts
+++ b/apps/landing-page/app/_lib/github.ts
@@ -21,26 +21,6 @@ function formatStars(count: unknown): string | null {
   return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}K`;
 }
 
-// Parse a display version (e.g. "v0.9.0") from a GitHub /releases/latest object.
-// getLatestRelease() reads the raw release (it also needs the asset list for the
-// download matrix), so it parses tag_name/name directly rather than going
-// through the release-metadata endpoint used for the header/home version chips.
-function formatVersion(release: unknown): string | null {
-  if (!release || typeof release !== 'object') return null;
-  const record = release as { name?: unknown; tag_name?: unknown };
-  const fromName = (name: unknown) => {
-    if (typeof name !== 'string') return null;
-    const match = name.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
-    return match ? `v${match[1]}` : null;
-  };
-  const fromTag = (tag: unknown) => {
-    if (typeof tag !== 'string') return null;
-    const cleaned = tag.replace(/^open-design[-_]?v?/i, '').trim();
-    return cleaned ? `v${cleaned.replace(/^v/, '')}` : null;
-  };
-  return fromName(record.name) ?? fromTag(record.tag_name);
-}
-
 async function fetchJson(url: string, headers?: Record<string, string>): Promise<unknown> {
   const response = await fetch(url, {
     headers,
@@ -71,13 +51,13 @@ export function getGithubRepoMeta(): Promise<GithubRepoMeta> {
 }
 
 /* ------------------------------------------------------------------ *
- * Latest-release assets — powers the dedicated /download page.
+ * Stable release assets — powers the dedicated /download page.
  *
- * Build-time fetch of `releases/latest` resolved into a per-platform
- * matrix so the page renders complete, indexable download links without
- * client JS. The client-side enhancer (download-enhancer.astro) refetches
- * live and patches hrefs, so the page stays correct between rebuilds.
- * Mirrors the asset-name conventions used by header-enhancer.astro.
+ * Build-time fetch of the stable R2 metadata resolved into a per-platform
+ * matrix so the page renders complete, indexable download links without client
+ * JS. The client-side enhancer refetches `/release-metadata` live and patches
+ * hrefs, so the page stays correct between rebuilds without sending installer
+ * traffic through GitHub release asset URLs.
  * ------------------------------------------------------------------ */
 
 const REPO_RELEASES = 'https://github.com/nexu-io/open-design/releases';
@@ -117,8 +97,21 @@ export interface LatestRelease {
 
 interface RawAsset {
   name?: unknown;
-  browser_download_url?: unknown;
+  url?: unknown;
   size?: unknown;
+  sha256Url?: unknown;
+}
+
+interface ReleaseMetadata {
+  versionTag?: unknown;
+  generatedAt?: unknown;
+  publishedAt?: unknown;
+  platforms?: {
+    mac?: { artifacts?: Record<string, RawAsset | undefined> };
+    macIntel?: { artifacts?: Record<string, RawAsset | undefined> };
+    win?: { artifacts?: Record<string, RawAsset | undefined> };
+    linux?: { artifacts?: Record<string, RawAsset | undefined> };
+  };
 }
 
 const EMPTY_MATRIX: ReleaseMatrix = {
@@ -135,36 +128,35 @@ function cleanVersion(versionLabel: string): string {
   return versionLabel.replace(/^v/, '');
 }
 
-function buildMatrix(rawAssets: RawAsset[]): ReleaseMatrix {
-  const assets = rawAssets.filter(
-    (a): a is { name: string; browser_download_url: string; size?: unknown } =>
-      !!a && typeof a.name === 'string' && typeof a.browser_download_url === 'string',
-  );
+function toReleaseUrl(versionLabel: string, tag: unknown): string {
+  if (typeof tag === 'string' && tag.length > 0) {
+    return `${REPO_RELEASES}/tag/${tag}`;
+  }
+  return `${REPO_RELEASES}/tag/open-design-${versionLabel}`;
+}
 
-  const sha256For = (name: string): string | null => {
-    const sib = assets.find((a) => a.name === `${name}.sha256`);
-    return sib ? sib.browser_download_url : null;
-  };
-
-  const pick = (match: (name: string) => boolean): ReleaseAsset | null => {
-    const a = assets.find((x) => !x.name.endsWith('.sha256') && match(x.name));
+function pickArtifact(a: RawAsset | undefined): ReleaseAsset | null {
     if (!a) return null;
+    if (typeof a.name !== 'string' || typeof a.url !== 'string') return null;
     return {
       name: a.name,
-      url: a.browser_download_url,
+      url: a.url,
       size: typeof a.size === 'number' && Number.isFinite(a.size) ? a.size : 0,
-      sha256Url: sha256For(a.name),
+      sha256Url: typeof a.sha256Url === 'string' ? a.sha256Url : null,
     };
-  };
+}
+
+function buildMatrixFromMetadata(metadata: ReleaseMetadata): ReleaseMatrix {
+  const platforms = metadata.platforms ?? {};
 
   return {
-    macArm64Dmg: pick((n) => n.endsWith('mac-arm64.dmg')),
-    macArm64Zip: pick((n) => n.endsWith('mac-arm64.zip')),
-    macX64Dmg: pick((n) => n.endsWith('mac-x64.dmg')),
-    macX64Zip: pick((n) => n.endsWith('mac-x64.zip')),
-    winSetup: pick((n) => /win.*setup\.exe$/.test(n)),
-    winPortable: pick((n) => /win.*portable\.zip$/.test(n)),
-    linux: pick((n) => /\.appimage$/i.test(n)),
+    macArm64Dmg: pickArtifact(platforms.mac?.artifacts?.dmg),
+    macArm64Zip: pickArtifact(platforms.mac?.artifacts?.zip),
+    macX64Dmg: pickArtifact(platforms.macIntel?.artifacts?.dmg),
+    macX64Zip: pickArtifact(platforms.macIntel?.artifacts?.zip),
+    winSetup: pickArtifact(platforms.win?.artifacts?.installer),
+    winPortable: pickArtifact(platforms.win?.artifacts?.portableZip),
+    linux: pickArtifact(platforms.linux?.artifacts?.appImage),
   };
 }
 
@@ -172,31 +164,30 @@ let latestReleasePromise: Promise<LatestRelease> | null = null;
 
 export function getLatestRelease(): Promise<LatestRelease> {
   latestReleasePromise ??= (async () => {
-    let release: unknown = null;
+    let metadata: unknown = null;
     try {
-      release = await fetchJson(`${REPO_API}/releases/latest`);
+      metadata = await fetchJson(RELEASE_METADATA_UPSTREAM_URL, { Accept: 'application/json' });
     } catch {
-      release = null;
+      metadata = null;
     }
 
-    const rec = (release && typeof release === 'object' ? release : {}) as {
-      tag_name?: unknown;
-      html_url?: unknown;
-      published_at?: unknown;
-      assets?: unknown;
-    };
+    const rec = (metadata && typeof metadata === 'object' ? metadata : {}) as ReleaseMetadata;
 
-    const versionLabel = formatVersion(release) ?? FALLBACK_META.versionLabel;
-    const rawAssets = Array.isArray(rec.assets) ? (rec.assets as RawAsset[]) : [];
-    const matrix = release ? buildMatrix(rawAssets) : EMPTY_MATRIX;
-    const resolved = Boolean(release) && Object.values(matrix).some((a) => a !== null);
+    const versionLabel = formatStableReleaseVersion(metadata) ?? FALLBACK_META.versionLabel;
+    const matrix = metadata ? buildMatrixFromMetadata(rec) : EMPTY_MATRIX;
+    const resolved = Boolean(metadata) && Object.values(matrix).some((a) => a !== null);
 
     return {
       version: cleanVersion(versionLabel),
       versionLabel,
-      tagName: typeof rec.tag_name === 'string' ? rec.tag_name : null,
-      publishedAt: typeof rec.published_at === 'string' ? rec.published_at : null,
-      releaseUrl: typeof rec.html_url === 'string' ? rec.html_url : REPO_RELEASES,
+      tagName: typeof rec.versionTag === 'string' ? rec.versionTag : null,
+      publishedAt:
+        typeof rec.publishedAt === 'string'
+          ? rec.publishedAt
+          : typeof rec.generatedAt === 'string'
+            ? rec.generatedAt
+            : null,
+      releaseUrl: toReleaseUrl(versionLabel, rec.versionTag),
       matrix,
       resolved,
     };

--- a/apps/landing-page/app/pages/download/index.astro
+++ b/apps/landing-page/app/pages/download/index.astro
@@ -2,14 +2,15 @@
 /*
  * /download/ — dedicated download center.
  *
- * Auto-reflects the latest GitHub release. The platform matrix is
- * rendered at build time from `getLatestRelease()` (SEO-friendly, works
+ * Auto-reflects the latest stable release metadata. The platform matrix is
+ * rendered at build time from stable release metadata (SEO-friendly, works
  * without JS); an inline enhancer detects the visitor's OS, highlights
- * the matching row, and refetches `releases/latest` to keep hrefs live
- * between rebuilds. Asset-name conventions mirror header-enhancer.astro.
+ * the matching row, and refetches `/release-metadata` to keep hrefs live
+ * between rebuilds. Artifact conventions mirror header-enhancer.astro.
  */
 import Layout from '../../_components/sub-page-layout.astro';
 import { getLatestRelease, type ReleaseAsset } from '../../_lib/github';
+import { RELEASE_METADATA_URL } from '../../_lib/release-metadata';
 import { getInfoPageCopy } from '../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../i18n';
 
@@ -174,12 +175,20 @@ const jsonLd = [
         <span class="dl-auto-os" data-dl-auto-os hidden></span>
       </a>
       <p class="dl-hero-meta">
-        <a class="inline-link" href={release.releaseUrl} target="_blank" rel="noreferrer noopener">
-          {release.versionLabel}
+        <a class="inline-link" href={release.releaseUrl} data-dl-release-link target="_blank" rel="noreferrer noopener">
+          <span data-dl-version data-github-version>
+            {release.versionLabel}
+          </span>
         </a>
-        {publishedLabel && <span class="dl-version-date"> · {page.publishedPrefix} {publishedLabel}</span>}
+        <span
+          class="dl-version-date"
+          data-dl-version-date
+          hidden={!publishedLabel}
+        >
+          {' '}· {page.publishedPrefix} <span data-dl-published-at>{publishedLabel}</span>
+        </span>
         <span> · </span>
-        <a class="inline-link" href={release.releaseUrl} target="_blank" rel="noreferrer noopener">{page.releaseNotes}</a>
+        <a class="inline-link" href={release.releaseUrl} data-dl-release-link target="_blank" rel="noreferrer noopener">{page.releaseNotes}</a>
       </p>
     </header>
 
@@ -192,7 +201,7 @@ const jsonLd = [
             <h2 class="dl-os">{card.osLabel}</h2>
             <p class="dl-card-sub">
               {card.arch && <span class="dl-arch">{card.arch}</span>}
-              <span class="dl-card-version">{release.versionLabel}</span>
+              <span class="dl-card-version" data-dl-version data-github-version>{release.versionLabel}</span>
             </p>
 
             {card.rows.length > 0 && (
@@ -204,14 +213,11 @@ const jsonLd = [
                         <a class="dl-link" href={row.asset.url} data-dl-key={row.key}>
                           <span class="dl-dl-icon" aria-hidden="true">{ICON_DOWNLOAD}</span>
                           {page.downloadVerb} <strong>{row.variant}</strong>
-                          {fmtSize(row.asset.size) && <span class="dl-size">{fmtSize(row.asset.size)}</span>}
+                          {fmtSize(row.asset.size) && <span class="dl-size" data-dl-size-key={row.key}>{fmtSize(row.asset.size)}</span>}
                         </a>
-                        {row.asset.sha256Url && (
-                          <a class="dl-sha" href={row.asset.sha256Url} target="_blank" rel="noreferrer noopener">{page.checksum}</a>
-                        )}
                       </>
                     ) : (
-                      <a class="dl-link dl-link-fallback" href={release.releaseUrl} target="_blank" rel="noreferrer noopener">
+                      <a class="dl-link dl-link-fallback" href={release.releaseUrl} data-dl-release-link target="_blank" rel="noreferrer noopener">
                         <span class="dl-dl-icon" aria-hidden="true">{ICON_DOWNLOAD}</span>
                         {row.variant} <span class="dl-size">→ Releases</span>
                       </a>
@@ -227,7 +233,7 @@ const jsonLd = [
              */}
             {card.note && (
               <p class="dl-note">
-                <a class="inline-link" href={release.releaseUrl} target="_blank" rel="noreferrer noopener">{card.note}</a>
+                <a class="inline-link" href={release.releaseUrl} data-dl-release-link target="_blank" rel="noreferrer noopener">{card.note}</a>
               </p>
             )}
           </div>
@@ -258,18 +264,16 @@ const jsonLd = [
       </div>
       <div class="info-cta-meta">
         <span class="stamp">● {common.live}</span>
-        <span>{release.versionLabel} · Apache-2.0</span>
+        <span><span data-dl-version data-github-version>{release.versionLabel}</span> · Apache-2.0</span>
         <span>{common.macWinLinux}</span>
       </div>
     </section>
   </article>
 
-  <script is:inline define:vars={{ autoPrefix: page.autoCtaPrefix }}>
+  <script is:inline define:vars={{ autoPrefix: page.autoCtaPrefix, RELEASE_METADATA_URL }}>
     (() => {
-      const REPO_API = 'https://api.github.com/repos/nexu-io/open-design';
-
       // Mirror header-enhancer.astro detection. Returns the matchKey used
-      // on each [data-dl-card] plus the asset-name matcher + os label.
+      // on each [data-dl-card] plus the direct download key + os label.
       const detect = () => {
         const ua = (navigator.userAgent || '').toLowerCase();
         const p = (
@@ -279,7 +283,7 @@ const jsonLd = [
         const isWin = /win/.test(p) || /windows/.test(ua);
         const isMac = /mac/.test(p) || (/mac os x/.test(ua) && !/iphone|ipad|ipod/.test(ua));
         const isLinux = /linux/.test(p) || (/linux/.test(ua) && !/android/.test(ua));
-        if (isWin) return { matchKey: 'win', os: 'Windows', match: (n) => /win.*setup\.exe$/.test(n) };
+        if (isWin) return { matchKey: 'win', os: 'Windows', downloadKey: 'win-setup' };
         if (isMac) {
           const intel = (() => {
             try {
@@ -290,57 +294,124 @@ const jsonLd = [
             } catch { return false; }
           })();
           return intel
-            ? { matchKey: 'mac-x64', os: 'macOS (Intel)', match: (n) => n.endsWith('mac-x64.dmg') }
-            : { matchKey: 'mac-arm64', os: 'macOS', match: (n) => n.endsWith('mac-arm64.dmg') };
+            ? { matchKey: 'mac-x64', os: 'macOS (Intel)', downloadKey: 'mac-x64-dmg' }
+            : { matchKey: 'mac-arm64', os: 'macOS', downloadKey: 'mac-arm64-dmg' };
         }
-        if (isLinux) return { matchKey: 'linux', os: 'Linux', match: () => false };
+        if (isLinux) return { matchKey: 'linux', os: 'Linux', downloadKey: null };
         return null;
       };
 
       const platform = detect();
-      if (!platform) return;
 
       // Highlight the recommended card + set the hero CTA OS label.
-      for (const card of document.querySelectorAll('[data-dl-card]')) {
-        if (card.getAttribute('data-dl-match') === platform.matchKey) {
-          card.setAttribute('data-dl-recommended', 'true');
-          const rec = card.querySelector('[data-dl-rec]');
-          if (rec) rec.hidden = false;
+      if (platform) {
+        for (const card of document.querySelectorAll('[data-dl-card]')) {
+          if (card.getAttribute('data-dl-match') === platform.matchKey) {
+            card.setAttribute('data-dl-recommended', 'true');
+            const rec = card.querySelector('[data-dl-rec]');
+            if (rec) rec.hidden = false;
+          }
         }
+        const osSlot = document.querySelector('[data-dl-auto-os]');
+        const labelSlot = document.querySelector('[data-dl-auto-label]');
+        if (osSlot) { osSlot.textContent = ` ${platform.os}`; osSlot.hidden = false; }
+        if (labelSlot) labelSlot.textContent = autoPrefix;
       }
-      const osSlot = document.querySelector('[data-dl-auto-os]');
-      const labelSlot = document.querySelector('[data-dl-auto-label]');
-      if (osSlot) { osSlot.textContent = ` ${platform.os}`; osSlot.hidden = false; }
-      if (labelSlot) labelSlot.textContent = autoPrefix;
 
-      // Live refetch: keep the hero CTA + matrix links current between rebuilds.
-      fetch(`${REPO_API}/releases/latest`, { headers: { Accept: 'application/vnd.github+json' } })
+      const formatReleaseVersion = (metadata) => {
+        const fromVersion = (version) => {
+          if (typeof version !== 'string') return null;
+          const match = version.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
+          return match ? `v${match[1]}` : null;
+        };
+        const fromTag = (tag) => {
+          if (typeof tag !== 'string') return null;
+          const cleaned = tag.replace(/^open-design[-_]?v?/i, '').trim();
+          return cleaned ? `v${cleaned.replace(/^v/, '')}` : null;
+        };
+        return (
+          fromVersion(metadata?.releaseVersion) ??
+          fromVersion(metadata?.stableVersion) ??
+          fromVersion(metadata?.baseVersion) ??
+          fromTag(metadata?.versionTag)
+        );
+      };
+
+      const releasePageUrl = (metadata, versionLabel) => {
+        if (typeof metadata?.versionTag === 'string' && metadata.versionTag.length > 0) {
+          return `https://github.com/nexu-io/open-design/releases/tag/${metadata.versionTag}`;
+        }
+        return versionLabel
+          ? `https://github.com/nexu-io/open-design/releases/tag/open-design-${versionLabel}`
+          : null;
+      };
+
+      const updateReleaseChrome = (metadata) => {
+        const versionLabel = formatReleaseVersion(metadata);
+        if (versionLabel) {
+          for (const slot of document.querySelectorAll('[data-dl-version]')) {
+            slot.textContent = versionLabel;
+          }
+        }
+        const releaseUrl = releasePageUrl(metadata, versionLabel);
+        if (releaseUrl) {
+          for (const link of document.querySelectorAll('[data-dl-release-link]')) {
+            link.href = releaseUrl;
+          }
+        }
+        const publishedAt =
+          typeof metadata?.publishedAt === 'string'
+            ? metadata.publishedAt
+            : typeof metadata?.generatedAt === 'string'
+              ? metadata.generatedAt
+              : null;
+        if (publishedAt && publishedAt.length >= 10) {
+          const dateSlot = document.querySelector('[data-dl-published-at]');
+          const wrapper = document.querySelector('[data-dl-version-date]');
+          if (dateSlot) dateSlot.textContent = publishedAt.slice(0, 10);
+          if (wrapper) wrapper.hidden = false;
+        }
+      };
+
+      const formatSize = (bytes) => {
+        if (!Number.isFinite(bytes) || bytes <= 0) return null;
+        const mb = bytes / (1024 * 1024);
+        return mb >= 1 ? `${mb.toFixed(0)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
+      };
+
+      const artifactMap = (metadata) => ({
+        'mac-arm64-dmg': metadata?.platforms?.mac?.artifacts?.dmg,
+        'mac-arm64-zip': metadata?.platforms?.mac?.artifacts?.zip,
+        'mac-x64-dmg': metadata?.platforms?.macIntel?.artifacts?.dmg,
+        'mac-x64-zip': metadata?.platforms?.macIntel?.artifacts?.zip,
+        'win-setup': metadata?.platforms?.win?.artifacts?.installer,
+        'win-portable': metadata?.platforms?.win?.artifacts?.portableZip,
+        'linux-appimage': metadata?.platforms?.linux?.artifacts?.appImage,
+      });
+
+      // Live refetch: keep version labels, release links, hero CTA, and matrix
+      // links current between static rebuilds.
+      fetch(RELEASE_METADATA_URL, { headers: { Accept: 'application/json' } })
         .then((r) => (r.ok ? r.json() : null))
-        .then((release) => {
-          const assets = Array.isArray(release && release.assets) ? release.assets : [];
-          if (assets.length === 0) return;
-          const byName = (re) =>
-            assets.find((a) => a && typeof a.name === 'string' && typeof a.browser_download_url === 'string' && re(a.name));
-          const map = {
-            'mac-arm64-dmg': (n) => n.endsWith('mac-arm64.dmg'),
-            'mac-arm64-zip': (n) => n.endsWith('mac-arm64.zip'),
-            'mac-x64-dmg': (n) => n.endsWith('mac-x64.dmg'),
-            'mac-x64-zip': (n) => n.endsWith('mac-x64.zip'),
-            'win-setup': (n) => /win.*setup\.exe$/.test(n),
-            'win-portable': (n) => /win.*portable\.zip$/.test(n),
-            'linux-appimage': (n) => /\.appimage$/i.test(n),
-          };
-          for (const [key, re] of Object.entries(map)) {
-            const asset = byName(re);
-            if (!asset) continue;
+        .then((metadata) => {
+          if (!metadata) return;
+          updateReleaseChrome(metadata);
+          const map = artifactMap(metadata);
+          for (const [key, asset] of Object.entries(map)) {
+            if (!asset || typeof asset.url !== 'string') continue;
             for (const link of document.querySelectorAll(`[data-dl-key="${key}"]`)) {
-              link.href = asset.browser_download_url;
+              link.href = asset.url;
+            }
+            const size = formatSize(asset.size);
+            if (!size) continue;
+            for (const slot of document.querySelectorAll(`[data-dl-size-key="${key}"]`)) {
+              slot.textContent = size;
             }
           }
-          const heroAsset = byName(platform.match);
+          const heroAsset = platform?.downloadKey ? map[platform.downloadKey] : null;
           const hero = document.querySelector('[data-dl-auto]');
-          if (heroAsset && hero) {
-            hero.href = heroAsset.browser_download_url;
+          if (heroAsset && typeof heroAsset.url === 'string' && hero) {
+            hero.href = heroAsset.url;
             hero.removeAttribute('target');
             hero.removeAttribute('rel');
           }
@@ -543,8 +614,6 @@ const jsonLd = [
   .dl-link:hover { color: var(--coral, #ed6f5c); }
   .dl-link:hover .dl-dl-icon { transform: translateY(2px); }
   .dl-size { font-size: 0.74rem; opacity: 0.55; }
-  .dl-sha { font-size: 0.68rem; opacity: 0.5; text-decoration: none; }
-  .dl-sha:hover { opacity: 1; text-decoration: underline; }
   .dl-note {
     font-size: 0.82rem;
     opacity: 0.78;


### PR DESCRIPTION
## Why

The download page could show stale release badges and route users through GitHub release asset URLs, which are slower for installer downloads. This came up while checking the public download cards after the stable release moved to 0.10.0.

This keeps the static build SEO-friendly, but makes both build-time rendering and client-side refresh use the stable release metadata served from `releases.open-design.ai`.

## What users will see

Visitors on `/download/` will see the latest release version, release date, and release links updated after page load. The macOS and Windows download card buttons now point at `https://releases.open-design.ai/stable/versions/...` package URLs instead of GitHub release asset URLs.

The per-card `SHA-256` links are no longer shown under the download buttons; users can still reach all release assets and checksums through the all-releases link.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Landing-page marketing surface only; none of the listed product runtime surfaces apply.

## Screenshots

Local preview checked at `http://127.0.0.1:17574/zh/download/`:

- visible version badges resolved to `v0.10.0`
- `SHA-256` download-card links count: `0`
- download-card hrefs resolve to `https://releases.open-design.ai/stable/versions/0.10.0/...`

## Bug fix verification

- Test path that reproduces the bug: no automated red spec; this is static landing-page rendering plus client-side release metadata enhancement.
- Did the test go red on `main` and green on this branch? no
- Verification used instead: local Astro preview and DOM check confirmed live version labels, R2 download links, release links, and removed checksum buttons.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/landing-page typecheck`
- `pnpm --filter @open-design/landing-page build`
- Local preview: `http://127.0.0.1:17574/zh/download/`
