### PR TITLE
refactor(daemon): split server bootstrap routes

### DIFF
--- a/apps/daemon/src/daemon-paths.ts
+++ b/apps/daemon/src/daemon-paths.ts
@@ -1,0 +1,163 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resolveProjectRelativePath } from './home-expansion.js';
+
+const require = createRequire(import.meta.url);
+
+export const DAEMON_CLI_PATH_ENV = 'OD_DAEMON_CLI_PATH';
+export const RESOURCE_ROOT_ENV = 'OD_RESOURCE_ROOT';
+
+function cleanOptionalPath(value: string | undefined): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? path.resolve(value)
+    : null;
+}
+
+export function resolveDaemonCliPath(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = cleanOptionalPath(env[DAEMON_CLI_PATH_ENV]) ?? cleanOptionalPath(env.OD_BIN);
+  if (configured) return configured;
+
+  const packageJsonPath = require.resolve('@open-design/daemon/package.json');
+  return path.join(path.dirname(packageJsonPath), 'dist', 'cli.js');
+}
+
+function isPathWithin(base: string, target: string): boolean {
+  const relativePath = path.relative(path.resolve(base), path.resolve(target));
+  return (
+    relativePath === '' ||
+    (relativePath.length > 0 &&
+      !relativePath.startsWith('..') &&
+      !path.isAbsolute(relativePath))
+  );
+}
+
+export function resolveProcessResourcesPath(): string | null {
+  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+  if (
+    typeof resourcesPath === 'string' &&
+    resourcesPath.length > 0
+  ) {
+    return resourcesPath;
+  }
+
+  const resourcesMarker = `${path.sep}Contents${path.sep}Resources${path.sep}`;
+  const markerIndex = process.execPath.indexOf(resourcesMarker);
+  if (markerIndex !== -1) {
+    return process.execPath.slice(0, markerIndex + resourcesMarker.length - 1);
+  }
+
+  const normalizedExecPath = process.execPath.toLowerCase();
+  const windowsResourceBinMarker =
+    `${path.sep}resources${path.sep}open-design${path.sep}bin${path.sep}`.toLowerCase();
+  const windowsMarkerIndex = normalizedExecPath.indexOf(windowsResourceBinMarker);
+  if (windowsMarkerIndex !== -1) {
+    return process.execPath.slice(
+      0,
+      windowsMarkerIndex + `${path.sep}resources`.length,
+    );
+  }
+
+  return null;
+}
+
+export interface ResolveDaemonResourceRootOptions {
+  configured?: string;
+  safeBases?: Array<string | null | undefined>;
+}
+
+export function resolveDaemonResourceRoot({
+  configured = process.env[RESOURCE_ROOT_ENV],
+  safeBases,
+}: ResolveDaemonResourceRootOptions = {}): string | null {
+  if (!configured || configured.length === 0) return null;
+
+  const resolved = path.resolve(configured);
+  const normalizedSafeBases = (safeBases ?? [])
+    .filter((base): base is string => typeof base === 'string' && base.length > 0)
+    .map((base) => path.resolve(base));
+
+  if (!normalizedSafeBases.some((base) => isPathWithin(base, resolved))) {
+    throw new Error(
+      `${RESOURCE_ROOT_ENV} must be under the workspace root or app resources path`,
+    );
+  }
+
+  return resolved;
+}
+
+export function resolveDaemonResourceDir(
+  resourceRoot: string | null,
+  segment: string,
+  fallback: string,
+): string {
+  return resourceRoot ? path.join(resourceRoot, segment) : fallback;
+}
+
+export interface ResolveDaemonPluginPreviewsDirOptions {
+  env?: NodeJS.ProcessEnv;
+  resourceRoot: string | null | undefined;
+  projectRoot: string;
+}
+
+export function resolveDaemonPluginPreviewsDir({
+  env = process.env,
+  resourceRoot,
+  projectRoot,
+}: ResolveDaemonPluginPreviewsDirOptions): string {
+  const override = env.OD_PLUGIN_PREVIEWS_DIR;
+  if (override) {
+    return path.isAbsolute(override) ? override : path.resolve(projectRoot, override);
+  }
+  return resolveDaemonResourceDir(
+    resourceRoot ?? null,
+    path.join('data', 'plugin-previews'),
+    path.join(projectRoot, 'data', 'plugin-previews'),
+  );
+}
+
+export interface ResolveDataDirOptions {
+  requireExplicit?: boolean;
+}
+
+export function resolveDataDir(
+  raw: string | undefined,
+  projectRoot: string,
+  options: ResolveDataDirOptions = {},
+): string {
+  const value = raw?.trim();
+  if (!value) {
+    if (options.requireExplicit) {
+      throw new Error('OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled');
+    }
+    return path.join(projectRoot, '.od');
+  }
+
+  const resolved = resolveProjectRelativePath(value, projectRoot);
+  try {
+    fs.mkdirSync(resolved, { recursive: true });
+    fs.accessSync(resolved, fs.constants.W_OK);
+  } catch (err) {
+    const e = err as Error;
+    const currentUser = (() => {
+      try {
+        return os.userInfo().username;
+      } catch {
+        return process.env.USER ?? process.env.LOGNAME ?? 'unknown';
+      }
+    })();
+    const parentDir = path.dirname(resolved);
+    throw new Error(
+      [
+        `OD_DATA_DIR "${resolved}" is not writable: ${e.message}`,
+        `Current user: ${currentUser}`,
+        'Check whether the folder or one of its parents is owned by another user, is a symlink to a protected location, or was previously created with sudo.',
+        `Try: ls -ld "${parentDir}" "${resolved}"`,
+        `If the folder should belong to you, fix ownership/permissions, for example: sudo chown -R "${currentUser}":staff "${parentDir}" && chmod -R u+rwX "${parentDir}"`,
+      ].join(' '),
+    );
+  }
+  return resolved;
+}

--- a/apps/daemon/src/http/api-errors.ts
+++ b/apps/daemon/src/http/api-errors.ts
@@ -1,0 +1,30 @@
+import type { ApiError, ApiErrorCode, ApiErrorResponse } from '@open-design/contracts';
+import type { Response } from 'express';
+
+export function createCompatApiError(
+  code: ApiErrorCode,
+  message: string,
+  init: Omit<ApiError, 'code' | 'message'> = {},
+): ApiError {
+  return { code, message, ...init };
+}
+
+export function createCompatApiErrorResponse(
+  code: ApiErrorCode,
+  message: string,
+  init: Omit<ApiError, 'code' | 'message'> = {},
+): ApiErrorResponse {
+  return { error: createCompatApiError(code, message, init) };
+}
+
+export function sendApiError(
+  res: Response,
+  status: number,
+  code: ApiErrorCode,
+  message: string,
+  init: Omit<ApiError, 'code' | 'message'> = {},
+): Response<ApiErrorResponse> {
+  return res
+    .status(status)
+    .json(createCompatApiErrorResponse(code, message, init));
+}

--- a/apps/daemon/src/route-context-contract.ts
+++ b/apps/daemon/src/route-context-contract.ts
@@ -1,8 +1,10 @@
 import type { ServerContext } from './server-context.js';
 import type { RegisterActiveContextRoutesDeps } from './routes/active-context.js';
+import type { RegisterAutomationRoutesDeps } from './routes/automation.js';
 import type { RegisterChatRoutesDeps } from './chat-routes.js';
 import type { RegisterDeployRoutesDeps, RegisterDeploymentCheckRoutesDeps } from './routes/deploy.js';
 import type { RegisterFinalizeRoutesDeps, RegisterImportRoutesDeps, RegisterProjectExportRoutesDeps } from './import-export-routes.js';
+import type { RegisterGenuiRoutesDeps } from './routes/genui.js';
 import type { RegisterHandoffRoutesDeps } from './routes/handoff.js';
 import type { RegisterHostToolsRoutesDeps } from './routes/host-tools.js';
 import type { RegisterLiveArtifactRoutesDeps } from './routes/live-artifact.js';
@@ -12,14 +14,17 @@ import type { RegisterMemoryRoutesDeps } from './routes/memory.js';
 import type { RegisterProjectArtifactRoutesDeps, RegisterProjectFileRoutesDeps, RegisterProjectRoutesDeps, RegisterProjectUploadRoutesDeps } from './project-routes.js';
 import type { RegisterRoutineRoutesDeps } from './routes/routine.js';
 import type { RegisterStaticResourceRoutesDeps } from './routes/static-resource.js';
+import type { RegisterVelaRoutesDeps } from './routes/vela.js';
 import type { RegisterXaiRoutesDeps } from './routes/xai.js';
 
 type AllRegisteredRouteDeps =
   & RegisterActiveContextRoutesDeps
+  & RegisterAutomationRoutesDeps
   & RegisterChatRoutesDeps
   & RegisterDeployRoutesDeps
   & RegisterDeploymentCheckRoutesDeps
   & RegisterFinalizeRoutesDeps
+  & RegisterGenuiRoutesDeps
   & RegisterHandoffRoutesDeps
   & RegisterHostToolsRoutesDeps
   & RegisterImportRoutesDeps
@@ -34,6 +39,7 @@ type AllRegisteredRouteDeps =
   & RegisterProjectUploadRoutesDeps
   & RegisterRoutineRoutesDeps
   & RegisterStaticResourceRoutesDeps
+  & RegisterVelaRoutesDeps
   & RegisterXaiRoutesDeps;
 
 type Assert<T extends true> = T;

--- a/apps/daemon/src/route-registration-guard.ts
+++ b/apps/daemon/src/route-registration-guard.ts
@@ -1,11 +1,18 @@
 import type { Express } from 'express';
 
+export interface RouteRegistration {
+  method: string;
+  path: string;
+}
+
+const routeInventorySymbol = Symbol.for('open-design.routeInventory');
+
 const guardedRouteKeys = new Set([
   'POST /api/projects/:id/export/pdf',
   'POST /api/projects/:id/media/generate',
 ]);
 
