### PR TITLE
[codex] Add MCP idle exit guard

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -649,24 +649,41 @@ export async function runMcpStdio({ daemonUrl, stdin, stdout, idleExit: idleExit
   // process open until the client disconnects (stdin EOF) so the cli.ts
   // top-level `process.exit(0)` doesn't kill us mid-handshake.
   let clientClosedDone: (() => void) | null = null;
+  let requestTransportClose: (() => void) | null = null;
   const clientClosed = new Promise<void>((resolve) => {
+    let closed = false;
+    let transportCloseRequested = false;
+    const existingOnClose = transport.onclose;
     clientClosedDone = () => {
+      if (closed) return;
+      closed = true;
       idleExit.stop();
       resolve();
     };
-    transport.onclose = clientClosedDone;
+    transport.onclose = () => {
+      try {
+        existingOnClose?.();
+      } finally {
+        clientClosedDone?.();
+      }
+    };
+    requestTransportClose = () => {
+      if (transportCloseRequested) return;
+      transportCloseRequested = true;
+      void transport.close().catch(() => clientClosedDone?.());
+    };
     const input = stdin ?? process.stdin;
-    input.once('end', clientClosedDone);
-    input.once('close', clientClosedDone);
+    input.once('end', requestTransportClose);
+    input.once('close', requestTransportClose);
   });
   try {
     await Promise.race([clientClosed, idleExit.waitForIdleExit()]);
   } finally {
     idleExit.stop();
-    if (clientClosedDone) {
+    if (requestTransportClose) {
       const input = stdin ?? process.stdin;
-      input.off('end', clientClosedDone);
-      input.off('close', clientClosedDone);
+      input.off('end', requestTransportClose);
+      input.off('close', requestTransportClose);
     }
     await server.close().catch(() => undefined);
   }

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -14,20 +14,34 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   CallToolRequestSchema,
+  type JSONRPCMessage,
   ListResourcesRequestSchema,
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { buildProjectRawFileUrl } from '@open-design/contracts';
 import { randomUUID } from 'node:crypto';
+import type { Readable, Writable } from 'node:stream';
 
 import { postCreateArtifactRequest } from './artifact-create.js';
 
 const SERVER_NAME = 'open-design';
 const SERVER_VERSION = '0.2.0';
+const MCP_IDLE_EXIT_TIMEOUT_MS = 30 * 60 * 1000;
+const MCP_IDLE_EXIT_POLL_MS = 60 * 1000;
 
 type JsonObject = Record<string, unknown>;
 interface RunMcpOptions { daemonUrl: string | URL }
+interface RunMcpStdioOptions extends RunMcpOptions {
+  stdin?: Readable;
+  stdout?: Writable;
+  idleExit?: McpIdleExitControllerOptions;
+}
+interface McpIdleExitControllerOptions {
+  idleTimeoutMs?: number;
+  pollIntervalMs?: number;
+  now?: () => number;
+}
 interface CatalogItem { id: string; name?: string; title?: string; description?: string; summary?: string }
 interface SkillsPayload { skills?: CatalogItem[] }
 interface PluginsPayload { plugins?: CatalogItem[] }
@@ -432,8 +446,17 @@ const TOOL_DEFS = [
   },
 ];
 
-export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
+export async function runMcpStdio({ daemonUrl, stdin, stdout, idleExit: idleExitOptions }: RunMcpStdioOptions): Promise<void> {
   const baseUrl = String(daemonUrl).replace(/\/$/, '');
+  const idleExit = createMcpIdleExitController(idleExitOptions);
+  const withMcpActivity = async <T>(run: () => Promise<T> | T): Promise<T> => {
+    const endActivity = idleExit.beginActivity();
+    try {
+      return await run();
+    } finally {
+      endActivity();
+    }
+  };
 
   const server = new Server(
     { name: SERVER_NAME, version: SERVER_VERSION },
@@ -533,11 +556,11 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
     },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  server.setRequestHandler(ListToolsRequestSchema, async () => withMcpActivity(() => ({
     tools: TOOL_DEFS,
-  }));
+  })));
 
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  server.setRequestHandler(ListResourcesRequestSchema, async () => withMcpActivity(async () => {
     const [skillsData, dsData] = await Promise.all([
       getJson<SkillsPayload>(`${baseUrl}/api/skills`).catch((): SkillsPayload => ({ skills: [] })),
       getJson<DesignSystemsPayload>(`${baseUrl}/api/design-systems`).catch((): DesignSystemsPayload => ({ designSystems: [] })),
@@ -567,9 +590,9 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
       });
     }
     return { resources };
-  });
+  }));
 
