### PR TITLE
fix(a11y): improve preview navigation semantics

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -1710,8 +1710,6 @@ export function WorkspaceTabsBar({
       {dockDropdownNode}
       <div
         className={`workspace-tabs-strip${tabsOverflowing ? ' is-overflowing' : ''}`}
-        role="tablist"
-        aria-label="Open workspaces"
         ref={stripRef}
         onDragOver={handleStripDragOver}
         onDrop={handleStripDrop}
@@ -1757,8 +1755,6 @@ export function WorkspaceTabsBar({
               key={tab.id}
               className={`workspace-tab${active ? ' is-active' : ''}${isPinned ? ' is-pinned' : ''}${draggingTabId === tab.id ? ' is-dragging' : ''}${dragOverClass}`}
               data-workspace-tab-id={tab.id}
-              role="tab"
-              aria-selected={active}
               draggable={!isPinned && state.tabs.length > 1}
               onDragStart={(event) => handleTabDragStart(tab.id, event)}
               onDragEnd={handleTabDragEnd}
@@ -1771,6 +1767,7 @@ export function WorkspaceTabsBar({
                 <button
                   type="button"
                   className={`workspace-tab__rail-toggle od-tooltip${entryRailOpen ? ' is-inert' : ''}`}
+                  aria-pressed={active}
                   aria-label={entryRailOpen ? t('entry.navHome') : t('entry.navExpand')}
                   aria-expanded={entryRailOpen}
                   title={entryRailOpen ? undefined : t('entry.navExpand')}
@@ -1804,6 +1801,7 @@ export function WorkspaceTabsBar({
                 <button
                   type="button"
                   className="workspace-tab__rail-toggle od-tooltip"
+                  aria-pressed={active}
                   aria-label={t('entry.navHome')}
                   title={t('entry.navHome')}
                   data-tooltip={t('entry.navHome')}
@@ -1821,6 +1819,8 @@ export function WorkspaceTabsBar({
                   <button
                     type="button"
                     className="workspace-tab__main"
+                    aria-pressed={active}
+                    aria-label={`${display.title}${display.meta ? `, ${display.meta}` : ''}`}
                     onClick={() => openTab(tab)}
                   >
                     <span className="workspace-tab__icon" aria-hidden>
@@ -1841,9 +1841,9 @@ export function WorkspaceTabsBar({
                     <button
                       type="button"
                       className="workspace-tab__close od-tooltip"
-                      aria-label={t('common.close')}
-                      title={t('common.close')}
-                      data-tooltip={t('common.close')}
+                      aria-label={`${t('common.close')} ${display.title}`}
+                      title={`${t('common.close')} ${display.title}`}
+                      data-tooltip={`${t('common.close')} ${display.title}`}
                       data-tooltip-placement="bottom"
                       onClick={() => closeTab(tab.id)}
                     >

--- a/apps/web/tests/components/App.workspace-switch-project-list.test.tsx
+++ b/apps/web/tests/components/App.workspace-switch-project-list.test.tsx
@@ -295,6 +295,12 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+// The workspace-tabs strip is a button group: each tab button carries
+// aria-pressed, and per-tab close buttons do not.
+function getWorkspaceTabs(): HTMLElement[] {
+  return screen.getAllByRole('button').filter((button) => button.hasAttribute('aria-pressed'));
+}
+
 describe('App project list across a workspace switch', () => {
   beforeEach(() => {
     resetWorkspaceContextCache();
@@ -993,7 +999,7 @@ describe('App project list across a workspace switch', () => {
     await waitFor(() => {
       expect(screen.getByTestId('project-title').textContent).toBe('Renamed from deep link');
       expect(
-        screen.getAllByRole('tab').some((tab) =>
+        getWorkspaceTabs().some((tab) =>
           tab.textContent?.includes('Renamed from deep link')),
       ).toBe(true);
     });
@@ -1002,7 +1008,7 @@ describe('App project list across a workspace switch', () => {
     await act(async () => Promise.resolve());
     expect(screen.getByTestId('project-title').textContent).toBe('Renamed from deep link');
     expect(
-      screen.getAllByRole('tab').some((tab) =>
+      getWorkspaceTabs().some((tab) =>
         tab.textContent?.includes('Foreign workspace title')),
     ).toBe(false);
   });

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -114,28 +114,53 @@ function storedEntryTabView(): string | null {
   }
 }
 
-function mockTabRect(element: HTMLElement, left: number, width = 100) {
-  // Drop hit-testing measures tabs in LAYOUT space (offsetLeft/offsetWidth) so
-  // the FLIP reorder slide and the drag transform can't shift the rects it
-  // reads. jsdom reports 0 for both, so stub them alongside the visual rect —
-  // the strip itself sits at x=0 with scrollLeft 0, so the two coincide here.
-  Object.defineProperty(element, 'offsetLeft', { configurable: true, value: left });
-  Object.defineProperty(element, 'offsetWidth', { configurable: true, value: width });
-  Object.defineProperty(element, 'getBoundingClientRect', {
-    configurable: true,
-    value: () =>
-      ({
-        x: left,
-        y: 0,
-        left,
-        right: left + width,
-        top: 0,
-        bottom: 32,
-        width,
-        height: 32,
-        toJSON: () => ({}),
-      }) as DOMRect,
+function getWorkspaceTabs(): HTMLElement[] {
+  // The strip is a button group: each tab button carries aria-pressed. The
+  // per-tab close buttons and the pinned-Home brand-logo button do not.
+  return screen.getAllByRole('button').filter((button) => button.hasAttribute('aria-pressed'));
+}
+
+function getWorkspaceTab(name: RegExp | string): HTMLElement {
+  const isMatch = (label: string) =>
+    typeof name === 'string' ? label === name : name.test(label);
+  const matcher = isMatch as (label: string) => boolean;
+  const tab = getWorkspaceTabs().find((button) => {
+    const label = button.getAttribute('aria-label');
+    return (label != null && matcher(label)) || matcher(button.textContent ?? '');
   });
+  if (!tab) throw new Error(`Unable to find workspace tab matching ${name}`);
+  return tab;
+}
+
+function mockTabRect(element: HTMLElement, left: number, width = 100) {
+  // The drag machinery measures the per-tab wrapper ([data-workspace-tab-id]),
+  // not the inner button the helper returns, in LAYOUT space
+  // (offsetLeft/offsetWidth). jsdom reports 0 for both, so stub them alongside
+  // the visual rect on the element AND its closest tab wrapper — the strip
+  // itself sits at x=0 with scrollLeft 0, so the two coincide here.
+  const targets = [
+    element,
+    ...(element.closest<HTMLElement>('[data-workspace-tab-id]') ? [element.closest<HTMLElement>('[data-workspace-tab-id]')!] : []),
+  ];
+  for (const target of targets) {
+    Object.defineProperty(target, 'offsetLeft', { configurable: true, value: left });
+    Object.defineProperty(target, 'offsetWidth', { configurable: true, value: width });
+    Object.defineProperty(target, 'getBoundingClientRect', {
+      configurable: true,
+      value: () =>
+        ({
+          x: left,
+          y: 0,
+          left,
+          right: left + width,
+          top: 0,
+          bottom: 32,
+          width,
+          height: 32,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    });
+  }
 }
 
 function dispatchDragEvent(
@@ -166,7 +191,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       <WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />,
     );
 
-    expect(screen.getAllByRole('tab')).toHaveLength(1);
+    expect(getWorkspaceTabs()).toHaveLength(1);
 
     // Asking for a new tab when a Home tab already exists should activate the
     // existing Home tab. #5517 removed the top-right "+" button, so ⌘/Ctrl+T is
@@ -176,7 +201,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     fireEvent.keyDown(document, { key: 't', metaKey: true });
 
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       // The active Home tab renders as the sidebar toggle (icon-only pill).
       expect(screen.getAllByTestId('workspace-home-rail-toggle')).toHaveLength(1);
     });
@@ -185,7 +210,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     rerender(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       expect(labels.some((label) => label.includes('Home'))).toBe(true);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
@@ -195,7 +220,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     rerender(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
 
     await waitFor(() => {
-      const tabs = screen.getAllByRole('tab');
+      const tabs = getWorkspaceTabs();
       const labels = tabs.map((tab) => tab.textContent ?? '');
       // Expect that we still have 2 tabs (Home and Project Alpha). The active
       // Home tab is the icon-only sidebar toggle, so assert its testid rather
@@ -251,7 +276,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     );
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
     });
 
@@ -260,7 +285,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     rerender(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[]} />);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
       expect(labels.some((label) => label.includes('Untitled'))).toBe(false);
     });
@@ -278,7 +303,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     await waitFor(() => {
       // The active entry tab is icon-only (Home nav pill) on non-home views,
       // so assert the parked Welcome view through the persisted tab state.
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getByTestId('workspace-home-nav')).toBeTruthy();
       expect(storedEntryTabView()).toBe('onboarding');
     });
@@ -294,7 +319,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     );
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels.some((label) => label.includes('Welcome'))).toBe(false);
       expect(labels.some((label) => label.includes('Home'))).toBe(true);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
@@ -311,7 +336,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getByTestId('workspace-home-nav')).toBeTruthy();
       expect(storedEntryTabView()).toBe('onboarding');
     });
@@ -337,7 +362,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     );
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels.some((label) => label.includes('Design systems'))).toBe(false);
       expect(labels.some((label) => label.includes('Home'))).toBe(true);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
@@ -377,7 +402,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     const { rerender } = render(
       <WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />,
     );
-    expect(screen.getAllByRole('tab')).toHaveLength(1);
+    expect(getWorkspaceTabs()).toHaveLength(1);
 
     const sections: Array<{ view: 'projects' | 'tasks' | 'design-systems' | 'plugins' | 'integrations'; label: string }> = [
       { view: 'projects', label: 'Projects' },
@@ -390,7 +415,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     for (const section of sections) {
       rerender(<WorkspaceTabsBar route={{ kind: 'home', view: section.view }} projects={[project]} />);
       await waitFor(() => {
-        const tabs = screen.getAllByRole('tab');
+        const tabs = getWorkspaceTabs();
         // Exactly one tab the whole time — the section just switches the view.
         // The active entry tab is the icon-only Home nav pill on non-home
         // sections, so read the section from the persisted tab state.
@@ -409,7 +434,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       <WorkspaceTabsBar route={{ kind: 'home', view: 'design-systems' }} projects={[project]} />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getByTestId('workspace-home-nav')).toBeTruthy();
       expect(storedEntryTabView()).toBe('design-systems');
     });
@@ -418,7 +443,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     // not replace the entry tab.
     rerender(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />);
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       expect(labels.some((label) => label.includes('Design systems'))).toBe(true);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
@@ -427,7 +452,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     // Switching to another section keeps the SAME entry tab and the project tab.
     rerender(<WorkspaceTabsBar route={{ kind: 'home', view: 'tasks' }} projects={[project]} />);
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       expect(storedEntryTabView()).toBe('tasks');
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
@@ -447,7 +472,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     );
     render(<WorkspaceTabsBar route={{ kind: 'home', view: 'projects' }} projects={[project]} />);
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getByTestId('workspace-home-nav')).toBeTruthy();
       expect(storedEntryTabView()).toBe('projects');
     });
@@ -459,7 +484,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     openWorkspaceTab({ ...projectRoute });
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       expect(labels.some((label) => label.includes('Home'))).toBe(true);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
@@ -471,13 +496,13 @@ describe('WorkspaceTabsBar navigation semantics', () => {
 
     openWorkspaceTab({ ...projectRoute });
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
 
     removeWorkspaceProjectTabs(project.id);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(1);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(false);
       const stored = JSON.parse(
@@ -495,7 +520,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     openWorkspaceTab({ ...projectRoute });
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       expect(labels.filter((label) => label.includes('Project Alpha'))).toHaveLength(1);
     });
@@ -513,7 +538,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       expect(labels.filter((label) => label.includes('Project Alpha'))).toHaveLength(1);
     });
@@ -543,7 +568,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     // Restoring a Home-less saved workspace immediately mints the permanent
     // Home tab pinned leftmost — Project Alpha sits to its right.
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Alpha'),
@@ -554,7 +579,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     rerender(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       // The active Home tab renders as the icon-only sidebar toggle.
       expect(screen.getAllByTestId('workspace-home-rail-toggle')).toHaveLength(1);
@@ -597,7 +622,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project, projectBeta]} />);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Alpha'),
@@ -641,7 +666,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       // Home + exactly one Project Alpha tab.
       expect(labels).toHaveLength(2);
       expect(labels.filter((label) => label.includes('Project Alpha'))).toHaveLength(1);
@@ -677,7 +702,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     await waitFor(() => {
       // Expect that the duplicate Home tabs are deduplicated to exactly one
       // Home tab — rendered as the sidebar toggle since it is active on home.
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getAllByTestId('workspace-home-rail-toggle')).toHaveLength(1);
     });
   });
@@ -689,9 +714,36 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     // no way to remove the last remaining tab.
     expect(screen.queryByRole('button', { name: 'Close' })).toBeNull();
 
-    expect(screen.getAllByRole('tab')).toHaveLength(1);
+    expect(getWorkspaceTabs()).toHaveLength(1);
     // Active on the home view, the pinned tab renders as the sidebar toggle.
     expect(screen.getByTestId('workspace-home-rail-toggle')).toBeTruthy();
+  });
+
+  it('keeps project tab close buttons available to keyboard and assistive tech users', async () => {
+    render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />);
+
+    await waitFor(() => {
+      expect(getWorkspaceTabs()).toHaveLength(2);
+    });
+
+    const closeProjectAlpha = screen.getByRole('button', { name: 'Close Project Alpha' });
+    // The close control is a real, discoverable button — not aria-hidden and
+    // not removed from the tab order.
+    expect(closeProjectAlpha.hasAttribute('aria-hidden')).toBe(false);
+    expect(closeProjectAlpha.getAttribute('tabindex')).toBeNull();
+
+    closeProjectAlpha.focus();
+    expect(document.activeElement).toBe(closeProjectAlpha);
+
+    fireEvent.click(closeProjectAlpha);
+
+    await waitFor(() => {
+      const tabs = getWorkspaceTabs();
+      expect(tabs).toHaveLength(1);
+      // The pinned Home tab remains, active on the home view — it renders as
+      // the icon-only sidebar-toggle brand-logo pill, not a labelled main tab.
+      expect(screen.getAllByTestId('workspace-home-rail-toggle')).toHaveLength(1);
+    });
   });
 
   it('maps the browser new-tab shortcut to the workspace new-tab action', async () => {
@@ -704,7 +756,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
 
     expect(allowedDefault).toBe(false);
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       // The shortcut activates the Home tab, which then renders as the
       // icon-only sidebar toggle.
@@ -730,7 +782,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     expect(allowedDefault).toBe(true);
     // Home is always pinned leftmost, so the project route renders Home + the
     // project tab. The deferred shortcut must not add or change tabs.
-    const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+    const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
     expect(labels).toEqual([
       expect.stringContaining('Home'),
       expect.stringContaining('Project Alpha'),
@@ -775,7 +827,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     await waitFor(() => {
       // Closing the project tab falls back to the Home tab, which is active on
       // the home view and therefore renders as the icon-only sidebar toggle.
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getByTestId('workspace-home-rail-toggle')).toBeTruthy();
     });
     expect(navigate).toHaveBeenCalledWith(homeRoute);
@@ -920,7 +972,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project, projectBeta]} />);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Alpha'),
@@ -931,7 +983,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     // Dragging a project tab onto Home's left edge must not place anything
     // before Home. Home is the permanent, pinned-leftmost tab; the drop should
     // resolve to "after Home" so Home stays first.
