### PR TITLE
fix(web): portal New Project design-system dropdown so it isn't clipped

### DIFF
--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Dialog, DialogDescription, DialogFooter, DialogTitle } from '@open-design/components';
 import { createTabToTracking } from '@open-design/contracts/analytics';
 import { isOpenDesignHostAvailable, pickHostWorkingDir } from '@open-design/host';
@@ -1999,7 +2000,22 @@ function DesignSystemPicker({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
+  // The open popover renders through a portal anchored to the trigger so it
+  // escapes the New Project modal's `.newproj-body { overflow-y: auto }` clip
+  // box. A plain `position: absolute` popover (the previous shape) was trapped
+  // inside that scroll container and got truncated when the trigger sat low in
+  // the body or the window was short (issue #4303). Mirrors the viewport-aware
+  // up/down placement of the shared DesignSystemPicker.
+  const [anchor, setAnchor] = useState<{
+    top?: number;
+    bottom?: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
 
   const byId = useMemo(() => {
     const map = new Map<string, DesignSystemSummary>();
@@ -2046,10 +2062,58 @@ function DesignSystemPicker({
     return () => window.clearTimeout(t);
   }, [open]);
 
+  // Anchor the portalled popover to the trigger, flipping above it when there
+  // isn't room below (e.g. the picker sits low in a short New Project modal).
+  useLayoutEffect(() => {
+    if (!open) {
+      setAnchor(null);
+      return undefined;
+    }
+    function updateAnchor() {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const viewport = window.innerWidth;
+      const width = Math.max(280, rect.width);
+      const left = Math.max(8, Math.min(viewport - width - 8, rect.left));
+      const gap = 6;
+      const margin = 12;
+      const spaceBelow = window.innerHeight - rect.bottom - gap - margin;
+      const spaceAbove = rect.top - gap - margin;
+      const openUp = spaceBelow < 280 && spaceAbove > spaceBelow;
+      if (openUp) {
+        setAnchor({
+          bottom: window.innerHeight - rect.top + gap,
+          left,
+          width,
+          maxHeight: Math.max(200, Math.min(440, spaceAbove)),
+        });
+      } else {
+        setAnchor({
+          top: rect.bottom + gap,
+          left,
+          width,
+          maxHeight: Math.max(200, Math.min(440, spaceBelow)),
+        });
+      }
+    }
+    updateAnchor();
+    window.addEventListener('resize', updateAnchor);
+    window.addEventListener('scroll', updateAnchor, true);
+    return () => {
+      window.removeEventListener('resize', updateAnchor);
+      window.removeEventListener('scroll', updateAnchor, true);
+    };
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
+      const target = e.target as Node;
+      if (wrapRef.current?.contains(target)) return;
+      // The popover is portalled outside `wrapRef`, so check it explicitly or
+      // every click inside the open list would dismiss the picker.
+      if (popoverRef.current?.contains(target)) return;
       setOpen(false);
     }
     function onKey(e: KeyboardEvent) {
@@ -2113,6 +2177,7 @@ function DesignSystemPicker({
     >
       <label className="newproj-label">{t('newproj.designSystem')}</label>
       <button
+        ref={triggerRef}
         type="button"
         data-testid="design-system-trigger"
         className={`ds-picker-trigger${open ? ' open' : ''}${primary ? '' : ' empty'}`}
@@ -2143,8 +2208,21 @@ function DesignSystemPicker({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div className="ds-picker-popover" role="listbox">
+      {open && anchor && typeof document !== 'undefined'
+        ? createPortal(
+        <div
+          ref={popoverRef}
+          className="ds-picker-popover ds-picker-popover-portal"
+          role="listbox"
+          data-placement={anchor.bottom !== undefined ? 'up' : 'down'}
+          style={{
+            top: anchor.top,
+            bottom: anchor.bottom,
+            left: anchor.left,
+            width: anchor.width,
+            maxHeight: anchor.maxHeight,
+          }}
+        >
           <div className="ds-picker-head">
             <input
               ref={searchRef}
@@ -2236,8 +2314,10 @@ function DesignSystemPicker({
               </button>
             </div>
           ) : null}
-        </div>
-      ) : null}
+        </div>,
+          document.body,
+        )
+        : null}
     </div>
   );
 }

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2078,22 +2078,33 @@ function DesignSystemPicker({
       const left = Math.max(8, Math.min(viewport - width - 8, rect.left));
       const gap = 6;
       const margin = 12;
+      const PREFERRED_MIN = 200;
+      const PREFERRED_MAX = 440;
       const spaceBelow = window.innerHeight - rect.bottom - gap - margin;
       const spaceAbove = rect.top - gap - margin;
-      const openUp = spaceBelow < 280 && spaceAbove > spaceBelow;
+      // Open upward only when there's more room above and below is cramped.
+      // Either way the popover is sized to the room on the chosen side.
+      const openUp = spaceBelow < PREFERRED_MIN + 80 && spaceAbove > spaceBelow;
+      const available = openUp ? spaceAbove : spaceBelow;
+      // Clamp the fixed popover to the side's actual space. The PREFERRED_MIN
+      // is only honored when the side can fit it; when both sides are tighter
+      // than that (a very short window), forcing 200px here would push the
+      // popover past the viewport instead of letting the list scroll inside a
+      // smaller box. Floor at >= 0 so an off-screen trigger can't yield NaN.
+      const maxHeight = Math.max(0, Math.min(PREFERRED_MAX, available));
       if (openUp) {
         setAnchor({
           bottom: window.innerHeight - rect.top + gap,
           left,
           width,
-          maxHeight: Math.max(200, Math.min(440, spaceAbove)),
+          maxHeight,
         });
       } else {
         setAnchor({
           top: rect.bottom + gap,
           left,
           width,
-          maxHeight: Math.max(200, Math.min(440, spaceBelow)),
+          maxHeight,
         });
       }
     }

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -137,6 +137,23 @@
   from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: translateY(0); }
 }
+/* Portalled variant (New Project design-system picker). Rendered into
+   document.body and positioned from the trigger's viewport rect, so it escapes
+   the modal's `.newproj-body { overflow-y: auto }` clip box that truncated the
+   list (issue #4303). `position: fixed` + the inline top/bottom/left/width/
+   max-height drive placement; the list flexes inside the bounded height and
+   scrolls instead of overflowing past the modal edge. z-index clears the New
+   Project modal backdrop (920). */
+.ds-picker-popover-portal {
+  position: fixed;
+  right: auto;
+  z-index: 1000;
+}
+.ds-picker-popover-portal .ds-picker-list {
+  max-height: none;
+  flex: 1 1 auto;
+  min-height: 0;
+}
 .ds-picker-head {
   display: flex;
   align-items: center;

--- a/e2e/ui/new-project-ds-picker-clipping.test.ts
+++ b/e2e/ui/new-project-ds-picker-clipping.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '../lib/playwright/mock-factory.js';
+
+// Repro for #4303: the New Project → "Design system" dropdown renders
+// misaligned/truncated. The local picker (NewProjectPanel.tsx) opens its
+// popover with plain `position: absolute` (`top: calc(100% + 6px)`, no
+// up-flip), anchored inside `.ds-picker`. Its clipping ancestor is
+// `.newproj-body { overflow-y: auto }` (the modal's scroll container), so when
+// the trigger sits low in the body — or the window is short — the popover
+// extends past the body's visible box and gets cut off. The shared
+// project/composer picker (DesignSystemPicker.tsx) avoids this by portalling to
+// document.body with viewport-aware up/down placement; the local one does not.
+
+const STORAGE_KEY = 'open-design:config';
+
+const AGENTS = [
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    bin: 'codex',
+    available: true,
+    version: '0.134.0',
+    models: [{ id: 'default', label: 'Default (CLI config)' }],
+  },
+];
+
+// Enough systems that the list wants its full height, so truncation is
+// unambiguous when the body clips it.
+const DESIGN_SYSTEMS = [
+  { id: 'nexu-soft-tech', title: 'Nexu Soft Tech', category: 'Product', summary: 'Warm utility system for product interfaces.', swatches: ['#F7F4EE', '#D6CBBF', '#1F2937', '#D97757'] },
+  { id: 'editorial-noir', title: 'Editorial Noir', category: 'Editorial', summary: 'High-contrast editorial system with expressive type.', swatches: ['#111111', '#F6EFE6', '#C44536', '#F2C14E'] },
+  { id: 'data-mist', title: 'Data Mist', category: 'Analytics', summary: 'Calm dashboard system for dense data products.', swatches: ['#EAF4F4', '#5EAAA8', '#05668D', '#0B132B'] },
+  { id: 'verdant-ops', title: 'Verdant Ops', category: 'Product', summary: 'Operational console system with green accents.', swatches: ['#0B3D2E', '#2D6A4F', '#95D5B2', '#D8F3DC'] },
+  { id: 'aurora-print', title: 'Aurora Print', category: 'Editorial', summary: 'Print-inspired editorial system with gradients.', swatches: ['#1A1423', '#3D314A', '#684756', '#96705B'] },
+  { id: 'signal-grid', title: 'Signal Grid', category: 'Analytics', summary: 'Dense telemetry grid system for control rooms.', swatches: ['#0D1B2A', '#1B263B', '#415A77', '#778DA9'] },
+];
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem('od.entry.railOpen', 'true');
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'default',
+        agentId: 'codex',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        privacyDecisionAt: 1,
+        telemetry: { metrics: false, content: false, artifactManifest: false },
+        agentModels: { codex: { model: 'default' } },
+      }),
+    );
+  }, STORAGE_KEY);
+
+  await page.route('**/api/app-config', async (route) => {
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          privacyDecisionAt: 1,
+          telemetry: { metrics: false, content: false, artifactManifest: false },
+          mode: 'daemon',
+          agentId: 'codex',
+          skillId: null,
+          designSystemId: null,
+          agentModels: { codex: { model: 'default' } },
+          agentCliEnv: {},
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/design-systems', async (route) => {
+    await route.fulfill({ json: { designSystems: DESIGN_SYSTEMS } });
+  });
+
+  await routeAgents(page, AGENTS);
+});
+
+test('[P1] design system dropdown is not clipped by the modal body', async ({ page }) => {
+  // A realistic-but-short desktop window, like the macOS report. The modal is
+  // `max-height: calc(100vh - 88px)` and `.newproj-body` scrolls, so a short
+  // window forces the popover to compete with the body's clip box.
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto('/');
+  await openNewProjectPanel(page);
+  await page.getByTestId('new-project-tab-prototype').click();
+  await expect(page.getByTestId('design-system-trigger')).toBeVisible();
+
+  await page.getByTestId('design-system-trigger').click();
+  const popover = page.locator('.ds-picker-popover');
+  await expect(popover).toBeVisible();
+  await expect(page.getByRole('option', { name: /Nexu Soft Tech/i })).toBeVisible();
+
+  await page.screenshot({ path: 'ui/reports/4303-ds-picker-open.png' });
+
+  // Measure clipping: the popover must fit within the scroll container's
+  // visible box. If it spills past `.newproj-body`'s bottom (or the viewport),
+  // the lower options are cut off — the reported truncation.
+  const geometry = await popover.evaluate((el: Element) => {
+    const body = el.closest('.newproj-body') as HTMLElement | null;
+    const bodyRect = body?.getBoundingClientRect() ?? null;
+    const popRect = el.getBoundingClientRect();
+    return {
+      popBottom: Math.round(popRect.bottom),
+      popTop: Math.round(popRect.top),
+      bodyBottom: bodyRect ? Math.round(bodyRect.bottom) : null,
+      bodyTop: bodyRect ? Math.round(bodyRect.top) : null,
+      viewportH: window.innerHeight,
+      // Is the picker's popover actually inside the scrolling/clipping body?
+      insideBody: !!body,
+    };
+  });
+
+  const overflowBelowBody =
+    geometry.bodyBottom != null ? geometry.popBottom - geometry.bodyBottom : 0;
+  const overflowBelowViewport = geometry.popBottom - geometry.viewportH;
+
+  expect(
+    overflowBelowBody,
+    `Popover bottom (${geometry.popBottom}) spills ${overflowBelowBody}px past .newproj-body bottom (${geometry.bodyBottom}) — lower options are clipped. Geometry: ${JSON.stringify(geometry)}`,
+  ).toBeLessThanOrEqual(0);
+
+  expect(
+    overflowBelowViewport,
+    `Popover bottom (${geometry.popBottom}) spills ${overflowBelowViewport}px past viewport (${geometry.viewportH}).`,
+  ).toBeLessThanOrEqual(0);
+});
+
+async function openNewProjectPanel(page: Page) {
+  if (await page.getByTestId('new-project-panel').isVisible()) return;
+  await ensureRailOpen(page);
+  await page.getByTestId('entry-nav-new-project').click();
+  await expect(page.getByTestId('new-project-modal')).toBeVisible();
+  await expect(page.getByTestId('new-project-panel')).toBeVisible();
+}

