### PR TITLE
[codex] Register prerelease workflow placeholder

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -1,0 +1,32 @@
+name: release-prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Optional git ref to build. Empty builds the dispatched ref."
+        required: false
+        type: string
+        default: ""
+      release_version:
+        description: "Base version (x.y.z). Required when ref is not release/vX.Y.Z."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Registered workflow placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain placeholder
+        run: |
+          cat <<'EOF'
+          This placeholder exists on the default branch so GitHub registers
+          release-prerelease for workflow_dispatch. Dispatch a branch that
+          contains the full release-prerelease.yml implementation to run the
+          actual prerelease validation and publish workflow.
+          EOF


### PR DESCRIPTION
## Why

This PR registers `release-prerelease.yml` on the default branch so GitHub Actions exposes it as a dispatchable workflow. We need that registration before validating the full prerelease workflow implementation from a feature branch; otherwise `gh workflow run release-prerelease.yml --ref <branch>` fails before it can load the branch implementation.

The pain being addressed is release-lane validation friction: without a default-branch workflow file, prerelease migration testing has to go through an unrelated wrapper workflow, which adds notification jobs and makes the validation path harder to reason about.

## What users will see

No product-facing behavior changes. Maintainers will see a new `release-prerelease` workflow entry in GitHub Actions; dispatching it on `main` only runs a placeholder explanation, while dispatching a branch that contains the full workflow can run that branch implementation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

Not a bug fix.

## Validation

- `.tmp/actionlint/actionlint.exe .github/workflows/release-prerelease.yml`
- `git diff --check`
