### PR TITLE
fix: prevent legacy Kimi CLI launch regressions

### DIFF
--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -149,6 +149,10 @@ async function withFakeDeepSeek<T>(script: string, run: () => Promise<T>): Promi
   return withFakeAgent('deepseek', script, run);
 }
 
+async function withFakeKimi<T>(script: string, run: () => Promise<T>): Promise<T> {
+  return withFakeAgent('kimi', script, run);
+}
+
 async function waitForFile(file: string, timeoutMs = 5_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -2849,6 +2853,67 @@ process.stdin.on('end', () => {
             ]),
           );
           await expect(fsp.readFile(stdinFile, 'utf8')).resolves.toBe('Reply with only: ok');
+        },
+      );
+    } finally {
+      await fsp.rm(markerDir, { recursive: true, force: true });
+    }
+  });
+
+  it('launches Kimi connection tests without the legacy acp positional arg', async () => {
+    const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-kimi-argv-'));
+    const argvFile = path.join(markerDir, 'argv.json');
+    try {
+      await withFakeKimi(
+        `
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.writeFileSync(${JSON.stringify(argvFile)}, JSON.stringify(args));
+if (args.includes('acp')) {
+  console.error('error: too many arguments. Expected 0 arguments but got 1.');
+  process.exit(1);
+}
+const promptIndex = args.indexOf('-p');
+if (promptIndex === -1 || args[promptIndex + 1] !== 'Reply with only: ok') {
+  console.error('missing connection-test prompt');
+  process.exit(1);
+}
+const outputFormatIndex = args.indexOf('--output-format');
+if (outputFormatIndex === -1 || args[outputFormatIndex + 1] !== 'stream-json') {
+  console.error('missing --output-format stream-json');
+  process.exit(1);
+}
+console.log(JSON.stringify({ role: 'assistant', content: 'ok' }));
+`,
+        async () => {
+          const res = await realFetch(`${baseUrl}/api/test/connection`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              mode: 'agent',
+              agentId: 'kimi',
+              model: 'moonshot-v1-32k',
+            }),
+          });
+          expect(res.status).toBe(200);
+          await expect(res.json()).resolves.toMatchObject({
+            ok: true,
+            kind: 'success',
+            agentName: 'Kimi CLI',
+            model: 'moonshot-v1-32k',
+            sample: 'ok',
+          });
+
+          await expect(fsp.readFile(argvFile, 'utf8')).resolves.toBe(
+            JSON.stringify([
+              '-p',
+              'Reply with only: ok',
+              '--output-format',
+              'stream-json',
+              '--model',
+              'moonshot-v1-32k',
+            ]),
+          );
         },
       );
     } finally {

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -486,6 +486,50 @@ test('detectAgents includes sanitized install and docs metadata from split runti
   }
 });
 
