### PR TITLE
feat(landing): add 2 community Open Design overview tutorials

### DIFF
--- a/apps/landing-page/app/content/tutorials/open-design-full-overview-vs-figma-purpleschool-anton-larichev.md
+++ b/apps/landing-page/app/content/tutorials/open-design-full-overview-vs-figma-purpleschool-anton-larichev.md
@@ -1,0 +1,14 @@
+---
+title: 'Open Design — полный обзор открытой альтернативы Claude Design и Figma'
+youtubeId: 1daG101QNwc
+summary: 'Полный обзор Open Design с установкой, настройкой интерфейса, работой с дизайн-системами и практическим созданием макета.'
+date: 2026-06-13
+category: Demo
+durationSeconds: 1431
+author: 'PurpleSchool | Anton Larichev'
+official: false
+---
+- Пошаговая установка и настройка Open Design с поддержкой различных моделей (Claude, Gemini, Qwen)
+- Обзор интерфейса платформы и возможностей работы с дизайн-системами
+- Практический пример: создание, корректировка и экспорт макета
+- Анализ применимости Open Design как альтернативы Claude Design и Figma для различных сценариев

--- a/apps/landing-page/app/content/tutorials/open-design-open-design-vs-claude-design-landing-page-roy-shavit.md
+++ b/apps/landing-page/app/content/tutorials/open-design-open-design-vs-claude-design-landing-page-roy-shavit.md
@@ -1,0 +1,14 @@
+---
+title: 'ככה תעצבו ברמה של Claude Design בלי לשרוף טוקנים'
+youtubeId: 17Wbq5r8tzA
+summary: 'הצג של Open Design, כלי עיצוב UI מקוד פתוח המאפשר יצירת דפי נחיתה ללא עלויות טוקנים בהשוואה ל-Claude Design.'
+date: 2026-06-14
+category: Demo
+durationSeconds: 866
+author: 'Roy Shavit | רועי שביט'
+official: false
+---
+- התקנה וקונפיגורציה של Open Design כולל זיהוי מודלים לוקליים ותמיכה בכל מודל זמין
+- בניית דף נחיתה מלא מאפס עם Design Systems, איטרציות inline edit וייצוא לקוד VS Code
+- יצירת סרטון מונפש באמצעות Hyper Frames וגרירה לפרסום דרך Vercel או Cloudflare Pages
+- השוואה מפורטת בין תוצאות Open Design ל-Claude Design עם הערכה של מקרי שימוש עבור כל כלי


### PR DESCRIPTION
## Why

Two community-made Open Design walkthroughs worth surfacing on `/tutorials/` — both are full overviews / demos that map directly to high-intent searches ("Open Design vs Claude Design", "Open Design overview"). Maintainer-selected (provided directly), so they skip the relevance gate.

## What users will see

Two new cards in the tutorials gallery (now 40 entries):
- **Open Design vs Claude Design — landing-page demo** (Roy Shavit, Hebrew, 14:26)
- **Open Design — full overview vs Claude Design & Figma** (PurpleSchool / Anton Larichev, Russian, 23:51)

Both play inline; copy is generated in each video's original language, consistent with the existing multilingual entries (the catalogue already mixes EN/ZH/other-language titles).

A third candidate (`Uvpb6xRDpDY`) was intentionally dropped — it's a 51-second Short, too thin for the gallery.

## Surface area

- [x] **Extension point** — new entries under `app/content/tutorials/` (content collection)
- [ ] None

## Validation

- `astro check` — 0 errors (both entries validate against the tutorials schema).
- Generated via `scripts/youtube-tutorials/generate-selected.ts` (YouTube Data API metadata + LLM copy).

### Note
Per-video titles/summaries stay in the source language and non-EN locale pages use the shared template — a known site-wide limitation, not specific to these entries. A per-video multilingual title/summary pass is tracked as a separate follow-up.