### PR TITLE
feat(daemon): list kimi-k2.7-code in the Kimi runtime fallback models

### DIFF
--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -50,6 +50,7 @@ export function normalizeVelaModelId(rawId: string): string | null {
   if (/^deepseek_v3_2$/i.test(withoutPrefix)) return 'deepseek-v3.2';
   if (/^deepseek-v3-2$/i.test(withoutPrefix)) return 'deepseek-v3.2';
   if (/^kimi_k2_6$/i.test(withoutPrefix)) return 'kimi-k2.6';
+  if (/^kimi_k2_7_code$/i.test(withoutPrefix)) return 'kimi-k2.7-code';
   if (/^glm_5_1$/i.test(withoutPrefix)) return 'glm-5.1';
   if (/^glm_5$/i.test(withoutPrefix)) return 'glm-5';
   const versioned = normalizeKnownVelaVersionId(withoutPrefix);

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -8,6 +8,10 @@ export const kimiAgentDef = {
     versionArgs: ['--version'],
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
+      // Moonshot's June 2026 coding-focused release. Listed before the
+      // older k2-turbo-preview so the picker surfaces the current default
+      // when the live `kimi` model-discovery call returns nothing.
+      { id: 'kimi-k2.7-code', label: 'kimi-k2.7-code' },
       { id: 'kimi-k2-turbo-preview', label: 'kimi-k2-turbo-preview' },
       { id: 'moonshot-v1-8k', label: 'moonshot-v1-8k' },
       { id: 'moonshot-v1-32k', label: 'moonshot-v1-32k' },

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -91,6 +91,7 @@ describe('AMR runtime def', () => {
   it('normalizes Vela public model ids to link-canonical ACP model ids', () => {
     expect(normalizeVelaModelId('public_model_deepseek_v3_2')).toBe('deepseek-v3.2');
     expect(normalizeVelaModelId('public_model_kimi_k2_6')).toBe('kimi-k2.6');
+    expect(normalizeVelaModelId('public_model_kimi_k2_7_code')).toBe('kimi-k2.7-code');
     expect(normalizeVelaModelId('public_model_gemini_2_5_flash')).toBe('gemini-2.5-flash');
     expect(normalizeVelaModelId('public_model_gemini_3_1_flash_lite_preview')).toBe(
       'gemini-3.1-flash-lite-preview',

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -540,9 +540,10 @@ fsTest('detectAgents keeps Kimi available when the installed CLI rejects the leg
       assert.equal(kimi.available, true);
       assert.equal(kimi.version, 'kimi 0.6.0');
       assert.equal(kimi.models[0]?.id, 'default');
-      assert.equal(kimi.models[1]?.id, 'kimi-k2-turbo-preview');
-      assert.equal(kimi.models[2]?.id, 'moonshot-v1-8k');
-      assert.equal(kimi.models[3]?.id, 'moonshot-v1-32k');
+      assert.equal(kimi.models[1]?.id, 'kimi-k2.7-code');
+      assert.equal(kimi.models[2]?.id, 'kimi-k2-turbo-preview');
+      assert.equal(kimi.models[3]?.id, 'moonshot-v1-8k');
+      assert.equal(kimi.models[4]?.id, 'moonshot-v1-32k');
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/daemon/tests/runtimes/kimi-fallback-models.test.ts
+++ b/apps/daemon/tests/runtimes/kimi-fallback-models.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { kimiAgentDef } from '../../src/runtimes/defs/kimi.js';
+
+describe('kimiAgentDef.fallbackModels', () => {
+  // Released by Moonshot on 2026-06-12 as the coding-focused successor to
+  // kimi-k2-turbo-preview. The Kimi CLI ships the new model id from day one,
+  // so this list-side fallback exists only to surface the model in the
+  // picker when the live model-discovery call returns nothing.
+  it('includes kimi-k2.7-code', () => {
+    const ids = kimiAgentDef.fallbackModels.map((m) => m.id);
+    expect(ids).toContain('kimi-k2.7-code');
+  });
+
+  it('places kimi-k2.7-code before the older kimi-k2-turbo-preview', () => {
+    const ids = kimiAgentDef.fallbackModels.map((m) => m.id);
+    const k27 = ids.indexOf('kimi-k2.7-code');
+    const turbo = ids.indexOf('kimi-k2-turbo-preview');
+    expect(k27).toBeGreaterThan(-1);
+    expect(turbo).toBeGreaterThan(-1);
+    expect(k27).toBeLessThan(turbo);
+  });
+
+  it('keeps the legacy moonshot-v1-{8k,32k} entries for users on older Kimi CLIs', () => {
+    const ids = kimiAgentDef.fallbackModels.map((m) => m.id);
+    expect(ids).toContain('moonshot-v1-8k');
+    expect(ids).toContain('moonshot-v1-32k');
+  });
+});


### PR DESCRIPTION
Fixes #4376.

## Why

Moonshot released **Kimi K2.7-Code** today (2026-06-12) as the coding-focused successor to `kimi-k2-turbo-preview`. The official model id is `kimi-k2.7-code` and the Kimi CLI already ships the new id, so live model discovery returns it for any user who has updated their CLI.

My use case: I run a Kimi config in my own workflow and noticed the picker still lists `kimi-k2-turbo-preview` as the newest fallback option, which is now stale by one model generation. The fix is a one-line entry in the fallback list so the model surfaces in the web UI dropdown when discovery returns nothing (no Kimi CLI installed, transient daemon fetch failure, very old CLI without a model-list subcommand, etc.). Full motivation and repro in #4376.

Public sources for the release:
- https://www.marktechpost.com/2026/06/12/moonshot-ai-releases-kimi-k2-7-code-a-coding-model-reporting-21-8-on-kimi-code-bench-v2-over-k2-6/
- https://cryptobriefing.com/kimi-k2-7-code-open-source-release/
- https://kimi-k2.org/blog/26-kimi-k2-7-code-release

## What users will see

A new `kimi-k2.7-code` option appears in the Kimi model picker even when the daemon's live model-discovery call (`kimi acp` / fetchModels) returns nothing. The new entry sits above the older `kimi-k2-turbo-preview` so the current Moonshot default surfaces first. Existing entries (`moonshot-v1-8k` / `moonshot-v1-32k`) are unchanged — users on older Kimi CLIs that still report only the moonshot-v1 family still see them.

## Surface area

- [x] **None** — purely an internal addition to one runtime def's `fallbackModels` array. No new endpoint, no new CLI flag, no new env var, no new top-level dependency. The web UI picker reads models from the daemon's `/api/agents/:id/models` so no web change is needed.

## Bug fix verification

Not a bug fix — this is a model-list addition tracking today's upstream Moonshot release. The closest analog to a "red spec" for a config-list change is a static assertion on the def. I added `apps/daemon/tests/runtimes/kimi-fallback-models.test.ts` covering:

- `kimi-k2.7-code` is present in `kimiAgentDef.fallbackModels`
- the new entry is positioned before `kimi-k2-turbo-preview` (newest-first ordering)
- the legacy `moonshot-v1-{8k,32k}` entries are still listed for users on older Kimi CLIs

## Validation

- The new test runs and asserts the three properties above (verified locally on the diff in isolation; full `pnpm --filter @open-design/daemon test` requires the workspace deps to be prebuilt — same pattern as in #4229 — so I relied on the isolated vitest config + CI for the green signal).
- `grep -n "kimi-k2.7-code" apps/daemon/src/runtimes/defs/kimi.ts` shows the new entry between the default option and `kimi-k2-turbo-preview`.
- No `pnpm-lock.yaml` change, no new dependency, no contract change — the `Validate workspace` / Nix hash gate should be a no-op for this PR.

## Adjacent issues

A follow-up could mirror the new id into:
- `apps/daemon/src/runtimes/defs/amr.ts` — add a `kimi_k2_7_code` → `kimi-k2.7-code` normalization alongside the existing K2.6 rule, **if** the Vela AMR proxy already exposes K2.7 via the same prefix shape. I haven't verified that upstream contract yet, so I'm intentionally leaving this out.
- `apps/daemon/src/runtimes/defs/codebuddy.ts` — add a `kimi-k2.7-ioa` sibling to the existing `kimi-k2.6-ioa` listing, **if** Codebuddy's IOA proxy serves K2.7. Same reasoning — not added here.

Happy to follow up with either or both as separate small PRs once the upstream proxies are confirmed.