### PR TITLE
landing: giant two-tone wordmark sign-off under the footer

### DIFF
--- a/apps/landing-page/app/_components/site-footer.astro
+++ b/apps/landing-page/app/_components/site-footer.astro
@@ -74,5 +74,11 @@ const X_TWITTER = 'https://x.com/nexudotio';
         </ul>
       </div>
     </div>
+    {/* Masthead sign-off — the giant two-tone wordmark, nothing else. */}
+    <div class='foot-masthead' data-od-id='footer-masthead'>
+      <p class='foot-masthead-wordmark'>
+        Open <span class='foot-masthead-accent'>Design</span><span class='foot-masthead-period'>.</span>
+      </p>
+    </div>
   </div>
 </footer>

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -4786,10 +4786,36 @@ footer .container {
 }
 .sub-footer-col a:hover { color: var(--coral); }
 
+/* ---------- footer masthead ----------
+ *
+ * Masthead sign-off under the footer link columns: a container-filling
+ * two-tone "Open Design." wordmark. One class contract shared by
+ * `site-footer.astro` and the homepage footer in `page.tsx`.
+ */
+.foot-masthead {
+  margin-top: 56px;
+}
+.foot-masthead-wordmark {
+  margin: 0;
+  font-weight: 800;
+  /* Fills the 964px column at the 1440px design width and degrades
+     fluidly; the nowrap keeps "Open Design." a single editorial line. */
+  font-size: clamp(52px, 10.4vw, 158px);
+  line-height: 1.04;
+  letter-spacing: -0.045em;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.foot-masthead-accent { color: var(--coral); }
+.foot-masthead-period { color: var(--ink); }
+
 @media (max-width: 720px) {
   .sub-footer .sub-footer-inner { padding-inline: 24px; }
   .sub-footer-grid { grid-template-columns: 1fr; gap: 32px; }
   .sub-footer { padding: 40px 0 24px; }
+  /* Clear the page-bottom GradualBlur band (4rem) so the wordmark
+     reads crisp at final scroll on phones. */
+  .foot-masthead { margin-top: 40px; padding-bottom: 48px; }
 }
 
 /* ---------- scroll-reveal motion ----------

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -1088,6 +1088,14 @@ export default function Page({
                 </ul>
               </div>
             </div>
+            {/* Masthead sign-off — same markup contract as
+                `site-footer.astro` so the shared `.foot-masthead` styles
+                in globals.css cover both footers. */}
+            <div className='foot-masthead' data-od-id='footer-masthead'>
+              <p className='foot-masthead-wordmark'>
+                Open <span className='foot-masthead-accent'>Design</span><span className='foot-masthead-period'>.</span>
+              </p>
+            </div>
           </div>
         </footer>
       </div>


### PR DESCRIPTION
## Why

Adds a masthead-style editorial closing to the landing page footer — a large "Open Design." wordmark that anchors both the homepage (`page.tsx`) and all locale sub-pages (`site-footer.astro`). Inspired by newspaper/magazine colophon typography; gives the page a strong, memorable sign-off instead of ending on link columns alone.

## What users will see

Below the footer link columns, a full-width two-tone wordmark:
- **"Open"** and **"."** in `--ink` (near-black)
- **"Design"** in `--coral` (brand green)
- Albert Sans 800, fluid `clamp(52px, 10.4vw, 158px)`, single line
- Mobile: extra bottom padding so it clears the GradualBlur band

## Surface area

- [x] Landing page UI (`apps/landing-page/`)
- [ ] CLI
- [ ] i18n keys (no new strings — wordmark text is fixed)
- [ ] New dependencies

## Test plan

- [ ] Desktop: scroll to bottom of homepage and locale sub-pages — wordmark appears below link columns
- [ ] Mobile (≤ 720px): wordmark clears the bottom GradualBlur overlay
- [ ] No visual regression on the footer link columns above