### PR TITLE
Fix design system preview image asset URLs

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -2513,9 +2513,9 @@ function DesignSystemProjectPanel({
     }));
   }
 
-  function openNeedsWorkFeedback(sectionTitle: string) {
+  function openNeedsWorkFeedback(sectionTitle: string, expansionKey: string) {
     setReviewDecisions((current) => ({ ...current, [sectionTitle]: 'needs-work' }));
-    setExpandedSections((current) => ({ ...current, [sectionTitle]: true }));
+    setExpandedSections((current) => ({ ...current, [expansionKey]: true }));
     setFeedbackSection(sectionTitle);
     setFeedbackText('');
   }
@@ -2626,7 +2626,7 @@ function DesignSystemProjectPanel({
               type="button"
               className={`ghost danger ${reviewDecisions[section.title] === 'needs-work' ? 'active' : ''}`}
               data-testid={`design-system-review-work-${slugForTestId(section.title)}`}
-              onClick={() => openNeedsWorkFeedback(section.title)}
+              onClick={() => openNeedsWorkFeedback(section.title, instanceId)}
             >
               <Icon name="comment" size={13} />
               Needs work...

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -2384,6 +2384,7 @@ function DesignSystemProjectPanel({
   const [status, setStatus] = useState(system.status ?? 'draft');
   const [statusBusy, setStatusBusy] = useState(false);
   const [cardManifest, setCardManifest] = useState<DesignSystemCardManifestMap>(() => new Map());
+  const [cardManifestError, setCardManifestError] = useState<string | null>(null);
   useEffect(() => {
     setStatus(system.status ?? 'draft');
   }, [system.status]);
@@ -2402,6 +2403,7 @@ function DesignSystemProjectPanel({
   useEffect(() => {
     if (!system.id || !manifestFileName || manifestCacheBustKey === null) {
       setCardManifest(new Map());
+      setCardManifestError(null);
       return undefined;
     }
     let cancelled = false;
@@ -2411,6 +2413,11 @@ function DesignSystemProjectPanel({
     }).then((text) => {
       if (cancelled) return;
       setCardManifest(parseDesignSystemCardManifest(text));
+      setCardManifestError(null);
+    }).catch((err: unknown) => {
+      if (cancelled) return;
+      setCardManifest(new Map());
+      setCardManifestError(err instanceof Error ? err.message : 'Unable to read _ds_manifest.json.');
     });
     return () => {
       cancelled = true;
@@ -2888,6 +2895,26 @@ function DesignSystemProjectPanel({
           <MissingBrandFontsBanner projectId={projectId} onUploadAssets={onUploadAssets} />
         ) : null}
 
+        {cardManifestError ? (
+          <div
+            className="ds-project-warning-card ds-project-warning-card--error"
+            data-testid="design-system-manifest-error"
+            role="alert"
+          >
+            <Icon name="alert-triangle" size={16} />
+            <span>
+              <strong>Design manifest needs attention</strong>
+              <small>{cardManifestError}</small>
+            </span>
+            {manifestFileName ? (
+              <Button variant="ghost" className="compact" onClick={() => onOpenFile(manifestFileName)}>
+                <Icon name="file" size={13} />
+                Open manifest
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
         <div className="ds-project-sections">
           {groupedSectionReviews.map((group) => (
             <div key={group.title} className="ds-project-section-group">
@@ -3098,30 +3125,38 @@ function isDesignSystemUiKitEntryPage(path: string): boolean {
 
 function parseDesignSystemCardManifest(text: string | null): DesignSystemCardManifestMap {
   if (!text) return new Map();
+  let parsed: { cards?: unknown };
   try {
-    const parsed = JSON.parse(text) as { cards?: unknown };
-    const cards = Array.isArray(parsed.cards) ? parsed.cards : [];
-    const entries: Array<[string, DesignSystemCardManifestEntry]> = [];
-    for (const card of cards) {
-      if (!card || typeof card !== 'object') continue;
-      const record = card as Record<string, unknown>;
-      if (typeof record.path !== 'string' || !record.path.trim()) continue;
-      const path = normalizeDesignSystemPath(record.path);
-      entries.push([
-        path,
-        {
-          path,
-          group: typeof record.group === 'string' ? record.group : undefined,
-          name: typeof record.name === 'string' ? record.name : undefined,
-          subtitle: typeof record.subtitle === 'string' ? record.subtitle : undefined,
-          viewport: typeof record.viewport === 'string' ? record.viewport : undefined,
-        },
-      ]);
-    }
-    return new Map(entries);
-  } catch {
-    return new Map();
+    parsed = JSON.parse(text) as { cards?: unknown };
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid _ds_manifest.json: ${detail}`);
   }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Invalid _ds_manifest.json: expected an object with a cards array.');
+  }
+  if (parsed.cards !== undefined && !Array.isArray(parsed.cards)) {
+    throw new Error('Invalid _ds_manifest.json: cards must be an array.');
+  }
+  const cards = Array.isArray(parsed.cards) ? parsed.cards : [];
+  const entries: Array<[string, DesignSystemCardManifestEntry]> = [];
+  for (const card of cards) {
+    if (!card || typeof card !== 'object') continue;
+    const record = card as Record<string, unknown>;
+    if (typeof record.path !== 'string' || !record.path.trim()) continue;
+    const path = normalizeDesignSystemPath(record.path);
+    entries.push([
+      path,
+      {
+        path,
+        group: typeof record.group === 'string' ? record.group : undefined,
+        name: typeof record.name === 'string' ? record.name : undefined,
+        subtitle: typeof record.subtitle === 'string' ? record.subtitle : undefined,
+        viewport: typeof record.viewport === 'string' ? record.viewport : undefined,
+      },
+    ]);
+  }
+  return new Map(entries);
 }
 
 function designSystemReviewPreviewDisplay(

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -3920,14 +3920,27 @@ async function fetchDesignSystemPreviewRelativeText(
 }
 
 function resolveDesignSystemPreviewRelativePath(ownerFileName: string, assetRef: string): string | null {
-  if (/^(?:https?:|data:|blob:|mailto:|tel:|#)/i.test(assetRef)) return null;
+  const ref = assetRef.trim();
+  if (/^(?:https?:|data:|blob:|mailto:|tel:|#)/i.test(ref)) return null;
+  if (isDesignSystemPreviewAppRootRef(ref)) return null;
   try {
-    const url = new URL(assetRef, `https://od.local/${baseDirForDesignSystemPreviewFile(ownerFileName)}`);
+    const url = new URL(ref, `https://od.local/${baseDirForDesignSystemPreviewFile(ownerFileName)}`);
     if (url.origin !== 'https://od.local') return null;
     return decodeURIComponent(url.pathname.replace(/^\/+/, ''));
   } catch {
     return null;
   }
+}
+
+function isDesignSystemPreviewAppRootRef(ref: string): boolean {
+  if (!ref.startsWith('/') || ref.startsWith('//')) return false;
+  const pathOnly = ref.split(/[?#]/, 1)[0]?.toLowerCase() ?? '';
+  return pathOnly === '/api'
+    || pathOnly.startsWith('/api/')
+    || pathOnly === '/artifacts'
+    || pathOnly.startsWith('/artifacts/')
+    || pathOnly === '/frames'
+    || pathOnly.startsWith('/frames/');
 }
 
 function rewriteDesignSystemPreviewCssUrls(css: string, projectId: string, stylesheetFileName: string): string {

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -347,6 +347,7 @@ interface DesignSystemCardManifestEntry {
   viewport?: string;
 }
 type DesignSystemCardManifestMap = Map<string, DesignSystemCardManifestEntry>;
+const DESIGN_SYSTEM_CARD_MANIFEST_OPTIONAL_STRING_FIELDS = ['group', 'name', 'subtitle', 'viewport'] as const;
 type DesignSystemGenerationStepStatus = 'pending' | 'running' | 'succeeded';
 interface DesignSystemGenerationStep {
   id: string;
@@ -3123,6 +3124,37 @@ function isDesignSystemUiKitEntryPage(path: string): boolean {
   return isDesignSystemUiKitFile(path) && /\.html?$/iu.test(path);
 }
 
+function designSystemManifestCardError(index: number, detail: string): Error {
+  const separator = detail.startsWith('.') ? '' : ' ';
+  return new Error(`Invalid _ds_manifest.json: cards[${index}]${separator}${detail}.`);
+}
+
+function optionalDesignSystemManifestString(
+  record: Record<string, unknown>,
+  field: (typeof DESIGN_SYSTEM_CARD_MANIFEST_OPTIONAL_STRING_FIELDS)[number],
+  index: number,
+): string | undefined {
+  const value = record[field];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') throw designSystemManifestCardError(index, `.${field} must be a string`);
+  return value;
+}
+
+function parseDesignSystemCardManifestEntry(card: unknown, index: number): DesignSystemCardManifestEntry {
+  if (!card || typeof card !== 'object' || Array.isArray(card)) {
+    throw designSystemManifestCardError(index, 'must be an object');
+  }
+  const record = card as Record<string, unknown>;
+  if (typeof record.path !== 'string' || !record.path.trim()) {
+    throw designSystemManifestCardError(index, '.path must be a non-empty string');
+  }
+  const entry: DesignSystemCardManifestEntry = { path: normalizeDesignSystemPath(record.path) };
+  for (const field of DESIGN_SYSTEM_CARD_MANIFEST_OPTIONAL_STRING_FIELDS) {
+    entry[field] = optionalDesignSystemManifestString(record, field, index);
+  }
+  return entry;
+}
+
 function parseDesignSystemCardManifest(text: string | null): DesignSystemCardManifestMap {
   if (!text) return new Map();
   let parsed: { cards?: unknown };
@@ -3140,21 +3172,9 @@ function parseDesignSystemCardManifest(text: string | null): DesignSystemCardMan
   }
   const cards = Array.isArray(parsed.cards) ? parsed.cards : [];
   const entries: Array<[string, DesignSystemCardManifestEntry]> = [];
-  for (const card of cards) {
-    if (!card || typeof card !== 'object') continue;
-    const record = card as Record<string, unknown>;
-    if (typeof record.path !== 'string' || !record.path.trim()) continue;
-    const path = normalizeDesignSystemPath(record.path);
-    entries.push([
-      path,
-      {
-        path,
-        group: typeof record.group === 'string' ? record.group : undefined,
-        name: typeof record.name === 'string' ? record.name : undefined,
-        subtitle: typeof record.subtitle === 'string' ? record.subtitle : undefined,
-        viewport: typeof record.viewport === 'string' ? record.viewport : undefined,
-      },
-    ]);
+  for (const [index, card] of cards.entries()) {
+    const entry = parseDesignSystemCardManifestEntry(card, index);
+    entries.push([entry.path, entry]);
   }
   return new Map(entries);
 }

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -3919,14 +3919,26 @@ async function fetchDesignSystemPreviewRelativeText(
   return fetchProjectFileText(projectId, filePath, { cache: 'no-store' });
 }
 
+type DesignSystemPreviewAssetPath = {
+  filePath: string;
+  suffix: string;
+};
+
 function resolveDesignSystemPreviewRelativePath(ownerFileName: string, assetRef: string): string | null {
+  return resolveDesignSystemPreviewAssetPath(ownerFileName, assetRef)?.filePath ?? null;
+}
+
+function resolveDesignSystemPreviewAssetPath(ownerFileName: string, assetRef: string): DesignSystemPreviewAssetPath | null {
   const ref = assetRef.trim();
   if (/^(?:https?:|data:|blob:|mailto:|tel:|#)/i.test(ref)) return null;
   if (isDesignSystemPreviewAppRootRef(ref)) return null;
   try {
     const url = new URL(ref, `https://od.local/${baseDirForDesignSystemPreviewFile(ownerFileName)}`);
     if (url.origin !== 'https://od.local') return null;
-    return decodeURIComponent(url.pathname.replace(/^\/+/, ''));
+    return {
+      filePath: decodeURIComponent(url.pathname.replace(/^\/+/, '')),
+      suffix: `${url.search}${url.hash}`,
+    };
   } catch {
     return null;
   }
@@ -3946,9 +3958,9 @@ function isDesignSystemPreviewAppRootRef(ref: string): boolean {
 function rewriteDesignSystemPreviewCssUrls(css: string, projectId: string, stylesheetFileName: string): string {
   return css.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/gi, (match, _quote: string, rawRef: string) => {
     const ref = rawRef.trim();
-    const filePath = resolveDesignSystemPreviewRelativePath(stylesheetFileName, ref);
-    if (!filePath) return match;
-    return `url("${escapeDesignSystemPreviewCssUrl(projectRawUrl(projectId, filePath))}")`;
+    const assetPath = resolveDesignSystemPreviewAssetPath(stylesheetFileName, ref);
+    if (!assetPath) return match;
+    return `url("${escapeDesignSystemPreviewCssUrl(projectRawUrl(projectId, assetPath.filePath) + assetPath.suffix)}")`;
   });
 }
 
@@ -3975,8 +3987,8 @@ function rewriteDesignSystemPreviewHtmlAssetUrls(html: string, projectId: string
 }
 
 function rewriteDesignSystemPreviewHtmlAssetRef(ref: string, projectId: string, ownerFileName: string): string {
-  const filePath = resolveDesignSystemPreviewRelativePath(ownerFileName, ref.trim());
-  return filePath ? projectRawUrl(projectId, filePath) : ref;
+  const assetPath = resolveDesignSystemPreviewAssetPath(ownerFileName, ref.trim());
+  return assetPath ? projectRawUrl(projectId, assetPath.filePath) + assetPath.suffix : ref;
 }
 
 function rewriteDesignSystemPreviewSrcset(srcset: string, projectId: string, ownerFileName: string): string {

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -2398,21 +2398,24 @@ function DesignSystemProjectPanel({
   const fileByName = new Map(files.map((file) => [file.name, file]));
   const manifestFile = files.find((file) => normalizeDesignSystemPath(file.name) === '_ds_manifest.json');
   const manifestFileName = manifestFile?.name ?? null;
-  const manifestSignature = manifestFile ? `${manifestFile.name}:${manifestFile.mtime}` : '';
+  const manifestCacheBustKey = manifestFile ? Math.round(manifestFile.mtime) : null;
   useEffect(() => {
-    if (!system.id || !manifestFileName) {
+    if (!system.id || !manifestFileName || manifestCacheBustKey === null) {
       setCardManifest(new Map());
       return undefined;
     }
     let cancelled = false;
-    void fetchProjectFileText(projectId, manifestFileName).then((text) => {
+    void fetchProjectFileText(projectId, manifestFileName, {
+      cache: 'no-store',
+      cacheBustKey: manifestCacheBustKey,
+    }).then((text) => {
       if (cancelled) return;
       setCardManifest(parseDesignSystemCardManifest(text));
     });
     return () => {
       cancelled = true;
     };
-  }, [manifestFileName, manifestSignature, projectId, system.id]);
+  }, [manifestCacheBustKey, manifestFileName, projectId, system.id]);
   const fontFiles = allFileNames.filter((name) =>
     /\.(otf|ttf|woff|woff2)$/i.test(name) || name.toLowerCase().includes('/fonts/'),
   );

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -3906,7 +3906,8 @@ async function inlineDesignSystemPreviewRelativeAssets(
     (next, replacement) => next.replace(replacement.from, () => replacement.to),
     html,
   );
-  return rewriteDesignSystemPreviewHtmlAssetUrls(withInlineAssets, projectId, ownerFileName);
+  const withInlineCssAssets = rewriteDesignSystemPreviewInlineCssAssetUrls(withInlineAssets, projectId, ownerFileName);
+  return rewriteDesignSystemPreviewHtmlAssetUrls(withInlineCssAssets, projectId, ownerFileName);
 }
 
 async function fetchDesignSystemPreviewRelativeText(
@@ -3982,6 +3983,28 @@ function rewriteDesignSystemPreviewHtmlAssetUrls(html: string, projectId: string
   return withDirectAssets.replace(srcsetAssetTags, (match, prefix: string, quote: string, rawSrcset: string) => {
     const rewritten = rewriteDesignSystemPreviewSrcset(rawSrcset, projectId, ownerFileName);
     if (rewritten === rawSrcset) return match;
+    return `${prefix}${quote}${escapeDesignSystemPreviewAttr(rewritten)}${quote}`;
+  });
+}
+
+function rewriteDesignSystemPreviewInlineCssAssetUrls(html: string, projectId: string, ownerFileName: string): string {
+  const withStyleBlocks = html.replace(/<style\b([^>]*)>([\s\S]*?)<\/style>/gi, (
+    match,
+    attrs: string,
+    css: string,
+  ) => {
+    const rewritten = rewriteDesignSystemPreviewCssUrls(css, projectId, ownerFileName);
+    if (rewritten === css) return match;
+    return `<style${attrs}>${rewritten}</style>`;
+  });
+  return withStyleBlocks.replace(/(\sstyle\s*=\s*)(['"])([\s\S]*?)\2/gi, (
+    match,
+    prefix: string,
+    quote: string,
+    css: string,
+  ) => {
+    const rewritten = rewriteDesignSystemPreviewCssUrls(css, projectId, ownerFileName);
+    if (rewritten === css) return match;
     return `${prefix}${quote}${escapeDesignSystemPreviewAttr(rewritten)}${quote}`;
   });
 }

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -2461,6 +2461,17 @@ function DesignSystemProjectPanel({
     ? sectionReviews.filter((item) => designSystemSectionVisibleDuringGeneration(item))
     : sectionReviews;
   const groupedSectionReviews = designSystemReviewGroups(visibleSectionReviews);
+  const reviewTocGroups = groupedSectionReviews
+    .map((group) => ({
+      title: group.title,
+      items: group.items.map((item) => ({
+        id: `design-system-section-${slugForTestId(`${group.title}:${item.section.title}`)}`,
+        label: item.section.title,
+        statusClass: designSystemSectionStatusClass(item.sectionStatus),
+        statusLabel: item.sectionStatusLabel,
+      })),
+    }))
+    .filter((group) => group.items.length > 0);
   const creatingInitialDraft = streaming && !published;
   const generationSteps = designSystemInitialGenerationSteps({
     files,
@@ -2541,8 +2552,7 @@ function DesignSystemProjectPanel({
     // default to show it is done. Gate that on the current status, not just the
     // stored decision: when a section is regenerated after approval its status
     // moves back to needs-attention, and it has to reopen so the "review again"
-    // notice and the review buttons (both rendered only while expanded) stay
-    // visible. Without the needsAttention guard a stale "looks-good" decision
+    // notice and regenerated preview stay visible. Without the needsAttention guard a stale "looks-good" decision
     // keeps the regenerated section collapsed and the change is easy to miss.
     // The user can still re-expand with the chevron (expandedSections[instanceId]),
     // and an active agent run forces it open.
@@ -2550,8 +2560,12 @@ function DesignSystemProjectPanel({
       !needsAttention && (reviewDecisions[section.title] ?? reviewEntry?.decision) === 'looks-good';
     const expanded =
       (expandedSections[instanceId] ?? (defaultExpanded && !reviewedGood)) || sectionActivity.running;
+    const sectionSlug = slugForTestId(instanceId);
+    const sectionAnchorId = `design-system-section-${sectionSlug}`;
+    const editableFile = designSystemSectionEditableFile(section, previewFile, fileByName);
     return (
       <section
+        id={sectionAnchorId}
         key={instanceId}
         className={[
           'ds-project-section',
@@ -2593,73 +2607,83 @@ function DesignSystemProjectPanel({
               </span>
             ) : null}
           </span>
-          {expanded ? (
-            <div className="ds-project-review-actions" aria-label={`${section.title} review`}>
+          <div className="ds-project-review-actions" aria-label={`${section.title} review`}>
+            <button
+              type="button"
+              className={`ghost success ${reviewDecisions[section.title] === 'looks-good' ? 'active' : ''}`}
+              data-testid={`design-system-review-good-${slugForTestId(section.title)}`}
+              onClick={() => {
+                markSectionReview(section.title, 'looks-good');
+                // Collapse on validate, overriding any manual expand so the
+                // section always tidies away once it is marked good.
+                setExpandedSections((current) => ({ ...current, [instanceId]: false }));
+              }}
+            >
+              <Icon name="check" size={13} />
+              Looks good
+            </button>
+            <button
+              type="button"
+              className={`ghost danger ${reviewDecisions[section.title] === 'needs-work' ? 'active' : ''}`}
+              data-testid={`design-system-review-work-${slugForTestId(section.title)}`}
+              onClick={() => openNeedsWorkFeedback(section.title)}
+            >
+              <Icon name="comment" size={13} />
+              Needs work...
+            </button>
+            {editableFile ? (
               <button
                 type="button"
-                className={`ghost success ${reviewDecisions[section.title] === 'looks-good' ? 'active' : ''}`}
-                data-testid={`design-system-review-good-${slugForTestId(section.title)}`}
-                onClick={() => {
-                  markSectionReview(section.title, 'looks-good');
-                  // Collapse on validate, overriding any manual expand so the
-                  // section always tidies away once it is marked good.
-                  setExpandedSections((current) => ({ ...current, [instanceId]: false }));
+                className="ghost compact"
+                data-testid={`design-system-review-edit-${sectionSlug}`}
+                title={`Edit ${editableFile.name}`}
+                onClick={() => onOpenFile(editableFile.name)}
+              >
+                <Icon name="edit" size={13} />
+                Edit
+              </button>
+            ) : null}
+            {feedbackSection === section.title ? (
+              <form
+                className="ds-project-feedback-popover"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  submitNeedsWorkFeedback(section.title, section.files);
                 }}
               >
-                <Icon name="check" size={13} />
-                Looks good
-              </button>
-              <button
-                type="button"
-                className={`ghost danger ${reviewDecisions[section.title] === 'needs-work' ? 'active' : ''}`}
-                data-testid={`design-system-review-work-${slugForTestId(section.title)}`}
-                onClick={() => openNeedsWorkFeedback(section.title)}
-              >
-                <Icon name="comment" size={13} />
-                Needs work...
-              </button>
-              {feedbackSection === section.title ? (
-                <form
-                  className="ds-project-feedback-popover"
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    submitNeedsWorkFeedback(section.title, section.files);
-                  }}
-                >
-                  <label htmlFor={`ds-feedback-${slugForTestId(section.title)}`}>
-                    Tell the agent what to change
-                  </label>
-                  <textarea
-                    id={`ds-feedback-${slugForTestId(section.title)}`}
-                    value={feedbackText}
-                    rows={3}
-                    placeholder={`e.g. tighten spacing in ${section.title}, regenerate this preview...`}
-                    onChange={(event) => setFeedbackText(event.target.value)}
-                    autoFocus
-                  />
-                  <div>
-                    <button
-                      type="button"
-                      className="ghost compact"
-                      onClick={() => {
-                        setFeedbackSection(null);
-                        setFeedbackText('');
-                      }}
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className="primary compact"
-                      disabled={!feedbackText.trim()}
-                    >
-                      Send
-                    </button>
-                  </div>
-                </form>
+                <label htmlFor={`ds-feedback-${slugForTestId(section.title)}`}>
+                  Tell the agent what to change
+                </label>
+                <textarea
+                  id={`ds-feedback-${slugForTestId(section.title)}`}
+                  value={feedbackText}
+                  rows={3}
+                  placeholder={`e.g. tighten spacing in ${section.title}, regenerate this preview...`}
+                  onChange={(event) => setFeedbackText(event.target.value)}
+                  autoFocus
+                />
+                <div>
+                  <button
+                    type="button"
+                    className="ghost compact"
+                    onClick={() => {
+                      setFeedbackSection(null);
+                      setFeedbackText('');
+                    }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    className="primary compact"
+                    disabled={!feedbackText.trim()}
+                  >
+                    Send
+                  </button>
+                </div>
+              </form>
               ) : null}
-            </div>
-          ) : null}
+          </div>
         </div>
         {expanded ? (
           <div className="ds-project-section-body">
@@ -2732,8 +2756,37 @@ function DesignSystemProjectPanel({
 
   return (
     <div className="ds-project-panel">
-      <div className="ds-project-main ds-project-main--review">
-        <div className="ds-project-head ds-project-head--review">
+      <div className="ds-project-review-layout">
+        {reviewTocGroups.length > 0 ? (
+          <nav
+            className="ds-project-toc"
+            aria-label="Design system sections"
+            data-testid="design-system-review-toc"
+          >
+            <div className="ds-project-toc__title">
+              <Icon name="panel-left" size={14} />
+              <span>Contents</span>
+            </div>
+            {reviewTocGroups.map((group) => (
+              <div key={group.title} className="ds-project-toc__group">
+                <strong>{group.title}</strong>
+                {group.items.map((item) => (
+                  <a key={item.id} href={`#${item.id}`}>
+                    <span
+                      className={['ds-project-toc__dot', item.statusClass].join(' ')}
+                      aria-label={item.statusLabel}
+                      title={item.statusLabel}
+                    />
+                    <span>{item.label}</span>
+                  </a>
+                ))}
+              </div>
+            ))}
+          </nav>
+        ) : null}
+
+        <div className="ds-project-main ds-project-main--review">
+          <div className="ds-project-head ds-project-head--review">
           <h1>
             {published
               ? `${systemDisplayName} design system`
@@ -2848,6 +2901,7 @@ function DesignSystemProjectPanel({
               <span>Preview cards will appear here as the agent creates them.</span>
             </div>
           ) : null}
+          </div>
         </div>
       </div>
     </div>
@@ -2870,6 +2924,19 @@ function designSystemHasSourceContext(system: DesignSystemSummary): boolean {
 
 function slugForTestId(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function designSystemSectionEditableFile(
+  section: DesignSystemProjectSection,
+  previewFile: ProjectFile | null,
+  fileByName: Map<string, ProjectFile>,
+): ProjectFile | null {
+  if (previewFile && (previewFile.kind === 'html' || previewFile.kind === 'sketch')) return previewFile;
+  const htmlFile = section.files
+    .map((name) => fileByName.get(name))
+    .find((file) => file?.kind === 'html');
+  if (htmlFile) return htmlFile;
+  return previewFile ?? section.files.map((name) => fileByName.get(name)).find(Boolean) ?? null;
 }
 
 function designSystemSectionPreviewFile(
@@ -3795,14 +3862,19 @@ async function inlineDesignSystemPreviewRelativeAssets(
     if (!rel || !/\bstylesheet\b/i.test(rel) || !href) continue;
     const stylesheetPath = resolveDesignSystemPreviewRelativePath(ownerFileName, href);
     if (!stylesheetPath) continue;
-    replacements.push(fetchProjectFileText(projectId, stylesheetPath, { cache: 'no-store' }).then((css) =>
-      css == null
-        ? null
-        : {
-            from: tag,
-            to: `<style data-od-inline-asset="${escapeDesignSystemPreviewAttr(href)}">\n${rewriteDesignSystemPreviewCssUrls(css, projectId, stylesheetPath).replace(/<\/style/gi, '<\\/style')}\n</style>`,
-          },
-    ));
+    replacements.push(fetchProjectFileText(projectId, stylesheetPath, { cache: 'no-store' }).then((css) => {
+      if (css == null) return null;
+      const safeCss = rewriteDesignSystemPreviewCssUrls(css, projectId, stylesheetPath)
+        .replace(/<\/style/gi, '<\\/style');
+      return {
+        from: tag,
+        to: [
+          `<style data-od-inline-asset="${escapeDesignSystemPreviewAttr(href)}">`,
+          safeCss,
+          '</style>',
+        ].join('\n'),
+      };
+    }));
   }
 
   const scripts = html.match(/<script\b[^>]*\bsrc\s*=\s*["'][^"']+["'][^>]*>\s*<\/script>/gi) ?? [];
@@ -3818,7 +3890,11 @@ async function inlineDesignSystemPreviewRelativeAssets(
         .replace(/\ssrc\s*=\s*(['"])[\s\S]*?\1/i, '');
       return {
         from: tag,
-        to: `<script${attrs} data-od-inline-asset="${escapeDesignSystemPreviewAttr(src)}">\n${js.replace(/<\/script/gi, '<\\/script')}\n</script>`,
+        to: [
+          `<script${attrs} data-od-inline-asset="${escapeDesignSystemPreviewAttr(src)}">`,
+          js.replace(/<\/script/gi, '<\\/script'),
+          '</script>',
+        ].join('\n'),
       };
     }));
   }
@@ -3826,7 +3902,11 @@ async function inlineDesignSystemPreviewRelativeAssets(
   const resolved = (await Promise.all(replacements)).filter(
     (replacement): replacement is { from: string; to: string } => replacement !== null,
   );
-  return resolved.reduce((next, replacement) => next.replace(replacement.from, () => replacement.to), html);
+  const withInlineAssets = resolved.reduce(
+    (next, replacement) => next.replace(replacement.from, () => replacement.to),
+    html,
+  );
+  return rewriteDesignSystemPreviewHtmlAssetUrls(withInlineAssets, projectId, ownerFileName);
 }
 
 async function fetchDesignSystemPreviewRelativeText(
@@ -3840,7 +3920,7 @@ async function fetchDesignSystemPreviewRelativeText(
 }
 
 function resolveDesignSystemPreviewRelativePath(ownerFileName: string, assetRef: string): string | null {
-  if (/^(?:https?:|data:|blob:|mailto:|tel:|#|\/)/i.test(assetRef)) return null;
+  if (/^(?:https?:|data:|blob:|mailto:|tel:|#)/i.test(assetRef)) return null;
   try {
     const url = new URL(assetRef, `https://od.local/${baseDirForDesignSystemPreviewFile(ownerFileName)}`);
     if (url.origin !== 'https://od.local') return null;
@@ -3857,6 +3937,46 @@ function rewriteDesignSystemPreviewCssUrls(css: string, projectId: string, style
     if (!filePath) return match;
     return `url("${escapeDesignSystemPreviewCssUrl(projectRawUrl(projectId, filePath))}")`;
   });
+}
+
+function rewriteDesignSystemPreviewHtmlAssetUrls(html: string, projectId: string, ownerFileName: string): string {
+  const directAssetTags = new RegExp(
+    '(<(?:img|source|video|audio|track|embed|object|image|use)\\b[^>]*?\\s' +
+      '(?:src|poster|data|href|xlink:href)\\s*=\\s*)([\'"])([\\s\\S]*?)\\2',
+    'gi',
+  );
+  const withDirectAssets = html.replace(directAssetTags, (match, prefix: string, quote: string, rawRef: string) => {
+    const rewritten = rewriteDesignSystemPreviewHtmlAssetRef(rawRef, projectId, ownerFileName);
+    if (rewritten === rawRef) return match;
+    return `${prefix}${quote}${escapeDesignSystemPreviewAttr(rewritten)}${quote}`;
+  });
+  const srcsetAssetTags = new RegExp(
+    '(<(?:img|source)\\b[^>]*?\\ssrcset\\s*=\\s*)([\'"])([\\s\\S]*?)\\2',
+    'gi',
+  );
+  return withDirectAssets.replace(srcsetAssetTags, (match, prefix: string, quote: string, rawSrcset: string) => {
+    const rewritten = rewriteDesignSystemPreviewSrcset(rawSrcset, projectId, ownerFileName);
+    if (rewritten === rawSrcset) return match;
+    return `${prefix}${quote}${escapeDesignSystemPreviewAttr(rewritten)}${quote}`;
+  });
+}
+
+function rewriteDesignSystemPreviewHtmlAssetRef(ref: string, projectId: string, ownerFileName: string): string {
+  const filePath = resolveDesignSystemPreviewRelativePath(ownerFileName, ref.trim());
+  return filePath ? projectRawUrl(projectId, filePath) : ref;
+}
+
+function rewriteDesignSystemPreviewSrcset(srcset: string, projectId: string, ownerFileName: string): string {
+  if (/\bdata:/i.test(srcset)) return srcset;
+  return srcset
+    .split(',')
+    .map((candidate) => {
+      const match = candidate.trim().match(/^(\S+)(\s+.+)?$/);
+      if (!match) return candidate;
+      const rewritten = rewriteDesignSystemPreviewHtmlAssetRef(match[1] ?? '', projectId, ownerFileName);
+      return `${rewritten}${match[2] ?? ''}`;
+    })
+    .join(', ');
 }
 
 function baseDirForDesignSystemPreviewFile(name: string): string {
@@ -3880,8 +4000,6 @@ function escapeDesignSystemPreviewAttr(value: string): string {
 function escapeDesignSystemPreviewCssUrl(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\a ');
 }
-
-
 
 function Tab({
   label,

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -1813,6 +1813,7 @@
 }
 
 .ds-project-panel {
+  container-type: inline-size;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -1908,6 +1909,85 @@
 .ds-project-main {
   width: min(940px, 100%);
   margin: 0 auto;
+}
+.ds-project-review-layout {
+  width: min(1400px, 100%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(180px, 230px) minmax(0, 1fr);
+  gap: 28px;
+  align-items: start;
+}
+.ds-project-review-layout .ds-project-main--review {
+  width: 100%;
+  margin: 0;
+}
+.ds-project-toc {
+  position: sticky;
+  top: 12px;
+  max-height: calc(100vh - 88px);
+  overflow: auto;
+  padding: 12px 10px 12px 0;
+  border-right: 1px solid var(--border);
+}
+.ds-project-toc__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 14px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.ds-project-toc__group {
+  display: grid;
+  gap: 2px;
+  margin-top: 14px;
+}
+.ds-project-toc__group:first-of-type {
+  margin-top: 0;
+}
+.ds-project-toc__group > strong {
+  margin: 0 0 4px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+}
+.ds-project-toc__group > a {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.25;
+  text-decoration: none;
+}
+.ds-project-toc__group > a:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+.ds-project-toc__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--blue);
+}
+.ds-project-toc__dot.is-approved {
+  background: var(--green);
+}
+.ds-project-toc__dot.is-work,
+.ds-project-toc__dot.is-missing {
+  background: var(--red);
+}
+.ds-project-toc__dot.is-running,
+.ds-project-toc__dot.is-planned {
+  background: var(--accent);
 }
 .ds-project-head {
   display: flex;
@@ -2234,7 +2314,7 @@
 .ds-project-sections {
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 38px;
 }
 .ds-project-section-head {
   position: relative;
@@ -2354,8 +2434,18 @@
   align-items: center;
   gap: 6px;
   padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  color: var(--text);
   font-size: 12px;
   white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+}
+.ds-project-review-actions button:hover {
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+  color: var(--text-strong);
 }
 .ds-project-review-actions button.active.success {
   border-color: color-mix(in srgb, var(--green) 42%, var(--border));
@@ -2593,7 +2683,7 @@
   color: var(--red);
 }
 .ds-project-main--review {
-  width: min(940px, 100%);
+  width: min(1180px, 100%);
 }
 .ds-project-head--review {
   display: flex;
@@ -2629,12 +2719,12 @@
 }
 .ds-project-section-group {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
-  gap: 10px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 18px;
 }
 .ds-project-section-group h2 {
   grid-column: 1 / -1;
-  margin: 0 0 2px 6px;
+  margin: 0 0 2px 2px;
   color: var(--text-muted);
   font-size: 14px;
   font-weight: 500;
@@ -2701,7 +2791,7 @@
   border-top: 1px solid var(--border);
 }
 .ds-project-review-item .ds-project-inline-preview {
-  height: clamp(170px, 20vw, 260px);
+  height: clamp(300px, 36vw, 520px);
   border: 0;
   border-radius: 0;
   box-shadow: none;
@@ -2711,11 +2801,11 @@
   grid-column: 1 / -1;
 }
 .ds-project-review-item--ui-kit .ds-project-inline-preview {
-  height: clamp(420px, 56vw, 760px);
+  height: clamp(560px, 64vw, 920px);
   background: #d8d8d8;
 }
 .ds-project-review-item--asset .ds-project-inline-preview {
-  height: clamp(220px, 28vw, 360px);
+  height: clamp(260px, 30vw, 420px);
 }
 .ds-project-review-item .ds-project-review-notice,
 .ds-project-review-item .ds-project-last-feedback,
@@ -2738,6 +2828,42 @@
   border: 0;
   border-radius: 0;
   background: var(--bg-subtle);
+}
+@container (max-width: 1040px) {
+  .ds-project-review-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ds-project-toc {
+    z-index: 5;
+    top: 0;
+    max-height: none;
+    padding: 10px 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+  }
+
+  .ds-project-toc__title {
+    margin-bottom: 8px;
+  }
+
+  .ds-project-toc__group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 8px;
+    overflow-x: auto;
+  }
+
+  .ds-project-toc__group > strong {
+    flex: none;
+    margin: 0 4px 0 0;
+  }
+
+  .ds-project-toc__group > a {
+    flex: none;
+  }
 }
 @media (max-width: 760px) {
   .ds-project-panel {

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -706,6 +706,61 @@ describe('FileWorkspace design-system project surface', () => {
     expect(unreviewed?.classList.contains('is-expanded')).toBe(true);
   });
 
+  it('re-expands a grouped section after Looks good collapses it and Needs work is clicked', async () => {
+    registryMocks.fetchProjectFileText.mockResolvedValue(JSON.stringify({
+      cards: [
+        {
+          path: 'preview/colors-primary.html',
+          group: 'Colors',
+          name: 'Primary Colors',
+          subtitle: 'Emerald green + navy ink',
+        },
+      ],
+    }));
+
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('_ds_manifest.json'),
+          workspaceFile('preview/colors-primary.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const section = Array.from(container.querySelectorAll('.ds-project-review-item')).find((item) =>
+      item.querySelector('.ds-project-section-title strong')?.textContent === 'Primary Colors',
+    );
+    expect(section?.classList.contains('is-expanded')).toBe(true);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="design-system-review-good-primary-colors"]')?.click();
+      await Promise.resolve();
+    });
+
+    expect(section?.classList.contains('is-collapsed')).toBe(true);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="design-system-review-work-primary-colors"]')?.click();
+      await Promise.resolve();
+    });
+
+    expect(section?.classList.contains('is-expanded')).toBe(true);
+    expect(section?.querySelector('.ds-project-feedback-popover')).toBeTruthy();
+  });
+
   it('reopens a looks-good section after it is regenerated so the review-again prompt stays visible', () => {
     const container = renderWorkspace(
       <FileWorkspace

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -258,6 +258,44 @@ describe('FileWorkspace design-system project surface', () => {
     expect(alert?.textContent).toContain('Invalid _ds_manifest.json');
   });
 
+  it('reports semantically invalid design-system card entries instead of silently skipping them', async () => {
+    registryMocks.fetchProjectFileText.mockResolvedValue(JSON.stringify({
+      cards: [
+        {
+          path: 'preview/type-display.html',
+          group: 123,
+          name: 'Display & Headings',
+        },
+      ],
+    }));
+
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('_ds_manifest.json'),
+          workspaceFile('preview/type-display.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const alert = container.querySelector<HTMLElement>('[data-testid="design-system-manifest-error"]');
+    expect(alert?.getAttribute('role')).toBe('alert');
+    expect(alert?.textContent).toContain('cards[0].group must be a string');
+  });
+
   it('does not duplicate the first review card above the grouped gallery after generation', async () => {
     registryMocks.fetchProjectFileText.mockResolvedValue(JSON.stringify({
       cards: [

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -230,6 +230,7 @@ describe('FileWorkspace design-system project surface', () => {
                 src="/assets/site/root.png"
                 srcset="/assets/site/root.png 1x, /assets/site/root@2x.png 2x"
               >
+              <img alt="Runtime artifact" src="/api/live-artifacts/hero.png">
               <script type="text/babel" src="Widget.jsx"></script>
               <script type="text/babel">ReactDOM.createRoot(document.getElementById("root")).render(<Widget />);</script>
             </body>
@@ -289,6 +290,8 @@ describe('FileWorkspace design-system project surface', () => {
     expect(srcdoc).toContain(
       'srcset="/api/projects/ds-acme/raw/assets/site/root.png 1x, /api/projects/ds-acme/raw/assets/site/root%402x.png 2x"',
     );
+    expect(srcdoc).toContain('src="/api/live-artifacts/hero.png"');
+    expect(srcdoc).not.toContain('/api/projects/ds-acme/raw/api/live-artifacts/hero.png');
     expect(srcdoc).not.toContain('src="Widget.jsx"');
   });
 

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -230,7 +230,9 @@ describe('FileWorkspace design-system project surface', () => {
                 src="/assets/site/root.png"
                 srcset="/assets/site/root.png 1x, /assets/site/root@2x.png 2x"
               >
+              <img alt="Cache" src="/assets/site/cache.png?v=2">
               <img alt="Runtime artifact" src="/api/live-artifacts/hero.png">
+              <svg><use href="../assets/site/icons.svg#logo"></use></svg>
               <script type="text/babel" src="Widget.jsx"></script>
               <script type="text/babel">ReactDOM.createRoot(document.getElementById("root")).render(<Widget />);</script>
             </body>
@@ -290,8 +292,10 @@ describe('FileWorkspace design-system project surface', () => {
     expect(srcdoc).toContain(
       'srcset="/api/projects/ds-acme/raw/assets/site/root.png 1x, /api/projects/ds-acme/raw/assets/site/root%402x.png 2x"',
     );
+    expect(srcdoc).toContain('src="/api/projects/ds-acme/raw/assets/site/cache.png?v=2"');
     expect(srcdoc).toContain('src="/api/live-artifacts/hero.png"');
     expect(srcdoc).not.toContain('/api/projects/ds-acme/raw/api/live-artifacts/hero.png');
+    expect(srcdoc).toContain('href="/api/projects/ds-acme/raw/ui_kits/assets/site/icons.svg#logo"');
     expect(srcdoc).not.toContain('src="Widget.jsx"');
   });
 

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -220,6 +220,16 @@ describe('FileWorkspace design-system project surface', () => {
             </head>
             <body>
               <div id="root"></div>
+              <img
+                alt="Hero"
+                src="../assets/site/hero.png"
+                srcset="../assets/site/hero.png 1x, ../assets/site/hero@2x.png 2x"
+              >
+              <img
+                alt="Root"
+                src="/assets/site/root.png"
+                srcset="/assets/site/root.png 1x, /assets/site/root@2x.png 2x"
+              >
               <script type="text/babel" src="Widget.jsx"></script>
               <script type="text/babel">ReactDOM.createRoot(document.getElementById("root")).render(<Widget />);</script>
             </body>
@@ -230,7 +240,11 @@ describe('FileWorkspace design-system project surface', () => {
         return Promise.resolve('function Widget(){ return <strong>Passive Book loaded</strong>; }');
       }
       if (name === 'colors_and_type.css') {
-        return Promise.resolve('@font-face { font-family: Passive; src: url("./fonts/brand.woff2"); } :root { --pb-green: #00d07e; }');
+        return Promise.resolve(`
+          @font-face { font-family: Passive; src: url("./fonts/brand.woff2"); }
+          .root-asset { background-image: url("/assets/site/root-bg.png"); }
+          :root { --pb-green: #00d07e; }
+        `);
       }
       return Promise.resolve(null);
     });
@@ -261,11 +275,21 @@ describe('FileWorkspace design-system project surface', () => {
     });
 
     const iframe = container.querySelector<HTMLIFrameElement>('.ds-project-review-item iframe');
-    expect(iframe?.getAttribute('srcdoc')).toContain('function Widget()');
-    expect(iframe?.getAttribute('srcdoc')).toContain('data-od-inline-asset="Widget.jsx"');
-    expect(iframe?.getAttribute('srcdoc')).toContain('data-od-inline-asset="../../colors_and_type.css"');
-    expect(iframe?.getAttribute('srcdoc')).toContain('url("/api/projects/ds-acme/raw/fonts/brand.woff2")');
-    expect(iframe?.getAttribute('srcdoc')).not.toContain('src="Widget.jsx"');
+    const srcdoc = iframe?.getAttribute('srcdoc') ?? '';
+    expect(srcdoc).toContain('function Widget()');
+    expect(srcdoc).toContain('data-od-inline-asset="Widget.jsx"');
+    expect(srcdoc).toContain('data-od-inline-asset="../../colors_and_type.css"');
+    expect(srcdoc).toContain('url("/api/projects/ds-acme/raw/fonts/brand.woff2")');
+    expect(srcdoc).toContain('src="/api/projects/ds-acme/raw/ui_kits/assets/site/hero.png"');
+    expect(srcdoc).toContain(
+      'srcset="/api/projects/ds-acme/raw/ui_kits/assets/site/hero.png 1x, /api/projects/ds-acme/raw/ui_kits/assets/site/hero%402x.png 2x"',
+    );
+    expect(srcdoc).toContain('url("/api/projects/ds-acme/raw/assets/site/root-bg.png")');
+    expect(srcdoc).toContain('src="/api/projects/ds-acme/raw/assets/site/root.png"');
+    expect(srcdoc).toContain(
+      'srcset="/api/projects/ds-acme/raw/assets/site/root.png 1x, /api/projects/ds-acme/raw/assets/site/root%402x.png 2x"',
+    );
+    expect(srcdoc).not.toContain('src="Widget.jsx"');
   });
 
   it('keeps project-backed design systems inside the normal workspace tabs with inline preview cards', () => {

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -228,6 +228,36 @@ describe('FileWorkspace design-system project surface', () => {
     });
   });
 
+  it('reports malformed design-system card manifests instead of silently falling back', async () => {
+    registryMocks.fetchProjectFileText.mockResolvedValue('{not json');
+
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('_ds_manifest.json'),
+          workspaceFile('preview/type-display.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const alert = container.querySelector<HTMLElement>('[data-testid="design-system-manifest-error"]');
+    expect(alert?.getAttribute('role')).toBe('alert');
+    expect(alert?.textContent).toContain('Invalid _ds_manifest.json');
+  });
+
   it('does not duplicate the first review card above the grouped gallery after generation', async () => {
     registryMocks.fetchProjectFileText.mockResolvedValue(JSON.stringify({
       cards: [

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -217,9 +217,11 @@ describe('FileWorkspace design-system project surface', () => {
           <html>
             <head>
               <link rel="stylesheet" href="../../colors_and_type.css">
+              <style>.inline-bg { background-image: url("/assets/site/inline-bg.png"); }</style>
             </head>
             <body>
               <div id="root"></div>
+              <div class="inline-style" style="background-image:url('/assets/site/inline-card.png')"></div>
               <img
                 alt="Hero"
                 src="../assets/site/hero.png"
@@ -284,6 +286,8 @@ describe('FileWorkspace design-system project surface', () => {
     expect(srcdoc).toContain('data-od-inline-asset="../../colors_and_type.css"');
     expect(srcdoc).toContain('url("/api/projects/ds-acme/raw/fonts/brand.woff2")');
     expect(srcdoc).toContain('src="/api/projects/ds-acme/raw/ui_kits/assets/site/hero.png"');
+    expect(srcdoc).toContain('url("/api/projects/ds-acme/raw/assets/site/inline-bg.png")');
+    expect(srcdoc).toContain('/api/projects/ds-acme/raw/assets/site/inline-card.png');
     expect(srcdoc).toContain(
       'srcset="/api/projects/ds-acme/raw/ui_kits/assets/site/hero.png 1x, /api/projects/ds-acme/raw/ui_kits/assets/site/hero%402x.png 2x"',
     );

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -143,12 +143,89 @@ describe('FileWorkspace design-system project surface', () => {
     const typeCard = itemByTitle('Display & Headings');
     const uiKitCard = itemByTitle('Website — Home (UI Kit)');
 
-    expect(registryMocks.fetchProjectFileText).toHaveBeenCalledWith('ds-acme', '_ds_manifest.json');
+    expect(registryMocks.fetchProjectFileText).toHaveBeenCalledWith('ds-acme', '_ds_manifest.json', {
+      cache: 'no-store',
+      cacheBustKey: Math.round(workspaceFile('_ds_manifest.json').mtime),
+    });
     expect(container.textContent).not.toContain('type-display');
     expect(typeCard?.textContent).toContain('Tahoma bold, tight');
     expect(typeCard?.classList.contains('ds-project-review-item--specimen')).toBe(true);
     expect(uiKitCard?.textContent).toContain('Full passivebook.com home recreation');
     expect(uiKitCard?.classList.contains('ds-project-review-item--ui-kit')).toBe(true);
+  });
+
+  it('refreshes design-system card manifest labels when the manifest mtime changes', async () => {
+    const firstManifest = workspaceFile('_ds_manifest.json');
+    const nextManifest = { ...firstManifest, mtime: firstManifest.mtime + 5_000 };
+    registryMocks.fetchProjectFileText.mockImplementation((
+      _projectId: string,
+      _name: string,
+      options?: { cacheBustKey?: number },
+    ) => {
+      if (options?.cacheBustKey === Math.round(nextManifest.mtime)) {
+        return Promise.resolve(JSON.stringify({
+          cards: [
+            {
+              path: 'preview/type-display.html',
+              group: 'Brand',
+              name: 'Fresh Type Label',
+              subtitle: 'Fresh subtitle',
+            },
+          ],
+        }));
+      }
+      return Promise.resolve(JSON.stringify({
+        cards: [
+          {
+            path: 'preview/type-display.html',
+            group: 'Brand',
+            name: 'Old Type Label',
+            subtitle: 'Old subtitle',
+          },
+        ],
+      }));
+    });
+
+    const renderDesignSystem = (manifestFile: ProjectFile) => (
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          manifestFile,
+          workspaceFile('preview/type-display.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem()}
+      />
+    );
+
+    const container = renderWorkspace(renderDesignSystem(firstManifest));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('Old Type Label');
+
+    await act(async () => {
+      root?.render(renderDesignSystem(nextManifest));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Fresh Type Label');
+    expect(container.textContent).not.toContain('Old Type Label');
+    expect(registryMocks.fetchProjectFileText).toHaveBeenCalledWith('ds-acme', '_ds_manifest.json', {
+      cache: 'no-store',
+      cacheBustKey: Math.round(firstManifest.mtime),
+    });
+    expect(registryMocks.fetchProjectFileText).toHaveBeenCalledWith('ds-acme', '_ds_manifest.json', {
+      cache: 'no-store',
+      cacheBustKey: Math.round(nextManifest.mtime),
+    });
   });
 
   it('does not duplicate the first review card above the grouped gallery after generation', async () => {

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -321,6 +321,76 @@ describe('FileWorkspace upload input', () => {
     expect(markup).not.toContain('<strong>avatar-1</strong>');
   });
 
+  it('renders a design-system contents rail with review and edit actions', () => {
+    const markup = renderToStaticMarkup(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('preview/logo.html'),
+          workspaceFile('ui_kits/website/index.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={{
+          id: 'user:passive-book',
+          title: 'Passive Book Design System',
+          category: 'Brand',
+          summary: 'Passive Book brand system',
+          source: 'user',
+          status: 'draft',
+        }}
+      />,
+    );
+
+    expect(markup).toContain('data-testid="design-system-review-toc"');
+    expect(markup).toContain('href="#design-system-section-');
+    expect(markup).toContain('Looks good');
+    expect(markup).toContain('Needs work...');
+    expect(markup).toContain('data-testid="design-system-review-edit-');
+    expect(markup).not.toContain('data-testid="design-system-review-open-');
+  });
+
+  it('opens the section preview file for editing from the design-system review card', () => {
+    const onTabsStateChange = vi.fn();
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('ui_kits/website/index.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={onTabsStateChange}
+        designSystemProject={{
+          id: 'user:passive-book',
+          title: 'Passive Book Design System',
+          category: 'Brand',
+          summary: 'Passive Book brand system',
+          source: 'user',
+          status: 'draft',
+        }}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTitle('Edit ui_kits/website/index.html'));
+    });
+
+    expect(onTabsStateChange).toHaveBeenCalledWith(expect.objectContaining({
+      active: 'ui_kits/website/index.html',
+      tabs: ['ui_kits/website/index.html'],
+    }));
+  });
+
   it('treats favicon previews as brand guidance', () => {
     const markup = renderToStaticMarkup(
       <FileWorkspace

--- a/apps/web/tests/styles/design-system-review-density.test.ts
+++ b/apps/web/tests/styles/design-system-review-density.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(new URL('../../src/styles/design-system-flow.css', import.meta.url), 'utf8');
+
+function cssDeclarations(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const rulePattern = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, 'g');
+  const matches = Array.from(css.matchAll(rulePattern));
+  return matches.at(-1)?.[1] ?? '';
+}
+
+function firstCssDeclarations(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const rulePattern = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, 'g');
+  return Array.from(css.matchAll(rulePattern)).at(0)?.[1] ?? '';
+}
+
+describe('design-system review preview density', () => {
+  it('keeps review sections as a spacious single-column stack', () => {
+    const reviewMain = cssDeclarations('.ds-project-main--review');
+    const group = cssDeclarations('.ds-project-section-group');
+    const inlinePreview = cssDeclarations('.ds-project-review-item .ds-project-inline-preview');
+    const uiKitPreview = cssDeclarations('.ds-project-review-item--ui-kit .ds-project-inline-preview');
+
+    expect(reviewMain).toContain('width: min(1180px, 100%);');
+    expect(group).toContain('grid-template-columns: minmax(0, 1fr);');
+    expect(group).toContain('gap: 18px;');
+    expect(inlinePreview).toContain('height: clamp(300px, 36vw, 520px);');
+    expect(uiKitPreview).toContain('height: clamp(560px, 64vw, 920px);');
+  });
+
+  it('keeps the contents rail separate from the review card stack', () => {
+    const layout = firstCssDeclarations('.ds-project-review-layout');
+    const toc = firstCssDeclarations('.ds-project-toc');
+
+    expect(layout).toContain('grid-template-columns: minmax(180px, 230px) minmax(0, 1fr);');
+    expect(toc).toContain('position: sticky;');
+    expect(toc).toContain('border-right: 1px solid var(--border);');
+  });
+});

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -8,7 +8,7 @@ import { T } from '@/timeouts';
 const STORAGE_KEY = 'open-design:config';
 const ACTIVE_ARTIFACT_PREVIEW_SELECTOR = '[data-testid="artifact-preview-frame"]:visible, [data-testid="artifact-preview-frame-url-load"]:visible, [data-testid="artifact-preview-frame-srcdoc"]:visible, [data-testid="live-artifact-preview-frame"]:visible';
 
-test.describe.configure({ timeout: 30_000 });
+test.describe.configure({ timeout: 45_000 });
 
 function artifactPreview(page: Page) {
   return page.locator(ACTIVE_ARTIFACT_PREVIEW_SELECTOR).first();
@@ -385,7 +385,7 @@ test('[P0] returning from an uploaded design file route to the project root keep
 
   await gotoProjectRoute(page, `/projects/${projectId}/files/${encodeURIComponent(uploadedName!)}`);
   await expect(fileTab).toBeVisible();
-  await gotoProjectRoute(page, `/projects/${projectId}`);
+  await navigateProjectRouteInApp(page, `/projects/${projectId}`);
 
   await expect(page.getByTestId('file-workspace')).toBeVisible();
   await expect(fileTab).toBeVisible();
@@ -459,7 +459,7 @@ test('[P0] returning from an artifact file route to the project root keeps the a
     throw new Error(`unexpected project route: ${current.pathname}`);
   }
 
-  await gotoProjectRoute(page, `/projects/${projectId}`);
+  await navigateProjectRouteInApp(page, `/projects/${projectId}`);
 
   await expect(page.getByTestId('file-workspace')).toBeVisible();
   await expect(artifactTab).toHaveAttribute('aria-selected', 'true');
@@ -538,7 +538,7 @@ test('[P0] @critical returning from an older conversation route to the project r
   await expect(routeHistoryList).toBeVisible();
   await expect(routeHistoryList.locator('.chat-conv-item').filter({ hasText: firstPrompt }).first()).toBeVisible();
 
-  await gotoProjectRoute(page, `/projects/${firstContext.projectId}`);
+  await navigateProjectRouteInApp(page, `/projects/${firstContext.projectId}`);
   await expect(page.getByTestId('chat-composer')).toBeVisible();
 });
 
@@ -653,7 +653,7 @@ test('[P0] @critical switching between conversations keeps the composer usable w
   await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
   await expect(page).toHaveURL(new RegExp(`/projects/${firstContext.projectId}/conversations/${firstContext.conversationId}$`));
 
-  await page.reload();
+  await reloadCurrentRoute(page);
   await expect(page.getByTestId('chat-composer')).toBeVisible();
   await expect(page).toHaveURL(new RegExp(`/projects/${firstContext.projectId}/conversations/${firstContext.conversationId}$`));
   await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
@@ -735,7 +735,7 @@ test('[P0] @critical reloading an older conversation route keeps the composer vi
   await composerInput.fill(restoredDraft);
   await expect(composerInput).toHaveText(restoredDraft);
 
-  await page.reload();
+  await reloadCurrentRoute(page);
   await expect(page.getByTestId('chat-composer')).toBeVisible();
   await page.getByTestId('conversation-history-trigger').click();
   const reloadedHistoryList = page.getByTestId('conversation-list');
@@ -937,7 +937,7 @@ test('[P0] @critical reloading an older conversation route keeps the composer av
   await expect((await uploadResponse).ok()).toBeTruthy();
   await expect(stagedAttachmentName(page, 'reload-staged-attachment.txt')).toBeVisible();
 
-  await page.reload();
+  await reloadCurrentRoute(page);
   await expect(page.getByTestId('chat-composer')).toBeVisible();
 });
 
@@ -1214,7 +1214,7 @@ test('[P0] returning from workspace surfaces keeps the older conversation reacha
   if (projects !== 'projects' || !projectId) {
     throw new Error(`unexpected project route: ${current.pathname}`);
   }
-  await gotoProjectRoute(page, `/projects/${projectId}`);
+  await navigateProjectRouteInApp(page, `/projects/${projectId}`);
 
   await expect(page.getByTestId('chat-composer')).toBeVisible();
   await page.getByTestId('conversation-history-trigger').click();
@@ -1627,7 +1627,7 @@ test('[P0] returning from a file deep-link to the project root keeps the chosen 
   await expect(fileTab).toHaveAttribute('aria-selected', 'true');
   await expect(page.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'false');
 
-  await gotoProjectRoute(page, `/projects/${projectId}`);
+  await navigateProjectRouteInApp(page, `/projects/${projectId}`);
 
   await expect(page.getByTestId('file-workspace')).toBeVisible();
   await expect(fileTab).toHaveAttribute('aria-selected', 'true');
@@ -1635,95 +1635,20 @@ test('[P0] returning from a file deep-link to the project root keeps the chosen 
 });
 
 test('[P0] returning from an artifact deep-link to the project root keeps the artifact tab reachable after returning to the project root', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
-
-  await page.route('**/api/runs', async (route) => {
-    await route.fulfill({
-      status: 202,
-      contentType: 'application/json',
-      body: '{"runId":"conversation-artifact-root-run"}',
-    });
-  });
-
-  await page.route('**/api/runs/*/events', async (route) => {
-    const artifact =
-      '<artifact identifier="conversation-root-artifact" type="text/html" title="Conversation Root Artifact">' +
-      '<!doctype html><html><body><main><h1>Conversation Root Artifact</h1></main></body></html>' +
-      '</artifact>';
-    const body = [
-      'event: start',
-      'data: {"bin":"mock-agent"}',
-      '',
-      'event: stdout',
-      `data: ${JSON.stringify({ chunk: artifact })}`,
-      '',
-      'event: end',
-      'data: {"code":0,"status":"succeeded"}',
-      '',
-      '',
-    ].join('\n');
-
-    await route.fulfill({
-      status: 200,
-      headers: {
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-      },
-      body,
-    });
-  });
-
-  await gotoEntryHome(page);
-  await createPrototypeProject(page, 'Conversation artifact surface root restore');
-  await expectWorkspaceReady(page);
-
-  const firstPrompt = 'First conversation should survive artifact root restore';
-  const secondPrompt = 'Second conversation should stay inactive during artifact root restore';
-
-  await sendPrompt(page, firstPrompt);
-  await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
-  const { projectId } = await getCurrentProjectContext(page);
-
-  await startNewConversation(page);
-  await expect(page.getByTestId('chat-composer-input')).toBeVisible();
-  await expect(page.getByTestId('chat-composer-input')).toHaveText('');
-  await sendPrompt(page, secondPrompt);
-  await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-
-  const artifactTab = page.getByRole('tab', { name: /conversation-root-artifact\.html/i });
-  await expect(artifactTab).toBeVisible();
-
-  await page.getByTestId('conversation-history-trigger').click();
-  const historyList = page.getByTestId('conversation-list');
-  await expect(historyList).toBeVisible();
-  await historyList
-    .locator('.chat-conv-item')
-    .filter({ hasText: firstPrompt })
-    .first()
-    .locator('[data-testid^="conversation-select-"]')
-    .click();
-
-  await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
-  await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt })).toHaveCount(0);
+  const projectId = await createEmptyProject(page, 'Artifact surface root restore');
+  await seedHtmlArtifact(
+    page,
+    projectId,
+    'conversation-root-artifact.html',
+    '<!doctype html><html><body><main><h1>Conversation Root Artifact</h1></main></body></html>',
+  );
+  await expectProjectFilesToIncludeSuffixes(page, projectId, ['conversation-root-artifact.html']);
 
   await gotoProjectRoute(page, `/projects/${projectId}/files/conversation-root-artifact.html`);
 
-  await expect(artifactTab).toBeVisible();
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+  const deepLinkedArtifactTab = page.getByRole('tab', { name: /conversation-root-artifact\.html/i });
+  await expect(deepLinkedArtifactTab).toBeVisible();
   await expect(artifactPreview(page)).toBeVisible();
   await expect(
     artifactPreviewFrame(page).getByRole('heading', {
@@ -1731,10 +1656,10 @@ test('[P0] returning from an artifact deep-link to the project root keeps the ar
     }),
   ).toBeVisible();
 
-  await gotoProjectRoute(page, `/projects/${projectId}`);
+  await navigateProjectRouteInApp(page, `/projects/${projectId}`);
 
   await expect(page.getByTestId('file-workspace')).toBeVisible();
-  await expect(artifactTab).toBeVisible();
+  await expect(page.getByRole('tab', { name: /conversation-root-artifact\.html/i })).toBeVisible();
 });
 
 test('[P0] a later completed run updates the workspace to the newest artifact tab', async ({ page }) => {
@@ -2769,6 +2694,19 @@ async function openNewProjectModal(page: Page) {
 
 async function gotoProjectRoute(page: Page, path: string) {
   await page.goto(path, { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
+}
+
+async function navigateProjectRouteInApp(page: Page, path: string) {
+  await page.evaluate((target) => {
+    window.history.pushState(null, '', target);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+  await expect(page).toHaveURL(new RegExp(`${escapeRegExp(path)}$`));
+}
+
+async function reloadCurrentRoute(page: Page) {
+  await page.reload({ waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
 }
 


### PR DESCRIPTION
## Summary
- rewrite design-system preview HTML image asset references to project raw URLs after CSS/JS inlining
- treat root-relative preview refs like `/assets/...` as project-root assets instead of app-origin URLs
- make the design-system review screen easier to navigate with a generated Contents rail
- keep review cards in a single vertical column, with wider/taller preview stages instead of a cramped mini-card grid
- add per-section Edit actions so previews can be focused as workspace file tabs from the Design System screen
- keep the existing per-section review actions visible: Looks good, Needs work..., Edit
- cover `img src`, `srcset`, CSS `url(...)`, review density, contents navigation, and Edit actions in regressions

## Surface area
- [x] Web design-system review previews in `FileWorkspace`
- [x] Design-system review tab navigation, spacing, and inline preview sizing
- [x] Per-section review/Edit action row
- [x] HTML asset attributes emitted into sandboxed `srcDoc` previews
- [x] CSS `url(...)` references from inlined design-system stylesheets
- [x] Relative refs like `../assets/...` and root-relative refs like `/assets/...`
- [ ] Daemon/storage APIs
- [ ] Non-design-system artifact preview paths

## Bug fix verification
Broken asset case: design-system previews with image refs such as `src="/assets/site/root.png"`, `srcset="/assets/site/root.png 1x, /assets/site/root@2x.png 2x"`, or `url("/assets/site/root-bg.png")` were left unchanged inside `srcDoc`, so the browser resolved them against the Open Design app origin instead of the project raw-file endpoint.

The regression now asserts those refs are rewritten to `/api/projects/<project>/raw/assets/...`; existing `../assets/...` coverage remains in place.

Cramped layout/workflow case: the design-system review gallery used `minmax(..., 280px)` and capped ordinary previews around 260px tall, which made full page/section examples look like cramped thumbnails. The review tab now uses a single-column review stack, taller preview stages, a generated Contents rail, and direct Edit actions. Container-based CSS keeps the Contents rail as a side nav on wide panes and moves it above the cards when the actual workspace pane is narrow, so it does not squeeze previews.

Local visual verification on the Passive Book design-system project showed 27 contents links, 27 review cards, 27 Looks good actions, 27 Needs work actions, 27 Edit actions, and 0 Open actions. In the split pane, each review group measured as one 748px column; in a wider viewport, the Contents rail measured as a 230px side rail while cards still stayed one column.

## Screenshots
Before: base review screen used a dense multi-column card grid with no Contents rail and no per-section Edit action.

![Before review grid](https://raw.githubusercontent.com/passive-book/open-design/pr-assets/design-system-review-layout/pr4177/before-grid.png)

After: PR layout adds a generated Contents rail, keeps review cards in one column, and shows Looks good / Needs work / Edit actions on each section.

![After TOC and actions](https://raw.githubusercontent.com/passive-book/open-design/pr-assets/design-system-review-layout/pr4177/after-toc-actions.png)

After: expanded section shows the taller preview stage in the same single-column review flow.

![After expanded preview](https://raw.githubusercontent.com/passive-book/open-design/pr-assets/design-system-review-layout/pr4177/after-expanded-preview.png)

## Validation
- `pnpm --filter @open-design/web exec vitest run tests/styles/design-system-review-density.test.ts tests/components/FileWorkspace.test.tsx tests/components/FileWorkspace.design-system.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`
- Local visual check with tools-dev web at `http://127.0.0.1:17573/projects/ds-passive-book-design-system`
- Screenshot pass on PR #4177: base `8359fb6` vs head `995dae9`, viewport `1600x1100`, Passive Book design-system project

## Notes
The local Passive Book Open Design project also had corrupted PNG files from the Claude export; I refreshed the local `.od` project assets from `forge/design/passive-book-design-system` so the current local page renders cleanly.
