### PR TITLE
fix(landing): share links use the current host, not hardcoded production

### DIFF
--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -215,8 +215,28 @@
     // textarea + copy-link per click, so the intents must be rebuilt from the
     // dialog's current payload each time it reopens. Exposed on `window` so
     // those per-card handlers can re-wire after they swap the payload.
+    // Share text + links are baked at build time against the canonical
+    // production host (Astro.site). Rewrite that origin to wherever the page is
+    // actually served so a share from staging/preview carries the matching host
+    // (e.g. staging.open-design.ai) instead of always pointing at production.
+    // On production this is a no-op (the origins match).
+    const SHARE_PROD_ORIGIN = 'https://open-design.ai';
+    const rewriteShareOrigin = (dialog) => {
+      const here = window.location.origin;
+      if (!here || here === SHARE_PROD_ORIGIN || !/^https?:/.test(here)) return;
+      const swap = (value) => (value ? value.split(SHARE_PROD_ORIGIN).join(here) : value);
+      const ta = dialog.querySelector('[data-share-text]');
+      if (ta && ta.value) ta.value = swap(ta.value);
+      const linkBtn = dialog.querySelector('[data-copy-link]');
+      if (linkBtn) {
+        const cur = linkBtn.getAttribute('data-copy-link');
+        if (cur) linkBtn.setAttribute('data-copy-link', swap(cur));
+      }
+    };
+
     const wireSharePlatforms = (dialog) => {
       if (!dialog) return;
+      rewriteShareOrigin(dialog);
       const ta = dialog.querySelector('[data-share-text]');
       const linkBtn = dialog.querySelector('[data-copy-link]');
       const message = ta ? (ta.value || ta.textContent || '').trim() : '';


### PR DESCRIPTION
## Why

Follow-up from the landing QA pass (#4221). On the plugin share dialog, the copied link + the social-share message were hardcoded to `https://open-design.ai` even when the page was served from another host. Reviewing on a non-production deploy (e.g. `staging.open-design.ai`) showed the share link pointing at production instead of the environment under test, which is confusing for QA and means a share from a preview deploy silently routes people to prod.

The share URL is baked at build time from `Astro.site` (the canonical production origin), and a static build can't know the deploy host — so the host has to be corrected at runtime.

## What users will see

When you open **Share this plugin** and copy the link (or jump to X/LinkedIn/Reddit/Facebook), the URL now matches the site you're actually on:
- Production (`open-design.ai`) — unchanged.
- Staging/preview (`staging.open-design.ai`, `*.pages.dev`) — the share link carries that host.
- Local dev — the local origin.

The social-intent buttons and both copy buttons all inherit the corrected URL.

## How

`rewriteShareOrigin` in `header-enhancer.astro` swaps the baked `https://open-design.ai` origin for `window.location.origin` in the dialog's `[data-share-text]` + `[data-copy-link]` when the dialog is wired (runs on every open, so grid pages that reuse one dialog across cards stay correct). No-op on production where the origins already match.

## Surface area

- [x] Web UI (landing page share dialog)

## Validation

- `pnpm --filter @open-design/landing-page typecheck` — 0 errors
- Verified on local dev: share link + copy-link + social intents carry `127.0.0.1` origin instead of `open-design.ai`.