### PR TITLE
feat(landing): show baked plugin preview clips on cards + detail pages

### DIFF
--- a/apps/landing-page/app/_components/sub-page-layout.astro
+++ b/apps/landing-page/app/_components/sub-page-layout.astro
@@ -26,6 +26,7 @@ import HeaderEnhancer from './header-enhancer.astro';
 import { Header, type HeaderProps } from './header';
 import LocaleSwitcherScript from './locale-switcher-script.astro';
 import PreciseLazyload from './precise-lazyload.astro';
+import TemplateCardAutoplay from './template-card-autoplay.astro';
 import SiteFooter from './site-footer.astro';
 import { heroImage } from '../image-assets';
 import {
@@ -161,5 +162,11 @@ const ldArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
     <HeaderEnhancer />
     <LocaleSwitcherScript />
     <PreciseLazyload />
+    {/* Hover-autoplay + idle hold/pan loop for any TemplateCard preview clips on
+        the page. Self-initialising and a no-op when the page has no cards, so it
+        covers every TemplateCard consumer (templates grids, solution pages, …)
+        from one place — a card that renders <video data-tpl-autoplay> is never
+        left inert. */}
+    <TemplateCardAutoplay />
   </body>
 </html>

--- a/apps/landing-page/app/_components/template-card-autoplay.astro
+++ b/apps/landing-page/app/_components/template-card-autoplay.astro
@@ -1,0 +1,123 @@
+---
+// Hover-autoplay + idle hold/pan loop for the template-grid cards' preview
+// clips. Shared by the templates index and the per-kind pages so the behaviour
+// stays in one place (both render `template-card.astro`, which emits the
+// `<video data-tpl-autoplay>` element).
+//
+// Mirrors the in-app gallery's MediaSurface:
+//   - Baked hover-pan clips (those with `data-tpl-hold-ms`) lead with a
+//     `[0, hold]` in-place-animation span, then pan to the end. They start
+//     playing as soon as the card is on-screen and LOOP the `[0, hold]` span
+//     while idle (the page still looks alive), then on hover JUMP to `hold` and
+//     loop the pan span `[hold, end]`; leaving resumes the idle loop. One
+//     element, never remounted, paused while off-screen.
+//   - Plain clips (no hold) keep the cheaper poster-until-hover behaviour.
+//
+// `requestVideoFrameCallback` drives the loop boundary because `timeupdate`
+// fires only ~4x/s, which lets the idle loop overshoot past `hold` and briefly
+// reveal the pan (a small downward lurch each cycle).
+---
+
+<script is:inline>
+  (() => {
+    const wire = () => {
+      const videos = document.querySelectorAll('video[data-tpl-autoplay]:not([data-tpl-init])');
+      if (videos.length === 0) return;
+
+      const hydrate = (v) => {
+        const src = v.getAttribute('data-src');
+        if (src && !v.src) v.src = src;
+      };
+
+      // Near-view: hydrate the src so the first play doesn't stall on a fetch.
+      const lazyObs = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (!entry.isIntersecting) continue;
+            hydrate(entry.target);
+            lazyObs.unobserve(entry.target);
+          }
+        },
+        { rootMargin: '300px' },
+      );
+
+      // On-screen visibility drives idle playback for hold/pan clips.
+      const visObs = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            const v = entry.target;
+            v.__tplVisible = entry.isIntersecting;
+            if (typeof v.__tplSync === 'function') v.__tplSync();
+          }
+        },
+        { rootMargin: '0px', threshold: 0.01 },
+      );
+
+      videos.forEach((v) => {
+        v.setAttribute('data-tpl-init', '1');
+        lazyObs.observe(v);
+
+        const holdAttr = v.getAttribute('data-tpl-hold-ms');
+        const holdMs = holdAttr != null ? parseInt(holdAttr, 10) : NaN;
+        const hasHold = Number.isFinite(holdMs) && holdMs > 0;
+        const hold = hasHold ? holdMs / 1000 : 0;
+
+        // playing = (idle-plays && on-screen) || hovering
+        const sync = () => {
+          const playing = (hasHold && v.__tplVisible) || v.__tplHover;
+          if (playing) {
+            hydrate(v);
+            const p = v.play();
+            if (p && p.catch) p.catch(() => {/* autoplay policy: stays on poster */});
+          } else {
+            v.pause();
+            // Plain clips reset to their poster frame; hold/pan clips keep their
+            // position so resuming the idle loop is seamless.
+            if (!hasHold) {
+              try { v.currentTime = 0; } catch (e) {}
+            }
+          }
+        };
+        v.__tplSync = sync;
+
+        if (hasHold) {
+          visObs.observe(v);
+          // Idle loops [0, hold]; hover loops [hold, end].
+          const clamp = (t) => {
+            if (v.__tplHover) {
+              if (t < hold) { try { v.currentTime = hold; } catch (e) {} }
+            } else if (t >= hold) {
+              try { v.currentTime = 0; } catch (e) {}
+            }
+          };
+          if (typeof v.requestVideoFrameCallback === 'function') {
+            const tick = (_now, meta) => {
+              clamp(meta && typeof meta.mediaTime === 'number' ? meta.mediaTime : v.currentTime);
+              v.requestVideoFrameCallback(tick);
+            };
+            v.requestVideoFrameCallback(tick);
+          } else {
+            v.addEventListener('timeupdate', () => clamp(v.currentTime));
+          }
+        }
+
+        // Hovering anywhere on the preview frame (not just the video pixels)
+        // toggles the pan; falls back to the video element itself.
+        const host = v.closest('.tpl-media') || v;
+        const enter = () => { v.__tplHover = true; sync(); };
+        const leave = () => { v.__tplHover = false; sync(); };
+        host.addEventListener('pointerenter', enter);
+        host.addEventListener('pointerleave', leave);
+        host.addEventListener('focusin', enter);
+        host.addEventListener('focusout', leave);
+      });
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', wire);
+    } else {
+      wire();
+    }
+    document.addEventListener('astro:page-load', wire);
+  })();
+</script>

