### PR TITLE
fix(daemon): keep Claude tool-use usage non-terminal (#4198) [v0.10.1]

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4510,6 +4510,7 @@ export function classifyChatRunCloseStatus(params: {
 
 type ClaudeStreamJsonBookkeepingRun = {
   stdinOpen?: boolean;
+  pendingHostAnswers?: Set<string>;
   turnCompletedCleanly?: boolean;
   child?: {
     stdin?: {
@@ -4531,18 +4532,34 @@ export function applyClaudeStreamJsonRunBookkeeping(
   if (!ev || typeof ev !== 'object') return;
   const event = ev as {
     type?: unknown;
+    name?: unknown;
+    id?: unknown;
     stopReason?: unknown;
   };
 
+  if (
+    run.stdinOpen &&
+    event.type === 'tool_use' &&
+    (event.name === 'AskUserQuestion' || event.name === 'ask_user_question') &&
+    typeof event.id === 'string'
+  ) {
+    if (!run.pendingHostAnswers) run.pendingHostAnswers = new Set();
+    run.pendingHostAnswers.add(event.id);
+    return;
+  }
+
   const cleanTerminalTurn =
-    // `stop_reason: tool_use` means the model paused to wait for tool
-    // execution (claude-code is about to run an internal tool). The
-    // conversation is still in flight, so don't close stdin yet.
-    (event.type === 'turn_end' && event.stopReason !== 'tool_use') ||
-    event.type === 'usage';
+    ((event.type === 'turn_end' &&
+      // `stop_reason: tool_use` means the model paused to wait for tool
+      // execution (claude-code is about to run an internal tool, or we owe a
+      // host tool_result). Either way the conversation is still in flight.
+      event.stopReason !== 'tool_use') ||
+      (event.type === 'usage' && event.stopReason !== 'tool_use')) &&
+    (!run.pendingHostAnswers || run.pendingHostAnswers.size === 0);
   if (!cleanTerminalTurn) return;
 
-  // Record clean completion so the close-status classifier ignores late
+  // Record clean completion even if stdin was already closed by the
+  // host-answer path. The close-status classifier reads this to ignore late
   // SessionEnd hook failures after the final assistant turn completed.
   run.turnCompletedCleanly = true;
   if (run.stdinOpen) {

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -547,4 +547,28 @@ describe('applyClaudeStreamJsonRunBookkeeping', () => {
     expect(run.stdinOpen).toBe(true);
     expect(run.child.stdin.end).not.toHaveBeenCalled();
   });
+
+  it('keeps stdin open when usage reports a tool_use stop reason', () => {
+    const run = {
+      stdinOpen: true,
+      pendingHostAnswers: new Set<string>(),
+      turnCompletedCleanly: false,
+      child: {
+        stdin: {
+          destroyed: false,
+          end: vi.fn(),
+        },
+      },
+    };
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'usage',
+      usage: { input_tokens: 6, output_tokens: 40831 },
+      stopReason: 'tool_use',
+    });
+
+    expect(run.turnCompletedCleanly).toBe(false);
+    expect(run.stdinOpen).toBe(true);
+    expect(run.child.stdin.end).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Cherry-pick of #4198 (`737447cb9`) onto `release/v0.10.1`. Tracked for the 0.10.1 patch via the release PR `release/v0.10.1 → main`.