### PR TITLE
fix(release): build the daily beta from main, not the latest release branch

### DIFF
--- a/.github/workflows/notify-daily-feishu.yml
+++ b/.github/workflows/notify-daily-feishu.yml
@@ -1,11 +1,18 @@
 name: notify-daily-feishu
 
-# Every morning (09:00 Asia/Shanghai) build a beta package off the currently
-# active release branch (highest-semver release/vX.Y.Z) by reusing release-beta,
-# then post a Feishu card with download links and the changelog since the
-# previously published beta — to the SAME Feishu bot as the per-push release
-# stream (FEISHU_RELEASE_WEBHOOK). The two streams share one group; their cards
-# stay distinguishable via CHANNEL_LABEL (Beta vs Nightly) and STREAM_LABEL.
+# Every morning (09:00 Asia/Shanghai) build a beta package off main (the
+# development tip) by reusing release-beta, then post a Feishu card with download
+# links and the changelog since the previously published beta — to the SAME
+# Feishu bot as the per-push release stream (FEISHU_RELEASE_WEBHOOK). The two
+# streams share one group; their cards stay distinguishable via CHANNEL_LABEL
+# (Beta vs Nightly) and STREAM_LABEL.
+#
+# Beta is the daily R&D channel, so it tracks main rather than a release branch:
+# a per-patch release/vX.Y.Z branch freezes once it ships stable, at which point
+# its base version equals the latest stable and release-beta's
+# strictly-greater-than-stable guard rejects every build. main always leads
+# stable, so it never hits that trap. Pass `ref` to build a one-off beta from a
+# specific branch (e.g. a release branch) instead.
 #
 # NOTE: schedule triggers only fire from the default branch (main), so this file
 # must live on main to run on its cron.
@@ -17,7 +24,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Override the release branch to build (e.g. release/v0.9.0). Empty auto-selects the highest-semver release branch."
+        description: "Override the ref to build (e.g. release/v0.10.1). Empty builds main."
         required: false
         type: string
         default: ""
@@ -32,16 +39,13 @@ concurrency:
 
 jobs:
   resolve:
-    name: Resolve active release branch
+    name: Resolve build ref
     if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.pick.outputs.ref }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Pick highest-semver release branch
+      - name: Pick build ref (main, or override)
         id: pick
         env:
           OVERRIDE_REF: ${{ inputs.ref }}
@@ -52,20 +56,11 @@ jobs:
             echo "ref=$OVERRIDE_REF" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          latest="$(git ls-remote --heads origin 'refs/heads/release/v*' \
-            | sed 's#.*refs/heads/##' \
-            | grep -E '^release/v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | sort -V \
-            | tail -1)"
-          if [ -z "$latest" ]; then
-            echo "no release/vX.Y.Z branch found" >&2
-            exit 1
-          fi
-          echo "active release branch: $latest"
-          echo "ref=$latest" >> "$GITHUB_OUTPUT"
+          echo "using default ref: main"
+          echo "ref=main" >> "$GITHUB_OUTPUT"
 
   build:
-    name: Build beta from active release branch
+    name: Build beta from main
     needs: resolve
     uses: ./.github/workflows/release-beta.yml
     secrets: inherit

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -285,16 +285,26 @@ describe("packaged smoke workflow", () => {
     }
   });
 
