### PR TITLE
fix(web): track vertical scroll deck pagination (#4218)

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1797,6 +1797,57 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     }
     return false;
   }
+  function verticalScrollRange(){
+    var targets = scrollTargets();
+    var value = 0;
+    for (var i=0; i<targets.length; i++) {
+      var candidate = targets[i];
+      value = Math.max(value, Math.max(0, (candidate.scrollHeight || 0) - (candidate.clientHeight || 0)));
+    }
+    return value;
+  }
+  function slidesStackedVertically(list){
+    // True when the slides are laid out as a vertical stack (each slide starts
+    // lower than the one before it). This is what separates a vertical long-form
+    // deck from a horizontal track / class-toggle / overlay deck, whose slides
+    // share the same top. It guards the vertical-scroll path so it can never
+    // fire on a horizontal deck that merely happens to also overflow vertically.
+    if (!list || list.length < 2) return false;
+    var prevTop = null;
+    var increasing = 0;
+    for (var i=0; i<list.length; i++) {
+      try {
+        var rect = list[i].getBoundingClientRect();
+        if (prevTop !== null && rect.top - prevTop > 1) increasing += 1;
+        prevTop = rect.top;
+      } catch (_) { return false; }
+    }
+    return increasing >= 1;
+  }
+  function isVerticalScrollDeck(list){
+    // A long-form deck whose scenes are stacked in one continuous scroll
+    // surface: real vertical scroll room plus vertically-stacked slides, and no
+    // horizontal scroll (which the horizontal path above already owns).
+    return verticalScrollRange() > 1 && !hasHorizontalScroll() && slidesStackedVertically(list);
+  }
+  function activeIndexFromVerticalScroll(list){
+    // The active scene is the one occupying the vertical center of the viewport.
+    // Using each slide's box (not scrollTop / innerHeight) keeps the counter
+    // accurate even when scenes are not all exactly one viewport tall.
+    var mid = Math.max(1, window.innerHeight) / 2;
+    var best = -1;
+    var bestDist = Infinity;
+    for (var i=0; i<list.length; i++) {
+      try {
+        var rect = list[i].getBoundingClientRect();
+        if (rect.top <= mid && rect.bottom >= mid) return i;
+        var center = rect.top + (rect.bottom - rect.top) / 2;
+        var dist = Math.abs(center - mid);
+        if (dist < bestDist) { bestDist = dist; best = i; }
+      } catch (_) {}
+    }
+    return best;
+  }
   function findActiveByClass(list){
     for (var i=0; i<list.length; i++) {
       var cl = list[i].classList;
@@ -1818,6 +1869,10 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (isScrollDeck()) {
       var w = Math.max(1, window.innerWidth);
       return Math.max(0, Math.min(list.length - 1, Math.round(maxScrollLeft() / w)));
+    }
+    if (isVerticalScrollDeck(list)) {
+      var byVerticalScroll = activeIndexFromVerticalScroll(list);
+      if (byVerticalScroll >= 0) return byVerticalScroll;
     }
     var byTransform = activeIndexFromTransform(list);
     if (byTransform >= 0) return byTransform;
@@ -1986,6 +2041,32 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     }
     setTimeout(report, 380);
   }
+  function scrollGoVertical(i){
+    var list = slides();
+    var next = Math.max(0, Math.min(list.length - 1, i));
+    var target = list[next];
+    // rect.top is the target scene's offset from the viewport top. Scrolling
+    // each container BY that delta (relative to its own current scrollTop)
+    // brings the scene to the top without depending on which container owns the
+    // scroll, so a non-scrolling sibling can't inflate the target and overshoot.
+    var delta = null;
+    if (target) {
+      try { delta = target.getBoundingClientRect().top; } catch (_) {}
+    }
+    var targets = scrollTargets();
+    for (var t=0; t<targets.length; t++) {
+      var current = Number(targets[t].scrollTop || 0);
+      var top = delta === null
+        ? next * Math.max(1, window.innerHeight)
+        : Math.max(0, current + delta);
+      try {
+        targets[t].scrollTo({ top: top, behavior: 'smooth' });
+      } catch (_) {
+        try { targets[t].scrollTop = top; } catch (__) {}
+      }
+    }
+    setTimeout(report, 380);
+  }
   function targetFor(action, list){
     var i = activeIndex(list);
     if (action === 'next') return i + 1;
@@ -2002,6 +2083,10 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       scrollGo(target);
       return;
     }
