### PR TITLE
feat(landing): SEO + UX overhaul for /plugins/ systems & detail pages

### DIFF
--- a/apps/landing-page/app/_components/plugin-contribute.astro
+++ b/apps/landing-page/app/_components/plugin-contribute.astro
@@ -1,0 +1,89 @@
+---
+/*
+ * Reusable "contribute a plugin" callout shown on every /plugins/ page
+ * (hub, category indexes, and detail pages). Points contributors at the
+ * GitHub PR flow — `plugins/_official/` for the catalogue entry plus the
+ * contribution guide. Pure link-out; no new repo files needed.
+ */
+import { getPluginsCopy } from '../_lib/plugins-i18n';
+import { localeFromPath } from '../i18n';
+
+const locale = localeFromPath(Astro.url.pathname);
+const pcopy = getPluginsCopy(locale);
+
+// Direct PR path — the bundled-plugin folder contributors add to (with
+// the contribution guide one click away in the repo root).
+const PR_URL =
+  'https://github.com/nexu-io/open-design/tree/main/plugins/_official';
+// Lower-barrier path — a prefilled issue for proposing a plugin without
+// opening a PR yourself. No labels set (avoids referencing a label that
+// might not exist).
+const ISSUE_URL =
+  'https://github.com/nexu-io/open-design/issues/new?title=' +
+  encodeURIComponent('[Plugin] ') +
+  '&body=' +
+  encodeURIComponent(
+    '**Plugin name:**\n\n' +
+      '**Type:** template / skill / design system\n\n' +
+      '**Link to your repo or files:**\n\n' +
+      '**What it does:**\n',
+  );
+---
+
+<aside class="plugin-contribute">
+  <div class="pc-text">
+    <h2 class="pc-title">{pcopy.contributeTitle}</h2>
+    <p class="pc-body">{pcopy.contributeBody}</p>
+  </div>
+  <div class="pc-actions">
+    <a class="btn btn-primary" href={PR_URL} target="_blank" rel="noopener">
+      {pcopy.contributeCta}
+    </a>
+    <a class="pc-guide" href={ISSUE_URL} target="_blank" rel="noopener">
+      {pcopy.contributeIssueCta}
+    </a>
+  </div>
+</aside>
+
+<style>
+  .plugin-contribute {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 28px;
+    flex-wrap: wrap;
+    margin: 8px 0 40px;
+    padding: 22px 28px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--paper-warm, #f5f5f5);
+  }
+  .pc-title {
+    margin: 0 0 8px;
+    font-size: 20px;
+  }
+  .pc-body {
+    margin: 0;
+    max-width: 560px;
+    color: var(--ink-soft, #434343);
+    line-height: 1.55;
+    font-size: 14.5px;
+  }
+  .pc-actions {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    flex-shrink: 0;
+  }
+  .pc-guide {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--ink, #262626);
+    white-space: nowrap;
+  }
+  @media (max-width: 640px) {
+    .plugin-contribute {
+      padding: 22px;
+    }
+  }
+</style>

--- a/apps/landing-page/app/_components/system-card.astro
+++ b/apps/landing-page/app/_components/system-card.astro
@@ -13,7 +13,9 @@
  */
 import type { SystemRecord } from '../_lib/catalog';
 import { detailHrefForSystemSlug } from '../_lib/bundled-plugins';
+import { getPluginsCopy } from '../_lib/plugins-i18n';
 import { localeFromPath, localizedHref } from '../i18n';
+import SystemPreview from './system-preview.astro';
 
 export interface Props {
   system: SystemRecord;
@@ -21,6 +23,7 @@ export interface Props {
 
 const { system } = Astro.props;
 const locale = localeFromPath(Astro.url.pathname);
+const pcopy = getPluginsCopy(locale);
 const href = (path: string) => localizedHref(path, locale);
 // The bundled-plugin detail page is canonical-only (no locale prefix); only
 // the `/plugins/systems/` index fallback has localized variants to link to.
@@ -29,17 +32,34 @@ const detailHref = detailHrefForSystemSlug(system.slug) ?? href('/plugins/system
 
 <li class="system-card">
   <a href={detailHref}>
-    <div class="system-swatches" aria-hidden="true">
+    <div class="system-cover">
       {system.palette.length > 0 ? (
-        system.palette.slice(0, 4).map((hex) => (
-          <span class="swatch" style={`background:${hex}`} />
-        ))
+        <SystemPreview system={system} compact />
       ) : (
-        <span class="swatch placeholder" />
+        <div class="system-swatches" aria-hidden="true">
+          <span class="swatch placeholder" />
+        </div>
       )}
     </div>
     <span class="system-name">{system.name}</span>
     <span class="system-cat">{system.categoryLabel}</span>
     {system.tagline && <p class="system-tagline">{system.tagline}</p>}
+    <span class="system-cta">{pcopy.systemCardCta}</span>
   </a>
 </li>
+
+<style>
+  .system-card .system-cover {
+    margin-bottom: 18px;
+  }
+  .system-card .system-cta {
+    display: inline-block;
+    margin-top: 14px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink, #262626);
+  }
+  .system-card a:hover .system-cta {
+    text-decoration: underline;
+  }
+</style>

--- a/apps/landing-page/app/_components/system-preview.astro
+++ b/apps/landing-page/app/_components/system-preview.astro
@@ -1,0 +1,387 @@
+---
+/*
+ * Design-example "live preview" for a design-system detail page.
+ *
+ * Renders an ORIGINAL mock product UI (browser chrome → nav → hero →
+ * feature cards → CTA) themed entirely from the system's palette tokens
+ * (the same colors documented in its DESIGN.md). It is not a screenshot
+ * of any real brand site — it's a generic mock re-skinned per system, so
+ * a visitor instantly sees what the design language looks like applied.
+ *
+ * Colours are derived heuristically from `system.palette`: the darkest
+ * swatch → ink, the lightest → surface, the most saturated mid-tone →
+ * accent, with safe fallbacks when a palette is thin or skewed.
+ */
+import type { SystemRecord } from '../_lib/catalog';
+
+interface Props {
+  system: SystemRecord;
+  /** Caption (localized) shown under the mock. Omitted in compact mode. */
+  caption?: string;
+  /** Compact card-thumbnail variant (lean markup, no caption). */
+  compact?: boolean;
+}
+
+const { system, caption, compact = false } = Astro.props as Props;
+
+const HEX = /^#?[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/;
+const toRgb = (h: string): [number, number, number] => {
+  let s = h.replace('#', '');
+  if (s.length === 3) s = s.split('').map((c) => c + c).join('');
+  const n = parseInt(s, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+};
+const lum = (rgb: [number, number, number]): number =>
+  0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+const sat = (rgb: [number, number, number]): number => {
+  const mx = Math.max(...rgb);
+  const mn = Math.min(...rgb);
+  return mx === 0 ? 0 : (mx - mn) / mx;
+};
+
+const swatches = (system.palette ?? [])
+  .filter((h) => HEX.test(h))
+  .map((h) => ({ h, rgb: toRgb(h) }));
+
+const byLum = [...swatches].sort((a, b) => lum(a.rgb) - lum(b.rgb));
+const darkest = byLum[0];
+const lightest = byLum[byLum.length - 1];
+const accentCand = [...swatches]
+  .filter((x) => sat(x.rgb) > 0.25 && lum(x.rgb) > 40 && lum(x.rgb) < 225)
+  .sort((a, b) => sat(b.rgb) - sat(a.rgb))[0];
+
+const ink = darkest && lum(darkest.rgb) < 115 ? darkest.h : '#14110b';
+const bg = lightest && lum(lightest.rgb) > 205 ? lightest.h : '#ffffff';
+const accent = (accentCand ?? darkest)?.h ?? '#533afd';
+
+const inkRgb = toRgb(ink);
+const accentRgb = toRgb(accent);
+const muted = `rgba(${inkRgb[0]}, ${inkRgb[1]}, ${inkRgb[2]}, 0.55)`;
+const line = `rgba(${inkRgb[0]}, ${inkRgb[1]}, ${inkRgb[2]}, 0.12)`;
+const accentSoft = `rgba(${accentRgb[0]}, ${accentRgb[1]}, ${accentRgb[2]}, 0.14)`;
+const accentInk = lum(accentRgb) > 150 ? '#14110b' : '#ffffff';
+
+const vars = [
+  `--pv-bg:${bg}`,
+  `--pv-ink:${ink}`,
+  `--pv-accent:${accent}`,
+  `--pv-accent-ink:${accentInk}`,
+  `--pv-accent-soft:${accentSoft}`,
+  `--pv-muted:${muted}`,
+  `--pv-line:${line}`,
+].join(';');
+
+const domain = `${system.slug}.com`;
+---
+
+{compact ? (
+  <div class="pv pv-compact" style={vars} role="img" aria-label={`${system.name} design system preview`}>
+    <div class="pv-chrome">
+      <span class="pv-dot"></span><span class="pv-dot"></span><span class="pv-dot"></span>
+    </div>
+    <div class="pv-screen">
+      <nav class="pv-nav">
+        <span class="pv-brand"><span class="pv-logo"></span>{system.name}</span>
+        <span class="pv-btn pv-btn-solid">Sign up</span>
+      </nav>
+      <div class="pv-h1">Build something people love.</div>
+      <div class="pv-cta-row">
+        <span class="pv-btn pv-btn-solid">Get started</span>
+        <span class="pv-btn pv-btn-ghost">Learn more</span>
+      </div>
+      <div class="pv-cards">
+        {['', '', ''].map(() => (
+          <div class="pv-card"><span class="pv-card-icon"></span><div class="pv-card-line"></div></div>
+        ))}
+      </div>
+    </div>
+  </div>
+) : (
+<figure class="sys-preview">
+  <div class="pv" style={vars} role="img" aria-label={caption}>
+    <div class="pv-chrome">
+      <span class="pv-dot"></span><span class="pv-dot"></span><span class="pv-dot"></span>
+      <span class="pv-url">{domain}</span>
+    </div>
+    <div class="pv-screen">
+      <nav class="pv-nav">
+        <span class="pv-brand"><span class="pv-logo"></span>{system.name}</span>
+        <span class="pv-links"><span>Product</span><span>Pricing</span><span>Docs</span></span>
+        <span class="pv-btn pv-btn-solid">Sign up</span>
+      </nav>
+      <div class="pv-hero">
+        <span class="pv-badge">NEW · LIVE PREVIEW</span>
+        <div class="pv-h1">Build something people love.</div>
+        <div class="pv-sub">A mock UI rendered with the {system.name} design tokens — colors pulled straight from its DESIGN.md.</div>
+        <div class="pv-cta-row">
+          <span class="pv-btn pv-btn-solid">Get started</span>
+          <span class="pv-btn pv-btn-ghost">Learn more</span>
+        </div>
+      </div>
+      <div class="pv-cards">
+        {['Fast', 'Secure', 'Simple'].map((t) => (
+          <div class="pv-card">
+            <span class="pv-card-icon"></span>
+            <div class="pv-card-title">{t}</div>
+            <div class="pv-card-line"></div>
+            <div class="pv-card-line short"></div>
+          </div>
+        ))}
+      </div>
+      <div class="pv-foot">
+        <span class="pv-input">you@email.com</span>
+        <span class="pv-btn pv-btn-solid">Subscribe</span>
+        <span class="pv-tag pv-tag-accent">Active</span>
+        <span class="pv-tag">Draft</span>
+      </div>
+    </div>
+  </div>
+  <figcaption>{caption}</figcaption>
+</figure>
+)}
+
+<style>
+  .sys-preview {
+    margin: 0 0 8px;
+  }
+  .sys-preview figcaption {
+    margin-top: 10px;
+    font-size: 13px;
+    color: var(--ink-mute, #595959);
+  }
+  .pv {
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    overflow: hidden;
+    background: var(--pv-bg);
+    color: var(--pv-ink);
+    box-shadow: 0 24px 60px -28px rgba(0, 0, 0, 0.28);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+  .pv-chrome {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 11px 14px;
+    border-bottom: 1px solid var(--pv-line);
+  }
+  .pv-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--pv-line);
+  }
+  .pv-url {
+    margin-left: 10px;
+    padding: 3px 12px;
+    border-radius: 999px;
+    background: var(--pv-accent-soft);
+    color: var(--pv-muted);
+    font-size: 12px;
+  }
+  .pv-screen {
+    padding: 26px 30px 30px;
+  }
+  .pv-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 38px;
+  }
+  .pv-brand {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    font-weight: 700;
+    font-size: 16px;
+  }
+  .pv-logo {
+    width: 22px;
+    height: 22px;
+    border-radius: 7px;
+    background: var(--pv-accent);
+  }
+  .pv-links {
+    display: flex;
+    gap: 22px;
+    font-size: 13px;
+    color: var(--pv-muted);
+  }
+  .pv-btn {
+    display: inline-flex;
+    align-items: center;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 8px 16px;
+    border-radius: 8px;
+    white-space: nowrap;
+  }
+  .pv-btn-solid {
+    background: var(--pv-accent);
+    color: var(--pv-accent-ink);
+  }
+  .pv-btn-ghost {
+    border: 1px solid var(--pv-line);
+    color: var(--pv-ink);
+  }
+  .pv-hero {
+    margin-bottom: 34px;
+  }
+  .pv-badge {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    padding: 5px 11px;
+    border-radius: 999px;
+    background: var(--pv-accent-soft);
+    color: var(--pv-accent);
+    margin-bottom: 16px;
+  }
+  .pv-h1 {
+    font-size: 40px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
+    margin-bottom: 14px;
+  }
+  .pv-sub {
+    max-width: 460px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--pv-muted);
+    margin-bottom: 22px;
+  }
+  .pv-cta-row {
+    display: flex;
+    gap: 12px;
+  }
+  .pv-cards {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    margin-bottom: 26px;
+  }
+  .pv-card {
+    border: 1px solid var(--pv-line);
+    border-radius: 10px;
+    padding: 16px;
+  }
+  .pv-card-icon {
+    display: block;
+    width: 26px;
+    height: 26px;
+    border-radius: 7px;
+    background: var(--pv-accent);
+    margin-bottom: 14px;
+  }
+  .pv-card-title {
+    font-size: 14px;
+    font-weight: 700;
+    margin-bottom: 9px;
+  }
+  .pv-card-line {
+    height: 7px;
+    border-radius: 4px;
+    background: var(--pv-line);
+    margin-bottom: 6px;
+  }
+  .pv-card-line.short {
+    width: 65%;
+  }
+  .pv-foot {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .pv-input {
+    flex: 1;
+    min-width: 180px;
+    padding: 9px 14px;
+    border: 1px solid var(--pv-line);
+    border-radius: 8px;
+    font-size: 13px;
+    color: var(--pv-muted);
+  }
+  .pv-tag {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 5px 11px;
+    border-radius: 999px;
+    border: 1px solid var(--pv-line);
+    color: var(--pv-muted);
+  }
+  .pv-tag-accent {
+    background: var(--pv-accent);
+    color: var(--pv-accent-ink);
+    border-color: transparent;
+  }
+  /* Compact card-thumbnail variant */
+  .pv-compact {
+    border-radius: 10px;
+    box-shadow: none;
+  }
+  .pv-compact .pv-chrome {
+    padding: 7px 10px;
+    gap: 5px;
+  }
+  .pv-compact .pv-dot {
+    width: 7px;
+    height: 7px;
+  }
+  .pv-compact .pv-screen {
+    padding: 14px 16px 16px;
+  }
+  .pv-compact .pv-nav {
+    margin-bottom: 14px;
+  }
+  .pv-compact .pv-brand {
+    font-size: 12px;
+    gap: 6px;
+  }
+  .pv-compact .pv-logo {
+    width: 16px;
+    height: 16px;
+    border-radius: 5px;
+  }
+  .pv-compact .pv-btn {
+    font-size: 10px;
+    padding: 5px 10px;
+    border-radius: 6px;
+  }
+  .pv-compact .pv-h1 {
+    font-size: 19px;
+    margin-bottom: 12px;
+  }
+  .pv-compact .pv-cta-row {
+    margin-bottom: 14px;
+  }
+  .pv-compact .pv-cards {
+    gap: 8px;
+    margin-bottom: 0;
+  }
+  .pv-compact .pv-card {
+    padding: 10px;
+  }
+  .pv-compact .pv-card-icon {
+    width: 16px;
+    height: 16px;
+    margin-bottom: 0;
+  }
+
+  @media (max-width: 640px) {
+    .pv-screen {
+      padding: 20px;
+    }
+    .pv-links {
+      display: none;
+    }
+    .pv-h1 {
+      font-size: 30px;
+    }
+    .pv-cards {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/apps/landing-page/app/_lib/plugins-i18n.ts
+++ b/apps/landing-page/app/_lib/plugins-i18n.ts
@@ -65,6 +65,27 @@ export interface PluginsCopy {
   systemsLabel: string;
   systemsHeading: (n: number) => string;
   systemsLead: string;
+  systemsMetaTitle: (n: number) => string;
+  systemsMetaDescription: string;
+  systemsAboutHead: string;
+  systemsAboutBody: string;
+  /** Lowercase category suffix appended to design-system detail titles/H1 (e.g. "design system"). */
+  detailSystemLabel: string;
+  /** Placeholder for the client-side catalog filter on templates / systems. */
+  searchPlaceholder: string;
+  /** Shown when a catalog filter matches nothing. */
+  searchNoResults: string;
+  /** Caption under the design-system mock-UI live preview. */
+  systemPreviewCaption: (name: string) => string;
+  /** CTA on a system catalog card, drilling into the detail page. */
+  systemCardCta: string;
+  /** "Contribute a plugin" callout shown on every plugins page. */
+  contributeTitle: string;
+  contributeBody: string;
+  /** Primary CTA — open a pull request directly. */
+  contributeCta: string;
+  /** Secondary CTA — open an issue (lower barrier than a PR). */
+  contributeIssueCta: string;
 
   craftLabel: string;
   craftHeading: (n: number) => string;
@@ -181,9 +202,26 @@ const en: PluginsCopy = {
     'Skills the agent loads mid-task — copywriting, color theory, creative direction, brainstorming. There’s no static demo because the outcome depends on your input, so each detail page reads like a brief: title, description, triggers, attribution.',
 
   systemsLabel: 'Plugins · Systems',
-  systemsHeading: (n) => `${n} design systems.`,
+  systemsHeading: () => 'Design systems, ready for your agent',
   systemsLead:
-    'Brand-anchored design systems plugins can adopt via `od.craft.requires`. Each ships its own palette, typography, motion, and voice; snap a project to a system and every plugin output inherits the same identity.',
+    'Browse real-world design system examples — brand-grade palette, typography, motion and voice your coding agent can snap any project to. Every system is open-source and runs with Claude, Codex, Cursor and more.',
+  systemsMetaTitle: (n) => `Design System Examples — ${n} Open-Source Design Systems | Open Design`,
+  systemsMetaDescription:
+    'Browse design system examples your coding agent can apply automatically — brand-grade palette, typography, motion and voice from real-world design systems. Open-source, BYOK, works with Claude, Codex and Cursor.',
+  systemsAboutHead: 'What is a design system?',
+  systemsAboutBody:
+    'A design system is a reusable set of brand foundations — color palette, typography, spacing, motion and voice — that keeps every screen consistent. In Open Design each design system is a plugin: snap a project to one and your coding agent inherits the palette, type, motion and voice automatically, so everything it generates stays on-brand.',
+  detailSystemLabel: 'design system',
+  searchPlaceholder: 'Search by name or keyword…',
+  searchNoResults: 'No matches. Try a different keyword.',
+  systemPreviewCaption: (name) =>
+    `Mock UI styled entirely with ${name}'s design tokens — a live preview of the design system, not a screenshot.`,
+  systemCardCta: 'View design system →',
+  contributeTitle: 'Built a plugin? Ship it to the catalogue.',
+  contributeBody:
+    'Every template, skill, and design system here is community-extensible. Open a pull request to add yours directly, or open an issue to propose one — merged contributions show up in this catalogue and in the product automatically.',
+  contributeCta: 'Open a pull request →',
+  contributeIssueCta: 'Or open an issue →',
 
   craftLabel: 'Plugins · Craft',
   craftHeading: (n) => `${n} craft principles.`,
@@ -375,9 +413,26 @@ const overrides: Partial<Record<LandingLocaleCode, Partial<PluginsCopy>>> = {
     skillsLead:
       'agent 在任务中加载的技能——文案、配色、创意指导、头脑风暴。没有静态 demo，输出取决于你的输入，所以每个详情页像一份简报：标题、描述、触发词、出处。',
     systemsLabel: '插件 · 设计系统',
-    systemsHeading: (n) => `${n} 个设计系统。`,
+    systemsHeading: () => '为你的 agent 准备的设计系统',
     systemsLead:
-      '插件可通过 `od.craft.requires` 采用的品牌设计系统。每个系统自带色板、字体、动效与文风；把项目绑到某个系统，所有插件输出都会继承同一身份。',
+      '浏览真实世界的设计系统范例——品牌级的色板、字体、动效与文风，你的 coding agent 可一键套用到任何项目。每个系统都开源，支持 Claude、Codex、Cursor 等。',
+    systemsMetaTitle: (n) => `设计系统范例 — ${n} 个开源设计系统 | Open Design`,
+    systemsMetaDescription:
+      '浏览你的 coding agent 可自动套用的设计系统范例——来自真实品牌的色板、字体、动效与文风。开源、BYOK，支持 Claude、Codex、Cursor。',
+    systemsAboutHead: '什么是设计系统？',
+    systemsAboutBody:
+      '设计系统是一套可复用的品牌基础——色板、字体、间距、动效与文风——让每个界面保持一致。在 Open Design 中，每个设计系统都是一个插件：把项目绑到某个系统，你的 coding agent 会自动继承它的色板、字体、动效与文风，产出始终贴合品牌。',
+    detailSystemLabel: '设计系统',
+    searchPlaceholder: '按名称或关键词搜索…',
+    searchNoResults: '没有匹配项，换个关键词试试。',
+    systemPreviewCaption: (name) =>
+      `用 ${name} 设计系统 token 渲染的示例界面 —— 设计效果实时预览，非截图。`,
+    systemCardCta: '查看设计系统 →',
+    contributeTitle: '做了一个 plugin？把它上架到目录。',
+    contributeBody:
+      '这里的每个模板、skill、设计系统都可由社区扩展。直接提一个 pull request 加上你的，或者提个 issue 提议——合并后会自动出现在这个目录和产品里。',
+    contributeCta: '提交 Pull Request →',
+    contributeIssueCta: '或提个 Issue →',
     craftLabel: '插件 · 工艺',
     craftHeading: (n) => `${n} 条工艺规则。`,
     craftLead:
@@ -486,8 +541,23 @@ const overrides: Partial<Record<LandingLocaleCode, Partial<PluginsCopy>>> = {
     skillsHeading: (n) => `${n} 個指令技能。`,
     skillsLead: 'agent 任務中載入的技能——文案、色彩、創意指導、發想。沒有靜態 demo，因為產出取決於你的輸入；每個詳情頁讀起來像一份 brief：標題、描述、觸發條件、署名。',
     systemsLabel: '外掛 · 設計系統',
-    systemsHeading: (n) => `${n} 個設計系統。`,
-    systemsLead: '外掛可透過 `od.craft.requires` 採用的品牌錨定設計系統。每一個都自帶色票、字體、動效與語氣；綁定一個專案到系統，所有外掛產出都繼承同一識別。',
+    systemsHeading: () => '為你的 agent 準備的設計系統',
+    systemsLead: '瀏覽真實世界的設計系統範例——品牌級的色票、字體、動效與語氣，你的 coding agent 可一鍵套用到任何專案。每個系統都開源，支援 Claude、Codex、Cursor 等。',
+    systemsMetaTitle: (n) => `設計系統範例 — ${n} 個開源設計系統 | Open Design`,
+    systemsMetaDescription: '瀏覽你的 coding agent 可自動套用的設計系統範例——來自真實品牌的色票、字體、動效與語氣。開源、BYOK，支援 Claude、Codex、Cursor。',
+    systemsAboutHead: '什麼是設計系統？',
+    systemsAboutBody: '設計系統是一套可重用的品牌基礎——色票、字體、間距、動效與語氣——讓每個介面保持一致。在 Open Design 中，每個設計系統都是一個外掛：綁定專案到某個系統，你的 coding agent 會自動繼承它的色票、字體、動效與語氣，產出始終貼合品牌。',
+    detailSystemLabel: '設計系統',
+    searchPlaceholder: '依名稱或關鍵字搜尋…',
+    searchNoResults: '沒有相符項目，換個關鍵字試試。',
+    systemPreviewCaption: (name) =>
+      `用 ${name} 設計系統 token 渲染的範例介面 —— 設計效果即時預覽，非截圖。`,
+    systemCardCta: '檢視設計系統 →',
+    contributeTitle: '做了一個 plugin？把它上架到目錄。',
+    contributeBody:
+      '這裡的每個範本、skill、設計系統都可由社群擴充。直接提一個 pull request 加上你的，或者提個 issue 提議——合併後會自動出現在這個目錄和產品裡。',
+    contributeCta: '提交 Pull Request →',
+    contributeIssueCta: '或提個 Issue →',
     craftLabel: '外掛 · 工藝',
     craftHeading: (n) => `${n} 條工藝原則。`,
     craftLead: '與品牌無關的工藝規則——可達性、RTL、動效曲線、攝影倫理。技能透過 `od.craft.requires` opt-in，外掛自動繼承相應嚴謹度。',

--- a/apps/landing-page/app/pages/plugins/[slug]/index.astro
+++ b/apps/landing-page/app/pages/plugins/[slug]/index.astro
@@ -13,15 +13,21 @@
  * not the folder name. Manifest ids are globally unique within the
  * registry so there's no risk of collision across buckets.
  */
+import { getCollection, render } from 'astro:content';
 import Layout from '../../../_components/sub-page-layout.astro';
+import SystemPreview from '../../../_components/system-preview.astro';
+import PluginContribute from '../../../_components/plugin-contribute.astro';
 import {
+  detailHrefForSystemSlug,
   getDetailPlugins,
   resolveBundledDescription,
   resolveBundledTitle,
   type BundledPluginRecord,
 } from '../../../_lib/bundled-plugins';
 import { getPluginsCopy } from '../../../_lib/plugins-i18n';
-import { localeFromPath, localizedHref } from '../../../i18n';
+import { bundledRecordOf, categorizePlugin } from '../../../_lib/plugin-facets';
+import { getSystemRecords, type SystemRecord } from '../../../_lib/catalog';
+import { getLandingUiCopy, localeFromPath, localizedHref } from '../../../i18n';
 
 export async function getStaticPaths() {
   return getDetailPlugins().map((plugin) => ({
@@ -44,13 +50,6 @@ const pcopy = getPluginsCopy(locale);
 // the per-locale lookup happens here.
 const pluginTitle = resolveBundledTitle(plugin, locale);
 const pluginDescription = resolveBundledDescription(plugin, locale);
-// `community` plugins carry a non-localized label: the i18n bucket map only
-// covers the _official buckets, so narrow before indexing it.
-const bucketLabel =
-  plugin.bucket === 'community'
-    ? 'Community'
-    : pcopy.detailBucketLabel[plugin.bucket];
-
 /*
  * Author normalisation. First-party manifests authored by Open Design
  * point at the org URL (`https://github.com/nexu-io`) — fine for the
@@ -67,8 +66,83 @@ const authorUrl = plugin.authorUrl
   ? (ORG_TO_REPO[plugin.authorUrl.replace(/\/$/, '')] ?? plugin.authorUrl)
   : undefined;
 
-const title = `${pluginTitle} · Open Design plugin`;
+/*
+ * Design-system detail pages target the "[brand] design system" search
+ * cluster (e.g. "stripe design system", "vercel design system" — low KD,
+ * long-tail across the ~142 systems). Their manifest title is the bare
+ * brand name ("Stripe"), so weave the category keyword into the SEO title
+ * + H1; every other bucket keeps the generic plugin framing.
+ */
+const isDesignSystem = plugin.bucket === 'design-systems';
+const headingTitle = isDesignSystem
+  ? `${pluginTitle} ${pcopy.detailSystemLabel}`
+  : pluginTitle;
+const title = isDesignSystem
+  ? `${pluginTitle} ${pcopy.detailSystemLabel} — palette, typography & tokens for your agent · Open Design`
+  : `${pluginTitle} · Open Design plugin`;
 const description = pluginDescription;
+
+const ui = getLandingUiCopy(locale);
+/*
+ * For design-system plugins, pull the DESIGN.md-derived SystemRecord so
+ * the detail page carries real brand substance — palette swatches, the
+ * visual theme, and related systems. The manifest alone (a one-line
+ * tagline + poster) is too thin to be the "last click" for a
+ * "[brand] design system" search. Matched by shared folder slug; reuse
+ * the same copy keys the legacy /systems/<slug>/ page used so every
+ * locale is already covered.
+ */
+const allSystems: ReadonlyArray<SystemRecord> = isDesignSystem
+  ? await getSystemRecords(locale)
+  : [];
+const systemRecord: SystemRecord | null = isDesignSystem
+  ? (allSystems.find((s) => s.slug === plugin.slug) ?? null)
+  : null;
+const relatedSystems: ReadonlyArray<SystemRecord> = systemRecord
+  ? allSystems
+      .filter(
+        (s) => s.slug !== systemRecord.slug && s.category === systemRecord.category,
+      )
+      .slice(0, 4)
+  : [];
+
+/*
+ * Render the full DESIGN.md body for design-system pages. The manifest
+ * carries only a one-line tagline; the real substance (color roles,
+ * typography, components, layout, do's & don'ts, agent prompt guide)
+ * lives in the DESIGN.md content collection. Matched by the same folder
+ * slug the SystemRecord uses (`entry.id` is `<slug>/DESIGN`). The
+ * leading `# ...` heading is hidden via CSS so the page keeps a single
+ * H1 (the brand "<X> design system" title above).
+ */
+const systemEntry = isDesignSystem
+  ? (await getCollection('systems')).find(
+      (e) => (e.id.split('/')[0] ?? e.id) === plugin.slug,
+    )
+  : undefined;
+const SystemContent = systemEntry ? (await render(systemEntry)).Content : null;
+
+/*
+ * Hierarchical breadcrumb (Plugin library › <category> › <item>). The
+ * middle crumb is the real catalog the item lives in, so every level is
+ * clickable back up the tree — design systems → /plugins/systems/,
+ * templates (categorize !== null) → /plugins/templates/, instruction
+ * skills (categorize === null) → /plugins/skills/. This replaces both
+ * the old standalone back link and the redundant small-caps eyebrow.
+ */
+const category = isDesignSystem
+  ? null
+  : categorizePlugin(bundledRecordOf(plugin));
+const crumbHref = isDesignSystem
+  ? '/plugins/systems/'
+  : category
+    ? '/plugins/templates/'
+    : '/plugins/skills/';
+const crumbLabel = isDesignSystem
+  ? pcopy.tileSystems
+  : category
+    ? pcopy.tileTemplates
+    : pcopy.tileSkills;
 
 /*
  * Share-dialog copy. The English template stays as a fallback inside
@@ -111,20 +185,16 @@ const jsonLd = [
   jsonLd={jsonLd}
   localeCanonicalOnly
 >
-  <nav class="breadcrumb" aria-label={pcopy.breadcrumbLabel}>
-    <a href={href('/')}>Open Design</a>
-    <span>/</span>
-    <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
-    <span>/</span>
-    <span aria-current="page">{pluginTitle}</span>
-  </nav>
-
   <article class="detail">
     <header class="detail-head">
-      <span class="label">
-        {pcopy.hubLabel} · {bucketLabel}
-      </span>
-      <h1 class="display">{pluginTitle}<span class="dot">.</span></h1>
+      <nav class="label detail-crumb" aria-label={pcopy.breadcrumbLabel}>
+        <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
+        <span class="crumb-sep" aria-hidden="true">·</span>
+        <a href={href(crumbHref)}>{crumbLabel}</a>
+        <span class="crumb-sep" aria-hidden="true">·</span>
+        <span aria-current="page">{pluginTitle}</span>
+      </nav>
+      <h1 class="display">{headingTitle}<span class="dot">.</span></h1>
       <p class="lead">{description}</p>
       <div class="detail-actions">
         <a class="btn btn-primary" href="https://github.com/nexu-io/open-design/releases" target="_blank" rel="noopener">
@@ -154,7 +224,11 @@ const jsonLd = [
       </div>
     </header>
 
-    {plugin.previewPoster && (
+    {systemRecord && systemRecord.palette.length > 0 && (
+      <SystemPreview system={systemRecord} caption={pcopy.systemPreviewCaption(pluginTitle)} />
+    )}
+
+    {plugin.previewPoster && !isDesignSystem && (
       <figure class="detail-preview">
         {plugin.previewType === 'video' && plugin.previewVideo ? (
           /*
@@ -234,6 +308,8 @@ const jsonLd = [
       </figure>
     )}
 
+    <PluginContribute />
+
     {/*
       Share modal — same DOM shape as the legacy /skills/<slug>/
       dialog so the global header-enhancer.astro click handlers
@@ -301,6 +377,27 @@ const jsonLd = [
       </form>
     </dialog>
 
+    {systemRecord && systemRecord.palette.length > 0 && (
+      <section class="detail-block">
+        <h2>{ui.catalog.systems.paletteSample}</h2>
+        <p class="block-lead">{ui.catalog.systems.paletteLead(systemRecord.palette.length)}</p>
+        <div class="palette-row">
+          {systemRecord.palette.map((hex) => (
+            <div class="palette-cell">
+              <span class="swatch" style={`background:${hex}`} />
+              <code>{hex}</code>
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    {SystemContent && (
+      <section class="detail-block designmd-body">
+        <SystemContent />
+      </section>
+    )}
+
     <dl class="detail-meta">
       {plugin.mode && (
         <Fragment>
@@ -350,10 +447,78 @@ const jsonLd = [
         </ul>
       </section>
     )}
+
+    {relatedSystems.length > 0 && (
+      <section class="detail-block">
+        <h2>{ui.catalog.systems.related(systemRecord?.categoryLabel ?? '')}</h2>
+        <ul class="related-grid">
+          {relatedSystems.map((r) => (
+            <li>
+              <a href={href(detailHrefForSystemSlug(r.slug) ?? '/plugins/systems/')}>
+                <span class="related-name">{r.name}</span>
+                <span class="related-desc">{r.tagline}</span>
+                <div class="system-swatches" aria-hidden="true">
+                  {r.palette.slice(0, 4).map((hex) => (
+                    <span class="swatch" style={`background:${hex}`} />
+                  ))}
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )}
   </article>
 </Layout>
 
 <style>
+  .detail-crumb a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .detail-crumb a:hover {
+    color: var(--ink, #262626);
+    text-decoration: underline;
+  }
+  .detail-crumb .crumb-sep {
+    margin: 0 0.45em;
+    opacity: 0.55;
+  }
+  /* Full DESIGN.md render. Hide the file's own title H1 so the page
+     keeps one visible H1 (the "<Brand> design system" title in the
+     header). DESIGN.md files carry exactly one H1 (the title); all other
+     headings are H2/H3. */
+  .designmd-body :global(h1) {
+    display: none;
+  }
+  .designmd-body :global(h2) {
+    margin-top: 1.8em;
+  }
+  .designmd-body :global(h3) {
+    margin-top: 1.3em;
+  }
+  .designmd-body :global(ul),
+  .designmd-body :global(ol) {
+    padding-left: 1.4em;
+  }
+  .designmd-body :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 12px 0;
+    font-size: 14px;
+  }
+  .designmd-body :global(th),
+  .designmd-body :global(td) {
+    border: 1px solid var(--line);
+    padding: 6px 10px;
+    text-align: left;
+  }
+  .designmd-body :global(pre) {
+    overflow-x: auto;
+    padding: 12px;
+    background: var(--paper-warm, #f5f5f5);
+    border: 1px solid var(--line);
+  }
   .detail-preview-static {
     width: 100%;
     height: auto;

--- a/apps/landing-page/app/pages/plugins/craft/index.astro
+++ b/apps/landing-page/app/pages/plugins/craft/index.astro
@@ -6,6 +6,7 @@
  * breadcrumb and `active="plugins"` for the nav highlight.
  */
 import Layout from '../../../_components/sub-page-layout.astro';
+import PluginContribute from '../../../_components/plugin-contribute.astro';
 import { getCraftRecords } from '../../../_lib/catalog';
 import { getPluginsCopy } from '../../../_lib/plugins-i18n';
 import { getLandingUiCopy, localeFromPath, localizedHref } from '../../../i18n';
@@ -30,19 +31,17 @@ const jsonLd = {
 ---
 
 <Layout title={title} description={description} active="plugins" jsonLd={jsonLd}>
-  <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href={href('/')}>Open Design</a>
-    <span>/</span>
-    <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
-    <span>/</span>
-    <span aria-current="page">{pcopy.tileCraft}</span>
-  </nav>
-
   <header class="catalog-head">
-    <span class="label">{pcopy.craftLabel}</span>
+    <nav class="label detail-crumb" aria-label="Breadcrumb">
+      <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
+      <span class="crumb-sep" aria-hidden="true">·</span>
+      <span aria-current="page">{pcopy.tileCraft}</span>
+    </nav>
     <h1 class="display">{pcopy.craftHeading(craft.length)}<span class="dot">.</span></h1>
     <p class="lead">{pcopy.craftLead}</p>
   </header>
+
+  <PluginContribute />
 
   <section class="catalog-grid" aria-label={ui.catalog.craft.allAria}>
     <ol>
@@ -60,4 +59,19 @@ const jsonLd = {
       ))}
     </ol>
   </section>
+
+  <style>
+    .detail-crumb a {
+      color: inherit;
+      text-decoration: none;
+    }
+    .detail-crumb a:hover {
+      color: var(--ink, #262626);
+      text-decoration: underline;
+    }
+    .detail-crumb .crumb-sep {
+      margin: 0 0.45em;
+      opacity: 0.55;
+    }
+  </style>
 </Layout>

--- a/apps/landing-page/app/pages/plugins/index.astro
+++ b/apps/landing-page/app/pages/plugins/index.astro
@@ -15,6 +15,7 @@
  * stay where they are; the hub is purely a discovery surface.
  */
 import Layout from '../../_components/sub-page-layout.astro';
+import PluginContribute from '../../_components/plugin-contribute.astro';
 import { getCraftRecords, getSystemRecords } from '../../_lib/catalog';
 import { getBundledPlugins } from '../../_lib/bundled-plugins';
 import { categorizePlugin, bundledRecordOf } from '../../_lib/plugin-facets';
@@ -86,6 +87,8 @@ const tiles = [
     </h1>
     <p class="lead">{pcopy.hubLead}</p>
   </header>
+
+  <PluginContribute />
 
   <section class="plugins-tile-grid" aria-label={pcopy.hubLabel}>
     {tiles.map((tile) => (

--- a/apps/landing-page/app/pages/plugins/skills/index.astro
+++ b/apps/landing-page/app/pages/plugins/skills/index.astro
@@ -11,6 +11,7 @@
  */
 import Layout from '../../../_components/sub-page-layout.astro';
 import PluginRow from '../../../_components/plugin-row.astro';
+import PluginContribute from '../../../_components/plugin-contribute.astro';
 import { getBundledPlugins } from '../../../_lib/bundled-plugins';
 import { bundledRecordOf, categorizePlugin } from '../../../_lib/plugin-facets';
 import { getPluginsCopy } from '../../../_lib/plugins-i18n';
@@ -38,19 +39,17 @@ const jsonLd = {
 ---
 
 <Layout title={title} description={description} active="plugins" jsonLd={jsonLd}>
-  <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href={href('/')}>Open Design</a>
-    <span>/</span>
-    <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
-    <span>/</span>
-    <span aria-current="page">{pcopy.tileSkills}</span>
-  </nav>
-
   <header class="catalog-head plugin-skills-head">
-    <span class="label">{pcopy.skillsLabel}</span>
+    <nav class="label detail-crumb" aria-label="Breadcrumb">
+      <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
+      <span class="crumb-sep" aria-hidden="true">·</span>
+      <span aria-current="page">{pcopy.tileSkills}</span>
+    </nav>
     <h1 class="display">{pcopy.skillsHeading(skills.length)}<span class="dot">.</span></h1>
     <p class="lead">{pcopy.skillsLead}</p>
   </header>
+
+  <PluginContribute />
 
   <section class="catalog-grid catalog-grid-skills" aria-label="All instruction skills">
     <ol>
@@ -65,8 +64,17 @@ const jsonLd = {
       border-top: 0;
       padding-top: 0;
     }
-    .plugin-skills-head .label {
-      display: none;
+    .detail-crumb a {
+      color: inherit;
+      text-decoration: none;
+    }
+    .detail-crumb a:hover {
+      color: var(--ink, #262626);
+      text-decoration: underline;
+    }
+    .detail-crumb .crumb-sep {
+      margin: 0 0.45em;
+      opacity: 0.55;
     }
   </style>
 </Layout>

--- a/apps/landing-page/app/pages/plugins/systems/index.astro
+++ b/apps/landing-page/app/pages/plugins/systems/index.astro
@@ -12,6 +12,7 @@
  */
 import Layout from '../../../_components/sub-page-layout.astro';
 import SystemCard from '../../../_components/system-card.astro';
+import PluginContribute from '../../../_components/plugin-contribute.astro';
 import { getSystemRecords } from '../../../_lib/catalog';
 import { getPluginsCopy } from '../../../_lib/plugins-i18n';
 import { getLandingUiCopy, localeFromPath, localizedHref } from '../../../i18n';
@@ -22,8 +23,8 @@ const pcopy = getPluginsCopy(locale);
 const href = (path: string) => localizedHref(path, locale);
 const systems = await getSystemRecords(locale);
 
-const title = `${pcopy.tileSystems} · ${systems.length} · Open Design`;
-const description = pcopy.systemsLead;
+const title = pcopy.systemsMetaTitle(systems.length);
+const description = pcopy.systemsMetaDescription;
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -36,19 +37,27 @@ const jsonLd = {
 ---
 
 <Layout title={title} description={description} active="plugins" jsonLd={jsonLd}>
-  <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href={href('/')}>Open Design</a>
-    <span>/</span>
-    <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
-    <span>/</span>
-    <span aria-current="page">{pcopy.tileSystems}</span>
-  </nav>
-
   <header class="catalog-head plugin-systems-head">
-    <span class="label">{pcopy.systemsLabel}</span>
+    <nav class="label detail-crumb" aria-label="Breadcrumb">
+      <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
+      <span class="crumb-sep" aria-hidden="true">·</span>
+      <span aria-current="page">{pcopy.tileSystems}</span>
+    </nav>
     <h1 class="display">{pcopy.systemsHeading(systems.length)}<span class="dot">.</span></h1>
     <p class="lead">{pcopy.systemsLead}</p>
   </header>
+
+  <PluginContribute />
+
+  <div class="catalog-search-wrap">
+    <input
+      type="search"
+      class="catalog-search"
+      data-catalog-search
+      placeholder={pcopy.searchPlaceholder}
+      aria-label={pcopy.searchPlaceholder}
+    />
+  </div>
 
   <section class="catalog-grid systems-grid" aria-label={ui.catalog.systems.allAria}>
     <ul>
@@ -56,13 +65,94 @@ const jsonLd = {
     </ul>
   </section>
 
+  <p class="catalog-no-results" data-catalog-empty hidden>{pcopy.searchNoResults}</p>
+
+  <section class="systems-about" aria-labelledby="systems-about-head">
+    <h2 id="systems-about-head">{pcopy.systemsAboutHead}</h2>
+    <p>{pcopy.systemsAboutBody}</p>
+  </section>
+
   <style>
     .plugin-systems-head {
       border-top: 0;
       padding-top: 0;
     }
-    .plugin-systems-head .label {
-      display: none;
+    .detail-crumb a {
+      color: inherit;
+      text-decoration: none;
+    }
+    .detail-crumb a:hover {
+      color: var(--ink, #262626);
+      text-decoration: underline;
+    }
+    .detail-crumb .crumb-sep {
+      margin: 0 0.45em;
+      opacity: 0.55;
+    }
+    .systems-about {
+      max-width: 760px;
+      margin: 64px auto 0;
+      padding-top: 32px;
+      border-top: 1px solid var(--line);
+    }
+    .systems-about h2 {
+      margin: 0 0 12px;
+    }
+    .systems-about p {
+      margin: 0;
+      color: var(--ink-soft, #434343);
+      line-height: 1.6;
+    }
+    .catalog-search-wrap {
+      margin: 0 0 24px;
+    }
+    .catalog-search {
+      width: 100%;
+      max-width: 420px;
+      padding: 10px 14px;
+      font-size: 15px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--paper, #fafafa);
+      color: var(--ink, #262626);
+    }
+    .catalog-search:focus {
+      outline: none;
+      border-color: var(--ink-mute, #595959);
+    }
+    .catalog-no-results {
+      margin: 24px 0;
+      color: var(--ink-mute, #595959);
     }
   </style>
+
+  <script>
+    (() => {
+      const init = () => {
+        const input = document.querySelector<HTMLInputElement>('[data-catalog-search]');
+        if (!input || input.dataset.bound) return;
+        input.dataset.bound = '1';
+        const items = Array.from(
+          document.querySelectorAll<HTMLElement>('.systems-grid > ul > li'),
+        );
+        const empty = document.querySelector<HTMLElement>('[data-catalog-empty]');
+        input.addEventListener('input', () => {
+          const q = input.value.trim().toLowerCase();
+          let shown = 0;
+          items.forEach((el) => {
+            const match = !q || (el.textContent || '').toLowerCase().includes(q);
+            el.hidden = !match;
+            if (match) shown += 1;
+          });
+          if (empty) empty.hidden = shown !== 0;
+        });
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+      } else {
+        init();
+      }
+      document.addEventListener('astro:page-load', init);
+    })();
+  </script>
 </Layout>

--- a/apps/landing-page/app/pages/plugins/templates/index.astro
+++ b/apps/landing-page/app/pages/plugins/templates/index.astro
@@ -22,6 +22,7 @@
  */
 import Layout from '../../../_components/sub-page-layout.astro';
 import TemplateCard from '../../../_components/template-card.astro';
+import PluginContribute from '../../../_components/plugin-contribute.astro';
 import { getBundledPlugins, type BundledPluginRecord } from '../../../_lib/bundled-plugins';
 import {
   PLUGIN_CATEGORIES,
@@ -128,11 +129,17 @@ const jsonLd = [
 <Layout title={title} description={description} active="plugins" jsonLd={jsonLd}>
   <header class="catalog-head tpl-hero plugin-templates-head">
     <div class="tpl-hero-text">
-      <span class="label">{pcopy.templatesHeroEyebrow}</span>
+      <nav class="label detail-crumb" aria-label="Breadcrumb">
+        <a href={href('/plugins/')}>{pcopy.hubLabel}</a>
+        <span class="crumb-sep" aria-hidden="true">·</span>
+        <span aria-current="page">{pcopy.tileTemplates}</span>
+      </nav>
       <h1 class="display">{pcopy.tileTemplates}<span class="dot">.</span></h1>
       <p class="lead">{pcopy.templatesHeroLead}</p>
     </div>
   </header>
+
+  <PluginContribute />
 
   <section class="filter-strip" id="filter-strip" aria-label={pcopy.artifactKindLabel}>
     <div class="filter-group">
@@ -155,6 +162,18 @@ const jsonLd = [
       </ul>
     </div>
   </section>
+
+  <div class="catalog-search-wrap">
+    <input
+      type="search"
+      class="catalog-search"
+      data-catalog-search
+      placeholder={pcopy.searchPlaceholder}
+      aria-label={pcopy.searchPlaceholder}
+    />
+  </div>
+
+  <p class="catalog-no-results" data-catalog-empty hidden>{pcopy.searchNoResults}</p>
 
   <section class="tpl-grid" aria-label={pcopy.tileTemplates}>
     {templates.map((item, idx) => (
@@ -256,8 +275,38 @@ const jsonLd = [
       border-top: 0;
       padding-top: 0;
     }
-    .plugin-templates-head .label {
-      display: none;
+    .detail-crumb a {
+      color: inherit;
+      text-decoration: none;
+    }
+    .detail-crumb a:hover {
+      color: var(--ink, #262626);
+      text-decoration: underline;
+    }
+    .detail-crumb .crumb-sep {
+      margin: 0 0.45em;
+      opacity: 0.55;
+    }
+    .catalog-search-wrap {
+      margin: 0 0 24px;
+    }
+    .catalog-search {
+      width: 100%;
+      max-width: 420px;
+      padding: 10px 14px;
+      font-size: 15px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--paper, #fafafa);
+      color: var(--ink, #262626);
+    }
+    .catalog-search:focus {
+      outline: none;
+      border-color: var(--ink-mute, #595959);
+    }
+    .catalog-no-results {
+      margin: 24px 0;
+      color: var(--ink-mute, #595959);
     }
   </style>
 </Layout>
@@ -379,6 +428,26 @@ const jsonLd = [
           positionPopover(btn);
         });
       });
+
+    // 3) Client-side filter for the card grid — typing narrows the
+    //    visible templates by name/keyword so users don't scroll the
+    //    whole catalogue to find one.
+    const search = document.querySelector<HTMLInputElement>('[data-catalog-search]');
+    if (search && !search.dataset.bound) {
+      search.dataset.bound = '1';
+      const cards = Array.from(document.querySelectorAll<HTMLElement>('.tpl-grid > *'));
+      const empty = document.querySelector<HTMLElement>('[data-catalog-empty]');
+      search.addEventListener('input', () => {
+        const q = search.value.trim().toLowerCase();
+        let shown = 0;
+        cards.forEach((el) => {
+          const match = !q || (el.textContent || '').toLowerCase().includes(q);
+          el.hidden = !match;
+          if (match) shown += 1;
+        });
+        if (empty) empty.hidden = shown !== 0;
+      });
+    }
   };
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Why

Doing SEO work on the `/plugins/` catalogue. It ranked for nothing non-branded: titles and H1s used internal product wording (\"Systems · 150\", bare brand names like \"Stripe\"), the design-system detail pages were thin (a one-line tagline + a generic text poster + a meta table), the breadcrumb wasn't hierarchical, and a 150-item catalogue had no search. SEMrush (US) shows a clean opening: `design system examples` (590 vol / KD 31) for the index, and the long-tail `[brand] design system` cluster (vercel KD16, notion KD19, shopify KD25, … across ~142 systems) for the detail pages — small per page, large in aggregate.

## What users will see

- **`/plugins/systems/`** — keyword-led title/description, an H1 that still leads with the Agent-Native framing (\"Design systems, ready for your agent\"), a new \"What is a design system?\" section, and **each catalogue card now shows a themed mini mock-UI** (a real product layout re-skinned with that system's palette) instead of a flat swatch bar, plus a \"View design system →\" CTA.
- **Design-system detail pages** (e.g. `/plugins/design-system-stripe/`) — a large **live preview**: an original mock product UI styled entirely from the system's design tokens (not a screenshot of any real site); the **full DESIGN.md** rendered (color roles, typography, components, layout, do's & don'ts, agent prompt guide); palette swatches; and related systems. Title/H1 now read \"Stripe design system\".
- **Hierarchical breadcrumb** merged into the small-caps eyebrow on every `/plugins/` page (Plugin library › Category › Item), each level clickable back up the tree.
- **Client-side search** on `/plugins/systems/` and `/plugins/templates/`.

## Surface area

- [x] **UI** — catalogue card previews, detail-page live preview + DESIGN.md render, breadcrumbs, search inputs
- [x] **i18n keys** — new `plugins-i18n` keys (en base + zh / zh-tw; other locales fall back to en)
- [x] **Default behavior change** — `/plugins/` titles/H1s/metas change; design-system detail pages render new content; system cards change from swatch bar to mock preview
- [ ] None

## Screenshots

Systems catalogue (themed card previews + CTA + hierarchical breadcrumb) and a design-system detail page (token-rendered live preview + DESIGN.md). Verified locally via `astro dev`.

## Validation

- `astro check` on `apps/landing-page` — 0 errors.
- Local `astro dev` walk-through: systems index (title/H1/H2/search/cards), `design-system-stripe|vercel|notion|airbnb|apple` (title/H1/live-preview colors/DESIGN.md/breadcrumb), a non-system detail (`od-code-migration` keeps generic framing + Skills breadcrumb), templates/skills/craft breadcrumbs, zh locale.

### Notes
- Design examples are **token-rendered mocks, not screenshots** of real brand sites — original work, no trademark/IP exposure, and it scales to all ~142 systems. Mirrors how the reference (designmd.co) does its \"live preview\".
- `designmd` / `design.md` were checked in SEMrush and are **not** real keywords yet (~10/mo coinage; \"design md\" is Maryland noise), so they are not targeted; `DESIGN.md` appears only as a concept term.
- Main-narrative constraint held: H1s keep the Agent-Native framing; keywords live in title / meta / H2 / item names, never as a \"cheaper alternative\" claim.