+fsTest('detectAgents keeps Kimi available when the installed CLI rejects the legacy acp positional arg', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-detect-kimi-modern-'));
+  try {
+    return await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      const kimiBin = join(dir, 'kimi');
+      writeFileSync(
+        kimiBin,
+        [
+          '#!/usr/bin/env node',
+          'const args = process.argv.slice(2);',
+          "if (args.includes('acp')) {",
+          "  console.error('error: too many arguments. Expected 0 arguments but got 1.');",
+          '  process.exit(1);',
+          '}',
+          "if (args.length === 1 && args[0] === '--version') {",
+          "  console.log('kimi 0.6.0');",
+          '  process.exit(0);',
+          '}',
+          "console.error('unexpected args: ' + JSON.stringify(args));",
+          'process.exit(1);',
+          '',
+        ].join('\n'),
+      );
+      chmodSync(kimiBin, 0o755);
+
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+
+      const agents = await detectAgents();
+      const kimi = agents.find((agent) => agent.id === 'kimi');
+
+      assert.ok(kimi);
+      assert.equal(kimi.available, true);
+      assert.equal(kimi.version, 'kimi 0.6.0');
+      assert.equal(kimi.models[0]?.id, 'default');
+      assert.equal(kimi.models[1]?.id, 'kimi-k2-turbo-preview');
+      assert.equal(kimi.models[2]?.id, 'moonshot-v1-8k');
+      assert.equal(kimi.models[3]?.id, 'moonshot-v1-32k');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 fsTest('detectAgents marks Codex available when nvm exposes a node shim but launch resolution upgrades it to the native binary', async () => {
   const home = mkdtempSync(join(tmpdir(), 'od-detect-codex-nvm-native-'));
   try {

--- a/mocks/README.md
+++ b/mocks/README.md
@@ -154,7 +154,8 @@ verified line-by-line against the parsers in `apps/daemon/src/`:
 | `gemini`          | `json-event-stream` (gemini kind)       | `json-event-stream.ts:handleGeminiEvent`     |
 | `cursor-agent`    | `json-event-stream` (cursor-agent kind) | `json-event-stream.ts:handleCursorEvent`     |
 | `deepseek` `qwen` `grok` | `plain`                          | `server.ts` (raw stdout = final assistant text) |
-| `devin` `hermes` `kilo` `kimi` `kiro` `vibe` | `acp-json-rpc` | `acp.ts:attachAcpSession`                       |
+| `kimi`            | `json-event-stream` (kimi kind)         | `json-event-stream.ts:handleKimiEvent`         |
+| `devin` `hermes` `kilo` `kiro` `vibe` | `acp-json-rpc` | `acp.ts:attachAcpSession`                       |
 | `vela` (AMR) | `acp-json-rpc` + `login` / `models` subcommands | `runtimes/defs/amr.ts` + `apps/daemon/tests/fixtures/fake-vela.mjs` (sibling stub) |
 
 > **Note on `cursor-agent`**: OD's parser does NOT recognize tool-call
@@ -164,7 +165,7 @@ verified line-by-line against the parsers in `apps/daemon/src/`:
 > `gemini` recognizes the current Gemini CLI `stream-json` tool_use /
 > tool_result frames and replays recorded tool calls through that envelope.
 
-> **Note on ACP agents** (`devin` / `hermes` / `kilo` / `kimi` / `kiro` /
+> **Note on ACP agents** (`devin` / `hermes` / `kilo` / `kiro` /
 > `vibe`): These do NOT stream stdout — they speak JSON-RPC v2 over stdio.
 > OD's daemon sends `initialize` → `session/new` → (optional `session/set_model`)
 > → `session/prompt`; the mock responds in order, streams text via
@@ -172,6 +173,11 @@ verified line-by-line against the parsers in `apps/daemon/src/`:
 > then responds to the prompt request with usage stats. Tool calls
 > aren't part of the ACP protocol on this path (tools surface via MCP or
 > other side channels), so they're dropped from playback.
+
+> **Note on `kimi`**: Modern Kimi CLI is not an ACP stdio adapter in Open
+> Design. The runtime launches it in prompt mode (`kimi -p ... --output-format
+> stream-json`), so the mock replays Kimi-flavored JSON-event-stream frames
+> instead of JSON-RPC.
 
 > **Note on `vela` (AMR)**: vela is the bin OD's AMR runtime spawns. It
 > extends the generic ACP shape with `agentCapabilities` + `models`
@@ -421,6 +427,7 @@ mocks/
 │   ├── format-gemini.mjs         ← matches handleGeminiEvent
 │   ├── format-cursor-agent.mjs   ← matches handleCursorEvent
 │   ├── format-acp.mjs            ← JSON-RPC server matching attachAcpSession
+│   ├── format-kimi.mjs           ← kimi stream-json renderer
 │   ├── format-vela.mjs           ← AMR vela: ACP + models block + set_model gate
 │   ├── vela-subcommands.mjs      ← `vela login` + `vela models` handlers
 │   └── format-plain.mjs          ← raw stdout (deepseek/qwen/grok)

--- a/mocks/lib/format-kimi.mjs
+++ b/mocks/lib/format-kimi.mjs
@@ -1,0 +1,60 @@
+// OD-faithful kimi renderer.
+//
+// Matches the JSONL shape OD's `json-event-stream.ts:handleKimiEvent`
+// parser accepts:
+//   {"role":"assistant","content":"..."}                  → text_delta
+//   {"role":"assistant","tool_calls":[...]}               → tool_use
+//   {"role":"tool","tool_call_id":"...","content":"..."} → tool_result
+//   {"role":"meta","type":"session.resume_hint",...}      → ignored
+
+import { writeFile } from 'node:fs/promises';
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+export async function renderAsKimi(events, opts = {}) {
+  const emit = opts.emit ?? (s => process.stdout.write(s));
+  const maxSleep = opts.maxSleepMs ?? 2000;
+  const meta = events.find(e => e.type === 'meta');
+  const results = new Map();
+  for (const e of events) if (e.type === 'tool_result') results.set(e.obs_id, e);
+
+  if (!opts.noDelay) await sleep(Math.min(maxSleep, 200));
+
+  for (const e of events) {
+    if (e.type === 'tool_call') {
+      const result = results.get(e.obs_id);
+      emit(JSON.stringify({
+        role: 'assistant',
+        tool_calls: [
+          {
+            type: 'function',
+            id: e.obs_id,
+            function: {
+              name: e.name,
+              arguments: JSON.stringify(e.input ?? null),
+            },
+          },
+        ],
+      }) + '\n');
+      emit(JSON.stringify({
+        role: 'tool',
+        tool_call_id: e.obs_id,
+        content: result?.output ?? '',
+      }) + '\n');
+      continue;
+    }
+    if (e.type === 'report') {
+      emit(JSON.stringify({
+        role: 'assistant',
+        content: e.content,
+      }) + '\n');
+      emit(JSON.stringify({
+        role: 'meta',
+        type: 'session.resume_hint',
+        session_id: meta?.session_id ?? `mock-${Date.now()}`,
+        content: 'To resume this session: kimi -r mock-session',
+      }) + '\n');
+      if (opts.reportFile) await writeFile(opts.reportFile, e.content).catch(() => {});
+    }
+  }
+}

--- a/mocks/mock-agent.mjs
+++ b/mocks/mock-agent.mjs
@@ -21,6 +21,7 @@ import { renderAsCodex }       from './lib/format-codex.mjs';
 import { renderAsClaude }      from './lib/format-claude.mjs';
 import { renderAsGemini }      from './lib/format-gemini.mjs';
 import { renderAsCursorAgent } from './lib/format-cursor-agent.mjs';
+import { renderAsKimi }        from './lib/format-kimi.mjs';
 import { renderAsPlain }       from './lib/format-plain.mjs';
 import { runAcpServer }        from './lib/format-acp.mjs';
 import { runVelaAcpServer }    from './lib/format-vela.mjs';
@@ -70,7 +71,8 @@ async function main() {
       'mock-agent: --as <agent> required\n' +
       '  supported: opencode | claude | amp | codex | gemini | cursor-agent |\n' +
       '             deepseek | qwen | grok | plain |\n' +
-      '             devin | hermes | kilo | kimi | kiro | vibe   (ACP)\n' +
+      '             kimi                                         (stream-json)\n' +
+      '             devin | hermes | kilo | kiro | vibe          (ACP)\n' +
       '             vela                                          (AMR — vela CLI)\n',
     );
     process.exit(2);
@@ -90,7 +92,7 @@ async function main() {
   // ACP agents read JSON-RPC messages off stdin one line at a time, so the
   // bulk-prompt buffering logic below doesn't apply — pickRecording sees no
   // prompt for hash-mode (use OD_MOCKS_TRACE or _POOL instead).
-  const ACP_AGENTS = new Set(['devin', 'hermes', 'kilo', 'kimi', 'kiro', 'vibe', 'vela']);
+  const ACP_AGENTS = new Set(['devin', 'hermes', 'kilo', 'kiro', 'vibe', 'vela']);
   const isAcp = ACP_AGENTS.has(opts.as);
   const prompt = isAcp ? '' : await readStdinIfPiped();
   const picked = await pickRecording({ prompt });
@@ -128,11 +130,11 @@ async function main() {
     case 'qwen':
     case 'grok':
     case 'plain':        await renderAsPlain(events, renderOpts);       break;
+    case 'kimi':         await renderAsKimi(events, renderOpts);        break;
     // ACP family — JSON-RPC server over stdio.
     case 'devin':
     case 'hermes':
     case 'kilo':
-    case 'kimi':
     case 'kiro':
     case 'vibe':         await runAcpServer(events, renderOpts);        break;
     // AMR (vela CLI) — ACP with vela-specific protocol extensions

--- a/mocks/mock-agent.mjs
+++ b/mocks/mock-agent.mjs
@@ -29,11 +29,13 @@ import { runVelaLogin, runVelaModels } from './lib/vela-subcommands.mjs';
 
 function parseArgs(argv) {
   const opts = { as: null, noDelay: false, reportFile: null, positionals: [] };
+  const flagsWithValue = new Set(['--as', '--agent', '--report-file', '-p', '--output-format', '--model', '-r']);
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--as' || a === '--agent') { opts.as = argv[++i]; continue; }
     if (a === '--no-delay')              { opts.noDelay = true; continue; }
     if (a === '--report-file')           { opts.reportFile = argv[++i]; continue; }
+    if (flagsWithValue.has(a))           { i++; continue; }
     if (a.startsWith('-')) continue;     // Unknown flag — silently skip (model/permission flags etc.)
     // Anything left is a positional — used by vela subcommand dispatch.
     opts.positionals.push(a);
@@ -49,6 +51,11 @@ function parseArgs(argv) {
     opts.reportFile = process.env.REPORT_FILE;
   }
   return opts;
+}
+
+function failUsage(message) {
+  process.stderr.write(`mock-agent: ${message}\n`);
+  process.exit(2);
 }
 
 async function readStdinIfPiped() {
@@ -67,15 +74,14 @@ async function readStdinIfPiped() {
 async function main() {
   const opts = parseArgs(process.argv.slice(2));
   if (!opts.as) {
-    process.stderr.write(
-      'mock-agent: --as <agent> required\n' +
+    failUsage(
+      '--as <agent> required\n' +
       '  supported: opencode | claude | amp | codex | gemini | cursor-agent |\n' +
       '             deepseek | qwen | grok | plain |\n' +
       '             kimi                                         (stream-json)\n' +
       '             devin | hermes | kilo | kiro | vibe          (ACP)\n' +
       '             vela                                          (AMR — vela CLI)\n',
     );
-    process.exit(2);
   }
 
   // `vela` dispatches by the first positional arg passed by OD (login /
@@ -87,6 +93,12 @@ async function main() {
     if (cmd === 'models') return runVelaModels();
     // Default: `agent run --runtime opencode` — fall through to the ACP
     // server below with the vela-flavored protocol.
+  }
+
+  // Modern Kimi rejects the old `kimi acp ...` launch shape; keep the
+  // shared mock aligned so adapter regressions fail fast in tests.
+  if (opts.as === 'kimi' && opts.positionals.length > 0) {
+    failUsage(`too many arguments: ${opts.positionals.join(' ')}`);
   }
 
   // ACP agents read JSON-RPC messages off stdin one line at a time, so the
@@ -141,8 +153,7 @@ async function main() {
     // (agentCapabilities + models block + strict set_model gate).
     case 'vela':         await runVelaAcpServer(events, renderOpts);    break;
     default:
-      process.stderr.write(`mock-agent: unknown agent "${opts.as}"\n`);
-      process.exit(2);
+      failUsage(`unknown agent "${opts.as}"`);
   }
 }
 

--- a/mocks/scripts/smoke-test.sh
+++ b/mocks/scripts/smoke-test.sh
@@ -154,6 +154,16 @@ else
   fail "kimi prompt-mode stream-json smoke failed"
 fi
 
+kimi_legacy_err="$amr_sandbox/kimi-legacy.err"
+if kimi acp -p "Reply with only: ok" --output-format stream-json \
+  > /dev/null 2> "$kimi_legacy_err"; then
+  fail "kimi legacy positional launch unexpectedly succeeded"
+elif grep -q 'too many arguments' "$kimi_legacy_err"; then
+  pass "kimi legacy positional launch fails with too many arguments"
+else
+  fail "kimi legacy positional launch failed without too many arguments"
+fi
+
 # ACP agents — JSON-RPC server. Send initialize+session/new+prompt and
 # verify the protocol responses come back in order.
 # kiro-cli and vibe-acp are the primary OD-facing bin names; test them

--- a/mocks/scripts/smoke-test.sh
+++ b/mocks/scripts/smoke-test.sh
@@ -144,11 +144,21 @@ else
   fail "vela strict set_model gate did not reject (negative-path regression)"
 fi
 
+# Kimi — prompt-mode stream-json. Newer Kimi CLIs reject an `acp`
+# positional arg, so keep this smoke check on the real prompt-mode
+# launch shape OD uses in Settings and chat.
+kimi_out=$(kimi -p "Reply with only: ok" --output-format stream-json 2>/dev/null || true)
+if printf '%s' "$kimi_out" | grep -q '"role":"assistant"'; then
+  pass "kimi prompt-mode stream-json smoke passed"
+else
+  fail "kimi prompt-mode stream-json smoke failed"
+fi
+
 # ACP agents — JSON-RPC server. Send initialize+session/new+prompt and
 # verify the protocol responses come back in order.
 # kiro-cli and vibe-acp are the primary OD-facing bin names; test them
 # alongside the fallback names (kiro, vibe).
-for agent in hermes kimi kilo kiro kiro-cli vibe vibe-acp devin; do
+for agent in hermes kilo kiro kiro-cli vibe vibe-acp devin; do
   out=$(cat <<EOF | "$agent" 2>/dev/null
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/tmp"}}


### PR DESCRIPTION
Closes #3860

## Why

Current Kimi CLI releases reject the legacy `kimi acp` launch shape with `too many arguments`, which is exactly the failure users hit from Settings > Local CLI > Test.

The runtime adapter in this branch history already launches Kimi in prompt mode, but the regression surface was still weak: there was no connection-test spec proving Settings uses the modern argv shape, no detection spec proving newer Kimi builds stay available, and the shared mock harness still modeled `kimi` as an ACP agent. This PR closes that gap so the newer Kimi contract stays covered.

## What users will see

Kimi CLI stays compatible with the Settings Local CLI test flow for current zero-positional-arg releases, and the repo's test/mocking surfaces now exercise that same launch contract instead of the stale ACP one.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

None.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/connection-test.test.ts`
  - `apps/daemon/tests/runtimes/env-and-detection.test.ts`
  - `mocks/scripts/smoke-test.sh`
- Did the test go red on `main` and green on this branch? no
- Why not: the Kimi runtime adapter on this branch lineage already uses prompt mode; this PR adds the missing regression coverage and updates the shared mocks that still treated `kimi` as ACP.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts tests/runtimes/env-and-detection.test.ts tests/runtimes/agent-args.test.ts tests/json-event-stream.test.ts`
- `bash mocks/scripts/smoke-test.sh`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>