### PR TITLE
[codex] Improve AMR onboarding sign-in errors

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1506,7 +1506,7 @@ function OnboardingView({
           const cancelResult = await cancelVelaLogin();
           closeAmrActivationWindowBestEffort();
           if (!cancelResult.ok) {
-            setAmrLoginError(t('settings.amrLoginErrorCompact'));
+            setAmrLoginError(onboardingAmrLoginError());
             return;
           }
           notifyAmrLoginStatusChanged('login-canceled');
@@ -1515,7 +1515,7 @@ function OnboardingView({
       }
       if (!loginResult.ok && !loginResult.alreadyRunning) {
         resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed');
-        setAmrLoginError(loginResult.error || t('settings.amrLoginErrorCompact'));
+        setAmrLoginError(onboardingAmrLoginError(loginResult.error));
         return;
       }
       if (await pollAmrLoginCompletion()) {
@@ -1542,10 +1542,17 @@ function OnboardingView({
     closeAmrActivationWindowBestEffort();
     setAmrLoginCancelPending(false);
     if (!result.ok) {
-      setAmrLoginError(t('settings.amrLoginErrorCompact'));
+      setAmrLoginError(onboardingAmrLoginError());
       return;
     }
     notifyAmrLoginStatusChanged('login-canceled');
+  }
+
+  function onboardingAmrLoginError(reason?: string | null): string {
+    const trimmedReason = reason?.trim();
+    const recovery = t('settings.amrLoginErrorRecovery');
+    if (trimmedReason) return `${trimmedReason} ${recovery}`;
+    return `${t('settings.amrLoginErrorCompact')} ${recovery}`;
   }
 
   async function pollAmrLoginCompletion(): Promise<boolean> {
@@ -1572,7 +1579,7 @@ function OnboardingView({
         } else {
           resolveAmrAuthTracking(analytics.track, 'failed', 'login_stopped');
         }
-        setAmrLoginError(t('settings.amrLoginErrorCompact'));
+        setAmrLoginError(onboardingAmrLoginError());
         return false;
       }
     }

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -252,6 +252,7 @@ export const ar: Dict = {
   'settings.amrAccountStatus': 'حالة حساب AMR',
   'settings.amrConsole': 'وحدة تحكّم AMR',
   'settings.amrLoginErrorCompact': 'فشل تسجيل الدخول إلى AMR.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'متقدّم',
   'settings.amrLogin': 'تسجيل الدخول',
   'settings.amrLogout': 'تسجيل الخروج',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -252,6 +252,7 @@ export const de: Dict = {
   'settings.amrAccountStatus': 'AMR-Kontostatus',
   'settings.amrConsole': 'AMR-Konsole',
   'settings.amrLoginErrorCompact': 'AMR-Anmeldung fehlgeschlagen.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Erweitert',
   'settings.amrLogin': 'Anmelden',
   'settings.amrLogout': 'Abmelden',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -252,6 +252,7 @@ export const en: Dict = {
   'settings.amrAccountStatus': 'AMR account status',
   'settings.amrConsole': 'AMR Console',
   'settings.amrLoginErrorCompact': 'AMR sign-in failed.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Advanced',
   'settings.amrLogin': 'Sign in',
   'settings.amrLogout': 'Sign out',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -252,6 +252,7 @@ export const esES: Dict = {
   'settings.amrAccountStatus': 'Estado de la cuenta AMR',
   'settings.amrConsole': 'Consola AMR',
   'settings.amrLoginErrorCompact': 'Error al iniciar sesión en AMR.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Avanzado',
   'settings.amrLogin': 'Iniciar sesión',
   'settings.amrLogout': 'Cerrar sesión',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -252,6 +252,7 @@ export const fa: Dict = {
   'settings.amrAccountStatus': 'وضعیت حساب AMR',
   'settings.amrConsole': 'کنسول AMR',
   'settings.amrLoginErrorCompact': 'ورود به AMR ناموفق بود.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'پیشرفته',
   'settings.amrLogin': 'ورود',
   'settings.amrLogout': 'خروج',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -252,6 +252,7 @@ export const fr: Dict = {
   'settings.amrAccountStatus': 'Statut du compte AMR',
   'settings.amrConsole': 'Console AMR',
   'settings.amrLoginErrorCompact': 'Échec de la connexion AMR.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Avancé',
   'settings.amrLogin': 'Se connecter',
   'settings.amrLogout': 'Se déconnecter',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -252,6 +252,7 @@ export const hu: Dict = {
   'settings.amrAccountStatus': 'AMR fiók állapota',
   'settings.amrConsole': 'AMR konzol',
   'settings.amrLoginErrorCompact': 'Az AMR bejelentkezés sikertelen.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Speciális',
   'settings.amrLogin': 'Bejelentkezés',
   'settings.amrLogout': 'Kijelentkezés',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -252,6 +252,7 @@ export const id: Dict = {
   'settings.amrAccountStatus': 'Status akun AMR',
   'settings.amrConsole': 'Konsol AMR',
   'settings.amrLoginErrorCompact': 'Proses masuk AMR gagal.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Lanjutan',
   'settings.amrLogin': 'Masuk',
   'settings.amrLogout': 'Keluar',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -252,6 +252,7 @@ export const it: Dict = {
   'settings.amrAccountStatus': 'Stato account AMR',
   'settings.amrConsole': 'Console AMR',
   'settings.amrLoginErrorCompact': 'Accesso AMR non riuscito.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Avanzate',
   'settings.amrLogin': 'Accedi',
   'settings.amrLogout': 'Esci',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -252,6 +252,7 @@ export const ja: Dict = {
   'settings.amrAccountStatus': 'AMR アカウントの状態',
   'settings.amrConsole': 'AMR コンソール',
   'settings.amrLoginErrorCompact': 'AMR へのサインインに失敗しました。',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': '詳細設定',
   'settings.amrLogin': 'サインイン',
   'settings.amrLogout': 'サインアウト',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -252,6 +252,7 @@ export const ko: Dict = {
   'settings.amrAccountStatus': 'AMR 계정 상태',
   'settings.amrConsole': 'AMR 콘솔',
   'settings.amrLoginErrorCompact': 'AMR 로그인에 실패했습니다.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': '고급',
   'settings.amrLogin': '로그인',
   'settings.amrLogout': '로그아웃',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -252,6 +252,7 @@ export const pl: Dict = {
   'settings.amrAccountStatus': 'Status konta AMR',
   'settings.amrConsole': 'Konsola AMR',
   'settings.amrLoginErrorCompact': 'Logowanie AMR nie powiodło się.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Zaawansowane',
   'settings.amrLogin': 'Zaloguj się',
   'settings.amrLogout': 'Wyloguj się',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -252,6 +252,7 @@ export const ptBR: Dict = {
   'settings.amrAccountStatus': 'Status da conta AMR',
   'settings.amrConsole': 'Console AMR',
   'settings.amrLoginErrorCompact': 'Falha no login do AMR.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Avançado',
   'settings.amrLogin': 'Entrar',
   'settings.amrLogout': 'Sair',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -252,6 +252,7 @@ export const ru: Dict = {
   'settings.amrAccountStatus': 'Статус аккаунта AMR',
   'settings.amrConsole': 'Консоль AMR',
   'settings.amrLoginErrorCompact': 'Не удалось войти в AMR.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Дополнительно',
   'settings.amrLogin': 'Войти',
   'settings.amrLogout': 'Выйти',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -252,6 +252,7 @@ export const th: Dict = {
   'settings.amrAccountStatus': 'สถานะบัญชี AMR',
   'settings.amrConsole': 'AMR Console',
   'settings.amrLoginErrorCompact': 'การลงชื่อเข้าใช้ AMR ล้มเหลว',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'ขั้นสูง',
   'settings.amrLogin': 'ลงชื่อเข้าใช้',
   'settings.amrLogout': 'ออกจากระบบ',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -252,6 +252,7 @@ export const tr: Dict = {
   'settings.amrAccountStatus': 'AMR hesap durumu',
   'settings.amrConsole': 'AMR Konsolu',
   'settings.amrLoginErrorCompact': 'AMR oturum açma başarısız oldu.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Gelişmiş',
   'settings.amrLogin': 'Oturum aç',
   'settings.amrLogout': 'Oturumu kapat',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -252,6 +252,7 @@ export const uk: Dict = {
   'settings.amrAccountStatus': 'Статус облікового запису AMR',
   'settings.amrConsole': 'Консоль AMR',
   'settings.amrLoginErrorCompact': 'Не вдалося ввійти в AMR.',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': 'Розширені',
   'settings.amrLogin': 'Увійти',
   'settings.amrLogout': 'Вийти',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -252,6 +252,7 @@ export const zhCN: Dict = {
   'settings.amrAccountStatus': 'AMR 账户状态',
   'settings.amrConsole': 'AMR 控制台',
   'settings.amrLoginErrorCompact': 'AMR 登录失败。',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': '高级设置',
   'settings.amrLogin': '登录',
   'settings.amrLogout': '登出',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -252,6 +252,7 @@ export const zhTW: Dict = {
   'settings.amrAccountStatus': 'AMR 帳戶狀態',
   'settings.amrConsole': '控制台',
   'settings.amrLoginErrorCompact': 'AMR 登入失敗。',
+  'settings.amrLoginErrorRecovery': 'Try signing in again. If the browser did not open, check your AMR installation or choose Local CLI for now.',
   'settings.advanced': '進階',
   'settings.amrLogin': '登入',
   'settings.amrLogout': '登出',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -283,6 +283,7 @@ export interface Dict {
   'settings.amrAccountStatus': string;
   'settings.amrConsole': string;
   'settings.amrLoginErrorCompact': string;
+  'settings.amrLoginErrorRecovery': string;
   'settings.apiSection': string;
   'settings.quickFillProvider': string;
   'settings.providerPreset': string;

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1936,6 +1936,7 @@
 }
 
 .onboarding-view__action-status {
+  max-width: min(100%, 560px);
   margin-right: auto;
   color: var(--text-muted);
   font-size: 12px;

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -411,9 +411,38 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Sign in to continue/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert').textContent).toBe(startupError);
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toContain(startupError);
+      expect(alert.textContent).toContain('Try signing in again.');
+      expect(alert.textContent).toContain('choose Local CLI');
     });
     expect(screen.queryByText('AMR sign-in failed.')).toBeNull();
+    expect(screen.queryByText('Signing in…')).toBeNull();
+  });
+
+  it('shows AMR sign-in recovery guidance when the daemon has no error detail', async () => {
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/integrations/vela/login') && init?.method === 'POST') {
+        return jsonResponse({}, 500);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    renderOnboarding();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Sign in to continue/i }));
+
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toContain('AMR sign-in failed.');
+      expect(alert.textContent).toContain('Try signing in again.');
+      expect(alert.textContent).toContain('check your AMR installation');
+      expect(alert.textContent).toContain('choose Local CLI');
+    });
     expect(screen.queryByText('Signing in…')).toBeNull();
   });
 
@@ -494,7 +523,10 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
       await vi.advanceTimersByTimeAsync(AMR_LOGIN_TIMEOUT_MS);
     });
     expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/login/cancel', { method: 'POST' });
-    expect(screen.getByText('AMR sign-in failed.')).toBeTruthy();
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('AMR sign-in failed.');
+    expect(alert.textContent).toContain('Try signing in again.');
+    expect(alert.textContent).toContain('choose Local CLI');
     expect(screen.queryByText('Signing in…')).toBeNull();
     expect(screen.getByRole('button', { name: /Sign in to continue/i }).hasAttribute('disabled')).toBe(false);
     expect(props.onCompleteOnboarding).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #3859

## Why

AMR onboarding could fail during the first-run Connect step with only `AMR sign-in failed.`. That hid daemon-provided startup errors and gave users no recovery path when the sign-in browser or local AMR setup was the failing part.

## What users will see

When AMR sign-in fails from Welcome onboarding, the inline error now includes the daemon failure reason when one is available and always adds recovery guidance to try signing in again, check the AMR installation if the browser did not open, or choose Local CLI for now. The action status area now has a width cap so the longer message wraps cleanly beside the onboarding buttons.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is inline onboarding error copy covered by component tests rather than a layout redesign.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.onboarding.test.tsx`
- Did the test go red on `main` and green on this branch? No. I updated the existing immediate-failure coverage and added an empty-error-body regression in the same component seam, then verified it green on this branch.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- EntryShell.onboarding.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>