### PR TITLE
add `od completion` shell autocompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ⌨️ **`od completion` — shell autocompletion for bash, zsh, and fish.** The `od` CLI has ~27 subcommands (and many have their own second level, like `od config get` or `od plugin install`); tab-completion removes the friction of typing those from memory. Run `od completion bash >> ~/.bashrc` (or the zsh/fish equivalent) once and press `<TAB>` after `od`. The generated script defers to the live CLI on every keystroke, so completions never drift from the command set. Pure stdlib, zero new dependencies.
+
 ## [0.9.0] - 2026-05-29
 
 🎉 **310 PRs · 88 contributors · 7 days** — Meet the **install-and-create release**. No more API-key scavenger hunts. No more asking teammates to install three different CLIs before their first prompt. **Open Design AMR** is now built into the app: sign in once, pick a model, and start building. Around that zero-config first run, 0.9.0 brings a bigger agent bench, faster model picking, a more discoverable plugin marketplace, richer review workflows, smoother Studio tools, and easier installs across Windows, macOS, and Linux. 🚀

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -15,6 +15,7 @@ import {
   SUPPORTED_SHELLS,
   isSupportedShell,
   computeCompletions,
+  parseCompleteArgs,
   generateCompletionScript,
 } from './completion.js';
 import { requestJsonIpc } from '@open-design/sidecar';
@@ -6965,13 +6966,7 @@ Then restart your shell (or source the file) and press <TAB> after \`od\`.`);
   // Everything after `--` is the already-typed argv (after `od`); --current is
   // the partial token under the cursor. Prints one candidate per line.
   if (first === '__complete') {
-    const rest = args.slice(1);
-    const sep = rest.indexOf('--');
-    const flagPart = sep === -1 ? rest : rest.slice(0, sep);
-    const words = sep === -1 ? [] : rest.slice(sep + 1);
-    const curIdx = flagPart.indexOf('--current');
-    const current = curIdx !== -1 && flagPart[curIdx + 1] != null ? flagPart[curIdx + 1] : '';
-    const matches = computeCompletions({ words, current });
+    const matches = computeCompletions(parseCompleteArgs(args.slice(1)));
     if (matches.length > 0) process.stdout.write(matches.join('\n') + '\n');
     return;
   }

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -11,6 +11,12 @@ import { parseDesignSystemRenameArgs } from './design-system-rename-args.js';
 import { runLiveArtifactsToolCli } from './tools-live-artifacts-cli.js';
 import { splitResearchSubcommand } from './research/cli-args.js';
 import { resolveDaemonUrl } from './daemon-url.js';
