### PR TITLE
Add Glass Design System UI Kit plugin

### DIFF
--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/README.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/README.md
@@ -1,0 +1,33 @@
+# G2 Design System UI Kit
+
+This community plugin packages a reviewable UI kit for the HiCatcat G2 AR glasses HUD design system.
+
+## What It Enables
+
+- Generate dark G2 HUD-style prototypes inside Open Design.
+- Reuse source-backed role components for call, message, AI card, teleprompter, device, and bottom command surfaces.
+- Switch between regular 640 display scale and compact 320 display scale.
+- Avoid generic mobile, SaaS dashboard, marketing page, and warm brand-kit styling.
+
+## Files
+
+- `SKILL.md` - Agent instructions.
+- `open-design.json` - Plugin manifest.
+- `index.html` - Browser-reviewable UI kit entry.
+- `colors_and_type.css` - G2 token CSS.
+- `components/` - React/Babel component files used by `index.html`.
+- `references/` - Provenance and source notes.
+
+## Review
+
+Open `index.html` in a browser. The page loads local CSS and component files from this plugin directory. It uses React, ReactDOM, and Babel from CDN only for the preview shell.
+
+The root element uses `data-g2-mode="regular"`. Change it to `data-g2-mode="compact"` to review the 320-mode scale.
+
+## Validation
+
+The plugin is valid when:
+
+- Every path named in `SKILL.md` and `open-design.json` exists.
+- `index.html` references `./colors_and_type.css` and files under `./components/`.
+- The visual direction stays aligned with G2 AR glasses HUD tokens.

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/SKILL.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/SKILL.md
@@ -1,0 +1,29 @@
+# G2 design system UI Kit
+
+This UI kit is the applied interface reference for the design system. Open `index.html` to review the composed app surface, then reuse the modular role components under `components/` when building new product-like artifacts.
+
+## Structure
+
+- `index.html` - Browser-reviewable entry that loads `../../colors_and_type.css`, React, ReactDOM, Babel, and the component files.
+- `components/App.jsx` - App shell that composes the role components.
+- `components/Sidebar.jsx` - Navigation rail or sidebar pattern.
+- `components/AssistantsList.jsx` - Object, assistant, or thread list pattern.
+- `components/ChatArea.jsx` - Primary workspace with message/content stream.
+- `components/InputBar.jsx` - Composer or command-entry surface.
+- `components/MessageBubble.jsx` - Message, note, or review-comment unit.
+
+## Usage
+
+Copy component files into a React prototype or open `index.html` directly for visual review. Keep `colors_and_type.css` loaded before the components so color, type, spacing, radius, and state variables resolve through the extracted token contract.
+
+## Design Notes
+
+Prefer source-backed component roles over static duplicate HTML. When repository evidence is available, replace this scaffold with components modeled from captured app shell, navigation, composer, message, and content surfaces.
+
+## Source
+
+Use parent `DESIGN.md`, `README.md`, `preview/`, and `context/` as the evidence trail for any future refinement.
+
+## Provenance
+
+Formalized by Open Design from candidate 33633026-3f08-4a00-86c8-1bbd1d3e1ce4.

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/SKILL.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/SKILL.md
@@ -1,29 +1,37 @@
-# G2 design system UI Kit
+# G2 Design System UI Kit
 
-This UI kit is the applied interface reference for the design system. Open `index.html` to review the composed app surface, then reuse the modular role components under `components/` when building new product-like artifacts.
+Use this skill when generating Open Design artifacts that should follow the HiCatcat G2 AR glasses HUD design system. This plugin packages a browser-reviewable UI kit, local token CSS, and modular React role components.
 
 ## Structure
 
-- `index.html` - Browser-reviewable entry that loads `../../colors_and_type.css`, React, ReactDOM, Babel, and the component files.
-- `components/App.jsx` - App shell that composes the role components.
-- `components/Sidebar.jsx` - Navigation rail or sidebar pattern.
-- `components/AssistantsList.jsx` - Object, assistant, or thread list pattern.
-- `components/ChatArea.jsx` - Primary workspace with message/content stream.
-- `components/InputBar.jsx` - Composer or command-entry surface.
-- `components/MessageBubble.jsx` - Message, note, or review-comment unit.
+- `index.html` - Browser-reviewable entry that loads `./colors_and_type.css`, React, ReactDOM, Babel, and the component files.
+- `colors_and_type.css` - Source-backed G2 token CSS for dark HUD color, type, spacing, radius, icon, stroke, and compact/regular display modes.
+- `components/App.jsx` - App shell that composes the G2 HUD surface.
+- `components/Sidebar.jsx` - Compact system rail for mode, call, messages, AI, and device controls.
+- `components/AssistantsList.jsx` - AI card and quick status pattern.
+- `components/ChatArea.jsx` - Primary message, call, and teleprompter workspace.
+- `components/InputBar.jsx` - Bottom command-entry surface.
+- `components/MessageBubble.jsx` - Message, note, and assistant response unit.
+- `README.md` - Human-readable package guide and validation notes.
 
 ## Usage
 
-Copy component files into a React prototype or open `index.html` directly for visual review. Keep `colors_and_type.css` loaded before the components so color, type, spacing, radius, and state variables resolve through the extracted token contract.
+Open `index.html` directly for visual review. Copy component files into a React prototype when building product-like artifacts. Keep `colors_and_type.css` loaded before the components so color, type, spacing, radius, stroke, and mode variables resolve through the G2 token contract.
 
 ## Design Notes
 
-Prefer source-backed component roles over static duplicate HTML. When repository evidence is available, replace this scaffold with components modeled from captured app shell, navigation, composer, message, and content surfaces.
+Use G2 as a dark AR glasses control interface, not a generic mobile app, SaaS dashboard, or marketing page. Preserve these source-backed cues:
 
-## Source
+- Black optical canvas.
+- White, secondary gray, and tertiary gray text.
+- `#333333` controls, borders, and disabled surfaces.
+- `#0D76FF` selected state.
+- `#0D76FFA6` focus and touch feedback.
+- Noto Sans Medium/Bold typography.
+- `data-g2-mode="regular"` for 640 mode and `data-g2-mode="compact"` for 320 mode.
 
