### PR TITLE
fix(frontmatter): a lone quote character is no longer parsed as an empty string

### DIFF
--- a/apps/daemon/src/frontmatter.ts
+++ b/apps/daemon/src/frontmatter.ts
@@ -147,13 +147,21 @@ function parseYamlSubset(src: string): FrontmatterObject {
 function coerce(raw: string | undefined): FrontmatterValue {
   if (raw === undefined) return '';
   let v = raw.trim();
-  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+  // Require at least two characters so a lone quote (`"`), whose first and
+  // last char are the same, isn't mistaken for an empty quoted string.
+  if (
+    v.length >= 2 &&
+    ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
+  ) {
     return v.slice(1, -1);
   }
   if (v === 'true') return true;
   if (v === 'false') return false;
   if (v === 'null' || v === '~') return null;
-  if (/^-?\d+$/.test(v)) return Number(v);
-  if (/^-?\d*\.\d+$/.test(v)) return Number(v);
+  // Only coerce numbers without a redundant leading zero. Per YAML 1.2 a
+  // leading-zero decimal like `01234` is a string (the zero is significant —
+  // zip codes, zero-padded ids), so `\d+` would corrupt it into `1234`.
+  if (/^-?(?:0|[1-9]\d*)$/.test(v)) return Number(v);
+  if (/^-?(?:0|[1-9]\d*)?\.\d+$/.test(v)) return Number(v);
   return v;
 }

--- a/apps/daemon/src/frontmatter.ts
+++ b/apps/daemon/src/frontmatter.ts
@@ -158,10 +158,9 @@ function coerce(raw: string | undefined): FrontmatterValue {
   if (v === 'true') return true;
   if (v === 'false') return false;
   if (v === 'null' || v === '~') return null;
-  // Only coerce numbers without a redundant leading zero. Per YAML 1.2 a
-  // leading-zero decimal like `01234` is a string (the zero is significant —
-  // zip codes, zero-padded ids), so `\d+` would corrupt it into `1234`.
-  if (/^-?(?:0|[1-9]\d*)$/.test(v)) return Number(v);
-  if (/^-?(?:0|[1-9]\d*)?\.\d+$/.test(v)) return Number(v);
+  // Coerce base-10 numeric scalars to Number, matching the YAML 1.2 core-schema
+  // int/float resolution (including leading-zero decimals like `01234`).
+  if (/^-?\d+$/.test(v)) return Number(v);
+  if (/^-?\d*\.\d+$/.test(v)) return Number(v);
   return v;
 }

--- a/apps/daemon/tests/frontmatter.test.ts
+++ b/apps/daemon/tests/frontmatter.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFrontmatter } from '../src/frontmatter.js';
+
+function data(src: string) {
+  return parseFrontmatter(`---\n${src}\n---\n`).data;
+}
+
+describe('parseFrontmatter scalar coercion', () => {
+  it('coerces plain integers and floats to numbers', () => {
+    expect(data('a: 42').a).toBe(42);
+    expect(data('a: -7').a).toBe(-7);
+    expect(data('a: 3.14').a).toBe(3.14);
+  });
+
+  it('coerces booleans and null', () => {
+    expect(data('a: true').a).toBe(true);
+    expect(data('a: false').a).toBe(false);
+    expect(data('a: null').a).toBe(null);
+    expect(data('a: ~').a).toBe(null);
+  });
+
+  // Per YAML 1.2, a leading-zero decimal like `01234` is a *string*, not a
+  // number — the leading zero is significant (zip codes, zero-padded ids,
+  // phone-like values). Coercing it to 1234 silently corrupts the value.
+  it('keeps leading-zero integers as strings', () => {
+    expect(data('zip: 01234').zip).toBe('01234');
+    expect(data('id: 007').id).toBe('007');
+  });
+
+  it('keeps a negative leading-zero integer as a string', () => {
+    expect(data('a: -01').a).toBe('-01');
+  });
+
+  it('still treats a bare zero as the number 0', () => {
+    expect(data('a: 0').a).toBe(0);
+  });
+
+  it('keeps leading-zero decimals as strings', () => {
+    // "00.5" has a redundant leading zero in the integer part -> string.
+    expect(data('a: 00.5').a).toBe('00.5');
+  });
+
+  it('still coerces a single zero before the decimal point', () => {
+    expect(data('a: 0.5').a).toBe(0.5);
+    expect(data('a: .5').a).toBe(0.5);
+  });
+
+  it('strips matching surrounding quotes', () => {
+    expect(data('a: "hello"').a).toBe('hello');
+    expect(data("a: 'world'").a).toBe('world');
+  });
+
+  // A value that is a single quote character is not a quoted string; slicing
+  // 1..-1 of a one-char string wrongly yields ''.
+  it('does not treat a lone quote character as an empty quoted string', () => {
+    expect(data('a: "').a).toBe('"');
+    expect(data("a: '").a).toBe("'");
+  });
+});

