### PR TITLE
fix(desktop): recover the window when the renderer dies or a load fails

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1534,6 +1534,17 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       reason: details.reason,
       exit_code: typeof details.exitCode === "number" ? details.exitCode : null,
     });
+    // A clean-exit is intentional teardown; a crash / OOM / OS kill of a
+    // backgrounded renderer leaves the window blank, so flag it for the poll
+    // loop to reload the app.
+    if (details.reason !== "clean-exit") markRendererFailed();
+  });
+  // A failed main-frame navigation parks the renderer on chrome-error:// (blank
+  // white) with no auto-retry. errorCode -3 (ABORTED) is a normal navigation
+  // cancel (a new load started), so ignore it and sub-frame failures; anything
+  // else means the load to the web server failed and needs a retry.
+  window.webContents.on("did-fail-load", (_event, errorCode, _description, _url, isMainFrame) => {
+    if (isMainFrame && errorCode !== -3) markRendererFailed();
   });
 
   const sendUpdaterStatus = (status = options.updater?.snapshot() ?? unavailableUpdaterStatus()) => {
@@ -1697,6 +1708,11 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   let pendingUrl: string | null = null;
   let stopped = false;
   let timer: NodeJS.Timeout | null = null;
+  // Set when the main-frame load fails (renderer parks on chrome-error://, blank
+  // white) or the renderer process is gone. The poll loop reloads the current URL
+  // to recover instead of leaving the window blank, e.g. after a long-minimized
+  // window is restored and its connection to the web server has dropped.
+  let rendererFailed = false;
 
   window.on("focus", () => showWindowButtons(window));
   window.on("blur", () => showWindowButtons(window));
@@ -1856,17 +1872,36 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     }, delayMs);
   };
 