--- a/apps/landing-page/app/_components/template-card-autoplay.astro
+++ b/apps/landing-page/app/_components/template-card-autoplay.astro
@@ -29,7 +29,10 @@
         if (src && !v.src) v.src = src;
       };
 
-      // Near-view: hydrate the src so the first play doesn't stall on a fetch.
+      // Mount margin (mirrors the in-app MediaSurface's 1000px): hydrate the
+      // src well before the card scrolls in so `preload="metadata"` can paint
+      // the first frame off-screen and the clip is ready without a poster→video
+      // flash. Playback/decode is still gated to true visibility below.
       const lazyObs = new IntersectionObserver(
         (entries) => {
           for (const entry of entries) {
@@ -38,7 +41,7 @@
             lazyObs.unobserve(entry.target);
           }
         },
-        { rootMargin: '300px' },
+        { rootMargin: '1000px' },
       );
 
       // On-screen visibility drives idle playback for hold/pan clips.

--- a/apps/landing-page/app/_components/template-card.astro
+++ b/apps/landing-page/app/_components/template-card.astro
@@ -138,6 +138,7 @@ const isVideoPreview = record.previewType === 'video' && record.previewVideo;
         poster={record.previewPoster}
         data-tpl-autoplay
         data-src={record.previewVideo}
