### PR TITLE
Rename CI provider workflows

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -13,20 +13,20 @@ on:
         required: false
         type: string
         default: ""
-      runner_run_id:
-        description: Optional ci-runner run id override
+      owned_run_id:
+        description: Optional ci-owned run id override
         required: false
         type: string
         default: ""
-      hosted_run_id:
-        description: Optional ci-hosted run id override
+      github_run_id:
+        description: Optional ci-github run id override
         required: false
         type: string
         default: ""
 
 permissions:
   # Keep write access here even while ci-gate is manual-only: the parked manual
-  # path still needs to dispatch ci-runner / ci-hosted runs when operators do
+  # path still needs to dispatch ci-owned / ci-github runs when operators do
   # not provide explicit run-id overrides. Do not downgrade this to read-only
   # unless the dispatch bootstrap moves elsewhere.
   actions: write
@@ -44,7 +44,7 @@ jobs:
     # switched over to ci-gate in a separate follow-up.
     #
     # Manual-only parking note:
-    # ci-gate / ci-runner / ci-hosted no longer auto-trigger on PR / push /
+    # ci-gate / ci-owned / ci-github no longer auto-trigger on PR / push /
     # merge_group. Keep the manual path usable so operators can still run the
     # parked stack on demand while deeper ci-gate redesign work is in flight.
     name: Validate workspace gate
@@ -54,10 +54,10 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
       TARGET_SHA: ${{ github.event_name == 'workflow_dispatch' && (inputs.target_sha || github.sha) || (github.event_name != 'workflow_dispatch' && (github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha) || '') }}
       TARGET_EVENT: ${{ github.event_name == 'workflow_dispatch' && (inputs.target_event || 'workflow_dispatch') || (github.event_name != 'workflow_dispatch' && github.event_name || '') }}
-      RUNNER_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.runner_run_id || '' }}
-      HOSTED_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.hosted_run_id || '' }}
-      RUNNER_WORKFLOW: ci-runner
-      HOSTED_WORKFLOW: ci-hosted
+      OWNED_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.owned_run_id || '' }}
+      GITHUB_RUN_ID_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.github_run_id || '' }}
+      OWNED_WORKFLOW: ci-owned
+      GITHUB_HOSTED_WORKFLOW: ci-github
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -74,8 +74,8 @@ jobs:
           set -euo pipefail
           target_sha='${{ inputs.target_sha }}'
           target_event='${{ inputs.target_event }}'
-          runner_run_id='${{ inputs.runner_run_id }}'
-          hosted_run_id='${{ inputs.hosted_run_id }}'
+          owned_run_id='${{ inputs.owned_run_id }}'
+          github_run_id='${{ inputs.github_run_id }}'
           has_target_override=0
           has_run_id_override=0
 
@@ -83,7 +83,7 @@ jobs:
             has_target_override=1
           fi
 
-          if [ -n "$runner_run_id" ] || [ -n "$hosted_run_id" ]; then
+          if [ -n "$owned_run_id" ] || [ -n "$github_run_id" ]; then
             has_run_id_override=1
           fi
 
@@ -95,23 +95,23 @@ jobs:
           # run ids. ci-gate can only bootstrap fresh child runs for the current
           # ref / workflow_dispatch event, so a looser combination would just
           # poll until timeout.
-          if [ "$has_target_override" = "1" ] && { [ -z "$runner_run_id" ] || [ -z "$hosted_run_id" ]; }; then
-            echo "target_sha/target_event overrides require both runner_run_id and hosted_run_id" >&2
+          if [ "$has_target_override" = "1" ] && { [ -z "$owned_run_id" ] || [ -z "$github_run_id" ]; }; then
+            echo "target_sha/target_event overrides require both owned_run_id and github_run_id" >&2
             exit 1
           fi
 
