### PR TITLE
[codex] Add Langfuse prompt blame metadata

### DIFF
--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -23,6 +23,7 @@ import {
   buildPromptStackFlatMetadata,
   promptStackWithoutContent,
   structuredPromptStackInput,
+  type PromptTelemetrySection,
   type PromptStackTelemetry,
 } from './prompt-telemetry.js';
 import type {
@@ -47,6 +48,7 @@ const SESSION_ID_MAX = 200; // Langfuse drops sessionIds longer than this.
 const HARD_BATCH_MAX_BYTES = 1024 * 1024;
 const DEFAULT_FETCH_TIMEOUT_MS = 20_000;
 const DEFAULT_FETCH_RETRIES = 1;
+const PROMPT_STACK_BLAME_MAX_SECTIONS = 8;
 let missingTelemetrySinkWarned = false;
 
 export interface LangfuseConfig {
@@ -631,6 +633,140 @@ function buildCostBreakdown(ctx: ReportContext): Record<string, unknown> {
   };
 }
 
+function cleanNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function sectionAttributionBytes(section: PromptTelemetrySection): number {
+  return cleanNumber(section.redactedBytes) ?? cleanNumber(section.rawBytes) ?? 0;
+}
+
+function redactedContentBytes(section: PromptTelemetrySection): number {
+  return Buffer.byteLength(section.redactedContent ?? '', 'utf8');
+}
+
+function allocateProportionalTokens(
+  total: number | undefined,
+  sections: Array<{ section: PromptTelemetrySection; weightBytes: number }>,
+): Map<PromptTelemetrySection, number> {
+  const out = new Map<PromptTelemetrySection, number>();
+  const cleanTotal = cleanNumber(total);
+  if (cleanTotal === undefined || cleanTotal <= 0) return out;
+  const totalWeight = sections.reduce((sum, item) => sum + item.weightBytes, 0);
+  if (totalWeight <= 0) return out;
+
+  let assigned = 0;
+  let largest: { section: PromptTelemetrySection; tokens: number } | null = null;
+  for (const item of sections) {
+    const exact = (cleanTotal * item.weightBytes) / totalWeight;
+    const rounded = Math.floor(exact);
+    out.set(item.section, rounded);
+    assigned += rounded;
+    if (!largest || item.weightBytes > sectionAttributionBytes(largest.section)) {
+      largest = { section: item.section, tokens: rounded };
+    }
+  }
+  const remainder = Math.round(cleanTotal) - assigned;
+  if (largest && remainder > 0) {
+    out.set(largest.section, (out.get(largest.section) ?? 0) + remainder);
+  }
+  return out;
+}
+
+function buildPromptStackBlameMetadata(
+  promptStack: PromptStackTelemetry | undefined,
+  usage: MessageSummary['usage'] | undefined,
+  timings: RunTimingAnalytics | undefined,
+): Record<string, unknown> {
+  if (!promptStack || promptStack.sections.length === 0) return {};
+  const weightedSections = promptStack.sections
+    .map((section) => ({
+      section,
+      weightBytes: sectionAttributionBytes(section),
+    }))
+    .filter((item) => item.weightBytes > 0);
+  if (weightedSections.length === 0) return {};
+
+  const totalBytes = weightedSections.reduce((sum, item) => sum + item.weightBytes, 0);
+  const sorted = [...weightedSections].sort(
+    (a, b) => b.weightBytes - a.weightBytes || a.section.ordinal - b.section.ordinal,
+  );
+  const cacheCreationBySection = allocateProportionalTokens(
+    usage?.cacheCreationInputTokens,
+    weightedSections,
+  );
+  const cacheReadBySection = allocateProportionalTokens(
+    usage?.cacheReadInputTokens,
+    weightedSections,
+  );
+  const inputEffectiveBySection = allocateProportionalTokens(
+    usage?.inputTokensEffective ?? usage?.inputTokens,
+    weightedSections,
+  );
+  const uncachedBySection = allocateProportionalTokens(
+    usage?.uncachedInputTokens,
+    weightedSections,
+  );
+
+  const sectionRow = ({ section, weightBytes }: { section: PromptTelemetrySection; weightBytes: number }) => {
+    const share = totalBytes > 0 ? weightBytes / totalBytes : 0;
+    return {
+      kind: section.kind,
+      ordinal: section.ordinal,
+      contentMode: section.contentMode,
+      rawBytes: section.rawBytes,
+      redactedBytes: section.redactedBytes,
+      redactedContentBytes: redactedContentBytes(section),
+      attributionBytes: weightBytes,
+      attributionShare: Number(share.toFixed(6)),
+      truncated: section.truncated,
+      ...(section.truncationReason ? { truncationReason: section.truncationReason } : {}),
+      estimatedInputEffectiveTokens: inputEffectiveBySection.get(section) ?? undefined,
+      estimatedCacheCreationInputTokens: cacheCreationBySection.get(section) ?? undefined,
+      estimatedCacheReadInputTokens: cacheReadBySection.get(section) ?? undefined,
+      estimatedUncachedInputTokens: uncachedBySection.get(section) ?? undefined,
+    };
+  };
+
+  const primary = sorted[0]!;
+  const primaryShare = totalBytes > 0 ? primary.weightBytes / totalBytes : 0;
+  return {
+    promptStack_topSectionsByBytes: sorted
+      .slice(0, PROMPT_STACK_BLAME_MAX_SECTIONS)
+      .map(sectionRow),
+    cacheCreationTokensBySection: sorted
+      .filter(({ section }) => (cacheCreationBySection.get(section) ?? 0) > 0)
+      .map(({ section, weightBytes }) => ({
+        kind: section.kind,
+        ordinal: section.ordinal,
+        attributionBytes: weightBytes,
+        estimatedCacheCreationInputTokens: cacheCreationBySection.get(section) ?? 0,
+      })),
+    promptStack_ttftAttribution: {
+      method: 'proportional_by_prompt_section_redacted_bytes',
+      estimation_warning:
+        'Provider reports aggregate prompt/cache tokens only; section token values are estimates for diagnosis, not billing truth.',
+      time_to_first_token_ms: timings?.time_to_first_token_ms,
+      spawn_to_first_token_ms: timings?.spawn_to_first_token_ms,
+      totalAttributionBytes: totalBytes,
+      sectionCount: weightedSections.length,
+      primarySectionKind: primary.section.kind,
+      primarySectionOrdinal: primary.section.ordinal,
+      primarySectionAttributionBytes: primary.weightBytes,
+      primarySectionAttributionShare: Number(primaryShare.toFixed(6)),
+      primarySectionEstimatedInputEffectiveTokens:
+        inputEffectiveBySection.get(primary.section) ?? undefined,
+      primarySectionEstimatedCacheCreationInputTokens:
+        cacheCreationBySection.get(primary.section) ?? undefined,
+      primarySectionEstimatedCacheReadInputTokens:
+        cacheReadBySection.get(primary.section) ?? undefined,
+      cacheTokenSource: usage?.cacheTokenSource,
+    },
+  };
+}
+
 function durationMs(startedAt: number, endedAt: number): number {
   return Math.max(0, Math.round(endedAt - startedAt));
 }
@@ -1101,6 +1237,11 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   const promptStackFlatMetadata = promptStack
     ? buildPromptStackFlatMetadata(promptStack)
     : {};
+  const promptStackBlameMetadata = buildPromptStackBlameMetadata(
+    promptStack,
+    ctx.message.usage,
+    ctx.run.timings,
+  );
   const generationInput = promptStack
     ? structuredPromptStackInput(promptStack)
     : inputText;
@@ -1157,6 +1298,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     arch: ctx.runtime?.arch,
     clientType: ctx.runtime?.clientType,
     ...promptStackFlatMetadata,
+    ...promptStackBlameMetadata,
   };
 
   // Generation-level model parameters mirror the Langfuse schema so the UI
