### PR TITLE
[codex] Fix Kimi Code runtime adapter

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -338,6 +338,56 @@ function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
   return false;
 }
 
+function handleKimiEvent(obj: unknown, onEvent: StreamEventHandler): boolean {
+  if (!isRecord(obj)) return false;
+
+  if (obj.role === 'assistant' && Array.isArray(obj.tool_calls)) {
+    for (const rawCall of obj.tool_calls) {
+      const call = isRecord(rawCall) ? rawCall : null;
+      const fn = isRecord(call?.function) ? call.function : null;
+      const id = typeof call?.id === 'string' && call.id.trim()
+        ? call.id.trim()
+        : null;
+      const name = typeof fn?.name === 'string' && fn.name.trim()
+        ? fn.name.trim()
+        : null;
+      if (!id || !name) continue;
+      const input = safeParseJson(fn?.arguments) ?? fn?.arguments ?? null;
+      onEvent({ type: 'tool_use', id, name, input });
+    }
+    return true;
+  }
+
+  if (
+    obj.role === 'tool' &&
+    typeof obj.tool_call_id === 'string' &&
+    obj.tool_call_id.trim()
+  ) {
+    onEvent({
+      type: 'tool_result',
+      toolUseId: obj.tool_call_id.trim(),
+      content: stringifyContent(obj.content),
+      isError: false,
+    });
+    return true;
+  }
+
+  if (
+    obj.role === 'assistant' &&
+    typeof obj.content === 'string' &&
+    obj.content.length > 0
+  ) {
+    onEvent({ type: 'text_delta', delta: obj.content });
+    return true;
+  }
+
+  if (obj.role === 'meta' && obj.type === 'session.resume_hint') {
+    return true;
+  }
+
+  return false;
+}
+
 function extractCursorText(message: unknown): string {
   const content = isRecord(message) ? message.content : undefined;
   const blocks = Array.isArray(content) ? content : [];
@@ -730,6 +780,7 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
 
     if (kind === 'opencode' && handleOpenCodeEvent(obj, onEvent, state)) return;
     if (kind === 'gemini' && handleGeminiEvent(obj, onEvent, state)) return;
+    if (kind === 'kimi' && handleKimiEvent(obj, onEvent)) return;
     if (kind === 'cursor-agent' && handleCursorEvent(obj, onEvent, state)) return;
     if (kind === 'codex' && handleCodexEvent(obj, onEvent, state)) return;
 

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -19,6 +19,11 @@ export const kimiAgentDef = {
       }
       return args;
     },
+    // Kimi's prompt mode requires the full composed prompt as `-p <prompt>`.
+    // Keep this under Windows' ~32 KB CreateProcess command-line ceiling so
+    // /api/chat can fail fast with AGENT_PROMPT_TOO_LARGE instead of letting
+    // spawn surface ENAMETOOLONG / E2BIG.
+    maxPromptArgBytes: 30_000,
     streamFormat: 'json-event-stream',
     eventParser: 'kimi',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -1,4 +1,4 @@
-import { detectAcpModels, DEFAULT_MODEL_OPTION } from './shared.js';
+import { DEFAULT_MODEL_OPTION } from './shared.js';
 import type { RuntimeAgentDef } from '../types.js';
 
 export const kimiAgentDef = {
@@ -6,22 +6,19 @@ export const kimiAgentDef = {
     name: 'Kimi CLI',
     bin: 'kimi',
     versionArgs: ['--version'],
-    fetchModels: async (resolvedBin, env) =>
-      detectAcpModels({
-        bin: resolvedBin,
-        args: ['acp'],
-        env,
-        timeoutMs: 15_000,
-        defaultModelOption: DEFAULT_MODEL_OPTION,
-      }),
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       { id: 'kimi-k2-turbo-preview', label: 'kimi-k2-turbo-preview' },
       { id: 'moonshot-v1-8k', label: 'moonshot-v1-8k' },
       { id: 'moonshot-v1-32k', label: 'moonshot-v1-32k' },
     ],
-    buildArgs: () => ['acp'],
-    streamFormat: 'acp-json-rpc',
-    mcpDiscovery: 'mature-acp',
-    externalMcpInjection: 'acp-merge',
+    buildArgs: (prompt, _imagePaths, _extraAllowedDirs = [], options = {}) => {
+      const args = ['-p', prompt, '--output-format', 'stream-json'];
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
+      return args;
+    },
+    streamFormat: 'json-event-stream',
+    eventParser: 'kimi',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -197,6 +197,67 @@ test('gemini stream emits init text and usage events', () => {
   ]);
 });
 
