### PR TITLE
fix: PlatformPicker dropdown covered by Companion surfaces section

### DIFF
--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1170,7 +1170,7 @@ function PlatformPicker({
 
   return (
     <div
-      className="newproj-section ds-picker platform-picker"
+      className={`newproj-section ds-picker platform-picker${open ? ' open' : ''}`}
       ref={wrapRef}
     >
       <label className="newproj-label">Target platforms</label>


### PR DESCRIPTION
## Why

When creating a new project, the PlatformPicker's "Target platforms" dropdown gets visually covered by the "Companion surfaces" section below it. This is a one-line CSS class fix.

Fixes #4183

## What users will see

The Target platforms dropdown now renders above subsequent form sections, matching the behavior of DesignSystemPicker and PromptTemplatePicker.

## Surface area checklist

- [x] Web UI — PlatformPicker dropdown z-index
- [ ] Desktop
- [ ] CLI
- [ ] Plugin / Skill / Design System
- [ ] Packaged app
- [ ] Docs
- [ ] i18n keys
- [ ] Env vars
- [ ] Root package.json deps