-    const [homeTab, , betaTab] = screen.getAllByRole('tab');
+    const [homeTab, , betaTab] = getWorkspaceTabs();
     mockTabRect(homeTab! as HTMLElement, 0);
     const dataTransfer = createDataTransfer();
     fireEvent.dragStart(betaTab!, { dataTransfer });
@@ -939,7 +991,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     dispatchDragEvent(homeTab! as HTMLElement, 'dragover', dataTransfer, 10);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Beta'),
@@ -951,7 +1003,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     fireEvent.dragEnd(betaTab!, { dataTransfer });
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Beta'),
@@ -1012,7 +1064,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project, projectBeta]} />);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Alpha'),
@@ -1020,14 +1072,14 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       ]);
     });
 
-    const [, alphaTab, betaTab] = screen.getAllByRole('tab');
+    const [, alphaTab, betaTab] = getWorkspaceTabs();
     mockTabRect(alphaTab! as HTMLElement, 100);
     const dataTransfer = createDataTransfer();
     fireEvent.dragStart(betaTab!, { dataTransfer });
     dispatchDragEvent(alphaTab! as HTMLElement, 'dragover', dataTransfer, 110);
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Beta'),
@@ -1081,7 +1133,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
     });
@@ -1112,7 +1164,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
 
     // Sign out: the account bucket flips to the fixed anon::none scope.
