### PR TITLE
fix: remove duplicate tooltip on workspace tabs and hide jump btn under conv history

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2097,11 +2097,11 @@ export function ChatPane({
                 keep it out of the a11y tree when it's not visible. */}
             <button
               type="button"
-              className={`chat-jump-btn${scrolledFromBottom ? ' chat-jump-btn-active' : ''}`}
+              className={`chat-jump-btn${scrolledFromBottom && !showConvList ? ' chat-jump-btn-active' : ''}`}
               onClick={jumpToBottom}
               title={t('chat.scrollToLatest')}
-              aria-hidden={!scrolledFromBottom}
-              tabIndex={scrolledFromBottom ? 0 : -1}
+              aria-hidden={!scrolledFromBottom || showConvList}
+              tabIndex={scrolledFromBottom && !showConvList ? 0 : -1}
             >
               <Icon name="arrow-up" size={12} style={{ transform: 'rotate(180deg)' }} />
               <span>{t('chat.jumpToLatest')}</span>

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -930,11 +930,9 @@ export function WorkspaceTabsBar({ route, projects, onboardingCompleted = false 
             >
               <button
                 type="button"
-                className="workspace-tab__main od-tooltip"
+                className="workspace-tab__main"
                 onClick={() => openTab(tab)}
-                title={display.title}
-                data-tooltip={display.title}
-                data-tooltip-placement="bottom"
+                aria-label={display.title}
                 onFocus={(event) => scheduleHoverPreview(tab.id, event.currentTarget.parentElement ?? event.currentTarget)}
                 onBlur={dismissHoverPreview}
               >


### PR DESCRIPTION
Fixes #3845
Fixes #4123

## Why

Picked these up while going through open issues.

#3845: `workspace-tab__main` had both `od-tooltip`/`data-tooltip` attributes and `scheduleHoverPreview` wired up. Hovering a workspace tab showed the styled preview card and a separate small tooltip at the same time.

#4123: "Jump to latest" is absolutely positioned at z-index 6 inside its own stacking context. The conversation history dropdown has z-index 30, but that only wins within the same stack. Since they were in independent stacks, the button bled through.

## What users will see

Hovering a workspace tab shows the preview card only, no tooltip alongside it.

Opening the conversation history dropdown: "Jump to latest" hides while it's open and comes back when it closes.

## Surface area

- [x] **UI** -- new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** -- new or changed
- [ ] **CLI / env var** -- new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** -- new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** -- new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** -- added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** -- adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** -- changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** -- internal refactor, docs, tests, or translation update only

## Screenshots
<img width="2784" height="2024" alt="image" src="https://github.com/user-attachments/assets/9fc271d4-ece5-41cf-a45f-6d2660094dc1" />

## Bug fix verification

No automated test. Both are visual/z-order bugs that unit tests can't see. Verified in the dev build via `pnpm tools-dev inspect desktop eval` and `screencapture`.
<img width="2784" height="2024" alt="image" src="https://github.com/user-attachments/assets/54e36a09-c6c2-4e4c-a896-9732678cafa6" />

## Validation

- `pnpm guard` passes
- `pnpm typecheck`: one pre-existing TS2322 in `IntegrationsView.tsx`, present on `main` before these changes
- `pnpm --filter @open-design/web typecheck`: same pre-existing error, no new failures