-Use parent `DESIGN.md`, `README.md`, `preview/`, and `context/` as the evidence trail for any future refinement.
+Do not invent off-token accent colors, glassmorphism, or landing-page hero compositions.
 
 ## Provenance
 
-Formalized by Open Design from candidate 33633026-3f08-4a00-86c8-1bbd1d3e1ce4.
+Formalized by Open Design from candidate 33633026-3f08-4a00-86c8-1bbd1d3e1ce4 and corrected so every referenced file is packaged in this plugin folder.

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/colors_and_type.css
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/colors_and_type.css
@@ -1,0 +1,238 @@
+:root {
+  color-scheme: dark;
+  --g2-bg: #000000;
+  --g2-text-primary: #ffffff;
+  --g2-text-secondary: #dddddd;
+  --g2-text-tertiary: #bbbbbb;
+  --g2-control: #333333;
+  --g2-control-gradient: linear-gradient(177deg, #ffffff40 0%, #ffffff0d 49.52%, #ffffff26 100%);
+  --g2-selected: #0d76ff;
+  --g2-focus: #0d76ffa6;
+  --g2-ai-01: linear-gradient(225deg, #78ffff 0%, #9442fe 100%);
+  --g2-ai-07: linear-gradient(135deg, #38f9c5 0%, #0d35ff 35.5%, #ff3fa9 76.64%, #ffce3a 100%);
+  --g2-font-family: "Noto Sans", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --g2-font-weight-body: 500;
+  --g2-font-weight-bold: 700;
+  --g2-font-size-s: 24px;
+  --g2-font-size-m: 32px;
+  --g2-font-size-l: 48px;
+  --g2-line-height-s: 32px;
+  --g2-line-height-m: 48px;
+  --g2-line-height-l: 60px;
+  --g2-space-1: 4px;
+  --g2-space-2: 8px;
+  --g2-space-3: 12px;
+  --g2-space-4: 16px;
+  --g2-space-5: 24px;
+  --g2-space-xl: 32px;
+  --g2-radius-sm: 12px;
+  --g2-radius-md: 16px;
+  --g2-radius-lg: 24px;
+  --g2-stroke: 2px;
+  --g2-icon-lg: 48px;
+  --g2-max-dialog: 520px;
+  --g2-max-message: 520px;
+  --g2-max-toast: 440px;
+  --g2-max-bottom-bar: 640px;
+  --g2-ai-status-size: 100px;
+}
+
+[data-g2-mode="compact"] {
+  --g2-font-size-s: 14px;
+  --g2-font-size-m: 20px;
+  --g2-font-size-l: 24px;
+  --g2-line-height-s: 16px;
+  --g2-line-height-m: 24px;
+  --g2-line-height-l: 32px;
+  --g2-space-1: 2px;
+  --g2-space-2: 4px;
+  --g2-space-3: 6px;
+  --g2-space-4: 8px;
+  --g2-space-5: 12px;
+  --g2-space-xl: 16px;
+  --g2-radius-sm: 6px;
+  --g2-radius-md: 8px;
+  --g2-radius-lg: 12px;
+  --g2-stroke: 1px;
+  --g2-icon-lg: 24px;
+  --g2-max-dialog: 260px;
+  --g2-max-message: 260px;
+  --g2-max-toast: 220px;
+  --g2-max-bottom-bar: 320px;
+  --g2-ai-status-size: 72px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--g2-bg);
+  color: var(--g2-text-primary);
+  font-family: var(--g2-font-family);
+  font-size: var(--g2-font-size-s);
+  font-weight: var(--g2-font-weight-body);
+  line-height: var(--g2-line-height-s);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.g2-app {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(96px, 160px) minmax(0, 1fr);
+  gap: var(--g2-space-5);
+  padding: var(--g2-space-5);
+  background:
+    radial-gradient(circle at 70% 18%, #0d76ff22, transparent 32%),
+    var(--g2-bg);
+}
+
+.g2-panel {
+  border: var(--g2-stroke) solid var(--g2-control);
+  border-radius: var(--g2-radius-md);
+  background: var(--g2-control);
+  color: var(--g2-text-primary);
+}
+
+.g2-sidebar,
+.g2-workspace,
+.g2-card,
+.g2-input-bar {
+  border: var(--g2-stroke) solid var(--g2-control);
+  border-radius: var(--g2-radius-md);
+  background: var(--g2-control);
+}
+
+.g2-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--g2-space-3);
+  padding: var(--g2-space-4);
+}
+
+.g2-nav-button,
+.g2-send-button {
+  border: var(--g2-stroke) solid transparent;
+  border-radius: var(--g2-radius-sm);
+  background: transparent;
+  color: var(--g2-text-secondary);
+  min-height: var(--g2-icon-lg);
+  padding: var(--g2-space-2) var(--g2-space-3);
+}
+
+.g2-nav-button[aria-current="true"],
+.g2-send-button {
+  background: var(--g2-selected);
+  color: var(--g2-text-primary);
+}
+
+.g2-nav-button:focus-visible,
+.g2-send-button:focus-visible,
+.g2-command-input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 var(--g2-stroke) var(--g2-focus);
+}
+
+.g2-workspace {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: var(--g2-space-5);
+  padding: var(--g2-space-5);
+  max-width: var(--g2-max-bottom-bar);
+  width: 100%;
+  margin: 0 auto;
+}
+
+.g2-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--g2-space-4);
+}
+
+.g2-title {
+  margin: 0;
+  font-size: var(--g2-font-size-m);
+  line-height: var(--g2-line-height-m);
+  font-weight: var(--g2-font-weight-bold);
+}
+
+.g2-meta,
+.g2-secondary {
+  color: var(--g2-text-secondary);
+}
+
+.g2-tertiary {
+  color: var(--g2-text-tertiary);
+}
+
+.g2-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.45fr);
+  gap: var(--g2-space-5);
+}
+
+.g2-thread,
+.g2-assistants {
+  display: flex;
+  flex-direction: column;
+  gap: var(--g2-space-3);
+}
+
+.g2-message {
+  max-width: var(--g2-max-message);
+  border-radius: var(--g2-radius-md);
+  padding: var(--g2-space-4);
+  background: #000000;
+  border: var(--g2-stroke) solid var(--g2-control);
+}
+
+.g2-message[data-tone="ai"] {
+  border-color: var(--g2-focus);
+}
+
+.g2-card {
+  padding: var(--g2-space-4);
+}
+
+.g2-ai-orb {
+  width: var(--g2-ai-status-size);
+  height: var(--g2-ai-status-size);
+  border-radius: 50%;
+  background: var(--g2-ai-07);
+  margin-bottom: var(--g2-space-3);
+}
+
+.g2-input-bar {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--g2-space-3);
+  padding: var(--g2-space-3);
+}
+
+.g2-command-input {
+  min-width: 0;
+  border: var(--g2-stroke) solid var(--g2-control);
+  border-radius: var(--g2-radius-sm);
+  background: #000000;
+  color: var(--g2-text-primary);
+  padding: var(--g2-space-2) var(--g2-space-3);
+}
+
+@media (max-width: 720px) {
+  .g2-app,
+  .g2-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .g2-sidebar {
+    flex-direction: row;
+    overflow-x: auto;
+  }
+}

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/App.jsx
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/App.jsx
@@ -1,0 +1,28 @@
+function App() {
+  const Sidebar = window.Sidebar;
+  const ChatArea = window.ChatArea;
+  const AssistantsList = window.AssistantsList;
+  const InputBar = window.InputBar;
+
+  return (
+    <div className="g2-app" data-g2-mode="regular">
+      <Sidebar />
+      <section className="g2-workspace">
+        <header className="g2-header">
+          <div>
+            <p className="g2-meta">G2 glasses HUD · regular 640 mode</p>
+            <h1 className="g2-title">Live control surface</h1>
+          </div>
+          <span className="g2-tertiary">Focus #0D76FFA6</span>
+        </header>
+        <div className="g2-layout">
+          <ChatArea />
+          <AssistantsList />
+        </div>
+        <InputBar />
+      </section>
+    </div>
+  );
+}
+
+window.App = App;

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/AssistantsList.jsx
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/AssistantsList.jsx
@@ -1,0 +1,17 @@
+function AssistantsList() {
+  return (
+    <aside className="g2-assistants" aria-label="AI status cards">
+      <section className="g2-card">
+        <div className="g2-ai-orb" aria-hidden="true" />
+        <strong>AI status</strong>
+        <p className="g2-secondary">Listening for contextual commands.</p>
+      </section>
+      <section className="g2-card">
+        <strong>Device</strong>
+        <p className="g2-tertiary">Battery 82% · Network stable</p>
+      </section>
+    </aside>
+  );
+}
+
+window.AssistantsList = AssistantsList;

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/ChatArea.jsx
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/ChatArea.jsx
@@ -1,0 +1,19 @@
+function ChatArea() {
+  const MessageBubble = window.MessageBubble;
+
+  return (
+    <main className="g2-thread" aria-label="G2 message workspace">
+      <MessageBubble sender="Call" meta="Connected">
+        Front display is active. Keep the action bar visible and controls close to the current task.
+      </MessageBubble>
+      <MessageBubble sender="Assistant" meta="AI reply" tone="ai">
+        Suggested next prompt is ready. Use the compact command surface when switching to 320 mode.
+      </MessageBubble>
+      <MessageBubble sender="Teleprompter" meta="Preview">
+        Keep type large, direct, and source-backed. Avoid dashboard density and marketing layout.
+      </MessageBubble>
+    </main>
+  );
+}
+
+window.ChatArea = ChatArea;

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/InputBar.jsx
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/InputBar.jsx
@@ -1,6 +1,6 @@
 function InputBar() {
   return (
-    <form className="g2-input-bar">
+    <form className="g2-input-bar" onSubmit={(event) => event.preventDefault()}>
       <input className="g2-command-input" aria-label="G2 command" placeholder="Speak or type a G2 command" />
       <button className="g2-send-button" type="button">Send</button>
     </form>

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/InputBar.jsx
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/InputBar.jsx
@@ -1,0 +1,10 @@
+function InputBar() {
+  return (
+    <form className="g2-input-bar">
+      <input className="g2-command-input" aria-label="G2 command" placeholder="Speak or type a G2 command" />
+      <button className="g2-send-button" type="button">Send</button>
+    </form>
+  );
+}
+
+window.InputBar = InputBar;

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/MessageBubble.jsx
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/MessageBubble.jsx
@@ -1,0 +1,10 @@
+function MessageBubble({ sender, meta, children, tone = "default" }) {
+  return (
+    <article className="g2-message" data-tone={tone}>
+      <div className="g2-meta">{sender} · {meta}</div>
+      <div>{children}</div>
+    </article>
+  );
+}
+
+window.MessageBubble = MessageBubble;

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/Sidebar.jsx
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/components/Sidebar.jsx
@@ -1,0 +1,15 @@
+function Sidebar() {
+  const items = ["Call", "Messages", "AI", "Device"];
+
+  return (
+    <nav className="g2-sidebar" aria-label="G2 HUD navigation">
+      {items.map((item, index) => (
+        <button className="g2-nav-button" aria-current={index === 0 ? "true" : undefined} key={item}>
+          {item}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+window.Sidebar = Sidebar;

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/index.html
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>G2 Design System UI Kit</title>
+    <link rel="stylesheet" href="./colors_and_type.css">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel" src="./components/MessageBubble.jsx"></script>
+    <script type="text/babel" src="./components/Sidebar.jsx"></script>
+    <script type="text/babel" src="./components/AssistantsList.jsx"></script>
+    <script type="text/babel" src="./components/ChatArea.jsx"></script>
+    <script type="text/babel" src="./components/InputBar.jsx"></script>
+    <script type="text/babel" src="./components/App.jsx"></script>
+    <script type="text/babel">
+      ReactDOM.createRoot(document.getElementById("root")).render(<window.App />);
+    </script>
+  </body>
+</html>

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/open-design.json
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "g2-design-system-ui-kit-mqgbmh2w",
+  "title": "G2 design system UI Kit",
+  "version": "0.1.0",
+  "description": "This UI kit is the applied interface reference for the design system. Open `index.html` to review the composed app surface, then reuse the modular role components under `components/` when building new product-like artifa",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/open-design.json
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/open-design.json
@@ -2,9 +2,9 @@
   "$schema": "https://open-design.ai/schemas/plugin.v1.json",
   "specVersion": "1.0.0",
   "name": "g2-design-system-ui-kit-mqgbmh2w",
-  "title": "G2 design system UI Kit",
+  "title": "G2 Design System UI Kit",
   "version": "0.1.0",
-  "description": "This UI kit is the applied interface reference for the design system. Open `index.html` to review the composed app surface, then reuse the modular role components under `components/` when building new product-like artifa",
+  "description": "A packaged Open Design UI kit for HiCatcat G2 AR glasses HUD prototypes. Includes index.html, local token CSS, and modular React components for regular 640 and compact 320 display modes.",
   "od": {
     "kind": "skill",
     "taskKind": "new-generation",

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/provenance.json
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/provenance.json
@@ -4,15 +4,15 @@
   "runId": "bc1b4d1f-a76f-4fa1-b83a-60bf8905dc6f",
   "conversationId": "40d20cfe-9a0b-41e1-9810-4ec34c7b3bd3",
   "provenance": {
-    "summary": "Detected from ui_kits/app/README.md, SKILL.md, README.md after a successful run.",
+    "summary": "Formalized from the G2 design system import, then corrected so all paths named by the skill and manifest are packaged inside this plugin folder.",
     "detectedAt": 1781594313727
   },
   "sourceRefs": [
     {
       "kind": "file",
-      "value": "ui_kits/app/README.md",
-      "label": "ui_kits/app/README.md",
-      "size": 1458,
+      "value": "index.html",
+      "label": "index.html",
+      "size": 0,
       "copied": true
     },
     {
@@ -24,9 +24,9 @@
     },
     {
       "kind": "file",
-      "value": "README.md",
-      "label": "README.md",
-      "size": 8619,
+      "value": "colors_and_type.css",
+      "label": "colors_and_type.css",
+      "size": 0,
       "copied": true
     }
   ]

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/provenance.json
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/provenance.json
@@ -1,0 +1,33 @@
+{
+  "candidateId": "33633026-3f08-4a00-86c8-1bbd1d3e1ce4",
+  "projectId": "ds-design-system",
+  "runId": "bc1b4d1f-a76f-4fa1-b83a-60bf8905dc6f",
+  "conversationId": "40d20cfe-9a0b-41e1-9810-4ec34c7b3bd3",
+  "provenance": {
+    "summary": "Detected from ui_kits/app/README.md, SKILL.md, README.md after a successful run.",
+    "detectedAt": 1781594313727
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "ui_kits/app/README.md",
+      "label": "ui_kits/app/README.md",
+      "size": 1458,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 1762,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 8619,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-1-README.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-1-README.md
@@ -1,25 +1,19 @@
-# G2 design system UI Kit
+# G2 Design System UI Kit Reference
 
-This UI kit is the applied interface reference for the design system. Open `index.html` to review the composed app surface, then reuse the modular role components under `components/` when building new product-like artifacts.
+This plugin packages a browser-reviewable G2 AR glasses HUD UI kit.
 
-## Structure
+## Packaged Files
 
-- `index.html` - Browser-reviewable entry that loads `../../colors_and_type.css`, React, ReactDOM, Babel, and the component files.
-- `components/App.jsx` - App shell that composes the role components.
-- `components/Sidebar.jsx` - Navigation rail or sidebar pattern.
-- `components/AssistantsList.jsx` - Object, assistant, or thread list pattern.
-- `components/ChatArea.jsx` - Primary workspace with message/content stream.
-- `components/InputBar.jsx` - Composer or command-entry surface.
-- `components/MessageBubble.jsx` - Message, note, or review-comment unit.
+- `index.html` - Preview entry for the composed HUD surface.
+- `colors_and_type.css` - Local G2 token CSS.
+- `components/App.jsx` - App shell.
+- `components/Sidebar.jsx` - HUD navigation rail.
+- `components/AssistantsList.jsx` - AI and device status cards.
+- `components/ChatArea.jsx` - Message, call, and teleprompter workspace.
+- `components/InputBar.jsx` - Bottom command surface.
+- `components/MessageBubble.jsx` - Message unit.
+- `README.md` - Package guide and validation notes.
 
-## Usage
+## Use
 
-Copy component files into a React prototype or open `index.html` directly for visual review. Keep `colors_and_type.css` loaded before the components so color, type, spacing, radius, and state variables resolve through the extracted token contract.
-
-## Design Notes
-
-Prefer source-backed component roles over static duplicate HTML. When repository evidence is available, replace this scaffold with components modeled from captured app shell, navigation, composer, message, and content surfaces.
-
-## Source
-
-Use parent `DESIGN.md`, `README.md`, `preview/`, and `context/` as the evidence trail for any future refinement.
+Open `index.html` to review the kit, or copy the component files into a React prototype. Keep `colors_and_type.css` loaded first so the G2 token variables resolve.

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-1-README.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-1-README.md
@@ -1,0 +1,25 @@
+# G2 design system UI Kit
+
+This UI kit is the applied interface reference for the design system. Open `index.html` to review the composed app surface, then reuse the modular role components under `components/` when building new product-like artifacts.
+
+## Structure
+
+- `index.html` - Browser-reviewable entry that loads `../../colors_and_type.css`, React, ReactDOM, Babel, and the component files.
+- `components/App.jsx` - App shell that composes the role components.
+- `components/Sidebar.jsx` - Navigation rail or sidebar pattern.
+- `components/AssistantsList.jsx` - Object, assistant, or thread list pattern.
+- `components/ChatArea.jsx` - Primary workspace with message/content stream.
+- `components/InputBar.jsx` - Composer or command-entry surface.
+- `components/MessageBubble.jsx` - Message, note, or review-comment unit.
+
+## Usage
+
+Copy component files into a React prototype or open `index.html` directly for visual review. Keep `colors_and_type.css` loaded before the components so color, type, spacing, radius, and state variables resolve through the extracted token contract.
+
+## Design Notes
+
+Prefer source-backed component roles over static duplicate HTML. When repository evidence is available, replace this scaffold with components modeled from captured app shell, navigation, composer, message, and content surfaces.
+
+## Source
+
+Use parent `DESIGN.md`, `README.md`, `preview/`, and `context/` as the evidence trail for any future refinement.

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-2-SKILL.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-2-SKILL.md
@@ -1,0 +1,36 @@
+---
+name: g2-design-system
+description: Use this skill when generating Open Design artifacts that should follow G2 design system.
+user-invocable: true
+---
+
+Read README.md, DESIGN.md, colors_and_type.css, preview/, preserved assets, context evidence, and ui_kits/app/ before generating any new interface.
+
+**What's inside:**
+- DESIGN.md as the canonical source-backed rules document.
+- colors_and_type.css as the reusable token stylesheet.
+- preview/ focused review cards for color, typography, spacing, components, and brand assets.
+- ui_kits/app/ as a browser-reviewable applied interface kit with modular role components.
+- context/ provenance and evidence notes for future refreshes.
+
+**Source context:**
+Imported design system extracted from `/Applications/Open Design.app/Contents/Resources/app/prebundled/.tmp/github-design-system-imports/HiCatcat-Design-System-20260616T065457869Z`.
+
+**When to use this skill:**
+- Creating product-like prototypes that should follow G2 design system.
+- Revising focused design-system preview cards or app UI kit components.
+- Building interfaces that need this package's captured density, hierarchy, tokens, and anti-patterns.
+
+**How to use:**
+1. Read DESIGN.md for product context, foundations, components, motion, voice, and anti-patterns.
+2. Load colors_and_type.css instead of hardcoding palette, typography, radius, or spacing values.
+3. Inspect preview/ cards for focused modules before inventing new styling.
+4. Reuse ui_kits/app/index.html and ui_kits/app/components/ as the applied component composition.
+5. Preserve the product context, hierarchy, density, and anti-patterns documented in DESIGN.md.
+
+**Design system highlights:**
+
+- Background: #fbfaf7
+- Foreground: #1f1d1b
+- Accent: #d66f4d
+- Border: #ddd8d0

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-2-SKILL.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-2-SKILL.md
@@ -1,36 +1,11 @@
 ---
-name: g2-design-system
-description: Use this skill when generating Open Design artifacts that should follow G2 design system.
+name: g2-design-system-ui-kit
+description: Use this skill when generating Open Design artifacts that should follow the HiCatcat G2 AR glasses HUD design system.
 user-invocable: true
 ---
 
-Read README.md, DESIGN.md, colors_and_type.css, preview/, preserved assets, context evidence, and ui_kits/app/ before generating any new interface.
+Read `SKILL.md`, `README.md`, `colors_and_type.css`, `index.html`, and the files under `components/` before generating a new G2 HUD interface.
 
-**What's inside:**
-- DESIGN.md as the canonical source-backed rules document.
-- colors_and_type.css as the reusable token stylesheet.
-- preview/ focused review cards for color, typography, spacing, components, and brand assets.
-- ui_kits/app/ as a browser-reviewable applied interface kit with modular role components.
-- context/ provenance and evidence notes for future refreshes.
+Use the source-backed G2 cues: black canvas, white and gray text hierarchy, `#333333` controls, `#0D76FF` selected state, `#0D76FFA6` focus/touch feedback, Noto Sans Medium/Bold, and compact/regular display modes.
 
-**Source context:**
-Imported design system extracted from `/Applications/Open Design.app/Contents/Resources/app/prebundled/.tmp/github-design-system-imports/HiCatcat-Design-System-20260616T065457869Z`.
-
-**When to use this skill:**
-- Creating product-like prototypes that should follow G2 design system.
-- Revising focused design-system preview cards or app UI kit components.
-- Building interfaces that need this package's captured density, hierarchy, tokens, and anti-patterns.
-
-**How to use:**
-1. Read DESIGN.md for product context, foundations, components, motion, voice, and anti-patterns.
-2. Load colors_and_type.css instead of hardcoding palette, typography, radius, or spacing values.
-3. Inspect preview/ cards for focused modules before inventing new styling.
-4. Reuse ui_kits/app/index.html and ui_kits/app/components/ as the applied component composition.
-5. Preserve the product context, hierarchy, density, and anti-patterns documented in DESIGN.md.
-
-**Design system highlights:**
-
-- Background: #fbfaf7
-- Foreground: #1f1d1b
-- Accent: #d66f4d
-- Border: #ddd8d0
+Do not use warm brand accents, generic SaaS dashboard patterns, marketing-page hero sections, or references to files not packaged in this plugin.

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-3-README.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-3-README.md
@@ -1,0 +1,133 @@
+# G2 design system
+
+A reusable Open Design package for the G2 AR/glasses HUD design system by HiCatcat.
+
+This README works as a Claude Design package guide — listing source/context references, package contents, preview cards, preserved assets, fonts, build artifacts, ui_kits/app, and a concrete reuse or review workflow for agents and reviewers.
+
+## Product Overview
+
+HiCatcat G2 is a glasses-mounted AR control interface design system. It defines the visual vocabulary for a dark-canvas HUD: control panels, calls, messages, AI cards, dialogs, toasts, teleprompter, and bottom action bar — purpose-built for compact 320px and regular 640px display modes. Not a generic mobile skin, brand site, or marketing page.
+
+**Product context:**
+- Primary profile: `glasses` (dark HUD, compact display modes)
+- Core style: black canvas (`#08090d`), high-contrast foreground
+- Font source: Noto Sans (Figma tokens in `tokens/sources/g2/Styles.json`)
+- Display modes: compact 320 (`Mode 320.tokens.json`), regular 640 (`Mode 640.tokens.json`)
+- Source repo: `https://github.com/HiCatcat/Design-System`
+- Local source: `/Users/meta-bounds/Documents/Codex/2026-06-02/md/Design-System`
+
+## Source and Context References
+
+| Reference | Path | Content |
+|---|---|---|
+| Import source | — | `HiCatcat-Design-System-20260616T065457869Z` (prebundled) |
+| Import evidence | `source/evidence.md` | 0 CSS variables detected; tokens use OD fallback |
+| Token source | `source/tokens.source.json` | Low confidence on color/type/spacing; 0 extracted tokens |
+| Contract report | `source/token-contract.report.json` | Full token coverage quality report |
+| Scanned files | `source/scanned-files.json` | Inventory of captured source files |
+| Snippets index | `source/snippets/INDEX.json` | Index of captured source code snippets |
+| Provenance | `context/provenance.md` + `context/provenance.json` | Structured capture metadata |
+
+## Package Contents
+
+| Path | Role |
+|---|---|
+| `DESIGN.md` | Canonical design rules: color, typography, spacing, motion, voice, anti-pattern, components, agent guidance |
+| `README.md` | This file — package guide with manifest, workflow, and reuse instructions |
+| `tokens.css` | OD-normalized token contract (`:root` CSS custom properties) |
+| `colors_and_type.css` | Companion palette with G2-branded warm accent (`#d66f4d`) |
+| `SKILL.md` | Agent skill definition — load when generating G2-system artifacts |
+| `USAGE.md` | Auto-generated read-order and do/avoid guide |
+| `components.html` | Compact fixture: button, input, card, nav proportions |
+| `components.manifest.json` | Structured component inventory: 5 groups, 12 selectors, 5 classes |
+| `manifest.json` | Package manifest for OD tooling |
+| `package.json` | Package metadata |
+| `design-tokens.json` | Derived Design Tokens JSON (OD format) |
+| `tailwind-v4.css` | Derived Tailwind v4 theme CSS |
+| `preview/` | 14 focused review cards (see Preview Manifest below) |
+| `ui_kits/app/` | React-based applied interface: Sidebar, ChatArea, AssistantsList, InputBar, MessageBubble, App shell |
+| `assets/` | Preserved brand asset: `logo.svg` |
+| `source/` | Import evidence: token source, contract report, scanned files, snippets index |
+| `context/` | Provenance and source-capture metadata |
+| `src/` | Source reference files (`design-system-reference.tsx`) |
+| `index.html` | Applied artifact: DevPulse developer SaaS analytics dashboard (dark theme) |
+
+## Preview Manifest
+
+Each `preview/*.html` card demonstrates a focused module of the design system. Open individually in a browser for visual review.
+
+| Path | Review purpose | Demonstrated tokens/assets |
+|---|---|---|
+| `preview/colors.html` | Full palette swatches | `tokens.css` — all color tokens |
+| `preview/colors-theme-light.html` | Light theme color application | `tokens.css` light palette |
+| `preview/colors-theme-dark.html` | Dark theme color application | `tokens.css` dark variant |
+| `preview/colors-primary.html` | Primary/accent color variants | `--accent` token family |
+| `preview/typography.html` | Type scale overview | `tokens.css` type tokens + font stacks |
+| `preview/typography-specimens.html` | Detailed type specimens | Font stack + scale tokens |
+| `preview/spacing.html` | Spacing scale overview | `tokens.css` space tokens |
+| `preview/spacing-tokens.html` | Spacing token application | Space token contract |
+| `preview/spacing-shadows.html` | Elevation and shadow tokens | `--elev-*` tokens |
+| `preview/spacing-radius.html` | Border radius tokens | `--radius-*` tokens |
+| `preview/components-buttons.html` | Button variants and states | `components.html` button patterns |
+| `preview/components-inputs.html` | Input field variants and states | `components.html` input patterns |
+| `preview/brand-assets.html` | Logo variants (light + dark backgrounds) | `assets/logo.svg` preserved brand asset |
+| `preview/app.html` | App shell with token-bound layout | `tokens.css` + layout primitives |
+
+## Preserved Assets, Fonts, and Build Artifacts
+
+### Preserved Assets
+| Asset | Path | Type | Size |
+|---|---|---|---|
+| Logo (warm) | `assets/logo.svg` | SVG | 518 B |
+
+The logo features a warm circle mark with "GD" monogram on `#fbfaf7` background, accent color `#d66f4d`.
+
+### Fonts
+No font files (`.ttf`, `.woff`, `.woff2`) were captured from the source import. The G2 source references Noto Sans through Figma tokens but does not bundle font files. `tokens.css` uses system font stacks with Inter as the primary sans-serif.
+
+### Build Artifacts
+No runtime or build artifacts were captured from the source import. The `context/` directory contains only provenance metadata (`provenance.md`, `provenance.json`). No `build/` directory exists — the G2 source repository provided Figma token JSON files (`Styles.json`, `Mode 320.tokens.json`, `Mode 640.tokens.json`) rather than compiled application assets.
+
+## ui_kits/app
+
+An applied React interface demonstrating G2 component composition. Loads `../../colors_and_type.css` for token binding and mounts modular JSX components via Babel standalone.
+
+**Entry point:** `ui_kits/app/index.html`
+
+**Components (`ui_kits/app/components/`):**
+
+| Component | File | Role |
+|---|---|---|
+| App | `App.jsx` | Shell composition with `title` and `summary` props |
+| Sidebar | `Sidebar.jsx` | Navigation sidebar |
+| AssistantsList | `AssistantsList.jsx` | AI assistant catalog |
+| ChatArea | `ChatArea.jsx` | Message thread display |
+| InputBar | `InputBar.jsx` | Compose input with send action |
+| MessageBubble | `MessageBubble.jsx` | Individual message card with role/sender |
+
+Each component is a self-contained Babel JSX module. Components export to `window` for cross-file access (e.g., `window.App`). All components together form a complete messaging/assistant interface — matching the G2 HUD's chat, message, and AI card patterns.
+
+## Review Workflow
+
+### For agents generating new G2-system artifacts:
+1. Read `DESIGN.md` — canonical rules for color, typography, spacing, motion, voice, and anti-pattern.
+2. Copy the `:root { ... }` block from `tokens.css` into the first `<style>` of your artifact.
+3. Check `components.manifest.json` for available component groups (buttons, inputs, cards, typography, layout primitives).
+4. Reference `components.html` for concrete proportions and state styling of those components.
+5. Open relevant `preview/*.html` cards for visual reference on color, type, spacing, and component appearance.
+6. For G2 AR/HUD contexts, apply the dark-theme override documented in `DESIGN.md` under Color → Dark-theme override.
+7. For React-based artifacts, reuse components from `ui_kits/app/components/` or use them as structural templates.
+
+### For human reviewers inspecting this package:
+1. Open `preview/colors.html` through `preview/app.html` in a browser to review the visual system end-to-end.
+2. Read `DESIGN.md` for the design rationale, product voice, and anti-pattern rules.
+3. Open `ui_kits/app/index.html` in a browser to see the composed React interface live.
+4. Review `components.html` for the compact component fixture.
+5. Examine `index.html` (DevPulse developer SaaS analytics dashboard) for a production-applied artifact using this system's dark theme.
+
+### For refreshing or updating this package:
+1. Update `DESIGN.md` sections as the source design evolves.
+2. Sync `tokens.css` with any new token definitions from the source.
+3. Regenerate `preview/` cards if token values change.
+4. Update `components.manifest.json` if component patterns change.
+5. Run the package audit: `od tools connectors design-system-package-audit --path . --fail-on-warnings`

--- a/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-3-README.md
+++ b/plugins/community/g2-design-system-ui-kit-mqgbmh2w/references/source-3-README.md
@@ -1,133 +1,19 @@
-# G2 design system
+# G2 AR Glasses HUD Source Notes
 
-A reusable Open Design package for the G2 AR/glasses HUD design system by HiCatcat.
+HiCatcat G2 is an AR glasses control interface design system. The plugin focuses on dark HUD surfaces: calls, messages, AI cards, dialogs, toasts, teleprompter, device information, and bottom command bars.
 
-This README works as a Claude Design package guide — listing source/context references, package contents, preview cards, preserved assets, fonts, build artifacts, ui_kits/app, and a concrete reuse or review workflow for agents and reviewers.
+## Token Direction
 
-## Product Overview
+- Background: `#000000`.
+- Primary text: `#FFFFFF`.
+- Secondary text: `#DDDDDD`.
+- Tertiary text: `#BBBBBB`.
+- Control, border, disabled: `#333333`.
+- Selected: `#0D76FF`.
+- Focus and touch feedback: `#0D76FFA6`.
+- Typography: Noto Sans Medium/Bold.
+- Modes: regular 640 and compact 320.
 
-HiCatcat G2 is a glasses-mounted AR control interface design system. It defines the visual vocabulary for a dark-canvas HUD: control panels, calls, messages, AI cards, dialogs, toasts, teleprompter, and bottom action bar — purpose-built for compact 320px and regular 640px display modes. Not a generic mobile skin, brand site, or marketing page.
+## Review Notes
 
-**Product context:**
-- Primary profile: `glasses` (dark HUD, compact display modes)
-- Core style: black canvas (`#08090d`), high-contrast foreground
-- Font source: Noto Sans (Figma tokens in `tokens/sources/g2/Styles.json`)
-- Display modes: compact 320 (`Mode 320.tokens.json`), regular 640 (`Mode 640.tokens.json`)
-- Source repo: `https://github.com/HiCatcat/Design-System`
-- Local source: `/Users/meta-bounds/Documents/Codex/2026-06-02/md/Design-System`
-
-## Source and Context References
-
-| Reference | Path | Content |
-|---|---|---|
-| Import source | — | `HiCatcat-Design-System-20260616T065457869Z` (prebundled) |
-| Import evidence | `source/evidence.md` | 0 CSS variables detected; tokens use OD fallback |
-| Token source | `source/tokens.source.json` | Low confidence on color/type/spacing; 0 extracted tokens |
-| Contract report | `source/token-contract.report.json` | Full token coverage quality report |
-| Scanned files | `source/scanned-files.json` | Inventory of captured source files |
-| Snippets index | `source/snippets/INDEX.json` | Index of captured source code snippets |
-| Provenance | `context/provenance.md` + `context/provenance.json` | Structured capture metadata |
-
-## Package Contents
-
-| Path | Role |
-|---|---|
-| `DESIGN.md` | Canonical design rules: color, typography, spacing, motion, voice, anti-pattern, components, agent guidance |
-| `README.md` | This file — package guide with manifest, workflow, and reuse instructions |
-| `tokens.css` | OD-normalized token contract (`:root` CSS custom properties) |
-| `colors_and_type.css` | Companion palette with G2-branded warm accent (`#d66f4d`) |
-| `SKILL.md` | Agent skill definition — load when generating G2-system artifacts |
-| `USAGE.md` | Auto-generated read-order and do/avoid guide |
-| `components.html` | Compact fixture: button, input, card, nav proportions |
-| `components.manifest.json` | Structured component inventory: 5 groups, 12 selectors, 5 classes |
-| `manifest.json` | Package manifest for OD tooling |
-| `package.json` | Package metadata |
-| `design-tokens.json` | Derived Design Tokens JSON (OD format) |
-| `tailwind-v4.css` | Derived Tailwind v4 theme CSS |
-| `preview/` | 14 focused review cards (see Preview Manifest below) |
-| `ui_kits/app/` | React-based applied interface: Sidebar, ChatArea, AssistantsList, InputBar, MessageBubble, App shell |
-| `assets/` | Preserved brand asset: `logo.svg` |
-| `source/` | Import evidence: token source, contract report, scanned files, snippets index |
-| `context/` | Provenance and source-capture metadata |
-| `src/` | Source reference files (`design-system-reference.tsx`) |
-| `index.html` | Applied artifact: DevPulse developer SaaS analytics dashboard (dark theme) |
-
-## Preview Manifest
-
-Each `preview/*.html` card demonstrates a focused module of the design system. Open individually in a browser for visual review.
-
-| Path | Review purpose | Demonstrated tokens/assets |
-|---|---|---|
-| `preview/colors.html` | Full palette swatches | `tokens.css` — all color tokens |
-| `preview/colors-theme-light.html` | Light theme color application | `tokens.css` light palette |
-| `preview/colors-theme-dark.html` | Dark theme color application | `tokens.css` dark variant |
-| `preview/colors-primary.html` | Primary/accent color variants | `--accent` token family |
-| `preview/typography.html` | Type scale overview | `tokens.css` type tokens + font stacks |
-| `preview/typography-specimens.html` | Detailed type specimens | Font stack + scale tokens |
-| `preview/spacing.html` | Spacing scale overview | `tokens.css` space tokens |
-| `preview/spacing-tokens.html` | Spacing token application | Space token contract |
-| `preview/spacing-shadows.html` | Elevation and shadow tokens | `--elev-*` tokens |
-| `preview/spacing-radius.html` | Border radius tokens | `--radius-*` tokens |
-| `preview/components-buttons.html` | Button variants and states | `components.html` button patterns |
-| `preview/components-inputs.html` | Input field variants and states | `components.html` input patterns |
-| `preview/brand-assets.html` | Logo variants (light + dark backgrounds) | `assets/logo.svg` preserved brand asset |
-| `preview/app.html` | App shell with token-bound layout | `tokens.css` + layout primitives |
-
-## Preserved Assets, Fonts, and Build Artifacts
-
-### Preserved Assets
-| Asset | Path | Type | Size |
-|---|---|---|---|
-| Logo (warm) | `assets/logo.svg` | SVG | 518 B |
-
-The logo features a warm circle mark with "GD" monogram on `#fbfaf7` background, accent color `#d66f4d`.
-
-### Fonts
-No font files (`.ttf`, `.woff`, `.woff2`) were captured from the source import. The G2 source references Noto Sans through Figma tokens but does not bundle font files. `tokens.css` uses system font stacks with Inter as the primary sans-serif.
-
-### Build Artifacts
-No runtime or build artifacts were captured from the source import. The `context/` directory contains only provenance metadata (`provenance.md`, `provenance.json`). No `build/` directory exists — the G2 source repository provided Figma token JSON files (`Styles.json`, `Mode 320.tokens.json`, `Mode 640.tokens.json`) rather than compiled application assets.
-
-## ui_kits/app
-
-An applied React interface demonstrating G2 component composition. Loads `../../colors_and_type.css` for token binding and mounts modular JSX components via Babel standalone.
-
-**Entry point:** `ui_kits/app/index.html`
-
-**Components (`ui_kits/app/components/`):**
-
-| Component | File | Role |
-|---|---|---|
-| App | `App.jsx` | Shell composition with `title` and `summary` props |
-| Sidebar | `Sidebar.jsx` | Navigation sidebar |
-| AssistantsList | `AssistantsList.jsx` | AI assistant catalog |
-| ChatArea | `ChatArea.jsx` | Message thread display |
-| InputBar | `InputBar.jsx` | Compose input with send action |
-| MessageBubble | `MessageBubble.jsx` | Individual message card with role/sender |
-
-Each component is a self-contained Babel JSX module. Components export to `window` for cross-file access (e.g., `window.App`). All components together form a complete messaging/assistant interface — matching the G2 HUD's chat, message, and AI card patterns.
-
-## Review Workflow
-
-### For agents generating new G2-system artifacts:
-1. Read `DESIGN.md` — canonical rules for color, typography, spacing, motion, voice, and anti-pattern.
-2. Copy the `:root { ... }` block from `tokens.css` into the first `<style>` of your artifact.
-3. Check `components.manifest.json` for available component groups (buttons, inputs, cards, typography, layout primitives).
-4. Reference `components.html` for concrete proportions and state styling of those components.
-5. Open relevant `preview/*.html` cards for visual reference on color, type, spacing, and component appearance.
-6. For G2 AR/HUD contexts, apply the dark-theme override documented in `DESIGN.md` under Color → Dark-theme override.
-7. For React-based artifacts, reuse components from `ui_kits/app/components/` or use them as structural templates.
-
-### For human reviewers inspecting this package:
-1. Open `preview/colors.html` through `preview/app.html` in a browser to review the visual system end-to-end.
-2. Read `DESIGN.md` for the design rationale, product voice, and anti-pattern rules.
-3. Open `ui_kits/app/index.html` in a browser to see the composed React interface live.
-4. Review `components.html` for the compact component fixture.
-5. Examine `index.html` (DevPulse developer SaaS analytics dashboard) for a production-applied artifact using this system's dark theme.
-
-### For refreshing or updating this package:
-1. Update `DESIGN.md` sections as the source design evolves.
-2. Sync `tokens.css` with any new token definitions from the source.
-3. Regenerate `preview/` cards if token values change.
-4. Update `components.manifest.json` if component patterns change.
-5. Run the package audit: `od tools connectors design-system-package-audit --path . --fail-on-warnings`
+This plugin intentionally packages the files referenced by `SKILL.md`: `index.html`, `colors_and_type.css`, and `components/`.


### PR DESCRIPTION
## Why

I am adding this because G2 AR/glasses HUD prototypes need an installable Open Design community plugin that keeps agents aligned with the source-backed G2 design direction: dark optical canvas, compact/regular display modes, HUD controls, AI cards, messages, teleprompter surfaces, and bottom command bars.

The original plugin scaffold referenced a browser entry, component files, and token CSS that were not packaged in the PR. Follow-up commits now package those files and address the preview behavior review: the command input form prevents default submit behavior, so pressing Enter in the static preview does not navigate or reload the page.

## What users will see

Users and agents get a new community skill/plugin: `G2 Design System UI Kit`.

It enables Open Design generation workflows for G2-style AR glasses HUD artifacts. The plugin now includes:

- `SKILL.md` for agent instructions.
- `index.html` for browser review of the composed G2 HUD surface.
- `colors_and_type.css` for local G2 token CSS.
- `components/` with modular React/Babel role components.
- `README.md` and `references/` notes that match the actual packaged files.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No app UI entry point changes. The plugin includes `plugins/community/g2-design-system-ui-kit-mqgbmh2w/index.html` as the browser-reviewable preview surface.

## Bug fix verification

The latest follow-up commit addresses review feedback in `components/InputBar.jsx` by adding `onSubmit={(event) => event.preventDefault()}` to the command form. This keeps the browser-reviewable static preview stable when Enter is pressed inside the command input.

## Validation

- Checked that the packaged files exist: `index.html`, `colors_and_type.css`, `components/App.jsx`, `components/Sidebar.jsx`, `components/AssistantsList.jsx`, `components/ChatArea.jsx`, `components/InputBar.jsx`, `components/MessageBubble.jsx`, `README.md`, `SKILL.md`, and `open-design.json`.
- Parsed and validated `open-design.json` with the locally installed Open Design packaged runtime: `/Applications/Open Design.app/Contents/Resources/app/node_modules/@open-design/plugin-runtime`.
- Verified package references from `index.html` resolve to local packaged files.
- Verified `components/InputBar.jsx` prevents default form submission in the preview.
- Confirmed the latest follow-up commit is pushed to the PR branch: `821d149 Prevent G2 input preview submit`.