### PR TITLE
fix(web):  z-index for workspace tabs popover

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -345,7 +345,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  z-index: 130;
+  z-index: 1100;
   -webkit-app-region: no-drag;
 }
 .workspace-tabs-popover,

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 const shellCss = readFileSync(new URL('../../src/styles/shell.css', import.meta.url), 'utf8');
 const routinesCss = readFileSync(new URL('../../src/styles/viewer/routines.css', import.meta.url), 'utf8');
+const composioCss = readFileSync(new URL('../../src/styles/viewer/composio.css', import.meta.url), 'utf8');
 const entryLayoutCss = readFileSync(new URL('../../src/styles/home/entry-layout.css', import.meta.url), 'utf8');
 
 function cssDeclarations(css: string, selector: string): string {
@@ -79,7 +80,9 @@ describe('workspace tabs chrome styles', () => {
     const activeProjectTab = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab.is-active');
     const tabSeparator = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab + .workspace-tab::before');
     const main = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab__main');
+    const popover = cssDeclarations(shellCss, '.workspace-tabs-popover');
     const preview = cssDeclarations(shellCss, '.workspace-tab-preview');
+    const presentOverlay = cssDeclarations(composioCss, '.present-overlay');
     const projectChrome = cssDeclarations(
       routinesCss,
       '.workspace-shell .workspace-tabs-chrome.app-chrome-header',
@@ -105,6 +108,9 @@ describe('workspace tabs chrome styles', () => {
     expect(ruleValue(sharedStrip, 'overflow-y')).toBe('hidden');
     expect(ruleValue(tabSeparator, 'display')).toBe('none');
     expect(ruleValue(main, 'z-index')).toBe('2');
+    expect(Number(ruleValue(popover, 'z-index'))).toBeGreaterThan(
+      Number(ruleValue(presentOverlay, 'z-index')),
+    );
     expect(ruleValue(preview, 'box-sizing')).toBe('border-box');
     expect(routinesCss).not.toContain('.workspace-shell .workspace-tab.is-active::before');
     expect(routinesCss).not.toContain('.workspace-shell .workspace-tab.is-active::after');


### PR DESCRIPTION
Fixes #4151 

## Why

While testing the in-tab presentation flow locally, I noticed the workspace tab search popover could appear behind the preview content. The preview presentation overlay sits above the old tab-search z-index, so the popover was visually covered even though it was open.

## What users will see

Opening the top workspace tab search while a preview is presented in the current tab now shows the search panel above the preview content.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before
<img width="597" height="380" alt="Image" src="https://github.com/user-attachments/assets/06020eed-af0f-4e31-aaf9-8d5725ad0107" />
After
<img width="562" height="362" alt="Image" src="https://github.com/user-attachments/assets/b0f9e7f8-572f-43ee-b994-10b888c8848e" />

## Bug fix verification

- Red-spec note: this is a CSS stacking-order regression, so the cheapest reliable coverage is a style-level assertion that the tab search popover remains above `.present-overlay`.

## Validation

- `corepack pnpm --filter @open-design/web test -- workspace-tabs-chrome`
- `corepack pnpm typecheck`
- `corepack pnpm guard`