### PR TITLE
fix(web): space built-in skill edit warning

### DIFF
--- a/apps/web/src/styles/viewer/plugin-inputs.css
+++ b/apps/web/src/styles/viewer/plugin-inputs.css
@@ -51,6 +51,39 @@
   border-radius: var(--radius-sm);
 }
 
+.settings-skills .skills-edit-builtin-warning {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px 12px;
+  margin: 0 10px 10px 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--warning, #d97706) 8%, var(--bg-panel));
+}
+.settings-skills .skills-edit-builtin-warning p {
+  flex: 1 1 240px;
+  min-width: 0;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+.settings-skills .skills-edit-builtin-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-left: auto;
+}
+.settings-skills .skills-edit-builtin-actions .btn {
+  min-height: 28px;
+  padding: 5px 12px;
+}
+
 .settings-skills .skills-row-detail {
   display: flex;
   flex-direction: column;
@@ -331,4 +364,3 @@
 
 	text-align: left;
 }
-

--- a/apps/web/src/styles/viewer/plugin-inputs.css
+++ b/apps/web/src/styles/viewer/plugin-inputs.css
@@ -364,3 +364,4 @@
 
 	text-align: left;
 }
+

--- a/apps/web/src/styles/viewer/plugin-inputs.css
+++ b/apps/web/src/styles/viewer/plugin-inputs.css
@@ -53,35 +53,31 @@
 
 .settings-skills .skills-edit-builtin-warning {
   display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px 12px;
-  margin: 0 10px 10px 14px;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
+  flex-direction: column;
+  gap: 12px;
+  margin: 2px 14px 14px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--warning, #d97706) 30%, var(--border));
   border-radius: var(--radius);
   background: color-mix(in srgb, var(--warning, #d97706) 8%, var(--bg-panel));
+  color: var(--text);
 }
 .settings-skills .skills-edit-builtin-warning p {
-  flex: 1 1 240px;
-  min-width: 0;
   margin: 0;
   color: var(--text-muted);
   font-size: 12.5px;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 .settings-skills .skills-edit-builtin-actions {
   display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  flex: 0 1 auto;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 8px;
-  margin-left: auto;
 }
 .settings-skills .skills-edit-builtin-actions .btn {
-  min-height: 28px;
-  padding: 5px 12px;
+  min-height: 30px;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
 }
 
 .settings-skills .skills-row-detail {


### PR DESCRIPTION
Fixes #3558

## Why

The built-in skill edit confirmation in Settings > Skills rendered with no dedicated warning-state styling. The warning text sat close to the row border, and the Cancel/Edit actions had little spacing from the surrounding content.

## User-facing change

When a user tries to edit a built-in skill, the confirmation warning now reads as a distinct warning block. The copy has more breathing room, the line-height is easier to scan, and the Cancel/Edit actions wrap with clearer spacing on narrow widths.

## Surface area

- Settings > Skills
- Built-in skill edit confirmation state
- CSS only: `apps/web/src/styles/viewer/plugin-inputs.css`

## What changed

- Added scoped styles for the built-in skill edit warning block.
- Gave the warning copy its own padding, border, background, and line-height.
- Added wrapped action spacing so the buttons have room without changing the edit flow.

## Scope

CSS only. No change to custom skill upload, skill override logic, built-in skill editing behavior, or broader Settings behavior.

## Validation

- Focused before/after screenshot added in the PR discussion for the built-in skill edit warning state.
- Design review from @chaoxiaoche confirmed no further UI/design blockers.
- Passed: `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/SkillsSection.test.tsx`
- Passed: `git diff --check`
- Not clean locally: `pnpm --dir apps/web run typecheck`. It currently fails on existing TypeScript contract drift in analytics and chat resumable types, outside this CSS-only change.