-          if [ "$has_run_id_override" = "1" ] && { [ -z "$runner_run_id" ] || [ -z "$hosted_run_id" ]; }; then
-            echo "runner_run_id and hosted_run_id must be supplied together" >&2
+          if [ "$has_run_id_override" = "1" ] && { [ -z "$owned_run_id" ] || [ -z "$github_run_id" ]; }; then
+            echo "owned_run_id and github_run_id must be supplied together" >&2
             exit 1
           fi
 
       - name: Record provider dispatch window
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner_run_id == '' && inputs.hosted_run_id == '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.owned_run_id == '' && inputs.github_run_id == '' }}
         shell: bash
         run: echo "PROVIDER_RUN_CREATED_AFTER=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
 
       - name: Dispatch manual provider runs
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner_run_id == '' && inputs.hosted_run_id == '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.owned_run_id == '' && inputs.github_run_id == '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -124,12 +124,12 @@ jobs:
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
-            "repos/${{ github.repository }}/actions/workflows/ci-runner.yml/dispatches" \
+            "repos/${{ github.repository }}/actions/workflows/ci-owned.yml/dispatches" \
             -f ref='${{ github.ref_name }}'
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
-            "repos/${{ github.repository }}/actions/workflows/ci-hosted.yml/dispatches" \
+            "repos/${{ github.repository }}/actions/workflows/ci-github.yml/dispatches" \
             -f ref='${{ github.ref_name }}' \
             -f inputs[mode]='nix'
 

--- a/.github/workflows/ci-github.yml
+++ b/.github/workflows/ci-github.yml
@@ -1,10 +1,10 @@
-name: ci-hosted
+name: ci-github
 
 on:
   workflow_dispatch:
     inputs:
       mode:
-        description: Hosted CI mode
+        description: GitHub-hosted CI mode
         required: true
         type: choice
         default: nix
@@ -16,16 +16,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-hosted-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'nix' }}
+  group: ci-github-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'nix' }}
   cancel-in-progress: true
 
 jobs:
-  hosted:
-    name: Hosted CI
+  github:
+    name: GitHub-hosted CI
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      CI_GATE_HOSTED_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'nix' }}
+      CI_GATE_GITHUB_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'nix' }}
       CI_GATE_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       CI_GATE_PLAYWRIGHT_INSTALL_FLAGS: --with-deps chromium
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
@@ -46,15 +46,15 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
-      - name: Run hosted CI protocol
-        run: .github/workflows/scripts/ci-gate.sh --provider hosted --mode "$CI_GATE_HOSTED_MODE" --results-path .od/ci-gate/ci-results.json
+      - name: Run GitHub-hosted CI protocol
+        run: .github/workflows/scripts/ci-gate.sh --provider github --mode "$CI_GATE_GITHUB_MODE" --results-path .od/ci-gate/ci-results.json
 
-      - name: Upload hosted CI results
+      - name: Upload GitHub-hosted CI results
         if: ${{ always() }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: ci-results-hosted
+          name: ci-results-github
           path: .od/ci-gate/ci-results.json
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/ci-owned.yml
+++ b/.github/workflows/ci-owned.yml
@@ -1,4 +1,4 @@
-name: ci-runner
+name: ci-owned
 
 on:
   workflow_dispatch:
@@ -7,12 +7,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-runner-${{ github.event.pull_request.number || github.ref }}
+  group: ci-owned-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  runner:
-    name: Runner CI
+  owned:
+    name: Owned CI
     runs-on: [self-hosted, Linux, ARM64, nexu-spark, open-design-ci]
     timeout-minutes: 120
     env:
@@ -24,15 +24,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Run runner CI protocol
-        run: .github/workflows/scripts/ci-gate.sh --provider runner --mode default --results-path .od/ci-gate/ci-results.json
+      - name: Run owned CI protocol
+        run: .github/workflows/scripts/ci-gate.sh --provider owned --mode default --results-path .od/ci-gate/ci-results.json
 
-      - name: Upload runner CI results
+      - name: Upload owned CI results
         if: ${{ always() }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: ci-results-runner
+          name: ci-results-owned
           path: .od/ci-gate/ci-results.json
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/scripts/ci-gate.sh
+++ b/.github/workflows/scripts/ci-gate.sh
@@ -27,20 +27,20 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ -z "$provider" ] || [ -z "$mode" ]; then
-  echo "usage: $0 --provider <runner|hosted> --mode <default|nix|full> [--results-path <path>]" >&2
+  echo "usage: $0 --provider <owned|github> --mode <default|nix|full> [--results-path <path>]" >&2
   exit 2
 fi
 
 case "$provider" in
-  runner)
+  owned)
     if [ "$mode" != "default" ]; then
