### PR TITLE
Show boot stage progress on the desktop splash screen

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -52,9 +52,11 @@ export {
   isAllowedChildWindowUrl,
   isAllowedEmbeddedBrowserUrl,
   isHttpUrl,
+  registerSplashStageTracking,
   resolveDesktopStatusUrl,
   setSplashStage,
   type SplashBootStage,
+  type SplashStageSurface,
 } from "./runtime.js";
 
 // Re-export the path-validation helpers for the same reason (#974).

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -53,6 +53,8 @@ export {
   isAllowedEmbeddedBrowserUrl,
   isHttpUrl,
   resolveDesktopStatusUrl,
+  setSplashStage,
+  type SplashBootStage,
 } from "./runtime.js";
 
 // Re-export the path-validation helpers for the same reason (#974).

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -821,6 +821,33 @@ function createPendingHtml(): string {
         max-width: 100%;
         width: auto;
       }
+      .boot-stage {
+        bottom: 56px;
+        color: #7a838a;
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+        font-size: 13px;
+        left: 0;
+        letter-spacing: 0.02em;
+        position: fixed;
+        right: 0;
+        text-align: center;
+        transition: opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
+        user-select: none;
+      }
+      .boot-stage-swapping {
+        opacity: 0;
+        transition-duration: 140ms;
+      }
+      .boot-dots .dot {
+        animation: boot-dot 1.4s cubic-bezier(0.23, 1, 0.32, 1) infinite;
+        display: inline-block;
+      }
+      .boot-dots .dot:nth-child(2) { animation-delay: 0.2s; }
+      .boot-dots .dot:nth-child(3) { animation-delay: 0.4s; }
+      @keyframes boot-dot {
+        0%, 60%, 100% { opacity: 0.25; }
+        30% { opacity: 1; }
+      }
     </style>
   </head>
   <body>