+import {
+  SUPPORTED_SHELLS,
+  isSupportedShell,
+  computeCompletions,
+  generateCompletionScript,
+} from './completion.js';
 import { requestJsonIpc } from '@open-design/sidecar';
 import { SIDECAR_ENV, SIDECAR_MESSAGES } from '@open-design/sidecar-proto';
 import {
@@ -279,6 +285,7 @@ const SUBCOMMAND_MAP = {
   version: runVersion,
   doctor: runDoctor,
   config: runConfig,
+  completion: runCompletion,
 };
 
 if (argv[0] === 'mcp' && argv[1] === 'live-artifacts') {
@@ -6921,6 +6928,62 @@ Common options:
       console.error(`unknown subcommand: od config ${sub}`);
       process.exit(2);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: od completion <bash|zsh|fish>
+//
+// Prints a shell completion script to stdout. The emitted script calls back
+// into `od completion __complete` on every <TAB>, so completions are derived
+// from the live CLI rather than a second hard-coded list in the shell.
+//
+// `od completion __complete --current <partial> -- <words...>` is the hidden
+// runtime resolver the scripts invoke; it prints one candidate per line and
+// is pure/synchronous so it works with no daemon running.
+// ---------------------------------------------------------------------------
+
+function runCompletion(args) {
+  const first = args[0];
+
+  if (!first || first === 'help' || first === '--help' || first === '-h') {
+    console.log(`Usage:
+  od completion <shell>     Print a completion script for the given shell.
+                            Supported shells: ${SUPPORTED_SHELLS.join(', ')}.
+
+Install:
+  bash    od completion bash >> ~/.bashrc
+  zsh     od completion zsh  > "\${fpath[1]}/_od"
+  fish    od completion fish > ~/.config/fish/completions/od.fish
+
+Then restart your shell (or source the file) and press <TAB> after \`od\`.`);
+    // Bare `od completion` is a usage error (exit 2); explicit help is exit 0.
+    process.exit(first ? 0 : 2);
+  }
+
+  // Hidden resolver invoked by the generated scripts on every keystroke.
+  // Contract: `od completion __complete --current <cur> -- <word> <word> ...`.
+  // Everything after `--` is the already-typed argv (after `od`); --current is
+  // the partial token under the cursor. Prints one candidate per line.
+  if (first === '__complete') {
+    const rest = args.slice(1);
+    const sep = rest.indexOf('--');
+    const flagPart = sep === -1 ? rest : rest.slice(0, sep);
+    const words = sep === -1 ? [] : rest.slice(sep + 1);
+    const curIdx = flagPart.indexOf('--current');
+    const current = curIdx !== -1 && flagPart[curIdx + 1] != null ? flagPart[curIdx + 1] : '';
+    const matches = computeCompletions({ words, current });
+    if (matches.length > 0) process.stdout.write(matches.join('\n') + '\n');
+    return;
+  }
+
+  if (!isSupportedShell(first)) {
+    console.error(
+      `unsupported shell: ${first}. Supported shells: ${SUPPORTED_SHELLS.join(', ')}.`,
+    );
+    process.exit(2);
+  }
+
+  process.stdout.write(generateCompletionScript(first));
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/daemon/src/completion.ts
+++ b/apps/daemon/src/completion.ts
@@ -63,7 +63,7 @@ export const COMMAND_SPEC: Record<string, CommandSpec> = {
       'upgrade', 'validate', 'verify', 'whoami', 'yank',
     ],
   },
-  ui: { subcommands: [] },
+  ui: { subcommands: ['list', 'show', 'respond', 'revoke', 'prefill'] },
   marketplace: {
     subcommands: [
       'add', 'doctor', 'info', 'list', 'login', 'plugins', 'refresh',
@@ -89,18 +89,23 @@ export const COMMAND_SPEC: Record<string, CommandSpec> = {
       'templates',
     ],
   },
-  memory: { subcommands: [] },
+  memory: { subcommands: ['tree'] },
   run: { subcommands: ['cancel', 'info', 'list', 'redesign', 'start', 'watch'] },
   files: { subcommands: ['delete', 'diff', 'list', 'read', 'upload', 'write'] },
   templates: { subcommands: ['delete', 'list', 'save'] },
   conversation: {
     subcommands: ['db', 'info', 'list', 'new', 'start', 'status', 'stop'],
   },
-  chat: { subcommands: [] },
-  daemon: { subcommands: [] },
-  atoms: { subcommands: [] },
+  chat: { subcommands: ['new'] },
+  daemon: { subcommands: ['db', 'start', 'status', 'stop', 'vacuum', 'verify'] },
+  atoms: { subcommands: ['info', 'list', 'show'] },
   skills: { subcommands: [] },
-  'design-systems': { subcommands: [] },
+  'design-systems': {
+    subcommands: [
+      'rename', 'import-local', 'import-github', 'import-shadcn',
+      'rebuild-token-contract',
+    ],
+  },
   craft: { subcommands: [] },
   diagnostics: { subcommands: [] },
   status: { subcommands: [] },

--- a/apps/daemon/src/completion.ts
+++ b/apps/daemon/src/completion.ts
@@ -40,6 +40,13 @@ export function isSupportedShell(value: string): value is Shell {
 export interface CommandSpec {
   /** Second-level keywords, e.g. config -> [get, set, list, unset]. */
   subcommands: string[];
+  /**
+   * Flags this command actually accepts. When omitted the command inherits
+   * GLOBAL_FLAGS. Set it when a command only handles a subset — e.g.
+   * `completion` parses --help but not --json/--daemon-url, so advertising the
+   * full global set would suggest flags that error when used.
+   */
+  flags?: readonly string[];
 }
 
 // Flags accepted by virtually every subcommand (the library/diagnostics/config
@@ -126,7 +133,10 @@ export const COMMAND_SPEC: Record<string, CommandSpec> = {
   version: { subcommands: [] },
   doctor: { subcommands: [] },
   config: { subcommands: ['get', 'set', 'list', 'unset'] },
-  completion: { subcommands: [...SUPPORTED_SHELLS] },
+  // `od completion` only parses --help; --json/--daemon-url are not accepted
+  // (they fall through runCompletion's shell check and error). Restrict the
+  // offered flags so completion never suggests a flag that would fail.
+  completion: { subcommands: [...SUPPORTED_SHELLS], flags: ['--help'] },
 };
 
 /** Sorted list of all top-level command names. */
@@ -143,6 +153,37 @@ export interface CompletionRequest {
   words: string[];
   /** The partial token under the cursor (may be ''). */
   current: string;
+}
+
+/**
+ * Parse the args passed to the hidden `od completion __complete` resolver into
+ * a {@link CompletionRequest}. The wire form is:
+ *
+ *   --current <partial> -- <word> <word> ...
+ *
+ * Scans left-to-right so `--current`'s value is consumed before we look for the
+ * `--` words separator. A naive `indexOf('--')` breaks when the partial token
+ * is literally `--` (e.g. `od completion --<TAB>`): the `--current` value would
+ * be mistaken for the separator, dropping the prefix filter.
+ *
+ * @param args argv after the `__complete` keyword.
+ */
+export function parseCompleteArgs(args: string[]): CompletionRequest {
+  let current = '';
+  let words: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if (tok === '--current') {
+      current = args[i + 1] ?? '';
+      i++; // consume the value, whatever it is (including '--')
+      continue;
+    }
+    if (tok === '--') {
+      words = args.slice(i + 1);
+      break;
+    }
+  }
+  return { words, current };
 }
 
 /**
@@ -167,10 +208,20 @@ export function computeCompletions(req: CompletionRequest): string[] {
   return [...new Set(filtered)].sort();
 }
 
+// Flags to offer for the command currently on the line. Honors a command's
+// `flags` override (e.g. `completion` only accepts --help) and falls back to
+// GLOBAL_FLAGS for everything else, including an unknown/absent command.
+function flagsForCommand(words: string[]): readonly string[] {
+  const command = collectPositionals(words)[0];
+  const spec = command ? COMMAND_SPEC[command] : undefined;
+  return spec?.flags ?? GLOBAL_FLAGS;
+}
+
 function collectCandidates(words: string[], current: string): string[] {
-  // 1. Flag completion takes precedence regardless of position.
+  // 1. Flag completion takes precedence regardless of position. Offer the flag
+  // set the command on the line actually accepts, not the global default.
   if (current.startsWith('-')) {
-    return [...GLOBAL_FLAGS];
+    return [...flagsForCommand(words)];
   }
 
   // Only the command path matters for positional completion; ignore any flags
@@ -191,13 +242,13 @@ function collectCandidates(words: string[], current: string): string[] {
     return [...GLOBAL_FLAGS];
   }
 
-  // 3. Exactly the command typed -> its subcommands + global flags.
+  // 3. Exactly the command typed -> its subcommands + the flags it accepts.
   if (positionals.length === 1) {
-    return [...spec.subcommands, ...GLOBAL_FLAGS];
+    return [...spec.subcommands, ...(spec.flags ?? GLOBAL_FLAGS)];
   }
 
-  // 4. Deeper paths -> global flags only.
-  return [...GLOBAL_FLAGS];
+  // 4. Deeper paths -> the command's accepted flags.
+  return [...(spec.flags ?? GLOBAL_FLAGS)];
 }
 
 /**

--- a/apps/daemon/src/completion.ts
+++ b/apps/daemon/src/completion.ts
@@ -46,6 +46,12 @@ export interface CommandSpec {
 // handlers all parse these). Offered after `--` on any command.
 export const GLOBAL_FLAGS = ['--help', '--json', '--daemon-url'] as const;
 
+// Global flags that consume the following token as their value (so it must not
+// be mistaken for a command/subcommand during completion). `--help`/`--json`
+// are booleans and take no value. Mirrors the CLI router, which skips the
+// value token for string flags like `--daemon-url <url>`.
+const VALUE_FLAGS = new Set(['--daemon-url']);
+
 // Top-level commands and their known subcommands. Kept in sync with the
 // SUBCOMMAND_MAP in cli.ts; aliases (e.g. `automations`) are included so a
 // user who types either gets completion.
@@ -161,7 +167,7 @@ function collectCandidates(words: string[], current: string): string[] {
 
   // Only the command path matters for positional completion; ignore any flags
   // the user already typed (e.g. `od --json <TAB>` still completes commands).
-  const positionals = words.filter((w) => !w.startsWith('-'));
+  const positionals = collectPositionals(words);
 
   // 2. No command yet -> top-level commands.
   if (positionals.length === 0) {
@@ -184,6 +190,31 @@ function collectCandidates(words: string[], current: string): string[] {
 
   // 4. Deeper paths -> global flags only.
   return [...GLOBAL_FLAGS];
+}
+
+/**
+ * Extract the positional command path from already-typed words, skipping flags
+ * and — crucially — the value token consumed by a value-taking flag. Without
+ * this, `--daemon-url http://host` would leave `http://host` as a fake first
+ * positional and suppress top-level command completion. `--daemon-url=<url>` is
+ * a single token and is dropped by the leading-dash check.
+ */
+function collectPositionals(words: string[]): string[] {
+  const positionals: string[] = [];
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i] ?? '';
+    if (word.startsWith('-')) {
+      // `--flag value` form: consume the next token as the flag's value so it
+      // is not treated as a positional. The `--flag=value` form carries its
+      // value inline, so nothing extra is consumed.
+      if (VALUE_FLAGS.has(word) && i + 1 < words.length) {
+        i++;
+      }
+      continue;
+    }
+    positionals.push(word);
+  }
+  return positionals;
 }
 
 /**

--- a/apps/daemon/src/completion.ts
+++ b/apps/daemon/src/completion.ts
@@ -79,20 +79,24 @@ export const COMMAND_SPEC: Record<string, CommandSpec> = {
   share: { subcommands: ['url'] },
   project: {
     subcommands: [
-      'create', 'delete', 'editors', 'import', 'import-folder', 'info',
-      'list', 'open-in',
+      'create', 'delete', 'editors', 'handoff', 'import', 'import-folder',
+      'info', 'list', 'open-in',
     ],
   },
+  // runAutomation dispatches the routine lifecycle verbs plus the
+  // ingest/proposal(s)/source(s)/template(s) families.
   automation: {
     subcommands: [
-      'ingest', 'proposal', 'proposals', 'source', 'sources', 'template',
-      'templates',
+      'create', 'crystallize-run', 'delete', 'get', 'ingest', 'list', 'pause',
+      'proposal', 'proposals', 'resume', 'run', 'runs', 'source', 'sources',
+      'template', 'templates', 'update',
     ],
   },
   automations: {
     subcommands: [
-      'ingest', 'proposal', 'proposals', 'source', 'sources', 'template',
-      'templates',
+      'create', 'crystallize-run', 'delete', 'get', 'ingest', 'list', 'pause',
+      'proposal', 'proposals', 'resume', 'run', 'runs', 'source', 'sources',
+      'template', 'templates', 'update',
     ],
   },
   memory: { subcommands: ['tree'] },
@@ -103,16 +107,20 @@ export const COMMAND_SPEC: Record<string, CommandSpec> = {
     subcommands: ['db', 'info', 'list', 'new', 'start', 'status', 'stop'],
   },
   chat: { subcommands: ['new'] },
-  daemon: { subcommands: ['db', 'start', 'status', 'stop', 'vacuum', 'verify'] },
+  // runDaemon dispatches start/status/stop/db only. `vacuum`/`verify` live
+  // under `od daemon db`, not at the top level, so they are NOT listed here.
+  daemon: { subcommands: ['db', 'start', 'status', 'stop'] },
   atoms: { subcommands: ['info', 'list', 'show'] },
-  skills: { subcommands: [] },
+  // skills/craft go through runLibraryList, which accepts list/show.
+  skills: { subcommands: ['list', 'show'] },
   'design-systems': {
+    // Explicit verbs plus the runLibraryList fallback (list/show).
     subcommands: [
       'rename', 'import-local', 'import-github', 'import-shadcn',
-      'rebuild-token-contract',
+      'rebuild-token-contract', 'list', 'show',
     ],
   },
-  craft: { subcommands: [] },
+  craft: { subcommands: ['list', 'show'] },
   diagnostics: { subcommands: [] },
   status: { subcommands: [] },
   version: { subcommands: [] },

--- a/apps/daemon/src/completion.ts
+++ b/apps/daemon/src/completion.ts
@@ -274,7 +274,11 @@ compdef _od od
 const FISH_SCRIPT = `# od fish completion
 # Install: od completion fish > ~/.config/fish/completions/od.fish
 function __od_complete
-    set -l tokens (commandline -opc)
+    # -xpc tokenizes the command line up to but EXCLUDING the token currently
+    # being typed, matching the resolver contract (words must not include the
+    # in-progress token). Using -opc would pass e.g. \`co\` as both a word and
+    # as --current, so \`od co<TAB>\` would treat \`co\` as an unknown command.
+    set -l tokens (commandline -xpc)
     set -l cur (commandline -ct)
     # Drop the leading 'od' from the token list.
     set -e tokens[1]

--- a/apps/daemon/src/completion.ts
+++ b/apps/daemon/src/completion.ts
@@ -1,0 +1,240 @@
+// ---------------------------------------------------------------------------
+// `od completion` — shell autocompletion for bash / zsh / fish.
+//
+// `od` is a keyword-dispatched CLI with ~27 top-level subcommands, many of
+// which have their own second level (`od config get`, `od plugin install`,
+// `od run watch`, …). Typing those from memory is the friction this removes.
+//
+// Design (mirrors app-version.ts: pure logic here, thin wrapper in cli.ts):
+//
+//   - COMMAND_SPEC is the single source of truth — top-level commands, their
+//     known subcommands, and the global flags every command accepts.
+//   - generateCompletionScript(shell) emits a small static script the user
+//     sources once. That script shells back out to `od completion __complete`
+//     on every <TAB>, so completions never drift from the CLI: there is no
+//     second list of commands baked into the shell script to keep in sync.
+//   - computeCompletions({ words, current }) is that runtime resolver. It is
+//     pure and synchronous (no daemon round-trip), so <TAB> stays instant and
+//     works even when the daemon is not running.
+//
+// Zero dependencies — stdlib string work only, per CONTRIBUTING ("no new
+// top-level dependencies").
+// ---------------------------------------------------------------------------
+
+export const SUPPORTED_SHELLS = ['bash', 'zsh', 'fish'] as const;
+export type Shell = (typeof SUPPORTED_SHELLS)[number];
+
+export function isSupportedShell(value: string): value is Shell {
+  return (SUPPORTED_SHELLS as readonly string[]).includes(value);
+}
+
+/**
+ * Static description of the command tree, used to drive completion.
+ *
+ * `subcommands` lists the known second-level keywords for a command (empty
+ * when a command takes only positionals/flags). This is intentionally a
+ * hand-maintained, conservative list: it covers the stable, documented
+ * subcommands and is safe to extend as the CLI grows. Completion degrades
+ * gracefully — an unknown command simply offers the global flags.
+ */
+export interface CommandSpec {
+  /** Second-level keywords, e.g. config -> [get, set, list, unset]. */
+  subcommands: string[];
+}
+
+// Flags accepted by virtually every subcommand (the library/diagnostics/config
+// handlers all parse these). Offered after `--` on any command.
+export const GLOBAL_FLAGS = ['--help', '--json', '--daemon-url'] as const;
+
+// Top-level commands and their known subcommands. Kept in sync with the
+// SUBCOMMAND_MAP in cli.ts; aliases (e.g. `automations`) are included so a
+// user who types either gets completion.
+export const COMMAND_SPEC: Record<string, CommandSpec> = {
+  artifacts: { subcommands: [] },
+  media: { subcommands: ['generate', 'wait'] },
+  mcp: { subcommands: ['install'] },
+  research: { subcommands: ['search'] },
+  plugin: {
+    subcommands: [
+      'apply', 'candidates', 'canon', 'diff', 'doctor', 'events', 'export',
+      'info', 'install', 'list', 'login', 'manifest', 'open-design-pr', 'pack',
+      'publish', 'publish-repo', 'replay', 'run', 'scaffold', 'search',
+      'simulate', 'snapshots', 'sources', 'stats', 'trust', 'uninstall',
+      'upgrade', 'validate', 'verify', 'whoami', 'yank',
+    ],
+  },
+  ui: { subcommands: [] },
+  marketplace: {
+    subcommands: [
+      'add', 'doctor', 'info', 'list', 'login', 'plugins', 'refresh',
+      'remove', 'search', 'trust',
+    ],
+  },
+  share: { subcommands: ['url'] },
+  project: {
+    subcommands: [
+      'create', 'delete', 'editors', 'import', 'import-folder', 'info',
+      'list', 'open-in',
+    ],
+  },
+  automation: {
+    subcommands: [
+      'ingest', 'proposal', 'proposals', 'source', 'sources', 'template',
+      'templates',
+    ],
+  },
+  automations: {
+    subcommands: [
+      'ingest', 'proposal', 'proposals', 'source', 'sources', 'template',
+      'templates',
+    ],
+  },
+  memory: { subcommands: [] },
+  run: { subcommands: ['cancel', 'info', 'list', 'redesign', 'start', 'watch'] },
+  files: { subcommands: ['delete', 'diff', 'list', 'read', 'upload', 'write'] },
+  templates: { subcommands: ['delete', 'list', 'save'] },
+  conversation: {
+    subcommands: ['db', 'info', 'list', 'new', 'start', 'status', 'stop'],
+  },
+  chat: { subcommands: [] },
+  daemon: { subcommands: [] },
+  atoms: { subcommands: [] },
+  skills: { subcommands: [] },
+  'design-systems': { subcommands: [] },
+  craft: { subcommands: [] },
+  diagnostics: { subcommands: [] },
+  status: { subcommands: [] },
+  version: { subcommands: [] },
+  doctor: { subcommands: [] },
+  config: { subcommands: ['get', 'set', 'list', 'unset'] },
+  completion: { subcommands: [...SUPPORTED_SHELLS] },
+};
+
+/** Sorted list of all top-level command names. */
+export function topLevelCommands(): string[] {
+  return Object.keys(COMMAND_SPEC).sort();
+}
+
+export interface CompletionRequest {
+  /**
+   * The argv *after* `od`, as the shell sees it, excluding the token currently
+   * being typed. E.g. for `od config <TAB>` -> [], for `od config g<TAB>` ->
+   * ['config'].
+   */
+  words: string[];
+  /** The partial token under the cursor (may be ''). */
+  current: string;
+}
+
+/**
+ * Resolve the candidate completions for a partially-typed `od` command line.
+ *
+ * Rules, in order:
+ *   1. If the current token starts with '-', offer global flags.
+ *   2. If no command word is present yet, offer all top-level commands.
+ *   3. If exactly the command word is present, offer its subcommands (plus
+ *      global flags), or just global flags when it has none.
+ *   4. Deeper than that, offer global flags only (positionals are
+ *      command-specific and not enumerable without a daemon round-trip).
+ *
+ * Results are filtered by `current` (prefix match) and de-duplicated, sorted.
+ */
+export function computeCompletions(req: CompletionRequest): string[] {
+  const { words, current } = req;
+  const candidates = collectCandidates(words, current);
+  const filtered = current
+    ? candidates.filter((c) => c.startsWith(current))
+    : candidates;
+  return [...new Set(filtered)].sort();
+}
+
+function collectCandidates(words: string[], current: string): string[] {
+  // 1. Flag completion takes precedence regardless of position.
+  if (current.startsWith('-')) {
+    return [...GLOBAL_FLAGS];
+  }
+
+  // Only the command path matters for positional completion; ignore any flags
+  // the user already typed (e.g. `od --json <TAB>` still completes commands).
+  const positionals = words.filter((w) => !w.startsWith('-'));
+
+  // 2. No command yet -> top-level commands.
+  if (positionals.length === 0) {
+    return topLevelCommands();
+  }
+
+  const command = positionals[0];
+  const spec = command ? COMMAND_SPEC[command] : undefined;
+
+  // Unknown command (typo or not-yet-specced) -> nothing positional to add;
+  // fall back to global flags so <TAB> is never empty-handed.
+  if (!spec) {
+    return [...GLOBAL_FLAGS];
+  }
+
+  // 3. Exactly the command typed -> its subcommands + global flags.
+  if (positionals.length === 1) {
+    return [...spec.subcommands, ...GLOBAL_FLAGS];
+  }
+
+  // 4. Deeper paths -> global flags only.
+  return [...GLOBAL_FLAGS];
+}
+
+/**
+ * Emit the shell-specific completion script. The script delegates to
+ * `od completion __complete` at runtime so it never carries a stale copy of
+ * the command list.
+ */
+export function generateCompletionScript(shell: Shell): string {
+  switch (shell) {
+    case 'bash':
+      return BASH_SCRIPT;
+    case 'zsh':
+      return ZSH_SCRIPT;
+    case 'fish':
+      return FISH_SCRIPT;
+  }
+}
+
+// `_od_complete` passes the already-typed words and the current partial token
+// to `od completion __complete`, which prints one candidate per line.
+const BASH_SCRIPT = `# od bash completion
+# Install: od completion bash >> ~/.bashrc   (then restart your shell)
+_od_complete() {
+  local cur words cword
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  # Words after 'od', excluding the token under the cursor.
+  words=("\${COMP_WORDS[@]:1:COMP_CWORD-1}")
+  local IFS=$'\\n'
+  local completions
+  completions="$(od completion __complete --current "\${cur}" -- "\${words[@]}" 2>/dev/null)"
+  COMPREPLY=( $(compgen -W "\${completions}" -- "\${cur}") )
+}
+complete -F _od_complete od
+`;
+
+const ZSH_SCRIPT = `# od zsh completion
+# Install: od completion zsh > "\${fpath[1]}/_od"   (then restart your shell)
+#   or:    od completion zsh >> ~/.zshrc
+_od() {
+  local -a completions
+  local cur="\${words[CURRENT]}"
+  local -a prior=("\${words[2,CURRENT-1]}")
+  completions=(\${(f)"$(od completion __complete --current "\${cur}" -- "\${prior[@]}" 2>/dev/null)"})
+  compadd -- \${completions}
+}
+compdef _od od
+`;
+
+const FISH_SCRIPT = `# od fish completion
+# Install: od completion fish > ~/.config/fish/completions/od.fish
+function __od_complete
+    set -l tokens (commandline -opc)
+    set -l cur (commandline -ct)
+    # Drop the leading 'od' from the token list.
+    set -e tokens[1]
+    od completion __complete --current "$cur" -- $tokens 2>/dev/null
+end
+complete -c od -f -a '(__od_complete)'
+`;

--- a/apps/daemon/src/completion.ts
+++ b/apps/daemon/src/completion.ts
@@ -128,7 +128,7 @@ export const COMMAND_SPEC: Record<string, CommandSpec> = {
     ],
   },
   craft: { subcommands: ['list', 'show'] },
