### PR TITLE
Claude/elegant thompson mdcwur

### DIFF
--- a/aegis-club/.env.example
+++ b/aegis-club/.env.example
@@ -1,0 +1,34 @@
+# ─────────────────────────────────────────────────────────────
+# Banco de dados (PostgreSQL)
+# Use o docker-compose incluído para subir um Postgres local:
+#   docker compose up -d
+# ─────────────────────────────────────────────────────────────
+DATABASE_URL="postgresql://aegis:aegis@localhost:5432/aegis_club?schema=public"
+
+# ─────────────────────────────────────────────────────────────
+# Sessão / autenticação
+# Gere um segredo forte: `openssl rand -base64 32`
+# ─────────────────────────────────────────────────────────────
+AUTH_SECRET="troque-isto-por-um-segredo-aleatorio-de-32-bytes"
+
+# URL pública da aplicação (usada no retorno do login da Steam)
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
+# ─────────────────────────────────────────────────────────────
+# Steam Web API
+# Crie sua chave em: https://steamcommunity.com/dev/apikey
+# Sem a chave o login real da Steam não busca avatar/nick,
+# mas o "login de desenvolvimento" continua funcionando.
+# ─────────────────────────────────────────────────────────────
+STEAM_API_KEY=""
+
+# Permite o botão de "login de desenvolvimento" (apenas fora de produção).
+# Útil para testar a plataforma sem configurar a Steam.
+NEXT_PUBLIC_ENABLE_DEV_LOGIN="true"
+
+# ─────────────────────────────────────────────────────────────
+# YouTube Data API (opcional)
+# Usada para validar/enriquecer os vídeos de tutoriais.
+# Sem a chave os embeds ainda funcionam pelo ID do vídeo.
+# ─────────────────────────────────────────────────────────────
+YOUTUBE_API_KEY=""

--- a/aegis-club/.eslintrc.json
+++ b/aegis-club/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+    ],
+    "@typescript-eslint/no-explicit-any": "warn"
+  }
+}

--- a/aegis-club/.gitignore
+++ b/aegis-club/.gitignore
@@ -1,0 +1,37 @@
+# dependencies
+node_modules
+.pnp
+.pnp.js
+
+# next.js
+.next
+out
+build
+next-env.d.ts
+
+# production
+dist
+
+# env
+.env
+.env.local
+.env*.local
+
+# prisma
+prisma/*.db
+prisma/*.db-journal
+prisma/migrations/dev.db*
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# misc
+.DS_Store
+*.pem
+coverage
+.vscode
+.idea
+.turbo

--- a/aegis-club/README.md
+++ b/aegis-club/README.md
@@ -1,0 +1,172 @@
+# 🛡️ Aegis Club
+
+**Plataforma competitiva da comunidade de Dota 2** — inspirada na Gamers Club do CS.
+Partidas equilibradas, um sistema de reputação que combate a toxicidade das
+ranqueadas comuns, tutoriais de heróis em vídeo, perfis de jogador e torneios
+criados pela própria comunidade.
+
+> Projeto comunitário, sem vínculo com a Valve. Dota 2 é marca da Valve Corporation.
+
+---
+
+## ✨ Funcionalidades
+
+- **Matchmaking 5x5 equilibrado** — fila com balanceamento por Elo interno
+  (`rankPoints`). Times são montados para partidas justas, e o host abre o lobby
+  no cliente do Dota 2 compartilhando nome/senha.
+- **Anti-toxicidade de verdade** — cada jogador tem um *behavior score* (0–10000).
+  Ao fim da partida você **elogia** quem somou e **denuncia** quem atrapalhou.
+  Quem tem conduta baixa cai na **fila de baixa prioridade**, isolado de quem
+  joga limpo.
+- **Tutoriais de heróis** — catálogo de heróis com guias em vídeo do YouTube,
+  curados e votados pela comunidade, separados por nível (iniciante →
+  avançado).
+- **Perfis e conexões** — perfil com medalha, conduta, estatísticas, heróis
+  favoritos, redes sociais e pedidos de amizade entre jogadores.
+- **Torneios** — crie e administre torneios com inscrição de times e
+  **chaveamento automático** (eliminação simples), reportando resultados e
+  avançando os vencedores na chave.
+- **Ranking** — leaderboard global e por região, por pontos de habilidade.
+
+---
+
+## 🧰 Stack
+
+| Camada        | Tecnologia                                            |
+| ------------- | ----------------------------------------------------- |
+| Framework     | [Next.js 15](https://nextjs.org) (App Router) + React 19 |
+| Linguagem     | TypeScript                                             |
+| Estilo        | Tailwind CSS                                           |
+| Banco         | PostgreSQL + [Prisma ORM](https://www.prisma.io)      |
+| Autenticação  | Steam (OpenID 2.0) + sessão JWT (`jose`)              |
+| Dados de Dota | [OpenDota API](https://docs.opendota.com) (opcional)  |
+
+---
+
+## 🚀 Começando
+
+### Pré-requisitos
+
+- Node.js **18.18+** (recomendado 20+)
+- [pnpm](https://pnpm.io) (`npm i -g pnpm`)
+- Docker (para subir o Postgres local) — ou um PostgreSQL próprio
+
+### Passo a passo
+
+```bash
+# 1. Instale as dependências
+pnpm install
+
+# 2. Configure as variáveis de ambiente
+cp .env.example .env
+#   → gere o AUTH_SECRET:  openssl rand -base64 32
+#   → (opcional) preencha STEAM_API_KEY para login real da Steam
+
+# 3. Suba o banco de dados (PostgreSQL via Docker)
+docker compose up -d
+
+# 4. Crie as tabelas e popule com dados de demonstração
+pnpm prisma migrate dev --name init
+pnpm db:seed
+
+# 5. Rode em desenvolvimento
+pnpm dev
+```
+
+Acesse **http://localhost:3000**.
+
+> **Sem chave da Steam?** Mantenha `NEXT_PUBLIC_ENABLE_DEV_LOGIN="true"` no `.env`
+> e use o botão **"Login de teste"** no topo para entrar com um usuário fictício
+> e explorar a plataforma. Esse atalho é automaticamente desativado em produção.
+
+### Login real com Steam
+
+1. Gere uma chave em https://steamcommunity.com/dev/apikey
+2. Coloque-a em `STEAM_API_KEY` no `.env`
+3. Garanta que `NEXT_PUBLIC_APP_URL` aponta para a URL pública correta
+   (a Steam redireciona o usuário de volta para `…/api/auth/steam/callback`).
+
+---
+
+## 📜 Scripts
+
+| Comando             | O que faz                                         |
+| ------------------- | ------------------------------------------------- |
+| `pnpm dev`          | Sobe o servidor de desenvolvimento                |
+| `pnpm build`        | `prisma generate` + build de produção             |
+| `pnpm start`        | Roda o build de produção                          |
+| `pnpm typecheck`    | Checagem de tipos com `tsc`                        |
+| `pnpm lint`         | ESLint (config do Next)                            |
+| `pnpm prisma:migrate` | Cria/aplica migrations em dev                    |
+| `pnpm db:push`      | Sincroniza o schema sem migration (protótipo)     |
+| `pnpm db:seed`      | Popula heróis, jogadores, tutoriais e um torneio  |
+| `pnpm db:reset`     | Reseta o banco e re-semeia                         |
+
+---
+
+## 🗂️ Estrutura
+
+```
+aegis-club/
+├── prisma/
+│   ├── schema.prisma      # modelo de dados (usuários, fila, partidas, reputação, torneios…)
+│   └── seed.ts            # dados de demonstração
+├── src/
+│   ├── app/               # rotas (App Router)
+│   │   ├── api/auth/       # login Steam, callback, dev login, logout
+│   │   ├── heroes/         # catálogo + detalhe + tutoriais
+│   │   ├── play/           # fila de matchmaking
+│   │   ├── match/[id]/     # lobby, ready-check, resultado, elogios/denúncias
+│   │   ├── tournaments/    # lista, criação, detalhe + chaveamento
+│   │   ├── profile/        # perfil público e edição
+│   │   ├── leaderboard/    # ranking
+│   │   └── dashboard/      # painel do jogador
+│   ├── components/        # UI (primitivos + componentes por feature)
+│   ├── lib/               # regras de negócio
+│   │   ├── matchmaking.ts  # formação e balanceamento de partidas
+│   │   ├── reputation.ts   # behavior score (anti-toxicidade)
+│   │   ├── ranking.ts      # medalhas + Elo de rankPoints
+│   │   ├── bracket.ts      # geração de chaveamento
+│   │   ├── steam.ts        # OpenID da Steam
+│   │   ├── session.ts      # sessão JWT
+│   │   └── opendota.ts     # integração OpenDota
+│   └── data/heroes.ts     # catálogo curado de heróis
+└── docker-compose.yml     # PostgreSQL local
+```
+
+---
+
+## 🧠 Como funciona o anti-toxicidade
+
+1. **Jogue e avalie.** Ao fim de cada partida, cada jogador pode elogiar
+   (`Amigável`, `Tolerante`, `Comunicativo`, `Boa liderança`) e denunciar
+   (`Comunicação abusiva`, `Feeding intencional`, `Sabotagem`, `Abandono`,
+   `Discurso de ódio`, `Trapaça`, `Smurf`).
+2. **O score evolui.** Elogios somam; denúncias subtraem (pesos diferentes por
+   gravidade — ver `src/lib/reputation.ts`). Conduta exemplar libera benefícios;
+   conduta ruim restringe.
+3. **Filas separadas.** Abaixo de `LOW_PRIORITY_THRESHOLD`, o jogador só encontra
+   partida com outros de baixa prioridade. Abaixo de
+   `RANKED_BEHAVIOR_THRESHOLD`, a fila ranqueada é bloqueada.
+
+> No MVP a penalidade é aplicada na hora para fins de demonstração. Em produção,
+> denúncias deveriam passar por revisão (campo `Report.status`) antes de impactar
+> o score — o modelo de dados já prevê isso.
+
+---
+
+## 🗺️ Roadmap (próximos passos)
+
+- [ ] Revisão de denúncias (overwatch da comunidade) antes da punição
+- [ ] Criação automática de lobby via Steam Game Coordinator / bot
+- [ ] Chat de lobby e de equipe em tempo real (WebSocket)
+- [ ] Anti-smurf e verificação de conta (horas de jogo via Steam)
+- [ ] Eliminação dupla e pontos corridos nos torneios
+- [ ] App/CLI para integração com bots de Discord
+- [ ] Importação completa de histórico via OpenDota
+
+---
+
+## 📄 Licença
+
+MIT — use, modifique e contribua.

--- a/aegis-club/docker-compose.yml
+++ b/aegis-club/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: aegis-club-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: aegis
+      POSTGRES_PASSWORD: aegis
+      POSTGRES_DB: aegis_club
+    ports:
+      - "5432:5432"
+    volumes:
+      - aegis_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aegis -d aegis_club"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  aegis_pgdata:

--- a/aegis-club/next.config.mjs
+++ b/aegis-club/next.config.mjs
@@ -1,0 +1,21 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      // Avatares e imagens da Steam
+      { protocol: "https", hostname: "avatars.steamstatic.com" },
+      { protocol: "https", hostname: "avatars.akamai.steamstatic.com" },
+      { protocol: "https", hostname: "steamcdn-a.akamaihd.net" },
+      // Recursos de heróis/itens do Dota 2 (CDN da Valve / OpenDota)
+      { protocol: "https", hostname: "cdn.cloudflare.steamstatic.com" },
+      { protocol: "https", hostname: "cdn.steamstatic.com" },
+      { protocol: "https", hostname: "api.opendota.com" },
+      // Thumbnails do YouTube
+      { protocol: "https", hostname: "i.ytimg.com" },
+      { protocol: "https", hostname: "img.youtube.com" },
+    ],
+  },
+};
+
+export default nextConfig;

--- a/aegis-club/package.json
+++ b/aegis-club/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "aegis-club",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Plataforma competitiva da comunidade de Dota 2: matchmaking com sistema anti-toxicidade, perfis, tutoriais de heróis e torneios.",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "prisma generate && next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "db:push": "prisma db push",
+    "db:seed": "tsx prisma/seed.ts",
+    "db:reset": "prisma migrate reset --force"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.2.1",
+    "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
+    "jose": "^5.9.6",
+    "lucide-react": "^0.469.0",
+    "next": "^15.1.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^2.6.0",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.12",
+    "@types/react": "^19.0.7",
+    "@types/react-dom": "^19.0.3",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "^15.1.6",
+    "postcss": "^8.4.49",
+    "prisma": "^6.2.1",
+    "tailwindcss": "^3.4.17",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  }
+}

--- a/aegis-club/pnpm-lock.yaml
+++ b/aegis-club/pnpm-lock.yaml
@@ -1,0 +1,4540 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@prisma/client':
+        specifier: ^6.2.1
+        version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.4.0
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
+      lucide-react:
+        specifier: ^0.469.0
+        version: 0.469.0(react@19.2.7)
+      next:
+        specifier: ^15.1.6
+        version: 15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+      tailwind-merge:
+        specifier: ^2.6.0
+        version: 2.6.1
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.12
+        version: 20.19.43
+      '@types/react':
+        specifier: ^19.0.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.17)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.15)
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      eslint-config-next:
+        specifier: ^15.1.6
+        version: 15.5.19(eslint@8.57.1)(typescript@5.9.3)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.15
+      prisma:
+        specifier: ^6.2.1
+        version: 6.19.3(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(tsx@4.22.4)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/eslintrc@2.1.4':
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@8.57.1':
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@humanwhocodes/config-array@0.13.0':
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@2.0.3':
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@next/env@15.5.19':
+    resolution: {integrity: sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==}
+
+  '@next/eslint-plugin-next@15.5.19':
+    resolution: {integrity: sha512-Ctwb4qYuMbHN/1oXLlTdMchwG8h8Xzwq+wGZZMgF3o6+uwyBKAI2c96bdOsl+C62PaUD0Jkh+QpNkhUeDlam0Q==}
+
+  '@next/swc-darwin-arm64@15.5.19':
+    resolution: {integrity: sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.19':
+    resolution: {integrity: sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.19':
+    resolution: {integrity: sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@15.5.19':
+    resolution: {integrity: sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@15.5.19':
+    resolution: {integrity: sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@15.5.19':
+    resolution: {integrity: sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@15.5.19':
+    resolution: {integrity: sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.19':
+    resolution: {integrity: sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@nolyfill/is-core-module@1.0.39':
+    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
+    engines: {node: '>=12.4.0'}
+
+  '@prisma/client@6.19.3':
+    resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@6.19.3':
+    resolution: {integrity: sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==}
+
+  '@prisma/debug@6.19.3':
+    resolution: {integrity: sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
+    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
+
+  '@prisma/engines@6.19.3':
+    resolution: {integrity: sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==}
+
+  '@prisma/fetch-engine@6.19.3':
+    resolution: {integrity: sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==}
+
+  '@prisma/get-platform@6.19.3':
+    resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
+
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@rushstack/eslint-patch@1.16.1':
+    resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@typescript-eslint/eslint-plugin@8.61.0':
+    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.61.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.61.0':
+    resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.61.0':
+    resolution: {integrity: sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.61.0':
+    resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.61.0':
+    resolution: {integrity: sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.61.0':
+    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.61.0':
+    resolution: {integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.61.0':
+    resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.61.0':
+    resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.61.0':
+    resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    resolution: {integrity: sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    resolution: {integrity: sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    resolution: {integrity: sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    resolution: {integrity: sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    resolution: {integrity: sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    resolution: {integrity: sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    resolution: {integrity: sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    resolution: {integrity: sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    resolution: {integrity: sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
+    cpu: [x64]
+    os: [win32]
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlast@1.2.5:
+    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlastindex@1.2.6:
+    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.tosorted@1.1.4:
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.10.37:
+    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  effect@3.21.0:
+    resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
+
+  electron-to-chromium@1.5.372:
+    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-iterator-helpers@1.3.3:
+    resolution: {integrity: sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-config-next@15.5.19:
+    resolution: {integrity: sha512-UZwkuhBCNxVZfo93MSHRDOVNWXooJJGcAUyTAVIp0+9QFhH4SqJxWY0s6Mk9C2kMi777HPMn3dseOrZshWpG9Q==}
+    peerDependencies:
+      eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  eslint-import-resolver-node@0.3.10:
+    resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
+
+  eslint-import-resolver-typescript@3.10.1:
+    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+      eslint-plugin-import-x: '*'
+    peerDependenciesMeta:
+      eslint-plugin-import:
+        optional: true
+      eslint-plugin-import-x:
+        optional: true
+
+  eslint-module-utils@2.13.0:
+    resolution: {integrity: sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-import@2.32.0:
+    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react@7.37.5:
+    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.2.0:
+    resolution: {integrity: sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-bun-module@2.0.0:
+    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
+  is-document.all@1.0.0:
+    resolution: {integrity: sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  iterator.prototype@1.1.5:
+    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
+    engines: {node: '>= 0.4'}
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lucide-react@0.469.0:
+    resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next@15.5.19:
+    resolution: {integrity: sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  node-exports-info@1.6.0:
+    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
+    engines: {node: '>= 0.4'}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  nypm@0.6.7:
+    resolution: {integrity: sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.entries@1.1.9:
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
+    engines: {node: '>= 0.4'}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-selector-parser@6.1.4:
+    resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prisma@6.19.3:
+    resolution: {integrity: sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  resolve@2.0.0-next.7:
+    resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stable-hash@0.0.5:
+    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.matchall@4.0.12:
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.repeat@1.0.0:
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+
+  string.prototype.trim@1.2.11:
+    resolution: {integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.10:
+    resolution: {integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.8:
+    resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
+    engines: {node: '>= 0.4'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unrs-resolver@1.12.2:
+    resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
+    engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/eslintrc@2.1.4':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@8.57.1': {}
+
+  '@humanwhocodes/config-array@0.13.0':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@next/env@15.5.19': {}
+
+  '@next/eslint-plugin-next@15.5.19':
+    dependencies:
+      fast-glob: 3.3.1
+
+  '@next/swc-darwin-arm64@15.5.19':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.19':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.19':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.19':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.19':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.19':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.19':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.19':
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@nolyfill/is-core-module@1.0.39': {}
+
+  '@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)':
+    optionalDependencies:
+      prisma: 6.19.3(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@prisma/config@6.19.3':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.21.0
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@6.19.3': {}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
+
+  '@prisma/engines@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/fetch-engine': 6.19.3
+      '@prisma/get-platform': 6.19.3
+
+  '@prisma/fetch-engine@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/get-platform': 6.19.3
+
+  '@prisma/get-platform@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
+
+  '@rtsao/scc@1.1.0': {}
+
+  '@rushstack/eslint-patch@1.16.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/json5@0.0.29': {}
+
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/type-utils': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      eslint: 8.57.1
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3
+      eslint: 8.57.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.61.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.61.0':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
+
+  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.61.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 8.57.1
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.61.0': {}
+
+  '@typescript-eslint/typescript-estree@8.61.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      eslint: 8.57.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.61.0':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.1': {}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    optional: true
+
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@5.0.2: {}
+
+  argparse@2.0.1: {}
+
+  aria-query@5.3.2: {}
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
+  array.prototype.findlast@1.2.5:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.findlastindex@1.2.6:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.tosorted@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
+  ast-types-flow@0.0.8: {}
+
+  async-function@1.0.0: {}
+
+  autoprefixer@10.5.0(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001799
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  axe-core@4.12.1: {}
+
+  axobject-query@4.1.0: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.37: {}
+
+  binary-extensions@2.3.0: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.37
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.372
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  c12@3.1.0:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 16.6.1
+      exsolve: 1.0.8
+      giget: 2.0.0
+      jiti: 2.7.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.1
+      rc9: 2.1.2
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
+
+  camelcase-css@2.0.1: {}
+
+  caniuse-lite@1.0.30001799: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.2: {}
+
+  client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@4.1.1: {}
+
+  concat-map@0.0.1: {}
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  cssesc@3.0.0: {}
+
+  csstype@3.2.3: {}
+
+  damerau-levenshtein@1.0.8: {}
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  date-fns@4.4.0: {}
+
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  deepmerge-ts@7.1.5: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
+  defu@6.1.7: {}
+
+  destr@2.0.5: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
+
+  doctrine@2.1.0:
+    dependencies:
+      esutils: 2.0.3
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
+  dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  effect@3.21.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  electron-to-chromium@1.5.372: {}
+
+  emoji-regex@9.2.2: {}
+
+  empathic@2.0.0: {}
+
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.2.0
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.11
+      string.prototype.trimend: 1.0.10
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.8
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.22
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-iterator-helpers@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-set-tostringtag: 2.1.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      iterator.prototype: 1.1.5
+      math-intrinsics: 1.1.0
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.4
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-config-next@15.5.19(eslint@8.57.1)(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 15.5.19
+      '@rushstack/eslint-patch': 1.16.1
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
+      eslint-plugin-react: 7.37.5(eslint@8.57.1)
+      eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
+  eslint-import-resolver-node@0.3.10:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.16.2
+      resolve: 2.0.0-next.7
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 8.57.1
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.17
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      hasown: 2.0.4
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.10
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.12.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 8.57.1
+      hasown: 2.0.4
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
+  eslint-plugin-react-hooks@5.2.0(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
+  eslint-plugin-react@7.37.5(eslint@8.57.1):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.3.3
+      eslint: 8.57.1
+      estraverse: 5.3.0
+      hasown: 2.0.4
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.7
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@8.57.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.3.1
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.2.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 3.4.3
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  exsolve@1.0.8: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@6.0.1:
+    dependencies:
+      flat-cache: 3.2.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@3.2.0:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+      rimraf: 3.0.2
+
+  flatted@3.4.2: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  fraction.js@5.3.4: {}
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.2.0:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+      hasown: 2.0.4
+      is-callable: 1.2.7
+      is-document.all: 1.0.0
+
+  functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.7
+      node-fetch-native: 1.6.7
+      nypm: 0.6.7
+      pathe: 2.0.3
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  graphemer@1.4.0: {}
+
+  has-bigints@1.1.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.4
+      side-channel: 1.1.1
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-bun-module@2.0.0:
+    dependencies:
+      semver: 7.8.4
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-document.all@1.0.0:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-number@7.0.0: {}
+
+  is-path-inside@3.0.3: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.22
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  iterator.prototype@1.1.5:
+    dependencies:
+      define-data-property: 1.1.4
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      has-symbols: 1.1.0
+      set-function-name: 2.0.2
+
+  jiti@1.21.7: {}
+
+  jiti@2.7.0: {}
+
+  jose@5.10.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
+
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      object.assign: 4.1.7
+      object.values: 1.2.1
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lucide-react@0.469.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  math-intrinsics@1.1.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  minimist@1.2.8: {}
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
+
+  napi-postinstall@0.3.4: {}
+
+  natural-compare@1.4.0: {}
+
+  next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@next/env': 15.5.19
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001799
+      postcss: 8.4.31
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.19
+      '@next/swc-darwin-x64': 15.5.19
+      '@next/swc-linux-arm64-gnu': 15.5.19
+      '@next/swc-linux-arm64-musl': 15.5.19
+      '@next/swc-linux-x64-gnu': 15.5.19
+      '@next/swc-linux-x64-musl': 15.5.19
+      '@next/swc-win32-arm64-msvc': 15.5.19
+      '@next/swc-win32-x64-msvc': 15.5.19
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  node-exports-info@1.6.0:
+    dependencies:
+      array.prototype.flatmap: 1.3.3
+      es-errors: 1.3.0
+      object.entries: 1.1.9
+      semver: 6.3.1
+
+  node-fetch-native@1.6.7: {}
+
+  node-releases@2.0.47: {}
+
+  normalize-path@3.0.0: {}
+
+  nypm@0.6.7:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.2.4
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  object.entries@1.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+
+  ohash@2.0.11: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
+
+  perfect-debounce@1.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pify@2.3.0: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
+  possible-typed-array-names@1.1.0: {}
+
+  postcss-import@15.1.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.15):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.15
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.15
+      tsx: 4.22.4
+
+  postcss-nested@6.2.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 6.1.4
+
+  postcss-selector-parser@6.1.4:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prisma@6.19.3(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': 6.19.3
+      '@prisma/engines': 6.19.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - magicast
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
+
+  queue-microtask@1.2.3: {}
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-is@16.13.1: {}
+
+  react@19.2.7: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  readdirp@4.1.2: {}
+
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  resolve@2.0.0-next.7:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      node-exports-info: 1.6.0
+      object-keys: 1.1.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  semver@7.8.4: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  source-map-js@1.2.1: {}
+
+  stable-hash@0.0.5: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.matchall@4.0.12:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      regexp.prototype.flags: 1.5.4
+      set-function-name: 2.0.2
+      side-channel: 1.1.1
+
+  string.prototype.repeat@1.0.0:
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.trim@1.2.11:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+      has-property-descriptors: 1.0.2
+      safe-regex-test: 1.1.0
+
+  string.prototype.trimend@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-bom@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  styled-jsx@5.1.6(react@19.2.7):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.7
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@2.6.1: {}
+
+  tailwindcss@3.4.19(tsx@4.22.4):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-import: 15.1.0(postcss@8.5.15)
+      postcss-js: 4.1.0(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)
+      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss-selector-parser: 6.1.4
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  text-table@0.2.0: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  type-fest@0.20.2: {}
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
+  typescript@5.9.3: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
+
+  undici-types@6.21.0: {}
+
+  unrs-resolver@1.12.2:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.12.2
+      '@unrs/resolver-binding-android-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-x64': 1.12.2
+      '@unrs/resolver-binding-freebsd-x64': 1.12.2
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-musl': 1.12.2
+      '@unrs/resolver-binding-openharmony-arm64': 1.12.2
+      '@unrs/resolver-binding-wasm32-wasi': 1.12.2
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.2.0
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.22
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
+
+  yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}

--- a/aegis-club/postcss.config.mjs
+++ b/aegis-club/postcss.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/aegis-club/prisma/schema.prisma
+++ b/aegis-club/prisma/schema.prisma
@@ -1,0 +1,477 @@
+// Aegis Club — schema de dados
+// Plataforma competitiva da comunidade de Dota 2.
+//
+// Convenção: nomes de modelos em inglês (idioma do código);
+// a interface para o usuário é em português (BR).
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+// ──────────────────────────────────────────────────────────────
+// Identidade e perfil
+// ──────────────────────────────────────────────────────────────
+
+enum Role {
+  PLAYER
+  ORGANIZER
+  ADMIN
+}
+
+enum DotaRole {
+  CARRY // posição 1
+  MID // posição 2
+  OFFLANE // posição 3
+  SOFT_SUPPORT // posição 4
+  HARD_SUPPORT // posição 5
+}
+
+enum Region {
+  SA // América do Sul
+  NA // América do Norte
+  EU // Europa
+  CIS
+  SEA // Sudeste Asiático
+  CHINA
+}
+
+model User {
+  id        String   @id @default(cuid())
+  // SteamID64 — identificador único da conta Steam
+  steamId   String?  @unique
+  nickname  String
+  email     String?  @unique
+  avatarUrl String?
+  role      Role     @default(PLAYER)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  profile Profile?
+
+  // Matchmaking
+  queueEntries QueueEntry[]
+  matchPlayers MatchPlayer[]
+
+  // Reputação
+  commendsGiven    Commend[] @relation("CommendFrom")
+  commendsReceived Commend[] @relation("CommendTo")
+  reportsMade      Report[]  @relation("ReportFrom")
+  reportsReceived  Report[]  @relation("ReportTo")
+
+  // Conexões sociais
+  friendshipsSent     Friendship[] @relation("FriendshipRequester")
+  friendshipsReceived Friendship[] @relation("FriendshipAddressee")
+
+  // Tutoriais e votos
+  tutorialsAuthored Tutorial[]     @relation("TutorialAuthor")
+  tutorialVotes     TutorialVote[]
+
+  // Torneios
+  tournamentsOrganized Tournament[] @relation("TournamentOrganizer")
+  teamsCaptained       Team[]       @relation("TeamCaptain")
+  teamMemberships      TeamMember[]
+
+  @@index([role])
+}
+
+model Profile {
+  id     String @id @default(cuid())
+  userId String @unique
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  bio       String?  @db.Text
+  country    String? // ISO-3166 alpha-2, ex: "BR"
+  region    Region   @default(SA)
+  mainRoles DotaRole[]
+
+  // Skill / ranking interno da plataforma (separado do MMR oficial da Valve)
+  rankPoints Int @default(1000) // ponto de partida ~ "Guardião"
+  // MMR público informado/importado (OpenDota), apenas exibição
+  publicMmr  Int?
+
+  // Reputação / comportamento (0–10000, começa em 7500 ~ "neutro/bom")
+  behaviorScore Int @default(7500)
+
+  // Estatísticas agregadas (atualizadas ao fim de cada partida)
+  matchesPlayed Int @default(0)
+  wins          Int @default(0)
+  losses        Int @default(0)
+  abandons      Int @default(0)
+
+  // Heróis favoritos (IDs de Hero) — exibidos no perfil
+  favoriteHeroIds Int[]
+
+  // Links sociais
+  discord String?
+  twitch  String?
+  youtube String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([rankPoints])
+  @@index([behaviorScore])
+}
+
+enum FriendshipStatus {
+  PENDING
+  ACCEPTED
+  BLOCKED
+}
+
+model Friendship {
+  id          String           @id @default(cuid())
+  requesterId String
+  addresseeId String
+  status      FriendshipStatus @default(PENDING)
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  requester User @relation("FriendshipRequester", fields: [requesterId], references: [id], onDelete: Cascade)
+  addressee User @relation("FriendshipAddressee", fields: [addresseeId], references: [id], onDelete: Cascade)
+
+  @@unique([requesterId, addresseeId])
+  @@index([addresseeId, status])
+}
+
+// ──────────────────────────────────────────────────────────────
+// Matchmaking competitivo
+// ──────────────────────────────────────────────────────────────
+
+enum QueueMode {
+  RANKED_5V5 // partida ranqueada padrão
+  UNRANKED_5V5 // casual
+}
+
+enum QueueStatus {
+  WAITING // procurando partida
+  MATCHED // alocado em uma partida
+  CANCELLED // saiu da fila
+}
+
+model QueueEntry {
+  id        String      @id @default(cuid())
+  userId    String
+  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  mode      QueueMode   @default(RANKED_5V5)
+  region    Region      @default(SA)
+  status    QueueStatus @default(WAITING)
+  // "instantâneo" de rankPoints/behaviorScore no momento da entrada na fila
+  rankPoints    Int
+  behaviorScore Int
+  preferredRoles DotaRole[]
+  matchId   String?
+  match     Match?      @relation(fields: [matchId], references: [id])
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+
+  @@index([status, mode, region])
+  @@index([userId])
+}
+
+enum MatchStatus {
+  DRAFTING // ready-check / formando lobby
+  LIVE // em andamento
+  COMPLETED // finalizada com resultado
+  CANCELLED // cancelada (ex: alguém não deu ready)
+}
+
+enum MatchSide {
+  RADIANT
+  DIRE
+}
+
+model Match {
+  id          String      @id @default(cuid())
+  mode        QueueMode   @default(RANKED_5V5)
+  region      Region      @default(SA)
+  status      MatchStatus @default(DRAFTING)
+  // ID do lobby no cliente do Dota 2 (preenchido manualmente pelo host) + senha
+  lobbyName     String?
+  lobbyPassword String?
+  // Resultado
+  radiantWin    Boolean?
+  // Média de rankPoints da partida (para balanceamento/relatórios)
+  averageRank   Int       @default(1000)
+
+  createdAt DateTime  @default(now())
+  startedAt DateTime?
+  endedAt   DateTime?
+
+  players      MatchPlayer[]
+  queueEntries QueueEntry[]
+  commends     Commend[]
+  reports      Report[]
+
+  @@index([status, region])
+}
+
+model MatchPlayer {
+  id      String @id @default(cuid())
+  matchId String
+  match   Match  @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  userId  String
+  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  team       MatchSide
+  // 0–4 dentro do time
+  slot       Int
+  ready      Boolean   @default(false)
+  abandoned  Boolean   @default(false)
+  heroId     Int?
+  // Pós-partida
+  won        Boolean?
+  rankDelta  Int? // variação de rankPoints aplicada ao fim
+  kills      Int?
+  deaths     Int?
+  assists    Int?
+
+  @@unique([matchId, userId])
+  @@unique([matchId, team, slot])
+  @@index([userId])
+}
+
+// ──────────────────────────────────────────────────────────────
+// Reputação / anti-toxicidade
+// ──────────────────────────────────────────────────────────────
+
+enum CommendCategory {
+  FRIENDLY // amigável
+  FORGIVING // tolerante
+  TEACHING // ensina/comunica bem
+  LEADERSHIP // boa liderança/shotcalling
+}
+
+model Commend {
+  id        String          @id @default(cuid())
+  matchId   String?
+  match     Match?          @relation(fields: [matchId], references: [id], onDelete: SetNull)
+  fromId    String
+  toId      String
+  from      User            @relation("CommendFrom", fields: [fromId], references: [id], onDelete: Cascade)
+  to        User            @relation("CommendTo", fields: [toId], references: [id], onDelete: Cascade)
+  category  CommendCategory
+  createdAt DateTime        @default(now())
+
+  // Um elogio por categoria, por par de jogadores, por partida
+  @@unique([matchId, fromId, toId, category])
+  @@index([toId])
+}
+
+enum ReportCategory {
+  TOXIC_CHAT // comunicação abusiva
+  INTENTIONAL_FEEDING // feeding intencional
+  GRIEFING // sabotagem
+  ABANDON // abandono
+  HATE_SPEECH // discurso de ódio
+  CHEATING // trapaça/scripts
+  SMURFING // conta secundária
+}
+
+enum ReportStatus {
+  OPEN
+  REVIEWED_VALID
+  REVIEWED_INVALID
+}
+
+model Report {
+  id        String         @id @default(cuid())
+  matchId   String?
+  match     Match?         @relation(fields: [matchId], references: [id], onDelete: SetNull)
+  fromId    String
+  toId      String
+  from      User           @relation("ReportFrom", fields: [fromId], references: [id], onDelete: Cascade)
+  to        User           @relation("ReportTo", fields: [toId], references: [id], onDelete: Cascade)
+  category  ReportCategory
+  comment   String?        @db.Text
+  status    ReportStatus   @default(OPEN)
+  createdAt DateTime       @default(now())
+
+  // Uma denúncia por par de jogadores, por partida
+  @@unique([matchId, fromId, toId])
+  @@index([toId, status])
+}
+
+// ──────────────────────────────────────────────────────────────
+// Heróis e tutoriais
+// ──────────────────────────────────────────────────────────────
+
+enum PrimaryAttribute {
+  STRENGTH
+  AGILITY
+  INTELLIGENCE
+  UNIVERSAL
+}
+
+model Hero {
+  // ID oficial do herói no Dota 2 (mesmo da OpenDota)
+  id            Int              @id
+  name          String           @unique // ex: "npc_dota_hero_juggernaut"
+  localizedName String // ex: "Juggernaut"
+  slug          String           @unique // ex: "juggernaut"
+  primaryAttr   PrimaryAttribute
+  // Papéis sugeridos (texto livre do dataset oficial), ex: ["Carry","Pusher"]
+  roles         String[]
+  // Complexidade 1–3 (estrelas no cliente do jogo)
+  complexity    Int              @default(1)
+  imageUrl      String?
+  iconUrl       String?
+
+  tutorials Tutorial[]
+
+  @@index([primaryAttr])
+}
+
+enum TutorialLevel {
+  BEGINNER // iniciante
+  INTERMEDIATE // intermediário
+  ADVANCED // avançado
+}
+
+model Tutorial {
+  id        String        @id @default(cuid())
+  heroId    Int
+  hero      Hero          @relation(fields: [heroId], references: [id], onDelete: Cascade)
+  title     String
+  // ID do vídeo do YouTube (ex: "dQw4w9WgXcQ"), extraído de qualquer URL
+  youtubeId String
+  level     TutorialLevel @default(BEGINNER)
+  language  String        @default("pt-BR")
+  authorId  String?
+  author    User?         @relation("TutorialAuthor", fields: [authorId], references: [id], onDelete: SetNull)
+  // votos agregados (denormalizado para ordenação rápida)
+  score     Int           @default(0)
+  approved  Boolean       @default(true)
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+
+  votes TutorialVote[]
+
+  @@index([heroId, level])
+  @@index([score])
+}
+
+model TutorialVote {
+  id         String   @id @default(cuid())
+  tutorialId String
+  tutorial   Tutorial @relation(fields: [tutorialId], references: [id], onDelete: Cascade)
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  value      Int // +1 ou -1
+  createdAt  DateTime @default(now())
+
+  @@unique([tutorialId, userId])
+}
+
+// ──────────────────────────────────────────────────────────────
+// Torneios
+// ──────────────────────────────────────────────────────────────
+
+enum TournamentFormat {
+  SINGLE_ELIMINATION
+  DOUBLE_ELIMINATION
+  ROUND_ROBIN
+}
+
+enum TournamentStatus {
+  DRAFT // criado, ainda não publicado
+  REGISTRATION // inscrições abertas
+  LIVE // em andamento
+  COMPLETED // finalizado
+  CANCELLED
+}
+
+model Tournament {
+  id          String           @id @default(cuid())
+  slug        String           @unique
+  name        String
+  description String?          @db.Text
+  format      TournamentFormat @default(SINGLE_ELIMINATION)
+  status      TournamentStatus @default(DRAFT)
+  region      Region           @default(SA)
+  maxTeams    Int              @default(8)
+  prizePool   String? // texto livre, ex: "R$ 500"
+  bannerUrl   String?
+
+  organizerId String
+  organizer   User   @relation("TournamentOrganizer", fields: [organizerId], references: [id], onDelete: Cascade)
+
+  registrationEndsAt DateTime?
+  startsAt           DateTime?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  teams   Team[]
+  matches TournamentMatch[]
+
+  @@index([status, region])
+}
+
+model Team {
+  id           String      @id @default(cuid())
+  tournamentId String?
+  tournament   Tournament? @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  name         String
+  tag          String // ex: "AEG"
+  logoUrl      String?
+  captainId    String
+  captain      User        @relation("TeamCaptain", fields: [captainId], references: [id], onDelete: Cascade)
+  // Posição/seed na chave
+  seed         Int?
+  eliminated   Boolean     @default(false)
+  createdAt    DateTime    @default(now())
+
+  members    TeamMember[]
+  homeMatches TournamentMatch[] @relation("MatchTeamA")
+  awayMatches TournamentMatch[] @relation("MatchTeamB")
+  wonMatches  TournamentMatch[] @relation("MatchWinner")
+
+  @@index([tournamentId])
+}
+
+model TeamMember {
+  id     String @id @default(cuid())
+  teamId String
+  team   Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  role   DotaRole?
+
+  @@unique([teamId, userId])
+  @@index([userId])
+}
+
+model TournamentMatch {
+  id           String     @id @default(cuid())
+  tournamentId String
+  tournament   Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  // Rodada (1 = primeira fase). Para single-elim, cresce até a final.
+  round        Int
+  // Posição da partida dentro da rodada (0-indexed)
+  position     Int
+  bracket      String     @default("WINNERS") // WINNERS | LOSERS | GRAND_FINAL
+
+  teamAId String?
+  teamA   Team?   @relation("MatchTeamA", fields: [teamAId], references: [id], onDelete: SetNull)
+  teamBId String?
+  teamB   Team?   @relation("MatchTeamB", fields: [teamBId], references: [id], onDelete: SetNull)
+
+  scoreA   Int     @default(0)
+  scoreB   Int     @default(0)
+  winnerId String?
+  winner   Team?   @relation("MatchWinner", fields: [winnerId], references: [id], onDelete: SetNull)
+
+  // Melhor de N (1, 3, 5)
+  bestOf    Int       @default(1)
+  scheduledAt DateTime?
+  completedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@unique([tournamentId, round, position, bracket])
+  @@index([tournamentId, round])
+}

--- a/aegis-club/prisma/seed.ts
+++ b/aegis-club/prisma/seed.ts
@@ -1,0 +1,194 @@
+/**
+ * Seed do banco: heróis, jogadores de demonstração, tutoriais e um torneio.
+ * Roda com `pnpm db:seed` (após `pnpm prisma migrate dev`).
+ */
+import { PrismaClient } from "@prisma/client";
+import { HEROES } from "../src/data/heroes";
+import { generateSingleElimination } from "../src/lib/bracket";
+import { slugify } from "../src/lib/utils";
+
+const prisma = new PrismaClient();
+
+// Vídeo público de placeholder para os tutoriais de demonstração.
+// Troque pelos IDs reais dos seus vídeos do YouTube no painel.
+const DEMO_YT = "aqz-KE-bpKQ";
+
+const DEMO_PLAYERS = [
+  { nickname: "AegisLover", rankPoints: 5200, behaviorScore: 9600 },
+  { nickname: "MidOuPaau", rankPoints: 4100, behaviorScore: 8800 },
+  { nickname: "SupportGod", rankPoints: 3950, behaviorScore: 9900 },
+  { nickname: "Carregador", rankPoints: 4600, behaviorScore: 7200 },
+  { nickname: "PosThree", rankPoints: 3300, behaviorScore: 8100 },
+  { nickname: "Wards4Life", rankPoints: 2800, behaviorScore: 9700 },
+  { nickname: "RoshKiller", rankPoints: 5100, behaviorScore: 6800 },
+  { nickname: "Calmaria", rankPoints: 2100, behaviorScore: 9990 },
+  { nickname: "Iniciante22", rankPoints: 600, behaviorScore: 7500 },
+  { nickname: "FeederFurioso", rankPoints: 1500, behaviorScore: 3200 },
+  { nickname: "Toxic_BR", rankPoints: 1800, behaviorScore: 2400 },
+  { nickname: "ShotCaller", rankPoints: 4400, behaviorScore: 9100 },
+];
+
+async function main() {
+  console.log("→ Semeando heróis…");
+  for (const h of HEROES) {
+    await prisma.hero.upsert({
+      where: { id: h.id },
+      update: {
+        localizedName: h.localizedName,
+        slug: h.slug,
+        primaryAttr: h.primaryAttr,
+        roles: h.roles,
+        complexity: h.complexity,
+        name: h.npc,
+      },
+      create: {
+        id: h.id,
+        name: h.npc,
+        localizedName: h.localizedName,
+        slug: h.slug,
+        primaryAttr: h.primaryAttr,
+        roles: h.roles,
+        complexity: h.complexity,
+      },
+    });
+  }
+
+  console.log("→ Semeando jogadores de demonstração…");
+  const regions = ["SA", "SA", "SA", "NA", "EU"] as const;
+  const allRoles = [
+    "CARRY",
+    "MID",
+    "OFFLANE",
+    "SOFT_SUPPORT",
+    "HARD_SUPPORT",
+  ] as const;
+  const users = [];
+  for (let i = 0; i < DEMO_PLAYERS.length; i++) {
+    const p = DEMO_PLAYERS[i];
+    const user = await prisma.user.upsert({
+      where: { email: `${slugify(p.nickname)}@demo.aegis` },
+      update: {},
+      create: {
+        nickname: p.nickname,
+        email: `${slugify(p.nickname)}@demo.aegis`,
+        role: i === 0 ? "ADMIN" : i === 11 ? "ORGANIZER" : "PLAYER",
+        profile: {
+          create: {
+            rankPoints: p.rankPoints,
+            behaviorScore: p.behaviorScore,
+            region: regions[i % regions.length],
+            mainRoles: [allRoles[i % allRoles.length]],
+            matchesPlayed: 40 + i * 7,
+            wins: 20 + i * 3,
+            losses: 20 + i * 4,
+            favoriteHeroIds: HEROES.slice(i % 8, (i % 8) + 3).map((h) => h.id),
+            bio: "Jogador da comunidade Aegis Club.",
+          },
+        },
+      },
+    });
+    users.push(user);
+  }
+
+  console.log("→ Semeando tutoriais…");
+  const tutHeroes = HEROES.slice(0, 6);
+  for (const h of tutHeroes) {
+    await prisma.tutorial.upsert({
+      where: { id: `seed-tut-${h.id}` },
+      update: {},
+      create: {
+        id: `seed-tut-${h.id}`,
+        heroId: h.id,
+        title: `Guia completo de ${h.localizedName} para iniciantes`,
+        youtubeId: DEMO_YT,
+        level: "BEGINNER",
+        language: "pt-BR",
+        authorId: users[0].id,
+        score: Math.floor(Math.random() * 50),
+      },
+    });
+  }
+
+  console.log("→ Semeando torneio de demonstração…");
+  const organizer = users[11];
+  const tournament = await prisma.tournament.upsert({
+    where: { slug: "copa-aegis-temporada-1" },
+    update: {},
+    create: {
+      slug: "copa-aegis-temporada-1",
+      name: "Copa Aegis — Temporada 1",
+      description:
+        "Torneio amador 5x5 da comunidade. Eliminação simples, melhor de 3 nas finais.",
+      format: "SINGLE_ELIMINATION",
+      status: "REGISTRATION",
+      region: "SA",
+      maxTeams: 4,
+      prizePool: "R$ 500 + Arcanas",
+      organizerId: organizer.id,
+      registrationEndsAt: new Date(Date.now() + 7 * 86400000),
+      startsAt: new Date(Date.now() + 8 * 86400000),
+    },
+  });
+
+  // 4 times de demonstração
+  const teamNames = [
+    ["Radiant Kings", "RDK"],
+    ["Dire Wolves", "DRW"],
+    ["Ancient Guardians", "ANC"],
+    ["Roshan Slayers", "RSH"],
+  ];
+  const teams = [];
+  for (let i = 0; i < teamNames.length; i++) {
+    const [name, tag] = teamNames[i];
+    const team = await prisma.team.upsert({
+      where: { id: `seed-team-${i}` },
+      update: {},
+      create: {
+        id: `seed-team-${i}`,
+        tournamentId: tournament.id,
+        name,
+        tag,
+        captainId: users[i].id,
+        seed: i + 1,
+        members: {
+          create: { userId: users[i].id, role: "CARRY" },
+        },
+      },
+    });
+    teams.push(team);
+  }
+
+  // Gera o chaveamento se ainda não existir
+  const existing = await prisma.tournamentMatch.count({
+    where: { tournamentId: tournament.id },
+  });
+  if (existing === 0) {
+    const bracket = generateSingleElimination(
+      teams.map((t) => ({ id: t.id, seed: t.seed ?? 0 })),
+    );
+    for (const m of bracket) {
+      await prisma.tournamentMatch.create({
+        data: {
+          tournamentId: tournament.id,
+          round: m.round,
+          position: m.position,
+          bracket: m.bracket,
+          teamAId: m.teamAId,
+          teamBId: m.teamBId,
+          bestOf: m.bracket === "GRAND_FINAL" ? 3 : 1,
+        },
+      });
+    }
+  }
+
+  console.log("✓ Seed concluído.");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/aegis-club/public/favicon.svg
+++ b/aegis-club/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fbe19a"/>
+      <stop offset="1" stop-color="#b98e22"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="7" fill="#0a0b0f"/>
+  <path d="M16 4l9 3v7c0 6-3.8 10.4-9 12-5.2-1.6-9-6-9-12V7l9-3z"
+        fill="none" stroke="url(#g)" stroke-width="2" stroke-linejoin="round"/>
+  <circle cx="16" cy="14" r="3.2" fill="url(#g)"/>
+</svg>

--- a/aegis-club/src/app/api/auth/dev/route.ts
+++ b/aegis-club/src/app/api/auth/dev/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { appUrl } from "@/lib/steam";
+import {
+  encodeSession,
+  SESSION_COOKIE,
+  sessionCookieOptions,
+} from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Login de desenvolvimento — cria/usa um usuário fictício e abre sessão.
+ * Desabilitado em produção. Útil para testar sem configurar a Steam.
+ */
+export async function GET() {
+  if (
+    process.env.NODE_ENV === "production" ||
+    process.env.NEXT_PUBLIC_ENABLE_DEV_LOGIN !== "true"
+  ) {
+    return NextResponse.json({ error: "Desabilitado" }, { status: 403 });
+  }
+
+  const user = await prisma.user.upsert({
+    where: { email: "dev@aegis.local" },
+    update: {},
+    create: {
+      email: "dev@aegis.local",
+      nickname: "Jogador Dev",
+      role: "ADMIN",
+      profile: { create: { rankPoints: 3000, behaviorScore: 9000 } },
+    },
+  });
+
+  const token = await encodeSession({
+    sub: user.id,
+    steamId: user.steamId,
+    nickname: user.nickname,
+    role: user.role,
+    avatarUrl: user.avatarUrl,
+  });
+
+  const res = NextResponse.redirect(`${appUrl()}/dashboard`);
+  res.cookies.set(SESSION_COOKIE, token, sessionCookieOptions());
+  return res;
+}

--- a/aegis-club/src/app/api/auth/logout/route.ts
+++ b/aegis-club/src/app/api/auth/logout/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { appUrl } from "@/lib/steam";
+import { SESSION_COOKIE, sessionCookieOptions } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  // 303 força o navegador a fazer GET na home após o logout.
+  const res = NextResponse.redirect(`${appUrl()}/`, 303);
+  res.cookies.set(SESSION_COOKIE, "", { ...sessionCookieOptions(), maxAge: 0 });
+  return res;
+}

