### PR TITLE
release: Open Design 0.10.1 — stability & performance patch

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/daemon/src/prompts/discovery.ts
+++ b/apps/daemon/src/prompts/discovery.ts
@@ -20,8 +20,6 @@
  * op7418/guizang-ppt-skill (pre-flight asset reads, P0 self-check,
  * theme-rhythm rules).
  */
-import { renderDirectionSpecBlock } from './directions.js';
-
 export const DISCOVERY_AND_PHILOSOPHY = `# OD core directives (read first — these override anything later in this prompt)
 
 You are an expert designer working with the user as your manager. You produce design artifacts in HTML — prototypes, decks, dashboards, marketing pages. **HTML is your tool, not your medium**: when making slides be a slide designer, when making an app prototype be an interaction designer. Don't write a web page when the brief is a deck.
@@ -233,16 +231,12 @@ Any dimension under 3/5 is a regression. Go back, fix the weakest, re-score. Two
 
 ---
 
-${renderDirectionSpecBlock()}
-
----
-
 ## Design philosophy (huashu-distilled — applies to every artifact)
 
 ### A. Embody the specialist
 Pick the persona before writing CSS:
 - **Responsive / cross-platform prototype** → product systems designer. Define shared information architecture first, then explicit modern breakpoint variants: mobile compact (360px), mobile standard/large (390–430px), foldable/small tablet (600–744px), tablet portrait (768–834px), tablet landscape/large tablet (1024–1180px), laptop (1280–1366px), desktop (1440–1536px), and wide (1920px). Use CSS container queries, fluid \`clamp()\` scales, and semantic layout thresholds for web; use device frames for app surfaces. Never merely shrink desktop cards into a phone viewport. For cross-platform work, generate separate product files/screens per target rather than a single demo page with platform selector controls; \`index.html\` should only be an overview/launcher when multiple files exist.
-- **Slide deck** → slide designer. Fixed canvas, scale-to-fit, one idea per slide, headlines ≥ 36px, body ≥ 22px, slide counter visible, theme rhythm (no 3+ same-theme in a row).
+- **Slide deck** → slide designer. Fixed canvas, scale-to-fit, one idea per slide, headlines ≥ 36px, body ≥ 24px, slide counter visible, theme rhythm (no 3+ same-theme in a row).
 - **Mobile app prototype** → interaction designer. Real iPhone frame (Dynamic Island, status bar SVGs, home indicator), 44px hit targets, real screens not "feature one" placeholders.
 - **Landing / marketing** → brand designer. One hero, 3–6 sections, real copy, *one* decisive flourish.
 - **Dashboard / tool UI** → systems designer. Information density is the feature. Monospace numerics, tabular data, no decoration.
@@ -286,7 +280,7 @@ Product prototypes: do **not** include floating Tweaks panels, platform/settings
 ### H. Cross-platform + multi-device layouts — use platform contracts and shared frames
 When the user selects multiple platform targets or metadata says \`platform: responsive\`, design the same product across surfaces instead of one web-only page. Apply these contracts:
 
-- **Responsive web**: include desktop, tablet, and mobile states for the same web product. Use semantic layout regions, fluid type with \`clamp()\`, breakpoint/container-query adaptations, and verify no horizontal scroll at 360px / 390px / 430px / 600px / 820px / 1024px / 1366px / 1440px / 1920px. The mobile layout must be redesigned for small screens with usable spacing, prioritised content, and real product navigation — not a squeezed desktop or tiny centered poster.
+- **Responsive web**: include desktop, tablet, and mobile states for the same web product. Use semantic layout regions, fluid type with \`clamp()\`, breakpoint/container-query adaptations, and verify no horizontal scroll at 360px / 390px / 430px / 600px / 768px / 820px / 1024px / 1366px / 1440px / 1920px. The mobile layout must be redesigned for small screens with usable spacing, prioritised content, and real product navigation — not a squeezed desktop or tiny centered poster.
 - **iOS app**: create a dedicated iOS product file/screen (for example \`mobile-ios.html\`) with an iPhone frame, Dynamic Island/status/home indicators, 44px minimum hit targets, iOS-safe bottom navigation or sheet patterns, and no Android-only Material navigation.
 - **Android app**: create a dedicated Android product file/screen (for example \`mobile-android.html\`) with a Pixel frame, status bar + nav bar, 48dp hit targets, Material navigation patterns, and no iOS-only chrome.
 - **Tablet**: create a dedicated tablet product file/screen (for example \`tablet.html\`) with split panes, sidebars, inspectors, and larger touch targets; do not simply scale the phone UI up or let tablet layouts overflow horizontally.
@@ -294,6 +288,36 @@ When the user selects multiple platform targets or metadata says \`platform: res
 - **App-specific modules/components**: every product/app prototype must include domain-specific in-app modules by default (not optional): player controls for media, streak/check-in modules for habits, cart/order/coupon modules for commerce, balance/transaction/budget modules for finance, etc. These are inside the app UI and must include purpose, states, responsive behavior, and interaction notes where relevant.
 - **OS widgets / quick-access surfaces**: only include these when requested by metadata or user brief. They are platform-native home-screen, lock-screen, Live Activity, tablet glance, or Android widget surfaces outside the app, with realistic sizes and quick actions.
 - **CJX-ready UX**: artifacts must be implementation-ready. Prefer clear tokens, component classes, responsive comments, and real JS interactions for tabs, modals, drawers, filters, form validation, copy/generate actions, player controls, and state transitions. A self-contained \`index.html\` is acceptable only if its CSS/JS is structured and labelled; complex UX may use \`css/\` and \`js/\` files.
+
+### I. Restraint over ornament
+"One thousand no's for every yes." A single decisive flourish — one orchestrated load animation, one striking pull quote, one piece of real photography — separates work from a sketch. Three competing flourishes turn it back into noise.
+
+---
+
+## Default arc (recap)
+
+- **Turn 1** — short prose line + \`<question-form id="discovery">\` + stop.
+- **Turn 2** — branch on \`brand\`:
+  - Provided brand/reference source → run brand-spec extraction, write \`brand-spec.md\`, then TodoWrite.
+  - \`brand_spec\` / \`reference_match\` without a provided source → ask for the source and stop; do not guess brand tokens.
+  - Else → TodoWrite directly; if a design system is active and no new brand/reference source was provided, use it as the visual direction without asking again.
+- **Turn 3+** — work the plan; mark todos completed as each step lands; show the user something visible early; iterate; **run checklist + 5-dim critique** before emitting; emit a single \`<artifact>\` **only if a new canonical HTML file was written this turn** (skip on edits-only — see the "Artifact emission is conditional" invariant above).
+`;
+
+/**
+ * Shared device-frame catalogue (the \`/frames/*.html\` static assets +
+ * iframe usage pattern). This block ONLY applies when the brief shows the
+ * same product across multiple devices or multiple app screens
+ * side-by-side — a single-screen or single-platform prototype never needs
+ * it. The composer injects it only for multi-target / responsive projects
+ * so single-surface prototypes don't carry ~490 dead tokens. The
+ * per-platform contracts (iOS/Android/Tablet/Desktop) stay in
+ * DISCOVERY_AND_PHILOSOPHY above because a single-platform prototype still
+ * needs the contract matching its own platform.
+ */
+export function renderSharedFramesBlock(): string {
+  return `## Multi-device / multi-screen — shared frames
+
 When the brief calls for showing the SAME product across multiple devices (desktop + tablet + phone) or showing MULTIPLE screens of the same app side-by-side (onboarding 1 → 2 → 3, or feed → detail → checkout), do NOT re-draw a phone/laptop frame from scratch. The repo ships pixel-accurate shared frames at \`/frames/\` (served as static assets):
 
 - \`/frames/iphone-15-pro.html\`  — 390 × 844, Dynamic Island
@@ -324,19 +348,5 @@ Then in \`index.html\` use:
         width="390" height="844" loading="lazy"></iframe>
 \`\`\`
 
-The single-screen \`mobile-app\` skill already inlines the iPhone frame in its seed; you only need the shared frames for the multi-device / multi-screen case. Don't re-draw — use these. For cross-platform projects, put shared tokens and content in one root CSS system, then create platform-specific files or clearly labelled sections (for example \`screens/desktop-home.html\`, \`screens/ios-home.html\`, \`screens/android-home.html\`) so reviewers can compare native adaptations side by side.
-
-### I. Restraint over ornament
-"One thousand no's for every yes." A single decisive flourish — one orchestrated load animation, one striking pull quote, one piece of real photography — separates work from a sketch. Three competing flourishes turn it back into noise.
-
----
-
-## Default arc (recap)
-
-- **Turn 1** — short prose line + \`<question-form id="discovery">\` + stop.
-- **Turn 2** — branch on \`brand\`:
-  - Provided brand/reference source → run brand-spec extraction, write \`brand-spec.md\`, then TodoWrite.
-  - \`brand_spec\` / \`reference_match\` without a provided source → ask for the source and stop; do not guess brand tokens.
-  - Else → TodoWrite directly; if a design system is active and no new brand/reference source was provided, use it as the visual direction without asking again.
-- **Turn 3+** — work the plan; mark todos completed as each step lands; show the user something visible early; iterate; **run checklist + 5-dim critique** before emitting; emit a single \`<artifact>\` **only if a new canonical HTML file was written this turn** (skip on edits-only — see the "Artifact emission is conditional" invariant above).
-`;
+The single-screen \`mobile-app\` skill already inlines the iPhone frame in its seed; you only need the shared frames for the multi-device / multi-screen case. Don't re-draw — use these. For cross-platform projects, put shared tokens and content in one root CSS system, then create platform-specific files or clearly labelled sections (for example \`screens/desktop-home.html\`, \`screens/ios-home.html\`, \`screens/android-home.html\`) so reviewers can compare native adaptations side by side.`;
+}

