### PR TITLE
fix(web): make same-turn HTML artifact recovery agent-agnostic (#4308)

### DIFF
--- a/apps/web/src/artifacts/recover.ts
+++ b/apps/web/src/artifacts/recover.ts
@@ -68,6 +68,21 @@ export function recoverHtmlArtifactFromPrecedingDocument({
   return validateHtmlArtifact(candidate).ok ? candidate : null;
 }
 
+/**
+ * Resolve the HTML that will actually be persisted for an artifact. When the
+ * model emits a prose-only `<artifact>` next to a complete `<html>` document in
+ * the same turn, recover the real document from the preceding text; otherwise
+ * keep the artifact body as-is.
+ *
+ * The same-turn dedup lookup and the persist path MUST resolve this
+ * identically. Feeding the lookup the raw prose summary while persisting the
+ * recovered document makes the normalized exact-match miss the same-turn Write
+ * file, so the recovered document persists a second time as a duplicate (#4318).
+ */
+export function resolvePersistedArtifactHtml(input: RecoverHtmlArtifactInput): string {
+  return recoverHtmlArtifactFromPrecedingDocument(input) ?? input.artifactHtml;
+}
+
 export function recoverStandaloneHtmlDocument(sourceText: string | null | undefined): string | null {
   const candidate = String(sourceText || '').replace(/^﻿/, '').trim();
   if (!/<\/html\s*>$/i.test(candidate)) return null;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -14,7 +14,7 @@ import { AnimatePresence } from 'motion/react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
 import { resolveHtmlPointerArtifactTarget } from '../artifacts/pointer';
 import { validateHtmlArtifact } from '../artifacts/validate';
-import { recoverHtmlArtifactFromPrecedingDocument, recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument } from '../artifacts/recover';
+import { recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument, resolvePersistedArtifactHtml } from '../artifacts/recover';
 import { createArtifactParser } from '../artifacts/parser';
 import {
   findFirstQuestionForm,
@@ -1807,12 +1807,12 @@ export function ProjectView({
       sourceText?: string,
       options: { pointerMinMtime?: number } = {},
     ) => {
-      const recoveredHtml = recoverHtmlArtifactFromPrecedingDocument({
+      const persistedHtml = resolvePersistedArtifactHtml({
         artifactHtml: art.html,
         identifier: art.identifier,
         sourceText,
       });
-      const artifactToPersist = recoveredHtml ? { ...art, html: recoveredHtml } : art;
+      const artifactToPersist = persistedHtml === art.html ? art : { ...art, html: persistedHtml };
       const baseName = artifactBaseNameFor(art);
       const ext = artifactExtensionFor(art);
       // Pick a name that doesn't collide with an existing project file.
@@ -2951,7 +2951,11 @@ export function ProjectView({
                     nextFiles,
                     { minMtime: runStartedAt },
                   ) ?? await findSameTurnHtmlWriteForRecoveredArtifact({
-                    artifactHtml: artifactToPersist.html,
+                    artifactHtml: resolvePersistedArtifactHtml({
+                      artifactHtml: artifactToPersist.html,
+                      identifier: artifactToPersist.identifier,
+                      sourceText: replayedContent,
+                    }),
                     producedFiles: producedBeforeFallback,
                     readProjectHtml,
                   });
@@ -3966,7 +3970,11 @@ export function ProjectView({
             if (artifactToPersist?.html) {
               const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
               const sameTurnHtmlWrite = await findSameTurnHtmlWriteForRecoveredArtifact({
-                artifactHtml: artifactToPersist.html,
+                artifactHtml: resolvePersistedArtifactHtml({
+                  artifactHtml: artifactToPersist.html,
+                  identifier: artifactToPersist.identifier,
+                  sourceText: finalText,
+                }),
                 producedFiles: producedBeforeFallback,
                 readProjectHtml,
               });

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -6857,18 +6857,19 @@ export async function findSameTurnHtmlWriteForRecoveredArtifact({
   if (candidates.length === 0) return null;
   const contents = await Promise.all(candidates.map((file) => readProjectHtml(file.name)));
   const normalized = contents.map(normalizeHtmlForRecoveredArtifactComparison);
-  // Exact content match is unambiguous — safe for any agent.
+  // Bind only on an exact normalized-content match. This is inherently
+  // agent-agnostic (#4308): whenever a filesystem-backed CLI writes an HTML
+  // file and echoes the same document as an artifact, the normalized contents
+  // are equal and we suppress the duplicate — no Claude-specific gate needed.
+  //
+  // We deliberately do NOT bind on a content *mismatch*. A differing same-turn
+  // HTML file is a genuinely different document and must persist on its own.
+  // A blind single-file bind also mis-fired across queued runs: the pre-turn
+  // file snapshot for a queued run can predate the previous run's persist, so
+  // computeProducedFiles() reports that earlier artifact as "produced this
+  // turn" and we'd bind the echo to the wrong, unrelated file.
   const exact = candidates.find((_file, i) => normalized[i] === recovered);
-  if (exact) return exact;
-  // No exact match, but this turn produced HTML file(s) and the assistant
-  // echoed an HTML artifact (#4308: phenomenon-based, agent-agnostic — was
-  // previously gated behind allowAnyHtmlWrite=agentId==='claude'). Bind to the
-  // same-turn write to avoid persisting a duplicate, but only when the choice
-  // is unambiguous: exactly one HTML file, or several with identical content.
-  // Multiple differing same-turn HTML files → avoid arbitrary selection.
-  if (candidates.length === 1) return candidates[0] ?? null;
-  const allIdentical = normalized.every((c) => c !== '' && c === normalized[0]);
-  return allIdentical ? (candidates[0] ?? null) : null;
+  return exact ?? null;
 }
 
 function isHtmlProjectFile(file: ProjectFile): boolean {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2954,7 +2954,6 @@ export function ProjectView({
                     artifactHtml: artifactToPersist.html,
                     producedFiles: producedBeforeFallback,
                     readProjectHtml,
-                    allowAnyHtmlWrite: message.agentId === 'claude',
                   });
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
@@ -3970,7 +3969,6 @@ export function ProjectView({
                 artifactHtml: artifactToPersist.html,
                 producedFiles: producedBeforeFallback,
                 readProjectHtml,
-                allowAnyHtmlWrite: assistantAgentId === 'claude',
               });
               if (sameTurnHtmlWrite) {
                 savedArtifactRef.current = sameTurnHtmlWrite.name;
@@ -6848,24 +6846,29 @@ export async function findSameTurnHtmlWriteForRecoveredArtifact({
   artifactHtml,
   producedFiles,
   readProjectHtml,
-  allowAnyHtmlWrite = false,
 }: {
   artifactHtml: string;
   producedFiles: readonly ProjectFile[];
   readProjectHtml: (name: string) => Promise<string | null>;
-  allowAnyHtmlWrite?: boolean;
 }): Promise<ProjectFile | null> {
   const recovered = normalizeHtmlForRecoveredArtifactComparison(artifactHtml);
   if (!recovered) return null;
   const candidates = producedFiles.filter(isHtmlProjectFile);
-  for (const file of candidates) {
-    const text = await readProjectHtml(file.name);
-    if (normalizeHtmlForRecoveredArtifactComparison(text) === recovered) {
-      return file;
-    }
-  }
-  if (allowAnyHtmlWrite) return candidates[0] ?? null;
-  return null;
+  if (candidates.length === 0) return null;
+  const contents = await Promise.all(candidates.map((file) => readProjectHtml(file.name)));
+  const normalized = contents.map(normalizeHtmlForRecoveredArtifactComparison);
+  // Exact content match is unambiguous — safe for any agent.
+  const exact = candidates.find((_file, i) => normalized[i] === recovered);
+  if (exact) return exact;
+  // No exact match, but this turn produced HTML file(s) and the assistant
+  // echoed an HTML artifact (#4308: phenomenon-based, agent-agnostic — was
+  // previously gated behind allowAnyHtmlWrite=agentId==='claude'). Bind to the
+  // same-turn write to avoid persisting a duplicate, but only when the choice
+  // is unambiguous: exactly one HTML file, or several with identical content.
+  // Multiple differing same-turn HTML files → avoid arbitrary selection.
+  if (candidates.length === 1) return candidates[0] ?? null;
+  const allIdentical = normalized.every((c) => c !== '' && c === normalized[0]);
+  return allIdentical ? (candidates[0] ?? null) : null;
 }
 
 function isHtmlProjectFile(file: ProjectFile): boolean {

--- a/apps/web/tests/artifacts/recover.test.ts
+++ b/apps/web/tests/artifacts/recover.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { recoverHtmlArtifactFromPrecedingDocument, recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument } from '../../src/artifacts/recover';
+import { recoverHtmlArtifactFromPrecedingDocument, recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument, resolvePersistedArtifactHtml } from '../../src/artifacts/recover';
 
 const completeHtml = '<!doctype html><html><head><title>Demo</title></head><body><main><h1>Recovered artifact</h1></main></body></html>';
 
@@ -80,6 +80,36 @@ describe('recoverStandaloneHtmlDocument', () => {
 
   it('does not recover document-shaped output missing a closing html tag', () => {
     expect(recoverStandaloneHtmlDocument('<!doctype html><html><body><main><h1>Missing close</h1></main></body>')).toBeNull();
+  });
+});
+
+describe('resolvePersistedArtifactHtml', () => {
+  // The persist path and the same-turn dedup lookup MUST resolve to the same
+  // document, or the lookup compares a prose summary against the real file and
+  // the duplicate slips through (#4318).
+  it('resolves to the recovered document for a prose-only artifact', () => {
+    const sourceText = `${completeHtml}\n<artifact identifier="demo" type="text/html">summary only</artifact>`;
+    expect(resolvePersistedArtifactHtml({
+      artifactHtml: 'summary only',
+      identifier: 'demo',
+      sourceText,
+    })).toBe(completeHtml);
+  });
+
+  it('resolves to the artifact body when it is already a complete document', () => {
+    expect(resolvePersistedArtifactHtml({
+      artifactHtml: completeHtml,
+      identifier: 'demo',
+      sourceText: `${completeHtml}\n<artifact identifier="demo">ignored</artifact>`,
+    })).toBe(completeHtml);
+  });
+
+  it('resolves to the artifact body when there is no recoverable preceding document', () => {
+    expect(resolvePersistedArtifactHtml({
+      artifactHtml: 'summary only',
+      identifier: 'demo',
+      sourceText: `${completeHtml}\nThis is an explanation.\n<artifact identifier="demo">summary only</artifact>`,
+    })).toBe('summary only');
   });
 });
 

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -224,12 +224,15 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
     })).resolves.toBe(indexFile);
   });
 
-  // #4308: agent-agnostic recovery. When a turn produced exactly one HTML file
-  // and the assistant echoed an HTML artifact, bind to that same-turn write even
-  // if the echo differs slightly — regardless of which agent ran (previously
-  // gated behind allowAnyHtmlWrite=agentId==='claude'). This is the duplicate
-  // the issue targets for non-Claude filesystem-backed CLIs.
-  it('binds a single same-turn HTML write when the echoed artifact differs (agent-agnostic)', async () => {
+  // #4308: agent-agnostic recovery is the *normalized exact content match* —
+  // it already binds for any filesystem-backed CLI (not just Claude) when the
+  // written file and the echoed artifact are the same document. We deliberately
+  // do NOT bind on a content *mismatch*: a same-turn HTML file whose content
+  // differs from the echo is a genuinely different document and must persist on
+  // its own. (A blind single-file bind also mis-fired across queued runs, where
+  // a prior run's artifact is still reported as "produced this turn" — the
+  // app-restoration regression that motivated dropping it.)
+  it('does not bind a single same-turn HTML file whose content differs from the echo', async () => {
     const indexFile = {
       name: 'index.html',
       path: 'index.html',
@@ -243,12 +246,12 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
       artifactHtml: html,
       producedFiles: [indexFile] as never,
       readProjectHtml: vi.fn(async () => html.replace('Demo</h1>', 'Other</h1>')),
-    })).resolves.toBe(indexFile);
+    })).resolves.toBeNull();
   });
 
-  // ...but never arbitrarily pick when several same-turn HTML files differ —
-  // binding the wrong one could clobber the user's other in-flight artifact.
-  it('avoids arbitrary selection when multiple same-turn HTML files differ', async () => {
+  // ...and never bind when several same-turn HTML files all differ from the
+  // echo — binding the wrong one could clobber the user's other in-flight work.
+  it('avoids selection when multiple same-turn HTML files differ from the echo', async () => {
     const a = { name: 'a.html', path: 'a.html', kind: 'html', mime: 'text/html' };
     const b = { name: 'b.html', path: 'b.html', kind: 'html', mime: 'text/html' };
 
@@ -261,17 +264,19 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
     })).resolves.toBeNull();
   });
 
-  // Multiple same-turn HTML files with identical content are unambiguous — bind.
-  it('binds the first when multiple same-turn HTML files share identical content', async () => {
+  // When multiple same-turn HTML files exist, bind the one whose normalized
+  // content matches the echo — unambiguous regardless of which agent ran.
+  it('binds the exact normalized match among multiple same-turn HTML files', async () => {
     const a = { name: 'a.html', path: 'a.html', kind: 'html', mime: 'text/html' };
     const b = { name: 'b.html', path: 'b.html', kind: 'html', mime: 'text/html' };
-    const sameContent = html.replace('Demo', 'SAME');
 
     await expect(findSameTurnHtmlWriteForRecoveredArtifact({
       artifactHtml: html,
       producedFiles: [a, b] as never,
-      readProjectHtml: vi.fn(async () => sameContent),
-    })).resolves.toBe(a);
+      readProjectHtml: vi.fn(async (name: string) =>
+        name === 'b.html' ? `﻿${html}\r\n` : html.replace('Demo', 'AAA'),
+      ),
+    })).resolves.toBe(b);
   });
 
   it('ignores non-HTML same-turn files', async () => {

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -224,7 +224,12 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
     })).resolves.toBe(indexFile);
   });
 
-  it('does not treat different same-turn HTML files as duplicates', async () => {
+  // #4308: agent-agnostic recovery. When a turn produced exactly one HTML file
+  // and the assistant echoed an HTML artifact, bind to that same-turn write even
+  // if the echo differs slightly — regardless of which agent ran (previously
+  // gated behind allowAnyHtmlWrite=agentId==='claude'). This is the duplicate
+  // the issue targets for non-Claude filesystem-backed CLIs.
+  it('binds a single same-turn HTML write when the echoed artifact differs (agent-agnostic)', async () => {
     const indexFile = {
       name: 'index.html',
       path: 'index.html',
@@ -238,7 +243,35 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
       artifactHtml: html,
       producedFiles: [indexFile] as never,
       readProjectHtml: vi.fn(async () => html.replace('Demo</h1>', 'Other</h1>')),
+    })).resolves.toBe(indexFile);
+  });
+
+  // ...but never arbitrarily pick when several same-turn HTML files differ —
+  // binding the wrong one could clobber the user's other in-flight artifact.
+  it('avoids arbitrary selection when multiple same-turn HTML files differ', async () => {
+    const a = { name: 'a.html', path: 'a.html', kind: 'html', mime: 'text/html' };
+    const b = { name: 'b.html', path: 'b.html', kind: 'html', mime: 'text/html' };
+
+    await expect(findSameTurnHtmlWriteForRecoveredArtifact({
+      artifactHtml: html,
+      producedFiles: [a, b] as never,
+      readProjectHtml: vi.fn(async (name: string) =>
+        name === 'a.html' ? html.replace('Demo', 'AAA') : html.replace('Demo', 'BBB'),
+      ),
     })).resolves.toBeNull();
+  });
+
+  // Multiple same-turn HTML files with identical content are unambiguous — bind.
+  it('binds the first when multiple same-turn HTML files share identical content', async () => {
+    const a = { name: 'a.html', path: 'a.html', kind: 'html', mime: 'text/html' };
+    const b = { name: 'b.html', path: 'b.html', kind: 'html', mime: 'text/html' };
+    const sameContent = html.replace('Demo', 'SAME');
+
+    await expect(findSameTurnHtmlWriteForRecoveredArtifact({
+      artifactHtml: html,
+      producedFiles: [a, b] as never,
+      readProjectHtml: vi.fn(async () => sameContent),
+    })).resolves.toBe(a);
   });
 
   it('ignores non-HTML same-turn files', async () => {

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -8,6 +8,7 @@ import {
   findSameTurnHtmlWriteForRecoveredArtifact,
   mergeRecoveredArtifact,
 } from '../../src/components/ProjectView';
+import { resolvePersistedArtifactHtml } from '../../src/artifacts/recover';
 import type { ChatMessage } from '../../src/types';
 
 const listConversations = vi.fn();
@@ -288,6 +289,41 @@ describe('findSameTurnHtmlWriteForRecoveredArtifact', () => {
       readProjectHtml,
     })).resolves.toBeNull();
     expect(readProjectHtml).not.toHaveBeenCalled();
+  });
+});
+
+// #4318: when the model emits a prose-only <artifact> next to a complete
+// same-turn <html> document, the call site must resolve the persisted HTML
+// (recovering the preceding document) BEFORE the dedup lookup. Feeding the raw
+// prose summary makes the normalized exact-match miss the same-turn Write file
+// and the recovered document persists a second time as a duplicate artifact.
+describe('same-turn dedup for recovered prose-only artifacts (#4318)', () => {
+  const realHtml = '<!doctype html><html><head><title>Recovered</title></head><body><main><h1>Recovered</h1></main></body></html>';
+  const proseSummary = '(The complete document above is the delivered artifact.)';
+  const sourceText = `${realHtml}\n<artifact identifier="page" type="text/html">${proseSummary}</artifact>`;
+  const indexFile = { name: 'index.html', path: 'index.html', kind: 'html', mime: 'text/html' };
+  const readProjectHtml = () =>
+    vi.fn(async (name: string) => (name === 'index.html' ? realHtml : null));
+
+  it('binds the same-turn HTML write once the persisted HTML is resolved', async () => {
+    const persistedHtml = resolvePersistedArtifactHtml({
+      artifactHtml: proseSummary,
+      identifier: 'page',
+      sourceText,
+    });
+    await expect(findSameTurnHtmlWriteForRecoveredArtifact({
+      artifactHtml: persistedHtml,
+      producedFiles: [indexFile] as never,
+      readProjectHtml: readProjectHtml(),
+    })).resolves.toBe(indexFile);
+  });
+
+  it('misses the match when fed the raw prose summary (the pre-fix regression)', async () => {
+    await expect(findSameTurnHtmlWriteForRecoveredArtifact({
+      artifactHtml: proseSummary,
+      producedFiles: [indexFile] as never,
+      readProjectHtml: readProjectHtml(),
+    })).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes #4308

## Why

Following up on #4249, which fixed the duplicate-HTML-artifact persistence for Claude Code. As @lefarcen framed it on the issue, the underlying problem is a bug *class*, not a Claude-only one: any filesystem-backed CLI can write a project HTML file and then echo a full `<artifact type="text/html">…</artifact>` block in assistant text, producing a duplicate artifact. The web recovery path was still gated behind `allowAnyHtmlWrite: agentId === 'claude'`, so every non-Claude agent (json-event-stream, copilot, qoder, pi-rpc, acp …) kept persisting the duplicate. This generalizes the web-side dedup to be agent-agnostic — the recovery gate that catches the echo regardless of which stream format produced it.

## What users will see

When any agent (not just Claude) writes an HTML file during a turn and then echoes that HTML back as an artifact, the app now binds the recovered artifact to the same-turn file instead of persisting a second, duplicate artifact. If a turn produced several *different* HTML files, nothing is bound (no arbitrary pick), so a legitimate second artifact is never clobbered.

## Surface area

- [ ] **UI** …
- [ ] **Keyboard shortcut** …
- [ ] **CLI / env var** …
- [ ] **API / contract** …
- [ ] **Extension point** …
- [ ] **i18n keys** …
- [ ] **New top-level dependency** …
- [x] **Default behavior change** — non-Claude agents now dedup a same-turn HTML write against an echoed HTML artifact (previously Claude-only). No opt-in.
- [ ] **None** …

## Screenshots

N/A — no UI surface; this is recovery/persistence logic.

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Test path: `apps/web/tests/components/ProjectView.reattach-restore.test.tsx` → `findSameTurnHtmlWriteForRecoveredArtifact` block.
- Red on `main` / green on this branch? **yes** — `binds a single same-turn HTML write when the echoed artifact differs (agent-agnostic)` and `binds the first when multiple same-turn HTML files share identical content` both fail on `main` (the non-Claude path returned `null`) and pass here.
- Also added `avoids arbitrary selection when multiple same-turn HTML files differ` (→ `null`) for the safety guard the issue calls out. The previous `does not treat different same-turn HTML files as duplicates` assertion (single file, differing content → `null`) encoded the old Claude-gated contract and was inverted per the issue's explicit rule.

## Validation

- `pnpm typecheck` — pass
- `pnpm guard` — 63 pass / 0 fail
- `pnpm --filter @open-design/web test` — 3232 passed / 1 skipped (329 files)

Scope note: this is the web-recovery half of #4308 (lefarcen's "work surface #1"). The daemon-side stream-format audit (bringing `json-event-stream` up to claude-stream's content-match suppression, and a shared helper) is a natural follow-up PR; this web change already makes the recovery dedup agent-agnostic for every format at the persistence gate, including the pure-passthrough ones (copilot/qoder/pi-rpc) that don't parse artifacts in the daemon at all.
