### PR TITLE
fix(daemon): report unavailable Codex Browser Use

### DIFF
--- a/apps/daemon/src/browser-use-diagnostics.ts
+++ b/apps/daemon/src/browser-use-diagnostics.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { BrowserUseDiscoveryFacts, BrowserUseRunState } from '@open-design/contracts';
+
+const BROWSER_USE_REGISTRY_BASENAME = 'codex-browser-use';
+const DEFAULT_STALE_THRESHOLD_MS = 10 * 60 * 1000;
+
+export function browserUseRegistryPath(tmpDir: string = os.tmpdir()): string {
+  return path.join(tmpDir, BROWSER_USE_REGISTRY_BASENAME);
+}
+
+export function isBrowserUseRequested(...values: unknown[]): boolean {
+  return values.some((value) => (
+    typeof value === 'string' &&
+    (
+      /(^|\s)@agent-browser(\s|$)/.test(value) ||
+      value.includes('Browser tab context:') ||
+      value.includes('Use the selected Open Design Browser tab as the bound target.')
+    )
+  ));
+}
+
+export function collectBrowserUseDiscoveryFacts({
+  registryPath = browserUseRegistryPath(),
+  now = Date.now(),
+  currentSessionId = null,
+  staleThresholdMs = DEFAULT_STALE_THRESHOLD_MS,
+}: {
+  registryPath?: string;
+  now?: number;
+  currentSessionId?: string | null;
+  staleThresholdMs?: number;
+} = {}): BrowserUseDiscoveryFacts {
+  try {
+    const entries = fs.readdirSync(registryPath, { withFileTypes: true });
+    let socketCount = 0;
+    let candidateCount = 0;
+    let staleCount = 0;
+    let newestMtime = 0;
+    let currentSessionIdPresent = currentSessionId ? false : null;
+
+    for (const entry of entries) {
+      const maybeSocket = entry.isSocket?.() || entry.name.endsWith('.sock');
+      if (!maybeSocket) continue;
+      socketCount += 1;
+      candidateCount += 1;
+      if (currentSessionId && entry.name.includes(currentSessionId)) {
+        currentSessionIdPresent = true;
+      }
+      try {
+        const stat = fs.statSync(path.join(registryPath, entry.name));
+        newestMtime = Math.max(newestMtime, stat.mtimeMs);
+        if (now - stat.mtimeMs > staleThresholdMs) staleCount += 1;
+      } catch {
+        staleCount += 1;
+      }
+    }
+
+    return {
+      registryPath,
+      registryExists: true,
+      socketCount,
+      candidateCount,
+      staleCount,
+      currentSessionIdPresent,
+      probeFailureCategory: 'not-probed',
+      ...(newestMtime > 0 ? { newestSocketAgeMs: Math.max(0, now - newestMtime) } : {}),
+      staleThresholdMs,
+    };
+  } catch (error) {
+    const code = typeof (error as { code?: unknown })?.code === 'string'
+      ? (error as { code: string }).code
+      : '';
+    return {
+      registryPath,
+      registryExists: false,
+      socketCount: 0,
+      candidateCount: 0,
+      staleCount: 0,
+      currentSessionIdPresent: currentSessionId ? false : null,
+      probeFailureCategory: code === 'ENOENT' ? 'registry-missing' : 'registry-unreadable',
+      staleThresholdMs,
+    };
+  }
+}
+
+export function buildBrowserUseRunState({
+  requested,
+  agentId,
+  diagnostics,
+}: {
+  requested: boolean;
+  agentId: string | null | undefined;
+  diagnostics?: BrowserUseDiscoveryFacts;
+}): BrowserUseRunState | null {
+  if (!requested || agentId !== 'codex') return null;
+  const facts = diagnostics ?? collectBrowserUseDiscoveryFacts();
+  return {
+    requested: true,
+    available: false,
+    reason: 'no-matching-browser-backend',
+    diagnostics: facts,
+  };
+}
+
+export function renderBrowserUseUnavailablePrompt(state: BrowserUseRunState | null): string {
+  if (!state || state.available) return '';
+  return [
+    '## Browser automation availability',
+    '',
+    `Browser automation was requested, but Open Design has not confirmed a matching in-app browser backend for this run. Reason: \`${state.reason}\`.`,
+    'Treat browser-use / in-app-browser automation as unavailable for this turn.',
+    'Do not use raw Google Chrome headless or ad-hoc Chrome fallback from the packaged desktop sandbox.',
+    'If the task requires browser evidence, report the unavailable reason and use only the provided browser tab URL, title, and saved project context until a backend is attached.',
+  ].join('\n');
+}

