### PR TITLE
fix(daemon): export built Vite HTML for PDF

### DIFF
--- a/apps/daemon/src/html-export-source.ts
+++ b/apps/daemon/src/html-export-source.ts
@@ -1,0 +1,61 @@
+import nodePath from 'node:path';
+
+export interface ResolveViteDistHtmlEntryOptions {
+  html: string;
+  maxOwnerBytes?: number;
+  metadata?: unknown;
+  projectId: string;
+  projectsRoot: string;
+  readProjectFile: (
+    projectsRoot: string,
+    projectId: string,
+    relPath: string,
+    metadata?: unknown,
+  ) => Promise<{ buffer: Buffer }>;
+  relPath: string;
+  resolveProjectFilePath: (
+    projectsRoot: string,
+    projectId: string,
+    relPath: string,
+    metadata?: unknown,
+  ) => Promise<{ mime: string; size: number }>;
+}
+
+export async function resolveViteDistHtmlEntry({
+  html,
+  maxOwnerBytes,
+  metadata,
+  projectId,
+  projectsRoot,
+  readProjectFile,
+  relPath,
+  resolveProjectFilePath,
+}: ResolveViteDistHtmlEntryOptions): Promise<{ html: string; relPath: string } | null> {
+  if (!isViteDevHtmlEntry(html)) return null;
+
+  const ownerDir = nodePath.posix.dirname(relPath.replace(/^\/+/, ''));
+  const distRelPath = ownerDir === '.' ? 'dist/index.html' : `${ownerDir}/dist/index.html`;
+  try {
+    const distMeta = await resolveProjectFilePath(projectsRoot, projectId, distRelPath, metadata);
+    if (typeof maxOwnerBytes === 'number' && distMeta.size > maxOwnerBytes) return null;
+    if (!distMeta.mime.startsWith('text/html')) return null;
+    const distFile = await readProjectFile(projectsRoot, projectId, distRelPath, metadata);
+    return {
+      html: rewriteViteDistRootAssetUrls(distFile.buffer.toString('utf8')),
+      relPath: distRelPath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isViteDevHtmlEntry(html: string): boolean {
+  return /<script\b[^>]*\btype\s*=\s*["']module["'][^>]*\bsrc\s*=\s*["']\/src\/[^"']+["'][^>]*>\s*<\/script>/i.test(html);
+}
+
+export function rewriteViteDistRootAssetUrls(html: string): string {
+  return html.replace(
+    /\b(href|src)\s*=\s*(["'])\/assets\//gi,
+    (_match, attr: string, quote: string) => `${attr}=${quote}assets/`,
+  );
+}

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -9,6 +9,7 @@ import {
   type InlineAssetReader,
 } from './inline-assets.js';
 import { sandboxImportedProjectRootUnavailableReason } from './sandbox-mode.js';
+import { resolveViteDistHtmlEntry } from './html-export-source.js';
 import { parseOrchestratorWorkspace } from './workspace-contract.js';
 
 export interface RegisterImportRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'ids' | 'paths' | 'imports' | 'auth' | 'projectStore' | 'conversations' | 'projectFiles' | 'validation'> {}
@@ -687,15 +688,17 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         };
       };
 
-      const exportSource = await resolveHtmlExportSource({
+      const html = file.buffer.toString('utf8');
+      const exportSource = await resolveViteDistHtmlEntry({
         projectId: req.params.id,
         projectsRoot: PROJECTS_DIR,
         relPath,
-        html: file.buffer.toString('utf8'),
+        html,
+        maxOwnerBytes: MAX_INLINE_OWNER_BYTES,
         metadata: project?.metadata,
         readProjectFile,
         resolveProjectFilePath,
-      });
+      }) ?? { html, relPath };
       const rendered = await inlineRelativeAssets(
         exportSource.html,
         exportSource.relPath,
@@ -724,53 +727,6 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
     }
   });
 
-}
-
-async function resolveHtmlExportSource({
-  projectId,
-  projectsRoot,
-  relPath,
-  html,
-  metadata,
-  readProjectFile,
-  resolveProjectFilePath,
-}: {
-  projectId: string;
-  projectsRoot: string;
-  relPath: string;
-  html: string;
-  metadata: unknown;
-  readProjectFile: (projectsRoot: string, projectId: string, relPath: string, metadata?: unknown) => Promise<{ buffer: Buffer }>;
-  resolveProjectFilePath: (projectsRoot: string, projectId: string, relPath: string, metadata?: unknown) => Promise<{ size: number; mime: string }>;
-}): Promise<{ html: string; relPath: string }> {
-  if (!isViteDevHtmlEntry(html)) return { html, relPath };
-
-  const ownerDir = nodePath.posix.dirname(relPath);
-  const distRelPath = ownerDir === '.' ? 'dist/index.html' : `${ownerDir}/dist/index.html`;
-  try {
-    const distMeta = await resolveProjectFilePath(projectsRoot, projectId, distRelPath, metadata);
-    if (distMeta.size > MAX_INLINE_OWNER_BYTES || !distMeta.mime.startsWith('text/html')) {
-      return { html, relPath };
-    }
-    const distFile = await readProjectFile(projectsRoot, projectId, distRelPath, metadata);
-    return {
-      html: rewriteViteDistRootAssetUrls(distFile.buffer.toString('utf8')),
-      relPath: distRelPath,
-    };
-  } catch {
-    return { html, relPath };
-  }
-}
-
-function isViteDevHtmlEntry(html: string): boolean {
-  return /<script\b[^>]*\btype\s*=\s*["']module["'][^>]*\bsrc\s*=\s*["']\/src\/[^"']+["'][^>]*>\s*<\/script>/i.test(html);
-}
-
-function rewriteViteDistRootAssetUrls(html: string): string {
-  return html.replace(
-    /\b(href|src)\s*=\s*(["'])\/assets\//gi,
-    (_match, attr: string, quote: string) => `${attr}=${quote}assets/`,
-  );
 }
 
 function buildProjectExportManifestResponse({

--- a/apps/daemon/src/pdf-export.ts
+++ b/apps/daemon/src/pdf-export.ts
@@ -2,7 +2,8 @@ import path from 'node:path';
 
 import type { DesktopExportPdfInput } from '@open-design/sidecar-proto';
 
-import { readProjectFile } from './projects.js';
+import { resolveViteDistHtmlEntry } from './html-export-source.js';
+import { readProjectFile, resolveProjectFilePath } from './projects.js';
 
 export interface BuildDesktopPdfExportInputOptions {
   daemonUrl: string;
@@ -17,14 +18,34 @@ export async function buildDesktopPdfExportInput(
   options: BuildDesktopPdfExportInputOptions,
 ): Promise<DesktopExportPdfInput> {
   const file = await readProjectFile(options.projectsRoot, options.projectId, options.fileName);
+  const exportSource = await resolvePdfExportSource(
+    options,
+    file.buffer.toString('utf8'),
+  );
   const title = displayTitle(options.title, options.fileName);
   return {
-    baseHref: rawBaseHref(options.daemonUrl, options.projectId, options.fileName),
+    baseHref: rawBaseHref(options.daemonUrl, options.projectId, exportSource.fileName),
     deck: options.deck === true,
     defaultFilename: `${safeFilename(title, 'artifact')}.pdf`,
-    html: file.buffer.toString('utf8'),
+    html: exportSource.html,
     title,
   };
+}
+
+async function resolvePdfExportSource(
+  options: BuildDesktopPdfExportInputOptions,
+  html: string,
+): Promise<{ html: string; fileName: string }> {
+  const viteDistEntry = await resolveViteDistHtmlEntry({
+    html,
+    projectId: options.projectId,
+    projectsRoot: options.projectsRoot,
+    readProjectFile,
+    relPath: options.fileName,
+    resolveProjectFilePath,
+  });
+  if (!viteDistEntry) return { html, fileName: options.fileName };
+  return { html: viteDistEntry.html, fileName: viteDistEntry.relPath };
 }
 
 function displayTitle(title: string | undefined, fileName: string): string {

--- a/apps/daemon/tests/pdf-export.test.ts
+++ b/apps/daemon/tests/pdf-export.test.ts
@@ -55,6 +55,86 @@ describe('buildDesktopPdfExportInput', () => {
     expect(input.title).toBe('index');
     expect(input.defaultFilename).toBe('index.pdf');
   });
+
+  it('keeps a successfully loaded empty HTML file exportable', async () => {
+    await writeFile(path.join(projectsRoot, projectId, 'empty.html'), '');
+
+    const input = await buildDesktopPdfExportInput({
+      daemonUrl: 'http://127.0.0.1:7456',
+      fileName: 'empty.html',
+      projectId,
+      projectsRoot,
+      title: 'Empty Export',
+    });
+
+    expect(input.baseHref).toBe('http://127.0.0.1:7456/api/projects/proj-pdf-test/raw/');
+    expect(input.html).toBe('');
+    expect(input.defaultFilename).toBe('Empty-Export.pdf');
+  });
+
+  it('uses the built dist HTML when a Vite dev entry is exported as PDF', async () => {
+    await mkdir(path.join(projectsRoot, projectId, 'dist', 'assets'), { recursive: true });
+    await writeFile(
+      path.join(projectsRoot, projectId, 'vite-entry.html'),
+      '<!doctype html><html><head><script type="module" src="/src/main.tsx"></script></head><body><div id="root"></div></body></html>',
+    );
+    await writeFile(
+      path.join(projectsRoot, projectId, 'dist', 'index.html'),
+      '<!doctype html><html><head>' +
+        '<script type="module" crossorigin src="/assets/app.js"></script>' +
+        '<link rel="stylesheet" crossorigin href="/assets/app.css">' +
+        '</head><body><div id="root">Built app</div></body></html>',
+    );
+    await writeFile(path.join(projectsRoot, projectId, 'dist', 'assets', 'app.js'), 'window.READY = true;');
+    await writeFile(path.join(projectsRoot, projectId, 'dist', 'assets', 'app.css'), 'body{background:#123456}');
+
+    const input = await buildDesktopPdfExportInput({
+      daemonUrl: 'http://127.0.0.1:7456',
+      fileName: 'vite-entry.html',
+      projectId,
+      projectsRoot,
+      title: 'Vite Export',
+    });
+
+    expect(input.baseHref).toBe('http://127.0.0.1:7456/api/projects/proj-pdf-test/raw/dist/');
+    expect(input.html).toContain('Built app');
+    expect(input.html).toContain('src="assets/app.js"');
+    expect(input.html).toContain('href="assets/app.css"');
+    expect(input.html).not.toContain('/src/main.tsx');
+    expect(input.html).not.toContain('/assets/app.js');
+    expect(input.html).not.toContain('/assets/app.css');
+  });
+
+  it('uses a nested built dist HTML base when a nested Vite dev entry is exported as PDF', async () => {
+    await mkdir(path.join(projectsRoot, projectId, 'pages', 'dist', 'assets'), { recursive: true });
+    await writeFile(
+      path.join(projectsRoot, projectId, 'pages', 'vite-entry.html'),
+      '<!doctype html><html><head><script type="module" src="/src/main.tsx"></script></head><body><div id="root"></div></body></html>',
+    );
+    await writeFile(
+      path.join(projectsRoot, projectId, 'pages', 'dist', 'index.html'),
+      '<!doctype html><html><head>' +
+        '<script type="module" crossorigin src="/assets/nested.js"></script>' +
+        '<link rel="stylesheet" crossorigin href="/assets/nested.css">' +
+        '</head><body><div id="root">Nested built app</div></body></html>',
+    );
+
+    const input = await buildDesktopPdfExportInput({
+      daemonUrl: 'http://127.0.0.1:7456',
+      fileName: 'pages/vite-entry.html',
+      projectId,
+      projectsRoot,
+      title: 'Nested Vite Export',
+    });
+
+    expect(input.baseHref).toBe('http://127.0.0.1:7456/api/projects/proj-pdf-test/raw/pages/dist/');
+    expect(input.html).toContain('Nested built app');
+    expect(input.html).toContain('src="assets/nested.js"');
+    expect(input.html).toContain('href="assets/nested.css"');
+    expect(input.html).not.toContain('/src/main.tsx');
+    expect(input.html).not.toContain('/assets/nested.js');
+    expect(input.html).not.toContain('/assets/nested.css');
+  });
 });
 
 describe('POST /api/projects/:id/export/pdf', () => {


### PR DESCRIPTION
Fixes #3702

## Why

`#3893` fixed standalone/Vite HTML downloads by resolving imported Vite dev entries to the built `dist/index.html` before export. The desktop PDF path still read the originally selected HTML file directly.

For Claude Design / Vite-style imports, that selected file can be only a dev shell like:

```html
<script type="module" src="/src/main.tsx"></script>
<div id="root"></div>
```

The desktop PDF renderer does not have a Vite dev server to transform `/src/main.tsx`, so it can render an empty root and produce a tiny/blank PDF. This PR reuses the same Vite-dist resolution for PDF export while preserving the `#3756` review concern: a successfully loaded empty HTML file is still exportable and is not treated as a failed load.

This is separate from #4329, which improves browser fallback print timing for already-rendered content. This PR changes the desktop PDF input when the selected imported entry is a Vite dev shell.

## What users will see

When users export an imported Claude Design / Vite-style standalone artifact as PDF, Open Design will render the built `dist/index.html` artifact instead of the raw dev-entry shell. That keeps the PDF export aligned with the existing HTML download behavior and avoids blank/tiny PDFs for imports whose selected entry file only points at `/src/main.tsx`.

## What changed

- Extracted the Vite dev-entry export resolver into `apps/daemon/src/html-export-source.ts`.
- Kept the existing inline HTML export route on that shared resolver.
- Updated `buildDesktopPdfExportInput` so PDF export uses the built sibling `dist/index.html` for Vite dev entries and points `baseHref` at the built asset directory (`raw/dist/`, `raw/pages/dist/`, etc.).
- Added PDF export regressions for:
  - root Vite dev entry → `dist/index.html`
  - nested Vite dev entry → sibling `dist/index.html`
  - successfully loaded empty HTML source remains exportable

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — PDF export now prefers the built Vite artifact for imported Vite dev-entry HTML when available
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a daemon-side PDF export input fix; the regression is covered by daemon tests.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/pdf-export.test.ts`
- Did the test go red on `main` and green on this branch? yes
  - RED on `origin/main`: the new Vite PDF tests failed because `baseHref` stayed at `raw/` / `raw/pages/` instead of `raw/dist/` / `raw/pages/dist/`.
  - GREEN on this branch: `tests/pdf-export.test.ts` passes with the built dist HTML and relative asset URLs.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/pdf-export.test.ts` from `apps/daemon` — passed (`6 passed`)
- `pnpm exec vitest run -c vitest.config.ts tests/export-inline-route.test.ts` from `apps/daemon` — passed (`42 passed`)
- `pnpm --filter @open-design/daemon run typecheck` — passed
- `pnpm guard` — passed

Note: validation emitted the existing engine warning because this local host is Node `v22.22.3` while the repo requests Node `~24`.
