### PR TITLE
fix(web): keep the manual-edit inline text session alive until explicit finish (#3646)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6142,14 +6142,22 @@ function HtmlViewer({
         return;
       }
       if (data.type === 'od-edit-text-commit') {
-        // Keep the apply promise so a pending finish (exit/dismiss) can await it
-        // before tearing down — otherwise the final edit can be dropped.
-        manualEditTextCommitInFlightRef.current = applyManualEdit({
+        // Keep the apply promise reachable so any teardown (host- or
+        // iframe-initiated) can await it and honor a failed save before tearing
+        // down. It self-clears once resolved, keyed to identity so a newer
+        // commit is never clobbered.
+        const commit = applyManualEdit({
           id: String(data.id),
           kind: 'set-text',
           value: String(data.value),
         }, 'Edit text');
-        void manualEditTextCommitInFlightRef.current;
+        manualEditTextCommitInFlightRef.current = commit;
+        void (async () => {
+          try { await commit; } catch { /* failure honored by teardown / surfaced by applyManualEdit */ }
+          if (manualEditTextCommitInFlightRef.current === commit) {
+            manualEditTextCommitInFlightRef.current = null;
+          }
+        })();
         return;
       }
       if (data.type === 'od-edit-text-session') {
@@ -6166,11 +6174,11 @@ function HtmlViewer({
           // settle() awaits the in-flight commit before resolving the caller's
           // teardown, so the final edit is never dropped.
           pending();
-        } else {
-          // Iframe-driven finish (Enter / clicking another target): nothing is
-          // awaiting teardown, so drop the now-stale commit promise.
-          manualEditTextCommitInFlightRef.current = null;
         }
+        // Iframe-driven finishes (Enter / clicking another target) leave the
+        // commit promise in place; it self-clears on resolution, and any later
+        // teardown still awaits it via settlePendingManualEditCommit so a failed
+        // save is never silently torn down.
         return;
       }
     }
@@ -6290,10 +6298,15 @@ function HtmlViewer({
   // resulting commit has been applied). Callers that tear down edit state must
   // await this so the final edit is never dropped — the #3647 exit-path bug.
   // A timeout backstops a detached iframe so teardown can never hang.
-  function finishManualEditTextSession(commit: boolean): Promise<void> {
+  // Resolves to whether the session ended cleanly: true when there was nothing
+  // to commit or the commit succeeded, false when the pending text commit
+  // failed (applyManualEdit returned false / threw). Callers that tear down
+  // edit state must honor a false result — keep edit mode open and preserve the
+  // error so a failed save never looks like a successful one (#4291 review).
+  function finishManualEditTextSession(commit: boolean): Promise<boolean> {
     const win = iframeRef.current?.contentWindow;
-    if (!win || !manualEditTextSessionIdRef.current) return Promise.resolve();
-    return new Promise<void>((resolve) => {
+    if (!win || !manualEditTextSessionIdRef.current) return Promise.resolve(true);
+    return new Promise<boolean>((resolve) => {
       let settled = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
       const settle = () => {
@@ -6305,14 +6318,20 @@ function HtmlViewer({
         // session and re-finish it with commit:true — turning cancel into save.
         manualEditTextSessionIdRef.current = null;
         if (manualEditTextFinishRef.current === settle) manualEditTextFinishRef.current = null;
-        // Always wait out the in-flight commit before resolving, so the final
-        // edit is persisted before teardown even if the timeout backstop won
-        // the race against the iframe's ack.
+        // Wait out the in-flight commit before resolving, so the final edit is
+        // persisted before teardown even if the timeout backstop won the race
+        // against the iframe's ack. The commit clears its own ref on resolution.
         const commitInFlight = manualEditTextCommitInFlightRef.current;
-        manualEditTextCommitInFlightRef.current = null;
         void (async () => {
-          try { await commitInFlight; } catch { /* applyManualEdit reports its own errors */ }
-          resolve();
+          let committed = true;
+          try {
+            // applyManualEdit resolves false when the save fails (or the source
+            // changed externally); surface that so callers can abort teardown.
+            if ((await commitInFlight) === false) committed = false;
+          } catch {
+            committed = false;
+          }
+          resolve(committed);
         })();
       };
       manualEditTextFinishRef.current = settle;
@@ -6323,8 +6342,30 @@ function HtmlViewer({
     });
   }
 
+  // Settles whatever inline text edit is still pending before teardown and
+  // reports whether it committed cleanly: the live session if one is active,
+  // otherwise an in-flight commit left by an iframe-driven finish (Enter /
+  // click-another-target). Returns false on a failed commit so callers keep
+  // edit mode open with the error rather than tearing down through it (#4291).
+  async function settlePendingManualEditCommit(): Promise<boolean> {
+    if (manualEditTextSessionIdRef.current) {
+      return finishManualEditTextSession(true);
+    }
+    const commitInFlight = manualEditTextCommitInFlightRef.current;
+    if (!commitInFlight) return true;
+    try {
+      return (await commitInFlight) !== false;
+    } catch {
+      return false;
+    }
+  }
+
   async function exitManualEditModeAfterFlush(): Promise<boolean> {
-    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(true);
+    // A failed text commit must keep edit mode open with its error visible,
+    // rather than tearing down (which would clear the error) and looking saved.
+    if (!(await settlePendingManualEditCommit())) {
+      return false;
+    }
     const ok = await flushManualEditStyleSave();
     if (!ok) return false;
     setManualEditPanelPosition(null);
@@ -6365,8 +6406,11 @@ function HtmlViewer({
 
   async function clearManualEditTargetSelection() {
     // If an inline edit is still live (e.g. clearing the selection from the
-    // panel mid-edit), commit it through the iframe first so it is not lost.
-    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(true);
+    // panel mid-edit), commit it first so it is not lost. Keep the selection
+    // and the error if that commit fails.
+    if (!(await settlePendingManualEditCommit())) {
+      return;
+    }
     cancelManualEditStyleDraft();
     selectedManualEditTargetIdRef.current = null;
     manualEditTextSessionIdRef.current = null;
@@ -6381,7 +6425,11 @@ function HtmlViewer({
   // the toolbar toggle's job. Dismiss flushes any in-flight tweak first so
   // nothing is lost; cancel reverts the in-flight unsaved tweak instead.
   async function dismissManualEditPanel() {
-    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(true);
+    // Closing the panel must not swallow a failed text commit: keep it open
+    // with the error if the pending edit could not be saved.
+    if (!(await settlePendingManualEditCommit())) {
+      return;
+    }
     const ok = await flushManualEditStyleSave();
     if (!ok) return;
     if (selectedManualEditTarget) void clearManualEditTargetSelection();

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4873,6 +4873,13 @@ function HtmlViewer({
   const [manualEditPageStylesOpen, setManualEditPageStylesOpen] = useState(false);
   const [manualEditPanelPosition, setManualEditPanelPosition] = useState<{ left: number; top: number } | null>(null);
   const selectedManualEditTargetIdRef = useRef<string | null>(null);
+  // Tracks the iframe's in-flight inline text edit. `finishManualEditTextSession`
+  // posts the explicit finish and resolves only after the iframe acks AND the
+  // resulting commit has been applied, so exit/dismiss/cancel never tear down
+  // mid-round-trip and drop the final edit (the #3647 exit-path regression).
+  const manualEditTextSessionIdRef = useRef<string | null>(null);
+  const manualEditTextFinishRef = useRef<(() => void) | null>(null);
+  const manualEditTextCommitInFlightRef = useRef<Promise<unknown> | null>(null);
   const [manualEditDraft, setManualEditDraft] = useState<ManualEditDraft>(() => emptyManualEditDraft());
   const [manualEditHistory, setManualEditHistory] = useState<ManualEditHistoryEntry[]>([]);
   const [manualEditUndone, setManualEditUndone] = useState<ManualEditHistoryEntry[]>([]);
@@ -6079,6 +6086,9 @@ function HtmlViewer({
       setManualEditPageStylesOpen(false);
       setManualEditPanelPosition(null);
       selectedManualEditTargetIdRef.current = null;
+      manualEditTextSessionIdRef.current = null;
+      manualEditTextFinishRef.current = null;
+      manualEditTextCommitInFlightRef.current = null;
       setManualEditError(null);
       manualEditPendingStyleRef.current = null;
       if (manualEditStyleTimerRef.current) {
@@ -6109,6 +6119,9 @@ function HtmlViewer({
         return;
       }
       if (data.type === 'od-edit-hover') {
+        // While an inline text edit is live, hovering must not surface or switch
+        // any affordance — that instability is the other half of #3646.
+        if (manualEditTextSessionIdRef.current) return;
         // Hover only surfaces a lightweight "edit params" affordance; it must
         // NOT switch the pinned inspector. The panel changes only when the
         // user clicks that affordance (or a container/image body), so moving
@@ -6129,11 +6142,35 @@ function HtmlViewer({
         return;
       }
       if (data.type === 'od-edit-text-commit') {
-        void applyManualEdit({
+        // Keep the apply promise so a pending finish (exit/dismiss) can await it
+        // before tearing down — otherwise the final edit can be dropped.
+        manualEditTextCommitInFlightRef.current = applyManualEdit({
           id: String(data.id),
           kind: 'set-text',
           value: String(data.value),
         }, 'Edit text');
+        void manualEditTextCommitInFlightRef.current;
+        return;
+      }
+      if (data.type === 'od-edit-text-session') {
+        const sessionId = String(data.id || '');
+        if (data.active) {
+          manualEditTextSessionIdRef.current = sessionId;
+          return;
+        }
+        if (manualEditTextSessionIdRef.current === sessionId) {
+          manualEditTextSessionIdRef.current = null;
+        }
+        const pending = manualEditTextFinishRef.current;
+        if (pending) {
+          // settle() awaits the in-flight commit before resolving the caller's
+          // teardown, so the final edit is never dropped.
+          pending();
+        } else {
+          // Iframe-driven finish (Enter / clicking another target): nothing is
+          // awaiting teardown, so drop the now-stale commit promise.
+          manualEditTextCommitInFlightRef.current = null;
+        }
         return;
       }
     }
@@ -6249,7 +6286,45 @@ function HtmlViewer({
     setManualEditError(null);
   }
 
+  // Ends the iframe's inline text edit and resolves only once it acks (and any
+  // resulting commit has been applied). Callers that tear down edit state must
+  // await this so the final edit is never dropped — the #3647 exit-path bug.
+  // A timeout backstops a detached iframe so teardown can never hang.
+  function finishManualEditTextSession(commit: boolean): Promise<void> {
+    const win = iframeRef.current?.contentWindow;
+    if (!win || !manualEditTextSessionIdRef.current) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        if (timer) { clearTimeout(timer); timer = null; }
+        // Mark the session ended even on the timeout path, so a follow-up
+        // clearManualEditTargetSelection (e.g. from cancel) does not see a live
+        // session and re-finish it with commit:true — turning cancel into save.
+        manualEditTextSessionIdRef.current = null;
+        if (manualEditTextFinishRef.current === settle) manualEditTextFinishRef.current = null;
+        // Always wait out the in-flight commit before resolving, so the final
+        // edit is persisted before teardown even if the timeout backstop won
+        // the race against the iframe's ack.
+        const commitInFlight = manualEditTextCommitInFlightRef.current;
+        manualEditTextCommitInFlightRef.current = null;
+        void (async () => {
+          try { await commitInFlight; } catch { /* applyManualEdit reports its own errors */ }
+          resolve();
+        })();
+      };
+      manualEditTextFinishRef.current = settle;
+      win.postMessage({ type: 'od-edit-text-finish', commit }, '*');
+      // Backstop a detached iframe so teardown can never hang; the ack path
+      // clears this timer when it wins.
+      timer = setTimeout(settle, 1500);
+    });
+  }
+
   async function exitManualEditModeAfterFlush(): Promise<boolean> {
+    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(true);
     const ok = await flushManualEditStyleSave();
     if (!ok) return false;
     setManualEditPanelPosition(null);
@@ -6289,8 +6364,12 @@ function HtmlViewer({
   }
 
   async function clearManualEditTargetSelection() {
+    // If an inline edit is still live (e.g. clearing the selection from the
+    // panel mid-edit), commit it through the iframe first so it is not lost.
+    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(true);
     cancelManualEditStyleDraft();
     selectedManualEditTargetIdRef.current = null;
+    manualEditTextSessionIdRef.current = null;
     setSelectedManualEditTarget(null);
     setManualEditPanelPosition(null);
     setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
@@ -6302,13 +6381,15 @@ function HtmlViewer({
   // the toolbar toggle's job. Dismiss flushes any in-flight tweak first so
   // nothing is lost; cancel reverts the in-flight unsaved tweak instead.
   async function dismissManualEditPanel() {
+    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(true);
     const ok = await flushManualEditStyleSave();
     if (!ok) return;
     if (selectedManualEditTarget) void clearManualEditTargetSelection();
     else setManualEditPageStylesOpen(false);
   }
 
-  function cancelManualEditPanel() {
+  async function cancelManualEditPanel() {
+    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(false);
     if (selectedManualEditTarget) {
       void clearManualEditTargetSelection();
     } else {
@@ -8072,7 +8153,7 @@ function HtmlViewer({
         void dismissManualEditPanel();
       }}
       onCancelDraft={() => {
-        cancelManualEditPanel();
+        void cancelManualEditPanel();
       }}
       onSaveDraft={() => {
         void dismissManualEditPanel();

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -363,8 +363,52 @@ export function buildManualEditBridge(enabled: boolean): string {
     } catch (e) {}
   }
   var guard = window.__odEditGuard || null;
+  // A single in-flight inline text edit. The session is deliberately NOT tied
+  // to iframe blur: moving the pointer to the host's floating inspector blurs
+  // the iframe, and committing/ending on blur is exactly the #3646 focus-loss
+  // bug. The session ends only on an explicit action — Enter, Escape, picking
+  // another target, clicking empty background, leaving edit mode, or an
+  // od-edit-text-finish message from the host.
+  var activeTextEdit = null;
+  function postTextSession(el, active, extra){
+    if (!el) return;
+    window.parent.postMessage(Object.assign({
+      type: 'od-edit-text-session',
+      id: stableId(el),
+      active: !!active
+    }, extra || {}), '*');
+  }
+  function finishActiveTextEdit(commit){
+    if (!activeTextEdit) return false;
+    var session = activeTextEdit;
+    activeTextEdit = null;
+    var el = session.el;
+    el.removeAttribute('contenteditable');
+    el.removeAttribute('data-od-editing');
+    el.removeEventListener('keydown', session.onKey);
+    if (guard) guard.editingEl = null;
+    var value = (el.textContent || '').trim();
+    var changed = value !== session.originalText.trim();
+    if (commit && changed) {
+      window.parent.postMessage({
+        type: 'od-edit-text-commit',
+        id: stableId(el),
+        value: value
+      }, '*');
+    } else if (!commit) {
+      el.textContent = session.originalText;
+    }
+    postTextSession(el, false, { committed: !!commit, changed: changed });
+    return true;
+  }
   function makeEditable(el, clickEvent){
-    if (!el || el.getAttribute('contenteditable') === 'true') return;
+    if (!el) return;
+    if (activeTextEdit && activeTextEdit.el === el) {
+      placeCaretFromClick(clickEvent, el);
+      return;
+    }
+    if (activeTextEdit) finishActiveTextEdit(true);
+    if (el.getAttribute('contenteditable') === 'true') return;
     var originalText = el.textContent || '';
     clearSelectedTarget();
     el.setAttribute('contenteditable', 'plaintext-only');
@@ -375,35 +419,16 @@ export function buildManualEditBridge(enabled: boolean): string {
     function onKey(ev){
       if (ev.key === 'Enter' && !ev.shiftKey) {
         ev.preventDefault();
-        finish(true);
-        try { el.blur(); } catch (e2) {}
+        finishActiveTextEdit(true);
       }
       if (ev.key === 'Escape') {
         ev.preventDefault();
-        finish(false);
-        try { el.blur(); } catch (e2) {}
+        finishActiveTextEdit(false);
       }
     }
+    activeTextEdit = { el: el, originalText: originalText, onKey: onKey };
     el.addEventListener('keydown', onKey);
-    function finish(commit){
-      el.removeAttribute('contenteditable');
-      el.removeAttribute('data-od-editing');
-      el.removeEventListener('blur', onBlur);
-      el.removeEventListener('keydown', onKey);
-      if (guard) guard.editingEl = null;
-      var value = (el.textContent || '').trim();
-      if (commit && value !== originalText.trim()) {
-        window.parent.postMessage({
-          type: 'od-edit-text-commit',
-          id: stableId(el),
-          value: value
-        }, '*');
-      } else if (!commit) {
-        el.textContent = originalText;
-      }
-    }
-    function onBlur(){ finish(true); }
-    el.addEventListener('blur', onBlur);
+    postTextSession(el, true);
   }
   function camelToKebab(name){ return String(name).replace(/[A-Z]/g, function(m){ return '-' + m.toLowerCase(); }); }
   function cssEscapeId(value){ if (typeof CSS !== 'undefined' && CSS.escape) return CSS.escape(value); return String(value).replace(/"/g, '\\\\"'); }
@@ -453,7 +478,12 @@ export function buildManualEditBridge(enabled: boolean): string {
     if (ev.data.type === 'od-edit-mode') {
       enabled = !!ev.data.enabled;
       document.documentElement.toggleAttribute('data-od-edit-mode', enabled);
-      if (!enabled) clearSelectedTarget();
+      if (!enabled) {
+        // Leaving edit mode commits the pending inline edit rather than
+        // dropping it (the #3647 exit-path regression).
+        finishActiveTextEdit(true);
+        clearSelectedTarget();
+      }
       if (enabled) setTimeout(postTargets, 0);
       return;
     }
@@ -471,6 +501,10 @@ export function buildManualEditBridge(enabled: boolean): string {
       applyPreviewStyles(ev.data.id, ev.data.styles || {}, ev.data.version);
       return;
     }
+    if (ev.data.type === 'od-edit-text-finish') {
+      finishActiveTextEdit(ev.data.commit !== false);
+      return;
+    }
   });
   document.addEventListener('click', function(ev){
     if (!enabled) return;
@@ -480,10 +514,16 @@ export function buildManualEditBridge(enabled: boolean): string {
     var el = closestTarget(ev);
     if (!el) {
       // Clicking empty canvas (no source-mapped ancestor) is the gesture for
-      // page-level styles; the host decides whether to surface the card.
+      // page-level styles; commit any in-flight edit first so the host and
+      // iframe stay in sync, then let the host decide whether to surface the
+      // page-styles card.
+      if (activeTextEdit) finishActiveTextEdit(true);
       window.parent.postMessage({ type: 'od-edit-background' }, '*');
       return;
     }
+    // Switching to a different target commits the in-flight edit first, so the
+    // previous edit is never silently dropped.
+    if (activeTextEdit && activeTextEdit.el !== el) finishActiveTextEdit(true);
     var kind = inferKind(el);
     window.parent.postMessage({ type: 'od-edit-select', target: targetFrom(el, true) }, '*');
     if (kind === 'text' || kind === 'link') {
@@ -493,6 +533,9 @@ export function buildManualEditBridge(enabled: boolean): string {
   }, true);
   document.addEventListener('pointerover', function(ev){
     if (!enabled) return;
+    // While editing, hovering must not retarget the inspector or surface a new
+    // affordance — that's the other half of the #3646 instability.
+    if (activeTextEdit) return;
     if (ev.target && ev.target.closest && ev.target.closest('[data-od-editing="true"]')) return;
     var el = closestTarget(ev);
     if (!el) return;

--- a/apps/web/src/edit-mode/types.ts
+++ b/apps/web/src/edit-mode/types.ts
@@ -120,13 +120,22 @@ export interface ManualEditTextCommitMessage {
   value: string;
 }
 
+export interface ManualEditTextSessionMessage {
+  type: 'od-edit-text-session';
+  id: string;
+  active: boolean;
+  changed?: boolean;
+  committed?: boolean;
+}
+
 export type ManualEditBridgeMessage =
   | ManualEditTargetMessage
   | ManualEditSelectMessage
   | ManualEditHoverMessage
   | ManualEditBackgroundMessage
   | ManualEditPreviewAppliedMessage
-  | ManualEditTextCommitMessage;
+  | ManualEditTextCommitMessage
+  | ManualEditTextSessionMessage;
 
 export const MANUAL_EDIT_STYLE_PROPS: readonly (keyof ManualEditStyles)[] = [
   'fontFamily', 'fontSize', 'fontWeight', 'color', 'textAlign', 'lineHeight', 'letterSpacing',

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1113,6 +1113,171 @@ describe('FileViewer SVG artifacts', () => {
     });
   });
 
+  // #4291 review: if the exit-time text commit fails, the close path must NOT
+  // tear down edit mode (which clears the error) and look like a successful
+  // save — it has to keep edit mode open with the error preserved.
+  it('keeps edit mode open and preserves the error when the exit-time text commit fails (#4291)', async () => {
+    const textTarget = {
+      ...manualEditTarget('card-title', 'Pricing that scales', 20),
+      kind: 'text' as const,
+      tagName: 'div',
+      text: 'Pricing that scales',
+      fields: { text: 'Pricing that scales' },
+      isLayoutContainer: false,
+      outerHtml: '<div data-od-id="card-title">Pricing that scales</div>',
+    };
+    vi.stubGlobal('fetch', vi.fn(async (url: unknown, opts?: { method?: string }) => {
+      const u = String(url);
+      if (u.includes('/files') && opts?.method === 'POST') {
+        return new Response(JSON.stringify({ error: { message: 'disk full' } }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      // The pre-save history check re-fetches the source; treat it as absent so
+      // the commit proceeds to the (failing) save.
+      return new Response('', { status: 404 });
+    }));
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={baseFile({
+          name: 'page.html',
+          path: 'page.html',
+          mime: 'text/html',
+          kind: 'html',
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Page',
+            entry: 'page.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml='<html><body><div data-od-id="card-title">Pricing that scales</div></body></html>'
+      />,
+    );
+
+    const toggle = screen.getByTestId('manual-edit-mode-toggle');
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-preview-frame').getAttribute('data-od-render-mode')).toBe('srcdoc');
+    });
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-select', target: textTarget },
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'card-title', active: true },
+    }));
+    expect(await screen.findByText('Pricing that scales')).toBeTruthy();
+
+    // Exit while editing; the iframe commits new text, but the save fails.
+    fireEvent.click(toggle);
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-commit', id: 'card-title', value: 'New title' },
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'card-title', active: false, committed: true, changed: true },
+    }));
+
+    // The save error is surfaced and edit mode stays open instead of tearing down.
+    expect(await screen.findByText(/Could not save the edited file/)).toBeTruthy();
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  // #4291 review (iframe-driven path): an Enter-committed edit can still be
+  // in flight when the user exits. Exit must await that commit and honor a
+  // failure even though no host-side finish is pending, instead of tearing
+  // down through the race and hiding the failed save.
+  it('keeps edit mode open when an iframe-committed edit fails while exit races it (#4291)', async () => {
+    const textTarget = {
+      ...manualEditTarget('card-title', 'Pricing that scales', 20),
+      kind: 'text' as const,
+      tagName: 'div',
+      text: 'Pricing that scales',
+      fields: { text: 'Pricing that scales' },
+      isLayoutContainer: false,
+      outerHtml: '<div data-od-id="card-title">Pricing that scales</div>',
+    };
+    let releaseSave!: () => void;
+    const savePending = new Promise<void>((resolve) => { releaseSave = resolve; });
+    vi.stubGlobal('fetch', vi.fn(async (url: unknown, opts?: { method?: string }) => {
+      const u = String(url);
+      if (u.includes('/files') && opts?.method === 'POST') {
+        await savePending; // hold the save in flight until the test releases it
+        return new Response(JSON.stringify({ error: { message: 'disk full' } }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('', { status: 404 });
+    }));
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={baseFile({
+          name: 'page.html',
+          path: 'page.html',
+          mime: 'text/html',
+          kind: 'html',
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Page',
+            entry: 'page.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml='<html><body><div data-od-id="card-title">Pricing that scales</div></body></html>'
+      />,
+    );
+
+    const toggle = screen.getByTestId('manual-edit-mode-toggle');
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-preview-frame').getAttribute('data-od-render-mode')).toBe('srcdoc');
+    });
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-select', target: textTarget },
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'card-title', active: true },
+    }));
+    expect(await screen.findByText('Pricing that scales')).toBeTruthy();
+
+    // Iframe-driven finish (Enter): commit + session-inactive with NO host finish.
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-commit', id: 'card-title', value: 'New title' },
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'card-title', active: false, committed: true, changed: true },
+    }));
+
+    // Exit while that commit is still in flight, then let the save fail.
+    fireEvent.click(toggle);
+    await Promise.resolve();
+    releaseSave();
+
+    expect(await screen.findByText(/Could not save the edited file/)).toBeTruthy();
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+  });
+
   it('renders sandbox-shim artifacts on the srcdoc transport without entering edit mode (#2791)', () => {
     const file = baseFile({
       name: 'search.html',

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1041,6 +1041,78 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.queryByText('Trend card')).toBeNull();
   });
 
+  // #3646 / #3647 exit-path regression: leaving edit mode while an inline text
+  // edit is live must ask the iframe to commit and WAIT for the session to end
+  // before tearing down, otherwise the final edit is dropped.
+  it('waits for the iframe to finish the inline text edit before leaving edit mode (#3646)', async () => {
+    const textTarget = {
+      ...manualEditTarget('copy', 'Editable copy', 20),
+      kind: 'text' as const,
+      tagName: 'p',
+      text: 'Editable copy',
+      fields: { text: 'Editable copy' },
+      isLayoutContainer: false,
+      outerHtml: '<p data-od-id="copy">Editable copy</p>',
+    };
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={baseFile({
+          name: 'page.html',
+          path: 'page.html',
+          mime: 'text/html',
+          kind: 'html',
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Page',
+            entry: 'page.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml='<html><body><p data-od-id="copy">Editable copy</p></body></html>'
+      />,
+    );
+
+    const toggle = screen.getByTestId('manual-edit-mode-toggle');
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-preview-frame').getAttribute('data-od-render-mode')).toBe('srcdoc');
+    });
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+
+    // An inline text edit is in progress inside the iframe.
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-select', target: textTarget },
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'copy', active: true },
+    }));
+
+    // Exiting asks the iframe to commit, then must stay in edit mode until the
+    // session is acknowledged (the prior fix tore down here and lost the edit).
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith({ type: 'od-edit-text-finish', commit: true }, '*');
+    });
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+
+    // The iframe acks the finished session; only now does exit complete.
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'copy', active: false, committed: true, changed: true },
+    }));
+
+    await waitFor(() => {
+      expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    });
+  });
+
   it('renders sandbox-shim artifacts on the srcdoc transport without entering edit mode (#2791)', () => {
     const file = baseFile({
       name: 'search.html',

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -365,7 +365,7 @@ describe('manual edit bridge target normalization', () => {
     expect(bridge).toContain("display.indexOf('flex') >= 0 || display.indexOf('grid') >= 0");
   });
 
-  it('turns text targets into inline editors and commits changed text', () => {
+  it('turns text targets into inline editors and commits changed text on explicit finish', () => {
     const dom = new JSDOM(
       `<main><h1 data-od-id="title">Original title</h1></main>${buildManualEditBridge(true)}`,
       { runScripts: 'dangerously', url: 'http://localhost' },
@@ -390,7 +390,10 @@ describe('manual edit bridge target normalization', () => {
     }, '*');
 
     title.textContent = 'Edited title';
-    title.dispatchEvent(new dom.window.FocusEvent('blur', { bubbles: false }));
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-text-finish', commit: true },
+    }));
 
     expect(title.hasAttribute('contenteditable')).toBe(false);
     expect(title.hasAttribute('data-od-editing')).toBe(false);
@@ -399,6 +402,85 @@ describe('manual edit bridge target normalization', () => {
       id: 'title',
       value: 'Edited title',
     }, '*');
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od-edit-text-session',
+      id: 'title',
+      active: false,
+      committed: true,
+      changed: true,
+    }, '*');
+
+    dom.window.close();
+  });
+
+  // #3646 focus-loss half: once editing, blurring the iframe (e.g. moving the
+  // pointer to the host's floating inspector) must NOT end the session or
+  // commit. Only an explicit finish (Enter/Escape/od-edit-text-finish) commits.
+  it('keeps the inline edit active on blur and commits only on explicit finish', () => {
+    const dom = new JSDOM(
+      `<main><h1 data-od-id="title">Original title</h1></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    title.dispatchEvent(new dom.window.MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 8,
+      clientY: 8,
+    }));
+    title.textContent = 'Edited title';
+    title.dispatchEvent(new dom.window.FocusEvent('blur', { bubbles: false }));
+
+    // Blur is no longer a commit trigger — the session stays live.
+    expect(title.getAttribute('contenteditable')).toBe('plaintext-only');
+    expect(title.getAttribute('data-od-editing')).toBe('true');
+    expect(postMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'od-edit-text-commit',
+    }), '*');
+
+    // The host drives the commit explicitly.
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-text-finish', commit: true },
+    }));
+
+    expect(title.hasAttribute('contenteditable')).toBe(false);
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od-edit-text-commit',
+      id: 'title',
+      value: 'Edited title',
+    }, '*');
+
+    dom.window.close();
+  });
+
+  // #3646 / review fix: clicking empty background while editing must commit and
+  // end the session (and tell the host), so host and iframe never desync.
+  it('commits an in-flight inline edit when clicking empty background', () => {
+    const dom = new JSDOM(
+      `<main><h1 data-od-id="title">Original</h1></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+    title.textContent = 'Edited';
+    dom.window.document.body.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od-edit-text-commit',
+      id: 'title',
+      value: 'Edited',
+    }, '*');
+    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'od-edit-text-session',
+      id: 'title',
+      active: false,
+    }), '*');
+    expect(postMessage).toHaveBeenCalledWith({ type: 'od-edit-background' }, '*');
+    expect(title.hasAttribute('contenteditable')).toBe(false);
 
     dom.window.close();
   });


### PR DESCRIPTION
Fixes #3646

> **Re-scoped.** #4382 landed the *container-vs-text targeting* half of #3646 (a click now drops a caret on bare `<div>`/`<li>`/`<td>`/`<h4>`–`<h6>` text leaves). This PR is rebased onto that and now covers the **other half** of the issue — the inline edit losing focus — which #4382 did not touch. #3646 stays open until both halves land.

## Why

In manual edit mode, once an inline text edit started, moving the pointer toward the floating inspector ended the session immediately, because the edit was committed on the iframe's `blur`. You go to nudge the font size and the caret is already gone — editing copy in nested layouts feels unreliable. Leaving edit mode or switching tools mid-edit could also drop the final edit entirely (the exit-path regression review flagged on the earlier #3647 attempt).

## What users will see

In manual edit mode on an HTML artifact:

- An inline text edit stays active until you explicitly finish it — Enter, Escape, Save, Cancel, leaving edit mode, clicking empty background, or selecting another element. Moving the pointer to the floating inspector no longer ends the edit.
- Leaving edit mode (or switching tools) while editing now commits the pending text edit instead of dropping it.
- If that exit-time commit fails (save error, or the source changed underneath), edit mode stays open and the error stays visible, instead of tearing down as though the edit had saved.

## Surface area

- [x] **UI** — manual edit mode in the artifact preview (`apps/web` FileViewer + the injected edit-mode bridge)

No CLI / contract / i18n surface: this is interaction behavior in the existing manual-edit feature.

## Screenshots

Manual edit mode on an HTML artifact (UI = zh-CN). Start editing the card title, then move the pointer onto the floating inspector — close button, font dropdown, changing the font — and the inline edit session stays alive the whole time; it only finalizes on explicit finish:

![Inline text edit survives moving the pointer to the floating inspector](https://github.com/user-attachments/assets/cba7f0e8-0815-4cca-926e-957c819d657a)

On `main` the session ended the moment the pointer left the text (committed on the iframe `blur`), so the inspector was effectively unusable mid-edit.

## Bug fix verification

Focus-loss is an interaction (the edit must survive the iframe blur when the pointer moves to the host inspector) — the recording above shows it end to end, and specs lock it in:

- `apps/web/tests/edit-mode/bridge.test.ts` — "keeps the inline edit active on blur and commits only on explicit finish" (red on `main`: blur committed and closed the session; green here), plus "turns text targets into inline editors and commits changed text on explicit finish" and "commits an in-flight inline edit when clicking empty background".
- `apps/web/tests/components/FileViewer.test.tsx` — "waits for the iframe to finish the inline text edit before leaving edit mode (#3646)", and the failed-commit paths "keeps edit mode open and preserves the error when the exit-time text commit fails" / "...when an iframe-committed edit fails while exit races it".

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/edit-mode/bridge.test.ts tests/components/FileViewer.test.tsx tests/components/manual-edit-kind.test.ts` — 206 pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm guard` — pass

## Relationship to #4382

Rebased onto #4382. The text-leaf classification (`inferKind` / `manualEditElementIsTextLeaf`) is #4382's and is kept as-is; this PR adds only the edit-session lifecycle: focus-loss decoupling (explicit-finish session instead of blur), the exit-path commit, and the failed-commit handling that keeps edit mode open.
