### PR TITLE
Improve outdated OpenCode CLI connection error

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1681,7 +1681,7 @@ function openCodeOutdatedCliDetail(output: string): string | null {
   const looksLikeOpenCodeHelp =
     /\bopencode\b/u.test(value) && /\b(?:usage|commands|options):/u.test(value);
   const looksLikeUnsupportedArgs =
-    /\b(?:unknown option|unknown argument|unexpected argument|unrecognized option|incompatible opencode args|required option|missing required)\b/u.test(value);
+    /\b(?:unknown option|unknown argument|unexpected argument|unrecognized option|invalid option|incompatible opencode args)\b/u.test(value);
 
   return looksLikeOpenCodeHelp || looksLikeUnsupportedArgs
     ? OPENCODE_OUTDATED_CLI_DETAIL

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1673,6 +1673,21 @@ function extractOpenCodeTextFromRawStdout(stdout: string): string {
   return text.join('');
 }
 
+const OPENCODE_OUTDATED_CLI_DETAIL =
+  'OpenCode CLI appears to be outdated or incompatible with this connection test. Update it with `npm i -g opencode-ai@latest`, then retry the OpenCode connection test.';
+
+function openCodeOutdatedCliDetail(output: string): string | null {
+  const value = output.toLowerCase();
+  const looksLikeOpenCodeHelp =
+    /\bopencode\b/u.test(value) && /\b(?:usage|commands|options):/u.test(value);
+  const looksLikeUnsupportedArgs =
+    /\b(?:unknown option|unknown argument|unexpected argument|unrecognized option|incompatible opencode args|required option|missing required)\b/u.test(value);
+
+  return looksLikeOpenCodeHelp || looksLikeUnsupportedArgs
+    ? OPENCODE_OUTDATED_CLI_DETAIL
+    : null;
+}
+
 interface AgentSpawnHandle {
   child: ReturnType<typeof spawn>;
   acpSession?: {
@@ -2218,6 +2233,27 @@ async function testAgentConnectionInternal(
       ]
         .filter(Boolean)
         .join(' · ');
+      if (input.agentId === 'opencode') {
+        const outdatedCliDetail = openCodeOutdatedCliDetail(rawDetail);
+        if (outdatedCliDetail) {
+          console.warn(
+            `[test:agent] ${def.name} → outdated_cli: ${redactSecrets(rawDetail)}`,
+          );
+          return {
+            ok: false,
+            kind: 'agent_spawn_failed',
+            latencyMs,
+            model,
+            agentName: def.name,
+            detail: outdatedCliDetail,
+            diagnostics: buildDiagnostics({
+              phase: 'spawn',
+              exitCode: winner.code,
+              signal: winner.signal,
+            }),
+          };
+        }
+      }
       const auth = classifyAgentAuthFailure(input.agentId, rawDetail);
       if (auth?.status === 'missing') {
         console.warn(`[test:agent] ${def.name} → auth_required: ${redactSecrets(rawDetail)}`);

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2725,6 +2725,41 @@ setTimeout(() => process.exit(0), 50);
     );
   });
 
+  it('reports outdated OpenCode CLI argument failures with update guidance', async () => {
+    const expectedDetail =
+      'OpenCode CLI appears to be outdated or incompatible with this connection test. Update it with `npm i -g opencode-ai@latest`, then retry the OpenCode connection test.';
+
+    await withFakeOpenCode(
+      `
+const args = process.argv.slice(2);
+if (args[0] === 'models') {
+  console.log('github-copilot/gpt-4o');
+  process.exit(0);
+}
+console.error('opencode');
+console.error('Usage: opencode [options] [command]');
+console.error('Options:');
+console.error('  --help  Show help');
+console.error('incompatible opencode args');
+process.exit(1);
+`,
+      async () => {
+        const res = await realFetch(`${baseUrl}/api/test/connection`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'agent', agentId: 'opencode' }),
+        });
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'OpenCode',
+          detail: expectedDetail,
+        });
+      },
+    );
+  });
+
   it('launches OpenCode connection tests with 1.3-compatible JSON stdin args', async () => {
     const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-opencode-argv-'));
     const argvFile = path.join(markerDir, 'argv.json');

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2760,6 +2760,36 @@ process.exit(1);
     );
   });
 
+  it('preserves unrelated OpenCode missing-required failures', async () => {
+    await withFakeOpenCode(
+      `
+const args = process.argv.slice(2);
+if (args[0] === 'models') {
+  console.log('github-copilot/gpt-4o');
+  process.exit(0);
+}
+console.error('missing required environment variable OPENAI_API_KEY');
+process.exit(1);
+`,
+      async () => {
+        const res = await realFetch(`${baseUrl}/api/test/connection`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'agent', agentId: 'opencode' }),
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'OpenCode',
+        });
+        expect(body.detail).toContain('missing required environment variable OPENAI_API_KEY');
+        expect(body.detail).not.toContain('OpenCode CLI appears to be outdated');
+      },
+    );
+  });
+
   it('launches OpenCode connection tests with 1.3-compatible JSON stdin args', async () => {
     const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-opencode-argv-'));
     const argvFile = path.join(markerDir, 'argv.json');

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2778,7 +2778,7 @@ process.exit(1);
           body: JSON.stringify({ mode: 'agent', agentId: 'opencode' }),
         });
         expect(res.status).toBe(200);
-        const body = await res.json();
+        const body = await res.json() as { detail?: string };
         expect(body).toMatchObject({
           ok: false,
           kind: 'agent_spawn_failed',


### PR DESCRIPTION
Fixes #4201

## Why

OpenCode connection tests could fail with raw `exit 1` output plus CLI help text when the installed OpenCode CLI was outdated or incompatible.

That made the failure hard to act on because users had to infer that they needed to update their local OpenCode CLI.

## What users will see

When the OpenCode connection test detects outdated or incompatible CLI output, users will now see actionable update guidance instead of raw process output:

> OpenCode CLI appears to be outdated or incompatible with this connection test. Update it with `npm i -g opencode-ai@latest`, then retry the OpenCode connection test.

## Surface area

- [ ] UI — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] Keyboard shortcut — new or changed
- [ ] CLI / env var — new od subcommand or flag, new tools-dev / tools-pack / tools-pr flag, or new OD_* env var
- [ ] API / contract — new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] Extension point — new entry under skills/, design-systems/, design-templates, or craft/, or change to the skills protocol
- [ ] i18n keys — added new translation keys (see TRANSLATIONS.md for the locale workflow)
- [ ] New top-level dependency — adding any new entry to the root package.json (dependencies or devDependencies); workspace-package package.json files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see CONTRIBUTING.md → Code style)
- [ ] Default behavior change — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] None — internal daemon/test bugfix for connection-test failure classification. No UI surface, no new endpoint, no new CLI flag, no new env var, and no new top-level dependency.

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts`
- Did the test go red on main and green on this branch? Not manually verified on main; added regression coverage that simulates an outdated/incompatible OpenCode CLI argument failure and verifies the new update guidance.
- Verification: `pnpm --filter @open-design/daemon test -- connection-test.test.ts -t "OpenCode"` passed.

## Validation

- `pnpm --filter @open-design/daemon test -- connection-test.test.ts -t "OpenCode"` passed: 4 passed.
- `git diff --check` passed, with only Windows LF/CRLF warnings.