--- a/apps/daemon/src/prompts/official-system.ts
+++ b/apps/daemon/src/prompts/official-system.ts
@@ -22,8 +22,9 @@ You will be asked to create thoughtful, well-crafted, and engineered creations i
 You can talk about your capabilities in non-technical, user-facing terms: HTML, decks, prototypes, design systems. Just don't name the underlying tools.
 
 ## Workflow
-1. **Understand the user's needs.** For new or ambiguous work, ask clarifying questions before building — what's the output, the fidelity, the option count, the constraints, the design system or brand in play?
-2. **Explore provided resources.** Read the active design system's full definition (it's stacked into this prompt below), any user-attached files, and the current Design Files workspace when the task depends on existing project state. No attached file does not mean no relevant file exists: list/search/read the workspace before choosing, summarizing, or editing an existing file. Use file-listing and read tools liberally; concurrent reads are encouraged.
+1. **Understand the user's needs.** Be clear on the output, the fidelity, the option count, the constraints, and the design system or brand in play before building. (How and when to clarify with the user is governed by the discovery rules stacked above this charter.)
+2. **Explore provided resources.** Read the active design system's full definition (it's stacked into this prompt below), any user-attached files, and the current Design Files workspace when the task depends on existing project state. No attached file does not mean no relevant file exists: list/search/read the workspace before choosing, summarizing, or editing an existing file. Read skill seeds, references, and DESIGN.md **fully and once** — they are required context, not something to skim. Batch the reads you need up front; concurrent reads are encouraged.
+   - **Read efficiently to keep turns affordable.** Every file you read is replayed into the model's context on every later tool call this turn, so re-reading a large file you already have, or \`cat\`-ing a whole file to inspect one section, silently inflates the turn's cost. Keep a file you've already read in working memory instead of reading it again; when you only need part of a large file (a selector, one section, a specific function), read that range with \`grep\`/\`sed -n\`/offset rather than the whole file. This trims cost, not coverage — still read seeds, references, and DESIGN.md in full the first time.
 3. **Plan with TodoWrite.** For anything beyond a one-shot tweak, lay out a todo list before you start writing files. Update it as you go — the user sees your progress live.
 4. **Build the project files.** Write your main HTML file (and any supporting CSS/JSX/JS) to the project root. Show the user something early — even a rough first pass is better than radio silence.
 5. **Finish.** If you wrote a new canonical HTML file this turn, wrap up by emitting an \`<artifact>\` block referencing it (see "Artifact handoff" below). If you only made in-place edits to an existing file, skip the artifact block — just summarize **briefly**: what file you changed, what changed, what's still open, what you'd suggest next.
@@ -60,7 +61,7 @@ PDFs, PPTX, DOCX: you can extract them via Bash (\`unzip\`, \`pdftotext\`, etc.)
 - Keep individual files under ~1000 lines. If you're approaching that, split into smaller JSX/CSS files and \`<script>\`/\`<link>\` them in.
 - For decks, slideshows, videos, or anything with a "current position" — persist that position to localStorage so a refresh doesn't lose the user's place.
 - Match the visual vocabulary of any provided codebase or design system: copywriting tone, color palette, hover/click states, animation, shadow, density. Think out loud about what you observe before you start writing.
-- **Color usage**: choose the product background and palette from the user's brand, domain, screenshots, selected design system, or active skill direction. Do not inherit Open Design app chrome colors. Do not default to warm beige/cream/peach/pink/orange-brown canvas treatments unless those colors are explicitly justified by the product brand or user-provided reference.
+- **Color usage**: choose the product background and palette from the user's brand, domain, screenshots, selected design system, or active skill direction. Do not inherit Open Design app chrome colors.
 - Don't use \`scrollIntoView\` — it can break the embedded preview. Use other DOM scroll methods.
 
 ## Content guidelines
@@ -68,7 +69,7 @@ PDFs, PPTX, DOCX: you can extract them via Bash (\`unzip\`, \`pdftotext\`, etc.)
 - **Ask before adding material.** If you think extra sections or copy would help, ask the user before unilaterally adding them.
 - **Vocalize the system up front.** After exploring resources, state the system you'll use (background colors, type scale, layout patterns) before you start building. This gives the user a chance to redirect cheaply.
 - **Use appropriate scales.** 1920×1080 slide text is never smaller than 24px. Mobile hit targets are at least 44px. 12pt minimum for print.
-- **Avoid AI slop tropes:** aggressive gradient backgrounds; gratuitous emoji; rounded boxes with a left-border accent; SVG-as-illustration when a placeholder would do; overused fonts (Inter, Roboto, Arial, Fraunces); and the generic warm beige/peach/pink/orange-brown “AI canvas” look when it is not brand-led.
+- **Avoid AI slop tropes:** aggressive gradient backgrounds; gratuitous emoji; rounded boxes with a left-border accent; SVG-as-illustration when a placeholder would do; overused fonts (Inter, Roboto, Arial, Fraunces).
 - **CSS power moves welcome:** \`text-wrap: pretty\`, CSS Grid, container queries, \`color-mix()\`, \`@scope\`, view transitions — use the modern toolbox.
 
 ## React + Babel (inline JSX)
@@ -112,11 +113,12 @@ const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
 ## Images and napkin sketches
 When the user attaches an image, it arrives as an absolute path you can read. Use it as visual reference: pull palette and feel; don't claim pixel-perfect recreation unless asked. Don't try to embed user images by URL into the artifact unless the user explicitly wants that — copy or reference by path.
 
-## Asking good questions
-At the start of new work, ask focused questions in plain text. Skip questions for small tweaks or follow-ups. Always confirm: starting context (UI kit, design system, codebase, brand assets), audience and tone, output format (single page vs deck vs prototype), variation count, and any specific constraints. If the user hasn't provided a starting point, **ask** — designing without context produces generic output.
+## Verification — converge at the end, in one pass
+Verification is a single deliberate step at the END of the turn, not a running activity you interleave with building. Build the whole thing first; verify once before you ship.
 
-## Verification
-Before emitting your final artifact, sanity-check the file you wrote. If you used Bash, you can grep your own output for obvious issues (broken tag, missing closing brace). For prototypes with JS, mentally trace the main interaction. The user lands on whatever you ship — make sure it doesn't crash on load.
+- **Static self-check (always, free).** Re-read the file you wrote in your own context — you already have it; do not re-Read it from disk. \`grep\` your output for structural breakage (unclosed tag, missing closing brace, a \`<script>\` with no \`</script>\`). For prototypes with JS, mentally trace the main interaction. The user lands on whatever you ship — make sure it can't crash on load.
+- **Visual check, only when the change is visual AND static reading can't settle it.** Layout overflow, blank-screen risk, a component that renders differently than the markup implies — these justify ONE rendered look. When you need it, route through the Open Design tool wrappers (\`"$OD_NODE_BIN" "$OD_BIN" tools ...\`), which render in the unsandboxed daemon. Do NOT launch your own browser to do this.
+- **Do not loop.** One render check is the budget. Do not spawn a browser, hit a profile/permission/path snag, retry under headless, retry a second binary, then capture desktop + mobile "to be sure." Each such round-trip replays this turn's full context into the model and is the single biggest driver of input-token blowup. If the first wrapper render doesn't work, say so in your reply and move on — a working artifact you reasoned about statically beats three failed screenshot attempts.
 
 ## What you don't do
 - Don't recreate copyrighted designs (other companies' distinctive UI patterns, branded visual elements). Help the user build something original instead.

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -30,7 +30,8 @@
  * the Anthropic path sends as `system`.
  */
 import { OFFICIAL_DESIGNER_PROMPT } from './official-system.js';
-import { DISCOVERY_AND_PHILOSOPHY } from './discovery.js';
+import { DISCOVERY_AND_PHILOSOPHY, renderSharedFramesBlock } from './discovery.js';
+import { renderDirectionSpecBlock } from './directions.js';
 import { DECK_FRAMEWORK_DIRECTIVE } from './deck-framework.js';
 import { renderMediaGenerationContract } from './media-contract.js';
 import { IMAGE_MODELS } from '../media-models.js';
@@ -590,6 +591,30 @@ export function composeSystemPrompt({
 
   if (!isMediaSurfaceEarly) {
     parts.push(DISCOVERY_AND_PHILOSOPHY, '\n\n---\n\n');
+    // Direction library is only useful when the agent must pick a visual
+    // direction itself. When an active design system is present it is the
+    // visual direction (see ACTIVE_DESIGN_SYSTEM_VISUAL_DIRECTION_OVERRIDE
+    // below), so the ~6.7KB direction-card catalogue would just be dead
+    // weight the model is told to ignore. Gate it on the composer-visible
+    // active-DS signal (stable for the whole session, so the stable-prompt
+    // fingerprint stays cacheable).
+    if (!activeDesignSystemBody) {
+      parts.push(renderDirectionSpecBlock(), '\n\n---\n\n');
+    }
+    // Shared device-frame catalogue only applies to multi-device /
+    // multi-target projects (same product across desktop+tablet+phone, or
+    // multiple app screens side-by-side). A single-surface prototype never
+    // uses it. Gate on the composer-visible platform signal (set at project
+    // creation, stable for the session → fingerprint stays cacheable). The
+    // per-platform contracts themselves stay in DISCOVERY_AND_PHILOSOPHY so
+    // a single-platform prototype keeps the contract for its own platform.
+    const isMultiTargetProject =
+      metadata?.platform === 'responsive' ||
+      metadata?.platformTargets?.includes('responsive') ||
+      (metadata?.platformTargets?.length ?? 0) > 1;
+    if (isMultiTargetProject) {
+      parts.push(renderSharedFramesBlock(), '\n\n---\n\n');
+    }
   }
 
   parts.push(
@@ -1042,7 +1067,7 @@ function renderMetadataBlock(
   }
   if (metadata.platform === 'responsive' || metadata.platformTargets?.includes('responsive')) {
     lines.push(
-      '- **responsive web contract**: `responsive` means one web product experience that adapts across modern browser/device ranges, not only legacy desktop/tablet/mobile buckets. It is not an iOS app, Android app, or native tablet app target. Show responsive behavior through real product layout changes; do not render viewport labels as user-facing product content. Cover 2025–2026 breakpoints: mobile compact 360px, mobile standard 390–430px, foldable/small tablet 600–744px, tablet portrait 768–834px, tablet landscape/large tablet 1024–1180px, laptop 1280–1366px, desktop 1440–1536px, and wide 1920px. Use fluid `clamp()` scales, container queries where useful, and explicit layout changes at semantic thresholds. Verify no horizontal scroll at 360px, 390px, 430px, 768px, 820px, 1024px, 1366px, 1440px, and 1920px unless the brief explicitly asks for a pan/board canvas.',
+      '- **responsive web contract**: `responsive` means one web product experience that adapts across modern browser/device ranges, not only legacy desktop/tablet/mobile buckets. It is not an iOS app, Android app, or native tablet app target. Show responsive behavior through real product layout changes; do not render viewport labels as user-facing product content. Cover 2025–2026 breakpoints: mobile compact 360px, mobile standard 390–430px, foldable/small tablet 600–744px, tablet portrait 768–834px, tablet landscape/large tablet 1024–1180px, laptop 1280–1366px, desktop 1440–1536px, and wide 1920px. Use fluid `clamp()` scales, container queries where useful, and explicit layout changes at semantic thresholds. Verify no horizontal scroll at 360px, 390px, 430px, 600px, 768px, 820px, 1024px, 1366px, 1440px, and 1920px unless the brief explicitly asks for a pan/board canvas.',
     );
   }
   if ((metadata.platformTargets?.length ?? 0) > 1) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4510,6 +4510,7 @@ export function classifyChatRunCloseStatus(params: {
 
 type ClaudeStreamJsonBookkeepingRun = {
   stdinOpen?: boolean;
+  pendingHostAnswers?: Set<string>;
   turnCompletedCleanly?: boolean;
   child?: {
     stdin?: {
@@ -4531,18 +4532,34 @@ export function applyClaudeStreamJsonRunBookkeeping(
   if (!ev || typeof ev !== 'object') return;
   const event = ev as {
     type?: unknown;
+    name?: unknown;
+    id?: unknown;
     stopReason?: unknown;
   };
 
+  if (
+    run.stdinOpen &&
+    event.type === 'tool_use' &&
+    (event.name === 'AskUserQuestion' || event.name === 'ask_user_question') &&
+    typeof event.id === 'string'
+  ) {
+    if (!run.pendingHostAnswers) run.pendingHostAnswers = new Set();
+    run.pendingHostAnswers.add(event.id);
+    return;
+  }
+
   const cleanTerminalTurn =
-    // `stop_reason: tool_use` means the model paused to wait for tool
-    // execution (claude-code is about to run an internal tool). The
-    // conversation is still in flight, so don't close stdin yet.
-    (event.type === 'turn_end' && event.stopReason !== 'tool_use') ||
-    event.type === 'usage';
+    ((event.type === 'turn_end' &&
+      // `stop_reason: tool_use` means the model paused to wait for tool
+      // execution (claude-code is about to run an internal tool, or we owe a
+      // host tool_result). Either way the conversation is still in flight.
+      event.stopReason !== 'tool_use') ||
+      (event.type === 'usage' && event.stopReason !== 'tool_use')) &&
+    (!run.pendingHostAnswers || run.pendingHostAnswers.size === 0);
   if (!cleanTerminalTurn) return;
 
-  // Record clean completion so the close-status classifier ignores late
+  // Record clean completion even if stdin was already closed by the
+  // host-answer path. The close-status classifier reads this to ignore late
   // SessionEnd hook failures after the final assistant turn completed.
   run.turnCompletedCleanly = true;
   if (run.stdinOpen) {

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -547,4 +547,28 @@ describe('applyClaudeStreamJsonRunBookkeeping', () => {
     expect(run.stdinOpen).toBe(true);
     expect(run.child.stdin.end).not.toHaveBeenCalled();
   });
+
+  it('keeps stdin open when usage reports a tool_use stop reason', () => {
+    const run = {
+      stdinOpen: true,
+      pendingHostAnswers: new Set<string>(),
+      turnCompletedCleanly: false,
+      child: {
+        stdin: {
+          destroyed: false,
+          end: vi.fn(),
+        },
+      },
+    };
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'usage',
+      usage: { input_tokens: 6, output_tokens: 40831 },
+      stopReason: 'tool_use',
+    });
+
+    expect(run.turnCompletedCleanly).toBe(false);
+    expect(run.stdinOpen).toBe(true);
+    expect(run.child.stdin.end).not.toHaveBeenCalled();
+  });
 });

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -97,6 +97,21 @@ describe('composeSystemPrompt', () => {
     expect(prompt).toContain('Keep machine-readable ids and object option `value` fields exact and unlocalized');
   });
 
+  it('injects the converged verification policy (no mid-build screenshot looping)', () => {
+    const prompt = composeSystemPrompt({});
+
+    // Verification must read as an end-of-turn, single-pass step.
+    expect(prompt).toContain('## Verification — converge at the end, in one pass');
+    // The hard cap on rendered visual checks — the lever against codex's
+    // self-initiated 6-12x screenshot retry chains that balloon input tokens.
+    expect(prompt).toContain('One render check is the budget');
+    expect(prompt).toContain('Do not loop');
+    // Safety valve: visual verification is converged, NOT removed.
+    expect(prompt).toContain('these justify ONE rendered look');
+    // Route to the official wrapper, not a self-launched browser.
+    expect(prompt).toContain('Do NOT launch your own browser to do this');
+  });
+
   it('preserves canonical default task-type options under locale overrides', () => {
     const prompt = composeSystemPrompt({ locale: 'zh-CN' });
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/web/src/artifacts/strip.ts
+++ b/apps/web/src/artifacts/strip.ts
@@ -164,6 +164,147 @@ function parseArtifactAttrs(raw: string): Record<string, string> {
   return out;
 }
 
+/**
+ * A project file that an artifact save confirmed wrote to disk, as recorded on
+ * the assistant message after a successful `persistArtifact` (producedFiles).
+ * `identifier` is the artifact-manifest `metadata.identifier` when present.
+ */
+export interface PersistedArtifactFileRef {
+  name: string;
+  identifier?: string;
+}
+
+// Mirrors ProjectView's artifactExtensionFor: the on-disk extension the
+// persist path picks from the artifact's type/identifier.
+function artifactExtensionForAttrs(attrs: Record<string, string>): '.html' | '.jsx' | '.tsx' {
+  const type = (attrs['type'] || '').toLowerCase();
+  const identifier = (attrs['identifier'] || '').toLowerCase();
+  if (type.includes('tsx') || identifier.endsWith('.tsx')) return '.tsx';
+  if (type.includes('jsx') || type.includes('react') || identifier.endsWith('.jsx')) return '.jsx';
+  return '.html';
+}
+
+// Mirrors ProjectView's artifactBaseNameFor: the slug the persist path derives
+// the file name from.
+function artifactBaseNameForAttrs(attrs: Record<string, string>): string {
+  return (
+    (attrs['identifier'] || attrs['title'] || 'artifact')
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'artifact'
+  );
+}
+
+/**
+ * Find the persisted project file this artifact block was saved to, or null
+ * when persistence cannot be confirmed. Match order mirrors
+ * `findExistingArtifactProjectFile`: manifest identifier first (strongest —
+ * survives the `-2`/`-3` collision-suffix renames), then the derived
+ * `<slug><ext>` / `<slug>-<n><ext>` file names.
+ */
+export function matchPersistedArtifactFile(
+  attrs: Record<string, string>,
+  persistedFiles: ReadonlyArray<PersistedArtifactFileRef>,
+): PersistedArtifactFileRef | null {
+  const identifier = attrs['identifier'] ?? '';
+  if (identifier) {
+    const byManifest = persistedFiles.find((f) => f.identifier === identifier);
+    if (byManifest) return byManifest;
+  }
+  const ext = artifactExtensionForAttrs(attrs);
+  const base = artifactBaseNameForAttrs(attrs);
+  const namePattern = new RegExp(
+    `^${base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:-\\d+)?${ext.replace('.', '\\.')}$`,
+  );
+  return persistedFiles.find((f) => namePattern.test(f.name)) ?? null;
+}
+
+/**
+ * Replace every real `<artifact …>…</artifact>` block whose body is CONFIRMED
+ * persisted to a project file with a one-line summary, for use in the
+ * multi-turn transcript sent to the agent.
+ *
+ * Once the artifact lives on disk the agent reads/edits it from there via
+ * grep/sed, never from this transcript copy, so re-sending the whole HTML each
+ * turn is pure waste — a 30K-token artifact balloons every subsequent turn's
+ * input. The summary keeps the metadata the agent needs (`identifier` /
+ * `title` / `type` and the saved file name) and points it at the on-disk file.
+ *
+ * Persistence is confirmed against `persistedFiles` — the producedFiles
+ * recorded on the assistant message after a successful save. `persistArtifact`
+ * has explicit refusal (validateHtmlArtifact) and write-failure
+ * (writeProjectTextFile → null) branches; on those paths the transcript copy
+ * is the ONLY surviving artifact body, so an unmatched block is left verbatim
+ * (the pre-existing 12K transcript truncation still applies downstream) and a
+ * follow-up turn can still inspect or repair it.
+ *
+ * Uses the same skip-range / real-open detection as {@link stripArtifact}, so
+ * a literal `<artifact …>` recited inside a code fence (a user or assistant
+ * explaining the protocol) is left intact — only genuine protocol blocks are
+ * summarized. Malformed / still-streaming blocks (real open, no real close)
+ * are left untouched, mirroring stripArtifact's conservative behavior.
+ */
+export function summarizeArtifactsForTranscript(
+  content: string,
+  persistedFiles: ReadonlyArray<PersistedArtifactFileRef>,
+): string {
+  if (persistedFiles.length === 0) return content;
+  let result = '';
+  let cursor = 0;
+  // Recompute skip ranges per iteration against the remaining tail so indices
+  // stay valid as we consume the string left to right.
+  while (cursor <= content.length) {
+    const tail = content.slice(cursor);
+    const { ranges: baseRanges, unclosedFenceStart } = computeSkipRanges(tail);
+    const ranges: Range[] =
+      unclosedFenceStart !== null ? [...baseRanges, [unclosedFenceStart, tail.length]] : baseRanges;
+    const open = findRealOpen(tail, 0, ranges);
+    if (open === -1) {
+      result += tail;
+      break;
+    }
+    const gt = tail.indexOf('>', open);
+    if (gt === -1) {
+      result += tail;
+      break;
+    }
+    const end = findUnskipped(tail, CLOSE, gt, ranges);
+    if (end === -1) {
+      // Real open but no real close — refuse to summarize (safer than eating
+      // to end-of-string on a malformed/streaming tag). Keep the rest as-is.
+      result += tail;
+      break;
+    }
+    const attrs = parseArtifactAttrs(tail.slice(open, gt));
+    const persisted = matchPersistedArtifactFile(attrs, persistedFiles);
+    result += persisted
+      ? tail.slice(0, open) + artifactTranscriptSummary(attrs, persisted)
+      // Unconfirmed save — the transcript copy may be the only surviving
+      // body. Keep the block verbatim and keep scanning past it.
+      : tail.slice(0, end + CLOSE.length);
+    cursor += end + CLOSE.length;
+  }
+  return result;
+}
+
+function artifactTranscriptSummary(
+  attrs: Record<string, string>,
+  persisted: PersistedArtifactFileRef,
+): string {
+  const id = attrs['identifier'] ?? '';
+  const title = attrs['title'] ?? '';
+  const type = attrs['type'] ?? 'text/html';
+  const meta = [
+    id ? `identifier="${id}"` : '',
+    title ? `title="${title}"` : '',
+    `type="${type}"`,
+  ]
+    .filter(Boolean)
+    .join(', ');
+  return `[artifact emitted on a prior turn — ${meta}. Its full content was saved to the project file "${persisted.name}" and is NOT repeated here. Read or modify that file on disk (list/grep the project directory if it was since renamed); do not rely on this transcript for its contents.]`;
+}
+
 export interface StreamingArtifact {
   artifactType: string;
   title: string;

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -47,6 +47,10 @@ function detectClientType(): 'desktop' | 'web' | 'unknown' {
   return 'unknown';
 }
 import { parseSseFrame } from './sse';
+import {
+  summarizeArtifactsForTranscript,
+  type PersistedArtifactFileRef,
+} from '../artifacts/strip';
 import { trackRunProgress, trackRunStart, trackRunTerminal } from '../observability/stuck-run';
 
 const MAX_TRANSCRIPT_MESSAGE_CHARS = 12_000;
@@ -154,7 +158,10 @@ function scopeHistoryToAgent(history: ChatMessage[], targetAgentId?: string): Ch
 // User content is preserved verbatim — a user message that legitimately
 // quotes `<question-form>` (e.g. discussing the markup with the agent)
 // must not be mangled.
-export function sanitizePriorAssistantTurnForTranscript(content: string): string {
+export function sanitizePriorAssistantTurnForTranscript(
+  content: string,
+  persistedArtifactFiles: ReadonlyArray<PersistedArtifactFileRef> = [],
+): string {
   let sanitized = content.replace(
     // `\1` backreference keeps the open/close tag names matched so we never
     // splice across a `<question-form>…</ask-question>` mismatch.
@@ -174,7 +181,42 @@ export function sanitizePriorAssistantTurnForTranscript(content: string): string
       return match;
     },
   );
+  // Replace prior-turn `<artifact>` HTML with a one-line summary — but ONLY
+  // for artifacts whose save to the project files is confirmed by the
+  // message's producedFiles record. persistArtifact has refusal and
+  // write-failure branches; on those paths the transcript copy is the only
+  // surviving artifact body, so an unconfirmed block stays verbatim (the
+  // 12K truncation below still bounds it) and a follow-up turn can repair it.
+  // For confirmed saves the agent reads/edits the file from disk, never from
+  // this transcript copy, so re-sending the whole document each turn is pure
+  // waste — the summary keeps identifier/title/type plus the saved file name.
+  // Runs before truncateForTranscript so the summarized message no longer
+  // trips the 12K cap. Uses markdown-aware detection so a literal
+  // `<artifact>` recited in a code fence survives.
+  sanitized = summarizeArtifactsForTranscript(sanitized, persistedArtifactFiles);
   return sanitized;
+}
+
+// producedFiles → the persistence evidence summarizeArtifactsForTranscript
+// matches artifact blocks against. producedFiles is the whole per-turn file
+// diff — tool-written files included — so a name collision with an unrelated
+// same-turn file must not count as proof the <artifact> body was saved. Only
+// artifact-originated saves qualify: persistArtifact always writes an explicit
+// (non-inferred) manifest, whereas tool-written files surface with no manifest
+// or a daemon-inferred one (`metadata.inferred === true`). Within that
+// narrowed set, the manifest identifier is the strongest link (it survives
+// `-2`/`-3` collision renames); the file name is the fallback for artifact
+// saves whose manifest predates identifier metadata.
+function persistedArtifactFilesOf(message: ChatMessage): PersistedArtifactFileRef[] {
+  return (message.producedFiles ?? [])
+    .filter((file) => file.artifactManifest && file.artifactManifest.metadata?.inferred !== true)
+    .map((file) => {
+      const identifier = file.artifactManifest?.metadata?.identifier;
+      return {
+        name: file.name,
+        identifier: typeof identifier === 'string' && identifier ? identifier : undefined,
+      };
+    });
 }
 
 export function buildDaemonTranscript(history: ChatMessage[], targetAgentId?: string): string {
@@ -184,7 +226,7 @@ export function buildDaemonTranscript(history: ChatMessage[], targetAgentId?: st
       const trimmed = m.content.trim();
       const sanitized =
         m.role === 'assistant'
-          ? sanitizePriorAssistantTurnForTranscript(trimmed)
+          ? sanitizePriorAssistantTurnForTranscript(trimmed, persistedArtifactFilesOf(m))
           : trimmed;
       return `## ${m.role}\n${escapeTranscriptRoleDelimiters(truncateForTranscript(sanitized))}`;
     })

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -380,7 +380,7 @@ describe('streamViaDaemon', () => {
     expect(sanitized).toBe(original);
   });
 
