### PR TITLE
fix(daemon): close stdin on AskUserQuestion tool_use so runs don't hang

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4572,7 +4572,6 @@ export function classifyChatRunCloseStatus(params: {
 
 type ClaudeStreamJsonBookkeepingRun = {
   stdinOpen?: boolean;
-  pendingHostAnswers?: Set<string>;
   turnCompletedCleanly?: boolean;
   child?: {
     stdin?: {
@@ -4599,30 +4598,18 @@ export function applyClaudeStreamJsonRunBookkeeping(
     stopReason?: unknown;
   };
 
-  if (
-    run.stdinOpen &&
-    event.type === 'tool_use' &&
-    (event.name === 'AskUserQuestion' || event.name === 'ask_user_question') &&
-    typeof event.id === 'string'
-  ) {
-    if (!run.pendingHostAnswers) run.pendingHostAnswers = new Set();
-    run.pendingHostAnswers.add(event.id);
-    return;
-  }
-
   const cleanTerminalTurn =
-    ((event.type === 'turn_end' &&
+    (event.type === 'turn_end' &&
       // `stop_reason: tool_use` means the model paused to wait for tool
-      // execution (claude-code is about to run an internal tool, or we owe a
-      // host tool_result). Either way the conversation is still in flight.
+      // execution (claude-code is about to run an internal tool). The
+      // conversation is still in flight.
       event.stopReason !== 'tool_use') ||
-      (event.type === 'usage' && event.stopReason !== 'tool_use')) &&
-    (!run.pendingHostAnswers || run.pendingHostAnswers.size === 0);
+    (event.type === 'usage' && event.stopReason !== 'tool_use');
   if (!cleanTerminalTurn) return;
 
-  // Record clean completion even if stdin was already closed by the
-  // host-answer path. The close-status classifier reads this to ignore late
-  // SessionEnd hook failures after the final assistant turn completed.
+  // Record clean completion even if stdin was already closed. The
+  // close-status classifier reads this to ignore late SessionEnd hook
+  // failures after the final assistant turn completed.
   run.turnCompletedCleanly = true;
   if (run.stdinOpen) {
     if (run.child?.stdin && !run.child.stdin.destroyed) {

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -551,7 +551,6 @@ describe('applyClaudeStreamJsonRunBookkeeping', () => {
   it('keeps stdin open when usage reports a tool_use stop reason', () => {
     const run = {
       stdinOpen: true,
-      pendingHostAnswers: new Set<string>(),
       turnCompletedCleanly: false,
       child: {
         stdin: {
@@ -570,5 +569,36 @@ describe('applyClaudeStreamJsonRunBookkeeping', () => {
     expect(run.turnCompletedCleanly).toBe(false);
     expect(run.stdinOpen).toBe(true);
     expect(run.child.stdin.end).not.toHaveBeenCalled();
+  });
+
+  it('closes stdin and records clean completion after an AskUserQuestion tool_use followed by end_turn (#4273)', () => {
+    // Regression test: the dead AskUserQuestion detection branch used to add
+    // the tool_use id to pendingHostAnswers and return early, preventing stdin
+    // from ever closing when the subsequent turn_end arrived.
+    const run = {
+      stdinOpen: true,
+      turnCompletedCleanly: false,
+      child: {
+        stdin: {
+          destroyed: false,
+          end: vi.fn(),
+        },
+      },
+    };
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'tool_use',
+      name: 'AskUserQuestion',
+      id: 'auq_123',
+    });
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'turn_end',
+      stopReason: 'end_turn',
+    });
+
+    expect(run.turnCompletedCleanly).toBe(true);
+    expect(run.stdinOpen).toBe(false);
+    expect(run.child.stdin.end).toHaveBeenCalled();
   });
 });

--- a/specs/change/20260529-claude-session-resume/spec.md
+++ b/specs/change/20260529-claude-session-resume/spec.md
@@ -34,8 +34,10 @@ Constraints:
 - Do not regress any existing behavior. Resume is best-effort: when a guard
   fails, the capability is absent, or `--resume` is rejected at runtime, the
   daemon falls back to today's full-transcript spawn for that turn.
-- Do not break the interactive `stream-json` / `AskUserQuestion` machinery
-  (`pendingHostAnswers`, `POST /api/runs/:id/tool-result`).
+- Do not break the `stream-json` input skeleton (generic mid-turn stdin
+  infrastructure). Note: the `AskUserQuestion` tool wiring and
+  `POST /api/runs/:id/tool-result` endpoint were removed in PR #4114; the
+  `pendingHostAnswers` dead branch was cleaned up in PR #4273.
 - Keep the daemon the source of truth: the stored session pointer is a cache
   keyed on daemon-owned conversation state, never the authoritative history.
 - Claude-only in v1. Other adapters keep `resumesSessionViaCli` unset and the

--- a/specs/change/20260529-claude-session-resume/spec.md
+++ b/specs/change/20260529-claude-session-resume/spec.md
@@ -117,7 +117,7 @@ it stays Claude-first and opt-out-able:
    next user message (`POST /api/chat`). The `AskUserQuestion` tool wiring and
    `POST /api/runs/:id/tool-result` endpoint were removed (PR #4114); the
    `stream-json` stdin skeleton is retained only as generic mid-turn input
-   infrastructure, with stdin closing on a `tool_use` stop reason. multica
+   infrastructure, with stdin staying open across `tool_use` pauses and closing only after a terminal non-`tool_use` turn/end result. multica
    disables `AskUserQuestion` entirely (`--disallowedTools AskUserQuestion`).
    Resume must not disturb the `<question-form>` clarification path.
 2. **Per-turn prompt rewriting.** OD recomposes the system prompt + skills +

--- a/specs/change/20260529-claude-session-resume/spec.md
+++ b/specs/change/20260529-claude-session-resume/spec.md
@@ -112,9 +112,14 @@ OD is a synchronous, interactive design-chat, not an async issue/task runner.
 These traits are why resume must be guarded rather than unconditional, and why
 it stays Claude-first and opt-out-able:
 
-1. **Interactive mid-turn tools.** OD keeps `stream-json` stdin open to answer
-   `AskUserQuestion` with a real `tool_result`. multica disables it
-   (`--disallowedTools AskUserQuestion`). Resume must not disturb this path.
+1. **Interactive mid-turn clarification.** OD routes clarifying questions
+   through the `<question-form>` markdown artifact; answers flow back as the
+   next user message (`POST /api/chat`). The `AskUserQuestion` tool wiring and
+   `POST /api/runs/:id/tool-result` endpoint were removed (PR #4114); the
+   `stream-json` stdin skeleton is retained only as generic mid-turn input
+   infrastructure, with stdin closing on a `tool_use` stop reason. multica
+   disables `AskUserQuestion` entirely (`--disallowedTools AskUserQuestion`).
+   Resume must not disturb the `<question-form>` clarification path.
 2. **Per-turn prompt rewriting.** OD recomposes the system prompt + skills +
    memory + design system into the `# Instructions` block of the stdin user
    message every turn. Because the instructions ride the stdin message (not a
@@ -336,8 +341,12 @@ per `AGENTS.md`:
 - **Capability probe.** A `claude --help` without `--resume` → flag never sent
   AND every turn carries the full transcript (skip-transcript stays off because
   `resolveResumeDecision` returns null without the capability).
-- **Interactive intact.** An `AskUserQuestion` turn still resolves via
-  `POST /api/runs/:id/tool-result` under resume.
+- **Interactive intact.** A clarifying-question turn (`<question-form>` artifact)
+  still resolves through `POST /api/chat` (the user's answer as the next message)
+  under resume; the `<question-form>` path is independent of session state and
+  is unaffected by `--resume`. (The `AskUserQuestion` tool wiring and
+  `POST /api/runs/:id/tool-result` endpoint were removed in PR #4114 and are
+  not part of this feature.)
 
 Human verification (per `AGENTS.md`, two namespaced runtimes: `main` vs branch):
 drive a multi-turn chat through production HTTP only; confirm continuity holds


### PR DESCRIPTION
Fixes #4273

## Why

**Use case:** Hit this directly while driving Open Design in Design Mode through the Claude Code CLI runtime. The agent asked a question, the Questions tab showed it with three answers, I selected one — and the **Continue** button stayed disabled with no way to proceed. The run hung indefinitely.

**Pain:** A run can wedge permanently. When the Claude Code CLI fires its built-in `AskUserQuestion` tool (which it does at its own discretion, independent of the daemon's system prompt), the daemon never closes stdin, so the run sits in `running` until the 600s inactivity watchdog kills it. The web UI gates the Continue button on "no active run," so it stays disabled the whole time. Likely the same defect surfacing as #3146 ("Daemon-spawned claude runs complete the API call but never exit; 600s watchdog kills them").

Root cause is an **incomplete cleanup from #4114**. That PR deleted the `AskUserQuestion` answer-delivery infrastructure (the `POST /api/runs/:id/tool-result` endpoint) but left the matching *detection* branch in `applyClaudeStreamJsonRunBookkeeping`. The branch stashes the tool_use id in `run.pendingHostAnswers` and returns early, holding stdin open to wait for a host `tool_result` that can no longer arrive. The subsequent `turn_end` then fails its `cleanTerminalTurn` check because of the `pendingHostAnswers.size === 0` guard, so stdin never closes.

## What users will see

Runs no longer hang after the agent emits a question. Previously, once the CLI fired its built-in `AskUserQuestion` tool, the run got stuck `running` forever and the **Continue** button stayed disabled. Now the turn terminates cleanly, the run reaches `succeeded`, and Continue enables as expected.

No change to the intended question UX: the agent still asks via the `<question-form>` artifact (Questions tab → answer posts as the next message). This fix only stops the *other* path — the CLI's built-in `AskUserQuestion` tool — from deadlocking the run. There is deliberately no answer-return wiring for that tool (removed in #4114); the turn simply ends cleanly instead of hanging.

This is a daemon-internal logic fix — no UI, CLI, or contract code changed.

## Surface area

- [x] **None** — internal daemon logic fix + regression test. No new UI / CLI / API surface, no contract or schema change.

## Screenshots

N/A — no UI code changed. The symptom is visual (disabled Continue button) but the cause and fix are entirely in daemon stdin-lifecycle bookkeeping. Reproducing the symptom live requires the CLI to fire its built-in `AskUserQuestion` tool, which is nondeterministic; verification is via the deterministic unit test below.

## Bug fix verification

- **Test path:** `apps/daemon/tests/chat-run-artifact-quiet-period.test.ts` → `applyClaudeStreamJsonRunBookkeeping` › "closes stdin and records clean completion after an AskUserQuestion tool_use followed by end_turn (#4273)"
- **Red on `main`, green on this branch?** Yes. The new test drives the exact event sequence (`AskUserQuestion` tool_use → `end_turn`) through the real bookkeeping function and asserts `stdinOpen === false` / `turnCompletedCleanly === true`. It fails on the pre-fix code (stdin stays open) and passes after removing the dead branch.

## Validation

- `pnpm guard` — pass (pre-existing design-system-manifest failures on `main` unrelated; confirmed by stash/run comparison)
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon test` — full suite; new test green; the 108 pre-existing failures match the untouched-branch baseline by name (no new failures)
- `pnpm --filter @open-design/daemon build` — pass
- Re-ran the regression file standalone on a fresh `pnpm install`: `38 passed (38)`

## Fix

Three deletions in `apps/daemon/src/server.ts`:
1. `pendingHostAnswers?: Set<string>` field on `ClaudeStreamJsonBookkeepingRun`
2. The dead `AskUserQuestion` detection branch in `applyClaudeStreamJsonRunBookkeeping`
3. The `pendingHostAnswers` clause in the `cleanTerminalTurn` condition

A non-`tool_use` `turn_end` now closes stdin regardless of preceding tool_use events. Also updated a stale `pendingHostAnswers` reference in `specs/change/20260529-claude-session-resume/spec.md`.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