+  // Flag the renderer as needing a reload and poll again promptly, rather than
+  // waiting up to RUNNING_POLL_MS. The next `tick` re-loads the current URL (see
+  // the `rendererFailed` branch) and clears the flag once the load succeeds. If
+  // the web server is still unreachable, discovery returns null and the loop
+  // naturally backs off to RUNNING_POLL_MS until it returns.
+  const markRendererFailed = () => {
+    if (stopped || window.isDestroyed()) return;
+    rendererFailed = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    schedule(PENDING_POLL_MS);
+  };
+
   const tick = async () => {
     if (stopped || window.isDestroyed()) return;
 
     try {
       const url = await options.discoverUrl();
-      if (url != null && url !== currentUrl) {
+      // Reload when the discovered URL changes, OR when the renderer is in a
+      // failed/blank state (URL unchanged but the page died), so a window
+      // restored from the background recovers instead of staying blank.
+      if (url != null && (url !== currentUrl || rendererFailed)) {
         pendingUrl = url;
         // Load the web app into the still-hidden main window as soon as it is
         // discovered; it mounts behind the splash so the swap is instant.
         await window.loadURL(url);
         currentUrl = url;
+        rendererFailed = false;
         pendingUrl = null;
         const nextPetUrl = desktopPetUrl(url);
         if (!petWindow.isDestroyed() && nextPetUrl !== currentPetUrl) {

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1713,6 +1713,12 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   // to recover instead of leaving the window blank, e.g. after a long-minimized
   // window is restored and its connection to the web server has dropped.
   let rendererFailed = false;
+  // True while a `tick()` is mid-flight. A failed `loadURL` inside a tick fires
+  // `did-fail-load` AND rejects into the tick's `catch`; without this guard both
+  // would queue a poll timer, leaving two independent loops (multiplying on each
+  // repeat failure). When set, `markRendererFailed` only flips the flag and lets
+  // the running tick own the next reschedule.
+  let ticking = false;
 
   window.on("focus", () => showWindowButtons(window));
   window.on("blur", () => showWindowButtons(window));
@@ -1880,6 +1886,9 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   const markRendererFailed = () => {
     if (stopped || window.isDestroyed()) return;
     rendererFailed = true;
+    // Mid-tick failures (a rejecting loadURL) are rescheduled by the tick's own
+    // catch/success path; scheduling here too would spawn a second poll loop.
+    if (ticking) return;
     if (timer) {
       clearTimeout(timer);
       timer = null;
@@ -1890,6 +1899,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   const tick = async () => {
     if (stopped || window.isDestroyed()) return;
 
+    ticking = true;
     try {
       const url = await options.discoverUrl();
       // Reload when the discovered URL changes, OR when the renderer is in a
@@ -1921,6 +1931,8 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       pendingUrl = null;
       console.error("desktop web discovery failed", error);
       schedule(PENDING_POLL_MS);
+    } finally {
+      ticking = false;
     }
   };
 

--- a/apps/desktop/tests/main/renderer-recovery-poll-loop.test.ts
+++ b/apps/desktop/tests/main/renderer-recovery-poll-loop.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, test } from "vitest";
+
+// The poll loop lives inside `createDesktopRuntime`, which builds real Electron
+// `BrowserWindow`s and so cannot be instantiated under vitest. Following the
+// pattern in `window-chrome.test.ts`, these tests assert on the runtime source
+// to pin the timer-ownership invariant: a single poll loop, even when a load
+// fails mid-tick. See nexu-io/open-design#4179 review.
+const runtimeSource = readFileSync(new URL("../../src/main/runtime.ts", import.meta.url), "utf8");
+
+const markRendererFailedBlock =
+  /const markRendererFailed = \(\) => \{([\s\S]*?)\n  \};/.exec(runtimeSource)?.[0] ?? "";
+
+describe("desktop renderer-recovery poll loop", () => {
+  test("tracks whether a tick is in flight", () => {
+    expect(runtimeSource).toContain("let ticking = false;");
+  });
+
+  test("the failure handler does not reschedule while a tick is in flight", () => {
+    // A rejecting `loadURL` inside a tick fires `did-fail-load` AND rejects into
+    // the tick's catch. If `markRendererFailed` scheduled unconditionally, both
+    // would queue a timer and the loop would fork. The early return on `ticking`
+    // must come before the `schedule(...)` call.
+    expect(markRendererFailedBlock).toContain("if (ticking) return;");
+    const guardIndex = markRendererFailedBlock.indexOf("if (ticking) return;");
+    const scheduleIndex = markRendererFailedBlock.indexOf("schedule(");
+    expect(guardIndex).toBeGreaterThan(-1);
+    expect(scheduleIndex).toBeGreaterThan(guardIndex);
+  });
+
+  test("tick marks itself in flight and always clears the flag", () => {
+    expect(runtimeSource).toMatch(/const tick = async \(\) => \{[\s\S]*?ticking = true;/);
+    expect(runtimeSource).toMatch(/\}\s*finally\s*\{\s*ticking = false;\s*\}/);
+  });
+
+  test("tick remains the place that reschedules after a failed discovery", () => {
+    // The catch still backs off and re-polls; we only removed the duplicate
+    // timer from the failure handler, not the loop's own recovery.
+    expect(runtimeSource).toMatch(/catch \(error\) \{[\s\S]*?schedule\(PENDING_POLL_MS\);/);
+  });
+});


### PR DESCRIPTION
## Why

I hit this myself: minimize the desktop app, leave it a while, restore it, and the window is blank white. The only way out was quitting and reopening. Digging in, the renderer was parked on `chrome-error://chromewebdata/` (a failed load) with nothing retrying it. When a window sits backgrounded, the OS can reclaim its renderer or its connection to the web server drops, and the main window had no path to recover from that.

## What users will see

After minimizing and restoring the app (or any transient renderer crash or load failure), the window reloads itself and comes back, instead of sitting blank until you quit and reopen.

## Surface area

- [x] **UI**: desktop window recovery behavior in `apps/desktop` (Electron main process). No new surface; this fixes how the existing window recovers.

## Screenshots

Before, blank white window after minimize then restore:

<img width="3224" height="2276" alt="Laravel 2026-06-11 16 40 47" src="https://github.com/user-attachments/assets/133faa9d-a6e8-4512-a010-29e6de713cad" />

After, the window reloads itself back to the app.

<img width="3028" height="2268" alt="CleanShot 2026-06-11 at 16 55 17@2x" src="https://github.com/user-attachments/assets/06e30894-07fd-4e3f-9f7a-c5615621f291" />

## Bug fix verification

A cheap red spec was not practical here: this is Electron main-process window lifecycle (renderer death and `did-fail-load`), which the web package's jsdom test environment cannot exercise, since there is no real renderer process or navigation to fail. I verified in the running desktop app via `tools-dev inspect desktop eval`. With the patched build, forcing the renderer to a refused port (`http://127.0.0.1:1/`) parks it on `chrome-error://`, and the next poll reloads it back to the mounted app (`data-od-app-mounted = 1`, full DOM). On the unpatched build the renderer stays blank.

## Validation

- Runtime recovery check in the running app (above).
- `pnpm --filter @open-design/desktop build` is clean (tsc). Main-process change only, no web type surface touched.