-  it('preserves <artifact> blocks — only question-form is stripped, the deliverable stays intact', () => {
+  it('replaces a persisted prior-turn <artifact> with a one-line summary (the deliverable lives on disk)', () => {
     const original = [
       'Build summary below.',
       '',
@@ -389,11 +389,181 @@ describe('streamViaDaemon', () => {
       '<html><body>slide content</body></html>',
       '</artifact>',
     ].join('\n');
-    const sanitized = sanitizePriorAssistantTurnForTranscript(original);
+    const sanitized = sanitizePriorAssistantTurnForTranscript(original, [
+      { name: 'deck.html', identifier: 'deck' },
+    ]);
 
+    // The HTML body is gone — no point re-sending it, the agent reads it from disk.
+    expect(sanitized).not.toContain('<!doctype html>');
+    expect(sanitized).not.toContain('slide content');
+    expect(sanitized).not.toContain('</artifact>');
+    // The summary keeps the metadata the agent needs to locate the file.
+    expect(sanitized).toContain('artifact emitted on a prior turn');
+    expect(sanitized).toContain('identifier="deck"');
+    expect(sanitized).toContain('title="Pitch deck"');
+    expect(sanitized).toContain('"deck.html"');
+    // Surrounding prose is preserved.
+    expect(sanitized).toContain('Build summary below.');
+  });
+
+  it('keeps an <artifact> body verbatim when its save is NOT confirmed (failed/refused persist path)', () => {
+    // persistArtifact has refusal (validateHtmlArtifact) and write-failure
+    // (writeProjectTextFile → null) branches. On those paths the transcript
+    // copy is the ONLY surviving artifact body — summarizing it would strand
+    // the next turn with no content to inspect or repair.
+    const original = [
+      '<artifact identifier="deck" type="text/html" title="Pitch deck">',
+      '<html><body>only surviving copy</body></html>',
+      '</artifact>',
+    ].join('\n');
+    // No producedFiles recorded for this artifact → no confirmed persistence.
+    expect(sanitizePriorAssistantTurnForTranscript(original, [])).toBe(original);
+    // A produced file that does not match the artifact also must not trigger
+    // summarization for it.
+    expect(
+      sanitizePriorAssistantTurnForTranscript(original, [{ name: 'other.html', identifier: 'other' }]),
+    ).toBe(original);
+  });
+
+  it('matches persistence by manifest identifier even when collision-suffix renames changed the file name', () => {
+    const original =
+      '<artifact identifier="deck" type="text/html" title="Pitch deck"><html>v3</html></artifact>';
+    const sanitized = sanitizePriorAssistantTurnForTranscript(original, [
+      { name: 'deck-3.html', identifier: 'deck' },
+    ]);
+    expect(sanitized).toContain('artifact emitted on a prior turn');
+    expect(sanitized).toContain('"deck-3.html"');
+    expect(sanitized).not.toContain('v3');
+  });
+
+  it('matches persistence by derived file name when the manifest carries no identifier (legacy files)', () => {
+    const original =
+      '<artifact identifier="deck" type="text/html" title="Pitch deck"><html>legacy</html></artifact>';
+    const sanitized = sanitizePriorAssistantTurnForTranscript(original, [{ name: 'deck.html' }]);
+    expect(sanitized).toContain('artifact emitted on a prior turn');
+    expect(sanitized).not.toContain('legacy');
+  });
+
+  it('summarizes only the persisted <artifact> when a turn emits multiple and one save failed', () => {
+    const sanitized = sanitizePriorAssistantTurnForTranscript(
+      [
+        '<artifact identifier="a" type="text/html" title="A"><html>aaa</html></artifact>',
+        'and',
+        '<artifact identifier="b" type="text/html" title="B"><html>bbb</html></artifact>',
+      ].join('\n'),
+      [{ name: 'a.html', identifier: 'a' }],
+    );
+    // `a` is confirmed on disk → summarized.
+    expect(sanitized).not.toContain('aaa');
+    expect(sanitized).toContain('identifier="a"');
+    // `b` never persisted → its body must survive in the transcript.
+    expect(sanitized).toContain('bbb');
+    expect((sanitized.match(/artifact emitted on a prior turn/g) ?? []).length).toBe(1);
+  });
+
+  it('leaves a literal <artifact> recited inside a code fence intact (not a real protocol block)', () => {
+    const original = [
+      'Here is how the artifact protocol looks:',
+      '',
+      '```html',
+      '<artifact identifier="x" type="text/html" title="X">...</artifact>',
+      '```',
+    ].join('\n');
+    const sanitized = sanitizePriorAssistantTurnForTranscript(original, [
+      { name: 'x.html', identifier: 'x' },
+    ]);
+    // Inside a fenced code block → a literal recitation, must survive.
     expect(sanitized).toBe(original);
-    expect(sanitized).toContain('<artifact');
-    expect(sanitized).toContain('<!doctype html>');
+  });
+
+  it('summarizes via buildDaemonTranscript using the message producedFiles as persistence evidence', () => {
+    const transcript = buildDaemonTranscript([
+      {
+        id: '1',
+        role: 'assistant',
+        content:
+          '<artifact identifier="deck" type="text/html" title="Pitch deck"><html>slide content</html></artifact>',
+        producedFiles: [
+          {
+            name: 'deck.html',
+            size: 100,
+            mtime: 1,
+            kind: 'html',
+            mime: 'text/html',
+            artifactManifest: {
+              version: 1,
+              kind: 'html',
+              title: 'Pitch deck',
+              entry: 'deck.html',
+              renderer: 'html',
+              exports: [],
+              metadata: { identifier: 'deck' },
+            },
+          },
+        ],
+      },
+    ]);
+    expect(transcript).toContain('artifact emitted on a prior turn');
+    expect(transcript).not.toContain('slide content');
+  });
+
+  it('does NOT treat an unrelated same-named tool-written file as artifact persistence evidence', () => {
+    // Regression for the producedFiles-evidence review: producedFiles is the
+    // whole per-turn diff, not just persistArtifact outputs. When the
+    // artifact save fails but a tool wrote `deck.html` in the same turn
+    // (surfacing with no manifest, or a daemon-inferred one), the filename
+    // coincidence must NOT summarize the <artifact> block — its transcript
+    // body is still the only surviving copy.
+    const artifactTurn =
+      '<artifact identifier="deck" type="text/html" title="Pitch deck"><html>only copy</html></artifact>';
+    const toolWrittenNoManifest = {
+      id: '1',
+      role: 'assistant' as const,
+      content: artifactTurn,
+      producedFiles: [
+        { name: 'deck.html', size: 10, mtime: 1, kind: 'html' as const, mime: 'text/html' },
+      ],
+    };
+    const toolWrittenInferredManifest = {
+      ...toolWrittenNoManifest,
+      id: '2',
+      producedFiles: [
+        {
+          name: 'deck.html',
+          size: 10,
+          mtime: 1,
+          kind: 'html' as const,
+          mime: 'text/html',
+          artifactManifest: {
+            version: 1 as const,
+            kind: 'html' as const,
+            title: 'deck.html',
+            entry: 'deck.html',
+            renderer: 'html' as const,
+            exports: ['html' as const],
+            metadata: { inferred: true },
+          },
+        },
+      ],
+    };
+    for (const message of [toolWrittenNoManifest, toolWrittenInferredManifest]) {
+      const transcript = buildDaemonTranscript([message]);
+      expect(transcript).toContain('only copy');
+      expect(transcript).not.toContain('artifact emitted on a prior turn');
+    }
+  });
+
+  it('does NOT summarize <artifact> in user messages (only assistant turns) via buildDaemonTranscript', () => {
+    const transcript = buildDaemonTranscript([
+      {
+        id: '1',
+        role: 'user',
+        content: 'Can you explain what <artifact identifier="z" type="text/html" title="Z">...</artifact> means?',
+      },
+    ]);
+    // User content is never sanitized — their artifact mention survives verbatim.
+    expect(transcript).toContain('<artifact identifier="z" type="text/html" title="Z">');
+    expect(transcript).not.toContain('artifact emitted on a prior turn');
   });
 
   it('sanitizes ONLY assistant content inside buildDaemonTranscript — user messages quoting <question-form> stay verbatim', () => {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -261,9 +261,9 @@ describe("packaged smoke workflow", () => {
   it("[P2] validates stable dry-run nightly metadata from a non-release ref", async () => {
     const objects: Record<string, unknown> = {};
     const fixture = await startStableNightlyMetadataServer(objects);
-    objects["nightly/versions/0.10.0.nightly.12/metadata.json"] = stableNightlyMetadataFixture(
-      "0.10.0",
-      "0.10.0.nightly.12",
+    objects["nightly/versions/0.10.1.nightly.12/metadata.json"] = stableNightlyMetadataFixture(
+      "0.10.1",
+      "0.10.1.nightly.12",
       fixture.origin,
     );
     const runnerTemp = await mkdtemp(join(tmpdir(), "od-release-stable-dry-run-"));
@@ -283,16 +283,16 @@ describe("packaged smoke workflow", () => {
           OPEN_DESIGN_RELEASE_CHANNEL: "stable",
           OPEN_DESIGN_RELEASE_DRY_RUN: "true",
           OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: fixture.origin,
-          OPEN_DESIGN_STABLE_NIGHTLY_VERSION: "0.10.0.nightly.12",
-          OPEN_DESIGN_STABLE_VERSION: "0.10.0",
+          OPEN_DESIGN_STABLE_NIGHTLY_VERSION: "0.10.1.nightly.12",
+          OPEN_DESIGN_STABLE_VERSION: "0.10.1",
           PATH: `${join(runnerTemp, "bin")}:${process.env.PATH ?? ""}`,
         },
       });
 
-      expect(result.stdout).toContain("[release-stable] validated nightly: 0.10.0.nightly.12");
+      expect(result.stdout).toContain("[release-stable] validated nightly: 0.10.1.nightly.12");
       expect(result.stdout).toContain("[release-stable] channel: stable");
       expect(result.stdout).toContain("[release-stable] dry run: true");
-      expect(result.stdout).toContain("[release-stable] version tag: open-design-v0.10.0");
+      expect(result.stdout).toContain("[release-stable] version tag: open-design-v0.10.1");
     } finally {
       await fixture.close();
       await rm(runnerTemp, { force: true, recursive: true });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "description": "Open Design renderer host bridge protocol.",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "description": "Open Design renderer host bridge protocol.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
🩹 **`open-design-v0.10.1` — a focused stability + performance patch on 0.10.0.** No new surface; just fixes and tuning for the shipped 0.10.0 line. The headline: Claude runs that pause to use a tool no longer get cut off and falsely marked "finished," and per-turn prompt/transcript overhead is meaningfully lighter.

## ⚡ Performance

- 🧠 **Leaner system prompt per turn.** System-prompt content is de-duplicated, injected on demand instead of every turn, and per-turn input is curbed — less redundant prompt overhead on each agent turn. (#4203) Thanks `@NJUHua`.
- 📜 **Lighter transcripts.** Prior-turn artifacts are summarized in the transcript instead of resending the full HTML every turn, cutting payload bloat on long conversations. (#4202) Thanks `@NJUHua`.

## 🐛 Fixed

- 🩺 **Runs no longer stop short at a tool boundary.** When a Claude (stream-json) run reported token usage while pausing to call a tool, Open Design could close the session's stdin too early — Claude exited 0 and the chat landed in a confusing "Stopped with unfinished work" state with no artifact. Usage at a `tool_use` boundary is no longer treated as completion, so the run continues until the work is actually done. (#4198) Thanks `@yinjialu`.

> 📥 **Download:** assets for `open-design-v0.10.1` are built by the nightly pipeline and publish to GitHub Releases and `releases.open-design.ai` — macOS arm64/Intel `.dmg`, Windows x64 installer — when the build completes.

## 🙏 Thanks to everyone who shipped 0.10.1

`@NJUHua` · `@yinjialu`

---

> ⚠️ **Merge with a *merge commit* — never squash or rebase.** This is the `release/v0.10.1 → main` back-merge; the merge-button choice is the entire safeguard. At cut time the diff is the `chore(release): prepare 0.10.1` bump; the patch fixes are cherry-picks already present in `main`.
>
> _Scope note: this delta is everything reachable from `release/v0.10.1` but not from the `open-design-v0.10.0` tag (`3c3d45aa3`) — the patch picks listed above plus the version bump._
