### PR TITLE
[codex] Hide stale jump affordance during next-step flyouts

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -313,6 +313,7 @@ interface Props {
   onArtifactDownload?: (fileName: string) => void;
   nextStepSkills?: SkillSummary[];
   toolboxSkillNames?: Partial<Record<DesignToolboxActionId, string | null>>;
+  onNextStepFlyoutOpenChange?: (open: boolean) => void;
 }
 
 // Props compared by reference to decide whether a memoized AssistantMessage can
@@ -414,6 +415,7 @@ function AssistantMessageImpl({
   onArtifactDownload,
   nextStepSkills,
   toolboxSkillNames,
+  onNextStepFlyoutOpenChange,
 }: Props) {
   const t = useT();
   const events = message.events ?? [];
@@ -792,6 +794,7 @@ function AssistantMessageImpl({
             toolboxSkillNames={isLast ? toolboxSkillNames : undefined}
             onShareToOpenDesign={showOpenDesignSubmission ? onShareToOpenDesign : undefined}
             shareToOpenDesignBusy={shareToOpenDesignBusy}
+            onFlyoutOpenChange={isLast ? onNextStepFlyoutOpenChange : undefined}
           />
         ) : null}
       </div>

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -820,6 +820,7 @@ export function ChatPane({
   const [conversationSearch, setConversationSearch] = useState('');
   const deferredConversationSearch = useDeferredValue(conversationSearch);
   const [scrolledFromBottom, setScrolledFromBottom] = useState(false);
+  const [nextStepFlyoutOpen, setNextStepFlyoutOpen] = useState(false);
   const [chatLogScrollable, setChatLogScrollable] = useState(false);
   const [chatLogScrolling, setChatLogScrolling] = useState(false);
   const [composerPortalTarget, setComposerPortalTarget] = useState<HTMLElement | null>(null);
@@ -830,6 +831,7 @@ export function ChatPane({
   } | null>(null);
   const [composerSlotHeight, setComposerSlotHeight] = useState(0);
   const [editingQueuedSendId, setEditingQueuedSendId] = useState<string | null>(null);
+  const showJumpToLatest = scrolledFromBottom && !nextStepFlyoutOpen;
   // Reverse scan (no array copy) + memo so this and the maps below don't
   // recompute on every non-`messages` render (scroll, hover, toggles).
   const lastAssistantId = useMemo(() => {
@@ -1951,6 +1953,7 @@ export function ChatPane({
                 onArtifactDownload={onArtifactDownload}
                 nextStepSkills={skills}
                 toolboxSkillNames={featuredToolboxSkillNames}
+                onNextStepFlyoutOpenChange={setNextStepFlyoutOpen}
                 onForkFromMessage={onForkFromMessage}
                 onAssistantFeedback={onAssistantFeedback}
                 forkingMessageId={forkingMessageId}
@@ -2097,11 +2100,11 @@ export function ChatPane({
                 keep it out of the a11y tree when it's not visible. */}
             <button
               type="button"
-              className={`chat-jump-btn${scrolledFromBottom ? ' chat-jump-btn-active' : ''}`}
+              className={`chat-jump-btn${showJumpToLatest ? ' chat-jump-btn-active' : ''}`}
               onClick={jumpToBottom}
               title={t('chat.scrollToLatest')}
-              aria-hidden={!scrolledFromBottom}
-              tabIndex={scrolledFromBottom ? 0 : -1}
+              aria-hidden={!showJumpToLatest}
+              tabIndex={showJumpToLatest ? 0 : -1}
             >
               <Icon name="arrow-up" size={12} style={{ transform: 'rotate(180deg)' }} />
               <span>{t('chat.jumpToLatest')}</span>
@@ -2247,6 +2250,7 @@ function ChatRows({
   onArtifactDownload,
   nextStepSkills,
   toolboxSkillNames,
+  onNextStepFlyoutOpenChange,
   onForkFromMessage,
   onAssistantFeedback,
   forkingMessageId,
@@ -2287,6 +2291,7 @@ function ChatRows({
   onArtifactDownload?: (fileName: string) => void;
   nextStepSkills?: SkillSummary[];
   toolboxSkillNames?: Partial<Record<DesignToolboxActionId, string | null>>;
+  onNextStepFlyoutOpenChange?: (open: boolean) => void;
   onForkFromMessage?: (message: ChatMessage) => void;
   onAssistantFeedback?: (message: ChatMessage, change: ChatMessageFeedbackChange) => void;
   forkingMessageId?: string | null;
@@ -2408,6 +2413,7 @@ function ChatRows({
         onArtifactDownload={onArtifactDownload}
         nextStepSkills={nextStepSkills}
         toolboxSkillNames={toolboxSkillNames}
+        onNextStepFlyoutOpenChange={onNextStepFlyoutOpenChange}
       />
     );
   };

--- a/apps/web/src/components/NextStepActions.tsx
+++ b/apps/web/src/components/NextStepActions.tsx
@@ -53,6 +53,9 @@ interface Props {
   // Contribute the artifact to the Open Design community gallery.
   onShareToOpenDesign?: () => void;
   shareToOpenDesignBusy?: boolean;
+  // Lets the chat pane hide overlapping floating controls while the cascading
+  // next-step menus are open.
+  onFlyoutOpenChange?: (open: boolean) => void;
 }
 
 const FLYOUT_GAP = 8;
@@ -103,6 +106,7 @@ export function NextStepActions({
   toolboxSkillNames,
   onShareToOpenDesign,
   shareToOpenDesignBusy = false,
+  onFlyoutOpenChange,
 }: Props) {
   const { t, locale } = useI18n();
   const analytics = useAnalytics();
@@ -129,6 +133,18 @@ export function NextStepActions({
   const [more, setMore] = useState<Anchor | null>(null);
   const [sub, setSub] = useState<({ kind: SubKind } & Anchor) | null>(null);
   const [toolboxQuery, setToolboxQuery] = useState('');
+  const flyoutOpen = !!(detail || more || sub);
+
+  useEffect(() => {
+    onFlyoutOpenChange?.(flyoutOpen);
+  }, [flyoutOpen, onFlyoutOpenChange]);
+
+  useEffect(
+    () => () => {
+      onFlyoutOpenChange?.(false);
+    },
+    [onFlyoutOpenChange],
+  );
 
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelClose = useCallback(() => {

--- a/apps/web/tests/components/NextStepActions.test.tsx
+++ b/apps/web/tests/components/NextStepActions.test.tsx
@@ -103,6 +103,20 @@ describe('NextStepActions', () => {
     expect(screen.getByTestId('next-step-more-share')).toBeTruthy();
   });
 
+  it('reports whether a cascading flyout is open', () => {
+    const onFlyoutOpenChange = vi.fn();
+    renderActions({ onFlyoutOpenChange });
+
+    expect(onFlyoutOpenChange).toHaveBeenLastCalledWith(false);
+
+    fireEvent.mouseEnter(screen.getByTestId('next-step-toolbox-more'));
+    expect(onFlyoutOpenChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.mouseEnter(screen.getByTestId('next-step-more-share'));
+    fireEvent.click(screen.getByTestId('next-step-share-share'));
+    expect(onFlyoutOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
   it('cascades into searchable non-featured toolbox actions and global resources', () => {
     renderActions();
     fireEvent.mouseEnter(screen.getByTestId('next-step-toolbox-more'));

--- a/apps/web/tests/components/chat-scroll-preservation.test.tsx
+++ b/apps/web/tests/components/chat-scroll-preservation.test.tsx
@@ -14,9 +14,10 @@ if (typeof HTMLElement.prototype.scrollTo !== 'function') {
 }
 
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatPane } from '../../src/components/ChatPane';
-import type { ChatMessage } from '../../src/types';
+import type { ChatMessage, ProjectFile } from '../../src/types';
 
 // jsdom does not run a layout engine, so scrollHeight/clientHeight/scrollTop
 // are all 0. The scroll-preservation effect derives "near bottom" and the
@@ -132,7 +133,22 @@ function setUserScroll(top: number) {
   if (el) fireEvent.scroll(el);
 }
 
-function chatPaneEl(messages: ChatMessage[], activeConversationId: string | null) {
+function producedHtmlFile(name: string): ProjectFile {
+  return {
+    name,
+    path: name,
+    size: 100,
+    mtime: Date.now(),
+    kind: 'html',
+    mime: 'text/html',
+  } as ProjectFile;
+}
+
+function chatPaneEl(
+  messages: ChatMessage[],
+  activeConversationId: string | null,
+  overrides: Partial<ComponentProps<typeof ChatPane>> = {},
+) {
   return (
     <ChatPane
       projectKindForTracking="prototype"
@@ -148,12 +164,17 @@ function chatPaneEl(messages: ChatMessage[], activeConversationId: string | null
       activeConversationId={activeConversationId}
       onSelectConversation={() => {}}
       onDeleteConversation={() => {}}
+      {...overrides}
     />
   );
 }
 
-function renderChatPane(messages: ChatMessage[], activeConversationId: string | null = null) {
-  return render(chatPaneEl(messages, activeConversationId));
+function renderChatPane(
+  messages: ChatMessage[],
+  activeConversationId: string | null = null,
+  overrides: Partial<ComponentProps<typeof ChatPane>> = {},
+) {
+  return render(chatPaneEl(messages, activeConversationId, overrides));
 }
 
 const sampleMessages: ChatMessage[] = [
@@ -235,6 +256,39 @@ describe('chat scroll behavior', () => {
     await flushFrame();
 
     expect(geom.scrollTop).toBe(1200);
+  });
+
+  it('hides the jump-to-latest pill while the next-step More flyout is open', async () => {
+    setGeom({ scrollHeight: 1000, clientHeight: 400, scrollTop: 1000 });
+    renderChatPane(
+      [
+        { id: 'u1', role: 'user', content: 'create a landing page', createdAt: Date.now() },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: 'Done.',
+          createdAt: Date.now(),
+          runStatus: 'succeeded',
+          producedFiles: [producedHtmlFile('landing.html')],
+        },
+      ],
+      'conv-1',
+      {
+        onArtifactShare: vi.fn(),
+        onArtifactDownload: vi.fn(),
+      },
+    );
+    await flushFrame();
+
+    setUserScroll(400);
+    const jumpButton = screen.getByRole('button', { name: /jump to latest/i });
+    expect(jumpButton.className).toContain('chat-jump-btn-active');
+    expect(jumpButton.getAttribute('aria-hidden')).toBe('false');
+
+    fireEvent.mouseEnter(screen.getByTestId('next-step-toolbox-more'));
+
+    expect(jumpButton.className).not.toContain('chat-jump-btn-active');
+    expect(jumpButton.getAttribute('aria-hidden')).toBe('true');
   });
 
   it('lands new conversation at its own bottom when switching conversations', async () => {


### PR DESCRIPTION
Fixes #4123

## Why

I opened this PR to fix the visible overlap reported in #4123: after the user scrolls up in chat, the floating Jump to latest pill can remain active while the Next Step More cascade is open. In that state it sits next to the menu and looks like an extra menu action, but it is not part of the next-step choice the user is making.

The pain is a user-facing UI bug in the chat pane. The menu should stay focused on next-step actions, and the scroll affordance should not compete with or visually attach itself to the flyout.

## What users will see

When users open the Next Step More menu while scrolled away from the latest chat message, the Jump to latest pill is temporarily hidden and removed from keyboard focus. Closing the menu restores the pill if the user is still scrolled away from the bottom.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the issue screenshot in #4123 shows the Jump to latest pill beside the Next Step More cascade.

After: not attached from this shell. The changed visible state is the absence of the overlapping pill while the flyout is open, covered by the regression test in `apps/web/tests/components/chat-scroll-preservation.test.tsx`.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/chat-scroll-preservation.test.tsx`
- Supporting state propagation test: `apps/web/tests/components/NextStepActions.test.tsx`
- Did the test go red on `main` and green on this branch? yes. With the new tests and old source, 2 assertions fail; restored branch source passes 19/19 focused tests.

## Validation

- `pnpm install --frozen-lockfile`
- `ESBUILD_BINARY_PATH=$PWD/node_modules/.pnpm/esbuild@0.27.7/node_modules/esbuild/bin/esbuild node node_modules/vitest/vitest.mjs run -c vitest.config.ts tests/components/NextStepActions.test.tsx tests/components/chat-scroll-preservation.test.tsx --pool=forks --maxWorkers=1` from `apps/web` — 19/19 passed
- Red check: temporarily restored the three source files to `HEAD^` while keeping the new tests; the two new assertions failed as expected
- `PATH=/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:$PATH NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm --filter @open-design/web typecheck`
- `git diff --check`

Known local blockers:

- `pnpm guard` is blocked by ignored local residue under `tools/pr/` (`dist/` and `node_modules/`), not by this diff.
- Root workspace typecheck reaches `@open-design/web` successfully, then stops in `apps/daemon` because that package script invokes old pnpm 10.15.0 inside this shell.