### PR TITLE
Fix plus menu empty search flyouts

### DIFF
--- a/apps/web/src/components/ComposerPlusMenu.tsx
+++ b/apps/web/src/components/ComposerPlusMenu.tsx
@@ -32,7 +32,6 @@ const PLUS_MENU_FLYOUT_WIDTH = 360;
 const PLUS_MENU_PLUGIN_FLYOUT_WIDTH = 466;
 const PLUS_MENU_PREFERRED_MIN_HEIGHT = 180;
 const PLUS_MENU_FLYOUT_MAX_HEIGHT = 320;
-const PLUS_MENU_SEARCH_LEAVE_GRACE_MS = 400;
 type PlusMenuFlyoutPlacement = 'right' | 'left' | 'contained';
 type PlusMenuFlyoutVerticalPlacement = 'down' | 'up';
 type PlusMenuPopupStyle = CSSProperties & Record<'--plus-menu-flyout-max-height', string>;
@@ -458,7 +457,9 @@ export function ComposerPlusMenu({
             testId="composer-plus-plugins"
             onOpen={(row) => openSubmenu('plugins', row)}
             onClose={scheduleCloseSubmenu}
-            flyoutClassName="plus-menu__flyout--plugins"
+            flyoutClassName={
+              filteredPlugins.length > 0 ? 'plus-menu__flyout--plugins' : undefined
+            }
           >
             <div className="plus-menu__plugin-pane">
               <div className="plus-menu__plugin-main">
@@ -617,35 +618,42 @@ function PlusSubmenuRow({
   children: ReactNode;
 }) {
   const rowRef = useRef<HTMLDivElement | null>(null);
-  const lastTextInputChangeAt = useRef<number | null>(null);
+  const flyoutRef = useRef<HTMLDivElement | null>(null);
+  const [lockedFlyoutHeight, setLockedFlyoutHeight] = useState<number | null>(null);
   function isSubmenuTextInput(element: Element | null): element is HTMLElement {
     return element instanceof HTMLElement
       && element.matches('input, textarea, [contenteditable="true"], [role="textbox"]');
   }
 
   function handleChangeCapture(event: ChangeEvent<HTMLDivElement>) {
-    if (isSubmenuTextInput(event.target instanceof Element ? event.target : null)) {
-      lastTextInputChangeAt.current = Date.now();
+    const target = event.target instanceof Element ? event.target : null;
+    if (!isSubmenuTextInput(target)) return;
+    const text = 'value' in target ? String(target.value) : target.textContent ?? '';
+    if (!text.trim()) {
+      setLockedFlyoutHeight(null);
+      return;
     }
+    setLockedFlyoutHeight((current) => {
+      if (current !== null) return current;
+      const height = flyoutRef.current?.getBoundingClientRect().height ?? 0;
+      return height > 0 ? height : null;
+    });
   }
 
-  function handleMouseLeave() {
-    const activeElement = typeof document !== 'undefined' ? document.activeElement : null;
-    const focusedTextInput =
-      isSubmenuTextInput(activeElement instanceof Element ? activeElement : null)
-      && rowRef.current?.contains(activeElement)
-      && lastTextInputChangeAt.current !== null
-      && Date.now() - lastTextInputChangeAt.current <= PLUS_MENU_SEARCH_LEAVE_GRACE_MS;
-    if (focusedTextInput) return;
-    onClose();
-  }
+  useEffect(() => {
+    if (!open) setLockedFlyoutHeight(null);
+  }, [open]);
+
+  const flyoutStyle = lockedFlyoutHeight === null
+    ? undefined
+    : ({ minHeight: `${lockedFlyoutHeight}px` } satisfies CSSProperties);
 
   return (
     <div
       ref={rowRef}
       className={`plus-menu__submenu-row${open ? ' is-open' : ''}`}
       onMouseEnter={() => onOpen(rowRef.current)}
-      onMouseLeave={handleMouseLeave}
+      onMouseLeave={onClose}
       onChangeCapture={handleChangeCapture}
     >
       <button
@@ -663,10 +671,12 @@ function PlusSubmenuRow({
       </button>
       {open ? (
         <div
+          ref={flyoutRef}
           className={`plus-menu__flyout${flyoutClassName ? ` ${flyoutClassName}` : ''}`}
           role="menu"
+          style={flyoutStyle}
           onMouseEnter={() => onOpen(rowRef.current)}
-          onMouseLeave={handleMouseLeave}
+          onMouseLeave={onClose}
         >
           {children}
         </div>

--- a/apps/web/src/components/ComposerPlusMenu.tsx
+++ b/apps/web/src/components/ComposerPlusMenu.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
   type CSSProperties,
   type ReactNode,
 } from 'react';
@@ -31,6 +32,7 @@ const PLUS_MENU_FLYOUT_WIDTH = 360;
 const PLUS_MENU_PLUGIN_FLYOUT_WIDTH = 466;
 const PLUS_MENU_PREFERRED_MIN_HEIGHT = 180;
 const PLUS_MENU_FLYOUT_MAX_HEIGHT = 320;
+const PLUS_MENU_SEARCH_LEAVE_GRACE_MS = 400;
 type PlusMenuFlyoutPlacement = 'right' | 'left' | 'contained';
 type PlusMenuFlyoutVerticalPlacement = 'down' | 'up';
 type PlusMenuPopupStyle = CSSProperties & Record<'--plus-menu-flyout-max-height', string>;
@@ -456,9 +458,7 @@ export function ComposerPlusMenu({
             testId="composer-plus-plugins"
             onOpen={(row) => openSubmenu('plugins', row)}
             onClose={scheduleCloseSubmenu}
-            flyoutClassName={
-              filteredPlugins.length > 0 ? 'plus-menu__flyout--plugins' : undefined
-            }
+            flyoutClassName="plus-menu__flyout--plugins"
           >
             <div className="plus-menu__plugin-pane">
               <div className="plus-menu__plugin-main">
@@ -584,6 +584,7 @@ export function ComposerPlusMenu({
               open={submenu === 'toolbox'}
               onOpen={(row) => openSubmenu('toolbox', row)}
               onClose={scheduleCloseSubmenu}
+              flyoutClassName="plus-menu__flyout--toolbox"
             >
               {renderToolbox(close)}
             </PlusSubmenuRow>
@@ -616,12 +617,36 @@ function PlusSubmenuRow({
   children: ReactNode;
 }) {
   const rowRef = useRef<HTMLDivElement | null>(null);
+  const lastTextInputChangeAt = useRef<number | null>(null);
+  function isSubmenuTextInput(element: Element | null): element is HTMLElement {
+    return element instanceof HTMLElement
+      && element.matches('input, textarea, [contenteditable="true"], [role="textbox"]');
+  }
+
+  function handleChangeCapture(event: ChangeEvent<HTMLDivElement>) {
+    if (isSubmenuTextInput(event.target instanceof Element ? event.target : null)) {
+      lastTextInputChangeAt.current = Date.now();
+    }
+  }
+
+  function handleMouseLeave() {
+    const activeElement = typeof document !== 'undefined' ? document.activeElement : null;
+    const focusedTextInput =
+      isSubmenuTextInput(activeElement instanceof Element ? activeElement : null)
+      && rowRef.current?.contains(activeElement)
+      && lastTextInputChangeAt.current !== null
+      && Date.now() - lastTextInputChangeAt.current <= PLUS_MENU_SEARCH_LEAVE_GRACE_MS;
+    if (focusedTextInput) return;
+    onClose();
+  }
+
   return (
     <div
       ref={rowRef}
       className={`plus-menu__submenu-row${open ? ' is-open' : ''}`}
       onMouseEnter={() => onOpen(rowRef.current)}
-      onMouseLeave={onClose}
+      onMouseLeave={handleMouseLeave}
+      onChangeCapture={handleChangeCapture}
     >
       <button
         type="button"
@@ -641,7 +666,7 @@ function PlusSubmenuRow({
           className={`plus-menu__flyout${flyoutClassName ? ` ${flyoutClassName}` : ''}`}
           role="menu"
           onMouseEnter={() => onOpen(rowRef.current)}
-          onMouseLeave={onClose}
+          onMouseLeave={handleMouseLeave}
         >
           {children}
         </div>

--- a/apps/web/src/components/ComposerPlusMenu.tsx
+++ b/apps/web/src/components/ComposerPlusMenu.tsx
@@ -457,9 +457,7 @@ export function ComposerPlusMenu({
             testId="composer-plus-plugins"
             onOpen={(row) => openSubmenu('plugins', row)}
             onClose={scheduleCloseSubmenu}
-            flyoutClassName={
-              filteredPlugins.length > 0 ? 'plus-menu__flyout--plugins' : undefined
-            }
+            flyoutClassName="plus-menu__flyout--plugins"
           >
             <div className="plus-menu__plugin-pane">
               <div className="plus-menu__plugin-main">

--- a/apps/web/src/styles/home/plus-menu.css
+++ b/apps/web/src/styles/home/plus-menu.css
@@ -215,6 +215,12 @@
   max-width: calc(100vw - 24px);
   overflow: hidden;
 }
+.plus-menu__flyout--toolbox {
+  min-width: 0;
+  max-width: none;
+  width: 360px;
+  max-width: calc(100vw - 24px);
+}
 .plus-menu__plugin-pane {
   display: flex;
   gap: 8px;
@@ -309,6 +315,9 @@
 /* Narrow surfaces (contained flyout) have no room for a side column, so
    the preview drops below the list and the hero height is capped. */
 .plus-menu__popup--flyout-contained .plus-menu__flyout--plugins {
+  width: auto;
+}
+.plus-menu__popup--flyout-contained .plus-menu__flyout--toolbox {
   width: auto;
 }
 .plus-menu__popup--flyout-contained .plus-menu__plugin-pane {

--- a/apps/web/tests/components/ComposerPlusMenu.test.tsx
+++ b/apps/web/tests/components/ComposerPlusMenu.test.tsx
@@ -7,7 +7,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useState, type ComponentProps } from 'react';
 import { ComposerPlusMenu } from '../../src/components/ComposerPlusMenu';
@@ -128,117 +128,74 @@ describe('ComposerPlusMenu pick-row caret protection', () => {
     expect(screen.getByText('Linear')).toBeTruthy();
   });
 
-  it('keeps the plugins flyout width class when search returns no plugins', () => {
-    renderMenu();
-    fireEvent.click(screen.getByTestId('plus-trigger'));
-
-    fireEvent.click(screen.getByRole('menuitem', { name: /Plugins/i }));
-    expect(document.querySelector('.plus-menu__flyout')?.className).toContain(
-      'plus-menu__flyout--plugins',
-    );
-
-    fireEvent.change(screen.getByPlaceholderText('Plugins'), {
-      target: { value: 'definitely-no-plugin' },
-    });
-
-    expect(screen.getByText('No installed plugins')).toBeTruthy();
-    expect(document.querySelector('.plus-menu__flyout')?.className).toContain(
-      'plus-menu__flyout--plugins',
-    );
-  });
-
-  it('keeps the plugins flyout open when empty-search layout changes fire mouseleave', () => {
-    vi.useFakeTimers();
+  it('keeps the plugins flyout height stable while search is active', () => {
     renderMenu();
     fireEvent.click(screen.getByTestId('plus-trigger'));
     fireEvent.click(screen.getByRole('menuitem', { name: /Plugins/i }));
 
-    const pluginSearch = screen.getByPlaceholderText('Plugins') as HTMLInputElement;
-    pluginSearch.focus();
-    expect(document.activeElement).toBe(pluginSearch);
-
-    fireEvent.change(pluginSearch, {
-      target: { value: 'definitely-no-plugin' },
-    });
     const flyout = document.querySelector('.plus-menu__flyout') as HTMLDivElement;
-    fireEvent.mouseLeave(flyout);
-    act(() => {
-      vi.advanceTimersByTime(250);
-    });
-
-    expect(screen.getByText('No installed plugins')).toBeTruthy();
-    expect(screen.getByPlaceholderText('Plugins')).toBeTruthy();
-  });
-
-  it('closes the plugins flyout after the empty-search mouseleave grace period', () => {
-    vi.useFakeTimers();
-    renderMenu();
-    fireEvent.click(screen.getByTestId('plus-trigger'));
-    fireEvent.click(screen.getByRole('menuitem', { name: /Plugins/i }));
+    flyout.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 466,
+        bottom: 286,
+        width: 466,
+        height: 286,
+        toJSON: () => ({}),
+      }) as DOMRect;
 
     const pluginSearch = screen.getByPlaceholderText('Plugins') as HTMLInputElement;
-    pluginSearch.focus();
     fireEvent.change(pluginSearch, {
       target: { value: 'definitely-no-plugin' },
     });
-    act(() => {
-      vi.advanceTimersByTime(450);
-    });
-    fireEvent.mouseLeave(document.querySelector('.plus-menu__flyout') as HTMLDivElement);
-    act(() => {
-      vi.advanceTimersByTime(250);
-    });
 
-    expect(screen.queryByText('No installed plugins')).toBeNull();
-    expect(screen.getByRole('menuitem', { name: /Plugins/i }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByText('No installed plugins')).toBeTruthy();
+    expect(flyout.style.minHeight).toBe('286px');
+
+    fireEvent.change(pluginSearch, {
+      target: { value: '' },
+    });
+    expect(flyout.style.minHeight).toBe('');
   });
 
-  it('keeps the design toolbox flyout width class when search returns no resources', () => {
-    renderMenu({
-      toolboxLabel: 'Design toolbox',
-      renderToolbox: () => <SearchableToolboxFixture />,
-    });
-    fireEvent.click(screen.getByTestId('plus-trigger'));
-
-    fireEvent.click(screen.getByRole('menuitem', { name: /Design toolbox/i }));
-    expect(document.querySelector('.plus-menu__flyout')?.className).toContain(
-      'plus-menu__flyout--toolbox',
-    );
-
-    fireEvent.change(screen.getByLabelText('Search design toolbox resources'), {
-      target: { value: 'definitely-no-resource' },
-    });
-
-    expect(screen.getByText('No toolbox resources')).toBeTruthy();
-    expect(document.querySelector('.plus-menu__flyout')?.className).toContain(
-      'plus-menu__flyout--toolbox',
-    );
-  });
-
-  it('keeps the design toolbox flyout open when empty-search layout changes fire mouseleave', () => {
-    vi.useFakeTimers();
+  it('keeps the design toolbox flyout height stable while search is active', () => {
     renderMenu({
       toolboxLabel: 'Design toolbox',
       renderToolbox: () => <SearchableToolboxFixture />,
     });
     fireEvent.click(screen.getByTestId('plus-trigger'));
     fireEvent.click(screen.getByRole('menuitem', { name: /Design toolbox/i }));
+
+    const flyout = document.querySelector('.plus-menu__flyout') as HTMLDivElement;
+    expect(flyout.className).toContain('plus-menu__flyout--toolbox');
+    flyout.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 360,
+        bottom: 248,
+        width: 360,
+        height: 248,
+        toJSON: () => ({}),
+      }) as DOMRect;
 
     const toolboxSearch = screen.getByLabelText('Search design toolbox resources') as HTMLInputElement;
-    toolboxSearch.focus();
-    expect(document.activeElement).toBe(toolboxSearch);
-
     fireEvent.change(toolboxSearch, {
       target: { value: 'definitely-no-resource' },
     });
-    const flyout = document.querySelector('.plus-menu__flyout') as HTMLDivElement;
-    fireEvent.mouseLeave(flyout);
-    act(() => {
-      vi.advanceTimersByTime(250);
-    });
 
     expect(screen.getByText('No toolbox resources')).toBeTruthy();
-    expect(screen.getByLabelText('Search design toolbox resources')).toBeTruthy();
+    expect(flyout.style.minHeight).toBe('248px');
+
+    fireEvent.change(toolboxSearch, {
+      target: { value: '' },
+    });
+    expect(flyout.style.minHeight).toBe('');
   });
 
   it('portals the menu and constrains it to the available viewport height', async () => {

--- a/apps/web/tests/components/ComposerPlusMenu.test.tsx
+++ b/apps/web/tests/components/ComposerPlusMenu.test.tsx
@@ -7,15 +7,16 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ComponentProps } from 'react';
+import { useState, type ComponentProps } from 'react';
 import { ComposerPlusMenu } from '../../src/components/ComposerPlusMenu';
 import { I18nProvider } from '../../src/i18n';
 import type { Locale } from '../../src/i18n/types';
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
 });
 
 const CONNECTOR = { id: 'c1', name: 'Notion', status: 'connected' } as never;
@@ -71,6 +72,31 @@ function expectPickRowPreventsMousedown(name: RegExp) {
   expect(event.defaultPrevented).toBe(true);
 }
 
+function SearchableToolboxFixture() {
+  const [query, setQuery] = useState('');
+  const hasResults = query.trim().length === 0;
+  return (
+    <>
+      <div className="plus-menu__search">
+        <input
+          aria-label="Search design toolbox resources"
+          value={query}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+        />
+      </div>
+      {hasResults ? (
+        <div className="plus-menu__list">
+          <button type="button" role="menuitem" className="plus-menu__item">
+            <span>Toolbox action</span>
+          </button>
+        </div>
+      ) : (
+        <div className="plus-menu__empty">No toolbox resources</div>
+      )}
+    </>
+  );
+}
+
 describe('ComposerPlusMenu pick-row caret protection', () => {
   it('cancels mousedown on the connector / plugin / MCP pick rows', () => {
     renderMenu();
@@ -100,6 +126,119 @@ describe('ComposerPlusMenu pick-row caret protection', () => {
     const mcpSearch = screen.getByPlaceholderText('MCP') as HTMLInputElement;
     expect(mcpSearch.value).toBe('');
     expect(screen.getByText('Linear')).toBeTruthy();
+  });
+
+  it('keeps the plugins flyout width class when search returns no plugins', () => {
+    renderMenu();
+    fireEvent.click(screen.getByTestId('plus-trigger'));
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /Plugins/i }));
+    expect(document.querySelector('.plus-menu__flyout')?.className).toContain(
+      'plus-menu__flyout--plugins',
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Plugins'), {
+      target: { value: 'definitely-no-plugin' },
+    });
+
+    expect(screen.getByText('No installed plugins')).toBeTruthy();
+    expect(document.querySelector('.plus-menu__flyout')?.className).toContain(
+      'plus-menu__flyout--plugins',
+    );
+  });
+
+  it('keeps the plugins flyout open when empty-search layout changes fire mouseleave', () => {
+    vi.useFakeTimers();
+    renderMenu();
+    fireEvent.click(screen.getByTestId('plus-trigger'));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Plugins/i }));
+
+    const pluginSearch = screen.getByPlaceholderText('Plugins') as HTMLInputElement;
+    pluginSearch.focus();
+    expect(document.activeElement).toBe(pluginSearch);
+
+    fireEvent.change(pluginSearch, {
+      target: { value: 'definitely-no-plugin' },
+    });
+    const flyout = document.querySelector('.plus-menu__flyout') as HTMLDivElement;
+    fireEvent.mouseLeave(flyout);
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.getByText('No installed plugins')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Plugins')).toBeTruthy();
+  });
+
+  it('closes the plugins flyout after the empty-search mouseleave grace period', () => {
+    vi.useFakeTimers();
+    renderMenu();
+    fireEvent.click(screen.getByTestId('plus-trigger'));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Plugins/i }));
+
+    const pluginSearch = screen.getByPlaceholderText('Plugins') as HTMLInputElement;
+    pluginSearch.focus();
+    fireEvent.change(pluginSearch, {
+      target: { value: 'definitely-no-plugin' },
+    });
+    act(() => {
+      vi.advanceTimersByTime(450);
+    });
+    fireEvent.mouseLeave(document.querySelector('.plus-menu__flyout') as HTMLDivElement);
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.queryByText('No installed plugins')).toBeNull();
+    expect(screen.getByRole('menuitem', { name: /Plugins/i }).getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps the design toolbox flyout width class when search returns no resources', () => {
+    renderMenu({
+      toolboxLabel: 'Design toolbox',
+      renderToolbox: () => <SearchableToolboxFixture />,
+    });
+    fireEvent.click(screen.getByTestId('plus-trigger'));
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /Design toolbox/i }));
+    expect(document.querySelector('.plus-menu__flyout')?.className).toContain(
+      'plus-menu__flyout--toolbox',
+    );
+
+    fireEvent.change(screen.getByLabelText('Search design toolbox resources'), {
+      target: { value: 'definitely-no-resource' },
+    });
+
+    expect(screen.getByText('No toolbox resources')).toBeTruthy();
+    expect(document.querySelector('.plus-menu__flyout')?.className).toContain(
+      'plus-menu__flyout--toolbox',
+    );
+  });
+
+  it('keeps the design toolbox flyout open when empty-search layout changes fire mouseleave', () => {
+    vi.useFakeTimers();
+    renderMenu({
+      toolboxLabel: 'Design toolbox',
+      renderToolbox: () => <SearchableToolboxFixture />,
+    });
+    fireEvent.click(screen.getByTestId('plus-trigger'));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Design toolbox/i }));
+
+    const toolboxSearch = screen.getByLabelText('Search design toolbox resources') as HTMLInputElement;
+    toolboxSearch.focus();
+    expect(document.activeElement).toBe(toolboxSearch);
+
+    fireEvent.change(toolboxSearch, {
+      target: { value: 'definitely-no-resource' },
+    });
+    const flyout = document.querySelector('.plus-menu__flyout') as HTMLDivElement;
+    fireEvent.mouseLeave(flyout);
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.getByText('No toolbox resources')).toBeTruthy();
+    expect(screen.getByLabelText('Search design toolbox resources')).toBeTruthy();
   });
 
   it('portals the menu and constrains it to the available viewport height', async () => {

--- a/apps/web/tests/components/ComposerPlusMenu.test.tsx
+++ b/apps/web/tests/components/ComposerPlusMenu.test.tsx
@@ -272,6 +272,47 @@ describe('ComposerPlusMenu pick-row caret protection', () => {
     }
   });
 
+  it('keeps the plugins flyout width class for empty search in a left-opening layout', () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 420 });
+
+    try {
+      renderMenu();
+      const trigger = screen.getByTestId('plus-trigger') as HTMLButtonElement;
+      trigger.getBoundingClientRect = () =>
+        ({
+          x: 620,
+          y: 376,
+          top: 376,
+          left: 620,
+          right: 648,
+          bottom: 404,
+          width: 28,
+          height: 28,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      fireEvent.click(trigger);
+      const menu = screen.getByRole('menu');
+      expect(menu.className).toContain('plus-menu__popup--flyout-left');
+
+      fireEvent.click(screen.getByRole('menuitem', { name: /Plugins/i }));
+      const pluginSearch = screen.getByPlaceholderText('Plugins') as HTMLInputElement;
+      fireEvent.change(pluginSearch, {
+        target: { value: 'definitely-no-plugin' },
+      });
+
+      const flyout = document.querySelector('.plus-menu__flyout') as HTMLDivElement;
+      expect(screen.getByText('No installed plugins')).toBeTruthy();
+      expect(flyout.className).toContain('plus-menu__flyout--plugins');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight });
+    }
+  });
+
   it('contains flyouts inside the menu when neither side has enough room', () => {
     const originalInnerWidth = window.innerWidth;
     const originalInnerHeight = window.innerHeight;


### PR DESCRIPTION
## Why
The composer plus menu's Plugins and Design toolbox flyouts could close immediately when a search returned no results. The filtered content/layout change could trigger mouseleave and schedule the submenu to close before users could see or edit the empty state. Fix https://github.com/nexu-io/open-design/issues/4269 

## What changed
- Keep the Plugins flyout on its wide layout while the Plugins submenu is open, including empty-search states.
- Preserve the existing height lock for active flyout searches so filtering to no results does not collapse the flyout under the pointer.
- Add regression coverage for empty plugin search in a left-opening layout, ensuring the Plugins flyout keeps `plus-menu__flyout--plugins` even when no plugins match.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)

## Screenshots

https://github.com/user-attachments/assets/b2627454-a5cd-4c09-8a6a-4c88cefb583e


## Bug fix verification

- Main / baseline behavior: the focused regression test for empty-search flyouts fails because the flyout height shrinks with the filtered results, causing the pointer to land outside the flyout and close the submenu before the empty state remains visible.
- This branch: the same regression test passes because active search preserves the flyout’s original height for plugin and Design toolbox flyouts, keeping the empty state visible while normal hover-close behavior still works when the pointer actually leaves.

## Validation
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ComposerPlusMenu.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`