### PR TITLE
fix(daemon): parse Antigravity JSONL stdout

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13433,6 +13433,22 @@ export async function startServer({
       }
       send('agent', ev);
     };
+    const parseBufferedAntigravityGeminiJsonEventStream = () => {
+      if (
+        def.id !== 'antigravity' ||
+        plaintextStdoutBuffer.length === 0
+      ) {
+        return false;
+      }
+      const bufferedStdout = plaintextStdoutBuffer.join('');
+      if (!looksLikeGeminiJsonEventStream(bufferedStdout)) return false;
+      trackingSubstantiveOutput = true;
+      const handler = createJsonEventStreamHandler('gemini', sendAgentEvent);
+      handler.feed(bufferedStdout);
+      handler.flush();
+      plaintextStdoutBuffer.length = 0;
+      return true;
+    };
 
     if (def.streamFormat === 'claude-stream-json') {
       const claude = createClaudeStreamHandler((ev) => {
@@ -13701,6 +13717,7 @@ export async function startServer({
         markRpcCloseReason('fatal_rpc_error');
         return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
       }
+      parseBufferedAntigravityGeminiJsonEventStream();
       if (agentStreamError) {
         markRpcCloseReason('stream_error');
         return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
@@ -13872,22 +13889,6 @@ export async function startServer({
           { retryable: true },
         ));
         return finishWithRetryDecision('failed', 0, signal);
-      }
-      if (
-        def.id === 'antigravity' &&
-        plaintextStdoutBuffer.length > 0
-      ) {
-        const bufferedStdout = plaintextStdoutBuffer.join('');
-        if (looksLikeGeminiJsonEventStream(bufferedStdout)) {
-          const handler = createJsonEventStreamHandler('gemini', sendAgentEvent);
-          handler.feed(bufferedStdout);
-          handler.flush();
-          plaintextStdoutBuffer.length = 0;
-          if (agentStreamError) {
-            markRpcCloseReason('stream_error');
-            return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
-          }
-        }
       }
       // ACP agents that don't shut down on stdin.end() (e.g. Devin for
       // Terminal) are forced to exit via SIGTERM from attachAcpSession after

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4600,6 +4600,77 @@ function resolveAcpStageTimeoutMs(): number | undefined {
   return Math.min(MAX_CHAT_RUN_INACTIVITY_TIMEOUT_MS, Math.max(0, Math.floor(raw)));
 }
 
+type GeminiJsonEventStreamEvent = Record<string, unknown>;
+
+function parseGeminiJsonEventStreamEvents(text: string): GeminiJsonEventStreamEvent[] | null {
+  const lines = text
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return null;
+  const events: GeminiJsonEventStreamEvent[] = [];
+  for (const line of lines) {
+    try {
+      const obj = JSON.parse(line);
+      if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+      events.push(obj as GeminiJsonEventStreamEvent);
+    } catch {
+      return null;
+    }
+  }
+  return events;
+}
+
+function isGeminiJsonEventStream(events: GeminiJsonEventStreamEvent[] | null): boolean {
+  if (!events || events.length === 0) return false;
+  const [firstEvent] = events;
+  if (
+    !firstEvent ||
+    firstEvent.type !== 'init' ||
+    typeof firstEvent.session_id !== 'string' ||
+    firstEvent.session_id.length === 0 ||
+    typeof firstEvent.model !== 'string' ||
+    firstEvent.model.length === 0
+  ) {
+    return false;
+  }
+  return events.every((event) => {
+    const type = event?.type;
+    return (
+      type === 'init' ||
+      type === 'message' ||
+      type === 'tool_use' ||
+      type === 'tool_result' ||
+      type === 'error' ||
+      type === 'result'
+    );
+  });
+}
+
+function geminiJsonEventStreamHasVisibleAssistantText(
+  events: GeminiJsonEventStreamEvent[] | null,
+): boolean {
+  if (!events) return false;
+  return events.some((event) => (
+    event.type === 'message' &&
+    event.role === 'assistant' &&
+    typeof event.content === 'string' &&
+    event.content.length > 0
+  ));
+}
+
+export function bufferedAntigravityGeminiFirstTokenAt(
+  text: string,
+  firstBufferedStdoutAt: number | null,
+): number | null {
+  if (firstBufferedStdoutAt === null) return null;
+  const events = parseGeminiJsonEventStreamEvents(text);
+  if (!isGeminiJsonEventStream(events)) return null;
+  return geminiJsonEventStreamHasVisibleAssistantText(events)
+    ? firstBufferedStdoutAt
+    : null;
+}
+
 export async function startServer({
   port = 7456,
   host = process.env.OD_BIND_HOST || '127.0.0.1',
@@ -13245,45 +13316,9 @@ export async function startServer({
     // guard below skips them via `trackingSubstantiveOutput`.
     let agentProducedOutput = false;
     let trackingSubstantiveOutput = false;
-    const looksLikeGeminiJsonEventStream = (text: string) => {
-      const lines = text
-        .split(/\r?\n/u)
-        .map((line) => line.trim())
-        .filter(Boolean);
-      if (lines.length === 0) return false;
-      const events: Record<string, unknown>[] = [];
-      for (const line of lines) {
-        try {
-          const obj = JSON.parse(line);
-          if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
-          events.push(obj as Record<string, unknown>);
-        } catch {
-          return false;
-        }
-      }
-      const [firstEvent] = events;
-      if (
-        !firstEvent ||
-        firstEvent.type !== 'init' ||
-        typeof firstEvent.session_id !== 'string' ||
-        firstEvent.session_id.length === 0 ||
-        typeof firstEvent.model !== 'string' ||
-        firstEvent.model.length === 0
-      ) {
-        return false;
-      }
-      return events.every((obj) => {
-        const type = obj?.type;
-        return (
-          type === 'init' ||
-          type === 'message' ||
-          type === 'tool_use' ||
-          type === 'tool_result' ||
-          type === 'error' ||
-          type === 'result'
-        );
-      });
-    };
+    const looksLikeGeminiJsonEventStream = (text: string) => (
+      isGeminiJsonEventStream(parseGeminiJsonEventStreamEvents(text))
+    );
     // Event types that count as "the agent actually produced something the
     // user can see." Lifecycle markers (`status`) and meter readings
     // (`usage`) deliberately do NOT count — a model can emit token-usage
@@ -13458,6 +13493,11 @@ export async function startServer({
       const bufferedStdout = plaintextStdoutBuffer.join('');
       if (!looksLikeGeminiJsonEventStream(bufferedStdout)) return false;
       trackingSubstantiveOutput = true;
+      const firstTokenAt = bufferedAntigravityGeminiFirstTokenAt(
+        bufferedStdout,
+        firstBufferedStdoutAt,
+      );
+      if (firstTokenAt !== null) noteFirstTokenAt(firstTokenAt);
       const handler = createJsonEventStreamHandler('gemini', sendAgentEvent);
       handler.feed(bufferedStdout);
       handler.flush();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4601,6 +4601,7 @@ function resolveAcpStageTimeoutMs(): number | undefined {
 }
 
 type GeminiJsonEventStreamEvent = Record<string, unknown>;
+type BufferedStdoutChunk = { text: string; receivedAt: number };
 
 function parseGeminiJsonEventStreamEvents(text: string): GeminiJsonEventStreamEvent[] | null {
   const lines = text
@@ -4660,15 +4661,40 @@ function geminiJsonEventStreamHasVisibleAssistantText(
 }
 
 export function bufferedAntigravityGeminiFirstTokenAt(
-  text: string,
-  firstBufferedStdoutAt: number | null,
+  chunks: readonly BufferedStdoutChunk[],
 ): number | null {
-  if (firstBufferedStdoutAt === null) return null;
+  if (chunks.length === 0) return null;
+  const text = chunks.map((chunk) => chunk.text).join('');
   const events = parseGeminiJsonEventStreamEvents(text);
   if (!isGeminiJsonEventStream(events)) return null;
-  return geminiJsonEventStreamHasVisibleAssistantText(events)
-    ? firstBufferedStdoutAt
-    : null;
+  if (!geminiJsonEventStreamHasVisibleAssistantText(events)) return null;
+
+  let offset = 0;
+  for (const line of text.split(/(\r?\n)/u)) {
+    const nextOffset = offset + line.length;
+    if (line.length > 0 && line.trim().length > 0) {
+      try {
+        const event = JSON.parse(line) as GeminiJsonEventStreamEvent;
+        if (
+          event?.type === 'message' &&
+          event.role === 'assistant' &&
+          typeof event.content === 'string' &&
+          event.content.length > 0
+        ) {
+          let consumed = 0;
+          for (const chunk of chunks) {
+            consumed += chunk.text.length;
+            if (consumed >= nextOffset) return chunk.receivedAt;
+          }
+          return chunks.at(-1)?.receivedAt ?? null;
+        }
+      } catch {
+        return null;
+      }
+    }
+    offset = nextOffset;
+  }
+  return null;
 }
 
 export async function startServer({
@@ -13301,7 +13327,7 @@ export async function startServer({
     // time before deciding whether to forward it. The auth-prompt guard
     // in the close handler suppresses the buffer when the output is an
     // OAuth prompt; otherwise the flush below sends the chunks in order.
-    const plaintextStdoutBuffer: string[] = [];
+    const plaintextStdoutBuffer: BufferedStdoutChunk[] = [];
     // Arrival time of the first buffered plain-text stdout chunk
     // (antigravity). First-token timing is stamped from this value only
     // when the buffer is actually flushed to the client at close time. If
@@ -13490,13 +13516,10 @@ export async function startServer({
       ) {
         return false;
       }
-      const bufferedStdout = plaintextStdoutBuffer.join('');
+      const bufferedStdout = plaintextStdoutBuffer.map((chunk) => chunk.text).join('');
       if (!looksLikeGeminiJsonEventStream(bufferedStdout)) return false;
       trackingSubstantiveOutput = true;
-      const firstTokenAt = bufferedAntigravityGeminiFirstTokenAt(
-        bufferedStdout,
-        firstBufferedStdoutAt,
-      );
+      const firstTokenAt = bufferedAntigravityGeminiFirstTokenAt(plaintextStdoutBuffer);
       if (firstTokenAt !== null) noteFirstTokenAt(firstTokenAt);
       const handler = createJsonEventStreamHandler('gemini', sendAgentEvent);
       handler.feed(bufferedStdout);
@@ -13710,8 +13733,9 @@ export async function startServer({
       // suppressed OAuth-prompt path never reports a TTFT (PR #3412).
       child.stdout.on('data', (chunk) => {
         noteAgentActivity();
-        if (firstBufferedStdoutAt === null) firstBufferedStdoutAt = Date.now();
-        plaintextStdoutBuffer.push(String(chunk));
+        const receivedAt = Date.now();
+        if (firstBufferedStdoutAt === null) firstBufferedStdoutAt = receivedAt;
+        plaintextStdoutBuffer.push({ text: String(chunk), receivedAt });
       });
     } else {
       // Plain / BYOK mode: guard raw stdout chunks (#3247).
@@ -14090,7 +14114,7 @@ export async function startServer({
         noteFirstTokenAt(firstBufferedStdoutAt);
       }
       for (const chunk of plaintextStdoutBuffer) {
-        send('stdout', { chunk });
+        send('stdout', { chunk: chunk.text });
       }
       // Capture the pi session file path for conversational continuity.
       // The session path is discovered by attachPiRpcSession when it

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13251,22 +13251,37 @@ export async function startServer({
         .map((line) => line.trim())
         .filter(Boolean);
       if (lines.length === 0) return false;
-      return lines.every((line) => {
+      const events: Record<string, unknown>[] = [];
+      for (const line of lines) {
         try {
           const obj = JSON.parse(line);
           if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
-          const type = obj.type;
-          return (
-            type === 'init' ||
-            type === 'message' ||
-            type === 'tool_use' ||
-            type === 'tool_result' ||
-            type === 'error' ||
-            type === 'result'
-          );
+          events.push(obj as Record<string, unknown>);
         } catch {
           return false;
         }
+      }
+      const [firstEvent] = events;
+      if (
+        !firstEvent ||
+        firstEvent.type !== 'init' ||
+        typeof firstEvent.session_id !== 'string' ||
+        firstEvent.session_id.length === 0 ||
+        typeof firstEvent.model !== 'string' ||
+        firstEvent.model.length === 0
+      ) {
+        return false;
+      }
+      return events.every((obj) => {
+        const type = obj?.type;
+        return (
+          type === 'init' ||
+          type === 'message' ||
+          type === 'tool_use' ||
+          type === 'tool_result' ||
+          type === 'error' ||
+          type === 'result'
+        );
       });
     };
     // Event types that count as "the agent actually produced something the

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13245,6 +13245,30 @@ export async function startServer({
     // guard below skips them via `trackingSubstantiveOutput`.
     let agentProducedOutput = false;
     let trackingSubstantiveOutput = false;
+    const looksLikeGeminiJsonEventStream = (text: string) => {
+      const lines = text
+        .split(/\r?\n/u)
+        .map((line) => line.trim())
+        .filter(Boolean);
+      if (lines.length === 0) return false;
+      return lines.every((line) => {
+        try {
+          const obj = JSON.parse(line);
+          if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
+          const type = obj.type;
+          return (
+            type === 'init' ||
+            type === 'message' ||
+            type === 'tool_use' ||
+            type === 'tool_result' ||
+            type === 'error' ||
+            type === 'result'
+          );
+        } catch {
+          return false;
+        }
+      });
+    };
     // Event types that count as "the agent actually produced something the
     // user can see." Lifecycle markers (`status`) and meter readings
     // (`usage`) deliberately do NOT count — a model can emit token-usage
@@ -13848,6 +13872,22 @@ export async function startServer({
           { retryable: true },
         ));
         return finishWithRetryDecision('failed', 0, signal);
+      }
+      if (
+        def.id === 'antigravity' &&
+        plaintextStdoutBuffer.length > 0
+      ) {
+        const bufferedStdout = plaintextStdoutBuffer.join('');
+        if (looksLikeGeminiJsonEventStream(bufferedStdout)) {
+          const handler = createJsonEventStreamHandler('gemini', sendAgentEvent);
+          handler.feed(bufferedStdout);
+          handler.flush();
+          plaintextStdoutBuffer.length = 0;
+          if (agentStreamError) {
+            markRpcCloseReason('stream_error');
+            return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
+          }
+        }
       }
       // ACP agents that don't shut down on stdin.end() (e.g. Devin for
       // Terminal) are forced to exit via SIGTERM from attachAcpSession after

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2022,6 +2022,49 @@ process.exit(0);
     );
   });
 
+  it('fails Antigravity Gemini JSONL output with no visible assistant content', async () => {
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }) + '\\n');
+process.stdout.write(JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 0, cached: 0, duration_ms: 25 } }) + '\\n');
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'Agent completed without producing any output');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: agent');
+        expect(eventsBody).toContain('"type":"usage"');
+        expect(eventsBody).toContain('event: error');
+        expect(eventsBody).toContain('AGENT_EXECUTION_FAILED');
+        expect(eventsBody).not.toContain('event: stdout');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
   it('surfaces Qoder assistant error records through the SSE error channel', async () => {
     const qoderErrorLine = JSON.stringify({
       type: 'assistant',

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from 'node:os';
 import { delimiter, join, resolve } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
+  bufferedAntigravityGeminiFirstTokenAt,
   composeLiveInstructionPrompt,
   resolveGrantedCodexImagegenOverride,
   resolveCodexGeneratedImagesDir,
@@ -2103,6 +2104,31 @@ process.exit(0);
         expect(statusBody.status).toBe('failed');
       },
     );
+  });
+
+  it('preserves the first buffered stdout timestamp for Antigravity Gemini assistant text', () => {
+    const timestamp = bufferedAntigravityGeminiFirstTokenAt(
+      [
+        JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }),
+        JSON.stringify({ type: 'message', role: 'assistant', content: 'Hello from Antigravity.', delta: true }),
+        JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 5 } }),
+      ].join('\n'),
+      1_234,
+    );
+
+    expect(timestamp).toBe(1_234);
+  });
+
+  it('does not stamp a first token timestamp for Antigravity Gemini streams without assistant text', () => {
+    const timestamp = bufferedAntigravityGeminiFirstTokenAt(
+      [
+        JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }),
+        JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 0 } }),
+      ].join('\n'),
+      1_234,
+    );
+
+    expect(timestamp).toBeNull();
   });
 
   it('surfaces Qoder assistant error records through the SSE error channel', async () => {

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2108,24 +2108,47 @@ process.exit(0);
 
   it('preserves the first buffered stdout timestamp for Antigravity Gemini assistant text', () => {
     const timestamp = bufferedAntigravityGeminiFirstTokenAt(
-      [
-        JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }),
-        JSON.stringify({ type: 'message', role: 'assistant', content: 'Hello from Antigravity.', delta: true }),
-        JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 5 } }),
-      ].join('\n'),
-      1_234,
+      [{
+        receivedAt: 1_234,
+        text: [
+          JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }),
+          JSON.stringify({ type: 'message', role: 'assistant', content: 'Hello from Antigravity.', delta: true }),
+          JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 5 } }),
+        ].join('\n'),
+      }],
     );
 
     expect(timestamp).toBe(1_234);
   });
 
