### PR TITLE
[codex] Add Social card home entry

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2779,6 +2779,7 @@ function homeHeroChipLabel(chipId: string, t: ReturnType<typeof useT>): string {
     case 'image': return t('homeHero.chip.image');
     case 'video': return t('homeHero.chip.video');
     case 'hyperframes': return t('homeHero.chip.hyperframes');
+    case 'social-card': return 'Social card';
     case 'audio': return t('homeHero.chip.audio');
     case 'create-plugin': return t('homeHero.chip.createPlugin');
     case 'figma': return t('homeHero.chip.figma');
@@ -2791,6 +2792,7 @@ function homeHeroChipTitle(chip: HomeHeroChip, t: ReturnType<typeof useT>): stri
   switch (chip.id) {
     case 'live-artifact': return t('homeHero.chip.liveArtifactHint');
     case 'hyperframes': return t('homeHero.chip.hyperframesHint');
+    case 'social-card': return 'Create Xiaohongshu/Rednote carousels and WeChat cover pairs from articles, notes, screenshots, or photos.';
     case 'create-plugin': return t('homeHero.chip.createPluginHint');
     case 'figma': return t('homeHero.chip.figmaHint');
     case 'template': return t('homeHero.chip.templateHint');
@@ -2883,6 +2885,8 @@ export function pluginMatchesExampleChip(record: InstalledPluginRecord, chipId: 
       return (has('image') || hasPart('image-template')) && !hasPart('video', 'audio', 'live-artifact');
     case 'video':
       return (has('video') || hasPart('video-template')) && !hasPart('hyperframes', 'audio');
+    case 'social-card':
+      return has('social-card') || hasPart('social-card', 'xiaohongshu', 'rednote', 'wechat-cover');
     case 'audio':
       // Exclude video / HyperFrames templates that merely carry an
       // `audio-reactive` tag (substring-matched by hasPart('audio')): their
@@ -3075,6 +3079,7 @@ function pluginPresetArtifactLabel(chipId: string, kind: PromptLocaleKind): stri
       case 'image': return '一张图片';
       case 'video': return '一段视频';
       case 'hyperframes': return '一段 HyperFrames 动效视频';
+      case 'social-card': return '一套社交图文卡片';
       case 'audio': return '一段音频';
       default: return '一个设计产物';
     }
@@ -3086,6 +3091,7 @@ function pluginPresetArtifactLabel(chipId: string, kind: PromptLocaleKind): stri
       case 'image': return '画像';
       case 'video': return '動画';
       case 'hyperframes': return 'HyperFrames のモーション動画';
+      case 'social-card': return 'ソーシャルカード';
       case 'audio': return 'オーディオ';
       default: return 'デザイン成果物';
     }
@@ -3096,6 +3102,7 @@ function pluginPresetArtifactLabel(chipId: string, kind: PromptLocaleKind): stri
     case 'image': return 'image';
     case 'video': return 'video';
     case 'hyperframes': return 'HyperFrames motion video';
+    case 'social-card': return 'social card package';
     case 'audio': return 'audio clip';
     default: return 'design artifact';
   }