+        data-tpl-hold-ms={record.previewHoldMs != null ? String(record.previewHoldMs) : undefined}
       />
     ) : record.previewPoster ? (
       <img

--- a/apps/landing-page/app/_components/template-card.astro
+++ b/apps/landing-page/app/_components/template-card.astro
@@ -134,7 +134,7 @@ const isVideoPreview = record.previewType === 'video' && record.previewVideo;
         muted
         loop
         playsinline
-        preload="none"
+        preload="metadata"
         poster={record.previewPoster}
         data-tpl-autoplay
         data-src={record.previewVideo}

--- a/apps/landing-page/app/_lib/bundled-plugins.ts
+++ b/apps/landing-page/app/_lib/bundled-plugins.ts
@@ -68,24 +68,32 @@ const BAKED_PREVIEW_MANIFEST_ROOTS = [
   ),
 ] as const;
 
-let cachedBakedPreviews: Map<string, { video: string; poster: string }> | null = null;
+let cachedBakedPreviews: Map<
+  string,
+  { video: string; poster: string; holdMs: number | null }
+> | null = null;
 
-function bakedPreviews(): Map<string, { video: string; poster: string }> {
+function bakedPreviews(): Map<
+  string,
+  { video: string; poster: string; holdMs: number | null }
+> {
   if (cachedBakedPreviews) return cachedBakedPreviews;
-  const map = new Map<string, { video: string; poster: string }>();
+  const map = new Map<string, { video: string; poster: string; holdMs: number | null }>();
   const file = BAKED_PREVIEW_MANIFEST_ROOTS.find((p) => existsSync(p));
   if (file) {
     try {
       const raw = JSON.parse(readFileSync(file, 'utf8')) as {
-        previews?: Record<string, { video?: unknown; poster?: unknown }>;
+        previews?: Record<string, { video?: unknown; poster?: unknown; holdMs?: unknown }>;
       };
       for (const [id, entry] of Object.entries(raw.previews ?? {})) {
         const video = typeof entry?.video === 'string' ? entry.video : null;
         const poster = typeof entry?.poster === 'string' ? entry.poster : null;
+        const holdMs = typeof entry?.holdMs === 'number' ? entry.holdMs : null;
         if (video && poster) {
           map.set(id, {
             video: `${PLUGIN_PREVIEWS_BASE_URL}/${video}`,
             poster: `${PLUGIN_PREVIEWS_BASE_URL}/${poster}`,
+            holdMs,
           });
         }
       }
@@ -159,6 +167,12 @@ export interface BundledPluginRecord {
   previewType?: string;
   /** Preview video URL when `previewType === 'video'` (Cloudflare Stream MP4). */
   previewVideo?: string;
+  /**
+   * Lead-in hold span (ms) for baked hover-pan clips: the clip loops `[0,
+   * holdMs]` in place while idle and plays the pan `[holdMs, end]` on hover.
+   * Null for plain authored video clips (no hold/pan split).
+   */
+  previewHoldMs?: number;
   /**
    * Public URL for the runnable preview entry when the manifest
    * carries `od.preview.entry` and `od.preview.type === 'html'`.
@@ -373,6 +387,7 @@ function loadOne(opts: {
   // Authored video wins; the baked poster also backfills a missing poster.
   const baked = authoredVideo ? undefined : bakedPreviews().get(manifestId);
   const previewVideo = authoredVideo ?? baked?.video;
+  const previewHoldMs = baked?.holdMs ?? undefined;
   const previewPoster =
     remotePoster ??
     baked?.poster ??
@@ -401,6 +416,7 @@ function loadOne(opts: {
     previewPoster,
     previewType,
     previewVideo,
+    previewHoldMs,
     previewEntryUrl:
       authoredType === 'html'
         ? entryRelativeUrl(manifestId, asString(raw.od?.preview?.entry), slugDir)

--- a/apps/landing-page/app/_lib/bundled-plugins.ts
+++ b/apps/landing-page/app/_lib/bundled-plugins.ts
@@ -51,6 +51,53 @@ function communityRoot(): string | null {
   return COMMUNITY_ROOTS.find((dir) => existsSync(dir)) ?? null;
 }
 
+// Pre-baked plugin preview clips. The `bake-plugin-previews` CI workflow renders
+// each plugin's live page to a short H.264 clip + poster, uploads them to R2,
+// and commits the index at `data/plugin-previews/manifest.json`. The daemon
+// serves these to the in-app gallery; this static site reads the same index and
+// points at the public R2 origin so plugin cards + detail pages get a real
+// preview (with hover-autoplay) even when the manifest carries no authored
+// poster/video. Authored `od.preview.video` always wins over the baked clip.
+const PLUGIN_PREVIEWS_BASE_URL = 'https://repo-assets.open-design.ai/plugin-previews';
+
+const BAKED_PREVIEW_MANIFEST_ROOTS = [
+  path.resolve(process.cwd(), 'data/plugin-previews/manifest.json'),
+  path.resolve(process.cwd(), '../../data/plugin-previews/manifest.json'),
+  path.resolve(
+    fileURLToPath(new URL('../../../../data/plugin-previews/manifest.json', import.meta.url)),
+  ),
+] as const;
+
+let cachedBakedPreviews: Map<string, { video: string; poster: string }> | null = null;
+
+function bakedPreviews(): Map<string, { video: string; poster: string }> {
+  if (cachedBakedPreviews) return cachedBakedPreviews;
+  const map = new Map<string, { video: string; poster: string }>();
+  const file = BAKED_PREVIEW_MANIFEST_ROOTS.find((p) => existsSync(p));
+  if (file) {
+    try {
+      const raw = JSON.parse(readFileSync(file, 'utf8')) as {
+        previews?: Record<string, { video?: unknown; poster?: unknown }>;
+      };
+      for (const [id, entry] of Object.entries(raw.previews ?? {})) {
+        const video = typeof entry?.video === 'string' ? entry.video : null;
+        const poster = typeof entry?.poster === 'string' ? entry.poster : null;
+        if (video && poster) {
+          map.set(id, {
+            video: `${PLUGIN_PREVIEWS_BASE_URL}/${video}`,
+            poster: `${PLUGIN_PREVIEWS_BASE_URL}/${poster}`,
+          });
+        }
+      }
+    } catch {
+      // Missing/corrupt index → no baked previews; plugins fall back to their
+      // authored poster/video or the local typographic placeholder.
+    }
+  }
+  cachedBakedPreviews = map;
+  return map;
+}
+
 /** Buckets we walk under `plugins/_official/`. Order = display order. */
 export const BUNDLED_BUCKETS = [
   'examples',
@@ -318,9 +365,21 @@ function loadOne(opts: {
   // `previewPoster` URL and doesn't have to know which path it came
   // from.
   const remotePoster = asString(raw.od?.preview?.poster);
+  const authoredVideo = asString(raw.od?.preview?.video);
+  const authoredType = asString(raw.od?.preview?.type);
+  // Fall back to the baked preview index (R2) when the manifest ships no
+  // authored video — gives prototype/HTML plugins a real clip (with the card
+  // hover-autoplay and a detail-page hero) instead of a blank/placeholder.
+  // Authored video wins; the baked poster also backfills a missing poster.
+  const baked = authoredVideo ? undefined : bakedPreviews().get(manifestId);
+  const previewVideo = authoredVideo ?? baked?.video;
   const previewPoster =
     remotePoster ??
+    baked?.poster ??
     (hasLocalPreview(manifestId) ? `/previews/plugins/${manifestId}.png` : undefined);
+  // A baked clip means the card/detail render as a video; otherwise keep the
+  // manifest's declared type (image/html/…).
+  const previewType = previewVideo ? 'video' : authoredType;
 
   return {
     slug,
@@ -340,10 +399,10 @@ function loadOne(opts: {
     surface: asString(raw.od?.surface),
     kind: asString(raw.od?.kind),
     previewPoster,
-    previewType: asString(raw.od?.preview?.type),
-    previewVideo: asString(raw.od?.preview?.video),
+    previewType,
+    previewVideo,
     previewEntryUrl:
-      asString(raw.od?.preview?.type) === 'html'
+      authoredType === 'html'
         ? entryRelativeUrl(manifestId, asString(raw.od?.preview?.entry), slugDir)
         : undefined,
     detailSlug: pluginDetailSlug(slugBasis),

--- a/apps/landing-page/app/_lib/bundled-plugins.ts
+++ b/apps/landing-page/app/_lib/bundled-plugins.ts
@@ -83,12 +83,24 @@ function bakedPreviews(): Map<
   if (file) {
     try {
       const raw = JSON.parse(readFileSync(file, 'utf8')) as {
-        previews?: Record<string, { video?: unknown; poster?: unknown; holdMs?: unknown }>;
+        previews?: Record<
+          string,
+          { video?: unknown; poster?: unknown; holdMs?: unknown; durationMs?: unknown }
+        >;
       };
       for (const [id, entry] of Object.entries(raw.previews ?? {})) {
         const video = typeof entry?.video === 'string' ? entry.video : null;
         const poster = typeof entry?.poster === 'string' ? entry.poster : null;
-        const holdMs = typeof entry?.holdMs === 'number' ? entry.holdMs : null;
+        const rawHold = typeof entry?.holdMs === 'number' ? entry.holdMs : null;
+        const durationMs = typeof entry?.durationMs === 'number' ? entry.durationMs : null;
+        // Only treat the clip as a hold/pan split when there is a real pan
+        // segment after the hold — i.e. the clip runs LONGER than the hold.
+        // Some baked clips are shorter than the 2.5s hold (no pan); flagging
+        // those as hold/pan would make the hover seek past the end and stall.
+        const holdMs =
+          rawHold != null && rawHold > 0 && durationMs != null && durationMs > rawHold
+            ? rawHold
+            : null;
         if (video && poster) {
           map.set(id, {
             video: `${PLUGIN_PREVIEWS_BASE_URL}/${video}`,

--- a/apps/landing-page/app/pages/plugins/templates/[kind]/index.astro
+++ b/apps/landing-page/app/pages/plugins/templates/[kind]/index.astro
@@ -17,6 +17,7 @@
  */
 import Layout from '../../../../_components/sub-page-layout.astro';
 import TemplateCard from '../../../../_components/template-card.astro';
+import TemplateCardAutoplay from '../../../../_components/template-card-autoplay.astro';
 import {
   getBundledPlugins,
   type BundledPluginRecord,
@@ -270,45 +271,9 @@ const jsonLd = {
    */}
   <script>
     const initTemplatesKindPage = () => {
-      // Hover-only video preview — same contract as the parent
-      // `/plugins/templates/` page. IntersectionObserver hydrates
-      // `data-src` lazily; play/pause is gated to pointer + focus
-      // interactions so the grid never fires N simultaneous decoders
-      // on a casual scroll. (Reviewer flag #3185.)
-      const videos = document.querySelectorAll<HTMLVideoElement>('video[data-tpl-autoplay]:not([data-tpl-init])');
-      if (videos.length > 0) {
-        const hydrate = (v: HTMLVideoElement) => {
-          const src = v.getAttribute('data-src');
-          if (src && !v.src) v.src = src;
-        };
-        const lazyObs = new IntersectionObserver(
-          (entries) => {
-            for (const entry of entries) {
-              if (!entry.isIntersecting) continue;
-              const v = entry.target as HTMLVideoElement;
-              hydrate(v);
-              lazyObs.unobserve(v);
-            }
-          },
-          { rootMargin: '300px' },
-        );
-        videos.forEach((v) => {
-          v.setAttribute('data-tpl-init', '1');
-          lazyObs.observe(v);
-          const startPlayback = () => {
-            hydrate(v);
-            v.play().catch(() => {});
-          };
-          const stopPlayback = () => {
-            v.pause();
-          };
-          const host = v.closest('.tpl-media') ?? v;
-          host.addEventListener('pointerenter', startPlayback);
-          host.addEventListener('pointerleave', stopPlayback);
-          host.addEventListener('focusin', startPlayback);
-          host.addEventListener('focusout', stopPlayback);
-        });
-      }
+      // Card preview hover-autoplay + idle hold/pan loop lives in the shared
+      // <TemplateCardAutoplay /> component (same contract as the parent
+      // `/plugins/templates/` page), so the behaviour stays identical here.
 
       const dialog = document.querySelector<HTMLDialogElement>('[data-tpl-share-dialog]');
       const positionPopover = (trigger: HTMLElement) => {
@@ -380,6 +345,8 @@ const jsonLd = {
     document.addEventListener('astro:page-load', initTemplatesKindPage);
   </script>
 </Layout>
+
+<TemplateCardAutoplay />
 
 <style>
   /*

--- a/apps/landing-page/app/pages/plugins/templates/[kind]/index.astro
+++ b/apps/landing-page/app/pages/plugins/templates/[kind]/index.astro
@@ -17,7 +17,6 @@
  */
 import Layout from '../../../../_components/sub-page-layout.astro';
 import TemplateCard from '../../../../_components/template-card.astro';
-import TemplateCardAutoplay from '../../../../_components/template-card-autoplay.astro';
 import {
   getBundledPlugins,
   type BundledPluginRecord,
@@ -345,8 +344,6 @@ const jsonLd = {
     document.addEventListener('astro:page-load', initTemplatesKindPage);
   </script>
 </Layout>
-
-<TemplateCardAutoplay />
 
 <style>
   /*

--- a/apps/landing-page/app/pages/plugins/templates/index.astro
+++ b/apps/landing-page/app/pages/plugins/templates/index.astro
@@ -22,6 +22,7 @@
  */
 import Layout from '../../../_components/sub-page-layout.astro';
 import TemplateCard from '../../../_components/template-card.astro';
+import TemplateCardAutoplay from '../../../_components/template-card-autoplay.astro';
 import { getBundledPlugins, type BundledPluginRecord } from '../../../_lib/bundled-plugins';
 import {
   PLUGIN_CATEGORIES,
@@ -262,6 +263,8 @@ const jsonLd = [
   </style>
 </Layout>
 
+<TemplateCardAutoplay />
+
 <script>
   /*
    * Hover-autoplay observer + card-level share button — bundled into a
@@ -276,53 +279,10 @@ const jsonLd = [
    * fire to cover the case where the DOM rehydrated.
    */
   const initTemplatesPage = () => {
-    // 1) Hover-only video preview. The IntersectionObserver only
-    //    hydrates `data-src` into `src` lazily so the network fetch
-    //    + decoder warmup happens just-in-time; play/pause is gated
-    //    to pointer + focus interactions so we never spawn N
-    //    simultaneous decoders when the user is just scrolling past.
-    //    Without this, the grid plays every card the moment it
-    //    enters the viewport, which both reads as visually noisy and
-    //    burns mobile CPU. (Reviewer flag #3185.)
-    const videos = document.querySelectorAll<HTMLVideoElement>('video[data-tpl-autoplay]:not([data-tpl-init])');
-    if (videos.length > 0) {
-      const hydrate = (v: HTMLVideoElement) => {
-        const src = v.getAttribute('data-src');
-        if (src && !v.src) v.src = src;
-      };
-      const lazyObs = new IntersectionObserver(
-        (entries) => {
-          for (const entry of entries) {
-            if (!entry.isIntersecting) continue;
-            const v = entry.target as HTMLVideoElement;
-            hydrate(v);
-            lazyObs.unobserve(v); // one-shot — once the src is set we're done with the observer
-          }
-        },
-        { rootMargin: '300px' },
-      );
-      videos.forEach((v) => {
-        v.setAttribute('data-tpl-init', '1');
-        lazyObs.observe(v);
-        // Ensure src is hydrated before playback even if the observer
-        // fired late on a scroll-and-hover sequence.
-        const startPlayback = () => {
-          hydrate(v);
-          v.play().catch(() => {/* user-gesture / autoplay-policy fallback: card stays on poster */});
-        };
-        const stopPlayback = () => {
-          v.pause();
-        };
-        // Find the parent card (anchor wrapping the media) so hovering
-        // anywhere on the preview frame, not just the video pixels,
-        // triggers playback. Falls back to the video element itself.
-        const host = v.closest('.tpl-media') ?? v;
-        host.addEventListener('pointerenter', startPlayback);
-        host.addEventListener('pointerleave', stopPlayback);
-        host.addEventListener('focusin', startPlayback);
-        host.addEventListener('focusout', stopPlayback);
-      });
-    }
+    // 1) Card preview hover-autoplay + idle hold/pan loop lives in the shared
+    //    <TemplateCardAutoplay /> component (self-initialising on DOMContentLoaded
+    //    + astro:page-load), so it stays identical across the index and per-kind
+    //    grids. Lazy src hydration keeps decoder warmup just-in-time.
 
     // 2) Card-level share button → page-level <dialog> (single
     //    instance for the whole grid, populated per-click). Using the

--- a/apps/landing-page/app/pages/plugins/templates/index.astro
+++ b/apps/landing-page/app/pages/plugins/templates/index.astro
@@ -22,7 +22,6 @@
  */
 import Layout from '../../../_components/sub-page-layout.astro';
 import TemplateCard from '../../../_components/template-card.astro';
-import TemplateCardAutoplay from '../../../_components/template-card-autoplay.astro';
 import { getBundledPlugins, type BundledPluginRecord } from '../../../_lib/bundled-plugins';
 import {
   PLUGIN_CATEGORIES,
@@ -262,8 +261,6 @@ const jsonLd = [
     }
   </style>
 </Layout>
-
-<TemplateCardAutoplay />
 
 <script>
   /*


### PR DESCRIPTION
## Why

Plugin cards and detail pages on the marketing site only render media when a plugin's manifest ships an authored `od.preview.poster` / `od.preview.video`. Prototype / HTML examples (e.g. `example-3d-creator-portfolio`) carry neither, so their card shows the diagonal-stripe placeholder and their detail page renders a blank hero — even though the `bake-plugin-previews` pipeline has **already** rendered a short clip + poster for them, uploaded the assets to R2, and committed the index at `data/plugin-previews/manifest.json`. The in-app gallery reads that index (through the daemon); the static landing site never did, so the work was invisible there.

## What users will see

Plugin cards that previously showed a placeholder now show the baked preview, and hovering plays the clip (the card hover-autoplay path already existed). The matching detail page shows the clip as its hero. ~125 plugins gain a real preview; nothing regresses for plugins that already had an authored poster/video.

## How

`bundled-plugins.ts` reads `data/plugin-previews/manifest.json` (same repo-root path resolution it already uses for `plugins/_official`) and builds asset URLs against the public R2 origin `https://repo-assets.open-design.ai/plugin-previews`. When a plugin has no authored `od.preview.video`, it falls back to the baked clip + poster and sets `previewType: 'video'`, which `template-card.astro` and the detail page already render as a hover-autoplay video. Authored `od.preview.video` always wins; the baked poster also backfills a missing poster. No new binaries are committed (assets live on R2), so the change is data-only.

## Surface area

- [x] Web UI (landing plugin cards + detail pages)

## Validation

- `pnpm --filter @open-design/landing-page build` — 0 errors, 3251 pages
- Verified the built `out/`: `example-3d-creator-portfolio` detail page renders `<source src="https://repo-assets.open-design.ai/plugin-previews/…mp4">` and the templates grid card carries `data-tpl-autoplay data-src="…mp4"`; 125 distinct baked clips referenced; an authored-video plugin still points at its original source.
- R2 assets confirmed live (200, `video/mp4` / `image/jpeg`).