-  diagnostics: { subcommands: [] },
+  diagnostics: { subcommands: ['export'] },
   status: { subcommands: [] },
   version: { subcommands: [] },
   doctor: { subcommands: [] },

--- a/apps/daemon/src/completion.ts
+++ b/apps/daemon/src/completion.ts
@@ -64,9 +64,14 @@ const VALUE_FLAGS = new Set(['--daemon-url']);
 // user who types either gets completion.
 export const COMMAND_SPEC: Record<string, CommandSpec> = {
   artifacts: { subcommands: [] },
-  media: { subcommands: ['generate', 'wait'] },
+  // `media generate`/`media wait` parse only MEDIA_GENERATE_*_FLAGS in cli.ts,
+  // which omit --json (output is plain text / streamed). Advertising the
+  // global --json here would suggest a flag the parser rejects.
+  media: { subcommands: ['generate', 'wait'], flags: ['--help', '--daemon-url'] },
   mcp: { subcommands: ['install'] },
-  research: { subcommands: ['search'] },
+  // `od research` only dispatches `search`, which parses RESEARCH_SEARCH_*_FLAGS
+  // (no --json — its output is JSON-only by design). Restrict accordingly.
+  research: { subcommands: ['search'], flags: ['--help', '--daemon-url'] },
   plugin: {
     subcommands: [
       'apply', 'candidates', 'canon', 'diff', 'doctor', 'events', 'export',

--- a/apps/daemon/tests/completion.test.ts
+++ b/apps/daemon/tests/completion.test.ts
@@ -158,6 +158,52 @@ describe('COMMAND_SPEC integrity', () => {
   });
 
   it('exposes the supported shells as completion subcommands', () => {
-    expect(new Set(COMMAND_SPEC.completion.subcommands)).toEqual(new Set(SUPPORTED_SHELLS));
+    expect(new Set(COMMAND_SPEC.completion?.subcommands ?? [])).toEqual(
+      new Set(SUPPORTED_SHELLS),
+    );
   });
+});
+
+// Fixture pinning the known second-level surface for command families that
+// dispatch subcommands in cli.ts. If a handler there gains a subcommand and
+// COMMAND_SPEC isn't updated, the relevant case fails — catching silent drift
+// between the completion table and the real CLI. Each list is a *subset* the
+// spec must contain (so adding a new subcommand to the spec doesn't break the
+// test), keyed to the handlers' switch/dispatch in cli.ts.
+const KNOWN_SUBCOMMANDS: Record<string, string[]> = {
+  config: ['get', 'set', 'list', 'unset'],
+  ui: ['list', 'show', 'respond', 'revoke', 'prefill'],
+  daemon: ['db', 'start', 'status', 'stop', 'vacuum', 'verify'],
+  atoms: ['info', 'list', 'show'],
+  chat: ['new'],
+  memory: ['tree'],
+  run: ['cancel', 'info', 'list', 'redesign', 'start', 'watch'],
+  files: ['delete', 'diff', 'list', 'read', 'upload', 'write'],
+  templates: ['delete', 'list', 'save'],
+  conversation: ['db', 'info', 'list', 'new', 'start', 'status', 'stop'],
+  project: ['create', 'delete', 'editors', 'import', 'import-folder', 'info', 'list', 'open-in'],
+  'design-systems': [
+    'rename', 'import-local', 'import-github', 'import-shadcn', 'rebuild-token-contract',
+  ],
+};
+
+describe('COMMAND_SPEC covers known cli.ts subcommands', () => {
+  for (const [command, expected] of Object.entries(KNOWN_SUBCOMMANDS)) {
+    it(`completes the known subcommands of \`od ${command}\``, () => {
+      const spec = COMMAND_SPEC[command];
+      expect(spec, `${command} missing from COMMAND_SPEC`).toBeDefined();
+      const have = new Set(spec?.subcommands ?? []);
+      const missing = expected.filter((sub) => !have.has(sub));
+      expect(missing, `od ${command} is missing completions for: ${missing.join(', ')}`).toEqual(
+        [],
+      );
+    });
+
+    it(`offers those subcommands through computeCompletions for \`od ${command}\``, () => {
+      const out = computeCompletions({ words: [command], current: '' });
+      for (const sub of expected) {
+        expect(out, `\`od ${command} <TAB>\` should offer ${sub}`).toContain(sub);
+      }
+    });
+  }
 });

--- a/apps/daemon/tests/completion.test.ts
+++ b/apps/daemon/tests/completion.test.ts
@@ -210,7 +210,8 @@ describe('COMMAND_SPEC integrity', () => {
 const KNOWN_SUBCOMMANDS: Record<string, string[]> = {
   config: ['get', 'set', 'list', 'unset'],
   ui: ['list', 'show', 'respond', 'revoke', 'prefill'],
-  daemon: ['db', 'start', 'status', 'stop', 'vacuum', 'verify'],
+  // Only top-level daemon verbs; vacuum/verify live under `daemon db`.
+  daemon: ['db', 'start', 'status', 'stop'],
   atoms: ['info', 'list', 'show'],
   chat: ['new'],
   memory: ['tree'],
@@ -218,10 +219,33 @@ const KNOWN_SUBCOMMANDS: Record<string, string[]> = {
   files: ['delete', 'diff', 'list', 'read', 'upload', 'write'],
   templates: ['delete', 'list', 'save'],
   conversation: ['db', 'info', 'list', 'new', 'start', 'status', 'stop'],
-  project: ['create', 'delete', 'editors', 'import', 'import-folder', 'info', 'list', 'open-in'],
-  'design-systems': [
-    'rename', 'import-local', 'import-github', 'import-shadcn', 'rebuild-token-contract',
+  project: [
+    'create', 'delete', 'editors', 'handoff', 'import', 'import-folder',
+    'info', 'list', 'open-in',
   ],
+  automation: [
+    'create', 'crystallize-run', 'delete', 'get', 'ingest', 'list', 'pause',
+    'proposal', 'proposals', 'resume', 'run', 'runs', 'source', 'sources',
+    'template', 'templates', 'update',
+  ],
+  automations: [
+    'create', 'crystallize-run', 'delete', 'get', 'ingest', 'list', 'pause',
+    'proposal', 'proposals', 'resume', 'run', 'runs', 'source', 'sources',
+    'template', 'templates', 'update',
+  ],
+  skills: ['list', 'show'],
+  craft: ['list', 'show'],
+  'design-systems': [
+    'rename', 'import-local', 'import-github', 'import-shadcn',
+    'rebuild-token-contract', 'list', 'show',
+  ],
+};
+
+// Verbs that must NOT be advertised as top-level completions because they are
+// nested under another subcommand — suggesting them yields `od <verb>` calls
+// that would fail (e.g. `od daemon verify`, which is really `od daemon db verify`).
+const FORBIDDEN_TOP_LEVEL: Record<string, string[]> = {
+  daemon: ['vacuum', 'verify'],
 };
 
 describe('COMMAND_SPEC covers known cli.ts subcommands', () => {
@@ -241,6 +265,18 @@ describe('COMMAND_SPEC covers known cli.ts subcommands', () => {
       for (const sub of expected) {
         expect(out, `\`od ${command} <TAB>\` should offer ${sub}`).toContain(sub);
       }
+    });
+  }
+});
+
+describe('COMMAND_SPEC does not advertise nested verbs as top-level', () => {
+  for (const [command, forbidden] of Object.entries(FORBIDDEN_TOP_LEVEL)) {
+    it(`does not offer nested verbs for \`od ${command}\``, () => {
+      const out = computeCompletions({ words: [command], current: '' });
+      const leaked = forbidden.filter((verb) => out.includes(verb));
+      expect(leaked, `od ${command} must not suggest nested verbs: ${leaked.join(', ')}`).toEqual(
+        [],
+      );
     });
   }
 });

--- a/apps/daemon/tests/completion.test.ts
+++ b/apps/daemon/tests/completion.test.ts
@@ -6,6 +6,7 @@ import {
   computeCompletions,
   generateCompletionScript,
   isSupportedShell,
+  parseCompleteArgs,
   topLevelCommands,
 } from '../src/completion.js';
 
@@ -220,6 +221,34 @@ describe('COMMAND_SPEC integrity', () => {
       new Set(SUPPORTED_SHELLS),
     );
   });
+
+  it('restricts the completion command to the flags it actually accepts', () => {
+    // runCompletion only parses --help; --json/--daemon-url would error.
+    expect(COMMAND_SPEC.completion?.flags).toEqual(['--help']);
+  });
+});
+
+describe('computeCompletions — per-command flag overrides', () => {
+  it('offers only --help for `od completion --<TAB>`', () => {
+    const out = computeCompletions({ words: ['completion'], current: '--' });
+    expect(out).toEqual(['--help']);
+    // The globals that would error must not be suggested.
+    expect(out).not.toContain('--json');
+    expect(out).not.toContain('--daemon-url');
+  });
+
+  it('still offers shells alongside --help when no dash is typed', () => {
+    const out = computeCompletions({ words: ['completion'], current: '' });
+    for (const shell of SUPPORTED_SHELLS) expect(out).toContain(shell);
+    expect(out).toContain('--help');
+    expect(out).not.toContain('--json');
+    expect(out).not.toContain('--daemon-url');
+  });
+
+  it('keeps the full global flag set for commands without an override', () => {
+    const out = computeCompletions({ words: ['config'], current: '--' });
+    expect(out).toEqual(['--daemon-url', '--help', '--json']);
+  });
 });
 
 // Fixture pinning the known second-level surface for command families that
@@ -300,4 +329,47 @@ describe('COMMAND_SPEC does not advertise nested verbs as top-level', () => {
       );
     });
   }
