### PR TITLE
fix(web): preserve HomeView prompt draft across workspace-tab switches

### DIFF
--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -307,11 +307,15 @@ export function HomeView({
       return '';
     }
   });
-  // Single source of truth for draft persistence. Every code path that mutates
-  // the visible prompt (handlePromptChange, plugin handoffs, picker/context
-  // actions, submit, clearActivePlugin) routes through `setPrompt`, so a
-  // single effect that mirrors `prompt` to localStorage covers them all —
-  // no per-site localStorage writes to keep in sync.
+  // Single source of truth for draft persistence. Every code path that
+  // mutates the visible prompt (handlePromptChange, plugin handoffs,
+  // picker/context actions, clearActivePlugin) routes through `setPrompt`,
+  // so a single effect that mirrors `prompt` to localStorage covers them
+  // all. The successful-submit path is the one exception: it intentionally
+  // does not touch the React `prompt` state (the composer keeps the user's
+  // last text so they can refine it), so it has its own dedicated
+  // `localStorage.removeItem` call below — the effect wouldn't otherwise
+  // observe the submission.
   useEffect(() => {
     try {
       if (prompt) {
@@ -1585,6 +1589,20 @@ export function HomeView({
     setSelectedPluginContexts([]);
     setSelectedMcpContexts([]);
     setSelectedConnectorContexts([]);
+    // Consume the persisted draft so the next HomeView mount comes back
+    // empty. The centralized useEffect above mirrors `prompt` to
+    // localStorage, but it only fires on state change. The successful
+    // submit path here intentionally does NOT mutate `prompt` (the
+    // composer keeps the user's last text so they can refine it without
+    // re-typing), so the effect would not otherwise observe the
+    // submission. We need a dedicated cleanup that removes the key
+    // outright — the second of the two options Siri-Ray offered on
+    // PR #4271 round-2.
+    try {
+      window.localStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
+    } catch {
+      // Storage may be unavailable in privacy modes.
+    }
   }
 
   return (

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -7,6 +7,10 @@
 // surface by lifting its plugin orchestration up here so the prompt
 // textarea can live centered in the hero.
 
+// localStorage key for persisting the home prompt draft across workspace-tab
+// switches. The draft is saved on every keystroke and cleared on submit.
+const HOME_PROMPT_DRAFT_KEY = 'od:home-prompt-draft';
+
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type {
   ApplyResult,
@@ -296,7 +300,13 @@ export function HomeView({
   }, []);
   const [mcpServers, setMcpServers] = useState<McpServerConfig[]>([]);
   const [mcpLoading, setMcpLoading] = useState(true);
-  const [prompt, setPrompt] = useState('');
+  const [prompt, setPrompt] = useState(() => {
+    try {
+      return window.localStorage.getItem(HOME_PROMPT_DRAFT_KEY) ?? '';
+    } catch {
+      return '';
+    }
+  });
   const [promptEditedByUser, setPromptEditedByUser] = useState(false);
   const examplePromptInfoRef = useRef<ExamplePromptInfo | null>(null);
   const handleExamplePromptStatusChange = useCallback((info: ExamplePromptInfo | null) => {
@@ -1061,6 +1071,16 @@ export function HomeView({
   function handlePromptChange(nextPrompt: string) {
     setPrompt(nextPrompt);
     setPromptEditedByUser(true);
+    // Persist the draft so it survives workspace-tab switches.
+    try {
+      if (nextPrompt) {
+        window.localStorage.setItem(HOME_PROMPT_DRAFT_KEY, nextPrompt);
+      } else {
+        window.localStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
+      }
+    } catch {
+      // Storage may be unavailable in privacy modes.
+    }
     if (!active?.queryTemplate) return;
     const extracted = extractPluginInputsFromPrompt(
       active.queryTemplate,
@@ -1190,6 +1210,12 @@ export function HomeView({
     setPendingChipId(null);
     setPrompt('');
     setPromptEditedByUser(false);
+    // Clear persisted draft when resetting the composer.
+    try {
+      window.localStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
+    } catch {
+      // Storage may be unavailable in privacy modes.
+    }
   }
 
   function clearActiveChipSelection() {
@@ -1559,6 +1585,12 @@ export function HomeView({
     setSelectedPluginContexts([]);
     setSelectedMcpContexts([]);
     setSelectedConnectorContexts([]);
+    // Clear persisted draft after successful submit.
+    try {
+      window.localStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
+    } catch {
+      // Storage may be unavailable in privacy modes.
+    }
   }
 
   return (

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -307,6 +307,22 @@ export function HomeView({
       return '';
     }
   });
+  // Single source of truth for draft persistence. Every code path that mutates
+  // the visible prompt (handlePromptChange, plugin handoffs, picker/context
+  // actions, submit, clearActivePlugin) routes through `setPrompt`, so a
+  // single effect that mirrors `prompt` to localStorage covers them all —
+  // no per-site localStorage writes to keep in sync.
+  useEffect(() => {
+    try {
+      if (prompt) {
+        window.localStorage.setItem(HOME_PROMPT_DRAFT_KEY, prompt);
+      } else {
+        window.localStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
+      }
+    } catch {
+      // Storage may be unavailable in privacy modes.
+    }
+  }, [prompt]);
   const [promptEditedByUser, setPromptEditedByUser] = useState(false);
   const examplePromptInfoRef = useRef<ExamplePromptInfo | null>(null);
   const handleExamplePromptStatusChange = useCallback((info: ExamplePromptInfo | null) => {
@@ -1071,16 +1087,6 @@ export function HomeView({
   function handlePromptChange(nextPrompt: string) {
     setPrompt(nextPrompt);
     setPromptEditedByUser(true);
-    // Persist the draft so it survives workspace-tab switches.
-    try {
-      if (nextPrompt) {
-        window.localStorage.setItem(HOME_PROMPT_DRAFT_KEY, nextPrompt);
-      } else {
-        window.localStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
-      }
-    } catch {
-      // Storage may be unavailable in privacy modes.
-    }
     if (!active?.queryTemplate) return;
     const extracted = extractPluginInputsFromPrompt(
       active.queryTemplate,
@@ -1210,12 +1216,6 @@ export function HomeView({
     setPendingChipId(null);
     setPrompt('');
     setPromptEditedByUser(false);
-    // Clear persisted draft when resetting the composer.
-    try {
-      window.localStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
-    } catch {
-      // Storage may be unavailable in privacy modes.
-    }
   }
 
   function clearActiveChipSelection() {
@@ -1585,12 +1585,6 @@ export function HomeView({
     setSelectedPluginContexts([]);
     setSelectedMcpContexts([]);
     setSelectedConnectorContexts([]);
-    // Clear persisted draft after successful submit.
-    try {
-      window.localStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
-    } catch {
-      // Storage may be unavailable in privacy modes.
-    }
   }
 
   return (

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -50,6 +50,11 @@ const PROMPT_TEMPLATES: PromptTemplateSummary[] = [
 afterEach(() => {
   vi.unstubAllGlobals();
   cleanup();
+  // The Home hero persists the typed prompt draft across unmount/remount
+  // (see #4270) so a test that types "X" in one case would otherwise
+  // rehydrate "X" on the next case's fresh mount. Clear localStorage
+  // between cases to keep each test anchored to a clean composer.
+  window.localStorage.clear();
 });
 
 describe('HomeView media composer options', () => {

--- a/apps/web/tests/components/HomeView.mention-files-cap.test.tsx
+++ b/apps/web/tests/components/HomeView.mention-files-cap.test.tsx
@@ -46,6 +46,11 @@ function stubContextFetch() {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  // The Home hero persists the typed prompt draft across unmount/remount
+  // (see #4270) so a test that types "X" in one case would otherwise
+  // rehydrate "X" on the next case's fresh mount. Clear localStorage
+  // between cases to keep each test anchored to a clean composer.
+  window.localStorage.clear();
 });
 
 describe('HomeView design-files mention picker', () => {

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -425,6 +425,11 @@ describe('HomeView prompt handoff', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     cleanup();
+    // The Home hero persists the typed prompt draft across unmount/remount
+    // (see #4270) so a test that types "X" in one case would otherwise
+    // rehydrate "X" on the next case's fresh mount. Clear localStorage
+    // between cases to keep each test anchored to a clean composer.
+    window.localStorage.clear();
   });
 
   it('consumes a plugin authoring handoff once and focuses the textarea', async () => {

--- a/apps/web/tests/components/HomeView.prompt-tab-switch.test.tsx
+++ b/apps/web/tests/components/HomeView.prompt-tab-switch.test.tsx
@@ -10,12 +10,21 @@
 // A follow-up review (Siri-Ray on PR #4271) called out that the prompt can
 // also change through paths that bypass `handlePromptChange` — plugin
 // handoffs, picker/context actions, context removals — and those changes
-// must be persisted too. The fix now centralizes draft persistence in a
-// single `useEffect` that mirrors `prompt` to localStorage on every
-// change, so every `setPrompt` call site is covered.
+// must be persisted too. The fix centralizes draft persistence in a
+// single `useEffect` that mirrors `prompt` to localStorage on every change,
+// so every `setPrompt` call site is covered.
+//
+// A second-round review (Siri-Ray on the same PR, after the centralization
+// landed) flagged that `submit()` does not consume the draft, so the
+// localStorage entry survives a successful submission. The fix takes the
+// conservative of the two options the reviewer offered: a dedicated
+// `localStorage.removeItem` on the success path of `submit()` — keeping
+// the React `prompt` state intact (so the user can refine) while still
+// ensuring the next HomeView mount does not rehydrate the just-submitted
+// text. Plus a regression test below.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { HomeView } from '../../src/components/HomeView';
 import { I18nProvider } from '../../src/i18n';
 import { writeHomeGuideStage } from '../../src/components/home-hero/firstRunGuide';
@@ -183,5 +192,60 @@ describe('HomeView prompt draft across workspace-tab unmount/remount', () => {
     await waitFor(() => {
       expect(input.textContent).toBe(SEEDED);
     });
+  });
+
+  it('consumes the draft on submit so the next mount comes back empty (Siri-Ray round-2)', async () => {
+    // Round-2 regression: the centralized useEffect only fires on `prompt`
+    // state change. The successful `submit()` path does not mutate `prompt`
+    // (the composer keeps the user's last text so they can refine), so the
+    // effect would not otherwise observe the submission and the
+    // localStorage entry would survive — the next HomeView mount would
+    // rehydrate the just-submitted text. Walk the scenario: type a prompt,
+    // click submit, assert the storage key is cleared, unmount, remount,
+    // assert the composer comes back empty.
+    writeHomeGuideStage('done');
+    stubPluginsFetch();
+
+    const onSubmit = vi.fn();
+    const first = render(
+      <I18nProvider initial="en">
+        <HomeView
+          projects={[] as never}
+          onSubmit={onSubmit}
+          onOpenProject={() => undefined}
+          onViewAllProjects={() => undefined}
+        />
+      </I18nProvider>,
+    );
+    await screen.findByTestId('home-hero-input');
+    setHomeHeroPrompt(TYPED_DRAFT);
+    // The useEffect should mirror the typed prompt to localStorage.
+    await waitFor(() => {
+      expect(window.localStorage.getItem(HOME_PROMPT_DRAFT_KEY)).toBe(TYPED_DRAFT);
+    });
+
+    // Click the send button — its data-testid is `home-hero-submit` (see
+    // HomeHero.tsx:1482-1484). HomeView's submit() runs, calls the
+    // onSubmit prop, then explicitly removes the storage key (the
+    // dedicated submit cleanup path; the centralized useEffect would
+    // not otherwise fire because `prompt` is unchanged).
+    const submitButton = await screen.findByTestId('home-hero-submit');
+    fireEvent.click(submitButton);
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(window.localStorage.getItem(HOME_PROMPT_DRAFT_KEY)).toBeNull();
+    });
+    first.unmount();
+
+    // Remount with no handoff. The lazy initializer must read an absent
+    // key and surface an empty composer — not the just-submitted text.
+    renderHome();
+    const input = await screen.findByTestId('home-hero-input');
+    // Give the SeedingPlugin a frame to settle; otherwise an unseeded
+    // editor can briefly show stale text from a prior render pass.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(input.textContent).toBe('');
   });
 });

--- a/apps/web/tests/components/HomeView.prompt-tab-switch.test.tsx
+++ b/apps/web/tests/components/HomeView.prompt-tab-switch.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+// Issue #4270: typing in the Home hero input and switching to a workspace
+// tab (a project file in the top workspace bar) used to lose the input
+// text on the return trip, because switching to a project file swaps
+// `<EntryView>` for `<ProjectView>` in `App.tsx:2054-2092` and `<HomeView>`
+// unmounts with its in-memory `prompt` state. The fix persists the draft
+// to localStorage and restores it on remount.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { HomeView } from '../../src/components/HomeView';
+import { I18nProvider } from '../../src/i18n';
+import { writeHomeGuideStage } from '../../src/components/home-hero/firstRunGuide';
+
+const HOME_PROMPT_DRAFT_KEY = 'od:home-prompt-draft';
+const TYPED_DRAFT = 'Build a deck for Q4';
+
+function stubPluginsFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: RequestInfo | URL) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }),
+  );
+}
+
+function renderHome() {
+  return render(
+    <I18nProvider initial="en">
+      <HomeView
+        projects={[] as never}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />
+    </I18nProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe('HomeView prompt draft across workspace-tab unmount/remount', () => {
+  it('restores the prompt from localStorage on a fresh mount', async () => {
+    // Pre-populate the draft key the way the previous HomeView instance
+    // would have left it after the user typed and then switched to a
+    // workspace tab. Simulating the prior session at the storage layer
+    // keeps this test deterministic across jsdom + Lexical versions.
+    writeHomeGuideStage('done');
+    window.localStorage.setItem(HOME_PROMPT_DRAFT_KEY, TYPED_DRAFT);
+    stubPluginsFetch();
+
+    renderHome();
+
+    const input = await screen.findByTestId('home-hero-input');
+    // The SeedingPlugin in LexicalComposerInput reseeds the editor from
+    // the `draft` prop in a useEffect after first render, so the input
+    // textContent lags the initial render by one frame. waitFor handles
+    // the propagation.
+    await waitFor(() => {
+      expect(input.textContent).toBe(TYPED_DRAFT);
+    });
+  });
+
+  it('starts with an empty prompt when localStorage is empty', async () => {
+    // Anchor the inverse: a fresh HomeView with no prior draft must not
+    // surface phantom text. This guards against an over-eager restore
+    // that, e.g., falls back to a non-empty default.
+    writeHomeGuideStage('done');
+    stubPluginsFetch();
+
+    renderHome();
+
+    const input = await screen.findByTestId('home-hero-input');
+    // Give the SeedingPlugin a frame to settle so a stale value can't
+    // sneak in via a re-render.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(input.textContent).toBe('');
+  });
+
+  it('survives a real unmount + remount cycle (the workspace-tab transition)', async () => {
+    // Walk the full bug scenario: first mount, unmount (the workspace-tab
+    // switch unmounts <HomeView>), second mount, assert restoration.
+    writeHomeGuideStage('done');
+    stubPluginsFetch();
+
+    const first = renderHome();
+    await screen.findByTestId('home-hero-input');
+    // Seed the storage layer to model the prior session having written
+    // the draft. We're testing the read path here; the write path is
+    // covered by the handlePromptChange handler in HomeView and by
+    // the integration of the two paths in the first test.
+    window.localStorage.setItem(HOME_PROMPT_DRAFT_KEY, TYPED_DRAFT);
+    first.unmount();
+
+    renderHome();
+    const input = await screen.findByTestId('home-hero-input');
+    await waitFor(() => {
+      expect(input.textContent).toBe(TYPED_DRAFT);
+    });
+  });
+});

--- a/apps/web/tests/components/HomeView.prompt-tab-switch.test.tsx
+++ b/apps/web/tests/components/HomeView.prompt-tab-switch.test.tsx
@@ -6,12 +6,20 @@
 // `<EntryView>` for `<ProjectView>` in `App.tsx:2054-2092` and `<HomeView>`
 // unmounts with its in-memory `prompt` state. The fix persists the draft
 // to localStorage and restores it on remount.
+//
+// A follow-up review (Siri-Ray on PR #4271) called out that the prompt can
+// also change through paths that bypass `handlePromptChange` — plugin
+// handoffs, picker/context actions, context removals — and those changes
+// must be persisted too. The fix now centralizes draft persistence in a
+// single `useEffect` that mirrors `prompt` to localStorage on every
+// change, so every `setPrompt` call site is covered.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { HomeView } from '../../src/components/HomeView';
 import { I18nProvider } from '../../src/i18n';
 import { writeHomeGuideStage } from '../../src/components/home-hero/firstRunGuide';
+import { setHomeHeroPrompt } from '../helpers/home-hero-lexical';
 
 const HOME_PROMPT_DRAFT_KEY = 'od:home-prompt-draft';
 const TYPED_DRAFT = 'Build a deck for Q4';
@@ -107,6 +115,73 @@ describe('HomeView prompt draft across workspace-tab unmount/remount', () => {
     const input = await screen.findByTestId('home-hero-input');
     await waitFor(() => {
       expect(input.textContent).toBe(TYPED_DRAFT);
+    });
+  });
+
+  it('persists a prompt change made via a non-handlePromptChange path (Siri-Ray review)', async () => {
+    // Regression case added per Siri-Ray's review on PR #4271: the original
+    // fix only persisted the draft from `handlePromptChange`, leaving the
+    // localStorage entry stale when other code paths (plugin handoffs,
+    // picker/context actions, context removals) mutate the visible prompt
+    // through `setPrompt` directly. The follow-up fix centralizes the
+    // sync in a single `useEffect` keyed on `prompt`, so every `setPrompt`
+    // call — regardless of caller — updates localStorage.
+    //
+    // Flow: type a draft through the normal path, unmount, mount again
+    // with a `plugin-authoring` handoff that seeds a different visible
+    // prompt (this routes through `setPrompt`, not `handlePromptChange`),
+    // unmount, mount a third time with no handoff, assert the latest
+    // visible prompt is restored — not the stale typed draft.
+    writeHomeGuideStage('done');
+    stubPluginsFetch();
+
+    // 1. Type the original draft through the editor; the useEffect should
+    //    mirror it to localStorage.
+    const first = renderHome();
+    await screen.findByTestId('home-hero-input');
+    setHomeHeroPrompt(TYPED_DRAFT);
+    await waitFor(() => {
+      expect(window.localStorage.getItem(HOME_PROMPT_DRAFT_KEY)).toBe(TYPED_DRAFT);
+    });
+    first.unmount();
+
+    // 2. Mount with a plugin-authoring handoff whose `prompt` differs
+    //    from what the user typed. The handoff is consumed in a useEffect
+    //    that calls `setPrompt(promptHandoff.prompt)` directly, bypassing
+    //    `handlePromptChange`. The centralized useEffect must catch this.
+    const SEEDED = 'Seeded by plugin-authoring handoff';
+    const second = render(
+      <I18nProvider initial="en">
+        <HomeView
+          projects={[] as never}
+          onSubmit={() => undefined}
+          onOpenProject={() => undefined}
+          onViewAllProjects={() => undefined}
+          promptHandoff={{
+            id: 1,
+            source: 'plugin-authoring',
+            prompt: SEEDED,
+            focus: false,
+            goal: 'test',
+            inputs: {},
+            queryTemplate: 'Create an Open Design plugin for: {{pluginGoal}}.',
+          }}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => {
+      expect(window.localStorage.getItem(HOME_PROMPT_DRAFT_KEY)).toBe(SEEDED);
+    });
+    second.unmount();
+
+    // 3. Remount with no handoff. The lazy initializer must rehydrate the
+    //    latest visible prompt (SEEDED), not the original typed draft
+    //    (TYPED_DRAFT). On the buggy code, the lazy initializer would
+    //    have read TYPED_DRAFT and surfaced the stale typed text.
+    renderHome();
+    const input = await screen.findByTestId('home-hero-input');
+    await waitFor(() => {
+      expect(input.textContent).toBe(SEEDED);
     });
   });
 });


### PR DESCRIPTION
Fixes #4270

## Why

**Use case.** I was checking a previously created design system from a project workspace tab while a Home prompt was in progress. When I clicked back to the Home tab, the prompt I'd been typing was gone — same workflow that #4270 reports. This is a friction I can solve locally without changing the product surface.

**Pain.** `apps/web/src/App.tsx:2054-2092` swaps `<EntryView>` for `<ProjectView>` whenever the route changes from `{ kind: 'home' }` to `{ kind: 'project' }`. `<HomeView>` lives inside `<EntryView>`, so the swap unmounts it and takes the in-memory `prompt` state with it. The other left-rail nav tabs (Projects, Plugins, etc.) live inside `<EntryView>` and don't unmount `<HomeView>`, so the bug is specific to the workspace-tab → project-file transition. The fix is local to the same component: persist the prompt draft to `localStorage` and rehydrate on mount. Chat already does this via `loadComposerDraft` / `saveComposerDraft` in `apps/web/src/components/ChatComposer.tsx:4775-4795`, so the pattern matches the existing convention.

## What users will see

Type a prompt in the Home hero input, click a project workspace tab to look at another project, then click back to the Home tab — the input now keeps what you typed. The prompt is also preserved across a full page refresh, matching Chat composer behavior.

Submitting the prompt still consumes the draft (it doesn't re-appear after a send). Clearing the active plugin still clears the prompt.

## Surface area

- [x] **None** for the product code — internal fix, no new UI, no CLI, no contract, no i18n key, no new dependency.
- [x] **Test code**: 3 test files in `apps/web/tests/components/` had `window.localStorage.clear()` added to their `afterEach` block (see "Test maintenance tax" below). No test logic, no assertions, no fixtures were changed.

## Screenshots

Before/after — fix on the left, `main` on the right, after typing "123", clicking a project workspace tab, then clicking back to Home. Fix preserves the prompt; `main` empties it.

https://github.com/user-attachments/assets/d7187ba3-742a-4f0b-bf07-92a54d378120

## Bug fix verification

- **Test path that reproduces the bug:** `apps/web/tests/components/HomeView.prompt-tab-switch.test.tsx` (new file, 3 cases)
- **Did the test go red on `main` and green on this branch?** Yes. With the product-code diff stashed (i.e. on `main`), 2/3 cases fail — the "restores the prompt from localStorage on a fresh mount" and "survives a real unmount + remount cycle" cases both surface an empty prompt. With the product-code diff applied, all 3 pass.
- **Human verification:** stood up two namespaced `tools-dev` runtimes (one on `main`, one on this branch) and drove both in the browser. The fix-runtime preserves the prompt across the workspace-tab transition; the main-runtime loses it, matching #4270.

## Test maintenance tax (read this before reviewing)

The fix made the Home hero prompt `localStorage`-backed. That changes a previously-internal piece of state into a piece of state that survives across HomeView unmount/remount cycles — including across jsdom test cases in the same suite. Three existing test suites in `apps/web/tests/components/` had been written against the implicit assumption that the prompt starts as `''` for every fresh `<HomeView>` mount:

1. `HomeView.prefill.test.tsx` — some cases type a prompt, others assert the composer is empty.
2. `HomeView.media-options.test.tsx` — same pattern, but also for media-chip "no auto-fill" assertions.
3. `HomeView.mention-files-cap.test.tsx` — some cases type `@design` to drive the @-picker; a later case pastes files and expects the file-staging path (not the @-mention path) to fire.

None of these suites had a `localStorage.clear()` in `afterEach` because none of them needed one before — the prompt was scoped to the React tree. The fix changes that scope. Each suite now needs to clear the storage key between cases.

I added a one-line `window.localStorage.clear()` to each of the three `afterEach` blocks, with a comment cross-referencing #4270. **No test logic, assertion, or fixture was changed** — just the cleanup. The other 8 `HomeView*.test.tsx` files were unaffected because they don't both type and assert emptiness.

I'm flagging this as a follow-up for review: two of the three affected suites (media-options test 1 + 2) over-assert by using `expect(promptIsEmpty()).toBe(true)` as a proxy for "the chip click did not change the prompt." A more robust assertion would be a before/after comparison of `homeHeroPromptText()`. That's out of scope for this PR — it's a test-author intent change, not a bug fix.

## Validation

**Local**:
- `pnpm guard` — 60/60 pass
- `pnpm typecheck` — clean
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm --filter @open-design/web test --run HomeView.prompt-tab-switch` — 3/3 pass
- `pnpm --filter @open-design/web test --run HomeView.prefill` — 22/22 pass
- `pnpm --filter @open-design/web test --run HomeView.media-options` — 14/14 pass
- `pnpm --filter @open-design/web test --run HomeView.mention-files-cap` — 7/7 pass
- `pnpm --filter @open-design/web test` — **330/330 test files, 3225/3225 tests pass** (1 skipped, unrelated). No failures on the fix branch.

**CI**:
- First CI run on the original commit (`1c967c1`) was red on `web_workspace_tests` for two cases in `HomeView.prefill.test.tsx`: `routes a plugin-use handoff from the Plugins page as the active driver and submits it as the run driver` and `seeds the rendered query on use-with-query and writes placeholder edits back into inputs`. Both failed with the persisted prompt leaking across cases (e.g. `expected 'User edited prompt' to be ''`).
- Second CI run on `492b4ef27` (first follow-up) was red again — same root cause, but in two more suites: `HomeView.media-options.test.tsx` (cases `keeps the prompt empty for Audio…` and `hides the full selector grid for media surfaces`) and `HomeView.mention-files-cap.test.tsx` (case `keeps the All overview count aligned with its preview-sized render`). I had incorrectly labeled these "pre-existing" in an earlier iteration of the PR body; they were all caused by the localStorage-backed fix.
- Third commit on this branch (`e832d5e20`) extends the same `afterEach` cleanup to those two suites. After that commit, locally the full web test suite is 3225/3225 pass. The new CI run on `e832d5e20` is in flight.
