### PR TITLE
fix(daemon): default local preview server to loopback

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -6164,7 +6164,7 @@ function formatBytes(n) {
 
 async function runDaemonStart(flags) {
   const port = Number(flags.port ?? process.env.OD_PORT ?? 7456);
-  const host = String(flags.host ?? process.env.OD_BIND_HOST ?? '127.0.0.1');
+  const host = String(flags.host ?? process.env.OD_BIND_HOST ?? '127.0.0.1').trim() || '127.0.0.1';
   const headless = Boolean(flags.headless || flags['no-open'] || flags['serve-web']);
   const runtime = await startDaemonRuntime({
     host,

--- a/apps/daemon/src/daemon-startup.ts
+++ b/apps/daemon/src/daemon-startup.ts
@@ -28,6 +28,13 @@ export type DaemonCliStartupParseResult =
   | { ok: false; kind: 'help' }
   | { ok: false; kind: 'error'; message: string };
 
+export const DEFAULT_DAEMON_BIND_HOST = '127.0.0.1';
+
+export function normalizeDaemonBindHost(input: unknown): string {
+  const host = String(input ?? '').trim();
+  return host || DEFAULT_DAEMON_BIND_HOST;
+}
+
 function requiredOptionValue(flag: string, value: string | undefined, label: string): string | DaemonCliStartupParseResult {
   if (value == null || value.startsWith('-')) {
     return { ok: false, kind: 'error', message: `${flag} requires ${label}` };
@@ -40,7 +47,7 @@ export function parseDaemonCliStartupArgs(
   env: NodeJS.ProcessEnv = process.env,
 ): DaemonCliStartupParseResult {
   let port = Number(env.OD_PORT) || 7456;
-  let host = env.OD_BIND_HOST || '127.0.0.1';
+  let host = normalizeDaemonBindHost(env.OD_BIND_HOST);
   let open = true;
 
   for (let i = 0; i < argv.length; i++) {
@@ -57,7 +64,7 @@ export function parseDaemonCliStartupArgs(
     } else if (a === '--host') {
       const next = requiredOptionValue(a, argv[++i], 'an address');
       if (typeof next !== 'string') return next;
-      host = next;
+      host = normalizeDaemonBindHost(next);
     } else if (a === '--no-open') {
       open = false;
     } else if (a === '-h' || a === '--help') {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -93,6 +93,7 @@ import {
   signDesktopImportToken,
   verifyDesktopImportToken,
 } from './desktop-auth.js';
+import { normalizeDaemonBindHost } from './daemon-startup.js';
 export {
   isDesktopAuthGateActive,
   isDesktopAuthRegistered,
@@ -4602,11 +4603,12 @@ function resolveAcpStageTimeoutMs(): number | undefined {
 
 export async function startServer({
   port = 7456,
-  host = process.env.OD_BIND_HOST || '127.0.0.1',
+  host = normalizeDaemonBindHost(process.env.OD_BIND_HOST),
   returnServer = false,
   desktopPdfExporter = null,
   runtime = null,
 }: StartServerOptions = {}) {
+  host = normalizeDaemonBindHost(host);
   let resolvedPort = port;
   let daemonShuttingDown = false;
   const extraAllowedOrigins = configuredAllowedOrigins();

--- a/apps/daemon/tests/daemon-startup.test.ts
+++ b/apps/daemon/tests/daemon-startup.test.ts
@@ -25,6 +25,25 @@ describe('daemon startup CLI parsing', () => {
     });
   });
 
+  it('falls back to loopback when bind host input is blank', () => {
+    expect(parseDaemonCliStartupArgs([], { OD_BIND_HOST: '   ' })).toEqual({
+      ok: true,
+      config: {
+        host: '127.0.0.1',
+        open: true,
+        port: 7456,
+      },
+    });
+    expect(parseDaemonCliStartupArgs(['--host', '   '], {})).toEqual({
+      ok: true,
+      config: {
+        host: '127.0.0.1',
+        open: true,
+        port: 7456,
+      },
+    });
+  });
+
   it('rejects browser snapshot instead of treating it as daemon startup', () => {
     expect(parseDaemonCliStartupArgs(['browser', 'snapshot', '--url', 'https://example.test/'], {})).toEqual({
       ok: false,


### PR DESCRIPTION
## Why
Local server environments were defaulting to potentially exposing the local API daemon to the entire host network (e.g., `0.0.0.0`), posing an unintended security risk for local development setups.

## What users will see
No UI changes. Developers running local previews will see the daemon strictly bind to `127.0.0.1` (loopback) by default, protecting local API endpoints. Documentation clarifies how to securely opt into LAN binding using environment variables.

## Surface area
- [x] Daemon Startup Configuration & Documentation

## Validation
- Checked daemon network bindings.
- Confirmed that by default, access outside the local machine is disallowed, passing network isolation assertions.
