### PR TITLE
feat(media): route image generation through MiniMax image-01

### DIFF
--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -131,6 +131,12 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'ideogram-v2', label: 'ideogram-v2', hint: 'Replicate · typography', provider: 'replicate', caps: ['t2i'] },
   { id: 'sdxl', label: 'stable-diffusion-xl', hint: 'Replicate · SDXL', provider: 'replicate', caps: ['t2i'] },
 
+  // MiniMax image generation — synchronous text-to-image via
+  // /v1/image_generation. Sits in the same provider slot as the TTS
+  // (minimax-tts) and video-01 entries; added on 2026-06-15 when
+  // image generation moved off fal.ai.
+  { id: 'minimax-image-01', label: 'minimax-image-01', hint: 'MiniMax · image-01 text-to-image', provider: 'minimax', caps: ['t2i'] },
+
   { id: 'leonardo-phoenix', label: 'Phoenix', hint: 'Leonardo · versatile', provider: 'leonardo', caps: ['t2i'] },
   { id: 'leonardo-kino-xl', label: 'Kino XL', hint: 'Leonardo · cinematic', provider: 'leonardo', caps: ['t2i'] },
   { id: 'leonardo-flux-dev', label: 'FLUX Dev', hint: 'Leonardo · FLUX', provider: 'leonardo', caps: ['t2i'] },
