### PR TITLE
fix(daemon): keep plan + critique stages stable for template/plugin generation

### DIFF
--- a/apps/daemon/src/plugins/apply.ts
+++ b/apps/daemon/src/plugins/apply.ts
@@ -140,6 +140,7 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
     pipeline: pipelineResolution.pipeline,
     taskKind,
     mode: manifest.od?.mode,
+    source: pipelineResolution.source,
   });
 
   const declaredSurfaces = manifest.od?.genui?.surfaces ?? [];

--- a/apps/daemon/src/plugins/apply.ts
+++ b/apps/daemon/src/plugins/apply.ts
@@ -139,6 +139,7 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
   const appliedPipeline = ensureCoreQualityStages({
     pipeline: pipelineResolution.pipeline,
     taskKind,
+    mode: manifest.od?.mode,
   });
 
   const declaredSurfaces = manifest.od?.genui?.surfaces ?? [];

--- a/apps/daemon/src/plugins/apply.ts
+++ b/apps/daemon/src/plugins/apply.ts
@@ -41,6 +41,7 @@ import {
   type ConnectorProbe,
 } from './connector-gate.js';
 import { deriveAutoAtomSurfaces } from './atoms/auto-surfaces.js';
+import { ensureCoreQualityStages } from './ensure-core-stages.js';
 import { getManifestContextCraft } from './context-craft.js';
 
 export class MissingInputError extends Error {
@@ -129,7 +130,16 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
     manifest,
     scenarios: input.registry.scenarios,
   });
-  const appliedPipeline = pipelineResolution.pipeline;
+  // Core quality-stage floor: a template/plugin that ships a
+  // generate-only pipeline (to reuse a locked reference seed) still runs
+  // the `plan` (TodoWrite) and `critique` (5-dimension quality /
+  // anti-slop) stages, so the five-stage main flow is stable whether the
+  // artifact came from a free-form prompt or a plugin. Pure media stays
+  // generate-only. See ensure-core-stages.ts for the full rationale.
+  const appliedPipeline = ensureCoreQualityStages({
+    pipeline: pipelineResolution.pipeline,
+    taskKind,
+  });
 
   const declaredSurfaces = manifest.od?.genui?.surfaces ?? [];
   const autoOAuth = input.connectorProbe

--- a/apps/daemon/src/plugins/ensure-core-stages.ts
+++ b/apps/daemon/src/plugins/ensure-core-stages.ts
@@ -99,12 +99,19 @@ export function ensureCoreQualityStages(input: EnsureCoreStagesInput): PluginPip
   const needCritique = !hasStage('critique');
   if (!needPlan && !needCritique) return pipeline;
 
+  // Insert plan immediately BEFORE and critique immediately AFTER the
+  // matched generate stage so the restored loop is exactly
+  // plan -> generate -> critique. The runner executes stages strictly in
+  // declaration order, so a pipeline with post-generate work (e.g.
+  // generate -> handoff) must keep critique between generate and handoff —
+  // appending critique to the very end would let downstream stages consume
+  // or publish output before the quality loop runs.
   const next: PipelineStage[] = [];
   for (const [i, stage] of stages.entries()) {
     if (i === generateIdx && needPlan) next.push(buildPlanStage());
     next.push(stage);
+    if (i === generateIdx && needCritique) next.push(buildCritiqueStage());
   }
-  if (needCritique) next.push(buildCritiqueStage());
 
   return { ...pipeline, stages: next };
 }

