### PR TITLE
fix(web): portal New Project modal picker dropdowns

### DIFF
--- a/apps/web/src/components/DsPickerPopover.tsx
+++ b/apps/web/src/components/DsPickerPopover.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { ReactNode, RefObject } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * Viewport-anchored placement for a portaled `.ds-picker-popover`.
+ *
+ * The in-modal pickers (platform / design system / model / prompt template)
+ * live inside `.newproj-body`, which is an `overflow-y: auto` scroll container,
+ * and amongst `.newproj-section` siblings that each form their own stacking
+ * context (a `transform` is retained by their `animation: … both` entrance).
+ * An inline `position: absolute` popover is therefore both clipped by the
+ * scroll box and unable to reliably paint above later sibling sections. This
+ * shape mirrors the proven trigger-anchored placement in `DesignSystemPicker`
+ * so the popover can be portaled to `document.body` and escape both traps.
+ */
+interface PopoverAnchor {
+  left: number;
+  width: number;
+  maxHeight: number;
+  // Vertical placement: open downward (anchored by `top`) by default, or
+  // upward (anchored by `bottom`) when the trigger sits near the viewport
+  // bottom with more room above than below.
+  top?: number;
+  bottom?: number;
+}
+
+interface DsPickerPopoverProps {
+  open: boolean;
+  triggerRef: RefObject<HTMLElement | null>;
+  onRequestClose: () => void;
+  className?: string;
+  role?: string;
+  id?: string;
+  ariaLabel?: string;
+  ariaMultiselectable?: boolean;
+  dataTestid?: string;
+  children: ReactNode;
+}
+
+/**
+ * Portaled, trigger-anchored popover for the New Project modal pickers.
+ *
+ * Owns placement (`getBoundingClientRect` + reposition on scroll/resize),
+ * `document.body` portaling, and the outside-click / Escape dismissal that each
+ * picker previously duplicated inline. The trigger and the portaled popover are
+ * both treated as "inside" so clicking either does not self-close.
+ */
+export function DsPickerPopover({
+  open,
+  triggerRef,
+  onRequestClose,
+  className,
+  role,
+  id,
+  ariaLabel,
+  ariaMultiselectable,
+  dataTestid,
+  children,
+}: DsPickerPopoverProps) {
+  const [anchor, setAnchor] = useState<PopoverAnchor | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setAnchor(null);
+      return undefined;
+    }
+    if (!triggerRef.current) return undefined;
+    function updateAnchor() {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const viewport = window.innerWidth;
+      // Match the trigger width — these dropdowns historically rendered
+      // edge-to-edge with their trigger (`left: 0; right: 0`).
+      const width = rect.width;
+      const left = Math.max(8, Math.min(viewport - width - 8, rect.left));
+      const gap = 6;
+      const margin = 12;
+      const spaceBelow = window.innerHeight - rect.bottom - gap - margin;
+      const spaceAbove = rect.top - gap - margin;
+      const openUp = spaceBelow < 280 && spaceAbove > spaceBelow;
+      if (openUp) {
+        setAnchor({
+          bottom: window.innerHeight - rect.top + gap,
+          left,
+          width,
+          maxHeight: Math.max(200, Math.min(420, spaceAbove)),
+        });
+      } else {
+        setAnchor({
+          top: rect.bottom + gap,
+          left,
+          width,
+          maxHeight: Math.max(200, Math.min(420, spaceBelow)),
+        });
+      }
+    }
+    updateAnchor();
+    window.addEventListener('resize', updateAnchor);
+    window.addEventListener('scroll', updateAnchor, true);
+    return () => {
+      window.removeEventListener('resize', updateAnchor);
+      window.removeEventListener('scroll', updateAnchor, true);
+    };
+  }, [open, triggerRef]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    function onPointer(e: MouseEvent) {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      onRequestClose();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onRequestClose();
+    }
+    // Defer listener registration by a tick so the click that opened the
+    // popover isn't re-interpreted as an outside-click in the same cycle
+    // (StrictMode also double-invokes the effect, which can race the event).
+    const id = window.setTimeout(() => {
+      document.addEventListener('mousedown', onPointer);
+      document.addEventListener('keydown', onKey);
+    }, 0);
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open, onRequestClose, triggerRef]);
+
+  if (!open || !anchor || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      ref={popoverRef}
+      className={`ds-picker-popover ds-picker-popover--portal${className ? ` ${className}` : ''}`}
+      role={role}
+      id={id}
+      aria-label={ariaLabel}
+      aria-multiselectable={ariaMultiselectable}
+      data-testid={dataTestid}
+      style={{
+        top: anchor.top,
+        bottom: anchor.bottom,
+        left: anchor.left,
+        width: anchor.width,
+        maxHeight: anchor.maxHeight,
+      }}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Dialog, DialogDescription, DialogFooter, DialogTitle } from '@open-design/components';
+import { DsPickerPopover } from './DsPickerPopover';
 import { createTabToTracking } from '@open-design/contracts/analytics';
 import { isOpenDesignHostAvailable, pickHostWorkingDir } from '@open-design/host';
 import type { OpenDesignHostProjectImportSuccess } from '@open-design/host';