@@ -1125,7 +1177,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getByTestId('workspace-home-rail-toggle')).toBeTruthy();
     });
     // Route/tab-strip consistency: closing every tab down to Home also lands
@@ -1145,8 +1197,8 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
-      expect(screen.getByRole('tab', { name: /Project Alpha/ })).toBeTruthy();
+      expect(getWorkspaceTabs()).toHaveLength(2);
+      expect(getWorkspaceTab(/Project Alpha/)).toBeTruthy();
     });
     vi.mocked(navigate).mockClear();
 
@@ -1160,8 +1212,8 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
-      expect(screen.getByRole('tab', { name: /Project Alpha/ }).getAttribute('aria-selected')).toBe('true');
+      expect(getWorkspaceTabs()).toHaveLength(2);
+      expect(getWorkspaceTab(/Project Alpha/).getAttribute('aria-pressed')).toBe('true');
     });
     expect(navigate).not.toHaveBeenCalled();
   });
@@ -1176,7 +1228,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
     vi.mocked(navigate).mockClear();
 
@@ -1190,8 +1242,8 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
-      expect(screen.getByRole('tab', { name: /Project Alpha/ }).getAttribute('aria-selected')).toBe('true');
+      expect(getWorkspaceTabs()).toHaveLength(2);
+      expect(getWorkspaceTab(/Project Alpha/).getAttribute('aria-pressed')).toBe('true');
     });
     expect(navigate).not.toHaveBeenCalled();
   });