-  server.setRequestHandler(ReadResourceRequestSchema, async (req) => {
+  server.setRequestHandler(ReadResourceRequestSchema, async (req) => withMcpActivity(async () => {
     const uri = req.params?.uri;
     if (uri === 'od://focus/active') {
       const data = await getJson<ActiveContext>(`${baseUrl}/api/active`);
@@ -609,27 +632,122 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
         },
       ],
     };
-  });
+  }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  server.setRequestHandler(CallToolRequestSchema, async (req) => withMcpActivity(async () => {
     const name = req.params?.name;
     const args: McpArgs = (req.params?.arguments ?? {}) as McpArgs;
     return handleMcpToolCall(baseUrl, name, args);
-  });
+  }));
 
-  const transport = new StdioServerTransport();
+  const transport = new StdioServerTransport(stdin, stdout);
+  trackMcpTransportActivity(transport, idleExit);
   await server.connect(transport);
 
   // server.connect() only *starts* the transport; it resolves once the
   // stdio reader is wired up, not when the stream closes. Hold the
   // process open until the client disconnects (stdin EOF) so the cli.ts
   // top-level `process.exit(0)` doesn't kill us mid-handshake.
-  await new Promise<void>((resolve) => {
-    const done = () => resolve();
-    transport.onclose = done;
-    process.stdin.once('end', done);
-    process.stdin.once('close', done);
+  let clientClosedDone: (() => void) | null = null;
+  const clientClosed = new Promise<void>((resolve) => {
+    clientClosedDone = () => {
+      idleExit.stop();
+      resolve();
+    };
+    transport.onclose = clientClosedDone;
+    const input = stdin ?? process.stdin;
+    input.once('end', clientClosedDone);
+    input.once('close', clientClosedDone);
   });
+  try {
+    await Promise.race([clientClosed, idleExit.waitForIdleExit()]);
+  } finally {
+    idleExit.stop();
+    if (clientClosedDone) {
+      const input = stdin ?? process.stdin;
+      input.off('end', clientClosedDone);
+      input.off('close', clientClosedDone);
+    }
+    await server.close().catch(() => undefined);
+  }
+}
+
+function trackMcpTransportActivity(
+  transport: StdioServerTransport,
+  idleExit: ReturnType<typeof createMcpIdleExitController>,
+) {
+  const existingOnMessage = transport.onmessage;
+  transport.onmessage = (message: JSONRPCMessage) => {
+    idleExit.markActivity();
+    existingOnMessage?.(message);
+  };
+}
+
+function createMcpIdleExitController(options: McpIdleExitControllerOptions = {}) {
+  const idleTimeoutMs = options.idleTimeoutMs ?? MCP_IDLE_EXIT_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? MCP_IDLE_EXIT_POLL_MS;
+  const now = options.now ?? Date.now;
+  let lastActivity = now();
+  let activeRequests = 0;
+  let resolved = false;
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let resolveIdle: (() => void) | null = null;
+  let waitPromise: Promise<void> | null = null;
+
+  const clearIdleInterval = () => {
+    if (!interval) return;
+    clearInterval(interval);
+    interval = null;
+  };
+
+  const stop = () => {
+    if (resolved) return;
+    resolved = true;
+    clearIdleInterval();
+    resolveIdle?.();
+  };
+
+  const markActivity = () => {
+    lastActivity = now();
+  };
+
+  const beginActivity = () => {
+    activeRequests += 1;
+    markActivity();
+    let ended = false;
+    return () => {
+      if (ended) return;
+      ended = true;
+      activeRequests = Math.max(0, activeRequests - 1);
+      markActivity();
+    };
+  };
+
+  const waitForIdleExit = () => {
+    if (resolved) {
+      return Promise.resolve();
+    }
+    if (waitPromise) {
+      return waitPromise;
+    }
+    waitPromise = new Promise<void>((resolve) => {
+      resolveIdle = resolve;
+      clearIdleInterval();
+      interval = setInterval(() => {
+        if (activeRequests > 0) return;
+        if (now() - lastActivity >= idleTimeoutMs) stop();
+      }, pollIntervalMs);
+      interval.unref?.();
+    });
+    return waitPromise;
+  };
+
+  return {
+    markActivity,
+    beginActivity,
+    waitForIdleExit,
+    stop,
+  };
 }
 
 function ok(payload: unknown) {
@@ -1755,4 +1873,4 @@ function errorMessage(err: unknown): string {
 }
 
 // Exported for unit tests only.
-export { extractRelativeRefs, resolveProjectId, resolveProjectArg, withActiveEcho, fetchProjectFile, getArtifact, getFile, createArtifact, handleMcpToolCall };
+export { extractRelativeRefs, resolveProjectId, resolveProjectArg, withActiveEcho, fetchProjectFile, getArtifact, getFile, createArtifact, handleMcpToolCall, createMcpIdleExitController };

--- a/apps/daemon/tests/mcp-idle-exit.test.ts
+++ b/apps/daemon/tests/mcp-idle-exit.test.ts
@@ -1,4 +1,6 @@
 import { PassThrough } from 'node:stream';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createMcpIdleExitController, runMcpStdio } from '../src/mcp.js';
@@ -133,6 +135,81 @@ describe('MCP stdio idle exit controller', () => {
       await run;
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it('does not write a tool response after stdin EOF aborts an in-flight request', async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const chunks: Buffer[] = [];
+    stdout.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+
+    let resolveProjectsRequested: (() => void) | undefined;
+    let releaseProjectsResponse: (() => void) | undefined;
+    const projectsRequested = new Promise<void>((resolve) => {
+      resolveProjectsRequested = resolve;
+    });
+    const httpServer = createServer(async (req, res) => {
+      if (req.url !== '/api/projects') {
+        res.writeHead(404).end();
+        return;
+      }
+
+      resolveProjectsRequested?.();
+      await new Promise<void>((release) => {
+        releaseProjectsResponse = release;
+      });
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ projects: [] }));
+    });
+
+    await new Promise<void>((resolveListen) => httpServer.listen(0, '127.0.0.1', resolveListen));
+    try {
+      const { port } = httpServer.address() as AddressInfo;
+      const run = runMcpStdio({
+        daemonUrl: `http://127.0.0.1:${port}`,
+        stdin,
+        stdout,
+        idleExit: {
+          idleTimeoutMs: 60_000,
+          pollIntervalMs: 60_000,
+        },
+      });
+
+      stdin.write(`${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'list_projects', arguments: {} },
+      })}\n`);
+
+      await projectsRequested;
+      stdin.end();
+      await run;
+      const staleResponseWritten = new Promise<boolean>((resolve) => {
+        let timeout: ReturnType<typeof setTimeout>;
+        const onData = (chunk: Buffer) => {
+          if (!Buffer.from(chunk).toString('utf8').includes('"id":1')) return;
+          clearTimeout(timeout);
+          stdout.off('data', onData);
+          resolve(true);
+        };
+        timeout = setTimeout(() => {
+          stdout.off('data', onData);
+          resolve(false);
+        }, 50);
+        stdout.on('data', onData);
+      });
+      releaseProjectsResponse?.();
+      expect(await staleResponseWritten).toBe(false);
+
+      const output = Buffer.concat(chunks).toString('utf8');
+      expect(output).not.toContain('"id":1');
+    } finally {
+      releaseProjectsResponse?.();
+      stdin.destroy();
+      stdout.destroy();
+      await new Promise<void>((resolveClose) => httpServer.close(() => resolveClose()));
     }
   });
 });

