### PR TITLE
chore(deps): approve node-pty build script for daemon PTY

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
       "electron",
       "electron-winstaller",
       "esbuild",
+      "node-pty",
       "protobufjs",
       "sharp"
     ]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,5 +22,6 @@ onlyBuiltDependencies:
   - electron
   - electron-winstaller
   - esbuild
+  - node-pty
   - protobufjs
   - sharp


### PR DESCRIPTION
## What

Add `node-pty` to the pnpm `onlyBuiltDependencies` allowlist (both `pnpm-workspace.yaml` and the root `package.json`).

## Why

pnpm 10 blocks native build scripts by default. After a fresh `pnpm install`, `node-pty`'s install hook is skipped silently, leaving the binary missing. When the daemon later tries to spawn a PTY for interactive skills, it fails with a missing native module.

This was previously masked by Node 22 + older pnpm behaviour. After upgrading to the required Node 24 toolchain (per `AGENTS.md`), the allowlist is the documented way to opt back in.

## Files

- `pnpm-workspace.yaml` — added `node-pty` to `onlyBuiltDependencies` (alphabetic position)
- `package.json` — mirrored in `pnpm.onlyBuiltDependencies` for compatibility with consumers that read package.json directly

## Verification

```bash
pnpm install           # node-pty prebuilt binary is downloaded and unpacked
pnpm rebuild           # rebuilds all native modules against the active Node ABI
node -e "require('node-pty')"   # loads cleanly
pnpm tools-dev start   # daemon starts; /health returns 200
```

## Impact

- No source-code or runtime behaviour change
- Unblocks interactive skills that depend on `node-pty` (PTY-backed agent spawns, terminal capture, etc.)
- Mirrors the existing allowlist entries (`better-sqlite3`, `sharp`, `esbuild`, …) that are already approved the same way