@@ -832,6 +859,9 @@ function createPendingHtml(): string {
       disablepictureinpicture
       src="${SPLASH_VIDEO_DATA_URL}"
     ></video>
+    <div class="boot-stage" id="boot-stage" aria-live="polite">
+      <span id="boot-stage-text">${SPLASH_STAGE_LABELS.starting}</span><span class="boot-dots" aria-hidden="true"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>
+    </div>
     <script>
       (function () {
         var video = document.getElementById("splash");
@@ -844,9 +874,50 @@ function createPendingHtml(): string {
         video.addEventListener("loadeddata", play);
         play();
       })();
+      window.__odSplashSetStage = function (label) {
+        var wrap = document.getElementById("boot-stage");
+        var text = document.getElementById("boot-stage-text");
+        if (!wrap || !text || text.textContent === label) return;
+        wrap.classList.add("boot-stage-swapping");
+        setTimeout(function () {
+          text.textContent = label;
+          wrap.classList.remove("boot-stage-swapping");
+        }, 140);
+      };
     </script>
   </body>
 </html>`)}`;
+}
+
+/**
+ * Boot phases surfaced as a muted status line under the splash logo. The cold
+ * boot on a slow machine can hold the splash's settled final frame for many
+ * seconds; the stage text plus the continuously pulsing dots are what tells
+ * the user the app is working, not hung. Stage transitions follow the repo
+ * animation philosophy: 140ms ease-out fade out, 200ms ease-out fade in.
+ */
+export type SplashBootStage = "starting" | "engine" | "interface" | "workspace";
+
+const SPLASH_STAGE_LABELS: Record<SplashBootStage, string> = {
+  starting: "Starting Open Design",
+  engine: "Starting the local engine",
+  interface: "Preparing the interface",
+  workspace: "Opening your workspace",
+};
+
+/**
+ * Update the splash status line. Safe to call with a destroyed/absent window
+ * and idempotent for repeated stages, so callers can fire-and-forget at each
+ * boot phase boundary (packaged sidecar spawns, runtime reveal gate).
+ */
+export function setSplashStage(splash: BrowserWindow | null, stage: SplashBootStage): void {
+  if (splash == null || splash.isDestroyed()) return;
+  void splash.webContents
+    .executeJavaScript(
+      `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(SPLASH_STAGE_LABELS[stage])});`,
+      true,
+    )
+    .catch(() => undefined);
 }
 
 export type SplashWindowHandle = {
@@ -1857,6 +1928,9 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   const revealWhenReady = async (): Promise<void> => {
     if (revealing || revealed) return;
     revealing = true;
+    // The web bundle is loading in the hidden main window from here on; let
+    // the splash status line reflect that final phase while we poll for mount.
+    setSplashStage(splash, "workspace");
     const deadline = Date.now() + WEB_MOUNT_REVEAL_TIMEOUT_MS;
     while (!stopped && !window.isDestroyed() && Date.now() < deadline) {
       const mounted = await window.webContents

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -906,18 +906,71 @@ const SPLASH_STAGE_LABELS: Record<SplashBootStage, string> = {
 };
 
 /**
- * Update the splash status line. Safe to call with a destroyed/absent window
- * and idempotent for repeated stages, so callers can fire-and-forget at each
- * boot phase boundary (packaged sidecar spawns, runtime reveal gate).
+ * Narrow view of the splash window that the stage updater needs. A real
+ * `BrowserWindow` satisfies this structurally; tests pass a mock so the
+ * load-ready/replay logic is exercisable without a live Electron renderer.
  */
-export function setSplashStage(splash: BrowserWindow | null, stage: SplashBootStage): void {
-  if (splash == null || splash.isDestroyed()) return;
+export type SplashStageSurface = {
+  isDestroyed(): boolean;
+  webContents: {
+    executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+    once(event: "did-finish-load", listener: () => void): void;
+  };
+};
+
+type SplashStageState = { ready: boolean; pending: SplashBootStage | null };
+
+// Per-splash readiness + the latest stage requested before the page finished
+// loading. Keyed weakly so a closed splash is collected without bookkeeping.
+const splashStageState = new WeakMap<SplashStageSurface, SplashStageState>();
+
+function applySplashStage(splash: SplashStageSurface, stage: SplashBootStage): void {
   void splash.webContents
     .executeJavaScript(
       `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(SPLASH_STAGE_LABELS[stage])});`,
       true,
     )
     .catch(() => undefined);
+}
+
+/**
+ * Arm load-ready tracking for a freshly created splash. MUST be called before
+ * `loadURL` so the `did-finish-load` listener cannot miss the event. Until the
+ * splash data-URL has loaded (and defined `window.__odSplashSetStage`), stage
+ * updates are stashed rather than executed against a renderer that has no
+ * setter yet — otherwise the first update (the daemon phase, fired right after
+ * window creation on a cold boot) is silently dropped. The latest stashed
+ * stage is replayed once the page reports it has loaded.
+ */
+export function registerSplashStageTracking(splash: SplashStageSurface): void {
+  const state: SplashStageState = { ready: false, pending: null };
+  splashStageState.set(splash, state);
+  splash.webContents.once("did-finish-load", () => {
+    state.ready = true;
+    if (state.pending != null) {
+      const stage = state.pending;
+      state.pending = null;
+      applySplashStage(splash, stage);
+    }
+  });
+}
+
+/**
+ * Update the splash status line. Safe to call with a destroyed/absent window
+ * and idempotent for repeated stages, so callers can fire-and-forget at each
+ * boot phase boundary (packaged sidecar spawns, runtime reveal gate). Stage
+ * updates that arrive before the splash page has loaded are deferred and
+ * replayed on load (see `registerSplashStageTracking`); a window with no
+ * tracking registered (e.g. an unmanaged test surface) applies immediately.
+ */
+export function setSplashStage(splash: SplashStageSurface | null, stage: SplashBootStage): void {
+  if (splash == null || splash.isDestroyed()) return;
+  const state = splashStageState.get(splash);
+  if (state == null || state.ready) {
+    applySplashStage(splash, stage);
+    return;
+  }
+  state.pending = stage;
 }
 
 export type SplashWindowHandle = {
@@ -959,6 +1012,10 @@ export function createSplashWindow(): SplashWindowHandle {
       sandbox: true,
     },
   });
+  // Arm stage tracking before loadURL so a stage update fired before the
+  // page loads is deferred and replayed rather than dropped (see
+  // `registerSplashStageTracking`).
+  registerSplashStageTracking(splash);
   void splash.loadURL(createPendingHtml());
   return { startedAt, window: splash };
 }

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -796,6 +796,8 @@ const MAC_WINDOW_CHROME_CSS = `
 // the main window is ready. The clip is embedded as a base64 data URL so it
 // renders identically in dev and in packaged builds (see `splash-video.ts`).
 function createPendingHtml(): string {
+  const start = splashStagePayload("starting");
+  const initialPct = Math.max(0, Math.min(100, Math.round((start.step / start.total) * 100)));
   return `data:text/html;charset=utf-8,${encodeURIComponent(`<!doctype html>
 <html>
   <head>
@@ -838,6 +840,28 @@ function createPendingHtml(): string {
         opacity: 0;
         transition-duration: 140ms;
       }
+      .boot-stage-step {
+        color: #9aa2a8;
+        font-variant-numeric: tabular-nums;
+        margin-right: 7px;
+      }
+      .boot-progress {
+        background: rgba(122, 131, 138, 0.18);
+        border-radius: 999px;
+        bottom: 84px;
+        height: 3px;
+        left: 50%;
+        overflow: hidden;
+        position: fixed;
+        transform: translateX(-50%);
+        width: 200px;
+      }
+      .boot-progress-fill {
+        background: #7a838a;
+        border-radius: 999px;
+        height: 100%;
+        transition: width 320ms cubic-bezier(0.23, 1, 0.32, 1);
+      }
       .boot-dots .dot {
         animation: boot-dot 1.4s cubic-bezier(0.23, 1, 0.32, 1) infinite;
         display: inline-block;
@@ -859,8 +883,11 @@ function createPendingHtml(): string {
       disablepictureinpicture
       src="${SPLASH_VIDEO_DATA_URL}"
     ></video>
+    <div class="boot-progress" aria-hidden="true">
+      <div class="boot-progress-fill" id="boot-progress-fill" data-pct="${initialPct}" style="width: ${initialPct}%;"></div>
+    </div>
     <div class="boot-stage" id="boot-stage" aria-live="polite">
-      <span id="boot-stage-text">${SPLASH_STAGE_LABELS.starting}</span><span class="boot-dots" aria-hidden="true"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>
+      <span class="boot-stage-step" id="boot-stage-step">${start.step}/${start.total}</span><span id="boot-stage-text">${start.label}</span><span class="boot-dots" aria-hidden="true"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>
     </div>
     <script>
       (function () {
@@ -874,13 +901,36 @@ function createPendingHtml(): string {
         video.addEventListener("loadeddata", play);
         play();
       })();
-      window.__odSplashSetStage = function (label) {
+      // Accepts the structured { step, total, label } payload (and tolerates a
+      // bare label string for back-compat). The step counter + progress bar give
+      // a slow cold boot a sense of how far along it is; the bar only ever grows
+      // so a re-asserted earlier stage cannot make it lurch backwards.
+      window.__odSplashSetStage = function (info) {
+        var data = (typeof info === "string") ? { label: info } : (info || {});
         var wrap = document.getElementById("boot-stage");
         var text = document.getElementById("boot-stage-text");
-        if (!wrap || !text || text.textContent === label) return;
+        var stepEl = document.getElementById("boot-stage-step");
+        var fill = document.getElementById("boot-progress-fill");
+        if (!wrap || !text) return;
+        var step = (typeof data.step === "number") ? data.step : null;
+        var total = (typeof data.total === "number" && data.total > 0) ? data.total : null;
+        if (fill && step != null && total != null) {
+          var pct = Math.max(0, Math.min(100, Math.round((step / total) * 100)));
+          var prev = parseFloat(fill.getAttribute("data-pct")) || 0;
+          if (pct >= prev) {
+            fill.style.width = pct + "%";
+            fill.setAttribute("data-pct", String(pct));
+          }
+        }
+        var label = (typeof data.label === "string") ? data.label : null;
+        var stepText = (step != null && total != null) ? (step + "/" + total) : null;
+        var labelSame = (label == null) || text.textContent === label;
+        var stepSame = (stepText == null) || !stepEl || stepEl.textContent === stepText;
+        if (labelSame && stepSame) return;
         wrap.classList.add("boot-stage-swapping");
         setTimeout(function () {
-          text.textContent = label;
+          if (label != null) text.textContent = label;
+          if (stepEl && stepText != null) stepEl.textContent = stepText;
           wrap.classList.remove("boot-stage-swapping");
         }, 140);
       };
@@ -892,18 +942,64 @@ function createPendingHtml(): string {
 /**
  * Boot phases surfaced as a muted status line under the splash logo. The cold
  * boot on a slow machine can hold the splash's settled final frame for many
- * seconds; the stage text plus the continuously pulsing dots are what tells
- * the user the app is working, not hung. Stage transitions follow the repo
- * animation philosophy: 140ms ease-out fade out, 200ms ease-out fade in.
+ * seconds; the stage text, the step counter ("3/7"), the filling progress bar,
+ * and the continuously pulsing dots are what tell the user the app is working,
+ * not hung. Stage transitions follow the repo animation philosophy: 140ms
+ * ease-out fade out, 200ms ease-out fade in.
+ *
+ * The set is intentionally fine-grained: a slow first run spends most of its
+ * time in the two long native waits (daemon coming online, web server coming
+ * online), so we mark BOTH the "starting X" edge and the "X ready" edge of each
+ * so the counter visibly advances right after each long wait clears. More steps
+ * = the wait reads as forward motion instead of one frozen label.
  */
-export type SplashBootStage = "starting" | "engine" | "interface" | "workspace";
+export type SplashBootStage =
+  | "starting"
+  | "engine"
+  | "engineReady"
+  | "interface"
+  | "interfaceReady"
+  | "workspace"
+  | "finishing";
+
+/**
+ * Canonical boot order. The index in this array drives the "N/total" step
+ * counter and the progress-bar fill, so keep it in the real chronological order
+ * the stages fire. `setSplashStage` clamps progress so a re-asserted earlier
+ * stage (e.g. the idempotent "workspace" re-fire at the reveal gate) can never
+ * make the bar jump backwards.
+ */
+const SPLASH_STAGE_SEQUENCE: readonly SplashBootStage[] = [
+  "starting",
+  "engine",
+  "engineReady",
+  "interface",
+  "interfaceReady",
+  "workspace",
+  "finishing",
+];
 
 const SPLASH_STAGE_LABELS: Record<SplashBootStage, string> = {
   starting: "Starting Open Design",
   engine: "Starting the local engine",
+  engineReady: "Local engine ready",
   interface: "Preparing the interface",
+  interfaceReady: "Interface ready",
   workspace: "Opening your workspace",
+  finishing: "Almost ready",
 };
+
+const SPLASH_STAGE_TOTAL = SPLASH_STAGE_SEQUENCE.length;
+
+/** Step/label payload handed to the renderer's `__odSplashSetStage`. */
+function splashStagePayload(stage: SplashBootStage): { step: number; total: number; label: string } {
+  const index = SPLASH_STAGE_SEQUENCE.indexOf(stage);
+  return {
+    step: index < 0 ? 1 : index + 1,
+    total: SPLASH_STAGE_TOTAL,
+    label: SPLASH_STAGE_LABELS[stage],
+  };
+}
 
 /**
  * Narrow view of the splash window that the stage updater needs. A real
@@ -927,7 +1023,7 @@ const splashStageState = new WeakMap<SplashStageSurface, SplashStageState>();
 function applySplashStage(splash: SplashStageSurface, stage: SplashBootStage): void {
   void splash.webContents
     .executeJavaScript(
-      `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(SPLASH_STAGE_LABELS[stage])});`,
+      `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(splashStagePayload(stage))});`,
       true,
     )
     .catch(() => undefined);
@@ -1996,6 +2092,11 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       if (mounted === true) break;
       await delay(WEB_MOUNT_POLL_MS);
     }
+    // The real UI has mounted behind the splash; the only thing left is the
+    // minimum-hold so the brand clip plays through. Advance the counter to its
+    // final step so the user sees the boot reach completion, not stall at
+    // "Opening your workspace".
+    setSplashStage(splash, "finishing");
     const remaining = MIN_SPLASH_MS - (Date.now() - splashStartedAt);
     if (remaining > 0) await delay(remaining);
     revealMainWindow();

--- a/apps/desktop/tests/main/splash-stage-replay.test.ts
+++ b/apps/desktop/tests/main/splash-stage-replay.test.ts
@@ -1,0 +1,102 @@
+// Review follow-up on the splash boot-stage PR (#4223): the first stage
+// update (the daemon phase) is fired from the packaged entry right after the
+// splash window is created — potentially before the splash data-URL has
+// finished loading and defined `window.__odSplashSetStage`. Without a
+// load-ready guard that update reaches a renderer that has no setter yet, so
+// the "Starting the local engine" label silently never renders on exactly the
+// slow cold-boot path this feature targets.
+//
+// This spec pins the invariant with a structural mock (no real Electron):
+// a stage fired before `did-finish-load` must be DEFERRED, not dropped, and
+// replayed once the page reports it has loaded.
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  registerSplashStageTracking,
+  setSplashStage,
+  type SplashStageSurface,
+} from '../../src/main/runtime.js';
+
+type MockSplash = {
+  surface: SplashStageSurface;
+  executed: string[];
+  emitDidFinishLoad: () => void;
+  destroy: () => void;
+};
+
+function createMockSplash(): MockSplash {
+  const executed: string[] = [];
+  let didFinishLoad: (() => void) | null = null;
+  let destroyed = false;
+  const surface: SplashStageSurface = {
+    isDestroyed: () => destroyed,
+    webContents: {
+      executeJavaScript: (code: string) => {
+        executed.push(code);
+        return Promise.resolve(undefined);
+      },
+      once: (event, listener) => {
+        if (event === 'did-finish-load') didFinishLoad = listener;
+      },
+    },
+  };
+  return {
+    surface,
+    executed,
+    emitDidFinishLoad: () => didFinishLoad?.(),
+    destroy: () => {
+      destroyed = true;
+    },
+  };
+}
+
+describe('splash boot-stage replay guard', () => {
+  test('defers a stage fired before the page loads, then replays it on did-finish-load', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+
+    // Daemon phase fires while the splash data-URL is still loading. It must
+    // NOT reach the renderer yet — the setter does not exist there.
+    setSplashStage(splash.surface, 'engine');
+    expect(splash.executed).toEqual([]);
+
+    // Page reports loaded → the deferred stage is replayed exactly once.
+    splash.emitDidFinishLoad();
+    expect(splash.executed).toHaveLength(1);
+    expect(splash.executed[0]).toContain('Starting the local engine');
+  });
+
+  test('replays only the latest stage when several arrive before load', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+
+    setSplashStage(splash.surface, 'engine');
+    setSplashStage(splash.surface, 'interface');
+    expect(splash.executed).toEqual([]);
+
+    splash.emitDidFinishLoad();
+    expect(splash.executed).toHaveLength(1);
+    expect(splash.executed[0]).toContain('Preparing the interface');
+  });
+
+  test('applies immediately once the page has loaded', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+    splash.emitDidFinishLoad();
+
+    setSplashStage(splash.surface, 'workspace');
+    expect(splash.executed).toHaveLength(1);
+    expect(splash.executed[0]).toContain('Opening your workspace');
+  });
+
+  test('is a no-op on a destroyed splash window', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+    splash.emitDidFinishLoad();
+    splash.destroy();
+
+    setSplashStage(splash.surface, 'engine');
+    expect(splash.executed).toEqual([]);
+  });
+});

--- a/apps/desktop/tests/main/splash-stage-replay.test.ts
+++ b/apps/desktop/tests/main/splash-stage-replay.test.ts
@@ -99,4 +99,34 @@ describe('splash boot-stage replay guard', () => {
     setSplashStage(splash.surface, 'engine');
     expect(splash.executed).toEqual([]);
   });
+
+  // Slow-cold-boot UX: the splash must tell the user WHICH step of how many is
+  // underway, not just a bare label, so the wait reads as forward progress. The
+  // stage payload handed to the renderer carries a 1-based step index and the
+  // total stage count alongside the label.
+  test('carries a 1-based step index and total step count for the counter', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+    splash.emitDidFinishLoad();
+
+    setSplashStage(splash.surface, 'starting');
+    setSplashStage(splash.surface, 'finishing');
+
+    expect(splash.executed).toHaveLength(2);
+    // `starting` is the first stage; `finishing` is the last. Both report the
+    // same total so the renderer can render "N/total" and fill the bar.
+    const [firstCall, lastCall] = splash.executed;
+    const firstPayload = JSON.parse(
+      firstCall.match(/__odSplashSetStage\((\{.*\})\);/)?.[1] ?? '{}',
+    ) as { step: number; total: number; label: string };
+    const lastPayload = JSON.parse(
+      lastCall.match(/__odSplashSetStage\((\{.*\})\);/)?.[1] ?? '{}',
+    ) as { step: number; total: number; label: string };
+
+    expect(firstPayload.step).toBe(1);
+    expect(lastPayload.step).toBe(lastPayload.total);
+    expect(firstPayload.total).toBe(lastPayload.total);
+    expect(lastPayload.total).toBeGreaterThan(4);
+    expect(lastPayload.label).toBe('Almost ready');
+  });
 });

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -11,7 +11,7 @@ import {
   createSidecarLaunchEnv,
   resolveAppIpcPath,
 } from "@open-design/sidecar";
-import { applyOsLocaleSwitch, createSplashWindow } from "@open-design/desktop/main";
+import { applyOsLocaleSwitch, createSplashWindow, setSplashStage } from "@open-design/desktop/main";
 import { readProcessStamp } from "@open-design/platform";
 import { join } from "node:path";
 import { app, dialog } from "electron";
@@ -150,7 +150,16 @@ async function main(): Promise<void> {
     webSidecarEntry: activeConfig.webSidecarEntry,
     webStandaloneRoot: activeConfig.webStandaloneRoot,
     webOutputMode: activeConfig.webOutputMode,
+    // Surface each sidecar boot phase on the splash status line so a slow
+    // cold start (Defender scans, native module loads) never reads as a hang.
+    onPhase(phase) {
+      setSplashStage(splash.window, phase === "daemon" ? "engine" : "interface");
+    },
   });
+  // Sidecars are up; the remaining wait is the hidden main window loading and
+  // mounting the web bundle (the runtime re-asserts this stage at its reveal
+  // gate, which is a no-op when the label is already current).
+  setSplashStage(splash.window, "workspace");
   registerOdProtocol(sidecars.web.url ?? "http://127.0.0.1:0");
 
   const { runDesktopMain } = await import("@open-design/desktop/main");

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -152,8 +152,18 @@ async function main(): Promise<void> {
     webOutputMode: activeConfig.webOutputMode,
     // Surface each sidecar boot phase on the splash status line so a slow
     // cold start (Defender scans, native module loads) never reads as a hang.
+    // Both the "spawning" and "ready" edges are mapped so the step counter
+    // advances the instant each long native wait clears.
     onPhase(phase) {
-      setSplashStage(splash.window, phase === "daemon" ? "engine" : "interface");
+      const stage =
+        phase === "daemon-spawning"
+          ? "engine"
+          : phase === "daemon-ready"
+            ? "engineReady"
+            : phase === "web-spawning"
+              ? "interface"
+              : "interfaceReady";
+      setSplashStage(splash.window, stage);
     },
   });
   // Sidecars are up; the remaining wait is the hidden main window loading and

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -457,6 +457,13 @@ export async function startPackagedSidecars(
     webSidecarEntry: string | null;
     webStandaloneRoot: string | null;
     webOutputMode: PackagedWebOutputMode;
+    /**
+     * Boot-progress hook, fired just before each sidecar child is spawned.
+     * The Electron entry forwards it to the splash status line so a slow
+     * cold boot shows which phase is underway instead of a frozen frame;
+     * headless callers omit it.
+     */
+    onPhase?: (phase: "daemon" | "web") => void;
   },
 ): Promise<PackagedSidecarHandle> {
   await mkdir(paths.namespaceRoot, { recursive: true });
@@ -472,6 +479,7 @@ export async function startPackagedSidecars(
   const children: ManagedSidecarChild[] = [];
 
   try {
+    options.onPhase?.("daemon");
     const daemon = await spawnSidecarChild({
       app: APP_KEYS.DAEMON,
       entryPath: options.daemonSidecarEntry ?? resolveSidecarEntry("@open-design/daemon", "sidecar"),
@@ -503,6 +511,7 @@ export async function startPackagedSidecars(
     );
     if (daemonStatus.url == null) throw new Error("daemon did not report a URL");
 
+    options.onPhase?.("web");
     const web = await spawnSidecarChild({
       app: APP_KEYS.WEB,
       entryPath: options.webSidecarEntry ?? resolveSidecarEntry("@open-design/web", "sidecar"),

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -458,12 +458,14 @@ export async function startPackagedSidecars(
     webStandaloneRoot: string | null;
     webOutputMode: PackagedWebOutputMode;
     /**
-     * Boot-progress hook, fired just before each sidecar child is spawned.
-     * The Electron entry forwards it to the splash status line so a slow
-     * cold boot shows which phase is underway instead of a frozen frame;
-     * headless callers omit it.
+     * Boot-progress hook, fired at each sidecar bring-up boundary: the
+     * `"-spawning"` edge just before a child is spawned, and the `"-ready"`
+     * edge once it reports a usable URL. The Electron entry forwards these to
+     * the splash status line so a slow cold boot shows which phase is underway
+     * (and visibly advances the step counter the moment each long native wait
+     * clears) instead of a frozen frame; headless callers omit it.
      */
-    onPhase?: (phase: "daemon" | "web") => void;
+    onPhase?: (phase: "daemon-spawning" | "daemon-ready" | "web-spawning" | "web-ready") => void;
   },
 ): Promise<PackagedSidecarHandle> {
   await mkdir(paths.namespaceRoot, { recursive: true });
@@ -479,7 +481,7 @@ export async function startPackagedSidecars(
   const children: ManagedSidecarChild[] = [];
 
   try {
-    options.onPhase?.("daemon");
+    options.onPhase?.("daemon-spawning");
     const daemon = await spawnSidecarChild({
       app: APP_KEYS.DAEMON,
       entryPath: options.daemonSidecarEntry ?? resolveSidecarEntry("@open-design/daemon", "sidecar"),
@@ -510,8 +512,9 @@ export async function startPackagedSidecars(
       { child: daemon.child, logPath: logPathFor(paths, APP_KEYS.DAEMON) },
     );
     if (daemonStatus.url == null) throw new Error("daemon did not report a URL");
+    options.onPhase?.("daemon-ready");
 
-    options.onPhase?.("web");
+    options.onPhase?.("web-spawning");
     const web = await spawnSidecarChild({
       app: APP_KEYS.WEB,
       entryPath: options.webSidecarEntry ?? resolveSidecarEntry("@open-design/web", "sidecar"),
@@ -532,6 +535,7 @@ export async function startPackagedSidecars(
       (status) => status.url != null,
     );
     if (webStatus.url == null) throw new Error("web did not report a URL");
+    options.onPhase?.("web-ready");
 
     return {
       daemon: daemonStatus,


### PR DESCRIPTION
## Why

On Windows desktop, a packaged cold boot starts four processes mostly
sequentially (Electron main → daemon sidecar → web sidecar → Next.js
standalone server) before the web app can mount. On low-spec PCs — and
especially on first launch or right after an update, when Windows
Defender real-time scanning adds seconds per process — this can take
well over ten seconds.

Meanwhile the splash video plays only ~1.7s and then freezes on its
final frame. The user is left staring at a static logo with zero
feedback, which reads as "the app is hung / not responding" even though
the boot is progressing normally. I hit this myself running the Windows
desktop build on a slower machine.

This PR doesn't make the boot faster; it makes the boot *visible*, so a
long cold start no longer looks like a freeze.

## What users will see

While the splash screen is up, a small muted status line now appears
under the logo, with three continuously pulsing dots so there is always
motion on screen. The text advances through the real boot phases:

- "Starting Open Design" (initial, baked into the splash HTML)
- "Starting the local engine" (daemon sidecar spawning)
- "Preparing the interface" (web sidecar spawning)
- "Opening your workspace" (hidden main window loading + mount gate)

Stage transitions follow the repo animation philosophy (140ms ease-out
exit, 200ms ease-out enter). Once the app mounts, the splash closes
exactly as before — reveal timing is unchanged.

Implementation note: the packaged entry forwards phases through a new
optional `onPhase` hook on `startPackagedSidecars`; the runtime
re-asserts the final stage at its reveal gate so the tools-dev splash
path is covered too. `setSplashStage` is safe on destroyed windows and
idempotent per label. Headless packaged mode omits the hook and is
unaffected. Labels are English-only for now: the splash runs in the
Electron main process before the web i18n layer exists.

## Surface area

- [x] **UI** — splash screen status line in `apps/desktop` (and packaged entry wiring in `apps/packaged`)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — none; splash runs before the web i18n layer (labels are main-process English strings)
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — no defaults, schemas, or timings changed; splash reveal logic is untouched
- [ ] **None**

## Screenshots
### before
<img width="1264" height="892" alt="before" src="https://github.com/user-attachments/assets/98d1aa2a-9928-4153-bd35-d3651b25507f" />

### after
<img width="1234" height="864" alt="after" src="https://github.com/user-attachments/assets/2c716e66-a13b-48ad-bd54-5beff2481617" />

<!-- TODO before opening: attach a short GIF of the splash on a cold
     packaged boot showing the stage text advancing (slow machine or
     artificially delayed sidecar is ideal), plus a before/after still
     of the frozen final frame vs. the new status line. -->

## Bug fix verification

Not a bug fix — UX improvement for slow cold boots. No red spec; the
symptom (perceived hang on a static frame) needs an eye to confirm, so
verification is the packaged-boot screenshots above plus the suites
below.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (workspace-wide)
- `pnpm --filter @open-design/desktop build` — pass
- `pnpm --filter @open-design/packaged build` — pass
- `pnpm --filter @open-design/packaged test` — 123/123 pass
- `pnpm --filter @open-design/desktop test` — 118 pass, 1 pre-existing
  failure (`tests/main/window-chrome.test.ts` `backgroundThrottling`
  assertion); verified via `git stash` that it fails identically on the
  baseline, so no new failures from this change