+  it('stamps Antigravity Gemini assistant text from the chunk that completes the first assistant message', () => {
+    const timestamp = bufferedAntigravityGeminiFirstTokenAt([
+      {
+        receivedAt: 1_234,
+        text: `${JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' })}\n`,
+      },
+      {
+        receivedAt: 5_678,
+        text: `${JSON.stringify({ type: 'message', role: 'assistant', content: 'Hello from Antigravity.', delta: true })}\n`,
+      },
+      {
+        receivedAt: 9_999,
+        text: `${JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 5 } })}\n`,
+      },
+    ]);
+
+    expect(timestamp).toBe(5_678);
+  });
+
   it('does not stamp a first token timestamp for Antigravity Gemini streams without assistant text', () => {
     const timestamp = bufferedAntigravityGeminiFirstTokenAt(
-      [
-        JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }),
-        JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 0 } }),
-      ].join('\n'),
-      1_234,
+      [{
+        receivedAt: 1_234,
+        text: [
+          JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }),
+          JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 0 } }),
+        ].join('\n'),
+      }],
     );
 
     expect(timestamp).toBeNull();

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -1978,6 +1978,50 @@ process.exit(0);
     );
   });
 
+  it('parses successful Antigravity Gemini JSONL output instead of forwarding raw stdout', async () => {
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }) + '\\n');
+process.stdout.write(JSON.stringify({ type: 'message', role: 'assistant', content: 'Hello from Antigravity.', delta: true }) + '\\n');
+process.stdout.write(JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 5, cached: 0, duration_ms: 25 } }) + '\\n');
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'event: final');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: agent');
+        expect(eventsBody).toContain('"type":"text_delta","delta":"Hello from Antigravity."');
+        expect(eventsBody).toContain('"type":"usage"');
+        expect(eventsBody).not.toContain('event: stdout');
+        expect(eventsBody).not.toContain('"role":"assistant"');
+        expect(statusBody.status).toBe('succeeded');
+      },
+    );
+  });
+
   it('surfaces Qoder assistant error records through the SSE error channel', async () => {
     const qoderErrorLine = JSON.stringify({
       type: 'assistant',

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2022,6 +2022,46 @@ process.exit(0);
     );
   });
 
+  it('forwards Antigravity plain stdout JSONL when it lacks the Gemini init marker', async () => {
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({ type: 'error', message: 'requested JSONL output' }) + '\\n');
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'return JSONL',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'event: final');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: stdout');
+        expect(eventsBody).toContain('requested JSONL output');
+        expect(eventsBody).not.toContain('event: error');
+        expect(statusBody.status).toBe('succeeded');
+      },
+    );
+  });
+
   it('fails Antigravity Gemini JSONL output with no visible assistant content', async () => {
     await withFakeAgent(
       'agy',


### PR DESCRIPTION
Closes #3654

## Why

Issue #3654 reports that Antigravity CLI runs in existing Gemini-created projects loop back into the initial discovery survey instead of treating a normal prompt as a continuing chat turn. The daemon was buffering Antigravity stdout for auth/quota classification, then forwarding successful buffered output as raw stdout. When `agy` emits Gemini-style JSONL, that means OD can persist protocol envelopes instead of assistant text, which can poison the conversation history and prompt the model to repeat the discovery form.

## What users will see

Antigravity replies are now decoded into normal assistant text and usage events when `agy` returns Gemini JSONL. Auth prompts and silent quota/auth failures still use the existing Antigravity-specific recovery messages.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is daemon stream handling only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/chat-route.test.ts` (`parses successful Antigravity Gemini JSONL output instead of forwarding raw stdout`)
- Did the test go red on `main` and green on this branch? Not run on `main`; the added assertion covers the previous raw-stdout behavior and is green on this branch.

## Validation

- `PATH="/Users/mrc/.nvm/versions/node/v24.13.0/bin:$PATH" pnpm exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t Antigravity` from `apps/daemon`
- `PATH="/Users/mrc/.nvm/versions/node/v24.13.0/bin:$PATH" pnpm guard`
- `PATH="/Users/mrc/.nvm/versions/node/v24.13.0/bin:$PATH" pnpm typecheck`

Note: an initial broad `pnpm --filter @open-design/daemon test -- chat-route.test.ts` invocation unexpectedly ran unrelated daemon suites and was stopped after unrelated local failures in Claude/OpenCode/BYOK tests. The focused Antigravity test was rerun directly under the repo-required Node 24 runtime and passed.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>