--- a/aegis-club/src/app/api/auth/steam/callback/route.ts
+++ b/aegis-club/src/app/api/auth/steam/callback/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifySteamCallback, fetchSteamProfile, appUrl } from "@/lib/steam";
+import { prisma } from "@/lib/prisma";
+import {
+  encodeSession,
+  SESSION_COOKIE,
+  sessionCookieOptions,
+} from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const steamId = await verifySteamCallback(url.searchParams);
+  if (!steamId) {
+    return NextResponse.redirect(`${appUrl()}/?auth=error`);
+  }
+
+  const profile = await fetchSteamProfile(steamId);
+
+  const user = await prisma.user.upsert({
+    where: { steamId },
+    update: {
+      nickname: profile.nickname,
+      avatarUrl: profile.avatarUrl ?? undefined,
+    },
+    create: {
+      steamId,
+      nickname: profile.nickname,
+      avatarUrl: profile.avatarUrl,
+      profile: { create: { country: profile.country ?? undefined } },
+    },
+  });
+
+  const token = await encodeSession({
+    sub: user.id,
+    steamId,
+    nickname: user.nickname,
+    role: user.role,
+    avatarUrl: user.avatarUrl,
+  });
+
+  const res = NextResponse.redirect(`${appUrl()}/dashboard`);
+  res.cookies.set(SESSION_COOKIE, token, sessionCookieOptions());
+  return res;
+}

--- a/aegis-club/src/app/api/auth/steam/login/route.ts
+++ b/aegis-club/src/app/api/auth/steam/login/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { buildSteamLoginUrl } from "@/lib/steam";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.redirect(buildSteamLoginUrl());
+}