@@ -1250,6 +1392,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
           cost_breakdown: costBreakdown,
           performance_diagnostics: performanceDiagnostics,
           ...promptStackFlatMetadata,
+          ...promptStackBlameMetadata,
         },
       },
     });
@@ -1278,6 +1421,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
           cost_breakdown: costBreakdown,
           performance_diagnostics: performanceDiagnostics,
           ...promptStackFlatMetadata,
+          ...promptStackBlameMetadata,
           reason: 'no_model_generation',
         },
       },

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -367,6 +367,97 @@ describe('buildTracePayload', () => {
     );
   });
 
+  it('adds prompt-stack byte and cache-token blame metadata for TTFT diagnosis', () => {
+    const promptTelemetry = buildPromptStackTelemetry({
+      composedPrompt: ['a'.repeat(1000), 'b'.repeat(500), 'c'.repeat(100)].join('\n'),
+      sections: [
+        { kind: 'daemonSystemPrompt', content: 'a'.repeat(1000) },
+        { kind: 'pluginStagePrompt', content: 'b'.repeat(500) },
+        { kind: 'userRequest', content: 'c'.repeat(100) },
+      ],
+    });
+    const ctx = makeCtx({
+      prefs: { metrics: true, content: true, artifactManifest: false },
+      promptTelemetry,
+    });
+    ctx.run = {
+      ...ctx.run,
+      timings: {
+        tool_call_count: 0,
+        total_duration_ms: 89_162,
+        time_to_first_token_ms: 26_613,
+        spawn_to_first_token_ms: 26_491,
+      },
+    };
+
+    const batch = buildTracePayload(ctx);
+    const trace = bodyOf(batch, 'trace-create');
+    const generation = bodyOf(batch, 'generation-create', 'llm');
+
+    expect(trace.metadata.promptStack_topSectionsByBytes).toEqual([
+      expect.objectContaining({
+        kind: 'daemonSystemPrompt',
+        rawBytes: 1000,
+        redactedBytes: 1000,
+        attributionBytes: 1000,
+        attributionShare: 0.625,
+        estimatedInputEffectiveTokens: 929,
+        estimatedCacheCreationInputTokens: 32,
+        estimatedCacheReadInputTokens: 126,
+        estimatedUncachedInputTokens: 772,
+      }),
+      expect.objectContaining({
+        kind: 'pluginStagePrompt',
+        rawBytes: 500,
+        attributionShare: 0.3125,
+        estimatedCacheCreationInputTokens: 15,
+      }),
+      expect.objectContaining({
+        kind: 'userRequest',
+        rawBytes: 100,
+        attributionShare: 0.0625,
+        estimatedCacheCreationInputTokens: 3,
+      }),
+    ]);
+    expect(trace.metadata.cacheCreationTokensBySection).toEqual([
+      {
+        kind: 'daemonSystemPrompt',
+        ordinal: 0,
+        attributionBytes: 1000,
+        estimatedCacheCreationInputTokens: 32,
+      },
+      {
+        kind: 'pluginStagePrompt',
+        ordinal: 1,
+        attributionBytes: 500,
+        estimatedCacheCreationInputTokens: 15,
+      },
+      {
+        kind: 'userRequest',
+        ordinal: 2,
+        attributionBytes: 100,
+        estimatedCacheCreationInputTokens: 3,
+      },
+    ]);
+    expect(trace.metadata.promptStack_ttftAttribution).toMatchObject({
+      method: 'proportional_by_prompt_section_redacted_bytes',
+      time_to_first_token_ms: 26_613,
+      spawn_to_first_token_ms: 26_491,
+      totalAttributionBytes: 1600,
+      sectionCount: 3,
+      primarySectionKind: 'daemonSystemPrompt',
+      primarySectionAttributionShare: 0.625,
+      primarySectionEstimatedCacheCreationInputTokens: 32,
+      cacheTokenSource: 'anthropic',
+    });
+    expect(generation.metadata.promptStack_topSectionsByBytes).toEqual(
+      trace.metadata.promptStack_topSectionsByBytes,
+    );
+    expect(generation.metadata.promptStack_ttftAttribution).toEqual(
+      trace.metadata.promptStack_ttftAttribution,
+    );
+  });
+
   it('omits prompt-stack redactedContent when metrics or content consent is off', () => {
     const promptTelemetry = buildPromptStackTelemetry({
       composedPrompt: '# User request\n\nBuild a card',


### PR DESCRIPTION
## Why

While diagnosing a slow first-token Langfuse trace, the trace showed aggregate prompt-stack byte counts and aggregate provider cache tokens, but it did not directly identify which prompt sections were most likely driving prompt prefill/cache work. That made TTFT analysis require manual section-by-section inspection.

This PR adds lightweight diagnostic metadata so operators can quickly spot the largest prompt-stack contributors and see honest, proportional cache-token estimates per section. The attribution is explicitly marked as estimated because providers report aggregate cache/input tokens, not per-section billing truth.

## What users will see

No end-user UI change. Langfuse traces for Open Design turns now include prompt-stack blame fields in trace and generation metadata, including `promptStack_topSectionsByBytes`, `cacheCreationTokensBySection`, and `promptStack_ttftAttribution`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

This is observability instrumentation, not a user-facing bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/langfuse-trace.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
