### PR TITLE
fix(web): balance forked conversation first screen

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -994,6 +994,12 @@ export function ChatPane({
     () => messages.find((m) => m.role === 'user')?.id,
     [messages],
   );
+  const shouldBalanceFinishedTranscript =
+    !loading &&
+    !streaming &&
+    !displayError &&
+    !hasActiveRunMessage &&
+    messages.length > 0;
   // Map each assistant message id to the user message that follows it (if any)
   // so the chat-side Questions banner can reopen that exact answered form in
   // the right-hand panel later.
@@ -1819,6 +1825,7 @@ export function ChatPane({
                 loading ? 'is-loading' : '',
                 chatLogScrollable ? 'is-scrollable' : '',
                 chatLogScrolling ? 'is-scrolling' : '',
+                shouldBalanceFinishedTranscript ? 'is-balanced-transcript' : '',
               ].filter(Boolean).join(' ')}
               ref={logRef}
               aria-busy={loading}

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -237,6 +237,9 @@
   background: color-mix(in srgb, var(--text-muted) 28%, transparent);
   background-clip: padding-box;
 }
+.chat-log.is-balanced-transcript > .msg:first-of-type {
+  margin-top: auto;
+}
 
 /* Anchor-to-top tail spacer. Height is driven imperatively by ChatPane; the
    negative margin cancels the flex `gap` so it contributes nothing when idle

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -231,6 +231,57 @@ describe('ChatPane streaming state', () => {
     expect(css).toContain('width: 24px;');
     expect(css).toContain('height: 24px;');
     expect(css).toContain('.chat-queued-send-overflow');
+    expect(css).toContain('.chat-log.is-balanced-transcript > .msg:first-of-type');
+    expect(css).toContain('margin-top: auto;');
+  });
+
+  it('balances finished transcripts near the composer without affecting active turns', () => {
+    const baseProps = {
+      projectKindForTracking: 'prototype' as const,
+      streaming: false,
+      error: null,
+      projectId: 'project-1',
+      projectFiles: [],
+      onEnsureProject: async () => 'project-1',
+      onSend: vi.fn(),
+      onStop: vi.fn(),
+      conversations,
+      activeConversationId: 'conv-1',
+      onSelectConversation: vi.fn(),
+      onDeleteConversation: vi.fn(),
+      projectMetadata,
+    };
+    const { container, rerender } = render(
+      <ChatPane
+        {...baseProps}
+        messages={[
+          { id: 'user-1', role: 'user', content: 'Make the landing page', createdAt: 1 },
+          { id: 'assistant-1', role: 'assistant', content: 'Done', createdAt: 2 },
+        ]}
+      />,
+    );
+
+    expect(container.querySelector('.chat-log')?.className).toContain('is-balanced-transcript');
+
+    rerender(
+      <ChatPane
+        {...baseProps}
+        streaming
+        messages={[
+          { id: 'user-1', role: 'user', content: 'Make the landing page', createdAt: 1 },
+          { id: 'assistant-1', role: 'assistant', content: 'Done', createdAt: 2 },
+          {
+            id: 'assistant-2',
+            role: 'assistant',
+            content: '',
+            createdAt: 3,
+            runStatus: 'running',
+          },
+        ]}
+      />,
+    );
+
+    expect(container.querySelector('.chat-log')?.className).not.toContain('is-balanced-transcript');
   });
 
   it('keeps composer popovers above the chat jump button', () => {


### PR DESCRIPTION
Closes #3886

## Why

Fork-from-here conversations can open with a short seeded transcript pinned to the top of the chat pane while the composer remains docked at the bottom. That leaves a large blank gap and makes the handoff into the new conversation feel unfinished.

## What users will see

Short finished chat transcripts now settle closer to the composer instead of sitting at the top of the pane. Active streaming turns keep the existing anchor behavior.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this runner.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatPane.streaming.test.tsx`
- Did the test go red on `main` and green on this branch? Not run; this runner does not have `node`, `corepack`, or `pnpm` on PATH.

## Validation

- `git diff --check`
- Attempted `pnpm --filter @open-design/web test -- apps/web/tests/components/ChatPane.streaming.test.tsx` (blocked: `pnpm: command not found`)
- Attempted Node/Corepack discovery (blocked: `node: command not found`, `corepack: command not found`)

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>