### PR TITLE
feat(daemon): add OD_ALLOWED_INTERNAL_HOSTS allowlist for internal provider endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ od skill list --scenario marketing
 
 **Security model.** Read-only by default, the daemon binds to `127.0.0.1`, and SSRF is blocked at the proxy edge. LAN exposure requires an explicit `OD_BIND_HOST` plus `OD_ALLOWED_ORIGINS`. Connector credentials and live-artifact preview routes stay loopback-only regardless.
 
+**Internally-hosted model endpoints.** To prevent SSRF, the daemon blocks provider base URLs that resolve to private/internal address ranges (RFC1918, link-local, CGNAT, and cloud-metadata IPs) by default, surfacing `Internal IPs blocked`. If you run an internally-hosted gateway (e.g. LiteLLM or Ollama on a VPN-only `10.x`/`192.168.x` address), opt that host out with `OD_ALLOWED_INTERNAL_HOSTS=<host1>,<host2>,...` — a comma- or whitespace-separated list of bare hostnames or IPs (`10.0.0.5`, `litellm.internal.corp`; a `host:port` or full URL is accepted and reduced to its hostname; IPv6 must be bracketed, e.g. `[fd00::1]`). The allowlist is strict opt-in (empty by default), exact-host (no subdomain/substring matching), and applies **only** to provider endpoints you configure (connection test, model discovery, BYOK chat). It deliberately does **not** relax the guard on download URLs returned inside upstream responses, which stay blocked. A malformed entry — or CIDR notation, which is not supported — is dropped with a warning rather than silently trusted, so a typo never quietly widens (or fails to widen) the guard. Allowlisting a hostname trusts whatever it resolves to (like `OD_ALLOWED_ORIGINS`); allowlist the resolved IP instead if you want the DNS-resolved address re-checked.
+
 ---
 
 ## Skills

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -58,12 +58,15 @@ import type { AgentCliEnvPrefs } from './app-config.js';
 import type { RuntimeAgentDef } from './runtimes/types.js';
 import { resolveModelForAgent } from './runtimes/models.js';
 import { preparePromptFileForAgent, type PreparedPromptFile } from './runtimes/prompt-file.js';