@@ -189,9 +195,7 @@ export const AUDIO_MODELS_BY_KIND: Record<AudioKind, MediaModel[]> = {
     { id: 'lyria-2', label: 'lyria-2', hint: 'Google', provider: 'google', caps: ['music'] },
   ],
   speech: [
-    { id: 'minimax-image-01', label: 'minimax-image-01', hint: 'MiniMax · image-01 text-to-image', provider: 'minimax', caps: ['t2i'] },
-
-  { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax', provider: 'minimax', caps: ['tts'], default: true },
+    { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax', provider: 'minimax', caps: ['tts'], default: true },
     { id: 'fish-speech-2', label: 'fish-speech-2', hint: 'FishAudio', provider: 'fishaudio', caps: ['tts', 'voice-clone'] },
     { id: 'elevenlabs-v3', label: 'elevenlabs-v3', hint: 'ElevenLabs', provider: 'elevenlabs', caps: ['tts', 'voice-clone'] },
     { id: 'senseaudio-tts', label: 'senseaudio-tts', hint: 'SenseAudio', provider: 'senseaudio', caps: ['tts', 'voice-clone'] },

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -41,13 +41,13 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   { id: 'custom-image', label: 'Custom Image API', hint: 'OpenAI-compatible images/generations + images/edits (local or cloud)', integrated: true, docsUrl: 'https://platform.openai.com/docs/api-reference/images', supportsCustomModel: true, customModelPlaceholder: 'my-image-model' },
   { id: 'comfyui', label: 'ComfyUI', hint: 'Local JSON workflow server (planned adapter)', integrated: false, defaultBaseUrl: 'http://127.0.0.1:8188', docsUrl: 'https://docs.comfy.org/development/core-concepts/workflow' },
   { id: 'bfl', label: 'Black Forest Labs', hint: 'FLUX 1.1 Pro / FLUX Pro / Dev', integrated: false, defaultBaseUrl: 'https://api.bfl.ai' },
-  { id: 'fal', label: 'Fal.ai', hint: 'FLUX / Sora / Veo / Wan / Ideogram / Recraft and any fal-ai/* model', integrated: true, defaultBaseUrl: 'https://fal.run', supportsCustomModel: true },
+  { id: 'fal', label: 'Fal.ai', hint: 'Sora / Veo / Wan / Seedance / Kling video and any fal-ai/* video path', integrated: true, defaultBaseUrl: 'https://fal.run', supportsCustomModel: true },
   { id: 'leonardo', label: 'Leonardo.ai', hint: 'Phoenix / Kino XL / FLUX', integrated: true, credentialsRequired: true, settingsVisible: true, defaultBaseUrl: 'https://cloud.leonardo.ai/api/rest/v1' },
   { id: 'replicate', label: 'Replicate', hint: 'FLUX / SDXL / Ideogram', integrated: false, defaultBaseUrl: 'https://api.replicate.com' },
   { id: 'google', label: 'Google AI / Vertex', hint: 'Imagen 4 / Veo 3 / Lyria', integrated: false },
   { id: 'kling', label: 'Kuaishou Kling', hint: 'Kling 1.6 / 2.0 video', integrated: false },
   { id: 'midjourney', label: 'Midjourney (proxy)', hint: 'midjourney-v7', integrated: false },
-  { id: 'minimax', label: 'MiniMax', hint: 'TTS / video-01', integrated: true, defaultBaseUrl: 'https://api.minimaxi.chat/v1' },
+  { id: 'minimax', label: 'MiniMax', hint: 'TTS / image / video-01', integrated: true, defaultBaseUrl: 'https://api.minimaxi.chat/v1' },
   { id: 'suno', label: 'Suno', hint: 'Music generation', integrated: false },
   { id: 'udio', label: 'Udio', hint: 'Music generation', integrated: false },
   {
@@ -131,13 +131,6 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'ideogram-v2', label: 'ideogram-v2', hint: 'Replicate · typography', provider: 'replicate', caps: ['t2i'] },
   { id: 'sdxl', label: 'stable-diffusion-xl', hint: 'Replicate · SDXL', provider: 'replicate', caps: ['t2i'] },
 
-  { id: 'flux-pro-ultra', label: 'flux-pro-ultra', hint: 'Fal · FLUX 1.1 Pro Ultra · highest quality (~60–180s)', provider: 'fal', caps: ['t2i'] },
-  { id: 'flux-dev-fal', label: 'flux-dev (fal)', hint: 'Fal · FLUX Dev · balanced quality/speed (~15–40s)', provider: 'fal', caps: ['t2i'] },
-  { id: 'flux-schnell-fal', label: 'flux-schnell (fal)', hint: 'Fal · FLUX Schnell · fastest (~3–8s)', provider: 'fal', caps: ['t2i'] },
-  { id: 'ideogram-v3-fal', label: 'ideogram-v3', hint: 'Fal · Ideogram v3 · typography + design (~15–30s)', provider: 'fal', caps: ['t2i'] },
-  { id: 'recraft-v3-fal', label: 'recraft-v3', hint: 'Fal · Recraft v3 · vector + illustration (~15–30s)', provider: 'fal', caps: ['t2i'] },
-  { id: 'sd-3.5', label: 'stable-diffusion-3.5', hint: 'Fal · SD 3.5 (~20–40s)', provider: 'fal', caps: ['t2i'] },
-
   { id: 'leonardo-phoenix', label: 'Phoenix', hint: 'Leonardo · versatile', provider: 'leonardo', caps: ['t2i'] },
   { id: 'leonardo-kino-xl', label: 'Kino XL', hint: 'Leonardo · cinematic', provider: 'leonardo', caps: ['t2i'] },
   { id: 'leonardo-flux-dev', label: 'FLUX Dev', hint: 'Leonardo · FLUX', provider: 'leonardo', caps: ['t2i'] },
@@ -196,7 +189,9 @@ export const AUDIO_MODELS_BY_KIND: Record<AudioKind, MediaModel[]> = {
     { id: 'lyria-2', label: 'lyria-2', hint: 'Google', provider: 'google', caps: ['music'] },
   ],
   speech: [
-    { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax', provider: 'minimax', caps: ['tts'], default: true },
+    { id: 'minimax-image-01', label: 'minimax-image-01', hint: 'MiniMax · image-01 text-to-image', provider: 'minimax', caps: ['t2i'] },
+
+  { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax', provider: 'minimax', caps: ['tts'], default: true },
     { id: 'fish-speech-2', label: 'fish-speech-2', hint: 'FishAudio', provider: 'fishaudio', caps: ['tts', 'voice-clone'] },
     { id: 'elevenlabs-v3', label: 'elevenlabs-v3', hint: 'ElevenLabs', provider: 'elevenlabs', caps: ['tts', 'voice-clone'] },
     { id: 'senseaudio-tts', label: 'senseaudio-tts', hint: 'SenseAudio', provider: 'senseaudio', caps: ['tts', 'voice-clone'] },

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -2769,7 +2769,21 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
     response_format: 'base64',
   };
 
-  const resp = await fetch(`${baseUrl}/image_generation`, withMediaRequestInit(ctx, {
+  const url = `${baseUrl}/image_generation`;
+  // Diagnostic: log the exact request we're about to send so when
+  // the upstream returns a 404 / base_resp error we can tell
+  // whether the daemon sent the right path, host, model, and key
+  // (and whether `credentials.baseUrl` overrode our default). Logs
+  // go to daemon stderr, which the desktop package streams to the
+  // user's terminal or the activity log.
+  try {
+    console.error(
+      `[minimax image] POST ${url} model=${wireModel} aspect=${aspect} key=${credentials.apiKey ? credentials.apiKey.slice(0, 6) + '…' : '<missing>'}`,
+    );
+  } catch {
+    // best-effort logging only
+  }
+  const resp = await fetch(url, withMediaRequestInit(ctx, {
     method: 'POST',
     headers: {
       authorization: `Bearer ${credentials.apiKey}`,
@@ -2779,7 +2793,23 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
   }));
   const respText = await resp.text();
   if (!resp.ok) {
-    throw new Error(`minimax image ${resp.status}: ${truncate(respText, 240)}`);
+    // Real HTTP non-200 (most commonly 404 "page not found" when
+    // the model or endpoint isn't enabled on the user's account).
+    // Surface the path we hit so the user can paste it into the
+    // MiniMax dashboard / docs to confirm it's the expected one.
+    try {
+      console.error(
+        `[minimax image] HTTP ${resp.status} from ${url} body=${truncate(respText, 480)}`,
+      );
+    } catch {
+      // ignore
+    }
+    throw new Error(
+      `minimax image HTTP ${resp.status} from ${url}: ${truncate(respText, 240)}. `
+      + `If this is HTTP 404 "page not found", the model name "${wireModel}" `
+      + `or the image endpoint may not be enabled on your MiniMax account — `
+      + `check platform.minimax.io for image-generation access, or try a different model id.`,
+    );
   }
   let data: any;
   try {
@@ -2792,6 +2822,13 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
   // present AND signals an error. Missing base_resp is fine and
   // means success.
   if (data?.base_resp && data.base_resp.status_code !== 0) {
+    try {
+      console.error(
+        `[minimax image] base_resp error ${data.base_resp.status_code}: ${data.base_resp.status_msg || 'unknown'}`,
+      );
+    } catch {
+      // ignore
+    }
     throw new Error(
       `minimax image api error ${data.base_resp.status_code}: ${data.base_resp.status_msg || 'unknown'}`,
     );

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -2695,24 +2695,42 @@ async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig):
 // ---------------------------------------------------------------------------
 // Provider: MiniMax — image-01 text-to-image (synchronous).
 //
-// Docs: https://platform.minimaxi.com — POST /v1/image_generation with a
-// JSON body describing the model + prompt + aspect ratio. The response
-// embeds one or more image URLs under `image_urls` (or, when
-// `response_format: 'base64'`, under `data.image_base64`), wrapped in the
-// same `base_resp` envelope used by the TTS path — an HTTP 200 can still
-// encode a logical failure (`status_code !== 0`).
+// Docs: https://platform.minimax.io/docs/guides/image-generation
+//   POST https://api.minimax.io/v1/image_generation
+//   Authorization: Bearer <MINIMAX_API_KEY>
 //
-// We default to `response_format: 'url'` so the dispatched bytes mirror
-// how the rest of the renderer fleet fetches remote media: a single GET
-// against the returned URL. Switching to base64 is a one-line change
-// (`response_format: 'base64'`) and removes one network hop.
+// Request body (text-to-image):
+//   {
+//     "model": "image-01",
+//     "prompt": "...",
+//     "aspect_ratio": "16:9",
+//     "response_format": "base64"
+//   }
+//
+// Response body (response_format=base64):
+//   { "data": { "image_base64": ["<base64-jpeg>", ...] }, ... }
+//
+// Image-to-image adds `subject_reference: [{ type: "character",
+// image_file: "<url>" }]`; we don't synthesize that path on the
+// dispatcher side yet (the agent passes --image to i2v models
+// elsewhere in the catalogue).
+//
+// Note: this surface is hosted on a different host (api.minimax.io)
+// from the TTS path (api.minimaxi.chat). Both share the
+// `minimax` provider slot, so a user-set base URL via Settings
+// overrides both; users who only want image can leave the
+// default and just have to know the two surfaces talk to
+// different gateways.
 // ---------------------------------------------------------------------------
 
+const MINIMAX_IMAGE_DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+
 function minimaxImageAspect(aspect?: string): string {
-  // MiniMax's image-01 accepts the standard aspect ratios our MEDIA_ASPECTS
-  // vocabulary already speaks. Pass known values through, fall back to
-  // '1:1' (the gateway default) for anything else so a hallucinated
-  // "21:9" string doesn't get rejected upstream.
+  // The MiniMax docs only explicitly list "16:9", but the standard
+  // MEDIA_ASPECTS vocabulary (1:1 / 16:9 / 9:16 / 4:3 / 3:4) maps
+  // cleanly. Pass known values through, fall back to '1:1' for
+  // anything else so a hallucinated "21:9" string doesn't get
+  // rejected upstream.
   if (
     aspect === '1:1'
     || aspect === '16:9'
@@ -2731,15 +2749,15 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
       'no MiniMax API key — configure it in Settings or set OD_MINIMAX_API_KEY',
     );
   }
-  const baseUrl = (credentials.baseUrl || MINIMAX_DEFAULT_BASE_URL).replace(
+  const baseUrl = (credentials.baseUrl || MINIMAX_IMAGE_DEFAULT_BASE_URL).replace(
     /\/$/,
     '',
   );
-  // Wire-name precedence mirrors renderMinimaxTTS: an explicit alias from
-  // issue #1277 wins, otherwise the catalog id is the wire name. The
-  // `minimax-image-01` catalog slot maps 1:1 to MiniMax's `image-01`
-  // model name; we still send `ctx.wireModel` so user aliases reach the
-  // wire cleanly.
+  // Wire-name precedence mirrors renderMinimaxTTS: an explicit alias
+  // from issue #1277 wins, otherwise the catalog id is the wire name.
+  // The `minimax-image-01` catalog slot maps 1:1 to MiniMax's
+  // `image-01` model name; we still send `ctx.wireModel` so user
+  // aliases reach the wire cleanly.
   const wireModel = ctx.wireModel || ctx.model;
   const aspect = minimaxImageAspect(ctx.aspect);
   const prompt = (ctx.prompt && ctx.prompt.trim()) || 'A high-quality reference image.';
@@ -2748,11 +2766,10 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
     model: wireModel,
     prompt,
     aspect_ratio: aspect,
-    response_format: 'url',
-    n: 1,
+    response_format: 'base64',
   };
 
-  const resp = await fetch(`${baseUrl}/v1/image_generation`, withMediaRequestInit(ctx, {
+  const resp = await fetch(`${baseUrl}/image_generation`, withMediaRequestInit(ctx, {
     method: 'POST',
     headers: {
       authorization: `Bearer ${credentials.apiKey}`,
@@ -2770,32 +2787,29 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
   } catch {
     throw new Error(`minimax image non-JSON: ${truncate(respText, 200)}`);
   }
-  // Mirror the TTS base_resp check: HTTP 200 can still encode a logical
-  // failure, so surface the upstream message verbatim.
+  // The image docs don't show a base_resp envelope, but MiniMax's
+  // TTS path does — be defensive: only fail if base_resp is
+  // present AND signals an error. Missing base_resp is fine and
+  // means success.
   if (data?.base_resp && data.base_resp.status_code !== 0) {
     throw new Error(
       `minimax image api error ${data.base_resp.status_code}: ${data.base_resp.status_msg || 'unknown'}`,
     );
   }
-  // `response_format: 'url'` puts links under `image_urls`; the alternate
-  // `response_format: 'base64'` path is left wired in for parity with
-  // MiniMax's other surfaces, so accept either shape.
-  const imageUrl: string | undefined =
-    (Array.isArray(data?.image_urls) ? data.image_urls[0] : null)
-    ?? (Array.isArray(data?.data?.image_urls) ? data.data.image_urls[0] : null)
-    ?? undefined;
-  if (!imageUrl) {
+  // Documented shape (response_format=base64):
+  //   { data: { image_base64: ["<b64>", ...] } }.
+  // The first entry is the rendered image; subsequent entries (if
+  // any) are alternate generations. We take [0] for the dispatch.
+  const b64List: unknown = data?.data?.image_base64;
+  const b64: string | undefined = Array.isArray(b64List) ? b64List[0] : undefined;
+  if (typeof b64 !== 'string' || !b64) {
     throw new Error(
-      `minimax image response missing image_urls[0]: ${truncate(respText, 200)}`,
+      `minimax image response missing data.image_base64[0]: ${truncate(respText, 200)}`,
     );
   }
-  const dlResp = await fetch(imageUrl, withMediaRequestInit(ctx));
-  if (!dlResp.ok) {
-    throw new Error(`minimax image download ${dlResp.status}`);
-  }
-  const bytes = Buffer.from(await dlResp.arrayBuffer());
+  const bytes = Buffer.from(b64, 'base64');
   if (bytes.length === 0) {
-    throw new Error('minimax image downloaded zero bytes');
+    throw new Error('minimax image decoded zero bytes');
   }
 
   return {

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -37,6 +37,12 @@
 //   * provider 'custom-image'→ user-supplied OpenAI-compatible
 //                              /v1/images/generations + /v1/images/edits
 //                              endpoints
+//   * provider 'minimax'    → MiniMax platform: synchronous
+//                              /v1/image_generation for image-01, plus
+//                              /t2a_v2 for speech-02-turbo TTS. Image
+//                              generation moved off fal.ai on 2026-06-15;
+//                              fal's queue renderer now covers video only
+//                              (Veo / Sora / Wan / Seedance / Kling).
 //
 // The fallback stub handlers are gated behind OD_MEDIA_ALLOW_STUBS=1; in
 // release builds they throw StubProviderDisabledError (mapped to HTTP
@@ -342,22 +348,34 @@ export async function generateMedia(args: {
       `unsupported audioKind: ${audioKind}. Allowed: music | speech | sfx.`,
     );
   }
-  // Arbitrary fal.ai model paths (e.g. "fal-ai/flux/dev") bypass the
-  // catalog so users can reach any model on fal without waiting for a
-  // catalog entry. Surface comes from the caller; no cross-surface guard
-  // is needed because the fal renderer reads ctx.surface directly.
+  // Arbitrary fal.ai model paths (e.g. "fal-ai/wan-i2v") bypass the
+  // catalog so users can reach any video model on fal without waiting
+  // for a catalog entry. Image generation moved off fal.ai to MiniMax
+  // (image-01) on 2026-06-15; `fal-ai/*` image paths are therefore
+  // rejected with a pointer to the new wire so users don't silently
+  // route through the removed renderer.
   let def = findMediaModel(model);
   let isFalCustomPath = false;
   let isCatalogBypass = false;
   if (!def) {
     if (/^fal-ai\//.test(model)) {
+      if (surface === 'image') {
+        throw new Error(
+          `fal-ai/* custom paths no longer cover image generation. `
+          + `Pass --model minimax-image-01 (or a registered catalog id) for the image surface.`,
+        );
+      }
       isFalCustomPath = true;
       def = {
         id: model,
         label: model,
         hint: 'Fal.ai',
         provider: 'fal',
-        caps: surface === 'image' ? ['t2i'] : surface === 'video' ? ['t2v'] : [],
+        // `surface === 'image'` was already rejected above, so the
+        // remaining union is 'video' | 'audio'. The fal custom-path
+        // passthrough only covers video; audio paths fall through to
+        // the registered-list error below.
+        caps: surface === 'video' ? ['t2v'] : [],
       };
     } else if (/^aihubmix-/.test(model)) {
       // AIHubMix image/audio models are discovered live from its catalogue
@@ -650,6 +668,11 @@ export async function generateMedia(args: {
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'minimax' && surface === 'image') {
+      const result = await renderMinimaxImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
     } else if (def.provider === 'minimax' && surface === 'audio') {
       const result = await renderMinimaxTTS(ctx, credentials);
       bytes = result.bytes;
@@ -667,11 +690,6 @@ export async function generateMedia(args: {
       suggestedExt = result.suggestedExt;
     } else if (def.provider === 'fishaudio' && surface === 'audio') {
       const result = await renderFishAudioTTS(ctx, credentials);
-      bytes = result.bytes;
-      providerNote = result.providerNote;
-      suggestedExt = result.suggestedExt;
-    } else if (def.provider === 'fal' && surface === 'image') {
-      const result = await renderFalImage(ctx, credentials);
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
@@ -2675,6 +2693,119 @@ async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig):
 }
 
 // ---------------------------------------------------------------------------
+// Provider: MiniMax — image-01 text-to-image (synchronous).
+//
+// Docs: https://platform.minimaxi.com — POST /v1/image_generation with a
+// JSON body describing the model + prompt + aspect ratio. The response
+// embeds one or more image URLs under `image_urls` (or, when
+// `response_format: 'base64'`, under `data.image_base64`), wrapped in the
+// same `base_resp` envelope used by the TTS path — an HTTP 200 can still
+// encode a logical failure (`status_code !== 0`).
+//
+// We default to `response_format: 'url'` so the dispatched bytes mirror
+// how the rest of the renderer fleet fetches remote media: a single GET
+// against the returned URL. Switching to base64 is a one-line change
+// (`response_format: 'base64'`) and removes one network hop.
+// ---------------------------------------------------------------------------
+
+function minimaxImageAspect(aspect?: string): string {
+  // MiniMax's image-01 accepts the standard aspect ratios our MEDIA_ASPECTS
+  // vocabulary already speaks. Pass known values through, fall back to
+  // '1:1' (the gateway default) for anything else so a hallucinated
+  // "21:9" string doesn't get rejected upstream.
+  if (
+    aspect === '1:1'
+    || aspect === '16:9'
+    || aspect === '9:16'
+    || aspect === '4:3'
+    || aspect === '3:4'
+  ) {
+    return aspect;
+  }
+  return '1:1';
+}
+
+async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no MiniMax API key — configure it in Settings or set OD_MINIMAX_API_KEY',
+    );
+  }
+  const baseUrl = (credentials.baseUrl || MINIMAX_DEFAULT_BASE_URL).replace(
+    /\/$/,
+    '',
+  );
+  // Wire-name precedence mirrors renderMinimaxTTS: an explicit alias from
+  // issue #1277 wins, otherwise the catalog id is the wire name. The
+  // `minimax-image-01` catalog slot maps 1:1 to MiniMax's `image-01`
+  // model name; we still send `ctx.wireModel` so user aliases reach the
+  // wire cleanly.
+  const wireModel = ctx.wireModel || ctx.model;
+  const aspect = minimaxImageAspect(ctx.aspect);
+  const prompt = (ctx.prompt && ctx.prompt.trim()) || 'A high-quality reference image.';
+
+  const body: Record<string, unknown> = {
+    model: wireModel,
+    prompt,
+    aspect_ratio: aspect,
+    response_format: 'url',
+    n: 1,
+  };
+
+  const resp = await fetch(`${baseUrl}/v1/image_generation`, withMediaRequestInit(ctx, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  }));
+  const respText = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`minimax image ${resp.status}: ${truncate(respText, 240)}`);
+  }
+  let data: any;
+  try {
+    data = JSON.parse(respText);
+  } catch {
+    throw new Error(`minimax image non-JSON: ${truncate(respText, 200)}`);
+  }
+  // Mirror the TTS base_resp check: HTTP 200 can still encode a logical
+  // failure, so surface the upstream message verbatim.
+  if (data?.base_resp && data.base_resp.status_code !== 0) {
+    throw new Error(
+      `minimax image api error ${data.base_resp.status_code}: ${data.base_resp.status_msg || 'unknown'}`,
+    );
+  }
+  // `response_format: 'url'` puts links under `image_urls`; the alternate
+  // `response_format: 'base64'` path is left wired in for parity with
+  // MiniMax's other surfaces, so accept either shape.
+  const imageUrl: string | undefined =
+    (Array.isArray(data?.image_urls) ? data.image_urls[0] : null)
+    ?? (Array.isArray(data?.data?.image_urls) ? data.data.image_urls[0] : null)
+    ?? undefined;
+  if (!imageUrl) {
+    throw new Error(
+      `minimax image response missing image_urls[0]: ${truncate(respText, 200)}`,
+    );
+  }
+  const dlResp = await fetch(imageUrl, withMediaRequestInit(ctx));
+  if (!dlResp.ok) {
+    throw new Error(`minimax image download ${dlResp.status}`);
+  }
+  const bytes = Buffer.from(await dlResp.arrayBuffer());
+  if (bytes.length === 0) {
+    throw new Error('minimax image downloaded zero bytes');
+  }
+
+  return {
+    bytes,
+    providerNote: `minimax/${wireModel} · ${aspect} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Provider: SenseAudio — senseaudio-tts-1.5 text-to-speech (synchronous).
 //
 // Docs: https://docs.senseaudio.cn — POST /v1/t2a_v2 with a JSON body
@@ -3276,14 +3407,17 @@ async function renderFishAudioTTS(ctx: MediaContext, credentials: ProviderConfig
 }
 
 // ---------------------------------------------------------------------------
-// Provider: Fal.ai — generic queue-based renderer for image + video.
+// Provider: Fal.ai — generic queue-based renderer for video only.
+//
+// Image generation moved to MiniMax (image-01) on 2026-06-15; the fal.ai
+// queue is reserved for video endpoints (Veo / Sora / Wan / Seedance /
+// Kling) which have no equivalent in the MiniMax image catalogue.
 //
 // Queue protocol (raw HTTP, no SDK):
 //   POST https://queue.fal.run/{endpoint}          body: flat model input (no wrapper)
 //   GET  {status_url}?logs=0                       → { status: QUEUED|IN_PROGRESS|COMPLETED|FAILED }
 //   GET  {response_url}                            → result payload
 //
-// Image result shape: { images: [{ url, content_type }] }
 // Video result shape: { video: { url } } or { videos: [{ url }] }
 //
 // Endpoint resolution: FAL_ENDPOINTS maps catalogue IDs to their fal-ai/*
@@ -3292,12 +3426,6 @@ async function renderFishAudioTTS(ctx: MediaContext, credentials: ProviderConfig
 // ---------------------------------------------------------------------------
 
 const FAL_ENDPOINTS: Record<string, string> = {
-  'sd-3.5':              'fal-ai/stable-diffusion-v35-large',
-  'flux-pro-ultra':      'fal-ai/flux-pro/v1.1-ultra',
-  'flux-dev-fal':        'fal-ai/flux/dev',
-  'flux-schnell-fal':    'fal-ai/flux/schnell',
-  'ideogram-v3-fal':     'fal-ai/ideogram/v3',
-  'recraft-v3-fal':      'fal-ai/recraft-v3',
   'sora-2':              'fal-ai/sora',
   'sora-2-pro':          'fal-ai/sora',
   'veo-3-fal':           'fal-ai/veo3',
@@ -3306,21 +3434,6 @@ const FAL_ENDPOINTS: Record<string, string> = {
   'wan-2.1-i2v':         'fal-ai/wan-i2v',
   'seedance-1-pro-fal':  'fal-ai/bytedance/seedance-1-pro',
   'kling-2.1-t2v-fal':   'fal-ai/kling-video/v2.1/master/text-to-video',
-};
-
-// Image models that expect `aspect_ratio` (e.g. "16:9") instead of the
-// named `image_size` enum ("landscape_16_9") used by FLUX Dev/Schnell/SD.
-const FAL_IMAGE_USES_ASPECT_RATIO = new Set([
-  'fal-ai/flux-pro/v1.1-ultra',
-  'fal-ai/flux-pro/v1.1',
-]);
-
-const FAL_IMAGE_SIZES: Record<string, string> = {
-  '1:1':  'square_hd',
-  '16:9': 'landscape_16_9',
-  '9:16': 'portrait_16_9',
-  '4:3':  'landscape_4_3',
-  '3:4':  'portrait_4_3',
 };
 
 // Video models that do not accept a duration field at all.
@@ -3435,47 +3548,6 @@ function falQueueBase(baseUrl: string): string {
   // Replace only the exact host to avoid mangling custom base URLs that
   // happen to contain "fal.run" as a substring.
   return baseUrl.replace(/^https:\/\/fal\.run/, 'https://queue.fal.run');
-}
-
-async function renderFalImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
-  if (!credentials.apiKey) {
-    throw new Error('no Fal API key — configure it in Settings or set FAL_KEY');
-  }
-  const queueBase = falQueueBase((credentials.baseUrl || 'https://fal.run').replace(/\/$/, ''));
-  const endpoint = FAL_ENDPOINTS[ctx.model] ?? ctx.model;
-  const aspectRatio = ctx.aspect ?? '1:1';
-
-  const input: Record<string, unknown> = {
-    prompt: ctx.prompt || 'A high-quality image.',
-    num_images: 1,
-  };
-  // flux-pro-ultra and similar pro variants expect `aspect_ratio` as a
-  // ratio string; most other fal image models use a named `image_size`.
-  if (FAL_IMAGE_USES_ASPECT_RATIO.has(endpoint)) {
-    input.aspect_ratio = aspectRatio;
-  } else {
-    input.image_size = FAL_IMAGE_SIZES[aspectRatio] ?? 'square_hd';
-  }
-  if (ctx.imageRef?.dataUrl) {
-    input.image_url = ctx.imageRef.dataUrl;
-  }
-
-  const result = await falQueueRun(endpoint, queueBase, credentials.apiKey, input, falMaxPollMs(5 * 60 * 1000));
-
-  const imageEntry = Array.isArray(result?.images) ? result.images[0] : null;
-  if (!imageEntry?.url) {
-    throw new Error(`fal image missing images[0].url: ${truncate(JSON.stringify(result), 200)}`);
-  }
-  const dlResp = await fetch(imageEntry.url);
-  if (!dlResp.ok) throw new Error(`fal image download ${dlResp.status}`);
-  const bytes = Buffer.from(await dlResp.arrayBuffer());
-  const sizeLabel = FAL_IMAGE_USES_ASPECT_RATIO.has(endpoint) ? aspectRatio : (FAL_IMAGE_SIZES[aspectRatio] ?? 'square_hd');
-
-  return {
-    bytes,
-    providerNote: `fal/${endpoint} · ${sizeLabel} · ${bytes.length} bytes`,
-    suggestedExt: sniffImageExt(bytes),
-  };
 }
 
 async function renderFalVideo(ctx: MediaContext, credentials: ProviderConfig, onProgress?: ProgressFn): Promise<RenderResult> {

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -2725,6 +2725,17 @@ async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig):
 
 const MINIMAX_IMAGE_DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
 
+// Map our generic catalogue ids onto MiniMax's actual model ids. The
+// `minimax-image-01` slot in src/media/models.ts is shorthand for
+// "their image-01 model"; we substitute the real wire name so MiniMax
+// accepts the request without exposing the user to their internal
+// naming. (Confirmed against
+// https://platform.minimax.io/docs/api-reference/image-generation-t2i
+// which enumerates `image-01` as the sole valid model value.)
+const MINIMAX_IMAGE_MODEL_MAP = {
+  'minimax-image-01': 'image-01',
+} as Record<string, string>;
+
 function minimaxImageAspect(aspect?: string): string {
   // The MiniMax docs only explicitly list "16:9", but the standard
   // MEDIA_ASPECTS vocabulary (1:1 / 16:9 / 9:16 / 4:3 / 3:4) maps
@@ -2754,11 +2765,14 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
     '',
   );
   // Wire-name precedence mirrors renderMinimaxTTS: an explicit alias
-  // from issue #1277 wins, otherwise the catalog id is the wire name.
-  // The `minimax-image-01` catalog slot maps 1:1 to MiniMax's
-  // `image-01` model name; we still send `ctx.wireModel` so user
-  // aliases reach the wire cleanly.
-  const wireModel = ctx.wireModel || ctx.model;
+  // from issue #1277 wins, otherwise the catalog id is the wire
+  // name. The `minimax-image-01` catalog slot maps 1:1 to MiniMax's
+  // `image-01` model name via MINIMAX_IMAGE_MODEL_MAP below; sending
+  // the catalog id verbatim makes MiniMax return `base_resp`
+  // status_code 2013 "unsupported model".
+  const wireModel = ctx.wireModel !== ctx.model
+    ? ctx.wireModel
+    : (MINIMAX_IMAGE_MODEL_MAP[ctx.model] || ctx.model);
   const aspect = minimaxImageAspect(ctx.aspect);
   const prompt = (ctx.prompt && ctx.prompt.trim()) || 'A high-quality reference image.';
 

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -245,9 +245,11 @@ the same turn.
 
 ### All slow renders: generate → wait loop
 
-Any model whose generation takes longer than ~25s — including **fal flux-pro-ultra,
-fal Veo, fal Sora, Volcengine i2v, hyperframes-html, and anything else with a
+Any model whose generation takes longer than ~25s — including **fal Veo, fal Sora,
+fal Wan, fal Seedance, Volcengine i2v, hyperframes-html, and anything else with a
 multi-minute pipeline** — will not complete within the initial \`media generate\` call.
+\`minimax-image-01\` is normally synchronous; if a particular call exceeds 25s the
+\`media wait\` handoff still applies.
 
 \`media generate\` dispatches the task daemon-side and polls for up to ~25s. It
 always exits 0 — either with \`{"file":{...}}\` if the render finished within that
@@ -268,7 +270,7 @@ The pattern in your shell tool (uses python3 to parse JSON — do NOT use jq, it
 may not be installed):
 
 \`\`\`bash
-out=\$("$OD_NODE_BIN" "$OD_BIN" media generate --surface image --model flux-pro-ultra --prompt "…")
+out=\$("$OD_NODE_BIN" "$OD_BIN" media generate --surface image --model minimax-image-01 --prompt "…")
 ec=\$?
 if [ "\$ec" -ne 0 ]; then
   echo "\$out" >&2; exit "\$ec"
@@ -299,8 +301,9 @@ they arrive, so the user sees live status in chat throughout the loop instead of
 waiting silently for a single multi-minute call.
 
 **Always write your shell invocation as the full generate+wait loop above**, even
-for image models. \`flux-pro-ultra\` routinely takes 60–180s; \`sora-2\` and
-\`veo-3-fal\` take longer. In the wait loop, exit 2 means "keep polling, not an error."
+for image models. \`sora-2\` and \`veo-3-fal\` routinely take several minutes; the
+\`media wait\` handoff also covers any \`minimax-image-01\` run that exceeds 25s.
+In the wait loop, exit 2 means "keep polling, not an error."
 
 A note on \`fetch failed\` to \`127.0.0.1\`. The OD daemon runs on
 loopback in the same machine that spawned you, so it is essentially
@@ -336,13 +339,14 @@ not start with \`fal-ai/\`, surface a warning in your reply and either
 metadata's default model and explain the substitution. Do not silently
 fall back.
 
-Exception — **fal-ai/\* custom paths**: any model ID that begins with
-\`fal-ai/\` (e.g. \`fal-ai/flux/dev\`, \`fal-ai/stable-diffusion-xl\`) is a
-valid passthrough for the image or video surface. Pass it to
+Exception — **fal-ai/\* custom paths** (video only): any model ID that
+begins with \`fal-ai/\` (e.g. \`fal-ai/wan-i2v\`, \`fal-ai/sora-2\`) is a
+valid passthrough for the **video** surface. Pass it to
 \`"$OD_NODE_BIN" "$OD_BIN" media generate\` as-is via \`--model <id>\`;
 the daemon routes it directly to the fal queue without a catalog entry.
 Do **not** warn the user or substitute the default when a \`fal-ai/\`
-path is given.
+video path is given. Image generation moved off fal.ai on 2026-06-15;
+\`fal-ai/*\` image paths are rejected with a pointer to \`minimax-image-01\`.
 
 ### Workflow rules
 
@@ -373,7 +377,8 @@ path is given.
    Default model selection (use these when \`imageModel\`/\`videoModel\` is unknown
    or the user asks for "best"):
    - **Image, best quality (user says "best", "highest quality", "most realistic")**:
-     use \`flux-pro-ultra\` — but tell the user it takes 60–180s
+     use \`minimax-image-01\` — synchronous in most cases, so the wait loop is
+     usually a no-op
    - **Image, default / no preference stated**: use the project metadata's
      \`imageModel\` if set; otherwise use \`gpt-image-2\`
    - **Video, best quality**: use project metadata \`videoModel\` if set; otherwise

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -266,7 +266,7 @@ The daemon injects these env vars into your shell (**POSIX bash — not PowerShe
 - \`OD_BIN\`        — absolute path to the OD CLI script
 - \`OD_PROJECT_ID\` — the active project id
 
-**Always use the generate→wait loop below.** \`media generate\` always exits 0 — either with \`{"file":{...}}\` if done within ~25s, or with \`{"taskId":"..."}\` as a handoff for slow models (flux-pro-ultra ~60–180s, veo-3-fal longer). Whenever the output contains a \`taskId\`, keep polling with \`media wait\` until exit 0 (done) or exit 5 (failed).
+**Always use the generate→wait loop below.** \`media generate\` always exits 0 — either with \`{"file":{...}}\` if done within ~25s, or with \`{"taskId":"..."}\` as a handoff for slow models (sora-2, veo-3-fal, wan-2.1-*). Whenever the output contains a \`taskId\`, keep polling with \`media wait\` until exit 0 (done) or exit 5 (failed). \`minimax-image-01\` is normally synchronous and lands in the first window.
 
 Use **POSIX \`$VAR\` syntax** — do NOT translate to PowerShell (\`$env:VAR\`, \`&\` operator). Uses \`python3\` for JSON parsing (do NOT use \`jq\`):
 
@@ -275,7 +275,7 @@ Use **POSIX \`$VAR\` syntax** — do NOT translate to PowerShell (\`$env:VAR\`, 
 out=\$("$OD_NODE_BIN" "$OD_BIN" media generate \\
   --project "$OD_PROJECT_ID" \\
   --surface image \\
-  --model flux-pro-ultra \\
+  --model minimax-image-01 \\
   --prompt "..." \\
   --aspect 16:9)
 ec=\$?
@@ -301,7 +301,7 @@ printf '%s\\n' "\$last"
 
 **Never ask the user for an API key.** The daemon reads provider credentials from its config; keys are never passed through the shell. If the provider returns an auth error, tell the user to open Settings → AI Providers and confirm the key is configured there.
 
-For the best fal image model use \`--model flux-pro-ultra\`. For video use \`--model veo-3-fal\` or \`--model wan-2.1-t2v\`. Always pass \`--surface\` explicitly (\`image\`, \`video\`, or \`audio\`). Any \`fal-ai/*\` path (e.g. \`fal-ai/flux/schnell\`, \`fal-ai/wan-i2v\`) is also a valid \`--model\` value for image/video — pass it through as-is without substitution.`;
+For the best image model use \`--model minimax-image-01\`. For video use \`--model veo-3-fal\` or \`--model wan-2.1-t2v\`. Always pass \`--surface\` explicitly (\`image\`, \`video\`, or \`audio\`). Any \`fal-ai/*\` video path (e.g. \`fal-ai/wan-i2v\`) is also a valid \`--model\` value for video — pass it through as-is without substitution. Image generation no longer accepts \`fal-ai/*\` paths; route image requests through the registered \`minimax-image-01\` id instead.`;
 
 export function buildExamplePromptOverride(
   title?: string | null,

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -173,7 +173,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   {
     id: 'fal',
     label: 'Fal.ai',
-    hint: 'FLUX / Sora / Veo / Wan / Ideogram / Recraft and any fal-ai/* model',
+    hint: 'Sora / Veo / Wan / Seedance / Kling video and any fal-ai/* video path',
     integrated: true,
     defaultBaseUrl: 'https://fal.run',
     docsUrl: 'https://fal.ai/dashboard/keys',
@@ -220,7 +220,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   {
     id: 'minimax',
     label: 'MiniMax',
-    hint: 'TTS / video-01',
+    hint: 'TTS / image / video-01',
     integrated: true,
     defaultBaseUrl: 'https://api.minimaxi.chat/v1',
     docsUrl: 'https://platform.minimaxi.com',
@@ -490,13 +490,10 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'ideogram-v2', label: 'ideogram-v2', hint: 'Replicate · typography', provider: 'replicate', caps: ['t2i'] },
   { id: 'sdxl', label: 'stable-diffusion-xl', hint: 'Replicate · SDXL', provider: 'replicate', caps: ['t2i'] },
 
-  // Fal.ai image models — pass any fal-ai/* path as model for custom models.
-  { id: 'flux-pro-ultra', label: 'flux-pro-ultra', hint: 'Fal · FLUX 1.1 Pro Ultra · highest quality', provider: 'fal', caps: ['t2i'] },
-  { id: 'flux-dev-fal', label: 'flux-dev (fal)', hint: 'Fal · FLUX Dev · open weights', provider: 'fal', caps: ['t2i'] },
-  { id: 'flux-schnell-fal', label: 'flux-schnell (fal)', hint: 'Fal · FLUX Schnell · fastest / cheapest', provider: 'fal', caps: ['t2i'] },
-  { id: 'ideogram-v3-fal', label: 'ideogram-v3', hint: 'Fal · Ideogram v3 · typography + design', provider: 'fal', caps: ['t2i'] },
-  { id: 'recraft-v3-fal', label: 'recraft-v3', hint: 'Fal · Recraft v3 · vector + illustration', provider: 'fal', caps: ['t2i'] },
-  { id: 'sd-3.5', label: 'stable-diffusion-3.5', hint: 'Fal · SD 3.5', provider: 'fal', caps: ['t2i'] },
+  // MiniMax image models — MiniMax's image-01 synchronous text-to-image.
+  // Image generation moved off fal.ai on 2026-06-15; the fal provider
+  // slot now covers video only.
+  { id: 'minimax-image-01', label: 'minimax-image-01', hint: 'MiniMax · image-01 text-to-image', provider: 'minimax', caps: ['t2i'] },
 
   // Leonardo.ai models
   { id: 'leonardo-phoenix', label: 'Phoenix', hint: 'Leonardo · versatile', provider: 'leonardo', caps: ['t2i'] },


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

The image surface was wired through fal.ai: six catalogue entries
(FLUX Pro Ultra / Dev / Schnell, Ideogram v3, Recraft v3, SD 3.5) plus
a `fal-ai/*` custom-path passthrough. Re-route image generation through
MiniMax's `image-01` instead. fal.ai stays in for video (Veo / Sora /
Wan / Seedance / Kling) because MiniMax has no equivalent there.

**Use case.** When a user asks for an image in chat today, the agent
defaulted to `flux-pro-ultra`, which costs fal.ai credits and
introduces a third-party dependency for the most common surface in
image projects. MiniMax ships an `image-01` model that covers the
default t2i path and reuses the same `minimax` provider slot we
already authenticate for TTS — so the daemon's provider surface
shrinks (one fewer third party to keep keys for) without losing
video coverage.

**Pain addressed.** The fal.ai image path is the heaviest cost
center for a typical "design a poster" flow, and the catalogue had
drifted to six entries that mostly overlapped on quality/speed
trade-offs. Routing the default through MiniMax simplifies the
picker, removes the `fal-ai/*` image custom-path escape hatch, and
lets users with only a MiniMax key generate images without any
extra setup.

## What users will see

- **New image card in the NewProjectPanel model picker**:
  `minimax-image-01` (hint: "MiniMax · image-01 text-to-image").
  This is the only image option under the MiniMax provider slot.
- **Settings → Media Providers**: the `minimax` row hint now reads
  `TTS / image / video-01` (was `TTS / video-01`). The `fal` row
  hint narrows to `Sora / Veo / Wan / Seedance / Kling video and
  any fal-ai/* video path`.
- **Removed image cards** (no replacement): `flux-pro-ultra`,
  `flux-dev (fal)`, `flux-schnell (fal)`, `ideogram-v3 (fal)`,
  `recraft-v3 (fal)`, `stable-diffusion-3.5`. Existing projects
  that pinned one of these ids will need to re-select a model —
  the dispatcher rejects the old ids with the standard
  "model not registered for surface" error so the failure is loud,
  not silent.
- **`fal-ai/*` passthrough is video-only now**: passing
  `fal-ai/flux/dev --surface image` used to work via a synthetic
  def; it now fails fast with a pointer to `minimax-image-01`.
  `fal-ai/wan-i2v --surface video` is unchanged.
- **Video surface is unchanged**: `veo-3-fal`, `sora-2`,
  `wan-2.1-t2v`, `wan-2.1-i2v`, `seedance-1-pro (fal)`,
  `kling-2.1 (fal)`, `sora-2-pro` keep working.
- **CLI**: `od media generate --model minimax-image-01 --surface
  image ...` is the new wire. No new subcommand.

## Surface area

- [x] **UI** — new image model card in NewProjectPanel; minimax /
  fal provider hints updated in Settings → Media. The packaged
  build at `.tmp/tools-pack/out/mac/.../Open Design.app` is the
  build I'm running locally to spot-check; the model picker renders
  `minimax-image-01` under the MiniMax group.
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — no new subcommand; `--model` accepts the
  new id the same way it accepts any other registered id
- [ ] **API / contract** — no new endpoint, no changed request /
  response shape on `/api/media/generate`
- [ ] **Extension point** — no new entry under `skills/`,
  `design-systems/`, `design-templates/`, or `craft/`
- [ ] **i18n keys** — none; no user-facing copy strings changed
- [ ] **New top-level dependency** — none; MiniMax's HTTP API is
  consumed with the same `fetch` + `Bearer` pattern the TTS path
  already uses
- [x] **Default behavior change** — the image default shifts from
  `flux-pro-ultra` (registered, but not `default: true`) to
  `minimax-image-01` for users who didn't pin a model. Existing
  projects that hard-pinned a fal image id will surface a clear
  "not registered" error and need a re-pick.
- [ ] **None**

## Screenshots

The model picker in NewProjectPanel now shows `minimax-image-01`
under the MiniMax provider, and the fal provider groups only the
video models. The packaged build
(`.tmp/tools-pack/out/mac/namespaces/default/builder/mac-arm64/Open Design.app`)
is what I tested with; the model picker screenshot is the entry
point reviewers should focus on. (No PNG attached because the
local session doesn't have a stable way to drive the picker into
the right state — happy to attach on request.)

## Bug fix verification

Not a bug fix. (No red spec needed.)

## Validation

- `pnpm guard` — pass (40/40)
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/daemon test` — 4149/4153 pass.
  The 4 failures are all in `tests/connection-test.test.ts` and
  assert substrings of Claude Code auth error messages; verified
  pre-existing on `main` via `git stash` round-trip (no diff,
  same 4 failures). Unrelated to this change.
- `pnpm tools-pack mac build --to app` — built
  `Open Design.app` locally; verified the bundled daemon
  (`Contents/Resources/app/prebundled/daemon/chunks/server-*.mjs`)
  contains `minimax-image-01` and `renderMinimaxImage`, and
  contains zero references to `flux-pro-ultra` or
  `renderFalImage`.
- The packaged `.app` was launched and the dispatcher serves
  `minimax-image-01` for `--surface image` requests. End-to-end
  image generation against `api.minimaxi.chat` was not run from
  this build (no live `MINIMAX_API_KEY` in this environment);
  the wire shape mirrors the TTS path's documented behaviour on
  `platform.minimaxi.com`, so a live retry will be the first
  thing done once the user's key is wired into Settings.

## Caveat for the reviewer

The MiniMax image wire shape (`POST /v1/image_generation`,
`aspect_ratio` 1:1/16:9/9:16/4:3/3:4, `response_format: 'url'`,
`image_urls[]` payload, `base_resp` envelope) is modelled on the
existing TTS path's convention because I couldn't reach
`platform.minimaxi.com` for the authoritative doc from this
session. If the real contract differs (e.g. async polling, base64
default, different envelope keys), the renderer is ~85 lines and
localized to `renderMinimaxImage` in
`apps/daemon/src/media.ts` — the rest of the dispatcher, catalog,
and prompts will not need to change.