+    if (isVerticalScrollDeck(list)) {
+      scrollGoVertical(target);
+      return;
+    }
     if (canSetActive(list) && setActive(target)) return;
     if (transformGo(target)) return;
     if (action === 'next') dispatchKey('ArrowRight');
@@ -2015,6 +2100,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (!list.length) return;
     var target = Math.max(0, Math.min(list.length - 1, i));
     if (isScrollDeck()) { scrollGo(target); return; }
+    if (isVerticalScrollDeck(list)) { scrollGoVertical(target); return; }
     if (canSetActive(list) && setActive(target)) return;
     if (transformGo(target)) return;
     var current = activeIndex(list);

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-vertical-scroll.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-vertical-scroll.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { buildSrcdoc } from '../../src/runtime/srcdoc';
+
+function extractDeckBridgeScript(srcdoc: string): string {
+  const match = srcdoc.match(/<script data-od-deck-bridge>([\s\S]*?)<\/script>/);
+  if (!match || !match[1]) {
+    throw new Error('deck bridge script not found in srcdoc');
+  }
+  return match[1];
+}
+
+function lastSlideState(parentPostMessage: ReturnType<typeof vi.fn>) {
+  const messages = parentPostMessage.mock.calls
+    .map((call) => call[0])
+    .filter((m) => m?.type === 'od:slide-state');
+  return messages.at(-1);
+}
+
+const VIEWPORT = 1000;
+const SCENES = 3;
+
+// Builds a vertical / long-form deck: three full-viewport scenes stacked in a
+// single scrollable document (no horizontal overflow, no transform track, no
+// active-class state, no hidden siblings). Navigation happens purely by
+// scrolling the page down. This is the shape from the "Cinematic Landing Page"
+// repro in issue #4218.
+function mountVerticalDeck() {
+  const bodyHtml = `
+    <section class="slide">SCENE 01 / 03</section>
+    <section class="slide">SCENE 02 / 03</section>
+    <section class="slide">SCENE 03 / 03</section>
+  `;
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  const parentPostMessage = vi.fn();
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: parentPostMessage },
+  });
+  Object.defineProperty(win, 'innerHeight', { configurable: true, value: VIEWPORT });
+  Object.defineProperty(win, 'innerWidth', { configurable: true, value: VIEWPORT });
+
+  // Vertical scroll room on the root scroller; no horizontal overflow.
+  for (const el of [win.document.body, win.document.documentElement]) {
+    Object.defineProperty(el, 'scrollHeight', { configurable: true, value: VIEWPORT * SCENES });
+    Object.defineProperty(el, 'clientHeight', { configurable: true, value: VIEWPORT });
+  }
+  Object.defineProperty(win.document, 'scrollingElement', {
+    configurable: true,
+    value: win.document.documentElement,
+  });
+
+  // Only the root scrolling element actually scrolls; body stays pinned at 0,
+  // matching how browsers expose one real scroller (see the horizontal
+  // scroll-container test). This keeps the bridge from double-counting siblings.
+  let scrollTop = 0;
+  const applyScrollTop = (value: number) => {
+    scrollTop = Math.max(0, Math.min(VIEWPORT * (SCENES - 1), value));
+  };
+  Object.defineProperty(win.document.documentElement, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: applyScrollTop,
+  });
+  Object.defineProperty(win.document.documentElement, 'scrollTo', {
+    configurable: true,
+    value: (opts: { top?: number }) => {
+      if (opts && typeof opts.top === 'number') applyScrollTop(opts.top);
+    },
+  });
+  Object.defineProperty(win.document.body, 'scrollTop', {
+    configurable: true,
+    get: () => 0,
+    set: () => {},
+  });
+  Object.defineProperty(win.document.body, 'scrollTo', {
+    configurable: true,
+    value: () => {},
+  });
+
+  // Each scene is one viewport tall, stacked vertically. Its viewport-relative
+  // top shifts up as the page scrolls down.
+  const scenes = Array.from(win.document.querySelectorAll('.slide')) as HTMLElement[];
+  scenes.forEach((scene, index) => {
+    scene.getBoundingClientRect = () => {
+      const top = index * VIEWPORT - scrollTop;
+      return {
+        top,
+        bottom: top + VIEWPORT,
+        left: 0,
+        right: VIEWPORT,
+        width: VIEWPORT,
+        height: VIEWPORT,
+        x: 0,
+        y: top,
+        toJSON() {},
+      } as DOMRect;
+    };
+  });
+
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+  win.dispatchEvent(new win.Event('load'));
+
+  return { win, parentPostMessage, getScrollTop: () => scrollTop };
+}
+
+describe('deck bridge - vertical scroll deck (#4218)', () => {
+  it('tracks the active scene from vertical scroll position', async () => {
+    const { win, parentPostMessage } = mountVerticalDeck();
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 250));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 0, count: 3 });
+
+    win.document.documentElement.scrollTop = VIEWPORT * 2;
+    win.document.dispatchEvent(new win.Event('scroll'));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 200));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
+
+    win.document.documentElement.scrollTop = VIEWPORT;
+    win.document.dispatchEvent(new win.Event('scroll'));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 200));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('navigates a vertical scroll deck by scrolling to the requested scene', async () => {
+    const { win, parentPostMessage, getScrollTop } = mountVerticalDeck();
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 420));
+
+    expect(getScrollTop()).toBe(VIEWPORT);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'last' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 420));
+
+    expect(getScrollTop()).toBe(VIEWPORT * 2);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
+  });
+});


