### PR TITLE
fix(web): insert skill mention before the async project patch

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1084,12 +1084,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     }
 
     async function insertSkillMention(skill: SkillSummary) {
-      const applied = await applyProjectSkill(skill);
-      if (!applied) return;
-      // Stage the skill so it rides this turn's skillIds, then insert an
-      // atomic `@<name>` pill carrying the skill's real id. The onChange
-      // prune keys on `skill:<id>` being present in the editor text, so the
-      // chip survives until the user deletes the pill.
+      // Stage + insert the `@<name>` pill *before* awaiting applyProjectSkill.
+      // Awaiting first let focus/selection drift during the project patch, so
+      // insertMention fell back to `$getRoot().selectEnd()` and dropped the
+      // pill at the end of the draft instead of the typed `@` trigger (#3596).
+      // insertPluginMention already inserts before its async apply; this
+      // mirrors that ordering. The onChange prune keys on `skill:<id>` being
+      // present in the editor text, so the chip survives until the user
+      // deletes the pill.
       setStagedSkills((prev) =>
         prev.some((s) => s.id === skill.id) ? prev : [...prev, skill],
       );
@@ -1098,6 +1100,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         entity: { id: skill.id, kind: 'skill', label: skill.name },
       });
       setMention(null);
+      await applyProjectSkill(skill);
     }
 
     function stageSkillForCurrentTurn(skill: SkillSummary) {

--- a/apps/web/tests/components/ChatComposer.skill-mention-caret.test.tsx
+++ b/apps/web/tests/components/ChatComposer.skill-mention-caret.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { type ComponentProps } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatComposer } from '../../src/components/ChatComposer';
+import { composerText, typeAndSettle } from '../helpers/lexical-composer';
+
+const SKILL = {
+  id: 'deck-builder',
+  name: 'Deck Builder',
+  description: 'Build a polished slide deck.',
+  triggers: ['deck'],
+  mode: 'deck' as const,
+  previewType: 'html',
+  designSystemRequired: false,
+  defaultFor: [],
+  upstream: null,
+  hasBody: true,
+  examplePrompt: 'Make a deck',
+  aggregatesExamples: false,
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+// Gate the project PATCH (applyProjectSkill) so the test can observe the
+// composer state *while the async apply is still in flight* — that mid-flight
+// window is exactly where the #3596 caret drift happened.
+let resolveProjectPatch: ((res: Response) => void) | null;
+let projectPatched: Promise<Response>;
+
+function renderComposer(
+  overrides: Partial<ComponentProps<typeof ChatComposer>> = {},
+) {
+  return render(
+    <ChatComposer
+      projectId="project-1"
+      projectFiles={[]}
+      streaming={false}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      onOpenMcpSettings={vi.fn()}
+      skills={[SKILL]}
+      {...overrides}
+    />,
+  );
+}
+
+async function flushMounts() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+function skillPill(): Element | null {
+  return screen
+    .getByTestId('chat-composer-input')
+    .querySelector('.composer-inline-mention[data-mention-kind="skill"]');
+}
+
+beforeEach(() => {
+  resolveProjectPatch = null;
+  projectPatched = new Promise<Response>((resolve) => {
+    resolveProjectPatch = resolve;
+  });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/skills') return jsonResponse({ skills: [SKILL] });
+      if (url === '/api/projects/project-1' && init?.method === 'PATCH') {
+        // Stay pending until the test resolves it.
+        return projectPatched;
+      }
+      return jsonResponse([]);
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+describe('ChatComposer skill mention caret (#3596)', () => {
+  it('inserts the skill pill before the async project patch resolves', async () => {
+    const onProjectSkillChange = vi.fn();
+    renderComposer({ onProjectSkillChange });
+    await flushMounts();
+
+    await typeAndSettle('@deck');
+    await waitFor(() => expect(screen.getByText('Deck Builder')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('Deck Builder'));
+
+    // The pill must land while applyProjectSkill's PATCH is still pending.
+    // Before the fix, insertSkillMention awaited the patch first, so the
+    // editor selection drifted and the pill was dropped at the end of the
+    // draft only after the patch resolved. Asserting the pill exists here —
+    // with onProjectSkillChange (fired post-patch) not yet called — pins the
+    // insert-before-await ordering that keeps the caret aligned.
+    await waitFor(() => expect(skillPill()).toBeTruthy());
+    expect(skillPill()?.textContent).toBe('@Deck Builder');
+    expect(onProjectSkillChange).not.toHaveBeenCalled();
+
+    act(() => {
+      resolveProjectPatch?.(
+        jsonResponse({ project: { id: 'project-1', skillId: SKILL.id } }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(onProjectSkillChange).toHaveBeenCalledWith('deck-builder'),
+    );
+    await waitFor(() => expect(composerText()).toBe('@Deck Builder '));
+  });
+});


### PR DESCRIPTION
Fixes #3596

## Why

Inserting a skill mention (`@<skill>`) from the composer left the visible caret out of sync with the real edit position on macOS — typing/deleting after the insert happened somewhere other than where the caret showed. @tandav-labs reported a clear repro + clip and confirmed it also happens for plugins; the maintainer's working hypothesis pointed at the async mention-insert path that the (inactivity-closed) #3219 was aiming at.

Root cause: `insertSkillMention` `await`ed `applyProjectSkill(skill)` — a project PATCH round-trip — **before** calling `editorRef.insertMention(...)`. During that await the Lexical `RangeSelection` can be lost (focus/re-render), so `insertMention` (`composer/LexicalComposerInput.tsx`) falls into its `$getRoot().selectEnd()` fallback and drops the pill at the **end of the draft** instead of the typed `@` trigger. `insertPluginMention` already inserts **before** its async apply; `insertSkillMention` was the only `await`-first insert path. #3368 (tools-menu mousedown focus guard) is already merged and addresses the click-focus side; this fixes the remaining async-ordering side.

## What users will see

Inserting a skill from the `@` picker now drops the `@<skill>` pill exactly at the caret, and the caret stays aligned with the real edit position while you keep typing — same as plugin/file/MCP mentions already do.

## Surface area

- [x] **UI** — composer caret/insertion behavior in `apps/web`

(No new default, schema, dependency, API, or i18n key — a single insertion-ordering fix.)

## Screenshots

The symptom is a caret/selection desync that only manifests when the editor's `RangeSelection` is actually dropped across the async PATCH — which happens on real macOS Safari (the reporter's env), but **not** in headless Chromium (the React re-render during the await doesn't blur the Lexical editor there, so selection survives and the bug doesn't reproduce). So a headless before/after clip isn't representative. The fix is instead pinned by the deterministic ordering test below + the structural fact that `insertSkillMention` was the lone `await`-first insert path. Happy to attach a real macOS-Safari before/after capture if you'd like one on the PR.

## Bug fix verification

- Test path: `apps/web/tests/components/ChatComposer.skill-mention-caret.test.tsx`
- Red on old order / green on this branch? **yes** — verified by reverting just the source reorder: the test times out waiting for the pill (it only appears after the PATCH resolves under the old `await`-first order), and passes once the insert runs before the await.
- The test gates the project PATCH (kept pending) and asserts the skill pill is inserted **while the apply is still in flight** (`onProjectSkillChange`, which fires post-patch, has not been called yet) — pinning the insert-before-await ordering that keeps the caret aligned. jsdom can't reproduce real-browser caret geometry, so the ordering invariant is the deterministic guard.

## Validation

- `pnpm typecheck` — clean (all packages)
- `pnpm --filter @open-design/web exec vitest run` for composer suites (`context-pickers`, `composer/*`, new caret test) — 47 passed / 1 skipped, no regressions

## Note on the dropped `if (!applied) return`

The old guard skipped staging/insert when the project PATCH failed. The fix inserts optimistically and then awaits, so a failed patch no longer rolls back the pill/stage — this deliberately matches the existing `insertPluginMention` behavior (also optimistic, no rollback). The chip stays user-deletable and the `onChange` prune keys on the pill token, so a residual pill is recoverable; keeping the user's explicit pick on a transient patch failure seemed better than silently dropping it. Happy to add rollback if you'd prefer.