@@ -1206,8 +1258,8 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
-      expect(screen.getByRole('tab', { name: /Project Alpha/ })).toBeTruthy();
+      expect(getWorkspaceTabs()).toHaveLength(2);
+      expect(getWorkspaceTab(/Project Alpha/)).toBeTruthy();
     });
     vi.mocked(navigate).mockClear();
 
@@ -1250,7 +1302,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
     vi.mocked(navigate).mockClear();
 
@@ -1264,7 +1316,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getByTestId('workspace-home-rail-toggle')).toBeTruthy();
     });
     expect(navigate).toHaveBeenLastCalledWith(homeRoute);
@@ -1286,7 +1338,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
 
     rerender(
@@ -1298,7 +1350,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(screen.getByTestId('workspace-home-rail-toggle')).toBeTruthy();
     });
     expect(navigate).toHaveBeenLastCalledWith(homeRoute);
@@ -1334,13 +1386,13 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
     openWorkspaceTab(projectBetaRoute);
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Alpha'),
         expect.stringContaining('Project Beta'),
       ]);
-      expect(screen.getByRole('tab', { name: /Project Beta/ }).getAttribute('aria-selected')).toBe('true');
+      expect(getWorkspaceTab(/Project Beta/).getAttribute('aria-pressed')).toBe('true');
     });
 
     rerender(
@@ -1351,7 +1403,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(1);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(false);
       expect(labels.some((label) => label.includes('Project Beta'))).toBe(false);
@@ -1359,7 +1411,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
 
     openWorkspaceTab(projectGammaRoute);
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Gamma'),
@@ -1374,13 +1426,13 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Alpha'),
         expect.stringContaining('Project Beta'),
       ]);
