### PR TITLE
fix(deploy): install bash and git in the Alpine runtime image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -80,7 +80,7 @@ COPY plugins/_official ./plugins/_official
 
 FROM ${RUNTIME_IMAGE}
 
-RUN apk add --no-cache tini poppler-utils && \
+RUN apk add --no-cache tini poppler-utils bash git && \
     addgroup -S -g 1001 open-design && \
     adduser -S -D -H -u 1001 -G open-design open-design
 


### PR DESCRIPTION
## Why

- **My use case:** I run the Docker deployment (`deploy/`) as a self-hosted OpenDesign server and wire up a private runtime layer that adds the Claude Code CLI on top of the published image. Every agent run failed the moment it tried to use its Bash tool — the agent reported *"no POSIX shell in this environment"* and refused to run shell commands, which makes a code-agent deployment effectively useless.
- **The pain:** The runtime stage is built on `node:24-alpine`, which ships only BusyBox `sh` and no `bash`. Agent CLIs (Claude Code, and the Codex/Gemini CLIs the README points people to install themselves) require a real `bash` for their Bash tool. With no `/bin/bash` present they fall back to the "no POSIX shell" path and can't execute anything. `git` is in the same boat — nearly every agent task wants it and it isn't installed either. The image only installs `tini` and `poppler-utils`, so nothing ever puts a usable shell or `git` in front of the agents the deployment is meant to host.

## What users will see

Self-hosted server operators who run the Docker image (and install an agent CLI per the README) will find that agents can actually run shell commands. Before this change, agents spawned in the container hit "no POSIX shell in this environment" and could not use their Bash tool; after it, `bash` and `git` are present in the runtime image and agent shell/git operations work.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the runtime Docker image now contains `bash` and `git`. Existing deployers who rebuild get a slightly larger image; agents that previously could not find a shell now can.
- [ ] **None**

## Screenshots

N/A — no UI surface; this is a runtime-image package change in `deploy/Dockerfile`.

## Bug fix verification

This is a deployment/runtime-image fix rather than an app-logic bug, so a falsifiable in-repo red spec wasn't cheap to write — reproducing it requires a full image build plus a running container, which the unit/e2e layers don't exercise. Verification I did instead, against the same `node:24-alpine`-derived base:

- **Before:** the base runtime image has no `/bin/bash`; agents report "no POSIX shell in this environment" and can't run their Bash tool.
- **After:** built an image that runs `apk add --no-cache bash git` on the same base, started the container, and confirmed inside it: `bash` runs, `git --version` → `git version 2.52.0`, and the agent's Bash tool executes shell commands instead of failing.

## Validation

This change is a single one-line addition to `deploy/Dockerfile` (`apk add` package list); it touches no TypeScript, so `pnpm guard` / `pnpm typecheck` are not applicable and were not run. I verified the package install on the same Alpine base image and confirmed `bash` and `git` are present and functional in the running container as described above.
