### PR TITLE
[codex] Highlight selected home prototype chip

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2667,11 +2667,12 @@ function ActiveTypeChip({ chip, onClear }: { chip: HomeHeroChip; onClear: () => 
   return (
     <button
       type="button"
-      className="home-hero__active-type-chip"
+      className="home-hero__active-type-chip is-active"
       data-testid="home-hero-active-type-chip"
       data-chip-id={chip.id}
       title={homeHeroChipTitle(chip, t)}
       aria-label={`${homeHeroChipLabel(chip.id, t)} ${t('common.delete')}`}
+      aria-pressed="true"
       onClick={onClear}
     >
       <span className="home-hero__active-type-chip-icon" aria-hidden>

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -1130,7 +1130,17 @@
   transition:
     background-color 120ms var(--ease-out),
     border-color 120ms var(--ease-out),
-    color 120ms var(--ease-out);
+    color 120ms var(--ease-out),
+    box-shadow 120ms var(--ease-out);
+}
+.home-hero__active-type-chip.is-active {
+  border-color: color-mix(in srgb, var(--selected) 42%, var(--border));
+  background: color-mix(in srgb, var(--selected) 10%, var(--bg-panel));
+  color: var(--selected);
+  font-weight: 650;
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--selected-soft) 66%, transparent),
+    var(--shadow-xs);
 }
 .home-hero__active-type-chip-icon {
   width: 13px;
@@ -1139,6 +1149,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border-radius: var(--radius-pill);
+}
+.home-hero__active-type-chip.is-active .home-hero__active-type-chip-icon {
+  background: color-mix(in srgb, var(--selected) 12%, transparent);
+  color: var(--selected);
 }
 .home-hero__active-type-chip-close {
   flex: 0 0 auto;
@@ -1156,9 +1171,12 @@
 .home-hero__active-type-chip:hover,
 .home-hero__active-type-chip:focus-visible {
   outline: none;
-  border-color: var(--border-strong);
-  background: var(--bg-subtle);
-  color: var(--accent);
+  border-color: color-mix(in srgb, var(--selected) 54%, var(--border-strong));
+  background: color-mix(in srgb, var(--selected) 14%, var(--bg-panel));
+  color: var(--selected);
+  box-shadow:
+    0 0 0 3px var(--selected-soft),
+    var(--shadow-xs);
 }
 .home-hero__active-type-chip:hover .home-hero__active-type-chip-close,
 .home-hero__active-type-chip:focus-visible .home-hero__active-type-chip-close {

--- a/apps/web/tests/components/HomeHero.rail.test.tsx
+++ b/apps/web/tests/components/HomeHero.rail.test.tsx
@@ -145,6 +145,8 @@ describe('HomeHero intent rail', () => {
     expect(screen.queryByTestId('home-hero-rail-video')).toBeNull();
     const node = screen.getByTestId('home-hero-active-type-chip');
     expect(node.getAttribute('data-chip-id')).toBe('video');
+    expect(node.className).toContain('is-active');
+    expect(node.getAttribute('aria-pressed')).toBe('true');
     expect(node.textContent).toContain('Video');
   });
 


### PR DESCRIPTION
## Why

The home composer already moved a selected creation type such as Prototype into the input footer, but that active chip used the same quiet gray treatment as an ordinary control. While checking the homepage flow, selecting Prototype did not provide a persistent visual selected state, so users could not easily tell that Prototype was the active mode once the rail collapsed into the composer.

Root cause: `ActiveTypeChip` rendered without an active semantic/state class, and `.home-hero__active-type-chip` only had the default gray pill styles. The selected state existed in app state, but not in the visual contract.

## What users will see

Selecting Prototype on the home screen now leaves a clearly highlighted Prototype chip in the composer. The chip uses the existing `--selected` blue treatment with a soft ring, selected text color, and stronger label weight, while still acting as the clear control for the selected type.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Browser smoke verified the home entry point after selecting Prototype. Computed state after click:

- `data-chip-id="prototype"`
- `aria-pressed="true"`
- `class="home-hero__active-type-chip is-active"`
- `color: rgb(37, 99, 235)`
- selected soft ring present via `box-shadow`

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeHero.rail.test.tsx`
- Did the test go red on `main` and green on this branch? No. This is a visual selected-state regression where the existing component test seam can lock DOM state (`is-active`, `aria-pressed`) but cannot assert the exact visual screenshot cheaply. Browser smoke was used for the visual computed-style check.

## Validation

- Browser smoke: `pnpm tools-dev run web --daemon-port 17456 --web-port 17573`, open `http://127.0.0.1:17573/`, click Prototype, verify active chip class/ARIA/computed selected color and ring.
- `pnpm --filter @open-design/web test -- tests/components/HomeHero.rail.test.tsx` (Vitest ran web suite: 330 files passed, 3246 tests passed, 1 skipped)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`