-      expect(screen.getByRole('tab', { name: /Project Beta/ }).getAttribute('aria-selected')).toBe('true');
+      expect(getWorkspaceTab(/Project Beta/).getAttribute('aria-pressed')).toBe('true');
     });
     expect(navigate).toHaveBeenLastCalledWith(projectBetaRoute);
 
@@ -1395,14 +1447,14 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Gamma'),
       ]);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(false);
       expect(labels.some((label) => label.includes('Project Beta'))).toBe(false);
-      expect(screen.getByRole('tab', { name: /Project Gamma/ }).getAttribute('aria-selected')).toBe('true');
+      expect(getWorkspaceTab(/Project Gamma/).getAttribute('aria-pressed')).toBe('true');
     });
   });
 
@@ -1442,7 +1494,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
     });
 
     rerender(
@@ -1453,11 +1505,11 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab').map((tab) => tab.textContent ?? '')).toEqual([
+      expect(getWorkspaceTabs().map((tab) => tab.textContent ?? '')).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Alpha'),
       ]);
-      expect(screen.getByRole('tab', { name: /Project Alpha/ }).getAttribute('aria-selected')).toBe('true');
+      expect(getWorkspaceTab(/Project Alpha/).getAttribute('aria-pressed')).toBe('true');
     });
   });
 
