### PR TITLE
[codex] Add ACP terminal auth recovery flow

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -237,8 +237,17 @@ function stringMap(value: unknown): Record<string, string> | undefined {
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
-function firstTerminalAuthMethod(authMethods: unknown): AcpTerminalAuthMetadata | null {
+function publicTerminalAuthMetadata(auth: AcpTerminalAuthMetadata): Omit<AcpTerminalAuthMetadata, 'command' | 'args' | 'env'> {
+  return {
+    kind: 'terminal-auth',
+    methodId: auth.methodId,
+    ...(auth.label ? { label: auth.label } : {}),
+  };
+}
+
+function terminalAuthMethod(authMethods: unknown, preferredMethodId?: string | null): AcpTerminalAuthMetadata | null {
   const methods = Array.isArray(authMethods) ? authMethods : [];
+  let first: AcpTerminalAuthMetadata | null = null;
   for (const rawMethod of methods) {
     const method = asObject(rawMethod);
     if (!method) continue;
@@ -261,7 +270,7 @@ function firstTerminalAuthMethod(authMethods: unknown): AcpTerminalAuthMetadata 
           : undefined;
     const args = stringArray(source?.args);
     const env = stringMap(source?.env);
-    return {
+    const auth: AcpTerminalAuthMetadata = {
       kind: 'terminal-auth',
       methodId,
       ...(label ? { label } : {}),
@@ -269,8 +278,10 @@ function firstTerminalAuthMethod(authMethods: unknown): AcpTerminalAuthMetadata 
       ...(args ? { args } : {}),
       ...(env ? { env } : {}),
     };
+    if (preferredMethodId && methodId === preferredMethodId) return auth;
+    if (!first) first = auth;
   }
-  return null;
+  return preferredMethodId ? null : first;
 }
 
 function promotedOpenCodeSessionErrorPayload(data: unknown, fallbackMessage: string) {
@@ -902,11 +913,7 @@ export async function detectAcpTerminalAuth({
         return;
       }
       if (obj?.id !== 1 || !result) return;
-      const auth = firstTerminalAuthMethod(result.authMethods);
-      if (methodId && auth?.methodId !== methodId) {
-        finish(resolve, null);
-        return;
-      }
+      const auth = terminalAuthMethod(result.authMethods, methodId);
       finish(resolve, auth);
     });
 
@@ -1209,7 +1216,7 @@ export function attachAcpSession({
         fail('Agent authentication requires a terminal sign-in. Open the sign-in terminal, complete the flow, then retry this run.', {
           details: {
             kind: 'acp_terminal_auth',
-            auth: terminalAuth,
+            auth: publicTerminalAuthMetadata(terminalAuth),
             upstreamMessage: rpcErr,
           },
           retryable: true,
@@ -1349,7 +1356,7 @@ export function attachAcpSession({
       return;
     }
     if (expectedId === 1) {
-      terminalAuth = firstTerminalAuthMethod(result.authMethods);
+      terminalAuth = terminalAuthMethod(result.authMethods);
       expectedId = nextId;
       writeRpc(
         nextId,

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -62,6 +62,15 @@ interface AcpModelConfigOption {
   values: unknown[];
 }
 
+export interface AcpTerminalAuthMetadata {
+  kind: 'terminal-auth';
+  methodId: string;
+  label?: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
 const MODEL_CONFIG_OPTION_IDS = new Set(['model', 'models', 'modelid', 'modelids']);
 
 interface DetectAcpModelsOptions {
@@ -73,6 +82,17 @@ interface DetectAcpModelsOptions {
   clientName?: string;
   clientVersion?: string;
   defaultModelOption?: ModelOption;
+}
+
+interface DetectAcpTerminalAuthOptions {
+  bin: string;
+  args: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  methodId?: string;
+  clientName?: string;
+  clientVersion?: string;
 }
 
 interface AttachAcpSessionOptions {
@@ -199,6 +219,58 @@ function rpcErrorData(raw: unknown): unknown {
 function rpcErrorRetryable(data: unknown): boolean | undefined {
   const details = asObject(data);
   return typeof details?.retryable === 'boolean' ? details.retryable : undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out = value.filter((item): item is string => typeof item === 'string');
+  return out.length > 0 ? out : undefined;
+}
+
+function stringMap(value: unknown): Record<string, string> | undefined {
+  const obj = asObject(value);
+  if (!obj) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(obj)) {
+    if (typeof raw === 'string') out[key] = raw;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function firstTerminalAuthMethod(authMethods: unknown): AcpTerminalAuthMetadata | null {
+  const methods = Array.isArray(authMethods) ? authMethods : [];
+  for (const rawMethod of methods) {
+    const method = asObject(rawMethod);
+    if (!method) continue;
+    const methodId = typeof method.id === 'string' && method.id.trim()
+      ? method.id.trim()
+      : '';
+    const meta = asObject(method._meta);
+    const terminalAuth = asObject(meta?.['terminal-auth']);
+    const directTerminal = method.type === 'terminal' ? method : null;
+    const source = terminalAuth ?? directTerminal;
+    const command = typeof source?.command === 'string' && source.command.trim()
+      ? source.command.trim()
+      : '';
+    if (!methodId || !command) continue;
+    const label =
+      typeof source?.label === 'string' && source.label.trim()
+        ? source.label.trim()
+        : typeof method.name === 'string' && method.name.trim()
+          ? method.name.trim()
+          : undefined;
+    const args = stringArray(source?.args);
+    const env = stringMap(source?.env);
+    return {
+      kind: 'terminal-auth',
+      methodId,
+      ...(label ? { label } : {}),
+      command,
+      ...(args ? { args } : {}),
+      ...(env ? { env } : {}),
+    };
+  }
+  return null;
 }
 
 function promotedOpenCodeSessionErrorPayload(data: unknown, fallbackMessage: string) {
@@ -779,6 +851,99 @@ export async function detectAcpModels({
   });
 }
 
+export async function detectAcpTerminalAuth({
+  bin,
+  args,
+  cwd = process.cwd(),
+  env = process.env,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  methodId,
+  clientName = 'open-design-auth-detect',
+  clientVersion = 'runtime-adapter',
+}: DetectAcpTerminalAuthOptions): Promise<AcpTerminalAuthMetadata | null> {
+  const effectiveTimeoutMs = resolveAcpTimeoutMs(env, timeoutMs);
+  return await new Promise<AcpTerminalAuthMetadata | null>((resolve, reject) => {
+    const child = spawn(bin, args, {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...env },
+    });
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    let settled = false;
+    let stderrBuf = '';
+    let timer: TimerHandle | null = null;
+
+    const finish = <T extends AcpTerminalAuthMetadata | null | Error>(
+      fn: (value: T) => void,
+      value: T,
+    ) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      try {
+        child.stdin.end();
+      } catch {}
+      if (!child.killed) child.kill('SIGTERM');
+      fn(value);
+    };
+
+    const fail = (message: string) => {
+      finish(reject, new Error(message));
+    };
+
+    const parser = createJsonLineStream((raw) => {
+      const obj = asObject(raw);
+      const result = asObject(obj?.result);
+      const rpcErr = rpcErrorMessage(raw);
+      if (rpcErr) {
+        fail(rpcErr);
+        return;
+      }
+      if (obj?.id !== 1 || !result) return;
+      const auth = firstTerminalAuthMethod(result.authMethods);
+      if (methodId && auth?.methodId !== methodId) {
+        finish(resolve, null);
+        return;
+      }
+      finish(resolve, auth);
+    });
+
+    child.stdout.on('data', (chunk) => parser.feed(chunk));
+    child.stdout.on('close', () => parser.flush());
+    child.stdin.on('error', (err) => fail(`stdin error: ${err.message}`));
+    child.stderr.on('data', (chunk) => {
+      stderrBuf = `${stderrBuf}${chunk}`.slice(-16_000);
+    });
+    child.on('error', (err) => fail(`spawn failed: ${err.message}`));
+    child.on('close', (code, signal) => {
+      parser.flush();
+      if (!settled) {
+        const errTail = stderrBuf.trim();
+        const suffix = errTail ? ` stderr=${errTail}` : '';
+        fail(`ACP auth detection exited code=${code} signal=${signal ?? 'none'}${suffix}`);
+      }
+    });
+
+    if (effectiveTimeoutMs > 0) {
+      timer = setTimeout(() => {
+        fail(`ACP auth detection timed out after ${effectiveTimeoutMs}ms`);
+      }, effectiveTimeoutMs);
+    }
+
+    try {
+      sendRpc(child.stdin, 1, 'initialize', {
+        protocolVersion: ACP_PROTOCOL_VERSION,
+        clientCapabilities: { terminal: true },
+        clientInfo: { name: clientName, version: clientVersion },
+      });
+    } catch (err) {
+      fail(`stdin write failed: ${errorMessage(err)}`);
+    }
+  });
+}
+
 export function attachAcpSession({
   child,
   prompt,
@@ -807,6 +972,7 @@ export function attachAcpSession({
   let sessionId: string | null = null;
   let activeModel: string | null = null;
   let modelConfigId: string | null = null;
+  let terminalAuth: AcpTerminalAuthMetadata | null = null;
   let emittedThinkingStart = false;
   let emittedFirstTokenStatus = false;
   let emittedTextChunk = false;
@@ -822,6 +988,7 @@ export function attachAcpSession({
   let dsmlArtifactSuppressorArmedAfterText = false;
   let dsmlArtifactSuppressorSawIncrementalProse = false;
   const acpArtifactWriteToolCallIds = new Set<string>();
+  let forceKillTimer: TimerHandle | null = null;
 
   const stageWatchdogDisabled = stageTimeoutMs <= 0;
   const resetStageTimer = (label: string) => {
@@ -840,6 +1007,18 @@ export function attachAcpSession({
   const clearStageTimer = () => {
     if (stageTimer) clearTimeout(stageTimer);
     stageTimer = null;
+  };
+
+  const terminateChild = () => {
+    if (!child.killed) child.kill('SIGTERM');
+    if (forceKillTimer) clearTimeout(forceKillTimer);
+    forceKillTimer = setTimeout(() => {
+      child.kill('SIGKILL');
+    }, 1_000);
+    child.once('close', () => {
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      forceKillTimer = null;
+    });
   };
 
   const amrModelUnavailablePayload = (message: string) => ({
@@ -868,12 +1047,17 @@ export function attachAcpSession({
     fatal = true;
     clearStageTimer();
     send('error', payload);
-    if (!child.killed) child.kill('SIGTERM');
+    terminateChild();
   };
 
   const fail = (
     message: string,
-    options: { forceModelUnavailable?: boolean; details?: unknown; retryable?: boolean } = {},
+    options: {
+      code?: 'AGENT_AUTH_REQUIRED' | 'AGENT_EXECUTION_FAILED';
+      forceModelUnavailable?: boolean;
+      details?: unknown;
+      retryable?: boolean;
+    } = {},
   ) => {
     if (finished) return;
     finished = true;
@@ -891,14 +1075,14 @@ export function attachAcpSession({
           : {
               message,
               error: {
-                code: 'AGENT_EXECUTION_FAILED',
+                code: options.code ?? 'AGENT_EXECUTION_FAILED',
                 message,
                 retryable: options.retryable ?? false,
                 ...(options.details === undefined ? {} : { details: options.details }),
               },
             },
     );
-    if (!child.killed) child.kill('SIGTERM');
+    terminateChild();
   };
 
   const writeRpc = (id: JsonRpcId, method: string, params: unknown, timeoutLabel: string) => {
@@ -1016,6 +1200,23 @@ export function attachAcpSession({
         return;
       }
       const retryable = rpcErrorRetryable(details);
+      if (
+        error?.code === -32000 &&
+        /auth/i.test(rpcErr) &&
+        terminalAuth &&
+        (obj.id === expectedId || obj.id === setModelRequestId)
+      ) {
+        fail('Agent authentication requires a terminal sign-in. Open the sign-in terminal, complete the flow, then retry this run.', {
+          details: {
+            kind: 'acp_terminal_auth',
+            auth: terminalAuth,
+            upstreamMessage: rpcErr,
+          },
+          retryable: true,
+          code: 'AGENT_AUTH_REQUIRED',
+        });
+        return;
+      }
       fail(rpcErr, {
         details,
         ...(retryable === undefined ? {} : { retryable }),
@@ -1148,6 +1349,7 @@ export function attachAcpSession({
       return;
     }
     if (expectedId === 1) {
+      terminalAuth = firstTerminalAuthMethod(result.authMethods);
       expectedId = nextId;
       writeRpc(
         nextId,
@@ -1213,6 +1415,8 @@ export function attachAcpSession({
   stdout.on('data', (chunk: string) => parser.feed(chunk));
   child.on('close', (code, signal) => {
     clearStageTimer();
+    if (forceKillTimer) clearTimeout(forceKillTimer);
+    forceKillTimer = null;
     parser.flush();
     if (!finished && !aborted && !fatal) {
       fail(`ACP session exited before completion (code=${code ?? 'null'}, signal=${signal ?? 'none'})`);
@@ -1223,7 +1427,7 @@ export function attachAcpSession({
 
   writeRpc(1, 'initialize', {
     protocolVersion: ACP_PROTOCOL_VERSION,
-    clientCapabilities: { terminal: false },
+    clientCapabilities: { terminal: true },
     clientInfo: { name: clientName, version: clientVersion },
   }, 'initialize');
 

--- a/apps/daemon/src/runtimes/terminal-launch.ts
+++ b/apps/daemon/src/runtimes/terminal-launch.ts
@@ -12,27 +12,67 @@ const execFileAsync = promisify(execFile);
 // the system keyring. Spawning a terminal from inside OD makes that
 // a one-click action instead of a "go open Terminal yourself" task.
 //
-// Each platform branch uses primitives that are safe against shell
-// injection BECAUSE we never accept user input here — the `command`
-// argument is always a hard-coded binary name like `agy`. Adding
-// caller-supplied flags or env vars to this helper would invalidate
-// that guarantee, so the signature is intentionally narrow.
+// Each platform branch quotes argv/env before handing it to the host
+// terminal's shell. Callers must still keep the source of commands
+// constrained: today these are either hard-coded adapter commands or
+// terminal-auth commands re-read from an ACP server's initialize response.
+
+export type TerminalLaunchCommand = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+};
 
 export type TerminalLaunchResult =
   | { ok: true; platform: NodeJS.Platform; via: string }
   | { ok: false; platform: NodeJS.Platform; reason: string };
 
+function normalizeCommand(input: string | TerminalLaunchCommand): Required<TerminalLaunchCommand> {
+  if (typeof input === 'string') return { command: input, args: [], env: {} };
+  return {
+    command: input.command,
+    args: Array.isArray(input.args) ? input.args : [],
+    env: input.env && typeof input.env === 'object' ? input.env : {},
+  };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function shellCommand(input: string | TerminalLaunchCommand): string {
+  const command = normalizeCommand(input);
+  const envPrefix = Object.entries(command.env)
+    .map(([key, value]) => `${key}=${shellQuote(value)}`)
+    .join(' ');
+  const argv = [command.command, ...command.args].map(shellQuote).join(' ');
+  return envPrefix ? `${envPrefix} ${argv}` : argv;
+}
+
+function cmdQuote(value: string): string {
+  return `"${value.replace(/(["^&|<>%])/g, '^$1')}"`;
+}
+
+function windowsCommand(input: string | TerminalLaunchCommand): string {
+  const command = normalizeCommand(input);
+  const envPrefix = Object.entries(command.env)
+    .map(([key, value]) => `set ${cmdQuote(`${key}=${value}`)}&&`)
+    .join('');
+  const argv = [command.command, ...command.args].map(cmdQuote).join(' ');
+  return `${envPrefix}${argv}`;
+}
+
 // macOS: AppleScript via osascript. Bringing Terminal.app to the
 // foreground and creating a new shell that immediately runs the
 // command is the canonical macOS pattern (same one VS Code uses for
 // "Open in External Terminal").
-async function launchOnDarwin(command: string): Promise<TerminalLaunchResult> {
+async function launchOnDarwin(command: string | TerminalLaunchCommand): Promise<TerminalLaunchResult> {
   // `do script "<cmd>"` opens a new Terminal window and runs <cmd>
   // in it; activate brings Terminal.app to the foreground so the
   // user actually sees the new window. Strict double-quote escaping
   // protects us if `command` ever grows special characters (today
   // it's just `agy`, so this is belt-and-suspenders).
-  const safe = command.replace(/"/g, '\\"');
+  const safe = shellCommand(command).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   const script = `tell application "Terminal" to do script "${safe}"\ntell application "Terminal" to activate`;
   try {
     await execFileAsync('osascript', ['-e', script], { timeout: 5_000 });
@@ -53,17 +93,18 @@ async function launchOnDarwin(command: string): Promise<TerminalLaunchResult> {
 // because terminals like xterm and x-terminal-emulator stay alive for
 // the duration of the interactive session — waiting for exit would time
 // out and kill the window mid-OAuth-flow.
-async function launchOnLinux(command: string): Promise<TerminalLaunchResult> {
+async function launchOnLinux(command: string | TerminalLaunchCommand): Promise<TerminalLaunchResult> {
   // Order matters: x-terminal-emulator is the Debian alternative that
   // resolves to whichever terminal the distro chose. Otherwise try the
   // common ones. Each requires a slightly different invocation syntax
   // (`-e` vs `--` vs `-x`), captured in this table.
+  const rendered = shellCommand(command);
   const attempts: Array<{ bin: string; args: string[] }> = [
-    { bin: 'x-terminal-emulator', args: ['-e', command] },
-    { bin: 'gnome-terminal', args: ['--', 'sh', '-c', `${command}; exec $SHELL`] },
-    { bin: 'konsole', args: ['-e', command] },
-    { bin: 'xfce4-terminal', args: ['-e', command] },
-    { bin: 'xterm', args: ['-e', command] },
+    { bin: 'x-terminal-emulator', args: ['-e', 'sh', '-lc', rendered] },
+    { bin: 'gnome-terminal', args: ['--', 'sh', '-lc', `${rendered}; exec $SHELL`] },
+    { bin: 'konsole', args: ['-e', 'sh', '-lc', rendered] },
+    { bin: 'xfce4-terminal', args: ['-e', `sh -lc ${shellQuote(rendered)}`] },
+    { bin: 'xterm', args: ['-e', 'sh', '-lc', rendered] },
   ];
   const errors: string[] = [];
   for (const { bin, args } of attempts) {
@@ -92,11 +133,12 @@ async function launchOnLinux(command: string): Promise<TerminalLaunchResult> {
 // when the next token is also quoted), and the inner `cmd /k` keeps
 // the window open after the command finishes so the user can see
 // OAuth output and finish the flow before the window closes.
-async function launchOnWindows(command: string): Promise<TerminalLaunchResult> {
+async function launchOnWindows(command: string | TerminalLaunchCommand): Promise<TerminalLaunchResult> {
+  const rendered = windowsCommand(command);
   try {
     await execFileAsync(
       'cmd.exe',
-      ['/c', 'start', 'Open Design', 'cmd.exe', '/k', command],
+      ['/c', 'start', 'Open Design', 'cmd.exe', '/k', rendered],
       { timeout: 5_000 },
     );
     return { ok: true, platform: 'win32', via: 'cmd /c start' };
@@ -110,7 +152,7 @@ async function launchOnWindows(command: string): Promise<TerminalLaunchResult> {
 }
 
 export async function launchAgentInSystemTerminal(
-  command: string,
+  command: string | TerminalLaunchCommand,
   platform: NodeJS.Platform = process.platform,
 ): Promise<TerminalLaunchResult> {
   switch (platform) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -188,7 +188,7 @@ import {
   revokeProjectSurface,
 } from './genui/index.js';
 import { composeMemoryBody, extractFromMessage } from './memory.js';
-import { attachAcpSession } from './acp.js';
+import { attachAcpSession, detectAcpTerminalAuth } from './acp.js';
 import { attachPiRpcSession } from './pi-rpc.js';
 import { stageAmrImagePaths } from './amr-image-staging.js';
 import {
@@ -2724,7 +2724,7 @@ export function upsertSkillPluginCandidateAssistantMessage(db, run, candidate) {
 
 function persistRunEventToAssistantMessage(db, run, event, data) {
   if (!run.assistantMessageId) return;
-  const persisted = runSseEventToPersistedAgentEvent(event, data);
+  const persisted = runSseEventToPersistedAgentEvent(event, data, { agentId: run.agentId });
   if (!persisted) return;
   try {
     appendMessageAgentEvent(db, run.assistantMessageId, persisted);
@@ -2733,7 +2733,44 @@ function persistRunEventToAssistantMessage(db, run, event, data) {
   }
 }
 
-function runSseEventToPersistedAgentEvent(event, data) {
+export function __forTestRunSseEventToPersistedAgentEvent(event, data, context = {}) {
+  return runSseEventToPersistedAgentEvent(event, data, context);
+}
+
+function persistedTerminalAuthFromErrorData(data, context = {}) {
+  const details = data?.error?.details;
+  if (!details || typeof details !== 'object') return null;
+  const auth = details.auth;
+  if (!auth || typeof auth !== 'object') return null;
+  if (auth.kind !== 'terminal-auth') return null;
+  const agentId = typeof auth.agentId === 'string'
+    ? auth.agentId
+    : typeof context.agentId === 'string'
+      ? context.agentId
+      : null;
+  if (agentId == null || typeof auth.methodId !== 'string' || typeof auth.command !== 'string') {
+    return null;
+  }
+  const args = Array.isArray(auth.args)
+    ? auth.args.filter((value) => typeof value === 'string')
+    : undefined;
+  const env = auth.env && typeof auth.env === 'object'
+    ? Object.fromEntries(
+      Object.entries(auth.env).filter((entry) => typeof entry[1] === 'string'),
+    )
+    : undefined;
+  return {
+    kind: 'terminal-auth',
+    agentId,
+    methodId: auth.methodId,
+    ...(typeof auth.label === 'string' ? { label: auth.label } : {}),
+    command: auth.command,
+    ...(args && args.length > 0 ? { args } : {}),
+    ...(env && Object.keys(env).length > 0 ? { env } : {}),
+  };
+}
+
+function runSseEventToPersistedAgentEvent(event, data, context = {}) {
   if (event === 'start') {
     return {
       kind: 'status',
@@ -2751,10 +2788,13 @@ function runSseEventToPersistedAgentEvent(event, data) {
       : typeof data?.message === 'string'
         ? data.message
         : '';
+    const auth = persistedTerminalAuthFromErrorData(data, context);
     return {
       kind: 'status',
       label: 'error',
       ...(message ? { detail: message } : {}),
+      ...(typeof data?.error?.code === 'string' ? { code: data.error.code } : {}),
+      ...(auth ? { auth } : {}),
     };
   }
   if (event !== 'agent') return null;
@@ -5321,6 +5361,90 @@ export async function startServer({
       const result = await launchAgentInSystemTerminal('agy');
       if (result.ok) {
         return res.json({ ok: true, platform: result.platform, via: result.via });
+      }
+      return res.status(500).json({
+        ok: false,
+        platform: result.platform,
+        error: result.reason,
+      });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: String(err),
+      });
+    }
+  });
+
+  app.post('/api/agents/:agentId/acp-terminal-auth-launch', requireLocalDaemonRequest, async (req, res) => {
+    const agentId = req.params.agentId;
+    const methodId = typeof req.body?.methodId === 'string' && req.body.methodId.trim()
+      ? req.body.methodId.trim()
+      : null;
+    if (!methodId) {
+      return res.status(400).json({
+        ok: false,
+        error: 'methodId is required',
+      });
+    }
+    const def = getAgentDef(agentId);
+    if (!def) {
+      return res.status(404).json({
+        ok: false,
+        error: `unknown agent: ${agentId}`,
+      });
+    }
+    if (def.streamFormat !== 'acp-json-rpc') {
+      return res.status(400).json({
+        ok: false,
+        error: `${def.name} does not use ACP terminal auth`,
+      });
+    }
+    try {
+      const appCfg = await readAppConfig(RUNTIME_DATA_DIR);
+      const configuredEnv = agentCliEnvForAgent(appCfg.agentCliEnv, def.id);
+      const agentLaunch = resolveAgentLaunch(def, configuredEnv);
+      const bin = agentLaunch.launchPath ?? agentLaunch.selectedPath;
+      if (!bin) {
+        return res.status(400).json({
+          ok: false,
+          error: `${def.name} executable was not found`,
+        });
+      }
+      const env = applyAgentLaunchEnv(
+        {
+          ...process.env,
+          ...(def.env || {}),
+          ...configuredEnv,
+        },
+        agentLaunch,
+      );
+      const auth = await detectAcpTerminalAuth({
+        bin,
+        args: def.buildArgs('', [], [], {}),
+        env,
+        methodId,
+        timeoutMs: 10_000,
+      });
+      if (!auth) {
+        return res.status(404).json({
+          ok: false,
+          error: `${def.name} did not advertise ACP terminal auth method ${methodId}`,
+        });
+      }
+      const { launchAgentInSystemTerminal } = await import('./runtimes/terminal-launch.js');
+      const result = await launchAgentInSystemTerminal({
+        command: auth.command,
+        args: auth.args ?? [],
+        env: auth.env ?? {},
+      });
+      if (result.ok) {
+        return res.json({
+          ok: true,
+          platform: result.platform,
+          via: result.via,
+          methodId: auth.methodId,
+          label: auth.label ?? null,
+        });
       }
       return res.status(500).json({
         ok: false,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2748,25 +2748,14 @@ function persistedTerminalAuthFromErrorData(data, context = {}) {
     : typeof context.agentId === 'string'
       ? context.agentId
       : null;
-  if (agentId == null || typeof auth.methodId !== 'string' || typeof auth.command !== 'string') {
+  if (agentId == null || typeof auth.methodId !== 'string') {
     return null;
   }
-  const args = Array.isArray(auth.args)
-    ? auth.args.filter((value) => typeof value === 'string')
-    : undefined;
-  const env = auth.env && typeof auth.env === 'object'
-    ? Object.fromEntries(
-      Object.entries(auth.env).filter((entry) => typeof entry[1] === 'string'),
-    )
-    : undefined;
   return {
     kind: 'terminal-auth',
     agentId,
     methodId: auth.methodId,
     ...(typeof auth.label === 'string' ? { label: auth.label } : {}),
-    command: auth.command,
-    ...(args && args.length > 0 ? { args } : {}),
-    ...(env && Object.keys(env).length > 0 ? { env } : {}),
   };
 }
 

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import { PassThrough } from 'node:stream';
 import path from 'node:path';
 import { test, vi } from 'vitest';
-import { attachAcpSession, buildAcpSessionNewParams, normalizeModels } from '../src/acp.js';
+import { attachAcpSession, buildAcpSessionNewParams, detectAcpTerminalAuth, normalizeModels } from '../src/acp.js';
 
 const DEFAULT_MODEL_OPTION = { id: 'default', label: 'Default (CLI config)' };
 
@@ -225,9 +225,6 @@ test('attachAcpSession promotes ACP terminal-auth failures with launch metadata'
               kind: 'terminal-auth',
               methodId: 'login',
               label: 'Login with Kimi account',
-              command: '/Users/test/.kimi-code/bin/kimi',
-              args: ['login'],
-              env: { KIMI_HOME: '/Users/test/.kimi-code' },
             },
           },
         },
@@ -235,6 +232,66 @@ test('attachAcpSession promotes ACP terminal-auth failures with launch metadata'
     },
   ]);
   assert.equal(child.killed, true);
+});
+
+test('detectAcpTerminalAuth returns the requested terminal-auth method', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-acp-auth-detect-'));
+  const mockPath = path.join(tmpDir, 'mock-acp.mjs');
+  fs.writeFileSync(
+    mockPath,
+    `process.stdout.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        authMethods: [
+          {
+            id: 'login-terminal',
+            type: 'terminal',
+            name: 'Terminal login',
+            _meta: {
+              'terminal-auth': {
+                command: '/usr/local/bin/kimi',
+                args: ['login', '--terminal'],
+              },
+            },
+          },
+          {
+            id: 'login-browser',
+            type: 'terminal',
+            name: 'Browser login',
+            _meta: {
+              'terminal-auth': {
+                label: 'Login with Kimi account',
+                command: '/usr/local/bin/kimi',
+                args: ['login', '--browser'],
+                env: { KIMI_HOME: '/Users/test/.kimi-code' },
+              },
+            },
+          },
+        ],
+      },
+    }) + '\\n');\nsetTimeout(() => {}, 10_000);\n`,
+    'utf8',
+  );
+  try {
+    const detected = await detectAcpTerminalAuth({
+      bin: process.execPath,
+      args: [mockPath],
+      methodId: 'login-browser',
+      timeoutMs: 5_000,
+    });
+
+    assert.deepEqual(detected, {
+      kind: 'terminal-auth',
+      methodId: 'login-browser',
+      label: 'Login with Kimi account',
+      command: '/usr/local/bin/kimi',
+      args: ['login', '--browser'],
+      env: { KIMI_HOME: '/Users/test/.kimi-code' },
+    });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test('attachAcpSession keeps legacy session/set_model when no model config option exists', () => {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -173,6 +173,70 @@ test('attachAcpSession sets selected models through ACP config options', () => {
   ]);
 });
 
+test('attachAcpSession promotes ACP terminal-auth failures with launch metadata', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {
+    authMethods: [
+      {
+        id: 'login',
+        type: 'terminal',
+        name: 'Login with Kimi account',
+        _meta: {
+          'terminal-auth': {
+            type: 'terminal',
+            label: 'Login with Kimi account',
+            command: '/Users/test/.kimi-code/bin/kimi',
+            args: ['login'],
+            env: { KIMI_HOME: '/Users/test/.kimi-code' },
+          },
+        },
+      },
+    ],
+  });
+  writeAcpError(child, 2, {
+    code: -32000,
+    message: 'Authentication required',
+  });
+
+  assert.deepEqual(events, [
+    {
+      event: 'error',
+      payload: {
+        message: 'Agent authentication requires a terminal sign-in. Open the sign-in terminal, complete the flow, then retry this run.',
+        error: {
+          code: 'AGENT_AUTH_REQUIRED',
+          message: 'Agent authentication requires a terminal sign-in. Open the sign-in terminal, complete the flow, then retry this run.',
+          retryable: true,
+          details: {
+            kind: 'acp_terminal_auth',
+            upstreamMessage: 'json-rpc id 2: Authentication required',
+            auth: {
+              kind: 'terminal-auth',
+              methodId: 'login',
+              label: 'Login with Kimi account',
+              command: '/Users/test/.kimi-code/bin/kimi',
+              args: ['login'],
+              env: { KIMI_HOME: '/Users/test/.kimi-code' },
+            },
+          },
+        },
+      },
+    },
+  ]);
+  assert.equal(child.killed, true);
+});
+
 test('attachAcpSession keeps legacy session/set_model when no model config option exists', () => {
   const child = new FakeAcpChild();
   const writes: string[] = [];

--- a/apps/daemon/tests/run-event-persistence.test.ts
+++ b/apps/daemon/tests/run-event-persistence.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { __forTestRunSseEventToPersistedAgentEvent } from '../src/server.js';
 
 describe('run event persistence', () => {
-  it('preserves ACP terminal-auth recovery metadata on persisted error status events', () => {
+  it('persists minimal ACP terminal-auth recovery metadata on error status events', () => {
     const event = __forTestRunSseEventToPersistedAgentEvent(
       'error',
       {
@@ -35,9 +35,6 @@ describe('run event persistence', () => {
         agentId: 'kimi',
         methodId: 'login',
         label: 'Login with Kimi account',
-        command: '/Users/test/.kimi-code/bin/kimi',
-        args: ['login'],
-        env: { KIMI_HOME: '/Users/test/.kimi' },
       },
     });
   });

--- a/apps/daemon/tests/run-event-persistence.test.ts
+++ b/apps/daemon/tests/run-event-persistence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { __forTestRunSseEventToPersistedAgentEvent } from '../src/server.js';
+
+describe('run event persistence', () => {
+  it('preserves ACP terminal-auth recovery metadata on persisted error status events', () => {
+    const event = __forTestRunSseEventToPersistedAgentEvent(
+      'error',
+      {
+        error: {
+          code: 'AGENT_AUTH_REQUIRED',
+          message: 'Agent authentication requires a terminal sign-in.',
+          details: {
+            kind: 'acp_terminal_auth',
+            auth: {
+              kind: 'terminal-auth',
+              methodId: 'login',
+              label: 'Login with Kimi account',
+              command: '/Users/test/.kimi-code/bin/kimi',
+              args: ['login'],
+              env: { KIMI_HOME: '/Users/test/.kimi' },
+            },
+          },
+        },
+      },
+      { agentId: 'kimi' },
+    );
+
+    expect(event).toEqual({
+      kind: 'status',
+      label: 'error',
+      detail: 'Agent authentication requires a terminal sign-in.',
+      code: 'AGENT_AUTH_REQUIRED',
+      auth: {
+        kind: 'terminal-auth',
+        agentId: 'kimi',
+        methodId: 'login',
+        label: 'Login with Kimi account',
+        command: '/Users/test/.kimi-code/bin/kimi',
+        args: ['login'],
+        env: { KIMI_HOME: '/Users/test/.kimi' },
+      },
+    });
+  });
+});

--- a/apps/daemon/tests/runtimes/terminal-launch.test.ts
+++ b/apps/daemon/tests/runtimes/terminal-launch.test.ts
@@ -18,4 +18,20 @@ describe('launchAgentInSystemTerminal', () => {
     expect(result.reason).toContain('not supported');
     expect(result.reason).toContain('aix');
   });
+
+  it('accepts structured command objects without treating arguments as unsupported platforms', async () => {
+    const result = await launchAgentInSystemTerminal(
+      {
+        command: '/usr/bin/kimi',
+        args: ['login'],
+        env: { KIMI_HOME: '/tmp/kimi home' },
+      },
+      'aix',
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.platform).toBe('aix');
+    expect(result.reason).toContain('not supported');
+  });
 });

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -28,7 +28,7 @@ import type { Dict } from '../i18n/types';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { projectRawUrl } from '../providers/registry';
 import type { TodoItem } from '../runtime/todos';
-import type { AppliedPluginSnapshot, ChatSessionMode, WorkspaceContextItem } from '@open-design/contracts';
+import type { AgentTerminalAuthMetadata, AppliedPluginSnapshot, ChatSessionMode, WorkspaceContextItem } from '@open-design/contracts';
 import type { TrackingProjectKind } from '@open-design/contracts/analytics';
 import {
   DESIGN_SYSTEM_WORKSPACE_DISPLAY_DESCRIPTION,
@@ -520,6 +520,7 @@ interface Props {
   onSwitchToLocalCli?: () => void;
   onOpenAmrSettings?: () => void;
   onSwitchToAmrAndRetry?: (failedAssistant: ChatMessage) => void;
+  onLaunchTerminalAuth?: (auth: AgentTerminalAuthMetadata) => Promise<void>;
   // PR #3157: Antigravity's `agy -p` can't complete OAuth on its own,
   // so the auth banner offers a "Sign in via terminal" button that
   // POSTs to /api/agents/antigravity/oauth-launch. Handler resolves
@@ -701,6 +702,7 @@ export function ChatPane({
   onSwitchToLocalCli,
   onOpenAmrSettings,
   onSwitchToAmrAndRetry,
+  onLaunchTerminalAuth,
   onLaunchAntigravityOauth,
   onOpenMcpSettings,
   onBrowsePlugins,
@@ -853,10 +855,16 @@ export function ChatPane({
     }
     return null;
   })();
+  const terminalAuth =
+    failedRunErrorEvent?.auth?.kind === 'terminal-auth'
+      ? failedRunErrorEvent.auth
+      : null;
   // Per-case failure UI (button + copy + whether to promote AMR). Only
   // meaningful for a failed run (retryAssistant present).
   const runFailureUi = retryAssistant
-    ? resolveRunFailureUi(failedRunErrorEvent?.code, retryAssistant.agentId)
+    ? resolveRunFailureUi(failedRunErrorEvent?.code, retryAssistant.agentId, {
+        hasTerminalAuth: terminalAuth !== null,
+      })
     : null;
   // Offer Continue (resume) when the failed run is resumable AND the active
   // agent still matches the agent that produced it. The daemon stores a
@@ -2005,10 +2013,14 @@ export function ChatPane({
                               type="button"
                               className="chat-error-action"
                               onClick={() => {
-                                onLaunchAntigravityOauth?.();
+                                if (terminalAuth) {
+                                  void onLaunchTerminalAuth?.(terminalAuth);
+                                } else {
+                                  onLaunchAntigravityOauth?.();
+                                }
                               }}
                             >
-                              {t('chat.antigravityError.launchTerminalCta')}
+                              {terminalAuth?.label ?? t('chat.antigravityError.launchTerminalCta')}
                             </button>
                           ) : runFailureUi.primaryAction === 'launch-terminal-switch-model' ? (
                             <button

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -859,11 +859,12 @@ export function ChatPane({
     failedRunErrorEvent?.auth?.kind === 'terminal-auth'
       ? failedRunErrorEvent.auth
       : null;
+  const canLaunchTerminalAuth = terminalAuth !== null && Boolean(onLaunchTerminalAuth);
   // Per-case failure UI (button + copy + whether to promote AMR). Only
   // meaningful for a failed run (retryAssistant present).
   const runFailureUi = retryAssistant
     ? resolveRunFailureUi(failedRunErrorEvent?.code, retryAssistant.agentId, {
-        hasTerminalAuth: terminalAuth !== null,
+        hasTerminalAuth: canLaunchTerminalAuth,
       })
     : null;
   // Offer Continue (resume) when the failed run is resumable AND the active

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -61,7 +61,7 @@ import {
   type ProjectFile,
   type ProjectFolder,
 } from '../types';
-import type { ChatSessionMode, WorkspaceContextItem } from '@open-design/contracts';
+import type { AgentTerminalAuthMetadata, ChatSessionMode, WorkspaceContextItem } from '@open-design/contracts';
 import { createTerminal, killTerminal } from '../state/projects';
 import type { QuestionForm } from '../artifacts/question-form';
 import { DesignFilesPanel, type DesignFilesNavState } from './DesignFilesPanel';
@@ -192,7 +192,7 @@ interface Props {
   // preview surface can offer the same one-click fix (AMR authorize, terminal
   // sign-in) instead of a bare retry.
   onAuthorizeAndRetry?: (message: ChatMessage) => void;
-  onLaunchTerminalAuth?: () => void;
+  onLaunchTerminalAuth?: (auth: AgentTerminalAuthMetadata) => Promise<void>;
   // Conversation id for the AMR promotion-card telemetry payload.
   conversationId?: string | null;
   // Project-level actions (settings, handoff, avatar menu) rendered at the
@@ -423,6 +423,7 @@ export function FileWorkspace({
   onActiveContextChange,
   onWorkspaceContextsChange,
   messages = [],
+  onLaunchTerminalAuth,
   conversationId,
   headerActions,
   questionForm = null,
@@ -2219,6 +2220,7 @@ export function FileWorkspace({
             onNewConversation={onNewConversation}
             activeConversationChat={activeConversationChat}
             onRequestOpenFile={openFile}
+            onLaunchTerminalAuth={onLaunchTerminalAuth}
           />
         ) : isTerminalTabId(activeTab) ? (
           <TerminalViewer

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -192,7 +192,8 @@ interface Props {
   // preview surface can offer the same one-click fix (AMR authorize, terminal
   // sign-in) instead of a bare retry.
   onAuthorizeAndRetry?: (message: ChatMessage) => void;
-  onLaunchTerminalAuth?: (auth: AgentTerminalAuthMetadata) => Promise<void>;
+  onLaunchTerminalAuth?: () => void;
+  onLaunchAcpTerminalAuth?: (auth: AgentTerminalAuthMetadata) => Promise<void>;
   // Conversation id for the AMR promotion-card telemetry payload.
   conversationId?: string | null;
   // Project-level actions (settings, handoff, avatar menu) rendered at the
@@ -424,6 +425,7 @@ export function FileWorkspace({
   onWorkspaceContextsChange,
   messages = [],
   onLaunchTerminalAuth,
+  onLaunchAcpTerminalAuth,
   conversationId,
   headerActions,
   questionForm = null,
@@ -2220,7 +2222,7 @@ export function FileWorkspace({
             onNewConversation={onNewConversation}
             activeConversationChat={activeConversationChat}
             onRequestOpenFile={openFile}
-            onLaunchTerminalAuth={onLaunchTerminalAuth}
+            onLaunchTerminalAuth={onLaunchAcpTerminalAuth}
           />
         ) : isTerminalTabId(activeTab) ? (
           <TerminalViewer

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -56,6 +56,7 @@ import { useProjectFileEvents, type ProjectEvent } from '../providers/project-ev
 import { useCoalescedCallback } from '../hooks/useCoalescedCallback';
 import {
   composeSystemPrompt,
+  type AgentTerminalAuthMetadata,
   type AudioVoiceOption,
   type MemorySystemPromptResponse,
   type ResearchOptions,
@@ -98,7 +99,7 @@ import { playSound, showCompletionNotification } from '../utils/notifications';
 import { randomUUID } from '../utils/uuid';
 import { DEFAULT_NOTIFICATIONS } from '../state/config';
 import type { TodoItem } from '../runtime/todos';
-import { appendErrorStatusEvent } from '../runtime/chat-events';
+import { acpTerminalAuthFromErrorDetails, appendErrorStatusEvent } from '../runtime/chat-events';
 import { RESUME_CONTINUE_PROMPT } from '../runtime/resume';
 import {
   buildDesignSystemPackageAuditRepairPrompt,
@@ -2393,11 +2394,16 @@ export function ProjectView({
   // rides along on the error status event so AssistantMessage can render the
   // hosted-AMR nudge for model/auth/quota failures on non-AMR agents.
   const appendAssistantErrorEvent = useCallback(
-    (messageId: string, message: string, code?: string) => {
+    (
+      messageId: string,
+      message: string,
+      code?: string,
+      auth?: ReturnType<typeof acpTerminalAuthFromErrorDetails>,
+    ) => {
       if (!message) return;
       updateMessageById(
         messageId,
-        (prev) => appendErrorStatusEvent(prev, message, code),
+        (prev) => appendErrorStatusEvent(prev, message, code, auth),
         true,
       );
     },
@@ -2815,6 +2821,10 @@ export function ProjectView({
             },
             onError: (err) => {
               const errorCode = (err as Error & { code?: string }).code;
+              const auth = acpTerminalAuthFromErrorDetails(
+                (err as Error & { details?: unknown }).details,
+                message.agentId,
+              );
               const resumable = (err as Error & { resumable?: boolean }).resumable === true;
               // A superseded reattached run must not paint a global failure
               // banner or re-finalize its message over the replacement run.
@@ -2825,7 +2835,7 @@ export function ProjectView({
               unregisterTextBuffer();
               if (runMayFinalize) {
                 setError(err.message);
-                appendAssistantErrorEvent(message.id, err.message, errorCode);
+                appendAssistantErrorEvent(message.id, err.message, errorCode, auth);
                 updateMessageById(
                   message.id,
                   (prev) => ({
@@ -3550,6 +3560,10 @@ export function ProjectView({
         onError: (err: Error) => {
           const endedAt = Date.now();
           const errorCode = (err as Error & { code?: string }).code;
+          const auth = acpTerminalAuthFromErrorDetails(
+            (err as Error & { details?: unknown }).details,
+            config.agentId,
+          );
           const resumable = (err as Error & { resumable?: boolean }).resumable === true;
           // A run superseded by a "send now" interrupt can still surface a
           // late disconnect error (e.g. a canceled stream that lost its
@@ -3563,7 +3577,7 @@ export function ProjectView({
           cancelSendTextBuffer();
           if (runMayFinalize) {
             setError(err.message);
-            appendAssistantErrorEvent(assistantId, err.message, errorCode);
+            appendAssistantErrorEvent(assistantId, err.message, errorCode, auth);
             updateAssistant((prev) => ({
               ...prev,
               endedAt,
@@ -4057,6 +4071,18 @@ export function ProjectView({
       }
     } catch (err) {
       console.warn('[antigravity] oauth-launch threw:', err);
+    }
+  }, []);
+
+  const handleLaunchTerminalAuth = useCallback(async (auth: AgentTerminalAuthMetadata) => {
+    try {
+      const { launchAcpTerminalAuth } = await import('../providers/daemon');
+      const result = await launchAcpTerminalAuth(auth.agentId, auth.methodId);
+      if (!result.ok) {
+        console.warn('[acp] terminal-auth launch failed:', result.error);
+      }
+    } catch (err) {
+      console.warn('[acp] terminal-auth launch threw:', err);
     }
   }, []);
   // Poll the AMR login status while a retry is armed, rather than only reacting
@@ -5654,6 +5680,7 @@ export function ProjectView({
               }}
               onOpenAmrSettings={onOpenAmrSettings}
               onSwitchToAmrAndRetry={handleSwitchToAmrAndRetry}
+              onLaunchTerminalAuth={handleLaunchTerminalAuth}
               onLaunchAntigravityOauth={handleLaunchAntigravityOauth}
               onOpenMcpSettings={onOpenMcpSettings}
               onBrowsePlugins={onBrowsePlugins}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5854,7 +5854,7 @@ export function ProjectView({
           conversationError={error}
           onRetry={handleRetry}
           onAuthorizeAndRetry={handleSwitchToAmrAndRetry}
-          onLaunchTerminalAuth={handleLaunchAntigravityOauth}
+          onLaunchTerminalAuth={handleLaunchTerminalAuth}
           conversationId={activeConversationId}
           headerActions={(
             <>

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5854,7 +5854,8 @@ export function ProjectView({
           conversationError={error}
           onRetry={handleRetry}
           onAuthorizeAndRetry={handleSwitchToAmrAndRetry}
-          onLaunchTerminalAuth={handleLaunchTerminalAuth}
+          onLaunchTerminalAuth={handleLaunchAntigravityOauth}
+          onLaunchAcpTerminalAuth={handleLaunchTerminalAuth}
           conversationId={activeConversationId}
           headerActions={(
             <>

--- a/apps/web/src/components/workspace/SideChatTab.tsx
+++ b/apps/web/src/components/workspace/SideChatTab.tsx
@@ -11,7 +11,7 @@ import type {
   Conversation,
   ProjectFile,
 } from '../../types';
-import type { ChatSessionMode } from '@open-design/contracts';
+import type { AgentTerminalAuthMetadata, ChatSessionMode } from '@open-design/contracts';
 import type { ChatSendMeta } from '../ChatComposer';
 import { useConversationChat } from './useConversationChat';
 import styles from './SideChatTab.module.css';
@@ -83,6 +83,7 @@ interface Props {
   activeConversationChat?: ActiveConversationChatState;
   /** Forward produced-file / tool-card open requests to the workspace. */
   onRequestOpenFile?: (name: string) => void;
+  onLaunchTerminalAuth?: (auth: AgentTerminalAuthMetadata) => Promise<void>;
 }
 
 // A ChatPane mounted as a workspace tab, bound to a single (usually
@@ -105,6 +106,7 @@ export function SideChatTab({
   onNewConversation,
   activeConversationChat,
   onRequestOpenFile,
+  onLaunchTerminalAuth,
 }: Props) {
   const t = useT();
   const sessionMode =
@@ -152,6 +154,7 @@ export function SideChatTab({
           onStop={controlledChat?.onStop ?? chat.onStop}
           onAssistantFeedback={controlledChat?.onAssistantFeedback}
           onRequestOpenFile={onRequestOpenFile}
+          onLaunchTerminalAuth={onLaunchTerminalAuth}
           conversations={conversations}
           activeConversationId={conversationId}
           // Intentionally omit `messagesConversationId`: `useConversationChat`

--- a/apps/web/src/components/workspace/useConversationChat.ts
+++ b/apps/web/src/components/workspace/useConversationChat.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { streamViaDaemon } from '../../providers/daemon';
 import { listMessages, saveMessage } from '../../state/projects';
-import { appendErrorStatusEvent } from '../../runtime/chat-events';
+import { acpTerminalAuthFromErrorDetails, appendErrorStatusEvent } from '../../runtime/chat-events';
 import { agentModelDisplayName } from '../../utils/agentLabels';
 import { randomUUID } from '../../utils/uuid';
 import { effectiveAgentModelChoice } from '../agentModelSelection';
@@ -257,12 +257,16 @@ export function useConversationChat(
           textBuffer.flush();
           const endedAt = Date.now();
           const code = (err as Error & { code?: string }).code;
+          const auth = acpTerminalAuthFromErrorDetails(
+            (err as Error & { details?: unknown }).details,
+            cfg.agentId,
+          );
           const resumable = (err as Error & { resumable?: boolean }).resumable === true;
           setError(err.message);
           setMessages((curr) => {
             const next = curr.map((m) => {
               if (m.id !== assistantId) return m;
-              const withError = appendErrorStatusEvent(m, err.message, code);
+              const withError = appendErrorStatusEvent(m, err.message, code, auth);
               return {
                 ...withError,
                 endedAt,

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -688,6 +688,44 @@ export async function launchAntigravityOauth(): Promise<LaunchAntigravityOauthRe
   }
 }
 
+export interface LaunchAcpTerminalAuthResult {
+  ok: boolean;
+  platform?: string;
+  via?: string;
+  methodId?: string;
+  label?: string | null;
+  error?: string;
+}
+
+export async function launchAcpTerminalAuth(
+  agentId: string,
+  methodId: string,
+): Promise<LaunchAcpTerminalAuthResult> {
+  try {
+    const resp = await fetch(`/api/agents/${encodeURIComponent(agentId)}/acp-terminal-auth-launch`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ methodId }),
+    });
+    const body = (await resp.json().catch(() => null)) as
+      | LaunchAcpTerminalAuthResult
+      | null;
+    if (!resp.ok) {
+      return {
+        ok: false,
+        error:
+          body?.error ?? `daemon returned ${resp.status} ${resp.statusText}`,
+      };
+    }
+    return body ?? { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export interface VelaUser {
   id: string;
   email: string;

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -101,6 +101,7 @@ export interface RunFailureUi {
 export function resolveRunFailureUi(
   code: string | null | undefined,
   agentId: string | null | undefined,
+  options: { hasTerminalAuth?: boolean } = {},
 ): RunFailureUi {
   if (agentId === 'amr') {
     if (code === 'AMR_AUTH_REQUIRED') {
@@ -152,6 +153,14 @@ export function resolveRunFailureUi(
         showSwitchCard: false,
       };
     }
+  }
+  if (code === 'AGENT_AUTH_REQUIRED' && options.hasTerminalAuth) {
+    return {
+      primaryAction: 'launch-terminal-auth',
+      messageKey: null,
+      secondaryRetry: true,
+      showSwitchCard: false,
+    };
   }
   // Agent-neutral: a mid-response connection drop (any agent) gets a clear,
   // localized "lost connection — retry" message instead of the raw SDK string.

--- a/apps/web/src/runtime/chat-events.ts
+++ b/apps/web/src/runtime/chat-events.ts
@@ -1,9 +1,60 @@
+import type { AgentTerminalAuthMetadata } from '@open-design/contracts';
 import type { ChatMessage } from '../types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out = value.filter((item): item is string => typeof item === 'string');
+  return out.length > 0 ? out : undefined;
+}
+
+function stringMap(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === 'string') out[key] = raw;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function acpTerminalAuthFromErrorDetails(
+  details: unknown,
+  agentId: string | null | undefined,
+): AgentTerminalAuthMetadata | undefined {
+  if (!agentId || !isRecord(details) || details.kind !== 'acp_terminal_auth') {
+    return undefined;
+  }
+  const auth = isRecord(details.auth) ? details.auth : null;
+  const methodId = typeof auth?.methodId === 'string' && auth.methodId.trim()
+    ? auth.methodId.trim()
+    : '';
+  const command = typeof auth?.command === 'string' && auth.command.trim()
+    ? auth.command.trim()
+    : '';
+  if (!methodId || !command) return undefined;
+  const label =
+    typeof auth?.label === 'string' && auth.label.trim()
+      ? auth.label.trim()
+      : undefined;
+  return {
+    kind: 'terminal-auth',
+    agentId,
+    methodId,
+    command,
+    ...(label ? { label } : {}),
+    ...(stringArray(auth?.args) ? { args: stringArray(auth?.args) } : {}),
+    ...(stringMap(auth?.env) ? { env: stringMap(auth?.env) } : {}),
+  };
+}
 
 export function appendErrorStatusEvent(
   message: ChatMessage,
   detail: string,
   code?: string,
+  auth?: AgentTerminalAuthMetadata,
 ): ChatMessage {
   if (!detail) return message;
   const events = message.events ?? [];
@@ -14,8 +65,15 @@ export function appendErrorStatusEvent(
   if (!detail?.trim()) {
     return message;
   }
+  const event = {
+    kind: 'status' as const,
+    label: 'error',
+    detail,
+    ...(code ? { code } : {}),
+    ...(auth ? { auth } : {}),
+  };
   return {
     ...message,
-    events: [...events, { kind: 'status', label: 'error', detail, ...(code ? { code } : {}) }],
+    events: [...events, event],
   };
 }

--- a/apps/web/src/runtime/chat-events.ts
+++ b/apps/web/src/runtime/chat-events.ts
@@ -5,21 +5,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function stringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const out = value.filter((item): item is string => typeof item === 'string');
-  return out.length > 0 ? out : undefined;
-}
-
-function stringMap(value: unknown): Record<string, string> | undefined {
-  if (!isRecord(value)) return undefined;
-  const out: Record<string, string> = {};
-  for (const [key, raw] of Object.entries(value)) {
-    if (typeof raw === 'string') out[key] = raw;
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
-}
-
 export function acpTerminalAuthFromErrorDetails(
   details: unknown,
   agentId: string | null | undefined,
@@ -31,10 +16,7 @@ export function acpTerminalAuthFromErrorDetails(
   const methodId = typeof auth?.methodId === 'string' && auth.methodId.trim()
     ? auth.methodId.trim()
     : '';
-  const command = typeof auth?.command === 'string' && auth.command.trim()
-    ? auth.command.trim()
-    : '';
-  if (!methodId || !command) return undefined;
+  if (!methodId) return undefined;
   const label =
     typeof auth?.label === 'string' && auth.label.trim()
       ? auth.label.trim()
@@ -43,10 +25,7 @@ export function acpTerminalAuthFromErrorDetails(
     kind: 'terminal-auth',
     agentId,
     methodId,
-    command,
     ...(label ? { label } : {}),
-    ...(stringArray(auth?.args) ? { args: stringArray(auth?.args) } : {}),
-    ...(stringMap(auth?.env) ? { env: stringMap(auth?.env) } : {}),
   };
 }
 

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -736,15 +736,21 @@
   padding: 10px 12px;
   border-radius: var(--radius);
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex-wrap: wrap;
   gap: 10px;
 }
-.chat-error-text { min-width: 0; }
+.chat-error-text {
+  flex: 1 0 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 .chat-error-actions {
-  flex: 0 0 auto;
+  flex: 1 1 100%;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
 }
 .chat-error-copy {

--- a/apps/web/tests/components/workspace/SideChatTab.test.tsx
+++ b/apps/web/tests/components/workspace/SideChatTab.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SideChatTab } from '../../../src/components/workspace/SideChatTab';
+import type { AgentTerminalAuthMetadata } from '@open-design/contracts';
 import type { AppConfig, Conversation } from '../../../src/types';
 
 const chatPaneMock = vi.fn((_: unknown) => <div data-testid="chat-pane" />);
@@ -77,5 +78,52 @@ describe('SideChatTab', () => {
         config,
       }),
     );
+  });
+
+  it('forwards ACP terminal-auth launcher to ChatPane', () => {
+    const config = {
+      mode: 'daemon',
+    } as unknown as AppConfig;
+    const conversations = [
+      {
+        id: 'conv-1',
+        title: 'Current',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        projectId: 'project-1',
+        messageCount: 1,
+        sessionMode: 'design',
+      },
+    ] as unknown as Conversation[];
+    const onLaunchTerminalAuth = vi.fn(async () => {});
+    const auth: AgentTerminalAuthMetadata = {
+      kind: 'terminal-auth',
+      agentId: 'kimi',
+      methodId: 'login',
+      label: 'Login with Kimi account',
+    };
+
+    render(
+      <SideChatTab
+        projectId="project-1"
+        conversationId="conv-1"
+        config={config}
+        agentsById={new Map()}
+        locale="en"
+        projectFiles={[]}
+        conversations={conversations}
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        onLaunchTerminalAuth={onLaunchTerminalAuth}
+      />,
+    );
+
+    const props = chatPaneMock.mock.calls[0]?.[0] as {
+      onLaunchTerminalAuth?: (value: AgentTerminalAuthMetadata) => Promise<void>;
+    };
+    expect(props.onLaunchTerminalAuth).toBe(onLaunchTerminalAuth);
+
+    void props.onLaunchTerminalAuth?.(auth);
+    expect(onLaunchTerminalAuth).toHaveBeenCalledWith(auth);
   });
 });

--- a/apps/web/tests/runtime/amr-guidance.test.ts
+++ b/apps/web/tests/runtime/amr-guidance.test.ts
@@ -134,4 +134,20 @@ describe('resolveRunFailureUi', () => {
       expect(ui.primaryAction).not.toBe('launch-terminal-auth');
     }
   });
+
+  it('offers terminal auth for non-antigravity ACP failures only when metadata exists', () => {
+    const defaultUi = resolveRunFailureUi('AGENT_AUTH_REQUIRED', 'kimi');
+    expect(defaultUi.primaryAction).toBe('retry');
+    expect(defaultUi.showSwitchCard).toBe(true);
+
+    const terminalUi = resolveRunFailureUi('AGENT_AUTH_REQUIRED', 'kimi', {
+      hasTerminalAuth: true,
+    });
+    expect(terminalUi).toMatchObject({
+      primaryAction: 'launch-terminal-auth',
+      messageKey: null,
+      secondaryRetry: true,
+      showSwitchCard: false,
+    });
+  });
 });

--- a/apps/web/tests/runtime/chat-events.test.ts
+++ b/apps/web/tests/runtime/chat-events.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../src/runtime/chat-events';
 
 describe('acpTerminalAuthFromErrorDetails', () => {
-  it('normalizes ACP terminal-auth details for persisted chat events', () => {
+  it('normalizes ACP terminal-auth details without exposing launch internals', () => {
     const auth = acpTerminalAuthFromErrorDetails(
       {
         kind: 'acp_terminal_auth',
@@ -26,9 +26,6 @@ describe('acpTerminalAuthFromErrorDetails', () => {
       agentId: 'kimi',
       methodId: 'login',
       label: 'Login with Kimi account',
-      command: '/Users/test/.kimi-code/bin/kimi',
-      args: ['login'],
-      env: { KIMI_HOME: '/Users/test/.kimi-code' },
     });
   });
 
@@ -57,8 +54,7 @@ describe('appendErrorStatusEvent', () => {
         kind: 'terminal-auth',
         agentId: 'kimi',
         methodId: 'login',
-        command: '/Users/test/.kimi-code/bin/kimi',
-        args: ['login'],
+        label: 'Login with Kimi account',
       },
     );
 
@@ -72,8 +68,7 @@ describe('appendErrorStatusEvent', () => {
           kind: 'terminal-auth',
           agentId: 'kimi',
           methodId: 'login',
-          command: '/Users/test/.kimi-code/bin/kimi',
-          args: ['login'],
+          label: 'Login with Kimi account',
         },
       },
     ]);

--- a/apps/web/tests/runtime/chat-events.test.ts
+++ b/apps/web/tests/runtime/chat-events.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  acpTerminalAuthFromErrorDetails,
+  appendErrorStatusEvent,
+} from '../../src/runtime/chat-events';
+
+describe('acpTerminalAuthFromErrorDetails', () => {
+  it('normalizes ACP terminal-auth details for persisted chat events', () => {
+    const auth = acpTerminalAuthFromErrorDetails(
+      {
+        kind: 'acp_terminal_auth',
+        auth: {
+          methodId: 'login',
+          label: 'Login with Kimi account',
+          command: '/Users/test/.kimi-code/bin/kimi',
+          args: ['login'],
+          env: { KIMI_HOME: '/Users/test/.kimi-code' },
+        },
+      },
+      'kimi',
+    );
+
+    expect(auth).toEqual({
+      kind: 'terminal-auth',
+      agentId: 'kimi',
+      methodId: 'login',
+      label: 'Login with Kimi account',
+      command: '/Users/test/.kimi-code/bin/kimi',
+      args: ['login'],
+      env: { KIMI_HOME: '/Users/test/.kimi-code' },
+    });
+  });
+
+  it('drops malformed terminal-auth details', () => {
+    expect(acpTerminalAuthFromErrorDetails({ kind: 'acp_terminal_auth' }, 'kimi')).toBeUndefined();
+    expect(acpTerminalAuthFromErrorDetails({
+      kind: 'acp_terminal_auth',
+      auth: { methodId: 'login', command: 'kimi' },
+    }, null)).toBeUndefined();
+  });
+});
+
+describe('appendErrorStatusEvent', () => {
+  it('persists terminal-auth metadata on error status events', () => {
+    const message = appendErrorStatusEvent(
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: '',
+        startedAt: 1,
+        events: [],
+      },
+      'Agent authentication requires a terminal sign-in.',
+      'AGENT_AUTH_REQUIRED',
+      {
+        kind: 'terminal-auth',
+        agentId: 'kimi',
+        methodId: 'login',
+        command: '/Users/test/.kimi-code/bin/kimi',
+        args: ['login'],
+      },
+    );
+
+    expect(message.events).toEqual([
+      {
+        kind: 'status',
+        label: 'error',
+        detail: 'Agent authentication requires a terminal sign-in.',
+        code: 'AGENT_AUTH_REQUIRED',
+        auth: {
+          kind: 'terminal-auth',
+          agentId: 'kimi',
+          methodId: 'login',
+          command: '/Users/test/.kimi-code/bin/kimi',
+          args: ['login'],
+        },
+      },
+    ]);
+  });
+});

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -281,6 +281,16 @@ export interface ChatRunCancelResponse {
   ok: true;
 }
 
+export interface AgentTerminalAuthMetadata {
+  kind: 'terminal-auth';
+  agentId: string;
+  methodId: string;
+  label?: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
 export interface ChatAttachment {
   path: string;
   name: string;
@@ -324,7 +334,7 @@ export type PersistedAgentEvent =
   // `code` carries the structured API error code for `label: 'error'`
   // status events (e.g. AGENT_AUTH_REQUIRED, RATE_LIMITED). Clients use it to
   // decide error-specific affordances such as the hosted-AMR nudge.
-  | { kind: 'status'; label: string; detail?: string; code?: string }
+  | { kind: 'status'; label: string; detail?: string; code?: string; auth?: AgentTerminalAuthMetadata }
   | { kind: 'text'; text: string }
   | { kind: 'thinking'; text: string }
   | {

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -286,9 +286,6 @@ export interface AgentTerminalAuthMetadata {
   agentId: string;
   methodId: string;
   label?: string;
-  command: string;
-  args?: string[];
-  env?: Record<string, string>;
 }
 
 export interface ChatAttachment {

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -926,6 +926,7 @@ export function wellKnownUserToolchainBins(
   dirs.push(
     join(home, ".local", "bin"),
     join(home, ".vite-plus", "bin"),
+    join(home, ".kimi-code", "bin"),
     join(home, ".opencode", "bin"),
     join(home, ".bun", "bin"),
     join(home, ".volta", "bin"),

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -724,6 +724,7 @@ describe("wellKnownUserToolchainBins", () => {
     try {
       const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
       expect(dirs).toContain(join(home, ".local", "bin"));
+      expect(dirs).toContain(join(home, ".kimi-code", "bin"));
       expect(dirs).toContain(join(home, ".opencode", "bin"));
       expect(dirs).toContain(join(home, ".bun", "bin"));
       expect(dirs).toContain(join(home, ".volta", "bin"));


### PR DESCRIPTION
## Why

Fixes #4192.

Kimi and other ACP agents can be logged in at the CLI level while still requiring the ACP client to advertise terminal-auth support and launch the ACP-provided terminal sign-in method. Open Design was initializing ACP with `terminal: false`, then flattening the upstream auth failure into a generic execution error. Users saw a dead-end failure instead of a direct sign-in path.

Root cause: the daemon did not opt into ACP terminal auth capabilities, did not preserve ACP terminal-auth metadata across streaming and persisted chat events, and the chat recovery card only knew about the existing Antigravity auth path.

## What changed

- Advertise ACP terminal auth support during initialize and detect ACP terminal-auth methods before session creation.
- Promote ACP auth failures to `AGENT_AUTH_REQUIRED` with structured terminal-auth launch metadata.
- Add a loopback-only daemon endpoint that re-probes the configured ACP agent and launches the server-verified terminal auth command.
- Wire web chat errors, persisted message events, and reloaded conversation history to show the provider-specific action, e.g. `Login with Kimi account`, plus Retry.
- Keep non-terminal-auth Kimi failures on the existing retry/AMR behavior.
- Add Kimi updated `~/.kimi-code/bin` location to the well-known toolchain path search.
- Fix the chat error-card layout so the recovery text cannot collapse into a one-character column when actions are present.

## What users will see

When an ACP agent such as Kimi reports terminal auth is required, the chat failure card says to complete terminal sign-in and shows a provider-specific CTA (`Login with Kimi account`) next to Retry. Clicking the CTA opens the terminal auth flow provided by the ACP agent; after completing it, the user can retry the same chat turn.

## Surface area

- [x] **UI** — new recovery CTA/error-card behavior in `apps/web` primary chat, side chat/workspace chat, persisted/reloaded error cards, and recovery-card layout.
- [ ] **Keyboard shortcut** — no new or changed shortcuts.
- [ ] **CLI / env var** — no new `od` subcommand, flag, tools flag, or `OD_*` env var; Kimi well-known bin discovery and ACP launcher re-probe stay server-side.
- [x] **API / contract** — ACP initialize terminal capability, terminal-auth detection/error promotion, loopback launch endpoint, persisted run-event normalization, and minimal browser-safe chat terminal-auth metadata shape in `packages/contracts`.
- [ ] **Extension point** — no entries or protocol changes under `skills/`, `design-systems/`, `design-templates/`, or `craft/`.
- [ ] **i18n keys** — no new translation keys; existing recovery copy/labels are reused or supplied by ACP metadata.
- [ ] **New top-level dependency** — no root `package.json` dependency changes.
- [x] **Default behavior change** — ACP agents that advertise terminal auth now show the provider-specific terminal sign-in action instead of generic retry/AMR recovery.
- [ ] **None** — this PR touches UI, API/contract, and default auth-recovery behavior.

## Screenshots

Browser smoke at `http://127.0.0.1:17657/projects/kimi-acp-auth-chat-1781230805/conversations/f6119538-8b31-4312-b2dc-b73862a4c742` verified the recovery card entry point in chat: one `Login with Kimi account` button, one `Retry` button, no AMR switch card, no browser console errors after clicking the terminal-auth CTA, and fixed error-card text wrapping.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/acp.test.ts`, `apps/daemon/tests/run-event-persistence.test.ts`, `apps/web/tests/runtime/chat-events.test.ts`, `apps/web/tests/components/workspace/SideChatTab.test.tsx`, and `apps/web/tests/components/ProjectView.run-isolation.test.tsx`.
- Did the test go red on `main` and green on this branch? The regression tests encode the previously missing ACP terminal-auth invariants and pass on this branch; the UI symptom was also verified in the running Browser smoke path.
- Before: ACP terminal-auth failures were flattened into generic retry behavior, browser-visible persisted chat metadata could include upstream launch `command`, `args`, and `env`, the daemon re-probe only considered the first advertised terminal-auth method, and secondary chat mounts could miss the actionable ACP auth CTA.
- After: persisted/chat metadata is limited to `agentId`, `methodId`, and optional `label`; the launch endpoint re-probes the ACP server and selects the requested terminal-auth method from the full advertised method list; primary chat, side chat, and workspace chat all receive actionable terminal-auth recovery.

## Validation

- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts tests/run-event-persistence.test.ts tests/runtimes/terminal-launch.test.ts -t 'terminal-auth|run event persistence|structured command'`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/runtime/amr-guidance.test.ts tests/runtime/chat-events.test.ts`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/workspace/SideChatTab.test.tsx tests/runtime/amr-guidance.test.ts`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ProjectView.run-isolation.test.tsx -t 'terminal launch recovery'`
- `pnpm --filter @open-design/web test`
- `pnpm --filter @open-design/platform test -- tests/index.test.ts -t wellKnownUserToolchainBins`
- `pnpm guard`
- `git diff --check`

## Adjacent issues

The Browser smoke clicked the terminal-auth CTA and verified the web-to-daemon launch path had no browser-side errors, but completing the interactive Kimi login remains a user action in Terminal.
