### PR TITLE
fix(release): accept releaseVersion/releaseNumber in beta metadata reader

### DIFF
--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -18,6 +18,7 @@ const releaseBetaSelfHostedWorkflowPath = join(workspaceRoot, ".github", "workfl
 const releasePreviewWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-preview.yml");
 const releaseStableWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-stable.yml");
 const releaseStableScriptPath = join(workspaceRoot, "scripts", "release-stable.ts");
+const releaseBetaScriptPath = join(workspaceRoot, "scripts", "release-beta.ts");
 const releasePublishMetadataScriptPath = join(
   workspaceRoot,
   ".github",
@@ -234,6 +235,53 @@ describe("packaged smoke workflow", () => {
     });
 
     expect(output).toContain("OPEN_DESIGN_STABLE_VERSION 0.10.1 must match release branch version 0.10.0");
+  });
+
+  it("[P2] reads beta metadata.json written with releaseVersion/releaseNumber field names", async () => {
+    // The unified publisher refactor (.github/workflow/scripts/release/storage)
+    // and the in-flight tools-release rewrite stamp beta/latest/metadata.json
+    // with generic releaseVersion/releaseNumber fields instead of the legacy
+    // betaVersion/betaNumber. scripts/release-beta.ts (the daily-beta reader)
+    // must accept those aliases or the scheduled build dies at metadata time.
+    const packagedVersion = JSON.parse(
+      await readFile(join(workspaceRoot, "apps", "packaged", "package.json"), "utf8"),
+    ).version as string;
+
+    const objects: Record<string, unknown> = {
+      "stable/latest/metadata.json": { channel: "stable", stableVersion: "0.0.1" },
+      "beta/latest/metadata.json": {
+        baseVersion: packagedVersion,
+        channel: "beta",
+        releaseNumber: 4,
+        releaseVersion: `${packagedVersion}-beta.4`,
+      },
+    };
+    const fixture = await startStableNightlyMetadataServer(objects);
+    const runnerTemp = await mkdtemp(join(tmpdir(), "od-release-beta-reader-"));
+    const outputPath = join(runnerTemp, "outputs.txt");
+
+    try {
+      const result = await execFileAsync(process.execPath, ["--experimental-strip-types", releaseBetaScriptPath], {
+        cwd: workspaceRoot,
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: outputPath,
+          GITHUB_REF_NAME: "main",
+          GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+          NODE_TLS_REJECT_UNAUTHORIZED: "0",
+          OPEN_DESIGN_BETA_METADATA_URL: `${fixture.origin}/beta/latest/metadata.json`,
+          OPEN_DESIGN_STABLE_METADATA_URL: `${fixture.origin}/stable/latest/metadata.json`,
+        },
+        maxBuffer: 1024 * 1024,
+      });
+
+      expect(result.stdout).toContain(`[release-beta] beta version: ${packagedVersion}-beta.5`);
+      const outputs = await readFile(outputPath, "utf8");
+      expect(outputs).toContain(`beta_version=${packagedVersion}-beta.5`);
+    } finally {
+      await fixture.close();
+      await rm(runnerTemp, { force: true, recursive: true });
+    }
   });
 
   it("[P2] supports release dry-run preflight without build or publish side effects", async () => {

--- a/scripts/release-beta.ts
+++ b/scripts/release-beta.ts
@@ -107,8 +107,12 @@ function parseBetaMetadataJson(value: string): ParsedBetaMetadata {
   }
 
   const record = parsed as Record<string, unknown>;
-  const betaVersion = readStringField(record, "betaVersion");
-  const betaNumber = readNumberField(record, "betaNumber");
+  // The unified release publisher and the in-flight tools-release rewrite stamp
+  // beta metadata.json with generic releaseVersion/releaseNumber fields, while
+  // the legacy publisher used betaVersion/betaNumber. Accept either spelling so
+  // the daily beta reader survives whichever publisher last wrote the feed.
+  const betaVersion = readStringField(record, "betaVersion") ?? readStringField(record, "releaseVersion");
+  const betaNumber = readNumberField(record, "betaNumber") ?? readNumberField(record, "releaseNumber");
   const baseVersion = readStringField(record, "baseVersion");
 
   if (betaVersion != null) {
@@ -123,7 +127,7 @@ function parseBetaMetadataJson(value: string): ParsedBetaMetadata {
   }
 
   if (baseVersion == null || betaNumber == null) {
-    fail("beta metadata.json must include betaVersion or baseVersion+betaNumber");
+    fail("beta metadata.json must include betaVersion/releaseVersion or baseVersion+betaNumber/releaseNumber");
   }
 
   const parsedBase = parseStableVersion(baseVersion);


### PR DESCRIPTION
## Why

The daily beta build (`notify-daily-feishu`, cron 09:00 Asia/Shanghai) has produced no Feishu package since 2026-06-12. Two independent failures stacked up:

1. **Version guard** — after stable `0.10.1` shipped, the active release branch's base version was no longer strictly greater than the latest stable. Fixed separately by #4379 (base bump to `0.10.2`).
2. **This PR — beta metadata schema drift.** Once the version guard cleared, the build failed at metadata time with:

   ```
   [release-beta] beta metadata.json must include betaVersion or baseVersion+betaNumber
   ```

   `scripts/release-beta.ts` (the daily-beta reader) only understood the legacy `betaVersion`/`betaNumber` fields. The unified release publisher (`.github/workflow/scripts/release/storage/publish-metadata.ts`) and the in-flight `tools-release` rewrite stamp `beta/latest/metadata.json` with generic `releaseVersion`/`releaseNumber` instead. Once a build from that newer tooling wrote the production feed (it currently reads `releaseVersion: 0.10.2-beta.4`, no `betaVersion`), the daily reader could no longer parse it and every downstream build/publish/**Feishu** step was skipped.

## What users will see

Nothing user-facing in the app. Internally, the daily beta reader once again parses the production R2 feed regardless of which publisher wrote it, so the morning beta build + Feishu card resume.

## What changed

- `scripts/release-beta.ts`: accept `releaseVersion`/`releaseNumber` as aliases for `betaVersion`/`betaNumber` when reading `beta/latest/metadata.json`. Backward- and forward-compatible — survives whichever publisher last wrote the feed.
- Red spec in `e2e/tests/packaged-smoke-workflow.test.ts`: runs the reader against an HTTPS fixture feed stamped with the new field names and asserts it computes the next beta. Went red on `main` (`must include betaVersion…`), green on this branch.

## Validation

- `pnpm --filter @open-design/e2e exec vitest run tests/packaged-smoke-workflow.test.ts` — 22 passed
- `pnpm guard` — 63 passed
- `pnpm --filter @open-design/e2e typecheck` — clean

## Surface area

- [x] Build / release tooling
- [x] Tests