--- a/e2e/ui/new-project-ds-picker-clipping.test.ts
+++ b/e2e/ui/new-project-ds-picker-clipping.test.ts
@@ -133,6 +133,65 @@ test('[P1] design system dropdown is not clipped by the modal body', async ({ pa
   ).toBeLessThanOrEqual(0);
 });
 
+// Review follow-up (#4346): on a very short window the trigger has little room
+// on *both* sides. A `Math.max(200, ...)` floor on the popover height would
+// still render a 200px box that overflows the viewport; the height must clamp
+// to the available side space and let the list scroll inside it instead.
+test('[P1] design system dropdown stays within a very short viewport (both sides tight)', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 360 });
+  await page.goto('/');
+  await openNewProjectPanel(page);
+  await page.getByTestId('new-project-tab-prototype').click();
+  await expect(page.getByTestId('design-system-trigger')).toBeVisible();
+
+  await page.getByTestId('design-system-trigger').click();
+  const popover = page.locator('.ds-picker-popover');
+  await expect(popover).toBeVisible();
+
+  const geometry = await popover.evaluate((el: Element) => {
+    const trigger = document.querySelector(
+      '[data-testid="design-system-trigger"]',
+    ) as HTMLElement | null;
+    const triggerRect = trigger?.getBoundingClientRect() ?? null;
+    const popRect = el.getBoundingClientRect();
+    const gap = 6;
+    const margin = 12;
+    return {
+      popTop: Math.round(popRect.top),
+      popBottom: Math.round(popRect.bottom),
+      viewportH: window.innerHeight,
+      spaceBelow: triggerRect
+        ? Math.round(window.innerHeight - triggerRect.bottom - gap - margin)
+        : null,
+      spaceAbove: triggerRect ? Math.round(triggerRect.top - gap - margin) : null,
+    };
+  });
+
+  // Confirm this case genuinely exercises the cramped branch the reviewer
+  // flagged: both sides under the 200px preferred minimum.
+  expect(
+    geometry.spaceAbove != null && geometry.spaceAbove < 200,
+    `Expected spaceAbove < 200 to exercise the tight branch; geometry: ${JSON.stringify(geometry)}`,
+  ).toBe(true);
+  expect(
+    geometry.spaceBelow != null && geometry.spaceBelow < 200,
+    `Expected spaceBelow < 200 to exercise the tight branch; geometry: ${JSON.stringify(geometry)}`,
+  ).toBe(true);
+
+  // The popover must stay fully within the viewport (it scrolls internally),
+  // not overflow it.
+  expect(
+    geometry.popBottom,
+    `Popover bottom (${geometry.popBottom}) overflows the short viewport (${geometry.viewportH}). Geometry: ${JSON.stringify(geometry)}`,
+  ).toBeLessThanOrEqual(geometry.viewportH + 1);
+  expect(
+    geometry.popTop,
+    `Popover top (${geometry.popTop}) is above the viewport. Geometry: ${JSON.stringify(geometry)}`,
+  ).toBeGreaterThanOrEqual(-1);
+});
+
 async function openNewProjectPanel(page: Page) {
   if (await page.getByTestId('new-project-panel').isVisible()) return;
   await ensureRailOpen(page);


### PR DESCRIPTION
Fixes #4303

## Why

I hit this while creating a new project in the desktop app: the **Design system**
selector dropdown in the New Project modal renders truncated — only the first
row or two are visible and the form sections below it (Target platforms, Create)
bleed through the cut-off list, so most design systems are unreachable.

Root cause: the local `DesignSystemPicker` in
`apps/web/src/components/NewProjectPanel.tsx` opens its popover with plain
`position: absolute` (`top: calc(100% + 6px)`, no up-flip), anchored inside
`.ds-picker`. Its clipping ancestor is `.newproj-body { overflow-y: auto }` —
the modal's scroll container — and the popover's containing block lives inside
that container, so the body's overflow clips the popover. The shared
project/composer picker (`DesignSystemPicker.tsx`) already solved this by
portalling to `document.body` with viewport-aware placement; the local one
never did.

This is **not** platform-specific: the affected path has no OS-conditional code
(`isMacPlatform()` is only used for ⌘/Ctrl shortcut detection), so it reproduces
identically in macOS desktop, Windows desktop, and the browser — anywhere the
modal's available height is short enough that the ~370px popover (the list
self-scrolls at `max-height: 320px`) overruns the body's visible bottom. In
practice that's when the modal viewport height is below ~760 CSS px: a short /
non-maximized window, a small laptop screen, or high display scaling. On a tall
maximized window the body grows to its full content height and the popover fits,
which is why some setups never see it.

