### PR TITLE
fix: document data-od-id contract in HTML prompt

### DIFF
--- a/apps/daemon/src/prompts/official-system.ts
+++ b/apps/daemon/src/prompts/official-system.ts
@@ -66,7 +66,7 @@ PDFs, PPTX, DOCX: you can extract them via Bash (\`unzip\`, \`pdftotext\`, etc.)
 ## Inspectable HTML
 Open Design's Inspect and Picker tools work best when meaningful visible elements have stable selectors. For generated HTML artifacts, add \`data-od-id="kebab-case-id"\` to inspectable elements the user is likely to point at or tune: page regions such as \`main\`, \`section\`, \`article\`, \`header\`, \`footer\`, \`nav\`, and \`aside\`; headings \`h1\` through \`h6\`; buttons, links, form controls, and key calls to action; repeated cards, list items, and primary content blocks.
 
-Use stable, descriptive kebab-case ids based on the element's role or content. Do not add \`data-od-id\` to tiny decorative elements such as spacers, dividers, icon wrappers, or purely visual flourishes.
+Use stable, descriptive kebab-case ids based on the element's role or content, and keep every \`data-od-id\` unique within the artifact. Repeated cards, list items, pricing rows, testimonials, and feature cells must get distinct ids such as \`feature-card-security\`, \`feature-card-speed\`, or \`feature-card-2\` when a semantic suffix is not available. Do not add \`data-od-id\` to tiny decorative elements such as spacers, dividers, icon wrappers, or purely visual flourishes.
 
 ## Content guidelines
 - **No filler.** Never pad with placeholder text, dummy sections, or stat-slop just to fill space. If a section feels empty, that's a design problem to solve with composition, not by inventing words.

--- a/apps/daemon/src/prompts/official-system.ts
+++ b/apps/daemon/src/prompts/official-system.ts
@@ -63,6 +63,11 @@ PDFs, PPTX, DOCX: you can extract them via Bash (\`unzip\`, \`pdftotext\`, etc.)
 - **Color usage**: choose the product background and palette from the user's brand, domain, screenshots, selected design system, or active skill direction. Do not inherit Open Design app chrome colors. Do not default to warm beige/cream/peach/pink/orange-brown canvas treatments unless those colors are explicitly justified by the product brand or user-provided reference.
 - Don't use \`scrollIntoView\` — it can break the embedded preview. Use other DOM scroll methods.
 
+## Inspectable HTML
+Open Design's Inspect and Picker tools work best when meaningful visible elements have stable selectors. For generated HTML artifacts, add \`data-od-id="kebab-case-id"\` to inspectable elements the user is likely to point at or tune: page regions such as \`main\`, \`section\`, \`article\`, \`header\`, \`footer\`, \`nav\`, and \`aside\`; headings \`h1\` through \`h6\`; buttons, links, form controls, and key calls to action; repeated cards, list items, and primary content blocks.
+
+Use stable, descriptive kebab-case ids based on the element's role or content. Do not add \`data-od-id\` to tiny decorative elements such as spacers, dividers, icon wrappers, or purely visual flourishes.
+
 ## Content guidelines
 - **No filler.** Never pad with placeholder text, dummy sections, or stat-slop just to fill space. If a section feels empty, that's a design problem to solve with composition, not by inventing words.
 - **Ask before adding material.** If you think extra sections or copy would help, ask the user before unilaterally adding them.

--- a/apps/daemon/tests/official-system-prompt.test.ts
+++ b/apps/daemon/tests/official-system-prompt.test.ts
@@ -3,12 +3,19 @@ import { describe, expect, it } from 'vitest';
 import { OFFICIAL_DESIGNER_PROMPT } from '../src/prompts/official-system.js';
 
 describe('official designer prompt', () => {
-  it('documents the data-od-id contract for meaningful inspectable HTML elements', () => {
+  it('documents unique data-od-id values for repeated inspectable HTML elements', () => {
     expect(OFFICIAL_DESIGNER_PROMPT).toContain('data-od-id');
     expect(OFFICIAL_DESIGNER_PROMPT).toContain('kebab-case');
     expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/h1.*h6|h1.*h2.*h3.*h4.*h5.*h6/s);
-    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/buttons?.*links?.*form controls?/is);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/buttons?|<button>/i);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/links?|<a>/i);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/form controls?/i);
     expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/cards?.*list items?/is);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/unique within the artifact/i);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/repeated cards?.*distinct ids/is);
+    expect(OFFICIAL_DESIGNER_PROMPT).toContain('feature-card-security');
+    expect(OFFICIAL_DESIGNER_PROMPT).toContain('feature-card-speed');
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/feature-card-2|numeric suffix/i);
     expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/decorative elements|spacers?|dividers?/is);
   });
 });

--- a/apps/daemon/tests/official-system-prompt.test.ts
+++ b/apps/daemon/tests/official-system-prompt.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { OFFICIAL_DESIGNER_PROMPT } from '../src/prompts/official-system.js';
+
+describe('official designer prompt', () => {
+  it('documents the data-od-id contract for meaningful inspectable HTML elements', () => {
+    expect(OFFICIAL_DESIGNER_PROMPT).toContain('data-od-id');
+    expect(OFFICIAL_DESIGNER_PROMPT).toContain('kebab-case');
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/h1.*h6|h1.*h2.*h3.*h4.*h5.*h6/s);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/buttons?.*links?.*form controls?/is);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/cards?.*list items?/is);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/decorative elements|spacers?|dividers?/is);
+  });
+});

--- a/packages/contracts/src/prompts/official-system.ts
+++ b/packages/contracts/src/prompts/official-system.ts
@@ -59,6 +59,11 @@ PDFs, PPTX, DOCX: you can extract them via Bash (\`unzip\`, \`pdftotext\`, etc.)
 - **Color usage**: choose the product background and palette from the user's brand, domain, screenshots, selected design system, or active skill direction. Do not inherit Open Design app chrome colors. Do not default to warm beige/cream/peach/pink/orange-brown canvas treatments unless those colors are explicitly justified by the product brand or user-provided reference.
 - Don't use \`scrollIntoView\` — it can break the embedded preview. Use other DOM scroll methods.
 
+## Inspectable HTML
+Open Design's Inspect and Picker tools work best when meaningful visible elements have stable selectors. For generated HTML artifacts, add \`data-od-id="kebab-case-id"\` to inspectable elements the user is likely to point at or tune: page regions such as \`main\`, \`section\`, \`article\`, \`header\`, \`footer\`, \`nav\`, and \`aside\`; headings \`h1\` through \`h6\`; buttons, links, form controls, and key calls to action; repeated cards, list items, and primary content blocks.
+
+Use stable, descriptive kebab-case ids based on the element's role or content, and keep every \`data-od-id\` unique within the artifact. Repeated cards, list items, pricing rows, testimonials, and feature cells must get distinct ids such as \`feature-card-security\`, \`feature-card-speed\`, or \`feature-card-2\` when a semantic suffix is not available. Do not add \`data-od-id\` to tiny decorative elements such as spacers, dividers, icon wrappers, or purely visual flourishes.
+
 ## Content guidelines
 - **No filler.** Never pad with placeholder text, dummy sections, or stat-slop just to fill space. If a section feels empty, that's a design problem to solve with composition, not by inventing words.
 - **Ask before adding material.** If you think extra sections or copy would help, ask the user before unilaterally adding them.

--- a/packages/contracts/tests/official-system-prompt.test.ts
+++ b/packages/contracts/tests/official-system-prompt.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { OFFICIAL_DESIGNER_PROMPT } from '../src/prompts/official-system.js';
+
+describe('official designer prompt', () => {
+  it('documents unique data-od-id values for repeated inspectable HTML elements', () => {
+    expect(OFFICIAL_DESIGNER_PROMPT).toContain('data-od-id');
+    expect(OFFICIAL_DESIGNER_PROMPT).toContain('kebab-case');
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/h1.*h6|h1.*h2.*h3.*h4.*h5.*h6/s);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/buttons?|<button>/i);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/links?|<a>/i);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/form controls?/i);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/cards?.*list items?/is);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/unique within the artifact/i);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/repeated cards?.*distinct ids/is);
+    expect(OFFICIAL_DESIGNER_PROMPT).toContain('feature-card-security');
+    expect(OFFICIAL_DESIGNER_PROMPT).toContain('feature-card-speed');
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/feature-card-2|numeric suffix/i);
+    expect(OFFICIAL_DESIGNER_PROMPT).toMatch(/decorative elements|spacers?|dividers?/is);
+  });
+});


### PR DESCRIPTION
Fixes #2045.

Replaces #2046, which was auto-closed by the PR queue bot after the implementation had been approved. The code carries the approved head forward and includes the PR-template follow-up requested on #2045/#2046.

## Why

Generated HTML artifacts can be hard to tune with Inspect and Picker when meaningful visible elements do not carry stable selectors. Runtime fallbacks can detect and explain under-annotated artifacts, but the better user experience is for newly generated HTML to be inspectable from the start.

This PR adds provider-agnostic prompt guidance so models tag meaningful user-facing HTML elements with stable, unique `data-od-id` values. It complements the runtime-side recovery work in #890 and #1022/#2039 without changing the runtime bridge, DOM fallback, or persistence semantics.

## What users will see

Newly generated HTML should more often expose useful Inspect/Picker targets on the elements users naturally want to select or tune: page regions, headings, buttons, links, form controls, calls to action, repeated cards, list items, and primary content blocks.

Repeated elements should stay individually targetable because the prompt now calls out unique ids such as `feature-card-security`, `feature-card-speed`, or a numeric suffix when needed.

Decorative implementation details such as spacers, dividers, icon wrappers, and purely visual flourishes are explicitly excluded so the picker surface stays meaningful instead of noisy.

## Surface area

- [x] Daemon official designer prompt: adds an `Inspectable HTML` section to `OFFICIAL_DESIGNER_PROMPT`.
- [x] Contracts official designer prompt: mirrors the same `data-od-id` contract for API/BYOK prompt composition.
- [x] Daemon prompt test coverage: covers `data-od-id` guidance, repeated-item uniqueness examples, and decorative-element exclusion.
- [x] Contracts prompt test coverage: covers the same contract so daemon and contracts prompt copies cannot drift silently.
- [x] No runtime bridge changes.
- [x] No DOM fallback changes.
- [x] No Inspect/Picker persistence changes.
- [x] No database, packaging, or provider-specific behavior changes.

## Bug-fix verification note

Before this PR, generated HTML could omit stable inspectable ids or reuse the same `data-od-id` across repeated cards/list items, which means Inspect/Picker could collapse those repeated targets and leave later items hard to tune directly. API/BYOK prompt composition also missed the same generation-time contract when only the daemon prompt copy was updated. After this PR, both prompt authorities tell models to tag meaningful elements and to keep repeated inspectable ids unique; daemon and contracts prompt tests now fail if that uniqueness contract drops out again.

## Validation

Local validation:

- `pnpm --filter @open-design/daemon exec vitest run tests/official-system-prompt.test.ts` (#2046 branch validation)
- `pnpm --filter @open-design/daemon typecheck` (#2046 branch validation)
- `pnpm --filter @open-design/contracts exec vitest run tests/official-system-prompt.test.ts`
- `pnpm --filter @open-design/contracts typecheck`

GitHub checks on #4305 were green before the contracts follow-up commit:

- Detect CI change scopes
- Guard changed file sizes
- Validate Nix flake
- Preflight
- Workspace unit tests
- Daemon workspace tests
- Browser tests
- Build workspaces
- Validate workspace
- Strict PR visual tests
- UI P0

Packaged smoke/runtime jobs were skipped by the existing change-scope rules because this is a prompt/test-only change.