### PR TITLE
fix chat composer control sizing

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -934,8 +934,12 @@
   .composer-row .session-mode-toggle__popover { left: auto; right: 0; }
   .composer-row .composer-send {
     width: 32px;
+    min-width: 32px;
     padding: 0;
     gap: 0;
+  }
+  .composer-row .composer-send > svg {
+    flex: 0 0 auto;
   }
   .composer-row .composer-send span { display: none; }
 }

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1627,12 +1627,22 @@
   font-weight: 600;
   box-shadow: none;
 }
-/* The session-mode ("Design"/CLI) toggle and the agent avatar are authored in
-   their own components and default to 32px. The composer now mounts under
-   .chat-composer-fixed-layer (a body-level portal), so chat.css's .app-scoped
-   normalization never reaches them and they drift taller than the + and the
-   working-dir pill. Pin both to the same 28px control height here — this is the
-   last-loaded stylesheet, so it wins — so the toolbar reads as one row. */
+@container (max-width: 430px) {
+  .app .composer-row .composer-send,
+  .chat-composer-fixed-layer .composer-row .composer-send {
+    width: 32px;
+    min-width: 32px;
+    padding: 0;
+  }
+  .app .composer-row .composer-send > svg,
+  .chat-composer-fixed-layer .composer-row .composer-send > svg {
+    flex: 0 0 auto;
+  }
+}
+/* The session-mode ("Design") toggle and the agent avatar are authored in
+   their own components and default to 32px. The composer can mount under
+   .chat-composer-fixed-layer (a body-level portal), so pair the selectors and
+   keep them on the same 28px toolbar rhythm. */
 .app .composer-row .session-mode-toggle,
 .app .composer-row .session-mode-toggle__trigger,
 .app .composer-row .avatar-agent-trigger,
@@ -1642,6 +1652,28 @@
   height: 28px;
   min-height: 28px;
   box-sizing: border-box;
+}
+.app .composer-row .avatar-agent-trigger,
+.chat-composer-fixed-layer .composer-row .avatar-agent-trigger {
+  display: inline-flex;
+  width: auto;
+  min-width: 47px;
+  grid-template-columns: none;
+  justify-content: center;
+  gap: 5px;
+  padding: 0 7px;
+}
+.app .composer-row .avatar-agent-trigger .agent-icon,
+.chat-composer-fixed-layer .composer-row .avatar-agent-trigger .agent-icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+}
+.app .composer-row .avatar-agent-trigger > :last-child,
+.chat-composer-fixed-layer .composer-row .avatar-agent-trigger > :last-child {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
 }
 .app .composer-send:disabled {
   background: var(--bg-subtle);


### PR DESCRIPTION
## Why

1. When the sidebar width shrinks, the send button switches to icon-only mode and appears much smaller than the other composer controls.
2. The CLI/agent selector spacing between the icon and dropdown chevron is inconsistent with the neighboring controls.

This PR keeps the fix scoped to those composer toolbar controls.

## What users will see

In the chat composer:

- The icon-only send button stays square and the send icon remains correctly sized/centered in narrow sidebars.
- The CLI/agent selector appears more compact, with tighter spacing between the agent icon and dropdown chevron.

No new settings, pages, or menu items are added.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)

## Screenshots

Before:

<img width="410" height="194" alt="截屏2026-06-11 22 01 18" src="https://github.com/user-attachments/assets/dbf6fee7-dac7-4bcf-a446-9e7f48f41d48" />

After:

<img width="379" height="211" alt="截屏2026-06-11 22 10 53" src="https://github.com/user-attachments/assets/1f26f3fd-7a0a-4c8b-bd07-672980fcceae" />

## Bug fix verification

- Reproduced on `main` by narrowing the chat sidebar until the composer send button switched to icon-only mode; the send control shrank below the neighboring controls and the CLI/agent selector spacing looked loose.
- Rechecked the same composer width on this branch; the send button stayed square with the icon centered, and the CLI/agent selector spacing matched the adjacent controls. The before/after screenshots above capture the main vs branch comparison.

## Validation

- [x] `pnpm --filter @open-design/web typecheck`
- [x] `pnpm guard`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @open-design/web test`