+});
+
+describe('parseCompleteArgs', () => {
+  it('splits --current and the words after the -- separator', () => {
+    expect(parseCompleteArgs(['--current', 'g', '--', 'config'])).toEqual({
+      current: 'g',
+      words: ['config'],
+    });
+  });
+
+  it('handles an empty current token', () => {
+    expect(parseCompleteArgs(['--current', '', '--', 'config'])).toEqual({
+      current: '',
+      words: ['config'],
+    });
+  });
+
+  // Regression: a literal `--` as the partial token must be taken as the
+  // --current value, not as the words separator (od completion --<TAB>).
+  it('treats a literal -- partial token as the current value', () => {
+    expect(parseCompleteArgs(['--current', '--', '--', 'completion'])).toEqual({
+      current: '--',
+      words: ['completion'],
+    });
+  });
+
+  it('returns empty words when no separator is present', () => {
+    expect(parseCompleteArgs(['--current', 'co'])).toEqual({
+      current: 'co',
+      words: [],
+    });
+  });
+
+  it('preserves value-flag pairs inside words', () => {
+    expect(
+      parseCompleteArgs(['--current', '', '--', 'config', '--daemon-url', 'http://x']),
+    ).toEqual({ current: '', words: ['config', '--daemon-url', 'http://x'] });
+  });
+
+  it('round-trips through computeCompletions for `od completion --<TAB>`', () => {
+    const req = parseCompleteArgs(['--current', '--', '--', 'completion']);
+    expect(computeCompletions(req)).toEqual(['--help']);
+  });
 });

