### PR TITLE
fix unified diff leaving a stray carriage return on CRLF lines

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -11,6 +11,7 @@ import { parseDesignSystemRenameArgs } from './design-system-rename-args.js';
 import { runLiveArtifactsToolCli } from './tools-live-artifacts-cli.js';
 import { splitResearchSubcommand } from './research/cli-args.js';
 import { resolveDaemonUrl } from './daemon-url.js';
+import { diffLine } from './diff-line.js';
 import { requestJsonIpc } from '@open-design/sidecar';
 import { SIDECAR_ENV, SIDECAR_MESSAGES } from '@open-design/sidecar-proto';
 import {
@@ -5669,17 +5670,6 @@ function diffLineBody(oldLines, newLines) {
   return out;
 }
 
-function diffLine(prefix, line) {
-  const value = String(line);
-  if (value.endsWith('\r\n')) return `${prefix}${renderDiffLineContent(value.slice(0, -1))}`;
-  if (value.endsWith('\n')) return `${prefix}${renderDiffLineContent(value.slice(0, -1))}`;
-  if (value.endsWith('\r')) return `${prefix}${renderDiffLineContent(value)}`;
-  return `${prefix}${renderDiffLineContent(value)}\n\\ No newline at end of file`;
-}
-
-function renderDiffLineContent(value) {
-  return String(value).replace(/\r/g, '\\r');
-}
 
 // `od templates …` is the headless face of NewProjectPanel /
 // ExamplesTab — same /api/templates store, same DTO shapes. External

--- a/apps/daemon/src/diff-line.ts
+++ b/apps/daemon/src/diff-line.ts
@@ -1,0 +1,27 @@
+// Rendering of a single unified-diff line. Extracted from cli.ts (a
+// dispatch-on-import script that can't be imported by tests) so the
+// line-ending handling can be unit-tested directly.
+//
+// A diff line carries its own trailing newline from `splitDiffLines`, which
+// preserves the original terminator (`\r\n`, `\n`, `\r`, or none). We strip the
+// terminator before rendering the body and surface a literal `\r` so a stray
+// carriage return is visible in the output rather than corrupting the line.
+
+/** Replace carriage returns with a visible escape so they don't hide in output. */
+export function renderDiffLineContent(value: string): string {
+  return String(value).replace(/\r/g, '\\r');
+}
+
+/**
+ * Render one unified-diff line: `<prefix><content>` with the line's own
+ * terminator stripped. A CRLF terminator must drop *both* characters — slicing
+ * only the final `\n` would leave a trailing `\r` that renders as a spurious
+ * `\r` on every Windows-style line.
+ */
+export function diffLine(prefix: string, line: string): string {
+  const value = String(line);
+  if (value.endsWith('\r\n')) return `${prefix}${renderDiffLineContent(value.slice(0, -2))}`;
+  if (value.endsWith('\n')) return `${prefix}${renderDiffLineContent(value.slice(0, -1))}`;
+  if (value.endsWith('\r')) return `${prefix}${renderDiffLineContent(value)}`;
+  return `${prefix}${renderDiffLineContent(value)}\n\\ No newline at end of file`;
+}

--- a/apps/daemon/tests/diff-line.test.ts
+++ b/apps/daemon/tests/diff-line.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { diffLine, renderDiffLineContent } from '../src/diff-line.js';
+
+describe('renderDiffLineContent', () => {
+  it('escapes carriage returns so they are visible', () => {
+    expect(renderDiffLineContent('a\rb')).toBe('a\\rb');
+  });
+
+  it('leaves plain content untouched', () => {
+    expect(renderDiffLineContent('hello world')).toBe('hello world');
+  });
+});
+
+describe('diffLine line-ending handling', () => {
+  it('strips a plain LF terminator', () => {
+    expect(diffLine('-', 'hello\n')).toBe('-hello');
+  });
+
+  // Regression: a CRLF terminator must drop both characters. Slicing only the
+  // final '\n' left a trailing '\r' that rendered as a spurious '\r'.
+  it('strips a full CRLF terminator without leaving a stray carriage return', () => {
+    expect(diffLine('-', 'hello\r\n')).toBe('-hello');
+    expect(diffLine('+', 'world\r\n')).toBe('+world');
+    expect(diffLine(' ', 'ctx\r\n')).toBe(' ctx');
+  });
+
+  it('preserves and escapes a lone trailing CR (no newline)', () => {
+    // A bare '\r' is not a line terminator here; it is content and is escaped.
+    expect(diffLine('-', 'hello\r')).toBe('-hello\\r');
+  });
+
+  it('escapes an interior carriage return regardless of terminator', () => {
+    expect(diffLine('-', 'a\rb\r\n')).toBe('-a\\rb');
+    expect(diffLine('-', 'a\rb\n')).toBe('-a\\rb');
+  });
+
+  it('flags a missing trailing newline', () => {
+    expect(diffLine('-', 'hello')).toBe('-hello\n\\ No newline at end of file');
+  });
+
+  it('keeps the prefix verbatim', () => {
+    expect(diffLine('+', 'x\n')).toBe('+x');
+    expect(diffLine(' ', 'x\n')).toBe(' x');
+  });
+});


### PR DESCRIPTION
## Why

While reading the unified-diff renderer used by `od plugin diff` (and the other diff paths in `cli.ts`), I noticed `diffLine` mishandles a CRLF line terminator: it strips only the trailing `\n` and leaves the `\r`, which then renders as a literal `\r` on every Windows-style line. So a diff of a file with CRLF endings shows a spurious `\r` at the end of each line.

The diff helpers live inside `cli.ts`, which dispatches on import and therefore can't be imported by a test — so the bug had no unit coverage. This PR extracts the single-line renderer into a tiny, testable module and fixes the off-by-one.

## What users will see

`od` diff output for CRLF (Windows) files no longer shows a trailing `\r` on each line:

```
# before
-hello\r
+world\r

# after
-hello
+world
```

A lone trailing `\r` with no newline is still shown (escaped) as content, and an LF line is unchanged.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — affects `od` unified-diff rendering (e.g. `od plugin diff`). No new subcommand/flag/env var; behavior of existing output is corrected.
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — only corrects malformed CRLF output; no opt-in behavior changes.
- [ ] **None**

## Screenshots

N/A (text diff rendering). Example covered in "What users will see" above.

## Bug fix verification

Per AGENTS.md → bug follow-up workflow, encoded as a falsifiable test:

- Test path: `apps/daemon/tests/diff-line.test.ts` (new).
- Did it go red before the fix? **Yes.** The pre-fix `diffLine('-', 'hello\r\n')` returns `"-hello\r"` (verified with a standalone probe of the original logic); the new `strips a full CRLF terminator…` test asserts `"-hello"`, so it fails on the old code and passes after the fix.

## Validation

All run locally on this branch:

- `pnpm --filter @open-design/daemon exec vitest run tests/diff-line.test.ts` → **8 passed**
- `pnpm --filter @open-design/daemon exec vitest run tests/plugins-diff.test.ts` (existing diff consumer) → passed, no regressions
- `pnpm --filter @open-design/daemon typecheck` → clean (the new `diff-line.ts` is type-checked; `cli.ts` keeps its existing `@ts-nocheck`)
- `pnpm --filter @open-design/daemon build` → clean
- Live check against the built `dist/diff-line.js`: `diffLine('-', 'hello\r\n')` → `"-hello"`, `diffLine('-', 'hello\n')` → `"-hello"`, `diffLine('-', 'hello\r')` → `"-hello\\r"`.

### Implementation notes

- New `apps/daemon/src/diff-line.ts` holds `diffLine` and `renderDiffLineContent`, moved verbatim from `cli.ts` except for the one-line fix (`slice(0, -2)` for the `\r\n` case). `cli.ts` now imports `diffLine`; the rest of the unified-diff machinery (`createUnifiedDiff`, `diffLineBody`, …) is unchanged and calls the imported function.
- Extraction is the minimum needed to make the renderer testable, since `cli.ts` runs its subcommand dispatch at import time.