--- a/aegis-club/src/app/dashboard/page.tsx
+++ b/aegis-club/src/app/dashboard/page.tsx
@@ -1,0 +1,248 @@
+import Link from "next/link";
+import {
+  Swords,
+  UserCog,
+  Trophy,
+  Activity,
+  ArrowRight,
+  Gauge,
+} from "lucide-react";
+import { getCurrentUser } from "@/lib/session";
+import { prisma } from "@/lib/prisma";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { RankBadge } from "@/components/ui/RankBadge";
+import { BehaviorMeter } from "@/components/ui/BehaviorMeter";
+import { Avatar } from "@/components/ui/Avatar";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { buttonVariants } from "@/components/ui/Button";
+import { cn, winRate } from "@/lib/utils";
+
+export const metadata = { title: "Painel" };
+
+export default async function DashboardPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return (
+      <div className="container-page py-16">
+        <EmptyState
+          icon={<Gauge className="h-10 w-10" />}
+          title="Entre para ver seu painel"
+          description="Conecte sua conta Steam para acessar fila, perfil e torneios."
+          action={
+            <Link
+              href="/api/auth/steam/login"
+              className={cn(buttonVariants({ variant: "primary" }))}
+            >
+              Entrar com Steam
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  const profile = user.profile;
+  const [activeQueue, recentMatches, openTournaments] = await Promise.all([
+    prisma.queueEntry.findFirst({
+      where: { userId: user.id, status: { in: ["WAITING", "MATCHED"] } },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.matchPlayer.findMany({
+      where: { userId: user.id },
+      include: { match: true },
+      orderBy: { match: { createdAt: "desc" } },
+      take: 5,
+    }),
+    prisma.tournament.findMany({
+      where: { status: { in: ["REGISTRATION", "LIVE"] } },
+      orderBy: { createdAt: "desc" },
+      take: 3,
+    }),
+  ]);
+
+  return (
+    <div className="container-page py-10">
+      {/* Cabeçalho */}
+      <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <Avatar src={user.avatarUrl} name={user.nickname} size="lg" />
+          <div>
+            <h1 className="text-2xl font-bold text-zinc-100">
+              Olá, {user.nickname}
+            </h1>
+            <div className="mt-1 flex items-center gap-3">
+              <RankBadge points={profile?.rankPoints ?? 1000} showPoints />
+              <Badge tone="neutral">{profile?.region ?? "SA"}</Badge>
+            </div>
+          </div>
+        </div>
+        <Link
+          href="/play"
+          className={cn(buttonVariants({ variant: "primary", size: "lg" }))}
+        >
+          <Swords className="h-4 w-4" />
+          Jogar agora
+        </Link>
+      </div>
+
+      {activeQueue && (
+        <div className="mb-6 flex items-center justify-between rounded-xl border border-aegis/30 bg-aegis/10 px-5 py-3">
+          <span className="text-sm text-aegis">
+            {activeQueue.status === "WAITING"
+              ? "Você está na fila procurando partida…"
+              : "Partida encontrada! Vá para o lobby."}
+          </span>
+          <Link
+            href={activeQueue.matchId ? `/match/${activeQueue.matchId}` : "/play"}
+            className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}
+          >
+            Ver
+          </Link>
+        </div>
+      )}
+
+      <div className="grid gap-5 lg:grid-cols-3">
+        {/* Conduta */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Conduta</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BehaviorMeter score={profile?.behaviorScore ?? 7500} />
+          </CardContent>
+        </Card>
+
+        {/* Estatísticas */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Estatísticas</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-3 gap-3 text-center">
+            <div>
+              <p className="text-2xl font-bold text-zinc-100">
+                {profile?.matchesPlayed ?? 0}
+              </p>
+              <p className="text-xs text-zinc-500">Partidas</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-radiant">
+                {profile?.wins ?? 0}
+              </p>
+              <p className="text-xs text-zinc-500">Vitórias</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-aegis">
+                {winRate(profile?.wins ?? 0, profile?.matchesPlayed ?? 0)}%
+              </p>
+              <p className="text-xs text-zinc-500">Win rate</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Atalhos */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Atalhos</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            <Link
+              href={`/profile/${user.id}`}
+              className={cn(buttonVariants({ variant: "secondary" }), "justify-between")}
+            >
+              Meu perfil <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/profile/edit"
+              className={cn(buttonVariants({ variant: "ghost" }), "justify-between")}
+            >
+              Editar perfil <UserCog className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/tournaments/new"
+              className={cn(buttonVariants({ variant: "ghost" }), "justify-between")}
+            >
+              Criar torneio <Trophy className="h-4 w-4" />
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Partidas recentes + torneios */}
+      <div className="mt-6 grid gap-5 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Activity className="h-4 w-4 text-aegis" /> Partidas recentes
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {recentMatches.length === 0 ? (
+              <p className="text-sm text-zinc-500">
+                Você ainda não jogou nenhuma partida pela plataforma.
+              </p>
+            ) : (
+              <ul className="divide-y divide-surface-border">
+                {recentMatches.map((mp) => (
+                  <li
+                    key={mp.id}
+                    className="flex items-center justify-between py-2.5 text-sm"
+                  >
+                    <Link
+                      href={`/match/${mp.matchId}`}
+                      className="link-muted font-mono"
+                    >
+                      #{mp.matchId.slice(-6)}
+                    </Link>
+                    <div className="flex items-center gap-2">
+                      <Badge tone={mp.team === "RADIANT" ? "radiant" : "dire"}>
+                        {mp.team === "RADIANT" ? "Radiant" : "Dire"}
+                      </Badge>
+                      {mp.won === true && <Badge tone="good">Vitória</Badge>}
+                      {mp.won === false && <Badge tone="bad">Derrota</Badge>}
+                      {mp.match.status !== "COMPLETED" && (
+                        <Badge tone="warn">Em aberto</Badge>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Trophy className="h-4 w-4 text-aegis" /> Torneios abertos
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {openTournaments.length === 0 ? (
+              <p className="text-sm text-zinc-500">
+                Nenhum torneio com inscrições abertas no momento.
+              </p>
+            ) : (
+              <ul className="divide-y divide-surface-border">
+                {openTournaments.map((t) => (
+                  <li key={t.id} className="py-2.5">
+                    <Link
+                      href={`/tournaments/${t.slug}`}
+                      className="flex items-center justify-between text-sm"
+                    >
+                      <span className="font-medium text-zinc-200">{t.name}</span>
+                      <Badge tone="aegis">
+                        {t.status === "LIVE" ? "Ao vivo" : "Inscrições"}
+                      </Badge>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/aegis-club/src/app/error.tsx
+++ b/aegis-club/src/app/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { TriangleAlert } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="container-page flex min-h-[60vh] flex-col items-center justify-center text-center">
+      <TriangleAlert className="h-12 w-12 text-dire" />
+      <h1 className="mt-4 font-display text-3xl font-bold text-zinc-100">
+        Algo deu errado
+      </h1>
+      <p className="mt-2 max-w-md text-zinc-400">
+        Ocorreu um erro inesperado. Você pode tentar novamente — se persistir,
+        verifique se o banco de dados está rodando.
+      </p>
+      <Button onClick={reset} className="mt-6">
+        Tentar de novo
+      </Button>
+    </div>
+  );
+}

--- a/aegis-club/src/app/globals.css
+++ b/aegis-club/src/app/globals.css
@@ -1,0 +1,59 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-display: "Inter", system-ui, sans-serif;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-bg text-zinc-200 antialiased;
+  background-image:
+    radial-gradient(900px 500px at 10% -10%, rgba(245, 196, 81, 0.06), transparent),
+    radial-gradient(800px 500px at 100% 0%, rgba(226, 54, 54, 0.06), transparent);
+  background-attachment: fixed;
+}
+
+/* Scrollbar discreta no tema escuro */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: #2a2f3a;
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #3a4150;
+  background-clip: padding-box;
+}
+
+@layer components {
+  .container-page {
+    @apply mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8;
+  }
+
+  /* Cartão base reutilizado em toda a interface */
+  .card {
+    @apply rounded-2xl border border-surface-border bg-surface shadow-card;
+  }
+
+  .link-muted {
+    @apply text-zinc-400 transition-colors hover:text-zinc-100;
+  }
+
+  /* Gradiente de marca para títulos de destaque */
+  .text-brand-gradient {
+    @apply bg-gradient-to-r from-aegis via-aegis-soft to-dire-soft bg-clip-text text-transparent;
+  }
+}

--- a/aegis-club/src/app/heroes/[slug]/page.tsx
+++ b/aegis-club/src/app/heroes/[slug]/page.tsx
@@ -1,0 +1,165 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, GraduationCap, LogIn } from "lucide-react";
+import type { PrimaryAttribute } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/session";
+import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { HeroAvatar } from "@/components/heroes/HeroAvatar";
+import { AddTutorialForm } from "@/components/heroes/AddTutorialForm";
+import { TutorialCard } from "@/components/heroes/TutorialCard";
+import { buttonVariants } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+const ATTR_LABELS: Record<PrimaryAttribute, string> = {
+  STRENGTH: "Força",
+  AGILITY: "Agilidade",
+  INTELLIGENCE: "Inteligência",
+  UNIVERSAL: "Universal",
+};
+
+const ATTR_TONE: Record<PrimaryAttribute, "dire" | "radiant" | "aegis" | "neutral"> =
+  {
+    STRENGTH: "dire",
+    AGILITY: "radiant",
+    INTELLIGENCE: "aegis",
+    UNIVERSAL: "neutral",
+  };
+
+function Stars({ complexity }: { complexity: number }) {
+  const filled = Math.max(0, Math.min(3, complexity));
+  return (
+    <span
+      className="text-sm tracking-tight text-aegis"
+      aria-label={`Complexidade ${filled} de 3`}
+    >
+      {"★".repeat(filled)}
+      <span className="text-surface-border">{"★".repeat(3 - filled)}</span>
+    </span>
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const hero = await prisma.hero.findUnique({
+    where: { slug },
+    select: { localizedName: true },
+  });
+  return { title: hero ? hero.localizedName : "Herói" };
+}
+
+export default async function HeroDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const user = await getCurrentUser();
+
+  const hero = await prisma.hero.findUnique({
+    where: { slug },
+    include: {
+      tutorials: {
+        where: { approved: true },
+        orderBy: [{ score: "desc" }, { createdAt: "desc" }],
+        include: {
+          author: { select: { id: true, nickname: true } },
+          votes: user
+            ? { where: { userId: user.id }, select: { value: true } }
+            : false,
+        },
+      },
+    },
+  });
+
+  if (!hero) {
+    notFound();
+  }
+
+  return (
+    <div className="container-page py-10">
+      <Link
+        href="/heroes"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-400 transition-colors hover:text-zinc-100"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Voltar aos heróis
+      </Link>
+
+      {/* Cabeçalho do herói */}
+      <div className="flex flex-wrap items-center gap-5 rounded-2xl border border-surface-border bg-surface/40 p-6">
+        <HeroAvatar slug={hero.slug} name={hero.localizedName} size="lg" />
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold text-zinc-100">
+            {hero.localizedName}
+          </h1>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone={ATTR_TONE[hero.primaryAttr]}>
+              {ATTR_LABELS[hero.primaryAttr]}
+            </Badge>
+            <Stars complexity={hero.complexity} />
+          </div>
+          {hero.roles.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {hero.roles.map((role) => (
+                <Badge key={role} tone="neutral">
+                  {role}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Tutoriais */}
+      <section className="mt-10 space-y-5">
+        <div className="flex items-center gap-2">
+          <GraduationCap className="h-5 w-5 text-aegis" />
+          <h2 className="text-xl font-bold text-zinc-100">Tutoriais</h2>
+        </div>
+
+        {user ? (
+          <AddTutorialForm heroId={hero.id} />
+        ) : (
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-surface-border bg-surface/40 px-5 py-4">
+            <p className="text-sm text-zinc-400">
+              Entre com sua conta Steam para contribuir com um tutorial.
+            </p>
+            <Link
+              href="/api/auth/steam/login"
+              className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}
+            >
+              <LogIn className="h-4 w-4" />
+              Entrar com Steam
+            </Link>
+          </div>
+        )}
+
+        {hero.tutorials.length === 0 ? (
+          <EmptyState
+            icon={<GraduationCap className="h-10 w-10" />}
+            title="Ainda não há tutoriais"
+            description={`Seja o primeiro a ensinar ${hero.localizedName} para a comunidade.`}
+          />
+        ) : (
+          <div className="grid gap-5 md:grid-cols-2">
+            {hero.tutorials.map((tutorial) => (
+              <TutorialCard
+                key={tutorial.id}
+                tutorial={tutorial}
+                currentUserId={user?.id}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/aegis-club/src/app/heroes/actions.ts
+++ b/aegis-club/src/app/heroes/actions.ts
@@ -1,0 +1,130 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { TutorialLevel } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireUser } from "@/lib/session";
+import { extractYoutubeId } from "@/lib/youtube";
+import { createTutorialSchema, voteTutorialSchema } from "@/lib/validations";
+
+export interface AddTutorialState {
+  ok?: boolean;
+  error?: string;
+}
+
+const TUTORIAL_LEVELS: readonly TutorialLevel[] = [
+  "BEGINNER",
+  "INTERMEDIATE",
+  "ADVANCED",
+];
+
+function parseLevel(value: FormDataEntryValue | null): TutorialLevel {
+  return TUTORIAL_LEVELS.includes(value as TutorialLevel)
+    ? (value as TutorialLevel)
+    : "BEGINNER";
+}
+
+/** Adiciona um tutorial em vídeo a um herói. */
+export async function addTutorial(
+  _prevState: AddTutorialState,
+  formData: FormData,
+): Promise<AddTutorialState> {
+  try {
+    const user = await requireUser();
+
+    const heroId = Number(formData.get("heroId"));
+    const title = String(formData.get("title") ?? "").trim();
+    const youtube = String(formData.get("youtube") ?? "").trim();
+    const level = parseLevel(formData.get("level"));
+
+    if (!Number.isInteger(heroId) || heroId <= 0) {
+      return { error: "Herói inválido." };
+    }
+
+    const youtubeId = extractYoutubeId(youtube);
+    if (!youtubeId) {
+      return { error: "Link do YouTube inválido." };
+    }
+
+    const parsed = createTutorialSchema.safeParse({
+      heroId,
+      title,
+      youtube,
+      level,
+      language: "pt-BR",
+    });
+    if (!parsed.success) {
+      const first = parsed.error.issues[0];
+      return {
+        error: first?.message ?? "Dados do tutorial inválidos.",
+      };
+    }
+
+    const hero = await prisma.hero.findUnique({
+      where: { id: heroId },
+      select: { slug: true },
+    });
+    if (!hero) {
+      return { error: "Herói não encontrado." };
+    }
+
+    await prisma.tutorial.create({
+      data: {
+        heroId,
+        title: parsed.data.title,
+        youtubeId,
+        level: parsed.data.level,
+        language: "pt-BR",
+        authorId: user.id,
+      },
+    });
+
+    revalidatePath(`/heroes/${hero.slug}`);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof Error && err.message === "UNAUTHENTICATED") {
+      return { error: "Você precisa entrar para enviar um tutorial." };
+    }
+    return { error: "Não foi possível enviar o tutorial. Tente novamente." };
+  }
+}
+
+/** Registra (ou troca) o voto do usuário e recalcula o score do tutorial. */
+export async function voteTutorial(
+  tutorialId: string,
+  value: number,
+): Promise<void> {
+  const user = await requireUser();
+
+  const parsed = voteTutorialSchema.safeParse({ value });
+  if (!parsed.success) {
+    throw new Error("Voto inválido.");
+  }
+  const safeValue = parsed.data.value;
+
+  const tutorial = await prisma.tutorial.findUnique({
+    where: { id: tutorialId },
+    select: { id: true, hero: { select: { slug: true } } },
+  });
+  if (!tutorial) {
+    throw new Error("Tutorial não encontrado.");
+  }
+
+  await prisma.tutorialVote.upsert({
+    where: { tutorialId_userId: { tutorialId, userId: user.id } },
+    create: { tutorialId, userId: user.id, value: safeValue },
+    update: { value: safeValue },
+  });
+
+  const agg = await prisma.tutorialVote.aggregate({
+    where: { tutorialId },
+    _sum: { value: true },
+  });
+
+  await prisma.tutorial.update({
+    where: { id: tutorialId },
+    data: { score: agg._sum.value ?? 0 },
+  });
+
+  revalidatePath(`/heroes/${tutorial.hero.slug}`);
+}

--- a/aegis-club/src/app/heroes/page.tsx
+++ b/aegis-club/src/app/heroes/page.tsx
@@ -1,0 +1,184 @@
+import Link from "next/link";
+import { Search, GraduationCap } from "lucide-react";
+import type { Prisma, PrimaryAttribute } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SectionHeading } from "@/components/ui/SectionHeading";
+import { HeroAvatar } from "@/components/heroes/HeroAvatar";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+export const metadata = { title: "Heróis" };
+export const dynamic = "force-dynamic";
+
+const ATTR_LABELS: Record<PrimaryAttribute, string> = {
+  STRENGTH: "Força",
+  AGILITY: "Agilidade",
+  INTELLIGENCE: "Inteligência",
+  UNIVERSAL: "Universal",
+};
+
+const ATTR_TONE: Record<PrimaryAttribute, "dire" | "radiant" | "aegis" | "neutral"> =
+  {
+    STRENGTH: "dire",
+    AGILITY: "radiant",
+    INTELLIGENCE: "aegis",
+    UNIVERSAL: "neutral",
+  };
+
+const FILTERS: { value: PrimaryAttribute | null; label: string }[] = [
+  { value: null, label: "Todos" },
+  { value: "STRENGTH", label: "Força" },
+  { value: "AGILITY", label: "Agilidade" },
+  { value: "INTELLIGENCE", label: "Inteligência" },
+  { value: "UNIVERSAL", label: "Universal" },
+];
+
+function isPrimaryAttr(value: string | undefined): value is PrimaryAttribute {
+  return (
+    value === "STRENGTH" ||
+    value === "AGILITY" ||
+    value === "INTELLIGENCE" ||
+    value === "UNIVERSAL"
+  );
+}
+
+function Stars({ complexity }: { complexity: number }) {
+  const filled = Math.max(0, Math.min(3, complexity));
+  return (
+    <span
+      className="text-xs tracking-tight text-aegis"
+      title={`Complexidade ${filled}/3`}
+      aria-label={`Complexidade ${filled} de 3`}
+    >
+      {"★".repeat(filled)}
+      <span className="text-surface-border">{"★".repeat(3 - filled)}</span>
+    </span>
+  );
+}
+
+export default async function HeroesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ attr?: string; q?: string }>;
+}) {
+  const sp = await searchParams;
+  const attr = isPrimaryAttr(sp.attr) ? sp.attr : null;
+  const q = (sp.q ?? "").trim();
+
+  const where: Prisma.HeroWhereInput = {};
+  if (attr) where.primaryAttr = attr;
+  if (q) {
+    where.localizedName = { contains: q, mode: "insensitive" };
+  }
+
+  const heroes = await prisma.hero.findMany({
+    where,
+    orderBy: { localizedName: "asc" },
+    include: { _count: { select: { tutorials: true } } },
+  });
+
+  function filterHref(value: PrimaryAttribute | null): string {
+    const params = new URLSearchParams();
+    if (value) params.set("attr", value);
+    if (q) params.set("q", q);
+    const qs = params.toString();
+    return qs ? `/heroes?${qs}` : "/heroes";
+  }
+
+  return (
+    <div className="container-page py-10">
+      <SectionHeading
+        eyebrow="Aprenda"
+        title="Heróis"
+        description="Explore o catálogo de heróis do Dota 2 e aprenda cada um com tutoriais em vídeo curados pela comunidade."
+      />
+
+      {/* Filtros e busca */}
+      <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+        <div className="flex flex-wrap gap-2">
+          {FILTERS.map((f) => {
+            const active = attr === f.value;
+            return (
+              <Link
+                key={f.label}
+                href={filterHref(f.value)}
+                className={cn(
+                  "rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors",
+                  active
+                    ? "border-aegis/40 bg-aegis/15 text-aegis"
+                    : "border-surface-border text-zinc-400 hover:border-aegis/40 hover:text-zinc-100",
+                )}
+              >
+                {f.label}
+              </Link>
+            );
+          })}
+        </div>
+
+        <form action="/heroes" method="get" className="flex items-center gap-2">
+          {attr && <input type="hidden" name="attr" value={attr} />}
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500" />
+            <input
+              type="search"
+              name="q"
+              defaultValue={q}
+              placeholder="Buscar herói…"
+              className="h-10 w-52 rounded-xl border border-surface-border bg-bg pl-9 pr-3 text-sm text-zinc-100 placeholder:text-zinc-600 focus-visible:border-aegis/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/40"
+            />
+          </div>
+          <Button type="submit" variant="secondary">
+            Buscar
+          </Button>
+        </form>
+      </div>
+
+      {heroes.length === 0 ? (
+        <EmptyState
+          icon={<GraduationCap className="h-10 w-10" />}
+          title="Nenhum herói encontrado"
+          description={
+            q
+              ? `Nada corresponde a "${q}". Tente outro termo ou limpe o filtro.`
+              : "Não há heróis para este filtro no momento."
+          }
+          action={
+            <Link href="/heroes">
+              <Button variant="outline">Limpar filtros</Button>
+            </Link>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          {heroes.map((hero) => (
+            <Link key={hero.id} href={`/heroes/${hero.slug}`} className="group">
+              <Card className="h-full p-4 transition-colors group-hover:border-aegis/40">
+                <div className="flex flex-col items-center gap-3 text-center">
+                  <HeroAvatar slug={hero.slug} name={hero.localizedName} size="lg" />
+                  <div className="space-y-2">
+                    <h3 className="font-semibold leading-tight text-zinc-100">
+                      {hero.localizedName}
+                    </h3>
+                    <div className="flex items-center justify-center gap-2">
+                      <Badge tone={ATTR_TONE[hero.primaryAttr]}>
+                        {ATTR_LABELS[hero.primaryAttr]}
+                      </Badge>
+                      <Stars complexity={hero.complexity} />
+                    </div>
+                    <p className="text-xs text-zinc-500">
+                      {hero._count.tutorials}{" "}
+                      {hero._count.tutorials === 1 ? "tutorial" : "tutoriais"}
+                    </p>
+                  </div>
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/aegis-club/src/app/layout.tsx
+++ b/aegis-club/src/app/layout.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Aegis Club — Dota 2 competitivo sem toxicidade",
+    template: "%s · Aegis Club",
+  },
+  description:
+    "Plataforma da comunidade de Dota 2: matchmaking justo com sistema anti-toxicidade, tutoriais de heróis, perfis e torneios.",
+  icons: { icon: "/favicon.svg" },
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="pt-BR" className="dark">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body className="flex min-h-screen flex-col">
+        <Navbar />
+        <main className="flex-1">{children}</main>
+        <Footer />
+      </body>
+    </html>
+  );
+}

--- a/aegis-club/src/app/leaderboard/page.tsx
+++ b/aegis-club/src/app/leaderboard/page.tsx
@@ -1,0 +1,171 @@
+import Link from "next/link";
+import { Crown, Trophy } from "lucide-react";
+import type { Region } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { Card, CardContent } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { RankBadge } from "@/components/ui/RankBadge";
+import { Avatar } from "@/components/ui/Avatar";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SectionHeading } from "@/components/ui/SectionHeading";
+import { behaviorTier } from "@/lib/reputation";
+import { cn, winRate } from "@/lib/utils";
+import { REGIONS, REGION_LABELS } from "@/components/profile/labels";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Ranking" };
+
+function parseRegion(value: string | undefined): Region | null {
+  return REGIONS.includes(value as Region) ? (value as Region) : null;
+}
+
+export default async function LeaderboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ region?: string }>;
+}) {
+  const { region: regionParam } = await searchParams;
+  const region = parseRegion(regionParam);
+
+  const profiles = await prisma.profile.findMany({
+    where: region ? { region } : undefined,
+    orderBy: { rankPoints: "desc" },
+    take: 100,
+    include: { user: true },
+  });
+
+  const chips: { label: string; region: Region | null }[] = [
+    { label: "Todos", region: null },
+    ...REGIONS.map((r) => ({ label: REGION_LABELS[r], region: r })),
+  ];
+
+  return (
+    <div className="container-page py-10">
+      <SectionHeading
+        eyebrow="Comunidade"
+        title="Ranking"
+        description="Os melhores da comunidade por pontos de habilidade."
+      />
+
+      {/* Filtros de região */}
+      <div className="mb-6 flex flex-wrap gap-2">
+        {chips.map((chip) => {
+          const active = chip.region === region;
+          return (
+            <Link
+              key={chip.label}
+              href={chip.region ? `/leaderboard?region=${chip.region}` : "/leaderboard"}
+              className={cn(
+                "inline-flex items-center rounded-full border px-3 py-1 text-sm transition-colors",
+                active
+                  ? "border-aegis/50 bg-aegis/15 text-aegis"
+                  : "border-surface-border text-zinc-400 hover:border-aegis/40 hover:text-zinc-200",
+              )}
+            >
+              {chip.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      {profiles.length === 0 ? (
+        <EmptyState
+          icon={<Trophy className="h-10 w-10" />}
+          title="Nenhum jogador no ranking"
+          description="Ainda não há jogadores nesta região. Que tal jogar a primeira partida?"
+        />
+      ) : (
+        <Card>
+          {/* Cabeçalho (apenas em telas maiores) */}
+          <div className="hidden border-b border-surface-border px-5 py-3 text-xs font-medium uppercase tracking-wide text-zinc-500 sm:grid sm:grid-cols-[3rem_1fr_10rem_5rem_5rem_4rem] sm:items-center sm:gap-3">
+            <span>#</span>
+            <span>Jogador</span>
+            <span>Medalha</span>
+            <span className="text-right">Pontos</span>
+            <span className="text-right">Win rate</span>
+            <span className="text-right">Conduta</span>
+          </div>
+
+          <ul className="divide-y divide-surface-border">
+            {profiles.map((profile, index) => {
+              const position = index + 1;
+              const tier = behaviorTier(profile.behaviorScore);
+              const isTop3 = position <= 3;
+              return (
+                <li
+                  key={profile.id}
+                  className={cn(
+                    "flex flex-wrap items-center gap-3 px-5 py-3 sm:grid sm:grid-cols-[3rem_1fr_10rem_5rem_5rem_4rem]",
+                    isTop3 && "bg-aegis/5",
+                  )}
+                >
+                  {/* Posição */}
+                  <span
+                    className={cn(
+                      "inline-flex w-8 items-center gap-1 text-base font-bold tabular-nums",
+                      isTop3 ? "text-aegis" : "text-zinc-500",
+                    )}
+                  >
+                    {isTop3 && <Crown className="h-4 w-4" />}
+                    {position}
+                  </span>
+
+                  {/* Jogador */}
+                  <Link
+                    href={`/profile/${profile.userId}`}
+                    className="flex min-w-0 flex-1 items-center gap-3"
+                  >
+                    <Avatar
+                      src={profile.user.avatarUrl}
+                      name={profile.user.nickname}
+                      size="sm"
+                    />
+                    <span
+                      className={cn(
+                        "truncate text-sm font-medium",
+                        isTop3 ? "text-zinc-100" : "text-zinc-200",
+                      )}
+                    >
+                      {profile.user.nickname}
+                    </span>
+                  </Link>
+
+                  {/* Medalha */}
+                  <span className="sm:justify-self-start">
+                    <RankBadge points={profile.rankPoints} />
+                  </span>
+
+                  {/* Pontos */}
+                  <span className="text-sm font-semibold tabular-nums text-zinc-200 sm:text-right">
+                    {profile.rankPoints}
+                    <span className="ml-1 text-xs font-normal text-zinc-500 sm:hidden">
+                      pts
+                    </span>
+                  </span>
+
+                  {/* Win rate */}
+                  <span className="text-sm tabular-nums text-zinc-400 sm:text-right">
+                    {winRate(profile.wins, profile.matchesPlayed)}%
+                  </span>
+
+                  {/* Conduta */}
+                  <span
+                    className="flex items-center gap-1.5 sm:justify-end"
+                    title={tier.label}
+                  >
+                    <span
+                      className={cn("h-2.5 w-2.5 rounded-full", tier.barColor)}
+                    />
+                    <span className="text-xs text-zinc-500 sm:hidden">
+                      {tier.label}
+                    </span>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/aegis-club/src/app/loading.tsx
+++ b/aegis-club/src/app/loading.tsx
@@ -1,0 +1,17 @@
+export default function Loading() {
+  return (
+    <div className="container-page py-20">
+      <div className="space-y-4">
+        <div className="h-8 w-48 animate-pulse rounded-lg bg-surface-hover" />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-32 animate-pulse rounded-2xl border border-surface-border bg-surface"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/aegis-club/src/app/match/[id]/actions.ts
+++ b/aegis-club/src/app/match/[id]/actions.ts
@@ -1,0 +1,341 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { Prisma } from "@prisma/client";
+import type { MatchSide } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireUser } from "@/lib/session";
+import { rankDelta } from "@/lib/ranking";
+import {
+  clampBehavior,
+  commendDelta,
+  reportDelta,
+  BEHAVIOR_START,
+} from "@/lib/reputation";
+import { commendSchema, reportSchema } from "@/lib/validations";
+
+export interface MatchActionResult {
+  ok: boolean;
+  error?: string;
+}
+
+function matchPath(matchId: string): string {
+  return `/match/${matchId}`;
+}
+
+/** O host é o jogador do slot 0 do time Radiant. */
+function isHost(team: MatchSide, slot: number): boolean {
+  return team === "RADIANT" && slot === 0;
+}
+
+/**
+ * Confirma presença (ready-check): marca o MatchPlayer do usuário como pronto.
+ */
+export async function setReady(matchId: string): Promise<MatchActionResult> {
+  const user = await requireUser();
+
+  const player = await prisma.matchPlayer.findUnique({
+    where: { matchId_userId: { matchId, userId: user.id } },
+  });
+  if (!player) {
+    return { ok: false, error: "Você não participa desta partida." };
+  }
+
+  await prisma.matchPlayer.update({
+    where: { id: player.id },
+    data: { ready: true },
+  });
+
+  revalidatePath(matchPath(matchId));
+  return { ok: true };
+}
+
+/**
+ * Atualiza nome/senha do lobby do Dota 2 (apenas o host).
+ */
+export async function setLobbyInfo(
+  matchId: string,
+  formData: FormData,
+): Promise<MatchActionResult> {
+  const user = await requireUser();
+
+  const player = await prisma.matchPlayer.findUnique({
+    where: { matchId_userId: { matchId, userId: user.id } },
+  });
+  if (!player || !isHost(player.team, player.slot)) {
+    return { ok: false, error: "Apenas o host pode definir o lobby." };
+  }
+
+  const lobbyName = String(formData.get("lobbyName") ?? "").trim();
+  const lobbyPassword = String(formData.get("lobbyPassword") ?? "").trim();
+
+  await prisma.match.update({
+    where: { id: matchId },
+    data: {
+      lobbyName: lobbyName || null,
+      lobbyPassword: lobbyPassword || null,
+    },
+  });
+
+  revalidatePath(matchPath(matchId));
+  return { ok: true };
+}
+
+/**
+ * Inicia a partida (apenas o host, e somente quando todos estão prontos).
+ */
+export async function startMatch(matchId: string): Promise<MatchActionResult> {
+  const user = await requireUser();
+
+  const match = await prisma.match.findUnique({
+    where: { id: matchId },
+    include: { players: true },
+  });
+  if (!match) {
+    return { ok: false, error: "Partida não encontrada." };
+  }
+
+  const host = match.players.find((p) => p.userId === user.id);
+  if (!host || !isHost(host.team, host.slot)) {
+    return { ok: false, error: "Apenas o host pode iniciar a partida." };
+  }
+
+  if (match.status !== "DRAFTING") {
+    return { ok: false, error: "A partida já foi iniciada." };
+  }
+
+  const allReady =
+    match.players.length > 0 && match.players.every((p) => p.ready);
+  if (!allReady) {
+    return {
+      ok: false,
+      error: "Aguarde todos confirmarem presença antes de iniciar.",
+    };
+  }
+
+  await prisma.match.update({
+    where: { id: matchId },
+    data: { status: "LIVE", startedAt: new Date() },
+  });
+
+  revalidatePath(matchPath(matchId));
+  return { ok: true };
+}
+
+/**
+ * Reporta o resultado da partida e liquida rankPoints/estatísticas.
+ * Qualquer participante pode reportar (modelo de confiança da comunidade).
+ */
+export async function reportResult(
+  matchId: string,
+  winner: "RADIANT" | "DIRE",
+): Promise<MatchActionResult> {
+  const user = await requireUser();
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      const match = await tx.match.findUnique({
+        where: { id: matchId },
+        include: { players: { include: { user: { include: { profile: true } } } } },
+      });
+      if (!match) {
+        throw new Error("Partida não encontrada.");
+      }
+
+      const isParticipant = match.players.some((p) => p.userId === user.id);
+      if (!isParticipant) {
+        throw new Error("Apenas participantes podem reportar o resultado.");
+      }
+
+      if (match.status === "COMPLETED") {
+        throw new Error("Esta partida já foi finalizada.");
+      }
+
+      const radiantPlayers = match.players.filter((p) => p.team === "RADIANT");
+      const direPlayers = match.players.filter((p) => p.team === "DIRE");
+
+      const avg = (players: typeof match.players): number => {
+        if (players.length === 0) return match.averageRank;
+        const sum = players.reduce(
+          (acc, p) => acc + (p.user.profile?.rankPoints ?? 1000),
+          0,
+        );
+        return Math.round(sum / players.length);
+      };
+      const radiantAvg = avg(radiantPlayers);
+      const direAvg = avg(direPlayers);
+
+      const radiantWin = winner === "RADIANT";
+
+      await tx.match.update({
+        where: { id: matchId },
+        data: {
+          radiantWin,
+          status: "COMPLETED",
+          endedAt: new Date(),
+        },
+      });
+
+      for (const p of match.players) {
+        const won = p.team === winner;
+        const teamAvg = p.team === "RADIANT" ? radiantAvg : direAvg;
+        const oppAvg = p.team === "RADIANT" ? direAvg : radiantAvg;
+        const delta = rankDelta(teamAvg, oppAvg, won);
+
+        await tx.matchPlayer.update({
+          where: { id: p.id },
+          data: { won, rankDelta: delta },
+        });
+
+        await tx.profile.update({
+          where: { userId: p.userId },
+          data: {
+            rankPoints: { increment: delta },
+            matchesPlayed: { increment: 1 },
+            wins: { increment: won ? 1 : 0 },
+            losses: { increment: won ? 0 : 1 },
+          },
+        });
+      }
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error:
+        err instanceof Error
+          ? err.message
+          : "Não foi possível reportar o resultado.",
+    };
+  }
+
+  revalidatePath(matchPath(matchId));
+  return { ok: true };
+}
+
+export interface CommendInput {
+  matchId: string;
+  toUserId: string;
+  category: "FRIENDLY" | "FORGIVING" | "TEACHING" | "LEADERSHIP";
+}
+
+/**
+ * Elogia um jogador da partida. Soma pontos de conduta ao alvo.
+ */
+export async function commendPlayer(
+  input: CommendInput,
+): Promise<MatchActionResult> {
+  const user = await requireUser();
+
+  const parsed = commendSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "Elogio inválido." };
+  }
+
+  if (parsed.data.toUserId === user.id) {
+    return { ok: false, error: "Você não pode elogiar a si mesmo." };
+  }
+
+  try {
+    await prisma.commend.create({
+      data: {
+        matchId: input.matchId,
+        fromId: user.id,
+        toId: parsed.data.toUserId,
+        category: parsed.data.category,
+      },
+    });
+  } catch (err) {
+    // Elogio repetido (mesma categoria/par/partida): ignora silenciosamente.
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return { ok: true };
+    }
+    return { ok: false, error: "Não foi possível registrar o elogio." };
+  }
+
+  const target = await prisma.profile.findUnique({
+    where: { userId: parsed.data.toUserId },
+  });
+  const current = target?.behaviorScore ?? BEHAVIOR_START;
+  await prisma.profile.update({
+    where: { userId: parsed.data.toUserId },
+    data: { behaviorScore: clampBehavior(current + commendDelta(parsed.data.category)) },
+  });
+
+  revalidatePath(matchPath(input.matchId));
+  return { ok: true };
+}
+
+export interface ReportInput {
+  matchId: string;
+  toUserId: string;
+  category:
+    | "TOXIC_CHAT"
+    | "INTENTIONAL_FEEDING"
+    | "GRIEFING"
+    | "ABANDON"
+    | "HATE_SPEECH"
+    | "CHEATING"
+    | "SMURFING";
+  comment?: string;
+}
+
+/**
+ * Denuncia um jogador da partida.
+ *
+ * NOTA: em produção, denúncias passam por revisão (manual ou automática
+ * agregando múltiplos relatos) ANTES de penalizar o alvo. Aqui aplicamos a
+ * penalidade direta para fins de demonstração do fluxo.
+ */
+export async function reportPlayer(
+  input: ReportInput,
+): Promise<MatchActionResult> {
+  const user = await requireUser();
+
+  const parsed = reportSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "Denúncia inválida." };
+  }
+
+  if (parsed.data.toUserId === user.id) {
+    return { ok: false, error: "Você não pode denunciar a si mesmo." };
+  }
+
+  try {
+    await prisma.report.create({
+      data: {
+        matchId: input.matchId,
+        fromId: user.id,
+        toId: parsed.data.toUserId,
+        category: parsed.data.category,
+        comment: parsed.data.comment?.trim() || null,
+      },
+    });
+  } catch (err) {
+    // Denúncia repetida (mesmo par/partida): ignora silenciosamente.
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return { ok: true };
+    }
+    return { ok: false, error: "Não foi possível registrar a denúncia." };
+  }
+
+  const target = await prisma.profile.findUnique({
+    where: { userId: parsed.data.toUserId },
+  });
+  const current = target?.behaviorScore ?? BEHAVIOR_START;
+  // reportDelta retorna valor negativo; clampBehavior garante o piso em 0.
+  await prisma.profile.update({
+    where: { userId: parsed.data.toUserId },
+    data: {
+      behaviorScore: clampBehavior(current + reportDelta(parsed.data.category)),
+    },
+  });
+
+  revalidatePath(matchPath(input.matchId));
+  return { ok: true };
+}

--- a/aegis-club/src/app/match/[id]/page.tsx
+++ b/aegis-club/src/app/match/[id]/page.tsx
@@ -1,0 +1,363 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  Swords,
+  CheckCircle2,
+  Clock,
+  Trophy,
+  Crown,
+  ShieldQuestion,
+} from "lucide-react";
+import type {
+  MatchSide,
+  MatchStatus,
+  QueueMode,
+  Region,
+} from "@prisma/client";
+import { getCurrentUser } from "@/lib/session";
+import { prisma } from "@/lib/prisma";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Avatar } from "@/components/ui/Avatar";
+import { RankBadge } from "@/components/ui/RankBadge";
+import { ReadyCheck } from "@/components/matchmaking/ReadyCheck";
+import { PostMatchPanel } from "@/components/matchmaking/PostMatchPanel";
+import {
+  CopyField,
+  LobbyInfoForm,
+  StartMatchButton,
+  ReportResultControls,
+} from "@/components/matchmaking/MatchLiveControls";
+import { cn } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Partida" };
+
+const MODE_LABELS: Record<QueueMode, string> = {
+  RANKED_5V5: "Ranqueada 5x5",
+  UNRANKED_5V5: "Normal 5x5",
+};
+
+const REGION_LABELS: Record<Region, string> = {
+  SA: "América do Sul",
+  NA: "América do Norte",
+  EU: "Europa",
+  CIS: "CIS",
+  SEA: "Sudeste Asiático",
+  CHINA: "China",
+};
+
+const STATUS_META: Record<
+  MatchStatus,
+  { label: string; tone: "neutral" | "aegis" | "radiant" | "warn" | "bad" }
+> = {
+  DRAFTING: { label: "Confirmando presença", tone: "warn" },
+  LIVE: { label: "Em andamento", tone: "aegis" },
+  COMPLETED: { label: "Finalizada", tone: "radiant" },
+  CANCELLED: { label: "Cancelada", tone: "bad" },
+};
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function MatchPage({ params }: PageProps) {
+  const { id } = await params;
+
+  const [match, viewer] = await Promise.all([
+    prisma.match.findUnique({
+      where: { id },
+      include: {
+        players: {
+          include: { user: { include: { profile: true } } },
+          orderBy: [{ team: "asc" }, { slot: "asc" }],
+        },
+      },
+    }),
+    getCurrentUser(),
+  ]);
+
+  if (!match) notFound();
+
+  const radiant = match.players.filter((p) => p.team === "RADIANT");
+  const dire = match.players.filter((p) => p.team === "DIRE");
+
+  const viewerPlayer = viewer
+    ? match.players.find((p) => p.userId === viewer.id)
+    : undefined;
+  const isParticipant = Boolean(viewerPlayer);
+  const isHost =
+    viewerPlayer?.team === "RADIANT" && viewerPlayer.slot === 0;
+  const allReady =
+    match.players.length > 0 && match.players.every((p) => p.ready);
+
+  const statusMeta = STATUS_META[match.status];
+
+  const winnerSide: MatchSide | null =
+    match.radiantWin === true ? "RADIANT" : match.radiantWin === false ? "DIRE" : null;
+
+  return (
+    <div className="container-page py-10">
+      {/* Cabeçalho */}
+      <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-aegis">
+            Partida
+          </p>
+          <h1 className="flex items-center gap-3 text-2xl font-bold text-zinc-100">
+            <Swords className="h-6 w-6 text-aegis" />
+            <span className="font-mono">#{match.id.slice(-6)}</span>
+          </h1>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Badge tone="neutral">{MODE_LABELS[match.mode]}</Badge>
+            <Badge tone="neutral">{REGION_LABELS[match.region]}</Badge>
+            <span className="text-xs text-zinc-500">
+              Rank médio {match.averageRank}
+            </span>
+          </div>
+        </div>
+        <Badge tone={statusMeta.tone}>{statusMeta.label}</Badge>
+      </div>
+
+      {/* Vencedor (COMPLETED) */}
+      {match.status === "COMPLETED" && winnerSide && (
+        <div className="mb-6 flex items-center gap-3 rounded-xl border border-radiant/30 bg-radiant/10 px-5 py-3">
+          <Trophy className="h-5 w-5 text-radiant" />
+          <span className="text-sm font-medium text-zinc-100">
+            Vitória do{" "}
+            <span
+              className={cn(
+                "font-semibold",
+                winnerSide === "RADIANT" ? "text-radiant" : "text-dire-soft",
+              )}
+            >
+              {winnerSide === "RADIANT" ? "Radiant" : "Dire"}
+            </span>
+          </span>
+        </div>
+      )}
+
+      {/* Times */}
+      <div className="grid gap-5 lg:grid-cols-2">
+        <TeamColumn
+          side="RADIANT"
+          players={radiant}
+          isWinner={winnerSide === "RADIANT"}
+          showDelta={match.status === "COMPLETED"}
+        />
+        <TeamColumn
+          side="DIRE"
+          players={dire}
+          isWinner={winnerSide === "DIRE"}
+          showDelta={match.status === "COMPLETED"}
+        />
+      </div>
+
+      {/* ── DRAFTING: ready-check + host ───────────────────────────── */}
+      {match.status === "DRAFTING" && (
+        <div className="mt-6 grid gap-5 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShieldQuestion className="h-4 w-4 text-aegis" />
+                Confirmação de presença
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+              <p className="text-sm text-zinc-400">
+                {match.players.filter((p) => p.ready).length}/
+                {match.players.length} jogadores prontos.
+              </p>
+              {isParticipant && viewerPlayer ? (
+                <ReadyCheck
+                  matchId={match.id}
+                  viewerReady={viewerPlayer.ready}
+                />
+              ) : (
+                <p className="text-sm text-zinc-500">
+                  Você está assistindo a esta partida.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {isHost && (
+            <Card className="border-aegis/30">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Crown className="h-4 w-4 text-aegis" />
+                  Controles do host
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-5">
+                <LobbyInfoForm
+                  matchId={match.id}
+                  lobbyName={match.lobbyName ?? ""}
+                  lobbyPassword={match.lobbyPassword ?? ""}
+                />
+                <div className="border-t border-surface-border pt-4">
+                  <StartMatchButton matchId={match.id} allReady={allReady} />
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {/* ── LIVE: lobby + reportar resultado ───────────────────────── */}
+      {match.status === "LIVE" && (
+        <div className="mt-6 grid gap-5 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Lobby no Dota 2</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              {match.lobbyName || match.lobbyPassword ? (
+                <>
+                  {match.lobbyName && (
+                    <CopyField label="Nome do lobby" value={match.lobbyName} />
+                  )}
+                  {match.lobbyPassword && (
+                    <CopyField label="Senha" value={match.lobbyPassword} />
+                  )}
+                </>
+              ) : (
+                <p className="text-sm text-zinc-500">
+                  O host ainda não informou os dados do lobby.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {isParticipant && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Reportar resultado</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ReportResultControls matchId={match.id} />
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {/* ── COMPLETED: avaliação pós-partida ───────────────────────── */}
+      {match.status === "COMPLETED" && isParticipant && viewer && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-aegis" />
+              Avaliar jogadores
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <PostMatchPanel
+              matchId={match.id}
+              viewerUserId={viewer.id}
+              players={match.players.map((p) => ({
+                userId: p.userId,
+                nickname: p.user.nickname,
+                avatarUrl: p.user.avatarUrl,
+              }))}
+            />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ── Coluna de um time ───────────────────────────────────────────────
+type TeamPlayer = {
+  id: string;
+  userId: string;
+  ready: boolean;
+  won: boolean | null;
+  rankDelta: number | null;
+  user: {
+    nickname: string;
+    avatarUrl: string | null;
+    profile: { rankPoints: number } | null;
+  };
+};
+
+function TeamColumn({
+  side,
+  players,
+  isWinner,
+  showDelta,
+}: {
+  side: MatchSide;
+  players: TeamPlayer[];
+  isWinner: boolean;
+  showDelta: boolean;
+}) {
+  const isRadiant = side === "RADIANT";
+  return (
+    <Card className={cn(isRadiant ? "border-radiant/30" : "border-dire/30")}>
+      <CardHeader className="flex items-center justify-between">
+        <CardTitle
+          className={cn(isRadiant ? "text-radiant" : "text-dire-soft")}
+        >
+          {isRadiant ? "Radiant" : "Dire"}
+        </CardTitle>
+        {isWinner && (
+          <Badge tone="good">
+            <Trophy className="h-3 w-3" />
+            Vencedor
+          </Badge>
+        )}
+      </CardHeader>
+      <CardContent className="p-0">
+        <ul className="divide-y divide-surface-border">
+          {players.map((p, i) => (
+            <li
+              key={p.id}
+              className="flex items-center justify-between gap-3 px-5 py-3"
+            >
+              <Link
+                href={`/profile/${p.userId}`}
+                className="flex min-w-0 items-center gap-3"
+              >
+                <Avatar
+                  src={p.user.avatarUrl}
+                  name={p.user.nickname}
+                  size="sm"
+                />
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-zinc-200">
+                    {i === 0 && (
+                      <Crown className="mr-1 inline h-3.5 w-3.5 text-aegis" />
+                    )}
+                    {p.user.nickname}
+                  </p>
+                  <RankBadge points={p.user.profile?.rankPoints ?? 1000} />
+                </div>
+              </Link>
+              <div className="flex shrink-0 items-center gap-3">
+                {showDelta && p.rankDelta !== null && (
+                  <span
+                    className={cn(
+                      "text-sm font-semibold tabular-nums",
+                      p.rankDelta >= 0 ? "text-behavior-good" : "text-dire-soft",
+                    )}
+                  >
+                    {p.rankDelta >= 0 ? "+" : ""}
+                    {p.rankDelta}
+                  </span>
+                )}
+                {!showDelta &&
+                  (p.ready ? (
+                    <CheckCircle2 className="h-5 w-5 text-behavior-good" />
+                  ) : (
+                    <Clock className="h-5 w-5 text-zinc-600" />
+                  ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/aegis-club/src/app/not-found.tsx
+++ b/aegis-club/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { ShieldAlert } from "lucide-react";
+import { buttonVariants } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+export default function NotFound() {
+  return (
+    <div className="container-page flex min-h-[60vh] flex-col items-center justify-center text-center">
+      <ShieldAlert className="h-12 w-12 text-aegis" />
+      <h1 className="mt-4 font-display text-3xl font-bold text-zinc-100">
+        Página não encontrada
+      </h1>
+      <p className="mt-2 max-w-md text-zinc-400">
+        A página que você procura não existe ou foi movida. Que tal voltar para a
+        base?
+      </p>
+      <Link
+        href="/"
+        className={cn(buttonVariants({ variant: "primary" }), "mt-6")}
+      >
+        Voltar para o início
+      </Link>
+    </div>
+  );
+}

--- a/aegis-club/src/app/page.tsx
+++ b/aegis-club/src/app/page.tsx
@@ -1,0 +1,199 @@
+import Link from "next/link";
+import {
+  Swords,
+  ShieldCheck,
+  GraduationCap,
+  Trophy,
+  Users,
+  ThumbsUp,
+  Gauge,
+  ArrowRight,
+} from "lucide-react";
+import { prisma } from "@/lib/prisma";
+import { buttonVariants } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { cn, compactNumber } from "@/lib/utils";
+
+async function getStats() {
+  try {
+    const [players, tournaments, heroes, matches] = await Promise.all([
+      prisma.user.count(),
+      prisma.tournament.count(),
+      prisma.hero.count(),
+      prisma.match.count(),
+    ]);
+    return { players, tournaments, heroes, matches };
+  } catch {
+    return { players: 0, tournaments: 0, heroes: 0, matches: 0 };
+  }
+}
+
+const FEATURES = [
+  {
+    icon: Swords,
+    title: "Matchmaking equilibrado",
+    text: "Filas 5x5 com balanceamento por Elo interno. Times montados para partidas justas, não estompadas.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Anti-toxicidade de verdade",
+    text: "Behavior score com elogios e denúncias. Jogadores tóxicos caem juntos na baixa prioridade — longe de quem joga limpo.",
+  },
+  {
+    icon: GraduationCap,
+    title: "Tutoriais de heróis",
+    text: "Aprenda cada herói com guias em vídeo do YouTube, curados pela comunidade e separados por nível.",
+  },
+  {
+    icon: Trophy,
+    title: "Torneios da comunidade",
+    text: "Crie e administre torneios com inscrição de times e chaveamento automático. Da pelada à grande final.",
+  },
+];
+
+export default async function HomePage() {
+  const stats = await getStats();
+
+  return (
+    <div>
+      {/* Hero */}
+      <section className="relative overflow-hidden">
+        <div className="container-page relative py-20 sm:py-28">
+          <div className="max-w-3xl animate-fade-in">
+            <Badge tone="aegis" className="mb-5">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              Dota 2 competitivo, do jeito certo
+            </Badge>
+            <h1 className="font-display text-4xl font-extrabold leading-tight tracking-tight text-zinc-50 sm:text-6xl">
+              Partidas justas.
+              <br />
+              <span className="text-brand-gradient">Sem toxicidade.</span>
+            </h1>
+            <p className="mt-6 max-w-xl text-lg text-zinc-400">
+              A plataforma da comunidade de Dota 2 inspirada na Gamers Club:
+              matchmaking equilibrado, reputação que importa, tutoriais de
+              heróis e torneios — tudo em um só lugar.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                href="/api/auth/steam/login"
+                className={cn(buttonVariants({ variant: "primary", size: "lg" }))}
+              >
+                Entrar com Steam
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/play"
+                className={cn(buttonVariants({ variant: "outline", size: "lg" }))}
+              >
+                Como funciona a fila
+              </Link>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <dl className="mt-16 grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {[
+              { label: "Jogadores", value: stats.players, icon: Users },
+              { label: "Heróis", value: stats.heroes, icon: Swords },
+              { label: "Partidas", value: stats.matches, icon: Gauge },
+              { label: "Torneios", value: stats.tournaments, icon: Trophy },
+            ].map((s) => (
+              <div key={s.label} className="card p-5">
+                <s.icon className="h-5 w-5 text-aegis" />
+                <dd className="mt-3 text-3xl font-bold text-zinc-100">
+                  {compactNumber(s.value)}
+                </dd>
+                <dt className="text-sm text-zinc-500">{s.label}</dt>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="container-page py-12">
+        <div className="grid gap-5 md:grid-cols-2">
+          {FEATURES.map((f) => (
+            <div
+              key={f.title}
+              className="card group p-6 transition-colors hover:border-aegis/40"
+            >
+              <div className="flex items-start gap-4">
+                <div className="rounded-xl bg-aegis/10 p-3 text-aegis">
+                  <f.icon className="h-6 w-6" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold text-zinc-100">
+                    {f.title}
+                  </h3>
+                  <p className="mt-1.5 text-sm leading-relaxed text-zinc-400">
+                    {f.text}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Como o anti-toxicidade funciona */}
+      <section className="container-page py-12">
+        <div className="card overflow-hidden">
+          <div className="grid gap-8 p-8 md:grid-cols-3">
+            {[
+              {
+                icon: ThumbsUp,
+                step: "1",
+                title: "Jogue e avalie",
+                text: "Ao fim de cada partida, elogie quem somou e denuncie quem atrapalhou.",
+              },
+              {
+                icon: Gauge,
+                step: "2",
+                title: "Seu score evolui",
+                text: "Boa conduta sobe o behavior score; denúncias validadas derrubam.",
+              },
+              {
+                icon: ShieldCheck,
+                step: "3",
+                title: "Filas separadas",
+                text: "Quem joga limpo encontra gente limpa. Tóxicos jogam entre si.",
+              },
+            ].map((s) => (
+              <div key={s.step} className="relative">
+                <span className="font-display text-5xl font-black text-surface-border">
+                  {s.step}
+                </span>
+                <s.icon className="mt-2 h-6 w-6 text-aegis" />
+                <h4 className="mt-3 font-semibold text-zinc-100">{s.title}</h4>
+                <p className="mt-1 text-sm text-zinc-400">{s.text}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA final */}
+      <section className="container-page py-16">
+        <div className="card flex flex-col items-center gap-4 bg-gradient-to-br from-surface to-bg-elevated p-10 text-center">
+          <Trophy className="h-10 w-10 text-aegis" />
+          <h2 className="font-display text-2xl font-bold text-zinc-50 sm:text-3xl">
+            Pronto para uma partida justa?
+          </h2>
+          <p className="max-w-md text-zinc-400">
+            Entre com sua conta Steam, monte seu perfil e caia na fila com gente
+            que respeita o jogo.
+          </p>
+          <Link
+            href="/api/auth/steam/login"
+            className={cn(buttonVariants({ variant: "primary", size: "lg" }))}
+          >
+            Começar agora
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/aegis-club/src/app/page.tsx
+++ b/aegis-club/src/app/page.tsx
@@ -14,6 +14,9 @@ import { buttonVariants } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { cn, compactNumber } from "@/lib/utils";
 
+// Renderiza sob demanda (lê contagens do banco a cada acesso).
+export const dynamic = "force-dynamic";
+
 async function getStats() {
   try {
     const [players, tournaments, heroes, matches] = await Promise.all([

--- a/aegis-club/src/app/play/actions.ts
+++ b/aegis-club/src/app/play/actions.ts
@@ -1,0 +1,91 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { QueueMode, Region } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireUser } from "@/lib/session";
+import { tryFormMatch } from "@/lib/matchmaking";
+import { canQueueRanked, BEHAVIOR_START } from "@/lib/reputation";
+import { joinQueueSchema } from "@/lib/validations";
+
+export interface QueueActionResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Entra na fila de matchmaking.
+ * Cria (ou reaproveita) uma QueueEntry em espera e tenta formar uma partida.
+ */
+export async function joinQueue(
+  mode: QueueMode,
+  region: Region,
+): Promise<QueueActionResult> {
+  const user = await requireUser();
+
+  const parsed = joinQueueSchema.safeParse({ mode, region });
+  if (!parsed.success) {
+    return { ok: false, error: "Modo ou região inválidos." };
+  }
+
+  const profile = await prisma.profile.findUnique({
+    where: { userId: user.id },
+  });
+  const rankPoints = profile?.rankPoints ?? 1000;
+  const behaviorScore = profile?.behaviorScore ?? BEHAVIOR_START;
+
+  // Conduta muito baixa não pode jogar ranqueada.
+  if (parsed.data.mode === "RANKED_5V5" && !canQueueRanked(behaviorScore)) {
+    return {
+      ok: false,
+      error:
+        "Sua conduta está abaixo do mínimo para a fila ranqueada. Jogue partidas limpas para recuperar.",
+    };
+  }
+
+  // Evita filas duplicadas: se já há uma entrada ativa, reaproveita.
+  const existing = await prisma.queueEntry.findFirst({
+    where: { userId: user.id, status: { in: ["WAITING", "MATCHED"] } },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (!existing) {
+    await prisma.queueEntry.create({
+      data: {
+        userId: user.id,
+        mode: parsed.data.mode,
+        region: parsed.data.region,
+        status: "WAITING",
+        rankPoints,
+        behaviorScore,
+      },
+    });
+  } else if (existing.status === "WAITING" && existing.mode !== parsed.data.mode) {
+    // Trocou de modo enquanto esperava: atualiza a entrada existente.
+    await prisma.queueEntry.update({
+      where: { id: existing.id },
+      data: { mode: parsed.data.mode, region: parsed.data.region },
+    });
+  }
+
+  // Tenta fechar uma partida 5x5 com quem está esperando.
+  await tryFormMatch(parsed.data.mode, parsed.data.region);
+
+  revalidatePath("/play");
+  return { ok: true };
+}
+
+/**
+ * Sai da fila: cancela todas as entradas em espera do usuário.
+ */
+export async function leaveQueue(): Promise<QueueActionResult> {
+  const user = await requireUser();
+
+  await prisma.queueEntry.updateMany({
+    where: { userId: user.id, status: "WAITING" },
+    data: { status: "CANCELLED" },
+  });
+
+  revalidatePath("/play");
+  return { ok: true };
+}

--- a/aegis-club/src/app/play/page.tsx
+++ b/aegis-club/src/app/play/page.tsx
@@ -1,0 +1,159 @@
+import Link from "next/link";
+import { Swords, Scale, ShieldCheck, Users2, ShieldAlert } from "lucide-react";
+import type { QueueMode } from "@prisma/client";
+import { getCurrentUser } from "@/lib/session";
+import { prisma } from "@/lib/prisma";
+import { Card, CardContent } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { BehaviorMeter } from "@/components/ui/BehaviorMeter";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SectionHeading } from "@/components/ui/SectionHeading";
+import { buttonVariants } from "@/components/ui/Button";
+import { canQueueRanked, BEHAVIOR_START } from "@/lib/reputation";
+import { cn } from "@/lib/utils";
+import { QueuePanel } from "@/components/matchmaking/QueuePanel";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Jogar" };
+
+const EXPLAINERS = [
+  {
+    icon: Scale,
+    title: "Matchmaking equilibrado",
+    description:
+      "Times são montados pelos seus rankPoints para que cada lado tenha chances justas de vitória.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Fila separada por conduta",
+    description:
+      "Quem coleciona denúncias cai na fila de baixa prioridade, longe das partidas saudáveis.",
+  },
+  {
+    icon: Users2,
+    title: "Partidas 5x5 com ready-check",
+    description:
+      "Ao reunir 10 jogadores compatíveis, abrimos um lobby com confirmação de presença.",
+  },
+] as const;
+
+export default async function PlayPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return (
+      <div className="container-page py-16">
+        <EmptyState
+          icon={<Swords className="h-10 w-10" />}
+          title="Entre para jogar"
+          description="Conecte sua conta Steam para entrar na fila e disputar partidas justas."
+          action={
+            <Link
+              href="/api/auth/steam/login"
+              className={cn(buttonVariants({ variant: "primary" }))}
+            >
+              Entrar com Steam
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  const profile = user.profile;
+  const region = profile?.region ?? "SA";
+  const behaviorScore = profile?.behaviorScore ?? BEHAVIOR_START;
+  const canRanked = canQueueRanked(behaviorScore);
+
+  const [rankedCount, unrankedCount, activeEntry] = await Promise.all([
+    prisma.queueEntry.count({
+      where: { status: "WAITING", mode: "RANKED_5V5", region },
+    }),
+    prisma.queueEntry.count({
+      where: { status: "WAITING", mode: "UNRANKED_5V5", region },
+    }),
+    prisma.queueEntry.findFirst({
+      where: { userId: user.id, status: { in: ["WAITING", "MATCHED"] } },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
+
+  const waitingCounts: Record<QueueMode, number> = {
+    RANKED_5V5: rankedCount,
+    UNRANKED_5V5: unrankedCount,
+  };
+
+  return (
+    <div className="container-page py-10">
+      <SectionHeading
+        eyebrow="Matchmaking"
+        title="Jogar agora"
+        description="Entre na fila e seja alocado em uma partida 5x5 equilibrada e saudável."
+      />
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Coluna principal: painel da fila */}
+        <div className="lg:col-span-2">
+          <QueuePanel
+            entry={
+              activeEntry
+                ? {
+                    mode: activeEntry.mode,
+                    status: activeEntry.status,
+                    matchId: activeEntry.matchId,
+                    createdAt: activeEntry.createdAt.getTime(),
+                  }
+                : null
+            }
+            region={region}
+            waitingCounts={waitingCounts}
+            canRanked={canRanked}
+          />
+        </div>
+
+        {/* Coluna lateral: conduta */}
+        <Card>
+          <CardContent className="flex flex-col gap-4 py-6">
+            <h3 className="text-sm font-semibold text-zinc-100">Sua conduta</h3>
+            <BehaviorMeter score={behaviorScore} />
+            {!canRanked && (
+              <Badge tone="bad" className="self-start">
+                <ShieldAlert className="h-3.5 w-3.5" />
+                Fila ranqueada bloqueada
+              </Badge>
+            )}
+            <p className="text-xs text-zinc-500">
+              Elogios recebidos elevam sua conduta; denúncias validadas a
+              reduzem. Partidas limpas recuperam pontos com o tempo.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Como funciona a fila */}
+      <div className="mt-10">
+        <h2 className="mb-4 text-lg font-semibold text-zinc-100">
+          Como funciona a fila
+        </h2>
+        <div className="grid gap-5 md:grid-cols-3">
+          {EXPLAINERS.map((item) => {
+            const Icon = item.icon;
+            return (
+              <Card key={item.title}>
+                <CardContent className="flex flex-col gap-3 py-6">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-aegis/10">
+                    <Icon className="h-5 w-5 text-aegis" />
+                  </span>
+                  <h3 className="text-sm font-semibold text-zinc-100">
+                    {item.title}
+                  </h3>
+                  <p className="text-sm text-zinc-400">{item.description}</p>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/aegis-club/src/app/profile/[id]/page.tsx
+++ b/aegis-club/src/app/profile/[id]/page.tsx
@@ -1,0 +1,399 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  Activity,
+  Gamepad2,
+  Heart,
+  Link2,
+  Pencil,
+  ShieldCheck,
+  Swords,
+  Trophy,
+  UserRound,
+} from "lucide-react";
+import { getCurrentUser } from "@/lib/session";
+import { prisma } from "@/lib/prisma";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { RankBadge } from "@/components/ui/RankBadge";
+import { BehaviorMeter } from "@/components/ui/BehaviorMeter";
+import { Avatar } from "@/components/ui/Avatar";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { buttonVariants } from "@/components/ui/Button";
+import { HeroAvatar } from "@/components/heroes/HeroAvatar";
+import { HEROES } from "@/data/heroes";
+import { cn, winRate } from "@/lib/utils";
+import {
+  ConnectButton,
+  type ConnectionState,
+} from "@/components/profile/ConnectButton";
+import { ImportSteamButton } from "@/components/profile/ImportSteamButton";
+import {
+  DOTA_ROLE_LABELS,
+  REGION_LABELS,
+} from "@/components/profile/labels";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Perfil" };
+
+const ROLE_BADGE: Partial<Record<"ORGANIZER" | "ADMIN", string>> = {
+  ORGANIZER: "Organizador",
+  ADMIN: "Admin",
+};
+
+/** Resolve a conexão (amizade) entre o visitante e o dono do perfil. */
+async function resolveConnection(
+  viewerId: string,
+  ownerId: string,
+): Promise<ConnectionState> {
+  const friendship = await prisma.friendship.findFirst({
+    where: {
+      OR: [
+        { requesterId: viewerId, addresseeId: ownerId },
+        { requesterId: ownerId, addresseeId: viewerId },
+      ],
+    },
+    select: { status: true },
+  });
+  if (!friendship) return "none";
+  if (friendship.status === "ACCEPTED") return "ACCEPTED";
+  if (friendship.status === "PENDING") return "PENDING";
+  return "none";
+}
+
+export default async function ProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const [user, viewer] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id },
+      include: { profile: true },
+    }),
+    getCurrentUser(),
+  ]);
+
+  if (!user) notFound();
+
+  const profile = user.profile;
+  const isSelf = viewer?.id === user.id;
+
+  const connection: ConnectionState =
+    viewer && !isSelf
+      ? await resolveConnection(viewer.id, user.id)
+      : "none";
+
+  // Heróis favoritos resolvidos pelo catálogo estático.
+  const favoriteHeroes = (profile?.favoriteHeroIds ?? [])
+    .map((heroId) => HEROES.find((h) => h.id === heroId))
+    .filter((h): h is (typeof HEROES)[number] => Boolean(h));
+
+  // Partidas recentes pela plataforma.
+  const recentMatches = await prisma.matchPlayer.findMany({
+    where: { userId: user.id },
+    include: { match: true },
+    orderBy: { match: { createdAt: "desc" } },
+    take: 8,
+  });
+
+  return (
+    <div className="container-page py-10">
+      {/* Cabeçalho */}
+      <Card className="mb-6">
+        <CardContent className="flex flex-wrap items-center gap-6 py-6">
+          <Avatar src={user.avatarUrl} name={user.nickname} size="xl" />
+
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-2xl font-bold text-zinc-100">
+                {user.nickname}
+              </h1>
+              {user.role !== "PLAYER" && (
+                <Badge tone="aegis">{ROLE_BADGE[user.role]}</Badge>
+              )}
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center gap-3">
+              <RankBadge points={profile?.rankPoints ?? 1000} showPoints />
+              <Badge tone="neutral">
+                {REGION_LABELS[profile?.region ?? "SA"]}
+              </Badge>
+              {profile?.country && (
+                <Badge tone="neutral">{profile.country}</Badge>
+              )}
+              {typeof profile?.publicMmr === "number" && (
+                <Badge tone="neutral">MMR público: {profile.publicMmr}</Badge>
+              )}
+            </div>
+
+            {profile?.bio && (
+              <p className="mt-3 max-w-2xl text-sm text-zinc-400">
+                {profile.bio}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col items-end gap-2">
+            {isSelf ? (
+              <>
+                <Link
+                  href="/profile/edit"
+                  className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}
+                >
+                  <Pencil className="h-4 w-4" />
+                  Editar perfil
+                </Link>
+                {user.steamId && <ImportSteamButton />}
+              </>
+            ) : (
+              viewer && (
+                <ConnectButton targetUserId={user.id} status={connection} />
+              )
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {!profile && (
+        <div className="mb-6">
+          <EmptyState
+            icon={<UserRound className="h-10 w-10" />}
+            title="Perfil ainda não configurado"
+            description={
+              isSelf
+                ? "Edite seu perfil para adicionar funções, heróis favoritos e redes sociais."
+                : "Este jogador ainda não preencheu o perfil."
+            }
+            action={
+              isSelf ? (
+                <Link
+                  href="/profile/edit"
+                  className={cn(buttonVariants({ variant: "primary" }))}
+                >
+                  Configurar perfil
+                </Link>
+              ) : undefined
+            }
+          />
+        </div>
+      )}
+
+      {/* Corpo */}
+      <div className="grid gap-5 lg:grid-cols-3">
+        {/* Conduta */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-4 w-4 text-aegis" /> Conduta
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BehaviorMeter score={profile?.behaviorScore ?? 7500} />
+          </CardContent>
+        </Card>
+
+        {/* Estatísticas */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Trophy className="h-4 w-4 text-aegis" /> Estatísticas
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-3 text-center sm:grid-cols-5">
+            <div>
+              <p className="text-2xl font-bold text-zinc-100">
+                {profile?.matchesPlayed ?? 0}
+              </p>
+              <p className="text-xs text-zinc-500">Partidas</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-radiant">
+                {profile?.wins ?? 0}
+              </p>
+              <p className="text-xs text-zinc-500">Vitórias</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-dire-soft">
+                {profile?.losses ?? 0}
+              </p>
+              <p className="text-xs text-zinc-500">Derrotas</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-aegis">
+                {winRate(profile?.wins ?? 0, profile?.matchesPlayed ?? 0)}%
+              </p>
+              <p className="text-xs text-zinc-500">Win rate</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-zinc-100">
+                {profile?.abandons ?? 0}
+              </p>
+              <p className="text-xs text-zinc-500">Abandonos</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Funções */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Swords className="h-4 w-4 text-aegis" /> Funções
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {profile && profile.mainRoles.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {profile.mainRoles.map((role) => (
+                  <Badge key={role} tone="neutral">
+                    {DOTA_ROLE_LABELS[role]}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-zinc-500">
+                Nenhuma função principal definida.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Heróis favoritos */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Heart className="h-4 w-4 text-aegis" /> Heróis favoritos
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {favoriteHeroes.length > 0 ? (
+              <div className="flex flex-wrap gap-3">
+                {favoriteHeroes.map((hero) => (
+                  <Link
+                    key={hero.id}
+                    href={`/heroes/${hero.slug}`}
+                    className="group flex flex-col items-center gap-1"
+                    title={hero.localizedName}
+                  >
+                    <HeroAvatar
+                      slug={hero.slug}
+                      name={hero.localizedName}
+                      size="md"
+                      className="transition-transform group-hover:-translate-y-0.5"
+                    />
+                    <span className="text-xs text-zinc-400 group-hover:text-zinc-200">
+                      {hero.localizedName}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-zinc-500">
+                Nenhum herói favorito selecionado.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Redes */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Link2 className="h-4 w-4 text-aegis" /> Redes
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {profile && (profile.discord || profile.twitch || profile.youtube) ? (
+              <ul className="space-y-2 text-sm">
+                {profile.discord && (
+                  <li className="flex items-center justify-between gap-3">
+                    <span className="text-zinc-500">Discord</span>
+                    <span className="truncate text-zinc-200">
+                      {profile.discord}
+                    </span>
+                  </li>
+                )}
+                {profile.twitch && (
+                  <li className="flex items-center justify-between gap-3">
+                    <span className="text-zinc-500">Twitch</span>
+                    <a
+                      href={`https://twitch.tv/${profile.twitch}`}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="link-muted truncate"
+                    >
+                      {profile.twitch}
+                    </a>
+                  </li>
+                )}
+                {profile.youtube && (
+                  <li className="flex items-center justify-between gap-3">
+                    <span className="text-zinc-500">YouTube</span>
+                    <a
+                      href={`https://youtube.com/${profile.youtube}`}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="link-muted truncate"
+                    >
+                      {profile.youtube}
+                    </a>
+                  </li>
+                )}
+              </ul>
+            ) : (
+              <p className="text-sm text-zinc-500">
+                Nenhuma rede social informada.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Partidas recentes */}
+        <Card className="lg:col-span-3">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Activity className="h-4 w-4 text-aegis" /> Partidas recentes
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {recentMatches.length === 0 ? (
+              <EmptyState
+                icon={<Gamepad2 className="h-8 w-8" />}
+                title="Sem partidas ainda"
+                description="As partidas disputadas pela plataforma aparecerão aqui."
+              />
+            ) : (
+              <ul className="divide-y divide-surface-border">
+                {recentMatches.map((mp) => (
+                  <li
+                    key={mp.id}
+                    className="flex items-center justify-between py-2.5 text-sm"
+                  >
+                    <Link
+                      href={`/match/${mp.matchId}`}
+                      className="link-muted font-mono"
+                    >
+                      #{mp.matchId.slice(-6)}
+                    </Link>
+                    <div className="flex items-center gap-2">
+                      <Badge tone={mp.team === "RADIANT" ? "radiant" : "dire"}>
+                        {mp.team === "RADIANT" ? "Radiant" : "Dire"}
+                      </Badge>
+                      {mp.won === true && <Badge tone="good">Vitória</Badge>}
+                      {mp.won === false && <Badge tone="bad">Derrota</Badge>}
+                      {mp.won === null && mp.match.status !== "COMPLETED" && (
+                        <Badge tone="warn">Em aberto</Badge>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/aegis-club/src/app/profile/actions.ts
+++ b/aegis-club/src/app/profile/actions.ts
@@ -1,0 +1,202 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { DotaRole, Region } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireUser } from "@/lib/session";
+import {
+  steamIdToAccountId,
+  fetchOpenDotaPlayer,
+  rankTierToApproxMmr,
+} from "@/lib/opendota";
+import { updateProfileSchema } from "@/lib/validations";
+
+export interface UpdateProfileState {
+  ok?: boolean;
+  error?: string;
+}
+
+export interface SimpleActionState {
+  ok?: boolean;
+  error?: string;
+}
+
+const DOTA_ROLES: readonly DotaRole[] = [
+  "CARRY",
+  "MID",
+  "OFFLANE",
+  "SOFT_SUPPORT",
+  "HARD_SUPPORT",
+];
+
+const REGIONS: readonly Region[] = ["SA", "NA", "EU", "CIS", "SEA", "CHINA"];
+
+function parseRoles(values: FormDataEntryValue[]): DotaRole[] {
+  const roles = values
+    .map((v) => String(v))
+    .filter((v): v is DotaRole => DOTA_ROLES.includes(v as DotaRole));
+  // Remove duplicatas preservando ordem.
+  return Array.from(new Set(roles)).slice(0, 5);
+}
+
+function parseRegion(value: FormDataEntryValue | null): Region {
+  return REGIONS.includes(value as Region) ? (value as Region) : "SA";
+}
+
+function parseHeroIds(values: FormDataEntryValue[]): number[] {
+  const ids = values
+    .map((v) => Number(v))
+    .filter((n) => Number.isInteger(n) && n > 0);
+  return Array.from(new Set(ids)).slice(0, 6);
+}
+
+/** Normaliza um campo de texto opcional: vazio vira undefined. */
+function optionalText(value: FormDataEntryValue | null): string | undefined {
+  const text = String(value ?? "").trim();
+  return text.length > 0 ? text : undefined;
+}
+
+/** Atualiza o nickname (User) e os campos de perfil (Profile). */
+export async function updateProfile(
+  _prevState: UpdateProfileState,
+  formData: FormData,
+): Promise<UpdateProfileState> {
+  try {
+    const user = await requireUser();
+
+    const nickname = String(formData.get("nickname") ?? "").trim();
+    const bio = optionalText(formData.get("bio"));
+    const region = parseRegion(formData.get("region"));
+    const mainRoles = parseRoles(formData.getAll("mainRoles"));
+    const favoriteHeroIds = parseHeroIds(formData.getAll("favoriteHeroIds"));
+    const discord = optionalText(formData.get("discord"));
+    const twitch = optionalText(formData.get("twitch"));
+    const youtube = optionalText(formData.get("youtube"));
+
+    const parsed = updateProfileSchema.safeParse({
+      nickname,
+      bio,
+      region,
+      mainRoles,
+      favoriteHeroIds,
+      discord,
+      twitch,
+      youtube,
+    });
+    if (!parsed.success) {
+      const first = parsed.error.issues[0];
+      return { error: first?.message ?? "Dados do perfil inválidos." };
+    }
+
+    const data = parsed.data;
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { nickname: data.nickname ?? nickname },
+    });
+
+    const profileData = {
+      bio: bio ?? null,
+      region,
+      mainRoles,
+      favoriteHeroIds,
+      discord: discord ?? null,
+      twitch: twitch ?? null,
+      youtube: youtube ?? null,
+    };
+
+    await prisma.profile.upsert({
+      where: { userId: user.id },
+      create: { userId: user.id, ...profileData },
+      update: profileData,
+    });
+
+    revalidatePath(`/profile/${user.id}`);
+    revalidatePath("/profile/edit");
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof Error && err.message === "UNAUTHENTICATED") {
+      return { error: "Você precisa entrar para editar seu perfil." };
+    }
+    return { error: "Não foi possível salvar o perfil. Tente novamente." };
+  }
+}
+
+/** Envia uma solicitação de conexão (amizade) para outro usuário. */
+export async function sendFriendRequest(
+  targetUserId: string,
+): Promise<SimpleActionState> {
+  try {
+    const user = await requireUser();
+
+    if (!targetUserId || targetUserId === user.id) {
+      return { error: "Você não pode se conectar consigo mesmo." };
+    }
+
+    const target = await prisma.user.findUnique({
+      where: { id: targetUserId },
+      select: { id: true },
+    });
+    if (!target) {
+      return { error: "Usuário não encontrado." };
+    }
+
+    try {
+      await prisma.friendship.create({
+        data: {
+          requesterId: user.id,
+          addresseeId: targetUserId,
+          status: "PENDING",
+        },
+      });
+    } catch {
+      // Já existe (restrição única) — ignora silenciosamente.
+    }
+
+    revalidatePath(`/profile/${targetUserId}`);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof Error && err.message === "UNAUTHENTICATED") {
+      return { error: "Você precisa entrar para se conectar." };
+    }
+    return { error: "Não foi possível enviar a solicitação." };
+  }
+}
+
+/** Importa o MMR público da Steam/OpenDota para o perfil do usuário. */
+export async function importSteamStats(): Promise<SimpleActionState> {
+  try {
+    const user = await requireUser();
+
+    if (!user.steamId) {
+      return { error: "Nenhuma conta Steam vinculada." };
+    }
+
+    const accountId = steamIdToAccountId(user.steamId);
+    const player = await fetchOpenDotaPlayer(accountId);
+    if (!player) {
+      return { error: "Não foi possível obter os dados da OpenDota." };
+    }
+
+    const publicMmr = rankTierToApproxMmr(player.rank_tier);
+    if (publicMmr === null) {
+      return {
+        error: "Seu perfil da OpenDota não expõe a medalha (rank tier).",
+      };
+    }
+
+    await prisma.profile.upsert({
+      where: { userId: user.id },
+      create: { userId: user.id, publicMmr },
+      update: { publicMmr },
+    });
+
+    revalidatePath(`/profile/${user.id}`);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof Error && err.message === "UNAUTHENTICATED") {
+      return { error: "Você precisa entrar para importar o MMR." };
+    }
+    return { error: "Não foi possível importar o MMR. Tente novamente." };
+  }
+}

--- a/aegis-club/src/app/profile/edit/page.tsx
+++ b/aegis-club/src/app/profile/edit/page.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { UserCog } from "lucide-react";
+import { getCurrentUser } from "@/lib/session";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { buttonVariants } from "@/components/ui/Button";
+import { SectionHeading } from "@/components/ui/SectionHeading";
+import { Card, CardContent } from "@/components/ui/Card";
+import { cn } from "@/lib/utils";
+import {
+  EditProfileForm,
+  type EditProfileValues,
+} from "@/components/profile/EditProfileForm";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Editar perfil" };
+
+export default async function EditProfilePage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return (
+      <div className="container-page py-16">
+        <EmptyState
+          icon={<UserCog className="h-10 w-10" />}
+          title="Entre para editar seu perfil"
+          description="Conecte sua conta Steam para personalizar funções, heróis favoritos e redes sociais."
+          action={
+            <Link
+              href="/api/auth/steam/login"
+              className={cn(buttonVariants({ variant: "primary" }))}
+            >
+              Entrar com Steam
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  const profile = user.profile;
+
+  const values: EditProfileValues = {
+    userId: user.id,
+    nickname: user.nickname,
+    bio: profile?.bio ?? "",
+    region: profile?.region ?? "SA",
+    mainRoles: profile?.mainRoles ?? [],
+    favoriteHeroIds: profile?.favoriteHeroIds ?? [],
+    discord: profile?.discord ?? "",
+    twitch: profile?.twitch ?? "",
+    youtube: profile?.youtube ?? "",
+  };
+
+  return (
+    <div className="container-page py-10">
+      <SectionHeading
+        eyebrow="Perfil"
+        title="Editar perfil"
+        description="Personalize como a comunidade vê você: apelido, funções, heróis favoritos e redes."
+        action={
+          <Link
+            href={`/profile/${user.id}`}
+            className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+          >
+            Ver perfil
+          </Link>
+        }
+      />
+
+      <Card>
+        <CardContent className="py-6">
+          <EditProfileForm values={values} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/aegis-club/src/app/tournaments/[slug]/page.tsx
+++ b/aegis-club/src/app/tournaments/[slug]/page.tsx
@@ -1,0 +1,322 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  Trophy,
+  Users,
+  Coins,
+  Calendar,
+  MapPin,
+  GitMerge,
+  Crown,
+} from "lucide-react";
+import type { Region, TournamentFormat, TournamentStatus } from "@prisma/client";
+import { getCurrentUser } from "@/lib/session";
+import { prisma } from "@/lib/prisma";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/Badge";
+import { Avatar } from "@/components/ui/Avatar";
+import { Bracket } from "@/components/tournaments/Bracket";
+import { RegisterTeamForm } from "@/components/tournaments/RegisterTeamForm";
+import { TournamentAdmin } from "@/components/tournaments/TournamentAdmin";
+
+export const dynamic = "force-dynamic";
+
+const FORMAT_LABELS: Record<TournamentFormat, string> = {
+  SINGLE_ELIMINATION: "Eliminação simples",
+  DOUBLE_ELIMINATION: "Eliminação dupla",
+  ROUND_ROBIN: "Pontos corridos",
+};
+
+const STATUS_LABELS: Record<TournamentStatus, string> = {
+  DRAFT: "Rascunho",
+  REGISTRATION: "Inscrições abertas",
+  LIVE: "Ao vivo",
+  COMPLETED: "Encerrado",
+  CANCELLED: "Cancelado",
+};
+
+const REGION_LABELS: Record<Region, string> = {
+  SA: "América do Sul",
+  NA: "América do Norte",
+  EU: "Europa",
+  CIS: "CIS",
+  SEA: "Sudeste Asiático",
+  CHINA: "China",
+};
+
+type BadgeTone = "neutral" | "aegis" | "radiant" | "dire" | "good" | "warn" | "bad";
+
+const STATUS_TONES: Record<TournamentStatus, BadgeTone> = {
+  DRAFT: "neutral",
+  REGISTRATION: "aegis",
+  LIVE: "radiant",
+  COMPLETED: "good",
+  CANCELLED: "bad",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const tournament = await prisma.tournament.findUnique({
+    where: { slug },
+    select: { name: true },
+  });
+  return { title: tournament?.name ?? "Torneio" };
+}
+
+export default async function TournamentDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  const [user, tournament] = await Promise.all([
+    getCurrentUser(),
+    prisma.tournament.findUnique({
+      where: { slug },
+      include: {
+        organizer: true,
+        teams: {
+          include: {
+            captain: true,
+            _count: { select: { members: true } },
+          },
+          orderBy: { seed: "asc" },
+        },
+        matches: {
+          include: { teamA: true, teamB: true, winner: true },
+          orderBy: [{ round: "asc" }, { position: "asc" }],
+        },
+      },
+    }),
+  ]);
+
+  if (!tournament) {
+    notFound();
+  }
+
+  const isOrganizer = user?.id === tournament.organizerId;
+  const isFull = tournament.teams.length >= tournament.maxTeams;
+  const alreadyCaptain = user
+    ? tournament.teams.some((t) => t.captainId === user.id)
+    : false;
+  const canRegister =
+    tournament.status === "REGISTRATION" &&
+    !!user &&
+    !alreadyCaptain &&
+    !isFull;
+
+  const bracketMatches = tournament.matches.map((m) => ({
+    id: m.id,
+    round: m.round,
+    position: m.position,
+    bracket: m.bracket,
+    scoreA: m.scoreA,
+    scoreB: m.scoreB,
+    winnerId: m.winnerId,
+    teamA: m.teamA
+      ? { id: m.teamA.id, name: m.teamA.name, tag: m.teamA.tag }
+      : null,
+    teamB: m.teamB
+      ? { id: m.teamB.id, name: m.teamB.name, tag: m.teamB.tag }
+      : null,
+  }));
+
+  return (
+    <div className="container-page py-10">
+      {/* Cabeçalho */}
+      <div className="mb-8">
+        <Link
+          href="/tournaments"
+          className="text-sm text-zinc-500 transition-colors hover:text-zinc-300"
+        >
+          ← Torneios
+        </Link>
+        <div className="mt-3 flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-zinc-100">
+              {tournament.name}
+            </h1>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <Badge tone={STATUS_TONES[tournament.status]}>
+                {STATUS_LABELS[tournament.status]}
+              </Badge>
+              <Badge tone="neutral">{FORMAT_LABELS[tournament.format]}</Badge>
+              <Badge tone="neutral">
+                <MapPin className="h-3 w-3" />
+                {REGION_LABELS[tournament.region]}
+              </Badge>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 rounded-xl border border-surface-border bg-surface/60 px-3 py-2">
+            <Avatar
+              src={tournament.organizer.avatarUrl}
+              name={tournament.organizer.nickname}
+              size="sm"
+            />
+            <div className="text-sm">
+              <p className="text-xs text-zinc-500">Organizado por</p>
+              <p className="font-medium text-zinc-200">
+                {tournament.organizer.nickname}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {tournament.description && (
+          <p className="mt-4 max-w-3xl whitespace-pre-line text-sm text-zinc-400">
+            {tournament.description}
+          </p>
+        )}
+
+        <dl className="mt-5 flex flex-wrap gap-x-8 gap-y-3 text-sm text-zinc-400">
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-zinc-500" />
+            <span>
+              {tournament.teams.length}/{tournament.maxTeams} times
+            </span>
+          </div>
+          {tournament.prizePool && (
+            <div className="flex items-center gap-2">
+              <Coins className="h-4 w-4 text-zinc-500" />
+              <span>{tournament.prizePool}</span>
+            </div>
+          )}
+          {tournament.registrationEndsAt && (
+            <div className="flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-zinc-500" />
+              <span>
+                Inscrições até{" "}
+                {dateFormatter.format(tournament.registrationEndsAt)}
+              </span>
+            </div>
+          )}
+          {tournament.startsAt && (
+            <div className="flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-zinc-500" />
+              <span>Início {dateFormatter.format(tournament.startsAt)}</span>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      {/* Painel do organizador */}
+      {isOrganizer && (
+        <div className="mb-8">
+          <TournamentAdmin
+            tournamentId={tournament.id}
+            status={tournament.status}
+            teamCount={tournament.teams.length}
+            matches={bracketMatches}
+          />
+        </div>
+      )}
+
+      <div className="grid gap-8 lg:grid-cols-[1fr_2fr]">
+        {/* Times inscritos */}
+        <section>
+          <h2 className="mb-4 flex items-center gap-2 text-xl font-bold text-zinc-100">
+            <Users className="h-5 w-5 text-aegis" />
+            Times inscritos
+          </h2>
+
+          {tournament.teams.length === 0 ? (
+            <p className="rounded-xl border border-dashed border-surface-border bg-surface/40 px-4 py-6 text-sm text-zinc-500">
+              Ainda não há times inscritos.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {tournament.teams.map((team) => (
+                <li
+                  key={team.id}
+                  className={cn(
+                    "flex items-center justify-between gap-3 rounded-xl border border-surface-border bg-surface/60 px-4 py-3",
+                    team.eliminated && "opacity-60",
+                  )}
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-xs text-zinc-500">
+                        {team.tag}
+                      </span>
+                      <span className="truncate font-medium text-zinc-100">
+                        {team.name}
+                      </span>
+                      {team.eliminated && (
+                        <Badge tone="bad">Eliminado</Badge>
+                      )}
+                    </div>
+                    <p className="mt-0.5 flex items-center gap-1.5 text-xs text-zinc-500">
+                      <Crown className="h-3 w-3" />
+                      {team.captain.nickname} · {team._count.members}{" "}
+                      {team._count.members === 1 ? "membro" : "membros"}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {canRegister && (
+            <div className="mt-5">
+              <h3 className="mb-3 text-sm font-semibold text-zinc-300">
+                Inscrever seu time
+              </h3>
+              <RegisterTeamForm tournamentId={tournament.id} />
+            </div>
+          )}
+          {tournament.status === "REGISTRATION" && user && alreadyCaptain && (
+            <p className="mt-4 text-sm text-zinc-500">
+              Você já inscreveu um time neste torneio.
+            </p>
+          )}
+          {tournament.status === "REGISTRATION" && !user && (
+            <p className="mt-4 text-sm text-zinc-500">
+              <Link
+                href="/api/auth/steam/login"
+                className="text-aegis hover:underline"
+              >
+                Entre
+              </Link>{" "}
+              para inscrever um time.
+            </p>
+          )}
+          {tournament.status === "REGISTRATION" && isFull && !alreadyCaptain && (
+            <p className="mt-4 text-sm text-zinc-500">
+              As inscrições estão lotadas.
+            </p>
+          )}
+        </section>
+
+        {/* Chaveamento */}
+        <section>
+          <h2 className="mb-4 flex items-center gap-2 text-xl font-bold text-zinc-100">
+            <GitMerge className="h-5 w-5 text-aegis" />
+            Chaveamento
+          </h2>
+
+          {tournament.matches.length > 0 ? (
+            <Bracket matches={bracketMatches} />
+          ) : (
+            <p className="flex items-center gap-2 rounded-xl border border-dashed border-surface-border bg-surface/40 px-4 py-6 text-sm text-zinc-500">
+              <Trophy className="h-4 w-4" />
+              Chaveamento será gerado quando o torneio começar.
+            </p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/aegis-club/src/app/tournaments/actions.ts
+++ b/aegis-club/src/app/tournaments/actions.ts
@@ -1,0 +1,406 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import type { Region, TournamentFormat } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireUser } from "@/lib/session";
+import { slugify } from "@/lib/utils";
+import {
+  generateSingleElimination,
+  nextSlot,
+  type SeededTeam,
+} from "@/lib/bracket";
+import {
+  createTeamSchema,
+  createTournamentSchema,
+  reportMatchResultSchema,
+} from "@/lib/validations";
+
+// ── Tipos de estado retornados aos formulários ────────────────────
+export interface CreateTournamentState {
+  ok?: boolean;
+  error?: string;
+}
+
+export interface RegisterTeamState {
+  ok?: boolean;
+  error?: string;
+}
+
+const TOURNAMENT_FORMATS: readonly TournamentFormat[] = [
+  "SINGLE_ELIMINATION",
+  "DOUBLE_ELIMINATION",
+  "ROUND_ROBIN",
+];
+
+const REGIONS: readonly Region[] = ["SA", "NA", "EU", "CIS", "SEA", "CHINA"];
+
+function parseFormat(value: FormDataEntryValue | null): TournamentFormat {
+  return TOURNAMENT_FORMATS.includes(value as TournamentFormat)
+    ? (value as TournamentFormat)
+    : "SINGLE_ELIMINATION";
+}
+
+function parseRegion(value: FormDataEntryValue | null): Region {
+  return REGIONS.includes(value as Region) ? (value as Region) : "SA";
+}
+
+/** Converte o valor de um input datetime-local em ISO, ou undefined se vazio. */
+function parseLocalDateTime(value: FormDataEntryValue | null): string | undefined {
+  const raw = String(value ?? "").trim();
+  if (!raw) return undefined;
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+/** Gera um slug único para o torneio (adiciona sufixo curto se houver colisão). */
+async function uniqueTournamentSlug(name: string): Promise<string> {
+  const base = slugify(name) || "torneio";
+  let slug = base;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const existing = await prisma.tournament.findUnique({
+      where: { slug },
+      select: { id: true },
+    });
+    if (!existing) return slug;
+    const suffix = Math.random().toString(36).slice(2, 6);
+    slug = `${base}-${suffix}`;
+  }
+  // Último recurso: timestamp garante unicidade.
+  return `${base}-${Date.now().toString(36)}`;
+}
+
+/** Cria um torneio em rascunho e leva o organizador para a página de detalhe. */
+export async function createTournament(
+  _prevState: CreateTournamentState,
+  formData: FormData,
+): Promise<CreateTournamentState> {
+  let slug: string;
+  try {
+    const user = await requireUser();
+
+    const name = String(formData.get("name") ?? "").trim();
+    const description = String(formData.get("description") ?? "").trim();
+    const prizePool = String(formData.get("prizePool") ?? "").trim();
+    const maxTeams = Number(formData.get("maxTeams"));
+    const format = parseFormat(formData.get("format"));
+    const region = parseRegion(formData.get("region"));
+    const registrationEndsAt = parseLocalDateTime(
+      formData.get("registrationEndsAt"),
+    );
+    const startsAt = parseLocalDateTime(formData.get("startsAt"));
+
+    const parsed = createTournamentSchema.safeParse({
+      name,
+      description: description || undefined,
+      format,
+      region,
+      maxTeams: Number.isFinite(maxTeams) ? maxTeams : 8,
+      prizePool: prizePool || undefined,
+      registrationEndsAt,
+      startsAt,
+    });
+    if (!parsed.success) {
+      const first = parsed.error.issues[0];
+      return { error: first?.message ?? "Dados do torneio inválidos." };
+    }
+
+    slug = await uniqueTournamentSlug(parsed.data.name);
+
+    await prisma.tournament.create({
+      data: {
+        slug,
+        name: parsed.data.name,
+        description: parsed.data.description ?? null,
+        format: parsed.data.format,
+        region: parsed.data.region,
+        maxTeams: parsed.data.maxTeams,
+        prizePool: parsed.data.prizePool ?? null,
+        status: "DRAFT",
+        organizerId: user.id,
+        registrationEndsAt: parsed.data.registrationEndsAt
+          ? new Date(parsed.data.registrationEndsAt)
+          : null,
+        startsAt: parsed.data.startsAt ? new Date(parsed.data.startsAt) : null,
+      },
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message === "UNAUTHENTICATED") {
+      return { error: "Você precisa entrar para criar um torneio." };
+    }
+    return { error: "Não foi possível criar o torneio. Tente novamente." };
+  }
+
+  // redirect lança internamente — fica fora do try/catch.
+  redirect(`/tournaments/${slug}`);
+}
+
+/** Inscreve um time no torneio (o usuário vira capitão e primeiro membro). */
+export async function registerTeam(
+  _prevState: RegisterTeamState,
+  formData: FormData,
+): Promise<RegisterTeamState> {
+  try {
+    const user = await requireUser();
+
+    const tournamentId = String(formData.get("tournamentId") ?? "").trim();
+    const name = String(formData.get("name") ?? "").trim();
+    const tag = String(formData.get("tag") ?? "").trim();
+
+    const parsed = createTeamSchema.safeParse({ tournamentId, name, tag });
+    if (!parsed.success) {
+      const first = parsed.error.issues[0];
+      return { error: first?.message ?? "Dados do time inválidos." };
+    }
+
+    const tournament = await prisma.tournament.findUnique({
+      where: { id: parsed.data.tournamentId },
+      select: {
+        slug: true,
+        status: true,
+        maxTeams: true,
+        _count: { select: { teams: true } },
+      },
+    });
+    if (!tournament) {
+      return { error: "Torneio não encontrado." };
+    }
+    if (tournament.status !== "REGISTRATION") {
+      return { error: "As inscrições deste torneio não estão abertas." };
+    }
+    if (tournament._count.teams >= tournament.maxTeams) {
+      return { error: "Este torneio já atingiu o número máximo de times." };
+    }
+
+    const alreadyCaptain = await prisma.team.findFirst({
+      where: {
+        tournamentId: parsed.data.tournamentId,
+        captainId: user.id,
+      },
+      select: { id: true },
+    });
+    if (alreadyCaptain) {
+      return { error: "Você já inscreveu um time neste torneio." };
+    }
+
+    await prisma.team.create({
+      data: {
+        tournamentId: parsed.data.tournamentId,
+        name: parsed.data.name,
+        tag: parsed.data.tag,
+        captainId: user.id,
+        members: { create: { userId: user.id } },
+      },
+    });
+
+    revalidatePath(`/tournaments/${tournament.slug}`);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof Error && err.message === "UNAUTHENTICATED") {
+      return { error: "Você precisa entrar para inscrever um time." };
+    }
+    return { error: "Não foi possível inscrever o time. Tente novamente." };
+  }
+}
+
+/** Garante que o usuário atual é o organizador do torneio; retorna o slug. */
+async function requireOrganizer(tournamentId: string): Promise<{
+  slug: string;
+}> {
+  const user = await requireUser();
+  const tournament = await prisma.tournament.findUnique({
+    where: { id: tournamentId },
+    select: { slug: true, organizerId: true },
+  });
+  if (!tournament) {
+    throw new Error("Torneio não encontrado.");
+  }
+  if (tournament.organizerId !== user.id) {
+    throw new Error("Apenas o organizador pode gerenciar este torneio.");
+  }
+  return { slug: tournament.slug };
+}
+
+/** Abre as inscrições de um torneio em rascunho. */
+export async function openRegistration(tournamentId: string): Promise<void> {
+  const { slug } = await requireOrganizer(tournamentId);
+  await prisma.tournament.update({
+    where: { id: tournamentId },
+    data: { status: "REGISTRATION" },
+  });
+  revalidatePath(`/tournaments/${slug}`);
+}
+
+/**
+ * Inicia o torneio: define seeds, gera o chaveamento de eliminação simples,
+ * avança automaticamente os "byes" e marca o torneio como Ao vivo.
+ */
+export async function startTournament(tournamentId: string): Promise<void> {
+  const { slug } = await requireOrganizer(tournamentId);
+
+  const teams = await prisma.team.findMany({
+    where: { tournamentId },
+    orderBy: { createdAt: "asc" },
+    select: { id: true, seed: true },
+  });
+  if (teams.length < 2) {
+    throw new Error("É preciso ao menos 2 times para iniciar o torneio.");
+  }
+
+  // Atribui seeds por ordem de inscrição quando ainda não definidos.
+  const seeded: SeededTeam[] = [];
+  for (let i = 0; i < teams.length; i++) {
+    const team = teams[i];
+    const seed = team.seed ?? i + 1;
+    if (team.seed == null) {
+      await prisma.team.update({
+        where: { id: team.id },
+        data: { seed },
+      });
+    }
+    seeded.push({ id: team.id, seed });
+  }
+
+  const bracket = generateSingleElimination(seeded);
+
+  // Cria as partidas apenas se ainda não existirem.
+  const existing = await prisma.tournamentMatch.count({ where: { tournamentId } });
+  if (existing === 0) {
+    await prisma.tournamentMatch.createMany({
+      data: bracket.map((m) => ({
+        tournamentId,
+        round: m.round,
+        position: m.position,
+        bracket: m.bracket,
+        teamAId: m.teamAId,
+        teamBId: m.teamBId,
+        bestOf: m.bracket === "GRAND_FINAL" ? 3 : 1,
+      })),
+    });
+  }
+
+  // Avança automaticamente os byes da primeira rodada (teamA definido, teamB nulo).
+  const round1 = await prisma.tournamentMatch.findMany({
+    where: { tournamentId, round: 1 },
+    orderBy: { position: "asc" },
+  });
+  for (const match of round1) {
+    if (match.teamAId && !match.teamBId && !match.winnerId) {
+      await prisma.tournamentMatch.update({
+        where: { id: match.id },
+        data: { winnerId: match.teamAId, completedAt: new Date() },
+      });
+      await advanceWinner(tournamentId, match.round, match.position, match.teamAId);
+    }
+  }
+
+  await prisma.tournament.update({
+    where: { id: tournamentId },
+    data: { status: "LIVE", startsAt: new Date() },
+  });
+  revalidatePath(`/tournaments/${slug}`);
+}
+
+/**
+ * Propaga o vencedor de (round, position) para o slot correspondente da
+ * próxima rodada. Retorna true se havia partida seguinte (não era a final).
+ */
+async function advanceWinner(
+  tournamentId: string,
+  round: number,
+  position: number,
+  winnerTeamId: string,
+): Promise<boolean> {
+  const target = nextSlot(position);
+  const next = await prisma.tournamentMatch.findFirst({
+    where: {
+      tournamentId,
+      round: round + 1,
+      position: target.position,
+    },
+    orderBy: { position: "asc" },
+  });
+  if (!next) return false;
+
+  await prisma.tournamentMatch.update({
+    where: { id: next.id },
+    data: target.slot === "A" ? { teamAId: winnerTeamId } : { teamBId: winnerTeamId },
+  });
+  return true;
+}
+
+/**
+ * Registra o resultado de uma partida do torneio. Apenas o organizador pode.
+ * Avança o vencedor; se era a final, marca o torneio como Encerrado.
+ */
+export async function reportTournamentMatch(input: {
+  matchId: string;
+  winnerTeamId: string;
+  scoreA: number;
+  scoreB: number;
+}): Promise<void> {
+  const user = await requireUser();
+
+  const parsed = reportMatchResultSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues[0]?.message ?? "Resultado inválido.");
+  }
+  const { matchId, winnerTeamId, scoreA, scoreB } = parsed.data;
+
+  const match = await prisma.tournamentMatch.findUnique({
+    where: { id: matchId },
+    include: {
+      tournament: { select: { id: true, slug: true, organizerId: true } },
+    },
+  });
+  if (!match) {
+    throw new Error("Partida não encontrada.");
+  }
+  if (match.tournament.organizerId !== user.id) {
+    throw new Error("Apenas o organizador pode registrar resultados.");
+  }
+  if (!match.teamAId || !match.teamBId) {
+    throw new Error("A partida ainda não tem os dois times definidos.");
+  }
+  if (winnerTeamId !== match.teamAId && winnerTeamId !== match.teamBId) {
+    throw new Error("O vencedor precisa ser um dos times da partida.");
+  }
+
+  const loserId =
+    winnerTeamId === match.teamAId ? match.teamBId : match.teamAId;
+
+  await prisma.tournamentMatch.update({
+    where: { id: matchId },
+    data: {
+      scoreA,
+      scoreB,
+      winnerId: winnerTeamId,
+      completedAt: new Date(),
+    },
+  });
+
+  // Elimina o perdedor (eliminação simples).
+  await prisma.team.update({
+    where: { id: loserId },
+    data: { eliminated: true },
+  });
+
+  const hadNext = await advanceWinner(
+    match.tournament.id,
+    match.round,
+    match.position,
+    winnerTeamId,
+  );
+
+  // Sem próxima partida = era a final → torneio encerrado.
+  if (!hadNext) {
+    await prisma.tournament.update({
+      where: { id: match.tournament.id },
+      data: { status: "COMPLETED" },
+    });
+  }
+
+  revalidatePath(`/tournaments/${match.tournament.slug}`);
+}

--- a/aegis-club/src/app/tournaments/new/page.tsx
+++ b/aegis-club/src/app/tournaments/new/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { Trophy } from "lucide-react";
+import { getCurrentUser } from "@/lib/session";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SectionHeading } from "@/components/ui/SectionHeading";
+import { buttonVariants } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+import { CreateTournamentForm } from "@/components/tournaments/CreateTournamentForm";
+
+export const metadata = { title: "Criar torneio" };
+
+export default async function NewTournamentPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return (
+      <div className="container-page py-16">
+        <EmptyState
+          icon={<Trophy className="h-10 w-10" />}
+          title="Entre para criar um torneio"
+          description="Conecte sua conta Steam para organizar campeonatos da comunidade."
+          action={
+            <Link
+              href="/api/auth/steam/login"
+              className={cn(buttonVariants({ variant: "primary" }))}
+            >
+              Entrar com Steam
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container-page max-w-3xl py-10">
+      <SectionHeading
+        eyebrow="Competitivo"
+        title="Criar torneio"
+        description="Configure o formato, a região e as inscrições. O torneio começa como rascunho."
+      />
+      <CreateTournamentForm />
+    </div>
+  );
+}

--- a/aegis-club/src/app/tournaments/page.tsx
+++ b/aegis-club/src/app/tournaments/page.tsx
@@ -1,0 +1,206 @@
+import Link from "next/link";
+import { Trophy, Users, Coins, Calendar, Plus } from "lucide-react";
+import type { Region, TournamentFormat, TournamentStatus } from "@prisma/client";
+import { getCurrentUser } from "@/lib/session";
+import { prisma } from "@/lib/prisma";
+import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SectionHeading } from "@/components/ui/SectionHeading";
+import { buttonVariants } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = { title: "Torneios" };
+
+const FORMAT_LABELS: Record<TournamentFormat, string> = {
+  SINGLE_ELIMINATION: "Eliminação simples",
+  DOUBLE_ELIMINATION: "Eliminação dupla",
+  ROUND_ROBIN: "Pontos corridos",
+};
+
+const STATUS_LABELS: Record<TournamentStatus, string> = {
+  DRAFT: "Rascunho",
+  REGISTRATION: "Inscrições abertas",
+  LIVE: "Ao vivo",
+  COMPLETED: "Encerrado",
+  CANCELLED: "Cancelado",
+};
+
+const REGION_LABELS: Record<Region, string> = {
+  SA: "América do Sul",
+  NA: "América do Norte",
+  EU: "Europa",
+  CIS: "CIS",
+  SEA: "Sudeste Asiático",
+  CHINA: "China",
+};
+
+type BadgeTone = "neutral" | "aegis" | "radiant" | "dire" | "good" | "warn" | "bad";
+
+const STATUS_TONES: Record<TournamentStatus, BadgeTone> = {
+  DRAFT: "neutral",
+  REGISTRATION: "aegis",
+  LIVE: "radiant",
+  COMPLETED: "good",
+  CANCELLED: "bad",
+};
+
+const STATUS_FILTERS: { value: TournamentStatus | "ALL"; label: string }[] = [
+  { value: "ALL", label: "Todos" },
+  { value: "REGISTRATION", label: STATUS_LABELS.REGISTRATION },
+  { value: "LIVE", label: STATUS_LABELS.LIVE },
+  { value: "COMPLETED", label: STATUS_LABELS.COMPLETED },
+  { value: "DRAFT", label: STATUS_LABELS.DRAFT },
+];
+
+function isStatus(value: string | undefined): value is TournamentStatus {
+  return (
+    value === "DRAFT" ||
+    value === "REGISTRATION" ||
+    value === "LIVE" ||
+    value === "COMPLETED" ||
+    value === "CANCELLED"
+  );
+}
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+export default async function TournamentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const { status } = await searchParams;
+  const activeStatus = isStatus(status) ? status : "ALL";
+
+  const [user, tournaments] = await Promise.all([
+    getCurrentUser(),
+    prisma.tournament.findMany({
+      where: activeStatus === "ALL" ? undefined : { status: activeStatus },
+      include: {
+        organizer: true,
+        _count: { select: { teams: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
+
+  return (
+    <div className="container-page py-10">
+      <SectionHeading
+        eyebrow="Competitivo"
+        title="Torneios"
+        description="Dispute, organize e acompanhe campeonatos da comunidade."
+        action={
+          user ? (
+            <Link
+              href="/tournaments/new"
+              className={cn(buttonVariants({ variant: "primary" }))}
+            >
+              <Plus className="h-4 w-4" />
+              Criar torneio
+            </Link>
+          ) : undefined
+        }
+      />
+
+      {/* Filtros de status */}
+      <div className="mb-6 flex flex-wrap gap-2">
+        {STATUS_FILTERS.map((filter) => {
+          const isActive = filter.value === activeStatus;
+          const href =
+            filter.value === "ALL"
+              ? "/tournaments"
+              : `/tournaments?status=${filter.value}`;
+          return (
+            <Link
+              key={filter.value}
+              href={href}
+              className={cn(
+                "rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors duration-200",
+                isActive
+                  ? "border-aegis/40 bg-aegis/15 text-aegis"
+                  : "border-surface-border text-zinc-400 hover:border-aegis/30 hover:text-zinc-200",
+              )}
+            >
+              {filter.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      {tournaments.length === 0 ? (
+        <EmptyState
+          icon={<Trophy className="h-10 w-10" />}
+          title="Nenhum torneio por aqui"
+          description="Ainda não há torneios com esse filtro. Que tal organizar o seu?"
+          action={
+            user ? (
+              <Link
+                href="/tournaments/new"
+                className={cn(buttonVariants({ variant: "primary" }))}
+              >
+                <Plus className="h-4 w-4" />
+                Criar torneio
+              </Link>
+            ) : undefined
+          }
+        />
+      ) : (
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {tournaments.map((t) => (
+            <div key={t.id} className="card flex flex-col p-5">
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <Link
+                  href={`/tournaments/${t.slug}`}
+                  className="text-lg font-semibold text-zinc-100 hover:text-aegis"
+                >
+                  {t.name}
+                </Link>
+                <Badge tone={STATUS_TONES[t.status]}>
+                  {STATUS_LABELS[t.status]}
+                </Badge>
+              </div>
+
+              <div className="mb-4 flex flex-wrap gap-2">
+                <Badge tone="neutral">{FORMAT_LABELS[t.format]}</Badge>
+                <Badge tone="neutral">{REGION_LABELS[t.region]}</Badge>
+              </div>
+
+              <dl className="mt-auto space-y-2 text-sm text-zinc-400">
+                <div className="flex items-center gap-2">
+                  <Users className="h-4 w-4 text-zinc-500" />
+                  <span>
+                    {t._count.teams}/{t.maxTeams} times
+                  </span>
+                </div>
+                {t.prizePool && (
+                  <div className="flex items-center gap-2">
+                    <Coins className="h-4 w-4 text-zinc-500" />
+                    <span>{t.prizePool}</span>
+                  </div>
+                )}
+                {t.startsAt && (
+                  <div className="flex items-center gap-2">
+                    <Calendar className="h-4 w-4 text-zinc-500" />
+                    <span>{dateFormatter.format(t.startsAt)}</span>
+                  </div>
+                )}
+              </dl>
+
+              <p className="mt-4 border-t border-surface-border pt-3 text-xs text-zinc-500">
+                Organizado por{" "}
+                <span className="text-zinc-300">{t.organizer.nickname}</span>
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/aegis-club/src/components/heroes/AddTutorialForm.tsx
+++ b/aegis-club/src/components/heroes/AddTutorialForm.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useActionState, useEffect, useId, useRef } from "react";
+import { useFormStatus } from "react-dom";
+import { Send } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { addTutorial, type AddTutorialState } from "@/app/heroes/actions";
+
+const LEVEL_OPTIONS: { value: string; label: string }[] = [
+  { value: "BEGINNER", label: "Iniciante" },
+  { value: "INTERMEDIATE", label: "Intermediário" },
+  { value: "ADVANCED", label: "Avançado" },
+];
+
+const initialState: AddTutorialState = {};
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      <Send className="h-4 w-4" />
+      {pending ? "Enviando…" : "Enviar tutorial"}
+    </Button>
+  );
+}
+
+export function AddTutorialForm({ heroId }: { heroId: number }) {
+  const [state, formAction] = useActionState(addTutorial, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+  const titleId = useId();
+  const youtubeId = useId();
+  const levelId = useId();
+
+  useEffect(() => {
+    if (state.ok) {
+      formRef.current?.reset();
+    }
+  }, [state.ok]);
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      className="space-y-4 rounded-2xl border border-surface-border bg-surface/60 p-5"
+    >
+      <input type="hidden" name="heroId" value={heroId} />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <label
+            htmlFor={titleId}
+            className="mb-1.5 block text-sm font-medium text-zinc-300"
+          >
+            Título
+          </label>
+          <input
+            id={titleId}
+            name="title"
+            type="text"
+            required
+            maxLength={120}
+            placeholder="Ex: Como dominar a lane com este herói"
+            className="w-full rounded-xl border border-surface-border bg-bg px-3.5 py-2.5 text-sm text-zinc-100 placeholder:text-zinc-600 focus-visible:border-aegis/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/40"
+          />
+        </div>
+
+        <div className="sm:col-span-2">
+          <label
+            htmlFor={youtubeId}
+            className="mb-1.5 block text-sm font-medium text-zinc-300"
+          >
+            Link do YouTube
+          </label>
+          <input
+            id={youtubeId}
+            name="youtube"
+            type="text"
+            required
+            placeholder="https://www.youtube.com/watch?v=…"
+            className="w-full rounded-xl border border-surface-border bg-bg px-3.5 py-2.5 text-sm text-zinc-100 placeholder:text-zinc-600 focus-visible:border-aegis/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/40"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor={levelId}
+            className="mb-1.5 block text-sm font-medium text-zinc-300"
+          >
+            Nível
+          </label>
+          <select
+            id={levelId}
+            name="level"
+            defaultValue="BEGINNER"
+            className="w-full rounded-xl border border-surface-border bg-bg px-3.5 py-2.5 text-sm text-zinc-100 focus-visible:border-aegis/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/40"
+          >
+            {LEVEL_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {state.error && (
+        <p className="text-sm text-behavior-bad" role="alert">
+          {state.error}
+        </p>
+      )}
+      {state.ok && (
+        <p className="text-sm text-behavior-good" role="status">
+          Tutorial enviado com sucesso!
+        </p>
+      )}
+
+      <div className="flex justify-end">
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/aegis-club/src/components/heroes/HeroAvatar.tsx
+++ b/aegis-club/src/components/heroes/HeroAvatar.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable @next/next/no-img-element */
+import { heroImageUrl } from "@/data/heroes";
+import { cn } from "@/lib/utils";
+
+const sizes = {
+  sm: "h-9 w-16",
+  md: "h-14 w-24",
+  lg: "h-20 w-36",
+};
+
+export function HeroAvatar({
+  slug,
+  name,
+  size = "md",
+  className,
+}: {
+  slug: string;
+  name: string;
+  size?: keyof typeof sizes;
+  className?: string;
+}) {
+  return (
+    <img
+      src={heroImageUrl(slug)}
+      alt={name}
+      loading="lazy"
+      className={cn(
+        "rounded-lg border border-surface-border object-cover",
+        sizes[size],
+        className,
+      )}
+    />
+  );
+}

--- a/aegis-club/src/components/heroes/TutorialCard.tsx
+++ b/aegis-club/src/components/heroes/TutorialCard.tsx
@@ -1,0 +1,65 @@
+import type { Tutorial, TutorialLevel, TutorialVote, User } from "@prisma/client";
+import { Card, CardContent } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { YouTubeEmbed } from "@/components/heroes/YouTubeEmbed";
+import { VoteButtons } from "@/components/heroes/VoteButtons";
+
+const LEVEL_LABELS: Record<TutorialLevel, string> = {
+  BEGINNER: "Iniciante",
+  INTERMEDIATE: "Intermediário",
+  ADVANCED: "Avançado",
+};
+
+const LEVEL_TONE: Record<
+  TutorialLevel,
+  "good" | "warn" | "bad" | "neutral" | "aegis"
+> = {
+  BEGINNER: "good",
+  INTERMEDIATE: "warn",
+  ADVANCED: "bad",
+};
+
+export type TutorialWithRelations = Tutorial & {
+  author: Pick<User, "id" | "nickname"> | null;
+  votes?: Pick<TutorialVote, "value">[];
+};
+
+export function TutorialCard({
+  tutorial,
+  currentUserId,
+}: {
+  tutorial: TutorialWithRelations;
+  currentUserId?: string | null;
+}) {
+  const myVote = tutorial.votes?.[0]?.value ?? 0;
+
+  return (
+    <Card className="overflow-hidden">
+      <YouTubeEmbed id={tutorial.youtubeId} title={tutorial.title} />
+      <CardContent className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="font-semibold leading-snug text-zinc-100">
+            {tutorial.title}
+          </h3>
+          <Badge tone={LEVEL_TONE[tutorial.level]}>
+            {LEVEL_LABELS[tutorial.level]}
+          </Badge>
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm text-zinc-500">
+            {tutorial.author
+              ? `por ${tutorial.author.nickname}`
+              : "Autor desconhecido"}
+          </p>
+          <VoteButtons
+            tutorialId={tutorial.id}
+            score={tutorial.score}
+            myVote={myVote}
+            canVote={Boolean(currentUserId)}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/aegis-club/src/components/heroes/VoteButtons.tsx
+++ b/aegis-club/src/components/heroes/VoteButtons.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useTransition } from "react";
+import { ThumbsUp, ThumbsDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { voteTutorial } from "@/app/heroes/actions";
+
+export function VoteButtons({
+  tutorialId,
+  score,
+  myVote,
+  canVote,
+}: {
+  tutorialId: string;
+  score: number;
+  /** Voto atual do usuário: 1, -1 ou 0/undefined se não votou. */
+  myVote?: number;
+  /** Falso quando o usuário não está autenticado. */
+  canVote: boolean;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  function cast(value: 1 | -1) {
+    if (!canVote || pending) return;
+    startTransition(async () => {
+      await voteTutorial(tutorialId, value);
+    });
+  }
+
+  return (
+    <div className="inline-flex items-center gap-1 rounded-xl border border-surface-border bg-surface/60 p-1">
+      <button
+        type="button"
+        onClick={() => cast(1)}
+        disabled={!canVote || pending}
+        aria-label="Votar a favor"
+        aria-pressed={myVote === 1}
+        className={cn(
+          "inline-flex h-8 w-8 items-center justify-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+          myVote === 1
+            ? "bg-behavior-good/20 text-behavior-good"
+            : "text-zinc-400 hover:bg-surface-hover hover:text-zinc-100",
+        )}
+      >
+        <ThumbsUp className="h-4 w-4" />
+      </button>
+
+      <span
+        className={cn(
+          "min-w-7 text-center text-sm font-semibold tabular-nums",
+          score > 0
+            ? "text-behavior-good"
+            : score < 0
+              ? "text-behavior-bad"
+              : "text-zinc-300",
+        )}
+      >
+        {score}
+      </span>
+
+      <button
+        type="button"
+        onClick={() => cast(-1)}
+        disabled={!canVote || pending}
+        aria-label="Votar contra"
+        aria-pressed={myVote === -1}
+        className={cn(
+          "inline-flex h-8 w-8 items-center justify-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+          myVote === -1
+            ? "bg-behavior-bad/20 text-behavior-bad"
+            : "text-zinc-400 hover:bg-surface-hover hover:text-zinc-100",
+        )}
+      >
+        <ThumbsDown className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/aegis-club/src/components/heroes/YouTubeEmbed.tsx
+++ b/aegis-club/src/components/heroes/YouTubeEmbed.tsx
@@ -1,0 +1,15 @@
+import { youtubeEmbedUrl } from "@/lib/youtube";
+
+export function YouTubeEmbed({ id, title }: { id: string; title: string }) {
+  return (
+    <div className="relative aspect-video w-full overflow-hidden rounded-xl border border-surface-border bg-black">
+      <iframe
+        src={youtubeEmbedUrl(id)}
+        title={title}
+        className="absolute inset-0 h-full w-full"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  );
+}

--- a/aegis-club/src/components/layout/Footer.tsx
+++ b/aegis-club/src/components/layout/Footer.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { Shield } from "lucide-react";
+
+export function Footer() {
+  return (
+    <footer className="mt-20 border-t border-surface-border bg-bg-soft">
+      <div className="container-page flex flex-col gap-6 py-10 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-zinc-100">
+            <Shield className="h-5 w-5 text-aegis" />
+            <span className="font-display text-lg font-bold tracking-tight">
+              Aegis Club
+            </span>
+          </div>
+          <p className="mt-2 max-w-md text-sm text-zinc-500">
+            Plataforma competitiva da comunidade de Dota 2. Partidas justas,
+            menos toxicidade, mais comunidade.
+          </p>
+        </div>
+        <nav className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+          <Link href="/play" className="link-muted">
+            Jogar
+          </Link>
+          <Link href="/heroes" className="link-muted">
+            Heróis
+          </Link>
+          <Link href="/tournaments" className="link-muted">
+            Torneios
+          </Link>
+          <Link href="/leaderboard" className="link-muted">
+            Ranking
+          </Link>
+        </nav>
+      </div>
+      <div className="border-t border-surface-border py-4 text-center text-xs text-zinc-600">
+        Projeto comunitário, sem vínculo com a Valve. Dota 2 é marca da Valve
+        Corporation.
+      </div>
+    </footer>
+  );
+}

--- a/aegis-club/src/components/layout/NavLinks.tsx
+++ b/aegis-club/src/components/layout/NavLinks.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+const LINKS = [
+  { href: "/play", label: "Jogar" },
+  { href: "/heroes", label: "Heróis" },
+  { href: "/tournaments", label: "Torneios" },
+  { href: "/leaderboard", label: "Ranking" },
+];
+
+export function NavLinks() {
+  const pathname = usePathname();
+  return (
+    <nav className="hidden items-center gap-1 md:flex">
+      {LINKS.map((link) => {
+        const active =
+          pathname === link.href || pathname.startsWith(`${link.href}/`);
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={cn(
+              "rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+              active
+                ? "bg-surface-hover text-aegis"
+                : "text-zinc-400 hover:bg-surface-hover hover:text-zinc-100",
+            )}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/aegis-club/src/components/layout/Navbar.tsx
+++ b/aegis-club/src/components/layout/Navbar.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import { Shield, LogOut } from "lucide-react";
+import { getCurrentUser } from "@/lib/session";
+import { Avatar } from "@/components/ui/Avatar";
+import { buttonVariants } from "@/components/ui/Button";
+import { NavLinks } from "@/components/layout/NavLinks";
+import { cn } from "@/lib/utils";
+
+export async function Navbar() {
+  const user = await getCurrentUser();
+  const devLogin = process.env.NEXT_PUBLIC_ENABLE_DEV_LOGIN === "true";
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-surface-border bg-bg/80 backdrop-blur-md">
+      <div className="container-page flex h-16 items-center justify-between gap-4">
+        <div className="flex items-center gap-6">
+          <Link href="/" className="flex items-center gap-2">
+            <Shield className="h-6 w-6 text-aegis" />
+            <span className="font-display text-lg font-extrabold tracking-tight text-zinc-100">
+              AEGIS<span className="text-aegis">CLUB</span>
+            </span>
+          </Link>
+          <NavLinks />
+        </div>
+
+        <div className="flex items-center gap-2">
+          {user ? (
+            <>
+              <Link
+                href={`/profile/${user.id}`}
+                className="flex items-center gap-2 rounded-xl px-2 py-1.5 transition-colors hover:bg-surface-hover"
+              >
+                <Avatar src={user.avatarUrl} name={user.nickname} size="sm" />
+                <span className="hidden text-sm font-medium text-zinc-200 sm:block">
+                  {user.nickname}
+                </span>
+              </Link>
+              <form action="/api/auth/logout" method="post">
+                <button
+                  type="submit"
+                  className="rounded-lg p-2 text-zinc-500 transition-colors hover:bg-surface-hover hover:text-dire-soft"
+                  title="Sair"
+                  aria-label="Sair"
+                >
+                  <LogOut className="h-4 w-4" />
+                </button>
+              </form>
+            </>
+          ) : (
+            <>
+              {devLogin && (
+                <Link
+                  href="/api/auth/dev"
+                  className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+                >
+                  Login de teste
+                </Link>
+              )}
+              <Link
+                href="/api/auth/steam/login"
+                className={cn(buttonVariants({ variant: "primary", size: "sm" }))}
+              >
+                Entrar com Steam
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/aegis-club/src/components/matchmaking/MatchLiveControls.tsx
+++ b/aegis-club/src/components/matchmaking/MatchLiveControls.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Copy, Check, LoaderCircle, Send } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import {
+  setLobbyInfo,
+  startMatch,
+  reportResult,
+} from "@/app/match/[id]/actions";
+
+// ── Campo copiável (nome/senha do lobby) ──────────────────────────────
+export function CopyField({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // navegadores sem clipboard API: silenciosamente ignora.
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl border border-surface-border bg-surface px-4 py-3">
+      <div className="min-w-0">
+        <p className="text-xs text-zinc-500">{label}</p>
+        <p className="truncate font-mono text-sm text-zinc-100">{value}</p>
+      </div>
+      <Button variant="ghost" size="sm" onClick={copy}>
+        {copied ? (
+          <Check className="h-4 w-4 text-behavior-good" />
+        ) : (
+          <Copy className="h-4 w-4" />
+        )}
+        {copied ? "Copiado" : "Copiar"}
+      </Button>
+    </div>
+  );
+}
+
+// ── Formulário de lobby do host (DRAFTING) ────────────────────────────
+export function LobbyInfoForm({
+  matchId,
+  lobbyName,
+  lobbyPassword,
+}: {
+  matchId: string;
+  lobbyName: string;
+  lobbyPassword: string;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function action(formData: FormData) {
+    setError(null);
+    setSaved(false);
+    startTransition(async () => {
+      const res = await setLobbyInfo(matchId, formData);
+      if (!res.ok) {
+        setError(res.error ?? "Não foi possível salvar o lobby.");
+      } else {
+        setSaved(true);
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <form action={action} className="flex flex-col gap-3">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="text-xs font-medium text-zinc-400">
+          Nome do lobby
+          <input
+            name="lobbyName"
+            defaultValue={lobbyName}
+            placeholder="ex: Aegis #1234"
+            className="mt-1 w-full rounded-lg border border-surface-border bg-surface px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/60"
+          />
+        </label>
+        <label className="text-xs font-medium text-zinc-400">
+          Senha
+          <input
+            name="lobbyPassword"
+            defaultValue={lobbyPassword}
+            placeholder="senha do lobby"
+            className="mt-1 w-full rounded-lg border border-surface-border bg-surface px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/60"
+          />
+        </label>
+      </div>
+      <div className="flex items-center gap-3">
+        <Button type="submit" variant="secondary" size="sm" disabled={pending}>
+          {pending ? (
+            <LoaderCircle className="h-4 w-4 animate-spin" />
+          ) : null}
+          Salvar lobby
+        </Button>
+        {saved && <span className="text-xs text-behavior-good">Lobby salvo.</span>}
+        {error && <span className="text-xs text-dire-soft">{error}</span>}
+      </div>
+    </form>
+  );
+}
+
+// ── Botão de iniciar partida do host (DRAFTING) ───────────────────────
+export function StartMatchButton({
+  matchId,
+  allReady,
+}: {
+  matchId: string;
+  allReady: boolean;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleStart() {
+    setError(null);
+    startTransition(async () => {
+      const res = await startMatch(matchId);
+      if (!res.ok) {
+        setError(res.error ?? "Não foi possível iniciar a partida.");
+      } else {
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <Button size="lg" onClick={handleStart} disabled={!allReady || pending}>
+        {pending ? <LoaderCircle className="h-4 w-4 animate-spin" /> : null}
+        Iniciar partida
+      </Button>
+      {!allReady && (
+        <p className="text-xs text-zinc-500">
+          Aguardando todos os jogadores confirmarem presença.
+        </p>
+      )}
+      {error && <p className="text-xs text-dire-soft">{error}</p>}
+    </div>
+  );
+}
+
+// ── Reportar resultado (LIVE) ─────────────────────────────────────────
+export function ReportResultControls({ matchId }: { matchId: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleReport(winner: "RADIANT" | "DIRE") {
+    setError(null);
+    startTransition(async () => {
+      const res = await reportResult(matchId, winner);
+      if (!res.ok) {
+        setError(res.error ?? "Não foi possível reportar o resultado.");
+      } else {
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-zinc-400">
+        Quando a partida terminar, registre quem venceu. Os rankPoints serão
+        atualizados automaticamente.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <Button
+          variant="secondary"
+          onClick={() => handleReport("RADIANT")}
+          disabled={pending}
+          className="border border-radiant/40 text-radiant hover:bg-radiant/10"
+        >
+          <Send className="h-4 w-4" />
+          Radiant venceu
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => handleReport("DIRE")}
+          disabled={pending}
+          className="border border-dire/40 text-dire-soft hover:bg-dire/10"
+        >
+          <Send className="h-4 w-4" />
+          Dire venceu
+        </Button>
+      </div>
+      {error && <p className="text-sm text-dire-soft">{error}</p>}
+    </div>
+  );
+}

--- a/aegis-club/src/components/matchmaking/PostMatchPanel.tsx
+++ b/aegis-club/src/components/matchmaking/PostMatchPanel.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { ThumbsUp, Flag, Check, LoaderCircle } from "lucide-react";
+import type { CommendCategory, ReportCategory } from "@prisma/client";
+import { Avatar } from "@/components/ui/Avatar";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { COMMEND_LABELS, REPORT_LABELS } from "@/lib/reputation";
+import { cn } from "@/lib/utils";
+import {
+  commendPlayer,
+  reportPlayer,
+} from "@/app/match/[id]/actions";
+
+export interface PostMatchPlayer {
+  userId: string;
+  nickname: string;
+  avatarUrl: string | null;
+}
+
+export interface PostMatchPanelProps {
+  matchId: string;
+  /** todos os jogadores da partida (o viewer é filtrado internamente) */
+  players: PostMatchPlayer[];
+  viewerUserId: string;
+}
+
+const COMMEND_CATEGORIES = Object.keys(COMMEND_LABELS) as CommendCategory[];
+const REPORT_CATEGORIES = Object.keys(REPORT_LABELS) as ReportCategory[];
+
+function PlayerRow({
+  matchId,
+  player,
+}: {
+  matchId: string;
+  player: PostMatchPlayer;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [commended, setCommended] = useState<CommendCategory | null>(null);
+  const [reported, setReported] = useState(false);
+  const [reportCategory, setReportCategory] = useState<ReportCategory>(
+    REPORT_CATEGORIES[0],
+  );
+  const [comment, setComment] = useState("");
+  const [showReport, setShowReport] = useState(false);
+
+  function handleCommend(category: CommendCategory) {
+    if (commended || pending) return;
+    setError(null);
+    startTransition(async () => {
+      const res = await commendPlayer({
+        matchId,
+        toUserId: player.userId,
+        category,
+      });
+      if (!res.ok) {
+        setError(res.error ?? "Não foi possível elogiar.");
+      } else {
+        setCommended(category);
+        router.refresh();
+      }
+    });
+  }
+
+  function handleReport() {
+    if (reported || pending) return;
+    setError(null);
+    startTransition(async () => {
+      const res = await reportPlayer({
+        matchId,
+        toUserId: player.userId,
+        category: reportCategory,
+        comment: comment.trim() || undefined,
+      });
+      if (!res.ok) {
+        setError(res.error ?? "Não foi possível denunciar.");
+      } else {
+        setReported(true);
+        setShowReport(false);
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <li className="flex flex-col gap-3 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Avatar src={player.avatarUrl} name={player.nickname} size="sm" />
+          <span className="text-sm font-medium text-zinc-200">
+            {player.nickname}
+          </span>
+          {commended && (
+            <Badge tone="good">
+              <Check className="h-3 w-3" />
+              {COMMEND_LABELS[commended]}
+            </Badge>
+          )}
+          {reported && (
+            <Badge tone="bad">
+              <Check className="h-3 w-3" />
+              Denunciado
+            </Badge>
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setShowReport((v) => !v)}
+          disabled={reported || pending}
+          aria-expanded={showReport}
+        >
+          <Flag className="h-4 w-4" />
+          Denunciar
+        </Button>
+      </div>
+
+      {/* Elogios */}
+      <div className="flex flex-wrap gap-2">
+        {COMMEND_CATEGORIES.map((cat) => {
+          const active = commended === cat;
+          const disabled = commended !== null || pending;
+          return (
+            <button
+              key={cat}
+              type="button"
+              onClick={() => handleCommend(cat)}
+              disabled={disabled}
+              aria-pressed={active}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                active
+                  ? "border-behavior-good/40 bg-behavior-good/15 text-behavior-good"
+                  : "border-surface-border text-zinc-300 hover:border-behavior-good/40 hover:text-behavior-good",
+                disabled && !active && "cursor-not-allowed opacity-40",
+              )}
+            >
+              <ThumbsUp className="h-3.5 w-3.5" />
+              {COMMEND_LABELS[cat]}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Formulário de denúncia (expansível) */}
+      {showReport && !reported && (
+        <div className="flex flex-col gap-2 rounded-xl border border-dire/30 bg-dire/5 p-3">
+          <label className="text-xs font-medium text-zinc-400">
+            Motivo da denúncia
+            <select
+              value={reportCategory}
+              onChange={(e) =>
+                setReportCategory(e.target.value as ReportCategory)
+              }
+              className="mt-1 w-full rounded-lg border border-surface-border bg-surface px-3 py-2 text-sm text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/60"
+            >
+              {REPORT_CATEGORIES.map((cat) => (
+                <option key={cat} value={cat}>
+                  {REPORT_LABELS[cat]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <textarea
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            maxLength={500}
+            rows={2}
+            placeholder="Comentário (opcional)"
+            className="w-full resize-none rounded-lg border border-surface-border bg-surface px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/60"
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowReport(false)}
+              disabled={pending}
+            >
+              Cancelar
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={handleReport}
+              disabled={pending}
+            >
+              {pending ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <Flag className="h-4 w-4" />
+              )}
+              Enviar denúncia
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {error && <p className="text-xs text-dire-soft">{error}</p>}
+    </li>
+  );
+}
+
+export function PostMatchPanel({
+  matchId,
+  players,
+  viewerUserId,
+}: PostMatchPanelProps) {
+  const others = players.filter((p) => p.userId !== viewerUserId);
+
+  if (others.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <p className="mb-2 text-sm text-zinc-400">
+        Reconheça os bons companheiros e denuncie quem prejudicou a partida.
+        Sua avaliação ajusta a conduta de cada jogador.
+      </p>
+      <ul className="divide-y divide-surface-border">
+        {others.map((player) => (
+          <PlayerRow key={player.userId} matchId={matchId} player={player} />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/aegis-club/src/components/matchmaking/QueuePanel.tsx
+++ b/aegis-club/src/components/matchmaking/QueuePanel.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  Swords,
+  LoaderCircle,
+  Users,
+  Timer,
+  CheckCircle2,
+  LogOut,
+  ShieldAlert,
+} from "lucide-react";
+import type { QueueMode, QueueStatus, Region } from "@prisma/client";
+import { Card, CardContent } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Button, buttonVariants } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+import { joinQueue, leaveQueue } from "@/app/play/actions";
+
+const MATCH_SIZE = 10;
+const POLL_MS = 4000;
+
+const MODE_LABELS: Record<QueueMode, string> = {
+  RANKED_5V5: "Ranqueada 5x5",
+  UNRANKED_5V5: "Normal 5x5",
+};
+
+const REGION_LABELS: Record<Region, string> = {
+  SA: "América do Sul",
+  NA: "América do Norte",
+  EU: "Europa",
+  CIS: "CIS",
+  SEA: "Sudeste Asiático",
+  CHINA: "China",
+};
+
+export interface ActiveEntry {
+  mode: QueueMode;
+  status: QueueStatus;
+  matchId: string | null;
+  /** epoch ms de quando entrou na fila */
+  createdAt: number;
+}
+
+export interface QueuePanelProps {
+  entry: ActiveEntry | null;
+  region: Region;
+  /** contagem de WAITING por modo, na região do usuário */
+  waitingCounts: Record<QueueMode, number>;
+  canRanked: boolean;
+}
+
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+export function QueuePanel({
+  entry,
+  region,
+  waitingCounts,
+  canRanked,
+}: QueuePanelProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<QueueMode>(
+    entry?.mode ?? (canRanked ? "RANKED_5V5" : "UNRANKED_5V5"),
+  );
+
+  const isWaiting = entry?.status === "WAITING";
+  const isMatched = entry?.status === "MATCHED";
+
+  // Sincroniza o modo selecionado com a entrada ativa.
+  useEffect(() => {
+    if (entry) setMode(entry.mode);
+  }, [entry]);
+
+  // Polling enquanto procura partida: atualiza o Server Component.
+  useEffect(() => {
+    if (!isWaiting) return;
+    const id = setInterval(() => router.refresh(), POLL_MS);
+    return () => clearInterval(id);
+  }, [isWaiting, router]);
+
+  // Cronômetro da fila.
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    if (!isWaiting) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [isWaiting]);
+
+  function handleJoin() {
+    setError(null);
+    startTransition(async () => {
+      const res = await joinQueue(mode, region);
+      if (!res.ok) setError(res.error ?? "Não foi possível entrar na fila.");
+      else router.refresh();
+    });
+  }
+
+  function handleLeave() {
+    setError(null);
+    startTransition(async () => {
+      const res = await leaveQueue();
+      if (!res.ok) setError(res.error ?? "Não foi possível sair da fila.");
+      else router.refresh();
+    });
+  }
+
+  // ── Partida encontrada ────────────────────────────────────────────
+  if (isMatched && entry?.matchId) {
+    return (
+      <Card className="border-aegis/40">
+        <CardContent className="flex flex-col items-center gap-4 py-10 text-center">
+          <span className="flex h-14 w-14 items-center justify-center rounded-full bg-aegis/15">
+            <CheckCircle2 className="h-7 w-7 text-aegis" />
+          </span>
+          <div>
+            <h3 className="text-lg font-semibold text-zinc-100">
+              Partida encontrada!
+            </h3>
+            <p className="mt-1 text-sm text-zinc-400">
+              Vá para o lobby e confirme que está pronto.
+            </p>
+          </div>
+          <Link
+            href={`/match/${entry.matchId}`}
+            className={cn(buttonVariants({ variant: "primary", size: "lg" }))}
+          >
+            <Swords className="h-4 w-4" />
+            Ir para o lobby
+          </Link>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ── Procurando partida ────────────────────────────────────────────
+  if (isWaiting && entry) {
+    const count = waitingCounts[entry.mode] ?? 0;
+    const elapsed = formatElapsed(now - entry.createdAt);
+    return (
+      <Card className="border-aegis/30">
+        <CardContent className="flex flex-col items-center gap-5 py-10 text-center">
+          <span className="relative flex h-16 w-16 items-center justify-center">
+            <span className="absolute inset-0 animate-ping rounded-full bg-aegis/20" />
+            <LoaderCircle className="h-10 w-10 animate-spin text-aegis" />
+          </span>
+          <div>
+            <h3 className="text-lg font-semibold text-zinc-100">
+              Procurando partida…
+            </h3>
+            <p className="mt-1 text-sm text-zinc-400">
+              {MODE_LABELS[entry.mode]} · {REGION_LABELS[region]}
+            </p>
+          </div>
+          <div className="flex items-center gap-6 text-sm">
+            <span className="inline-flex items-center gap-1.5 text-zinc-300">
+              <Users className="h-4 w-4 text-aegis" />
+              <span className="font-semibold text-zinc-100">
+                {Math.min(count, MATCH_SIZE)}/{MATCH_SIZE}
+              </span>{" "}
+              na fila
+            </span>
+            <span className="inline-flex items-center gap-1.5 text-zinc-300 tabular-nums">
+              <Timer className="h-4 w-4 text-aegis" />
+              {elapsed}
+            </span>
+          </div>
+          {error && <p className="text-sm text-dire-soft">{error}</p>}
+          <Button variant="danger" onClick={handleLeave} disabled={pending}>
+            <LogOut className="h-4 w-4" />
+            Sair da fila
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ── Entrar na fila ────────────────────────────────────────────────
+  const rankedDisabled = !canRanked;
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-5 py-6">
+        <div>
+          <p className="mb-2 text-sm font-medium text-zinc-300">Modo</p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => !rankedDisabled && setMode("RANKED_5V5")}
+              disabled={rankedDisabled}
+              aria-pressed={mode === "RANKED_5V5"}
+              className={cn(
+                "flex-1 rounded-xl border px-4 py-3 text-sm font-medium transition-colors",
+                mode === "RANKED_5V5"
+                  ? "border-aegis/50 bg-aegis/10 text-aegis"
+                  : "border-surface-border text-zinc-300 hover:border-aegis/40",
+                rankedDisabled && "cursor-not-allowed opacity-50",
+              )}
+            >
+              {MODE_LABELS.RANKED_5V5}
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("UNRANKED_5V5")}
+              aria-pressed={mode === "UNRANKED_5V5"}
+              className={cn(
+                "flex-1 rounded-xl border px-4 py-3 text-sm font-medium transition-colors",
+                mode === "UNRANKED_5V5"
+                  ? "border-aegis/50 bg-aegis/10 text-aegis"
+                  : "border-surface-border text-zinc-300 hover:border-aegis/40",
+              )}
+            >
+              {MODE_LABELS.UNRANKED_5V5}
+            </button>
+          </div>
+          {rankedDisabled && (
+            <p className="mt-2 inline-flex items-center gap-1.5 text-xs text-dire-soft">
+              <ShieldAlert className="h-3.5 w-3.5" />
+              Fila ranqueada bloqueada pela sua conduta atual.
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-zinc-400">Região</span>
+          <Badge tone="neutral">{REGION_LABELS[region]}</Badge>
+        </div>
+
+        <div className="flex items-center justify-between text-sm text-zinc-400">
+          <span className="inline-flex items-center gap-1.5">
+            <Users className="h-4 w-4" />
+            Na fila agora
+          </span>
+          <span className="font-semibold text-zinc-200">
+            {waitingCounts[mode] ?? 0} jogador(es)
+          </span>
+        </div>
+
+        {error && <p className="text-sm text-dire-soft">{error}</p>}
+
+        <Button size="lg" onClick={handleJoin} disabled={pending}>
+          <Swords className="h-4 w-4" />
+          {pending ? "Entrando…" : "Entrar na fila"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/aegis-club/src/components/matchmaking/ReadyCheck.tsx
+++ b/aegis-club/src/components/matchmaking/ReadyCheck.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle2, LoaderCircle } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { setReady } from "@/app/match/[id]/actions";
+
+export interface ReadyCheckProps {
+  matchId: string;
+  /** o jogador (viewer) já confirmou presença? */
+  viewerReady: boolean;
+}
+
+export function ReadyCheck({ matchId, viewerReady }: ReadyCheckProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  if (viewerReady) {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-xl border border-behavior-good/30 bg-behavior-good/10 px-4 py-2 text-sm font-medium text-behavior-good">
+        <CheckCircle2 className="h-4 w-4" />
+        Você está pronto
+      </span>
+    );
+  }
+
+  function handleReady() {
+    setError(null);
+    startTransition(async () => {
+      const res = await setReady(matchId);
+      if (!res.ok) {
+        setError(res.error ?? "Não foi possível confirmar presença.");
+      } else {
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <Button size="lg" onClick={handleReady} disabled={pending}>
+        {pending ? (
+          <LoaderCircle className="h-4 w-4 animate-spin" />
+        ) : (
+          <CheckCircle2 className="h-4 w-4" />
+        )}
+        {pending ? "Confirmando…" : "Estou pronto"}
+      </Button>
+      {error && <p className="text-sm text-dire-soft">{error}</p>}
+    </div>
+  );
+}

--- a/aegis-club/src/components/profile/ConnectButton.tsx
+++ b/aegis-club/src/components/profile/ConnectButton.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { UserPlus, Check, Clock, LoaderCircle } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { sendFriendRequest } from "@/app/profile/actions";
+
+/** Estado da conexão entre o visitante e o dono do perfil. */
+export type ConnectionState = "none" | "PENDING" | "ACCEPTED";
+
+export function ConnectButton({
+  targetUserId,
+  status,
+}: {
+  targetUserId: string;
+  status: ConnectionState;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  if (status === "ACCEPTED") {
+    return (
+      <Badge tone="good">
+        <Check className="h-3.5 w-3.5" />
+        Conectados
+      </Badge>
+    );
+  }
+
+  if (status === "PENDING") {
+    return (
+      <Button variant="secondary" size="sm" disabled>
+        <Clock className="h-4 w-4" />
+        Solicitação enviada
+      </Button>
+    );
+  }
+
+  function handleConnect() {
+    setError(null);
+    startTransition(async () => {
+      const result = await sendFriendRequest(targetUserId);
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={handleConnect}
+        disabled={isPending}
+      >
+        {isPending ? (
+          <LoaderCircle className="h-4 w-4 animate-spin" />
+        ) : (
+          <UserPlus className="h-4 w-4" />
+        )}
+        Conectar
+      </Button>
+      {error && <p className="text-xs text-dire-soft">{error}</p>}
+    </div>
+  );
+}

--- a/aegis-club/src/components/profile/EditProfileForm.tsx
+++ b/aegis-club/src/components/profile/EditProfileForm.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import Link from "next/link";
+import { Save, LoaderCircle, CheckCircle2 } from "lucide-react";
+import type { DotaRole, Region } from "@prisma/client";
+import { Button, buttonVariants } from "@/components/ui/Button";
+import { HeroAvatar } from "@/components/heroes/HeroAvatar";
+import { HEROES } from "@/data/heroes";
+import { cn } from "@/lib/utils";
+import { updateProfile, type UpdateProfileState } from "@/app/profile/actions";
+import { DOTA_ROLES, DOTA_ROLE_LABELS, REGIONS, REGION_LABELS } from "./labels";
+
+/** Valores atuais (serializáveis) passados pelo Server Component. */
+export interface EditProfileValues {
+  userId: string;
+  nickname: string;
+  bio: string;
+  region: Region;
+  mainRoles: DotaRole[];
+  favoriteHeroIds: number[];
+  discord: string;
+  twitch: string;
+  youtube: string;
+}
+
+const initialState: UpdateProfileState = {};
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" variant="primary" disabled={pending}>
+      {pending ? (
+        <LoaderCircle className="h-4 w-4 animate-spin" />
+      ) : (
+        <Save className="h-4 w-4" />
+      )}
+      Salvar alterações
+    </Button>
+  );
+}
+
+export function EditProfileForm({ values }: { values: EditProfileValues }) {
+  const [state, formAction] = useActionState(updateProfile, initialState);
+
+  const fieldClass =
+    "w-full rounded-xl border border-surface-border bg-surface px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-aegis/60 focus:outline-none focus:ring-2 focus:ring-aegis/30";
+  const labelClass = "mb-1.5 block text-sm font-medium text-zinc-300";
+
+  return (
+    <form action={formAction} className="space-y-7">
+      {/* Identificação */}
+      <div>
+        <label htmlFor="nickname" className={labelClass}>
+          Apelido
+        </label>
+        <input
+          id="nickname"
+          name="nickname"
+          type="text"
+          required
+          minLength={2}
+          maxLength={32}
+          defaultValue={values.nickname}
+          placeholder="Como você quer ser chamado"
+          className={fieldClass}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="bio" className={labelClass}>
+          Biografia
+        </label>
+        <textarea
+          id="bio"
+          name="bio"
+          rows={4}
+          maxLength={500}
+          defaultValue={values.bio}
+          placeholder="Fale um pouco sobre você (máx. 500 caracteres)"
+          className={cn(fieldClass, "resize-y")}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="region" className={labelClass}>
+          Região
+        </label>
+        <select
+          id="region"
+          name="region"
+          defaultValue={values.region}
+          className={fieldClass}
+        >
+          {REGIONS.map((region) => (
+            <option key={region} value={region}>
+              {REGION_LABELS[region]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Funções */}
+      <fieldset>
+        <legend className={labelClass}>Funções principais</legend>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {DOTA_ROLES.map((role) => (
+            <label
+              key={role}
+              className="flex cursor-pointer items-center gap-2 rounded-xl border border-surface-border bg-surface px-3 py-2 text-sm text-zinc-200 transition-colors hover:border-aegis/40"
+            >
+              <input
+                type="checkbox"
+                name="mainRoles"
+                value={role}
+                defaultChecked={values.mainRoles.includes(role)}
+                className="h-4 w-4 accent-aegis"
+              />
+              {DOTA_ROLE_LABELS[role]}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Heróis favoritos */}
+      <fieldset>
+        <legend className={labelClass}>Heróis favoritos</legend>
+        <p className="mb-3 text-xs text-zinc-500">
+          Selecione até 6 heróis para destacar no seu perfil.
+        </p>
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6">
+          {HEROES.map((hero) => (
+            <label
+              key={hero.id}
+              className="group relative cursor-pointer overflow-hidden rounded-lg border border-surface-border transition-colors has-[:checked]:border-aegis has-[:checked]:ring-2 has-[:checked]:ring-aegis/40"
+              title={hero.localizedName}
+            >
+              <input
+                type="checkbox"
+                name="favoriteHeroIds"
+                value={hero.id}
+                defaultChecked={values.favoriteHeroIds.includes(hero.id)}
+                className="peer sr-only"
+              />
+              <HeroAvatar
+                slug={hero.slug}
+                name={hero.localizedName}
+                size="sm"
+                className="h-12 w-full rounded-none border-0"
+              />
+              <span className="absolute inset-0 hidden items-center justify-center bg-aegis/30 peer-checked:flex">
+                <CheckCircle2 className="h-5 w-5 text-bg" />
+              </span>
+              <span className="block truncate bg-surface px-1 py-0.5 text-center text-[10px] text-zinc-400">
+                {hero.localizedName}
+              </span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Redes */}
+      <div className="grid gap-5 sm:grid-cols-3">
+        <div>
+          <label htmlFor="discord" className={labelClass}>
+            Discord
+          </label>
+          <input
+            id="discord"
+            name="discord"
+            type="text"
+            maxLength={64}
+            defaultValue={values.discord}
+            placeholder="usuario#0000"
+            className={fieldClass}
+          />
+        </div>
+        <div>
+          <label htmlFor="twitch" className={labelClass}>
+            Twitch
+          </label>
+          <input
+            id="twitch"
+            name="twitch"
+            type="text"
+            maxLength={64}
+            defaultValue={values.twitch}
+            placeholder="seu_canal"
+            className={fieldClass}
+          />
+        </div>
+        <div>
+          <label htmlFor="youtube" className={labelClass}>
+            YouTube
+          </label>
+          <input
+            id="youtube"
+            name="youtube"
+            type="text"
+            maxLength={64}
+            defaultValue={values.youtube}
+            placeholder="seu_canal"
+            className={fieldClass}
+          />
+        </div>
+      </div>
+
+      {/* Feedback + ações */}
+      {state.error && (
+        <p className="rounded-xl border border-dire/30 bg-dire/10 px-3 py-2 text-sm text-dire-soft">
+          {state.error}
+        </p>
+      )}
+      {state.ok && (
+        <p className="flex items-center gap-2 rounded-xl border border-radiant/30 bg-radiant/10 px-3 py-2 text-sm text-radiant">
+          <CheckCircle2 className="h-4 w-4" />
+          Perfil atualizado com sucesso.
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <SubmitButton />
+        <Link
+          href={`/profile/${values.userId}`}
+          className={cn(buttonVariants({ variant: "ghost" }))}
+        >
+          Cancelar
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/aegis-club/src/components/profile/ImportSteamButton.tsx
+++ b/aegis-club/src/components/profile/ImportSteamButton.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Download, LoaderCircle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { importSteamStats } from "@/app/profile/actions";
+
+export function ImportSteamButton() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  function handleImport() {
+    setError(null);
+    setDone(false);
+    startTransition(async () => {
+      const result = await importSteamStats();
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      setDone(true);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleImport}
+        disabled={isPending}
+      >
+        {isPending ? (
+          <LoaderCircle className="h-4 w-4 animate-spin" />
+        ) : done ? (
+          <CheckCircle2 className="h-4 w-4 text-radiant" />
+        ) : (
+          <Download className="h-4 w-4" />
+        )}
+        Importar MMR da Steam
+      </Button>
+      {error && <p className="text-xs text-dire-soft">{error}</p>}
+      {done && !error && (
+        <p className="text-xs text-radiant">MMR atualizado com sucesso.</p>
+      )}
+    </div>
+  );
+}

--- a/aegis-club/src/components/profile/labels.ts
+++ b/aegis-club/src/components/profile/labels.ts
@@ -1,0 +1,39 @@
+import type { DotaRole, Region } from "@prisma/client";
+
+/** Rótulos (pt-BR) das funções/posições do Dota 2. */
+export const DOTA_ROLE_LABELS: Record<DotaRole, string> = {
+  CARRY: "Carregador (1)",
+  MID: "Meio (2)",
+  OFFLANE: "Offlane (3)",
+  SOFT_SUPPORT: "Suporte (4)",
+  HARD_SUPPORT: "Suporte (5)",
+};
+
+/** Rótulos (pt-BR) das regiões de jogo. */
+export const REGION_LABELS: Record<Region, string> = {
+  SA: "América do Sul",
+  NA: "América do Norte",
+  EU: "Europa",
+  CIS: "CIS",
+  SEA: "Sudeste Asiático",
+  CHINA: "China",
+};
+
+/** Ordem canônica das funções (para listas e checkboxes). */
+export const DOTA_ROLES: readonly DotaRole[] = [
+  "CARRY",
+  "MID",
+  "OFFLANE",
+  "SOFT_SUPPORT",
+  "HARD_SUPPORT",
+];
+
+/** Ordem canônica das regiões (para selects e filtros). */
+export const REGIONS: readonly Region[] = [
+  "SA",
+  "NA",
+  "EU",
+  "CIS",
+  "SEA",
+  "CHINA",
+];

--- a/aegis-club/src/components/tournaments/Bracket.tsx
+++ b/aegis-club/src/components/tournaments/Bracket.tsx
@@ -1,0 +1,140 @@
+import { Trophy } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface BracketTeam {
+  id: string;
+  name: string;
+  tag: string;
+}
+
+export interface BracketMatch {
+  id: string;
+  round: number;
+  position: number;
+  bracket: string;
+  scoreA: number;
+  scoreB: number;
+  winnerId: string | null;
+  teamA: BracketTeam | null;
+  teamB: BracketTeam | null;
+}
+
+/** Rótulo da rodada — a última (ou a GRAND_FINAL) vira "Final". */
+function roundLabel(round: number, totalRounds: number, isFinal: boolean): string {
+  if (isFinal) return "Final";
+  if (round === totalRounds - 1) return "Semifinal";
+  return `Rodada ${round}`;
+}
+
+function TeamRow({
+  team,
+  score,
+  isWinner,
+  decided,
+}: {
+  team: BracketTeam | null;
+  score: number;
+  isWinner: boolean;
+  decided: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 rounded-lg px-2.5 py-1.5 text-sm",
+        isWinner
+          ? "bg-aegis/10 text-zinc-100 ring-1 ring-aegis/40"
+          : "text-zinc-300",
+      )}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        {team ? (
+          <>
+            <span className="shrink-0 font-mono text-xs text-zinc-500">
+              {team.tag}
+            </span>
+            <span className="truncate">{team.name}</span>
+          </>
+        ) : (
+          <span className="italic text-zinc-600">A definir</span>
+        )}
+      </span>
+      <span
+        className={cn(
+          "shrink-0 font-mono text-sm",
+          decided ? "text-zinc-100" : "text-zinc-600",
+        )}
+      >
+        {score}
+      </span>
+    </div>
+  );
+}
+
+export function Bracket({ matches }: { matches: BracketMatch[] }) {
+  if (matches.length === 0) return null;
+
+  // Agrupa as partidas por rodada, em ordem crescente.
+  const byRound = new Map<number, BracketMatch[]>();
+  for (const m of matches) {
+    const list = byRound.get(m.round) ?? [];
+    list.push(m);
+    byRound.set(m.round, list);
+  }
+  const rounds = [...byRound.entries()]
+    .map(([round, list]) => ({
+      round,
+      matches: list.sort((a, b) => a.position - b.position),
+    }))
+    .sort((a, b) => a.round - b.round);
+
+  const totalRounds = rounds.length;
+
+  return (
+    <div className="flex gap-4 overflow-x-auto pb-2">
+      {rounds.map(({ round, matches: roundMatches }) => {
+        const isFinalColumn =
+          round === totalRounds ||
+          roundMatches.some((m) => m.bracket === "GRAND_FINAL");
+        return (
+          <div
+            key={round}
+            className="flex min-w-[15rem] flex-col gap-3"
+          >
+            <h4 className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-aegis">
+              {isFinalColumn && <Trophy className="h-3.5 w-3.5" />}
+              {roundLabel(round, totalRounds, isFinalColumn)}
+            </h4>
+            <div className="flex flex-1 flex-col justify-around gap-3">
+              {roundMatches.map((m) => {
+                const decided = m.winnerId != null;
+                return (
+                  <div
+                    key={m.id}
+                    className="space-y-1 rounded-xl border border-surface-border bg-surface/60 p-2"
+                  >
+                    <TeamRow
+                      team={m.teamA}
+                      score={m.scoreA}
+                      isWinner={
+                        decided && m.winnerId === m.teamA?.id
+                      }
+                      decided={decided}
+                    />
+                    <TeamRow
+                      team={m.teamB}
+                      score={m.scoreB}
+                      isWinner={
+                        decided && m.winnerId === m.teamB?.id
+                      }
+                      decided={decided}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/aegis-club/src/components/tournaments/CreateTournamentForm.tsx
+++ b/aegis-club/src/components/tournaments/CreateTournamentForm.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useActionState, useId } from "react";
+import { useFormStatus } from "react-dom";
+import { Trophy } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import {
+  createTournament,
+  type CreateTournamentState,
+} from "@/app/tournaments/actions";
+
+const FORMAT_OPTIONS: { value: string; label: string }[] = [
+  { value: "SINGLE_ELIMINATION", label: "Eliminação simples" },
+  { value: "DOUBLE_ELIMINATION", label: "Eliminação dupla" },
+  { value: "ROUND_ROBIN", label: "Pontos corridos" },
+];
+
+const REGION_OPTIONS: { value: string; label: string }[] = [
+  { value: "SA", label: "América do Sul" },
+  { value: "NA", label: "América do Norte" },
+  { value: "EU", label: "Europa" },
+  { value: "CIS", label: "CIS" },
+  { value: "SEA", label: "Sudeste Asiático" },
+  { value: "CHINA", label: "China" },
+];
+
+const initialState: CreateTournamentState = {};
+
+const fieldClass =
+  "w-full rounded-xl border border-surface-border bg-bg px-3.5 py-2.5 text-sm text-zinc-100 placeholder:text-zinc-600 focus-visible:border-aegis/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/40";
+const labelClass = "mb-1.5 block text-sm font-medium text-zinc-300";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      <Trophy className="h-4 w-4" />
+      {pending ? "Criando…" : "Criar torneio"}
+    </Button>
+  );
+}
+
+export function CreateTournamentForm() {
+  const [state, formAction] = useActionState(createTournament, initialState);
+  const nameId = useId();
+  const descId = useId();
+  const formatId = useId();
+  const regionId = useId();
+  const maxTeamsId = useId();
+  const prizeId = useId();
+  const regEndsId = useId();
+  const startsId = useId();
+
+  return (
+    <form
+      action={formAction}
+      className="space-y-4 rounded-2xl border border-surface-border bg-surface/60 p-5"
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <label htmlFor={nameId} className={labelClass}>
+            Nome do torneio
+          </label>
+          <input
+            id={nameId}
+            name="name"
+            type="text"
+            required
+            minLength={4}
+            maxLength={80}
+            placeholder="Ex: Copa Aegis de Verão"
+            className={fieldClass}
+          />
+        </div>
+
+        <div className="sm:col-span-2">
+          <label htmlFor={descId} className={labelClass}>
+            Descrição{" "}
+            <span className="text-zinc-500">(opcional)</span>
+          </label>
+          <textarea
+            id={descId}
+            name="description"
+            rows={4}
+            maxLength={2000}
+            placeholder="Regras, premiação, formato e detalhes do campeonato."
+            className={fieldClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor={formatId} className={labelClass}>
+            Formato
+          </label>
+          <select
+            id={formatId}
+            name="format"
+            defaultValue="SINGLE_ELIMINATION"
+            className={fieldClass}
+          >
+            {FORMAT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor={regionId} className={labelClass}>
+            Região
+          </label>
+          <select
+            id={regionId}
+            name="region"
+            defaultValue="SA"
+            className={fieldClass}
+          >
+            {REGION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor={maxTeamsId} className={labelClass}>
+            Máximo de times
+          </label>
+          <input
+            id={maxTeamsId}
+            name="maxTeams"
+            type="number"
+            min={2}
+            max={64}
+            defaultValue={8}
+            className={fieldClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor={prizeId} className={labelClass}>
+            Premiação{" "}
+            <span className="text-zinc-500">(opcional)</span>
+          </label>
+          <input
+            id={prizeId}
+            name="prizePool"
+            type="text"
+            maxLength={120}
+            placeholder="Ex: R$ 500"
+            className={fieldClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor={regEndsId} className={labelClass}>
+            Fim das inscrições{" "}
+            <span className="text-zinc-500">(opcional)</span>
+          </label>
+          <input
+            id={regEndsId}
+            name="registrationEndsAt"
+            type="datetime-local"
+            className={fieldClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor={startsId} className={labelClass}>
+            Início do torneio{" "}
+            <span className="text-zinc-500">(opcional)</span>
+          </label>
+          <input
+            id={startsId}
+            name="startsAt"
+            type="datetime-local"
+            className={fieldClass}
+          />
+        </div>
+      </div>
+
+      {state.error && (
+        <p className="text-sm text-behavior-bad" role="alert">
+          {state.error}
+        </p>
+      )}
+
+      <div className="flex justify-end">
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/aegis-club/src/components/tournaments/RegisterTeamForm.tsx
+++ b/aegis-club/src/components/tournaments/RegisterTeamForm.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useActionState, useEffect, useId, useRef } from "react";
+import { useFormStatus } from "react-dom";
+import { UserPlus } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { registerTeam, type RegisterTeamState } from "@/app/tournaments/actions";
+
+const initialState: RegisterTeamState = {};
+
+const fieldClass =
+  "w-full rounded-xl border border-surface-border bg-bg px-3.5 py-2.5 text-sm text-zinc-100 placeholder:text-zinc-600 focus-visible:border-aegis/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/40";
+const labelClass = "mb-1.5 block text-sm font-medium text-zinc-300";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      <UserPlus className="h-4 w-4" />
+      {pending ? "Inscrevendo…" : "Inscrever time"}
+    </Button>
+  );
+}
+
+export function RegisterTeamForm({ tournamentId }: { tournamentId: string }) {
+  const [state, formAction] = useActionState(registerTeam, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+  const nameId = useId();
+  const tagId = useId();
+
+  useEffect(() => {
+    if (state.ok) {
+      formRef.current?.reset();
+    }
+  }, [state.ok]);
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      className="space-y-4 rounded-2xl border border-surface-border bg-surface/60 p-5"
+    >
+      <input type="hidden" name="tournamentId" value={tournamentId} />
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="sm:col-span-2">
+          <label htmlFor={nameId} className={labelClass}>
+            Nome do time
+          </label>
+          <input
+            id={nameId}
+            name="name"
+            type="text"
+            required
+            minLength={2}
+            maxLength={40}
+            placeholder="Ex: Aegis Esports"
+            className={fieldClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor={tagId} className={labelClass}>
+            Tag
+          </label>
+          <input
+            id={tagId}
+            name="tag"
+            type="text"
+            required
+            minLength={1}
+            maxLength={6}
+            placeholder="AEG"
+            className={fieldClass}
+          />
+        </div>
+      </div>
+
+      {state.error && (
+        <p className="text-sm text-behavior-bad" role="alert">
+          {state.error}
+        </p>
+      )}
+      {state.ok && (
+        <p className="text-sm text-behavior-good" role="status">
+          Time inscrito com sucesso!
+        </p>
+      )}
+
+      <div className="flex justify-end">
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/aegis-club/src/components/tournaments/TournamentAdmin.tsx
+++ b/aegis-club/src/components/tournaments/TournamentAdmin.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Play, DoorOpen, Save, AlertCircle } from "lucide-react";
+import type { TournamentStatus } from "@prisma/client";
+import { Button } from "@/components/ui/Button";
+import {
+  openRegistration,
+  startTournament,
+  reportTournamentMatch,
+} from "@/app/tournaments/actions";
+
+interface AdminTeam {
+  id: string;
+  name: string;
+  tag: string;
+}
+
+export interface AdminMatch {
+  id: string;
+  round: number;
+  position: number;
+  bracket: string;
+  scoreA: number;
+  scoreB: number;
+  winnerId: string | null;
+  teamA: AdminTeam | null;
+  teamB: AdminTeam | null;
+}
+
+const fieldClass =
+  "w-16 rounded-lg border border-surface-border bg-bg px-2 py-1.5 text-sm text-zinc-100 focus-visible:border-aegis/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/40";
+const selectClass =
+  "rounded-lg border border-surface-border bg-bg px-2 py-1.5 text-sm text-zinc-100 focus-visible:border-aegis/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/40";
+
+function teamLabel(team: AdminTeam): string {
+  return `${team.tag} — ${team.name}`;
+}
+
+function ReportMatchRow({ match }: { match: AdminMatch }) {
+  const teamA = match.teamA;
+  const teamB = match.teamB;
+  const [scoreA, setScoreA] = useState(match.scoreA);
+  const [scoreB, setScoreB] = useState(match.scoreB);
+  const [winnerTeamId, setWinnerTeamId] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  if (!teamA || !teamB) return null;
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    if (!winnerTeamId) {
+      setError("Selecione o time vencedor.");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        await reportTournamentMatch({
+          matchId: match.id,
+          winnerTeamId,
+          scoreA,
+          scoreB,
+        });
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Não foi possível salvar o resultado.",
+        );
+      }
+    });
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="space-y-2 rounded-xl border border-surface-border bg-bg/40 p-3"
+    >
+      <div className="text-xs text-zinc-500">
+        Rodada {match.round} · {teamLabel(teamA)} vs {teamLabel(teamB)}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="flex items-center gap-1.5 text-sm text-zinc-300">
+          <span className="font-mono text-xs text-zinc-500">{teamA.tag}</span>
+          <input
+            type="number"
+            min={0}
+            max={5}
+            value={scoreA}
+            onChange={(e) => setScoreA(Number(e.target.value))}
+            className={fieldClass}
+            aria-label={`Placar de ${teamLabel(teamA)}`}
+          />
+        </label>
+        <label className="flex items-center gap-1.5 text-sm text-zinc-300">
+          <span className="font-mono text-xs text-zinc-500">{teamB.tag}</span>
+          <input
+            type="number"
+            min={0}
+            max={5}
+            value={scoreB}
+            onChange={(e) => setScoreB(Number(e.target.value))}
+            className={fieldClass}
+            aria-label={`Placar de ${teamLabel(teamB)}`}
+          />
+        </label>
+        <select
+          value={winnerTeamId}
+          onChange={(e) => setWinnerTeamId(e.target.value)}
+          className={selectClass}
+          aria-label="Time vencedor"
+        >
+          <option value="">Vencedor…</option>
+          <option value={teamA.id}>{teamLabel(teamA)}</option>
+          <option value={teamB.id}>{teamLabel(teamB)}</option>
+        </select>
+        <Button type="submit" size="sm" disabled={pending}>
+          <Save className="h-4 w-4" />
+          {pending ? "Salvando…" : "Salvar"}
+        </Button>
+      </div>
+      {error && (
+        <p className="flex items-center gap-1.5 text-xs text-behavior-bad" role="alert">
+          <AlertCircle className="h-3.5 w-3.5" />
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}
+
+export function TournamentAdmin({
+  tournamentId,
+  status,
+  teamCount,
+  matches,
+}: {
+  tournamentId: string;
+  status: TournamentStatus;
+  teamCount: number;
+  matches: AdminMatch[];
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function runAction(action: () => Promise<void>) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await action();
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Não foi possível concluir a ação.",
+        );
+      }
+    });
+  }
+
+  // Partidas pendentes: sem vencedor e com os dois times definidos.
+  const pendingMatches = matches
+    .filter((m) => !m.winnerId && m.teamA && m.teamB)
+    .sort((a, b) => a.round - b.round || a.position - b.position);
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-aegis/30 bg-aegis/5 p-5">
+      <h3 className="text-sm font-semibold uppercase tracking-widest text-aegis">
+        Painel do organizador
+      </h3>
+
+      {status === "DRAFT" && (
+        <div className="space-y-2">
+          <p className="text-sm text-zinc-400">
+            O torneio está em rascunho. Abra as inscrições para receber times.
+          </p>
+          <Button
+            type="button"
+            disabled={pending}
+            onClick={() => runAction(() => openRegistration(tournamentId))}
+          >
+            <DoorOpen className="h-4 w-4" />
+            {pending ? "Abrindo…" : "Abrir inscrições"}
+          </Button>
+        </div>
+      )}
+
+      {status === "REGISTRATION" && (
+        <div className="space-y-2">
+          <p className="text-sm text-zinc-400">
+            Inscrições abertas. Inicie o torneio para gerar o chaveamento.
+          </p>
+          <Button
+            type="button"
+            disabled={pending || teamCount < 2}
+            onClick={() => runAction(() => startTournament(tournamentId))}
+          >
+            <Play className="h-4 w-4" />
+            {pending ? "Iniciando…" : "Iniciar torneio"}
+          </Button>
+          {teamCount < 2 && (
+            <p className="text-xs text-zinc-500">
+              É preciso ao menos 2 times inscritos para iniciar.
+            </p>
+          )}
+        </div>
+      )}
+
+      {status === "LIVE" && (
+        <div className="space-y-3">
+          <p className="text-sm text-zinc-400">
+            Registre o resultado de cada partida para avançar o chaveamento.
+          </p>
+          {pendingMatches.length === 0 ? (
+            <p className="text-sm text-zinc-500">
+              Nenhuma partida aguardando resultado no momento.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {pendingMatches.map((m) => (
+                <ReportMatchRow key={m.id} match={m} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {(status === "COMPLETED" || status === "CANCELLED") && (
+        <p className="text-sm text-zinc-400">
+          {status === "COMPLETED"
+            ? "Torneio encerrado."
+            : "Torneio cancelado."}
+        </p>
+      )}
+
+      {error && (
+        <p
+          className="flex items-center gap-1.5 text-sm text-behavior-bad"
+          role="alert"
+        >
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/aegis-club/src/components/ui/Avatar.tsx
+++ b/aegis-club/src/components/ui/Avatar.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable @next/next/no-img-element */
+import { cn } from "@/lib/utils";
+
+const sizes = {
+  sm: "h-8 w-8 text-xs",
+  md: "h-10 w-10 text-sm",
+  lg: "h-16 w-16 text-lg",
+  xl: "h-24 w-24 text-2xl",
+};
+
+export function Avatar({
+  src,
+  name,
+  size = "md",
+  className,
+}: {
+  src?: string | null;
+  name: string;
+  size?: keyof typeof sizes;
+  className?: string;
+}) {
+  const initials = name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+
+  return (
+    <span
+      className={cn(
+        "relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-surface-border bg-surface-hover font-semibold text-aegis",
+        sizes[size],
+        className,
+      )}
+    >
+      {src ? (
+        // Avatares vêm de domínios variados (Steam); <img> evita config extra.
+        <img src={src} alt={name} className="h-full w-full object-cover" />
+      ) : (
+        <span>{initials || "?"}</span>
+      )}
+    </span>
+  );
+}

--- a/aegis-club/src/components/ui/Badge.tsx
+++ b/aegis-club/src/components/ui/Badge.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+
+type Tone =
+  | "neutral"
+  | "aegis"
+  | "radiant"
+  | "dire"
+  | "good"
+  | "warn"
+  | "bad";
+
+const tones: Record<Tone, string> = {
+  neutral: "bg-surface-hover text-zinc-300 border-surface-border",
+  aegis: "bg-aegis/15 text-aegis border-aegis/30",
+  radiant: "bg-radiant/15 text-radiant border-radiant/30",
+  dire: "bg-dire/15 text-dire-soft border-dire/30",
+  good: "bg-behavior-good/15 text-behavior-good border-behavior-good/30",
+  warn: "bg-behavior-warn/15 text-behavior-warn border-behavior-warn/30",
+  bad: "bg-behavior-bad/15 text-behavior-bad border-behavior-bad/30",
+};
+
+export function Badge({
+  children,
+  tone = "neutral",
+  className,
+}: {
+  children: React.ReactNode;
+  tone?: Tone;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium",
+        tones[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/aegis-club/src/components/ui/BehaviorMeter.tsx
+++ b/aegis-club/src/components/ui/BehaviorMeter.tsx
@@ -1,0 +1,35 @@
+import { behaviorTier, BEHAVIOR_MAX } from "@/lib/reputation";
+import { cn } from "@/lib/utils";
+
+export function BehaviorMeter({
+  score,
+  showLabel = true,
+  className,
+}: {
+  score: number;
+  showLabel?: boolean;
+  className?: string;
+}) {
+  const tier = behaviorTier(score);
+  const pct = Math.round((score / BEHAVIOR_MAX) * 100);
+
+  return (
+    <div className={cn("w-full", className)}>
+      {showLabel && (
+        <div className="mb-1.5 flex items-center justify-between text-sm">
+          <span className="text-zinc-400">Conduta</span>
+          <span className={cn("font-semibold", tier.color)}>{tier.label}</span>
+        </div>
+      )}
+      <div className="h-2 w-full overflow-hidden rounded-full bg-surface-border">
+        <div
+          className={cn("h-full rounded-full transition-all", tier.barColor)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      {showLabel && (
+        <p className="mt-1 text-xs text-zinc-500">{tier.description}</p>
+      )}
+    </div>
+  );
+}

--- a/aegis-club/src/components/ui/Button.tsx
+++ b/aegis-club/src/components/ui/Button.tsx
@@ -1,0 +1,51 @@
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+type Variant = "primary" | "secondary" | "ghost" | "danger" | "outline";
+type Size = "sm" | "md" | "lg";
+
+const base =
+  "inline-flex items-center justify-center gap-2 rounded-xl font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aegis/60 disabled:cursor-not-allowed disabled:opacity-50";
+
+const variants: Record<Variant, string> = {
+  primary:
+    "bg-aegis text-bg hover:bg-aegis-soft shadow-glow font-semibold",
+  secondary: "bg-surface-hover text-zinc-100 hover:bg-surface-border",
+  ghost: "text-zinc-300 hover:bg-surface-hover",
+  danger: "bg-dire text-white hover:bg-dire-soft",
+  outline:
+    "border border-surface-border text-zinc-200 hover:border-aegis/50 hover:text-white",
+};
+
+const sizes: Record<Size, string> = {
+  sm: "h-8 px-3 text-sm",
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-6 text-base",
+};
+
+export function buttonVariants({
+  variant = "primary",
+  size = "md",
+}: {
+  variant?: Variant;
+  size?: Size;
+} = {}) {
+  return cn(base, variants[variant], sizes[size]);
+}
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  ),
+);
+Button.displayName = "Button";

--- a/aegis-club/src/components/ui/Card.tsx
+++ b/aegis-club/src/components/ui/Card.tsx
@@ -1,0 +1,49 @@
+import { cn } from "@/lib/utils";
+
+export function Card({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return <div className={cn("card", className)}>{children}</div>;
+}
+
+export function CardHeader({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn("border-b border-surface-border p-5", className)}>
+      {children}
+    </div>
+  );
+}
+
+export function CardTitle({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <h3 className={cn("text-lg font-semibold text-zinc-100", className)}>
+      {children}
+    </h3>
+  );
+}
+
+export function CardContent({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return <div className={cn("p-5", className)}>{children}</div>;
+}

--- a/aegis-club/src/components/ui/EmptyState.tsx
+++ b/aegis-club/src/components/ui/EmptyState.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: {
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center rounded-2xl border border-dashed border-surface-border bg-surface/40 px-6 py-14 text-center",
+        className,
+      )}
+    >
+      {icon && <div className="mb-3 text-zinc-500">{icon}</div>}
+      <h3 className="text-base font-semibold text-zinc-200">{title}</h3>
+      {description && (
+        <p className="mt-1 max-w-sm text-sm text-zinc-500">{description}</p>
+      )}
+      {action && <div className="mt-5">{action}</div>}
+    </div>
+  );
+}

--- a/aegis-club/src/components/ui/RankBadge.tsx
+++ b/aegis-club/src/components/ui/RankBadge.tsx
@@ -1,0 +1,29 @@
+import { Medal } from "lucide-react";
+import { rankTier } from "@/lib/ranking";
+import { cn } from "@/lib/utils";
+
+export function RankBadge({
+  points,
+  showPoints = false,
+  className,
+}: {
+  points: number;
+  showPoints?: boolean;
+  className?: string;
+}) {
+  const tier = rankTier(points);
+  return (
+    <span className={cn("inline-flex items-center gap-1.5", className)}>
+      <Medal className={cn("h-4 w-4", tier.color)} />
+      <span className={cn("text-sm font-semibold", tier.color)}>
+        {tier.name}
+        {tier.division > 0 && (
+          <span className="ml-1 text-aegis">{"★".repeat(tier.division)}</span>
+        )}
+      </span>
+      {showPoints && (
+        <span className="text-xs text-zinc-500">({points} pts)</span>
+      )}
+    </span>
+  );
+}

--- a/aegis-club/src/components/ui/SectionHeading.tsx
+++ b/aegis-club/src/components/ui/SectionHeading.tsx
@@ -1,0 +1,28 @@
+export function SectionHeading({
+  eyebrow,
+  title,
+  description,
+  action,
+}: {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
+      <div>
+        {eyebrow && (
+          <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-aegis">
+            {eyebrow}
+          </p>
+        )}
+        <h2 className="text-2xl font-bold text-zinc-100">{title}</h2>
+        {description && (
+          <p className="mt-1 max-w-2xl text-sm text-zinc-400">{description}</p>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/aegis-club/src/data/heroes.ts
+++ b/aegis-club/src/data/heroes.ts
@@ -1,0 +1,66 @@
+/**
+ * Catálogo curado de heróis do Dota 2 (subconjunto popular).
+ * IDs e nomes seguem o padrão oficial / OpenDota, então as imagens da CDN
+ * da Valve resolvem direto pelo `slug`.
+ *
+ * A imagem fica em:
+ *   https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/heroes/<slug>.png
+ */
+
+export type PrimaryAttr = "STRENGTH" | "AGILITY" | "INTELLIGENCE" | "UNIVERSAL";
+
+export interface HeroSeed {
+  id: number;
+  npc: string; // npc_dota_hero_*
+  localizedName: string;
+  slug: string;
+  primaryAttr: PrimaryAttr;
+  roles: string[];
+  complexity: 1 | 2 | 3;
+}
+
+export const HEROES: HeroSeed[] = [
+  { id: 1, npc: "npc_dota_hero_antimage", localizedName: "Anti-Mage", slug: "antimage", primaryAttr: "AGILITY", roles: ["Carry", "Escape", "Nuker"], complexity: 1 },
+  { id: 8, npc: "npc_dota_hero_juggernaut", localizedName: "Juggernaut", slug: "juggernaut", primaryAttr: "AGILITY", roles: ["Carry", "Pusher", "Escape"], complexity: 1 },
+  { id: 11, npc: "npc_dota_hero_nevermore", localizedName: "Shadow Fiend", slug: "nevermore", primaryAttr: "AGILITY", roles: ["Carry", "Nuker"], complexity: 2 },
+  { id: 44, npc: "npc_dota_hero_phantom_assassin", localizedName: "Phantom Assassin", slug: "phantom_assassin", primaryAttr: "AGILITY", roles: ["Carry", "Escape"], complexity: 1 },
+  { id: 6, npc: "npc_dota_hero_drow_ranger", localizedName: "Drow Ranger", slug: "drow_ranger", primaryAttr: "AGILITY", roles: ["Carry", "Disabler", "Pusher"], complexity: 1 },
+  { id: 35, npc: "npc_dota_hero_sniper", localizedName: "Sniper", slug: "sniper", primaryAttr: "AGILITY", roles: ["Carry", "Nuker"], complexity: 1 },
+  { id: 67, npc: "npc_dota_hero_spectre", localizedName: "Spectre", slug: "spectre", primaryAttr: "AGILITY", roles: ["Carry", "Durable", "Escape"], complexity: 1 },
+  { id: 41, npc: "npc_dota_hero_faceless_void", localizedName: "Faceless Void", slug: "faceless_void", primaryAttr: "AGILITY", roles: ["Carry", "Initiator", "Disabler"], complexity: 2 },
+  { id: 48, npc: "npc_dota_hero_luna", localizedName: "Luna", slug: "luna", primaryAttr: "AGILITY", roles: ["Carry", "Pusher", "Nuker"], complexity: 1 },
+  { id: 93, npc: "npc_dota_hero_slark", localizedName: "Slark", slug: "slark", primaryAttr: "AGILITY", roles: ["Carry", "Escape", "Disabler"], complexity: 2 },
+
+  { id: 17, npc: "npc_dota_hero_storm_spirit", localizedName: "Storm Spirit", slug: "storm_spirit", primaryAttr: "INTELLIGENCE", roles: ["Carry", "Escape", "Nuker"], complexity: 3 },
+  { id: 13, npc: "npc_dota_hero_puck", localizedName: "Puck", slug: "puck", primaryAttr: "INTELLIGENCE", roles: ["Initiator", "Escape", "Nuker"], complexity: 3 },
+  { id: 74, npc: "npc_dota_hero_invoker", localizedName: "Invoker", slug: "invoker", primaryAttr: "UNIVERSAL", roles: ["Carry", "Nuker", "Disabler"], complexity: 3 },
+  { id: 22, npc: "npc_dota_hero_zuus", localizedName: "Zeus", slug: "zuus", primaryAttr: "INTELLIGENCE", roles: ["Carry", "Nuker"], complexity: 1 },
+  { id: 25, npc: "npc_dota_hero_lina", localizedName: "Lina", slug: "lina", primaryAttr: "UNIVERSAL", roles: ["Carry", "Support", "Nuker"], complexity: 2 },
+  { id: 5, npc: "npc_dota_hero_crystal_maiden", localizedName: "Crystal Maiden", slug: "crystal_maiden", primaryAttr: "INTELLIGENCE", roles: ["Support", "Disabler", "Nuker"], complexity: 1 },
+  { id: 26, npc: "npc_dota_hero_lion", localizedName: "Lion", slug: "lion", primaryAttr: "INTELLIGENCE", roles: ["Support", "Disabler", "Nuker"], complexity: 1 },
+  { id: 31, npc: "npc_dota_hero_lich", localizedName: "Lich", slug: "lich", primaryAttr: "INTELLIGENCE", roles: ["Support", "Nuker"], complexity: 1 },
+  { id: 64, npc: "npc_dota_hero_jakiro", localizedName: "Jakiro", slug: "jakiro", primaryAttr: "INTELLIGENCE", roles: ["Support", "Nuker", "Pusher"], complexity: 1 },
+  { id: 86, npc: "npc_dota_hero_rubick", localizedName: "Rubick", slug: "rubick", primaryAttr: "INTELLIGENCE", roles: ["Support", "Disabler", "Nuker"], complexity: 3 },
+
+  { id: 14, npc: "npc_dota_hero_pudge", localizedName: "Pudge", slug: "pudge", primaryAttr: "STRENGTH", roles: ["Disabler", "Initiator", "Durable"], complexity: 2 },
+  { id: 2, npc: "npc_dota_hero_axe", localizedName: "Axe", slug: "axe", primaryAttr: "STRENGTH", roles: ["Initiator", "Durable", "Disabler"], complexity: 1 },
+  { id: 18, npc: "npc_dota_hero_sven", localizedName: "Sven", slug: "sven", primaryAttr: "STRENGTH", roles: ["Carry", "Disabler", "Initiator"], complexity: 1 },
+  { id: 42, npc: "npc_dota_hero_skeleton_king", localizedName: "Wraith King", slug: "skeleton_king", primaryAttr: "STRENGTH", roles: ["Carry", "Durable", "Disabler"], complexity: 1 },
+  { id: 7, npc: "npc_dota_hero_earthshaker", localizedName: "Earthshaker", slug: "earthshaker", primaryAttr: "STRENGTH", roles: ["Initiator", "Disabler", "Nuker"], complexity: 2 },
+  { id: 29, npc: "npc_dota_hero_tidehunter", localizedName: "Tidehunter", slug: "tidehunter", primaryAttr: "STRENGTH", roles: ["Initiator", "Durable", "Disabler"], complexity: 1 },
+  { id: 16, npc: "npc_dota_hero_sand_king", localizedName: "Sand King", slug: "sand_king", primaryAttr: "UNIVERSAL", roles: ["Initiator", "Disabler", "Nuker"], complexity: 2 },
+  { id: 99, npc: "npc_dota_hero_bristleback", localizedName: "Bristleback", slug: "bristleback", primaryAttr: "STRENGTH", roles: ["Carry", "Durable", "Initiator"], complexity: 1 },
+  { id: 104, npc: "npc_dota_hero_legion_commander", localizedName: "Legion Commander", slug: "legion_commander", primaryAttr: "STRENGTH", roles: ["Carry", "Initiator", "Durable"], complexity: 2 },
+  { id: 129, npc: "npc_dota_hero_mars", localizedName: "Mars", slug: "mars", primaryAttr: "STRENGTH", roles: ["Initiator", "Durable", "Disabler"], complexity: 2 },
+
+  { id: 9, npc: "npc_dota_hero_mirana", localizedName: "Mirana", slug: "mirana", primaryAttr: "UNIVERSAL", roles: ["Carry", "Support", "Escape"], complexity: 2 },
+  { id: 21, npc: "npc_dota_hero_windrunner", localizedName: "Windranger", slug: "windrunner", primaryAttr: "UNIVERSAL", roles: ["Carry", "Support", "Disabler"], complexity: 2 },
+  { id: 114, npc: "npc_dota_hero_monkey_king", localizedName: "Monkey King", slug: "monkey_king", primaryAttr: "UNIVERSAL", roles: ["Carry", "Escape", "Disabler"], complexity: 2 },
+  { id: 136, npc: "npc_dota_hero_marci", localizedName: "Marci", slug: "marci", primaryAttr: "UNIVERSAL", roles: ["Support", "Initiator", "Carry"], complexity: 2 },
+];
+
+export const heroImageUrl = (slug: string) =>
+  `https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/heroes/${slug}.png`;
+
+export const heroIconUrl = (slug: string) =>
+  `https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/heroes/icons/${slug}.png`;

--- a/aegis-club/src/lib/bracket.ts
+++ b/aegis-club/src/lib/bracket.ts
@@ -1,0 +1,99 @@
+/**
+ * Geração de chaveamento (single elimination) para torneios.
+ */
+
+export interface SeededTeam {
+  id: string;
+  seed: number;
+}
+
+export interface BracketMatchInput {
+  round: number;
+  position: number;
+  bracket: "WINNERS" | "LOSERS" | "GRAND_FINAL";
+  teamAId: string | null;
+  teamBId: string | null;
+}
+
+export function nextPowerOfTwo(n: number): number {
+  let p = 1;
+  while (p < n) p *= 2;
+  return Math.max(2, p);
+}
+
+/**
+ * Ordem padrão de seeds num chaveamento (1 vs N, etc).
+ * Para size=4 → [1,4,3,2]; size=8 → [1,8,5,4,3,6,7,2].
+ */
+export function seedOrder(size: number): number[] {
+  let rounds = [1, 2];
+  while (rounds.length < size) {
+    const next: number[] = [];
+    const total = rounds.length * 2 + 1;
+    for (const s of rounds) {
+      next.push(s);
+      next.push(total - s);
+    }
+    rounds = next;
+  }
+  return rounds;
+}
+
+/**
+ * Cria todas as partidas de um chaveamento de eliminação simples.
+ * Times além da contagem viram "bye" (adversário nulo → avança sozinho).
+ */
+export function generateSingleElimination(
+  teams: SeededTeam[],
+): BracketMatchInput[] {
+  const sorted = [...teams].sort((a, b) => a.seed - b.seed);
+  const size = nextPowerOfTwo(sorted.length);
+  const order = seedOrder(size);
+
+  // Mapeia cada posição de seed (1..size) para um time ou null (bye).
+  const bySeed = new Map<number, SeededTeam>();
+  sorted.forEach((t, i) => bySeed.set(i + 1, t));
+
+  const matches: BracketMatchInput[] = [];
+  const totalRounds = Math.log2(size);
+
+  // Rodada 1
+  for (let i = 0; i < size / 2; i++) {
+    const seedA = order[i * 2];
+    const seedB = order[i * 2 + 1];
+    matches.push({
+      round: 1,
+      position: i,
+      bracket: "WINNERS",
+      teamAId: bySeed.get(seedA)?.id ?? null,
+      teamBId: bySeed.get(seedB)?.id ?? null,
+    });
+  }
+
+  // Rodadas seguintes (vazias até serem preenchidas pelos vencedores)
+  for (let round = 2; round <= totalRounds; round++) {
+    const count = size / 2 ** round;
+    for (let pos = 0; pos < count; pos++) {
+      matches.push({
+        round,
+        position: pos,
+        bracket: round === totalRounds ? "GRAND_FINAL" : "WINNERS",
+        teamAId: null,
+        teamBId: null,
+      });
+    }
+  }
+
+  return matches;
+}
+
+/** Onde o vencedor de (round, position) avança na próxima rodada. */
+export function nextSlot(position: number): {
+  position: number;
+  slot: "A" | "B";
+} {
+  return {
+    position: Math.floor(position / 2),
+    slot: position % 2 === 0 ? "A" : "B",
+  };
+}

--- a/aegis-club/src/lib/matchmaking.ts
+++ b/aegis-club/src/lib/matchmaking.ts
@@ -1,0 +1,133 @@
+/**
+ * Motor de matchmaking.
+ *
+ * Estilo "Gamers Club": os jogadores entram numa fila, e quando há 10
+ * compatíveis o sistema forma uma partida 5x5 equilibrada e abre um
+ * ready-check. O host cria o lobby no cliente do Dota 2 e compartilha
+ * nome/senha; ao fim, todos podem elogiar/denunciar.
+ *
+ * A compatibilidade considera modo, região e — crucialmente — o behavior
+ * score: jogadores de baixa prioridade só caem com outros de baixa
+ * prioridade, isolando a toxicidade das partidas saudáveis.
+ */
+
+import type { Prisma, QueueMode, Region } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { isLowPriority } from "@/lib/reputation";
+
+export const MATCH_SIZE = 10;
+const TEAM_SIZE = 5;
+
+interface BalanceablePlayer {
+  userId: string;
+  rankPoints: number;
+}
+
+/**
+ * Divide 10 jogadores em dois times equilibrados.
+ * Heurística gananciosa: ordena por rankPoints (desc) e aloca cada
+ * jogador ao time com menor soma atual, respeitando o tamanho máximo.
+ */
+export function balanceTeams<T extends BalanceablePlayer>(
+  players: T[],
+): { radiant: T[]; dire: T[] } {
+  const sorted = [...players].sort((a, b) => b.rankPoints - a.rankPoints);
+  const radiant: T[] = [];
+  const dire: T[] = [];
+  let radiantSum = 0;
+  let direSum = 0;
+
+  for (const p of sorted) {
+    const radiantFull = radiant.length >= TEAM_SIZE;
+    const direFull = dire.length >= TEAM_SIZE;
+    const goRadiant = direFull
+      ? true
+      : radiantFull
+        ? false
+        : radiantSum <= direSum;
+    if (goRadiant) {
+      radiant.push(p);
+      radiantSum += p.rankPoints;
+    } else {
+      dire.push(p);
+      direSum += p.rankPoints;
+    }
+  }
+  return { radiant, dire };
+}
+
+export function averageRank(players: BalanceablePlayer[]): number {
+  if (players.length === 0) return 1000;
+  const sum = players.reduce((acc, p) => acc + p.rankPoints, 0);
+  return Math.round(sum / players.length);
+}
+
+/**
+ * Tenta formar uma partida a partir das entradas em espera.
+ * Retorna o id da partida criada, ou null se ainda não há 10 compatíveis.
+ *
+ * Roda dentro de uma transação para evitar alocar o mesmo jogador duas vezes.
+ */
+export async function tryFormMatch(
+  mode: QueueMode,
+  region: Region,
+): Promise<string | null> {
+  return prisma.$transaction(async (tx) => {
+    const waiting = await tx.queueEntry.findMany({
+      where: { status: "WAITING", mode, region },
+      orderBy: { createdAt: "asc" },
+      take: 200,
+    });
+
+    // Separa em "saudáveis" e "baixa prioridade" para não misturar.
+    const healthy = waiting.filter((e) => !isLowPriority(e.behaviorScore));
+    const lowPrio = waiting.filter((e) => isLowPriority(e.behaviorScore));
+
+    const pool =
+      healthy.length >= MATCH_SIZE
+        ? healthy
+        : lowPrio.length >= MATCH_SIZE
+          ? lowPrio
+          : null;
+
+    if (!pool) return null;
+
+    // Pega os 10 que esperam há mais tempo (prioridade por fila).
+    const chosen = pool.slice(0, MATCH_SIZE);
+    const { radiant, dire } = balanceTeams(
+      chosen.map((e) => ({ userId: e.userId, rankPoints: e.rankPoints, id: e.id })),
+    );
+
+    const avg = averageRank(chosen);
+
+    const playerData: Prisma.MatchPlayerCreateWithoutMatchInput[] = [
+      ...radiant.map((p, i) => ({
+        user: { connect: { id: p.userId } },
+        team: "RADIANT" as const,
+        slot: i,
+      })),
+      ...dire.map((p, i) => ({
+        user: { connect: { id: p.userId } },
+        team: "DIRE" as const,
+        slot: i,
+      })),
+    ];
+
+    const match = await tx.match.create({
+      data: {
+        mode,
+        region,
+        status: "DRAFTING",
+        averageRank: avg,
+        players: { create: playerData },
+      },
+    });
+
+    await tx.queueEntry.updateMany({
+      where: { id: { in: chosen.map((e) => e.id) } },
+      data: { status: "MATCHED", matchId: match.id },
+    });
+
+    return match.id;
+  });
+}

--- a/aegis-club/src/lib/opendota.ts
+++ b/aegis-club/src/lib/opendota.ts
@@ -1,0 +1,76 @@
+/**
+ * Integração leve com a OpenDota (https://docs.opendota.com/).
+ * Usada para importar a lista de heróis e estatísticas públicas de jogadores.
+ * Tudo opcional — a plataforma funciona com os dados estáticos de heróis.
+ */
+
+const OPENDOTA = "https://api.opendota.com/api";
+const STEAM_ID_OFFSET = 76561197960265728n;
+
+/** Converte SteamID64 no account_id de 32 bits usado pela OpenDota. */
+export function steamIdToAccountId(steamId64: string): number {
+  return Number(BigInt(steamId64) - STEAM_ID_OFFSET);
+}
+
+export interface OpenDotaHero {
+  id: number;
+  name: string; // npc_dota_hero_*
+  localized_name: string;
+  primary_attr: "str" | "agi" | "int" | "all";
+  attack_type: string;
+  roles: string[];
+}
+
+export async function fetchOpenDotaHeroes(): Promise<OpenDotaHero[]> {
+  const res = await fetch(`${OPENDOTA}/heroes`, {
+    next: { revalidate: 60 * 60 * 24 },
+  });
+  if (!res.ok) throw new Error(`OpenDota /heroes falhou: ${res.status}`);
+  return res.json();
+}
+
+export interface OpenDotaPlayer {
+  account_id: number;
+  personaname?: string;
+  rank_tier?: number | null;
+  leaderboard_rank?: number | null;
+  win?: number;
+  lose?: number;
+}
+
+export async function fetchOpenDotaPlayer(
+  accountId: number,
+): Promise<OpenDotaPlayer | null> {
+  try {
+    const [profileRes, wlRes] = await Promise.all([
+      fetch(`${OPENDOTA}/players/${accountId}`, {
+        next: { revalidate: 60 * 30 },
+      }),
+      fetch(`${OPENDOTA}/players/${accountId}/wl`, {
+        next: { revalidate: 60 * 30 },
+      }),
+    ]);
+    if (!profileRes.ok) return null;
+    const profile = await profileRes.json();
+    const wl = wlRes.ok ? await wlRes.json() : { win: 0, lose: 0 };
+    return {
+      account_id: accountId,
+      personaname: profile?.profile?.personaname,
+      rank_tier: profile?.rank_tier ?? null,
+      leaderboard_rank: profile?.leaderboard_rank ?? null,
+      win: wl?.win ?? 0,
+      lose: wl?.lose ?? 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Converte rank_tier da OpenDota (ex: 55) para MMR aproximado de exibição. */
+export function rankTierToApproxMmr(rankTier?: number | null): number | null {
+  if (!rankTier) return null;
+  const medal = Math.floor(rankTier / 10); // 1..8
+  const stars = rankTier % 10; // 0..5
+  // Aproximação grosseira: cada medalha ~770 de MMR, cada estrela ~154.
+  return Math.round((medal - 1) * 770 + stars * 154);
+}

--- a/aegis-club/src/lib/prisma.ts
+++ b/aegis-club/src/lib/prisma.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from "@prisma/client";
+
+// Reaproveita a instância do PrismaClient em desenvolvimento para evitar
+// esgotar o pool de conexões com o hot-reload do Next.js.
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/aegis-club/src/lib/ranking.ts
+++ b/aegis-club/src/lib/ranking.ts
@@ -1,0 +1,71 @@
+/**
+ * Ranking interno da plataforma (rankPoints) e medalhas no estilo Dota 2.
+ * Usamos um Elo simples para variação de pontos a cada partida.
+ */
+
+export interface RankTier {
+  key: string;
+  name: string;
+  /** 1–5 (estrelas), 0 = sem divisão (Imortal) */
+  division: number;
+  color: string;
+  /** faixa mínima de rankPoints */
+  min: number;
+}
+
+// Medalhas do Dota: Arauto, Guardião, Cruzado, Arconte, Lenda, Ancião, Divino, Imortal.
+const MEDALS: Array<{ key: string; name: string; color: string; base: number }> =
+  [
+    { key: "herald", name: "Arauto", color: "text-stone-400", base: 0 },
+    { key: "guardian", name: "Guardião", color: "text-amber-700", base: 770 },
+    { key: "crusader", name: "Cruzado", color: "text-orange-400", base: 1540 },
+    { key: "archon", name: "Arconte", color: "text-emerald-400", base: 2310 },
+    { key: "legend", name: "Lenda", color: "text-sky-400", base: 3080 },
+    { key: "ancient", name: "Ancião", color: "text-violet-400", base: 3850 },
+    { key: "divine", name: "Divino", color: "text-fuchsia-400", base: 4620 },
+    { key: "immortal", name: "Imortal", color: "text-aegis", base: 5400 },
+  ];
+
+const DIVISION_SPAN = 770 / 5; // largura de cada estrela dentro de uma medalha
+
+export function rankTier(points: number): RankTier {
+  // Encontra a medalha mais alta cujo base <= points
+  let medal = MEDALS[0];
+  for (const m of MEDALS) {
+    if (points >= m.base) medal = m;
+  }
+  if (medal.key === "immortal") {
+    return { ...medal, division: 0, min: medal.base };
+  }
+  const within = points - medal.base;
+  const division = Math.min(5, Math.floor(within / DIVISION_SPAN) + 1);
+  return { ...medal, division, min: medal.base };
+}
+
+export function rankLabel(points: number): string {
+  const t = rankTier(points);
+  return t.division > 0 ? `${t.name} ${"★".repeat(t.division)}` : t.name;
+}
+
+// ── Elo ──────────────────────────────────────────────────────────
+const K_FACTOR = 32;
+
+export function expectedScore(playerAvg: number, opponentAvg: number): number {
+  return 1 / (1 + 10 ** ((opponentAvg - playerAvg) / 400));
+}
+
+/**
+ * Variação de rankPoints para um jogador.
+ * @param teamAvg média do time do jogador
+ * @param opponentAvg média do time adversário
+ * @param won venceu?
+ */
+export function rankDelta(
+  teamAvg: number,
+  opponentAvg: number,
+  won: boolean,
+): number {
+  const expected = expectedScore(teamAvg, opponentAvg);
+  const actual = won ? 1 : 0;
+  return Math.round(K_FACTOR * (actual - expected));
+}

--- a/aegis-club/src/lib/reputation.ts
+++ b/aegis-club/src/lib/reputation.ts
@@ -1,0 +1,132 @@
+/**
+ * Sistema de reputação / comportamento — o coração do anti-toxicidade.
+ *
+ * O "behavior score" vai de 0 a 10000 (mesma escala mental do Dota oficial).
+ * Jogadores começam em 7500. Elogios sobem, denúncias validadas descem,
+ * partidas limpas recuperam lentamente. Abaixo de um limite, o jogador
+ * fica restrito à fila de baixa prioridade (ou bloqueado da ranqueada).
+ */
+
+import type { CommendCategory, ReportCategory } from "@prisma/client";
+
+export const BEHAVIOR_MIN = 0;
+export const BEHAVIOR_MAX = 10000;
+export const BEHAVIOR_START = 7500;
+
+/** Abaixo disto o jogador não entra na fila ranqueada. */
+export const RANKED_BEHAVIOR_THRESHOLD = 4000;
+/** Abaixo disto entra na fila de "baixa prioridade" (só com outros tóxicos). */
+export const LOW_PRIORITY_THRESHOLD = 6000;
+
+export interface BehaviorTier {
+  key: "excellent" | "good" | "fair" | "poor" | "critical";
+  label: string;
+  description: string;
+  /** classe de cor Tailwind para texto */
+  color: string;
+  /** classe de cor Tailwind para fundo de barra */
+  barColor: string;
+}
+
+export function behaviorTier(score: number): BehaviorTier {
+  if (score >= 9000)
+    return {
+      key: "excellent",
+      label: "Exemplar",
+      description: "Referência de boa conduta na comunidade.",
+      color: "text-behavior-good",
+      barColor: "bg-behavior-good",
+    };
+  if (score >= 7000)
+    return {
+      key: "good",
+      label: "Confiável",
+      description: "Bom companheiro de equipe.",
+      color: "text-radiant",
+      barColor: "bg-radiant",
+    };
+  if (score >= LOW_PRIORITY_THRESHOLD)
+    return {
+      key: "fair",
+      label: "Neutro",
+      description: "Comportamento dentro do esperado, com atenção.",
+      color: "text-behavior-warn",
+      barColor: "bg-behavior-warn",
+    };
+  if (score >= RANKED_BEHAVIOR_THRESHOLD)
+    return {
+      key: "poor",
+      label: "Em observação",
+      description: "Denúncias recentes. Fila ranqueada limitada.",
+      color: "text-dire-soft",
+      barColor: "bg-dire-soft",
+    };
+  return {
+    key: "critical",
+    label: "Restrito",
+    description: "Restrito à fila de baixa prioridade.",
+    color: "text-dire",
+    barColor: "bg-dire",
+  };
+}
+
+export function canQueueRanked(behaviorScore: number): boolean {
+  return behaviorScore >= RANKED_BEHAVIOR_THRESHOLD;
+}
+
+export function isLowPriority(behaviorScore: number): boolean {
+  return behaviorScore < LOW_PRIORITY_THRESHOLD;
+}
+
+/** Quanto cada elogio recebido soma no behavior score. */
+const COMMEND_WEIGHT: Record<CommendCategory, number> = {
+  FRIENDLY: 80,
+  FORGIVING: 80,
+  TEACHING: 100,
+  LEADERSHIP: 100,
+};
+
+/** Quanto cada denúncia validada subtrai do behavior score. */
+const REPORT_WEIGHT: Record<ReportCategory, number> = {
+  TOXIC_CHAT: 250,
+  INTENTIONAL_FEEDING: 400,
+  GRIEFING: 500,
+  ABANDON: 300,
+  HATE_SPEECH: 800,
+  CHEATING: 1500,
+  SMURFING: 400,
+};
+
+/** Recompensa por terminar uma partida sem ser denunciado. */
+export const CLEAN_MATCH_BONUS = 50;
+/** Penalidade por abandono. */
+export const ABANDON_PENALTY = 600;
+
+export function clampBehavior(score: number): number {
+  return Math.max(BEHAVIOR_MIN, Math.min(BEHAVIOR_MAX, Math.round(score)));
+}
+
+export function commendDelta(category: CommendCategory): number {
+  return COMMEND_WEIGHT[category] ?? 50;
+}
+
+export function reportDelta(category: ReportCategory): number {
+  return -(REPORT_WEIGHT[category] ?? 250);
+}
+
+export const COMMEND_LABELS: Record<CommendCategory, string> = {
+  FRIENDLY: "Amigável",
+  FORGIVING: "Tolerante",
+  TEACHING: "Comunicativo",
+  LEADERSHIP: "Boa liderança",
+};
+
+export const REPORT_LABELS: Record<ReportCategory, string> = {
+  TOXIC_CHAT: "Comunicação abusiva",
+  INTENTIONAL_FEEDING: "Feeding intencional",
+  GRIEFING: "Sabotagem (griefing)",
+  ABANDON: "Abandono",
+  HATE_SPEECH: "Discurso de ódio",
+  CHEATING: "Trapaça / scripts",
+  SMURFING: "Smurf (conta secundária)",
+};

--- a/aegis-club/src/lib/session.ts
+++ b/aegis-club/src/lib/session.ts
@@ -1,0 +1,84 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { SignJWT, jwtVerify } from "jose";
+import type { Role } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export const SESSION_COOKIE = "aegis_session";
+const SESSION_MAX_AGE = 60 * 60 * 24 * 30; // 30 dias
+
+export interface SessionPayload {
+  sub: string; // userId
+  steamId: string | null;
+  nickname: string;
+  role: Role;
+  avatarUrl: string | null;
+}
+
+function secretKey(): Uint8Array {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret || secret.length < 16) {
+    throw new Error(
+      "AUTH_SECRET ausente ou muito curto. Defina-o no .env (>= 16 caracteres).",
+    );
+  }
+  return new TextEncoder().encode(secret);
+}
+
+export async function encodeSession(payload: SessionPayload): Promise<string> {
+  return new SignJWT({ ...payload })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(`${SESSION_MAX_AGE}s`)
+    .sign(secretKey());
+}
+
+export async function decodeSession(
+  token: string,
+): Promise<SessionPayload | null> {
+  try {
+    const { payload } = await jwtVerify(token, secretKey());
+    return payload as unknown as SessionPayload;
+  } catch {
+    return null;
+  }
+}
+
+/** Lê a sessão atual a partir do cookie (somente leitura do JWT). */
+export async function getSession(): Promise<SessionPayload | null> {
+  const store = await cookies();
+  const token = store.get(SESSION_COOKIE)?.value;
+  if (!token) return null;
+  return decodeSession(token);
+}
+
+/** Retorna o usuário atual do banco (ou null). */
+export async function getCurrentUser() {
+  const session = await getSession();
+  if (!session) return null;
+  const user = await prisma.user.findUnique({
+    where: { id: session.sub },
+    include: { profile: true },
+  });
+  return user;
+}
+
+/** Igual a getCurrentUser, mas lança se não autenticado. Use em rotas protegidas. */
+export async function requireUser() {
+  const user = await getCurrentUser();
+  if (!user) {
+    throw new Error("UNAUTHENTICATED");
+  }
+  return user;
+}
+
+/** Opções padrão do cookie de sessão (para route handlers). */
+export function sessionCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+  };
+}

--- a/aegis-club/src/lib/steam.ts
+++ b/aegis-club/src/lib/steam.ts
@@ -1,0 +1,112 @@
+/**
+ * Autenticação via Steam usando OpenID 2.0.
+ * Não depende de bibliotecas externas: monta a URL de login e valida a
+ * asserção de retorno conversando diretamente com o endpoint da Steam.
+ */
+
+const STEAM_OPENID = "https://steamcommunity.com/openid/login";
+const STEAM_ID_PREFIX = "https://steamcommunity.com/openid/id/";
+
+export function appUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+}
+
+/** URL para onde redirecionamos o usuário a fim de iniciar o login. */
+export function buildSteamLoginUrl(): string {
+  const realm = appUrl();
+  const returnTo = `${realm}/api/auth/steam/callback`;
+  const params = new URLSearchParams({
+    "openid.ns": "http://specs.openid.net/auth/2.0",
+    "openid.mode": "checkid_setup",
+    "openid.return_to": returnTo,
+    "openid.realm": realm,
+    "openid.identity": "http://specs.openid.net/auth/2.0/identifier_select",
+    "openid.claimed_id": "http://specs.openid.net/auth/2.0/identifier_select",
+  });
+  return `${STEAM_OPENID}?${params.toString()}`;
+}
+
+/**
+ * Valida a asserção devolvida pela Steam e retorna o SteamID64.
+ * Reenvia os parâmetros recebidos com `openid.mode=check_authentication`.
+ */
+export async function verifySteamCallback(
+  query: URLSearchParams,
+): Promise<string | null> {
+  const claimedId = query.get("openid.claimed_id");
+  if (!claimedId || !claimedId.startsWith(STEAM_ID_PREFIX)) return null;
+
+  const body = new URLSearchParams();
+  query.forEach((value, key) => {
+    if (key.startsWith("openid.")) body.append(key, value);
+  });
+  body.set("openid.mode", "check_authentication");
+
+  const res = await fetch(STEAM_OPENID, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+    cache: "no-store",
+  });
+  const text = await res.text();
+  if (!/is_valid\s*:\s*true/i.test(text)) return null;
+
+  const steamId = claimedId.slice(STEAM_ID_PREFIX.length);
+  return /^\d{17}$/.test(steamId) ? steamId : null;
+}
+
+export interface SteamProfile {
+  steamId: string;
+  nickname: string;
+  avatarUrl: string | null;
+  country: string | null;
+}
+
+/**
+ * Busca nome e avatar via Steam Web API (GetPlayerSummaries).
+ * Sem STEAM_API_KEY, retorna um perfil mínimo baseado no SteamID.
+ */
+export async function fetchSteamProfile(
+  steamId: string,
+): Promise<SteamProfile> {
+  const key = process.env.STEAM_API_KEY;
+  if (!key) {
+    return {
+      steamId,
+      nickname: `Jogador ${steamId.slice(-4)}`,
+      avatarUrl: null,
+      country: null,
+    };
+  }
+  try {
+    const url = new URL(
+      "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/",
+    );
+    url.searchParams.set("key", key);
+    url.searchParams.set("steamids", steamId);
+    const res = await fetch(url, { cache: "no-store" });
+    const data = (await res.json()) as {
+      response?: {
+        players?: Array<{
+          personaname?: string;
+          avatarfull?: string;
+          loccountrycode?: string;
+        }>;
+      };
+    };
+    const p = data.response?.players?.[0];
+    return {
+      steamId,
+      nickname: p?.personaname ?? `Jogador ${steamId.slice(-4)}`,
+      avatarUrl: p?.avatarfull ?? null,
+      country: p?.loccountrycode ?? null,
+    };
+  } catch {
+    return {
+      steamId,
+      nickname: `Jogador ${steamId.slice(-4)}`,
+      avatarUrl: null,
+      country: null,
+    };
+  }
+}

--- a/aegis-club/src/lib/utils.ts
+++ b/aegis-club/src/lib/utils.ts
@@ -1,0 +1,38 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Combina classes do Tailwind resolvendo conflitos. */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+/** Gera um slug seguro a partir de um texto livre. */
+export function slugify(input: string): string {
+  return input
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+/** Formata um número grande de forma compacta (1.2k, 3.4M). */
+export function compactNumber(value: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+/** Percentual de vitórias. */
+export function winRate(wins: number, matchesPlayed: number): number {
+  if (matchesPlayed <= 0) return 0;
+  return Math.round((wins / matchesPlayed) * 100);
+}
+
+/** Atalho de espera (usado em retries). */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/aegis-club/src/lib/validations.ts
+++ b/aegis-club/src/lib/validations.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+// ── Perfil ────────────────────────────────────────────────────────
+export const dotaRoleEnum = z.enum([
+  "CARRY",
+  "MID",
+  "OFFLANE",
+  "SOFT_SUPPORT",
+  "HARD_SUPPORT",
+]);
+
+export const regionEnum = z.enum(["SA", "NA", "EU", "CIS", "SEA", "CHINA"]);
+
+export const updateProfileSchema = z.object({
+  nickname: z.string().min(2).max(32).optional(),
+  bio: z.string().max(500).optional(),
+  region: regionEnum.optional(),
+  mainRoles: z.array(dotaRoleEnum).max(5).optional(),
+  favoriteHeroIds: z.array(z.number().int().positive()).max(6).optional(),
+  discord: z.string().max(64).optional(),
+  twitch: z.string().max(64).optional(),
+  youtube: z.string().max(64).optional(),
+});
+
+// ── Fila / matchmaking ────────────────────────────────────────────
+export const joinQueueSchema = z.object({
+  mode: z.enum(["RANKED_5V5", "UNRANKED_5V5"]).default("RANKED_5V5"),
+  region: regionEnum.default("SA"),
+  preferredRoles: z.array(dotaRoleEnum).max(5).optional(),
+});
+
+// ── Reputação ─────────────────────────────────────────────────────
+export const commendSchema = z.object({
+  matchId: z.string().optional(),
+  toUserId: z.string().min(1),
+  category: z.enum(["FRIENDLY", "FORGIVING", "TEACHING", "LEADERSHIP"]),
+});
+
+export const reportSchema = z.object({
+  matchId: z.string().optional(),
+  toUserId: z.string().min(1),
+  category: z.enum([
+    "TOXIC_CHAT",
+    "INTENTIONAL_FEEDING",
+    "GRIEFING",
+    "ABANDON",
+    "HATE_SPEECH",
+    "CHEATING",
+    "SMURFING",
+  ]),
+  comment: z.string().max(500).optional(),
+});
+
+// ── Tutoriais ─────────────────────────────────────────────────────
+export const createTutorialSchema = z.object({
+  heroId: z.number().int().positive(),
+  title: z.string().min(4).max(120),
+  youtube: z.string().min(5), // URL ou ID; normalizado no servidor
+  level: z.enum(["BEGINNER", "INTERMEDIATE", "ADVANCED"]).default("BEGINNER"),
+  language: z.string().default("pt-BR"),
+});
+
+export const voteTutorialSchema = z.object({
+  value: z.union([z.literal(1), z.literal(-1)]),
+});
+
+// ── Torneios ──────────────────────────────────────────────────────
+export const createTournamentSchema = z.object({
+  name: z.string().min(4).max(80),
+  description: z.string().max(2000).optional(),
+  format: z
+    .enum(["SINGLE_ELIMINATION", "DOUBLE_ELIMINATION", "ROUND_ROBIN"])
+    .default("SINGLE_ELIMINATION"),
+  region: regionEnum.default("SA"),
+  maxTeams: z.number().int().min(2).max(64).default(8),
+  prizePool: z.string().max(120).optional(),
+  registrationEndsAt: z.string().datetime().optional(),
+  startsAt: z.string().datetime().optional(),
+});
+
+export const createTeamSchema = z.object({
+  tournamentId: z.string().min(1),
+  name: z.string().min(2).max(40),
+  tag: z.string().min(1).max(6),
+});
+
+export const reportMatchResultSchema = z.object({
+  matchId: z.string().min(1),
+  winnerTeamId: z.string().min(1),
+  scoreA: z.number().int().min(0).max(5).default(0),
+  scoreB: z.number().int().min(0).max(5).default(0),
+});
+
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+export type JoinQueueInput = z.infer<typeof joinQueueSchema>;
+export type CreateTournamentInput = z.infer<typeof createTournamentSchema>;

--- a/aegis-club/src/lib/youtube.ts
+++ b/aegis-club/src/lib/youtube.ts
@@ -1,0 +1,43 @@
+/**
+ * Utilitários para vídeos do YouTube usados nos tutoriais de heróis.
+ * Aceitamos qualquer formato de URL e guardamos apenas o ID do vídeo.
+ */
+
+const YT_PATTERNS: RegExp[] = [
+  /youtube\.com\/watch\?v=([\w-]{11})/,
+  /youtu\.be\/([\w-]{11})/,
+  /youtube\.com\/embed\/([\w-]{11})/,
+  /youtube\.com\/shorts\/([\w-]{11})/,
+];
+
+/** Extrai o ID de 11 caracteres de uma URL (ou retorna o próprio ID se já vier limpo). */
+export function extractYoutubeId(input: string): string | null {
+  const trimmed = input.trim();
+  if (/^[\w-]{11}$/.test(trimmed)) return trimmed;
+  for (const re of YT_PATTERNS) {
+    const m = trimmed.match(re);
+    if (m?.[1]) return m[1];
+  }
+  return null;
+}
+
+export function youtubeEmbedUrl(id: string): string {
+  return `https://www.youtube.com/embed/${id}`;
+}
+
+export function youtubeWatchUrl(id: string): string {
+  return `https://www.youtube.com/watch?v=${id}`;
+}
+
+export function youtubeThumbnail(
+  id: string,
+  quality: "default" | "hq" | "max" = "hq",
+): string {
+  const file =
+    quality === "max"
+      ? "maxresdefault"
+      : quality === "hq"
+        ? "hqdefault"
+        : "default";
+  return `https://i.ytimg.com/vi/${id}/${file}.jpg`;
+}

--- a/aegis-club/tailwind.config.ts
+++ b/aegis-club/tailwind.config.ts
@@ -1,0 +1,80 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: [
+    "./src/app/**/*.{ts,tsx}",
+    "./src/components/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        // Base — tema escuro inspirado no Dota 2
+        bg: {
+          DEFAULT: "#0a0b0f",
+          soft: "#101218",
+          elevated: "#161922",
+        },
+        surface: {
+          DEFAULT: "#14161d",
+          hover: "#1b1e28",
+          border: "#252934",
+        },
+        // Aegis = ouro (cor da Aegis of the Immortal)
+        aegis: {
+          DEFAULT: "#f5c451",
+          soft: "#fbe19a",
+          dark: "#b98e22",
+        },
+        // Dire / vermelho competitivo
+        dire: {
+          DEFAULT: "#e23636",
+          soft: "#ff6b6b",
+          dark: "#9b2020",
+        },
+        // Radiant / verde
+        radiant: {
+          DEFAULT: "#9bc53d",
+          soft: "#c0e072",
+          dark: "#5e7a1f",
+        },
+        // Reputação / comportamento
+        behavior: {
+          good: "#4ade80",
+          warn: "#facc15",
+          bad: "#f87171",
+        },
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "var(--font-sans)", "sans-serif"],
+      },
+      borderRadius: {
+        xl: "0.9rem",
+        "2xl": "1.25rem",
+      },
+      boxShadow: {
+        glow: "0 0 0 1px rgba(245,196,81,0.18), 0 8px 30px -8px rgba(245,196,81,0.25)",
+        card: "0 10px 30px -12px rgba(0,0,0,0.6)",
+      },
+      keyframes: {
+        "fade-in": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        pulseSoft: {
+          "0%, 100%": { opacity: "1" },
+          "50%": { opacity: "0.55" },
+        },
+      },
+      animation: {
+        "fade-in": "fade-in 0.35s cubic-bezier(0.23,1,0.32,1)",
+        "pulse-soft": "pulseSoft 1.8s ease-in-out infinite",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/aegis-club/tsconfig.json
+++ b/aegis-club/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
