### PR TITLE
[codex] Fix composer BYOK model switching

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2067,6 +2067,7 @@ function AppInner() {
         onModeChange={handleModeChange}
         onAgentChange={handleAgentChange}
         onAgentModelChange={handleAgentModelChange}
+        onApiModelChange={handleApiModelChange}
         onRefreshAgents={refreshAgents}
         onThemeChange={handleThemeChange}
         onOpenSettings={openSettings}

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -176,7 +176,14 @@ export function AvatarMenu({
   )?.label;
 
   const apiProtocol = config.apiProtocol ?? 'openai';
-  const byokProvider = KNOWN_PROVIDERS.find((provider) => provider.protocol === apiProtocol);
+  const byokProvider =
+    KNOWN_PROVIDERS.find(
+      (provider) =>
+        provider.protocol === apiProtocol &&
+        (config.apiProviderBaseUrl
+          ? provider.baseUrl === config.apiProviderBaseUrl
+          : provider.baseUrl === config.baseUrl),
+    ) ?? KNOWN_PROVIDERS.find((provider) => provider.protocol === apiProtocol);
   const byokProviderModelsKey = providerModelsCacheKey(
     apiProtocol,
     config.baseUrl ?? '',
@@ -219,7 +226,9 @@ export function AvatarMenu({
 
   const byokModelOptions = mergeProviderModelOptions(
     fetchedByokModels,
-    SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol] ?? [],
+    byokProvider?.models?.length
+      ? byokProvider.models
+      : SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol] ?? [],
   );
 
   return (

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -305,6 +305,7 @@ interface Props {
     id: string,
     choice: { model?: string; reasoning?: string },
   ) => void;
+  onApiModelChange?: (model: string) => void;
   onRefreshAgents: () => void;
   onThemeChange?: (theme: AppConfig['theme']) => void;
   onOpenSettings: (section?: SettingsSection) => void;
@@ -806,6 +807,7 @@ export function ProjectView({
   onModeChange,
   onAgentChange,
   onAgentModelChange,
+  onApiModelChange,
   onRefreshAgents,
   onThemeChange,
   onOpenSettings,
@@ -5545,6 +5547,16 @@ export function ProjectView({
           ...(project?.id ? { project_id: project.id } : {}),
         });
         onAgentModelChange(agentId, choice);
+      }}
+      onApiModelChange={(model) => {
+        trackComposerBarClick(analytics.track, {
+          page_name: 'chat_panel',
+          area: 'chat_composer',
+          element: 'agent_model_select',
+          model_id: model,
+          ...(project?.id ? { project_id: project.id } : {}),
+        });
+        onApiModelChange?.(model);
       }}
       onOpenSettings={onOpenSettings}
       onRefreshAgents={onRefreshAgents}

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -543,6 +543,76 @@ test('[P0] project detail composer agent and model switches carry into the next 
   expect(runRequestBodies[0]?.model).toBe('sonnet');
 });
 
+test('[P0] @critical project detail composer BYOK model switch persists from the agent menu', async ({ page }) => {
+  test.setTimeout(60_000);
+  const config = {
+    mode: 'daemon',
+    apiKey: 'sk-openai-test',
+    apiProtocol: 'openai',
+    apiVersion: '',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o-2024-05-13',
+    apiProviderBaseUrl: 'https://api.openai.com/v1',
+    agentId: 'codex',
+    skillId: null,
+    designSystemId: null,
+    onboardingCompleted: true,
+    privacyDecisionAt: 1,
+    telemetry: { metrics: false, content: false, artifactManifest: false },
+    mediaProviders: {},
+    agentModels: { codex: { model: 'default' } },
+    agentCliEnv: {},
+  };
+
+  await page.addInitScript(
+    ({ key, value }) => {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    },
+    { key: STORAGE_KEY, value: config },
+  );
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() === 'PUT') {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ config: body }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ config }),
+    });
+  });
+
+  await page.goto('/');
+  await createProject(page, 'Composer BYOK model switch');
+  await expectWorkspaceReady(page);
+
+  const { menu } = await openComposerAgentMenu(page);
+  await menu.getByRole('button', { name: /API · BYOK|Use API/i }).click();
+
+  const modelSelect = menu.locator('.avatar-model-section [role="combobox"]').first();
+  await expect(modelSelect).toContainText('gpt-4o-2024-05-13');
+  await modelSelect.click();
+  const modelPopover = page.getByTestId('avatar-byok-model-popover');
+  await expect(modelPopover.getByRole('option', { name: /^gpt-4o-mini$/i })).toBeVisible();
+  await expect(modelPopover.getByRole('option', { name: /deepseek/i })).toHaveCount(0);
+  await expect(modelPopover.getByRole('option', { name: /MiniMax/i })).toHaveCount(0);
+  await modelPopover.getByRole('option', { name: /^gpt-4o-mini$/i }).click();
+
+  await expect(modelSelect).toContainText('gpt-4o-mini');
+  await expect.poll(async () => page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  }, STORAGE_KEY)).toMatchObject({
+    mode: 'api',
+    model: 'gpt-4o-mini',
+  });
+});
+
 test('[P0] clearing the project design system removes designSystemId from the next run request', async ({ page }) => {
   const patchBodies: Array<Record<string, unknown>> = [];
   const runRequestBodies: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Summary

- Wire the project composer AvatarMenu BYOK model picker to the app-level API model change handler.
- Use the active BYOK provider preset as the fallback model list in the composer menu, so OpenAI without a key/live fetch only shows OpenAI preset models.
- Add a P0 E2E regression for switching the project composer menu from Local CLI to BYOK and selecting a BYOK model.

Fixes #4207

## Validation

- pnpm -C e2e exec tsc -p tsconfig.json --noEmit
- OD_PORT=35741 OD_WEB_PORT=35742 pnpm -C e2e exec playwright test -c playwright.config.ts ui/project-management-flows.test.ts --grep "composer BYOK model switch"

## Notes

- Verified manually in local Electron after restart.
- `pnpm --filter @open-design/web exec tsc --noEmit` is currently blocked on latest main by `src/components/IntegrationsView.tsx(135,17)` (`gate_card` analytics enum), unrelated to this PR.
- A later rerun of the targeted Playwright command on the fresh branch timed out waiting for config.webServer; the same regression passed before branch cleanup and the E2E TypeScript check passes.