## What users will see

Opening **New Project → Design system** now expands the dropdown cleanly over
the rest of the form, with every design system visible and properly aligned.
When the picker sits low in a short window the popover flips above the trigger;
when the list is taller than the available space it scrolls inside the popover
instead of being cut off at the modal edge.

## Surface area

- [x] **UI** — New Project modal design-system dropdown (`apps/web`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

> Presentation-only fix to an existing capability; the design-system selection
> contract is unchanged, so there's no CLI/contract surface to mirror.

## Screenshots

Faithful render of the repo's real stylesheets (`tokens.css`, `artifacts.css`,
`connectors.css`, `new-project-modal.css`) with the component DOM at 1280×720.

| Before (truncated) | After (portalled) |
| --- | --- |
| <img width="1280" height="720" alt="buggysettled720" src="https://github.com/user-attachments/assets/741fd3cc-9a62-46a7-8826-28fc54378ed2" /> | <img width="1280" height="720" alt="afterrealsettled720" src="https://github.com/user-attachments/assets/cf66da02-0561-44e7-ab5e-c5037f4401dc" /> |

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/new-project-ds-picker-clipping.test.ts`
- Did the test go red on `main` and green on this branch? Designed to: pre-fix
  the `position: absolute` popover's layout rect overflows both `.newproj-body`
  and the viewport (red); post-fix it's portalled and clamped within the
  viewport (green). I could not execute the full Playwright stack in my
  environment (browser download was network-blocked), so please confirm the
  red→green on a CI runner.
- Verification I did instead: rendered the repo's real stylesheets with the new
  portal DOM in a headless browser and confirmed the truncation is gone and the
  full list is reachable (screenshots above).

## Validation

- `pnpm guard` ✓
- `pnpm --filter @open-design/web typecheck` ✓
- Visual verification via the headless render described above.

---

Adjacent issue (out of scope, follow-up): the sibling `PlatformPicker` in the
same file uses the identical absolute-popover pattern and has the same latent
clipping; left for its own fix.