### PR TITLE
fix(web): detect decks with slide-prefixed classes

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5205,9 +5205,10 @@ function HtmlViewer({
   // never surface and the deck becomes a static, unnavigable preview.
   const looksLikeDeck = useMemo(() => {
     if (!source) return false;
-    return /class\s*=\s*['"][^'"]*\bslide\b/i.test(source);
+    return /class\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])/i.test(source);
   }, [source]);
   const effectiveDeck = isDeck || looksLikeDeck;
+  const showDeckNavigation = effectiveDeck && (slideState === null || slideState.count > 0);
   const livePreviewSource = inlinedSource ?? source;
   // Freeze the iframe input on the snapshot taken at Edit-mode entry. Any
   // source rewrite during edit (1.5s debounced set-style patches) stays
@@ -8023,7 +8024,7 @@ function HtmlViewer({
               />
             </>
           ) : null}
-          {showPreviewToolbarControls && effectiveDeck ? (
+          {showPreviewToolbarControls && showDeckNavigation ? (
             <span
               className="deck-nav"
               role="group"

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -786,6 +786,38 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
   });
 
+  it('does not treat slide-prefixed helper classes as deck slides', () => {
+    const file = baseFile({
+      name: 'page.html',
+      path: 'page.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'page.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const markup = renderToStaticMarkup(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={file}
+        liveHtml={
+          '<html><body><div class="slide-meta">1 / 12</div><div class="slide-number">1</div></body></html>'
+        }
+      />,
+    );
+
+    expect(markup).toContain('data-testid="artifact-preview-frame"');
+    expect(markup).toContain('data-od-render-mode="url-load" data-od-active="true"');
+    expect(markup).not.toContain('class="deck-nav"');
+  });
+
   it('reloads a URL-loaded HTML preview with a new cache key without replacing the iframe', () => {
     const file = baseFile({
       name: 'page.html',


### PR DESCRIPTION
## Summary

The host deck heuristic treated classes like `slide-meta` and `slide-number` as standalone `slide` classes, which could enable deck controls for non-deck HTML and produce an invalid `1 / 0` counter.

This tightens the class-token match to only detect a real `slide` class and hides host deck navigation if the iframe reports zero slides.

## E2E verification

- ![after](https://files.catbox.moe/v77flr.png): real preview UI showing `slide-meta.html` rendered without the host deck counter.
- `evidence/e2e.txt`: Playwright UI check result for the seeded `slide-meta.html` preview.
- `evidence/tests.txt`: `FileViewer.test.tsx` passed, including the new regression test.
- `evidence/build.txt`: web production build passed.

Fixes #4320

