### PR TITLE
test(desktop): anchor window-chrome regex to the main app window

### DIFF
--- a/apps/desktop/tests/main/window-chrome.test.ts
+++ b/apps/desktop/tests/main/window-chrome.test.ts
@@ -4,9 +4,14 @@ import { describe, expect, test } from "vitest";
 
 const runtimeSource = readFileSync(new URL("../../src/main/runtime.ts", import.meta.url), "utf8");
 
+// Anchor on `const window = new BrowserWindow({` rather than the first
+// `new BrowserWindow({` in the file. The splash and pet windows are declared
+// earlier and share `title: "Open Design"` / `width: 1280,`, so a looser regex
+// captures the splash block (which has no backgroundThrottling) instead of the
+// main app window. See nexu-io/open-design#4245.
 describe("desktop BrowserWindow chrome options", () => {
   test("hides Electron's native menu bar in the Windows/Linux app window", () => {
-    const browserWindowBlock = /new BrowserWindow\(\{([\s\S]*?)title: "Open Design",([\s\S]*?)webPreferences:/.exec(runtimeSource)?.[0] ?? "";
+    const browserWindowBlock = /const window = new BrowserWindow\(\{([\s\S]*?)title: "Open Design",([\s\S]*?)webPreferences:/.exec(runtimeSource)?.[0] ?? "";
 
     expect(browserWindowBlock).toContain("autoHideMenuBar: true");
   });
@@ -19,7 +24,7 @@ describe("desktop BrowserWindow chrome options", () => {
   });
 
   test("keeps the visible renderer responsive when Chromium misclassifies visibility", () => {
-    const browserWindowBlock = /new BrowserWindow\(\{([\s\S]*?)title: "Open Design",([\s\S]*?)width: 1280,/.exec(runtimeSource)?.[0] ?? "";
+    const browserWindowBlock = /const window = new BrowserWindow\(\{([\s\S]*?)title: "Open Design",([\s\S]*?)width: 1280,/.exec(runtimeSource)?.[0] ?? "";
 
     expect(browserWindowBlock).toContain("backgroundThrottling: false");
   });


### PR DESCRIPTION
Fixes #4245

## Why

The desktop test `window-chrome.test.ts` > "keeps the visible renderer responsive when Chromium misclassifies visibility" fails on `main`. It checks that the main app window sets `backgroundThrottling: false`, but its regex matches the splash window instead.

The regex used `exec` (first match) with non-greedy `[\s\S]*?` groups, so it captured the first `new BrowserWindow({` in `runtime.ts`. Since #3674 added the brand splash window, `createSplashWindow` is the first `BrowserWindow` in the file, and it also has `title: "Open Design"` and `width: 1280,`. The splash window has no `backgroundThrottling: false` (only the main app window does), so the captured block was the splash and the assertion failed.

The sibling test ("hides Electron's native menu bar") had the same latent bug: it also anchored to the first `new BrowserWindow({` and captured the splash block. It passed only because the splash window happens to set `autoHideMenuBar: true`, so it was checking the wrong window by luck.

## What changed

Both regexes now anchor on the main window's unique declaration, `const window = new BrowserWindow({`, instead of the first `new BrowserWindow({`. That skips the splash and pet windows declared earlier in the file and targets the app window regardless of how many other windows get added later. Added a comment above the suite explaining the anchor.

## What users will see

No user-facing change. This is a test-only fix that turns the desktop suite green again.

## Surface area

- [ ] **UI** -- new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** -- new or changed
- [ ] **CLI / env var** -- new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** -- new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** -- new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** -- added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** -- adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** -- changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** -- internal refactor, docs, tests, or translation update only

## Bug fix verification

The failing test reproduces on `main`: running its exact regex against `main`'s `runtime.ts` captures the splash block (no `backgroundThrottling: false`), so the assertion is false. With the anchor change, `pnpm --filter @open-design/desktop test window-chrome` goes from 1 failing to all passing, and the full desktop suite is 119/119.

## Validation

- `pnpm --filter @open-design/desktop test`: 119 passed (was 118 passed, 1 failed)
- `pnpm --filter @open-design/desktop typecheck`: clean