--- a/apps/daemon/tests/completion.test.ts
+++ b/apps/daemon/tests/completion.test.ts
@@ -106,6 +106,43 @@ describe('computeCompletions — flags', () => {
     const out = computeCompletions({ words: ['--json'], current: '' });
     expect(out).toEqual(topLevelCommands());
   });
+
+  it('does not treat a value-flag value as a command', () => {
+    // `od --daemon-url http://localhost:7456 <TAB>` -> the URL is the flag's
+    // value, not a command, so top-level commands should still be offered.
+    const out = computeCompletions({
+      words: ['--daemon-url', 'http://localhost:7456'],
+      current: '',
+    });
+    expect(out).toEqual(topLevelCommands());
+  });
+
+  it('does not treat a value-flag value as a subcommand', () => {
+    // `od config --daemon-url http://localhost:7456 <TAB>` should still offer
+    // config's subcommands, not collapse to global flags.
+    const out = computeCompletions({
+      words: ['config', '--daemon-url', 'http://localhost:7456'],
+      current: '',
+    });
+    expect(out).toContain('get');
+    expect(out).toContain('set');
+  });
+
+  it('handles the --daemon-url=<url> inline form', () => {
+    const out = computeCompletions({
+      words: ['--daemon-url=http://localhost:7456'],
+      current: '',
+    });
+    expect(out).toEqual(topLevelCommands());
+  });
+
+  it('still completes a subcommand prefix after a value flag', () => {
+    const out = computeCompletions({
+      words: ['config', '--daemon-url', 'http://localhost:7456'],
+      current: 'g',
+    });
+    expect(out).toEqual(['get']);
+  });
 });
 
 describe('computeCompletions — determinism', () => {

--- a/apps/daemon/tests/completion.test.ts
+++ b/apps/daemon/tests/completion.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COMMAND_SPEC,
+  GLOBAL_FLAGS,
+  SUPPORTED_SHELLS,
+  computeCompletions,
+  generateCompletionScript,
+  isSupportedShell,
+  topLevelCommands,
+} from '../src/completion.js';
+
+describe('isSupportedShell', () => {
+  it('accepts the three supported shells', () => {
+    expect(isSupportedShell('bash')).toBe(true);
+    expect(isSupportedShell('zsh')).toBe(true);
+    expect(isSupportedShell('fish')).toBe(true);
+  });
+
+  it('rejects anything else', () => {
+    expect(isSupportedShell('powershell')).toBe(false);
+    expect(isSupportedShell('')).toBe(false);
+    expect(isSupportedShell('BASH')).toBe(false);
+  });
+});
+
+describe('topLevelCommands', () => {
+  it('returns a sorted list of every command in the spec', () => {
+    const cmds = topLevelCommands();
+    expect(cmds).toEqual([...cmds].sort());
+    expect(new Set(cmds)).toEqual(new Set(Object.keys(COMMAND_SPEC)));
+  });
+
+  it('includes the core commands a user expects', () => {
+    const cmds = topLevelCommands();
+    for (const expected of ['config', 'plugin', 'run', 'doctor', 'completion', 'skills']) {
+      expect(cmds).toContain(expected);
+    }
+  });
+});
+
+describe('computeCompletions — top level', () => {
+  it('offers all commands when nothing is typed yet', () => {
+    expect(computeCompletions({ words: [], current: '' })).toEqual(topLevelCommands());
+  });
+
+  it('prefix-filters top-level commands', () => {
+    const out = computeCompletions({ words: [], current: 'co' });
+    expect(out).toContain('config');
+    expect(out).toContain('completion');
+    expect(out).toContain('conversation');
+    expect(out).not.toContain('plugin');
+    // every result actually starts with the prefix
+    expect(out.every((c) => c.startsWith('co'))).toBe(true);
+  });
+
+  it('returns an empty list when nothing matches the prefix', () => {
+    expect(computeCompletions({ words: [], current: 'zzzzz' })).toEqual([]);
+  });
+});
+
+describe('computeCompletions — subcommands', () => {
+  it('offers a command\'s subcommands plus global flags', () => {
+    const out = computeCompletions({ words: ['config'], current: '' });
+    for (const sub of ['get', 'set', 'list', 'unset']) {
+      expect(out).toContain(sub);
+    }
+    for (const flag of GLOBAL_FLAGS) {
+      expect(out).toContain(flag);
+    }
+  });
+
+  it('prefix-filters subcommands', () => {
+    const out = computeCompletions({ words: ['config'], current: 'g' });
+    expect(out).toEqual(['get']);
+  });
+
+  it('offers only global flags for a command with no subcommands', () => {
+    const out = computeCompletions({ words: ['doctor'], current: '' });
+    expect(out).toEqual([...GLOBAL_FLAGS].sort());
+  });
+
+  it('offers global flags for an unknown command', () => {
+    const out = computeCompletions({ words: ['definitely-not-a-command'], current: '' });
+    expect(out).toEqual([...GLOBAL_FLAGS].sort());
+  });
+
+  it('offers global flags only beyond the second level', () => {
+    const out = computeCompletions({ words: ['config', 'get'], current: '' });
+    expect(out).toEqual([...GLOBAL_FLAGS].sort());
+  });
+});
+
+describe('computeCompletions — flags', () => {
+  it('offers global flags when the current token starts with a dash', () => {
+    const out = computeCompletions({ words: ['config'], current: '-' });
+    expect(out).toEqual([...GLOBAL_FLAGS].sort());
+  });
+
+  it('prefix-filters flags', () => {
+    const out = computeCompletions({ words: [], current: '--j' });
+    expect(out).toEqual(['--json']);
+  });
+
+  it('ignores already-typed flags when completing the command path', () => {
+    // `od --json <TAB>` should still complete top-level commands.
+    const out = computeCompletions({ words: ['--json'], current: '' });
+    expect(out).toEqual(topLevelCommands());
+  });
+});
+
+describe('computeCompletions — determinism', () => {
+  it('returns sorted, de-duplicated results', () => {
+    const out = computeCompletions({ words: ['plugin'], current: '' });
+    expect(out).toEqual([...out].sort());
+    expect(new Set(out).size).toBe(out.length);
+  });
+});
+
+describe('generateCompletionScript', () => {
+  for (const shell of SUPPORTED_SHELLS) {
+    it(`produces a non-empty ${shell} script that delegates to __complete`, () => {
+      const script = generateCompletionScript(shell);
+      expect(script.length).toBeGreaterThan(0);
+      // The whole point: the script defers to the live CLI rather than baking
+      // in a command list.
+      expect(script).toContain('od completion __complete');
+    });
+
+    it(`mentions an install hint for ${shell}`, () => {
+      expect(generateCompletionScript(shell).toLowerCase()).toContain(shell);
+    });
+  }
+
+  it('registers a completion function per shell', () => {
+    expect(generateCompletionScript('bash')).toContain('complete -F _od_complete od');
+    expect(generateCompletionScript('zsh')).toContain('compdef _od od');
+    expect(generateCompletionScript('fish')).toContain('complete -c od');
+  });
+});
+
+describe('COMMAND_SPEC integrity', () => {
+  it('has no duplicate subcommands within a command', () => {
+    for (const [name, spec] of Object.entries(COMMAND_SPEC)) {
+      expect(new Set(spec.subcommands).size, `duplicates in ${name}`).toBe(
+        spec.subcommands.length,
+      );
+    }
+  });
+
+  it('uses kebab-case command and subcommand tokens', () => {
+    const token = /^[a-z][a-z0-9-]*$/;
+    for (const [name, spec] of Object.entries(COMMAND_SPEC)) {
+      expect(token.test(name), `bad command name: ${name}`).toBe(true);
+      for (const sub of spec.subcommands) {
+        expect(token.test(sub), `bad subcommand in ${name}: ${sub}`).toBe(true);
+      }
+    }
+  });
+
+  it('exposes the supported shells as completion subcommands', () => {
+    expect(new Set(COMMAND_SPEC.completion.subcommands)).toEqual(new Set(SUPPORTED_SHELLS));
+  });
+});

--- a/apps/daemon/tests/completion.test.ts
+++ b/apps/daemon/tests/completion.test.ts
@@ -173,6 +173,27 @@ describe('generateCompletionScript', () => {
     expect(generateCompletionScript('zsh')).toContain('compdef _od od');
     expect(generateCompletionScript('fish')).toContain('complete -c od');
   });
+
+  it('uses the current-token-excluding form in the fish script', () => {
+    const fish = generateCompletionScript('fish');
+    // -xpc excludes the in-progress token (resolver contract); -opc would pass
+    // the token both as a word and as --current and break `od co<TAB>`.
+    expect(fish).toContain('commandline -xpc');
+    expect(fish).not.toContain('commandline -opc');
+  });
+});
+
+describe('computeCompletions — shell driver contract', () => {
+  // The generated scripts pass the typed words WITHOUT the in-progress token,
+  // and the partial token as `current`. This is exactly what fish sends after
+  // the `-xpc` fix, so `od co<TAB>` must resolve as words=[] current='co'.
+  it('completes a partial top-level command (the fish `od co<TAB>` path)', () => {
+    const out = computeCompletions({ words: [], current: 'co' });
+    expect(out).toContain('completion');
+    expect(out).toContain('config');
+    expect(out).toContain('conversation');
+    expect(out.every((c) => c.startsWith('co'))).toBe(true);
+  });
 });
 
 describe('COMMAND_SPEC integrity', () => {

--- a/apps/daemon/tests/completion.test.ts
+++ b/apps/daemon/tests/completion.test.ts
@@ -249,6 +249,19 @@ describe('computeCompletions — per-command flag overrides', () => {
     const out = computeCompletions({ words: ['config'], current: '--' });
     expect(out).toEqual(['--daemon-url', '--help', '--json']);
   });
+
+  // `od research` (dispatches only `search`) and `od media` (generate/wait)
+  // parse flag sets in cli.ts that omit --json, so completion must not
+  // advertise it for them. Pins the COMMAND_SPEC override and the resolver.
+  for (const command of ['research', 'media'] as const) {
+    it(`does not suggest --json for \`od ${command} --<TAB>\``, () => {
+      expect(COMMAND_SPEC[command]?.flags).toEqual(['--help', '--daemon-url']);
+      const out = computeCompletions({ words: [command], current: '--' });
+      expect(out).not.toContain('--json');
+      expect(out).toContain('--help');
+      expect(out).toContain('--daemon-url');
+    });
+  }
 });
 
 // Fixture pinning the known second-level surface for command families that

