### PR TITLE
fix(ci): flaky resume test cleanup

### DIFF
--- a/apps/daemon/tests/run-resume-on-failure.test.ts
+++ b/apps/daemon/tests/run-resume-on-failure.test.ts
@@ -45,7 +45,7 @@ describe('resume-on-failure runtime', () => {
       await new Promise<void>((resolve) => started?.server.close(() => resolve()));
     }
     started = null;
-    if (binDir) await rm(binDir, { recursive: true, force: true });
+    if (binDir) await removeTempDir(binDir);
     binDir = null;
     restoreEnv(originalEnv);
   });
@@ -384,4 +384,13 @@ function flagValue(args: string[], flag: string): string | null {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 50,
+  });
 }


### PR DESCRIPTION
## Why

The main CI run https://github.com/nexu-io/open-design/actions/runs/27468131463 failed in `Daemon workspace tests (1/3)` while cleaning up `tests/run-resume-on-failure.test.ts`. The test behavior had already completed, but `fs.rm` hit `ENOTEMPTY` on the temporary fake Claude CLI directory, which makes the daemon shard flaky and blocks unrelated PRs after merge.

## What users will see

No user-facing change. This only makes daemon test cleanup more reliable in CI.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/run-resume-on-failure.test.ts`
- Did the test go red on `main` and green on this branch? No. This was an observed CI flake in main push run 27468131463, not a deterministic assertion failure.
- Verification instead: reran the focused test and the same daemon shard that failed in CI after making cleanup retry transient `ENOTEMPTY`/busy filesystem races.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/run-resume-on-failure.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts --shard 1/3`