@@ -1132,7 +1133,7 @@ function PlatformPicker({
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const listboxId = useId();
 
   function togglePlatform(next: NewProjectPlatform) {
@@ -1143,39 +1144,16 @@ function PlatformPicker({
     onChange(updated.length > 0 ? updated : ['responsive']);
   }
 
-  useEffect(() => {
-    if (!open) return;
-    function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    // Defer listener registration by a tick so the very click that opened
-    // the popover doesn't get re-interpreted as an outside-click on the
-    // mousedown that follows in the same event cycle.
-    const tid = window.setTimeout(() => {
-      document.addEventListener('mousedown', onPointer);
-      document.addEventListener('keydown', onKey);
-    }, 0);
-    return () => {
-      window.clearTimeout(tid);
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
-
   const primary = DESIGN_PLATFORMS.find((o) => o.value === value[0]) ?? null;
   const extraCount = Math.max(0, value.length - 1);
 
   return (
     <div
       className={`newproj-section ds-picker platform-picker${open ? ' open' : ''}`}
-      ref={wrapRef}
     >
       <label className="newproj-label">Target platforms</label>
       <button
+        ref={triggerRef}
         type="button"
         className={`ds-picker-trigger${open ? ' open' : ''}${primary ? '' : ' empty'}`}
         onClick={() => setOpen((v) => !v)}
@@ -1198,16 +1176,17 @@ function PlatformPicker({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div
-          className="ds-picker-popover"
-          id={listboxId}
-          role="listbox"
-          aria-label="Target platforms"
-          aria-multiselectable="true"
-        >
-          <div className="ds-picker-list">
-            {DESIGN_PLATFORMS.map((option) => {
+      <DsPickerPopover
+        open={open}
+        triggerRef={triggerRef}
+        onRequestClose={() => setOpen(false)}
+        id={listboxId}
+        role="listbox"
+        ariaLabel="Target platforms"
+        ariaMultiselectable
+      >
+        <div className="ds-picker-list">
+          {DESIGN_PLATFORMS.map((option) => {
               const active = value.includes(option.value);
               return (
                 <button
@@ -1231,9 +1210,8 @@ function PlatformPicker({
                 </button>
               );
             })}
-          </div>
         </div>
-      ) : null}
+      </DsPickerPopover>
     </div>
   );
 }
@@ -1667,7 +1645,7 @@ function PromptTemplatePicker({
   // soon as a pick succeeds or the user picks a different template.
   const [lastFailedPick, setLastFailedPick] =
     useState<PromptTemplateSummary | null>(null);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
 
   const surfaceScoped = useMemo(
@@ -1692,26 +1670,6 @@ function PromptTemplatePicker({
     if (!open) return;
     const id = window.setTimeout(() => searchRef.current?.focus(), 30);
     return () => window.clearTimeout(id);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    const id = window.setTimeout(() => {
-      document.addEventListener('mousedown', onPointer);
-      document.addEventListener('keydown', onKey);
-    }, 0);
-    return () => {
-      window.clearTimeout(id);
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
   }, [open]);
 
   async function pickTemplate(summary: PromptTemplateSummary) {
@@ -1754,9 +1712,10 @@ function PromptTemplatePicker({
     : t('newproj.promptTemplateNoneSub');
 
   return (
-    <div className="newproj-section ds-picker prompt-template-picker" ref={wrapRef}>
+    <div className="newproj-section ds-picker prompt-template-picker">
       <label className="newproj-label">{t('newproj.promptTemplateLabel')}</label>
       <button
+        ref={triggerRef}
         type="button"
         data-testid="prompt-template-trigger"
         className={`ds-picker-trigger${open ? ' open' : ''}${value ? '' : ' empty'}`}
@@ -1776,8 +1735,12 @@ function PromptTemplatePicker({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div className="ds-picker-popover" role="listbox">
+      <DsPickerPopover
+        open={open}
+        triggerRef={triggerRef}
+        onRequestClose={() => setOpen(false)}
+        role="listbox"
+      >
           <div className="ds-picker-head">
             <input
               ref={searchRef}
@@ -1848,8 +1811,7 @@ function PromptTemplatePicker({
               })
             )}
           </div>
-        </div>
-      ) : null}
+      </DsPickerPopover>
       {error ? (
         <div
           className="prompt-template-error"
@@ -1998,7 +1960,7 @@ function DesignSystemPicker({
   const t = useT();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
 
   const byId = useMemo(() => {
@@ -2046,29 +2008,6 @@ function DesignSystemPicker({
     return () => window.clearTimeout(t);
   }, [open]);
 
-  useEffect(() => {
-    if (!open) return;
-    function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    // Defer listener registration by a tick so the very click that opened
-    // the popover doesn't get re-interpreted as an outside-click on the
-    // mousedown that follows in the same event cycle (StrictMode also
-    // double-invokes the effect, which can race the same event).
-    const t = window.setTimeout(() => {
-      document.addEventListener('mousedown', onPointer);
-      document.addEventListener('keydown', onKey);
-    }, 0);
-    return () => {
-      window.clearTimeout(t);
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
 
   function toggle(id: string) {
     if (multi) {
@@ -2109,10 +2048,10 @@ function DesignSystemPicker({
     <div
       className={`newproj-section ds-picker${open ? ' open' : ''}`}
       data-testid="design-system-picker"
-      ref={wrapRef}
     >
       <label className="newproj-label">{t('newproj.designSystem')}</label>
       <button
+        ref={triggerRef}
         type="button"
         data-testid="design-system-trigger"
         className={`ds-picker-trigger${open ? ' open' : ''}${primary ? '' : ' empty'}`}
@@ -2143,8 +2082,12 @@ function DesignSystemPicker({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div className="ds-picker-popover" role="listbox">
+      <DsPickerPopover
+        open={open}
+        triggerRef={triggerRef}
+        onRequestClose={() => setOpen(false)}
+        role="listbox"
+      >
           <div className="ds-picker-head">
             <input
               ref={searchRef}
@@ -2236,8 +2179,7 @@ function DesignSystemPicker({
               </button>
             </div>
           ) : null}
-        </div>
-      ) : null}
+      </DsPickerPopover>
     </div>
   );
 }
@@ -2502,7 +2444,7 @@ function MediaModelCards({
   const t = useT();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
 
   // Group models by provider once. The trigger row needs the same provider
@@ -2588,25 +2530,6 @@ function MediaModelCards({
     return () => window.clearTimeout(id);
   }, [open]);
 
-  useEffect(() => {
-    if (!open) return;
-    function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    const id = window.setTimeout(() => {
-      document.addEventListener('mousedown', onPointer);
-      document.addEventListener('keydown', onKey);
-    }, 0);
-    return () => {
-      window.clearTimeout(id);
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
 
   function pick(modelId: string) {
     onChange(modelId);
@@ -2626,9 +2549,10 @@ function MediaModelCards({
     : t('newproj.modelMissingSub');
 
   return (
-    <div className="newproj-section ds-picker model-picker" ref={wrapRef}>
+    <div className="newproj-section ds-picker model-picker">
       <label className="newproj-label">{label}</label>
       <button
+        ref={triggerRef}
         type="button"
         data-testid="model-picker-trigger"
         className={`ds-picker-trigger${open ? ' open' : ''}${selected ? '' : ' empty'}`}
@@ -2647,8 +2571,12 @@ function MediaModelCards({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div className="ds-picker-popover" role="listbox">
+      <DsPickerPopover
+        open={open}
+        triggerRef={triggerRef}
+        onRequestClose={() => setOpen(false)}
+        role="listbox"
+      >
           <div className="ds-picker-head">
             <input
               ref={searchRef}
@@ -2705,8 +2633,7 @@ function MediaModelCards({
               ))
             )}
           </div>
-        </div>
-      ) : null}
+      </DsPickerPopover>
     </div>
   );
 }

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -137,6 +137,26 @@
   from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: translateY(0); }
 }
+/* Portaled variant — rendered into `document.body` by `DsPickerPopover` so the
+   New Project modal pickers escape the `.newproj-body` scroll clip and the
+   per-`.newproj-section` stacking contexts. `position`, `left/top/bottom`,
+   `width` and `max-height` are supplied by the trigger-anchored inline style;
+   the z-index must clear the modal backdrop (`new-project-modal.css`, z 920). */
+.ds-picker-popover--portal {
+  position: fixed;
+  z-index: 1000;
+}
+/* The popover height is viewport-bounded by the inline `max-height`, so the
+   inner list fills the remaining space and scrolls rather than relying on its
+   own fixed 320px cap (which could overflow a short popover near the edge). */
+.ds-picker-popover--portal .ds-picker-head {
+  flex: 0 0 auto;
+}
+.ds-picker-popover--portal .ds-picker-list {
+  max-height: none;
+  flex: 1 1 auto;
+  min-height: 0;
+}
 .ds-picker-head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Why

While creating a new project from the **New project** modal, opening the
**Target platforms** dropdown made the menu overlap and bleed through the rest
of the form (the Companion toggles and the Fidelity cards showed through it),
and the list was clipped at the bottom (e.g. "App Android" was cut off). The
dropdown was effectively unusable. I hit this myself building a prototype, so
this scratches a real first-run papercut.

Root cause: the in-modal pickers rendered their `.ds-picker-popover` **inline**
as a `position: absolute` child of the trigger, which sits inside two hostile
ancestors:

- `.newproj-body` is the modal's scroll container (`overflow-y: auto`), which
  clips any absolutely-positioned descendant — hence the truncated list.
- Every `.newproj-section` retains a `transform` after its entrance animation
  (`animation: … both`), so each section becomes its own stacking context and
  the popover could not reliably paint above the later sibling sections — hence
  the bleed-through. The existing `:has` z-index fallback was too fragile to
  cover it.

The sibling standalone `DesignSystemPicker` does **not** have this bug because
it portals its popover to `document.body` and positions it from the trigger's
`getBoundingClientRect()`. This PR brings the in-modal pickers up to that same,
proven pattern.

## What users will see

In the New project modal, the **Target platforms** dropdown — and the design
system, model, and prompt-template dropdowns — now open as a solid, opaque
panel that floats above the rest of the form instead of bleeding into it. The
full option list is reachable and scrolls inside the menu, and the menu
re-anchors to its trigger when the modal body is scrolled or the window is
resized. No change to what the controls do, only to how the menu renders.

## Surface area

- [x] **UI** — fixes the New project modal picker dropdowns in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

This is a pure web-UI rendering fix, so the UI/CLI dual-track rule does not
apply — no user-facing capability is added or removed, only the popover's
render path changes.

## Screenshots

Entry point: New project → Prototype → **Target platforms**.

**After** — the menu renders as a solid panel floating above the form, the full
option list is reachable, and it re-anchors to its trigger on modal scroll /
window resize:

![New Project — Target platforms dropdown after the fix](https://raw.githubusercontent.com/valhalla94/open-design/pr-assets/od-after-screenshot.png)

**Before** (as originally reported, `it-IT` locale): the open Target platforms
menu overlapped the Companion toggles and Fidelity cards and was clipped at the
bottom ("App Android" cut off) — the menu had no opaque panel, so the form
fields bled through it.

## Bug fix verification

No cheap red automated spec was written, and this is deliberate: the defect is a
**layout/stacking** one — `overflow` clipping and per-section stacking contexts
created by a retained `transform`. jsdom (the web package's test environment)
does not implement layout, `overflow` clipping, or stacking-context painting, so
a unit test cannot observe the symptom; it would only re-assert the new DOM
shape, not the bug.

Verification instead:

- The four in-modal pickers now render their popover through the shared
  `DsPickerPopover`, which portals to `document.body` — structurally escaping
  both the scroll clip and the sibling stacking contexts, the same mechanism the
  already-correct `DesignSystemPicker` relies on.
- Manually confirmed in the running app (`pnpm tools-dev run web`): the Target
  platforms menu opens as an opaque panel above the toggles/Fidelity cards, with
  the full list reachable and no bleed-through. The reporter also confirmed the
  fix on their machine.

## Validation

- `pnpm guard` — pass (63 tests)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web build` — pass
- `pnpm --filter @open-design/web test` for the affected components —
  `NewProjectPanel.*` (×3) and `HomeView.media-options` pass. The remaining
  full-suite failures reproduce identically on `main` (cross-test
  `document.body` pollution and a `localStorage` teardown flake) and are
  unrelated to this change — confirmed by stashing the diff and re-running on
  `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