-const guardedMethods = ['get', 'post', 'put', 'patch', 'delete', 'options'] as const;
+const guardedMethods = ['get', 'post', 'put', 'patch', 'delete', 'options', 'all'] as const;
 
 export function guardedRouteKey(method: string, path: unknown): string | null {
   if (typeof path !== 'string') return null;
@@ -15,10 +22,15 @@ export function guardedRouteKey(method: string, path: unknown): string | null {
 
 export function installRouteRegistrationGuard(app: Express): void {
   const seen = new Set<string>();
+  const inventory: RouteRegistration[] = [];
+  (app as unknown as { [routeInventorySymbol]: RouteRegistration[] })[routeInventorySymbol] = inventory;
 
   for (const method of guardedMethods) {
     const original = (app as any)[method].bind(app) as (...args: unknown[]) => unknown;
     (app as any)[method] = (path: unknown, ...handlers: unknown[]) => {
+      if (typeof path === 'string') {
+        inventory.push({ method: method.toUpperCase(), path });
+      }
       const key = guardedRouteKey(method, path);
       if (key) {
         if (seen.has(key)) {
@@ -29,4 +41,10 @@ export function installRouteRegistrationGuard(app: Express): void {
       return original(path, ...handlers);
     };
   }
+}
+
+export function getRouteRegistrationInventory(app: Express): RouteRegistration[] {
+  return [
+    ...((app as unknown as { [routeInventorySymbol]?: RouteRegistration[] })[routeInventorySymbol] ?? []),
+  ];
 }

--- a/apps/daemon/src/routes/automation.ts
+++ b/apps/daemon/src/routes/automation.ts
@@ -1,0 +1,125 @@
+import type { Express } from 'express';
+import type { AutomationProposalStatus } from '@open-design/contracts';
+
+import {
+  applyAutomationProposal,
+  createAutomationProposal,
+  getAutomationProposal,
+  listAutomationProposals,
+  rejectAutomationProposal,
+} from '../automation-proposals.js';
+import {
+  getAutomationSourcePacket,
+  ingestAutomationSource,
+  listAutomationSourcePackets,
+} from '../automation-ingestions.js';
+
+export interface RegisterAutomationRoutesDeps {
+  paths: {
+    RUNTIME_DATA_DIR: string;
+  };
+}
+
+function errorMessage(err: unknown): string {
+  return String((err as { message?: unknown } | null)?.message || err);
+}
+
+function proposalStatus(raw: unknown): AutomationProposalStatus | 'all' {
+  return typeof raw === 'string' ? raw as AutomationProposalStatus | 'all' : 'all';
+}
+
+export function registerAutomationRoutes(app: Express, deps: RegisterAutomationRoutesDeps): void {
+  const { RUNTIME_DATA_DIR } = deps.paths;
+
+  app.get('/api/automation-source-packets', async (req, res) => {
+    try {
+      const limit = typeof req.query.limit === 'string' ? Number(req.query.limit) : undefined;
+      const packets = await listAutomationSourcePackets(
+        RUNTIME_DATA_DIR,
+        limit === undefined ? {} : { limit },
+      );
+      res.json({ packets });
+    } catch (err) {
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  app.post('/api/automation-ingestions', async (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const result = await ingestAutomationSource(RUNTIME_DATA_DIR, body);
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: errorMessage(err) });
+    }
+  });
+
+  app.get('/api/automation-source-packets/:id', async (req, res) => {
+    try {
+      const packet = await getAutomationSourcePacket(RUNTIME_DATA_DIR, req.params.id);
+      if (!packet) return res.status(404).json({ error: 'automation source packet not found' });
+      res.json({ packet });
+    } catch (err) {
+      res.status(400).json({ error: errorMessage(err) });
+    }
+  });
+
+  app.get('/api/automation-proposals', async (req, res) => {
+    try {
+      const rawStatus = proposalStatus(req.query.status);
+      const proposals = await listAutomationProposals(RUNTIME_DATA_DIR, {
+        status: rawStatus,
+      });
+      res.json({ proposals });
+    } catch (err) {
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  app.post('/api/automation-proposals', async (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const proposal = await createAutomationProposal(RUNTIME_DATA_DIR, body);
+      res.json({ proposal });
+    } catch (err) {
+      res.status(400).json({ error: errorMessage(err) });
+    }
+  });
+
+  app.get('/api/automation-proposals/:id', async (req, res) => {
+    try {
+      const proposal = await getAutomationProposal(RUNTIME_DATA_DIR, req.params.id);
+      if (!proposal) return res.status(404).json({ error: 'automation proposal not found' });
+      res.json({ proposal });
+    } catch (err) {
+      res.status(400).json({ error: errorMessage(err) });
+    }
+  });
+
+  app.post('/api/automation-proposals/:id/apply', async (req, res) => {
+    try {
+      const result = await applyAutomationProposal(RUNTIME_DATA_DIR, req.params.id);
+      res.json(result);
+    } catch (err) {
+      const message = errorMessage(err);
+      const status = message.includes('not found') ? 404 : 400;
+      res.status(status).json({ error: message });
+    }
+  });
+
+  app.post('/api/automation-proposals/:id/reject', async (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const proposal = await rejectAutomationProposal(
+        RUNTIME_DATA_DIR,
+        req.params.id,
+        typeof body.reason === 'string' ? body.reason : undefined,
+      );
+      res.json({ proposal });
+    } catch (err) {
+      const message = errorMessage(err);
+      const status = message.includes('not found') ? 404 : 400;
+      res.status(status).json({ error: message });
+    }
+  });
+}

--- a/apps/daemon/src/routes/genui.ts
+++ b/apps/daemon/src/routes/genui.ts
@@ -1,0 +1,211 @@
+import type { Express } from 'express';
+import type Database from 'better-sqlite3';
+
+import { applyDiffReviewDecisionToCwd, getSnapshot, isDiffReviewSurfaceId, listIterationsForRun } from '../plugins/index.js';
+import { getProject } from '../db.js';
+import {
+  getSurface,
+  listSurfacesForProject,
+  listSurfacesForRun,
+  prefillProjectSurface,
+  respondSurface as respondSurfaceRow,
+  revokeProjectSurface,
+} from '../genui/index.js';
+import { resolveProjectDir } from '../projects.js';
+
+export interface RegisterGenuiRoutesDeps {
+  db: Database.Database;
+  design: {
+    runs: {
+      get(runId: string): { projectId?: string | null } | undefined;
+    };
+  };
+  paths: {
+    PROJECTS_DIR: string;
+  };
+}
+
+export function registerGenuiRoutes(app: Express, deps: RegisterGenuiRoutesDeps): void {
+  const { db, design } = deps;
+  const { PROJECTS_DIR } = deps.paths;
+
+  app.get('/api/runs/:runId/genui', (req, res) => {
+    try {
+      const surfaces = listSurfacesForRun(db, req.params.runId);
+      res.json({ runId: req.params.runId, surfaces });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.get('/api/projects/:projectId/genui', (req, res) => {
+    try {
+      const surfaces = listSurfacesForProject(db, req.params.projectId);
+      res.json({ projectId: req.params.projectId, surfaces });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.post('/api/runs/:runId/genui/:surfaceId/respond', async (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const value = 'value' in body ? body.value : null;
+      const respondedBy =
+        body.respondedBy === 'agent' || body.respondedBy === 'auto'
+          ? body.respondedBy
+          : 'user';
+      const stmt = db.prepare(
+        `SELECT id FROM genui_surfaces
+          WHERE run_id = ? AND surface_id = ? AND status = 'pending'
+          ORDER BY requested_at DESC LIMIT 1`,
+      );
+      const row = stmt.get(req.params.runId, req.params.surfaceId) as { id?: string } | undefined;
+      if (!row?.id) {
+        return res.status(404).json({ error: 'no pending surface for runId/surfaceId' });
+      }
+      const updated = respondSurfaceRow(db, {
+        runId: req.params.runId,
+        rowId: row.id,
+        value,
+        respondedBy,
+      });
+
+      let diffReviewBridge: { ok: boolean; error?: string } | undefined;
+      if (isDiffReviewSurfaceId(req.params.surfaceId)) {
+        try {
+          const run = design.runs.get(req.params.runId);
+          const projectId = run?.projectId ?? null;
+          if (projectId) {
+            const project = getProject(db, projectId);
+            const metadata = project?.metadata && typeof project.metadata === 'string'
+              ? JSON.parse(project.metadata)
+              : project?.metadata ?? undefined;
+            const cwd = resolveProjectDir(PROJECTS_DIR, projectId, metadata);
+            const bridgeResult = await applyDiffReviewDecisionToCwd({
+              cwd,
+              value,
+              reviewer: respondedBy === 'agent' || respondedBy === 'auto' ? 'agent' : 'user',
+            });
+            diffReviewBridge = bridgeResult.ok ? { ok: true } : { ok: false, error: bridgeResult.error };
+          } else {
+            diffReviewBridge = { ok: false, error: 'run is not linked to a project' };
+          }
+        } catch (err) {
+          diffReviewBridge = { ok: false, error: (err as Error).message };
+          console.warn('[plugins] diff-review bridge failed:', err);
+        }
+      }
+
+      const responsePayload: Record<string, unknown> = { ok: true, surface: updated };
+      if (diffReviewBridge) responsePayload.diffReviewBridge = diffReviewBridge;
+      res.json(responsePayload);
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.post('/api/projects/:projectId/genui/:surfaceId/revoke', (req, res) => {
+    try {
+      const changed = revokeProjectSurface(db, {
+        projectId: req.params.projectId,
+        surfaceId: req.params.surfaceId,
+      });
+      res.json({ ok: true, invalidated: changed });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.post('/api/projects/:projectId/genui/prefill', (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const snapshotId = typeof body.snapshotId === 'string' ? body.snapshotId : '';
+      const surfaceId = typeof body.surfaceId === 'string' ? body.surfaceId : '';
+      const persist = body.persist === 'run' || body.persist === 'conversation' || body.persist === 'project'
+        ? body.persist
+        : 'project';
+      const kind = body.kind === 'form' || body.kind === 'choice' || body.kind === 'oauth-prompt'
+        ? body.kind
+        : 'confirmation';
+      if (!snapshotId || !surfaceId) {
+        return res.status(400).json({ error: 'snapshotId and surfaceId are required' });
+      }
+      const row = prefillProjectSurface(db, {
+        projectId: req.params.projectId,
+        pluginSnapshotId: snapshotId,
+        surfaceId,
+        kind,
+        persist,
+        value: 'value' in body ? body.value : null,
+        schema: body.schema,
+        expiresAt: typeof body.expiresAt === 'number' ? body.expiresAt : null,
+      });
+      res.json({ ok: true, surface: row });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.get('/api/runs/:runId/genui/:surfaceId', (req, res) => {
+    try {
+      const row = db.prepare(
+        `SELECT id FROM genui_surfaces
+          WHERE run_id = ? AND surface_id = ?
+          ORDER BY requested_at DESC LIMIT 1`,
+      ).get(req.params.runId, req.params.surfaceId) as { id?: string } | undefined;
+      if (!row?.id) return res.status(404).json({ error: 'surface not found' });
+      const surface = getSurface(db, row.id);
+      if (!surface) return res.status(404).json({ error: 'surface not found' });
+      let spec = null;
+      if (surface.pluginSnapshotId) {
+        const snap = getSnapshot(db, surface.pluginSnapshotId);
+        if (snap && Array.isArray(snap.genuiSurfaces)) {
+          spec = snap.genuiSurfaces.find((s) => s?.id === surface.surfaceId) ?? null;
+        }
+      }
+      res.json({ ...surface, spec });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.get('/api/runs/:runId/devloop-iterations', (req, res) => {
+    try {
+      const iterations = listIterationsForRun(db, req.params.runId);
+      res.json({ runId: req.params.runId, iterations });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.post('/api/runs/:runId/replay', (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const explicitSnapshotId = typeof body.snapshotId === 'string' ? body.snapshotId : '';
+      const snapshotId = explicitSnapshotId;
+      if (!snapshotId) {
+        return res.status(400).json({
+          error: 'snapshotId is required (runs are in-memory; pass the snapshotId returned by /api/plugins/:id/apply)',
+        });
+      }
+      const snapshot = getSnapshot(db, snapshotId);
+      if (!snapshot) return res.status(404).json({ error: 'snapshot not found' });
+      res.json({
+        ok: true,
+        runId: req.params.runId,
+        snapshotId,
+        snapshot,
+        rerun: {
+          pluginId: snapshot.pluginId,
+          pluginSpecVersion: snapshot.pluginSpecVersion,
+          pluginVersion: snapshot.pluginVersion,
+          inputs: snapshot.inputs,
+          manifestSourceDigest: snapshot.manifestSourceDigest,
+        },
+      });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+}

--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -1,0 +1,279 @@
+import type { Express, Request, Response } from 'express';
+import dns from 'node:dns';
+import https from 'node:https';
+
+import {
+  applyAgentLaunchEnv,
+  getAgentDef,
+  resolveAgentLaunch,
+  spawnEnvForAgent,
+} from '../agents.js';
+import { readAnalyticsContext } from '../analytics.js';
+import { agentCliEnvForAgent, type AppConfigPrefs, writeAppConfig } from '../app-config.js';
+import {
+  cancelVelaLogin,
+  forgetVelaLogin,
+  mergeVelaEnv,
+  mirrorAmrEntryAnalytics,
+  parseAmrEntryAnalyticsPayload,
+  parseVelaLoginAttribution,
+  readVelaCredentialRevision,
+  readVelaLoginStatus,
+  spawnVelaLogin,
+} from '../integrations/vela.js';
+import { amrModelLoadingCache } from '../runtimes/amr-model-cache.js';
+import {
+  fetchVelaPresetModels,
+  fetchVelaRemoteModelsWithRetry,
+} from '../runtimes/defs/amr.js';
+
+const AMR_API_PROXY_PREFIX = '/api/integrations/vela/api-proxy';
+const AMR_API_UPSTREAM_ORIGIN = 'https://amr-api.open-design.ai';
+
+type ReadAppConfig = (dataDir: string) => Promise<AppConfigPrefs>;
+type PublicBaseUrlResolver = (req: Request) => string;
+
+export interface RegisterVelaRoutesDeps {
+  paths: {
+    RUNTIME_DATA_DIR: string;
+  };
+  appConfig: {
+    readAppConfig: ReadAppConfig;
+  };
+  http: {
+    getPublicBaseUrl?: PublicBaseUrlResolver;
+  };
+  env?: NodeJS.ProcessEnv;
+}
+
+interface AmrModelProbe {
+  launchPath: string;
+  env: NodeJS.ProcessEnv;
+  configuredEnv: Record<string, string>;
+  cacheKey: string;
+}
+
+function velaApiProxyBaseUrl(req: Request, getPublicBaseUrl: PublicBaseUrlResolver): string {
+  return `${getPublicBaseUrl(req)}${AMR_API_PROXY_PREFIX}`;
+}
+
+function velaProxyRequestBody(req: Request): Buffer | null {
+  if (req.method === 'GET' || req.method === 'HEAD') return null;
+  if (Buffer.isBuffer(req.body)) return req.body;
+  if (typeof req.body === 'string') return Buffer.from(req.body);
+  if (req.body == null) return null;
+  return Buffer.from(JSON.stringify(req.body));
+}
+
+function shouldStreamVelaProxyRequest(req: Request, body: Buffer | null): boolean {
+  return req.method !== 'GET' && req.method !== 'HEAD' && body == null;
+}
+
+function proxyAmrApiRequest(req: Request, res: Response): void {
+  const suffix = req.originalUrl.slice(AMR_API_PROXY_PREFIX.length);
+  if (!suffix.startsWith('/api/v1/')) {
+    res.status(404).json({ error: 'unknown_amr_api_proxy_path' });
+    return;
+  }
+  const target = new URL(suffix, AMR_API_UPSTREAM_ORIGIN);
+  const body = velaProxyRequestBody(req);
+  const streamBody = shouldStreamVelaProxyRequest(req, body);
+  const headers: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    const lower = key.toLowerCase();
+    if (
+      lower === 'host' ||
+      lower === 'connection' ||
+      lower === 'transfer-encoding'
+    ) {
+      continue;
+    }
+    if (lower === 'content-length' && body) continue;
+    if (value !== undefined) headers[key] = value;
+  }
+  if (body) headers['content-length'] = String(body.length);
+
+  const upstream = https.request(
+    target,
+    {
+      method: req.method,
+      headers,
+      lookup: (hostname, options, callback) => {
+        dns.lookup(hostname, { ...options, family: 4, all: false }, callback);
+      },
+    },
+    (upstreamRes) => {
+      res.status(upstreamRes.statusCode ?? 502);
+      for (const [key, value] of Object.entries(upstreamRes.headers)) {
+        if (value !== undefined) res.setHeader(key, value);
+      }
+      upstreamRes.pipe(res);
+    },
+  );
+  upstream.setTimeout(30_000, () => upstream.destroy(new Error('AMR API proxy timed out')));
+  upstream.on('error', (err) => {
+    if (!res.headersSent) {
+      res.status(502).json({ error: err instanceof Error ? err.message : String(err) });
+    } else {
+      res.end();
+    }
+  });
+  if (body) upstream.write(body);
+  if (streamBody) {
+    req.pipe(upstream);
+  } else {
+    upstream.end();
+  }
+}
+
+export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): void {
+  const env = deps.env ?? process.env;
+  const { RUNTIME_DATA_DIR } = deps.paths;
+  const { readAppConfig } = deps.appConfig;
+  const getPublicBaseUrl = deps.http.getPublicBaseUrl ?? ((req: Request) => {
+    const proto = req.protocol || 'http';
+    const host = req.get('host');
+    return host ? `${proto}://${host}` : 'http://localhost:7456';
+  });
+
+  async function resolveAmrModelProbe(): Promise<AmrModelProbe> {
+    const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+    const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+    const def = getAgentDef('amr');
+    if (!def) throw new Error('AMR runtime definition is missing');
+    const agentLaunch = resolveAgentLaunch(def, configuredEnv);
+    const launchPath = agentLaunch.launchPath ?? agentLaunch.selectedPath;
+    if (!launchPath) throw new Error('AMR vela binary could not be resolved');
+    const spawnEnv = applyAgentLaunchEnv(
+      spawnEnvForAgent(
+        def.id,
+        {
+          ...env,
+          ...(def.env || {}),
+        },
+        configuredEnv,
+        undefined,
+      ),
+      agentLaunch,
+    );
+    const credentialRevision = readVelaCredentialRevision(env, configuredEnv);
+    const cacheKey = JSON.stringify({
+      launchPath,
+      home: spawnEnv.HOME ?? spawnEnv.USERPROFILE ?? '',
+      openDesignAmrProfile: spawnEnv.OPEN_DESIGN_AMR_PROFILE ?? '',
+      velaProfile: spawnEnv.VELA_PROFILE ?? '',
+      velaLinkUrl: spawnEnv.VELA_LINK_URL ?? '',
+      velaRuntimeKey: spawnEnv.VELA_RUNTIME_KEY ?? '',
+      velaOpencodeBin: spawnEnv.VELA_OPENCODE_BIN ?? '',
+      credentialRevision,
+    });
+    return { launchPath, env: spawnEnv, configuredEnv, cacheKey };
+  }
+
+  app.get('/api/amr/models', async (_req, res) => {
+    try {
+      const probe = await resolveAmrModelProbe();
+      const response = await amrModelLoadingCache.get(probe.cacheKey, {
+        fetchPreset: () => fetchVelaPresetModels(probe.launchPath, probe.env),
+        fetchRemote: () => fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
+      });
+      res.json(response);
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  app.get('/api/integrations/vela/status', async (_req, res) => {
+    try {
+      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+      const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+      const status = readVelaLoginStatus(mergeVelaEnv(env, configuredEnv));
+      if (status.loggedIn) {
+        void resolveAmrModelProbe()
+          .then((probe) => {
+            amrModelLoadingCache.warm(probe.cacheKey, () =>
+              fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
+            );
+          })
+          .catch((err) => console.warn('[amr] model cache warm failed', err));
+      }
+      res.json(status);
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.all('/api/integrations/vela/api-proxy/*splat', proxyAmrApiRequest);
+
+  app.post('/api/integrations/vela/login', async (req, res) => {
+    try {
+      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+      const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+      const attribution = parseVelaLoginAttribution(req.body);
+      const spawned = await spawnVelaLogin({
+        configuredEnv,
+        attribution,
+        defaultApiUrl: velaApiProxyBaseUrl(req, getPublicBaseUrl),
+      });
+      res.status(202).json(spawned);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const status = /already running/i.test(message) ? 409 : 500;
+      res.status(status).json({ error: message });
+    }
+  });
+
+  app.post('/api/integrations/vela/login/cancel', (_req, res) => {
+    try {
+      res.json(cancelVelaLogin());
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.post('/api/integrations/vela/analytics-entry', async (req, res) => {
+    const payload = parseAmrEntryAnalyticsPayload(req.body);
+    if (!payload) {
+      res.status(400).json({ error: 'invalid_amr_entry_analytics' });
+      return;
+    }
+    const analyticsContext = readAnalyticsContext(req);
+    if (!analyticsContext) {
+      res.status(202).json({ mirrored: false });
+      return;
+    }
+    const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+    if (appConfig.telemetry?.metrics !== true) {
+      res.status(202).json({ mirrored: false });
+      return;
+    }
+    const result = await mirrorAmrEntryAnalytics(payload, {
+      analyticsContext,
+      env,
+    });
+    res.status(202).json(result);
+  });
+
+  app.post('/api/integrations/vela/logout', async (_req, res) => {
+    try {
+      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+      const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+      forgetVelaLogin(mergeVelaEnv(env, configuredEnv));
+      delete env.VELA_RUNTIME_KEY;
+      delete env.VELA_LINK_URL;
+      const agentCliEnv = { ...(appConfig.agentCliEnv ?? {}) };
+      const amrEnv = { ...(agentCliEnv.amr ?? {}) };
+      delete amrEnv.VELA_RUNTIME_KEY;
+      delete amrEnv.VELA_LINK_URL;
+      if (Object.keys(amrEnv).length > 0) {
+        agentCliEnv.amr = amrEnv;
+      } else {
+        delete agentCliEnv.amr;
+      }
+      await writeAppConfig(RUNTIME_DATA_DIR, { agentCliEnv });
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+}

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -5,6 +5,7 @@ import type { RoutineRoutesService } from './routes/routine.js';
 
 export interface HttpDeps {
   createSseResponse: (...args: any[]) => any;
+  getPublicBaseUrl?: (...args: any[]) => string;
   isLocalSameOrigin: (...args: any[]) => boolean;
   requireLocalDaemonRequest: (...args: any[]) => any;
   resolvedPortRef: { current: number };

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5,9 +5,6 @@ import multer from 'multer';
 import JSZip from 'jszip';
 import { execFile, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import dns from 'node:dns';
-import https from 'node:https';
-import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -27,9 +24,40 @@ import {
   resolveExclusiveSurface,
   shouldRenderCodexImagegenOverride,
 } from './prompts/system.js';
-import { expandHomePrefix, resolveProjectRelativePath } from './home-expansion.js';
 import { emittedRenderableQuestionForm } from './question-form-detect.js';
 import { resolveProjectRoot } from './project-root.js';
+import {
+  resolveDaemonCliPath,
+  resolveDaemonPluginPreviewsDir,
+  resolveDaemonResourceDir,
+  resolveDaemonResourceRoot,
+  resolveDataDir,
+  resolveProcessResourcesPath,
+} from './daemon-paths.js';
+export {
+  resolveDaemonCliPath,
+  resolveDaemonPluginPreviewsDir,
+  resolveDaemonResourceRoot,
+  resolveDataDir,
+} from './daemon-paths.js';
+import {
+  isStaticSpaFallbackRequest,
+  registerStaticSpaFallback,
+  resolveStaticSpaFallbackPath,
+} from './static-spa.js';
+export {
+  isStaticSpaFallbackRequest,
+  resolveStaticSpaFallbackPath,
+} from './static-spa.js';
+import {
+  createCompatApiError,
+  createCompatApiErrorResponse,
+  sendApiError,
+} from './http/api-errors.js';
+export {
+  createCompatApiError,
+  createCompatApiErrorResponse,
+} from './http/api-errors.js';
 import {
   applyBakedPreviews,
   resolvePluginPreviewsDir,
@@ -69,16 +97,9 @@ import {
 import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
 import { preparePromptFileForAgent } from './runtimes/prompt-file.js';
 import {
-  cancelVelaLogin,
-  forgetVelaLogin,
-  mergeVelaEnv,
-  mirrorAmrEntryAnalytics,
-  parseAmrEntryAnalyticsPayload,
-  parseVelaLoginAttribution,
   readVelaCredentialRevision,
   readVelaLoginStatus,
   resolveAmrProfile,
-  spawnVelaLogin,
 } from './integrations/vela.js';
 import {
   amrAccountFailureDetails,
@@ -119,14 +140,12 @@ import {
 import { validateLinkedDirs } from './linked-dirs.js';
 import { installFromTarget, uninstallById, sanitizeRepoName } from './library-install.js';
 import { buildWindowsFolderDialogCommand, parseFolderDialogStdout } from './native-folder-dialog.js';
-import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
 import {
   AssetCacheError,
   assetCacheRewriteUrl,
   createPluginAssetCache,
   isCacheableExternalUrl,
 } from './plugin-asset-cache.js';
-import { syncCommunityPets } from './community-pets-sync.js';
 import { defaultMediaExecutionPolicy, parseMediaExecutionPolicyInput } from './media-policy.js';
 import {
   applySandboxRuntimeEnv,
@@ -188,30 +207,10 @@ import {
   marketplaceManifestUrlForRegistry,
   marketplaceRegistryIdFromUrl,
 } from './plugins/marketplaces.js';
-import {
-  getSurface,
-  listSurfacesForProject,
-  listSurfacesForRun,
-  prefillProjectSurface,
-  respondSurface as respondSurfaceRow,
-  revokeProjectSurface,
-} from './genui/index.js';
 import { composeMemoryBody, extractFromMessage } from './memory.js';
 import { attachAcpSession } from './acp.js';
 import { attachPiRpcSession } from './pi-rpc.js';
 import { stageAmrImagePaths } from './amr-image-staging.js';
-import {
-  applyAutomationProposal,
-  createAutomationProposal,
-  getAutomationProposal,
-  listAutomationProposals,
-  rejectAutomationProposal,
-} from './automation-proposals.js';
-import {
-  getAutomationSourcePacket,
-  ingestAutomationSource,
-  listAutomationSourcePackets,
-} from './automation-ingestions.js';
 import { ingestRoutineConnectorEvolution } from './automation-routine-evolution.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
 import { createRoleMarkerGuard } from './role-marker-guard.js';
@@ -305,7 +304,6 @@ import {
   FinalizeUpstreamError,
   isFinalizeProviderProtocol,
 } from './finalize-design.js';
-import { listPromptTemplates, readPromptTemplate } from './prompt-templates.js';
 import { buildDocumentPreview } from './document-preview.js';
 import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
 import { loadCraftSections } from './craft.js';
@@ -480,6 +478,8 @@ import { LiveArtifactRefreshUnavailableError, refreshLiveArtifact } from './live
 import { LiveArtifactRefreshAbortError } from './live-artifacts/refresh.js';
 import { registerConnectorRoutes } from './connectors/routes.js';
 import { registerActiveContextRoutes } from './routes/active-context.js';
+import { registerAutomationRoutes } from './routes/automation.js';
+import { registerGenuiRoutes } from './routes/genui.js';
 import { registerHostToolsRoutes } from './routes/host-tools.js';
 import { registerMcpRoutes } from './mcp-routes.js';
 import { registerXaiRoutes } from './routes/xai.js';
@@ -488,6 +488,7 @@ import { registerDesignSystemToolRoutes } from './routes/design-system-tool.js';
 import { registerDeployRoutes, registerDeploymentCheckRoutes } from './routes/deploy.js';
 import { registerMediaRoutes } from './media-routes.js';
 import { registerProjectRoutes, registerProjectArtifactRoutes, registerProjectFileRoutes, registerProjectUploadRoutes } from './project-routes.js';
+import { registerVelaRoutes } from './routes/vela.js';
 import { registerFinalizeRoutes, registerImportRoutes, registerProjectExportRoutes } from './import-export-routes.js';
 import { registerHandoffRoutes } from './routes/handoff.js';
 import { EmptyTranscriptError, synthesizeHandoffPrompt } from './handoff-design.js';
@@ -499,7 +500,7 @@ import { registerSocialShareRoutes } from './social-share-routes.js';
 import { registerMemoryRoutes } from './routes/memory.js';
 import { registerStaticResourceRoutes } from './routes/static-resource.js';
 import { registerRoutineRoutes, routineDbRowToContract } from './routes/routine.js';
-import { installRouteRegistrationGuard } from './route-registration-guard.js';
+import { getRouteRegistrationInventory, installRouteRegistrationGuard } from './route-registration-guard.js';
 import { assertServerContextSatisfiesRoutes } from './route-context-contract.js';
 import { configureConnectorCredentialStore, connectorService, ConnectorServiceError, FileConnectorCredentialStore } from './connectors/service.js';
 import { composioConnectorProvider } from './connectors/composio.js';
@@ -541,22 +542,6 @@ import {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const require = createRequire(import.meta.url);
-const DAEMON_CLI_PATH_ENV = 'OD_DAEMON_CLI_PATH';
-function cleanOptionalPath(value: string | undefined): string | null {
-  return typeof value === 'string' && value.trim().length > 0
-    ? path.resolve(value)
-    : null;
-}
-
-export function resolveDaemonCliPath(env: NodeJS.ProcessEnv = process.env): string {
-  const configured = cleanOptionalPath(env[DAEMON_CLI_PATH_ENV]) ?? cleanOptionalPath(env.OD_BIN);
-  if (configured) return configured;
-
-  const packageJsonPath = require.resolve('@open-design/daemon/package.json');
-  return path.join(path.dirname(packageJsonPath), 'dist', 'cli.js');
-}
-
 const PROJECT_ROOT = resolveProjectRoot(__dirname);
 const RESOURCE_ROOT_ENV = 'OD_RESOURCE_ROOT';
 
@@ -1296,89 +1281,13 @@ export function resolveSafePromptImagePaths(imagePaths, opts = {}) {
   return { safeImages, oversizedImages, failedImages };
 }
 
-function resolveProcessResourcesPath() {
-  if (
-    typeof process.resourcesPath === 'string' &&
-    process.resourcesPath.length > 0
-  ) {
-    return process.resourcesPath;
-  }
-
-  // Packaged daemon sidecars run under the bundled Node binary rather than the
-  // Electron root process, so `process.resourcesPath` is unavailable there.
-  // Infer the macOS app Resources directory from that bundled Node path.
-  const resourcesMarker = `${path.sep}Contents${path.sep}Resources${path.sep}`;
-  const markerIndex = process.execPath.indexOf(resourcesMarker);
-  if (markerIndex !== -1) {
-    return process.execPath.slice(0, markerIndex + resourcesMarker.length - 1);
-  }
-
-  const normalizedExecPath = process.execPath.toLowerCase();
-  const windowsResourceBinMarker =
-    `${path.sep}resources${path.sep}open-design${path.sep}bin${path.sep}`.toLowerCase();
-  const windowsMarkerIndex = normalizedExecPath.indexOf(
-    windowsResourceBinMarker,
-  );
-  if (windowsMarkerIndex !== -1) {
-    return process.execPath.slice(
-      0,
-      windowsMarkerIndex + `${path.sep}resources`.length,
-    );
-  }
-
-  return null;
-}
-
-export function resolveDaemonResourceRoot({
-  configured = process.env[RESOURCE_ROOT_ENV],
-  safeBases = [
+const DAEMON_RESOURCE_ROOT = resolveDaemonResourceRoot({
+  safeBases: [
     PROJECT_ROOT,
     resolveProcessResourcesPath(),
     process.env.OD_INSTALLATION_DIR,
   ],
-} = {}) {
-  if (!configured || configured.length === 0) return null;
-
-  const resolved = path.resolve(configured);
-  const normalizedSafeBases = safeBases
-    .filter((base) => typeof base === 'string' && base.length > 0)
-    .map((base) => path.resolve(base));
-
-  if (!normalizedSafeBases.some((base) => isPathWithin(base, resolved))) {
-    throw new Error(
-      `${RESOURCE_ROOT_ENV} must be under the workspace root or app resources path`,
-    );
-  }
-
-  return resolved;
-}
-
-function resolveDaemonResourceDir(resourceRoot, segment, fallback) {
-  return resourceRoot ? path.join(resourceRoot, segment) : fallback;
-}
-
-// Where the daemon reads the baked plugin-preview manifest from. In a packaged
-// build the bundled manifest lives under the resource root (OD_RESOURCE_ROOT,
-// Resources/open-design) like every other resource tree — NOT under PROJECT_ROOT,
-// which for the prebundled daemon resolves to Resources/app (two levels up from
-// the sidecar) and has no data/. An explicit OD_PLUGIN_PREVIEWS_DIR override and
-// the dev PROJECT_ROOT layout still win. Exported for regression coverage.
-export function resolveDaemonPluginPreviewsDir({ env = process.env, resourceRoot, projectRoot }) {
-  // Resolve the override from the injected `env` (absolute passthrough, relative
-  // against projectRoot) rather than re-reading process.env, so the helper is
-  // pure and the override path is actually testable.
-  const override = env.OD_PLUGIN_PREVIEWS_DIR;
-  if (override) {
-    return path.isAbsolute(override) ? override : path.resolve(projectRoot, override);
-  }
-  return resolveDaemonResourceDir(
-    resourceRoot,
-    path.join('data', 'plugin-previews'),
-    path.join(projectRoot, 'data', 'plugin-previews'),
-  );
-}
-
-const DAEMON_RESOURCE_ROOT = resolveDaemonResourceRoot();
+});
 // Built web app lives in `out/` — that's where Next.js writes the static
 // export configured in next.config.ts. The folder name used to be `dist/`
 // when this project shipped with Vite; the daemon serves whatever the
@@ -1451,31 +1360,6 @@ const PLUGIN_REGISTRY_DIR = resolveDaemonResourceDir(
 );
 const OFFICIAL_MARKETPLACE_ID = 'official';
 const OFFICIAL_PLUGIN_SOURCE_REPO = 'github:nexu-io/open-design@main';
-
-export function isStaticSpaFallbackRequest(req) {
-  if (req.method !== 'GET' && req.method !== 'HEAD') return false;
-  if (req.path === '/api' || req.path.startsWith('/api/')) return false;
-  if (req.path === '/artifacts' || req.path.startsWith('/artifacts/')) return false;
-  if (req.path === '/frames' || req.path.startsWith('/frames/')) return false;
-  if (req.path === '/_next' || req.path.startsWith('/_next/')) return false;
-
-  const accept = req.get?.('accept') ?? '';
-  return accept.length === 0 || accept.includes('text/html') || accept.includes('*/*');
-}
-
-export function resolveStaticSpaFallbackPath(req, staticDir) {
-  const indexPath = path.join(staticDir, 'index.html');
-  if (!fs.existsSync(indexPath) || !isStaticSpaFallbackRequest(req)) return null;
-  return indexPath;
-}
-
-export function registerStaticSpaFallback(app, staticDir) {
-  app.get('/*splat', (req, res, next) => {
-    const indexPath = resolveStaticSpaFallbackPath(req, staticDir);
-    if (indexPath == null) return next();
-    res.sendFile(indexPath);
-  });
-}
 
 function defaultMarketplaceSeedConfig(id) {
   return {
@@ -1550,48 +1434,6 @@ function createMarketplaceFetcher(seedId, bundledMarketplaceEntries) {
   };
 }
 
-export function resolveDataDir(raw, projectRoot, options = {}) {
-  const value = raw?.trim();
-  if (!value) {
-    if (options.requireExplicit) {
-      throw new Error('OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled');
-    }
-    return path.join(projectRoot, '.od');
-  }
-  // expandHomePrefix is shared with media-config.ts so OD_DATA_DIR and
-  // OD_MEDIA_CONFIG_DIR can never split state under a $HOME-style value.
-  // Some launchers (systemd unit files, NixOS modules, certain Docker
-  // entrypoints, Windows scheduled tasks) pass OD_DATA_DIR with literal
-  // $HOME or ${HOME} because the variable is never expanded by a shell;
-  // expandHomePrefix turns those (and the ~ shorthand, with both / and \
-  // separators) into os.homedir() before path.resolve runs so launch
-  // surfaces stay consistent.
-  const resolved = resolveProjectRelativePath(value, projectRoot);
-  try {
-    fs.mkdirSync(resolved, { recursive: true });
-    fs.accessSync(resolved, fs.constants.W_OK);
-  } catch (err) {
-    const e = err;
-    const currentUser = (() => {
-      try {
-        return os.userInfo().username;
-      } catch {
-        return process.env.USER ?? process.env.LOGNAME ?? 'unknown';
-      }
-    })();
-    const parentDir = path.dirname(resolved);
-    throw new Error(
-      [
-        `OD_DATA_DIR "${resolved}" is not writable: ${e.message}`,
-        `Current user: ${currentUser}`,
-        `Check whether the folder or one of its parents is owned by another user, is a symlink to a protected location, or was previously created with sudo.`,
-        `Try: ls -ld "${parentDir}" "${resolved}"`,
-        `If the folder should belong to you, fix ownership/permissions, for example: sudo chown -R "${currentUser}":staff "${parentDir}" && chmod -R u+rwX "${parentDir}"`,
-      ].join(' '),
-    );
-  }
-  return resolved;
-}
 const SANDBOX_MODE_ENABLED = isSandboxModeEnabled(process.env);
 const RUNTIME_DATA_DIR = resolveDataDir(process.env.OD_DATA_DIR, PROJECT_ROOT, {
   requireExplicit: SANDBOX_MODE_ENABLED,
@@ -2187,33 +2029,6 @@ export function composeProjectDisplayStatus(
  * @param {Omit<ApiError, 'code' | 'message'>} [init]
  * @returns {ApiError}
  */
-export function createCompatApiError(code, message, init = {}) {
-  return { code, message, ...init };
-}
-
-/**
- * @param {ApiErrorCode} code
- * @param {string} message
- * @param {Omit<ApiError, 'code' | 'message'>} [init]
- * @returns {ApiErrorResponse}
- */
-export function createCompatApiErrorResponse(code, message, init = {}) {
-  return { error: createCompatApiError(code, message, init) };
-}
-
-/**
- * @param {import('express').Response} res
- * @param {number} status
- * @param {ApiErrorCode} code
- * @param {string} message
- * @param {Omit<ApiError, 'code' | 'message'>} [init]
- */
-function sendApiError(res, status, code, message, init = {}) {
-  return res
-    .status(status)
-    .json(createCompatApiErrorResponse(code, message, init));
-}
-
 function normalizeProjectPluginFolderPath(input) {
   const value = String(input ?? '').replace(/\\/g, '/').trim();
   if (!value || value.includes('\0') || value.startsWith('/') || /^[A-Za-z]:\//.test(value)) {
@@ -4404,6 +4219,13 @@ export interface StartServerOptions {
   runtime?: DaemonRuntimeContext | null;
 }
 
+export interface StartServerResult {
+  url: string;
+  server: import('node:http').Server;
+  shutdown: () => Promise<void> | void;
+  routeInventory: import('./route-registration-guard.js').RouteRegistration[];
+}
+
 const DEFAULT_CHAT_RUN_INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_CHAT_RUN_INACTIVITY_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // After a successful live-artifact registration the daemon switches the
@@ -5673,93 +5495,8 @@ export async function startServer({
     appConfig: { readAppConfig },
   });
 
-  app.get('/api/automation-source-packets', async (req, res) => {
-    try {
-      const limit = typeof req.query.limit === 'string' ? Number(req.query.limit) : undefined;
-      const packets = await listAutomationSourcePackets(RUNTIME_DATA_DIR, { limit });
-      res.json({ packets });
-    } catch (err) {
-      res.status(500).json({ error: String((err && err.message) || err) });
-    }
-  });
-
-  app.post('/api/automation-ingestions', async (req, res) => {
-    try {
-      const body = req.body && typeof req.body === 'object' ? req.body : {};
-      const result = await ingestAutomationSource(RUNTIME_DATA_DIR, body);
-      res.json(result);
-    } catch (err) {
-      res.status(400).json({ error: String((err && err.message) || err) });
-    }
-  });
-
-  app.get('/api/automation-source-packets/:id', async (req, res) => {
-    try {
-      const packet = await getAutomationSourcePacket(RUNTIME_DATA_DIR, req.params.id);
-      if (!packet) return res.status(404).json({ error: 'automation source packet not found' });
-      res.json({ packet });
-    } catch (err) {
-      res.status(400).json({ error: String((err && err.message) || err) });
-    }
-  });
-
-  app.get('/api/automation-proposals', async (req, res) => {
-    try {
-      const rawStatus = typeof req.query.status === 'string' ? req.query.status : 'all';
-      const proposals = await listAutomationProposals(RUNTIME_DATA_DIR, {
-        status: rawStatus,
-      });
-      res.json({ proposals });
-    } catch (err) {
-      res.status(500).json({ error: String((err && err.message) || err) });
-    }
-  });
-
-  app.post('/api/automation-proposals', async (req, res) => {
-    try {
-      const body = req.body && typeof req.body === 'object' ? req.body : {};
-      const proposal = await createAutomationProposal(RUNTIME_DATA_DIR, body);
-      res.json({ proposal });
-    } catch (err) {
-      res.status(400).json({ error: String((err && err.message) || err) });
-    }
-  });
-
-  app.get('/api/automation-proposals/:id', async (req, res) => {
-    try {
-      const proposal = await getAutomationProposal(RUNTIME_DATA_DIR, req.params.id);
-      if (!proposal) return res.status(404).json({ error: 'automation proposal not found' });
-      res.json({ proposal });
-    } catch (err) {
-      res.status(400).json({ error: String((err && err.message) || err) });
-    }
-  });
-
-  app.post('/api/automation-proposals/:id/apply', async (req, res) => {
-    try {
-      const result = await applyAutomationProposal(RUNTIME_DATA_DIR, req.params.id);
-      res.json(result);
-    } catch (err) {
-      const message = String((err && err.message) || err);
-      const status = message.includes('not found') ? 404 : 400;
-      res.status(status).json({ error: message });
-    }
-  });
-
-  app.post('/api/automation-proposals/:id/reject', async (req, res) => {
-    try {
-      const body = req.body && typeof req.body === 'object' ? req.body : {};
-      const proposal = await rejectAutomationProposal(
-        RUNTIME_DATA_DIR,
-        req.params.id,
-        typeof body.reason === 'string' ? body.reason : undefined,
-      );
-      res.json({ proposal });
-    } catch (err) {
-      const message = String((err && err.message) || err);
-      const status = message.includes('not found') ? 404 : 400;
-      res.status(status).json({ error: message });
-    }
+  registerAutomationRoutes(app, {
+    paths: { RUNTIME_DATA_DIR },
   });
 
   // Reconcile follow-up — the inline POST /api/projects body that lived
@@ -6050,6 +5787,7 @@ export async function startServer({
     sendMulterError,
     sendLiveArtifactRouteError,
     createSseResponse,
+    getPublicBaseUrl,
     requireLocalDaemonRequest,
     isLocalSameOrigin,
     resolvedPortRef,
@@ -6781,86 +6519,6 @@ export async function startServer({
     res.json({ ok: true });
   });
 
-  const AMR_API_PROXY_PREFIX = '/api/integrations/vela/api-proxy';
-  const AMR_API_UPSTREAM_ORIGIN = 'https://amr-api.open-design.ai';
-
-  function velaApiProxyBaseUrl(req) {
-    return `${getPublicBaseUrl(req)}${AMR_API_PROXY_PREFIX}`;
-  }
-
-  function velaProxyRequestBody(req) {
-    if (req.method === 'GET' || req.method === 'HEAD') return null;
-    if (Buffer.isBuffer(req.body)) return req.body;
-    if (typeof req.body === 'string') return Buffer.from(req.body);
-    if (req.body == null) return null;
-    return Buffer.from(JSON.stringify(req.body));
-  }
-
-  function shouldStreamVelaProxyRequest(req, body) {
-    return req.method !== 'GET' && req.method !== 'HEAD' && body == null;
-  }
-
-  function proxyAmrApiRequest(req, res) {
-    const suffix = req.originalUrl.slice(AMR_API_PROXY_PREFIX.length);
-    if (!suffix.startsWith('/api/v1/')) {
-      res.status(404).json({ error: 'unknown_amr_api_proxy_path' });
-      return;
-    }
-    const target = new URL(suffix, AMR_API_UPSTREAM_ORIGIN);
-    const body = velaProxyRequestBody(req);
-    const streamBody = shouldStreamVelaProxyRequest(req, body);
-    const headers = {};
-    for (const [key, value] of Object.entries(req.headers)) {
-      const lower = key.toLowerCase();
-      if (
-        lower === 'host' ||
-        lower === 'connection' ||
-        lower === 'transfer-encoding'
-      ) {
-        continue;
-      }
-      if (lower === 'content-length' && body) continue;
-      headers[key] = value;
-    }
-    if (body) headers['content-length'] = String(body.length);
-
-    const upstream = https.request(
-      target,
-      {
-        method: req.method,
-        headers,
-        lookup: (hostname, options, callback) => {
-          dns.lookup(hostname, { ...options, family: 4, all: false }, callback);
-        },
-      },
-      (upstreamRes) => {
-        res.status(upstreamRes.statusCode ?? 502);
-        for (const [key, value] of Object.entries(upstreamRes.headers)) {
-          if (value !== undefined) res.setHeader(key, value);
-        }
-        upstreamRes.pipe(res);
-      },
-    );
-    upstream.setTimeout(30_000, () => upstream.destroy(new Error('AMR API proxy timed out')));
-    upstream.on('error', (err) => {
-      if (!res.headersSent) {
-        res.status(502).json({ error: err instanceof Error ? err.message : String(err) });
-      } else {
-        res.end();
-      }
-    });
-    if (body) upstream.write(body);
-    if (streamBody) {
-      req.pipe(upstream);
-    } else {
-      upstream.end();
-    }
-  }
-
-  // AMR (vela) login integration — see `apps/daemon/src/integrations/vela.ts`.
-  // The vela CLI owns the device-authorization UX (URL + code + browser open);
-  // these routes only surface enough state for Open Design's Settings card to
-  // show login status and trigger a login from a button.
   async function resolveAmrModelProbe() {
     const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
     const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
@@ -6895,223 +6553,11 @@ export async function startServer({
     return { launchPath, env, configuredEnv, cacheKey };
   }
 
-  app.get('/api/amr/models', async (_req, res) => {
-    try {
-      const probe = await resolveAmrModelProbe();
-      const response = await amrModelLoadingCache.get(probe.cacheKey, {
-        fetchPreset: () => fetchVelaPresetModels(probe.launchPath, probe.env),
-        fetchRemote: () => fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
-      });
-      res.json(response);
-    } catch (err) {
-      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
-    }
-  });
-
-  app.get('/api/integrations/vela/status', async (_req, res) => {
-    try {
-      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
-      const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
-      const status = readVelaLoginStatus(mergeVelaEnv(process.env, configuredEnv));
-      if (status.loggedIn) {
-        void resolveAmrModelProbe()
-          .then((probe) => {
-            amrModelLoadingCache.warm(probe.cacheKey, () =>
-              fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
-            );
-          })
-          .catch((err) => console.warn('[amr] model cache warm failed', err));
-      }
-      res.json(status);
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.all('/api/integrations/vela/api-proxy/*splat', proxyAmrApiRequest);
-
-  app.post('/api/integrations/vela/login', async (req, res) => {
-    try {
-      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
-      const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
-      const attribution = parseVelaLoginAttribution(req.body);
-      const spawned = await spawnVelaLogin({
-        configuredEnv,
-        attribution,
-        defaultApiUrl: velaApiProxyBaseUrl(req),
-      });
-      res.status(202).json(spawned);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      // "already running" is a 409 (resolvable by waiting/polling); everything
-      // else (missing vela binary, spawn failure) is a 500.
-      const status = /already running/i.test(message) ? 409 : 500;
-      res.status(status).json({ error: message });
-    }
-  });
-
-  app.post('/api/integrations/vela/login/cancel', (_req, res) => {
-    try {
-      res.json(cancelVelaLogin());
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.post('/api/integrations/vela/analytics-entry', async (req, res) => {
-    const payload = parseAmrEntryAnalyticsPayload(req.body);
-    if (!payload) {
-      res.status(400).json({ error: 'invalid_amr_entry_analytics' });
-      return;
-    }
-    // Consent gate. The web fetch wrapper attaches `x-od-analytics-*` headers
-    // only when Privacy → metrics is on (apps/web/src/analytics/provider.tsx),
-    // so a null context means the user is opted out — never forward the click
-    // to the external AMR endpoint. Mirrors the analytics-capture invariant.
-    const analyticsContext = readAnalyticsContext(req);
-    if (!analyticsContext) {
-      res.status(202).json({ mirrored: false });
-      return;
-    }
-    // Defense in depth: re-read telemetry.metrics from app-config so a stale
-    // header leak after opt-out still cannot ship behavior to AMR, matching
-    // createAnalyticsService.capture (apps/daemon/src/analytics.ts).
-    const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
-    if (appConfig.telemetry?.metrics !== true) {
-      res.status(202).json({ mirrored: false });
-      return;
-    }
-    const result = await mirrorAmrEntryAnalytics(payload, {
-      analyticsContext,
-      env: process.env,
-    });
-    res.status(202).json(result);
-  });
-
-  app.post('/api/integrations/vela/logout', async (_req, res) => {
-    try {
-      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
-      const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
-      forgetVelaLogin(mergeVelaEnv(process.env, configuredEnv));
-      delete process.env.VELA_RUNTIME_KEY;
-      delete process.env.VELA_LINK_URL;
-      const agentCliEnv = { ...(appConfig.agentCliEnv ?? {}) };
-      const amrEnv = { ...(agentCliEnv.amr ?? {}) };
-      delete amrEnv.VELA_RUNTIME_KEY;
-      delete amrEnv.VELA_LINK_URL;
-      if (Object.keys(amrEnv).length > 0) {
-        agentCliEnv.amr = amrEnv;
-      } else {
-        delete agentCliEnv.amr;
-      }
-      await writeAppConfig(RUNTIME_DATA_DIR, { agentCliEnv });
-      res.json({ ok: true });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.get('/api/skills', async (_req, res) => {
-    try {
-      const skills = await listAllSkills();
-      // Strip full body + on-disk dir from the listing — frontend fetches the
-      // body via /api/skills/:id when needed (keeps the listing payload small).
-      res.json({
-        skills: skills.map(({ body, dir: _dir, ...rest }) => ({
-          ...rest,
-          hasBody: typeof body === 'string' && body.length > 0,
-        })),
-      });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.get('/api/skills/:id', async (req, res) => {
-    try {
-      const skills = await listAllSkills();
-      const skill = findSkillById(skills, req.params.id);
-      if (!skill) return res.status(404).json({ error: 'skill not found' });
-      const { dir: _dir, ...serializable } = skill;
-      res.json(serializable);
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  // Codex hatch-pet registry — pets packaged by the upstream `hatch-pet`
-  // skill under `${CODEX_HOME:-$HOME/.codex}/pets/`. Surfaced so the web
-  // pet settings can offer one-click adoption of recently-hatched pets.
-  app.get('/api/codex-pets', async (_req, res) => {
-    try {
-      const result = await listCodexPets({
-        baseUrl: '',
-        bundledRoot: BUNDLED_PETS_DIR,
-      });
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  // One-click community sync. Hits the Codex Pet Share + j20 Hatchery
-  // catalogs and drops every pet into `${CODEX_HOME:-$HOME/.codex}/pets/`
-  // so `GET /api/codex-pets` (and the web Pet settings) pick them up
-  // immediately. The body is intentionally tiny — we keep the heavier
-  // tuning knobs (`--limit`, `--concurrency`) on the CLI script and
-  // only surface `force` + `source` here.
-  app.post('/api/codex-pets/sync', async (req, res) => {
-    try {
-      const body = req.body && typeof req.body === 'object' ? req.body : {};
-      const sourceRaw = typeof body.source === 'string' ? body.source : 'all';
-      const source =
-        sourceRaw === 'petshare' || sourceRaw === 'hatchery'
-          ? sourceRaw
-          : 'all';
-      const result = await syncCommunityPets({
-        source,
-        force: Boolean(body.force),
-      });
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ error: String((err && err.message) || err) });
-    }
-  });
-
-  app.get('/api/codex-pets/:id/spritesheet', async (req, res) => {
-    try {
-      const sheet = await readCodexPetSpritesheet(req.params.id, {
-        bundledRoot: BUNDLED_PETS_DIR,
-      });
-      if (!sheet) {
-        return res
-          .status(404)
-          .type('text/plain')
-          .send('codex pet spritesheet not found');
-      }
-      const mime =
-        sheet.ext === 'webp'
-          ? 'image/webp'
-          : sheet.ext === 'gif'
-            ? 'image/gif'
-            : 'image/png';
-      res.type(mime);
-      // Same-origin callers (the web app proxies `/api/*` through to
-      // the daemon, so PetSettings adoption fetches arrive same-origin)
-      // do not need any CORS header here. We only echo
-      // `Access-Control-Allow-Origin` for sandboxed iframes / data:
-      // URIs (Origin: null) which need it to draw the bytes onto a
-      // canvas without tainting. Local pet bytes should not be exposed
-      // to arbitrary third-party origins via a wildcard ACAO.
-      if (req.headers.origin === 'null') {
-        res.setHeader('Access-Control-Allow-Origin', 'null');
-      }
-      res.setHeader('Cache-Control', 'no-store');
-      const buf = await fs.promises.readFile(sheet.absPath);
-      res.send(buf);
-    } catch (err) {
-      res.status(500).type('text/plain').send(String(err));
-    }
+  registerVelaRoutes(app, {
+    paths: { RUNTIME_DATA_DIR },
+    appConfig: { readAppConfig },
+    http: { getPublicBaseUrl },
+    env: process.env,
   });
 
   app.get('/api/design-systems', async (_req, res) => {
@@ -8836,238 +8282,10 @@ export async function startServer({
     }
   });
 
-  // Phase 2A: GenUI surface read/write + devloop iteration history + replay.
-  // Spec §10.3 for the surface lifecycle, §10.2 for devloop, §11.5 for the
-  // route shapes. The surface writers go through `apps/daemon/src/genui/store.ts`
-  // (sole writer of `genui_surfaces`) so the F8 cross-conversation cache stays
-  // intact.
-  app.get('/api/runs/:runId/genui', (req, res) => {
-    try {
-      const surfaces = listSurfacesForRun(db, req.params.runId);
-      res.json({ runId: req.params.runId, surfaces });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.get('/api/projects/:projectId/genui', (req, res) => {
-    try {
-      const surfaces = listSurfacesForProject(db, req.params.projectId);
-      res.json({ projectId: req.params.projectId, surfaces });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.post('/api/runs/:runId/genui/:surfaceId/respond', async (req, res) => {
-    try {
-      const body = req.body && typeof req.body === 'object' ? req.body : {};
-      const value = 'value' in body ? body.value : null;
-      const respondedBy =
-        body.respondedBy === 'agent' || body.respondedBy === 'auto'
-          ? body.respondedBy
-          : 'user';
-      // The CLI / web pass `surfaceId` (the plugin-declared id) — look up
-      // the matching pending row scoped to the run, then write through.
-      const stmt = db.prepare(
-        `SELECT id FROM genui_surfaces
-          WHERE run_id = ? AND surface_id = ? AND status = 'pending'
-          ORDER BY requested_at DESC LIMIT 1`,
-      );
-      const row = stmt.get(req.params.runId, req.params.surfaceId) as { id?: string } | undefined;
-      if (!row?.id) {
-        return res.status(404).json({ error: 'no pending surface for runId/surfaceId' });
-      }
-      const updated = respondSurfaceRow(db, { rowId: row.id, value, respondedBy });
-
-      // Plan §3.R1 / spec §10.3 / §21.5 — auto-bridge for the
-      // diff-review choice surface. When the surface id matches the
-      // auto-derived prefix, we immediately persist the decision into
-      // the run's project cwd so the next pipeline stage (handoff,
-      // typically) sees `<cwd>/review/decision.json` without a second
-      // turn through the agent. Best-effort: failures don't block the
-      // 200 response — the agent or a follow-up call can retry.
-      let diffReviewBridge: { ok: boolean; error?: string } | undefined;
-      if (isDiffReviewSurfaceId(req.params.surfaceId)) {
-        try {
-          const run = design.runs.get(req.params.runId);
-          const projectId = (run as { projectId?: string | null } | undefined)?.projectId ?? null;
-          if (projectId) {
-            const project = getProject(db, projectId);
-            const metadata = project?.metadata && typeof project.metadata === 'string'
-              ? JSON.parse(project.metadata)
-              : project?.metadata ?? undefined;
-            const cwd = resolveProjectDir(PROJECTS_DIR, projectId, metadata);
-            const bridgeResult = await applyDiffReviewDecisionToCwd({
-              cwd,
-              value,
-              reviewer: respondedBy === 'agent' || respondedBy === 'auto' ? 'agent' : 'user',
-            });
-            diffReviewBridge = bridgeResult.ok ? { ok: true } : { ok: false, error: bridgeResult.error };
-          } else {
-            diffReviewBridge = { ok: false, error: 'run is not linked to a project' };
-          }
-        } catch (err) {
-          diffReviewBridge = { ok: false, error: (err as Error).message };
-          console.warn('[plugins] diff-review bridge failed:', err);
-        }
-      }
-
-      const responsePayload: Record<string, unknown> = { ok: true, surface: updated };
-      if (diffReviewBridge) responsePayload.diffReviewBridge = diffReviewBridge;
-      res.json(responsePayload);
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.post('/api/projects/:projectId/genui/:surfaceId/revoke', (req, res) => {
-    try {
-      const changed = revokeProjectSurface(db, {
-        projectId: req.params.projectId,
-        surfaceId: req.params.surfaceId,
-      });
-      res.json({ ok: true, invalidated: changed });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.post('/api/projects/:projectId/genui/prefill', (req, res) => {
-    try {
-      const body = req.body && typeof req.body === 'object' ? req.body : {};
-      const snapshotId = typeof body.snapshotId === 'string' ? body.snapshotId : '';
-      const surfaceId  = typeof body.surfaceId  === 'string' ? body.surfaceId  : '';
-      const persist    = body.persist === 'run' || body.persist === 'conversation' || body.persist === 'project'
-        ? body.persist
-        : 'project';
-      const kind = body.kind === 'form' || body.kind === 'choice' || body.kind === 'oauth-prompt'
-        ? body.kind
-        : 'confirmation';
-      if (!snapshotId || !surfaceId) {
-        return res.status(400).json({ error: 'snapshotId and surfaceId are required' });
-      }
-      const row = prefillProjectSurface(db, {
-        projectId:        req.params.projectId,
-        pluginSnapshotId: snapshotId,
-        surfaceId,
-        kind,
-        persist,
-        value:            'value' in body ? body.value : null,
-        schema:           body.schema,
-        expiresAt:        typeof body.expiresAt === 'number' ? body.expiresAt : null,
-      });
-      res.json({ ok: true, surface: row });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.get('/api/runs/:runId/genui/:surfaceId', (req, res) => {
-    try {
-      const row = db.prepare(
-        `SELECT id FROM genui_surfaces
-          WHERE run_id = ? AND surface_id = ?
-          ORDER BY requested_at DESC LIMIT 1`,
-      ).get(req.params.runId, req.params.surfaceId) as { id?: string } | undefined;
-      if (!row?.id) return res.status(404).json({ error: 'surface not found' });
-      const surface = getSurface(db, row.id);
-      if (!surface) return res.status(404).json({ error: 'surface not found' });
-      // Plan §6 Phase 2A.5 — enrich the response with the surface
-      // spec (incl. schema, prompt, persist tier) pulled out of the
-      // pinned AppliedPluginSnapshot. This is what `od ui show`
-      // returns to headless callers so a code agent can inspect the
-      // JSON Schema before responding via `od ui respond --value-json`.
-      // The store only persists `schemaDigest` (for the cross-conv
-      // cache); the canonical schema lives on the snapshot.
-      let spec = null;
-      if (surface.pluginSnapshotId) {
-        const snap = getSnapshot(db, surface.pluginSnapshotId);
-        if (snap && Array.isArray(snap.genuiSurfaces)) {
-          spec = snap.genuiSurfaces.find((s) => s?.id === surface.surfaceId) ?? null;
-        }
-      }
-      res.json({ ...surface, spec });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.get('/api/runs/:runId/devloop-iterations', (req, res) => {
-    try {
-      const iterations = listIterationsForRun(db, req.params.runId);
-      res.json({ runId: req.params.runId, iterations });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  // Replay: rebuild a run by reading its `applied_plugin_snapshot_id`
-  // and returning the snapshot for the caller (CLI / agent driver) to
-  // re-launch with. Phase 2A keeps replay headless: the daemon does not
-  // auto-restart the agent — it returns the materialized inputs that
-  // would re-produce the run if re-applied. Spec §8.2.1 invariants
-  // guarantee byte-equality across replays.
-  app.post('/api/runs/:runId/replay', (req, res) => {
-    try {
-      const body = req.body && typeof req.body === 'object' ? req.body : {};
-      const explicitSnapshotId = typeof body.snapshotId === 'string' ? body.snapshotId : '';
-      let snapshotId = explicitSnapshotId;
-      if (!snapshotId) {
-        // Phase 2A keeps `runs` in-memory; the caller must pass `snapshotId`
-        // (e.g. the value persisted on the client after the original apply).
-        // Once `runs.applied_plugin_snapshot_id` lands as a SQL column, the
-        // server resolves the link itself.
-        return res.status(400).json({
-          error: 'snapshotId is required (runs are in-memory; pass the snapshotId returned by /api/plugins/:id/apply)',
-        });
-      }
-      const snapshot = getSnapshot(db, snapshotId);
-      if (!snapshot) return res.status(404).json({ error: 'snapshot not found' });
-      res.json({
-        ok:        true,
-        runId:     req.params.runId,
-        snapshotId,
-        snapshot,
-        // The caller re-launches the agent by re-applying these inputs;
-        // the digest match guarantees byte-equality (§8.2.1).
-        rerun: {
-          pluginId:             snapshot.pluginId,
-          pluginSpecVersion:    snapshot.pluginSpecVersion,
-          pluginVersion:        snapshot.pluginVersion,
-          inputs:               snapshot.inputs,
-          manifestSourceDigest: snapshot.manifestSourceDigest,
-        },
-      });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.get('/api/prompt-templates', async (_req, res) => {
-    try {
-      const templates = await listPromptTemplates(PROMPT_TEMPLATES_DIR);
-      res.json({
-        promptTemplates: templates.map(({ prompt: _prompt, ...rest }) => rest),
-      });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  app.get('/api/prompt-templates/:surface/:id', async (req, res) => {
-    try {
-      const tpl = await readPromptTemplate(
-        PROMPT_TEMPLATES_DIR,
-        req.params.surface,
-        req.params.id,
-      );
-      if (!tpl)
-        return res.status(404).json({ error: 'prompt template not found' });
-      res.json({ promptTemplate: tpl });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
+  registerGenuiRoutes(app, {
+    db,
+    design,
+    paths: { PROJECTS_DIR },
   });
 
   // Showcase HTML for a design system — palette swatches, typography
@@ -15841,7 +15059,12 @@ export async function startServer({
           console.log(`[od] daemon listening on ${url}`);
         }
         daemonUrl = url;
-        resolve(returnServer ? { url, server, shutdown: shutdownDaemonRuns } : url);
+        resolve(returnServer ? {
+          url,
+          server,
+          shutdown: shutdownDaemonRuns,
+          routeInventory: getRouteRegistrationInventory(app),
+        } : url);
       });
     } catch (error) {
       cleanupDaemonBackgroundWork();

--- a/apps/daemon/src/static-spa.ts
+++ b/apps/daemon/src/static-spa.ts
@@ -1,0 +1,34 @@
+import type { Express } from 'express';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface StaticSpaFallbackRequestLike {
+  method: string;
+  path: string;
+  get?: (name: string) => string | undefined;
+}
+
+export function isStaticSpaFallbackRequest(req: StaticSpaFallbackRequestLike): boolean {
+  if (req.method !== 'GET' && req.method !== 'HEAD') return false;
+  if (req.path === '/api' || req.path.startsWith('/api/')) return false;
+  if (req.path === '/artifacts' || req.path.startsWith('/artifacts/')) return false;
+  if (req.path === '/frames' || req.path.startsWith('/frames/')) return false;
+  if (req.path === '/_next' || req.path.startsWith('/_next/')) return false;
+
+  const accept = req.get?.('accept') ?? '';
+  return accept.length === 0 || accept.includes('text/html') || accept.includes('*/*');
+}
+
+export function resolveStaticSpaFallbackPath(req: StaticSpaFallbackRequestLike, staticDir: string): string | null {
+  const indexPath = path.join(staticDir, 'index.html');
+  if (!fs.existsSync(indexPath) || !isStaticSpaFallbackRequest(req)) return null;
+  return indexPath;
+}
+
+export function registerStaticSpaFallback(app: Express, staticDir: string): void {
+  app.get('/*splat', (req, res, next) => {
+    const indexPath = resolveStaticSpaFallbackPath(req, staticDir);
+    if (indexPath == null) return next();
+    res.sendFile(indexPath);
+  });
+}

--- a/apps/daemon/tests/server-bootstrap-regression.test.ts
+++ b/apps/daemon/tests/server-bootstrap-regression.test.ts
@@ -1,0 +1,185 @@
+import type http from 'node:http';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  isStaticSpaFallbackRequest,
+  resolveDataDir,
+  startServer,
+  type StartServerResult,
+} from '../src/server.js';
+
+let server: http.Server;
+let baseUrl: string;
+let shutdown: (() => Promise<void> | void) | undefined;
+let routeInventory: StartServerResult['routeInventory'];
+
+beforeAll(async () => {
+  const started = (await startServer({ port: 0, returnServer: true })) as StartServerResult;
+  baseUrl = started.url;
+  server = started.server;
+  shutdown = started.shutdown;
+  routeInventory = started.routeInventory;
+});
+
+afterAll(async () => {
+  await Promise.resolve(shutdown?.());
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('server route inventory', () => {
+  it('records bootstrap and migrated domain routes in registration order', () => {
+    const routeKeys = routeInventory.map((route) => `${route.method} ${route.path}`);
+    const fallbackIndex = routeKeys.indexOf('GET /*splat');
+
+    const automationRouteKeys = [
+      'GET /api/automation-source-packets',
+      'POST /api/automation-ingestions',
+      'GET /api/automation-source-packets/:id',
+      'GET /api/automation-proposals',
+      'POST /api/automation-proposals',
+      'GET /api/automation-proposals/:id',
+      'POST /api/automation-proposals/:id/apply',
+      'POST /api/automation-proposals/:id/reject',
+    ];
+    const velaRouteKeys = [
+      'GET /api/amr/models',
+      'GET /api/integrations/vela/status',
+      'ALL /api/integrations/vela/api-proxy/*splat',
+      'POST /api/integrations/vela/login',
+      'POST /api/integrations/vela/login/cancel',
+      'POST /api/integrations/vela/analytics-entry',
+      'POST /api/integrations/vela/logout',
+    ];
+    const genuiRouteKeys = [
+      'GET /api/runs/:runId/genui',
+      'GET /api/projects/:projectId/genui',
+      'POST /api/runs/:runId/genui/:surfaceId/respond',
+      'POST /api/projects/:projectId/genui/:surfaceId/revoke',
+      'POST /api/projects/:projectId/genui/prefill',
+      'GET /api/runs/:runId/genui/:surfaceId',
+      'GET /api/runs/:runId/devloop-iterations',
+      'POST /api/runs/:runId/replay',
+    ];
+
+    expect(routeKeys).toEqual(expect.arrayContaining([
+      'GET /api/health',
+      'GET /api/ready',
+      'GET /api/version',
+      'GET /api/daemon/status',
+      'GET /api/skills',
+      'GET /api/codex-pets',
+      'GET /api/prompt-templates',
+      'GET /*splat',
+    ]));
+
+    expect(routeKeys.filter((key) => automationRouteKeys.includes(key))).toEqual(automationRouteKeys);
+    expect(routeKeys.filter((key) => velaRouteKeys.includes(key))).toEqual(velaRouteKeys);
+    expect(routeKeys.filter((key) => genuiRouteKeys.includes(key))).toEqual(genuiRouteKeys);
+
+    expect(fallbackIndex).toBeGreaterThan(-1);
+    expect(routeKeys.indexOf('GET /api/health')).toBeLessThan(fallbackIndex);
+    expect(routeKeys.indexOf('GET /api/automation-source-packets')).toBeLessThan(
+      routeKeys.indexOf('GET /api/skills'),
+    );
+    for (const [index, key] of routeKeys.entries()) {
+      if (key.includes(' /api/')) {
+        expect(index, `${key} should register before SPA fallback`).toBeLessThan(fallbackIndex);
+      }
+    }
+    expect(routeKeys.filter((key) => key === 'GET /api/skills')).toHaveLength(1);
+  });
+});
+
+describe('bootstrap route regressions', () => {
+  it('keeps health, ready, version, and daemon status available', async () => {
+    const [health, ready, version, status] = await Promise.all([
+      fetch(`${baseUrl}/api/health`),
+      fetch(`${baseUrl}/api/ready`),
+      fetch(`${baseUrl}/api/version`),
+      fetch(`${baseUrl}/api/daemon/status`),
+    ]);
+
+    expect(health.status).toBe(200);
+    expect(ready.status).toBe(200);
+    expect(version.status).toBe(200);
+    expect(status.status).toBe(200);
+  });
+
+  it('keeps lightweight extracted-route responses stable without fixtures', async () => {
+    const [
+      automationList,
+      automationMissing,
+      velaProxyUnknownPath,
+      genuiRunList,
+      genuiRunSurfaceMissing,
+      devloopIterations,
+      replayMissingSnapshot,
+    ] = await Promise.all([
+      fetch(`${baseUrl}/api/automation-source-packets`),
+      fetch(`${baseUrl}/api/automation-source-packets/missing-packet`),
+      fetch(`${baseUrl}/api/integrations/vela/api-proxy/not-api-v1`),
+      fetch(`${baseUrl}/api/runs/missing-run/genui`),
+      fetch(`${baseUrl}/api/runs/missing-run/genui/missing-surface`),
+      fetch(`${baseUrl}/api/runs/missing-run/devloop-iterations`),
+      fetch(`${baseUrl}/api/runs/missing-run/replay`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      }),
+    ]);
+
+    expect(automationList.status).toBe(200);
+    expect(await automationList.json()).toEqual({ packets: [] });
+
+    expect(automationMissing.status).toBe(404);
+    expect(await automationMissing.json()).toEqual({ error: 'automation source packet not found' });
+
+    expect(velaProxyUnknownPath.status).toBe(404);
+    expect(await velaProxyUnknownPath.json()).toEqual({ error: 'unknown_amr_api_proxy_path' });
+
+    expect(genuiRunList.status).toBe(200);
+    expect(await genuiRunList.json()).toEqual({ runId: 'missing-run', surfaces: [] });
+
+    expect(genuiRunSurfaceMissing.status).toBe(404);
+    expect(await genuiRunSurfaceMissing.json()).toEqual({ error: 'surface not found' });
+
+    expect(devloopIterations.status).toBe(200);
+    expect(await devloopIterations.json()).toEqual({ runId: 'missing-run', iterations: [] });
+
+    expect(replayMissingSnapshot.status).toBe(400);
+    expect(await replayMissingSnapshot.json()).toEqual({
+      error: 'snapshotId is required (runs are in-memory; pass the snapshotId returned by /api/plugins/:id/apply)',
+    });
+  });
+});
+
+describe('static SPA fallback classification', () => {
+  const makeReq = (path: string, method = 'GET', accept = 'text/html') => ({
+    method,
+    path,
+    get: (name: string) => (name.toLowerCase() === 'accept' ? accept : ''),
+  });
+
+  it('does not classify API, artifacts, frames, or _next requests as SPA fallbacks', () => {
+    expect(isStaticSpaFallbackRequest(makeReq('/api/projects') as never)).toBe(false);
+    expect(isStaticSpaFallbackRequest(makeReq('/artifacts/x') as never)).toBe(false);
+    expect(isStaticSpaFallbackRequest(makeReq('/frames/x') as never)).toBe(false);
+    expect(isStaticSpaFallbackRequest(makeReq('/_next/static/app.js') as never)).toBe(false);
+  });
+
+  it('requires a GET or HEAD request with an HTML-compatible Accept header', () => {
+    expect(isStaticSpaFallbackRequest(makeReq('/workspace') as never)).toBe(true);
+    expect(isStaticSpaFallbackRequest(makeReq('/workspace', 'HEAD') as never)).toBe(true);
+    expect(isStaticSpaFallbackRequest(makeReq('/workspace', 'POST') as never)).toBe(false);
+    expect(isStaticSpaFallbackRequest(makeReq('/workspace', 'GET', 'application/json') as never)).toBe(false);
+  });
+});
+
+describe('daemon data dir resolver', () => {
+  it('requires explicit OD_DATA_DIR in sandbox mode and resolves project-relative dirs', () => {
+    expect(() => resolveDataDir('', '/tmp/open-design-test', { requireExplicit: true })).toThrow(
+      /OD_DATA_DIR is required/,
+    );
+    expect(resolveDataDir('relative-data', '/tmp/open-design-test')).toBe('/tmp/open-design-test/relative-data');
+  });
+});


### PR DESCRIPTION
## Why

`apps/daemon/src/server.ts` had grown into a large mixed-responsibility file, making route, path, and bootstrap changes harder to review safely. This PR starts the planned server split with a behavior-preserving first slice so later route/domain extractions have a tested pattern to follow.

The pain addressed is daemon maintainability: route registration order, daemon path resolution, API error helpers, SPA fallback behavior, and low-coupling route domains now have clearer owners and regression coverage.

## What users will see

No user-facing behavior change. Existing daemon APIs keep the same paths and response shapes; this is an internal refactor plus characterization coverage.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI changes.

## Bug fix verification

Not a bug fix.

## Validation

- [x] `pnpm --filter @open-design/daemon typecheck`
- [x] `pnpm vitest run -c vitest.config.ts tests/server-bootstrap-regression.test.ts`
- [x] `pnpm vitest run -c vitest.config.ts tests/static-resource-routes.test.ts tests/server-bootstrap-regression.test.ts`
- [x] `pnpm vitest run -c vitest.config.ts tests/integrations/vela.routes.test.ts`
- [x] `pnpm vitest run -c vitest.config.ts tests/plugins-genui-spec-enrichment.test.ts`
- [x] `pnpm guard`
- [ ] Full `pnpm --filter @open-design/daemon test` — attempted; exceeded local timeout. Targeted route/type coverage above passed. `tests/chat-route.test.ts` has unrelated local failures in Claude/OpenCode assertions that were not part of this server route split.
