### PR TITLE
Fix PPT preview zoom scrolling

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { createPortal, flushSync } from 'react-dom';
 import { Button, Input, Select } from '@open-design/components';
 import { APP_CHROME_FILE_ACTIONS_ID, APP_CHROME_FILE_ACTIONS_SELECTOR } from './AppChromeHeader';
@@ -176,6 +176,7 @@ function resolveChromeActionsHost(): HTMLElement | null {
 }
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+const useBrowserLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 type SlideState = { active: number; count: number };
 type BoardTool = 'inspect' | 'pod';
 type StrokePoint = { x: number; y: number };
@@ -965,6 +966,76 @@ function PreviewScaleShell({
   return (
     <div style={sizerStyle}>
       <div style={shellStyle}>{children}</div>
+    </div>
+  );
+}
+
+function clampedPreviewScaleScrollOffset(
+  scrollOffset: number,
+  viewportSize: number,
+  scrollSize: number,
+  previousScale: number,
+  nextScale: number,
+) {
+  if (viewportSize <= 0 || scrollSize <= viewportSize || previousScale <= 0 || nextScale <= 0) return 0;
+  const nextOffset = ((scrollOffset + viewportSize / 2) * nextScale / previousScale) - viewportSize / 2;
+  return Math.max(0, Math.min(scrollSize - viewportSize, nextOffset));
+}
+
+function anchoredPreviewScaleScrollPosition(
+  frame: HTMLElement,
+  previousScale: number,
+  nextScale: number,
+) {
+  return {
+    scrollLeft: clampedPreviewScaleScrollOffset(
+      frame.scrollLeft,
+      frame.clientWidth,
+      frame.scrollWidth,
+      previousScale,
+      nextScale,
+    ),
+    scrollTop: clampedPreviewScaleScrollOffset(
+      frame.scrollTop,
+      frame.clientHeight,
+      frame.scrollHeight,
+      previousScale,
+      nextScale,
+    ),
+  };
+}
+
+function PreviewScaleScrollFrame({
+  viewport,
+  previewScale,
+  className,
+  style,
+  children,
+}: {
+  viewport: PreviewViewportId;
+  previewScale: number;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}) {
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const previousScaleRef = useRef(normalizedPreviewScale(previewScale));
+
+  useBrowserLayoutEffect(() => {
+    const frame = frameRef.current;
+    const previousScale = previousScaleRef.current;
+    const nextScale = normalizedPreviewScale(previewScale);
+    previousScaleRef.current = nextScale;
+    if (!frame || viewport !== 'desktop' || previousScale === nextScale) return;
+
+    const nextScroll = anchoredPreviewScaleScrollPosition(frame, previousScale, nextScale);
+    frame.scrollLeft = nextScroll.scrollLeft;
+    frame.scrollTop = nextScroll.scrollTop;
+  }, [previewScale, viewport]);
+
+  return (
+    <div ref={frameRef} className={className} style={style}>
+      {children}
     </div>
   );
 }
@@ -1821,7 +1892,12 @@ export function LiveArtifactViewer({
           aria-hidden={mode === 'preview' ? undefined : true}
           style={previewViewportStyle(previewViewport, previewScale, previewBodySize)}
         >
-          <div className="preview-frame-clip" style={previewScaleScrollStyle(previewViewport, previewScale)}>
+          <PreviewScaleScrollFrame
+            viewport={previewViewport}
+            previewScale={previewScale}
+            className="preview-frame-clip"
+            style={previewScaleScrollStyle(previewViewport, previewScale)}
+          >
             <PreviewScaleShell viewport={previewViewport} previewScale={previewScale}>
               <PreviewDrawOverlay>
                 <iframe
@@ -1833,7 +1909,7 @@ export function LiveArtifactViewer({
                 />
               </PreviewDrawOverlay>
             </PreviewScaleShell>
-          </div>
+          </PreviewScaleScrollFrame>
         </div>
         {mode !== 'preview' && loading ? (
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
@@ -10682,7 +10758,9 @@ function HtmlViewer({
               className={manualEditMode ? 'manual-edit-canvas' : 'comment-preview-canvas'}
               data-testid={manualEditMode ? undefined : 'comment-preview-canvas'}
             >
-              <div
+              <PreviewScaleScrollFrame
+                viewport={previewViewport}
+                previewScale={previewScale}
                 className={manualEditMode ? undefined : 'comment-frame-clip'}
                 style={manualEditMode
                   ? { height: '100%', ...previewScaleScrollStyle(previewViewport, previewScale) }
@@ -10821,7 +10899,7 @@ function HtmlViewer({
                     </div>
                   </PreviewDrawOverlay>
                 </PreviewScaleShell>
-              </div>
+              </PreviewScaleScrollFrame>
               {boardMode ? (
                 <CommentPreviewOverlays
                   comments={commentCreateMode ? visibleSideComments : []}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -886,11 +886,12 @@ function previewScaleShellStyle(
   viewport: PreviewViewportId,
   previewScale: number,
 ): CSSProperties & Record<string, string | number> {
+  const scale = normalizedPreviewScale(previewScale);
   if (viewport === 'desktop') {
     return {
-      width: `${100 / previewScale}%`,
-      height: `${100 / previewScale}%`,
-      transform: `scale(${previewScale})`,
+      width: `${100 / scale}%`,
+      height: `${100 / scale}%`,
+      transform: `scale(${scale})`,
       transformOrigin: '0 0',
     };
   }
@@ -902,20 +903,70 @@ function previewScaleShellStyle(
   };
 }
 
+function normalizedPreviewScale(previewScale: number) {
+  return Number.isFinite(previewScale) && previewScale > 0 ? previewScale : 1;
+}
+
+function previewScaleScrollStyle(
+  viewport: PreviewViewportId,
+  previewScale: number,
+): CSSProperties | undefined {
+  if (viewport !== 'desktop') return undefined;
+  return { overflow: normalizedPreviewScale(previewScale) > 1 ? 'auto' : 'hidden' };
+}
+
+function previewScaleSizerStyle(
+  viewport: PreviewViewportId,
+  previewScale: number,
+  frozenWidth: number | null,
+): CSSProperties | undefined {
+  if (viewport !== 'desktop') return undefined;
+  const scale = normalizedPreviewScale(previewScale);
+  return {
+    position: 'relative',
+    width: frozenWidth ? `${frozenWidth * scale}px` : `${scale * 100}%`,
+    height: `${scale * 100}%`,
+  };
+}
+
 function manualEditPreviewShellStyle(
   viewport: PreviewViewportId,
   previewScale: number,
   frozenWidth: number | null,
 ): CSSProperties & Record<string, string | number> {
+  const scale = normalizedPreviewScale(previewScale);
   if (viewport === 'desktop' && frozenWidth) {
     return {
-      width: `${frozenWidth / previewScale}px`,
-      height: `${100 / previewScale}%`,
-      transform: `scale(${previewScale})`,
+      width: `${frozenWidth}px`,
+      height: `${100 / scale}%`,
+      transform: `scale(${scale})`,
       transformOrigin: '0 0',
     };
   }
   return previewScaleShellStyle(viewport, previewScale);
+}
+
+function PreviewScaleShell({
+  viewport,
+  previewScale,
+  frozenWidth = null,
+  children,
+}: {
+  viewport: PreviewViewportId;
+  previewScale: number;
+  frozenWidth?: number | null;
+  children: ReactNode;
+}) {
+  const shellStyle = frozenWidth === null
+    ? previewScaleShellStyle(viewport, previewScale)
+    : manualEditPreviewShellStyle(viewport, previewScale, frozenWidth);
+  const sizerStyle = previewScaleSizerStyle(viewport, previewScale, frozenWidth);
+  if (!sizerStyle) return <div style={shellStyle}>{children}</div>;
+  return (
+    <div style={sizerStyle}>
+      <div style={shellStyle}>{children}</div>
+    </div>
+  );
 }
 
 function deploymentTimestamp(deployment: WebDeploymentInfo): number {
@@ -1770,8 +1821,8 @@ export function LiveArtifactViewer({
           aria-hidden={mode === 'preview' ? undefined : true}
           style={previewViewportStyle(previewViewport, previewScale, previewBodySize)}
         >
-          <div className="preview-frame-clip">
-            <div style={previewScaleShellStyle(previewViewport, previewScale)}>
+          <div className="preview-frame-clip" style={previewScaleScrollStyle(previewViewport, previewScale)}>
+            <PreviewScaleShell viewport={previewViewport} previewScale={previewScale}>
               <PreviewDrawOverlay>
                 <iframe
                   ref={iframeRef}
@@ -1781,7 +1832,7 @@ export function LiveArtifactViewer({
                   src={previewUrl}
                 />
               </PreviewDrawOverlay>
-            </div>
+            </PreviewScaleShell>
           </div>
         </div>
         {mode !== 'preview' && loading ? (
@@ -10631,13 +10682,16 @@ function HtmlViewer({
               className={manualEditMode ? 'manual-edit-canvas' : 'comment-preview-canvas'}
               data-testid={manualEditMode ? undefined : 'comment-preview-canvas'}
             >
-              <div className={manualEditMode ? undefined : 'comment-frame-clip'} style={manualEditMode ? { height: '100%' } : undefined}>
-                <div
-                  style={
-                    manualEditMode
-                      ? manualEditPreviewShellStyle(previewViewport, previewScale, manualEditViewportWidth)
-                      : previewScaleShellStyle(previewViewport, previewScale)
-                  }
+              <div
+                className={manualEditMode ? undefined : 'comment-frame-clip'}
+                style={manualEditMode
+                  ? { height: '100%', ...previewScaleScrollStyle(previewViewport, previewScale) }
+                  : previewScaleScrollStyle(previewViewport, previewScale)}
+              >
+                <PreviewScaleShell
+                  viewport={previewViewport}
+                  previewScale={previewScale}
+                  frozenWidth={manualEditMode ? manualEditViewportWidth : null}
                 >
                   <PreviewDrawOverlay
                     active={drawOverlayOpen}
@@ -10766,7 +10820,7 @@ function HtmlViewer({
                       />
                     </div>
                   </PreviewDrawOverlay>
-                </div>
+                </PreviewScaleShell>
               </div>
               {boardMode ? (
                 <CommentPreviewOverlays

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -293,6 +293,62 @@ describe('FileViewer preview scale', () => {
     expect(clip!.contains(container.querySelector('.deck-nav'))).toBe(false);
   });
 
+  it('keeps the desktop deck viewport centered when zoom changes (#3177)', async () => {
+    const file = baseFile({
+      name: 'deck.html',
+      path: 'deck.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Deck',
+        entry: 'deck.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={file}
+        liveHtml='<html><body><section class="slide">One</section><section class="slide">Two</section></body></html>'
+      />,
+    );
+
+    const clip = container.querySelector<HTMLElement>('.comment-frame-clip');
+    expect(clip).toBeTruthy();
+    Object.defineProperties(clip!, {
+      clientWidth: { configurable: true, value: 500 },
+      clientHeight: { configurable: true, value: 400 },
+      scrollWidth: {
+        configurable: true,
+        get() {
+          const sizer = clip!.firstElementChild as HTMLElement | null;
+          const scale = Number.parseFloat(sizer?.style.width ?? '100%') / 100 || 1;
+          return Math.round(1000 * scale);
+        },
+      },
+      scrollHeight: {
+        configurable: true,
+        get() {
+          const sizer = clip!.firstElementChild as HTMLElement | null;
+          const scale = Number.parseFloat(sizer?.style.height ?? '100%') / 100 || 1;
+          return Math.round(800 * scale);
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByText('100%').closest('button')!);
+    fireEvent.click(screen.getByRole('menuitem', { name: '200%' }));
+
+    await waitFor(() => {
+      expect(clip!.scrollLeft).toBe(250);
+      expect(clip!.scrollTop).toBe(200);
+    });
+  });
+
   it('clamps mobile and tablet overlay scale to the iframe auto-fit scale', () => {
     expect(effectivePreviewScale('mobile', 1, { width: 390, height: 844 })).toBeLessThan(1);
     expect(effectivePreviewScale('tablet', 1.25, { width: 820, height: 700 })).toBeLessThan(1);

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -250,6 +250,49 @@ describe('FileViewer preview scale', () => {
     expect(effectivePreviewScale('desktop', 1.5, { width: 320, height: 480 })).toBe(1.5);
   });
 
+  it('keeps desktop deck zoom scrollable while preserving the iframe viewport size (#3177)', () => {
+    const file = baseFile({
+      name: 'deck.html',
+      path: 'deck.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Deck',
+        entry: 'deck.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={file}
+        liveHtml='<html><body><section class="slide">One</section><section class="slide">Two</section></body></html>'
+      />,
+    );
+
+    fireEvent.click(screen.getByText('100%').closest('button')!);
+    fireEvent.click(screen.getByRole('menuitem', { name: '150%' }));
+
+    const clip = container.querySelector<HTMLElement>('.comment-frame-clip');
+    expect(clip).toBeTruthy();
+    expect(clip!.style.overflow).toBe('auto');
+
+    const scaleSizer = clip!.firstElementChild as HTMLElement | null;
+    expect(scaleSizer?.style.width).toBe('150%');
+    expect(scaleSizer?.style.height).toBe('150%');
+
+    const scaleShell = scaleSizer?.firstElementChild as HTMLElement | null;
+    expect(scaleShell?.style.width).toBe(`${100 / 1.5}%`);
+    expect(scaleShell?.style.height).toBe(`${100 / 1.5}%`);
+    expect(scaleShell?.style.transform).toBe('scale(1.5)');
+    expect(container.querySelector('.deck-nav')).toBeTruthy();
+    expect(clip!.contains(container.querySelector('.deck-nav'))).toBe(false);
+  });
+
   it('clamps mobile and tablet overlay scale to the iframe auto-fit scale', () => {
     expect(effectivePreviewScale('mobile', 1, { width: 390, height: 844 })).toBeLessThan(1);
     expect(effectivePreviewScale('tablet', 1.25, { width: 820, height: 700 })).toBeLessThan(1);


### PR DESCRIPTION
Fixes #3177

## Why

I picked this up from the community-help queue after the earlier attempt at #3217 closed without merging. The issue is user-facing: deck/PPT preview zoom should enlarge the slide canvas in a predictable way without making the surrounding preview chrome feel tied to the scaled content, and zoom above 100% should remain reachable instead of clipping off the enlarged canvas.

The root cause is the desktop preview scale layer using an inverse-size shell directly inside the clipped frame. That kept the transformed visual output at the original frame size, which made zoom feel reversed/unintuitive. Switching only to direct scaling fixes the direction, but leaves transformed overflow outside the scrollable layout box. This PR keeps the iframe's base viewport size stable while adding a desktop-only layout sizer that expands the scroll area to match the requested zoom.

## What users will see

Deck/PPT HTML previews keep the existing zoom control, but selecting 125%, 150%, or 200% now gives the scaled slide content a matching scrollable area. The host slide navigation remains outside the scaled preview frame.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** - changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This PR does not add a new UI entry point; the changed behavior is covered by a focused DOM/layout regression test for the deck preview zoom layer.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx`, test `keeps desktop deck zoom scrollable while preserving the iframe viewport size (#3177)`.
- Did the test go red on `main` and green on this branch? yes. Before the source change, the new test failed because `.comment-frame-clip` had no scroll overflow and no 150% scale sizer. After the fix, the focused test and full `FileViewer` test file pass.

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx -t "#3177"` - pass
- `corepack pnpm exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx` - pass, 157 tests
- `corepack pnpm --filter @open-design/web typecheck` - pass
- `corepack pnpm guard` - failed before PR-specific checks due existing stale `design-systems/*/manifest.json` generated artifacts (`design-tokens.json` / `tailwind-v4.css` stale across many design systems). I did not regenerate those unrelated assets in this PR.
- `corepack pnpm typecheck` - local script could not run directly because `pnpm` is not installed on PATH in this Windows checkout; running the equivalent with `corepack pnpm -r --workspace-concurrency=4 --if-present run typecheck` passed through `apps/web` and then failed later when `apps/daemon` invoked nested `pnpm` directly.
