### PR TITLE
fix(web): restore edit mode undo for deleted elements

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -158,6 +158,19 @@ function isManualEditNativeUndoTarget(target: EventTarget | null): boolean {
   return contentEditable == null || contentEditable.toLowerCase() !== 'false';
 }
 
+type ManualEditHistoryShortcutAction = 'undo' | 'redo';
+
+function manualEditHistoryShortcutAction(event: KeyboardEvent): ManualEditHistoryShortcutAction | null {
+  if (event.altKey || event.isComposing) return null;
+  if (!event.metaKey && !event.ctrlKey) return null;
+
+  const key = event.key.toLowerCase();
+  if (key === 'z' && !event.shiftKey) return 'undo';
+  if (key === 'z' && event.shiftKey) return 'redo';
+  if (key === 'y' && event.ctrlKey && !event.metaKey && !event.shiftKey) return 'redo';
+  return null;
+}
+
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 type SlideState = { active: number; count: number };
 type BoardTool = 'inspect' | 'pod';
@@ -5942,6 +5955,15 @@ function HtmlViewer({
       if (!isOurPreviewIframeSource(ev.source)) return;
       const data = ev.data as ManualEditBridgeMessage | null;
       if (!data?.type) return;
+      if (data.type === 'od-edit-history-shortcut') {
+        if (manualEditSavingRef.current) return;
+        if (data.action === 'undo' && manualEditHistory.length > 0) {
+          void undoManualEdit();
+        } else if (data.action === 'redo' && manualEditUndone.length > 0) {
+          void redoManualEdit();
+        }
+        return;
+      }
       if (data.type === 'od-edit-targets' && Array.isArray(data.targets)) {
         setManualEditTargets(data.targets);
         // Target broadcasts can be briefly empty while the iframe/save path is
@@ -5990,7 +6012,7 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [isOurPreviewIframeSource, manualEditMode, source]);
+  }, [isOurPreviewIframeSource, manualEditHistory, manualEditMode, manualEditUndone, source]);
 
   function nextManualEditPreviewVersion(): number {
     manualEditPreviewVersionRef.current += 1;
@@ -6327,18 +6349,14 @@ function HtmlViewer({
   useEffect(() => {
     if (!manualEditMode) return;
     function onKeyDown(event: KeyboardEvent) {
-      if (manualEditSavingRef.current || event.altKey || event.isComposing) return;
-      if (!event.metaKey && !event.ctrlKey) return;
+      if (manualEditSavingRef.current) return;
       if (isManualEditNativeUndoTarget(event.target)) return;
 
-      const key = event.key.toLowerCase();
-      const undo = key === 'z' && !event.shiftKey;
-      const redo = (key === 'z' && event.shiftKey)
-        || (key === 'y' && event.ctrlKey && !event.metaKey && !event.shiftKey);
-      if (undo && manualEditHistory.length > 0) {
+      const action = manualEditHistoryShortcutAction(event);
+      if (action === 'undo' && manualEditHistory.length > 0) {
         event.preventDefault();
         void undoManualEdit();
-      } else if (redo && manualEditUndone.length > 0) {
+      } else if (action === 'redo' && manualEditUndone.length > 0) {
         event.preventDefault();
         void redoManualEdit();
       }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -150,6 +150,14 @@ function resolveChromeActionsHost(): HTMLElement | null {
     ?? document.getElementById(APP_CHROME_FILE_ACTIONS_ID);
 }
 
+function isManualEditNativeUndoTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const editable = target.closest('input, textarea, select, [role="textbox"], [contenteditable]');
+  if (!editable) return false;
+  const contentEditable = editable.getAttribute('contenteditable');
+  return contentEditable == null || contentEditable.toLowerCase() !== 'false';
+}
+
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 type SlideState = { active: number; count: number };
 type BoardTool = 'inspect' | 'pod';
@@ -6316,6 +6324,29 @@ function HtmlViewer({
     }
   }
 
+  useEffect(() => {
+    if (!manualEditMode) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (manualEditSavingRef.current || event.altKey || event.isComposing) return;
+      if (!event.metaKey && !event.ctrlKey) return;
+      if (isManualEditNativeUndoTarget(event.target)) return;
+
+      const key = event.key.toLowerCase();
+      const undo = key === 'z' && !event.shiftKey;
+      const redo = (key === 'z' && event.shiftKey)
+        || (key === 'y' && event.ctrlKey && !event.metaKey && !event.shiftKey);
+      if (undo && manualEditHistory.length > 0) {
+        event.preventDefault();
+        void undoManualEdit();
+      } else if (redo && manualEditUndone.length > 0) {
+        event.preventDefault();
+        void redoManualEdit();
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [manualEditHistory, manualEditMode, manualEditUndone]);
+
   // Inspect-mode picker: same `od:comment-target` payload, different sink.
   // The bridge tags the message with a computed-style snapshot so the panel
   // can show real starting values for color / typography / spacing / radius.
@@ -8123,6 +8154,40 @@ function HtmlViewer({
               >
                 <RemixIcon name="edit-line" size={15} />
               </button>
+              {manualEditMode && !manualEditPanelActive ? (
+                <>
+                  <button
+                    type="button"
+                    className="viewer-action viewer-action-icon od-tooltip"
+                    data-testid="manual-edit-toolbar-undo"
+                    data-tooltip={t('manualEdit.undo')}
+                    data-tooltip-placement="bottom"
+                    title={t('manualEdit.undo')}
+                    aria-label={t('manualEdit.undo')}
+                    disabled={manualEditSaving || manualEditHistory.length === 0}
+                    onClick={() => {
+                      void undoManualEdit();
+                    }}
+                  >
+                    <RemixIcon name="arrow-go-back-line" size={15} />
+                  </button>
+                  <button
+                    type="button"
+                    className="viewer-action viewer-action-icon od-tooltip"
+                    data-testid="manual-edit-toolbar-redo"
+                    data-tooltip={t('manualEdit.redo')}
+                    data-tooltip-placement="bottom"
+                    title={t('manualEdit.redo')}
+                    aria-label={t('manualEdit.redo')}
+                    disabled={manualEditSaving || manualEditUndone.length === 0}
+                    onClick={() => {
+                      void redoManualEdit();
+                    }}
+                  >
+                    <RemixIcon name="arrow-go-forward-line" size={15} />
+                  </button>
+                </>
+              ) : null}
               <span className="viewer-toolbar-tool-divider" aria-hidden />
               <button
                 type="button"

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from 'react';
+import { Button } from '@open-design/components';
 import { useT } from '../i18n';
 import { emptyManualEditStyles, type ManualEditHistoryEntry, type ManualEditPatch, type ManualEditStyles, type ManualEditTarget } from '../edit-mode/types';
 import { Icon } from './Icon';
+import { RemixIcon } from './RemixIcon';
 
 export interface ManualEditDraft {
   text: string;
@@ -27,6 +29,7 @@ export function ManualEditPanel({
   draft,
   error,
   canUndo,
+  canRedo,
   busy,
   onDraftChange,
   onStyleChange,
@@ -37,6 +40,8 @@ export function ManualEditPanel({
   onExit,
   onApplyPatch,
   onPickImage,
+  onUndo,
+  onRedo,
   pageStylesEnabled = true,
   floatingStyle,
   floatingClassName,
@@ -270,6 +275,30 @@ export function ManualEditPanel({
                   </button>
                 )
               ) : null}
+              <div className="manual-edit-footer-history">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="manual-edit-history-btn"
+                  aria-label={t('manualEdit.undo')}
+                  title={t('manualEdit.undo')}
+                  disabled={busy || !canUndo}
+                  onClick={onUndo}
+                >
+                  <RemixIcon name="arrow-go-back-line" size={15} />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="manual-edit-history-btn"
+                  aria-label={t('manualEdit.redo')}
+                  title={t('manualEdit.redo')}
+                  disabled={busy || !canRedo}
+                  onClick={onRedo}
+                >
+                  <RemixIcon name="arrow-go-forward-line" size={15} />
+                </Button>
+              </div>
             </div>
             <div className="manual-edit-footer-right">
               <button

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -75,6 +75,30 @@ export function buildManualEditBridge(enabled: boolean): string {
   function isSourceMappable(el){
     return !!(el && el.hasAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute(sourcePathAttr)));
   }
+  function isNativeUndoTarget(target){
+    var el = target && target.nodeType === 1 ? target : target && target.parentElement ? target.parentElement : null;
+    if (!el || !el.closest) return false;
+    var editable = el.closest('input, textarea, select, [role="textbox"], [contenteditable]');
+    if (!editable) return false;
+    var contentEditable = editable.getAttribute('contenteditable');
+    return contentEditable == null || String(contentEditable).toLowerCase() !== 'false';
+  }
+  function historyShortcutAction(ev){
+    if (!enabled || ev.altKey || ev.isComposing) return null;
+    if (!ev.metaKey && !ev.ctrlKey) return null;
+    var key = String(ev.key || '').toLowerCase();
+    if (key === 'z' && !ev.shiftKey) return 'undo';
+    if (key === 'z' && ev.shiftKey) return 'redo';
+    if (key === 'y' && ev.ctrlKey && !ev.metaKey && !ev.shiftKey) return 'redo';
+    return null;
+  }
+  function onHistoryShortcutKeydown(ev){
+    if (isNativeUndoTarget(ev.target)) return;
+    var action = historyShortcutAction(ev);
+    if (!action) return;
+    ev.preventDefault();
+    window.parent.postMessage({ type: 'od-edit-history-shortcut', action: action }, '*');
+  }
   function isDiscoveryTarget(el){
     return !!(el && el.matches && el.matches(discoverySelector));
   }
@@ -370,6 +394,7 @@ export function buildManualEditBridge(enabled: boolean): string {
     if (!el) return;
     postHoverTarget(el);
   }, true);
+  document.addEventListener('keydown', onHistoryShortcutKeydown);
   window.addEventListener('resize', postTargets);
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', postTargets);
   else setTimeout(postTargets, 0);

--- a/apps/web/src/edit-mode/types.ts
+++ b/apps/web/src/edit-mode/types.ts
@@ -120,13 +120,19 @@ export interface ManualEditTextCommitMessage {
   value: string;
 }
 
+export interface ManualEditHistoryShortcutMessage {
+  type: 'od-edit-history-shortcut';
+  action: 'undo' | 'redo';
+}
+
 export type ManualEditBridgeMessage =
   | ManualEditTargetMessage
   | ManualEditSelectMessage
   | ManualEditHoverMessage
   | ManualEditBackgroundMessage
   | ManualEditPreviewAppliedMessage
-  | ManualEditTextCommitMessage;
+  | ManualEditTextCommitMessage
+  | ManualEditHistoryShortcutMessage;
 
 export const MANUAL_EDIT_STYLE_PROPS: readonly (keyof ManualEditStyles)[] = [
   'fontFamily', 'fontSize', 'fontWeight', 'color', 'textAlign', 'lineHeight', 'letterSpacing',

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -1011,6 +1011,18 @@
 .manual-edit-footer-left {
   flex: 1 1 auto;
 }
+.manual-edit-footer-history {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.manual-edit-history-btn {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-color: transparent;
+  border-radius: var(--radius);
+}
 .manual-edit-footer-right {
   flex: 0 0 auto;
 }

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -337,7 +337,165 @@ describe('FileViewer manual edit history regressions', () => {
         .not.toContain('data-od-id="hero"');
     });
   });
+
+  it('restores and redoes a deleted element from edit history controls', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero">Hero</h1><p data-od-id="body">Body</p></body></html>';
+    let persistedSource = initialSource;
+    const savedSources: string[] = [];
+    vi.stubGlobal('fetch', createPersistenceFetchMock({
+      getPersistedSource: () => persistedSource,
+      setPersistedSource: (source) => {
+        persistedSource = source;
+        savedSources.push(source);
+      },
+    }));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    await selectManualEditTarget();
+
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { id: 'hero', kind: 'remove-element' },
+        'Delete element',
+      );
+    });
+
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+    expect(savedSources[0]).not.toContain('data-od-id="hero"');
+    await waitFor(() => expect(screen.queryByTestId('mock-manual-edit-panel')).toBeNull());
+
+    const undoButton = screen.getByTestId('manual-edit-toolbar-undo') as HTMLButtonElement;
+    const redoButton = screen.getByTestId('manual-edit-toolbar-redo') as HTMLButtonElement;
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(true);
+
+    fireEvent.click(undoButton);
+
+    await waitFor(() => expect(savedSources).toHaveLength(2));
+    expect(savedSources[1]).toContain('data-od-id="hero"');
+    await waitFor(() => {
+      expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc)
+        .toContain('data-od-id="hero"');
+    });
+    expect((screen.getByTestId('manual-edit-toolbar-undo') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId('manual-edit-toolbar-redo') as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(screen.getByTestId('manual-edit-toolbar-redo'));
+
+    await waitFor(() => expect(savedSources).toHaveLength(3));
+    expect(savedSources[2]).not.toContain('data-od-id="hero"');
+    await waitFor(() => {
+      expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc)
+        .not.toContain('data-od-id="hero"');
+    });
+  });
+
+  it('handles edit history shortcuts without intercepting native text input undo', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero">Hero</h1><p data-od-id="body">Body</p></body></html>';
+    let persistedSource = initialSource;
+    const savedSources: string[] = [];
+    vi.stubGlobal('fetch', createPersistenceFetchMock({
+      getPersistedSource: () => persistedSource,
+      setPersistedSource: (source) => {
+        persistedSource = source;
+        savedSources.push(source);
+      },
+    }));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    await selectManualEditTarget();
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { id: 'hero', kind: 'remove-element' },
+        'Delete element',
+      );
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+
+    const input = document.createElement('input');
+    const textarea = document.createElement('textarea');
+    const select = document.createElement('select');
+    const contentEditable = document.createElement('div');
+    const contentEditableChild = document.createElement('span');
+    contentEditable.setAttribute('contenteditable', 'true');
+    contentEditable.appendChild(contentEditableChild);
+    const textbox = document.createElement('div');
+    textbox.setAttribute('role', 'textbox');
+
+    for (const target of [input, textarea, select, contentEditableChild, textbox]) {
+      document.body.appendChild(target === contentEditableChild ? contentEditable : target);
+      fireEvent.keyDown(target, { key: 'z', ctrlKey: true });
+      expect(savedSources).toHaveLength(1);
+      (target === contentEditableChild ? contentEditable : target).remove();
+    }
+
+    expect(fireEvent.keyDown(window, { key: 'z', metaKey: true })).toBe(false);
+    await waitFor(() => expect(savedSources).toHaveLength(2));
+    expect(savedSources[1]).toContain('data-od-id="hero"');
+
+    fireEvent.keyDown(window, { key: 'y', metaKey: true });
+    expect(savedSources).toHaveLength(2);
+
+    expect(fireEvent.keyDown(window, { key: 'z', ctrlKey: true, shiftKey: true })).toBe(false);
+    await waitFor(() => expect(savedSources).toHaveLength(3));
+    expect(savedSources[2]).not.toContain('data-od-id="hero"');
+
+    expect(fireEvent.keyDown(window, { key: 'z', ctrlKey: true })).toBe(false);
+    await waitFor(() => expect(savedSources).toHaveLength(4));
+    expect(fireEvent.keyDown(window, { key: 'y', ctrlKey: true })).toBe(false);
+    await waitFor(() => expect(savedSources).toHaveLength(5));
+    expect(savedSources[4]).not.toContain('data-od-id="hero"');
+
+    clickManualTool('manual-edit-mode-toggle');
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('false');
+    });
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    expect(savedSources).toHaveLength(5);
+  });
 });
+
+function createPersistenceFetchMock({
+  getPersistedSource,
+  setPersistedSource,
+}: {
+  getPersistedSource: () => string;
+  setPersistedSource: (source: string) => void;
+}) {
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (url.includes('/api/projects/project-1/deployments')) {
+      return new Response(JSON.stringify({ deployments: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+      const payload = JSON.parse(String(init.body)) as { content: string };
+      setPersistedSource(payload.content);
+      return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/api/projects/project-1/raw/preview.html')) {
+      return new Response(getPersistedSource(), { status: 200 });
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  });
+}
 
 function htmlPreviewFile(): ProjectFile {
   return {

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -54,6 +54,52 @@ async function selectManualEditTarget(target = heroTarget()) {
   await waitFor(() => expect(panelState.props).not.toBeNull());
 }
 
+function extractManualEditBridgeScript(srcdoc: string): string {
+  const match = srcdoc.match(/<script data-od-edit-bridge>([\s\S]*?)<\/script>/);
+  if (!match?.[1]) throw new Error('Manual edit bridge script not found');
+  return match[1];
+}
+
+function installManualEditBridgeFromFrame(frame: HTMLIFrameElement): {
+  doc: Document;
+  win: Window & typeof globalThis;
+} {
+  const win = frame.contentWindow as (Window & typeof globalThis) | null;
+  const doc = frame.contentDocument;
+  if (!win || !doc) throw new Error('Preview frame document not ready');
+
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: {
+      postMessage(message: unknown) {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: message,
+          source: win,
+        }));
+      },
+    },
+  });
+
+  const evaluate = new win.Function(extractManualEditBridgeScript(frame.srcdoc));
+  evaluate.call(win);
+  win.dispatchEvent(new win.MessageEvent('message', {
+    data: { type: 'od-edit-mode', enabled: true },
+  }));
+  return { doc, win };
+}
+
+function dispatchIframeHistoryShortcut(
+  win: Window & typeof globalThis,
+  target: EventTarget,
+  init: KeyboardEventInit,
+): boolean {
+  return target.dispatchEvent(new win.KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  }));
+}
+
 afterEach(() => {
   cleanup();
   panelState.props = null;
@@ -388,6 +434,79 @@ describe('FileViewer manual edit history regressions', () => {
 
     fireEvent.click(screen.getByTestId('manual-edit-toolbar-redo'));
 
+    await waitFor(() => expect(savedSources).toHaveLength(3));
+    expect(savedSources[2]).not.toContain('data-od-id="hero"');
+    await waitFor(() => {
+      expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc)
+        .not.toContain('data-od-id="hero"');
+    });
+  });
+
+  it('routes edit history shortcuts from the preview iframe document', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero">Hero</h1><p data-od-id="body">Body</p></body></html>';
+    let persistedSource = initialSource;
+    const savedSources: string[] = [];
+    vi.stubGlobal('fetch', createPersistenceFetchMock({
+      getPersistedSource: () => persistedSource,
+      setPersistedSource: (source) => {
+        persistedSource = source;
+        savedSources.push(source);
+      },
+    }));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    await selectManualEditTarget();
+
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { id: 'hero', kind: 'remove-element' },
+        'Delete element',
+      );
+    });
+
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+    expect(savedSources[0]).not.toContain('data-od-id="hero"');
+    await waitFor(() => {
+      expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc)
+        .not.toContain('data-od-id="hero"');
+    });
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const { doc, win } = installManualEditBridgeFromFrame(frame);
+
+    const input = doc.createElement('input');
+    const textarea = doc.createElement('textarea');
+    const select = doc.createElement('select');
+    const contentEditable = doc.createElement('div');
+    const contentEditableChild = doc.createElement('span');
+    contentEditable.setAttribute('contenteditable', 'true');
+    contentEditable.appendChild(contentEditableChild);
+    const textbox = doc.createElement('div');
+    textbox.setAttribute('role', 'textbox');
+
+    for (const target of [input, textarea, select, contentEditableChild, textbox]) {
+      const host = target === contentEditableChild ? contentEditable : target;
+      doc.body.appendChild(host);
+      expect(dispatchIframeHistoryShortcut(win, target, { key: 'z', ctrlKey: true })).toBe(true);
+      expect(savedSources).toHaveLength(1);
+      host.remove();
+    }
+
+    expect(dispatchIframeHistoryShortcut(win, doc, { key: 'z', ctrlKey: true })).toBe(false);
+    await waitFor(() => expect(savedSources).toHaveLength(2));
+    expect(savedSources[1]).toContain('data-od-id="hero"');
+    await waitFor(() => {
+      expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc)
+        .toContain('data-od-id="hero"');
+    });
+
+    expect(dispatchIframeHistoryShortcut(win, doc, { key: 'z', ctrlKey: true, shiftKey: true })).toBe(false);
     await waitFor(() => expect(savedSources).toHaveLength(3));
     expect(savedSources[2]).not.toContain('data-od-id="hero"');
     await waitFor(() => {

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -151,6 +151,38 @@ describe('ManualEditPanel', () => {
     expect(onSaveDraft).toHaveBeenCalledTimes(1);
   });
 
+  it('routes undo and redo controls according to history availability', () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    renderPanel({ canUndo: true, canRedo: false, onUndo, onRedo });
+
+    const undoButton = host.querySelector('button[aria-label="Undo"]') as HTMLButtonElement | null;
+    const redoButton = host.querySelector('button[aria-label="Redo"]') as HTMLButtonElement | null;
+    if (!undoButton || !redoButton) throw new Error('History controls not found');
+
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(true);
+
+    act(() => {
+      undoButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    expect(onRedo).not.toHaveBeenCalled();
+
+    renderPanel({ canUndo: false, canRedo: true, onUndo, onRedo });
+    const updatedUndoButton = host.querySelector('button[aria-label="Undo"]') as HTMLButtonElement | null;
+    const updatedRedoButton = host.querySelector('button[aria-label="Redo"]') as HTMLButtonElement | null;
+    if (!updatedUndoButton || !updatedRedoButton) throw new Error('Updated history controls not found');
+
+    expect(updatedUndoButton.disabled).toBe(true);
+    expect(updatedRedoButton.disabled).toBe(false);
+
+    act(() => {
+      updatedRedoButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+
   it('normalizes font stacks and writes a usable font-family value', () => {
     const onDraftChange = vi.fn();
     const onStyleChange = vi.fn();
@@ -524,6 +556,10 @@ describe('ManualEditPanel', () => {
     pageStylesEnabled = true,
     floatingStyle,
     onFloatingPositionChange,
+    canUndo = false,
+    canRedo = false,
+    onUndo = vi.fn(),
+    onRedo = vi.fn(),
   }: {
     onDraftChange?: OnDraftChange;
     onApplyPatch?: OnApplyPatch;
@@ -539,6 +575,10 @@ describe('ManualEditPanel', () => {
     pageStylesEnabled?: boolean;
     floatingStyle?: CSSProperties;
     onFloatingPositionChange?: (position: { left: number; top: number }) => void;
+    canUndo?: boolean;
+    canRedo?: boolean;
+    onUndo?: () => void;
+    onRedo?: () => void;
   } = {}) {
     const draft = {
       ...emptyManualEditDraft('<html></html>'),
@@ -555,8 +595,8 @@ describe('ManualEditPanel', () => {
           draft={draft}
           history={[]}
           error={null}
-          canUndo={false}
-          canRedo={false}
+          canUndo={canUndo}
+          canRedo={canRedo}
           pageStylesEnabled={pageStylesEnabled}
           onSelectTarget={vi.fn<(target: ManualEditTarget) => void>()}
           onDraftChange={onDraftChange}
@@ -567,8 +607,8 @@ describe('ManualEditPanel', () => {
           onClearSelection={onClearSelection}
           onCancelDraft={onCancelDraft}
           onSaveDraft={onSaveDraft}
-          onUndo={vi.fn<() => void>()}
-          onRedo={vi.fn<() => void>()}
+          onUndo={onUndo}
+          onRedo={onRedo}
           floatingStyle={floatingStyle}
           onFloatingPositionChange={onFloatingPositionChange}
         />,


### PR DESCRIPTION
Fixes #2866

## Why

I’m opening this PR to fix a user-facing Edit mode regression where deleted elements could not be restored after removal.

The underlying manual edit history already captured deletion changes, but users had no reachable undo/redo controls for this workflow. This was especially painful because deleting an element closes the inspector, leaving users without a way to recover the removed element from the Edit mode UI.

## What users will see

In Edit mode, users can now undo and redo manual edits, including deleted elements.

Undo/Redo controls appear in the manual edit panel, and when the inspector closes after deleting an element, Undo/Redo remain reachable from the preview toolbar. Keyboard shortcuts also work while Edit mode is active.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [x] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

TODO: Attach a screenshot or short GIF showing the Edit mode toolbar Undo/Redo controls after deleting an element.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/web/tests/components/FileViewer.manual-edit-history.test.tsx`
  - `apps/web/tests/components/ManualEditPanel.test.tsx`
- Did the test go red on `main` and green on this branch?
  - No. I added focused regression coverage on this branch and verified it passes locally, but I did not run the new test-only patch against `main`.
- Verification:
  - Covered deleting an element in Edit mode, undo restoring it, redo deleting it again, toolbar disabled/enabled state, shortcut handling, and native input undo guard.

## Validation

- `pnpm --filter @open-design/web test -- tests/components/ManualEditPanel.test.tsx tests/components/FileViewer.manual-edit-history.test.tsx`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web build`
- `pnpm typecheck`
- `git diff --check`

Known local validation notes:

- `pnpm --filter @open-design/web test` currently fails on unrelated baseline tests.
- `pnpm guard` currently fails on stale generated design-system manifests/Tailwind artifacts unrelated to this patch.