### PR TITLE
chore(release): bump version to 0.10.2 on main

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -261,9 +261,9 @@ describe("packaged smoke workflow", () => {
   it("[P2] validates stable dry-run nightly metadata from a non-release ref", async () => {
     const objects: Record<string, unknown> = {};
     const fixture = await startStableNightlyMetadataServer(objects);
-    objects["nightly/versions/0.10.1.nightly.12/metadata.json"] = stableNightlyMetadataFixture(
-      "0.10.1",
-      "0.10.1.nightly.12",
+    objects["nightly/versions/0.10.2.nightly.12/metadata.json"] = stableNightlyMetadataFixture(
+      "0.10.2",
+      "0.10.2.nightly.12",
       fixture.origin,
     );
     const runnerTemp = await mkdtemp(join(tmpdir(), "od-release-stable-dry-run-"));
@@ -283,16 +283,16 @@ describe("packaged smoke workflow", () => {
           OPEN_DESIGN_RELEASE_CHANNEL: "stable",
           OPEN_DESIGN_RELEASE_DRY_RUN: "true",
           OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: fixture.origin,
-          OPEN_DESIGN_STABLE_NIGHTLY_VERSION: "0.10.1.nightly.12",
-          OPEN_DESIGN_STABLE_VERSION: "0.10.1",
+          OPEN_DESIGN_STABLE_NIGHTLY_VERSION: "0.10.2.nightly.12",
+          OPEN_DESIGN_STABLE_VERSION: "0.10.2",
           PATH: `${join(runnerTemp, "bin")}:${process.env.PATH ?? ""}`,
         },
       });
 
-      expect(result.stdout).toContain("[release-stable] validated nightly: 0.10.1.nightly.12");
+      expect(result.stdout).toContain("[release-stable] validated nightly: 0.10.2.nightly.12");
       expect(result.stdout).toContain("[release-stable] channel: stable");
       expect(result.stdout).toContain("[release-stable] dry run: true");
-      expect(result.stdout).toContain("[release-stable] version tag: open-design-v0.10.1");
+      expect(result.stdout).toContain("[release-stable] version tag: open-design-v0.10.2");
     } finally {
       await fixture.close();
       await rm(runnerTemp, { force: true, recursive: true });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "description": "Open Design renderer host bridge protocol.",

--- a/packages/launcher-proto/package.json
+++ b/packages/launcher-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/launcher-proto",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

The daily beta build needs to run from `main` (the development tip) instead of a per-patch release branch that freezes at ship time. For that, `main` must carry a version strictly greater than the latest stable. After #4381, `main` reads `0.10.1` — but stable `0.10.1` already shipped, so `0.10.1 == latest stable` and `scripts/release-beta.ts`'s strictly-greater-than-stable guard still fails:

```
[release-beta] packaged base version 0.10.1 must be strictly greater than latest stable 0.10.1
```

This advances the 0.10.x dev line one patch ahead of stable so a beta build from `main` is possible again.

## What users will see

Nothing user-facing in the app. Internally, builds off `main` are stamped `0.10.2-beta.N`, continuing the existing beta line already on R2 (`0.10.2-beta.4` → next `0.10.2-beta.5`).

## What changed

- Bump version `0.10.1 → 0.10.2` across the same 16 lockstep `0.10.x` workspace `package.json` that #4381 bumped (apps/daemon, apps/desktop, apps/landing-page, apps/packaged, apps/web, e2e, root, packages/contracts, packages/download, packages/host, packages/launcher-proto, packages/platform, packages/sidecar-proto, packages/sidecar, tools/dev, tools/pack).
- Align the `[P2] validates stable dry-run nightly metadata` fixture in `e2e/tests/packaged-smoke-workflow.test.ts` to `0.10.2` (it validates `OPEN_DESIGN_STABLE_VERSION` against `apps/packaged/package.json`, same as #4381 did `0.10.0 → 0.10.1`).

## Validation

- `pnpm --filter @open-design/e2e exec vitest run tests/packaged-smoke-workflow.test.ts` — 21 passed
- `pnpm guard` — passed

## Surface area

- [x] Build / release tooling
- [x] Tests