### PR TITLE
[codex] Show Codex thinking status

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -682,7 +682,7 @@ function handleCodexEvent(obj: unknown, onEvent: StreamEventHandler, state: Pars
   if (obj.type === 'turn.started') {
     state.codexPreviousEventWasAgentMessage = false;
     state.codexLastAgentMessageEndedWithNewline = false;
-    onEvent({ type: 'status', label: 'running' });
+    onEvent({ type: 'status', label: 'thinking' });
     return true;
   }
 
@@ -780,6 +780,9 @@ function handleCodexEvent(obj: unknown, onEvent: StreamEventHandler, state: Pars
     const usage: Usage = {};
     if (typeof obj.usage.input_tokens === 'number') usage.input_tokens = obj.usage.input_tokens;
     if (typeof obj.usage.output_tokens === 'number') usage.output_tokens = obj.usage.output_tokens;
+    if (typeof obj.usage.reasoning_output_tokens === 'number') {
+      usage.thought_tokens = obj.usage.reasoning_output_tokens;
+    }
     if (typeof obj.usage.cached_input_tokens === 'number') {
       usage.cached_read_tokens = obj.usage.cached_input_tokens;
     }

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -1109,9 +1109,40 @@ test('codex json stream emits status text and usage events', () => {
 
   assert.deepEqual(events, [
     { type: 'status', label: 'initializing' },
-    { type: 'status', label: 'running' },
+    { type: 'status', label: 'thinking' },
     { type: 'text_delta', delta: 'hello' },
     { type: 'usage', usage: { input_tokens: 12, output_tokens: 3, cached_read_tokens: 4 } },
+  ]);
+});
+
+test('codex json stream emits thinking status and reasoning token usage', () => {
+  const { events, handler } = collectEvents('codex');
+
+  handler.feed(
+    JSON.stringify({ type: 'turn.started' }) + '\n' +
+    JSON.stringify({
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 12,
+        cached_input_tokens: 4,
+        output_tokens: 3,
+        reasoning_output_tokens: 8,
+      },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'status', label: 'thinking' },
+    {
+      type: 'usage',
+      usage: {
+        input_tokens: 12,
+        output_tokens: 3,
+        thought_tokens: 8,
+        cached_read_tokens: 4,
+      },
+    },
   ]);
 });
 
@@ -1520,7 +1551,7 @@ test('codex json stream treats reconnect errors as status warnings not fatal (re
 
   assert.deepEqual(events, [
     { type: 'status', label: 'initializing' },
-    { type: 'status', label: 'running' },
+    { type: 'status', label: 'thinking' },
     { type: 'status', label: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' },
     { type: 'text_delta', delta: 'OK' },
     { type: 'usage', usage: { input_tokens: 5, output_tokens: 2, cached_read_tokens: 0 } },
@@ -1543,7 +1574,7 @@ test('codex json stream treats stream disconnect reconnect errors as status warn
 
   assert.deepEqual(events, [
     { type: 'status', label: 'initializing' },
-    { type: 'status', label: 'running' },
+    { type: 'status', label: 'thinking' },
     {
       type: 'status',
       label: 'Reconnecting... 2/5 (stream disconnected before completion: Connection reset by peer (os error 54))',

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -592,6 +592,9 @@ function AssistantMessageImpl({
   // start so switching project tabs or remounting the message cannot restart it.
   const hasContent = blocks.some((b) => b.kind !== "status") || fileOps.length > 0;
   const preparing = streaming && !hasContent;
+  const preparingStatus = preparing && events.some((e) => e.kind === "status" && e.label === "thinking")
+    ? "thinking"
+    : "preparing";
 
   // Index of the trailing text block — the streaming caret rides the end of
   // the last prose block so it tracks the final character as tokens arrive.
@@ -757,6 +760,7 @@ function AssistantMessageImpl({
                   hasUnfinishedTodos: unfinishedTodos.length > 0,
                   hasEmptyResponse,
                   preparing,
+                  preparingStatus,
                   copyMarkdown,
                   onFork: canFork ? onForkFromMessage : undefined,
                   forking,
@@ -773,6 +777,7 @@ function AssistantMessageImpl({
                 hasUnfinishedTodos={unfinishedTodos.length > 0}
                 hasEmptyResponse={hasEmptyResponse}
                 preparing={preparing}
+                preparingStatus={preparingStatus}
                 copyMarkdown={copyMarkdown}
                 onFork={canFork ? onForkFromMessage : undefined}
                 forking={forking}
@@ -955,6 +960,7 @@ interface AssistantFooterProps {
   // Pre-output phase: streaming but nothing rendered yet. The label shimmers
   // "Preparing…"; once content lands it flips to "Working".
   preparing?: boolean;
+  preparingStatus?: "preparing" | "thinking";
   copyMarkdown?: string;
   onFork?: () => void;
   forking?: boolean;
@@ -973,6 +979,7 @@ function AssistantFooter({
   hasUnfinishedTodos,
   hasEmptyResponse,
   preparing = false,
+  preparingStatus = "preparing",
   copyMarkdown,
   onFork,
   forking = false,
@@ -1011,7 +1018,9 @@ function AssistantFooter({
       <span className={`assistant-label${streaming && preparing ? " shimmer-text shimmer-prepare" : ""}`}>
         {streaming
           ? preparing
-            ? t("assistant.statusPreparing")
+            ? preparingStatus === "thinking"
+              ? t("assistant.statusThinking")
+              : t("assistant.statusPreparing")
             : t("assistant.workingLabel")
           : hasEmptyResponse
           ? t("assistant.emptyResponseLabel")


### PR DESCRIPTION
## Why

Codex CLI does not expose live reasoning text through `codex exec --json`, but it does expose turn lifecycle events and reports hidden reasoning token usage at turn completion. While investigating TTFT and first-output behavior, Codex turns looked stuck in the generic pre-output “Preparing...” state even after the model turn had started.

This PR gives users a more accurate progress signal during Codex hidden reasoning without inventing or exposing chain-of-thought text.

## What users will see

When a Codex run has started but no assistant text, tool card, or file output has appeared yet, the assistant footer now shows “Thinking” instead of “Preparing...”. Once text/tools/files arrive, the footer returns to the normal working state.

Codex still does not show a collapsible thinking transcript because the CLI does not stream reasoning text in the observed JSON event stream.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The changed UI is a transient streaming footer state before the first Codex-visible output; local dev was started for manual verification at `http://127.0.0.1:51394`.

## Bug fix verification

- Test path that reproduces the behavior: `apps/daemon/tests/json-event-stream.test.ts`
- Did the test go red on `main` and green on this branch? no; this is an observability/UX improvement rather than a red-spec bug fix.
- Additional verification: locally ran `codex exec --json` and confirmed Codex emits `turn.started`, final `agent_message`, and `turn.completed.usage.reasoning_output_tokens`, but no live reasoning text.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
