### PR TITLE
feat(landing): keyword-optimize tutorials TDK across locales

### DIFF
--- a/apps/landing-page/app/i18n.ts
+++ b/apps/landing-page/app/i18n.ts
@@ -4257,10 +4257,10 @@ const LANDING_UI_COPY: LandingUiCopy = {
     },
   },
   tutorials: {
-    title: 'Tutorials',
-    seoTitle: 'Tutorials — Open Design',
+    title: 'Open Design Tutorials',
+    seoTitle: 'Open Design Tutorials — How to Use Open Design',
     description:
-      'Watch Open Design from the inside — getting-started walkthroughs, plugin tutorials, demos, and community deep-dives, curated from YouTube and embedded for in-page playback.',
+      'Learn how to use Open Design with step-by-step video tutorials — getting started, plugins, design systems, and real workflows. Every guide plays right on the page.',
     categoriesLabel: 'Tutorial categories',
     categories: {
       all: 'All',

--- a/apps/landing-page/app/landing-ui-i18n.ts
+++ b/apps/landing-page/app/landing-ui-i18n.ts
@@ -188,9 +188,9 @@ function buildUiCopy(t: UiText): DeepPartial<LandingUiCopy> {
       },
     },
     tutorials: {
-      title: t.guides,
-      seoTitle: `${t.guides} — Open Design`,
-      description: `${t.guides}: Open Design / YouTube / ${t.skills} / ${t.systems} / ${t.community}.`,
+      title: `Open Design ${t.guides}`,
+      seoTitle: `Open Design ${t.guides} — Open Design`,
+      description: `Open Design ${t.guides}: ${t.skills} / ${t.systems} / ${t.community}.`,
       categoriesLabel: `${t.guides} · ${t.category}`,
       categories: {
         all: t.all,
@@ -539,10 +539,10 @@ const zhTw: UiText = {
 const make = (text: UiText): DeepPartial<LandingUiCopy> => buildUiCopy(text);
 
 const zhTutorialsCopy = {
-  title: '教程',
-  seoTitle: '教程 — Open Design',
+  title: 'Open Design 教程',
+  seoTitle: 'Open Design 教程 — 如何使用 Open Design',
   description:
-    '观看 Open Design 的上手 walkthrough、插件教程、演示、评测与社区视频。所有视频都在页面内播放，并保留原始 YouTube 来源。',
+    'Open Design 使用教程合集：手把手视频带你上手 Open Design，涵盖安装入门、插件、设计系统与实战工作流，全部可在页面内直接观看。',
   categoriesLabel: '教程分类',
   categories: {
     all: '全部',
@@ -572,10 +572,10 @@ const zhTutorialsCopy = {
 } satisfies NonNullable<DeepPartial<LandingUiCopy>['tutorials']>;
 
 const zhTwTutorialsCopy = {
-  title: '教學',
-  seoTitle: '教學 — Open Design',
+  title: 'Open Design 教學',
+  seoTitle: 'Open Design 教學 — 如何使用 Open Design',
   description:
-    '觀看 Open Design 的上手 walkthrough、外掛教學、演示、評測與社群影片。所有影片都在頁面內播放，並保留原始 YouTube 來源。',
+    'Open Design 使用教學合集：手把手影片帶你上手 Open Design，涵蓋安裝入門、外掛、設計系統與實戰工作流，全部可在頁面內直接觀看。',
   categoriesLabel: '教學分類',
   categories: {
     all: '全部',

--- a/apps/landing-page/app/landing-ui-i18n.ts
+++ b/apps/landing-page/app/landing-ui-i18n.ts
@@ -189,7 +189,7 @@ function buildUiCopy(t: UiText): DeepPartial<LandingUiCopy> {
     },
     tutorials: {
       title: `Open Design ${t.guides}`,
-      seoTitle: `Open Design ${t.guides} — Open Design`,
+      seoTitle: `Open Design ${t.guides}`,
       description: `Open Design ${t.guides}: ${t.skills} / ${t.systems} / ${t.community}.`,
       categoriesLabel: `${t.guides} · ${t.category}`,
       categories: {


### PR DESCRIPTION
## Why

SEO pass on `/tutorials/`. The page targeted nothing: the title/H1 were a generic "Tutorials" / "教程", and the localized descriptions read like machine translation (zh had "上手 walkthrough", "保留原始 YouTube 来源"). Google autocomplete shows real demand for `open design tutorials`, `how to use open design`, `open design 使用教程`, `open design 如何使用` — none of which the page surfaced.

## What users will see

The tutorials index now leads with the brand + intent in every language:

- **en** — H1 "Open Design Tutorials"; `<title>` "Open Design Tutorials — How to Use Open Design"; a natural, keyword-led meta description.
- **zh / zh-tw** — rewritten natively (no more Chinglish): "Open Design 教程 — 如何使用 Open Design" / "…教學…", with a description that reads like real Chinese.
- **other locales (ja / ko / de / fr / …)** — the shared template now brand-leads the title ("Open Design {localized: guides}") instead of the bare localized word.

No layout change — title/description/H1 copy only.

## Surface area

- [x] **i18n keys** — tutorials `title` / `seoTitle` / `description` copy updated (en in `i18n.ts`; zh / zh-tw / template in `landing-ui-i18n.ts`)
- [x] **Default behavior change** — every locale's `/tutorials/` title + meta description changes
- [ ] None

## Validation

- `astro check` — 0 errors.
- Local `astro dev` verified rendered `<title>` + H1 for en, zh, zh-tw, fr, ja.

### Notes
- The real render source for zh/zh-tw tutorials copy is `landing-ui-i18n.ts` (the `EXTRA_LOCALIZED_LANDING_UI_COPY` merged last), not the shadowed `i18n.ts` override — edits were made there so they actually take effect.
- Scope is TDK only. Follow-ups (separate PRs): a "how to use Open Design" body/FAQ section for informational intent, detail-page `<title>` de-duplication + per-video zh titles, and a YouTube-transcript → text-tutorial pipeline to give detail pages real indexable content.