### PR TITLE
fix(web): hide the jump-to-latest button while the conv-history dropdown is open

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2094,14 +2094,17 @@ export function ChatPane({
             {/* Always mounted so the CSS transition can play in both
                 directions; the `chat-jump-btn-active` class flips the
                 slide + opacity, and `aria-hidden` + `tabIndex={-1}`
-                keep it out of the a11y tree when it's not visible. */}
+                keep it out of the a11y tree when it's not visible.
+                Also suppressed while the conversation-history dropdown is
+                open: the dropdown sits in a separate stacking context, so
+                without this the button bleeds through it (#4123). */}
             <button
               type="button"
-              className={`chat-jump-btn${scrolledFromBottom ? ' chat-jump-btn-active' : ''}`}
+              className={`chat-jump-btn${scrolledFromBottom && !showConvList ? ' chat-jump-btn-active' : ''}`}
               onClick={jumpToBottom}
               title={t('chat.scrollToLatest')}
-              aria-hidden={!scrolledFromBottom}
-              tabIndex={scrolledFromBottom ? 0 : -1}
+              aria-hidden={!scrolledFromBottom || showConvList}
+              tabIndex={scrolledFromBottom && !showConvList ? 0 : -1}
             >
               <Icon name="arrow-up" size={12} style={{ transform: 'rotate(180deg)' }} />
               <span>{t('chat.jumpToLatest')}</span>


### PR DESCRIPTION
Fixes #4123

## Why

The floating "Jump to latest" button is absolutely positioned at z-index 6 inside its own stacking context. The conversation-history dropdown is z-index 30, but z-index only competes within a shared stacking context. Since the two live in separate stacks, the button bleeds through the open dropdown.

This was previously bundled into #4238 alongside a workspace-tab tooltip change. That tooltip change is now obsolete (the entry topbar tooltip-unification in #4079 took the opposite approach), and #4238 has gone conflicting, so I'm landing the still-valid jump-button fix on its own off current main.

## What users will see

When the conversation-history dropdown is open, the "Jump to latest" button no longer shows through it. It hides while the dropdown is open and comes back when it closes.

## Surface area

- [x] **UI** -- new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** -- new or changed
- [ ] **CLI / env var** -- new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** -- new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** -- new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** -- added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** -- adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** -- changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** -- internal refactor, docs, tests, or translation update only

## Screenshots

Conversation-history dropdown open, chat scrolled up.

Before (button bleeds through the open dropdown):

<img width="1113" height="647" alt="image" src="https://github.com/user-attachments/assets/6d2ee0af-4fdd-47fb-9cfb-a069bfdf46de" />

After (button hidden while the dropdown is open):

<img width="1113" height="647" alt="image" src="https://github.com/user-attachments/assets/d2369b92-1171-4497-8246-d4adaea6208d" />

## Bug fix verification

No automated test. It's a z-order/stacking-context bug that only shows in the rendered UI. Verified in the dev build: with the dropdown open and the log scrolled up, the button is hidden; closing the dropdown brings it back.

## Validation

- `pnpm --filter @open-design/web typecheck`: clean