-      echo "runner only supports --mode default" >&2
+      echo "owned only supports --mode default" >&2
       exit 2
     fi
     ;;
-  hosted)
+  github)
     if [ "$mode" != "nix" ] && [ "$mode" != "full" ]; then
-      echo "hosted only supports --mode nix|full" >&2
+      echo "github only supports --mode nix|full" >&2
       exit 2
     fi
     ;;
@@ -119,13 +119,13 @@ append_result() {
 is_real_action() {
   local action="$1"
   case "$provider:$mode:$action" in
-    runner:default:nix)
+    owned:default:nix)
       return 1
       ;;
-    hosted:nix:nix)
+    github:nix:nix)
       return 0
       ;;
-    hosted:nix:*)
+    github:nix:*)
       return 1
       ;;
     *)

--- a/.github/workflows/scripts/ci/aggregate-results.ts
+++ b/.github/workflows/scripts/ci/aggregate-results.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-type Provider = "runner" | "hosted";
+type Provider = "owned" | "github";
 type ActionName =
   | "nix"
   | "guard"
@@ -72,10 +72,10 @@ const token = process.env.GITHUB_TOKEN ?? "";
 const repository = process.env.GITHUB_REPOSITORY ?? "";
 let targetSha = process.env.TARGET_SHA ?? "";
 let targetEvent = process.env.TARGET_EVENT ?? "";
-const runnerWorkflow = process.env.RUNNER_WORKFLOW ?? "ci-runner";
-const hostedWorkflow = process.env.HOSTED_WORKFLOW ?? "ci-hosted";
-const runnerRunId = process.env.RUNNER_RUN_ID ?? "";
-const hostedRunId = process.env.HOSTED_RUN_ID ?? "";
+const ownedWorkflow = process.env.OWNED_WORKFLOW ?? "ci-owned";
+const githubWorkflow = process.env.GITHUB_HOSTED_WORKFLOW ?? "ci-github";
+const ownedRunId = process.env.OWNED_RUN_ID ?? "";
+const githubRunId = process.env.GITHUB_RUN_ID_OVERRIDE ?? "";
 const timeoutSeconds = Number(process.env.POLL_TIMEOUT_SECONDS ?? "3600");
 const pollIntervalSeconds = Number(process.env.POLL_INTERVAL_SECONDS ?? "20");
 const summaryPath = process.env.GITHUB_STEP_SUMMARY ?? "";