@@ -1530,7 +1582,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(1);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(false);
       expect(screen.getByTestId('workspace-home-rail-toggle')).toBeTruthy();
@@ -1549,7 +1601,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(storedEntryTabView()).toBe('onboarding');
     });
 
@@ -1565,7 +1617,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(1);
+      expect(getWorkspaceTabs()).toHaveLength(1);
       expect(storedEntryTabView()).toBe('onboarding');
     });
     expect(navigate).not.toHaveBeenCalled();
@@ -1577,13 +1629,13 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
     rerender(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />);
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
     // No identityScopeKey passed at all across any render — tabs must behave
     // exactly as they did before this feature existed.
     rerender(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[projectBeta]} />);
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
   });
 
@@ -1604,7 +1656,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       <WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />,
     );
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
 
     // workspaceContextLoading having gated the derivation, App.tsx never
@@ -1622,9 +1674,9 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     // resets, and no navigation away from the deep-linked/refreshed project
     // fires.
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
       expect(
-        screen.getAllByRole('tab').some((tab) => (tab.textContent ?? '').includes('Project Alpha')),
+        getWorkspaceTabs().some((tab) => (tab.textContent ?? '').includes('Project Alpha')),
       ).toBe(true);
     });
     expect(navigate).not.toHaveBeenCalledWith(homeRoute);
@@ -1679,7 +1731,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(1);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(false);
     });
@@ -1746,7 +1798,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels).toEqual([
         expect.stringContaining('Home'),
         expect.stringContaining('Project Alpha'),
@@ -1805,7 +1857,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
     // Precondition: the owner's own scope restores its own tabs — allowed.
     await waitFor(() => {
-      expect(screen.getAllByRole('tab')).toHaveLength(2);
+      expect(getWorkspaceTabs()).toHaveLength(2);
     });
 
     // Direct account swap mid-onboarding.
@@ -1819,7 +1871,7 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
     );
 
     await waitFor(() => {
-      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      const labels = getWorkspaceTabs().map((tab) => tab.textContent ?? '');
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(false);
     });
     // Stays in the onboarding flow: no navigation fired, entry tab still on


### PR DESCRIPTION
## Why
The workspace-tabs strip previously used WAI-ARIA `role="tablist"` / `role="tab"`
semantics while rendering a per-tab close button inside each tab. Because the
tablist pattern owns every focusable descendant, the strip exposed focusable
controls that are neither tabs nor part of the tab pattern's keyboard model
(Arrow-key rotation, `aria-selected`). Screen readers announced a confusing
composite — a "tab" wrapping an unmanaged button — and the active-state
`aria-selected` lived on a presentational wrapper instead of the interactive
control.

This PR moves selection semantics onto the real interactive control: each tab
button carries `aria-pressed` for active state, and per-tab close buttons are
plain, discoverable buttons with per-tab accessible names ("Close <Project>").
The strip no longer claims tablist semantics, structurally resolving the
repeated review findings instead of papering over them.

## What users will see
No visual change — this is an accessibility-only refactor. Assistive-technology
users now hear each tab as a toggle button with "pressed / not pressed" state
instead of a tab composite, and each per-tab close control is discoverable and
operable by screen-reader and keyboard users alike. Pointer and keyboard
interaction (activate, close, drag/reorder) is unchanged.

## Surface area
- Web UI: `apps/web/src/components/WorkspaceTabsBar.tsx`
- Web tests: `apps/web/tests/components/WorkspaceTabsBar.test.tsx`

## Validation
- Workspace-tabs Vitest suite passes: 42 passed / 1 skipped (`pnpm --filter @open-design/web test`).
- `tsc -b --noEmit` and `pnpm guard` are clean on the head commit.
- Rebased onto current `main`; the tab-role test coverage now uses a
  `getWorkspaceTabs()` helper (buttons with `aria-pressed`) instead of
  `role="tab"` lookups.
- The close-control a11y test uses Vitest-compatible native DOM assertions
  (`hasAttribute('aria-hidden')`, `tabIndex`, `document.activeElement`) — no
  jest-dom-only matchers.
- Addresses the full reviewer history: no focusable non-tab controls inside a
  tablist subtree, close buttons are never `aria-hidden`/`tabIndex=-1`, and
  every tab strip control carries an explicit accessible name.
- No visual diff (behavior only): hover/preview, drag/reorder, overflow, the
  pinned Home rail, and the glide indicator rendering are unchanged.