### PR TITLE
fix(desktop,web): parent native dialogs to renderer window and raise design system picker stacking context

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1288,6 +1288,27 @@ async function reportRendererCrash(
   }
 }
 
+/**
+ * Native directory picker, parented to the renderer window that initiated
+ * the IPC call. Parenting makes the dialog window-modal and hands it
+ * keyboard focus (most visibly on Windows): without a parent the focus
+ * stays on the Electron window, so pressing Esc falls through to the web
+ * app and closes the in-app modal *behind* the still-open native picker.
+ * With a parent the picker owns Esc and cancels itself.
+ */
+async function showDirectoryPickerForSender(
+  sender: Electron.WebContents,
+): Promise<Electron.OpenDialogReturnValue> {
+  const parent =
+    BrowserWindow.fromWebContents(sender) ?? BrowserWindow.getFocusedWindow();
+  const pickerOptions: Electron.OpenDialogOptions = {
+    properties: ["openDirectory", "createDirectory"],
+  };
+  return parent
+    ? dialog.showOpenDialog(parent, pickerOptions)
+    : dialog.showOpenDialog(pickerOptions);
+}
+
 export async function createDesktopRuntime(options: DesktopRuntimeOptions): Promise<DesktopRuntime> {
   const preloadPath = options.preloadPath ?? join(dirname(fileURLToPath(import.meta.url)), "preload.cjs");
   applyDockIcon();
@@ -1332,7 +1353,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   // import boundary while leaving web-only deployments untouched.
   ipcMain.handle(
     "dialog:pick-and-import",
-    async (_event, init?: { name?: string; skillId?: string | null; designSystemId?: string | null }) => {
+    async (event, init?: { name?: string; skillId?: string | null; designSystemId?: string | null }) => {
       // Defensive failsafe for non-production runtimes (test harnesses
       // that construct createDesktopRuntime without a secret). Round-5
       // production wiring in runDesktopMain ALWAYS passes the per-process
@@ -1355,7 +1376,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       if (!apiBaseUrl) {
         return { ok: false, reason: "daemon API URL not available" };
       }
-      const result = await dialog.showOpenDialog({ properties: ["openDirectory", "createDirectory"] });
+      const result = await showDirectoryPickerForSender(event.sender);
       if (result.canceled || result.filePaths.length === 0) {
         return { ok: false, canceled: true };
       }
@@ -1384,7 +1405,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   // POST are a single main-process transaction.
   ipcMain.handle(
     "dialog:pick-and-replace-working-dir",
-    async (_event, init?: { projectId?: string }) => {
+    async (event, init?: { projectId?: string }) => {
       if (options.desktopAuthSecret == null) {
         return { ok: false, reason: "desktop auth secret not registered" };
       }
@@ -1398,7 +1419,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       if (!apiBaseUrl) {
         return { ok: false, reason: "daemon API URL not available" };
       }
-      const result = await dialog.showOpenDialog({ properties: ["openDirectory", "createDirectory"] });
+      const result = await showDirectoryPickerForSender(event.sender);
       if (result.canceled || result.filePaths.length === 0) {
         return { ok: false, canceled: true };
       }
@@ -1421,11 +1442,11 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   // spends the token on POST /api/projects/:id/working-dir once the project
   // exists. Main remains the single source of filesystem paths crossing into
   // the daemon (same trust boundary as dialog:pick-and-replace-working-dir).
-  ipcMain.handle("dialog:pick-working-dir", async () => {
+  ipcMain.handle("dialog:pick-working-dir", async (event) => {
     if (options.desktopAuthSecret == null) {
       return { ok: false, reason: "desktop auth secret not registered" };
     }
-    const result = await dialog.showOpenDialog({ properties: ["openDirectory", "createDirectory"] });
+    const result = await showDirectoryPickerForSender(event.sender);
     if (result.canceled || result.filePaths.length === 0) {
       return { ok: false, canceled: true };
     }

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -1,13 +1,14 @@
 /* -------- Design system picker (custom popover dropdown) ------------ */
 .ds-picker { position: relative; }
-/* Each `.newproj-section` keeps a residual identity transform from the
-   `od-fade-slide-up` entrance animation (`animation-fill-mode: both`), which
-   makes every section its own stacking context. `.ds-picker` is such a
-   section, so the popover's `z-index` is trapped inside the picker and cannot
-   rise above later sibling sections (Target platforms, Companion, Fidelity,
-   Create) — they would paint over the open dropdown. Lift the OPEN picker's
-   whole stacking context above its siblings to keep the popover on top. */
-.ds-picker.open { z-index: 40; }
+/* While its popover is open, the picker must paint above its sibling
+   sections. Each `.newproj-section` keeps a transform applied after the
+   entrance animation (`od-fade-slide-up ... both` in entrance.css), which
+   makes every section its own stacking context — the popover's z-index
+   alone can't escape its section, so later siblings (Target platforms,
+   model picker, toggles, …) would cover the open list. Raising the open
+   picker's section above its `z-index: auto` siblings restores the
+   expected "dropdown on top" order. */
+.ds-picker:has(.ds-picker-popover) { z-index: 31; }
 .ds-picker-trigger {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fixes #

    ## Why

    - **Use Case:**
      - **Desktop Dialog Focus/Modal Behavior:** The desktop app uses native folder selection dialogs (e.g., when
  picking a project working directory or importing files). Previously, these dialogs were not parented to the renderer
  window. On Windows especially, this led to a focus issue: when the dialog was open, the parent Electron window still
  retained keyboard focus. Pressing `Esc` failed to cancel the native folder picker and instead fell through to the
  underlying web app, dismissing whatever in-app modal was open behind it. Parenting the dialog to the sender window
  ensures that the dialog is window-modal and captures/handles the keyboard focus correctly.
      - **Web Stacking Context (Design System Picker):** When launching the design system picker dropdown popover in
  the new project screen, it was being overlapped by sibling sections (e.g., target platforms, model picker). This
  occurred because the sibling sections have entrance animations (`transform` properties) which establish their own
  local stacking contexts. As a result, simply setting a `z-index` on the popover was insufficient to escape the
  parent container's stacking boundary.

    - **Pain Addressed:**
      - Frustrating keyboard shortcut bugs on desktop where pressing `Esc` accidentally closed underlying app
  dialogs/modals instead of the foreground native picker.
      - Visual overlap glitch on web where the design system dropdown popover was rendered underneath subsequent form
  fields/sections.

    ## What users will see

    - **Desktop folder selection:** Dismissing the native folder selection dialog using the `Esc` key will now
  correctly cancel/close the dialog itself, rather than dismissing the in-app modal beneath it.
    - **Design System Picker:** The dropdown popover for the design system selection now renders properly on top of
  all subsequent sections on the page.

    ## Surface area

    - [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop`
  (including Electron menu bar)
    - [ ] **Keyboard shortcut** — new or changed
    - [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new
  `OD_*` env var
    - [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
    - [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or
  change to the skills protocol
    - [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
    - [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or
  `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs.
  what bytes we ship (see `CONTRIBUTING.md` → Code style)
    - [ ] **Default behavior change** — changes what existing users experience without opting in (default model,
  default setting, file/SQLite schema, auto-network on startup, auto-install)
    - [ ] **None** — internal refactor, docs, tests, or translation update only

    ## Screenshots

    *Visual styling correction to `.ds-picker` popover stacking context and native dialog parenting modal focus
  correction.*

    ## Bug fix verification

    - **Verification performed:**
      - Manually tested desktop build to confirm that native folders dialogs parented via `BrowserWindow.
  fromWebContents(sender)` behave as window-modal and intercept keyboard interactions (like pressing `Esc`) correctly.
      - Inspected the layout of the project generation page in `apps/web` to confirm `.ds-picker:has(.ds-picker-
  popover)` elevates the stacking context above animated sibling sections.

    ## Validation

    - Checked code correctness manually for TypeScript types and imports.
    - Performed visual review of CSS hierarchy and Electron IPC `WebContents` handling.