@@ -3881,6 +3888,8 @@ function briefForChipId(chipId: string): Record<string, string> {
       return { artifact_type: 'video', style: 'cinematic, high-quality, on-brand' };
     case 'hyperframes':
       return { artifact_type: 'motion graphic / animated sequence', style: 'cinematic, polished transitions' };
+    case 'social-card':
+      return { artifact_type: 'social card package', platform: 'Xiaohongshu / Rednote or WeChat', style: 'Guizang editorial or Swiss' };
     case 'audio':
       return { artifact_type: 'audio', style: 'professional, polished, brand-appropriate' };
     default:

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2886,7 +2886,10 @@ export function pluginMatchesExampleChip(record: InstalledPluginRecord, chipId: 
     case 'video':
       return (has('video') || hasPart('video-template')) && !hasPart('hyperframes', 'audio');
     case 'social-card':
-      return has('social-card') || hasPart('social-card', 'xiaohongshu', 'rednote', 'wechat-cover');
+      return (
+        fieldString(record.manifest?.od ?? {}, 'mode') === 'image' &&
+        (has('social-card') || hasPart('social-card', 'xiaohongshu', 'rednote', 'wechat-cover'))
+      );
     case 'audio':
       // Exclude video / HyperFrames templates that merely carry an
       // `audio-reactive` tag (substring-matched by hasPart('audio')): their

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1858,6 +1858,7 @@ function homeHeroChipLabelForId(chipId: string, t: ReturnType<typeof useI18n>['t
     case 'image': return t('homeHero.chip.image');
     case 'video': return t('homeHero.chip.video');
     case 'hyperframes': return t('homeHero.chip.hyperframes');
+    case 'social-card': return 'Social card';
     case 'audio': return t('homeHero.chip.audio');
     case 'create-plugin': return t('homeHero.chip.createPlugin');
     case 'figma': return t('homeHero.chip.figma');

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1464,7 +1464,7 @@ export function HomeView({
     // fields (`subject`/`style`/`aspect`/`mediaKind` stay), so the
     // od-media-generation apply still validates.
     const submittedPluginInputs = submittedActive
-      ? stripArtifactFooterInputs(submittedApplyInputs)
+      ? stripArtifactFooterInputs(submittedApplyInputs, submittedActive.chipId)
       : defaultInputs;
     const activeInputsChangedForSubmit = submittedActive
       ? !inputsEqual(submittedActive.result?.appliedPlugin?.inputs ?? submittedActive.inputs, submittedPluginInputs)
@@ -1894,19 +1894,24 @@ const ARTIFACT_FOOTER_FIELD_NAMES = new Set([
   'voice',
 ]);
 
-// The prototype/deck footer no longer exposes these settings, so any plugin
-// default for them must NOT be seeded into the Home composer's inputs — that
-// would forward a prefilled value (e.g. `fidelity: high-fidelity`) to the run
-// instead of leaving it "unknown" for the first-turn discovery flow to ask.
+// The prototype/deck/media footer no longer exposes these settings, so any
+// plugin default for them must NOT be forwarded to the run. Social card also
+// defers `platform`: the single Home chip covers Xiaohongshu/Rednote and
+// WeChat cover pairs, so first-turn discovery must collect the target package.
 function stripArtifactFooterInputs(
   inputs: Record<string, unknown>,
+  chipId?: string | null,
 ): Record<string, unknown> {
-  if (!Object.keys(inputs).some((key) => ARTIFACT_FOOTER_FIELD_NAMES.has(key))) {
+  const deferredNames =
+    chipId === 'social-card'
+      ? new Set([...ARTIFACT_FOOTER_FIELD_NAMES, 'platform'])
+      : ARTIFACT_FOOTER_FIELD_NAMES;
+  if (!Object.keys(inputs).some((key) => deferredNames.has(key))) {
     return inputs;
   }
   const next: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(inputs)) {
-    if (ARTIFACT_FOOTER_FIELD_NAMES.has(key)) continue;
+    if (deferredNames.has(key)) continue;
     next[key] = value;
   }
   return next;

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -186,7 +186,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
       pluginId: 'example-guizang-social-card',
       projectKind: 'image',
       inputs: {
-        platform: 'xiaohongshu',
         styleMode: 'auto',
         pageCount: '5-9',
       },

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -33,7 +33,8 @@ import type { IconName } from '../Icon';
 // independently of the default-binding mapping.
 export type ChipScenarioPluginId =
   | DefaultScenarioPluginId
-  | 'example-hyperframes';
+  | 'example-hyperframes'
+  | 'example-guizang-social-card';
 
 export type ChipAction =
   | {
@@ -171,6 +172,23 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
         subject: 'a short product reveal',
         style: 'cinematic, high-quality, on-brand',
         aspect: '16:9',
+      },
+    },
+  },
+  {
+    id: 'social-card',
+    label: 'Social card',
+    icon: 'share',
+    group: 'create',
+    hint: 'Create Xiaohongshu/Rednote carousels and WeChat cover pairs from articles, notes, screenshots, or photos.',
+    action: {
+      kind: 'apply-scenario',
+      pluginId: 'example-guizang-social-card',
+      projectKind: 'image',
+      inputs: {
+        platform: 'xiaohongshu',
+        styleMode: 'auto',
+        pageCount: '5-9',
       },
     },
   },

--- a/apps/web/tests/components/HomeHero.example-chip-filter.test.ts
+++ b/apps/web/tests/components/HomeHero.example-chip-filter.test.ts
@@ -83,6 +83,36 @@ const mediaGeneration = make({
   tags: ['scenario', 'first-party', 'media-generation', 'image', 'video', 'audio'],
 });
 
+// Mirrors plugins/_official/examples/guizang-social-card.
+const guizangSocialCard = make({
+  id: 'example-guizang-social-card',
+  title: 'Guizang Social Card',
+  tags: ['example', 'third-party', 'social-card', 'xiaohongshu', 'rednote', 'wechat-cover', 'image'],
+  mode: 'image',
+  surface: 'web',
+  scenario: 'marketing',
+});
+
+// Mirrors plugins/_official/examples/card-xiaohongshu.
+const xiaohongshuPrototypeCard = make({
+  id: 'example-card-xiaohongshu',
+  title: 'Xiaohongshu Card',
+  tags: ['example', 'first-party', 'prototype', 'marketing', 'web', 'desktop', 'xhs', 'untitled', 'carousel'],
+  mode: 'prototype',
+  surface: 'web',
+  scenario: 'marketing',
+});
+
+// Mirrors plugins/_official/examples/html-ppt-xhs-post.
+const xhsDeckPost = make({
+  id: 'example-html-ppt-xhs-post',
+  title: 'Html Ppt Xhs Post',
+  tags: ['example', 'first-party', 'deck', 'marketing', 'web', 'untitled', 'xhs', 'xhs-post', 'xiaohongshu'],
+  mode: 'deck',
+  surface: 'web',
+  scenario: 'marketing',
+});
+
 describe('pluginMatchesExampleChip — audio chip', () => {
   it('keeps a genuine audio template under the audio chip', () => {
     expect(pluginMatchesExampleChip(audioJingle, 'audio')).toBe(true);
@@ -97,6 +127,17 @@ describe('pluginMatchesExampleChip — audio chip', () => {
   });
 });
 
+describe('pluginMatchesExampleChip — social-card chip', () => {
+  it('keeps social-card image workflows under the social-card chip', () => {
+    expect(pluginMatchesExampleChip(guizangSocialCard, 'social-card')).toBe(true);
+  });
+
+  it('rejects non-image Xiaohongshu examples from the social-card chip', () => {
+    expect(pluginMatchesExampleChip(xiaohongshuPrototypeCard, 'social-card')).toBe(false);
+    expect(pluginMatchesExampleChip(xhsDeckPost, 'social-card')).toBe(false);
+  });
+});
+
 describe('homeHeroExamplePluginsForChip — audio chip', () => {
   const installed = [audioJingle, brandSizzleReel, mediaGeneration];
 
@@ -105,5 +146,16 @@ describe('homeHeroExamplePluginsForChip — audio chip', () => {
     expect(ids).toContain('example-audio-jingle');
     expect(ids).not.toContain('video-template-hyperframes-brand-sizzle-reel');
     expect(ids).not.toContain('od-media-generation');
+  });
+});
+
+describe('homeHeroExamplePluginsForChip — social-card chip', () => {
+  const installed = [guizangSocialCard, xiaohongshuPrototypeCard, xhsDeckPost];
+
+  it('shows social-card image workflows but not prototype or deck Xiaohongshu examples', () => {
+    const ids = homeHeroExamplePluginsForChip('social-card', installed, 'en').map((p) => p.id);
+    expect(ids).toContain('example-guizang-social-card');
+    expect(ids).not.toContain('example-card-xiaohongshu');
+    expect(ids).not.toContain('example-html-ppt-xhs-post');
   });
 });

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -267,6 +267,55 @@ const LIVE_ARTIFACT_IMAGE_TEMPLATE_PLUGIN = {
   },
 };
 
+const SOCIAL_CARD_PLUGIN = {
+  ...DEFAULT_PLUGIN,
+  id: 'example-guizang-social-card',
+  title: 'Guizang Social Card',
+  source: '/tmp/guizang-social-card',
+  fsPath: '/tmp/guizang-social-card',
+  manifest: {
+    ...DEFAULT_PLUGIN.manifest,
+    name: 'example-guizang-social-card',
+    title: 'Guizang Social Card',
+    description: 'Create Xiaohongshu/Rednote carousels and WeChat cover pairs.',
+    od: {
+      kind: 'scenario',
+      taskKind: 'new-generation',
+      mode: 'image',
+      surface: 'web',
+      scenario: 'marketing',
+      useCase: {
+        query: 'Use the Guizang Social Card workflow to turn my source content into a {{platform}} social card package.',
+      },
+      inputs: [
+        {
+          name: 'platform',
+          type: 'select',
+          required: false,
+          label: 'Platform',
+          options: ['xiaohongshu', 'wechat-cover-pair', 'social-card'],
+          default: 'xiaohongshu',
+        },
+        {
+          name: 'styleMode',
+          type: 'select',
+          required: false,
+          label: 'Style mode',
+          options: ['auto', 'editorial', 'swiss'],
+          default: 'auto',
+        },
+        {
+          name: 'pageCount',
+          type: 'string',
+          required: false,
+          label: 'Page count',
+          default: '5-9',
+        },
+      ],
+    },
+  },
+};
+
 const AUTHORING_DEFAULT_SCENARIO_INPUTS = {
   artifactKind: 'Open Design plugin',
   audience: 'Open Design plugin authors',
@@ -408,6 +457,24 @@ const LIVE_ARTIFACT_APPLY_RESULT = {
   },
   projectMetadata: {
     skillId: 'live-artifact',
+  },
+};
+
+const SOCIAL_CARD_APPLY_RESULT = {
+  ...AUTHORING_APPLY_RESULT,
+  query: SOCIAL_CARD_PLUGIN.manifest.od.useCase.query,
+  inputs: SOCIAL_CARD_PLUGIN.manifest.od.inputs,
+  appliedPlugin: {
+    ...AUTHORING_APPLY_RESULT.appliedPlugin,
+    snapshotId: 'snap-social-card',
+    pluginId: 'example-guizang-social-card',
+    inputs: {
+      styleMode: 'auto',
+      pageCount: '5-9',
+    },
+  },
+  projectMetadata: {
+    kind: 'image',
   },
 };
 
@@ -784,6 +851,76 @@ describe('HomeView prompt handoff', () => {
       { pluginInputs?: Record<string, unknown> },
     ];
     expect(protoSubmittedInputs).not.toHaveProperty('fidelity');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('leaves Social card platform unanswered so discovery can ask for the target package', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [SOCIAL_CARD_PLUGIN] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (typeof url === 'string' && url.includes('/apply')) {
+        return new Response(JSON.stringify(SOCIAL_CARD_APPLY_RESULT), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    stubAnimationFrame();
+    const onSubmit = vi.fn();
+
+    render(
+      <HomeView
+        projects={[]}
+        designSystems={[]}
+        defaultDesignSystemId={null}
+        onSubmit={onSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+
+    await clearActiveTypeChip();
+    fireEvent.click(await screen.findByTestId('home-hero-rail-social-card'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-hero-active-type-chip').textContent).toContain('Social card');
+    });
+    expect(fetchMock.mock.calls.some(([url]) => (
+      typeof url === 'string' && url.includes('/api/plugins/example-guizang-social-card/apply')
+    ))).toBe(false);
+    expect(homeHeroPromptValue()).toBe('');
+
+    await setPromptAndSettle('Turn this article into a WeChat cover pair.');
+    fireEvent.click(screen.getByTestId('home-hero-submit'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      '/api/plugins/example-guizang-social-card/apply',
+      expect.anything(),
+    ));
+    const applyCall = fetchMock.mock.calls.find(([url]) => (
+      typeof url === 'string' && url.includes('/api/plugins/example-guizang-social-card/apply')
+    ));
+    const applyInputs = JSON.parse(String((applyCall?.[1] as RequestInit).body)).inputs;
+    expect(applyInputs).toEqual({
+      styleMode: 'auto',
+      pageCount: '5-9',
+    });
+    expect(applyInputs).not.toHaveProperty('platform');
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      pluginId: 'example-guizang-social-card',
+      projectKind: 'image',
+      prompt: 'Turn this article into a WeChat cover pair.',
+      pluginInputs: {
+        styleMode: 'auto',
+        pageCount: '5-9',
+      },
+    })));
     expect(screen.queryByRole('alert')).toBeNull();
   });
 

--- a/plugins/_official/examples/guizang-social-card/SKILL.md
+++ b/plugins/_official/examples/guizang-social-card/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: guizang-social-card
+zh_name: "归藏社交图文卡"
+en_name: "Guizang Social Card"
+description: "Create Guizang-style social card packages for Xiaohongshu/Rednote carousels and WeChat cover pairs."
+zh_description: "为小红书/Rednote 图文组图和公众号封面对创建归藏风格社交图文卡。"
+category: image
+scenario: marketing
+tags: ["social-card", "xiaohongshu", "rednote", "wechat-cover", "carousel", "editorial", "swiss"]
+od:
+  mode: image
+  surface: web
+  scenario: marketing
+  upstream: "https://github.com/op7418/guizang-social-card-skill"
+  preview:
+    type: html
+    entry: example.html
+  design_system:
+    requires: false
+  example_prompt: "Use the Guizang Social Card workflow to turn my source content into a Xiaohongshu/Rednote carousel or WeChat cover pair."
+  example_prompt_i18n:
+    zh-CN: "使用「归藏社交图文卡」工作流，把我的素材做成小红书/Rednote 图文组图或公众号封面对。"
+---
+
+# Guizang Social Card
+
+Use this plugin when the user asks for Xiaohongshu/Rednote carousel images, social cards, article thumbnails, WeChat official account cover pairs, or magazine/Swiss style static social graphics.
+
+This is an Open Design wrapper for the upstream skill:
+https://github.com/op7418/guizang-social-card-skill
+
+Do not copy or edit the upstream Guizang PPT skill. Keep all generated work in the current project folder unless the user asks for a specific output path.
+
+## Output
+
+- Xiaohongshu/Rednote package: a cover plus content pages, usually 5-9 pages, sized for 3:4 social cards.
+- WeChat package: a paired 21:9 main cover and 1:1 square share cover, composed together so the relationship can be inspected.
+- Review artifact: single-file HTML first, then PNG exports after the user accepts the direction.
+
+## Intake
+
+Gather only missing details that change the output:
+
+- Target platform: Xiaohongshu/Rednote carousel, WeChat cover pair, or generic social card.
+- Source content: article, notes, subtitles, product update, screenshots, photos, or pasted copy.
+- Supplied images/screenshots and where they should appear.
+- Style preference if any: Editorial magazine, Swiss international, tech, lifestyle, outdoor, data/report, etc.
+- Hard constraints: exact title, forbidden words, logo use, no image on square cover, screenshot readability, attribution needs.
+
+If the user provides text but no images, ask once whether to use their own images, web-sourced images, or generated images. Accept their choice and proceed.
+
+## Style Modes
+
+Pick one mode per package.
+
+Editorial magazine:
+
+- Serif/Songti display plus quiet sans body.
+- Paper, ink, grain, photo wells, marginalia, pull quotes, and slow editorial pacing.
+- Best for narrative, lifestyle, travel, reading, film, essays, and considered observation.
+
+Swiss international:
+
+- Strict left-aligned grid, hairline rules, mono labels, light large display type, and one high-saturation accent.
+- Best for product reviews, data, methods, tutorials, release notes, AI tools, and structured comparison.
+
+Do not mix the two systems unless the user explicitly asks for a hybrid.
+
+## Page Planning
+
+Before coding, make an internal page plan:
+
+```text
+Page 01 / cover / hook / image source / layout intent
+Page 02 / point / key copy / visual evidence / layout intent
+...
+```
+
+Each page must carry one visual argument. Remove detail that belongs in the post body instead of the image.
+
+## Build Rules
+
+- Produce a single-file HTML artifact for review.
+- Use CSS Grid and exact fixed poster dimensions.
+- For Rednote cards, default to 1080x1440.
+- For WeChat covers, include both 2100x900 and 1080x1080 in the same artifact.
+- Keep text readable at thumbnail size.
+- Do not use lorem ipsum or placeholder content.
+- Do not place visible instructions, shortcuts, or usage text inside the images.
+- Do not use decorative blobs, generic SaaS nested cards, or meaningless sticker shapes.
+- Never blindly crop 21:9 into 1:1; compose the square cover separately.
+
+## Image Handling
+
+- User images and screenshots come first.
+- Preserve screenshot content unless the user asks for redesign.
+- Text over photos needs subject mapping, safe zones, and a thumbnail legibility check.
+- If web images are used, save source URLs in `assets/SOURCES.md` and disclose them before finalizing.
+
+## Delivery
+
+Show the HTML or rendered PNGs first, then ask whether to run an automatic validation pass. If validation is requested, check overflow, footer collisions, tiny text, under-filled cards, and image crop problems before final delivery.

--- a/plugins/_official/examples/guizang-social-card/example.html
+++ b/plugins/_official/examples/guizang-social-card/example.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Guizang Social Card Preview</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --paper: #f4efe6;
+        --ink: #161412;
+        --muted: #6f675c;
+        --rule: rgba(22, 20, 18, 0.18);
+        --accent: #2147ff;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #e8e4dc;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--ink);
+      }
+
+      .preview {
+        display: flex;
+        align-items: center;
+        gap: 28px;
+        padding: 32px;
+      }
+
+      .poster {
+        position: relative;
+        overflow: hidden;
+        background:
+          radial-gradient(circle at 20% 8%, rgba(33, 71, 255, 0.14), transparent 34%),
+          linear-gradient(135deg, rgba(255, 255, 255, 0.62), transparent 42%),
+          var(--paper);
+        border: 1px solid rgba(22, 20, 18, 0.16);
+        box-shadow: 0 22px 70px rgba(30, 28, 24, 0.18);
+      }
+
+      .poster::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background-image:
+          linear-gradient(var(--rule) 1px, transparent 1px),
+          linear-gradient(90deg, var(--rule) 1px, transparent 1px);
+        background-size: 48px 48px;
+        opacity: 0.2;
+      }
+
+      .poster--xhs {
+        width: 270px;
+        height: 360px;
+        padding: 28px;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .poster--wide {
+        width: 420px;
+        height: 180px;
+        padding: 24px 30px;
+        display: grid;
+        grid-template-columns: 1fr 138px;
+        gap: 24px;
+      }
+
+      .kicker {
+        font-size: 10px;
+        line-height: 1;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--accent);
+        font-weight: 700;
+      }
+
+      h1,
+      h2 {
+        margin: 0;
+        font-family: Georgia, "Times New Roman", "Noto Serif SC", serif;
+        letter-spacing: 0;
+      }
+
+      h1 {
+        margin-top: 18px;
+        max-width: 11ch;
+        font-size: 42px;
+        line-height: 0.92;
+      }
+
+      h2 {
+        font-size: 28px;
+        line-height: 0.96;
+      }
+
+      .summary {
+        margin-top: auto;
+        display: grid;
+        gap: 10px;
+      }
+
+      .line {
+        border-top: 1px solid var(--rule);
+        padding-top: 8px;
+        font-size: 11px;
+        line-height: 1.35;
+        color: var(--muted);
+      }
+
+      .index {
+        position: absolute;
+        right: 24px;
+        bottom: 20px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 10px;
+        color: var(--muted);
+      }
+
+      .photo {
+        align-self: stretch;
+        border: 1px solid var(--rule);
+        background:
+          linear-gradient(145deg, rgba(33, 71, 255, 0.78), rgba(22, 20, 18, 0.78)),
+          linear-gradient(90deg, #d8c6a3, #f6efe1);
+      }
+
+      .wide-copy {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        min-width: 0;
+      }
+
+      .wide-copy p {
+        margin: 14px 0 0;
+        max-width: 34ch;
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.45;
+      }
+
+      @media (max-width: 760px) {
+        .preview {
+          flex-direction: column;
+          transform: scale(0.9);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="preview" aria-label="Guizang Social Card preview">
+      <section class="poster poster--xhs">
+        <div class="kicker">Rednote / 3:4</div>
+        <h1>One idea per card</h1>
+        <div class="summary">
+          <div class="line">Editorial rhythm for story posts.</div>
+          <div class="line">Swiss grid for product and data explainers.</div>
+        </div>
+        <div class="index">01 / 06</div>
+      </section>
+
+      <section class="poster poster--wide">
+        <div class="wide-copy">
+          <div>
+            <div class="kicker">WeChat cover pair</div>
+            <h2>Long cover plus square share card</h2>
+            <p>Composed as a matched system instead of cropping one ratio into another.</p>
+          </div>
+          <div class="line">HTML first. PNG export after review.</div>
+        </div>
+        <div class="photo" aria-hidden="true"></div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/plugins/_official/examples/guizang-social-card/open-design.json
+++ b/plugins/_official/examples/guizang-social-card/open-design.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "example-guizang-social-card",
+  "title": "Guizang Social Card",
+  "title_i18n": {
+    "en": "Guizang Social Card",
+    "zh-CN": "归藏社交图文卡"
+  },
+  "version": "0.1.0",
+  "description": "Wrapper plugin for the Guizang Social Card workflow: Xiaohongshu/Rednote carousel image sets and WeChat 21:9 + 1:1 cover pairs from articles, notes, screenshots, or photos.",
+  "description_i18n": {
+    "en": "Wrapper plugin for the Guizang Social Card workflow: Xiaohongshu/Rednote carousel image sets and WeChat 21:9 + 1:1 cover pairs from articles, notes, screenshots, or photos.",
+    "zh-CN": "归藏社交图文卡工作流包装插件：把文章、笔记、截图或照片生成小红书/Rednote 图文组图，以及公众号 21:9 + 1:1 封面对。"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Open Design",
+    "url": "https://github.com/nexu-io"
+  },
+  "homepage": "https://github.com/op7418/guizang-social-card-skill",
+  "tags": [
+    "example",
+    "third-party",
+    "social-card",
+    "xiaohongshu",
+    "rednote",
+    "wechat-cover",
+    "carousel",
+    "image",
+    "editorial",
+    "swiss",
+    "guizang"
+  ],
+  "compat": {
+    "agentSkills": [
+      {
+        "path": "./SKILL.md"
+      }
+    ]
+  },
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "image",
+    "platform": "social",
+    "scenario": "marketing",
+    "surface": "web",
+    "upstream": "https://github.com/op7418/guizang-social-card-skill",
+    "preview": {
+      "type": "html",
+      "entry": "./example.html",
+      "motion": "static"
+    },
+    "useCase": {
+      "query": {
+        "en": "Use the Guizang Social Card workflow to turn my source content into a {{platform}} social card package. Choose Editorial or Swiss style based on the content, plan each page as one clear visual argument, create single-file HTML for review, and render PNG outputs when ready.",
+        "zh-CN": "使用「归藏社交图文卡」工作流，把我的素材做成 {{platform}} 社交图文卡。根据内容选择电子杂志风或瑞士国际主义风，每页只表达一个清晰观点，先生成单文件 HTML 供检查，确认后渲染 PNG 输出。"
+      },
+      "exampleOutputs": [
+        {
+          "path": "./example.html",
+          "title": "Guizang Social Card",
+          "title_i18n": {
+            "en": "Guizang Social Card",
+            "zh-CN": "归藏社交图文卡"
+          }
+        }
+      ]
+    },
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ],
+      "assets": [
+        "./example.html"
+      ]
+    },
+    "inputs": [
+      {
+        "name": "platform",
+        "type": "select",
+        "required": false,
+        "label": "Platform",
+        "options": [
+          "xiaohongshu",
+          "wechat-cover-pair",
+          "social-card"
+        ],
+        "default": "xiaohongshu"
+      },
+      {
+        "name": "styleMode",
+        "type": "select",
+        "required": false,
+        "label": "Style mode",
+        "options": [
+          "auto",
+          "editorial",
+          "swiss"
+        ],
+        "default": "auto"
+      },
+      {
+        "name": "pageCount",
+        "type": "string",
+        "required": false,
+        "label": "Page count",
+        "placeholder": "5-9",
+        "default": "5-9"
+      }
+    ],
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}


### PR DESCRIPTION
## Why

The Home hero has quick entries for common artifact types, but social card workflows were only reachable indirectly through the broader Image/plugin gallery path. This adds a first-class Social card entry so users can start Xiaohongshu/Rednote carousel and WeChat cover-pair work directly from Home.

The plugin is added as an Open Design wrapper around the upstream Guizang social-card workflow, with attribution kept in the manifest and skill context.

## What users will see

Home now shows a `Social card` chip in the creation rail. Selecting it binds the Guizang Social Card plugin, shows matching social-card presets under the composer, and lets users seed a social-card prompt before sending.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Local visual verification: opened `http://127.0.0.1:17574`, skipped onboarding, confirmed the Home rail shows `Social card`; clicking it selected the active type chip and surfaced the Guizang Social Card preset with no error.

## Bug fix verification

- Not a bug fix.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm --filter @open-design/plugin-runtime typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test -- apps/web/tests/components/HomeHero.rail.test.tsx apps/web/tests/components/HomeView.prefill.test.tsx`