--- a/apps/daemon/tests/frontmatter.test.ts
+++ b/apps/daemon/tests/frontmatter.test.ts
@@ -20,28 +20,27 @@ describe('parseFrontmatter scalar coercion', () => {
     expect(data('a: ~').a).toBe(null);
   });
 
-  // Per YAML 1.2, a leading-zero decimal like `01234` is a *string*, not a
-  // number — the leading zero is significant (zip codes, zero-padded ids,
-  // phone-like values). Coercing it to 1234 silently corrupts the value.
-  it('keeps leading-zero integers as strings', () => {
-    expect(data('zip: 01234').zip).toBe('01234');
-    expect(data('id: 007').id).toBe('007');
+  // The YAML 1.2 core schema resolves base-10 numeric scalars as numbers,
+  // including leading-zero decimals (`[-+]?[0-9]+` for ints). We match the
+  // schema so existing frontmatter consumers keep getting numbers.
+  it('coerces leading-zero integers to numbers (YAML 1.2 core schema)', () => {
+    expect(data('zip: 01234').zip).toBe(1234);
+    expect(data('id: 007').id).toBe(7);
   });
 
-  it('keeps a negative leading-zero integer as a string', () => {
-    expect(data('a: -01').a).toBe('-01');
+  it('coerces a negative leading-zero integer to a number', () => {
+    expect(data('a: -01').a).toBe(-1);
   });
 
-  it('still treats a bare zero as the number 0', () => {
+  it('treats a bare zero as the number 0', () => {
     expect(data('a: 0').a).toBe(0);
   });
 
-  it('keeps leading-zero decimals as strings', () => {
-    // "00.5" has a redundant leading zero in the integer part -> string.
-    expect(data('a: 00.5').a).toBe('00.5');
+  it('coerces leading-zero decimals to numbers', () => {
+    expect(data('a: 00.5').a).toBe(0.5);
   });
 
-  it('still coerces a single zero before the decimal point', () => {
+  it('coerces a single zero before the decimal point', () => {
     expect(data('a: 0.5').a).toBe(0.5);
     expect(data('a: .5').a).toBe(0.5);
   });

--- a/packages/plugin-runtime/src/parsers/frontmatter.ts
+++ b/packages/plugin-runtime/src/parsers/frontmatter.ts
@@ -186,13 +186,21 @@ function parseYamlSubset(src: string): FrontmatterObject {
 function coerce(raw: string | undefined): FrontmatterValue {
   if (raw === undefined) return '';
   const v = raw.trim();
-  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+  // Require at least two characters so a lone quote (`"`), whose first and
+  // last char are the same, isn't mistaken for an empty quoted string.
+  if (
+    v.length >= 2 &&
+    ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
+  ) {
     return v.slice(1, -1);
   }
   if (v === 'true') return true;
   if (v === 'false') return false;
   if (v === 'null' || v === '~') return null;
-  if (/^-?\d+$/.test(v)) return Number(v);
-  if (/^-?\d*\.\d+$/.test(v)) return Number(v);
+  // Only coerce numbers without a redundant leading zero. Per YAML 1.2 a
+  // leading-zero decimal like `01234` is a string (the zero is significant —
+  // zip codes, zero-padded ids), so `\d+` would corrupt it into `1234`.
+  if (/^-?(?:0|[1-9]\d*)$/.test(v)) return Number(v);
+  if (/^-?(?:0|[1-9]\d*)?\.\d+$/.test(v)) return Number(v);
   return v;
 }

--- a/packages/plugin-runtime/src/parsers/frontmatter.ts
+++ b/packages/plugin-runtime/src/parsers/frontmatter.ts
@@ -197,10 +197,9 @@ function coerce(raw: string | undefined): FrontmatterValue {
   if (v === 'true') return true;
   if (v === 'false') return false;
   if (v === 'null' || v === '~') return null;
-  // Only coerce numbers without a redundant leading zero. Per YAML 1.2 a
-  // leading-zero decimal like `01234` is a string (the zero is significant —
-  // zip codes, zero-padded ids), so `\d+` would corrupt it into `1234`.
-  if (/^-?(?:0|[1-9]\d*)$/.test(v)) return Number(v);
-  if (/^-?(?:0|[1-9]\d*)?\.\d+$/.test(v)) return Number(v);
+  // Coerce base-10 numeric scalars to Number, matching the YAML 1.2 core-schema
+  // int/float resolution (including leading-zero decimals like `01234`).
+  if (/^-?\d+$/.test(v)) return Number(v);
+  if (/^-?\d*\.\d+$/.test(v)) return Number(v);
   return v;
 }

--- a/packages/plugin-runtime/tests/parsers.test.ts
+++ b/packages/plugin-runtime/tests/parsers.test.ts
@@ -125,4 +125,26 @@ describe('parseFrontmatter', () => {
     const raw2 = '---\nname: foo\n---foo\nbody';
     expect(parseFrontmatter(raw2)).toEqual({ data: {}, body: raw2 });
   });
+
+  it('coerces plain numbers, booleans, and null', () => {
+    const { data } = parseFrontmatter('---\na: 42\nb: 3.14\nc: true\nd: null\n---\n');
+    expect(data['a']).toBe(42);
+    expect(data['b']).toBe(3.14);
+    expect(data['c']).toBe(true);
+    expect(data['d']).toBe(null);
+  });
+
+  // Per YAML 1.2, a leading-zero decimal like `01234` is a string (the zero
+  // is significant). Coercing it to 1234 would silently corrupt the value.
+  it('keeps leading-zero integers as strings', () => {
+    const { data } = parseFrontmatter('---\nzip: 01234\nid: 007\nzero: 0\n---\n');
+    expect(data['zip']).toBe('01234');
+    expect(data['id']).toBe('007');
+    expect(data['zero']).toBe(0);
+  });
+
+  it('does not treat a lone quote character as an empty quoted string', () => {
+    const { data } = parseFrontmatter('---\na: "\n---\n');
+    expect(data['a']).toBe('"');
+  });
 });

--- a/packages/plugin-runtime/tests/parsers.test.ts
+++ b/packages/plugin-runtime/tests/parsers.test.ts
@@ -134,12 +134,13 @@ describe('parseFrontmatter', () => {
     expect(data['d']).toBe(null);
   });
 
-  // Per YAML 1.2, a leading-zero decimal like `01234` is a string (the zero
-  // is significant). Coercing it to 1234 would silently corrupt the value.
-  it('keeps leading-zero integers as strings', () => {
+  // The YAML 1.2 core schema resolves base-10 numeric scalars as numbers,
+  // including leading-zero forms. We match the schema so frontmatter
+  // consumers keep getting numbers.
+  it('coerces leading-zero integers to numbers (YAML 1.2 core schema)', () => {
     const { data } = parseFrontmatter('---\nzip: 01234\nid: 007\nzero: 0\n---\n');
-    expect(data['zip']).toBe('01234');
-    expect(data['id']).toBe('007');
+    expect(data['zip']).toBe(1234);
+    expect(data['id']).toBe(7);
     expect(data['zero']).toBe(0);
   });
 


### PR DESCRIPTION
## Why

While reading the frontmatter parser I found a small correctness bug in `coerce`: a value that is a single quote character (`"` or `'`) was treated as an empty quoted string. The quote-stripping branch checked only that the first and last characters matched, so for a one-character string the same character satisfies both ends and `slice(1, -1)` returns `""`. A field like `prefix: "` would silently become an empty string instead of the literal quote.

## What changed

`coerce` now requires at least two characters before stripping matching surrounding quotes, so a lone quote stays itself:

- `prefix: "` -> `"` (was `""`)
- `prefix: '` -> `'` (was `""`)
- `name: "hello"` -> `hello` (unchanged, real quoted string)

Numeric coercion is unchanged. Leading-zero scalars are still resolved as numbers to match the YAML 1.2 core schema (`01234` -> `1234`, `007` -> `7`, `-01` -> `-1`, `00.5` -> `0.5`), per review feedback on this PR. Tests assert that behavior explicitly so it stays pinned.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** - bug fix to a parser edge case; no schema/network/default-flow change.

## Bug fix verification

Encoded as a falsifiable test that goes red before the fix:

- Test paths: `apps/daemon/tests/frontmatter.test.ts` and the extended `parseFrontmatter` block in `packages/plugin-runtime/tests/parsers.test.ts`.
- The lone-quote case is red on `main` (returns `""`) and green on this branch (returns `"`).

## Validation

All run locally on this branch:

- `pnpm --filter @open-design/daemon exec vitest run tests/frontmatter.test.ts` -> **9 passed**
- `pnpm --filter @open-design/plugin-runtime exec vitest run tests/parsers.test.ts` -> **17 passed**
- `pnpm --filter @open-design/daemon typecheck` -> clean
- `pnpm --filter @open-design/plugin-runtime typecheck` -> clean

### Note

Both parser copies (`apps/daemon/src/frontmatter.ts` and `packages/plugin-runtime/src/parsers/frontmatter.ts`) are documented mirrors, so the identical fix is applied to both to keep them in sync.
