### PR TITLE
fix(daemon): stop imported-folder file listing from exhausting the libuv fs pool

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -105,21 +105,42 @@ export async function ensureProject(projectsRoot, projectId, metadata?) {
   return dir;
 }
 
+// Coalesce concurrent full walks of the same project directory. The file panel
+// polls GET /api/projects/:id/files and run prepare lists files too, so without
+// this an imported folder with a large tree could have several overlapping
+// recursive walks in flight at once — multiplying filesystem work and helping
+// exhaust the libuv threadpool. Keyed by the resolved project directory.
+const inFlightProjectWalks = new Map<string, Promise<any[]>>();
+
 export async function listFiles(projectsRoot, projectId, opts = {}) {
   const metadata = opts?.metadata;
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
-  const out = [];
-  // Skip generated dependency/build trees for all project roots. Standard OD
-  // projects can contain framework installs too; surfacing package HTML like
-  // node_modules/tslib/*.html as artifacts produces blank previews.
-  await collectFiles(dir, '', out, isIgnoredProjectDirName, dir);
-  // Newest first — matches the visual order users expect after generating.
-  out.sort((a, b) => b.mtime - a.mtime);
+  let walk = inFlightProjectWalks.get(dir);
+  if (!walk) {
+    walk = (async () => {
+      try {
+        const out = [];
+        // Skip generated dependency/build trees for all project roots. Standard
+        // OD projects can contain framework installs too; surfacing package HTML
+        // like node_modules/tslib/*.html as artifacts produces blank previews.
+        await collectFiles(dir, '', out, isIgnoredProjectDirName, dir);
+        // Newest first — matches the visual order users expect after generating.
+        out.sort((a, b) => b.mtime - a.mtime);
+        return out;
+      } finally {
+        inFlightProjectWalks.delete(dir);
+      }
+    })();
+    inFlightProjectWalks.set(dir, walk);
+  }
+  const out = await walk;
   const since = Number(opts.since);
   if (Number.isFinite(since) && since > 0) {
     return out.filter((f) => Number(f.mtime) > since);
   }
-  return out;
+  // Return a shallow copy so a caller can't mutate the snapshot shared with
+  // other coalesced callers.
+  return out.slice();
 }
 
 export async function listProjectFolders(projectsRoot, projectId, opts = {}) {
@@ -239,6 +260,10 @@ async function collectFiles(dir, relDir, out, shouldSkipDir?: (name: string) => 
     if (err && err.code === 'ENOENT') return;
     throw err;
   }
+  // Sidecar manifests (`<name>.artifact.json`) always live next to their file,
+  // so the directory listing already tells us whether one exists — no per-file
+  // probe read needed.
+  const entryNames = new Set(entries.map((e) => e.name));
   for (const e of entries) {
     if (e.name.startsWith('.')) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
@@ -251,7 +276,8 @@ async function collectFiles(dir, relDir, out, shouldSkipDir?: (name: string) => 
     if (!e.isFile()) continue;
     if (e.name.endsWith('.artifact.json')) continue;
     const st = await stat(full);
-    const manifest = await readManifestForPath(projectRoot, rel);
+    const manifestPresent = entryNames.has(`${e.name}.artifact.json`);
+    const manifest = await readManifestForPath(projectRoot, rel, manifestPresent);
     out.push({
       name: rel,
       path: rel,
@@ -907,18 +933,27 @@ export async function reconcileHtmlArtifactManifest(projectsRoot, projectId, nam
   return validated.value;
 }
 
-async function readManifestForPath(projectDirPath, relPath) {
+async function readManifestForPath(projectDirPath, relPath, manifestPresent?) {
   if (containsIgnoredProjectDirSegment(relPath)) return null;
   const fullPath = path.join(projectDirPath, relPath);
   if (await isViteDevHtmlEntry(projectDirPath, relPath, fullPath)) return null;
-  const manifestPath = path.join(projectDirPath, artifactManifestNameFor(relPath));
-  try {
-    const raw = await readFile(manifestPath, 'utf8');
-    const parsed = parseManifest(raw);
-    if (parsed) return parsed;
-  } catch (err) {
-    if (!err || err.code !== 'ENOENT') {
-      // ignore malformed/invalid manifests and fallback to inference
+  // `manifestPresent === false` means the caller already saw, from the
+  // directory listing, that no `<name>.artifact.json` sibling exists — so skip
+  // the read entirely. Imported folders hold thousands of files and zero
+  // sidecars; without this hint collectFiles fired one failing ENOENT readFile
+  // per file, and the polled GET /api/projects/:id/files walk piled those onto
+  // the 4-thread libuv pool until it deadlocked every fs-backed API. See
+  // tests/project-files-manifest-fanout.test.ts.
+  if (manifestPresent !== false) {
+    const manifestPath = path.join(projectDirPath, artifactManifestNameFor(relPath));
+    try {
+      const raw = await readFile(manifestPath, 'utf8');
+      const parsed = parseManifest(raw);
+      if (parsed) return parsed;
+    } catch (err) {
+      if (!err || err.code !== 'ENOENT') {
+        // ignore malformed/invalid manifests and fallback to inference
+      }
     }
   }
   return inferLegacyManifest(relPath);

--- a/apps/daemon/tests/project-files-manifest-fanout.test.ts
+++ b/apps/daemon/tests/project-files-manifest-fanout.test.ts
@@ -1,0 +1,123 @@
+// Red-spec for the imported-folder file-listing deadlock.
+//
+// Symptom (observed live): sending a prompt / opening a project whose working
+// directory is a large imported folder hung the daemon at "Preparing…". All
+// four libuv filesystem worker threads were stuck in uv__fs_work at 0% CPU and
+// every fs-backed API (/api/health, /api/projects, the run itself) hung, while
+// SQLite-only /api/runs stayed instant.
+//
+// Root cause: listFiles() -> collectFiles() walks the folder and, per file,
+// calls readManifestForPath(), which UNCONDITIONALLY readFile()s
+// `<file>.artifact.json`. Imported folders have thousands of files and zero
+// sidecars, so this is one failing ENOENT read per file. GET
+// /api/projects/:id/files is polled by the UI, so overlapping walks piled
+// thousands of failing threadpool reads onto the 4-thread libuv pool and
+// exhausted it.
+//
+// These specs pin the two invariants of the fix:
+//  1. No `<file>.artifact.json` read is issued for files that have no sidecar.
+//  2. Concurrent listFiles() walks of the same project coalesce (single-flight)
+//     instead of multiplying the filesystem work.
+// A real sidecar is still read (behaviour preserved).
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const counters = vi.hoisted(() => ({
+  artifactReads: [] as string[],
+  readdirCalls: 0,
+  readdirDelayMs: 0,
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('node:fs/promises');
+  return {
+    ...actual,
+    default: actual,
+    readFile: (p: any, ...rest: any[]) => {
+      if (typeof p === 'string' && p.endsWith('.artifact.json')) {
+        counters.artifactReads.push(p);
+      }
+      return (actual.readFile as any)(p, ...rest);
+    },
+    readdir: async (p: any, ...rest: any[]) => {
+      counters.readdirCalls += 1;
+      if (counters.readdirDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, counters.readdirDelayMs));
+      }
+      return (actual.readdir as any)(p, ...rest);
+    },
+  };
+});
+
+const { listFiles } = await import('../src/projects.js');
+
+describe('listFiles imported-folder fan-out', () => {
+  let projectsRoot: string;
+
+  beforeEach(() => {
+    projectsRoot = mkdtempSync(path.join(tmpdir(), 'od-files-fanout-'));
+    counters.artifactReads.length = 0;
+    counters.readdirCalls = 0;
+    counters.readdirDelayMs = 0;
+  });
+
+  afterEach(() => {
+    rmSync(projectsRoot, { recursive: true, force: true });
+  });
+
+  it('issues no .artifact.json reads for a tree whose files have no sidecars', async () => {
+    const root = path.join(projectsRoot, 'p1');
+    await mkdir(path.join(root, 'sub'), { recursive: true });
+    for (let i = 0; i < 30; i += 1) {
+      await writeFile(path.join(root, `page-${i}.html`), '<html></html>');
+    }
+    await writeFile(path.join(root, 'sub', 'logo.svg'), '<svg/>');
+
+    counters.artifactReads.length = 0;
+    const files = await listFiles(projectsRoot, 'p1');
+
+    expect(files.length).toBe(31);
+    // The bug: one failing ENOENT readFile per file (31). The fix: zero, because
+    // collectFiles already knows from the directory listing that no sidecar exists.
+    expect(counters.artifactReads).toEqual([]);
+  });
+
+  it('still reads a real .artifact.json sidecar when one is present', async () => {
+    const root = path.join(projectsRoot, 'p2');
+    await mkdir(root, { recursive: true });
+    await writeFile(path.join(root, 'card.html'), '<html></html>');
+    const sidecar = path.join(root, 'card.html.artifact.json');
+    await writeFile(sidecar, JSON.stringify({ kind: 'prototype' }));
+
+    counters.artifactReads.length = 0;
+    const files = await listFiles(projectsRoot, 'p2');
+
+    expect(files.some((f: any) => f.path === 'card.html')).toBe(true);
+    // Behaviour preserved: the sidecar that actually exists is still read.
+    expect(counters.artifactReads).toContain(sidecar);
+  });
+
+  it('coalesces concurrent walks of the same project (single-flight)', async () => {
+    const root = path.join(projectsRoot, 'p3');
+    await mkdir(path.join(root, 'a'), { recursive: true });
+    await writeFile(path.join(root, 'a', 'x.txt'), 'x');
+
+    counters.readdirCalls = 0;
+    counters.readdirDelayMs = 25; // hold the first walk open so the second overlaps it
+    const [r1, r2] = await Promise.all([
+      listFiles(projectsRoot, 'p3'),
+      listFiles(projectsRoot, 'p3'),
+    ]);
+    counters.readdirDelayMs = 0;
+
+    expect(r1.length).toBe(1);
+    expect(r2.length).toBe(1);
+    // Two directories (root + a). Without single-flight each of the two callers
+    // runs its own walk -> 4 readdir calls. With single-flight -> 2.
+    expect(counters.readdirCalls).toBe(2);
+  });
+});


### PR DESCRIPTION
## Why

Reported by a user driving Open Design locally: every prompt against a project whose working directory is an imported folder hung at **"Preparing…"** indefinitely, in both Ask and Design modes. Diagnosis showed it wasn't the agent/runtime at all — the daemon's filesystem threadpool was deadlocked.

The pain: any prompt against an imported-folder project (e.g. a brand-kit folder with a few thousand files) silently bricks the daemon. All filesystem-backed APIs (`/api/health`, `/api/projects`, the run) hang; only SQLite-only routes like `/api/runs` keep responding. The app looks frozen and only a restart recovers it.

Root cause: `listFiles()` → `collectFiles()` walks the working directory and, per file, calls `readManifestForPath()`, which **unconditionally** `readFile()`s `<file>.artifact.json`. Imported folders have thousands of files and zero sidecars, so this is one *failing* ENOENT read per file. `GET /api/projects/:id/files` is polled by the file panel (and files are listed again on run prepare), so overlapping recursive walks of a large folder pile thousands of failing reads onto Node's 4-thread libuv filesystem pool and exhaust it. Confirmed live: all 4 `libuv-worker` threads stuck in `uv__fs_work` at 0% CPU with ~180 fds held open.

## What users will see

Sending a prompt — or opening a project — whose working directory is a large imported folder no longer freezes the app at "Preparing…". The daemon stays responsive under the file-panel's polling. No behaviour change for normal projects.

## Surface area

- [x] **None** — internal fix + tests. No UI/CLI/contract/i18n/dependency changes; the `/api/projects/:id/files` response shape is unchanged.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/project-files-manifest-fanout.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — on `main`, "issues no `.artifact.json` reads…" sees one ENOENT read per file and "coalesces concurrent walks…" sees duplicated `readdir`s; both pass after the fix. (The third spec guards that a real sidecar is still read.)
- Live verification: against the fixed daemon, 12 concurrent `GET /api/projects/:id/files` on the offending ~3000-entry folder all returned `200` in ~30 ms while `/api/health` stayed at 1–9 ms; on `main` this pattern wedges the pool permanently.

## The fix

- `collectFiles` derives whether a `<name>.artifact.json` sibling exists from the directory listing it already has, and skips the probe read when it doesn't (`readManifestForPath` gains a `manifestPresent` hint). Sidecars that exist are still read — manifest behaviour is unchanged.
- `listFiles` single-flights concurrent walks of the same project directory, so a polled endpoint can't pile up overlapping recursive walks.

## Adjacent issues (out of scope)

- `apps/daemon/tests/chat-route.test.ts` → "passes OPENCODE_CONFIG_CONTENT external_directory rules for the managed project cwd" fails on `main` independently of this change (verified by stashing this fix). Left for a separate follow-up.

## Validation

- `pnpm guard` (56 pass), `pnpm typecheck` (clean)
- `pnpm --filter @open-design/daemon test project-files-manifest-fanout` (3 pass)
- `pnpm --filter @open-design/daemon test folder-import-projects project-archive project-file-rename db-pre-turn-file-names mcp-get-file` (46 pass)
- Live: concurrent file-list burst on the offending folder + concurrent `/api/health` (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
