### PR TITLE
[codex] Track touched files for trace object uploads

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -106,6 +106,7 @@ function migrate(db: SqliteDb): void {
       events_json TEXT,
       attachments_json TEXT,
       produced_files_json TEXT,
+      trace_object_files_json TEXT,
       feedback_json TEXT,
       pre_turn_file_names_json TEXT,
       session_mode TEXT,
@@ -275,6 +276,9 @@ function migrate(db: SqliteDb): void {
   }
   if (!messageCols.some((c: DbRow) => c.name === 'pre_turn_file_names_json')) {
     db.exec(`ALTER TABLE messages ADD COLUMN pre_turn_file_names_json TEXT`);
+  }
+  if (!messageCols.some((c: DbRow) => c.name === 'trace_object_files_json')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN trace_object_files_json TEXT`);
   }
   if (!messageCols.some((c: DbRow) => c.name === 'session_mode')) {
     db.exec(`ALTER TABLE messages ADD COLUMN session_mode TEXT`);
@@ -1178,6 +1182,7 @@ export function listMessages(db: SqliteDb, conversationId: string) {
               attachments_json AS attachmentsJson,
               comment_attachments_json AS commentAttachmentsJson,
               produced_files_json AS producedFilesJson,
+              trace_object_files_json AS traceObjectFilesJson,
               feedback_json AS feedbackJson,
               pre_turn_file_names_json AS preTurnFileNamesJson,
               session_mode AS sessionMode,
@@ -1204,7 +1209,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
           SET role = ?, content = ?, agent_id = ?, agent_name = ?,
               run_id = ?, run_status = ?, last_run_event_id = ?,
               events_json = ?, attachments_json = ?, comment_attachments_json = ?,
-              produced_files_json = ?, feedback_json = ?,
+              produced_files_json = ?, trace_object_files_json = ?, feedback_json = ?,
               pre_turn_file_names_json = ?,
               session_mode = ?, run_context_json = ?, applied_plugin_snapshot_json = ?,
               started_at = ?, ended_at = ?
@@ -1221,6 +1226,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.attachments ? JSON.stringify(m.attachments) : null,
       m.commentAttachments ? JSON.stringify(m.commentAttachments) : null,
       m.producedFiles ? JSON.stringify(m.producedFiles) : null,
+      m.traceObjectFiles ? JSON.stringify(m.traceObjectFiles) : null,
       m.feedback ? JSON.stringify(m.feedback) : null,
       m.preTurnFileNames ? JSON.stringify(m.preTurnFileNames) : null,
       normalizeMessageSessionModeForStorage(m.sessionMode),
@@ -1237,20 +1243,20 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       )
       .get(conversationId) as DbRow | undefined;
     const position = (max?.m ?? -1) + 1;
-    // 22 values: id, conversation_id, role, content, agent_id, agent_name,
+    // 23 values: id, conversation_id, role, content, agent_id, agent_name,
     // run_id, run_status, last_run_event_id, events_json, attachments_json,
-    // comment_attachments_json, produced_files_json, feedback_json,
-    // pre_turn_file_names_json, session_mode, run_context_json,
+    // comment_attachments_json, produced_files_json, trace_object_files_json,
+    // feedback_json, pre_turn_file_names_json, session_mode, run_context_json,
     // applied_plugin_snapshot_json, started_at, ended_at, position, created_at.
     db.prepare(
       `INSERT INTO messages
          (id, conversation_id, role, content, agent_id, agent_name,
           run_id, run_status, last_run_event_id, events_json,
           attachments_json, comment_attachments_json, produced_files_json,
-          feedback_json, pre_turn_file_names_json,
+          trace_object_files_json, feedback_json, pre_turn_file_names_json,
           session_mode, run_context_json, applied_plugin_snapshot_json,
           started_at, ended_at, position, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       m.id,
       conversationId,
@@ -1265,6 +1271,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.attachments ? JSON.stringify(m.attachments) : null,
       m.commentAttachments ? JSON.stringify(m.commentAttachments) : null,
       m.producedFiles ? JSON.stringify(m.producedFiles) : null,
+      m.traceObjectFiles ? JSON.stringify(m.traceObjectFiles) : null,
       m.feedback ? JSON.stringify(m.feedback) : null,
       m.preTurnFileNames ? JSON.stringify(m.preTurnFileNames) : null,
       normalizeMessageSessionModeForStorage(m.sessionMode),
@@ -1290,6 +1297,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
               attachments_json AS attachmentsJson,
               comment_attachments_json AS commentAttachmentsJson,
               produced_files_json AS producedFilesJson,
+              trace_object_files_json AS traceObjectFilesJson,
               feedback_json AS feedbackJson,
               pre_turn_file_names_json AS preTurnFileNamesJson,
               session_mode AS sessionMode,
@@ -1647,6 +1655,7 @@ function normalizeMessage(row: DbRow) {
     attachments: parseJsonOrUndef(row.attachmentsJson),
     commentAttachments: parseJsonOrUndef(row.commentAttachmentsJson),
     producedFiles: parseJsonOrUndef(row.producedFilesJson),
+    traceObjectFiles: parseJsonOrUndef(row.traceObjectFilesJson),
     feedback: parseJsonOrUndef(row.feedbackJson),
     preTurnFileNames: parseJsonOrUndef(row.preTurnFileNamesJson),
     sessionMode: normalizeMessageSessionMode(row.sessionMode),

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -35,6 +35,7 @@ import {
   type ReportContext,
   type RuntimeInfo,
   type TelemetrySinkConfig,
+  type TraceObjectSummary,
   type ToolCallSummary,
   type TurnInfo,
 } from './langfuse-trace.js';
@@ -55,7 +56,7 @@ import {
 import { classifyRunFailure } from './run-failure-classification.js';
 import { deriveRunErrorCode, runResultFromStatus } from './run-result.js';
 import { buildTraceObjectManifests } from './trace-object-manifest.js';
-import type { TraceArtifactObjectSource } from './trace-object-manifest.js';
+import type { TraceArtifactObjectSource, TraceObjectUploadManifests } from './trace-object-manifest.js';
 
 interface DaemonRunRecord {
   id: string;
@@ -657,7 +658,7 @@ function buildTraceSafeManifests(args: {
   projectId: string | null | undefined;
   runId: string;
   attachmentsRaw: unknown;
-  producedFilesRaw: unknown;
+  traceObjectFilesRaw: unknown;
 }): TraceSafeManifestResult {
   const attachmentManifest: AttachmentManifestEntry[] = [];
   const artifactManifest: ArtifactManifestEntry[] = [];
@@ -720,8 +721,8 @@ function buildTraceSafeManifests(args: {
     unavailable = true;
   }
 
-  if (Array.isArray(args.producedFilesRaw)) {
-    for (const [index, raw] of args.producedFilesRaw.entries()) {
+  if (Array.isArray(args.traceObjectFilesRaw)) {
+    for (const [index, raw] of args.traceObjectFilesRaw.entries()) {
       if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
         partial = true;
         continue;
@@ -789,7 +790,7 @@ function buildTraceSafeManifests(args: {
         approved_by: null,
       });
     }
-  } else if (args.producedFilesRaw !== undefined && args.producedFilesRaw !== null) {
+  } else if (args.traceObjectFilesRaw !== undefined && args.traceObjectFilesRaw !== null) {
     unavailable = true;
   }
 
@@ -797,6 +798,45 @@ function buildTraceSafeManifests(args: {
     attachmentManifest,
     artifactManifest,
     completeness: unavailable ? 'unavailable' : partial ? 'partial' : 'complete',
+  };
+}
+
+function traceObjectFilesForTelemetry(traceObjectFilesRaw: unknown, producedFilesRaw: unknown): unknown {
+  return Array.isArray(traceObjectFilesRaw) ? traceObjectFilesRaw : producedFilesRaw;
+}
+
+function buildTraceObjectSummary(args: {
+  traceObjectFilesRaw: unknown;
+  uploaded?: FinalTraceSafeManifests | TraceObjectUploadManifests;
+}): TraceObjectSummary {
+  const files = Array.isArray(args.traceObjectFilesRaw)
+    ? args.traceObjectFilesRaw.filter((item) => item && typeof item === 'object' && !Array.isArray(item)) as Array<Record<string, unknown>>
+    : [];
+  const byReason = (reason: string) =>
+    files.filter((file) => file.traceObjectReason === reason).length;
+  const entries = args.uploaded?.artifactManifest ?? [];
+  const skipReasons: Record<string, number> = {};
+  let uploadedCount = 0;
+  for (const entry of entries) {
+    if (entry.status === 'ok' && entry.stored_in_open_design === true) {
+      uploadedCount += 1;
+      continue;
+    }
+    const reason = entry.reason ?? entry.status;
+    skipReasons[reason] = (skipReasons[reason] ?? 0) + 1;
+  }
+  if (files.length > 0 && entries.length === 0) {
+    skipReasons.object_upload_unavailable = files.length;
+  }
+  return {
+    new_file_count: byReason('new'),
+    modified_file_count: byReason('modified'),
+    recovered_file_count: byReason('recovered'),
+    candidate_file_count: files.length,
+    uploaded_file_count: uploadedCount,
+    skipped_file_count: Math.max(0, entries.length - uploadedCount) +
+      (entries.length === 0 ? files.length : 0),
+    skip_reasons: skipReasons,
   };
 }
 
@@ -842,6 +882,7 @@ export async function reportRunCompletedFromDaemon(
 
     let messageContent = '';
     let producedFilesRaw: unknown = undefined;
+    let traceObjectFilesRaw: unknown = undefined;
     let attachmentsRaw: unknown = undefined;
     if (run.conversationId && run.assistantMessageId) {
       try {
@@ -860,6 +901,7 @@ export async function reportRunCompletedFromDaemon(
           messageContent = typeof m.content === 'string' ? m.content : '';
           // listMessages returns producedFiles already parsed (db.ts:965).
           producedFilesRaw = m.producedFiles;
+          traceObjectFilesRaw = traceObjectFilesForTelemetry(m.traceObjectFiles, producedFilesRaw);
           attachmentsRaw = collectPriorUserAttachments(allMessages, assistantIndex);
         }
       } catch (err) {
@@ -922,7 +964,7 @@ export async function reportRunCompletedFromDaemon(
       ...getRuntimeInfo(opts.appVersion ?? null),
       ...(run.clientType ? { clientType: run.clientType } : {}),
     };
-    const artifacts = summarizeProducedFiles(producedFilesRaw);
+    const artifacts = summarizeProducedFiles(traceObjectFilesRaw);
     const diagnostics = summarizeRunDiagnosticsForAnalytics({
       events: run.events,
       exitCode: run.exitCode ?? null,
@@ -935,7 +977,7 @@ export async function reportRunCompletedFromDaemon(
       projectId: run.projectId,
       runId: run.id,
       attachmentsRaw,
-      producedFilesRaw,
+      traceObjectFilesRaw,
     });
     const objectManifestOptions = {
       installationId,
@@ -944,12 +986,18 @@ export async function reportRunCompletedFromDaemon(
       projectsRoot: path.join(dataDir, 'projects'),
       ...(run.projectMetadata ? { projectMetadata: run.projectMetadata } : {}),
       ...(run.projectAttachmentPaths ? { attachmentPaths: run.projectAttachmentPaths } : {}),
-      artifacts: buildTraceObjectArtifactSources(producedFilesRaw),
+      artifacts: buildTraceObjectArtifactSources(traceObjectFilesRaw),
       prompt: telemetryPrompt,
       prefs,
       ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
     } satisfies Parameters<typeof buildTraceObjectManifests>[0];
-    const buildContext = (finalManifests: FinalTraceSafeManifests): ReportContext => ({
+    const buildContext = (
+      finalManifests: FinalTraceSafeManifests,
+      traceObjectSummary = buildTraceObjectSummary({
+        traceObjectFilesRaw,
+        uploaded: finalManifests,
+      }),
+    ): ReportContext => ({
       installationId,
       projectId: run.projectId ?? '',
       conversationId: run.conversationId ?? '',
@@ -985,6 +1033,7 @@ export async function reportRunCompletedFromDaemon(
         ? { inputTextSnapshotManifest: finalManifests.inputTextSnapshotManifest }
         : {}),
       manifestCompleteness: finalManifests.completeness,
+      traceObjectSummary,
       tools: collectToolCalls(run.events, startedAt, endedAt),
       agentEvents: collectAgentEvents(run.events, startedAt, endedAt, run.agentId),
       eventsSummary: summarizeEvents(run.events, durationMs),
@@ -1011,7 +1060,10 @@ export async function reportRunCompletedFromDaemon(
     const uploadedManifests = await buildTraceObjectManifests(objectManifestOptions);
     const finalManifests = mergeTraceSafeManifests(manifests, uploadedManifests);
     return await reportRunCompleted(
-      buildContext(finalManifests),
+      buildContext(finalManifests, buildTraceObjectSummary({
+        traceObjectFilesRaw,
+        ...(uploadedManifests ? { uploaded: uploadedManifests } : {}),
+      })),
       opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {},
     );
   } catch (err) {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -203,6 +203,16 @@ export interface InputTextSnapshotManifestEntry extends TraceSafeObjectManifestB
   type: 'text';
 }
 
+export interface TraceObjectSummary {
+  new_file_count: number;
+  modified_file_count: number;
+  recovered_file_count: number;
+  candidate_file_count: number;
+  uploaded_file_count: number;
+  skipped_file_count: number;
+  skip_reasons: Record<string, number>;
+}
+
 export interface ToolCallSummary {
   id: string;
   name: string;
@@ -272,6 +282,7 @@ export interface ReportContext {
   artifactManifest?: ArtifactManifestEntry[];
   inputTextSnapshotManifest?: InputTextSnapshotManifestEntry[];
   manifestCompleteness?: ObjectManifestCompleteness;
+  traceObjectSummary?: TraceObjectSummary;
   tools?: ToolCallSummary[];
   agentEvents?: AgentEventSummary[];
   eventsSummary: EventsSummary;
@@ -1139,6 +1150,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     artifact_manifest_truncated: artifactManifestTruncated,
     input_text_snapshot_manifest: inputTextSnapshotManifest,
     input_text_snapshot_manifest_truncated: inputTextSnapshotManifestTruncated,
+    trace_object_summary: ctx.traceObjectSummary,
     manifest_completeness: wantsArtifacts
       ? (ctx.manifestCompleteness ?? 'unavailable')
       : undefined,

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -12,6 +12,7 @@ interface FakeMessage {
   content: string;
   attachments?: Array<Record<string, unknown>>;
   producedFiles?: Array<Record<string, unknown>>;
+  traceObjectFiles?: Array<Record<string, unknown>>;
 }
 
 function makeDb(messagesByConvo: Record<string, FakeMessage[]> = {}) {
@@ -776,6 +777,89 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       status: 'ok',
       stored_in_open_design: true,
     });
+  });
+
+  it('uploads modified existing files from traceObjectFiles and records object summary metadata', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: true },
+    });
+    const projectDir = path.join(dataDir, 'projects', 'proj-1');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(path.join(projectDir, 'existing.html'), '<!doctype html><h1>modified</h1>');
+    const uploadedFilenames: string[] = [];
+    const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
+      if (url.includes('/api/objects/authorize')) {
+        return new Response(JSON.stringify({ upload_token: 'upload-token' }), { status: 200 });
+      }
+      if (url.includes('/api/objects/batch')) {
+        const parsed = JSON.parse(init.body as string) as {
+          objects: Array<{ storage_ref: string; filename: string; content_base64: string }>;
+        };
+        uploadedFilenames.push(...parsed.objects.map((object) => object.filename));
+        return new Response(
+          JSON.stringify({
+            objects: parsed.objects.map((object) => ({
+              storage_ref: object.storage_ref,
+              status: 'available',
+              size_bytes: Buffer.from(object.content_base64, 'base64').byteLength,
+              sha256: 'sha256:uploaded-artifact',
+            })),
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('{}', { status: 207 });
+    });
+
+    process.env.OPEN_DESIGN_OBJECT_RELAY_URL = 'https://telemetry.open-design.ai/api/objects/batch';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            { id: 'user-1', role: 'user', content: 'Update the existing page.' },
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              content: 'done',
+              producedFiles: [],
+              traceObjectFiles: [
+                {
+                  name: 'existing.html',
+                  kind: 'html',
+                  size: 34,
+                  traceObjectReason: 'modified',
+                },
+              ],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun() as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      delete process.env.OPEN_DESIGN_OBJECT_RELAY_URL;
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+
+    expect(uploadedFilenames).toEqual(['existing.html']);
+    const finalBatch = JSON.parse(fetchSpy.mock.calls.at(-1)![1]!.body as string).batch as any[];
+    expect(finalBatch[0].body.metadata.trace_object_summary).toEqual({
+      new_file_count: 0,
+      modified_file_count: 1,
+      recovered_file_count: 0,
+      candidate_file_count: 1,
+      uploaded_file_count: 1,
+      skipped_file_count: 0,
+      skip_reasons: {},
+    });
+    expect(finalBatch[0].body.metadata.artifacts).toEqual([
+      { slug: 'existing.html', type: 'html', sizeBytes: 34 },
+    ]);
   });
 
   it('derives manifest completeness from merged uploaded and fallback manifests', async () => {
@@ -1719,6 +1803,9 @@ function makeDbWithListMessages(messagesByConvo: Record<string, FakeMessage[]>) 
             commentAttachmentsJson: null,
             producedFilesJson: m.producedFiles
               ? JSON.stringify(m.producedFiles)
+              : null,
+            traceObjectFilesJson: m.traceObjectFiles
+              ? JSON.stringify(m.traceObjectFiles)
               : null,
             createdAt: 0,
             startedAt: null,

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2769,7 +2769,6 @@ export function ProjectView({
                   endedAt: prev.endedAt ?? Date.now(),
                 }),
                 true,
-                { telemetryFinalized: true },
               );
               void (async () => {
                 const preTurn = message.preTurnFileNames;
@@ -2809,14 +2808,12 @@ export function ProjectView({
                 );
                 const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
                 if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
-                if (produced.length > 0 || traceObjectFiles.length > 0) {
-                  updateMessageById(
-                    message.id,
-                    (prev) => ({ ...prev, producedFiles: produced, traceObjectFiles }),
-                    true,
-                    { telemetryFinalized: true },
-                  );
-                }
+                updateMessageById(
+                  message.id,
+                  (prev) => ({ ...prev, producedFiles: produced, traceObjectFiles }),
+                  true,
+                  { telemetryFinalized: true },
+                );
                 await auditDesignSystemWorkspaceAfterRun(message.id);
               })();
               onProjectsRefresh();

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1087,6 +1087,9 @@ export function ProjectView({
   // "live" tab that was causing flicker against manual opens.
   const pendingWritesRef = useRef<Map<string, string>>(new Map());
   const traceTouchedFilePathsRef = useRef<Set<string>>(new Set());
+  const clearTraceTouchedFilePaths = useCallback(() => {
+    traceTouchedFilePathsRef.current.clear();
+  }, []);
   // Track which conversation the current messages belong to, so we can
   // correctly gate new-conversation creation even during async loads.
   const messagesConversationIdRef = useRef<string | null>(null);
@@ -3323,8 +3326,7 @@ export function ProjectView({
           });
         }
         if (ev.kind === 'tool_use' && isFileWriteToolName(ev.name)) {
-          const input = ev.input as { file_path?: unknown; filePath?: unknown } | null;
-          const filePath = input?.file_path ?? input?.filePath;
+          const filePath = extractFileWriteToolPath(ev.input);
           if (typeof filePath === 'string' && filePath.length > 0) {
             // Preserve the full path so decideAutoOpenAfterWrite can do a
             // path-suffix match against the project's relative file paths.
@@ -3458,6 +3460,7 @@ export function ProjectView({
           if (!runMayFinalize) {
             textBuffer.cancel();
             cancelSendTextBuffer();
+            clearTraceTouchedFilePaths();
             return;
           }
           textBuffer.flush();
@@ -3509,6 +3512,7 @@ export function ProjectView({
             if (ownsCurrentRun) updateConversationLatestRun('failed', endedAt);
             void refreshProjectFiles();
             onProjectsRefresh();
+            clearTraceTouchedFilePaths();
             return;
           }
           const endedAt = Date.now();
@@ -3535,35 +3539,38 @@ export function ProjectView({
           // and attach the new files to the assistant message as download
           // chips.
           void (async () => {
-            let nextFiles = await refreshProjectFiles();
-            const finalText = streamedText || fullText;
-            const artifactToPersist = parsedArtifact?.html
-              ? parsedArtifact
-              : artifactFromStandaloneHtml(finalText);
-            if (artifactToPersist?.html) {
-              await persistArtifact(artifactToPersist, nextFiles, finalText);
-              nextFiles = await refreshProjectFiles();
+            try {
+              let nextFiles = await refreshProjectFiles();
+              const finalText = streamedText || fullText;
+              const artifactToPersist = parsedArtifact?.html
+                ? parsedArtifact
+                : artifactFromStandaloneHtml(finalText);
+              if (artifactToPersist?.html) {
+                await persistArtifact(artifactToPersist, nextFiles, finalText);
+                nextFiles = await refreshProjectFiles();
+              }
+              const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+              const traceObjectFiles = computeTraceObjectFiles(
+                beforeFileNames,
+                nextFiles,
+                traceTouchedFilePathsRef.current,
+              ) ?? [];
+              const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
+              if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
+              setMessages((curr) => {
+                const updated = curr.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, producedFiles: produced, traceObjectFiles }
+                    : m,
+                );
+                const finalized = updated.find((m) => m.id === assistantId);
+                if (finalized) persistMessage(finalized, { telemetryFinalized: true });
+                return updated;
+              });
+              await auditDesignSystemWorkspaceAfterRun(assistantId);
+            } finally {
+              clearTraceTouchedFilePaths();
             }
-            const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
-            const traceObjectFiles = computeTraceObjectFiles(
-              beforeFileNames,
-              nextFiles,
-              traceTouchedFilePathsRef.current,
-            ) ?? [];
-            const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
-            if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
-            setMessages((curr) => {
-              const updated = curr.map((m) =>
-                m.id === assistantId
-                  ? { ...m, producedFiles: produced, traceObjectFiles }
-                  : m,
-              );
-              const finalized = updated.find((m) => m.id === assistantId);
-              if (finalized) persistMessage(finalized, { telemetryFinalized: true });
-              return updated;
-            });
-            traceTouchedFilePathsRef.current.clear();
-            await auditDesignSystemWorkspaceAfterRun(assistantId);
           })();
           onProjectsRefresh();
         },
@@ -3608,6 +3615,7 @@ export function ProjectView({
             return curr;
           });
           void refreshProjectFiles();
+          clearTraceTouchedFilePaths();
         },
       };
 
@@ -3709,6 +3717,7 @@ export function ProjectView({
             if (isTerminalRunStatus(runStatus)) {
               clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
               scheduleConversationMessageRefresh(runConversationId);
+              if (runStatus !== 'succeeded') clearTraceTouchedFilePaths();
             }
           },
           onRunEventId: (lastRunEventId) => {
@@ -3855,6 +3864,7 @@ export function ProjectView({
       requestOpenFile,
       persistMessage,
       persistMessageById,
+      clearTraceTouchedFilePaths,
       auditDesignSystemWorkspaceAfterRun,
       patchAttachedStatuses,
       updateMessageById,
@@ -3888,6 +3898,7 @@ export function ProjectView({
       controller.abort();
     }
     reattachControllersRef.current.clear();
+    clearTraceTouchedFilePaths();
     setStreaming(false);
     streamingConversationIdRef.current = null;
     setStreamingConversationId(null);
@@ -3896,7 +3907,7 @@ export function ProjectView({
       for (const message of finalized) persistMessage(message, { telemetryFinalized: true });
       return next;
     });
-  }, [cancelSendTextBuffer, cancelReattachTextBuffers, persistMessage]);
+  }, [cancelSendTextBuffer, cancelReattachTextBuffers, clearTraceTouchedFilePaths, persistMessage]);
 
   // Flip the deck preview to the slide a queued send's marked element lives on
   // the moment that send starts processing. No-op for plain prompts or marks
@@ -6393,10 +6404,7 @@ export function extractTouchedFilePathsFromEvents(events: ChatMessage['events'])
     if (!event || typeof event !== 'object') continue;
     const rec = event as Record<string, unknown>;
     if (rec.kind === 'tool_use' && isFileWriteToolName(rec.name)) {
-      const input = rec.input && typeof rec.input === 'object'
-        ? rec.input as Record<string, unknown>
-        : null;
-      const filePath = input?.file_path ?? input?.filePath ?? input?.path;
+      const filePath = extractFileWriteToolPath(rec.input);
       if (typeof rec.id === 'string' && typeof filePath === 'string' && filePath) {
         pending.set(rec.id, filePath);
       }
@@ -6417,7 +6425,22 @@ export function extractTouchedFilePathsFromEvents(events: ChatMessage['events'])
 }
 
 function isFileWriteToolName(value: unknown): boolean {
-  return value === 'Write' || value === 'write' || value === 'Edit';
+  return (
+    value === 'Write'
+    || value === 'write'
+    || value === 'create_file'
+    || value === 'Edit'
+    || value === 'str_replace_edit'
+    || value === 'MultiEdit'
+    || value === 'multi_edit'
+  );
+}
+
+function extractFileWriteToolPath(input: unknown): string | null {
+  if (!input || typeof input !== 'object') return null;
+  const rec = input as Record<string, unknown>;
+  const filePath = rec.file_path ?? rec.filePath ?? rec.path;
+  return typeof filePath === 'string' && filePath ? filePath : null;
 }
 
 export function clearStreamingConversationMarker(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1079,13 +1079,6 @@ export function ProjectView({
   // last name we persisted so re-renders during streaming don't spawn
   // duplicate writes.
   const savedArtifactRef = useRef<string | null>(null);
-  // Pending Write tool invocations: tool_use_id -> destination basename.
-  // When the matching tool_result lands we refresh the file list and open
-  // the file as a tab once. Keying off the tool_use_id (rather than
-  // diffing the file list at end-of-turn) lets us auto-open the moment
-  // the agent's Write actually completes, without the previous synthetic
-  // "live" tab that was causing flicker against manual opens.
-  const pendingWritesRef = useRef<Map<string, string>>(new Map());
   // Track which conversation the current messages belong to, so we can
   // correctly gate new-conversation creation even during async loads.
   const messagesConversationIdRef = useRef<string | null>(null);
@@ -1321,7 +1314,6 @@ export function ProjectView({
     setAudioVoiceOptionsError(null);
     setArtifact(null);
     savedArtifactRef.current = null;
-    pendingWritesRef.current.clear();
     (async () => {
       try {
         const list = await listConversations(project.id);
@@ -1425,7 +1417,6 @@ export function ProjectView({
     streamingConversationIdRef.current = null;
     setStreamingConversationId(null);
     savedArtifactRef.current = null;
-    pendingWritesRef.current.clear();
     if (messagesConversationIdRef.current !== activeConversationId) {
       messagesConversationIdRef.current = null;
     }
@@ -1443,7 +1434,6 @@ export function ProjectView({
         setArtifact(null);
         setError(null);
         savedArtifactRef.current = null;
-        pendingWritesRef.current.clear();
         messagesConversationIdRef.current = activeConversationId;
         setMessagesConversationId(activeConversationId);
         setFailedMessagesConversationId(null);
@@ -1456,7 +1446,6 @@ export function ProjectView({
         setArtifact(null);
         setError(message);
         savedArtifactRef.current = null;
-        pendingWritesRef.current.clear();
         messagesConversationIdRef.current = null;
         setMessagesConversationId(null);
         setFailedMessagesConversationId(activeConversationId);
@@ -3251,8 +3240,13 @@ export function ProjectView({
       // agent finishes and surface anything new (e.g. a generated .pptx)
       // as download chips on the assistant message.
       const beforeFileNames = new Set(preTurnFileNames);
+      // Pending Write/Edit tool invocations for this run: tool_use_id -> path.
+      // Keeping this local prevents a superseded stream's late tool_result from
+      // consuming a replacement run's colliding tool id.
+      const pendingWrites = new Map<string, string>();
       const traceTouchedFilePaths = new Set<string>();
       const clearTraceTouchedFilePaths = () => {
+        pendingWrites.clear();
         traceTouchedFilePaths.clear();
       };
 
@@ -3328,13 +3322,13 @@ export function ProjectView({
             // Reducing to a basename here would lose the segment alignment
             // we need to disambiguate same-basename collisions across the
             // project tree and outside it.
-            pendingWritesRef.current.set(ev.id, filePath);
+            pendingWrites.set(ev.id, filePath);
           }
         }
         if (ev.kind === 'tool_result') {
-          const filePath = pendingWritesRef.current.get(ev.toolUseId);
+          const filePath = pendingWrites.get(ev.toolUseId);
           if (filePath) {
-            pendingWritesRef.current.delete(ev.toolUseId);
+            pendingWrites.delete(ev.toolUseId);
             if (!ev.isError) {
               traceTouchedFilePaths.add(filePath);
               // Refresh first so FileWorkspace's file list (and the tab

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1086,6 +1086,7 @@ export function ProjectView({
   // the agent's Write actually completes, without the previous synthetic
   // "live" tab that was causing flicker against manual opens.
   const pendingWritesRef = useRef<Map<string, string>>(new Map());
+  const traceTouchedFilePathsRef = useRef<Set<string>>(new Set());
   // Track which conversation the current messages belong to, so we can
   // correctly gate new-conversation creation even during async loads.
   const messagesConversationIdRef = useRef<string | null>(null);
@@ -1322,6 +1323,7 @@ export function ProjectView({
     setArtifact(null);
     savedArtifactRef.current = null;
     pendingWritesRef.current.clear();
+    traceTouchedFilePathsRef.current.clear();
     (async () => {
       try {
         const list = await listConversations(project.id);
@@ -1426,6 +1428,7 @@ export function ProjectView({
     setStreamingConversationId(null);
     savedArtifactRef.current = null;
     pendingWritesRef.current.clear();
+    traceTouchedFilePathsRef.current.clear();
     if (messagesConversationIdRef.current !== activeConversationId) {
       messagesConversationIdRef.current = null;
     }
@@ -1444,6 +1447,7 @@ export function ProjectView({
         setError(null);
         savedArtifactRef.current = null;
         pendingWritesRef.current.clear();
+        traceTouchedFilePathsRef.current.clear();
         messagesConversationIdRef.current = activeConversationId;
         setMessagesConversationId(activeConversationId);
         setFailedMessagesConversationId(null);
@@ -1457,6 +1461,7 @@ export function ProjectView({
         setError(message);
         savedArtifactRef.current = null;
         pendingWritesRef.current.clear();
+        traceTouchedFilePathsRef.current.clear();
         messagesConversationIdRef.current = null;
         setMessagesConversationId(null);
         setFailedMessagesConversationId(activeConversationId);
@@ -2799,12 +2804,20 @@ export function ProjectView({
                 }
                 const diff = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
                 const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
+                const traceObjectFiles = mergeRecoveredTraceObjectFile(
+                  computeTraceObjectFiles(
+                    beforeFileNames,
+                    nextFiles,
+                    extractTouchedFilePathsFromEvents(message.events),
+                  ) ?? [],
+                  recoveredExistingArtifact,
+                );
                 const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
                 if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
-                if (produced.length > 0) {
+                if (produced.length > 0 || traceObjectFiles.length > 0) {
                   updateMessageById(
                     message.id,
-                    (prev) => ({ ...prev, producedFiles: produced }),
+                    (prev) => ({ ...prev, producedFiles: produced, traceObjectFiles }),
                     true,
                     { telemetryFinalized: true },
                   );
@@ -3309,7 +3322,7 @@ export function ProjectView({
             return next;
           });
         }
-        if (ev.kind === 'tool_use' && ((ev.name === 'Write' || ev.name === 'write') || ev.name === 'Edit')) {
+        if (ev.kind === 'tool_use' && isFileWriteToolName(ev.name)) {
           const input = ev.input as { file_path?: unknown; filePath?: unknown } | null;
           const filePath = input?.file_path ?? input?.filePath;
           if (typeof filePath === 'string' && filePath.length > 0) {
@@ -3326,6 +3339,7 @@ export function ProjectView({
           if (filePath) {
             pendingWritesRef.current.delete(ev.toolUseId);
             if (!ev.isError) {
+              traceTouchedFilePathsRef.current.add(filePath);
               // Refresh first so FileWorkspace's file list (and the tab
               // body) sees the new content before we ask it to focus.
               // Only auto-open if the file actually landed in the project's
@@ -3531,18 +3545,24 @@ export function ProjectView({
               nextFiles = await refreshProjectFiles();
             }
             const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+            const traceObjectFiles = computeTraceObjectFiles(
+              beforeFileNames,
+              nextFiles,
+              traceTouchedFilePathsRef.current,
+            ) ?? [];
             const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
             if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
             setMessages((curr) => {
               const updated = curr.map((m) =>
                 m.id === assistantId
-                  ? { ...m, producedFiles: produced }
+                  ? { ...m, producedFiles: produced, traceObjectFiles }
                   : m,
               );
               const finalized = updated.find((m) => m.id === assistantId);
               if (finalized) persistMessage(finalized, { telemetryFinalized: true });
               return updated;
             });
+            traceTouchedFilePathsRef.current.clear();
             await auditDesignSystemWorkspaceAfterRun(assistantId);
           })();
           onProjectsRefresh();
@@ -6283,6 +6303,61 @@ export function computeProducedFiles(
   return filterImplicitProducedFiles(next.filter((f) => !set.has(f.name)));
 }
 
+export function computeTraceObjectFiles(
+  beforeNames: ReadonlySet<string> | readonly string[] | undefined,
+  next: readonly ProjectFile[],
+  touchedPaths: Iterable<string> = [],
+): ProjectFile[] | undefined {
+  if (!beforeNames) return undefined;
+  const set = beforeNames instanceof Set ? beforeNames : new Set(beforeNames);
+  const byName = new Map<string, ProjectFile>();
+  for (const file of filterImplicitProducedFiles(next.filter((f) => !set.has(f.name)))) {
+    byName.set(file.name, { ...file, traceObjectReason: 'new' });
+  }
+  for (const rawPath of touchedPaths) {
+    const file = findTouchedProjectFile(rawPath, next);
+    if (!file) continue;
+    byName.set(file.name, {
+      ...file,
+      traceObjectReason: set.has(file.name) ? 'modified' : 'new',
+    });
+  }
+  return [...byName.values()];
+}
+
+function findTouchedProjectFile(rawPath: string, files: readonly ProjectFile[]): ProjectFile | null {
+  const normalized = normalizeComparableFilePath(rawPath);
+  if (!normalized) return null;
+  const basename = normalized.split('/').pop() ?? normalized;
+  const normalizedFiles = files.map((file) => ({
+    file,
+    candidates: [
+      normalizeComparableFilePath(file.path ?? ''),
+      normalizeComparableFilePath(file.name),
+    ].filter(Boolean),
+  }));
+  const exact = normalizedFiles.find(({ candidates }) =>
+    candidates.some((candidate) =>
+      candidate === normalized ||
+      candidate.endsWith(`/${normalized}`) ||
+      normalized.endsWith(`/${candidate}`),
+    ),
+  );
+  if (exact) return exact.file;
+  const basenameMatches = normalizedFiles.filter(({ candidates }) =>
+    candidates.some((candidate) => candidate.split('/').pop() === basename),
+  );
+  return basenameMatches.length === 1 ? basenameMatches[0]!.file : null;
+}
+
+function normalizeComparableFilePath(value: string): string {
+  return value
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter((part) => part && part !== '.')
+    .join('/');
+}
+
 // Reattach with a recovered (on-disk) artifact must still include any
 // other files the turn produced before the artifact write — replacing
 // the diff with a single file was the regression noted on PR #2383.
@@ -6293,6 +6368,56 @@ export function mergeRecoveredArtifact(
   if (!recovered) return [...diff];
   if (diff.some((f) => f.name === recovered.name)) return [...diff];
   return [...diff, recovered];
+}
+
+export function mergeRecoveredTraceObjectFile(
+  files: readonly ProjectFile[],
+  recovered: ProjectFile | null,
+): ProjectFile[] {
+  const out = [...files];
+  if (!recovered) return out;
+  const existing = out.findIndex((file) => file.name === recovered.name);
+  const tagged = { ...recovered, traceObjectReason: 'recovered' as const };
+  if (existing >= 0) {
+    out[existing] = { ...out[existing]!, traceObjectReason: out[existing]!.traceObjectReason ?? 'recovered' };
+    return out;
+  }
+  return [...out, tagged];
+}
+
+export function extractTouchedFilePathsFromEvents(events: ChatMessage['events']): string[] {
+  if (!Array.isArray(events)) return [];
+  const pending = new Map<string, string>();
+  const touched: string[] = [];
+  for (const event of events) {
+    if (!event || typeof event !== 'object') continue;
+    const rec = event as Record<string, unknown>;
+    if (rec.kind === 'tool_use' && isFileWriteToolName(rec.name)) {
+      const input = rec.input && typeof rec.input === 'object'
+        ? rec.input as Record<string, unknown>
+        : null;
+      const filePath = input?.file_path ?? input?.filePath ?? input?.path;
+      if (typeof rec.id === 'string' && typeof filePath === 'string' && filePath) {
+        pending.set(rec.id, filePath);
+      }
+    }
+    if (rec.kind === 'tool_result') {
+      const toolUseId = typeof rec.toolUseId === 'string'
+        ? rec.toolUseId
+        : typeof rec.tool_use_id === 'string'
+          ? rec.tool_use_id
+          : '';
+      const filePath = pending.get(toolUseId);
+      if (!filePath) continue;
+      pending.delete(toolUseId);
+      if (rec.isError !== true) touched.push(filePath);
+    }
+  }
+  return touched;
+}
+
+function isFileWriteToolName(value: unknown): boolean {
+  return value === 'Write' || value === 'write' || value === 'Edit';
 }
 
 export function clearStreamingConversationMarker(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1086,10 +1086,6 @@ export function ProjectView({
   // the agent's Write actually completes, without the previous synthetic
   // "live" tab that was causing flicker against manual opens.
   const pendingWritesRef = useRef<Map<string, string>>(new Map());
-  const traceTouchedFilePathsRef = useRef<Set<string>>(new Set());
-  const clearTraceTouchedFilePaths = useCallback(() => {
-    traceTouchedFilePathsRef.current.clear();
-  }, []);
   // Track which conversation the current messages belong to, so we can
   // correctly gate new-conversation creation even during async loads.
   const messagesConversationIdRef = useRef<string | null>(null);
@@ -1326,7 +1322,6 @@ export function ProjectView({
     setArtifact(null);
     savedArtifactRef.current = null;
     pendingWritesRef.current.clear();
-    traceTouchedFilePathsRef.current.clear();
     (async () => {
       try {
         const list = await listConversations(project.id);
@@ -1431,7 +1426,6 @@ export function ProjectView({
     setStreamingConversationId(null);
     savedArtifactRef.current = null;
     pendingWritesRef.current.clear();
-    traceTouchedFilePathsRef.current.clear();
     if (messagesConversationIdRef.current !== activeConversationId) {
       messagesConversationIdRef.current = null;
     }
@@ -1450,7 +1444,6 @@ export function ProjectView({
         setError(null);
         savedArtifactRef.current = null;
         pendingWritesRef.current.clear();
-        traceTouchedFilePathsRef.current.clear();
         messagesConversationIdRef.current = activeConversationId;
         setMessagesConversationId(activeConversationId);
         setFailedMessagesConversationId(null);
@@ -1464,7 +1457,6 @@ export function ProjectView({
         setError(message);
         savedArtifactRef.current = null;
         pendingWritesRef.current.clear();
-        traceTouchedFilePathsRef.current.clear();
         messagesConversationIdRef.current = null;
         setMessagesConversationId(null);
         setFailedMessagesConversationId(activeConversationId);
@@ -3260,6 +3252,10 @@ export function ProjectView({
       // agent finishes and surface anything new (e.g. a generated .pptx)
       // as download chips on the assistant message.
       const beforeFileNames = new Set(preTurnFileNames);
+      const traceTouchedFilePaths = new Set<string>();
+      const clearTraceTouchedFilePaths = () => {
+        traceTouchedFilePaths.clear();
+      };
 
       const parser = createArtifactParser();
       let parsedArtifact: Artifact | null = null;
@@ -3341,7 +3337,7 @@ export function ProjectView({
           if (filePath) {
             pendingWritesRef.current.delete(ev.toolUseId);
             if (!ev.isError) {
-              traceTouchedFilePathsRef.current.add(filePath);
+              traceTouchedFilePaths.add(filePath);
               // Refresh first so FileWorkspace's file list (and the tab
               // body) sees the new content before we ask it to focus.
               // Only auto-open if the file actually landed in the project's
@@ -3553,7 +3549,7 @@ export function ProjectView({
               const traceObjectFiles = computeTraceObjectFiles(
                 beforeFileNames,
                 nextFiles,
-                traceTouchedFilePathsRef.current,
+                traceTouchedFilePaths,
               ) ?? [];
               const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
               if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
@@ -3864,7 +3860,6 @@ export function ProjectView({
       requestOpenFile,
       persistMessage,
       persistMessageById,
-      clearTraceTouchedFilePaths,
       auditDesignSystemWorkspaceAfterRun,
       patchAttachedStatuses,
       updateMessageById,
@@ -3898,7 +3893,6 @@ export function ProjectView({
       controller.abort();
     }
     reattachControllersRef.current.clear();
-    clearTraceTouchedFilePaths();
     setStreaming(false);
     streamingConversationIdRef.current = null;
     setStreamingConversationId(null);
@@ -3907,7 +3901,7 @@ export function ProjectView({
       for (const message of finalized) persistMessage(message, { telemetryFinalized: true });
       return next;
     });
-  }, [cancelSendTextBuffer, cancelReattachTextBuffers, clearTraceTouchedFilePaths, persistMessage]);
+  }, [cancelSendTextBuffer, cancelReattachTextBuffers, persistMessage]);
 
   // Flip the deck preview to the slide a queued send's marked element lives on
   // the moment that send starts processing. No-op for plain prompts or marks

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2802,7 +2802,9 @@ export function ProjectView({
                   computeTraceObjectFiles(
                     beforeFileNames,
                     nextFiles,
-                    extractTouchedFilePathsFromEvents(message.events),
+                    extractTouchedFilePathsFromEvents(
+                      needsFullReplay ? replayedEvents : message.events,
+                    ),
                   ) ?? [],
                   recoveredExistingArtifact,
                 );

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -372,6 +372,88 @@ describe('ProjectView daemon reattach restore', () => {
     });
   });
 
+  it('finalizes reattached telemetry only after trace object files are restored', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-reattach-trace',
+        role: 'assistant',
+        content: '',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-trace',
+        runStatus: 'running',
+        preTurnFileNames: ['existing.html'],
+        events: [
+          {
+            kind: 'tool_use',
+            id: 'tool-edit',
+            name: 'str_replace_edit',
+            input: { path: 'existing.html' },
+          },
+          { kind: 'tool_result', toolUseId: 'tool-edit', content: '', isError: false },
+        ],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    const beforeFiles = [
+      { name: 'existing.html', path: '/p/existing.html', size: 1, updatedAt: 0 },
+    ];
+    const afterFiles = [
+      { name: 'existing.html', path: '/p/existing.html', size: 2, updatedAt: 1 },
+    ];
+    fetchProjectFiles.mockResolvedValueOnce(beforeFiles).mockResolvedValue(afterFiles);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-trace',
+      status: 'running',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: null,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+
+    let capturedOnDone: (() => void) | null = null;
+    reattachDaemonRun.mockImplementation(async (options: any) => {
+      capturedOnDone = options.handlers.onDone;
+      return new Promise<void>(() => {});
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    expect(capturedOnDone).not.toBeNull();
+    capturedOnDone!();
+
+    await waitFor(() => {
+      const saves = saveMessage.mock.calls
+        .map((call) => ({
+          message: call[2] as ChatMessage,
+          options: call[3] as { telemetryFinalized?: boolean } | undefined,
+        }))
+        .filter(({ message }) => message?.id === 'msg-reattach-trace');
+      const firstFinalizedIndex = saves.findIndex(
+        ({ options }) => options?.telemetryFinalized === true,
+      );
+      expect(firstFinalizedIndex).toBeGreaterThan(-1);
+      expect(saves[firstFinalizedIndex]!.message.traceObjectFiles?.map((file) => [
+        file.name,
+        file.traceObjectReason,
+      ])).toEqual([['existing.html', 'modified']]);
+      expect(
+        saves.slice(0, firstFinalizedIndex).some(
+          ({ options }) => options?.telemetryFinalized === true,
+        ),
+      ).toBe(false);
+    });
+  });
+
   it('clears touched-file paths after a failed run before the next successful run finalizes', async () => {
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([]);

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ProjectView,
   computeProducedFiles,
+  computeTraceObjectFiles,
+  extractTouchedFilePathsFromEvents,
   mergeRecoveredArtifact,
 } from '../../src/components/ProjectView';
 import type { ChatMessage } from '../../src/types';
@@ -177,6 +179,34 @@ describe('computeProducedFiles', () => {
 
   it('returns undefined when no baseline is provided', () => {
     expect(computeProducedFiles(undefined, [] as never)).toBeUndefined();
+  });
+});
+
+describe('computeTraceObjectFiles', () => {
+  it('includes existing files touched by successful write tools', () => {
+    const before = ['existing.html'];
+    const next = [
+      { name: 'existing.html', path: 'existing.html', size: 10, mtime: 2, kind: 'html', mime: 'text/html' },
+      { name: 'new.pptx', path: 'new.pptx', size: 20, mtime: 3, kind: 'presentation', mime: 'application/vnd.openxmlformats-officedocument.presentationml.presentation' },
+    ];
+
+    const files = computeTraceObjectFiles(before, next as never, ['existing.html']);
+
+    expect(files?.map((file) => [file.name, file.traceObjectReason])).toEqual([
+      ['new.pptx', 'new'],
+      ['existing.html', 'modified'],
+    ]);
+  });
+
+  it('recovers successful write paths from persisted tool events', () => {
+    const touched = extractTouchedFilePathsFromEvents([
+      { kind: 'tool_use', id: 'tool-1', name: 'Edit', input: { file_path: 'existing.html' } },
+      { kind: 'tool_result', toolUseId: 'tool-1', isError: false },
+      { kind: 'tool_use', id: 'tool-2', name: 'Write', input: { file_path: 'failed.html' } },
+      { kind: 'tool_result', toolUseId: 'tool-2', isError: true },
+    ] as never);
+
+    expect(touched).toEqual(['existing.html']);
   });
 });
 

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -435,6 +435,105 @@ describe('ProjectView daemon reattach restore', () => {
     });
   });
 
+  it('keeps touched-file paths isolated when a previous successful run finalizes late', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+
+    const projectFiles = [
+      { name: 'first.html', path: 'first.html', size: 10, mtime: 1, kind: 'html', mime: 'text/html' },
+      { name: 'second.html', path: 'second.html', size: 10, mtime: 1, kind: 'html', mime: 'text/html' },
+    ];
+    fetchProjectFiles.mockResolvedValue(projectFiles);
+
+    streamViaDaemon
+      .mockImplementationOnce(async (options: any) => {
+        options.onRunCreated('run-first');
+        options.handlers.onAgentEvent({
+          kind: 'tool_use',
+          id: 'tool-first',
+          name: 'str_replace_edit',
+          input: { path: 'first.html' },
+        });
+        options.handlers.onAgentEvent({
+          kind: 'tool_result',
+          toolUseId: 'tool-first',
+          content: '',
+          isError: false,
+        });
+        options.handlers.onDelta('first done');
+        options.handlers.onDone('first done');
+      })
+      .mockImplementationOnce(async (options: any) => {
+        options.onRunCreated('run-second');
+        options.handlers.onAgentEvent({
+          kind: 'tool_use',
+          id: 'tool-second',
+          name: 'str_replace_edit',
+          input: { path: 'second.html' },
+        });
+        options.handlers.onAgentEvent({
+          kind: 'tool_result',
+          toolUseId: 'tool-second',
+          content: '',
+          isError: false,
+        });
+        options.handlers.onDelta('second done');
+        options.handlers.onDone('second done');
+      });
+
+    renderProjectView();
+    await waitFor(() => expect(chatPaneHarness.onSend).toBeTruthy());
+    await waitFor(() => expect(fetchProjectFiles).toHaveBeenCalled());
+
+    let resolveFirstFinalRefresh: ((files: typeof projectFiles) => void) | null = null;
+    let resolveSecondFinalRefresh: ((files: typeof projectFiles) => void) | null = null;
+    let refreshCall = 0;
+    fetchProjectFiles.mockClear();
+    fetchProjectFiles.mockImplementation(() => {
+      refreshCall += 1;
+      if (refreshCall === 2) {
+        return new Promise<typeof projectFiles>((resolve) => {
+          resolveFirstFinalRefresh = resolve;
+        });
+      }
+      if (refreshCall === 4) {
+        return new Promise<typeof projectFiles>((resolve) => {
+          resolveSecondFinalRefresh = resolve;
+        });
+      }
+      return Promise.resolve(projectFiles);
+    });
+
+    await chatPaneHarness.onSend!('first run', [], []);
+    await waitFor(() => expect(resolveFirstFinalRefresh).toBeTruthy());
+
+    await waitFor(() => {
+      const started = chatPaneHarness.onSend!('second run', [], []);
+      expect(started).toBeTruthy();
+    });
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(resolveSecondFinalRefresh).toBeTruthy());
+
+    resolveFirstFinalRefresh!(projectFiles);
+    await Promise.resolve();
+    resolveSecondFinalRefresh!(projectFiles);
+
+    await waitFor(() => {
+      const secondRunFinal = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .filter((m) => m?.runId === 'run-second' && Array.isArray(m.traceObjectFiles))
+        .at(-1);
+      expect(secondRunFinal?.traceObjectFiles?.map((file) => file.name)).toEqual(['second.html']);
+    });
+  });
+
   it('reaches succeeded state via the SSE end event even when only the terminal event replays', async () => {
     const startedAt = Date.now();
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -39,6 +39,7 @@ const chatPaneHarness = vi.hoisted(() => ({
     commentAttachments?: unknown[],
     meta?: unknown,
   ) => unknown),
+  onStop: null as null | (() => void),
 }));
 
 vi.mock('../../src/i18n', () => ({
@@ -110,8 +111,15 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 }));
 
 vi.mock('../../src/components/ChatPane', () => ({
-  ChatPane: ({ onSend }: { onSend: typeof chatPaneHarness.onSend }) => {
+  ChatPane: ({
+    onSend,
+    onStop,
+  }: {
+    onSend: typeof chatPaneHarness.onSend;
+    onStop: typeof chatPaneHarness.onStop;
+  }) => {
     chatPaneHarness.onSend = onSend;
+    chatPaneHarness.onStop = onStop;
     return null;
   },
 }));
@@ -264,6 +272,7 @@ describe('ProjectView daemon reattach restore', () => {
     cleanup();
     vi.clearAllMocks();
     chatPaneHarness.onSend = null;
+    chatPaneHarness.onStop = null;
     window.sessionStorage.clear();
   });
 
@@ -712,6 +721,98 @@ describe('ProjectView daemon reattach restore', () => {
     resolveFirstFinalRefresh!(projectFiles);
     await Promise.resolve();
     resolveSecondFinalRefresh!(projectFiles);
+
+    await waitFor(() => {
+      const secondRunFinal = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .filter((m) => m?.runId === 'run-second' && Array.isArray(m.traceObjectFiles))
+        .at(-1);
+      expect(secondRunFinal?.traceObjectFiles?.map((file) => file.name)).toEqual(['second.html']);
+    });
+  });
+
+  it('keeps replacement touched files when a superseded run emits a late colliding tool result', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+
+    const projectFiles = [
+      { name: 'first.html', path: 'first.html', size: 10, mtime: 1, kind: 'html', mime: 'text/html' },
+      { name: 'second.html', path: 'second.html', size: 10, mtime: 1, kind: 'html', mime: 'text/html' },
+    ];
+    fetchProjectFiles.mockResolvedValue(projectFiles);
+
+    let firstHandlers: {
+      onAgentEvent: (ev: unknown) => void;
+    } | null = null;
+    let secondHandlers: {
+      onAgentEvent: (ev: unknown) => void;
+      onDelta: (text: string) => void;
+      onDone: (text?: string) => void;
+    } | null = null;
+
+    streamViaDaemon
+      .mockImplementationOnce(async (options: any) => {
+        options.onRunCreated('run-first');
+        firstHandlers = options.handlers;
+        options.handlers.onAgentEvent({
+          kind: 'tool_use',
+          id: 'tool-collide',
+          name: 'str_replace_edit',
+          input: { path: 'first.html' },
+        });
+        return new Promise<void>(() => {});
+      })
+      .mockImplementationOnce(async (options: any) => {
+        options.onRunCreated('run-second');
+        secondHandlers = options.handlers;
+        options.handlers.onAgentEvent({
+          kind: 'tool_use',
+          id: 'tool-collide',
+          name: 'str_replace_edit',
+          input: { path: 'second.html' },
+        });
+        return new Promise<void>(() => {});
+      });
+
+    renderProjectView();
+    await waitFor(() => expect(chatPaneHarness.onSend).toBeTruthy());
+    await waitFor(() => expect(chatPaneHarness.onStop).toBeTruthy());
+
+    void chatPaneHarness.onSend!('first run', [], []);
+    await waitFor(() => expect(firstHandlers).toBeTruthy());
+
+    chatPaneHarness.onStop!();
+    await waitFor(() => {
+      const stopped = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .find((m) => m?.runId === 'run-first' && m.runStatus === 'canceled');
+      expect(stopped).toBeTruthy();
+    });
+
+    void chatPaneHarness.onSend!('second run', [], []);
+    await waitFor(() => expect(secondHandlers).toBeTruthy());
+
+    firstHandlers!.onAgentEvent({
+      kind: 'tool_result',
+      toolUseId: 'tool-collide',
+      content: '',
+      isError: false,
+    });
+    secondHandlers!.onAgentEvent({
+      kind: 'tool_result',
+      toolUseId: 'tool-collide',
+      content: '',
+      isError: false,
+    });
+    secondHandlers!.onDelta('second done');
+    secondHandlers!.onDone('second done');
 
     await waitFor(() => {
       const secondRunFinal = saveMessage.mock.calls

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -32,6 +32,15 @@ const patchConversation = vi.fn();
 const patchProject = vi.fn();
 const saveTabs = vi.fn();
 
+const chatPaneHarness = vi.hoisted(() => ({
+  onSend: null as null | ((
+    prompt: string,
+    attachments: unknown[],
+    commentAttachments?: unknown[],
+    meta?: unknown,
+  ) => unknown),
+}));
+
 vi.mock('../../src/i18n', () => ({
   // ProjectView calls useI18n() (for locale/t); mock it like the other
   // ProjectView suites so the render does not throw on a missing export.
@@ -78,6 +87,7 @@ vi.mock('../../src/router', () => ({
 }));
 
 vi.mock('../../src/state/projects', () => ({
+  cacheTabsLocally: vi.fn((projectId: string, tabs: unknown) => ({ projectId, tabs })),
   createConversation: (...args: unknown[]) => createConversation(...args),
   deleteConversation: vi.fn(),
   getTemplate: (...args: unknown[]) => getTemplate(...args),
@@ -86,6 +96,7 @@ vi.mock('../../src/state/projects', () => ({
   loadTabs: (...args: unknown[]) => loadTabs(...args),
   patchConversation: (...args: unknown[]) => patchConversation(...args),
   patchProject: (...args: unknown[]) => patchProject(...args),
+  persistTabsToDaemonNow: vi.fn(),
   saveMessage: (...args: unknown[]) => saveMessage(...args),
   saveTabs: (...args: unknown[]) => saveTabs(...args),
 }));
@@ -99,7 +110,10 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 }));
 
 vi.mock('../../src/components/ChatPane', () => ({
-  ChatPane: () => null,
+  ChatPane: ({ onSend }: { onSend: typeof chatPaneHarness.onSend }) => {
+    chatPaneHarness.onSend = onSend;
+    return null;
+  },
 }));
 
 vi.mock('../../src/components/FileWorkspace', () => ({
@@ -208,6 +222,21 @@ describe('computeTraceObjectFiles', () => {
 
     expect(touched).toEqual(['existing.html']);
   });
+
+  it('recovers supported write/edit aliases with path inputs from persisted tool events', () => {
+    const touched = extractTouchedFilePathsFromEvents([
+      { kind: 'tool_use', id: 'tool-1', name: 'create_file', input: { path: 'created.html' } },
+      { kind: 'tool_result', toolUseId: 'tool-1', isError: false },
+      { kind: 'tool_use', id: 'tool-2', name: 'str_replace_edit', input: { path: 'edited.html' } },
+      { kind: 'tool_result', toolUseId: 'tool-2', isError: false },
+      { kind: 'tool_use', id: 'tool-3', name: 'MultiEdit', input: { path: 'multi.html' } },
+      { kind: 'tool_result', toolUseId: 'tool-3', isError: false },
+      { kind: 'tool_use', id: 'tool-4', name: 'multi_edit', input: { path: 'failed.html' } },
+      { kind: 'tool_result', toolUseId: 'tool-4', isError: true },
+    ] as never);
+
+    expect(touched).toEqual(['created.html', 'edited.html', 'multi.html']);
+  });
 });
 
 describe('mergeRecoveredArtifact', () => {
@@ -234,6 +263,7 @@ describe('ProjectView daemon reattach restore', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    chatPaneHarness.onSend = null;
     window.sessionStorage.clear();
   });
 
@@ -339,6 +369,69 @@ describe('ProjectView daemon reattach restore', () => {
         .at(-1);
       expect(lastWithProduced?.producedFiles?.map((f) => f.name)).toEqual(['new.pptx']);
       expect(lastWithProduced?.runStatus).toBe('succeeded');
+    });
+  });
+
+  it('clears touched-file paths after a failed run before the next successful run finalizes', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+
+    const projectFiles = [
+      { name: 'existing.html', path: 'existing.html', size: 10, mtime: 1, kind: 'html', mime: 'text/html' },
+    ];
+    fetchProjectFiles.mockResolvedValue(projectFiles);
+    streamViaDaemon
+      .mockImplementationOnce(async (options: any) => {
+        options.onRunCreated('run-failed');
+        options.handlers.onAgentEvent({
+          kind: 'tool_use',
+          id: 'tool-1',
+          name: 'str_replace_edit',
+          input: { path: 'existing.html' },
+        });
+        options.handlers.onAgentEvent({
+          kind: 'tool_result',
+          toolUseId: 'tool-1',
+          content: '',
+          isError: false,
+        });
+        options.onRunStatus('failed');
+        options.handlers.onError(new Error('failed after edit'));
+      })
+      .mockImplementationOnce(async (options: any) => {
+        options.onRunCreated('run-succeeded');
+        options.handlers.onDelta('done');
+        options.handlers.onDone('done');
+      });
+
+    renderProjectView();
+    await waitFor(() => expect(chatPaneHarness.onSend).toBeTruthy());
+
+    await chatPaneHarness.onSend!('first run', [], []);
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const failed = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .find((m) => m?.runId === 'run-failed' && m.runStatus === 'failed');
+      expect(failed).toBeTruthy();
+    });
+
+    await chatPaneHarness.onSend!('second run', [], []);
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+
+    await waitFor(() => {
+      const secondRunFinal = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .filter((m) => m?.runId === 'run-succeeded' && Array.isArray(m.traceObjectFiles))
+        .at(-1);
+      expect(secondRunFinal?.traceObjectFiles).toEqual([]);
     });
   });
 

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -419,17 +419,35 @@ describe('ProjectView daemon reattach restore', () => {
     });
     listActiveChatRuns.mockResolvedValue([]);
 
-    let capturedOnDone: (() => void) | null = null;
+    let captured: {
+      onAgentEvent: (ev: unknown) => void;
+      onDone: () => void;
+    } | null = null;
     reattachDaemonRun.mockImplementation(async (options: any) => {
-      capturedOnDone = options.handlers.onDone;
+      captured = {
+        onAgentEvent: options.handlers.onAgentEvent,
+        onDone: options.handlers.onDone,
+      };
       return new Promise<void>(() => {});
     });
 
     renderProjectView();
 
     await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
-    expect(capturedOnDone).not.toBeNull();
-    capturedOnDone!();
+    expect(captured).not.toBeNull();
+    captured!.onAgentEvent({
+      kind: 'tool_use',
+      id: 'tool-edit',
+      name: 'str_replace_edit',
+      input: { path: 'existing.html' },
+    });
+    captured!.onAgentEvent({
+      kind: 'tool_result',
+      toolUseId: 'tool-edit',
+      content: '',
+      isError: false,
+    });
+    captured!.onDone();
 
     await waitFor(() => {
       const saves = saveMessage.mock.calls
@@ -451,6 +469,94 @@ describe('ProjectView daemon reattach restore', () => {
           ({ options }) => options?.telemetryFinalized === true,
         ),
       ).toBe(false);
+    });
+  });
+
+  it('uses replayed events for trace object files during a full reattach replay', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-reattach-full-replay-trace',
+        role: 'assistant',
+        content: '',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-full-replay-trace',
+        runStatus: 'running',
+        preTurnFileNames: ['existing.html'],
+        events: [],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    const beforeFiles = [
+      { name: 'existing.html', path: '/p/existing.html', size: 1, updatedAt: 0 },
+    ];
+    const afterFiles = [
+      { name: 'existing.html', path: '/p/existing.html', size: 2, updatedAt: 1 },
+    ];
+    fetchProjectFiles.mockResolvedValueOnce(beforeFiles).mockResolvedValue(afterFiles);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-full-replay-trace',
+      status: 'running',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: null,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+
+    let captured: {
+      onAgentEvent: (ev: unknown) => void;
+      onDone: () => void;
+    } | null = null;
+    reattachDaemonRun.mockImplementation(async (options: any) => {
+      captured = {
+        onAgentEvent: options.handlers.onAgentEvent,
+        onDone: options.handlers.onDone,
+      };
+      return new Promise<void>(() => {});
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    expect(captured).not.toBeNull();
+    captured!.onAgentEvent({
+      kind: 'tool_use',
+      id: 'tool-edit',
+      name: 'str_replace_edit',
+      input: { path: 'existing.html' },
+    });
+    captured!.onAgentEvent({
+      kind: 'tool_result',
+      toolUseId: 'tool-edit',
+      content: '',
+      isError: false,
+    });
+    captured!.onDone();
+
+    await waitFor(() => {
+      const finalized = saveMessage.mock.calls
+        .map((call) => ({
+          message: call[2] as ChatMessage,
+          options: call[3] as { telemetryFinalized?: boolean } | undefined,
+        }))
+        .filter(
+          ({ message, options }) =>
+            message?.id === 'msg-reattach-full-replay-trace' &&
+            options?.telemetryFinalized === true,
+        )
+        .at(-1);
+      expect(finalized?.message.traceObjectFiles?.map((file) => [
+        file.name,
+        file.traceObjectReason,
+      ])).toEqual([['existing.html', 'modified']]);
     });
   });
 

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -382,6 +382,7 @@ export interface ChatMessage {
   attachments?: ChatAttachment[];
   commentAttachments?: ChatCommentAttachment[];
   producedFiles?: ProjectFile[];
+  traceObjectFiles?: ProjectFile[];
   // Diff baseline so reattach can rebuild producedFiles after reload.
   preTurnFileNames?: string[];
   feedback?: ChatMessageFeedback;

--- a/packages/contracts/src/api/files.ts
+++ b/packages/contracts/src/api/files.ts
@@ -40,6 +40,7 @@ export interface ProjectFile {
   artifactKind?: ArtifactKind;
   artifactManifest?: ArtifactManifest;
   stubGuardWarning?: ProjectFileStubGuardWarning;
+  traceObjectReason?: 'new' | 'modified' | 'recovered';
 }
 
 export interface ProjectFolder {


### PR DESCRIPTION
## Why

0.10.0 的观测对账里，R2 只覆盖了新产物文件，已有文件被 agent 修改但没有作为 attachment/produced file 出现时，Langfuse 里看不到这部分最终文件内容，R2 也不会上传。

这个 PR 把“一轮 run 里被写过的文件”单独记录下来，用于 R2 artifact 上传和 Langfuse 统计，方便后续对账时区分：新增文件、修改已有文件、恢复出来的文件，以及为什么没有上传。

## What users will see

用户界面没有新入口。默认观测行为会变：当 agent 修改已有项目文件时，这些最终文件也会进入 trace object 上传候选；Langfuse metadata 里会多一个 `trace_object_summary`，用于看本轮候选文件数、实际上传数和跳过原因。

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. No UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/langfuse-bridge.test.ts`, `apps/web/tests/components/ProjectView.reattach-restore.test.tsx`
- Did the test go red on `main` and green on this branch? no; this is telemetry coverage hardening for 0.10.1 rather than a user-visible regression spec.
- Verification: added focused tests for modified existing files entering R2 artifact upload and for touched-file extraction from successful write/edit tool events.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ProjectView.reattach-restore.test.tsx`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/langfuse-bridge.test.ts`
- `pnpm guard`
- `pnpm typecheck`
