### PR TITLE
fix(web): remove duplicate tooltip on Discord badge in icon-only mode

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -730,7 +730,6 @@ export function EntryShell({
                 className="entry-discord-badge"
                 href={DISCORD_URL}
                 aria-label={discordAriaLabel}
-                title={discordAriaLabel}
                 data-tooltip={discordAriaLabel}
                 data-testid="entry-discord-badge"
               >


### PR DESCRIPTION
Fixes #4053

## Why

The chip bar uses CSS `::after` to show tooltips on any `[data-tooltip]` child. The Discord badge had both `data-tooltip` and `title` set to the same string, but no `od-tooltip` class. Without that class the JS tooltip system never suppresses the native browser tooltip. In icon-only mode you got both at once, stacked.

Dropping `title` fixes it. `aria-label` stays for screen readers; `data-tooltip` still feeds the CSS tooltip.

## What users will see

Hovering the Discord badge in icon-only mode shows one tooltip, not two.

## Surface area

- [x] **UI** -- new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** -- new or changed
- [ ] **CLI / env var** -- new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** -- new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** -- new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** -- added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** -- adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** -- changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** -- internal refactor, docs, tests, or translation update only

## Screenshots

**Before** (two tooltips stacked):
<img width="800" height="160" alt="image" src="https://github.com/user-attachments/assets/4405116b-fe6e-4837-9e9b-beb615b8f6f9" />

**After** (single styled tooltip):
<img width="800" height="160" alt="image" src="https://github.com/user-attachments/assets/af77e382-161b-4810-b61b-2cf95d5b610e" />

## Bug fix verification

No automated test. It only shows on hover in icon-only mode. Verified visually in the dev build by temporarily injecting `title` back via `pnpm tools-dev inspect desktop eval`.

## Validation

- `pnpm guard` passes
- `pnpm --filter @open-design/web typecheck`: one pre-existing TS2322 in `IntegrationsView.tsx`, present on `main` before this change