--- a/apps/daemon/src/plugins/ensure-core-stages.ts
+++ b/apps/daemon/src/plugins/ensure-core-stages.ts
@@ -71,21 +71,41 @@ export interface EnsureCoreStagesInput {
   // Manifest `od.mode` (image/video/audio/web/deck/...). Media modes are
   // excluded from injection regardless of atom shape.
   mode?: string | undefined;
+  // How `resolveAppliedPipeline` produced `pipeline`: 'declared' (the
+  // manifest carried `od.pipeline`) vs 'scenario' (it omitted it and we
+  // fell back to a bundled scenario). The fallback keys on `taskKind`
+  // ONLY (see pipeline-fallback.ts), so a media manifest with no
+  // `od.pipeline` falls back to the full new-generation scenario
+  // (discovery -> plan -> generate -> critique). We need `source` to
+  // collapse that scenario-derived media pipeline back to generate-only.
+  source?: 'declared' | 'scenario' | 'none' | undefined;
 }
 
 // Returns the pipeline with `plan` + `critique` guaranteed when the
 // pipeline produces a design artifact; otherwise returns it unchanged
 // (same reference when nothing is injected).
 export function ensureCoreQualityStages(input: EnsureCoreStagesInput): PluginPipeline | undefined {
-  const { pipeline, taskKind, mode } = input;
+  const { pipeline, taskKind, mode, source } = input;
   if (!pipeline || !Array.isArray(pipeline.stages)) return pipeline;
   // Scope to the design-generation taskKind; migration / authoring /
   // media-generation flows own their own stage contracts.
   if (taskKind !== 'new-generation') return pipeline;
-  // Pure media (image/video/audio) stays generate-only even when the
-  // pipeline's atoms look like a code artifact — bundled media scenarios
-  // ship an example-driven `file-write`/`live-artifact` pipeline.
-  if (mode && MEDIA_MODES.has(mode)) return pipeline;
+  // Pure media (image/video/audio) stays generate-only. Two shapes reach
+  // here for a media manifest:
+  //   - It DECLARED its own pipeline (every shipped media plugin ships an
+  //     example-driven generate-only pipeline) — leave it verbatim; never
+  //     inject plan/critique even though the atoms look like a code artifact.
+  //   - It OMITTED `od.pipeline` and fell back to the new-generation
+  //     scenario (the fallback keys on taskKind only, ignoring mode), so it
+  //     arrives as discovery -> plan -> generate -> critique. Collapse that
+  //     back to the generate stage so media stays generate-only as promised.
+  if (mode && MEDIA_MODES.has(mode)) {
+    if (source === 'scenario') {
+      const generate = pipeline.stages.find((s) => s.id === 'generate');
+      if (generate) return { ...pipeline, stages: [generate] };
+    }
+    return pipeline;
+  }
 
   const stages = pipeline.stages;
   const generateIdx = stages.findIndex(

--- a/apps/daemon/src/plugins/ensure-core-stages.ts
+++ b/apps/daemon/src/plugins/ensure-core-stages.ts
@@ -1,0 +1,91 @@
+// Core quality-stage floor for design-artifact generation.
+//
+// Why: template / community plugins frequently declare a generate-only
+// pipeline — `stages: [{ id: 'generate', atoms: ['file-write','live-artifact'] }]`
+// — so they can ship a locked reference seed without re-running
+// discovery. But `resolveAppliedPipeline` returns that declaration
+// verbatim (`source: 'declared'`), so it REPLACES the core scenario
+// pipeline. The `plan` (TodoWrite) and `critique` (5-dimension quality /
+// anti-slop) stages then never run: the agent generates with no
+// harness-driven critique loop and, at best, narrates a self-evaluation
+// inline — unverifiable theater. Observed symptom: "using a plugin
+// skipped the five-stage main flow — no todolist, no real anti-slop".
+//
+// This floor guarantees that any pipeline producing a code/document
+// design artifact (a `generate` stage whose atoms include `file-write`
+// or `live-artifact`) carries a `plan` and a `critique` stage, whether
+// the artifact came from a free-form prompt (od-default / od-new-generation,
+// which already declare both — a no-op here) or a template/plugin.
+//
+// Deliberately OUT OF SCOPE:
+//   - Pure media generation (image/video/audio — generate atoms like
+//     `image-generate` / `video-generate`) stays generate-only; a raw
+//     image has nothing for critique-theater to score.
+//   - `task-type` / `discovery` question forms are NOT injected: a
+//     template already knows its task type and locked direction, and
+//     re-raising those GenUI surfaces would interrogate the user for
+//     answers the template already encodes.
+//   - The injected `plan` carries only `todo-write`, NOT
+//     `direction-picker`: a template's direction is fixed by its
+//     reference seed, so we add the todolist without re-exploring
+//     directions the template intentionally locked.
+//
+// Pure module — no fs / SQLite / network — so the daemon's apply path
+// stays pure.
+
+import type { PluginPipeline, PipelineStage } from '@open-design/contracts';
+
+// Atoms whose presence in a `generate` stage mark the output as a
+// code/document artifact that benefits from plan + critique.
+const DESIGN_ARTIFACT_ATOMS = new Set(['file-write', 'live-artifact']);
+
+// Mirrors the `plan` / `critique` stages declared by the bundled
+// od-new-generation scenario, minus `direction-picker` (see header).
+function buildPlanStage(): PipelineStage {
+  return { id: 'plan', atoms: ['todo-write'] };
+}
+function buildCritiqueStage(): PipelineStage {
+  return {
+    id:     'critique',
+    atoms:  ['critique-theater'],
+    repeat: true,
+    until:  'critique.score>=4 || iterations>=3',
+  };
+}
+
+export interface EnsureCoreStagesInput {
+  pipeline: PluginPipeline | undefined;
+  taskKind: string;
+}
+
+// Returns the pipeline with `plan` + `critique` guaranteed when the
+// pipeline produces a design artifact; otherwise returns it unchanged
+// (same reference when nothing is injected).
+export function ensureCoreQualityStages(input: EnsureCoreStagesInput): PluginPipeline | undefined {
+  const { pipeline, taskKind } = input;
+  if (!pipeline || !Array.isArray(pipeline.stages)) return pipeline;
+  // Scope to the design-generation taskKind; migration / authoring /
+  // media-generation flows own their own stage contracts.
+  if (taskKind !== 'new-generation') return pipeline;
+
+  const stages = pipeline.stages;
+  const generateIdx = stages.findIndex(
+    (s) => s.id === 'generate' && (s.atoms ?? []).some((a) => DESIGN_ARTIFACT_ATOMS.has(a)),
+  );
+  // Not a design-artifact generate pipeline (e.g. pure image/video media).
+  if (generateIdx < 0) return pipeline;
+
+  const hasStage = (id: string): boolean => stages.some((s) => s.id === id);
+  const needPlan = !hasStage('plan');
+  const needCritique = !hasStage('critique');
+  if (!needPlan && !needCritique) return pipeline;
+
+  const next: PipelineStage[] = [];
+  for (const [i, stage] of stages.entries()) {
+    if (i === generateIdx && needPlan) next.push(buildPlanStage());
+    next.push(stage);
+  }
+  if (needCritique) next.push(buildCritiqueStage());
+
+  return { ...pipeline, stages: next };
+}

--- a/apps/daemon/src/plugins/ensure-core-stages.ts
+++ b/apps/daemon/src/plugins/ensure-core-stages.ts
@@ -18,9 +18,15 @@
 // which already declare both — a no-op here) or a template/plugin.
 //
 // Deliberately OUT OF SCOPE:
-//   - Pure media generation (image/video/audio — generate atoms like
-//     `image-generate` / `video-generate`) stays generate-only; a raw
-//     image has nothing for critique-theater to score.
+//   - Pure media generation (image/video/audio) stays generate-only; a
+//     raw image/video/audio has nothing for critique-theater to score.
+//     This is gated on the manifest's media `mode` (image/video/audio),
+//     NOT on atom shape alone: bundled media scenarios such as
+//     `image-poster` / `audio-jingle` ship an example-driven
+//     `generate: [file-write, live-artifact]` pipeline (they seed an
+//     `example.html`), so the atom shape is indistinguishable from a
+//     code/document artifact. The media `mode` is the only explicit
+//     non-media signal, so it must win before the atom-shape check.
 //   - `task-type` / `discovery` question forms are NOT injected: a
 //     template already knows its task type and locked direction, and
 //     re-raising those GenUI surfaces would interrogate the user for
@@ -39,6 +45,12 @@ import type { PluginPipeline, PipelineStage } from '@open-design/contracts';
 // code/document artifact that benefits from plan + critique.
 const DESIGN_ARTIFACT_ATOMS = new Set(['file-write', 'live-artifact']);
 
+// Manifest media modes whose output is a raw image/video/audio asset.
+// A pipeline in any of these modes stays generate-only even when its
+// atoms look like a code artifact (bundled media scenarios seed an
+// `example.html`, so the atom shape alone is not decisive).
+const MEDIA_MODES = new Set(['image', 'video', 'audio']);
+
 // Mirrors the `plan` / `critique` stages declared by the bundled
 // od-new-generation scenario, minus `direction-picker` (see header).
 function buildPlanStage(): PipelineStage {
@@ -56,17 +68,24 @@ function buildCritiqueStage(): PipelineStage {
 export interface EnsureCoreStagesInput {
   pipeline: PluginPipeline | undefined;
   taskKind: string;
+  // Manifest `od.mode` (image/video/audio/web/deck/...). Media modes are
+  // excluded from injection regardless of atom shape.
+  mode?: string | undefined;
 }
 
 // Returns the pipeline with `plan` + `critique` guaranteed when the
 // pipeline produces a design artifact; otherwise returns it unchanged
 // (same reference when nothing is injected).
 export function ensureCoreQualityStages(input: EnsureCoreStagesInput): PluginPipeline | undefined {
-  const { pipeline, taskKind } = input;
+  const { pipeline, taskKind, mode } = input;
   if (!pipeline || !Array.isArray(pipeline.stages)) return pipeline;
   // Scope to the design-generation taskKind; migration / authoring /
   // media-generation flows own their own stage contracts.
   if (taskKind !== 'new-generation') return pipeline;
+  // Pure media (image/video/audio) stays generate-only even when the
+  // pipeline's atoms look like a code artifact — bundled media scenarios
+  // ship an example-driven `file-write`/`live-artifact` pipeline.
+  if (mode && MEDIA_MODES.has(mode)) return pipeline;
 
   const stages = pipeline.stages;
   const generateIdx = stages.findIndex(

--- a/apps/daemon/tests/plugins-core-quality-stages.test.ts
+++ b/apps/daemon/tests/plugins-core-quality-stages.test.ts
@@ -177,6 +177,22 @@ describe('core quality-stage floor', () => {
     expect(ids.indexOf('critique')).toBeGreaterThan(ids.indexOf('generate'));
   });
 
+  // Regression: critique must land immediately AFTER generate, not at the
+  // end of the pipeline. A template with post-generate work
+  // (generate -> handoff) would otherwise become generate -> handoff ->
+  // critique, letting the downstream stage run before the quality loop.
+  it('inserts critique right after generate, before any post-generate stage', () => {
+    const plugin = templateFixture({
+      stages: [
+        { id: 'generate', atoms: ['file-write', 'live-artifact'] },
+        { id: 'handoff', atoms: ['file-write'] },
+      ],
+    });
+    const { result } = applyPlugin({ plugin, inputs: {}, registry: REGISTRY });
+    const ids = stageIds(result.pipeline);
+    expect(ids).toEqual(['plan', 'generate', 'critique', 'handoff']);
+  });
+
   it('does not duplicate stages a template already declares', () => {
     const plugin = templateFixture({
       stages: [

--- a/apps/daemon/tests/plugins-core-quality-stages.test.ts
+++ b/apps/daemon/tests/plugins-core-quality-stages.test.ts
@@ -109,6 +109,7 @@ describe('core quality-stage floor', () => {
   // them to plan -> generate -> critique.
   it.each([
     ['image', 'plugins/_official/examples/image-poster/open-design.json'],
+    ['video', 'plugins/_official/examples/vfx-text-cursor/open-design.json'],
     ['audio', 'plugins/_official/examples/audio-jingle/open-design.json'],
   ])('leaves the bundled %s media template generate-only despite file-write/live-artifact atoms', (mode, relPath) => {
     const manifest = JSON.parse(

--- a/apps/daemon/tests/plugins-core-quality-stages.test.ts
+++ b/apps/daemon/tests/plugins-core-quality-stages.test.ts
@@ -194,6 +194,95 @@ describe('core quality-stage floor', () => {
     expect(ids).toEqual(['plan', 'generate', 'critique', 'handoff']);
   });
 
+  // Regression: a media manifest that omits `od.pipeline` falls back to
+  // the new-generation scenario (the fallback keys on taskKind only,
+  // ignoring mode), arriving as discovery -> plan -> generate -> critique.
+  // The media guard must collapse that scenario-derived pipeline back to
+  // generate-only, otherwise "pure media stays generate-only" is broken
+  // for fallback-driven media plugins.
+  it('collapses a scenario-fallback media pipeline back to generate-only', () => {
+    const plugin: InstalledPluginRecord = {
+      ...templateFixture({ stages: [] }),
+      manifest: {
+        name: 'media-no-pipeline',
+        title: 'Media No Pipeline',
+        version: '1.0.0',
+        description: 'A media plugin that omits od.pipeline.',
+        od: {
+          kind: 'skill',
+          taskKind: 'new-generation',
+          mode: 'image',
+          useCase: { query: 'Make a poster.' },
+          capabilities: ['prompt:inject', 'fs:write'],
+          // deliberately no `pipeline` — forces scenario fallback
+        },
+      },
+    } as InstalledPluginRecord;
+
+    const registryWithScenario = {
+      ...REGISTRY,
+      scenarios: [
+        {
+          id: 'od-new-generation',
+          taskKind: 'new-generation' as const,
+          pipeline: {
+            stages: [
+              { id: 'discovery', atoms: ['question-form'] },
+              { id: 'plan', atoms: ['todo-write'] },
+              { id: 'generate', atoms: ['file-write', 'live-artifact'] },
+              { id: 'critique', atoms: ['critique-theater'], repeat: true, until: 'critique.score>=4 || iterations>=3' },
+            ],
+          },
+        },
+      ],
+    };
+
+    const { result } = applyPlugin({ plugin, inputs: {}, registry: registryWithScenario });
+    expect(stageIds(result.pipeline)).toEqual(['generate']);
+  });
+
+  // Control: a NON-media manifest that omits od.pipeline keeps the full
+  // scenario fallback untouched (plan + critique already present → no-op).
+  it('leaves a non-media scenario-fallback pipeline intact', () => {
+    const plugin: InstalledPluginRecord = {
+      ...templateFixture({ stages: [] }),
+      manifest: {
+        name: 'web-no-pipeline',
+        title: 'Web No Pipeline',
+        version: '1.0.0',
+        description: 'A web plugin that omits od.pipeline.',
+        od: {
+          kind: 'skill',
+          taskKind: 'new-generation',
+          mode: 'web',
+          useCase: { query: 'Build a landing page.' },
+          capabilities: ['prompt:inject', 'fs:write'],
+        },
+      },
+    } as InstalledPluginRecord;
+
+    const registryWithScenario = {
+      ...REGISTRY,
+      scenarios: [
+        {
+          id: 'od-new-generation',
+          taskKind: 'new-generation' as const,
+          pipeline: {
+            stages: [
+              { id: 'discovery', atoms: ['question-form'] },
+              { id: 'plan', atoms: ['todo-write'] },
+              { id: 'generate', atoms: ['file-write', 'live-artifact'] },
+              { id: 'critique', atoms: ['critique-theater'], repeat: true, until: 'critique.score>=4 || iterations>=3' },
+            ],
+          },
+        },
+      ],
+    };
+
+    const { result } = applyPlugin({ plugin, inputs: {}, registry: registryWithScenario });
+    expect(stageIds(result.pipeline)).toEqual(['discovery', 'plan', 'generate', 'critique']);
+  });
+
   it('does not duplicate stages a template already declares', () => {
     const plugin = templateFixture({
       stages: [

--- a/apps/daemon/tests/plugins-core-quality-stages.test.ts
+++ b/apps/daemon/tests/plugins-core-quality-stages.test.ts
@@ -102,6 +102,45 @@ describe('core quality-stage floor', () => {
     expect(stageIds(result.pipeline)).toEqual(['generate']);
   });
 
+  // Regression for the blocking review: bundled media scenarios seed an
+  // `example.html`, so they ship `generate: [file-write, live-artifact]`
+  // — the SAME atom shape as a code artifact. The media `mode` must keep
+  // them generate-only; gating on atom shape alone would wrongly rewrite
+  // them to plan -> generate -> critique.
+  it.each([
+    ['image', 'plugins/_official/examples/image-poster/open-design.json'],
+    ['audio', 'plugins/_official/examples/audio-jingle/open-design.json'],
+  ])('leaves the bundled %s media template generate-only despite file-write/live-artifact atoms', (mode, relPath) => {
+    const manifest = JSON.parse(
+      readFileSync(path.join(REPO_ROOT, relPath), 'utf8'),
+    ) as PluginManifest;
+    // Sanity: the shipped media template carries the code-artifact atom
+    // shape, so this guards the exact false-positive class the reviewer flagged.
+    expect(manifest.od?.mode).toBe(mode);
+    const atoms = manifest.od?.pipeline?.stages.find((s) => s.id === 'generate')?.atoms ?? [];
+    expect(atoms).toEqual(expect.arrayContaining(['file-write', 'live-artifact']));
+
+    const plugin: InstalledPluginRecord = {
+      id: manifest.name,
+      title: manifest.title ?? manifest.name,
+      version: manifest.version,
+      sourceKind: 'bundled',
+      source: `/bundled/${manifest.name}`,
+      sourceMarketplaceId: undefined,
+      pinnedRef: undefined,
+      sourceDigest: undefined,
+      trust: 'trusted',
+      capabilitiesGranted: ['prompt:inject', 'fs:write'],
+      fsPath: `/bundled/${manifest.name}`,
+      installedAt: 0,
+      updatedAt: 0,
+      manifest,
+    } as InstalledPluginRecord;
+
+    const { result } = applyPlugin({ plugin, inputs: {}, registry: REGISTRY });
+    expect(stageIds(result.pipeline)).toEqual(['generate']);
+  });
+
   it('repairs the real bundled web-prototype template (generate-only on disk)', () => {
     const manifest = JSON.parse(
       readFileSync(

--- a/apps/daemon/tests/plugins-core-quality-stages.test.ts
+++ b/apps/daemon/tests/plugins-core-quality-stages.test.ts
@@ -1,0 +1,154 @@
+// Red spec for the core quality-stage floor (tom 问题排查).
+//
+// Bug: template / community plugins commonly declare a generate-only
+// pipeline (`stages: [{ id: 'generate', atoms: ['file-write','live-artifact'] }]`)
+// to reuse a locked reference seed. resolveAppliedPipeline returns that
+// verbatim (`source: 'declared'`), so the `plan` (TodoWrite) and
+// `critique` (5-dimension quality / anti-slop) stages never run. The
+// colleague's symptom: using a plugin/template skipped the five-stage
+// main flow — no todolist, no real anti-slop critique loop.
+//
+// Invariant under test: when a plugin produces a code/document design
+// artifact (a `generate` stage whose atoms include `file-write` or
+// `live-artifact`), the applied pipeline always carries `plan` and
+// `critique` — whether the artifact came from a free-form prompt or a
+// template. Pure media generation (image/video/audio) stays
+// generate-only.
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applyPlugin } from '../src/plugins/apply.js';
+import type { InstalledPluginRecord, PluginManifest, PluginPipeline } from '@open-design/contracts';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const REGISTRY = {
+  skills: [],
+  designSystems: [],
+  craft: [],
+  atoms: [
+    { id: 'file-write', label: 'File write' },
+    { id: 'live-artifact', label: 'Live artifact' },
+    { id: 'todo-write', label: 'Todo write' },
+    { id: 'critique-theater', label: 'Critique theater' },
+    { id: 'image-generate', label: 'Image generate' },
+  ],
+};
+
+function templateFixture(pipeline: PluginPipeline, taskKind = 'new-generation'): InstalledPluginRecord {
+  return {
+    id: 'sample-template',
+    title: 'Sample Template',
+    version: '1.0.0',
+    sourceKind: 'local',
+    source: '/tmp/sample-template',
+    sourceMarketplaceId: undefined,
+    pinnedRef: undefined,
+    sourceDigest: undefined,
+    trust: 'trusted',
+    capabilitiesGranted: ['prompt:inject', 'fs:write'],
+    fsPath: '/tmp/sample-template',
+    installedAt: 0,
+    updatedAt: 0,
+    manifest: {
+      name: 'sample-template',
+      title: 'Sample Template',
+      version: '1.0.0',
+      description: 'Fixture mirroring a generate-only HTML template.',
+      od: {
+        kind: 'scenario',
+        taskKind: taskKind as 'new-generation',
+        useCase: { query: 'Build a landing page.' },
+        capabilities: ['prompt:inject', 'fs:write'],
+        pipeline,
+      },
+    },
+  } as InstalledPluginRecord;
+}
+
+function stageIds(pipeline: PluginPipeline | undefined): string[] {
+  return (pipeline?.stages ?? []).map((s) => s.id);
+}
+
+describe('core quality-stage floor', () => {
+  it('injects plan + critique into a generate-only HTML/live-artifact template', () => {
+    const plugin = templateFixture({
+      stages: [{ id: 'generate', atoms: ['file-write', 'live-artifact'] }],
+    });
+    const { result } = applyPlugin({ plugin, inputs: {}, registry: REGISTRY });
+    const ids = stageIds(result.pipeline);
+
+    expect(ids).toContain('plan');
+    expect(ids).toContain('generate');
+    expect(ids).toContain('critique');
+    // plan must precede generate; critique must follow it.
+    expect(ids.indexOf('plan')).toBeLessThan(ids.indexOf('generate'));
+    expect(ids.indexOf('critique')).toBeGreaterThan(ids.indexOf('generate'));
+
+    const critique = result.pipeline!.stages.find((s) => s.id === 'critique');
+    expect(critique?.atoms).toContain('critique-theater');
+    expect(critique?.repeat).toBe(true);
+    const plan = result.pipeline!.stages.find((s) => s.id === 'plan');
+    expect(plan?.atoms).toContain('todo-write');
+  });
+
+  it('leaves a pure media (image) generate-only pipeline untouched', () => {
+    const plugin = templateFixture({
+      stages: [{ id: 'generate', atoms: ['image-generate'] }],
+    });
+    const { result } = applyPlugin({ plugin, inputs: {}, registry: REGISTRY });
+    expect(stageIds(result.pipeline)).toEqual(['generate']);
+  });
+
+  it('repairs the real bundled web-prototype template (generate-only on disk)', () => {
+    const manifest = JSON.parse(
+      readFileSync(
+        path.join(REPO_ROOT, 'plugins/_official/examples/web-prototype/open-design.json'),
+        'utf8',
+      ),
+    ) as PluginManifest;
+    // Sanity: the shipped template really is generate-only — this is the
+    // exact shape the screenshots' templates carry.
+    expect(manifest.od?.pipeline?.stages.map((s) => s.id)).toEqual(['generate']);
+
+    const plugin: InstalledPluginRecord = {
+      id: 'web-prototype',
+      title: manifest.title ?? 'web-prototype',
+      version: manifest.version,
+      sourceKind: 'bundled',
+      source: '/bundled/web-prototype',
+      sourceMarketplaceId: undefined,
+      pinnedRef: undefined,
+      sourceDigest: undefined,
+      trust: 'trusted',
+      capabilitiesGranted: ['prompt:inject', 'fs:write'],
+      fsPath: '/bundled/web-prototype',
+      installedAt: 0,
+      updatedAt: 0,
+      manifest,
+    } as InstalledPluginRecord;
+
+    const { result } = applyPlugin({ plugin, inputs: {}, registry: REGISTRY });
+    const ids = stageIds(result.pipeline);
+    expect(ids).toContain('plan');
+    expect(ids).toContain('critique');
+    expect(ids.indexOf('plan')).toBeLessThan(ids.indexOf('generate'));
+    expect(ids.indexOf('critique')).toBeGreaterThan(ids.indexOf('generate'));
+  });
+
+  it('does not duplicate stages a template already declares', () => {
+    const plugin = templateFixture({
+      stages: [
+        { id: 'plan', atoms: ['todo-write'] },
+        { id: 'generate', atoms: ['file-write', 'live-artifact'] },
+        { id: 'critique', atoms: ['critique-theater'], repeat: true, until: 'critique.score>=4 || iterations>=3' },
+      ],
+    });
+    const { result } = applyPlugin({ plugin, inputs: {}, registry: REGISTRY });
+    const ids = stageIds(result.pipeline);
+    expect(ids.filter((id) => id === 'plan')).toHaveLength(1);
+    expect(ids.filter((id) => id === 'critique')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Why

A teammate reported that generating from a **plugin/template** skipped the five-stage main flow: no TodoWrite todolist, and no real anti-AI-slop critique — the agent only narrated an inline "5-dimension self-evaluation" instead of running the harness critique loop. Diagnostics (packaged 0.10.0) confirmed: the whole conversation ran a single bare `generate` stage.

**Root cause.** Pipeline stages come from the applied plugin's `od.pipeline.stages`. Every HTML template (`web-prototype`, `saas-landing`, `kami-landing`, …) ships `stages: [{ id: 'generate', atoms: ['file-write','live-artifact'] }]` to reuse a locked reference seed. `resolveAppliedPipeline` returns that declaration verbatim, so it **replaces** the core scenario pipeline — `plan` (TodoWrite) and `critique` (`critique-theater`, the 5-dimension quality / anti-slop loop with `repeat until critique.score>=4 || iterations>=3`) never run. Free-form Home prompts go through `od-default`, which already declares all five stages, so they were unaffected — hence the "only happens with plugins/templates" intermittency.

The "五维自评通过 / P0 通过" lines users saw in those runs are the **model narrating** a self-check inside the single generate stage (the template SKILL asks for it) — not the harness critique stage. That self-narration is unverifiable; it's slop about anti-slop.

## What users will see

When you generate from a template/plugin that produces an HTML/live-artifact, the conversation now reliably runs the **plan** stage (the pinned todolist appears) and the **critique** stage (the real 5-dimension quality / anti-slop pass), exactly like free-form generation. Pure media templates (image/video/audio) are unchanged — they stay generate-only.

Note: this fixes new applies; already-applied template conversations keep their stored generate-only snapshot, so start a fresh conversation (or re-apply the template) to get the repaired flow.

## Surface area

- [x] **Default behavior change** — template/plugin design generation now always runs plan + critique; persisted in the applied-plugin snapshot. Pure-media generation is untouched.

## Bug fix verification

- Test path: `apps/daemon/tests/plugins-core-quality-stages.test.ts`
- Red on `main`, green on this branch? **yes** — pre-fix the generate-only template yields `['generate']` (`expected [ 'generate' ] to include 'plan'`); post-fix it yields `plan → generate → critique`.
- The spec also drives the **real bundled `web-prototype` manifest** off disk (the exact shape the reported templates carry) to prove the repair on shipped product data, plus a guard that pure-media (`image-generate`) stays generate-only and that already-complete pipelines aren't duplicated.

## How it works

New pure helper `apps/daemon/src/plugins/ensure-core-stages.ts` (`ensureCoreQualityStages`), called in the plugin apply path right after `resolveAppliedPipeline`. When `taskKind === 'new-generation'` and the pipeline has a `generate` stage whose atoms include `file-write`/`live-artifact`, it injects a `plan` (`todo-write` only — `direction-picker` is intentionally omitted so the template's locked direction is respected) and a `critique` (`critique-theater`, `repeat`/`until` mirroring the bundled scenario) if missing. Pure media stays generate-only; `task-type`/`discovery` question forms are not injected so the template's known task type/direction aren't re-interrogated.

## Validation

- `pnpm --filter @open-design/daemon test -- plugins` — **479 passed** (incl. new `plugins-core-quality-stages` spec, 4 tests)
- `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm guard` — clean