### PR TITLE
feat(skills): clone any URL into an editable HTML artifact

### DIFF
--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -94,6 +94,10 @@ const residualAllowedExactPaths = new Set([
   // runtime deps (puppeteer-core + a headless Chrome + ffmpeg) are provided by
   // the CI environment and never pulled into the daemon/web TS build or bundle.
   "scripts/bake-plugin-previews.mjs",
+  // clone-website skill capture engine. Skills run in the user's agent cwd with
+  // no TS build step, so this ships as a directly-runnable .mjs; it imports
+  // Playwright at runtime to render a URL and snapshot it into editable HTML.
+  "skills/clone-website/assets/capture.mjs",
   "scripts/scaffold-html-ppt-skills.mjs",
   "scripts/sync-hyperframes-skill.mjs",
   "scripts/verify-media-models.mjs",

--- a/skills/clone-website/SKILL.md
+++ b/skills/clone-website/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: clone-website
+zh_name: "网站复刻"
+en_name: "Clone Website"
+description: |
+  Clone any public URL into a self-contained, editable HTML artifact, then fix
+  it up to the user's requirements. Renders the page in headless Chromium so
+  client-rendered (React/Vue/SPA) sites are captured the way a human sees them —
+  not the empty shell that a raw source download returns — inlines stylesheets
+  and images, drops scripts for a stable static snapshot, and saves a full-page
+  reference screenshot to diff against while editing. Use when the user pastes a
+  URL and asks to copy, clone, mirror, replicate, or "make the same as" a site,
+  optionally with changes (rewrite copy, swap colors, drop sections, rebrand).
+triggers:
+  - "clone website"
+  - "clone this url"
+  - "copy this website"
+  - "mirror this page"
+  - "replicate this site"
+  - "make the same as this url"
+  - "复刻网站"
+  - "克隆网页"
+  - "照着这个网址做"
+  - "把这个网站复制一份"
+od:
+  mode: prototype
+  surface: web
+  platform: desktop
+  scenario: design
+  category: web-artifacts
+  preview:
+    type: html
+    entry: example.html
+  design_system:
+    requires: false
+  craft:
+    requires:
+      - typography
+      - color
+      - anti-ai-slop
+  capabilities_required:
+    - file_write
+  example_prompt: |
+    Clone https://stripe.com into an editable HTML file, then change the hero
+    headline to "Payments for builders" and swap the accent color to emerald.
+---
+
+# Clone Website
+
+Turn a URL into an editable, self-contained `index.html` the user can keep
+shaping inside Open Design. The hard part of cloning is **fidelity on modern
+sites**: most marketing and product pages render their content with JavaScript,
+so downloading the raw HTML source returns an empty `<div id="root">`. This
+skill renders the page in a real browser first, then snapshots what was painted.
+
+## Workflow
+
+1. **Capture.** Run the bundled snapshot tool against the URL. Default
+   (rendered) mode is correct for almost everything:
+
+   ```bash
+   node assets/capture.mjs "<url>" --out index.html --shot reference.png
+   ```
+
+   - It launches headless Chromium, waits for network idle, scrolls to trigger
+     lazy-loaded content, inlines stylesheets, base64-inlines images, removes
+     `<script>` tags (a static snapshot must not re-run hydration that would
+     wipe the DOM), and injects `<base href>` so any non-inlined asset still
+     loads. It also writes `reference.png`, a full-page screenshot.
+   - If it reports **Playwright not found**, install it once
+     (`npm i -D playwright && npx playwright install chromium`) or fall back to
+     static mode for server-rendered sites: add `--static`.
+   - Tuning flags: `--max-asset-kb <n>` (asset inline ceiling, default 512),
+     `--viewport <w>x<h>` (default 1440x900), `--wait-ms <n>` (extra settle
+     time), `--keep-scripts` (rarely wanted — risks re-render/redirect).
+
+2. **Sanity-check the snapshot.** Open `index.html` and confirm the real
+   content is present (headings, sections, copy), not a blank shell. If the page
+   came back empty, the site likely blocked headless access or needed an
+   interaction — increase `--wait-ms`, or note the limitation to the user rather
+   than shipping an empty clone. Compare against `reference.png` for layout.
+
+3. **Apply the user's fixes.** Edit `index.html` directly to satisfy what they
+   asked for — rewrite copy, swap colors/fonts, remove sections, rebrand, make
+   it responsive, strip tracking. Treat `reference.png` as the visual ground
+   truth for everything you are *not* changing, so edits stay surgical and the
+   rest of the page keeps its pixel-level look.
+
+4. **Preview.** The artifact is `index.html`; it renders in the Open Design
+   preview iframe with no external build step. Verify it loads and the requested
+   changes are visible.
+
+## Fidelity notes — be honest about these
+
+- **Inlined:** stylesheets, `<img>` images (up to the size cap), the rendered
+  DOM. These carry the bulk of the visual fidelity.
+- **Left as network URLs (via `<base href>`):** web fonts, CSS
+  `background-image` assets, and any image over the size cap. The clone looks
+  pixel-perfect while online; for a fully offline mirror, raise
+  `--max-asset-kb` and tell the user fonts may still hot-link.
+- **Dropped:** JavaScript behavior (carousels, menus, animations). The snapshot
+  is the painted end-state, not an interactive reimplementation. If the user
+  needs interactivity back, rebuild it intentionally rather than restoring the
+  original scripts.
+
+## Why the bundled tool, not a hand-rolled snapshot
+
+A rendered page keeps its visual state in three places, and a naive
+`document.outerHTML` dump only captures the first:
+
+1. **DOM + attributes** — survives serialization.
+2. **External `<link>` CSS** — survives as a reference, but its `url()` and
+   `@import` resolve relative to the *stylesheet's* location, not the document.
+   Inline the CSS without rewriting them and every font / background-image 404s,
+   so the page falls back to system fonts with the wrong metrics.
+3. **Runtime-only CSS** — styled-components / emotion and other CSS-in-JS inject
+   rules straight into the CSSOM via `insertRule`, leaving their `<style>` tags'
+   text nodes *empty*; constructable `adoptedStyleSheets` live in no `<style>`
+   at all. A raw dump loses all of it, so the clone renders the right DOM and
+   the right fonts but the wrong type sizes, weights, and layout.
+
+`assets/capture.mjs` flattens the live CSSOM back into the document for all
+three cases (absolute `url()` rewriting + re-serializing every sheet's
+`cssRules`, including the empty styled-components tags and adopted sheets).
+**Do not** swap it for a `curl`-and-regex snapshot or a one-off `outerHTML`
+dump — that reintroduces exactly these losses.
+
+**Failure signature:** if the clone has the right text and fonts but the type
+sizes / weights / spacing look off, that is CSS-in-JS loss (item 3), not a
+content problem. Re-run `capture.mjs` rather than patching sizes by hand.
+
+## Boundaries
+
+- Only clone pages the user is authorized to copy. Decline obvious wholesale
+  rip-offs of someone else's product passed off as original; cloning for
+  reference, learning, redesign, or one's own site is the intended use.
+- Do not capture pages behind a login or paywall unless the user owns the
+  account and explicitly asks.
+- For "make it *feel* like this" rather than a 1:1 copy, prefer the
+  `reference-design-contract` skill (turns references into a reusable
+  `DESIGN.md`); this skill is for faithful structural clones.

--- a/skills/clone-website/assets/capture.mjs
+++ b/skills/clone-website/assets/capture.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+// capture.mjs — pixel-level snapshot of any URL into a self-contained, editable index.html
+//
+// Default mode renders the page in headless Chromium (so SPAs that paint client-side
+// are captured the way a human sees them), inlines stylesheets, base64-inlines images,
+// drops <script> (a static snapshot must not re-run hydration that would wipe the DOM),
+// and injects <base href> so any asset we did not inline still resolves over the network.
+//
+// Static mode (--static) skips the browser entirely and pulls the raw HTML + assets with
+// Node fetch. Use it as a fallback when Chromium / Playwright is unavailable, or when you
+// already know the target is server-rendered.
+//
+//   node capture.mjs <url> [options]
+//     --out <file>          output HTML path        (default: index.html)
+//     --shot <file>         full-page screenshot     (default: reference.png; rendered mode only)
+//     --static              skip the browser, fetch raw HTML only
+//     --keep-scripts        keep <script> tags (rarely wanted; risks re-render/redirect)
+//     --max-asset-kb <n>    skip inlining assets larger than n KB (default: 512)
+//     --wait-ms <n>         extra settle time after network idle (default: 1200)
+//     --viewport <w>x<h>    rendered viewport        (default: 1440x900)
+
+const args = process.argv.slice(2);
+const url = args.find((a) => !a.startsWith('--'));
+const opt = (name, def) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] && !args[i + 1].startsWith('--') ? args[i + 1] : def;
+};
+const flag = (name) => args.includes(`--${name}`);
+
+if (!url) {
+  console.error('usage: node capture.mjs <url> [--out index.html] [--static] [--shot reference.png]');
+  process.exit(2);
+}
+
+const OUT = opt('out', 'index.html');
+const SHOT = opt('shot', 'reference.png');
+const MAX_ASSET = Number(opt('max-asset-kb', '512')) * 1024;
+const WAIT_MS = Number(opt('wait-ms', '1200'));
+const [VPW, VPH] = opt('viewport', '1440x900').split('x').map(Number);
+const KEEP_SCRIPTS = flag('keep-scripts');
+const STATIC = flag('static');
+
+const origin = new URL(url).origin;
+const abs = (href) => {
+  try { return new URL(href, url).href; } catch { return href; }
+};
+
+// Fetch a binary asset and return a data: URI, or null on failure / oversize.
+async function inlineAsset(assetUrl) {
+  try {
+    const res = await fetch(assetUrl, { redirect: 'follow' });
+    if (!res.ok) return null;
+    const type = res.headers.get('content-type')?.split(';')[0] || 'application/octet-stream';
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length > MAX_ASSET) return null;
+    return `data:${type};base64,${buf.toString('base64')}`;
+  } catch {
+    return null;
+  }
+}
+
+// Replace every absolute asset URL in `html` (img src/srcset + url(...) in inline CSS we
+// already inlined) with a base64 data URI. Best-effort: anything that fails stays as a
+// network URL and still loads thanks to <base href>.
+async function inlineImages(html, urls) {
+  const unique = [...new Set(urls)].filter((u) => /^https?:/.test(u));
+  const map = new Map();
+  const limit = 8;
+  for (let i = 0; i < unique.length; i += limit) {
+    const batch = unique.slice(i, i + limit);
+    const dataUris = await Promise.all(batch.map(inlineAsset));
+    batch.forEach((u, j) => dataUris[j] && map.set(u, dataUris[j]));
+  }
+  for (const [u, data] of map) {
+    html = html.split(u).join(data);
+  }
+  return { html, inlined: map.size, total: unique.length };
+}
+
+function finalizeHtml(html) {
+  // Guarantee a <base href> so non-inlined relative assets resolve against the origin.
+  if (!/<base\s/i.test(html)) {
+    html = html.replace(/<head([^>]*)>/i, `<head$1>\n  <base href="${origin}/">`);
+  }
+  const banner = `<!-- cloned from ${url} via clone-website skill — static snapshot, edit freely -->\n`;
+  return banner + html;
+}
+
+async function runStatic() {
+  const res = await fetch(url, { redirect: 'follow', headers: { 'user-agent': 'Mozilla/5.0 clone-website' } });
+  let html = await res.text();
+  // Pull <img src> + srcset targets to absolute, then inline.
+  const imgUrls = [];
+  html = html.replace(/\b(src|href)=(["'])(.*?)\2/gi, (m, attr, q, val) => {
+    if (attr === 'src' && /\.(png|jpe?g|gif|webp|svg|avif|ico)(\?|$)/i.test(val)) {
+      const a = abs(val); imgUrls.push(a); return `${attr}=${q}${a}${q}`;
+    }
+    return m;
+  });
+  const { html: inlined, inlined: n, total } = await inlineImages(html, imgUrls);
+  if (!KEEP_SCRIPTS) html = stripScripts(inlined); else html = inlined;
+  await (await import('node:fs/promises')).writeFile(OUT, finalizeHtml(html), 'utf8');
+  console.log(`[static] wrote ${OUT} (${n}/${total} assets inlined)`);
+}
+
+function stripScripts(html) {
+  return html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '').replace(/<script\b[^>]*\/>/gi, '');
+}
+
+async function runRendered() {
+  let chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch {
+    try { ({ chromium } = await import('playwright-core')); } catch {
+      console.error('[rendered] Playwright not found. Install it or use --static.');
+      console.error('  npm i -D playwright && npx playwright install chromium');
+      process.exit(3);
+    }
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const ctx = await browser.newContext({
+    viewport: { width: VPW || 1440, height: VPH || 900 },
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 clone-website',
+    deviceScaleFactor: 2,
+  });
+  const page = await ctx.newPage();
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 45000 }).catch(() => {});
+
+  // Trigger lazy-loaded content: scroll to the bottom in steps, then back to top.
+  await page.evaluate(async () => {
+    await new Promise((resolve) => {
+      let y = 0;
+      const step = () => {
+        window.scrollTo(0, y);
+        y += window.innerHeight;
+        if (y < document.body.scrollHeight) setTimeout(step, 120);
+        else { window.scrollTo(0, 0); resolve(); }
+      };
+      step();
+    });
+  });
+  await page.waitForTimeout(WAIT_MS);
+
+  if (SHOT) await page.screenshot({ path: SHOT, fullPage: true }).catch(() => {});
+
+  // In-page: inline cross-origin stylesheets, absolutize img src/srcset, collect asset URLs.
+  const { html, imgUrls } = await page.evaluate(async () => {
+    const toAbs = (h, base) => { try { return new URL(h, base || location.href).href; } catch { return h; } };
+
+    // CSS url(...) and @import resolve relative to the STYLESHEET's location, not the
+    // document. Once a sheet is inlined into a <style>, that base is lost — fonts and
+    // background-images would 404 and the page falls back to system fonts (wrong sizes,
+    // wrong weights). Rewrite every relative reference to an absolute URL against the
+    // sheet's own href before inlining.
+    const absolutizeCss = (css, baseHref) => {
+      css = css.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/g, (m, q, u) =>
+        /^(data:|https?:|blob:|#)/i.test(u) ? m : `url(${q}${toAbs(u, baseHref)}${q})`);
+      css = css.replace(/@import\s+(['"])([^'"]+)\1/g, (m, q, u) =>
+        /^(data:|https?:)/i.test(u) ? m : `@import ${q}${toAbs(u, baseHref)}${q}`);
+      return css;
+    };
+
+    // Replace each <link rel=stylesheet> with a <style> holding its (url-rewritten) rules.
+    for (const link of [...document.querySelectorAll('link[rel~="stylesheet"]')]) {
+      try {
+        let cssText = '';
+        const baseHref = link.href || location.href;
+        const sheet = [...document.styleSheets].find((s) => s.href === link.href);
+        if (sheet) {
+          try { cssText = [...sheet.cssRules].map((r) => r.cssText).join('\n'); } catch { cssText = ''; }
+        }
+        if (!cssText && link.href) {
+          const res = await fetch(link.href).catch(() => null);
+          if (res && res.ok) cssText = await res.text();
+        }
+        if (cssText) {
+          const style = document.createElement('style');
+          style.textContent = absolutizeCss(cssText, baseHref);
+          link.replaceWith(style);
+        } else if (link.href) {
+          link.setAttribute('href', link.href); // pin the surviving link to an absolute URL
+        }
+      } catch { /* leave the link; <base> keeps it loading */ }
+    }
+
+    // CSS-in-JS (styled-components, emotion, …) injects rules straight into the CSSOM via
+    // insertRule, leaving the <style> tag's text node EMPTY — so a raw outerHTML snapshot
+    // loses every one of those rules and the page collapses to default sizing. Re-serialize
+    // each live sheet's cssRules back into its <style> text. This is what fixes "fonts load
+    // but sizes are wrong" on styled-components sites.
+    for (const styleEl of [...document.querySelectorAll('style')]) {
+      try {
+        const sheet = styleEl.sheet;
+        if (!sheet) continue;
+        let rules; try { rules = [...sheet.cssRules]; } catch { continue; }
+        if (!rules.length) continue;
+        const serialized = rules.map((r) => r.cssText).join('\n');
+        if (serialized.length > (styleEl.textContent || '').length) {
+          styleEl.textContent = absolutizeCss(serialized, location.href);
+        }
+      } catch { /* keep whatever text the tag already had */ }
+    }
+
+    // Constructable stylesheets (document.adoptedStyleSheets) live in no <style> at all —
+    // materialize them into appended <style> tags so they survive serialization.
+    try {
+      for (const sheet of document.adoptedStyleSheets || []) {
+        let rules; try { rules = [...sheet.cssRules]; } catch { continue; }
+        if (!rules.length) continue;
+        const s = document.createElement('style');
+        s.setAttribute('data-adopted', '');
+        s.textContent = absolutizeCss(rules.map((r) => r.cssText).join('\n'), location.href);
+        document.head.appendChild(s);
+      }
+    } catch { /* adoptedStyleSheets unsupported or blocked */ }
+
+    // Absolutize image URLs so Node can fetch + inline them afterwards.
+    const imgUrls = [];
+    for (const img of [...document.querySelectorAll('img')]) {
+      if (img.getAttribute('src')) { const a = toAbs(img.getAttribute('src')); img.setAttribute('src', a); imgUrls.push(a); }
+      img.removeAttribute('srcset'); // collapse responsive sets onto the resolved src
+      img.removeAttribute('loading');
+    }
+    return { html: '<!doctype html>\n' + document.documentElement.outerHTML, imgUrls };
+  });
+
+  await browser.close();
+
+  let out = KEEP_SCRIPTS ? html : stripScripts(html);
+  const { html: inlined, inlined: n, total } = await inlineImages(out, imgUrls);
+  await (await import('node:fs/promises')).writeFile(OUT, finalizeHtml(inlined), 'utf8');
+  console.log(`[rendered] wrote ${OUT} (${n}/${total} images inlined)${SHOT ? `, screenshot ${SHOT}` : ''}`);
+}
+
+(STATIC ? runStatic() : runRendered()).catch((err) => {
+  console.error('[capture] failed:', err?.message || err);
+  process.exit(1);
+});

--- a/skills/clone-website/example.html
+++ b/skills/clone-website/example.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Clone Website</title>
+  <style>
+    :root {
+      --ink: #0f1115;
+      --muted: #6b7280;
+      --line: #e7e8ec;
+      --accent: #0e7c5a;
+      --accent-soft: #e7f5ef;
+      --bg: #fbfbfa;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrap { max-width: 760px; margin: 0 auto; padding: 56px 28px 72px; }
+    .eyebrow {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-size: 12px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--accent); background: var(--accent-soft);
+      padding: 6px 12px; border-radius: 999px;
+    }
+    h1 { font-size: clamp(30px, 5vw, 46px); line-height: 1.05; letter-spacing: -0.02em; margin: 20px 0 14px; }
+    .lede { font-size: 18px; line-height: 1.6; color: var(--muted); max-width: 56ch; margin: 0; }
+    .flow {
+      display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; align-items: center; gap: 14px;
+      margin: 40px 0; padding: 22px; background: #fff; border: 1px solid var(--line); border-radius: 16px;
+    }
+    .node { text-align: center; }
+    .node b { display: block; font-size: 14px; }
+    .node span { display: block; font-size: 12px; color: var(--muted); margin-top: 4px; }
+    .arrow { color: var(--accent); font-size: 18px; }
+    .steps { display: grid; gap: 12px; margin-top: 8px; }
+    .step {
+      display: grid; grid-template-columns: 28px 1fr; gap: 14px; align-items: start;
+      padding: 16px 18px; background: #fff; border: 1px solid var(--line); border-radius: 14px;
+    }
+    .num {
+      width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center;
+      font-size: 13px; font-weight: 700; color: #fff; background: var(--accent);
+    }
+    .step h3 { margin: 2px 0 4px; font-size: 15px; }
+    .step p { margin: 0; font-size: 13.5px; line-height: 1.55; color: var(--muted); }
+    code { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; color: var(--accent); background: var(--accent-soft); padding: 2px 6px; border-radius: 5px; }
+    .foot { margin-top: 34px; font-size: 13px; color: var(--muted); border-top: 1px solid var(--line); padding-top: 18px; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <span class="eyebrow">● Clone Website</span>
+    <h1>Paste a URL. Get an editable copy.</h1>
+    <p class="lede">Renders the live page in a real browser, snapshots what was painted, and hands you a self-contained HTML file to reshape — fixes, rebrand, or all of it.</p>
+
+    <div class="flow">
+      <div class="node"><b>Any URL</b><span>SPA or static</span></div>
+      <div class="arrow">→</div>
+      <div class="node"><b>Render &amp; snapshot</b><span>headless Chromium</span></div>
+      <div class="arrow">→</div>
+      <div class="node"><b>index.html</b><span>yours to edit</span></div>
+    </div>
+
+    <div class="steps">
+      <div class="step"><div class="num">1</div><div><h3>Capture</h3><p>Waits for the page to finish rendering, inlines CSS and images, drops scripts for a stable snapshot, and saves a <code>reference.png</code> to diff against.</p></div></div>
+      <div class="step"><div class="num">2</div><div><h3>Fix to spec</h3><p>Rewrite copy, swap the palette, drop sections, rebrand — surgical edits with the screenshot as ground truth for everything you keep.</p></div></div>
+      <div class="step"><div class="num">3</div><div><h3>Preview</h3><p>Self-contained HTML renders straight in the Open Design preview, no build step.</p></div></div>
+    </div>
+
+    <p class="foot">Why render instead of download source? Most modern sites paint content with JavaScript — a raw source download returns an empty shell. This captures what a human actually sees.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Why

**Use case (mine, building on OD):** I wanted a "paste any URL → get an editable copy" flow inside Open Design — capture a reference site once, then reshape it (rewrite copy, rebrand, swap palette, strip sections) instead of rebuilding from a screenshot. None of the existing skills cover faithful URL mirroring: `image-to-code` generates references first, `redesign-existing-projects` works on a codebase you already have, and `reference-design-contract` distills references into a `DESIGN.md` rather than reproducing the page.

**Pain:** the obvious approach — download the page source and patch it — fails on the modern web. Most marketing/product pages render their content with JavaScript, so a raw source fetch returns an empty `<div id="root">`. You need to render the page, then snapshot what was actually painted.

## What users will see

A new **`clone-website`** skill in the Prototype mode picker / Settings → Skills (triggers like "clone this url", "复刻网站"). Paste a URL and the agent renders it in headless Chromium, snapshots it into a self-contained, editable `index.html` (plus a `reference.png` to diff against), then applies whatever changes you asked for. The artifact previews in the workspace with no build step.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [x] **Extension point** — new `skills/clone-website/` entry. Skills are agent-invoked (discovered via `/api/skills`, triggered by prompt), so the capability is reachable from both the web UI and the `od` CLI through the same run path; it needs no dedicated subcommand or endpoint.
- [ ] **i18n keys**
- [ ] **New top-level dependency** — none. The capture engine imports Playwright at runtime in the user's agent cwd; it is not added to any workspace manifest.
- [ ] **Default behavior change** — no; adding a skill changes nothing for users who don't invoke it.
- [ ] **None**

## Screenshots

Not a UI change. Fidelity was validated against `https://linear.app` (a styled-components SPA): the cloned `index.html`, rendered offline with scripts stripped, reproduces the hero headline at the original's exact `64px` / weight `510` and keeps the full styled-components styling.

## Bug fix verification

Not a bug fix — new feature. During development two snapshot-fidelity defects were found and fixed in the capture engine, each verified by measuring computed styles of the clone vs. the live page:
- CSS `url()` / `@import` resolved against the document instead of the stylesheet after inlining → fonts/background-images 404'd. Fixed by rewriting them to absolute URLs pre-inline.
- CSS-in-JS (styled-components/emotion) injects rules via `insertRule`, leaving `<style>` tags' text nodes empty, and constructable `adoptedStyleSheets` live in no `<style>` at all → a plain `outerHTML` dump dropped all of it and the page collapsed to default typography. Fixed by re-serializing every live sheet's `cssRules` back into the document. Both root causes and the failure signature are documented in `SKILL.md` so the agent uses the tested engine rather than hand-rolling a snapshot.

## Validation

- `pnpm guard` — pass (allowlisted the `.mjs` capture asset with a documented reason: skills run in the agent cwd with no TS build step).
- `pnpm typecheck` — pass.
- `capture.mjs` exercised on real sites: `example.com`, `iana.org`, `en.wikipedia.org` (image inlining), `quotes.toscrape.com/js/` (rendered mode captured 10 items vs. 0 for `--static`, proving the SPA case), and `linear.app` (pixel-level typography match after the fixes above).
