### PR TITLE
[codex] Fix Langfuse PostHog report closure

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3049,11 +3049,12 @@ export function createFinalizedMessageTelemetryReporter({
     skipReason,
     status,
   }) => {
-    if (!analyticsContext || !design?.analytics?.capture || !runId || !delivery) return;
+    const context = analyticsContext ?? run?.analyticsContext ?? null;
+    if (!context || !design?.analytics?.capture || !runId || !delivery) return;
     const terminalResult = status ? runResultFromStatus(status) : undefined;
     design.analytics.capture({
       eventName: 'langfuse_report_result',
-      context: analyticsContext,
+      context,
       appVersion: appVersionForCapture(),
       properties: {
         page_name: 'chat_panel',
@@ -14795,6 +14796,9 @@ export async function startServer({
     // here so PostHog actually receives the event. Both fire under the
     // same insert_id prefix so any web-side mirror dedupes by $insert_id.
     const analyticsContext = readAnalyticsContext(req);
+    if (analyticsContext) {
+      run.analyticsContext = analyticsContext;
+    }
     design.runs.wait(run).then((status: { status: string }) => {
       reportRunCompletionTelemetryFallback({
         analyticsContext: analyticsContext ?? null,

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -422,6 +422,69 @@ describe('Langfuse message finalization gate', () => {
     );
   });
 
+  it('falls back to the run analytics context when final message headers are missing', async () => {
+    const run = {
+      id: 'run-accepted-headerless-finalize',
+      projectId: 'project-1',
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      agentId: 'codex',
+      model: 'default',
+      status: 'succeeded',
+      createdAt: 1,
+      updatedAt: 2,
+      events: [],
+      analyticsContext: {
+        deviceId: 'device-from-run',
+        sessionId: 'session-from-run',
+        clientType: 'desktop',
+        locale: 'zh-CN',
+        requestId: 'request-from-run',
+      },
+    };
+    const capture = vi.fn();
+    const report = vi.fn(async () => ({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted' as const,
+    }));
+    const reporter = createFinalizedMessageTelemetryReporter({
+      design: {
+        analytics: { capture },
+        getAppVersion: () => '0.7.0',
+        runs: { get: vi.fn(() => run) },
+      },
+      db: 'db',
+      dataDir: '/tmp/od-data',
+      reportedRuns: new Set<string>(),
+      getAppVersion: () => ({ version: '0.7.0', channel: 'beta', packaged: true }),
+      report,
+    });
+
+    reporter(
+      { ...terminalMessage, runId: run.id, endedAt: 1234 },
+      { telemetryFinalized: true },
+      {
+        projectId: 'project-1',
+        conversationId: 'conv-1',
+      },
+    );
+    await Promise.resolve();
+
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventName: 'langfuse_report_result',
+        context: run.analyticsContext,
+        insertId: 'run-accepted-headerless-finalize-langfuse-report-final_message-accepted',
+        properties: expect.objectContaining({
+          run_id: 'run-accepted-headerless-finalize',
+          langfuse_delivery_status: 'accepted',
+          langfuse_report_result: 'accepted',
+          langfuse_report_trigger: 'final_message',
+        }),
+      }),
+    );
+  });
+
   it('captures skipped Langfuse reporting when a finalized message references a missing run', () => {
     const capture = vi.fn();
     const reporter = createFinalizedMessageTelemetryReporter({


### PR DESCRIPTION
## Why

We need reliable Langfuse loss-rate reporting for support/debug workflows. PostHog already records whether a run is expected to produce a Langfuse trace, but the follow-up `langfuse_report_result` event could disappear when the final message persistence path did not carry analytics headers. That made PostHog look like it had a huge unknown Langfuse loss bucket even when direct Langfuse sampling showed the traces existed.

This PR keeps the run-created analytics context on the in-memory run and reuses it when the final message write has no request analytics context, so PostHog receives the final Langfuse `accepted` / `failed` / `skipped` closure event.

## What users will see

No user-facing UI change. Internal observability becomes more accurate: Langfuse trace-loss dashboards can distinguish actual Langfuse failures from missing PostHog closure events.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/telemetry-message-finalization.test.ts`
- Did the test go red on `main` and green on this branch? Not rerun on `main`; the added regression test exercises the headerless final-message path that previously had no fallback analytics context.
- Additional verification: sampled PostHog `langfuse_expected=true` runs against Langfuse by `run_id`; 20/20 sampled traces existed, confirming the observed gap was the PostHog closure event rather than Langfuse ingest.

## Validation

- `pnpm exec vitest run tests/telemetry-message-finalization.test.ts -c vitest.config.ts --reporter verbose --pool forks --maxWorkers=1`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
