### PR TITLE
fix(web): drop a text caret on bare div/li/td/h4-6 in edit mode

### DIFF
--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -1,4 +1,5 @@
-export const MANUAL_EDIT_DISCOVERY_SELECTOR = 'main, nav, section, article, header, footer, div, h1, h2, h3, p, a, button, img, strong, span';
+export const MANUAL_EDIT_DISCOVERY_SELECTOR =
+  'main, nav, section, article, aside, header, footer, div, h1, h2, h3, h4, h5, h6, p, a, button, img, ul, ol, li, dl, dt, dd, table, thead, tbody, tfoot, tr, td, th, caption, blockquote, figure, figcaption, label, summary, pre, code, strong, em, b, i, small, mark, span';
 export const MANUAL_EDIT_SOURCE_PATH_ATTR = 'data-od-source-path';
 export const MANUAL_EDIT_HOST_NODE_SELECTOR = [
   '[data-od-sandbox-shim]',
@@ -9,6 +10,17 @@ export const MANUAL_EDIT_HOST_NODE_SELECTOR = [
   '[data-od-edit-bridge-style]',
   '[data-od-deck-fix]',
 ].join(',');
+
+// Tags that, when they appear as a child, still leave the parent as a single
+// run of editable text rather than a structural container. Block-level
+// children (another <div>, <p>, <li>, <table>…) flip an element to a container.
+export const MANUAL_EDIT_INLINE_TAGS = new Set<string>([
+  'a', 'span', 'strong', 'em', 'b', 'i', 'u', 's', 'small', 'mark', 'sub', 'sup',
+  'code', 'kbd', 'samp', 'var', 'abbr', 'time', 'cite', 'q', 'br', 'wbr', 'del',
+  'ins', 'bdi', 'bdo', 'data', 'dfn', 'label', 'output', 'ruby', 'rt', 'rp',
+]);
+
+export type ManualEditKind = 'text' | 'link' | 'image' | 'container';
 
 export function manualEditDomPathForElement(el: Element): string {
   const parts: number[] = [];
@@ -41,6 +53,41 @@ export function isMeaningfulManualEditElement(el: Element, rect: Pick<DOMRect, '
 
 export function isSourceMappableManualEditElement(el: Element): boolean {
   return el.hasAttribute('data-od-id') || el.hasAttribute(MANUAL_EDIT_SOURCE_PATH_ATTR);
+}
+
+/**
+ * An element is a "text leaf" when it carries visible text and every element
+ * child is inline formatting (no nested block that would make it a layout
+ * container). This — not the tag name — is what decides whether a click drops
+ * a text caret: a bare `<div>Title</div>` or an `<li>`/`<td>`/`<h4>` is just as
+ * editable as a `<p>`, while a `<div>` wrapping other blocks stays a container
+ * you style rather than type into.
+ */
+export function manualEditElementHasOnlyInlineContent(el: Element): boolean {
+  const text = (el.textContent || '').trim();
+  if (!text) return false;
+  const children = el.children;
+  for (let i = 0; i < children.length; i++) {
+    const tag = children[i].tagName ? children[i].tagName.toLowerCase() : '';
+    if (!MANUAL_EDIT_INLINE_TAGS.has(tag)) return false;
+  }
+  return true;
+}
+
+/**
+ * Classify what a click on an element should do in manual edit mode. `text`
+ * and `link` drop a text caret (and still expose styles); `container` and
+ * `image` only select for styling. An explicit `data-od-edit` attribute always
+ * wins so authored markup can opt a node in or out.
+ */
+export function manualEditKindForElement(el: Element): ManualEditKind {
+  const explicit = el.getAttribute('data-od-edit');
+  if (explicit) return explicit as ManualEditKind;
+  const tag = el.tagName ? el.tagName.toLowerCase() : '';
+  if (tag === 'a') return 'link';
+  if (tag === 'img') return 'image';
+  if (manualEditElementHasOnlyInlineContent(el)) return 'text';
+  return 'container';
 }
 
 export function buildManualEditKeyboardGuard(): string {
@@ -132,6 +179,7 @@ export function buildManualEditBridge(enabled: boolean): string {
   var discoverySelector = ${JSON.stringify(MANUAL_EDIT_DISCOVERY_SELECTOR)};
   var hostNodeSelector = ${JSON.stringify(MANUAL_EDIT_HOST_NODE_SELECTOR)};
   var sourcePathAttr = ${JSON.stringify(MANUAL_EDIT_SOURCE_PATH_ATTR)};
+  var inlineTags = ${JSON.stringify(Array.from(MANUAL_EDIT_INLINE_TAGS).reduce((acc, tag) => { acc[tag] = true; return acc; }, {} as Record<string, true>))};
   var styleProps = ['fontFamily','fontSize','fontWeight','color','textAlign','lineHeight','letterSpacing','width','height','minHeight','gap','flexDirection','justifyContent','alignItems','backgroundColor','opacity','padding','paddingTop','paddingRight','paddingBottom','paddingLeft','margin','marginTop','marginRight','marginBottom','marginLeft','border','borderTopWidth','borderRightWidth','borderBottomWidth','borderLeftWidth','borderStyle','borderColor','borderRadius'];
   function isHostNode(el){
     return !!(el && el.matches && el.matches(hostNodeSelector));
@@ -161,14 +209,24 @@ export function buildManualEditBridge(enabled: boolean): string {
   function isDiscoveryTarget(el){
     return !!(el && el.matches && el.matches(discoverySelector));
   }
+  function hasOnlyInlineContent(el){
+    var text = (el.textContent || '').trim();
+    if (!text) return false;
+    var children = el.children;
+    for (var i = 0; i < children.length; i++) {
+      var tag = children[i].tagName ? children[i].tagName.toLowerCase() : '';
+      if (!inlineTags[tag]) return false;
+    }
+    return true;
+  }
   function inferKind(el){
     var explicit = el.getAttribute('data-od-edit');
     if (explicit) return explicit;
     var tag = el.tagName ? el.tagName.toLowerCase() : '';
     if (tag === 'a') return 'link';
     if (tag === 'img') return 'image';
-    if (['section','main','nav','div','article','header','footer'].indexOf(tag) >= 0) return 'container';
-    return 'text';
+    if (hasOnlyInlineContent(el)) return 'text';
+    return 'container';
   }
   function labelFor(el, id, kind){
     var explicit = el.getAttribute('data-od-label');

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -11,15 +11,6 @@ export const MANUAL_EDIT_HOST_NODE_SELECTOR = [
   '[data-od-deck-fix]',
 ].join(',');
 
-// Tags that, when they appear as a child, still leave the parent as a single
-// run of editable text rather than a structural container. Block-level
-// children (another <div>, <p>, <li>, <table>…) flip an element to a container.
-export const MANUAL_EDIT_INLINE_TAGS = new Set<string>([
-  'a', 'span', 'strong', 'em', 'b', 'i', 'u', 's', 'small', 'mark', 'sub', 'sup',
-  'code', 'kbd', 'samp', 'var', 'abbr', 'time', 'cite', 'q', 'br', 'wbr', 'del',
-  'ins', 'bdi', 'bdo', 'data', 'dfn', 'label', 'output', 'ruby', 'rt', 'rp',
-]);
-
 export type ManualEditKind = 'text' | 'link' | 'image' | 'container';
 
 export function manualEditDomPathForElement(el: Element): string {
@@ -56,23 +47,21 @@ export function isSourceMappableManualEditElement(el: Element): boolean {
 }
 
 /**
- * An element is a "text leaf" when it carries visible text and every element
- * child is inline formatting (no nested block that would make it a layout
- * container). This — not the tag name — is what decides whether a click drops
- * a text caret: a bare `<div>Title</div>` or an `<li>`/`<td>`/`<h4>` is just as
- * editable as a `<p>`, while a `<div>` wrapping other blocks stays a container
- * you style rather than type into.
+ * A "text leaf" carries visible text and has NO element children, so a click
+ * can drop a caret and the committed text round-trips through the source
+ * patcher. This — not the tag name — is what makes a bare `<div>Title</div>`,
+ * an `<li>`, a `<td>`, or an `<h4>` editable, exactly like a `<p>`.
+ *
+ * Elements with element children (even inline ones like `<strong>`/`<a>`) are
+ * deliberately NOT text leaves: `applyManualEditPatch` rejects a `set-text`
+ * patch whenever the target `hasElementChildren`, so offering a caret there
+ * would let the user type and then fail to persist. Those stay containers
+ * (style-only) until the patcher can persist nested markup.
  */
-export function manualEditElementHasOnlyInlineContent(el: Element): boolean {
+export function manualEditElementIsTextLeaf(el: Element): boolean {
   const text = (el.textContent || '').trim();
   if (!text) return false;
-  const children = el.children;
-  for (let i = 0; i < children.length; i++) {
-    const child = children[i];
-    const tag = child && child.tagName ? child.tagName.toLowerCase() : '';
-    if (!MANUAL_EDIT_INLINE_TAGS.has(tag)) return false;
-  }
-  return true;
+  return el.children.length === 0;
 }
 
 /**
@@ -87,7 +76,7 @@ export function manualEditKindForElement(el: Element): ManualEditKind {
   const tag = el.tagName ? el.tagName.toLowerCase() : '';
   if (tag === 'a') return 'link';
   if (tag === 'img') return 'image';
-  if (manualEditElementHasOnlyInlineContent(el)) return 'text';
+  if (manualEditElementIsTextLeaf(el)) return 'text';
   return 'container';
 }
 
@@ -180,7 +169,6 @@ export function buildManualEditBridge(enabled: boolean): string {
   var discoverySelector = ${JSON.stringify(MANUAL_EDIT_DISCOVERY_SELECTOR)};
   var hostNodeSelector = ${JSON.stringify(MANUAL_EDIT_HOST_NODE_SELECTOR)};
   var sourcePathAttr = ${JSON.stringify(MANUAL_EDIT_SOURCE_PATH_ATTR)};
-  var inlineTags = ${JSON.stringify(Array.from(MANUAL_EDIT_INLINE_TAGS).reduce((acc, tag) => { acc[tag] = true; return acc; }, {} as Record<string, true>))};
   var styleProps = ['fontFamily','fontSize','fontWeight','color','textAlign','lineHeight','letterSpacing','width','height','minHeight','gap','flexDirection','justifyContent','alignItems','backgroundColor','opacity','padding','paddingTop','paddingRight','paddingBottom','paddingLeft','margin','marginTop','marginRight','marginBottom','marginLeft','border','borderTopWidth','borderRightWidth','borderBottomWidth','borderLeftWidth','borderStyle','borderColor','borderRadius'];
   function isHostNode(el){
     return !!(el && el.matches && el.matches(hostNodeSelector));
@@ -210,15 +198,10 @@ export function buildManualEditBridge(enabled: boolean): string {
   function isDiscoveryTarget(el){
     return !!(el && el.matches && el.matches(discoverySelector));
   }
-  function hasOnlyInlineContent(el){
+  function isTextLeaf(el){
     var text = (el.textContent || '').trim();
     if (!text) return false;
-    var children = el.children;
-    for (var i = 0; i < children.length; i++) {
-      var tag = children[i].tagName ? children[i].tagName.toLowerCase() : '';
-      if (!inlineTags[tag]) return false;
-    }
-    return true;
+    return el.children.length === 0;
   }
   function inferKind(el){
     var explicit = el.getAttribute('data-od-edit');
@@ -226,7 +209,7 @@ export function buildManualEditBridge(enabled: boolean): string {
     var tag = el.tagName ? el.tagName.toLowerCase() : '';
     if (tag === 'a') return 'link';
     if (tag === 'img') return 'image';
-    if (hasOnlyInlineContent(el)) return 'text';
+    if (isTextLeaf(el)) return 'text';
     return 'container';
   }
   function labelFor(el, id, kind){

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -68,7 +68,8 @@ export function manualEditElementHasOnlyInlineContent(el: Element): boolean {
   if (!text) return false;
   const children = el.children;
   for (let i = 0; i < children.length; i++) {
-    const tag = children[i].tagName ? children[i].tagName.toLowerCase() : '';
+    const child = children[i];
+    const tag = child && child.tagName ? child.tagName.toLowerCase() : '';
     if (!MANUAL_EDIT_INLINE_TAGS.has(tag)) return false;
   }
   return true;

--- a/apps/web/tests/components/manual-edit-kind.test.ts
+++ b/apps/web/tests/components/manual-edit-kind.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { manualEditKindForElement } from '../../src/edit-mode/bridge';
+
+function makeEl(html: string): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = html.trim();
+  return wrapper.firstElementChild as HTMLElement;
+}
+
+describe('manualEditKindForElement', () => {
+  it('treats a bare div holding only text as editable text (not a container)', () => {
+    // Regression: card titles authored as <div>Text</div> used to be forced to
+    // 'container' purely by tag name, so the text cursor never appeared.
+    expect(manualEditKindForElement(makeEl('<div>Sprint board</div>'))).toBe('text');
+  });
+
+  it('treats a div with block-level children as a container', () => {
+    expect(manualEditKindForElement(makeEl('<div><p>one</p><p>two</p></div>'))).toBe('container');
+  });
+
+  it('treats a div wrapping only inline formatting as editable text', () => {
+    expect(manualEditKindForElement(makeEl('<div>Hello <strong>world</strong></div>'))).toBe('text');
+  });
+
+  it('treats list items as editable text', () => {
+    expect(manualEditKindForElement(makeEl('<li>Backlog item</li>'))).toBe('text');
+  });
+
+  it('treats table cells as editable text', () => {
+    expect(manualEditKindForElement(makeEl('<td>3 pts</td>'))).toBe('text');
+  });
+
+  it('treats h4/h5/h6 headings as editable text', () => {
+    expect(manualEditKindForElement(makeEl('<h4>Sub heading</h4>'))).toBe('text');
+    expect(manualEditKindForElement(makeEl('<h6>Fine print</h6>'))).toBe('text');
+  });
+
+  it('keeps paragraphs with inline children editable', () => {
+    expect(manualEditKindForElement(makeEl('<p>See <a href="#">link</a> now</p>'))).toBe('text');
+  });
+
+  it('keeps anchors as links and images as images', () => {
+    expect(manualEditKindForElement(makeEl('<a href="#">Go</a>'))).toBe('link');
+    expect(manualEditKindForElement(makeEl('<img src="x.png" alt="x" />'))).toBe('image');
+  });
+
+  it('treats an empty container as a container, not text', () => {
+    expect(manualEditKindForElement(makeEl('<div></div>'))).toBe('container');
+  });
+
+  it('respects an explicit data-od-edit override', () => {
+    expect(manualEditKindForElement(makeEl('<div data-od-edit="container">Text</div>'))).toBe('container');
+  });
+});

--- a/apps/web/tests/components/manual-edit-kind.test.ts
+++ b/apps/web/tests/components/manual-edit-kind.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import { manualEditKindForElement } from '../../src/edit-mode/bridge';
 
@@ -27,7 +28,9 @@ describe('manualEditKindForElement', () => {
   });
 
   it('treats table cells as editable text', () => {
-    expect(manualEditKindForElement(makeEl('<td>3 pts</td>'))).toBe('text');
+    const table = document.createElement('table');
+    table.innerHTML = '<tbody><tr><td>3 pts</td></tr></tbody>';
+    expect(manualEditKindForElement(table.querySelector('td')!)).toBe('text');
   });
 
   it('treats h4/h5/h6 headings as editable text', () => {

--- a/apps/web/tests/components/manual-edit-kind.test.ts
+++ b/apps/web/tests/components/manual-edit-kind.test.ts
@@ -19,15 +19,19 @@ describe('manualEditKindForElement', () => {
     expect(manualEditKindForElement(makeEl('<div><p>one</p><p>two</p></div>'))).toBe('container');
   });
 
-  it('treats a div wrapping only inline formatting as editable text', () => {
-    expect(manualEditKindForElement(makeEl('<div>Hello <strong>world</strong></div>'))).toBe('text');
+  it('treats an element with inline child markup as a container, not text', () => {
+    // The source patcher rejects a set-text commit when the target has element
+    // children ("This element contains nested markup"), so we must NOT offer a
+    // caret there — it would type then fail to persist. Style-only container.
+    expect(manualEditKindForElement(makeEl('<div>Hello <strong>world</strong></div>'))).toBe('container');
+    expect(manualEditKindForElement(makeEl('<p>See <a href="#">link</a> now</p>'))).toBe('container');
   });
 
-  it('treats list items as editable text', () => {
+  it('treats list items (text-only) as editable text', () => {
     expect(manualEditKindForElement(makeEl('<li>Backlog item</li>'))).toBe('text');
   });
 
-  it('treats table cells as editable text', () => {
+  it('treats table cells (text-only) as editable text', () => {
     const table = document.createElement('table');
     table.innerHTML = '<tbody><tr><td>3 pts</td></tr></tbody>';
     expect(manualEditKindForElement(table.querySelector('td')!)).toBe('text');
@@ -36,10 +40,6 @@ describe('manualEditKindForElement', () => {
   it('treats h4/h5/h6 headings as editable text', () => {
     expect(manualEditKindForElement(makeEl('<h4>Sub heading</h4>'))).toBe('text');
     expect(manualEditKindForElement(makeEl('<h6>Fine print</h6>'))).toBe('text');
-  });
-
-  it('keeps paragraphs with inline children editable', () => {
-    expect(manualEditKindForElement(makeEl('<p>See <a href="#">link</a> now</p>'))).toBe('text');
   });
 
   it('keeps anchors as links and images as images', () => {


### PR DESCRIPTION
## Why

While editing a generated page in manual edit mode (the pencil), I hit the exact thing in the screenshot below: clicking some text drops a caret and lets me type, but clicking other text — card titles, list items, table cells — only pops the SIZE/LAYOUT style card and never lets me edit the words. It reads as "some text is editable, some isn't," which is confusing and makes edit mode feel broken.

Root cause: the edit bridge decided **text vs. container purely from the tag name**. `div/section/nav/article/header/footer` were always treated as containers, and only a fixed whitelist of tags (`p, span, strong, h1–h3, a, button, img`) could be hit at all. So text authored as a bare `<div>Title</div>`, or inside `<li>` / `<td>` / `<th>` / `<h4>–<h6>`, fell through to "container" — restyle only, never editable.

## What users will see

In edit mode, clicking text now drops an edit caret on **any element that is purely text** — a bare `<div>` title, an `<li>`, a `<td>`, an `<h4>`–`<h6>` — exactly like a `<p>`. Elements that wrap other elements stay style-only containers. Both gestures hold: **select a text leaf → edit the text; select a container → change its styles.**

The decision now looks at **content structure** instead of the tag name: a *text leaf* is visible text with **no element children**, which is exactly the set the source patcher can persist (`applyManualEditPatch` rejects a `set-text` commit when the target `hasElementChildren`). Elements that contain markup — even inline `<strong>`/`<a>` — remain containers so we never hand out a caret that can't be saved. The discovery selector was also widened so list / table / heading tags get source-path annotations and become selectable in the first place.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — manual edit mode now opens a text caret on any childless text element (bare div/li/td/h4-6), not just a fixed tag whitelist; container styling is unchanged.

## Screenshots

Reported symptom: in edit mode, clicking a `<div>`-based card title only opens the SIZE/LAYOUT style card — no text caret appears (while `<p>`/`<span>` text edits fine).

> Visual verification was done locally against this branch on a clean build (a single-file Kanban page exercising bare-div titles, `<li>`, `<td>`, `<h4>`–`<h6>`): all become editable, and font-size editing works. Before/after screenshots to follow.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/manual-edit-kind.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — red on `main` (`manualEditKindForElement is not a function`), green here (9 cases covering bare div / li / td / h4-6 as text, and block- and inline-child elements as containers).

## Validation

- `apps/web` — `vitest run tests/components/manual-edit-kind.test.ts` → 9/9 pass.
- `apps/web` — `vitest run manual-edit edit-mode srcdoc` → 14 files / 140 tests pass (no regression in existing edit-mode / source-path / srcdoc suites).
- `apps/web` — `tsc -b --noEmit` (package typecheck) → pass.
- Full `pnpm guard` + `next build` typecheck run in CI.