-  it("[P2] daily beta build tracks main instead of the highest release branch", async () => {
+  it("[P2] daily beta resolve defaults to main and preserves the ref override", async () => {
     // Beta is the daily R&D channel and must track the development tip (main).
     // Selecting the highest-semver release/vX.Y.Z branch stalls the build: once
     // that branch ships stable, its base version equals the latest stable and
     // release-beta's strictly-greater-than-stable guard rejects every run until
     // someone hand-bumps the retired branch. main always leads stable, so it
     // never hits that trap.
+    //
+    // Scope every assertion to the resolve job so a refactor elsewhere in the
+    // workflow cannot keep this green while changing the build-ref control flow,
+    // and prove both branches of that control flow: the empty-input default
+    // builds main, and the workflow_dispatch override is still propagated.
     const workflow = await readFile(notifyDailyFeishuWorkflowPath, "utf8");
-    expect(workflow).toContain('echo "ref=main" >> "$GITHUB_OUTPUT"');
-    expect(workflow).not.toContain("refs/heads/release/v*");
+    const resolveJob = sectionBetween(workflow, "  resolve:", "\n  build:");
+    // Override path: workflow_dispatch ref is wired in and forwarded verbatim.
+    expect(resolveJob).toContain("OVERRIDE_REF: ${{ inputs.ref }}");
+    expect(resolveJob).toContain('echo "ref=$OVERRIDE_REF" >> "$GITHUB_OUTPUT"');
+    // Default path: an empty input builds main, never a release branch.
+    expect(resolveJob).toContain('echo "ref=main" >> "$GITHUB_OUTPUT"');
+    expect(resolveJob).not.toContain("refs/heads/release/v*");
   });
 
   it("[P2] supports release dry-run preflight without build or publish side effects", async () => {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -19,6 +19,7 @@ const releasePreviewWorkflowPath = join(workspaceRoot, ".github", "workflows", "
 const releaseStableWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-stable.yml");
 const releaseStableScriptPath = join(workspaceRoot, "scripts", "release-stable.ts");
 const releaseBetaScriptPath = join(workspaceRoot, "scripts", "release-beta.ts");
+const notifyDailyFeishuWorkflowPath = join(workspaceRoot, ".github", "workflows", "notify-daily-feishu.yml");
 const releasePublishMetadataScriptPath = join(
   workspaceRoot,
   ".github",
@@ -282,6 +283,18 @@ describe("packaged smoke workflow", () => {
       await fixture.close();
       await rm(runnerTemp, { force: true, recursive: true });
     }
+  });
+
+  it("[P2] daily beta build tracks main instead of the highest release branch", async () => {
+    // Beta is the daily R&D channel and must track the development tip (main).
+    // Selecting the highest-semver release/vX.Y.Z branch stalls the build: once
+    // that branch ships stable, its base version equals the latest stable and
+    // release-beta's strictly-greater-than-stable guard rejects every run until
+    // someone hand-bumps the retired branch. main always leads stable, so it
+    // never hits that trap.
+    const workflow = await readFile(notifyDailyFeishuWorkflowPath, "utf8");
+    expect(workflow).toContain('echo "ref=main" >> "$GITHUB_OUTPUT"');
+    expect(workflow).not.toContain("refs/heads/release/v*");
   });
 
   it("[P2] supports release dry-run preflight without build or publish side effects", async () => {


### PR DESCRIPTION
## Why

The daily beta build (`notify-daily-feishu`, cron 09:00 Asia/Shanghai) silently stalled for ~5 days after stable `0.10.1` shipped, so the Feishu group got no beta package. Root cause: the workflow's `resolve` job picked the **highest-semver `release/vX.Y.Z` branch** and built beta off it. Once that branch ships stable, its base version equals the latest stable, and `scripts/release-beta.ts`'s strictly-greater-than-stable guard rejects every run:

```
[release-beta] packaged base version 0.10.1 must be strictly greater than latest stable 0.10.1
```

Until someone hand-bumps the (now retiring) release branch, the scheduled build dies at metadata time and every downstream build/publish/Feishu step is skipped. Tying the daily R&D channel to a frozen release branch is the structural flaw.

This was the last piece; the version guard (#4387) and the metadata schema reader (#4383) are already on main, and a manual `ref=main` dispatch built `0.10.2-beta` end-to-end with a Feishu card. This makes the **scheduled** run do the same automatically.

## What users will see

Nothing user-facing in the app. Internally, tomorrow's 09:00 build runs off `main` and produces `0.10.2-beta.N` with a Feishu card, instead of failing on the retired `release/v0.10.1` branch.

## What changed

- `notify-daily-feishu.yml`: `resolve` now defaults the build ref to `main` instead of selecting the highest release branch. The `workflow_dispatch` `ref` input is kept for one-off builds from a specific branch (e.g. a release branch). Dropped the now-unused checkout + `git ls-remote` logic and refreshed the header/comments.
- Red spec in `e2e/tests/packaged-smoke-workflow.test.ts`: asserts the workflow defaults to `ref=main` and no longer enumerates `refs/heads/release/v*`. Went red on `main`, green on this branch.

## Validation

- `pnpm --filter @open-design/e2e exec vitest run tests/packaged-smoke-workflow.test.ts` — 23 passed
- `pnpm guard` — 63 passed
- `pnpm --filter @open-design/e2e typecheck` — clean

## Surface area

- [x] Build / release tooling
- [x] Tests