--- a/apps/daemon/src/diagnostics-export.ts
+++ b/apps/daemon/src/diagnostics-export.ts
@@ -27,6 +27,7 @@ import {
 import { readCurrentAppVersionInfo } from './app-version.js';
 import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import { spawnEnvForAgent } from './agents.js';
+import { collectBrowserUseDiscoveryFacts } from './browser-use-diagnostics.js';
 
 interface ResolvedAgentHomes {
   amrOpenCodeHome: string | null;
@@ -150,6 +151,7 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
       const versionInfo = await readCurrentAppVersionInfo().catch(() => null);
       const home = homedir();
       const agentHomes = await resolveAgentHomes(options.dataDir);
+      const browserUse = collectBrowserUseDiscoveryFacts();
       const sources = [
         ...buildSidecarLogSources(options.runtime),
         ...(await buildRunEventLogSources(options.runsDir)),
@@ -180,6 +182,7 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
             mode: options.runtime?.mode ?? null,
             base: options.runtime?.base ?? null,
             projectRoot: options.projectRoot,
+            browserUse,
           },
           warnings: options.runtime == null ? [STANDALONE_LAUNCH_WARNING] : undefined,
         },

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -66,6 +66,7 @@ export function createChatRunService({
         typeof meta.pluginId === 'string' && meta.pluginId ? meta.pluginId : null,
       mediaExecution: normalizeMediaExecutionPolicyForRun(meta.mediaExecution),
       toolBundle: normalizeRunToolBundleForRun(meta.toolBundle),
+      browserUse: meta.browserUse && typeof meta.browserUse === 'object' ? meta.browserUse : null,
       status: 'queued',
       createdAt: now,
       updatedAt: now,
@@ -160,6 +161,7 @@ export function createChatRunService({
     eventsLogPath: run.eventsLogPath ?? null,
     mediaExecution: run.mediaExecution ?? normalizeMediaExecutionPolicyForRun(null),
     toolBundle: summarizeRunToolBundle(run.toolBundle),
+    ...(run.browserUse ? { browserUse: run.browserUse } : {}),
   });
 
   const finish = (run, status, code: number | null = null, signal: string | null = null) => {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -34,6 +34,12 @@ import {
   PLUGIN_PREVIEWS_ROUTE,
 } from './plugin-preview-bakes.js';
 import { userFacingAgentLabel } from './user-facing-agent-label.js';
+import {
+  buildBrowserUseRunState,
+  collectBrowserUseDiscoveryFacts,
+  isBrowserUseRequested,
+  renderBrowserUseUnavailablePrompt,
+} from './browser-use-diagnostics.js';
 
 export { resolveProjectRoot };
 import { createCommandInvocation } from '@open-design/platform';
@@ -11320,6 +11326,17 @@ export async function startServer({
     ) {
       return design.runs.fail(run, 'BAD_REQUEST', 'message required');
     }
+    const browserUseRunState = buildBrowserUseRunState({
+      requested: isBrowserUseRequested(message, currentPrompt, systemPrompt),
+      agentId: def.id,
+    });
+    if (browserUseRunState) {
+      run.browserUse = browserUseRunState;
+      design.runs.emit(run, 'diagnostic', {
+        type: 'browser_use_unavailable',
+        ...browserUseRunState,
+      });
+    }
     if (run.cancelRequested || design.runs.isTerminal(run.status)) return;
     const runId = run.id;
 
@@ -11690,9 +11707,10 @@ export async function startServer({
       agentResumeCtx.storedStablePromptHash,
       currentStableHash,
     );
+    const browserUsePromptGuard = renderBrowserUseUnavailablePrompt(run.browserUse ?? null);
     const clientInstructionParts = includeStableInstructions
-      ? [researchCommandContract, runContextPrompt, systemPrompt]
-      : [researchCommandContract, runContextPrompt];
+      ? [researchCommandContract, runContextPrompt, browserUsePromptGuard, systemPrompt]
+      : [researchCommandContract, runContextPrompt, browserUsePromptGuard];
     const clientInstructionPrompt = clientInstructionParts
       .map((part) => (typeof part === 'string' ? part.trim() : ''))
       .filter(Boolean)
@@ -11755,6 +11773,7 @@ export async function startServer({
         { kind: 'runtimeToolPrompt', content: runtimeToolPrompt },
         { kind: 'researchCommandContract', content: researchCommandContract },
         { kind: 'runContextPrompt', content: runContextPrompt },
+        { kind: 'browserUsePromptGuard', content: browserUsePromptGuard },
         { kind: 'clientSystemPrompt', content: clientInstructionPrompt },
         { kind: 'echoGuard', content: ECHO_GUARD },
         { kind: 'userRequest', content: userRequestPrompt },
@@ -12724,11 +12743,20 @@ export async function startServer({
       ));
       return design.runs.finish(run, 'failed', 1, null);
     }
+    const browserUseRuntimeEnv = run.browserUse
+      ? {
+          OD_BROWSER_USE_REQUESTED: run.browserUse.requested ? '1' : '0',
+          OD_BROWSER_USE_AVAILABLE: run.browserUse.available ? '1' : '0',
+          ...(run.browserUse.reason ? { OD_BROWSER_USE_UNAVAILABLE_REASON: run.browserUse.reason } : {}),
+          OD_BROWSER_USE_REGISTRY_PATH: run.browserUse.diagnostics?.registryPath ?? '',
+        }
+      : {};
     const agentSpawnEnv = spawnEnvForAgent(
       def.id,
       {
         ...createAgentRuntimeEnv(process.env, daemonUrl, toolTokenGrant),
         ...(def.env || {}),
+        ...browserUseRuntimeEnv,
       },
       configuredAgentEnv,
       undefined,

--- a/apps/daemon/tests/browser-use-diagnostics.test.ts
+++ b/apps/daemon/tests/browser-use-diagnostics.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildBrowserUseRunState,
+  collectBrowserUseDiscoveryFacts,
+  isBrowserUseRequested,
+  renderBrowserUseUnavailablePrompt,
+} from '../src/browser-use-diagnostics.js';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'browser-use-diagnostics-test-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('browser use diagnostics', () => {
+  it('detects Browser Use prompts from the Open Design Browser menu', () => {
+    expect(isBrowserUseRequested('hello')).toBe(false);
+    expect(isBrowserUseRequested('@agent-browser\n\nBrowser tab context:')).toBe(true);
+    expect(isBrowserUseRequested('Use the selected Open Design Browser tab as the bound target.')).toBe(true);
+  });
+
+  it('returns a missing-registry snapshot without reading socket contents', () => {
+    const facts = collectBrowserUseDiscoveryFacts({
+      registryPath: join(tempDir, 'missing'),
+      now: 1_000,
+    });
+
+    expect(facts).toMatchObject({
+      registryExists: false,
+      socketCount: 0,
+      candidateCount: 0,
+      staleCount: 0,
+      currentSessionIdPresent: null,
+      probeFailureCategory: 'registry-missing',
+    });
+  });
+
+  it('counts socket candidates and stale entries from the registry directory', async () => {
+    const fresh = join(tempDir, 'fresh-session.sock');
+    const stale = join(tempDir, 'old-session.sock');
+    await writeFile(fresh, '', 'utf8');
+    await writeFile(stale, '', 'utf8');
+    await writeFile(join(tempDir, 'note.txt'), 'not a socket', 'utf8');
+    await utimes(fresh, new Date(10_000), new Date(10_000));
+    await utimes(stale, new Date(1_000), new Date(1_000));
+
+    const facts = collectBrowserUseDiscoveryFacts({
+      registryPath: tempDir,
+      now: 11_000,
+      currentSessionId: 'fresh-session',
+      staleThresholdMs: 5_000,
+    });
+
+    expect(facts).toMatchObject({
+      registryExists: true,
+      socketCount: 2,
+      candidateCount: 2,
+      staleCount: 1,
+      currentSessionIdPresent: true,
+      probeFailureCategory: 'not-probed',
+      newestSocketAgeMs: 1_000,
+      staleThresholdMs: 5_000,
+    });
+  });
+
+  it('builds a typed unavailable state for Codex browser requests', () => {
+    const state = buildBrowserUseRunState({
+      requested: true,
+      agentId: 'codex',
+      diagnostics: collectBrowserUseDiscoveryFacts({
+        registryPath: join(tempDir, 'missing'),
+      }),
+    });
+
+    expect(state).toMatchObject({
+      requested: true,
+      available: false,
+      reason: 'no-matching-browser-backend',
+    });
+  });
+
+  it('leaves non-Codex browser requests outside this Codex-specific state', () => {
+    expect(buildBrowserUseRunState({
+      requested: true,
+      agentId: 'amr',
+      diagnostics: collectBrowserUseDiscoveryFacts({
+        registryPath: join(tempDir, 'missing'),
+      }),
+    })).toBeNull();
+  });
+
+  it('renders a prompt guard that blocks raw Chrome fallback', () => {
+    const state = buildBrowserUseRunState({
+      requested: true,
+      agentId: 'codex',
+      diagnostics: collectBrowserUseDiscoveryFacts({
+        registryPath: join(tempDir, 'missing'),
+      }),
+    });
+
+    const prompt = renderBrowserUseUnavailablePrompt(state);
+
+    expect(prompt).toContain('no-matching-browser-backend');
+    expect(prompt).toContain('Do not use raw Google Chrome headless');
+  });
+});

--- a/apps/daemon/tests/diagnostics-export.test.ts
+++ b/apps/daemon/tests/diagnostics-export.test.ts
@@ -65,8 +65,24 @@ describe('diagnostics export handler — non-sidecar launch', () => {
     const manifest = JSON.parse(manifestRaw) as {
       warnings: string[];
       files: DiagnosticsManifestFile[];
+      extra?: {
+        browserUse?: {
+          registryPath?: string;
+          socketCount?: number;
+          candidateCount?: number;
+          staleCount?: number;
+          probeFailureCategory?: string;
+        };
+      };
     };
     expect(manifest.warnings).toContain(STANDALONE_LAUNCH_WARNING);
+    expect(manifest.extra?.browserUse).toMatchObject({
+      registryPath: expect.stringContaining('codex-browser-use'),
+      probeFailureCategory: expect.any(String),
+    });
+    expect(typeof manifest.extra?.browserUse?.socketCount).toBe('number');
+    expect(typeof manifest.extra?.browserUse?.candidateCount).toBe('number');
+    expect(typeof manifest.extra?.browserUse?.staleCount).toBe('number');
     // Standalone launches intentionally omit sidecar-managed daemon/web/desktop
     // log files, but real developer machines may still contribute matching
     // macOS crash reports from /Library/Logs/DiagnosticReports. Keep the test

--- a/apps/daemon/tests/runs.test.ts
+++ b/apps/daemon/tests/runs.test.ts
@@ -101,6 +101,41 @@ describe('chat run service shutdown', () => {
     });
   });
 
+  it('stores Browser Use availability on run status bodies', () => {
+    const runs = createRuns();
+    const run = runs.create({
+      projectId: 'project-1',
+      conversationId: 'conv-a',
+      browserUse: {
+        requested: true,
+        available: false,
+        reason: 'no-matching-browser-backend',
+        diagnostics: {
+          registryPath: '/tmp/codex-browser-use',
+          registryExists: false,
+          socketCount: 0,
+          candidateCount: 0,
+          staleCount: 0,
+          currentSessionIdPresent: null,
+          probeFailureCategory: 'registry-missing',
+          staleThresholdMs: 600_000,
+        },
+      },
+    });
+
+    expect(runs.statusBody(run)).toMatchObject({
+      browserUse: {
+        requested: true,
+        available: false,
+        reason: 'no-matching-browser-backend',
+        diagnostics: {
+          registryPath: '/tmp/codex-browser-use',
+          probeFailureCategory: 'registry-missing',
+        },
+      },
+    });
+  });
+
   it('stores a run-scoped tool bundle and returns a redacted status summary', () => {
     const runs = createRuns();
     const run = runs.create({

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -150,6 +150,32 @@ export interface RunScopedToolBundleSummary {
   }>;
 }
 
+export type BrowserUseUnavailableReason = 'no-matching-browser-backend';
+
+export type BrowserUseProbeFailureCategory =
+  | 'not-probed'
+  | 'registry-missing'
+  | 'registry-unreadable';
+
+export interface BrowserUseDiscoveryFacts {
+  registryPath: string;
+  registryExists: boolean;
+  socketCount: number;
+  candidateCount: number;
+  staleCount: number;
+  currentSessionIdPresent: boolean | null;
+  probeFailureCategory: BrowserUseProbeFailureCategory;
+  newestSocketAgeMs?: number;
+  staleThresholdMs: number;
+}
+
+export interface BrowserUseRunState {
+  requested: boolean;
+  available: boolean;
+  reason?: BrowserUseUnavailableReason;
+  diagnostics: BrowserUseDiscoveryFacts;
+}
+
 export interface ChatRunCreateRequest extends ChatRequest {
   projectId: string;
   conversationId: string;
@@ -271,6 +297,8 @@ export interface ChatRunStatusResponse {
   mediaExecution?: MediaExecutionPolicy;
   /** Run-scoped tool bundle summary with secrets and command details redacted. */
   toolBundle?: RunScopedToolBundleSummary;
+  /** Browser Use availability for runs that requested in-app browser automation. */
+  browserUse?: BrowserUseRunState;
 }
 
 export interface ChatRunListResponse {


### PR DESCRIPTION
Fixes #3815

## Why

TheHive is testing Open Design as part of a real agent-assisted design workflow. During Codex Browser Use validation, the Browser Use UI can request browser evidence, but the Codex run path may not have a matching in-app browser backend attached. That makes browser QA appear available when it is not, and it can push agents toward raw Chrome headless fallback inside the packaged desktop sandbox.

This PR keeps the issue scoped to the aligned first cut: typed unavailable state, sanitized diagnostics facts, and a prompt/runtime guard against raw Chrome fallback. It does not implement the broader backend attachment path tracked separately.

## What users will see

When a Codex run requests Browser Use via the Open Design Browser prompt and no matching backend is confirmed, the run records a `browser_use_unavailable` diagnostic and exposes `browserUse` on the run status body.

Diagnostics export now includes sanitized Browser Use registry facts such as registry path, socket count, candidate count, stale count, and probe category. The agent prompt also states that in-app browser automation is unavailable and blocks ad-hoc raw Chrome fallback.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/browser-use-diagnostics.test.ts`, plus status and diagnostics coverage in `apps/daemon/tests/runs.test.ts` and `apps/daemon/tests/diagnostics-export.test.ts`.
- Did the test go red on `main` and green on this branch? Not rerun on `main`; the new tests cover behavior that did not exist on `main`.
- Additional verification: checked the Browser Use prompt source in `apps/web/src/components/DesignBrowserPanel.tsx` and kept the runtime state Codex-specific.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/browser-use-diagnostics.test.ts tests/runs.test.ts tests/diagnostics-export.test.ts` with Node 24 on PATH
- `pnpm --filter @open-design/daemon typecheck` with Node 24 on PATH

Agent involvement: implemented by Aegis at TheAngryPit request.