@@ -210,7 +210,7 @@ function parseWorkflowResult(raw: unknown): WorkflowResult {
   if (data.schemaVersion !== 1) {
     throw new Error(`unsupported schemaVersion: ${String(data.schemaVersion)}`);
   }
-  if (data.provider !== "runner" && data.provider !== "hosted") {
+  if (data.provider !== "owned" && data.provider !== "github") {
     throw new Error(`unsupported provider: ${String(data.provider)}`);
   }
   if (!Array.isArray(data.actions)) {
@@ -290,7 +290,7 @@ function validateIdentity(result: WorkflowResult, provider: Provider): void {
   if (result.headSha !== targetSha) {
     throw new Error(`${provider} result headSha ${result.headSha} does not match target ${targetSha}`);
   }
-  const explicitRunId = provider === "runner" ? runnerRunId : hostedRunId;
+  const explicitRunId = provider === "owned" ? ownedRunId : githubRunId;
   const skipStrictEventMatch = targetEvent === "workflow_dispatch" && explicitRunId !== "";
   if (!skipStrictEventMatch && result.eventName !== targetEvent && result.eventName !== "workflow_dispatch") {
     throw new Error(`${provider} result event ${result.eventName} does not match target ${targetEvent}`);
@@ -301,11 +301,11 @@ function validateIdentity(result: WorkflowResult, provider: Provider): void {
   }
 }
 
-function summarizeAction(action: ActionName, runner: WorkflowResult, hosted: WorkflowResult): {
+function summarizeAction(action: ActionName, owned: WorkflowResult, github: WorkflowResult): {
   passed: boolean;
   reason: string;
 } {
-  const candidates = [runner, hosted]
+  const candidates = [owned, github]
     .flatMap((result) => result.actions.filter((entry) => entry.action === action).map((entry) => ({ ...entry, provider: result.provider })));
   const realCandidates = candidates.filter((entry) => entry.kind === "real");
   if (realCandidates.some((entry) => entry.status === "success")) {
@@ -326,23 +326,23 @@ async function appendSummary(lines: string[]): Promise<void> {
 
 async function main(): Promise<void> {
   if (!targetSha || !targetEvent) {
-    const seedRunId = runnerRunId || hostedRunId;
+    const seedRunId = ownedRunId || githubRunId;
     if (!seedRunId) {
-      throw new Error("TARGET_SHA and TARGET_EVENT are required unless a runner_run_id or hosted_run_id is provided");
+      throw new Error("TARGET_SHA and TARGET_EVENT are required unless an owned_run_id or github_run_id is provided");
     }
     const seedRun = await fetchRunById(seedRunId);
     targetSha ||= seedRun.head_sha;
     targetEvent ||= seedRun.event;
   }
 
-  const runnerRun = await waitForRun(runnerWorkflow, runnerRunId);
-  const hostedRun = await waitForRun(hostedWorkflow, hostedRunId);
+  const ownedRun = await waitForRun(ownedWorkflow, ownedRunId);
+  const githubRun = await waitForRun(githubWorkflow, githubRunId);
 
-  const runnerResult = await downloadResultArtifact("runner", runnerRun.id);
-  const hostedResult = await downloadResultArtifact("hosted", hostedRun.id);
+  const ownedResult = await downloadResultArtifact("owned", ownedRun.id);
+  const githubResult = await downloadResultArtifact("github", githubRun.id);
 
-  validateIdentity(runnerResult, "runner");
-  validateIdentity(hostedResult, "hosted");
+  validateIdentity(ownedResult, "owned");
+  validateIdentity(githubResult, "github");
 
   const failures: string[] = [];
   const summaryLines = [
@@ -350,15 +350,15 @@ async function main(): Promise<void> {
     "",
     `Target SHA: \`${targetSha}\``,
     `Target event: \`${targetEvent}\``,
-    `Runner run: [${runnerRun.id}](${runnerRun.html_url}) conclusion=\`${runnerRun.conclusion ?? "null"}\``,
-    `Hosted run: [${hostedRun.id}](${hostedRun.html_url}) conclusion=\`${hostedRun.conclusion ?? "null"}\` mode=\`${hostedResult.mode}\``,
+    `Owned run: [${ownedRun.id}](${ownedRun.html_url}) conclusion=\`${ownedRun.conclusion ?? "null"}\``,
+    `GitHub-hosted run: [${githubRun.id}](${githubRun.html_url}) conclusion=\`${githubRun.conclusion ?? "null"}\` mode=\`${githubResult.mode}\``,
     "",
     "| Action | Result | Reason |",
     "| --- | --- | --- |",
   ];
 
   for (const action of ACTIONS) {
-    const outcome = summarizeAction(action, runnerResult, hostedResult);
+    const outcome = summarizeAction(action, ownedResult, githubResult);
     summaryLines.push(`| \`${action}\` | ${outcome.passed ? "pass" : "fail"} | ${outcome.reason} |`);
     if (!outcome.passed) {
       failures.push(`${action}: ${outcome.reason}`);


### PR DESCRIPTION
## Summary

- Rename the parked provider workflows from `ci-runner` / `ci-hosted` to `ci-owned` / `ci-github`.
- Update ci-gate dispatch inputs, workflow names, artifact names, and provider protocol values to match the new semantics.
- Avoid GitHub Actions reserved env names by using `GITHUB_RUN_ID_OVERRIDE` for the ci-github explicit run id.

## Validation

- `bash -n .github/workflows/scripts/ci-gate.sh`
- `node --experimental-strip-types --check .github/workflows/scripts/ci/aggregate-results.ts`
- `git diff --check`
- `actionlint .github/workflows/ci-gate.yml .github/workflows/ci-owned.yml .github/workflows/ci-github.yml`