### PR DESCRIPTION
Fixes #4218

## Why

I generate a lot of vertical / long-form artifacts — landing pages and "cinematic" scroll decks where each scene is a full-height section stacked in one continuous scrollable page. The preview toolbar shows pagination for them (e.g. `1 / 3`), but the counter never moves: I can scroll all the way down to `SCENE 03 / 03` and the toolbar still reads `1 / 3`, and the prev / next buttons don't go anywhere. It makes the pagination look broken and makes me wonder whether content is missing or the preview is stuck.

The deck bridge derives the active page only from horizontal scroll position, a translated track, an active-class marker, or computed visibility. A vertical long-form deck matches none of those, so the active index is always 0 — the count is detected correctly, but the position never tracks where you actually are.

## What users will see

In the preview of a vertical / long-form artifact whose scenes are stacked in one scroll surface:

- The toolbar page counter now updates as you scroll — scrolling to the third scene shows `3 / 3` instead of staying pinned at `1 / 3`.
- The prev / next buttons now navigate between scenes (they scroll the target scene into view) instead of doing nothing.
- Horizontal decks, transform-track decks, and class-toggle decks are unchanged — the new path only activates for a genuinely vertical scroll layout.

## Surface area

- [x] **UI** — preview pagination in the artifact viewer (the injected deck bridge in `apps/web/src/runtime/srcdoc.ts`)

No CLI / contract / i18n surface: this is preview interaction behavior inside the existing deck-bridge.

## Screenshots

Same vertical deck, scrolled all the way down to `SCENE 03 / 03` — before vs after:

| Before — counter pinned at 1 / 3 | After — counter tracks 3 / 3 |
| --- | --- |
| <img width="420" alt="before: scrolled to scene 3 but the toolbar still shows 1 / 3" src="https://github.com/user-attachments/assets/b4f834fd-14bf-40ed-8d69-61c9b4d06410"> | <img width="420" alt="after: scrolled to scene 3 and the toolbar shows 3 / 3" src="https://github.com/user-attachments/assets/ec400963-826d-401b-b77d-c41cc8aa50cb"> |

## Bug fix verification

Red spec first, in `apps/web/tests/runtime/srcdoc-deck-bridge-vertical-scroll.test.ts`:

- "tracks the active scene from vertical scroll position" — scrolling a stacked full-height deck must move the reported active index.
- "navigates a vertical scroll deck by scrolling to the requested scene" — prev / next / first / last must scroll the target scene into view.

Both go red on `main` (active index stays 0; navigation never scrolls) and green on this branch. The five existing deck-bridge suites (horizontal scroll-container, transform-driven, framework-deck, nested-slides, design-template-deck-nav) stay green, confirming the new vertical path doesn't regress the other deck types.

Also verified live with a seeded vertical deck artifact: scrolling to the last scene moves the toolbar counter to `3 / 3` (after) versus staying at `1 / 3` (before) — the attached screenshots.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/runtime/` — 303 pass (incl. the new vertical-scroll spec and all deck-bridge suites)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm guard` — pass
