### PR TITLE
[codex] Fix Claude HTML artifact echo

### DIFF
--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -41,7 +41,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-export function createClaudeStreamHandler(onEvent: EventSink) {
+interface ClaudeStreamHandlerOptions {
+  suppressHtmlArtifactsAfterFileWrite?: boolean;
+}
+
+export function createClaudeStreamHandler(
+  onEvent: EventSink,
+  options: ClaudeStreamHandlerOptions = {},
+) {
   let buffer = '';
 
   // Per-content-block scratch, keyed by `${messageId}:${blockIndex}`.
@@ -73,6 +80,9 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   let suppressDuplicateArtifactText = false;
   let artifactOpenCandidate = '';
   let pendingArtifactText = '';
+  let duplicateArtifactCandidate = '';
+  const recentWriteContents: string[] = [];
+  let wroteHtmlFileThisTurn = false;
 
   function normalizeTaskStatus(value: unknown): RuntimeTask['status'] {
     if (value === 'completed' || value === 'in_progress' || value === 'stopped') {
@@ -165,6 +175,12 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
     if (emitCanonicalTaskSnapshot(id, name, input)) return;
     if (isFileWriteToolUse(name, input)) {
       suppressNextArtifactText = true;
+      const content = fileWriteContent(input);
+      if (content) {
+        wroteHtmlFileThisTurn = wroteHtmlFileThisTurn || isHtmlWriteToolInput(input);
+        recentWriteContents.push(normalizeArtifactEchoContent(content));
+        if (recentWriteContents.length > 5) recentWriteContents.shift();
+      }
     }
     onEvent({
       type: 'tool_use',
@@ -222,7 +238,8 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
     if (
       !suppressNextArtifactText &&
       !suppressDuplicateArtifactText &&
-      artifactOpenCandidate.length === 0
+      artifactOpenCandidate.length === 0 &&
+      recentWriteContents.length === 0
     ) {
       return text;
     }
@@ -230,30 +247,61 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
     const current = `${artifactOpenCandidate}${text}`;
     artifactOpenCandidate = '';
     if (suppressDuplicateArtifactText) {
-      const closeIndex = current.indexOf('</artifact>');
+      duplicateArtifactCandidate += current;
+      const closeIndex = duplicateArtifactCandidate.indexOf('</artifact>');
       if (closeIndex === -1) return '';
+      const closeEnd = closeIndex + '</artifact>'.length;
+      const candidate = duplicateArtifactCandidate.slice(0, closeEnd);
+      const rest = duplicateArtifactCandidate.slice(closeEnd);
+      duplicateArtifactCandidate = '';
       suppressDuplicateArtifactText = false;
       suppressNextArtifactText = false;
-      return stripDuplicateArtifactText(current.slice(closeIndex + '</artifact>'.length));
+      const duplicate = isRedundantWrittenArtifact(candidate);
+      if (options.suppressHtmlArtifactsAfterFileWrite !== true) {
+        recentWriteContents.length = 0;
+      }
+      return `${duplicate ? '' : candidate}${stripDuplicateArtifactText(rest)}`;
     }
     const openIndex = current.indexOf(openTag);
     if (openIndex === -1) {
       const candidateLength = artifactOpenCandidateLength(current, openTag);
-      if (suppressNextArtifactText && candidateLength > 0) {
+      if ((suppressNextArtifactText || recentWriteContents.length > 0) && candidateLength > 0) {
         artifactOpenCandidate = current.slice(-candidateLength);
         return current.slice(0, -candidateLength);
-      }
-      if (suppressNextArtifactText) {
-        suppressNextArtifactText = false;
-        return current;
       }
       return current;
     }
     suppressDuplicateArtifactText = true;
     suppressNextArtifactText = false;
+    duplicateArtifactCandidate = current.slice(openIndex);
     const prefix = `${pendingArtifactText}${current.slice(0, openIndex)}`;
     pendingArtifactText = '';
-    return `${prefix}${stripDuplicateArtifactText(current.slice(openIndex))}`;
+    return `${prefix}${stripDuplicateArtifactText('')}`;
+  }
+
+  function isRedundantWrittenArtifact(candidate: string): boolean {
+    const gt = candidate.indexOf('>');
+    const close = candidate.lastIndexOf('</artifact>');
+    if (gt === -1 || close === -1 || close <= gt) return false;
+    if (
+      options.suppressHtmlArtifactsAfterFileWrite === true &&
+      isHtmlArtifact(candidate) &&
+      wroteHtmlFileThisTurn
+    ) return true;
+    const body = normalizeArtifactEchoContent(candidate.slice(gt + 1, close));
+    return recentWriteContents.some((content) => content === body);
+  }
+
+  function isHtmlArtifact(candidate: string): boolean {
+    const openTag = candidate.slice(0, Math.max(0, candidate.indexOf('>') + 1));
+    return /\btype\s*=\s*["']text\/html["']/i.test(openTag);
+  }
+
+  function normalizeArtifactEchoContent(value: string): string {
+    return value
+      .replace(/^\uFEFF/, '')
+      .replace(/\r\n?/g, '\n')
+      .replace(/^(?:\s|\\r|\\n)+|(?:\s|\\r|\\n)+$/g, '');
   }
 
   function artifactOpenCandidateLength(text: string, openTag: string): number {
@@ -278,6 +326,21 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
     if (!writesFile) return false;
     if (/\.(html|htm|css|js|jsx|ts|tsx|md)$/iu.test(path)) return true;
     return typeof input.content === 'string' || typeof input.new_string === 'string';
+  }
+
+  function fileWriteContent(input: unknown): string | null {
+    if (!isRecord(input)) return null;
+    if (typeof input.content === 'string') return input.content;
+    if (typeof input.new_string === 'string') return input.new_string;
+    return null;
+  }
+
+  function isHtmlWriteToolInput(input: unknown): boolean {
+    if (!isRecord(input)) return false;
+    const rawPath = input.file_path ?? input.filePath;
+    if (typeof rawPath === 'string' && /\.(?:html?|xhtml)$/i.test(rawPath)) return true;
+    const content = fileWriteContent(input);
+    return typeof content === 'string' && /<!doctype\s+html\b|<html\b/i.test(content);
   }
 
   function feed(chunk: string) {
@@ -387,6 +450,10 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       // close stream-json input stdin.
       if (stopReason) {
         onEvent({ type: 'turn_end', stopReason });
+        if (stopReason !== 'tool_use') {
+          recentWriteContents.length = 0;
+          wroteHtmlFileThisTurn = false;
+        }
       }
       if (typeof obj.error === 'string' && obj.error.trim()) {
         onEvent({
@@ -527,11 +594,15 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   }
 
   function flushPendingArtifactText() {
-    const text = `${pendingArtifactText}${artifactOpenCandidate}`;
+    const text = `${pendingArtifactText}${artifactOpenCandidate}${duplicateArtifactCandidate}`;
     if (!text) return;
     pendingArtifactText = '';
     artifactOpenCandidate = '';
+    duplicateArtifactCandidate = '';
     suppressNextArtifactText = false;
+    suppressDuplicateArtifactText = false;
+    recentWriteContents.length = 0;
+    wroteHtmlFileThisTurn = false;
     emitSafeText(currentMessageId, text);
   }
 

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -82,7 +82,6 @@ export function createClaudeStreamHandler(
   let pendingArtifactText = '';
   let duplicateArtifactCandidate = '';
   const recentWriteContents: string[] = [];
-  let wroteHtmlFileThisTurn = false;
 
   function normalizeTaskStatus(value: unknown): RuntimeTask['status'] {
     if (value === 'completed' || value === 'in_progress' || value === 'stopped') {
@@ -177,7 +176,6 @@ export function createClaudeStreamHandler(
       suppressNextArtifactText = true;
       const content = fileWriteContent(input);
       if (content) {
-        wroteHtmlFileThisTurn = wroteHtmlFileThisTurn || isHtmlWriteToolInput(input);
         recentWriteContents.push(normalizeArtifactEchoContent(content));
         if (recentWriteContents.length > 5) recentWriteContents.shift();
       }
@@ -283,18 +281,8 @@ export function createClaudeStreamHandler(
     const gt = candidate.indexOf('>');
     const close = candidate.lastIndexOf('</artifact>');
     if (gt === -1 || close === -1 || close <= gt) return false;
-    if (
-      options.suppressHtmlArtifactsAfterFileWrite === true &&
-      isHtmlArtifact(candidate) &&
-      wroteHtmlFileThisTurn
-    ) return true;
     const body = normalizeArtifactEchoContent(candidate.slice(gt + 1, close));
     return recentWriteContents.some((content) => content === body);
-  }
-
-  function isHtmlArtifact(candidate: string): boolean {
-    const openTag = candidate.slice(0, Math.max(0, candidate.indexOf('>') + 1));
-    return /\btype\s*=\s*["']text\/html["']/i.test(openTag);
   }
 
   function normalizeArtifactEchoContent(value: string): string {
@@ -452,7 +440,6 @@ export function createClaudeStreamHandler(
         onEvent({ type: 'turn_end', stopReason });
         if (stopReason !== 'tool_use') {
           recentWriteContents.length = 0;
-          wroteHtmlFileThisTurn = false;
         }
       }
       if (typeof obj.error === 'string' && obj.error.trim()) {
@@ -602,7 +589,6 @@ export function createClaudeStreamHandler(
     suppressNextArtifactText = false;
     suppressDuplicateArtifactText = false;
     recentWriteContents.length = 0;
-    wroteHtmlFileThisTurn = false;
     emitSafeText(currentMessageId, text);
   }
 

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -82,6 +82,7 @@ export function createClaudeStreamHandler(
   let pendingArtifactText = '';
   let duplicateArtifactCandidate = '';
   const recentWriteContents: string[] = [];
+  let wroteHtmlFileThisTurn = false;
 
   function normalizeTaskStatus(value: unknown): RuntimeTask['status'] {
     if (value === 'completed' || value === 'in_progress' || value === 'stopped') {
@@ -176,6 +177,7 @@ export function createClaudeStreamHandler(
       suppressNextArtifactText = true;
       const content = fileWriteContent(input);
       if (content) {
+        wroteHtmlFileThisTurn = wroteHtmlFileThisTurn || isHtmlWriteToolInput(input);
         recentWriteContents.push(normalizeArtifactEchoContent(content));
         if (recentWriteContents.length > 5) recentWriteContents.shift();
       }
@@ -281,8 +283,18 @@ export function createClaudeStreamHandler(
     const gt = candidate.indexOf('>');
     const close = candidate.lastIndexOf('</artifact>');
     if (gt === -1 || close === -1 || close <= gt) return false;
+    if (
+      options.suppressHtmlArtifactsAfterFileWrite === true &&
+      isHtmlArtifact(candidate) &&
+      wroteHtmlFileThisTurn
+    ) return true;
     const body = normalizeArtifactEchoContent(candidate.slice(gt + 1, close));
     return recentWriteContents.some((content) => content === body);
+  }
+
+  function isHtmlArtifact(candidate: string): boolean {
+    const openTag = candidate.slice(0, Math.max(0, candidate.indexOf('>') + 1));
+    return /\btype\s*=\s*["']text\/html["']/i.test(openTag);
   }
 
   function normalizeArtifactEchoContent(value: string): string {
@@ -440,6 +452,7 @@ export function createClaudeStreamHandler(
         onEvent({ type: 'turn_end', stopReason });
         if (stopReason !== 'tool_use') {
           recentWriteContents.length = 0;
+          wroteHtmlFileThisTurn = false;
         }
       }
       if (typeof obj.error === 'string' && obj.error.trim()) {
@@ -589,6 +602,7 @@ export function createClaudeStreamHandler(
     suppressNextArtifactText = false;
     suppressDuplicateArtifactText = false;
     recentWriteContents.length = 0;
+    wroteHtmlFileThisTurn = false;
     emitSafeText(currentMessageId, text);
   }
 

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -305,6 +305,18 @@ printf '%s\\n' "\$last"
 
 For the best fal image model use \`--model flux-pro-ultra\`. For video use \`--model veo-3-fal\` or \`--model wan-2.1-t2v\`. Always pass \`--surface\` explicitly (\`image\`, \`video\`, or \`audio\`). Any \`fal-ai/*\` path (e.g. \`fal-ai/flux/schnell\`, \`fal-ai/wan-i2v\`) is also a valid \`--model\` value for image/video — pass it through as-is without substitution.`;
 
+const CLAUDE_FILESYSTEM_ARTIFACT_HANDOFF_OVERRIDE = `
+
+---
+
+## Claude Code filesystem handoff
+
+You are running as Claude Code with filesystem tools. When you write or edit an HTML file in the project folder with Write/Edit, that file is already visible in the user's file panel and preview.
+
+- Do not output the full same HTML again in a \`<artifact type="text/html">...</artifact>\` block after writing it to disk.
+- After the final self-check, briefly name the written file and summarize the result instead.
+- Only emit a full HTML \`<artifact>\` block if you could not write the project file through the filesystem tools.`;
+
 export function buildExamplePromptOverride(
   title?: string | null,
   brief?: Record<string, string> | null,
@@ -823,6 +835,10 @@ export function composeSystemPrompt({
     parts.push(
       "\n\n---\n\n## Gemini todo tool mapping\n\nWhen an Open Design instruction says to call `TodoWrite`, use Gemini CLI's native `write_todos` tool only if it is present in the current tool list. Pass the full task list as `todos`, with each item using `description` for the task text and `status` set to `pending`, `in_progress`, `completed`, `cancelled`, or `blocked`.\n\nIf `write_todos` is not present, do not simulate it with markdown, plan-mode files, JSON files, TODO files, or shell commands. Continue the work normally without a todo tool.",
     );
+  }
+
+  if (agentId === 'claude') {
+    parts.push(CLAUDE_FILESYSTEM_ARTIFACT_HANDOFF_OVERRIDE);
   }
 
   // Mid-conversation clarification reuses the same `<question-form>` flow as

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13476,7 +13476,7 @@ export async function startServer({
         try {
           applyClaudeStreamJsonRunBookkeeping(run, ev);
         } catch {}
-      });
+      }, { suppressHtmlArtifactsAfterFileWrite: def.id === 'claude' });
       child.stdout.on('data', (chunk) => claude.feed(chunk));
       child.on('close', () => claude.flush());
     } else if (def.streamFormat === 'qoder-stream-json') {

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -256,7 +256,7 @@ describe('structured agent stream fixtures', () => {
     })).toBe(false);
   });
 
-  it('preserves later Claude artifact text after plain prose clears file-write suppression', () => {
+  it('suppresses duplicate Claude artifact text after intervening prose', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
     handler.feed(`${JSON.stringify({
@@ -310,7 +310,110 @@ describe('structured agent stream fixtures', () => {
     });
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: '<artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>Done',
+      delta: 'Done',
+    });
+    expect(events.some((event) => {
+      if (typeof event !== 'object' || event === null) return false;
+      const record = event as { type?: string; delta?: string };
+      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<!doctype html>');
+    })).toBe(false);
+  });
+
+  it('suppresses later Claude HTML artifact text after prose even when content differs from the write', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler(
+      (event: unknown) => events.push(event),
+      { suppressHtmlArtifactsAfterFileWrite: true },
+    );
+    handler.feed(`${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: 'msg-1' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu-write-1', name: 'Write' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: '{"file_path":"index.html","content":"<!doctype html><html>written</html>"}',
+        },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_stop',
+        index: 0,
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: '全部完成。\\n\\n' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 1,
+        delta: {
+          type: 'text_delta',
+          text: '<artifact identifier="page" type="text/html">\\n<!doctype html><html>different</html>\\n</artifact>Done',
+        },
+      },
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: '全部完成。\\n\\n',
+    });
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Done',
+    });
+    expect(events.some((event) => {
+      if (typeof event !== 'object' || event === null) return false;
+      const record = event as { type?: string; delta?: string };
+      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<html>different</html>');
+    })).toBe(false);
+  });
+
+  it('preserves different later HTML artifacts unless Claude filesystem suppression is enabled', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-1',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu-write-1',
+            name: 'Write',
+            input: {
+              file_path: 'index.html',
+              content: '<!doctype html><html>written</html>',
+            },
+          },
+          {
+            type: 'text',
+            text: 'Final:\\n\\n<artifact identifier="page" type="text/html">\\n<!doctype html><html>different</html>\\n</artifact>',
+          },
+        ],
+      },
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Final:\\n\\n<artifact identifier="page" type="text/html">\\n<!doctype html><html>different</html>\\n</artifact>',
     });
   });
 
@@ -399,9 +502,12 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
-  it('preserves later Claude artifact text after suppressing immediate file-write echo', () => {
+  it('suppresses later Claude HTML artifact text after suppressing immediate file-write echo', () => {
     const events: unknown[] = [];
-    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    const handler = createClaudeStreamHandler(
+      (event: unknown) => events.push(event),
+      { suppressHtmlArtifactsAfterFileWrite: true },
+    );
     handler.feed(`${JSON.stringify({
       type: 'assistant',
       message: {
@@ -435,12 +541,14 @@ describe('structured agent stream fixtures', () => {
     });
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: 'Final artifact:\\n\\n<artifact identifier="final" type="text/html">\\n<!doctype html><html>final</html>\\n</artifact>',
+      delta: 'Final artifact:\\n\\n',
     });
     expect(events.some((event) => {
       if (typeof event !== 'object' || event === null) return false;
       const record = event as { type?: string; delta?: string };
-      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<html>helper</html>');
+      return record.type === 'text_delta' && typeof record.delta === 'string' && (
+        record.delta.includes('<html>helper</html>') || record.delta.includes('<html>final</html>')
+      );
     })).toBe(false);
   });
 

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -319,7 +319,7 @@ describe('structured agent stream fixtures', () => {
     })).toBe(false);
   });
 
-  it('suppresses later Claude HTML artifact text after prose even when content differs from the write', () => {
+  it('preserves later Claude HTML artifact text after prose when content differs from the write', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler(
       (event: unknown) => events.push(event),
@@ -376,13 +376,8 @@ describe('structured agent stream fixtures', () => {
     });
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: 'Done',
+      delta: '<artifact identifier="page" type="text/html">\\n<!doctype html><html>different</html>\\n</artifact>Done',
     });
-    expect(events.some((event) => {
-      if (typeof event !== 'object' || event === null) return false;
-      const record = event as { type?: string; delta?: string };
-      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<html>different</html>');
-    })).toBe(false);
   });
 
   it('preserves different later HTML artifacts unless Claude filesystem suppression is enabled', () => {
@@ -502,7 +497,7 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
-  it('suppresses later Claude HTML artifact text after suppressing immediate file-write echo', () => {
+  it('preserves distinct later Claude HTML artifact text after suppressing immediate file-write echo', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler(
       (event: unknown) => events.push(event),
@@ -541,14 +536,12 @@ describe('structured agent stream fixtures', () => {
     });
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: 'Final artifact:\\n\\n',
+      delta: 'Final artifact:\\n\\n<artifact identifier="final" type="text/html">\\n<!doctype html><html>final</html>\\n</artifact>',
     });
     expect(events.some((event) => {
       if (typeof event !== 'object' || event === null) return false;
       const record = event as { type?: string; delta?: string };
-      return record.type === 'text_delta' && typeof record.delta === 'string' && (
-        record.delta.includes('<html>helper</html>') || record.delta.includes('<html>final</html>')
-      );
+      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<html>helper</html>');
     })).toBe(false);
   });
 

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -319,7 +319,7 @@ describe('structured agent stream fixtures', () => {
     })).toBe(false);
   });
 
-  it('preserves later Claude HTML artifact text after prose when content differs from the write', () => {
+  it('suppresses later Claude HTML artifact text after prose even when content differs from the write', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler(
       (event: unknown) => events.push(event),
@@ -376,8 +376,13 @@ describe('structured agent stream fixtures', () => {
     });
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: '<artifact identifier="page" type="text/html">\\n<!doctype html><html>different</html>\\n</artifact>Done',
+      delta: 'Done',
     });
+    expect(events.some((event) => {
+      if (typeof event !== 'object' || event === null) return false;
+      const record = event as { type?: string; delta?: string };
+      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<html>different</html>');
+    })).toBe(false);
   });
 
   it('preserves different later HTML artifacts unless Claude filesystem suppression is enabled', () => {
@@ -497,7 +502,7 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
-  it('preserves distinct later Claude HTML artifact text after suppressing immediate file-write echo', () => {
+  it('suppresses later Claude HTML artifact text after suppressing immediate file-write echo', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler(
       (event: unknown) => events.push(event),
@@ -536,12 +541,14 @@ describe('structured agent stream fixtures', () => {
     });
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: 'Final artifact:\\n\\n<artifact identifier="final" type="text/html">\\n<!doctype html><html>final</html>\\n</artifact>',
+      delta: 'Final artifact:\\n\\n',
     });
     expect(events.some((event) => {
       if (typeof event !== 'object' || event === null) return false;
       const record = event as { type?: string; delta?: string };
-      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<html>helper</html>');
+      return record.type === 'text_delta' && typeof record.delta === 'string' && (
+        record.delta.includes('<html>helper</html>') || record.delta.includes('<html>final</html>')
+      );
     })).toBe(false);
   });
 

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -624,7 +624,7 @@ function AssistantMessageImpl({
               <ProseBlock
                 key={i}
                 text={b.text}
-                hideRecoveredHtmlFallback={message.agentId === "grok-build" && !streaming}
+                hideRecoveredHtmlFallback={(message.agentId === "grok-build" || message.agentId === "claude") && !streaming}
                 assistantMessageId={message.id}
                 isLastAssistant={!!isLast}
                 streaming={streaming}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2785,12 +2785,18 @@ export function ProjectView({
                   ? parsedArtifact
                   : artifactFromStandaloneHtml(replayedContent);
                 if (artifactToPersist?.html) {
+                  const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
                   const runStartedAt = status.createdAt || message.startedAt || message.createdAt;
                   recoveredExistingArtifact = findExistingArtifactProjectFile(
                     artifactToPersist,
                     nextFiles,
                     { minMtime: runStartedAt },
-                  );
+                  ) ?? await findSameTurnHtmlWriteForRecoveredArtifact({
+                    artifactHtml: artifactToPersist.html,
+                    producedFiles: producedBeforeFallback,
+                    readProjectHtml,
+                    allowAnyHtmlWrite: message.agentId === 'claude',
+                  });
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
                     requestOpenFile(recoveredExistingArtifact.name);
@@ -2925,6 +2931,7 @@ export function ProjectView({
     clearActiveRunRefs,
     clearCurrentRunStreamingMarker,
     refreshProjectFiles,
+    readProjectHtml,
     persistArtifact,
     requestOpenFile,
     onProjectsRefresh,
@@ -3529,8 +3536,20 @@ export function ProjectView({
               ? parsedArtifact
               : artifactFromStandaloneHtml(finalText);
             if (artifactToPersist?.html) {
-              await persistArtifact(artifactToPersist, nextFiles, finalText);
-              nextFiles = await refreshProjectFiles();
+              const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+              const sameTurnHtmlWrite = await findSameTurnHtmlWriteForRecoveredArtifact({
+                artifactHtml: artifactToPersist.html,
+                producedFiles: producedBeforeFallback,
+                readProjectHtml,
+                allowAnyHtmlWrite: assistantAgentId === 'claude',
+              });
+              if (sameTurnHtmlWrite) {
+                savedArtifactRef.current = sameTurnHtmlWrite.name;
+                requestOpenFile(sameTurnHtmlWrite.name);
+              } else {
+                await persistArtifact(artifactToPersist, nextFiles, finalText);
+                nextFiles = await refreshProjectFiles();
+              }
             }
             const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
             const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
@@ -3834,6 +3853,7 @@ export function ProjectView({
       projectFiles,
       refreshProjectFiles,
       refreshLiveArtifacts,
+      readProjectHtml,
       requestOpenFile,
       persistMessage,
       persistMessageById,
@@ -6304,6 +6324,42 @@ export function mergeRecoveredArtifact(
   if (!recovered) return [...diff];
   if (diff.some((f) => f.name === recovered.name)) return [...diff];
   return [...diff, recovered];
+}
+
+export async function findSameTurnHtmlWriteForRecoveredArtifact({
+  artifactHtml,
+  producedFiles,
+  readProjectHtml,
+  allowAnyHtmlWrite = false,
+}: {
+  artifactHtml: string;
+  producedFiles: readonly ProjectFile[];
+  readProjectHtml: (name: string) => Promise<string | null>;
+  allowAnyHtmlWrite?: boolean;
+}): Promise<ProjectFile | null> {
+  const recovered = normalizeHtmlForRecoveredArtifactComparison(artifactHtml);
+  if (!recovered) return null;
+  const candidates = producedFiles.filter(isHtmlProjectFile);
+  for (const file of candidates) {
+    const text = await readProjectHtml(file.name);
+    if (normalizeHtmlForRecoveredArtifactComparison(text) === recovered) {
+      return file;
+    }
+  }
+  if (allowAnyHtmlWrite) return candidates[0] ?? null;
+  return null;
+}
+
+function isHtmlProjectFile(file: ProjectFile): boolean {
+  const name = (file.path || file.name).toLowerCase();
+  return file.kind === 'html' || /\.(?:html?|xhtml)$/u.test(name);
+}
+
+function normalizeHtmlForRecoveredArtifactComparison(value: string | null | undefined): string {
+  return String(value || '')
+    .replace(/^\uFEFF/, '')
+    .replace(/\r\n?/g, '\n')
+    .trim();
 }
 
 export function clearStreamingConversationMarker(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2795,7 +2795,6 @@ export function ProjectView({
                     artifactHtml: artifactToPersist.html,
                     producedFiles: producedBeforeFallback,
                     readProjectHtml,
-                    allowAnyHtmlWrite: message.agentId === 'claude',
                   });
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
@@ -3541,7 +3540,6 @@ export function ProjectView({
                 artifactHtml: artifactToPersist.html,
                 producedFiles: producedBeforeFallback,
                 readProjectHtml,
-                allowAnyHtmlWrite: assistantAgentId === 'claude',
               });
               if (sameTurnHtmlWrite) {
                 savedArtifactRef.current = sameTurnHtmlWrite.name;
@@ -6330,12 +6328,10 @@ export async function findSameTurnHtmlWriteForRecoveredArtifact({
   artifactHtml,
   producedFiles,
   readProjectHtml,
-  allowAnyHtmlWrite = false,
 }: {
   artifactHtml: string;
   producedFiles: readonly ProjectFile[];
   readProjectHtml: (name: string) => Promise<string | null>;
-  allowAnyHtmlWrite?: boolean;
 }): Promise<ProjectFile | null> {
   const recovered = normalizeHtmlForRecoveredArtifactComparison(artifactHtml);
   if (!recovered) return null;
@@ -6346,7 +6342,6 @@ export async function findSameTurnHtmlWriteForRecoveredArtifact({
       return file;
     }
   }
-  if (allowAnyHtmlWrite) return candidates[0] ?? null;
   return null;
 }
 

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2795,6 +2795,7 @@ export function ProjectView({
                     artifactHtml: artifactToPersist.html,
                     producedFiles: producedBeforeFallback,
                     readProjectHtml,
+                    allowAnyHtmlWrite: message.agentId === 'claude',
                   });
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
@@ -3540,6 +3541,7 @@ export function ProjectView({
                 artifactHtml: artifactToPersist.html,
                 producedFiles: producedBeforeFallback,
                 readProjectHtml,
+                allowAnyHtmlWrite: assistantAgentId === 'claude',
               });
               if (sameTurnHtmlWrite) {
                 savedArtifactRef.current = sameTurnHtmlWrite.name;
@@ -6328,10 +6330,12 @@ export async function findSameTurnHtmlWriteForRecoveredArtifact({
   artifactHtml,
   producedFiles,
   readProjectHtml,
+  allowAnyHtmlWrite = false,
 }: {
   artifactHtml: string;
   producedFiles: readonly ProjectFile[];
   readProjectHtml: (name: string) => Promise<string | null>;
+  allowAnyHtmlWrite?: boolean;
 }): Promise<ProjectFile | null> {
   const recovered = normalizeHtmlForRecoveredArtifactComparison(artifactHtml);
   if (!recovered) return null;
@@ -6342,6 +6346,7 @@ export async function findSameTurnHtmlWriteForRecoveredArtifact({
       return file;
     }
   }
+  if (allowAnyHtmlWrite) return candidates[0] ?? null;
   return null;
 }
 

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ProjectView,
   computeProducedFiles,
+  findSameTurnHtmlWriteForRecoveredArtifact,
   mergeRecoveredArtifact,
 } from '../../src/components/ProjectView';
 import type { ChatMessage } from '../../src/types';
@@ -197,6 +198,58 @@ describe('mergeRecoveredArtifact', () => {
   it('returns the diff unchanged when no artifact was recovered', () => {
     const merged = mergeRecoveredArtifact([fileA] as never, null);
     expect(merged.map((f) => f.name)).toEqual(['helper.txt']);
+  });
+});
+
+describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
+  const html = '<!doctype html><html><head><title>Demo</title></head><body><main><h1>Demo</h1></main></body></html>';
+
+  it('returns the same-turn HTML file when fallback content matches a Write output', async () => {
+    const indexFile = {
+      name: 'index.html',
+      path: 'index.html',
+      size: html.length,
+      mtime: 2,
+      kind: 'html',
+      mime: 'text/html',
+    };
+    const readProjectHtml = vi.fn(async (name: string) =>
+      name === 'index.html' ? `\uFEFF${html}\r\n` : null,
+    );
+
+    await expect(findSameTurnHtmlWriteForRecoveredArtifact({
+      artifactHtml: `\n${html}\n`,
+      producedFiles: [indexFile] as never,
+      readProjectHtml,
+    })).resolves.toBe(indexFile);
+  });
+
+  it('does not treat different same-turn HTML files as duplicates', async () => {
+    const indexFile = {
+      name: 'index.html',
+      path: 'index.html',
+      size: html.length,
+      mtime: 2,
+      kind: 'html',
+      mime: 'text/html',
+    };
+
+    await expect(findSameTurnHtmlWriteForRecoveredArtifact({
+      artifactHtml: html,
+      producedFiles: [indexFile] as never,
+      readProjectHtml: vi.fn(async () => html.replace('Demo</h1>', 'Other</h1>')),
+    })).resolves.toBeNull();
+  });
+
+  it('ignores non-HTML same-turn files', async () => {
+    const readProjectHtml = vi.fn(async () => html);
+
+    await expect(findSameTurnHtmlWriteForRecoveredArtifact({
+      artifactHtml: html,
+      producedFiles: [{ name: 'notes.md', path: 'notes.md', kind: 'text' }] as never,
+      readProjectHtml,
+    })).resolves.toBeNull();
+    expect(readProjectHtml).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -224,10 +224,10 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
     })).resolves.toBe(indexFile);
   });
 
-  it('does not treat different same-turn HTML files as duplicates', async () => {
+  it('does not treat different same-turn HTML files as duplicates even for Claude-shaped fallback input', async () => {
     const indexFile = {
-      name: 'index.html',
-      path: 'index.html',
+      name: 'helper.html',
+      path: 'helper.html',
       size: html.length,
       mtime: 2,
       kind: 'html',
@@ -238,7 +238,8 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
       artifactHtml: html,
       producedFiles: [indexFile] as never,
       readProjectHtml: vi.fn(async () => html.replace('Demo</h1>', 'Other</h1>')),
-    })).resolves.toBeNull();
+      allowAnyHtmlWrite: true,
+    } as never)).resolves.toBeNull();
   });
 
   it('ignores non-HTML same-turn files', async () => {

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -224,10 +224,10 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
     })).resolves.toBe(indexFile);
   });
 
-  it('does not treat different same-turn HTML files as duplicates even for Claude-shaped fallback input', async () => {
+  it('does not treat different same-turn HTML files as duplicates', async () => {
     const indexFile = {
-      name: 'helper.html',
-      path: 'helper.html',
+      name: 'index.html',
+      path: 'index.html',
       size: html.length,
       mtime: 2,
       kind: 'html',
@@ -238,8 +238,7 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
       artifactHtml: html,
       producedFiles: [indexFile] as never,
       readProjectHtml: vi.fn(async () => html.replace('Demo</h1>', 'Other</h1>')),
-      allowAnyHtmlWrite: true,
-    } as never)).resolves.toBeNull();
+    })).resolves.toBeNull();
   });
 
   it('ignores non-HTML same-turn files', async () => {


### PR DESCRIPTION
## Why

While testing Claude Code generation, a completed `Write(index.html)` was followed by a second full `<artifact type="text/html">...</artifact>` in streamed text. The UI kept timing until Claude finished emitting that duplicate HTML, then the completion path saved the streamed artifact as a second design file.

Root cause: Claude Code now has a filesystem-backed delivery path through `Write/Edit`, but the shared artifact handoff prompt still asked agents to emit a final HTML artifact after creating a new canonical file. That prompt is still useful for agents that rely on final text artifacts, but it conflicts with Claude Code's project-file source of truth.

## What users will see

When using Claude Code, generated HTML files written to the project should no longer be echoed back as a second streaming code artifact or saved as a duplicate file at the end of the run. Other agents keep the existing artifact handoff behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This changes Claude Code streaming/persistence behavior rather than adding a new UI entry point.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/structured-streams.test.ts`
- Did the test go red on `main` and green on this branch? The new regression covers the observed Claude shape: a file `Write` followed by a later HTML artifact with different content. It passes on this branch; I did not run it on `main` after writing the fix.
- Additional verification: inspected the affected run log and confirmed Claude emitted both a `Write(index.html)` and a later `<artifact identifier="nexus-dashboard" type="text/html">...` text delta. The two saved files were similar but not byte-identical.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/structured-streams.test.ts`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`