+import { configuredAllowedInternalHosts } from './origin-validation.js';
 import {
+  isAllowlistedInternalHost,
   isBlockedExternalApiHostname,
   isLoopbackApiHost,
   validateBaseUrl,
   type AgentTestRequest,
   type BaseUrlValidationResult,
+  type ValidateBaseUrlOptions,
   type ConnectionTestDiagnostics,
   type ConnectionTestKind,
   type ConnectionTestPhase,
@@ -113,12 +116,18 @@ function looksLikeIpLiteral(hostname: string): boolean {
 export async function validateBaseUrlResolved(
   baseUrl: string,
   lookup: DnsLookupFn = defaultDnsLookup,
+  options: ValidateBaseUrlOptions = {},
 ): Promise<BaseUrlValidationResult> {
-  const sync = validateBaseUrl(baseUrl);
+  const sync = validateBaseUrl(baseUrl, options);
   if (sync.error || !sync.parsed) return sync;
 
   const hostname = sync.parsed.hostname.toLowerCase();
   if (isLoopbackApiHost(hostname)) return sync;
+  // Issue #3225 — an operator who trusts this hostname has opted it out of the
+  // guard entirely, so skip the resolved-IP block even though it points into
+  // private space. The sync check above already honored a literal-IP allowlist
+  // entry; this covers the hostname-that-resolves-private case.
+  if (isAllowlistedInternalHost(hostname, options.allowedInternalHosts)) return sync;
   if (looksLikeIpLiteral(hostname)) return sync;
 
   let addresses: DnsLookupAddress[];
@@ -131,12 +140,38 @@ export async function validateBaseUrlResolved(
   for (const addr of addresses) {
     const ip = String(addr.address).toLowerCase();
     if (isLoopbackApiHost(ip)) continue;
+    // A resolved address the operator explicitly allowlisted (they listed the
+    // IP rather than the hostname) is permitted; everything else in private
+    // space is still blocked.
+    if (isAllowlistedInternalHost(ip, options.allowedInternalHosts)) continue;
     if (isBlockedExternalApiHostname(ip)) {
       return { error: 'Internal IPs blocked', forbidden: true };
     }
   }
 
   return sync;
+}
+
+/**
+ * Validate a base URL that the USER deliberately configured as a provider
+ * endpoint (connection test, model discovery, BYOK chat dispatch). Identical
+ * to {@link validateBaseUrlResolved} except it honors the operator's
+ * `OD_ALLOWED_INTERNAL_HOSTS` allowlist (issue #3225), so an internally hosted
+ * gateway on an RFC1918 address can be reached when — and only when — the
+ * operator opted in.
+ *
+ * INVARIANT: use this ONLY for user-configured endpoints. URLs that arrive
+ * inside an upstream response (image/video download links) are
+ * attacker-controllable and MUST stay on the strict {@link assertExternalAssetUrl}
+ * / {@link validateBaseUrlResolved} path, which never consults the allowlist.
+ */
+export function validateUserProviderBaseUrl(
+  baseUrl: string,
+  lookup: DnsLookupFn = defaultDnsLookup,
+): Promise<BaseUrlValidationResult> {
+  return validateBaseUrlResolved(baseUrl, lookup, {
+    allowedInternalHosts: configuredAllowedInternalHosts(),
+  });
 }
 
 /**
@@ -1229,7 +1264,7 @@ export async function testProviderConnection(
   const start = Date.now();
   const model = String(input.model ?? '');
   const normalizedInput = normalizeProviderTestInput(input);
-  const validated = await validateBaseUrlResolved(normalizedInput.baseUrl);
+  const validated = await validateUserProviderBaseUrl(normalizedInput.baseUrl);
   if (validated.error || !validated.parsed) {
     const kind: ConnectionTestKind = validated.forbidden ? 'forbidden' : 'invalid_base_url';
     return {

--- a/apps/daemon/src/integrations/provider-models.ts
+++ b/apps/daemon/src/integrations/provider-models.ts
@@ -8,7 +8,7 @@ import type {
   ProviderModelsResponse,
 } from '@open-design/contracts/api/providerModels';
 import { isLoopbackApiHost } from '@open-design/contracts/api/connectionTest';
-import { redactSecrets, validateBaseUrlResolved } from '../connectionTest.js';
+import { redactSecrets, validateUserProviderBaseUrl } from '../connectionTest.js';
 import { googleProviderModelsUrl, normalizeGoogleModelId } from './google-models.js';
 import { aihubmixHeaders, aihubmixCatalogUrl, parseAIHubMixCatalog } from './aihubmix.js';
 
@@ -221,7 +221,7 @@ export async function listProviderModels(
     };
   }
 
-  const validated = await validateBaseUrlResolved(input.baseUrl);
+  const validated = await validateUserProviderBaseUrl(input.baseUrl);
   if (validated.error || !validated.parsed) {
     return {
       ok: false,

--- a/apps/daemon/src/origin-validation.ts
+++ b/apps/daemon/src/origin-validation.ts
@@ -32,6 +32,63 @@ export function configuredAllowedHosts(origins = configuredAllowedOrigins()): st
   return origins.map((origin) => new URL(origin).host);
 }
 
+// Issue #3225 — operator-declared allowlist of internal hosts that are exempt
+// from the default-deny SSRF guard for USER-CONFIGURED provider endpoints (an
+// internally-hosted LiteLLM/Ollama on an RFC1918 address reachable only over
+// VPN). Comma- or whitespace-separated; each entry may be a bare host
+// (`10.0.0.5`), `host:port`, or a full URL — only the hostname is retained,
+// since the SSRF block is host-based. IPv6 literals must be bracketed
+// (`[fd00::1]` or `[fd00::1]:4000`) so the port is unambiguous; the brackets
+// are stripped here so the result compares directly against a resolved
+// address. An empty/unset value yields `[]`, preserving the strict default
+// for every deployment that does not opt in.
+//
+// A malformed entry — or CIDR notation, which the host-based matcher cannot
+// honor — is dropped with a warning rather than silently trusted, so a typo
+// can never quietly widen (or quietly fail to widen) the guard. This list is
+// threaded ONLY into the user-configured-endpoint validators, never the
+// attacker-controllable asset-download guard (`assertExternalAssetUrl`).
+export function configuredAllowedInternalHosts(
+  env: NodeJS.ProcessEnv = process.env,
+  warn: (message: string) => void = (message) => console.warn(message),
+): string[] {
+  const raw = env.OD_ALLOWED_INTERNAL_HOSTS || '';
+  if (!raw.trim()) return [];
+  const hosts: string[] = [];
+  for (const part of raw.split(/[,\s]+/)) {
+    const entry = part.trim();
+    if (!entry) continue;
+    // A bare `10.0.0.0/24` parses as host `10.0.0.0` + path `/24`, so keeping
+    // it would silently trust a single network address the operator never
+    // meant. Reject loudly. (A full URL whose path happens to look numeric
+    // still carries a scheme, so exclude those from the CIDR heuristic.)
+    if (!entry.includes('://') && /^[^/]+\/\d{1,3}$/.test(entry)) {
+      warn(
+        `[ssrf] ignoring CIDR entry in OD_ALLOWED_INTERNAL_HOSTS: ${JSON.stringify(entry)} — list individual hosts instead`,
+      );
+      continue;
+    }
+    let hostname = '';
+    try {
+      const url = new URL(entry.includes('://') ? entry : `http://${entry}`);
+      hostname = url.hostname.toLowerCase();
+      if (hostname.startsWith('[') && hostname.endsWith(']')) {
+        hostname = hostname.slice(1, -1);
+      }
+    } catch {
+      hostname = '';
+    }
+    if (!hostname) {
+      warn(
+        `[ssrf] ignoring malformed OD_ALLOWED_INTERNAL_HOSTS entry: ${JSON.stringify(entry)}`,
+      );
+      continue;
+    }
+    hosts.push(hostname);
+  }
+  return hosts;
+}
+
 export function allowedBrowserPorts(
   port: number | string | null | undefined,
   env: NodeJS.ProcessEnv = process.env,

--- a/apps/daemon/src/routes/chat.ts
+++ b/apps/daemon/src/routes/chat.ts
@@ -32,7 +32,7 @@ import {
 } from '../integrations/aihubmix.js';
 import { isSafeId as isSafeProjectId } from '../projects.js';
 import { projectKindToTracking } from '@open-design/contracts/analytics';
-import { proxyDispatcherRequestInit, validateBaseUrlResolved } from '../connectionTest.js';
+import { proxyDispatcherRequestInit, validateUserProviderBaseUrl } from '../connectionTest.js';
 import { googleStreamGenerateContentUrl } from '../integrations/google-models.js';
 import { createRoleMarkerGuard } from '../role-marker-guard.js';
 import { authorizeReasoningEgress, sendReasoningEgressDenial } from '../reasoning-egress.js';
@@ -439,10 +439,10 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
   // DNS-aware wrapper. The sync `validateBaseUrl` only inspects the literal
   // hostname string, so a public DNS name pointing at an internal address
   // (`internal.example.com → 10.0.0.5`) still passes. We delegate to
-  // `validateBaseUrlResolved` here so every proxy/stream handler runs the
+  // `validateUserProviderBaseUrl` here so every proxy/stream handler runs the
   // same resolved-IP check before issuing the upstream request.
   const validateExternalApiBaseUrl = (baseUrl: string) => {
-    return validateBaseUrlResolved(baseUrl);
+    return validateUserProviderBaseUrl(baseUrl);
   };
 
   const proxyErrorCode = (status: number) => {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -20,6 +20,7 @@ import {
   testAgentConnection,
   testProviderConnection,
   validateBaseUrlResolved,
+  validateUserProviderBaseUrl,
   type DnsLookupAddress,
 } from '../src/connectionTest.js';
 import { listProviderModels } from '../src/integrations/provider-models.js';
@@ -521,6 +522,37 @@ describe('POST /api/provider/models', () => {
       ).toBe(false);
     } finally {
       dnsSpy.mockRestore();
+    }
+  });
+
+  it('lets an operator-allowlisted internal endpoint reach the upstream model fetch (#3225)', async () => {
+    // The exact symptom in #3225 — "Could not fetch models: Internal IPs
+    // blocked". With the host opted in via OD_ALLOWED_INTERNAL_HOSTS, model
+    // discovery must reach the internal gateway instead of returning forbidden.
+    vi.stubEnv('OD_ALLOWED_INTERNAL_HOSTS', '10.0.0.5');
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({ data: [{ id: 'gpt-4o-internal' }] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const res = await realFetch(`${baseUrl}/api/provider/models`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          protocol: 'openai',
+          baseUrl: 'http://10.0.0.5:11434/v1',
+          apiKey: 'sk-good',
+        }),
+      });
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).not.toMatchObject({ kind: 'forbidden' });
+      expect(
+        fetchMock.mock.calls.some(([input]) =>
+          String(input).includes('10.0.0.5'),
+        ),
+      ).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
     }
   });
 
@@ -4005,5 +4037,72 @@ describe('validateBaseUrlResolved (DNS-aware base URL validation)', () => {
     const result = await validateBaseUrlResolved('https://offline.example.com/v1', failingLookup);
     expect(result.error).toBeUndefined();
     expect(failingLookup).toHaveBeenCalledOnce();
+  });
+
+  it('exempts a literal internal IP passed via allowedInternalHosts without resolving DNS (#3225)', async () => {
+    const lookup = lookupReturning([]);
+    const result = await validateBaseUrlResolved('http://10.0.0.5:4000/v1', lookup, {
+      allowedInternalHosts: ['10.0.0.5'],
+    });
+    expect(result.error).toBeUndefined();
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('exempts an allowlisted hostname even though it resolves into private space (#3225)', async () => {
+    const result = await validateBaseUrlResolved(
+      'https://litellm.internal:4000/v1',
+      lookupReturning([{ address: '10.0.0.5', family: 4 }]),
+      { allowedInternalHosts: ['litellm.internal'] },
+    );
+    expect(result.error).toBeUndefined();
+  });
+
+  it('exempts a non-allowlisted hostname whose resolved address is itself allowlisted (#3225)', async () => {
+    const result = await validateBaseUrlResolved(
+      'https://gateway.example.com/v1',
+      lookupReturning([{ address: '10.0.0.5', family: 4 }]),
+      { allowedInternalHosts: ['10.0.0.5'] },
+    );
+    expect(result.error).toBeUndefined();
+  });
+
+  it('still blocks a resolved private address that is NOT on the allowlist (#3225)', async () => {
+    const result = await validateBaseUrlResolved(
+      'https://other.example.com/v1',
+      lookupReturning([{ address: '192.168.1.5', family: 4 }]),
+      { allowedInternalHosts: ['10.0.0.5'] },
+    );
+    expect(result).toMatchObject({ error: 'Internal IPs blocked', forbidden: true });
+  });
+});
+
+describe('validateUserProviderBaseUrl: OD_ALLOWED_INTERNAL_HOSTS opt-in (issue #3225)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('exempts an operator-allowlisted literal internal IP for user-configured endpoints', async () => {
+    vi.stubEnv('OD_ALLOWED_INTERNAL_HOSTS', '10.0.0.5');
+    const result = await validateUserProviderBaseUrl('http://10.0.0.5:4000/v1');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('exempts a hostname that resolves into private space when that hostname is allowlisted', async () => {
+    vi.stubEnv('OD_ALLOWED_INTERNAL_HOSTS', 'litellm.internal');
+    const lookup = vi.fn(async () => [{ address: '10.0.0.5', family: 4 }]);
+    const result = await validateUserProviderBaseUrl('http://litellm.internal:4000/v1', lookup);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('still blocks a private endpoint that is not on the allowlist', async () => {
+    vi.stubEnv('OD_ALLOWED_INTERNAL_HOSTS', '10.0.0.5');
+    const result = await validateUserProviderBaseUrl('http://192.168.1.5:4000/v1');
+    expect(result).toMatchObject({ error: 'Internal IPs blocked', forbidden: true });
+  });
+
+  it('keeps the attacker-controllable asset guard strict — the plain resolver never consults the allowlist', async () => {
+    vi.stubEnv('OD_ALLOWED_INTERNAL_HOSTS', '10.0.0.5');
+    const result = await validateBaseUrlResolved('http://10.0.0.5:4000/v1');
+    expect(result).toMatchObject({ error: 'Internal IPs blocked', forbidden: true });
   });
 });

--- a/apps/daemon/tests/origin-validation.test.ts
+++ b/apps/daemon/tests/origin-validation.test.ts
@@ -5,6 +5,7 @@ import type { NextFunction, Request, Response } from 'express';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   allowedBrowserPorts,
+  configuredAllowedInternalHosts,
   configuredAllowedOrigins,
   isAllowedBrowserOrigin,
   isLocalSameOrigin,
@@ -650,5 +651,46 @@ describe('isLocalSameOrigin: Sec-Fetch-Site fallback for no-Origin same-origin G
       },
     };
     expect(isLocalSameOrigin(req, 7456, env)).toBe(false);
+  });
+});
+
+describe('configuredAllowedInternalHosts: OD_ALLOWED_INTERNAL_HOSTS parsing (issue #3225)', () => {
+  it('returns [] when the env var is unset or blank', () => {
+    expect(configuredAllowedInternalHosts({})).toEqual([]);
+    expect(configuredAllowedInternalHosts({ OD_ALLOWED_INTERNAL_HOSTS: '   ' })).toEqual([]);
+  });
+
+  it('splits on commas and whitespace and keeps only the hostname', () => {
+    const env = {
+      OD_ALLOWED_INTERNAL_HOSTS: '10.0.0.5, litellm.internal:4000  https://gw.corp/v1',
+    };
+    expect(configuredAllowedInternalHosts(env)).toEqual([
+      '10.0.0.5',
+      'litellm.internal',
+      'gw.corp',
+    ]);
+  });
+
+  it('lowercases and strips brackets from IPv6 literal entries', () => {
+    const env = { OD_ALLOWED_INTERNAL_HOSTS: '[FD00::1]:4000' };
+    expect(configuredAllowedInternalHosts(env)).toEqual(['fd00::1']);
+  });
+
+  it('warns and skips a malformed entry instead of silently trusting it', () => {
+    const warnings: string[] = [];
+    const env = { OD_ALLOWED_INTERNAL_HOSTS: '10.0.0.5, http://, good.internal' };
+    const hosts = configuredAllowedInternalHosts(env, (m) => warnings.push(m));
+    expect(hosts).toEqual(['10.0.0.5', 'good.internal']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/OD_ALLOWED_INTERNAL_HOSTS/);
+  });
+
+  it('warns and skips a CIDR entry rather than silently narrowing it to one host', () => {
+    const warnings: string[] = [];
+    const env = { OD_ALLOWED_INTERNAL_HOSTS: '10.0.0.0/24, 10.0.0.5' };
+    const hosts = configuredAllowedInternalHosts(env, (m) => warnings.push(m));
+    expect(hosts).toEqual(['10.0.0.5']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/CIDR/i);
   });
 });

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -795,6 +795,15 @@ export function isValidApiBaseUrl(value: string): boolean {
   const trimmed = value.trim();
   if (!/^https?:\/\//i.test(trimmed)) return false;
   const result = validateBaseUrl(trimmed);
+  // The internal-IP / SSRF decision belongs to the daemon, which is the single
+  // source of truth and honors the operator's OD_ALLOWED_INTERNAL_HOSTS
+  // allowlist — a value the browser cannot see (#3225). A `forbidden` result
+  // here is a syntactically-valid URL that points at an internal address; keep
+  // it UI-valid so the operator can run the connection test / model fetch and
+  // get the daemon's authoritative answer (allowed when listed, a clear
+  // "Internal IPs blocked" otherwise). Only genuinely malformed URLs stay
+  // invalid client-side.
+  if (result.forbidden) return true;
   return Boolean(result.parsed && !result.error);
 }
 

--- a/apps/web/src/components/byok/validation.ts
+++ b/apps/web/src/components/byok/validation.ts
@@ -163,24 +163,31 @@ export function validateByokDraft(
       message: 'Base URL is required.',
       action: 'focus_base_url',
     });
-  } else if (validateBaseUrl(baseUrl).error) {
-    issues.push({
-      field: 'base_url',
-      level: 'error',
-      code: 'base_url_invalid',
-      message: 'Base URL must be a valid public http:// or https:// URL.',
-      action: 'focus_base_url',
-    });
-  } else if (protocol === 'google' && baseUrl) {
-    const host = baseUrlHostname(baseUrl);
-    if (host === 'api.anthropic.com' || host === 'api.openai.com') {
+  } else {
+    // #3225 — a `forbidden` result is a syntactically-valid URL that points at
+    // an internal address. Don't block it here: the Test / model-fetch actions
+    // gate on these issues, and the daemon owns the OD_ALLOWED_INTERNAL_HOSTS
+    // decision. Only genuinely malformed / non-http URLs are a client blocker.
+    const baseUrlCheck = validateBaseUrl(baseUrl);
+    if (baseUrlCheck.error && !baseUrlCheck.forbidden) {
       issues.push({
         field: 'base_url',
         level: 'error',
         code: 'base_url_invalid',
-        message: `Base URL points to ${host}. For Google Gemini use ${GOOGLE_GEMINI_DEFAULT_BASE_URL}.`,
+        message: 'Base URL must be a valid public http:// or https:// URL.',
         action: 'focus_base_url',
       });
+    } else if (protocol === 'google' && baseUrl) {
+      const host = baseUrlHostname(baseUrl);
+      if (host === 'api.anthropic.com' || host === 'api.openai.com') {
+        issues.push({
+          field: 'base_url',
+          level: 'error',
+          code: 'base_url_invalid',
+          message: `Base URL points to ${host}. For Google Gemini use ${GOOGLE_GEMINI_DEFAULT_BASE_URL}.`,
+          action: 'focus_base_url',
+        });
+      }
     }
   }
 

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -677,8 +677,11 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Customize' }));
+    // A non-http scheme is still rejected client-side. (An internal-IP URL is
+    // no longer rejected here — it is syntactically valid and the daemon owns
+    // the allowlist decision; see #3225.)
     fireEvent.change(screen.getByLabelText('Base URL'), {
-      target: { value: 'http://10.0.0.5:11434/v1' },
+      target: { value: 'ftp://api.example.com' },
     });
     expect(screen.getByRole('alert').textContent).toContain(
       'Use a public http:// or https:// URL.',

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -235,12 +235,15 @@ describe('SettingsDialog provider model fetch helpers', () => {
         'openai',
       ),
     ).toBe(false);
+    // #3225 — an internal-IP endpoint is now fetchable from the UI's
+    // perspective; the daemon enforces the OD_ALLOWED_INTERNAL_HOSTS allowlist
+    // and returns the authoritative allow/block decision.
     expect(
       canFetchProviderModels(
         { apiKey: 'sk-openai', baseUrl: 'http://10.0.0.5:11434/v1' },
         'openai',
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       canFetchProviderModels(
         { apiKey: 'azure-key', baseUrl: 'https://example.openai.azure.com' },
@@ -307,17 +310,35 @@ describe('SettingsDialog API Base URL validation', () => {
     expect(isValidApiBaseUrl('ftp://api.example.com')).toBe(false);
     expect(isValidApiBaseUrl('http:api.example.com')).toBe(false);
     expect(isValidApiBaseUrl('https://')).toBe(false);
-    expect(isValidApiBaseUrl('http://0.0.0.0:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://10.0.0.5:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://100.64.0.1:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://169.254.1.5:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://172.16.0.5:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://192.168.1.5:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://224.0.0.1:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://[::]:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://[fd00::1]:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://[fe80::1]:11434/v1')).toBe(false);
-    expect(isValidApiBaseUrl('http://[::ffff:192.168.1.5]:11434/v1')).toBe(false);
+  });
+
+  it('keeps syntactically-valid internal-IP base URLs UI-valid so the daemon allowlist can decide (#3225)', () => {
+    // The internal-IP / SSRF decision belongs to the daemon, which honors the
+    // operator's OD_ALLOWED_INTERNAL_HOSTS allowlist — a value the browser
+    // cannot see. These are well-formed URLs that merely point at internal
+    // addresses, so the client must not block them: the operator needs to run
+    // the connection test / model fetch and get the daemon's authoritative
+    // answer (allowed when listed, "Internal IPs blocked" otherwise).
+    for (const internal of [
+      'http://0.0.0.0:11434/v1',
+      'http://10.0.0.5:11434/v1',
+      'http://100.64.0.1:11434/v1',
+      'http://169.254.1.5:11434/v1',
+      'http://172.16.0.5:11434/v1',
+      'http://192.168.1.5:11434/v1',
+      'http://224.0.0.1:11434/v1',
+      'http://[::]:11434/v1',
+      'http://[fd00::1]:11434/v1',
+      'http://[fe80::1]:11434/v1',
+      'http://[::ffff:192.168.1.5]:11434/v1',
+    ]) {
+      expect(isValidApiBaseUrl(internal)).toBe(true);
+    }
+  });
+
+  it('still rejects genuinely malformed URLs client-side', () => {
+    expect(isValidApiBaseUrl('http://')).toBe(false);
+    expect(isValidApiBaseUrl('http:// /v1')).toBe(false);
   });
 });
 

--- a/apps/web/tests/components/byok-validation.test.ts
+++ b/apps/web/tests/components/byok-validation.test.ts
@@ -102,6 +102,36 @@ describe('BYOK draft validation', () => {
     ).toBe(true);
   });
 
+  it('treats a syntactically-valid internal-IP base URL as non-blocking, deferring to the daemon (#3225)', () => {
+    // The Test / model-fetch actions gate on blockingByokDraftIssues; an
+    // internal endpoint must not be blocked here or the operator can never
+    // reach the daemon's OD_ALLOWED_INTERNAL_HOSTS decision.
+    const result = validateByokDraft('openai', {
+      apiKey: 'sk-internal',
+      baseUrl: 'http://10.0.0.5:4000/v1',
+      model: 'gpt-4o',
+    });
+    expect(result.issues).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'base_url_invalid' }),
+      ]),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('still flags a genuinely malformed base URL as base_url_invalid', () => {
+    const result = validateByokDraft('openai', {
+      apiKey: 'sk-internal',
+      baseUrl: 'ftp://api.example.com',
+      model: 'gpt-4o',
+    });
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'base_url_invalid' }),
+      ]),
+    );
+  });
+
   it('can enforce first-party key shape when the first-party Base URL looks mistyped', () => {
     const withoutHint = validateByokDraft('anthropic', {
       apiKey: 'sk-openai-key',

--- a/e2e/ui/settings-api-protocol.test.ts
+++ b/e2e/ui/settings-api-protocol.test.ts
@@ -269,7 +269,10 @@ test('[P0] BYOK save stays disabled until required fields are valid', async ({ p
   await expect.poll(async () => readSavedConfig(page)).toMatchObject({ apiKey: 'sk-openai-test' });
 
   const baseUrlInput = dialog.getByLabel('Base URL');
-  await baseUrlInput.fill('http://10.0.0.5:11434/v1');
+  // A non-http scheme is still rejected client-side. (An internal-IP URL is no
+  // longer rejected here — it is syntactically valid and the daemon owns the
+  // OD_ALLOWED_INTERNAL_HOSTS decision; see #3225.)
+  await baseUrlInput.fill('ftp://api.example.com');
   await expect(dialog.locator('#settings-base-url-error')).toContainText(/public http:\/\/ or https:\/\//i);
 
   await baseUrlInput.fill('http://localhost:11434/v1');

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -108,7 +108,52 @@ export function isBlockedExternalApiHostname(hostname: string): boolean {
   return Boolean(mapped && isBlockedIpv4(mapped));
 }
 
-export function validateBaseUrl(baseUrl: string): BaseUrlValidationResult {
+// Normalized forms a hostname can be matched under: the bracket-stripped,
+// lowercased, trailing-dot-stripped string plus, for IPv4-mapped IPv6
+// literals, the dotted-quad form. Both an allowlist entry and a candidate
+// host are reduced through this so `10.0.0.5`, `10.0.0.5.`, `[::ffff:10.0.0.5]`
+// and `10.0.0.5` all compare equal.
+function internalHostMatchForms(hostname: string): string[] {
+  const normalized = normalizeBracketedIpv6(hostname);
+  const forms = new Set<string>([normalized]);
+  const mapped = ipv4MappedToDotted(hostname);
+  if (mapped) forms.add(mapped.toLowerCase());
+  return [...forms];
+}
+
+// Issue #3225 — explicit, operator-declared escape hatch from the
+// default-deny internal-IP guard. Returns true only when `hostname` matches
+// a host the operator deliberately trusted (see `OD_ALLOWED_INTERNAL_HOSTS`
+// on the daemon). An empty/absent allowlist always returns false, so the
+// strict default is preserved unless an operator opts in. This is consulted
+// ONLY for user-configured provider endpoints, never for the
+// attacker-controllable asset-download SSRF guard.
+export function isAllowlistedInternalHost(
+  hostname: string,
+  allowedInternalHosts?: readonly string[],
+): boolean {
+  if (!allowedInternalHosts || allowedInternalHosts.length === 0) return false;
+  const candidateForms = internalHostMatchForms(hostname);
+  for (const entry of allowedInternalHosts) {
+    if (typeof entry !== 'string' || !entry.trim()) continue;
+    const entryForms = internalHostMatchForms(entry.trim());
+    if (entryForms.some((form) => candidateForms.includes(form))) return true;
+  }
+  return false;
+}
+
+export interface ValidateBaseUrlOptions {
+  // Hosts the operator has explicitly declared trusted (issue #3225). Each
+  // entry is a bare hostname or IP literal; a host that matches is exempted
+  // from the internal-IP block. Defaults to none, keeping the strict
+  // default-deny behavior for every caller that does not opt in.
+  allowedInternalHosts?: readonly string[];
+}
+
+export function validateBaseUrl(
+  baseUrl: string,
+  options: ValidateBaseUrlOptions = {},
+): BaseUrlValidationResult {
   let parsed: ParsedBaseUrl;
   try {
     parsed = new URL(String(baseUrl).replace(/\/+$/, ''));
@@ -119,7 +164,11 @@ export function validateBaseUrl(baseUrl: string): BaseUrlValidationResult {
     return { error: 'Only http/https allowed' };
   }
   const hostname = parsed.hostname.toLowerCase();
-  if (!isLoopbackApiHost(hostname) && isBlockedExternalApiHostname(hostname)) {
+  if (
+    !isLoopbackApiHost(hostname) &&
+    !isAllowlistedInternalHost(hostname, options.allowedInternalHosts) &&
+    isBlockedExternalApiHostname(hostname)
+  ) {
     return { error: 'Internal IPs blocked', forbidden: true };
   }
   return { parsed };

--- a/packages/contracts/tests/connection-test.test.ts
+++ b/packages/contracts/tests/connection-test.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isAllowlistedInternalHost,
   isLoopbackApiHost,
   validateBaseUrl,
 } from '../src/api/connectionTest';
@@ -65,5 +66,48 @@ describe('provider base URL validation', () => {
         forbidden: true,
       });
     }
+  });
+});
+
+describe('operator internal-host allowlist (issue #3225)', () => {
+  it('exempts a literal internal IP the operator explicitly allowlisted', () => {
+    expect(
+      validateBaseUrl('http://10.0.0.5:4000/v1', {
+        allowedInternalHosts: ['10.0.0.5'],
+      }).error,
+    ).toBeUndefined();
+  });
+
+  it('keeps the strict default-deny when the allowlist is empty or absent', () => {
+    expect(validateBaseUrl('http://10.0.0.5:4000/v1')).toMatchObject({
+      error: 'Internal IPs blocked',
+      forbidden: true,
+    });
+    expect(
+      validateBaseUrl('http://10.0.0.5:4000/v1', { allowedInternalHosts: [] }),
+    ).toMatchObject({ error: 'Internal IPs blocked', forbidden: true });
+  });
+
+  it('only exempts the allowlisted host, still blocking other internal ranges', () => {
+    expect(
+      validateBaseUrl('http://192.168.1.5:4000/v1', {
+        allowedInternalHosts: ['10.0.0.5'],
+      }),
+    ).toMatchObject({ error: 'Internal IPs blocked', forbidden: true });
+  });
+
+  it('matches across bracket, trailing-dot, and IPv4-mapped normalized forms', () => {
+    // An operator who lists `10.0.0.5` should also exempt the trailing-dot
+    // FQDN form and the IPv4-mapped IPv6 literal of the same address.
+    expect(isAllowlistedInternalHost('10.0.0.5.', ['10.0.0.5'])).toBe(true);
+    expect(isAllowlistedInternalHost('[::ffff:10.0.0.5]', ['10.0.0.5'])).toBe(true);
+    expect(isAllowlistedInternalHost('10.0.0.5', ['[::ffff:10.0.0.5]'])).toBe(true);
+    expect(isAllowlistedInternalHost('FD00::1', ['[fd00::1]'])).toBe(true);
+  });
+
+  it('returns false for an empty allowlist or a non-matching host', () => {
+    expect(isAllowlistedInternalHost('10.0.0.5', [])).toBe(false);
+    expect(isAllowlistedInternalHost('10.0.0.5', undefined)).toBe(false);
+    expect(isAllowlistedInternalHost('10.0.0.5', ['192.168.1.5'])).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #3225

## Why

Scratching an itch for teams running an internally-hosted model gateway. After the 0.8.0 SSRF hardening, a provider base URL that resolves into a private/internal range (e.g. a VPN-only LiteLLM or Ollama on a `10.x` / `192.168.x` address) is hard-blocked with `Internal IPs blocked`, with no way to opt a trusted host out. The reporter (and a second commenter with the same setup) had to fall back to a brittle localhost proxy relay. The maintainer mapped out the `OD_ALLOWED_INTERNAL_HOSTS` allowlist approach in the thread and invited `/claim`.

This restores the legitimate enterprise BYOK pattern while keeping the SSRF boundary intact for everything the operator did **not** explicitly trust.

## What users will see

- Operators can set `OD_ALLOWED_INTERNAL_HOSTS=10.0.0.5,litellm.internal` (a daemon env var) to opt specific internal hosts out of the SSRF block. **Default (unset) changes nothing** — the strict default-deny stays for every deployment that does not opt in.
- In **Settings → AI Providers**, a Base URL pointing at an internal address (e.g. `http://10.0.0.5:4000/v1`) is no longer rejected client-side with *"Use a public http:// or https:// URL."* It is accepted so the connection test / model fetch can run, and the daemon returns the authoritative allow/block decision (allowed when allowlisted, a clear `Internal IPs blocked` otherwise).

## Surface area

- [x] **UI** — Settings base-URL validation relaxed for syntactically-valid internal-IP URLs (no new widget)
- [x] **CLI / env var** — new `OD_ALLOWED_INTERNAL_HOSTS`
- [x] **API / contract** — `packages/contracts` `validateBaseUrl` gains a `ValidateBaseUrlOptions` arg; new exported `isAllowlistedInternalHost`
- [x] **Default behavior change** — internal-IP base URLs are now submittable in Settings (still blocked at the daemon unless allowlisted)

## Screenshots

Settings → Execution mode → BYOK → OpenAI, with an internal endpoint `http://10.0.0.5:4000/v1` typed into the **Base URL** field.

**Before** — the client rejects the internal-IP URL with *"Use a public http:// or https:// URL."*, so the operator can never reach the daemon's allowlist check:

<img width="1280" height="720" alt="od3225-before" src="https://github.com/user-attachments/assets/72b3c740-9d01-4843-9e05-f685e20da49e" />

**After** — the URL is accepted (no client-side error) and the **Test** button becomes available, so the connection test / model fetch runs and the daemon returns the authoritative allow/block decision:

<img width="1280" height="720" alt="od3225-after" src="https://github.com/user-attachments/assets/4d1245d9-5f61-4757-8e10-683c04e7eb55" />

<sub>Captured with the repo's Playwright e2e harness (headless Chromium).</sub>

## Bug fix verification

Each layer was written red-first (failing on `main`, green on this branch):

- `packages/contracts/tests/connection-test.test.ts` — allowlist exemption across normalized host forms + strict default-deny when empty/absent.
- `apps/daemon/tests/origin-validation.test.ts` — `OD_ALLOWED_INTERNAL_HOSTS` parsing, and **malformed / CIDR entries are dropped with a warning** rather than silently trusted.
- `apps/daemon/tests/connection-test.test.ts` — DNS-resolved guard honors the allowlist (literal-IP, allowlisted-hostname, and allowlisted-resolved-IP cases), non-allowlisted private targets still blocked, and the attacker-controllable asset guard **stays strict** even with an allowlist configured.
- `apps/web/tests/components/SettingsDialog.test.ts` — internal-IP base URLs are UI-valid; genuinely malformed URLs still rejected.

Did the tests go red on `main` and green on this branch? **yes**

The allowlist is threaded into the three user-configured provider paths: connection test (`testProviderConnection`), model discovery (`listProviderModels` — the exact `Could not fetch models: Internal IPs blocked` symptom in this issue), and BYOK chat proxy/stream (`chat-routes.ts`).

- **Deliberately not changed:** the attacker-controllable asset-download guard (`assertExternalAssetUrl` → `validateBaseUrlResolved` with no allowlist). Download URLs returned inside upstream responses never consult the allowlist and stay blocked.
- **No CIDR support** — the matcher is exact-host. A CIDR entry (`10.0.0.0/24`) is rejected loudly rather than silently narrowed to one address, so a typo can't quietly mis-scope the guard.
- Allowlisting a hostname trusts whatever it resolves to (same trade-off as `OD_ALLOWED_ORIGINS`); allowlist the resolved IP if you want the DNS-resolved address re-checked.
- **Out of scope (separate pre-existing issue):** the codegen finalize handler `POST /api/projects/:id/finalize/anthropic` validates its base URL via a second `validateExternalApiBaseUrl` wrapper in `server.ts`, but the call site (`server.ts:9631`) does not `await` it — so `validated.error` is read off a pending Promise and that SSRF check is currently a no-op regardless of this change. I left it untouched rather than expand this PR into an unrelated async-correctness fix; happy to follow up separately if you'd like it threaded + awaited.

## Validation

- `pnpm guard` ✓ · `pnpm typecheck` ✓ (all packages)
- `pnpm --filter @open-design/contracts test` ✓ (165)
- `pnpm --filter @open-design/daemon test` ✓ (full suite green; two unrelated tests — `chat-route.test.ts` OPENCODE_CONFIG and `origin-validation.test.ts` OD_WEB_PORT — are pre-existing cross-file flakes that pass in isolation)
- `pnpm --filter @open-design/web test` ✓ (3221 passed, 1 skipped)

