### PR TITLE
chore(ci): stabilize visual regression screenshots

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -11,6 +11,7 @@ import {
   FILE_SYSTEM_READ_ERROR_MESSAGE,
   isFileSystemReadError,
 } from '../utils/fileSystemErrors';
+import { isVisualStabilityMode } from '../utils/visualStability';
 import { selectInitialDesignPreviewFile } from './design-files/designArtifacts';
 import type { PluginFolderAgentAction } from './design-files/pluginFolderActions';
 import { getPluginFolderCandidates } from './design-files/pluginFolders';
@@ -201,6 +202,11 @@ function RotatingTip() {
   useEffect(() => {
     const tips = tipsRef.current;
     const full = tips[index] ?? '';
+    if (isVisualStabilityMode()) {
+      setIndex(0);
+      setTyped(tips[0] ?? '');
+      return;
+    }
     if (prefersReducedMotion()) {
       setTyped(full);
       if (tips.length < 2) return;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -110,6 +110,7 @@ import {
 } from '../providers/registry';
 import { MEDIA_PROVIDERS } from '../media/models';
 import { useByokImageModelOptions, useByokVideoModelOptions, useByokSpeechModelOptions } from '../media/aihubmix-image-models';
+import { isVisualStabilityMode } from '../utils/visualStability';
 import { XaiOAuthControl } from './XaiOAuthControl';
 import type { MediaProvider } from '../media/models';
 import { Toast } from './Toast';
@@ -1311,6 +1312,7 @@ export function SettingsDialog({
   const modelSelectRef = useRef<HTMLButtonElement | null>(null);
   const customModelInputRef = useRef<HTMLInputElement | null>(null);
   const focusByokRequiredFieldAfterProtocolSwitchRef = useRef(false);
+  const visualStabilityMode = isVisualStabilityMode();
   // Tracks whether the current BYOK model value came from an explicit user
   // pick (combobox selection or custom entry) rather than an auto-populated
   // provider preset. The account-model auto-switch must never overwrite a
@@ -2554,6 +2556,7 @@ export function SettingsDialog({
   ]);
   useEffect(() => {
     if (cfg.mode !== 'api') return;
+    if (visualStabilityMode) return;
     if (providerTestState.status === 'running') return;
     if (byokFirstPartyBaseUrl?.hostTypo) return;
     if (blockingByokDraftIssues(byokDraftValidation).length > 0) return;
@@ -2573,9 +2576,11 @@ export function SettingsDialog({
     cfg.mode,
     cfg.model,
     providerTestState.status,
+    visualStabilityMode,
   ]);
   useEffect(() => {
     if (cfg.mode !== 'api') return;
+    if (visualStabilityMode) return;
     if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;
     if (byokFirstPartyBaseUrl?.hostTypo) return;
     if (blockingByokDraftIssues(byokModelFetchDraftValidation).length > 0) return;
@@ -2598,6 +2603,7 @@ export function SettingsDialog({
     byokModelFetchDraftValidation,
     providerModelsCommittedKey,
     providerModelsKey,
+    visualStabilityMode,
   ]);
   const currentProviderModelsResult =
     providerModelsState.status === 'done' &&

--- a/apps/web/src/components/plugins-home/cards/DesignSystemSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/DesignSystemSurface.tsx
@@ -7,6 +7,7 @@
 // uses native lazy loading so off-screen cards do not eagerly render.
 
 import { useEffect, useState } from 'react';
+import { isVisualStabilityMode } from '../../../utils/visualStability';
 import type { DesignPreviewSpec } from '../preview';
 
 interface Props {
@@ -15,10 +16,14 @@ interface Props {
 }
 
 export function DesignSystemSurface({ preview, inView }: Props) {
-  const [ready, setReady] = useState(false);
+  const [ready, setReady] = useState(() => isVisualStabilityMode());
 
   useEffect(() => {
     if (!preview.designSystemId) return;
+    if (isVisualStabilityMode()) {
+      setReady(true);
+      return;
+    }
     if (!inView) {
       setReady(false);
       return;

--- a/apps/web/src/components/plugins-home/cards/HtmlSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/HtmlSurface.tsx
@@ -23,6 +23,7 @@
 // scrolling doesn't re-probe the same plugin.
 
 import { useEffect, useState } from 'react';
+import { isVisualStabilityMode } from '../../../utils/visualStability';
 import type { HtmlPreviewSpec } from '../preview';
 
 interface Props {
@@ -71,7 +72,7 @@ async function probe(url: string): Promise<'ok' | 'unreachable'> {
 
 export function HtmlSurface({ preview, pluginId, pluginTitle, inView, eager = false }: Props) {
   const [armed, setArmed] = useState(false);
-  const [shouldProbe, setShouldProbe] = useState(false);
+  const [shouldProbe, setShouldProbe] = useState(() => isVisualStabilityMode());
   const [probeState, setProbeState] = useState<ProbeState>(() => {
     const cached = probeCache.get(preview.src);
     return cached ?? 'idle';
@@ -79,13 +80,17 @@ export function HtmlSurface({ preview, pluginId, pluginTitle, inView, eager = fa
 
   useEffect(() => {
     setArmed(false);
-    setShouldProbe(false);
+    setShouldProbe(isVisualStabilityMode());
     const cached = probeCache.get(preview.src);
     setProbeState(cached ?? 'idle');
   }, [preview.src]);
 
   useEffect(() => {
     if (!inView) return;
+    if (isVisualStabilityMode()) {
+      setShouldProbe(true);
+      return;
+    }
     if (probeCache.has(preview.src)) {
       setShouldProbe(true);
       return;
@@ -120,6 +125,10 @@ export function HtmlSurface({ preview, pluginId, pluginTitle, inView, eager = fa
   // that linger get the live preview without requiring hover.
   useEffect(() => {
     if (probeState !== 'ok') return;
+    if (isVisualStabilityMode()) {
+      if (inView) setArmed(true);
+      return;
+    }
     if (eager) {
       if (inView) setArmed(true);
       return;

--- a/apps/web/src/utils/visualStability.ts
+++ b/apps/web/src/utils/visualStability.ts
@@ -1,0 +1,10 @@
+export const VISUAL_STABILITY_STORAGE_KEY = 'open-design:visual-stability';
+
+export function isVisualStabilityMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(VISUAL_STABILITY_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -1,11 +1,12 @@
 import { expect } from '@playwright/test';
-import type { Page, Route } from '@playwright/test';
+import type { Locator, Page, Route } from '@playwright/test';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { fulfillAgentsRoute } from './mock-factory.js';
 
 const STORAGE_KEY = 'open-design:config';
 const GITHUB_STARS_STORAGE_KEY = 'open-design:gh-stars';
+const VISUAL_STABILITY_STORAGE_KEY = 'open-design:visual-stability';
 const VISUAL_STYLE_ID = 'od-visual-stability-style';
 // Keep this exact-route mock narrow so unrelated GitHub UI still behaves normally.
 const VISUAL_GITHUB_REPO_API = 'https://api.github.com/repos/nexu-io/open-design';
@@ -40,6 +41,9 @@ const VISUAL_CONFIG = {
   privacyDecisionAt: 1,
   telemetry: { metrics: false, content: false, artifactManifest: false },
 } satisfies VisualConfig;
+
+const visualStableTimeoutMs = 10_000;
+const visualStableFrameCount = 3;
 
 const MOCK_AGENT = {
   id: 'mock',
@@ -154,13 +158,14 @@ export async function configureVisualPage(page: Page, options: VisualPageOptions
   const config = { ...VISUAL_CONFIG, ...(options.config ?? {}) };
   const agents = options.agents ?? [MOCK_AGENT];
 
-  await page.addInitScript(([key, config, githubStarsKey, githubStarsCount]) => {
+  await page.addInitScript(([key, config, githubStarsKey, githubStarsCount, visualStabilityKey]) => {
     window.localStorage.setItem(key, JSON.stringify(config));
     window.localStorage.setItem(
       githubStarsKey,
       JSON.stringify({ count: githubStarsCount, ts: Date.now() }),
     );
-  }, [STORAGE_KEY, config, GITHUB_STARS_STORAGE_KEY, VISUAL_GITHUB_STARS] as const);
+    window.localStorage.setItem(visualStabilityKey, '1');
+  }, [STORAGE_KEY, config, GITHUB_STARS_STORAGE_KEY, VISUAL_GITHUB_STARS, VISUAL_STABILITY_STORAGE_KEY] as const);
 
   await page.route('**/api/app-config', async (route) => {
     await fulfillGet(route, { config });
@@ -346,17 +351,24 @@ export async function configureVisualPage(page: Page, options: VisualPageOptions
   });
 
   await page.addInitScript(([styleId]) => {
-    const style = document.createElement('style');
-    style.id = styleId;
-    style.textContent = `
+    const installStabilityStyle = () => {
+      if (document.getElementById(styleId) != null) return;
+      const style = document.createElement('style');
+      style.id = styleId;
+      style.textContent = `
       *, *::before, *::after {
         animation: none !important;
         transition: none !important;
         caret-color: transparent !important;
         scroll-behavior: auto !important;
+        overflow-anchor: none !important;
       }
     `;
-    document.head.appendChild(style);
+      (document.head ?? document.documentElement).appendChild(style);
+    };
+
+    installStabilityStyle();
+    document.addEventListener('DOMContentLoaded', installStabilityStyle, { once: true });
   }, [VISUAL_STYLE_ID] as const);
 }
 
@@ -394,8 +406,128 @@ export async function captureVisual(page: Page, name: string): Promise<string> {
   const safeName = sanitizeVisualName(name);
   const outputPath = path.join(outputDir, `${safeName}.png`);
   await mkdir(outputDir, { recursive: true });
+  await waitForVisualStable(page);
   await page.screenshot({ path: outputPath, animations: 'disabled', caret: 'hide' });
   return outputPath;
+}
+
+export async function scrollVisualLocatorIntoStableView(
+  page: Page,
+  locator: Locator,
+  options: { containerSelector?: string; topOffset?: number } = {},
+): Promise<void> {
+  await locator.evaluate(
+    (element, { containerSelector, topOffset }) => {
+      const target = element as HTMLElement;
+      const container = target.closest(containerSelector) as HTMLElement | null;
+      if (container != null) {
+        const targetRect = target.getBoundingClientRect();
+        const containerRect = container.getBoundingClientRect();
+        container.scrollTop = Math.max(
+          0,
+          container.scrollTop + targetRect.top - containerRect.top - topOffset,
+        );
+        return;
+      }
+
+      const scrollRoot = document.scrollingElement;
+      if (scrollRoot == null) return;
+      window.scrollTo({
+        top: Math.max(0, window.scrollY + target.getBoundingClientRect().top - topOffset),
+        behavior: 'instant',
+      });
+    },
+    {
+      containerSelector: options.containerSelector ?? '.entry-main--scroll',
+      topOffset: options.topOffset ?? 56,
+    },
+  );
+  await waitForVisualStable(page);
+}
+
+export async function waitForVisualStable(page: Page): Promise<void> {
+  await page.waitForLoadState('networkidle', { timeout: visualStableTimeoutMs }).catch(() => {});
+  await waitForVisualFrameAssets(page);
+  await waitForVisualLayoutStable(page);
+}
+
+async function waitForVisualFrameAssets(page: Page): Promise<void> {
+  for (const frame of page.frames()) {
+    await frame.evaluate(async () => {
+      await document.fonts.ready;
+      await Promise.all(
+        Array.from(document.images, async (image) => {
+          if (image.complete && image.naturalWidth > 0) return;
+          await image.decode().catch(() => {});
+        }),
+      );
+    }).catch(() => {});
+  }
+}
+
+async function waitForVisualLayoutStable(page: Page): Promise<void> {
+  await page.waitForFunction(
+    (requiredStableFrames) => new Promise<boolean>((resolve) => {
+      let previousSignature = '';
+      let stableFrames = 0;
+
+      const sample = () => {
+        const body = document.body;
+        const root = document.documentElement;
+        const visibleRects = Array.from(document.querySelectorAll('body *'))
+          .filter((element) => {
+            const style = window.getComputedStyle(element);
+            if (style.visibility === 'hidden' || style.display === 'none' || Number(style.opacity) === 0) {
+              return false;
+            }
+            const rect = element.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+          })
+          .slice(0, 600)
+          .map((element) => {
+            const rect = element.getBoundingClientRect();
+            return [
+              element.tagName,
+              Math.round(rect.x * 10) / 10,
+              Math.round(rect.y * 10) / 10,
+              Math.round(rect.width * 10) / 10,
+              Math.round(rect.height * 10) / 10,
+            ].join(':');
+          })
+          .join('|');
+
+        const signature = [
+          root.clientWidth,
+          root.clientHeight,
+          root.scrollWidth,
+          root.scrollHeight,
+          body?.scrollWidth ?? 0,
+          body?.scrollHeight ?? 0,
+          window.scrollX,
+          window.scrollY,
+          visibleRects,
+        ].join('~');
+
+        if (signature === previousSignature) {
+          stableFrames += 1;
+        } else {
+          previousSignature = signature;
+          stableFrames = 0;
+        }
+
+        if (stableFrames >= requiredStableFrames) {
+          resolve(true);
+          return;
+        }
+
+        window.requestAnimationFrame(sample);
+      };
+
+      window.requestAnimationFrame(sample);
+    }),
+    visualStableFrameCount,
+    { timeout: visualStableTimeoutMs },
+  ).catch(() => {});
 }
 
 function sanitizeVisualName(name: string): string {

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -175,6 +175,43 @@ export async function configureVisualPage(page: Page, options: VisualPageOptions
     await fulfillAgentsRoute(route, agents);
   });
 
+  await page.route('**/api/test/connection', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      json: {
+        ok: true,
+        kind: 'success',
+        latencyMs: 1,
+        model: config.model,
+        sample: 'Visual connection check.',
+      },
+    });
+  });
+
+  await page.route('**/api/provider/models', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      json: {
+        ok: true,
+        kind: 'success',
+        latencyMs: 1,
+        models: [
+          { id: 'gpt-4o', label: 'GPT-4o' },
+          { id: 'gpt-4o-mini', label: 'GPT-4o mini' },
+          { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+        ],
+      },
+    });
+  });
+
   await page.route('**/api/health', async (route) => {
     await fulfillGet(route, { ok: true });
   });

--- a/e2e/ui/visual-home.test.ts
+++ b/e2e/ui/visual-home.test.ts
@@ -4,6 +4,7 @@ import {
   captureVisual,
   configureVisualPage,
   gotoVisualHome,
+  scrollVisualLocatorIntoStableView,
   waitForVisualFonts,
   waitForVisualProjects,
 } from '@/playwright/visual';
@@ -107,7 +108,7 @@ test('[P2] captures the home plugin catalog surface', async ({ page }) => {
   await expect(page.getByTestId('recent-projects-strip')).toBeVisible();
   const community = home.getByTestId('plugins-home-section');
   await expect(community).toBeVisible();
-  await community.scrollIntoViewIfNeeded();
+  await scrollVisualLocatorIntoStableView(page, community);
   await expect(home.locator('article.plugins-home__card--gallery').first()).toBeVisible();
   await expect(home.getByTestId('plugins-home-search')).toBeVisible();
 


### PR DESCRIPTION
## Why

Visual regression review had noisy false positives because several screenshots could be captured before loading, animation, scrolling, or BYOK connection state settled. This made diffs look like product changes even when the UI was only mid-transition or mid-request.

The latest BYOK settings cases were especially unstable because the visual fixture used `sk-visual` while Settings still auto-tested the provider and auto-fetched models, so screenshots could catch either `Testing connection…` or a finished invalid-key state.

## What users will see

No production user-facing behavior changes. Visual regression snapshots should be more deterministic, including the home catalog, useful-info copy, plugin surfaces, and BYOK Settings screens.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this PR changes the visual test harness and screenshot stabilization behavior rather than adding a UI surface.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/visual-home.test.ts`
- Did the test go red on `main` and green on this branch? No. The false positives are timing-dependent visual instability rather than a deterministic red assertion.
- Verification used instead: focused Playwright visual runs for the unstable home catalog and BYOK settings cases, plus typecheck and web tests.

## Validation

- `pnpm --dir e2e typecheck`
- `pnpm --dir e2e exec playwright test -c playwright.visual.config.ts --list`
- `pnpm --filter @open-design/web test -- plugins-home-preview plugins-home-preview-surface DesignFilesPanel`
- `pnpm --filter @open-design/daemon build`
- `pnpm --dir e2e exec playwright test -c playwright.visual.config.ts ui/visual-home.test.ts -g "captures the home plugin catalog surface"`
- `pnpm --filter @open-design/web test -- SettingsDialog ByokConnectionTestControl`
- `pnpm --dir e2e exec playwright test -c playwright.visual.config.ts ui/visual-home.test.ts -g "settings BYOK (OpenAI|model dropdown)"`

Known pre-existing local check failures:

- `pnpm --filter @open-design/web typecheck` currently fails on unrelated AMR attribution type errors in `src/analytics/amr-attribution.ts`.
- `pnpm guard` currently fails on unrelated local `apps/.od/package.json` / `tools/pr` guard state.
