### PR TITLE
fix(daemon): proxy AMR login API over IPv4

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -167,6 +167,7 @@ function validateTelemetry(raw: unknown): TelemetryPrefs | undefined {
 const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['amr', new Set([
     'VELA_BIN',
+    'VELA_API_URL',
     'VELA_LINK_URL',
     'VELA_RUNTIME_KEY',
     'VELA_OPENCODE_BIN',

--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -318,6 +318,7 @@ export interface SpawnVelaLoginDeps {
   configuredEnv?: Record<string, string>;
   baseEnv?: NodeJS.ProcessEnv;
   attribution?: AmrEntryAttribution | null;
+  defaultApiUrl?: string | null;
 }
 
 async function waitForImmediateLoginFailure(child: ChildProcess): Promise<void> {
@@ -378,7 +379,11 @@ export async function spawnVelaLogin(
   const def = getAgentDef('amr');
   if (!def) throw new Error('AMR runtime def not registered');
   const baseEnv = deps.baseEnv ?? process.env;
-  const configuredEnv = deps.configuredEnv ?? {};
+  const configuredEnv = withDefaultVelaApiUrl(
+    deps.configuredEnv ?? {},
+    baseEnv,
+    deps.defaultApiUrl,
+  );
   const launch = resolveAgentLaunch(def, configuredEnv);
   const bin = launch.selectedPath;
   if (!bin) {
@@ -418,6 +423,18 @@ export async function spawnVelaLogin(
     startedAt: new Date().toISOString(),
     profile: resolveAmrProfile(env),
   };
+}
+
+function withDefaultVelaApiUrl(
+  configuredEnv: Record<string, string>,
+  baseEnv: NodeJS.ProcessEnv,
+  defaultApiUrl: string | null | undefined,
+): Record<string, string> {
+  const trimmed = defaultApiUrl?.trim();
+  if (!trimmed) return configuredEnv;
+  if ((configuredEnv.VELA_API_URL ?? '').trim()) return configuredEnv;
+  if ((baseEnv.VELA_API_URL ?? '').trim()) return configuredEnv;
+  return { ...configuredEnv, VELA_API_URL: trimmed };
 }
 
 export function parseVelaLoginAttribution(input: unknown): AmrEntryAttribution | null {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6651,9 +6651,7 @@ export async function startServer({
   const AMR_API_UPSTREAM_ORIGIN = 'https://amr-api.open-design.ai';
 
   function velaApiProxyBaseUrl(req) {
-    const hostHeader = req.get('host');
-    if (!hostHeader) return '';
-    return `http://${hostHeader}${AMR_API_PROXY_PREFIX}`;
+    return `${getPublicBaseUrl(req)}${AMR_API_PROXY_PREFIX}`;
   }
 
   function velaProxyRequestBody(req) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5,6 +5,8 @@ import multer from 'multer';
 import JSZip from 'jszip';
 import { execFile, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import dns from 'node:dns';
+import https from 'node:https';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -6645,6 +6647,75 @@ export async function startServer({
     res.json({ ok: true });
   });
 
+  const AMR_API_PROXY_PREFIX = '/api/integrations/vela/api-proxy';
+  const AMR_API_UPSTREAM_ORIGIN = 'https://amr-api.open-design.ai';
+
+  function velaApiProxyBaseUrl(req) {
+    const hostHeader = req.get('host');
+    if (!hostHeader) return '';
+    return `http://${hostHeader}${AMR_API_PROXY_PREFIX}`;
+  }
+
+  function velaProxyRequestBody(req) {
+    if (req.method === 'GET' || req.method === 'HEAD') return null;
+    if (Buffer.isBuffer(req.body)) return req.body;
+    if (typeof req.body === 'string') return Buffer.from(req.body);
+    if (req.body == null) return null;
+    return Buffer.from(JSON.stringify(req.body));
+  }
+
+  function proxyAmrApiRequest(req, res) {
+    const suffix = req.originalUrl.slice(AMR_API_PROXY_PREFIX.length);
+    if (!suffix.startsWith('/api/v1/')) {
+      res.status(404).json({ error: 'unknown_amr_api_proxy_path' });
+      return;
+    }
+    const target = new URL(suffix, AMR_API_UPSTREAM_ORIGIN);
+    const body = velaProxyRequestBody(req);
+    const headers = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+      const lower = key.toLowerCase();
+      if (
+        lower === 'host' ||
+        lower === 'connection' ||
+        lower === 'content-length' ||
+        lower === 'transfer-encoding'
+      ) {
+        continue;
+      }
+      headers[key] = value;
+    }
+    if (body) headers['content-length'] = String(body.length);
+
+    const upstream = https.request(
+      target,
+      {
+        method: req.method,
+        headers,
+        lookup: (hostname, options, callback) => {
+          dns.lookup(hostname, { ...options, family: 4, all: false }, callback);
+        },
+      },
+      (upstreamRes) => {
+        res.status(upstreamRes.statusCode ?? 502);
+        for (const [key, value] of Object.entries(upstreamRes.headers)) {
+          if (value !== undefined) res.setHeader(key, value);
+        }
+        upstreamRes.pipe(res);
+      },
+    );
+    upstream.setTimeout(30_000, () => upstream.destroy(new Error('AMR API proxy timed out')));
+    upstream.on('error', (err) => {
+      if (!res.headersSent) {
+        res.status(502).json({ error: err instanceof Error ? err.message : String(err) });
+      } else {
+        res.end();
+      }
+    });
+    if (body) upstream.write(body);
+    upstream.end();
+  }
+
   // AMR (vela) login integration — see `apps/daemon/src/integrations/vela.ts`.
   // The vela CLI owns the device-authorization UX (URL + code + browser open);
   // these routes only surface enough state for Open Design's Settings card to
@@ -6716,12 +6787,18 @@ export async function startServer({
     }
   });
 
+  app.all('/api/integrations/vela/api-proxy/*splat', proxyAmrApiRequest);
+
   app.post('/api/integrations/vela/login', async (req, res) => {
     try {
       const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
       const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
       const attribution = parseVelaLoginAttribution(req.body);
-      const spawned = await spawnVelaLogin({ configuredEnv, attribution });
+      const spawned = await spawnVelaLogin({
+        configuredEnv,
+        attribution,
+        defaultApiUrl: velaApiProxyBaseUrl(req),
+      });
       res.status(202).json(spawned);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6662,6 +6662,10 @@ export async function startServer({
     return Buffer.from(JSON.stringify(req.body));
   }
 
+  function shouldStreamVelaProxyRequest(req, body) {
+    return req.method !== 'GET' && req.method !== 'HEAD' && body == null;
+  }
+
   function proxyAmrApiRequest(req, res) {
     const suffix = req.originalUrl.slice(AMR_API_PROXY_PREFIX.length);
     if (!suffix.startsWith('/api/v1/')) {
@@ -6670,17 +6674,18 @@ export async function startServer({
     }
     const target = new URL(suffix, AMR_API_UPSTREAM_ORIGIN);
     const body = velaProxyRequestBody(req);
+    const streamBody = shouldStreamVelaProxyRequest(req, body);
     const headers = {};
     for (const [key, value] of Object.entries(req.headers)) {
       const lower = key.toLowerCase();
       if (
         lower === 'host' ||
         lower === 'connection' ||
-        lower === 'content-length' ||
         lower === 'transfer-encoding'
       ) {
         continue;
       }
+      if (lower === 'content-length' && body) continue;
       headers[key] = value;
     }
     if (body) headers['content-length'] = String(body.length);
@@ -6711,7 +6716,11 @@ export async function startServer({
       }
     });
     if (body) upstream.write(body);
-    upstream.end();
+    if (streamBody) {
+      req.pipe(upstream);
+    } else {
+      upstream.end();
+    }
   }
 
   // AMR (vela) login integration — see `apps/daemon/src/integrations/vela.ts`.

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -320,6 +320,7 @@ describe('app-config', () => {
           },
           amr: {
             VELA_BIN: '~/bin/vela',
+            VELA_API_URL: '  https://custom-amr.example  ',
             OPEN_DESIGN_AMR_PROFILE: '  local  ',
             OPENCODE_TEST_HOME: '  ~/.open-design-amr-opencode  ',
             HOME: 'should-not-persist',
@@ -343,6 +344,7 @@ describe('app-config', () => {
         codex: { CODEX_HOME: '~/.codex-alt', CODEX_BIN: '~/bin/codex-next', OPENAI_API_KEY: 'sk-proxy-openai' },
         amr: {
           VELA_BIN: '~/bin/vela',
+          VELA_API_URL: 'https://custom-amr.example',
           OPEN_DESIGN_AMR_PROFILE: 'local',
           OPENCODE_TEST_HOME: '~/.open-design-amr-opencode',
         },

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -289,6 +289,9 @@ function loginAndExit() {
     stderr.write(`${env.FAKE_VELA_LOGIN_FAIL}\n`);
     exit(1);
   }
+  if (env.FAKE_VELA_ENV_DUMP_PATH) {
+    writeFileSync(env.FAKE_VELA_ENV_DUMP_PATH, JSON.stringify(env, null, 2), 'utf8');
+  }
   const profile = (env.VELA_PROFILE || 'prod').trim() || 'prod';
   const allowed = new Set(['prod', 'test', 'local']);
   if (!allowed.has(profile)) {

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -174,6 +174,7 @@ afterEach(() => {
   delete process.env.FAKE_VELA_LOGIN_USER_EMAIL;
   delete process.env.FAKE_VELA_LOGIN_USER_PLAN;
   delete process.env.FAKE_VELA_ENV_DUMP_PATH;
+  delete process.env.OD_PUBLIC_BASE_URL;
   delete process.env.VELA_RUNTIME_KEY;
   delete process.env.VELA_LINK_URL;
   delete process.env.OPEN_DESIGN_AMR_ANALYTICS_URL;
@@ -349,6 +350,21 @@ describe('POST /api/integrations/vela/login', () => {
     await waitForFile(dumpPath);
     const env = JSON.parse(readFileSync(dumpPath, 'utf8'));
     expect(env.VELA_API_URL).toBe(`${baseUrl}/api/integrations/vela/api-proxy`);
+  });
+
+  it('derives the default login API proxy from OD_PUBLIC_BASE_URL when configured', async () => {
+    const dumpPath = path.join(tmpHome, 'vela-env-public-base-url.json');
+    process.env.FAKE_VELA_ENV_DUMP_PATH = dumpPath;
+    process.env.OD_PUBLIC_BASE_URL = 'https://open-design.example.com/';
+
+    const { status } = await postJson(`${baseUrl}/api/integrations/vela/login`);
+    expect(status).toBe(202);
+
+    await waitForFile(dumpPath);
+    const env = JSON.parse(readFileSync(dumpPath, 'utf8'));
+    expect(env.VELA_API_URL).toBe(
+      'https://open-design.example.com/api/integrations/vela/api-proxy',
+    );
   });
 
   it('preserves an explicitly configured VELA_API_URL during login', async () => {

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -122,6 +122,15 @@ function seedLogin(profile: string, payload: Record<string, unknown> = {}): void
   writeFileSync(configPath(), JSON.stringify(full, null, 2), 'utf8');
 }
 
+async function waitForFile(file: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (existsSync(file)) return;
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${file}`);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
 beforeAll(async () => {
   // The login route resolves the vela binary through the daemon's
   // `agentCliEnvForAgent` projection of `app-config.json` (NOT process.env),
@@ -164,6 +173,7 @@ afterEach(() => {
   delete process.env.FAKE_VELA_LOGIN_FAIL;
   delete process.env.FAKE_VELA_LOGIN_USER_EMAIL;
   delete process.env.FAKE_VELA_LOGIN_USER_PLAN;
+  delete process.env.FAKE_VELA_ENV_DUMP_PATH;
   delete process.env.VELA_RUNTIME_KEY;
   delete process.env.VELA_LINK_URL;
   delete process.env.OPEN_DESIGN_AMR_ANALYTICS_URL;
@@ -329,6 +339,46 @@ describe('GET /api/integrations/vela/status', () => {
 });
 
 describe('POST /api/integrations/vela/login', () => {
+  it('routes default vela login API traffic through the daemon AMR API proxy', async () => {
+    const dumpPath = path.join(tmpHome, 'vela-env.json');
+    process.env.FAKE_VELA_ENV_DUMP_PATH = dumpPath;
+
+    const { status } = await postJson(`${baseUrl}/api/integrations/vela/login`);
+    expect(status).toBe(202);
+
+    await waitForFile(dumpPath);
+    const env = JSON.parse(readFileSync(dumpPath, 'utf8'));
+    expect(env.VELA_API_URL).toBe(`${baseUrl}/api/integrations/vela/api-proxy`);
+  });
+
+  it('preserves an explicitly configured VELA_API_URL during login', async () => {
+    const dataDir = process.env.OD_DATA_DIR as string;
+    const previous = await readAppConfig(dataDir);
+    const dumpPath = path.join(tmpHome, 'vela-env-custom-url.json');
+    process.env.FAKE_VELA_ENV_DUMP_PATH = dumpPath;
+    await writeAppConfig(dataDir, {
+      ...previous,
+      agentCliEnv: {
+        ...(previous.agentCliEnv ?? {}),
+        amr: {
+          ...((previous.agentCliEnv?.amr as Record<string, string>) ?? {}),
+          VELA_BIN: FAKE_VELA,
+          VELA_API_URL: 'https://custom-amr.example',
+        },
+      },
+    });
+    try {
+      const { status } = await postJson(`${baseUrl}/api/integrations/vela/login`);
+      expect(status).toBe(202);
+
+      await waitForFile(dumpPath);
+      const env = JSON.parse(readFileSync(dumpPath, 'utf8'));
+      expect(env.VELA_API_URL).toBe('https://custom-amr.example');
+    } finally {
+      await writeAppConfig(dataDir, previous as unknown as Record<string, unknown>);
+    }
+  });
+
   it('spawns the configured vela binary and surfaces a pid + startedAt + profile', async () => {
     process.env.FAKE_VELA_LOGIN_USER_EMAIL = 'login-route@example.com';
     const { status, body } = await postJson<{

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -14,13 +14,15 @@
 
 import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { createServer } from 'node:http';
+import https from 'node:https';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type http from 'node:http';
+import { PassThrough } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { startServer } from '../../src/server.js';
 import { readAppConfig, writeAppConfig } from '../../src/app-config.js';
@@ -601,6 +603,64 @@ describe('POST /api/integrations/vela/login', () => {
     expect(after.body.loggedIn).toBe(false);
     expect(after.body.loginInFlight).toBe(false);
     expect(existsSync(configPath())).toBe(false);
+  });
+});
+
+describe('ALL /api/integrations/vela/api-proxy/*', () => {
+  it('forwards form-encoded POST bodies to the AMR API upstream', async () => {
+    const upstreamRequests: Array<{
+      href: string;
+      method: string;
+      headers: Record<string, string>;
+      body: string;
+    }> = [];
+    const requestSpy = vi.spyOn(https, 'request').mockImplementation(((target, options, callback) => {
+      const req = new PassThrough() as any;
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer | string) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      req.on('finish', () => {
+        upstreamRequests.push({
+          href: target instanceof URL ? target.href : String(target),
+          method: String(options?.method ?? ''),
+          headers: options?.headers as Record<string, string>,
+          body: Buffer.concat(chunks).toString('utf8'),
+        });
+        const upstreamRes = new PassThrough() as any;
+        upstreamRes.statusCode = 201;
+        upstreamRes.headers = { 'content-type': 'application/json' };
+        callback?.(upstreamRes);
+        upstreamRes.end(JSON.stringify({ ok: true }));
+      });
+      req.setTimeout = () => req;
+      return req;
+    }) as typeof https.request);
+
+    try {
+      const body = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'device-code-123',
+      }).toString();
+      const resp = await fetch(`${baseUrl}/api/integrations/vela/api-proxy/api/v1/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      });
+
+      expect(resp.status).toBe(201);
+      expect(await resp.json()).toEqual({ ok: true });
+      expect(upstreamRequests).toHaveLength(1);
+      expect(upstreamRequests[0]?.href).toBe('https://amr-api.open-design.ai/api/v1/oauth/token');
+      expect(upstreamRequests[0]?.method).toBe('POST');
+      expect(upstreamRequests[0]?.headers['content-type']).toContain(
+        'application/x-www-form-urlencoded',
+      );
+      expect(upstreamRequests[0]?.headers['content-length']).toBe(String(Buffer.byteLength(body)));
+      expect(upstreamRequests[0]?.body).toBe(body);
+    } finally {
+      requestSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Why

Closes #3726.

AMR sign-in can fail before device authorization starts when `amr-api.open-design.ai` resolves to a broken edge path. The bundled Vela CLI owns the auth flow, so Open Design needs to give daemon-started login a transport path that avoids the failing client-side DNS/edge selection while preserving operator overrides.

## What users will see

Clicking Authorize on the AMR card now starts Vela login through a daemon-local AMR API proxy. The proxy forwards AMR API calls to `amr-api.open-design.ai` over IPv4, so the Settings sign-in flow can get past the TLS/edge failure. Users with a custom `VELA_API_URL` keep that explicit setting.

## Surface area

- [ ] Web UI
- [x] Daemon integration
- [ ] Shared contracts
- [ ] i18n copy
- [x] Tests
- [x] CLI/env var: allows `VELA_API_URL` in saved AMR CLI env so explicit overrides remain supported

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/integrations/vela.routes.test.ts tests/integrations/vela.test.ts tests/app-config.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>