### PR TITLE
fix(daemon): surface actionable hint when OpenCode CLI is outdated

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -38,6 +38,7 @@ import { attachAcpSession } from './acp.js';
 import { attachPiRpcSession } from './pi-rpc.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
 import { diagnoseClaudeCliFailure } from './claude-diagnostics.js';
+import { diagnoseOpenCodeCliFailure } from './opencode-diagnostics.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
 import { agentCliEnvForAgent, validateAgentCliEnv } from './app-config.js';
@@ -2230,6 +2231,32 @@ async function testAgentConnectionInternal(
           detail: auth.message ?? cursorAuthGuidance(),
           diagnostics: buildDiagnostics({
             phase: 'connection_smoke_test',
+            exitCode: winner.code,
+            signal: winner.signal,
+          }),
+        };
+      }
+      const opencodeDiagnostic = diagnoseOpenCodeCliFailure({
+        agentId: input.agentId,
+        exitCode: winner.code,
+        signal: winner.signal,
+        stderrTail,
+        stdoutTail: rawStdoutTail || buffered,
+        resolvedBin: executableResolution.selectedPath,
+      });
+      if (opencodeDiagnostic) {
+        console.warn(
+          `[test:agent] ${def.name} → opencode_diagnostic: ${opencodeDiagnostic.detail}`,
+        );
+        return {
+          ok: false,
+          kind: 'agent_spawn_failed',
+          latencyMs,
+          model,
+          agentName: def.name,
+          detail: opencodeDiagnostic.detail,
+          diagnostics: buildDiagnostics({
+            phase: 'spawn',
             exitCode: winner.code,
             signal: winner.signal,
           }),

--- a/apps/daemon/src/opencode-diagnostics.ts
+++ b/apps/daemon/src/opencode-diagnostics.ts
@@ -1,0 +1,103 @@
+import { redactSecrets } from './redact.js';
+
+export interface OpenCodeCliDiagnosticInput {
+  agentId: string;
+  exitCode?: number | null;
+  signal?: string | null;
+  stderrTail?: string | null;
+  stdoutTail?: string | null;
+  resolvedBin?: string | null;
+}
+
+export interface OpenCodeCliDiagnostic {
+  message: string;
+  detail: string;
+  retryable: boolean;
+  /**
+   * Stable `ApiErrorCode` for this failure class, when one is more specific
+   * than the generic `AGENT_EXECUTION_FAILED`. Mirrors the convention used by
+   * `claude-diagnostics.ts`.
+   */
+  code?: string;
+}
+
+const body = (input: OpenCodeCliDiagnosticInput): string =>
+  [input.stderrTail, input.stdoutTail]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .join('\n');
+
+// Marker fragments emitted by `opencode --help` / `opencode run --help` when
+// an old CLI doesn't recognize one of the flags Open Design now passes
+// (`run --format json`, etc.) and falls through to dumping its own usage to
+// stderr.
+//
+// Each marker is anchored on the flag name AND its descriptor text so a
+// single substring like `--prompt` mentioned in an unrelated error message
+// (model output, provider error) does not match. We additionally require
+// >=2 markers in the same tail before classifying the failure as a help-text
+// dump — see #4201 for the failing stderr shape this is taken from.
+const HELP_TEXT_MARKERS: readonly RegExp[] = [
+  /-p,\s+--prompt\s+string\s+Prompt to run in non-interactive mode/i,
+  /-q,\s+--quiet\s+Hide spinner in non-interactive mode/i,
+  /-v,\s+--version\s+Version/i,
+  /--format[^.\n]{0,40}\(default "text"\)/i,
+  /\(json,\s+text\)\s+\(default "text"\)/i,
+];
+
+const looksLikeHelpTextDump = (text: string): boolean => {
+  if (!text.trim()) return false;
+  let matchCount = 0;
+  for (const re of HELP_TEXT_MARKERS) {
+    if (re.test(text)) matchCount += 1;
+    if (matchCount >= 2) return true;
+  }
+  return false;
+};
+
+const withContext = (
+  message: string,
+  detail: string,
+  input: OpenCodeCliDiagnosticInput,
+  code?: string,
+): OpenCodeCliDiagnostic => {
+  const diagnosticTail = redactSecrets(body(input))
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(-240);
+  const context: string[] = [message, detail];
+  if (diagnosticTail) context.push(`OpenCode output: ${diagnosticTail}`);
+  if (input.resolvedBin) {
+    context.push(`Resolved OpenCode binary: ${input.resolvedBin}.`);
+  }
+  return {
+    message: redactSecrets(message),
+    detail: redactSecrets(context.filter(Boolean).join(' ')),
+    retryable: true,
+    ...(code ? { code } : {}),
+  };
+};
+
+/**
+ * Classifies an OpenCode CLI process failure when the failure shape indicates
+ * the installed CLI is too old for the flags Open Design now passes. The
+ * caller still uses the generic `agent_spawn_failed` envelope; this just
+ * upgrades `detail` from `exit 1 · stderr: <raw help fragment>` to an
+ * actionable update hint plus an explicit GUI-vs-global-CLI boundary note.
+ *
+ * The GUI does not update a user's globally installed CLI, so the message
+ * tells them to run `npm i -g opencode-ai@latest` themselves and retry.
+ */
+export function diagnoseOpenCodeCliFailure(
+  input: OpenCodeCliDiagnosticInput,
+): OpenCodeCliDiagnostic | null {
+  if (input.agentId !== 'opencode') return null;
+  if (input.exitCode === 0 && !input.signal) return null;
+  if (!looksLikeHelpTextDump(body(input))) return null;
+
+  return withContext(
+    'The detected OpenCode CLI looks too old for Open Design to drive — its help output came back instead of a streamed response.',
+    'Update your global install with `npm i -g opencode-ai@latest`, then retry. Open Design uses the globally installed `opencode` / `opencode-cli` and does not update it for you.',
+    input,
+    'AGENT_CLI_OUTDATED',
+  );
+}

--- a/apps/daemon/tests/opencode-diagnostics.test.ts
+++ b/apps/daemon/tests/opencode-diagnostics.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { diagnoseOpenCodeCliFailure } from '../src/opencode-diagnostics.js';
+
+describe('diagnoseOpenCodeCliFailure', () => {
+  // Repro from #4201: a globally installed `opencode-cli` that predates the
+  // flags Open Design now passes (`run --format json`) dumps its own help
+  // text to stderr and exits 1. The surfaced error today is the raw
+  // `exit 1 · stderr: , json) (default "text") -p, --prompt string ...`
+  // help-fragment, which gives the user no indication that updating the CLI
+  // is the fix.
+  it('maps the outdated opencode-cli help-text dump to an update hint (#4201)', () => {
+    const stderrTail =
+      ', json) (default "text") ' +
+      '-p, --prompt string Prompt to run in non-interactive mode ' +
+      '-q, --quiet Hide spinner in non-interactive mode ' +
+      '-v, --version Version.';
+
+    const diagnostic = diagnoseOpenCodeCliFailure({
+      agentId: 'opencode',
+      exitCode: 1,
+      stderrTail,
+    });
+
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.message.toLowerCase()).toContain('opencode');
+    expect(diagnostic?.message.toLowerCase()).toContain('too old');
+    expect(diagnostic?.detail).toContain('npm i -g opencode-ai@latest');
+    expect(diagnostic?.detail.toLowerCase()).toContain('does not update it for you');
+    expect(diagnostic?.code).toBe('AGENT_CLI_OUTDATED');
+  });
+
+  it('includes the resolved binary path in the detail when available', () => {
+    const diagnostic = diagnoseOpenCodeCliFailure({
+      agentId: 'opencode',
+      exitCode: 1,
+      stderrTail:
+        '-p, --prompt string Prompt to run in non-interactive mode ' +
+        '-v, --version Version',
+      resolvedBin: '/usr/local/bin/opencode-cli',
+    });
+
+    expect(diagnostic?.detail).toContain('/usr/local/bin/opencode-cli');
+  });
+
+  it('does not classify failures from a different agent id', () => {
+    const diagnostic = diagnoseOpenCodeCliFailure({
+      agentId: 'codex',
+      exitCode: 1,
+      stderrTail:
+        '-p, --prompt string Prompt to run in non-interactive mode ' +
+        '-q, --quiet Hide spinner in non-interactive mode',
+    });
+
+    expect(diagnostic).toBeNull();
+  });
+
+  it('does not fire on clean exits', () => {
+    const diagnostic = diagnoseOpenCodeCliFailure({
+      agentId: 'opencode',
+      exitCode: 0,
+      stderrTail:
+        '-p, --prompt string Prompt to run in non-interactive mode',
+    });
+
+    expect(diagnostic).toBeNull();
+  });
+
+  it('does not false-positive on a single stray help-text substring', () => {
+    // A model error that happens to mention a flag name once should not be
+    // misclassified as an outdated-CLI help dump.
+    const diagnostic = diagnoseOpenCodeCliFailure({
+      agentId: 'opencode',
+      exitCode: 1,
+      stderrTail:
+        'Model error: please pass --prompt explicitly when piping input',
+    });
+
+    expect(diagnostic).toBeNull();
+  });
+
+  it('does not fire on a generic non-help-text exit', () => {
+    const diagnostic = diagnoseOpenCodeCliFailure({
+      agentId: 'opencode',
+      exitCode: 1,
+      stderrTail: 'Error: provider returned 503 Service Unavailable',
+    });
+
+    expect(diagnostic).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #4201

## Why

A Discord user (`trashken`, via #4201) ran Open Design's "Test with OpenCode" against a globally-installed `opencode-cli` that predated the flags Open Design now passes (`run --format json`). The old CLI fell through to dumping its own help text to stderr and exiting 1, and the connection-test surface showed them the raw fragment:

```
Could not start OpenCode: exit 1 · stderr: , json) (default "text") -p, --prompt string Prompt to run in non-interactive mode -q, --quiet Hide spinner in non-interactive mode -v, --version Version.
```

That tells the user nothing about the actual fix (`npm i -g opencode-ai@latest`) and reads as a generic process failure. Maintainer comment on the issue invited a focused diagnosis + actionable update hint, plus an explicit note that the GUI does not update the user's globally-installed CLI.

This PR is that fix.

## What users will see

When OpenCode's "Test" exits 1 because the globally-installed CLI is too old for the flags Open Design now passes, the failure detail changes from a raw `exit 1 · stderr: …` help-text fragment to an actionable diagnosis:

> The detected OpenCode CLI looks too old for Open Design to drive — its help output came back instead of a streamed response. Update your global install with `npm i -g opencode-ai@latest`, then retry. Open Design uses the globally installed `opencode` / `opencode-cli` and does not update it for you.

The diagnostic also includes the resolved OpenCode binary path when known and a redacted tail of the OpenCode output, so users can confirm Open Design hit the install they expect.

Up-to-date OpenCode CLIs and unrelated provider/network failures are unaffected — the classifier only fires when the failure tail matches >=2 distinct help-output markers.

## Surface area

- [x] **None** — internal change to the daemon's connection-test failure classification. No UI surface, no new endpoint, no new CLI flag, no new env var, no new top-level dependency.

(The error copy that surfaces in the existing connection-test result envelope changes for one specific failure shape; no schema or contract change.)

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Test path that reproduces the bug: `apps/daemon/tests/opencode-diagnostics.test.ts`
- Did the test go red on `main` and green on this branch? **Yes.** The classifier (`apps/daemon/src/opencode-diagnostics.ts`) does not exist on `main`, so the import in the new spec file is unresolvable there — the spec is red until the source change lands. With the source change, the suite is green:
  - 6/6 tests pass locally.
- Red spec covers:
  - the exact `#4201` stderr shape → outdated-CLI diagnosis with the `npm i -g opencode-ai@latest` hint and the GUI-vs-global-CLI boundary sentence
  - resolved binary path is appended to the detail when present
  - non-`opencode` `agentId` → `null` (no cross-classification)
  - clean exit (`exitCode: 0`, no signal) → `null`
  - **false-positive guard**: a single stray `--prompt` substring in an unrelated model error → `null`
  - generic non-help-text exit (e.g. `Error: provider returned 503 Service Unavailable`) → `null`

## Validation

- `apps/daemon/tests/opencode-diagnostics.test.ts` — 6 passing locally via vitest.
- `pnpm guard` / `pnpm typecheck` — could not run a full pass on this machine because the workspace packages `@open-design/platform`, `@open-design/contracts`, `@open-design/sidecar`, `@open-design/sidecar-proto` need to be built first and several of the existing TS errors on a fresh checkout are pre-existing on `main`. The new files (`opencode-diagnostics.ts`, `opencode-diagnostics.test.ts`) only import `./redact.js` from the same package and standard library, so they don't introduce new cross-package coupling. Happy to run the full validation set on a clean reproduce if it would help reviewers.

## Implementation notes

- `apps/daemon/src/opencode-diagnostics.ts` mirrors the shape of `apps/daemon/src/claude-diagnostics.ts` so the call site in `connectionTest.ts` reads identically (`diagnoseClaudeCliFailure` → `diagnoseOpenCodeCliFailure`).
- The marker regexes anchor on flag-name + descriptor (e.g. `-p,\s+--prompt\s+string\s+Prompt to run in non-interactive mode`) instead of bare `--prompt`, and the function requires >=2 markers in the same tail, so model errors that mention a flag name once aren't misclassified.
- A new stable error code `AGENT_CLI_OUTDATED` is set on the returned diagnostic for future per-class triage (matches the `AGENT_CONNECTION_DROPPED` pattern already in `claude-diagnostics.ts`).
- The classifier runs before the existing `diagnoseClaudeCliFailure` check; on a hit it returns the standard `agent_spawn_failed` envelope with the upgraded `detail`, keeping the existing response shape.

## Adjacent issues

- #4186 ("Docker: OpenCode not detected — daemon looks for `opencode-cli` but npm installs `opencode`") is being investigated separately by the original reporter and maintainer in that thread; this PR doesn't touch resolution / `fallbackBins` behaviour and is out of scope here.