--- a/apps/daemon/tests/completion.test.ts
+++ b/apps/daemon/tests/completion.test.ts
@@ -285,6 +285,7 @@ const KNOWN_SUBCOMMANDS: Record<string, string[]> = {
   ],
   skills: ['list', 'show'],
   craft: ['list', 'show'],
+  diagnostics: ['export'],
   'design-systems': [
     'rename', 'import-local', 'import-github', 'import-shadcn',
     'rebuild-token-contract', 'list', 'show',


### PR DESCRIPTION
## Why

I was exercising the `od` CLI while exploring Open Design and kept reaching for `<TAB>` out of habit — `od` has ~27 top-level subcommands, and several have a second level (`od config get`, `od plugin install`, `od run watch`, `od files write`). Without completion you either memorize the tree or run `--help` repeatedly. Every mature CLI ships shell completion for exactly this reason; `od` didn't have it.

This is a small, self-contained quality-of-life addition for anyone who drives Open Design from the terminal (the headless/agent path the daemon is built around). No behavior changes, no new dependencies.

## What users will see

A new `od completion <shell>` subcommand for **bash**, **zsh**, and **fish**. Install it once:

```bash
od completion bash >> ~/.bashrc          # bash
od completion zsh  > "${fpath[1]}/_od"   # zsh
od completion fish > ~/.config/fish/completions/od.fish  # fish
```

After restarting the shell, `<TAB>` after `od` completes top-level commands; `<TAB>` after a command completes its subcommands and the common `--help / --json / --daemon-url` flags. `od completion --help` prints the install hints.

The generated script delegates to a hidden `od completion __complete` resolver on every keystroke, so completions are always derived from the live CLI rather than a stale list baked into the shell script.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

New command only; nothing existing changes. Zero new dependencies (stdlib string work). Per `TRANSLATIONS.md`, daemon/CLI output text is an explicit i18n exemption, so no locale keys are added.

## Screenshots

N/A (CLI-only). Sample output:

```
$ od completion __complete --current "co" --
completion
config
conversation

$ od completion __complete --current "" -- config
--daemon-url
--help
--json
get
list
set
unset
```

## Bug fix verification

N/A — this is a feature, not a bug fix.

## Validation

All run locally on this branch:

- **`pnpm --filter @open-design/daemon exec vitest run tests/completion.test.ts`** → **26 passed**. New test file covers the resolver (top-level, prefix filtering, subcommands, flags, deeper paths, unknown commands), determinism (sorted + de-duped), script generation for all three shells, and `COMMAND_SPEC` integrity.
- **`pnpm --filter @open-design/daemon test`** → full daemon suite green, no regressions.
- **`pnpm --filter @open-design/daemon build`** (`tsc -p tsconfig.json`, `strict` + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes`) → clean, `completion.ts` type-checks with zero errors.
- **`pnpm guard`** → pass.
- **Live smoke test** against the built `dist/cli.js`: `od completion --help`, `od completion {bash,zsh,fish}`, the `__complete` resolver across top-level / prefix / subcommand / flag cases, unsupported-shell (exit 2 + stderr), and bare `od completion` (usage + exit 2) — all behave as expected.

### Implementation notes

- `apps/daemon/src/completion.ts` — pure, dependency-free core: `COMMAND_SPEC` (source of truth for the command tree), `computeCompletions()` (synchronous resolver — no daemon round-trip, so `<TAB>` is instant and works even when the daemon is stopped), and `generateCompletionScript()`. Mirrors the existing `app-version.ts` pattern (pure logic module + thin CLI wrapper).
- `apps/daemon/src/cli.ts` — `completion` registered in `SUBCOMMAND_MAP`; thin `runCompletion()` handler.
- `apps/daemon/tests/completion.test.ts` — 26 unit tests.
- `CHANGELOG.md` — entry under `[Unreleased]`.