+test('kimi stream emits OpenAI-style tool calls, tool results, and assistant text', () => {
+  const { events, handler } = collectEvents('kimi');
+
+  handler.feed(
+    JSON.stringify({
+      role: 'assistant',
+      tool_calls: [
+        {
+          type: 'function',
+          id: 'tool-1',
+          function: {
+            name: 'Write',
+            arguments: '{"path":"index.html","content":"<html></html>"}',
+          },
+        },
+      ],
+    }) +
+    '\n' +
+    JSON.stringify({
+      role: 'tool',
+      tool_call_id: 'tool-1',
+      content: 'Wrote 13 bytes to index.html',
+    }) +
+    '\n' +
+    JSON.stringify({
+      role: 'assistant',
+      content: 'Done.',
+    }) +
+    '\n' +
+    JSON.stringify({
+      role: 'meta',
+      type: 'session.resume_hint',
+      session_id: 'session-1',
+      content: 'To resume this session: kimi -r session-1',
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'tool-1',
+      name: 'Write',
+      input: {
+        path: 'index.html',
+        content: '<html></html>',
+      },
+    },
+    {
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      content: 'Wrote 13 bytes to index.html',
+      isError: false,
+    },
+    {
+      type: 'text_delta',
+      delta: 'Done.',
+    },
+  ]);
+});
+
 test('gemini stream handles real stream-json user, tool, and error frames', () => {
   const { events, handler } = collectEvents('gemini');
 

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { test } from 'vitest';
 import {
-  AGENT_DEFS, aider, antigravity, assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, gemini, grokBuild, join, kilo, kiro, mkdtempSync, opencode, pi, qoder, qwen, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
+  AGENT_DEFS, aider, antigravity, assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, gemini, grokBuild, join, kilo, kimi, kiro, mkdtempSync, opencode, pi, qoder, qwen, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
 } from './helpers/test-helpers.js';
 import { writeAntigravityModelSelection } from '../../src/runtimes/defs/antigravity.js';
 import type { TestAgentDef } from './helpers/test-helpers.js';
@@ -698,6 +698,32 @@ test('kilo args use acp subcommand for json-rpc streaming', () => {
 
   assert.deepEqual(args, ['acp']);
   assert.equal(kilo.streamFormat, 'acp-json-rpc');
+});
+
+test('kimi args use prompt-mode JSONL instead of ACP', () => {
+  const prompt = 'design a page';
+  const args = kimi.buildArgs(prompt, [], [], {});
+
+  assert.deepEqual(args, ['-p', prompt, '--output-format', 'stream-json']);
+  assert.equal(args.includes('acp'), false);
+  assert.equal(args.includes('--yolo'), false);
+  assert.equal(kimi.streamFormat, 'json-event-stream');
+  assert.equal(kimi.eventParser, 'kimi');
+  assert.equal(kimi.mcpDiscovery, undefined);
+  assert.equal(kimi.externalMcpInjection, undefined);
+});
+
+test('kimi args pass explicit model selections through prompt mode', () => {
+  const args = kimi.buildArgs('hello', [], [], { model: 'moonshot-v1-32k' });
+
+  assert.deepEqual(args, [
+    '-p',
+    'hello',
+    '--output-format',
+    'stream-json',
+    '--model',
+    'moonshot-v1-32k',
+  ]);
 });
 
 test('kilo fetchModels falls back to fallbackModels when detection fails', async () => {

--- a/apps/daemon/tests/runtimes/prompt-budget.test.ts
+++ b/apps/daemon/tests/runtimes/prompt-budget.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  assert, checkPromptArgvBudget, checkWindowsCmdShimCommandLineBudget, checkWindowsDirectExeCommandLineBudget, claude, deepseek, deepseekMaxPromptArgBytes, grokBuild, vibe,
+  assert, checkPromptArgvBudget, checkWindowsCmdShimCommandLineBudget, checkWindowsDirectExeCommandLineBudget, claude, deepseek, deepseekMaxPromptArgBytes, grokBuild, kimi, vibe,
 } from './helpers/test-helpers.js';
 import type { TestAgentDef } from './helpers/test-helpers.js';
 
@@ -105,6 +105,22 @@ test('checkPromptArgvBudget gives DeepSeek-specific guidance for large contexts'
   assert.match(flagged.message, /currently accepts prompts only as a command-line argument/);
   assert.match(flagged.message, /API\/provider model connection/);
   assert.match(flagged.message, /stdin-capable adapter/);
+});
+
+test('Kimi prompt mode declares and enforces an argv-byte budget', () => {
+  assert.equal(kimi.maxPromptArgBytes, 30_000);
+
+  const oversized = 'x'.repeat(kimi.maxPromptArgBytes + 1);
+  const flagged = checkPromptArgvBudget(kimi, oversized);
+  assert.ok(flagged, 'oversized Kimi prompts must trip the argv-byte guard');
+  assert.equal(flagged.code, 'AGENT_PROMPT_TOO_LARGE');
+  assert.equal(flagged.limit, kimi.maxPromptArgBytes);
+  assert.equal(flagged.bytes, kimi.maxPromptArgBytes + 1);
+  assert.match(flagged.message, /Kimi CLI/);
+  assert.match(flagged.message, /command-line argument/);
+  assert.match(flagged.message, /stdin support/);
+
+  assert.equal(checkPromptArgvBudget(kimi, 'hello'), null);
 });
 
 test('checkPromptArgvBudget is a no-op for Grok Build because it uses prompt files', () => {

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -926,6 +926,7 @@ export function wellKnownUserToolchainBins(
   dirs.push(
     join(home, ".local", "bin"),
     join(home, ".vite-plus", "bin"),
+    join(home, ".kimi-code", "bin"),
     join(home, ".opencode", "bin"),
     join(home, ".bun", "bin"),
     join(home, ".volta", "bin"),

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -724,6 +724,7 @@ describe("wellKnownUserToolchainBins", () => {
     try {
       const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
       expect(dirs).toContain(join(home, ".local", "bin"));
+      expect(dirs).toContain(join(home, ".kimi-code", "bin"));
       expect(dirs).toContain(join(home, ".opencode", "bin"));
       expect(dirs).toContain(join(home, ".bun", "bin"));
       expect(dirs).toContain(join(home, ".volta", "bin"));


### PR DESCRIPTION
Fixes #4190

## Why

I hit this while debugging the currently running Open Design instance after the local Kimi Code CLI was updated. The updated CLI is installed at `/Users/lucifer/.kimi-code/bin/kimi` and works in prompt JSONL mode, but Open Design was both missing that official install path under GUI-launched daemon environments and treating Kimi as an ACP runtime.

The pain is user-facing: Kimi can show as unavailable in Settings/configure flows, and when forced through ACP the run fails during `session/new` with `Authentication required` even though the same CLI can run authenticated prompt-mode jobs.

## What users will see

Users with the current Kimi Code CLI installed in the official `~/.kimi-code/bin` location should see Kimi as available from Open Design. Runs launched with Kimi use the working prompt-mode stream instead of the failing ACP session path.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed. Browser verification opened the smoke project in the local app at `http://127.0.0.1:17657/projects/kimi-smoke-1781228499694`.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/agent-args.test.ts` covers Kimi no longer launching ACP and `apps/daemon/tests/json-event-stream.test.ts` covers the new Kimi prompt-mode stream shape. `packages/platform/tests/index.test.ts` covers detection of `~/.kimi-code/bin`.
- Did the test go red on `main` and green on this branch? no — the runtime failure depends on the locally updated Kimi CLI behavior, so I reproduced it directly against `kimi acp` and `/api/agents`, then added focused regression tests for the adapter/parser/resolver behavior.
- Live verification: direct `kimi acp` accepted `initialize` but returned `Authentication required` on `session/new`; direct `kimi -p ... --output-format stream-json` succeeded and could write a file. After the fix, `/api/agents` reports Kimi available at `/Users/lucifer/.kimi-code/bin/kimi`, and a daemon Kimi run succeeded with output file `kimi-open-design-smoke.txt` containing `KIMI_OPEN_DESIGN_SMOKE_OK`.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/platform build`
- `pnpm --filter @open-design/platform test -- tests/index.test.ts -t wellKnownUserToolchainBins`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts -t "kimi stream"`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts -t "kimi args"`
- Browser plugin opened the local Open Design smoke project successfully after the Kimi run completed.
