### PR TITLE
fix(web,daemon): sanitize preview document title so printed PDF filenames are Teams-safe

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -802,9 +802,22 @@ function daemonDecodeHtmlEntitiesForTitle(encoded: string): string {
 }
 
 function daemonSanitizePreviewTitle(text: string): string {
-  let result = text.replace(/^~\$/, '');
+  // Trim first so that leading whitespace cannot hide a ~$ prefix from the
+  // anchor-based check below (e.g. "  ~$Invoice" would otherwise survive).
+  let result = text.trim();
+  // Remove every leading ~$ prefix. A single replace(/^~\$/, '') is not
+  // enough when the prefix is doubled ("~$~$Doc"). Loop until stable, then
+  // re-trim in case a space followed the prefix ("~$ Invoice" → " Invoice").
+  let prev: string;
+  do {
+    prev = result;
+    result = result.replace(/^~\$/, '').trim();
+  } while (result !== prev);
+  // Replace each disallowed character (or run of them) with a single hyphen.
+  // Character class: : # % & * { } \ < > ? / + | "
   // eslint-disable-next-line no-useless-escape
   result = result.replace(/[:#%&*{}\\<>?/+|"]+/g, '-');
+  // Final trim to remove any spaces exposed by the substitution.
   return result.trim();
 }
 

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -749,6 +749,136 @@ function injectUrlPreviewBridge(html: string, bridge: 'scroll' | 'selection' | '
   return injectBeforeBodyClose(html, 'data-od-url-snapshot-bridge', URL_PREVIEW_SNAPSHOT_BRIDGE);
 }
 
+// ---------------------------------------------------------------------------
+// Teams-safe title sanitization for the URL-load preview path (issue #3918).
+//
+// When a user prints an HTML preview via Cmd+P → "Save as PDF", Chromium uses
+// the iframe's document <title> as the default filename. The URL-load iframe
+// uses sandbox="allow-scripts allow-downloads" (no allow-same-origin), so the
+// host page cannot access contentDocument to rewrite the title after load.
+// Instead we rewrite it here, in the daemon response, before the browser
+// parses the document. The web srcDoc path has its own sanitizeTitleInDoc in
+// apps/web/src/runtime/srcdoc.ts — keep the two in sync when the logic changes.
+// ---------------------------------------------------------------------------
+
+/** Named non-ASCII entities common in business/design document titles. */
+const DAEMON_NAMED_ENTITY_MAP: Record<string, string> = {
+  agrave: 'à', aacute: 'á', acirc: 'â', atilde: 'ã', auml: 'ä', aring: 'å',
+  aelig: 'æ', ccedil: 'ç',
+  egrave: 'è', eacute: 'é', ecirc: 'ê', euml: 'ë',
+  igrave: 'ì', iacute: 'í', icirc: 'î', iuml: 'ï',
+  eth: 'ð', ntilde: 'ñ',
+  ograve: 'ò', oacute: 'ó', ocirc: 'ô', otilde: 'õ', ouml: 'ö', oslash: 'ø',
+  ugrave: 'ù', uacute: 'ú', ucirc: 'û', uuml: 'ü',
+  yacute: 'ý', thorn: 'þ', yuml: 'ÿ',
+  Agrave: 'À', Aacute: 'Á', Acirc: 'Â', Atilde: 'Ã', Auml: 'Ä', Aring: 'Å',
+  AElig: 'Æ', Ccedil: 'Ç',
+  Egrave: 'È', Eacute: 'É', Ecirc: 'Ê', Euml: 'Ë',
+  Igrave: 'Ì', Iacute: 'Í', Icirc: 'Î', Iuml: 'Ï',
+  ETH: 'Ð', Ntilde: 'Ñ',
+  Ograve: 'Ò', Oacute: 'Ó', Ocirc: 'Ô', Otilde: 'Õ', Ouml: 'Ö', Oslash: 'Ø',
+  Ugrave: 'Ù', Uacute: 'Ú', Ucirc: 'Û', Uuml: 'Ü',
+  Yacute: 'Ý', THORN: 'Þ',
+  ndash: '–', mdash: '—', lsquo: '‘', rsquo: '’',
+  ldquo: '“', rdquo: '”', hellip: '…', trade: '™', reg: '®',
+  copy: '©', deg: '°', euro: '€', pound: '£', yen: '¥',
+};
+
+function daemonSafeFromCodePoint(cp: number): string {
+  if (cp < 0 || cp > 0x10ffff) return '�';
+  return String.fromCodePoint(cp);
+}
+
+function daemonDecodeHtmlEntitiesForTitle(encoded: string): string {
+  return encoded
+    .replace(/&([A-Za-z]+);/g, (match: string, name: string) => DAEMON_NAMED_ENTITY_MAP[name] ?? match)
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (_: string, n: string) => daemonSafeFromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_: string, h: string) => daemonSafeFromCodePoint(parseInt(h, 16)));
+}
+
+function daemonSanitizePreviewTitle(text: string): string {
+  let result = text.replace(/^~\$/, '');
+  // eslint-disable-next-line no-useless-escape
+  result = result.replace(/[:#%&*{}\\<>?/+|"]+/g, '-');
+  return result.trim();
+}
+
+/**
+ * Find the offset of the first real `<title>` tag in html[0..searchLimit)
+ * that is not inside an HTML comment or a `<script>`/`<style>` block.
+ * Returns -1 if no real title is found.
+ */
+function daemonFindRealTitleOffset(html: string, searchLimit: number): number {
+  let i = 0;
+  const limit = Math.min(html.length, searchLimit);
+  while (i < limit) {
+    if (html.charCodeAt(i) === 60 /* < */ && html.slice(i, i + 4) === '<!--') {
+      const end = html.indexOf('-->', i + 4);
+      if (end < 0) return -1;
+      i = end + 3;
+      continue;
+    }
+    if (html.charCodeAt(i) === 60 /* < */) {
+      const tagMatch = /^<(script|style)\b/i.exec(html.slice(i, i + 20));
+      if (tagMatch) {
+        const closingTag = `</${tagMatch[1]}`;
+        const end = html.toLowerCase().indexOf(closingTag.toLowerCase(), i + tagMatch[0].length);
+        if (end < 0) return -1;
+        const closeEnd = html.indexOf('>', end);
+        i = closeEnd >= 0 ? closeEnd + 1 : end + closingTag.length;
+        continue;
+      }
+    }
+    if (html.charCodeAt(i) === 60 /* < */) {
+      if (/^<title[\s>]/i.test(html.slice(i, i + 8))) return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Rewrite the `<title>` in html so the resulting PDF filename is Teams-safe.
+ * Only the real `<head>` title is changed; `<title>` inside comments or script
+ * blocks is left untouched. Mirrors sanitizeTitleInDoc in srcdoc.ts.
+ */
+function daemonSanitizeTitleInDoc(html: string): string {
+  const lower = html.toLowerCase();
+  const bodyStart = lower.indexOf('<body');
+  const headEnd = lower.lastIndexOf('</head>', bodyStart >= 0 ? bodyStart - 1 : lower.length - 1);
+  const searchLimit = headEnd >= 0
+    ? headEnd + 7
+    : bodyStart >= 0
+      ? bodyStart
+      : html.length;
+
+  const titleStart = daemonFindRealTitleOffset(html, searchLimit);
+  if (titleStart < 0) return html;
+
+  const openTagEnd = html.indexOf('>', titleStart);
+  if (openTagEnd < 0) return html;
+
+  const closingTagStart = html.toLowerCase().indexOf('</title>', openTagEnd + 1);
+  if (closingTagStart < 0) return html;
+
+  const closingTagEnd = html.indexOf('>', closingTagStart);
+  if (closingTagEnd < 0) return html;
+
+  const openTag = html.slice(titleStart, openTagEnd + 1);
+  const rawContent = html.slice(openTagEnd + 1, closingTagStart);
+  const closeTag = html.slice(closingTagStart, closingTagEnd + 1);
+
+  const decoded = daemonDecodeHtmlEntitiesForTitle(rawContent);
+  const safe = daemonSanitizePreviewTitle(decoded);
+
+  return html.slice(0, titleStart) + openTag + safe + closeTag + html.slice(closingTagEnd + 1);
+}
+
 function normalizeChatSessionMode(value: unknown): ChatSessionMode {
   return value === 'chat' ? 'chat' : 'design';
 }
@@ -2304,6 +2434,12 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
             /^text\/html(?:;|$)/i.test(file.mime)
           ) {
             let html = Buffer.isBuffer(transformed) ? transformed.toString('utf8') : transformed;
+            // Sanitize the <title> so Cmd+P → "Save as PDF" produces a
+            // Teams-safe filename. The URL-load iframe uses sandbox without
+            // allow-same-origin, so the host cannot rewrite contentDocument.title
+            // after load — we must do it here in the response. The srcDoc path
+            // has its own sanitization in buildSrcdoc (apps/web/src/runtime/srcdoc.ts).
+            html = daemonSanitizeTitleInDoc(html);
             if (wantsUrlPreviewScrollBridge(req.query.odPreviewBridge)) {
               html = injectUrlPreviewBridge(html, 'scroll');
             }

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -846,8 +846,10 @@ function daemonFindRealTitleOffset(html: string, searchLimit: number): number {
  * Rewrite the `<title>` in html so the resulting PDF filename is Teams-safe.
  * Only the real `<head>` title is changed; `<title>` inside comments or script
  * blocks is left untouched. Mirrors sanitizeTitleInDoc in srcdoc.ts.
+ *
+ * Exported for unit testing; not part of the public API surface.
  */
-function daemonSanitizeTitleInDoc(html: string): string {
+export function daemonSanitizeTitleInDoc(html: string): string {
   const lower = html.toLowerCase();
   const bodyStart = lower.indexOf('<body');
   const headEnd = lower.lastIndexOf('</head>', bodyStart >= 0 ? bodyStart - 1 : lower.length - 1);

--- a/apps/daemon/tests/project-routes-title-sanitize.test.ts
+++ b/apps/daemon/tests/project-routes-title-sanitize.test.ts
@@ -88,6 +88,62 @@ describe('daemonSanitizeTitleInDoc – Teams-disallowed characters', () => {
     expect(title).toBe('Invoice Sable Studio INV-2025-0142');
   });
 
+  // ---------------------------------------------------------------------------
+  // Defect #5 (issue #3918): leading whitespace hides the ~$ prefix from the
+  // anchor-based strip, so trim must happen BEFORE the ~$ check.
+  // ---------------------------------------------------------------------------
+
+  it('strips ~$ even when leading whitespace precedes it ("  ~$Invoice #1")', () => {
+    // Bug: replace(/^~\$/, '') is anchored to position 0; when the title has
+    // leading spaces the anchor misses, and after .trim() the result still
+    // starts with "~$".
+    const html = `<!doctype html>
+<html>
+  <head><title>  ~$Invoice #1</title></head>
+  <body></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+
+    expect(title).not.toBeNull();
+    expect(title).not.toMatch(/^~\$/);
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+    expect(title).not.toMatch(/^\s|\s$/);
+  });
+
+  it('strips ~$ when a space follows the prefix ("~$ Invoice")', () => {
+    // After stripping "~$" the remaining " Invoice" must also be trimmed so
+    // no leading space survives.
+    const html = `<!doctype html>
+<html>
+  <head><title>~$ Invoice</title></head>
+  <body></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+
+    expect(title).not.toBeNull();
+    expect(title).not.toMatch(/^~\$/);
+    expect(title).not.toMatch(/^\s/);
+  });
+
+  it('strips a doubled ~$ prefix ("~$~$Doc")', () => {
+    // A doubled prefix must be fully removed; a single strip would leave "~$Doc".
+    const html = `<!doctype html>
+<html>
+  <head><title>~$~$Doc</title></head>
+  <body></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+
+    expect(title).not.toBeNull();
+    expect(title).not.toMatch(/^~\$/);
+  });
+
   it('leaves body content outside <title> completely unchanged', () => {
     const html = `<!doctype html>
 <html>

--- a/apps/daemon/tests/project-routes-title-sanitize.test.ts
+++ b/apps/daemon/tests/project-routes-title-sanitize.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Regression tests for daemon-side Teams-safe URL-load preview title sanitization
+ * (issue #3918).
+ *
+ * The daemon's /api/projects/:id/raw/:file handler serves static HTML previews
+ * (e.g. design-templates/invoice/example.html) to the URL-load iframe. Because
+ * that iframe uses sandbox="allow-scripts allow-downloads" without allow-same-origin,
+ * the host page cannot access contentDocument.title after load. The daemon therefore
+ * must rewrite <title> in the HTTP response body before the browser parses it.
+ *
+ * daemonSanitizeTitleInDoc (exported from project-routes.ts) is the function that
+ * does this. It mirrors sanitizeTitleInDoc in apps/web/src/runtime/srcdoc.ts.
+ *
+ * Teams-disallowed character set (per maintainer lefarcen, issue #3918):
+ *   : # % & * { } \ < > ? / + | "
+ * Plus: leading/trailing spaces, and the sequence ~$
+ */
+import { describe, expect, it } from 'vitest';
+import { daemonSanitizeTitleInDoc } from '../src/project-routes.js';
+
+// Characters that Microsoft Teams rejects in filenames.
+const TEAMS_DISALLOWED = /[:#%&*{}\\<>?/+|"]/;
+
+/** Extract the text content of the first <title> tag in an HTML string. */
+function extractTitle(html: string): string | null {
+  const m = /<title[^>]*>([^<]*)<\/title>/i.exec(html);
+  return m != null ? (m[1] ?? null) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Core sanitization: Teams-disallowed characters are replaced in <title>
+// ---------------------------------------------------------------------------
+describe('daemonSanitizeTitleInDoc – Teams-disallowed characters', () => {
+  it('replaces Teams-disallowed chars in a typical invoice title', () => {
+    // Covers the reported repro: "Invoice #INV/2025:Acme & Co"
+    const html = `<!doctype html>
+<html>
+  <head>
+    <title>Invoice #INV/2025:Acme &amp; Co</title>
+  </head>
+  <body>
+    <h1>Invoice</h1>
+    <p>Client: Acme &amp; Co</p>
+    <p>Invoice: INV/2025</p>
+  </body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+
+    expect(title).not.toBeNull();
+    // No Teams-disallowed character may appear in the rewritten title.
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+    // No leading or trailing space.
+    expect(title).not.toMatch(/^\s|\s$/);
+    // Body content outside <title> must be left exactly as-is.
+    expect(result).toContain('Acme &amp; Co');
+    expect(result).toContain('INV/2025');
+  });
+
+  it('replaces every character from the full Teams-disallowed set', () => {
+    const allDisallowed = ':#%&*{}\\<>?/+|"';
+    const html = `<!doctype html>
+<html>
+  <head><title>A${allDisallowed}B</title></head>
+  <body></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+
+    expect(title).not.toBeNull();
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+    expect(title).toContain('A');
+    expect(title).toContain('B');
+  });
+
+  it('leaves an already-safe title unchanged', () => {
+    const html = `<!doctype html>
+<html>
+  <head><title>Invoice Sable Studio INV-2025-0142</title></head>
+  <body><p>Content</p></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+
+    expect(title).toBe('Invoice Sable Studio INV-2025-0142');
+  });
+
+  it('leaves body content outside <title> completely unchanged', () => {
+    const html = `<!doctype html>
+<html>
+  <head><title>Safe Title</title></head>
+  <body>
+    <p>Invoice #INV/2025:Acme &amp; Co</p>
+  </body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    // Body paragraph must not have been touched.
+    expect(result).toContain('<p>Invoice #INV/2025:Acme &amp; Co</p>');
+    // Title is safe.
+    expect(TEAMS_DISALLOWED.test(extractTitle(result)!)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect #2: out-of-range numeric entities must not throw
+// ---------------------------------------------------------------------------
+describe('daemonSanitizeTitleInDoc – out-of-range numeric entities', () => {
+  it('does not throw on a decimal numeric entity beyond the Unicode range (&#9999999999;)', () => {
+    // String.fromCodePoint throws RangeError for values > 0x10FFFF without the
+    // safeFromCodePoint guard. This test would crash before the fix.
+    const html = `<!doctype html>
+<html>
+  <head><title>Invoice &#9999999999; Report</title></head>
+  <body></body>
+</html>`;
+
+    expect(() => daemonSanitizeTitleInDoc(html)).not.toThrow();
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+    expect(title).not.toBeNull();
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+  });
+
+  it('does not throw on a hex numeric entity beyond the Unicode range (&#x110000;)', () => {
+    const html = `<!doctype html>
+<html>
+  <head><title>Doc &#x110000; End</title></head>
+  <body></body>
+</html>`;
+
+    expect(() => daemonSanitizeTitleInDoc(html)).not.toThrow();
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+    expect(title).not.toBeNull();
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect #3: named non-ASCII entities must not leave orphaned `name;` remnants
+// ---------------------------------------------------------------------------
+describe('daemonSanitizeTitleInDoc – named non-ASCII entities', () => {
+  it('does not leave orphaned entity text when &ccedil; appears in the title', () => {
+    // Before the fix: "&" is stripped first, leaving the literal string "ccedil;"
+    // in the title. After the fix: &ccedil; is decoded to ç before sanitizing.
+    const html = `<!doctype html>
+<html>
+  <head><title>Fran&ccedil;ois Invoice</title></head>
+  <body></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+
+    expect(title).not.toBeNull();
+    // The literal "ccedil;" must not appear in the output title.
+    expect(title).not.toContain('ccedil;');
+    // The non-entity parts of the title must still be present.
+    expect(title).toContain('ois Invoice');
+  });
+
+  it('does not leave orphaned entity text for &eacute;', () => {
+    const html = `<!doctype html>
+<html>
+  <head><title>R&eacute;sum&eacute; 2025</title></head>
+  <body></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+
+    expect(title).not.toBeNull();
+    expect(title).not.toContain('eacute;');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect #4: only the real <head> title must be rewritten; not imposters in
+// comments or <script> blocks
+// ---------------------------------------------------------------------------
+describe('daemonSanitizeTitleInDoc – only rewrites the real <head> title', () => {
+  it('does not treat a <title> inside an HTML comment as the document title', () => {
+    // The comment appears before the real <title>. Without the fix the comment's
+    // <title> would be matched first and the real title would be left unsanitized.
+    const html = `<!doctype html>
+<html>
+  <head>
+    <!-- <title>Fake Title &amp; Bad</title> -->
+    <title>Real Invoice Title</title>
+  </head>
+  <body></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+
+    // The real title must still be present and unaltered (it is already safe).
+    expect(result).toContain('<title>Real Invoice Title</title>');
+    // The comment content must be untouched.
+    expect(result).toContain('<!-- <title>Fake Title &amp; Bad</title> -->');
+  });
+
+  it('does not treat a <title> inside a <script> string as the document title', () => {
+    const html = `<!doctype html>
+<html>
+  <head>
+    <script>var x = '<title>Script Title &amp; Broken</title>';</script>
+    <title>Real Safe Title</title>
+  </head>
+  <body></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+
+    // Real title must still be there (already safe, so unchanged).
+    expect(result).toContain('<title>Real Safe Title</title>');
+    // Script content must not have been mutated.
+    expect(result).toContain("var x = '<title>Script Title &amp; Broken</title>';");
+  });
+
+  it('returns html unchanged when there is no <title> element', () => {
+    const html = `<!doctype html>
+<html>
+  <head></head>
+  <body><p>No title here</p></body>
+</html>`;
+
+    const result = daemonSanitizeTitleInDoc(html);
+    expect(result).toBe(html);
+  });
+});

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -45,18 +45,27 @@ export type SrcdocOptions = {
  * Titles that are already safe pass through unchanged.
  *
  * Invariant: the returned string contains none of the Teams-disallowed
- * characters and has no leading or trailing spaces.
+ * characters and has no leading or trailing spaces, and does not start
+ * with the ~$ prefix.
  */
 export function sanitizePreviewTitle(text: string): string {
-  // Remove the ~$ prefix Teams rejects (temporary-file marker).
-  let result = text.replace(/^~\$/, '');
+  // Trim first so that leading whitespace cannot hide a ~$ prefix from the
+  // anchor-based check below (e.g. "  ~$Invoice" would otherwise survive).
+  let result = text.trim();
+  // Remove every leading ~$ prefix. A single replace(/^~\$/, '') is not
+  // enough when the prefix is doubled ("~$~$Doc"). Loop until stable, then
+  // re-trim in case a space followed the prefix ("~$ Invoice" → " Invoice").
+  let prev: string;
+  do {
+    prev = result;
+    result = result.replace(/^~\$/, '').trim();
+  } while (result !== prev);
   // Replace each disallowed character (or run of them) with a single hyphen.
   // Character class: : # % & * { } \ < > ? / + | "
   // eslint-disable-next-line no-useless-escape
   result = result.replace(/[:#%&*{}\\<>?/+|"]+/g, '-');
-  // Trim leading and trailing spaces that remain after substitution.
-  result = result.trim();
-  return result;
+  // Final trim to remove any spaces exposed by the substitution.
+  return result.trim();
 }
 
 /**

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -60,45 +60,169 @@ export function sanitizePreviewTitle(text: string): string {
 }
 
 /**
+ * A small set of common named non-ASCII entities that appear in real-world
+ * titles (e.g. &ccedil; → ç, &eacute; → é). Keeping this narrow avoids
+ * shipping a full HTML entity table while still preventing the "orphaned
+ * name;" garbage that results when & is stripped before entity detection.
+ * Characters produced here that are Teams-disallowed get cleaned up by the
+ * subsequent sanitizePreviewTitle pass.
+ */
+const NAMED_ENTITY_MAP: Record<string, string> = {
+  // Latin-1 letters most likely to appear in design/business titles
+  agrave: 'à', aacute: 'á', acirc: 'â', atilde: 'ã', auml: 'ä', aring: 'å',
+  aelig: 'æ', ccedil: 'ç',
+  egrave: 'è', eacute: 'é', ecirc: 'ê', euml: 'ë',
+  igrave: 'ì', iacute: 'í', icirc: 'î', iuml: 'ï',
+  eth: 'ð', ntilde: 'ñ',
+  ograve: 'ò', oacute: 'ó', ocirc: 'ô', otilde: 'õ', ouml: 'ö', oslash: 'ø',
+  ugrave: 'ù', uacute: 'ú', ucirc: 'û', uuml: 'ü',
+  yacute: 'ý', thorn: 'þ', yuml: 'ÿ',
+  Agrave: 'À', Aacute: 'Á', Acirc: 'Â', Atilde: 'Ã', Auml: 'Ä', Aring: 'Å',
+  AElig: 'Æ', Ccedil: 'Ç',
+  Egrave: 'È', Eacute: 'É', Ecirc: 'Ê', Euml: 'Ë',
+  Igrave: 'Ì', Iacute: 'Í', Icirc: 'Î', Iuml: 'Ï',
+  ETH: 'Ð', Ntilde: 'Ñ',
+  Ograve: 'Ò', Oacute: 'Ó', Ocirc: 'Ô', Otilde: 'Õ', Ouml: 'Ö', Oslash: 'Ø',
+  Ugrave: 'Ù', Uacute: 'Ú', Ucirc: 'Û', Uuml: 'Ü',
+  Yacute: 'Ý', THORN: 'Þ',
+  // Common punctuation / symbols that can appear in business document titles
+  ndash: '–', mdash: '—', lsquo: '‘', rsquo: '’',
+  ldquo: '“', rdquo: '”', hellip: '…', trade: '™', reg: '®',
+  copy: '©', deg: '°', euro: '€', pound: '£', yen: '¥',
+};
+
+/**
+ * Safe wrapper around String.fromCodePoint that returns U+FFFD for
+ * out-of-range values instead of throwing RangeError.
+ */
+function safeFromCodePoint(cp: number): string {
+  if (cp < 0 || cp > 0x10ffff) return '�';
+  return String.fromCodePoint(cp);
+}
+
+/**
  * Decode the minimal HTML entities that browsers render in <title> text:
  * &amp; → & , &lt; → < , &gt; → > , &quot; → " , &apos; → ' , &#N; / &#xN;
- * This is intentionally narrow — <title> does not support rich HTML, and a
- * full entity-decode table is not needed.
+ * Also decodes a small set of common named non-ASCII entities (e.g. &ccedil;)
+ * so they do not leave orphaned "name;" fragments after the & is sanitized.
+ * Numeric entities with out-of-range code points fall back to U+FFFD instead
+ * of throwing RangeError.
  */
 function decodeHtmlEntitiesForTitle(encoded: string): string {
   return encoded
+    // Named non-ASCII entities first — before the standard 5 named entities
+    // below, so &amp; still converts to & (not left as a lookup miss).
+    .replace(/&([A-Za-z]+);/g, (match, name: string) => NAMED_ENTITY_MAP[name] ?? match)
+    // Standard 5 named entities.
     .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&apos;/gi, "'")
-    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)));
+    // Numeric entities — range-checked to avoid RangeError on huge code points.
+    .replace(/&#(\d+);/g, (_, n: string) => safeFromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h: string) => safeFromCodePoint(parseInt(h, 16)));
+}
+
+/**
+ * Find the character offset of the first real `<title>` tag in an HTML string
+ * that is not inside an HTML comment (`<!-- … -->`), a `<script>` block, or a
+ * `<style>` block. Returns -1 when no real title is found.
+ *
+ * The scan is O(n) over the head region. It keeps track of whether the current
+ * cursor is inside a comment / script / style and skips any `<title>` found
+ * within those contexts.
+ */
+function findRealTitleOffset(html: string, searchLimit: number): number {
+  let i = 0;
+  const limit = Math.min(html.length, searchLimit);
+  while (i < limit) {
+    // Check for HTML comment start
+    if (html.charCodeAt(i) === 60 /* < */ && html.slice(i, i + 4) === '<!--') {
+      const end = html.indexOf('-->', i + 4);
+      if (end < 0) return -1; // unclosed comment — no title after this
+      i = end + 3;
+      continue;
+    }
+    // Check for <script or <style (case-insensitive)
+    if (html.charCodeAt(i) === 60 /* < */) {
+      const tagMatch = /^<(script|style)\b/i.exec(html.slice(i, i + 20));
+      if (tagMatch) {
+        const closingTag = `</${tagMatch[1]}`;
+        const end = html.toLowerCase().indexOf(closingTag.toLowerCase(), i + tagMatch[0].length);
+        if (end < 0) return -1; // unclosed script/style — no title after this
+        const closeEnd = html.indexOf('>', end);
+        i = closeEnd >= 0 ? closeEnd + 1 : end + closingTag.length;
+        continue;
+      }
+    }
+    // Check for <title (case-insensitive)
+    if (html.charCodeAt(i) === 60 /* < */) {
+      if (/^<title[\s>]/i.test(html.slice(i, i + 8))) {
+        return i;
+      }
+    }
+    i++;
+  }
+  return -1;
 }
 
 /**
  * Rewrite the <title> element in an HTML string so its text content is
- * Teams-filename-safe. Only the <title> tag text is changed; all other
- * document content is passed through unchanged.
+ * Teams-filename-safe. Only the real `<title>` in the `<head>` region is
+ * changed — `<title>` occurrences inside HTML comments, `<script>` blocks,
+ * or `<style>` blocks are left untouched.
  *
- * Strategy: locate the first <title>…</title> in the <head> region, decode
- * any HTML entities in its text (because browsers decode them before using
- * the title as a filename), sanitize the decoded text, then substitute the
- * plain sanitized text back. After sanitization the text is guaranteed free
- * of characters that need HTML encoding in a title context.
+ * Strategy:
+ *   1. Locate the `<head>`…`</head>` region (or the area before `<body>`).
+ *   2. Within that region, scan past comments and script/style blocks to find
+ *      the first unambiguous `<title>` start tag.
+ *   3. Decode HTML entities in its text, sanitize, and splice back.
  *
- * Pure string replacement — no DOMParser — so it works identically in Node
+ * Pure string operations — no DOMParser — so it works identically in Node
  * test environments and in the browser.
+ *
+ * @public — exported for daemon-side URL-load title sanitization.
  */
-function sanitizeTitleInDoc(html: string): string {
-  return html.replace(
-    /(<title[^>]*>)([\s\S]*?)(<\/title>)/i,
-    (_match, open, raw, close) => {
-      const decoded = decodeHtmlEntitiesForTitle(raw);
-      const safe = sanitizePreviewTitle(decoded);
-      return `${open}${safe}${close}`;
-    },
-  );
+export function sanitizeTitleInDoc(html: string): string {
+  const lower = html.toLowerCase();
+
+  // Find the end of the <head> region. Use the last </head> before <body>
+  // (mirrors injectBeforeHeadEnd logic) so we don't pick up </head> literals
+  // inside <script>/<style>.
+  const bodyStart = lower.indexOf('<body');
+  const headEnd = lower.lastIndexOf('</head>', bodyStart >= 0 ? bodyStart - 1 : lower.length - 1);
+
+  // The region to search: up to (and including) </head> if found, otherwise
+  // up to <body> if found, otherwise the entire document.
+  const searchLimit = headEnd >= 0
+    ? headEnd + 7 // include the </head> tag itself
+    : bodyStart >= 0
+      ? bodyStart
+      : html.length;
+
+  // Find the real <title> start offset, skipping comments and script/style.
+  const titleStart = findRealTitleOffset(html, searchLimit);
+  if (titleStart < 0) return html;
+
+  // Locate the end of the <title> open tag.
+  const openTagEnd = html.indexOf('>', titleStart);
+  if (openTagEnd < 0) return html;
+
+  // Locate the matching </title>.
+  const closingTagStart = html.toLowerCase().indexOf('</title>', openTagEnd + 1);
+  if (closingTagStart < 0) return html;
+  const closingTagEnd = html.indexOf('>', closingTagStart);
+  if (closingTagEnd < 0) return html;
+
+  const openTag = html.slice(titleStart, openTagEnd + 1);
+  const rawContent = html.slice(openTagEnd + 1, closingTagStart);
+  const closeTag = html.slice(closingTagStart, closingTagEnd + 1);
+
+  const decoded = decodeHtmlEntitiesForTitle(rawContent);
+  const safe = sanitizePreviewTitle(decoded);
+
+  return html.slice(0, titleStart) + openTag + safe + closeTag + html.slice(closingTagEnd + 1);
 }
 
 export function buildSrcdoc(

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -34,6 +34,73 @@ export type SrcdocOptions = {
   previewFocusGuard?: boolean;
 };
 
+/**
+ * Sanitize a document title string so the resulting PDF filename is accepted by
+ * Microsoft Teams. Teams rejects filenames that contain any of:
+ *   : # % & * { } \ < > ? / + | "
+ * as well as leading/trailing spaces and the prefix sequence "~$".
+ *
+ * Each disallowed character (or run of disallowed characters) is replaced with
+ * a single hyphen. The result is trimmed of leading and trailing whitespace.
+ * Titles that are already safe pass through unchanged.
+ *
+ * Invariant: the returned string contains none of the Teams-disallowed
+ * characters and has no leading or trailing spaces.
+ */
+export function sanitizePreviewTitle(text: string): string {
+  // Remove the ~$ prefix Teams rejects (temporary-file marker).
+  let result = text.replace(/^~\$/, '');
+  // Replace each disallowed character (or run of them) with a single hyphen.
+  // Character class: : # % & * { } \ < > ? / + | "
+  // eslint-disable-next-line no-useless-escape
+  result = result.replace(/[:#%&*{}\\<>?/+|"]+/g, '-');
+  // Trim leading and trailing spaces that remain after substitution.
+  result = result.trim();
+  return result;
+}
+
+/**
+ * Decode the minimal HTML entities that browsers render in <title> text:
+ * &amp; → & , &lt; → < , &gt; → > , &quot; → " , &apos; → ' , &#N; / &#xN;
+ * This is intentionally narrow — <title> does not support rich HTML, and a
+ * full entity-decode table is not needed.
+ */
+function decodeHtmlEntitiesForTitle(encoded: string): string {
+  return encoded
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)));
+}
+
+/**
+ * Rewrite the <title> element in an HTML string so its text content is
+ * Teams-filename-safe. Only the <title> tag text is changed; all other
+ * document content is passed through unchanged.
+ *
+ * Strategy: locate the first <title>…</title> in the <head> region, decode
+ * any HTML entities in its text (because browsers decode them before using
+ * the title as a filename), sanitize the decoded text, then substitute the
+ * plain sanitized text back. After sanitization the text is guaranteed free
+ * of characters that need HTML encoding in a title context.
+ *
+ * Pure string replacement — no DOMParser — so it works identically in Node
+ * test environments and in the browser.
+ */
+function sanitizeTitleInDoc(html: string): string {
+  return html.replace(
+    /(<title[^>]*>)([\s\S]*?)(<\/title>)/i,
+    (_match, open, raw, close) => {
+      const decoded = decodeHtmlEntitiesForTitle(raw);
+      const safe = sanitizePreviewTitle(decoded);
+      return `${open}${safe}${close}`;
+    },
+  );
+}
+
 export function buildSrcdoc(
   html: string,
   options: SrcdocOptions = {}
@@ -50,7 +117,12 @@ export function buildSrcdoc(
   </head>
   <body>${html}</body>
 </html>`;
-  const withOdIds = annotateMissingOdIds(wrapped);
+  // Sanitize <title> text before any other transformation so that when the
+  // user prints the preview iframe (Cmd+P → Save as PDF), Chromium uses the
+  // sanitized title as the default filename — one that Microsoft Teams will
+  // accept. Only the title text changes; visible page content is untouched.
+  const withSafeTitle = sanitizeTitleInDoc(wrapped);
+  const withOdIds = annotateMissingOdIds(withSafeTitle);
   const withSourcePaths = options.editBridge ? annotateManualEditSourcePaths(withOdIds) : withOdIds;
   const withBase = options.baseHref ? injectBaseHref(withSourcePaths, options.baseHref) : withSourcePaths;
   const withShim = injectSandboxShim(withBase);

--- a/apps/web/tests/runtime/srcdoc-preview-title-sanitize.test.ts
+++ b/apps/web/tests/runtime/srcdoc-preview-title-sanitize.test.ts
@@ -12,7 +12,11 @@
  * Plus: leading/trailing spaces, and the sequence ~$
  */
 import { describe, expect, it } from 'vitest';
-import { buildSrcdoc, sanitizePreviewTitle } from '../../src/runtime/srcdoc';
+import {
+  buildSrcdoc,
+  sanitizePreviewTitle,
+  sanitizeTitleInDoc,
+} from '../../src/runtime/srcdoc';
 
 // Characters that Teams rejects in filenames.
 const TEAMS_DISALLOWED = /[:#%&*{}\\<>?/+|"]/;
@@ -123,5 +127,118 @@ describe('buildSrcdoc – Teams-safe title', () => {
     expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
     // Must not expose the literal &amp; or & in the title
     expect(title).not.toContain('&');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect #2: decodeHtmlEntitiesForTitle must not throw on out-of-range entities
+// ---------------------------------------------------------------------------
+describe('decodeHtmlEntitiesForTitle – out-of-range numeric entities', () => {
+  it('does not throw on a decimal numeric entity beyond Unicode range (&#9999999999;)', () => {
+    // Out-of-range code point — String.fromCodePoint throws RangeError without
+    // the fix. buildSrcdoc must succeed and produce a Teams-safe title.
+    const html = `<!doctype html>
+<html>
+  <head><title>Invoice &#9999999999; Report</title></head>
+  <body><p>Content</p></body>
+</html>`;
+
+    expect(() => buildSrcdoc(html)).not.toThrow();
+    const result = buildSrcdoc(html);
+    const title = extractTitle(result);
+    expect(title).not.toBeNull();
+    // The entity itself should have been replaced by a fallback (original text or U+FFFD),
+    // not left as a raw code-point that would crash the filename logic.
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+  });
+
+  it('does not throw on a hex numeric entity beyond Unicode range (&#x110000;)', () => {
+    const html = `<!doctype html>
+<html>
+  <head><title>Doc &#x110000; End</title></head>
+  <body></body>
+</html>`;
+
+    expect(() => buildSrcdoc(html)).not.toThrow();
+    const result = buildSrcdoc(html);
+    const title = extractTitle(result);
+    expect(title).not.toBeNull();
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect #3: named non-ASCII entities must not leave orphaned `name;` remnants
+// ---------------------------------------------------------------------------
+describe('sanitizeTitleInDoc – named non-ASCII entities', () => {
+  it('does not leave orphaned entity text when a named non-ASCII entity is in the title', () => {
+    // &ccedil; is ç. Before the fix: "&" is stripped, leaving literal "ccedil;"
+    // in the title. After the fix: ç should appear (or be decoded then sanitized).
+    const html = `<!doctype html>
+<html>
+  <head><title>Fran&ccedil;ois Invoice</title></head>
+  <body></body>
+</html>`;
+
+    const result = sanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+    expect(title).not.toBeNull();
+    // The word "ccedil;" must not appear literally in the title
+    expect(title).not.toContain('ccedil;');
+    // The title should still contain "ois Invoice" (the non-entity parts)
+    expect(title).toContain('ois Invoice');
+  });
+
+  it('handles &eacute; without leaving orphaned entity text', () => {
+    const html = `<!doctype html>
+<html>
+  <head><title>R&eacute;sum&eacute; 2025</title></head>
+  <body></body>
+</html>`;
+
+    const result = sanitizeTitleInDoc(html);
+    const title = extractTitle(result);
+    expect(title).not.toBeNull();
+    expect(title).not.toContain('eacute;');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect #4: sanitizeTitleInDoc must not match <title> inside comments or scripts
+// ---------------------------------------------------------------------------
+describe('sanitizeTitleInDoc – only rewrites the real <head> title', () => {
+  it('does not treat a <title> inside an HTML comment as the document title', () => {
+    // The comment's <title> must not be matched; only the real <head><title> is changed.
+    const html = `<!doctype html>
+<html>
+  <head>
+    <!-- <title>Fake Title &amp; Bad</title> -->
+    <title>Real Invoice Title</title>
+  </head>
+  <body></body>
+</html>`;
+
+    const result = sanitizeTitleInDoc(html);
+    // The real title must still be present and unchanged (it's already safe)
+    expect(result).toContain('<title>Real Invoice Title</title>');
+    // The comment content must be unchanged
+    expect(result).toContain('<!-- <title>Fake Title &amp; Bad</title> -->');
+  });
+
+  it('does not treat a <title> inside a <script> string as the document title', () => {
+    const html = `<!doctype html>
+<html>
+  <head>
+    <script>var x = '<title>Script Title & Broken</title>';</script>
+    <title>Real Safe Title</title>
+  </head>
+  <body></body>
+</html>`;
+
+    const result = sanitizeTitleInDoc(html);
+    // Real title must still be there (already safe, so unchanged)
+    expect(result).toContain('<title>Real Safe Title</title>');
+    // Script content must not have been mutated
+    expect(result).toContain("var x = '<title>Script Title & Broken</title>';");
   });
 });

--- a/apps/web/tests/runtime/srcdoc-preview-title-sanitize.test.ts
+++ b/apps/web/tests/runtime/srcdoc-preview-title-sanitize.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression tests for Teams-safe preview document titles (issue #3918).
+ *
+ * When a user prints an HTML preview (Cmd+P → Save as PDF), Chromium uses
+ * the iframe document's <title> as the default filename. Invoice titles
+ * (and other design-template titles) can contain characters Microsoft Teams
+ * rejects in filenames, making the PDF unshareable. The srcDoc build path
+ * must sanitize <title> text so the resulting filename is Teams-safe.
+ *
+ * Teams-disallowed character set (per maintainer lefarcen, issue #3918):
+ *   : # % & * { } \ < > ? / + | "
+ * Plus: leading/trailing spaces, and the sequence ~$
+ */
+import { describe, expect, it } from 'vitest';
+import { buildSrcdoc, sanitizePreviewTitle } from '../../src/runtime/srcdoc';
+
+// Characters that Teams rejects in filenames.
+const TEAMS_DISALLOWED = /[:#%&*{}\\<>?/+|"]/;
+
+function extractTitle(html: string): string | null {
+  const m = /<title[^>]*>([^<]*)<\/title>/i.exec(html);
+  return m != null ? (m[1] ?? null) : null;
+}
+
+describe('sanitizePreviewTitle', () => {
+  it('replaces each Teams-disallowed character with a hyphen', () => {
+    // Typical invoice title with several disallowed chars
+    const input = 'Invoice #INV/2025:Acme & Co';
+    const result = sanitizePreviewTitle(input);
+
+    expect(TEAMS_DISALLOWED.test(result)).toBe(false);
+    expect(result).not.toMatch(/^\s|\s$/); // no leading/trailing spaces
+  });
+
+  it('handles the ~$ prefix that Teams also rejects', () => {
+    const result = sanitizePreviewTitle('~$Invoice 2025');
+
+    expect(result).not.toMatch(/^~\$/);
+  });
+
+  it('collapses consecutive replacement hyphens into one', () => {
+    // "A & * B" has two consecutive disallowed chars; should not become "A---B"
+    const result = sanitizePreviewTitle('A & * B');
+
+    expect(result).not.toMatch(/--/);
+  });
+
+  it('trims leading and trailing spaces from the result', () => {
+    const result = sanitizePreviewTitle('  Invoice  ');
+
+    expect(result).toBe('Invoice');
+  });
+
+  it('leaves a title with no disallowed characters unchanged', () => {
+    const clean = 'Invoice Sable Studio INV-2025-0142';
+
+    expect(sanitizePreviewTitle(clean)).toBe(clean);
+  });
+
+  it('replaces all chars from the full disallowed set', () => {
+    // Build a string that has every disallowed char
+    const allDisallowed = ':#%&*{}\\<>?/+|"';
+    const result = sanitizePreviewTitle('A' + allDisallowed + 'B');
+
+    expect(TEAMS_DISALLOWED.test(result)).toBe(false);
+    expect(result).toContain('A');
+    expect(result).toContain('B');
+  });
+});
+
+describe('buildSrcdoc – Teams-safe title', () => {
+  it('sanitizes <title> in the srcDoc output so printed PDFs have Teams-safe filenames', () => {
+    // Simulate an invoice template title that contains Teams-disallowed chars.
+    // This is the real-world shape from design-templates/invoice/example.html.
+    const invoiceHtml = `<!doctype html>
+<html>
+  <head>
+    <title>Invoice #INV/2025:Acme &amp; Co</title>
+  </head>
+  <body>
+    <h1>Invoice</h1>
+    <p>Client: Acme &amp; Co</p>
+    <p>Invoice: INV/2025</p>
+  </body>
+</html>`;
+
+    const result = buildSrcdoc(invoiceHtml);
+
+    const title = extractTitle(result);
+    expect(title).not.toBeNull();
+    // The title must not contain any Teams-disallowed characters.
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+    // The visible page body content must be unchanged.
+    expect(result).toContain('Acme &amp; Co');
+    expect(result).toContain('INV/2025');
+  });
+
+  it('does not alter titles that are already Teams-safe', () => {
+    const html = `<!doctype html>
+<html>
+  <head><title>Invoice Sable Studio INV-2025-0142</title></head>
+  <body><p>Content</p></body>
+</html>`;
+
+    const result = buildSrcdoc(html);
+    const title = extractTitle(result);
+
+    expect(title).toBe('Invoice Sable Studio INV-2025-0142');
+  });
+
+  it('handles HTML entities in title text (decodes before sanitizing)', () => {
+    // &amp; is "&" which is disallowed. The sanitizer must decode then sanitize.
+    const html = `<!doctype html>
+<html>
+  <head><title>Invoice &amp; Receipt</title></head>
+  <body><p>Content</p></body>
+</html>`;
+
+    const result = buildSrcdoc(html);
+    const title = extractTitle(result);
+
+    expect(title).not.toBeNull();
+    expect(TEAMS_DISALLOWED.test(title!)).toBe(false);
+    // Must not expose the literal &amp; or & in the title
+    expect(title).not.toContain('&');
+  });
+});

--- a/apps/web/tests/runtime/srcdoc-preview-title-sanitize.test.ts
+++ b/apps/web/tests/runtime/srcdoc-preview-title-sanitize.test.ts
@@ -61,6 +61,38 @@ describe('sanitizePreviewTitle', () => {
     expect(sanitizePreviewTitle(clean)).toBe(clean);
   });
 
+  // ---------------------------------------------------------------------------
+  // Defect #5 (issue #3918): leading whitespace hides the ~$ prefix from the
+  // anchor-based strip, so trim must happen BEFORE the ~$ check.
+  // ---------------------------------------------------------------------------
+
+  it('strips ~$ even when leading whitespace precedes it ("  ~$Invoice #1")', () => {
+    // Bug: replace(/^~\$/, '') is anchored to position 0; when the input has
+    // leading spaces the anchor misses, and after .trim() the result still
+    // starts with "~$".
+    const result = sanitizePreviewTitle('  ~$Invoice #1');
+
+    expect(result).not.toMatch(/^~\$/);
+    expect(TEAMS_DISALLOWED.test(result)).toBe(false);
+    expect(result).not.toMatch(/^\s|\s$/);
+  });
+
+  it('strips ~$ when a space follows the prefix ("~$ Invoice")', () => {
+    // After stripping "~$" the remaining " Invoice" must also be trimmed so
+    // no leading space survives.
+    const result = sanitizePreviewTitle('~$ Invoice');
+
+    expect(result).not.toMatch(/^~\$/);
+    expect(result).not.toMatch(/^\s/);
+  });
+
+  it('strips a doubled ~$ prefix ("~$~$Doc")', () => {
+    // A doubled prefix must be fully removed; a single strip leaves "~$Doc".
+    const result = sanitizePreviewTitle('~$~$Doc');
+
+    expect(result).not.toMatch(/^~\$/);
+  });
+
   it('replaces all chars from the full disallowed set', () => {
     // Build a string that has every disallowed char
     const allDisallowed = ':#%&*{}\\<>?/+|"';


### PR DESCRIPTION
Fixes #3918

## Why

**Use case:** Picked this up from the `help wanted` backlog after confirming the root cause with the maintainer's notes on the issue.

**Pain:** When a user prints an invoice preview (Cmd+P → "Save as PDF"), Chromium uses the previewed document's `<title>` as the default filename. Invoice titles interpolate values (invoice id, date, workspace name) that can contain characters Microsoft Teams rejects in filenames — `: # % & * { } \ < > ? / + | "`, leading/trailing spaces, and a leading `~$` — so the exported PDF can't be shared in Teams.

## What users will see

Invoice (and other HTML preview) PDFs saved via Cmd+P now get a filename with the Teams-disallowed characters replaced by `-`, so the file shares cleanly in Teams. Only the print/filename behavior changes — the visible on-page content of the invoice is untouched.

## Surface area

- [x] **None** — internal sanitization in the preview pipeline (web srcDoc build + daemon raw-artifact route) plus tests. No new UI / CLI / contract surface, no schema change, no user-visible copy.

## Screenshots

N/A — no UI code or layout changed. The fix sanitizes the document `<title>` that the browser uses as the default print filename. Verified by deterministic unit tests on both rendering paths (see below).

## Bug fix verification

Per AGENTS.md "Bug follow-up workflow", encoded as falsifiable tests that go red before the source change:

- **Web (srcDoc path):** `apps/web/tests/runtime/srcdoc-preview-title-sanitize.test.ts` — 15 tests. Red on unfixed code (`sanitizePreviewTitle is not a function` / unsanitized title), green after.
- **Daemon (URL-load path):** `apps/daemon/tests/project-routes-title-sanitize.test.ts` — 11 tests. Red-confirmed, green after.

**Why two paths:** a static invoice (no scripts/bridges) is rendered through the **URL-load** iframe, not srcDoc — `shouldUrlLoadHtmlPreview()` returns true for it. The URL-load iframe is sandboxed without `allow-same-origin` (opaque origin), so the parent cannot rewrite `contentDocument.title` client-side. The title is therefore sanitized **server-side** in the daemon's `/api/projects/:id/raw/:file` HTML transform (`daemonSanitizeTitleInDoc`). The srcDoc path (bridge-mode previews) is sanitized in `buildSrcdoc` (`sanitizeTitleInDoc`). Both paths are covered.

This PR went through an adversarial review pass that caught the URL-load gap (the first iteration only covered srcDoc) plus three hardening issues — all addressed here:
- `RangeError` on out-of-range numeric entities (`&#9999999999;`) → range-checked `safeFromCodePoint`.
- Named non-ASCII entities (`&ccedil;`) leaving orphaned remnants → named-entity decode map.
- `<title>` regex matching a `<title>` inside a comment/script before the real head title → head-scoped scan.

## Validation

- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web test` — full suite; 15 new tests green; no new failures vs baseline (pre-existing CSS-module test failures unrelated)
- `pnpm --filter @open-design/daemon test` — full suite; 11 new tests green; no new failures vs baseline (one pre-existing `projects-routes.test.ts` symlink case fails only under Windows without symlink privilege — environmental)
- `pnpm --filter @open-design/web build` — pass
- `pnpm guard` — pre-existing design-system manifest staleness only (fails identically on `main`)

## Note for reviewers

The sanitization logic is intentionally duplicated across `apps/web/src/runtime/srcdoc.ts` and `apps/daemon/src/project-routes.ts` because the repo boundary rules forbid web/daemon importing each other's `src/`. If you'd prefer it hoisted into a shared pure package, happy to follow up — flagging rather than silently duplicating.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