--- a/apps/daemon/tests/mcp-idle-exit.test.ts
+++ b/apps/daemon/tests/mcp-idle-exit.test.ts
@@ -1,0 +1,138 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createMcpIdleExitController, runMcpStdio } from '../src/mcp.js';
+
+describe('MCP stdio idle exit controller', () => {
+  it('resolves after the idle timeout when no MCP activity arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const controller = createMcpIdleExitController({
+        idleTimeoutMs: 30_000,
+        pollIntervalMs: 1_000,
+        now: () => now,
+      });
+
+      let resolved = false;
+      void controller.waitForIdleExit().then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(resolved).toBe(false);
+
+      now = 30_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resets the idle clock when MCP activity arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const controller = createMcpIdleExitController({
+        idleTimeoutMs: 30_000,
+        pollIntervalMs: 1_000,
+        now: () => now,
+      });
+
+      let resolved = false;
+      void controller.waitForIdleExit().then(() => {
+        resolved = true;
+      });
+
+      now = 29_000;
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(resolved).toBe(false);
+
+      controller.markActivity();
+
+      now = 58_000;
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(resolved).toBe(false);
+
+      now = 59_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not resolve while an MCP request is in flight', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const controller = createMcpIdleExitController({
+        idleTimeoutMs: 30_000,
+        pollIntervalMs: 1_000,
+        now: () => now,
+      });
+      const endActivity = controller.beginActivity();
+
+      let resolved = false;
+      void controller.waitForIdleExit().then(() => {
+        resolved = true;
+      });
+
+      now = 60_000;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(resolved).toBe(false);
+
+      endActivity();
+
+      now = 89_000;
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(resolved).toBe(false);
+
+      now = 90_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the stdio server alive when the client sends protocol pings', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(0));
+      const stdin = new PassThrough();
+      const stdout = new PassThrough();
+      let exited = false;
+      const run = runMcpStdio({
+        daemonUrl: 'http://127.0.0.1:1',
+        stdin,
+        stdout,
+        idleExit: {
+          idleTimeoutMs: 30_000,
+          pollIntervalMs: 1_000,
+        },
+      }).then(() => {
+        exited = true;
+      });
+
+      await Promise.resolve();
+      stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' })}\n`);
+
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(exited).toBe(false);
+
+      stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'ping' })}\n`);
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(exited).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(exited).toBe(true);
+      stdin.destroy();
+      stdout.destroy();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #4400

## Why

I hit this while investigating Codex Desktop repeatedly spawning Open Design's stdio MCP helper and leaving older helpers alive for hours. The primary lifecycle bug is still on the MCP client side when it never sends EOF to the previous child, but Open Design can defensively avoid waiting forever in abandoned `od mcp` processes.

This PR addresses that user-facing pain by giving the stdio MCP server an idle-exit guard: if a client has stopped sending requests and also does not close stdin, the helper exits cleanly after the idle window instead of accumulating indefinitely.

## What users will see

There is no UI change. Users who register Open Design as an MCP server in clients such as Codex will see abandoned, idle Open Design MCP helper processes clean themselves up after 30 minutes of no MCP activity. Active requests keep the helper alive until they finish, then the idle clock starts again.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/mcp-idle-exit.test.ts`
- Did the test go red on `main` and green on this branch? Yes. Before the source change, the new spec failed with `TypeError: createMcpIdleExitController is not a function`; after the fix, the same file passes with 3 tests.

The spec covers:

- idle helpers resolve after the timeout with no MCP activity
- new MCP activity resets the idle clock
- in-flight MCP requests prevent idle exit until the request completes

## Validation

- `pnpm install` — completed in the fresh worktree so local Vitest/typecheck tooling was available
- `pnpm exec vitest run -c vitest.config.ts tests/mcp-idle-exit.test.ts` from `apps/daemon` — passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm --filter @open-design/daemon build` — passed
- `pnpm guard` from the repo root — passed

Local note: this machine is running Node `v26.3.0`, while the repo asks for `~24`, so the commands print engine warnings even though the checks above completed successfully.
