### PR TITLE
Add Codex subscription media provider

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -144,6 +144,15 @@ function configFile(dataDir: string): string {
   return path.join(dataDir, 'app-config.json');
 }
 
+export function appConfigDir(projectRoot: string, env: NodeJS.ProcessEnv = process.env): string {
+  const raw = env.OD_DATA_DIR;
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return path.join(projectRoot, '.od');
+  }
+  const expanded = expandHomePrefix(raw.trim());
+  return path.isAbsolute(expanded) ? expanded : path.resolve(projectRoot, expanded);
+}
+
 const AGENT_MODEL_KEYS: ReadonlySet<string> = new Set(['model', 'reasoning']);
 
 const TELEMETRY_KEYS: ReadonlySet<string> = new Set([

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -32,6 +32,7 @@ export type MediaModel = {
 
 export const MEDIA_PROVIDERS: MediaProvider[] = [
   { id: 'openai', label: 'OpenAI', hint: 'gpt-image-2 / dall-e-3', integrated: true, defaultBaseUrl: 'https://api.openai.com/v1' },
+  { id: 'codex', label: 'Codex Subscription', hint: 'gpt-image-2 via local Codex CLI login', integrated: true, credentialsRequired: false, docsUrl: 'https://developers.openai.com/codex' },
   { id: 'volcengine', label: 'Volcengine Ark (Doubao)', hint: 'Seedance 2.0 / Seedream', integrated: true, defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/v3' },
   { id: 'grok', label: 'xAI Grok Imagine', hint: 'grok-imagine — image + video with native audio', integrated: true, defaultBaseUrl: 'https://api.x.ai/v1' },
   { id: 'hyperframes', label: 'HyperFrames', hint: 'Local HTML -> MP4 renderer', integrated: true, credentialsRequired: false, settingsVisible: false },
@@ -90,6 +91,7 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'gpt-image-1-mini', label: 'gpt-image-1-mini', hint: 'OpenAI · low-cost variant', provider: 'openai', caps: ['t2i', 'i2i'] },
   { id: 'dall-e-3', label: 'dall-e-3', hint: 'OpenAI · classic', provider: 'openai', caps: ['t2i'] },
   { id: 'dall-e-2', label: 'dall-e-2', hint: 'OpenAI · legacy', provider: 'openai', caps: ['t2i'] },
+  { id: 'codex-gpt-image-2', label: 'gpt-image-2 (Codex)', hint: 'Codex Subscription · local CLI imagegen', provider: 'codex', caps: ['t2i', 'i2i'] },
 
   { id: 'doubao-seedream-3-0-t2i-250415', label: 'seedream-3.0', hint: 'ByteDance · Doubao image', provider: 'volcengine', caps: ['t2i'] },
   { id: 'doubao-seededit-3-0-i2i-250628', label: 'seededit-3.0', hint: 'ByteDance · image edit', provider: 'volcengine', caps: ['i2i'] },

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -935,24 +935,15 @@ function codexImagePrompt(ctx: MediaContext): string {
   return `${prefix} ${prompt}${aspect}`;
 }
 
-function sanitizeCodexImagegenEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const env = { ...baseEnv };
-  const blocked = new Set(['openai_api_key', 'codex_api_key', 'anthropic_api_key']);
-  for (const key of Object.keys(env)) {
-    if (blocked.has(key.toLowerCase())) delete env[key];
-  }
-  return env;
-}
-
 async function resolveCodexImagegenEnv(): Promise<NodeJS.ProcessEnv> {
   const dataDir = process.env.OD_DATA_DIR?.trim();
-  if (!dataDir) return sanitizeCodexImagegenEnv(process.env);
+  if (!dataDir) return spawnEnvForAgent('codex', process.env);
   try {
     const appConfig = await readAppConfig(dataDir);
     const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'codex');
-    return sanitizeCodexImagegenEnv(spawnEnvForAgent('codex', process.env, configuredEnv));
+    return spawnEnvForAgent('codex', process.env, configuredEnv);
   } catch {
-    return sanitizeCodexImagegenEnv(process.env);
+    return spawnEnvForAgent('codex', process.env);
   }
 }
 

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -68,7 +68,7 @@ import { assertAndFetchExternalAsset } from './connectionTest.js';
 import { resolveModelAlias, resolveProviderConfig } from './media-config.js';
 import { codexNeedsDangerFullAccessSandbox } from './runtimes/defs/codex.js';
 import { spawnEnvForAgent } from './agents.js';
-import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
+import { agentCliEnvForAgent, appConfigDir, readAppConfig } from './app-config.js';
 import {
   ensureProject,
   kindFor,
@@ -935,9 +935,8 @@ function codexImagePrompt(ctx: MediaContext): string {
   return `${prefix} ${prompt}${aspect}`;
 }
 
-async function resolveCodexImagegenEnv(): Promise<NodeJS.ProcessEnv> {
-  const dataDir = process.env.OD_DATA_DIR?.trim();
-  if (!dataDir) return spawnEnvForAgent('codex', process.env);
+async function resolveCodexImagegenEnv(projectRoot: string): Promise<NodeJS.ProcessEnv> {
+  const dataDir = appConfigDir(projectRoot);
   try {
     const appConfig = await readAppConfig(dataDir);
     const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'codex');
@@ -1040,7 +1039,7 @@ async function runCodexImagegen(
 }
 
 async function renderCodexImage(ctx: MediaContext): Promise<RenderResult> {
-  const env = await resolveCodexImagegenEnv();
+  const env = await resolveCodexImagegenEnv(ctx.projectRoot);
   const generatedRoot = codexGeneratedImagesRoot(env);
   await mkdir(generatedRoot, { recursive: true });
   const { stdout } = await runCodexImagegen(ctx, generatedRoot, env);

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -67,6 +67,8 @@ import {
 import { assertAndFetchExternalAsset } from './connectionTest.js';
 import { resolveModelAlias, resolveProviderConfig } from './media-config.js';
 import { codexNeedsDangerFullAccessSandbox } from './runtimes/defs/codex.js';
+import { spawnEnvForAgent } from './agents.js';
+import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import {
   ensureProject,
   kindFor,
@@ -933,8 +935,8 @@ function codexImagePrompt(ctx: MediaContext): string {
   return `${prefix} ${prompt}${aspect}`;
 }
 
-function codexImagegenEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
+function sanitizeCodexImagegenEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
   const blocked = new Set(['openai_api_key', 'codex_api_key', 'anthropic_api_key']);
   for (const key of Object.keys(env)) {
     if (blocked.has(key.toLowerCase())) delete env[key];
@@ -942,11 +944,23 @@ function codexImagegenEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-function codexImagegenArgs(ctx: MediaContext, generatedRoot: string): string[] {
+async function resolveCodexImagegenEnv(): Promise<NodeJS.ProcessEnv> {
+  const dataDir = process.env.OD_DATA_DIR?.trim();
+  if (!dataDir) return sanitizeCodexImagegenEnv(process.env);
+  try {
+    const appConfig = await readAppConfig(dataDir);
+    const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'codex');
+    return sanitizeCodexImagegenEnv(spawnEnvForAgent('codex', process.env, configuredEnv));
+  } catch {
+    return sanitizeCodexImagegenEnv(process.env);
+  }
+}
+
+function codexImagegenArgs(ctx: MediaContext, generatedRoot: string, env: NodeJS.ProcessEnv): string[] {
   const sandbox = codexNeedsDangerFullAccessSandbox()
     ? ['--sandbox', 'danger-full-access']
     : ['--sandbox', 'workspace-write', '-c', 'sandbox_workspace_write.network_access=true'];
-  const model = process.env.OD_CODEX_IMAGEGEN_MODEL?.trim() || CODEX_IMAGE_ORCHESTRATOR_MODEL;
+  const model = env.OD_CODEX_IMAGEGEN_MODEL?.trim() || CODEX_IMAGE_ORCHESTRATOR_MODEL;
   const args = [
     'exec',
     '--json',
@@ -961,7 +975,7 @@ function codexImagegenArgs(ctx: MediaContext, generatedRoot: string): string[] {
     '--model',
     model,
   ];
-  if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') args.push('--disable', 'plugins');
+  if (env.OD_CODEX_DISABLE_PLUGINS === '1') args.push('--disable', 'plugins');
   for (const ref of ctx.imageRefs) args.push('-i', ref.abs);
   return args;
 }
@@ -998,11 +1012,15 @@ async function readCodexGeneratedImage(generatedRoot: string, threadId: string):
   return bytes;
 }
 
-async function runCodexImagegen(ctx: MediaContext, generatedRoot: string): Promise<{ stderr: string; stdout: string }> {
-  const codexBin = process.env.CODEX_BIN?.trim() || 'codex';
-  const child = spawn(codexBin, codexImagegenArgs(ctx, generatedRoot), {
+async function runCodexImagegen(
+  ctx: MediaContext,
+  generatedRoot: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ stderr: string; stdout: string }> {
+  const codexBin = env.CODEX_BIN?.trim() || 'codex';
+  const child = spawn(codexBin, codexImagegenArgs(ctx, generatedRoot, env), {
     cwd: ctx.projectRoot,
-    env: codexImagegenEnv(),
+    env,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
   const stdout: Buffer[] = [];
@@ -1031,15 +1049,16 @@ async function runCodexImagegen(ctx: MediaContext, generatedRoot: string): Promi
 }
 
 async function renderCodexImage(ctx: MediaContext): Promise<RenderResult> {
-  const generatedRoot = codexGeneratedImagesRoot();
+  const env = await resolveCodexImagegenEnv();
+  const generatedRoot = codexGeneratedImagesRoot(env);
   await mkdir(generatedRoot, { recursive: true });
-  const { stdout } = await runCodexImagegen(ctx, generatedRoot);
+  const { stdout } = await runCodexImagegen(ctx, generatedRoot, env);
   const threadId = parseCodexThreadId(stdout);
   const bytes = await readCodexGeneratedImage(generatedRoot, threadId);
   const imageModel = codexImageModelLabel(ctx.model);
   return {
     bytes,
-    providerNote: `codex/${imageModel} via ${process.env.OD_CODEX_IMAGEGEN_MODEL?.trim() || CODEX_IMAGE_ORCHESTRATOR_MODEL} · ${ctx.aspect} · ${bytes.length} bytes`,
+    providerNote: `codex/${imageModel} via ${env.OD_CODEX_IMAGEGEN_MODEL?.trim() || CODEX_IMAGE_ORCHESTRATOR_MODEL} · ${ctx.aspect} · ${bytes.length} bytes`,
     suggestedExt: sniffImageExt(bytes),
   };
 }

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -20,6 +20,7 @@
 //                              plus text-to-speech via /v1/audio/speech,
 //                              with auto-detection for Azure OpenAI
 //                              deployments based on the configured base URL
+//   * provider 'codex'      → local Codex CLI subscription imagegen
 //   * provider 'volcengine' → Volcengine Ark async tasks API for
 //                              Doubao Seedance 2.0 (video) and Seedream
 //                              (image)
@@ -46,7 +47,7 @@
 // so the CLI can exit non-zero and the agent can't silently narrate the
 // placeholder as the final result.
 
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
@@ -65,6 +66,7 @@ import {
 } from './media-models.js';
 import { assertAndFetchExternalAsset } from './connectionTest.js';
 import { resolveModelAlias, resolveProviderConfig } from './media-config.js';
+import { codexNeedsDangerFullAccessSandbox } from './runtimes/defs/codex.js';
 import {
   ensureProject,
   kindFor,
@@ -126,6 +128,7 @@ type MediaContext = {
   requestInit: MediaRequestInit;
   /** Additional reference images for multi-image i2v / style reference flows. */
   imageRefs: ImageRef[];
+  projectRoot: string;
 };
 type RenderResult = { bytes: Buffer; providerNote: string; suggestedExt?: string };
 type JsonRecord = Record<string, unknown>;
@@ -148,6 +151,7 @@ const NANOBANANA_DEFAULT_MODEL = 'gemini-3.1-flash-image-preview';
 const NANOBANANA_DEFAULT_IMAGE_SIZE = '1K';
 const IMAGEROUTER_DEFAULT_BASE_URL = 'https://api.imagerouter.io/v1/openai';
 const CUSTOM_IMAGE_MODEL_ID = 'custom-image';
+const CODEX_IMAGE_ORCHESTRATOR_MODEL = 'gpt-5.5';
 
 const DEFAULT_OUTPUT_BY_SURFACE = {
   image: 'image.png',
@@ -485,6 +489,7 @@ export async function generateMedia(args: {
     imageRef,
     requestInit: requestInit || {},
     imageRefs,
+    projectRoot,
   };
 
   const credentials = await resolveProviderConfig(projectRoot, def.provider);
@@ -521,6 +526,11 @@ export async function generateMedia(args: {
       suggestedExt = result.suggestedExt;
     } else if (def.provider === 'openai' && surface === 'image') {
       const result = await renderOpenAIImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'codex' && surface === 'image') {
+      const result = await renderCodexImage(ctx);
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
@@ -901,6 +911,136 @@ async function renderOpenAIImage(ctx: MediaContext, credentials: ProviderConfig)
     bytes,
     providerNote: `${tag}/${ctx.wireModel} · ${ctx.aspect} · ${bytes.length} bytes`,
     suggestedExt: '.png',
+  };
+}
+
+function codexGeneratedImagesRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.CODEX_HOME?.trim() || path.join(os.homedir(), '.codex');
+  const resolvedHome = home.startsWith('~/') ? path.join(os.homedir(), home.slice(2)) : home;
+  return path.resolve(resolvedHome, 'generated_images');
+}
+
+function codexImageModelLabel(model: string): string {
+  return model.startsWith('codex-') ? model.slice('codex-'.length) : model;
+}
+
+function codexImagePrompt(ctx: MediaContext): string {
+  const prompt = ctx.prompt || 'A high-quality reference image.';
+  const aspect = ctx.aspect ? `\nAspect ratio: ${ctx.aspect}.` : '';
+  const prefix = ctx.imageRefs.length > 0
+    ? '$imagegen Edit the attached reference image:'
+    : '$imagegen';
+  return `${prefix} ${prompt}${aspect}`;
+}
+
+function codexImagegenEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  const blocked = new Set(['openai_api_key', 'codex_api_key', 'anthropic_api_key']);
+  for (const key of Object.keys(env)) {
+    if (blocked.has(key.toLowerCase())) delete env[key];
+  }
+  return env;
+}
+
+function codexImagegenArgs(ctx: MediaContext, generatedRoot: string): string[] {
+  const sandbox = codexNeedsDangerFullAccessSandbox()
+    ? ['--sandbox', 'danger-full-access']
+    : ['--sandbox', 'workspace-write', '-c', 'sandbox_workspace_write.network_access=true'];
+  const model = process.env.OD_CODEX_IMAGEGEN_MODEL?.trim() || CODEX_IMAGE_ORCHESTRATOR_MODEL;
+  const args = [
+    'exec',
+    '--json',
+    '--skip-git-repo-check',
+    ...sandbox,
+    '-c',
+    'default_permissions=":workspace"',
+    '-C',
+    ctx.projectRoot,
+    '--add-dir',
+    generatedRoot,
+    '--model',
+    model,
+  ];
+  if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') args.push('--disable', 'plugins');
+  for (const ref of ctx.imageRefs) args.push('-i', ref.abs);
+  return args;
+}
+
+function parseCodexThreadId(stdout: string): string {
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const obj = JSON.parse(line) as { thread_id?: unknown; type?: unknown };
+      if (obj.type === 'thread.started' && typeof obj.thread_id === 'string') {
+        return obj.thread_id;
+      }
+    } catch {
+      // Non-JSON progress belongs in stdout on some CLI builds; ignore it.
+    }
+  }
+  throw new Error('codex imagegen did not emit a thread.started thread_id');
+}
+
+async function readCodexGeneratedImage(generatedRoot: string, threadId: string): Promise<Buffer> {
+  const threadDir = path.join(generatedRoot, threadId);
+  const entries = await readdir(threadDir);
+  const match = entries
+    .filter((name) => /^ig_.*\.(?:png|jpe?g|webp)$/i.test(name))
+    .sort()[0];
+  if (!match) {
+    throw new Error(`codex imagegen produced no ig_* image in ${threadDir}`);
+  }
+  const imagePath = path.join(threadDir, match);
+  const bytes = await readFile(imagePath);
+  if (process.env.OD_CODEX_KEEP_GENERATED_IMAGES !== '1') {
+    await rm(threadDir, { recursive: true, force: true });
+  }
+  return bytes;
+}
+
+async function runCodexImagegen(ctx: MediaContext, generatedRoot: string): Promise<{ stderr: string; stdout: string }> {
+  const codexBin = process.env.CODEX_BIN?.trim() || 'codex';
+  const child = spawn(codexBin, codexImagegenArgs(ctx, generatedRoot), {
+    cwd: ctx.projectRoot,
+    env: codexImagegenEnv(),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  const timeoutMs = Number(process.env.OD_CODEX_IMAGEGEN_TIMEOUT_MS || 300_000);
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`codex imagegen timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)));
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const out = Buffer.concat(stdout).toString('utf8');
+      const err = Buffer.concat(stderr).toString('utf8');
+      if (code !== 0) reject(new Error(`codex imagegen exited ${code}: ${truncate(err || out, 1000)}`));
+      else resolve({ stdout: out, stderr: err });
+    });
+    child.stdin.end(codexImagePrompt(ctx));
+  });
+}
+
+async function renderCodexImage(ctx: MediaContext): Promise<RenderResult> {
+  const generatedRoot = codexGeneratedImagesRoot();
+  await mkdir(generatedRoot, { recursive: true });
+  const { stdout } = await runCodexImagegen(ctx, generatedRoot);
+  const threadId = parseCodexThreadId(stdout);
+  const bytes = await readCodexGeneratedImage(generatedRoot, threadId);
+  const imageModel = codexImageModelLabel(ctx.model);
+  return {
+    bytes,
+    providerNote: `codex/${imageModel} via ${process.env.OD_CODEX_IMAGEGEN_MODEL?.trim() || CODEX_IMAGE_ORCHESTRATOR_MODEL} · ${ctx.aspect} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
   };
 }
 

--- a/apps/daemon/tests/media-openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media-openai-compatible-providers.test.ts
@@ -520,6 +520,71 @@ process.stdin.on('end', () => {
     expect(bytes.length).toBeGreaterThan(0);
   });
 
+  it('uses default app-config Codex CLI env overrides when OD_DATA_DIR is absent', async () => {
+    const dataDir = path.join(projectRoot, '.od');
+    const generatedHome = path.join(root, 'default-codex-home');
+    const codexBin = path.join(root, 'default-codex.mjs');
+    const wrongCodexBin = path.join(root, 'wrong-default-codex.mjs');
+    await mkdir(dataDir, { recursive: true });
+    await writeFile(path.join(dataDir, 'app-config.json'), JSON.stringify({
+      agentCliEnv: {
+        codex: {
+          CODEX_BIN: codexBin,
+          CODEX_HOME: generatedHome,
+        },
+      },
+    }), 'utf8');
+    await writeFile(wrongCodexBin, `#!/usr/bin/env node
+process.stderr.write('wrong codex bin used without OD_DATA_DIR');
+process.exit(24);
+`, 'utf8');
+    await chmod(wrongCodexBin, 0o755);
+    await writeFile(codexBin, `#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const pngBase64 = '${PNG_BASE64}';
+const expectedHome = ${JSON.stringify(generatedHome)};
+const args = process.argv.slice(2);
+const addDirIndex = args.indexOf('--add-dir');
+const generatedRoot = addDirIndex >= 0 ? args[addDirIndex + 1] : '';
+if (process.env.CODEX_HOME !== expectedHome) {
+  process.stderr.write('default CODEX_HOME override was not forwarded');
+  process.exit(25);
+}
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { stdin += chunk; });
+process.stdin.on('end', () => {
+  if (!stdin.includes('$imagegen') || !generatedRoot) process.exit(26);
+  const threadId = 'default-codex-thread';
+  const outDir = path.join(generatedRoot, threadId);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(path.join(outDir, 'ig_0001.png'), Buffer.from(pngBase64, 'base64'));
+  process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: threadId }) + '\\n');
+});
+`, 'utf8');
+    await chmod(codexBin, 0o755);
+    delete process.env.OD_DATA_DIR;
+    process.env.CODEX_BIN = wrongCodexBin;
+    process.env.CODEX_HOME = path.join(root, 'wrong-default-codex-home');
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'codex-gpt-image-2',
+      prompt: 'A compact green app icon with a folded page motif',
+      output: 'codex-default-config.png',
+    });
+
+    expect(result.providerId).toBe('codex');
+    expect(result.providerNote).toContain('codex/gpt-image-2');
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'codex-default-config.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
   it('preserves Codex custom gateway credentials for subscription image generation', async () => {
     const dataDir = path.join(root, 'app-data');
     const generatedHome = path.join(root, 'gateway-codex-home');

--- a/apps/daemon/tests/media-openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media-openai-compatible-providers.test.ts
@@ -519,4 +519,68 @@ process.stdin.on('end', () => {
     const bytes = await readFile(path.join(projectsRoot, 'project-1', 'codex-configured.png'));
     expect(bytes.length).toBeGreaterThan(0);
   });
+
+  it('preserves Codex custom gateway credentials for subscription image generation', async () => {
+    const dataDir = path.join(root, 'app-data');
+    const generatedHome = path.join(root, 'gateway-codex-home');
+    const codexBin = path.join(root, 'gateway-codex.mjs');
+    const gatewayUrl = 'https://gateway.example.test/v1';
+    await mkdir(dataDir, { recursive: true });
+    await writeFile(path.join(dataDir, 'app-config.json'), JSON.stringify({
+      agentCliEnv: {
+        codex: {
+          CODEX_BIN: codexBin,
+          CODEX_HOME: generatedHome,
+          OPENAI_BASE_URL: gatewayUrl,
+          OPENAI_API_KEY: 'gateway-openai-key',
+        },
+      },
+    }), 'utf8');
+    await writeFile(codexBin, `#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const pngBase64 = '${PNG_BASE64}';
+const expectedBaseUrl = ${JSON.stringify(gatewayUrl)};
+const args = process.argv.slice(2);
+const addDirIndex = args.indexOf('--add-dir');
+const generatedRoot = addDirIndex >= 0 ? args[addDirIndex + 1] : '';
+if (process.env.OPENAI_BASE_URL !== expectedBaseUrl) {
+  process.stderr.write('OPENAI_BASE_URL override was not forwarded');
+  process.exit(21);
+}
+if (process.env.OPENAI_API_KEY !== 'gateway-openai-key') {
+  process.stderr.write('OPENAI_API_KEY was not preserved for custom gateway');
+  process.exit(22);
+}
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { stdin += chunk; });
+process.stdin.on('end', () => {
+  if (!stdin.includes('$imagegen') || !generatedRoot) process.exit(23);
+  const threadId = 'gateway-codex-thread';
+  const outDir = path.join(generatedRoot, threadId);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(path.join(outDir, 'ig_0001.png'), Buffer.from(pngBase64, 'base64'));
+  process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: threadId }) + '\\n');
+});
+`, 'utf8');
+    await chmod(codexBin, 0o755);
+    process.env.OD_DATA_DIR = dataDir;
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'codex-gpt-image-2',
+      prompt: 'A compact green app icon with a folded page motif',
+      output: 'codex-gateway.png',
+    });
+
+    expect(result.providerId).toBe('codex');
+    expect(result.providerNote).toContain('codex/gpt-image-2');
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'codex-gateway.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
 });

--- a/apps/daemon/tests/media-openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media-openai-compatible-providers.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +15,8 @@ describe('OpenAI-compatible media providers', () => {
   const realFetch = globalThis.fetch;
   const originalImageRouterKey = process.env.OD_IMAGEROUTER_API_KEY;
   const originalCustomImageKey = process.env.OD_CUSTOM_IMAGE_API_KEY;
+  const originalCodexBin = process.env.CODEX_BIN;
+  const originalCodexHome = process.env.CODEX_HOME;
   const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
   const originalDataDir = process.env.OD_DATA_DIR;
 
@@ -25,6 +27,8 @@ describe('OpenAI-compatible media providers', () => {
     await mkdir(projectsRoot, { recursive: true });
     delete process.env.OD_IMAGEROUTER_API_KEY;
     delete process.env.OD_CUSTOM_IMAGE_API_KEY;
+    delete process.env.CODEX_BIN;
+    delete process.env.CODEX_HOME;
     delete process.env.OD_MEDIA_CONFIG_DIR;
     delete process.env.OD_DATA_DIR;
   });
@@ -41,6 +45,16 @@ describe('OpenAI-compatible media providers', () => {
       delete process.env.OD_CUSTOM_IMAGE_API_KEY;
     } else {
       process.env.OD_CUSTOM_IMAGE_API_KEY = originalCustomImageKey;
+    }
+    if (originalCodexBin == null) {
+      delete process.env.CODEX_BIN;
+    } else {
+      process.env.CODEX_BIN = originalCodexBin;
+    }
+    if (originalCodexHome == null) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = originalCodexHome;
     }
     if (originalMediaConfigDir == null) {
       delete process.env.OD_MEDIA_CONFIG_DIR;
@@ -390,6 +404,50 @@ describe('OpenAI-compatible media providers', () => {
     expect(result.name).toBe('imagerouter.mp4');
     expect(result.providerNote).toContain('imagerouter/xAI/grok-imagine-video');
     const bytes = await readFile(path.join(projectsRoot, 'project-1', 'imagerouter.mp4'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('renders Codex subscription images through the local Codex CLI', async () => {
+    const generatedHome = path.join(root, 'codex-home');
+    const codexBin = path.join(root, 'fake-codex.mjs');
+    await writeFile(codexBin, `#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const pngBase64 = '${PNG_BASE64}';
+const args = process.argv.slice(2);
+const addDirIndex = args.indexOf('--add-dir');
+const generatedRoot = addDirIndex >= 0 ? args[addDirIndex + 1] : '';
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { stdin += chunk; });
+process.stdin.on('end', () => {
+  if (!stdin.includes('$imagegen') || !generatedRoot) process.exit(7);
+  const threadId = 'codex-thread-test';
+  const outDir = path.join(generatedRoot, threadId);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(path.join(outDir, 'ig_0001.png'), Buffer.from(pngBase64, 'base64'));
+  process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: threadId }) + '\\n');
+  process.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 4, output_tokens: 2 } }) + '\\n');
+});
+`, 'utf8');
+    await chmod(codexBin, 0o755);
+    process.env.CODEX_BIN = codexBin;
+    process.env.CODEX_HOME = generatedHome;
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'codex-gpt-image-2',
+      prompt: 'A compact green app icon with a folded page motif',
+      output: 'codex.png',
+    });
+
+    expect(result.providerId).toBe('codex');
+    expect(result.providerNote).toContain('codex/gpt-image-2');
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'codex.png'));
     expect(bytes.length).toBeGreaterThan(0);
   });
 });

--- a/apps/daemon/tests/media-openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media-openai-compatible-providers.test.ts
@@ -450,4 +450,73 @@ process.stdin.on('end', () => {
     const bytes = await readFile(path.join(projectsRoot, 'project-1', 'codex.png'));
     expect(bytes.length).toBeGreaterThan(0);
   });
+
+  it('uses app-config Codex CLI env overrides for subscription image generation', async () => {
+    const dataDir = path.join(root, 'app-data');
+    const generatedHome = path.join(root, 'configured-codex-home');
+    const codexBin = path.join(root, 'configured-codex.mjs');
+    const wrongCodexBin = path.join(root, 'wrong-codex.mjs');
+    await mkdir(dataDir, { recursive: true });
+    await writeFile(path.join(dataDir, 'app-config.json'), JSON.stringify({
+      agentCliEnv: {
+        codex: {
+          CODEX_BIN: codexBin,
+          CODEX_HOME: generatedHome,
+        },
+      },
+    }), 'utf8');
+    await writeFile(wrongCodexBin, `#!/usr/bin/env node
+process.stderr.write('wrong codex bin used');
+process.exit(17);
+`, 'utf8');
+    await chmod(wrongCodexBin, 0o755);
+    await writeFile(codexBin, `#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const pngBase64 = '${PNG_BASE64}';
+const expectedHome = ${JSON.stringify(generatedHome)};
+const args = process.argv.slice(2);
+const addDirIndex = args.indexOf('--add-dir');
+const generatedRoot = addDirIndex >= 0 ? args[addDirIndex + 1] : '';
+if (process.env.CODEX_HOME !== expectedHome) {
+  process.stderr.write('CODEX_HOME override was not forwarded');
+  process.exit(18);
+}
+if (!generatedRoot.startsWith(path.join(expectedHome, 'generated_images'))) {
+  process.stderr.write('generated root did not use configured CODEX_HOME');
+  process.exit(19);
+}
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { stdin += chunk; });
+process.stdin.on('end', () => {
+  if (!stdin.includes('$imagegen') || !generatedRoot) process.exit(20);
+  const threadId = 'configured-codex-thread';
+  const outDir = path.join(generatedRoot, threadId);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(path.join(outDir, 'ig_0001.png'), Buffer.from(pngBase64, 'base64'));
+  process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: threadId }) + '\\n');
+});
+`, 'utf8');
+    await chmod(codexBin, 0o755);
+    process.env.OD_DATA_DIR = dataDir;
+    process.env.CODEX_BIN = wrongCodexBin;
+    process.env.CODEX_HOME = path.join(root, 'wrong-codex-home');
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'codex-gpt-image-2',
+      prompt: 'A compact green app icon with a folded page motif',
+      output: 'codex-configured.png',
+    });
+
+    expect(result.providerId).toBe('codex');
+    expect(result.providerNote).toContain('codex/gpt-image-2');
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'codex-configured.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2479,7 +2479,7 @@ function MediaProjectOptions(props:
 
 export function supportedModels(surface: 'image' | 'video' | 'audio', models: MediaModel[]): MediaModel[] {
   const supportedProviders: Record<'image' | 'video' | 'audio', Set<string>> = {
-    image: new Set(['openai', 'volcengine', 'grok', 'nanobanana', 'openrouter', 'imagerouter', 'leonardo', 'custom-image', 'aihubmix']),
+    image: new Set(['openai', 'codex', 'volcengine', 'grok', 'nanobanana', 'openrouter', 'imagerouter', 'leonardo', 'custom-image', 'aihubmix']),
     video: new Set(['volcengine', 'hyperframes', 'grok', 'openrouter', 'imagerouter', 'aihubmix']),
     audio: new Set(['minimax', 'fishaudio', 'senseaudio', 'elevenlabs', 'openai', 'volcengine', 'aihubmix']),
   };
@@ -2516,6 +2516,8 @@ function MediaModelCards({
       providerId: string;
       providerLabel: string;
       status: 'configured' | 'integrated' | 'unsupported';
+      sortIndex: number;
+      sortPriority: number;
       models: MediaModel[];
     }> = [];
     for (const model of models) {
@@ -2523,9 +2525,7 @@ function MediaModelCards({
       const providerId = provider?.id ?? model.provider;
       if (!isMediaProviderPickerReady(providerId, mediaProviders)) continue;
       const entry = mediaProviders?.[providerId];
-      const configured =
-        provider?.credentialsRequired === false ||
-        isStoredMediaProviderEntryPresent(entry);
+      const configured = provider?.credentialsRequired !== false && isStoredMediaProviderEntryPresent(entry);
       let group = out.find((g) => g.providerId === providerId);
       if (!group) {
         group = {
@@ -2536,13 +2536,15 @@ function MediaModelCards({
             : provider?.integrated
               ? 'integrated'
               : 'unsupported',
+          sortIndex: out.length,
+          sortPriority: configured ? 0 : provider?.credentialsRequired === false ? 1 : 2,
           models: [],
         };
         out.push(group);
       }
       group.models.push(model);
     }
-    return out;
+    return out.sort((a, b) => a.sortPriority - b.sortPriority || a.sortIndex - b.sortIndex);
   }, [models, mediaProviders]);
 
   const selected = useMemo(() => {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -6194,6 +6194,7 @@ function MediaProvidersSection({
           // the "Coming soon" <details> below.
           const disabled = false;
           const supportsCustomModel = provider.supportsCustomModel === true;
+          const requiresCredentials = provider.credentialsRequired !== false;
           const clearable = isStoredMediaProviderEntryPresent(entry);
           const apiKeyVisible = visibleApiKeys.has(provider.id);
           return (
@@ -6235,107 +6236,109 @@ function MediaProvidersSection({
                 */}
               </div>
               {provider.id === 'grok' ? <XaiOAuthControl /> : null}
-              <div className="media-provider-body">
-                <div className="media-provider-secret-field">
+              {requiresCredentials ? (
+                <div className="media-provider-body">
+                  <div className="media-provider-secret-field">
+                    <input
+                      type={apiKeyVisible ? 'text' : 'password'}
+                      value={entry.apiKey}
+                      placeholder={isSavedState ? t('settings.connectorsReplaceKeyPlaceholder') : t('settings.mediaProviderPlaceholder')}
+                      aria-label={`${provider.label} ${t('settings.mediaProviderApiKey')}`}
+                      disabled={disabled}
+                      onFocus={() => {
+                        trackSettingsMediaProvidersClick(analytics.track, {
+                          page_name: 'settings',
+                          area: 'media_providers',
+                          element: 'key_input',
+                          providers_id: provider.id,
+                          is_configured: clearable,
+                        });
+                      }}
+                      onChange={(e) => updateProvider(provider, { apiKey: e.target.value })}
+                    />
+                    <button
+                      type="button"
+                      className="secret-visibility-button"
+                      disabled={disabled}
+                      aria-label={
+                        apiKeyVisible
+                          ? `${provider.label} ${t('settings.hideKey')}`
+                          : `${provider.label} ${t('settings.showKey')}`
+                      }
+                      aria-pressed={apiKeyVisible}
+                      onClick={() => toggleApiKeyVisibility(provider.id)}
+                    >
+                        <Icon name={apiKeyVisible ? 'eye' : 'eye-off'} size={15} />
+                      </button>
+                    </div>
                   <input
-                    type={apiKeyVisible ? 'text' : 'password'}
-                    value={entry.apiKey}
-                    placeholder={isSavedState ? t('settings.connectorsReplaceKeyPlaceholder') : t('settings.mediaProviderPlaceholder')}
-                    aria-label={`${provider.label} ${t('settings.mediaProviderApiKey')}`}
+                    value={entry.baseUrl}
+                    placeholder={provider.defaultBaseUrl || t('settings.mediaProviderBaseUrlPlaceholder')}
+                    aria-label={`${provider.label} ${t('settings.mediaProviderBaseUrl')}`}
                     disabled={disabled}
                     onFocus={() => {
                       trackSettingsMediaProvidersClick(analytics.track, {
                         page_name: 'settings',
                         area: 'media_providers',
-                        element: 'key_input',
+                        element: 'url_input',
                         providers_id: provider.id,
                         is_configured: clearable,
                       });
                     }}
-                    onChange={(e) => updateProvider(provider, { apiKey: e.target.value })}
+                    onChange={(e) => updateProvider(provider, { baseUrl: e.target.value })}
                   />
+                  {supportsCustomModel ? (
+                    <input
+                      value={entry.model ?? ''}
+                      placeholder="gemini-3.1-flash-image-preview"
+                      aria-label={`${provider.label} model`}
+                      disabled={disabled}
+                      onChange={(e) => updateProvider(provider, { model: e.target.value })}
+                    />
+                  ) : null}
                   <button
                     type="button"
-                    className="secret-visibility-button"
-                    disabled={disabled}
-                    aria-label={
-                      apiKeyVisible
-                        ? `${provider.label} ${t('settings.hideKey')}`
-                        : `${provider.label} ${t('settings.showKey')}`
-                    }
-                    aria-pressed={apiKeyVisible}
-                    onClick={() => toggleApiKeyVisibility(provider.id)}
+                    className="ghost"
+                    disabled={!clearable}
+                    onClick={() => {
+                      trackSettingsMediaProvidersClick(analytics.track, {
+                        page_name: 'settings',
+                        area: 'media_providers',
+                        element: 'clear',
+                        providers_id: provider.id,
+                        // The click reports the state at the moment the
+                        // user pressed Clear; the actual clear only lands
+                        // after they confirm the dialog below, but the
+                        // dashboard cares about the intent signal.
+                        is_configured: clearable,
+                      });
+                      // Match the existing window.confirm guard the rest of
+                      // the app uses for destructive actions (conversation
+                      // delete, design delete, file delete in FileWorkspace).
+                      // Without this a stray click on the row's Clear button
+                      // wipes the saved key with no recovery. Issue #737.
+                      if (
+                        !confirm(
+                          t('settings.mediaProviderClearConfirm', {
+                            name: provider.label,
+                          }),
+                        )
+                      ) {
+                        return;
+                      }
+                      updateProvider(provider, {
+                        apiKey: '',
+                        baseUrl: '',
+                        model: '',
+                        apiKeyConfigured: false,
+                        apiKeyTail: '',
+                      });
+                    }}
                   >
-                      <Icon name={apiKeyVisible ? 'eye' : 'eye-off'} size={15} />
-                    </button>
-                  </div>
-                <input
-                  value={entry.baseUrl}
-                  placeholder={provider.defaultBaseUrl || t('settings.mediaProviderBaseUrlPlaceholder')}
-                  aria-label={`${provider.label} ${t('settings.mediaProviderBaseUrl')}`}
-                  disabled={disabled}
-                  onFocus={() => {
-                    trackSettingsMediaProvidersClick(analytics.track, {
-                      page_name: 'settings',
-                      area: 'media_providers',
-                      element: 'url_input',
-                      providers_id: provider.id,
-                      is_configured: clearable,
-                    });
-                  }}
-                  onChange={(e) => updateProvider(provider, { baseUrl: e.target.value })}
-                />
-                {supportsCustomModel ? (
-                  <input
-                    value={entry.model ?? ''}
-                    placeholder="gemini-3.1-flash-image-preview"
-                    aria-label={`${provider.label} model`}
-                    disabled={disabled}
-                    onChange={(e) => updateProvider(provider, { model: e.target.value })}
-                  />
-                ) : null}
-                <button
-                  type="button"
-                  className="ghost"
-                  disabled={!clearable}
-                  onClick={() => {
-                    trackSettingsMediaProvidersClick(analytics.track, {
-                      page_name: 'settings',
-                      area: 'media_providers',
-                      element: 'clear',
-                      providers_id: provider.id,
-                      // The click reports the state at the moment the
-                      // user pressed Clear; the actual clear only lands
-                      // after they confirm the dialog below, but the
-                      // dashboard cares about the intent signal.
-                      is_configured: clearable,
-                    });
-                    // Match the existing window.confirm guard the rest of
-                    // the app uses for destructive actions (conversation
-                    // delete, design delete, file delete in FileWorkspace).
-                    // Without this a stray click on the row's Clear button
-                    // wipes the saved key with no recovery. Issue #737.
-                    if (
-                      !confirm(
-                        t('settings.mediaProviderClearConfirm', {
-                          name: provider.label,
-                        }),
-                      )
-                    ) {
-                      return;
-                    }
-                    updateProvider(provider, {
-                      apiKey: '',
-                      baseUrl: '',
-                      model: '',
-                      apiKeyConfigured: false,
-                      apiKeyTail: '',
-                    });
-                  }}
-                >
-                  {t('settings.mediaProviderClear')}
-                </button>
-              </div>
+                    {t('settings.mediaProviderClear')}
+                  </button>
+                </div>
+              ) : null}
             </div>
           );
         })}

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -29,6 +29,7 @@ import type { AudioKind, MediaAspect } from '../types';
  */
 export type MediaProviderId =
   | 'openai'
+  | 'codex'
   | 'volcengine'
   | 'grok'
   | 'hyperframes'
@@ -90,6 +91,14 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     integrated: true,
     defaultBaseUrl: 'https://api.openai.com/v1',
     docsUrl: 'https://platform.openai.com/api-keys',
+  },
+  {
+    id: 'codex',
+    label: 'Codex Subscription',
+    hint: 'gpt-image-2 via local Codex CLI login',
+    integrated: true,
+    credentialsRequired: false,
+    docsUrl: 'https://developers.openai.com/codex',
   },
   {
     id: 'volcengine',
@@ -360,6 +369,13 @@ export const IMAGE_MODELS: MediaModel[] = [
     hint: 'OpenAI · legacy',
     provider: 'openai',
     caps: ['t2i'],
+  },
+  {
+    id: 'codex-gpt-image-2',
+    label: 'gpt-image-2 (Codex)',
+    hint: 'Codex Subscription · local CLI imagegen',
+    provider: 'codex',
+    caps: ['t2i', 'i2i'],
   },
 
   // Volcengine — Doubao Seedream image generation.

--- a/apps/web/tests/components/NewProjectPanel.media.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.media.test.tsx
@@ -73,7 +73,30 @@ describe('NewProjectPanel media provider badges', () => {
     expect(screen.queryByTestId('model-picker-option-gpt-image-2')).toBeNull();
   });
 
-  it('does not submit a hidden default model when no image provider is eligible', async () => {
+  it('shows Codex subscription image models without media API credentials', () => {
+    render(
+      <NewProjectPanel
+        skills={[]}
+        designSystems={[]}
+        defaultDesignSystemId={null}
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+        mediaProviders={{}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Media' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Image' }));
+    fireEvent.click(screen.getByTestId('model-picker-trigger'));
+
+    const codexGroup = screen.getByText('Codex Subscription').closest('.ds-picker-group');
+    expect(codexGroup?.textContent).toContain('Integrated');
+    expect(screen.getByTestId('model-picker-option-codex-gpt-image-2')).toBeTruthy();
+  });
+
+  it('uses Codex subscription as the no-key image fallback', async () => {
     const onCreate = vi.fn();
     render(
       <NewProjectPanel
@@ -91,10 +114,10 @@ describe('NewProjectPanel media provider badges', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Media' }));
     fireEvent.click(screen.getByRole('tab', { name: 'Image' }));
     await waitFor(() => {
-      expect(screen.getByTestId('model-picker-trigger').textContent).toContain('Pick a model');
+      expect(screen.getByTestId('model-picker-trigger').textContent).toContain('gpt-image-2 (Codex)');
     });
     fireEvent.change(screen.getByTestId('new-project-name'), {
-      target: { value: 'No configured image model' },
+      target: { value: 'Codex fallback image' },
     });
     fireEvent.click(screen.getByTestId('create-project'));
 
@@ -102,11 +125,11 @@ describe('NewProjectPanel media provider badges', () => {
       expect.objectContaining({
         metadata: expect.objectContaining({
           kind: 'image',
+          imageModel: 'codex-gpt-image-2',
           imageAspect: '1:1',
         }),
       }),
     );
-    expect(onCreate.mock.calls[0]?.[0].metadata).not.toHaveProperty('imageModel');
   });
 
   it('does not treat OpenAI OAuth-only markers as usable image credentials', () => {

--- a/apps/web/tests/components/SettingsDialog.media.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.media.test.tsx
@@ -32,6 +32,17 @@ describe('SettingsDialog media providers', () => {
     );
   });
 
+  it('shows Codex Subscription without API key fields', () => {
+    renderDialog({
+      ...DEFAULT_CONFIG,
+      mediaProviders: {},
+    });
+
+    expect(screen.getByText('Codex Subscription')).toBeTruthy();
+    expect(screen.queryByLabelText('Codex Subscription API key')).toBeNull();
+    expect(screen.queryByLabelText('Codex Subscription Base URL')).toBeNull();
+  });
+
   it('shows daemon fallback notice and reloads media providers from daemon', async () => {
     const reloadMock = vi.fn(async () => ({
       openai: {


### PR DESCRIPTION
## Why

Open Design had OpenAI API media providers, but users who rely on their local Codex CLI subscription login could not select that path from Settings, New Project media creation, or `od media generate`. This adds a no-API-key Codex Subscription provider that shells out to local `codex exec $imagegen` and consumes the generated `ig_*` image.

## What users will see

- Settings -> Media Providers shows a new `Codex Subscription` provider with no API key or Base URL fields.
- New media image projects can choose `gpt-image-2 (Codex)`.
- If no image API provider is configured, Codex is the no-key image fallback.
- If an API provider is explicitly configured, it stays ahead of the Codex fallback in the picker.
- `od media generate` can render `codex-gpt-image-2` through the local Codex CLI and saves the returned image into the project.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Settings -> Media Providers shows `Codex Subscription` without API key/Base URL fields:

![Settings Media Providers showing Codex Subscription](https://raw.githubusercontent.com/passive-book/open-design/pr-assets/codex-subscription-media-provider/pr4244/settings-media-providers-codex.png)

New Project -> Media -> Image defaults to `gpt-image-2 (Codex)` when no image API provider is configured:

![New Project image default selecting gpt-image-2 Codex](https://raw.githubusercontent.com/passive-book/open-design/pr-assets/codex-subscription-media-provider/pr4244/new-project-no-key-codex-default.png)

The no-key picker shows the Codex provider as `Integrated`, not `Configured`, because this UI has not verified the user's local Codex login:

![New Project image picker showing Codex Subscription integrated](https://raw.githubusercontent.com/passive-book/open-design/pr-assets/codex-subscription-media-provider/pr4244/new-project-no-key-codex-picker.png)

When an API provider is configured, it remains ahead of the Codex fallback:

![New Project image picker showing configured OpenAI ahead of Codex](https://raw.githubusercontent.com/passive-book/open-design/pr-assets/codex-subscription-media-provider/pr4244/new-project-openai-configured-picker.png)

## Relation to #4129

PR #4129 and this PR solve the same no-API-key Codex image-generation problem, but with different product shapes:

- #4129 adds an opt-in `codex-cli` local provider/model, no Settings card, keeps the default image model unchanged, and includes a fail-fast Codex auth classification path.
- This PR adds `Codex Subscription` to Settings -> Media Providers, makes it visible as a no-key provider, and uses it as the no-key image fallback while keeping configured API providers ahead of it.

The useful distinction for review is product behavior: #4129 is explicit opt-in; this PR is discoverable in Settings and provides a fallback for users without image API keys. If maintainers prefer the #4129 shape, the daemon auth preflight and naming choices there are worth carrying over.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/web/tests/components/SettingsDialog.media.test.tsx`
  - `apps/web/tests/components/NewProjectPanel.media.test.tsx`
  - `apps/daemon/tests/media-openai-compatible-providers.test.ts`
- Did the test go red on `main` and green on this branch? yes, the new focused tests were written red-first for the missing Codex provider/model dispatch and are green on this branch.

## Validation

- `PATH=/home/abhishek/.local/opt/node-v24.16.0-linux-arm64/bin:$PATH corepack pnpm exec vitest run -c vitest.config.ts tests/components/NewProjectPanel.media.test.tsx tests/components/SettingsDialog.media.test.tsx` from `apps/web` — passed, 18 tests.
- `PATH=/home/abhishek/.local/opt/node-v24.16.0-linux-arm64/bin:$PATH corepack pnpm exec vitest run -c vitest.config.ts tests/media-openai-compatible-providers.test.ts` from `apps/daemon` — passed, 8 tests.
- `PATH=/home/abhishek/.local/opt/node-v24.16.0-linux-arm64/bin:$PATH corepack pnpm --filter @open-design/daemon typecheck` — passed.
- `PATH=/home/abhishek/.local/opt/node-v24.16.0-linux-arm64/bin:$PATH corepack pnpm guard` — passed.
- Known unrelated blocker: `PATH=/home/abhishek/.local/opt/node-v24.16.0-linux-arm64/bin:$PATH corepack pnpm --filter @open-design/web typecheck` fails in untouched `src/components/IntegrationsView.tsx(135,17)` because `ConnectorsBrowser` can emit `gate_card`, but `trackIntegrationsConnectorsTabClick` does not include that enum value.
