### PR TITLE
fix(diagnostics): desktop export delegates to daemon so run/AMR logs are captured

### DIFF
--- a/apps/daemon/src/diagnostics-export.ts
+++ b/apps/daemon/src/diagnostics-export.ts
@@ -152,9 +152,10 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
       const home = homedir();
       const agentHomes = await resolveAgentHomes(options.dataDir);
       const browserUse = collectBrowserUseDiscoveryFacts();
+      const runEventSources = await buildRunEventLogSources(options.runsDir);
       const sources = [
         ...buildSidecarLogSources(options.runtime),
-        ...(await buildRunEventLogSources(options.runsDir)),
+        ...runEventSources,
         ...(await buildAgentCliLogSources({
           homeDir: home,
           dataDir: options.dataDir ?? null,
@@ -165,6 +166,20 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
         })),
       ];
       const username = safeUsername();
+
+      // Surface "expected-but-empty" so a reader can tell a collection gap
+      // apart from "no runs happened". buildRunEventLogSources returns [] both
+      // when the dir is missing AND when persistence is off, adding no manifest
+      // entries — without this note an empty bundle looks like a clean run.
+      const warnings: string[] = [];
+      if (options.runtime == null) warnings.push(STANDALONE_LAUNCH_WARNING);
+      if (options.runsDir && runEventSources.length === 0) {
+        warnings.push(
+          `No per-run event logs found under ${options.runsDir}. Either no chat ` +
+            `runs have executed in this data dir, or run-event persistence is ` +
+            `disabled (server.ts createChatRunService runsLogDir).`,
+        );
+      }
 
       const result = await buildDiagnosticsZip({
         context: {
@@ -184,7 +199,7 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
             projectRoot: options.projectRoot,
             browserUse,
           },
-          warnings: options.runtime == null ? [STANDALONE_LAUNCH_WARNING] : undefined,
+          warnings: warnings.length > 0 ? warnings : undefined,
         },
         sources,
         redaction: { username },

--- a/apps/daemon/tests/diagnostics-export.test.ts
+++ b/apps/daemon/tests/diagnostics-export.test.ts
@@ -228,4 +228,25 @@ describe('diagnostics export handler — run event logs', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('warns when runsDir is set but no per-run event logs were found', async () => {
+    // An empty/absent runs dir adds no manifest file entries, so without an
+    // explicit warning an empty bundle is indistinguishable from a healthy run
+    // — exactly the gap that made an AMR loop look like "nothing happened."
+    const runsDir = join(tmpdir(), `od-diag-empty-runs-${randomUUID()}`);
+    const handler = createDiagnosticsExportHandler({
+      runtime: null,
+      projectRoot: '/tmp/test-project',
+      runsDir,
+    });
+    const res = mockResponse();
+    await handler({} as never, res as never, () => undefined);
+
+    expect(res.capturedStatus).toBe(200);
+    const zip = await JSZip.loadAsync(res.capturedPayload!);
+    const manifest = JSON.parse(await zip.file('summary/manifest.json')!.async('string')) as {
+      warnings: string[];
+    };
+    expect(manifest.warnings.some((w) => w.includes('No per-run event logs found'))).toBe(true);
+  });
 });

--- a/apps/desktop/src/main/diagnostics-fetch.ts
+++ b/apps/desktop/src/main/diagnostics-fetch.ts
@@ -1,0 +1,35 @@
+import { DIAGNOSTICS_EXPORT_PATH } from "@open-design/diagnostics";
+
+export interface FetchDiagnosticsBundleDeps {
+  /** Injectable fetch for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Fetch the complete diagnostics bundle from the daemon's own export endpoint
+ * and return its bytes.
+ *
+ * The daemon is the single source of truth for the bundle: it resolves its real
+ * `RUNTIME_DATA_DIR` (`.od` in tools-dev, `<namespaceRoot>/data` when packaged,
+ * or any `OD_DATA_DIR` override) and from there collects per-run
+ * `runs/<id>/events.jsonl`, the agent CLI logs (claude/codex/opencode/amr),
+ * the sidecar daemon/web/desktop logs, and host crash reports. The desktop main
+ * process used to rebuild this bundle itself, but it had to *guess* the data dir
+ * from the sidecar namespace layout — a guess that is wrong in dev (the daemon
+ * writes to `<projectRoot>/.od`, not `<namespaceRoot>/data`) and under any
+ * `OD_DATA_DIR` override, silently dropping the run-event and AMR logs that are
+ * the whole point of a support bundle. Delegating to the daemon endpoint removes
+ * that drift entirely.
+ */
+export async function fetchDiagnosticsBundle(
+  baseUrl: string,
+  deps: FetchDiagnosticsBundleDeps = {},
+): Promise<Buffer> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const url = new URL(DIAGNOSTICS_EXPORT_PATH, baseUrl).toString();
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`GET ${DIAGNOSTICS_EXPORT_PATH} failed with HTTP ${response.status}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}

--- a/apps/desktop/src/main/diagnostics.ts
+++ b/apps/desktop/src/main/diagnostics.ts
@@ -1,126 +1,32 @@
-import { readFile, writeFile } from "node:fs/promises";
-import { homedir, userInfo } from "node:os";
-import { dirname, join } from "node:path";
+import { writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { BrowserWindow, app, dialog, ipcMain, shell } from "electron";
 
-import {
-  APP_KEYS,
-  OPEN_DESIGN_SIDECAR_CONTRACT,
-  SIDECAR_MODES,
-  type SidecarStamp,
-} from "@open-design/sidecar-proto";
-import {
-  resolveLogFilePath,
-  resolveRuntimeNamespaceRoot,
-  type SidecarRuntimeContext,
-} from "@open-design/sidecar";
-import {
-  DIAGNOSTICS_FILENAME_PREFIX,
-  buildAgentCliLogSources,
-  buildDiagnosticsZip,
-  buildRunEventLogSources,
-  diagnosticsFileName,
-  type LogSource,
-} from "@open-design/diagnostics";
+import { DIAGNOSTICS_FILENAME_PREFIX, diagnosticsFileName } from "@open-design/diagnostics";
+
+import { fetchDiagnosticsBundle } from "./diagnostics-fetch.js";
 
 export const DESKTOP_DIAGNOSTICS_IPC_CHANNEL = "diagnostics:export-to-file";
-
-const TAIL_BYTES_PER_LOG = 4 * 1024 * 1024;
 
 export type DesktopDiagnosticsExportResult =
   | { ok: true; path: string }
   | { ok: false; cancelled: true }
   | { ok: false; cancelled: false; message: string };
 
-function safeUsername(): string | undefined {
-  try {
-    const info = userInfo();
-    return info?.username && info.username.length > 0 ? info.username : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function expandTilde(value: unknown): string | null {
-  if (typeof value !== "string" || value.trim().length === 0) return null;
-  const trimmed = value.trim();
-  if (trimmed === "~") return homedir();
-  if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
-  return trimmed;
-}
-
-interface AgentHomeOverrides {
-  amrOpenCodeHome: string | null;
-  claudeConfigDir: string | null;
-  codexHome: string | null;
-}
-
-// Best-effort read of user `agentCliEnv.<agent>.*` home overrides
-// (`OPENCODE_TEST_HOME` / `CLAUDE_CONFIG_DIR` / `CODEX_HOME`) from the daemon's
-// app-config, so the log sweep targets the same homes a real run uses. The
-// daemon resolves these authoritatively via spawnEnvForAgent; the desktop main
-// process may not import daemon internals, so it reads the config file directly
-// and applies only leading-`~` expansion (overrides are effectively absolute).
-// Missing values fall back to the collector's defaults.
-async function readAgentHomeOverrides(dataDir: string): Promise<AgentHomeOverrides> {
-  try {
-    const raw = await readFile(join(dataDir, "app-config.json"), "utf8");
-    const agentCliEnv = (JSON.parse(raw) as {
-      agentCliEnv?: Record<string, Record<string, unknown> | undefined>;
-    }).agentCliEnv;
-    return {
-      amrOpenCodeHome: expandTilde(agentCliEnv?.amr?.OPENCODE_TEST_HOME),
-      claudeConfigDir: expandTilde(agentCliEnv?.claude?.CLAUDE_CONFIG_DIR),
-      codexHome: expandTilde(agentCliEnv?.codex?.CODEX_HOME),
-    };
-  } catch {
-    return { amrOpenCodeHome: null, claudeConfigDir: null, codexHome: null };
-  }
-}
-
-function buildSidecarLogSources(runtime: SidecarRuntimeContext<SidecarStamp>): LogSource[] {
-  // In packaged builds `runtime.base` is `<namespaceRoot>/runtime`, so the log
-  // tree lives a level UP at `<namespaceRoot>/logs`; `resolveRuntimeNamespaceRoot`
-  // accounts for that (a plain `resolveNamespaceRoot` here resolved every
-  // daemon/web log to an ENOENT phantom path and captured none of them).
-  const namespaceRoot = resolveRuntimeNamespaceRoot({
-    contract: OPEN_DESIGN_SIDECAR_CONTRACT,
-    runtime,
-    runtimeMode: SIDECAR_MODES.RUNTIME,
-  });
-  const apps = [APP_KEYS.DAEMON, APP_KEYS.WEB, APP_KEYS.DESKTOP];
-  const sources: LogSource[] = [];
-  for (const appKey of apps) {
-    const absolutePath = resolveLogFilePath({
-      app: appKey,
-      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
-      runtimeRoot: namespaceRoot,
-    });
-    sources.push({
-      name: `logs/${appKey}/latest.log`,
-      absolutePath,
-      kind: "text",
-      tailBytes: TAIL_BYTES_PER_LOG,
-    });
-    // Only desktop runs an Electron renderer that writes `renderer.log`
-    // (see apps/desktop/src/main/runtime.ts). daemon and web are pure Node
-    // services with no renderer process, so listing the file there only
-    // produces missing-file placeholders and manifest warnings.
-    if (appKey === APP_KEYS.DESKTOP) {
-      sources.push({
-        name: `logs/${appKey}/renderer.log`,
-        absolutePath: join(dirname(absolutePath), "renderer.log"),
-        kind: "text",
-        tailBytes: TAIL_BYTES_PER_LOG,
-      });
-    }
-  }
-  return sources;
+export interface DesktopDiagnosticsDeps {
+  /**
+   * Resolve the daemon base URL the bundle is fetched from. Mirrors the
+   * app-config base-URL discovery (daemon URL → web URL → sidecar web
+   * discovery) so the export targets the same daemon the rest of the desktop
+   * talks to. Throws when no URL is available.
+   */
+  discoverDaemonBaseUrl: () => Promise<string>;
 }
 
 export async function exportDiagnosticsToFile(
-  runtime: SidecarRuntimeContext<SidecarStamp>,
+  deps: DesktopDiagnosticsDeps,
   parentWindow: BrowserWindow | null,
 ): Promise<DesktopDiagnosticsExportResult> {
   const filename = diagnosticsFileName(DIAGNOSTICS_FILENAME_PREFIX);
@@ -147,61 +53,14 @@ export async function exportDiagnosticsToFile(
   }
 
   try {
-    // The packaged daemon writes its runtime data at `<namespaceRoot>/data`
-    // (OD_DATA_DIR), with per-run event logs under `data/runs` and the
-    // AMR-managed OpenCode home under `data/amr`. Derive both so this export
-    // — the one users actually trigger from the desktop UI — carries the same
-    // run/agent diagnostics the daemon HTTP export does, instead of only the
-    // three sidecar logs.
-    const namespaceRoot = resolveRuntimeNamespaceRoot({
-      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
-      runtime,
-      runtimeMode: SIDECAR_MODES.RUNTIME,
-    });
-    const dataDir = join(namespaceRoot, "data");
-    const runsDir = join(dataDir, "runs");
-    // Honor user `agentCliEnv.<agent>.*` home overrides so relocated CLI homes
-    // are not missed; absent values fall back to the collector's defaults.
-    const agentHomes = await readAgentHomeOverrides(dataDir);
-    const sources: LogSource[] = [
-      ...buildSidecarLogSources(runtime),
-      ...(await buildRunEventLogSources(runsDir)),
-      ...(await buildAgentCliLogSources({
-        homeDir: homedir(),
-        dataDir,
-        amrOpenCodeHome: agentHomes.amrOpenCodeHome,
-        claudeConfigDir: agentHomes.claudeConfigDir,
-        codexHome: agentHomes.codexHome,
-        xdgDataHome: process.env.XDG_DATA_HOME ?? null,
-      })),
-    ];
-    const result = await buildDiagnosticsZip({
-      context: {
-        app: { name: "open-design", version: app.getVersion(), packaged: app.isPackaged },
-        source: "desktop-ipc",
-        namespace: runtime.namespace,
-        extra: {
-          electronVersion: process.versions.electron,
-          chromiumVersion: process.versions.chrome,
-          base: runtime.base,
-          mode: runtime.mode,
-          sourceTag: runtime.source,
-        },
-      },
-      sources,
-      redaction: { username: safeUsername() },
-      crashReports: {
-        // Restrict to Open Design's own process names. A generic "Electron"
-        // substring would sweep up crash reports from any other Electron app
-        // on the host (VS Code, Slack, …) and leak unrelated user data into
-        // the support bundle.
-        matchSubstrings: ["Open Design", "open-design"],
-        withinDays: 7,
-        maxReports: 10,
-        homeDir: homedir(),
-      },
-    });
-    await writeFile(choice.filePath, result.zip);
+    // Delegate the bundle to the daemon's own export endpoint instead of
+    // rebuilding it here with a guessed data dir. The daemon owns its real
+    // RUNTIME_DATA_DIR, so the bundle's run-event logs (`runs/<id>/events.jsonl`)
+    // and AMR/agent CLI logs resolve correctly in dev, packaged, and
+    // OD_DATA_DIR-override setups alike. See diagnostics-fetch.ts.
+    const baseUrl = await deps.discoverDaemonBaseUrl();
+    const zip = await fetchDiagnosticsBundle(baseUrl);
+    await writeFile(choice.filePath, zip);
     // Reveal the saved file in Finder (macOS) / Explorer (Windows) / file
     // manager (Linux) so the user can drag it into Slack / email without
     // having to navigate manually. Failures here are non-fatal.
@@ -217,10 +76,10 @@ export async function exportDiagnosticsToFile(
   }
 }
 
-export function registerDesktopDiagnosticsIpc(runtime: SidecarRuntimeContext<SidecarStamp>): () => void {
+export function registerDesktopDiagnosticsIpc(deps: DesktopDiagnosticsDeps): () => void {
   const handler = async (event: Electron.IpcMainInvokeEvent): Promise<DesktopDiagnosticsExportResult> => {
     const senderWindow = BrowserWindow.fromWebContents(event.sender);
-    return await exportDiagnosticsToFile(runtime, senderWindow);
+    return await exportDiagnosticsToFile(deps, senderWindow);
   };
   ipcMain.handle(DESKTOP_DIAGNOSTICS_IPC_CHANNEL, handler);
   return () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -192,6 +192,27 @@ function createWebDiscovery(runtime: SidecarRuntimeContext<SidecarStamp>): () =>
   };
 }
 
+// Resolve the daemon base URL the same way app-config reads/writes do: an
+// explicit daemon URL, else the web URL (which proxies `/api/*` to the daemon),
+// else sidecar web discovery. Shared by app-config menu actions and the
+// diagnostics export so they all target the same daemon. Throws when none is
+// available.
+function resolveDaemonBaseUrl(
+  runtime: SidecarRuntimeContext<SidecarStamp>,
+  options: Pick<DesktopMainOptions, "discoverDaemonUrl" | "discoverWebUrl">,
+): () => Promise<string> {
+  return async () => {
+    const baseUrl =
+      (await options.discoverDaemonUrl?.()) ??
+      (await options.discoverWebUrl?.()) ??
+      (await createWebDiscovery(runtime)());
+    if (!baseUrl) {
+      throw new Error("daemon URL is unavailable");
+    }
+    return baseUrl;
+  };
+}
+
 export function normalizeAmrEnvironmentProfile(profile: unknown): AmrEnvironmentProfile {
   if (typeof profile !== "string") return "prod";
   const trimmed = profile.trim();
@@ -309,16 +330,7 @@ function installDesktopMenu(
     dialog.showErrorBox(message, detail);
   };
 
-  const discoverAppConfigBaseUrl = async (): Promise<string> => {
-    const baseUrl =
-      (await options.discoverDaemonUrl?.()) ??
-      (await options.discoverWebUrl?.()) ??
-      (await createWebDiscovery(runtime)());
-    if (!baseUrl) {
-      throw new Error("daemon URL is unavailable");
-    }
-    return baseUrl;
-  };
+  const discoverAppConfigBaseUrl = resolveDaemonBaseUrl(runtime, options);
 
   const readCurrentAmrProfile = async (): Promise<AmrEnvironmentProfile> => {
     const baseUrl = await discoverAppConfigBaseUrl();
@@ -352,7 +364,10 @@ function installDesktopMenu(
 
   const exportDiagnostics = () => {
     const focused = BrowserWindow.getFocusedWindow();
-    void exportDiagnosticsToFile(runtime, focused).catch((error: unknown) => {
+    void exportDiagnosticsToFile(
+      { discoverDaemonBaseUrl: discoverAppConfigBaseUrl },
+      focused,
+    ).catch((error: unknown) => {
       console.error("desktop diagnostics export from menu failed", error);
     });
   };
@@ -604,10 +619,10 @@ export async function runDesktopMain(
     },
     { openPath: (path) => shell.openPath(path) },
   );
-  // Resolve the namespace root the same way the diagnostics export does
-  // (apps/desktop/src/main/diagnostics.ts). In packaged builds `runtime.base`
-  // is `<namespaceRoot>/runtime`, so re-appending the namespace via
-  // `resolveNamespaceRoot` would write renderer.log to a phantom
+  // Resolve the namespace root the same way the daemon diagnostics export does
+  // (apps/daemon/src/diagnostics-export.ts buildSidecarLogSources). In packaged
+  // builds `runtime.base` is `<namespaceRoot>/runtime`, so re-appending the
+  // namespace via `resolveNamespaceRoot` would write renderer.log to a phantom
   // `<namespaceRoot>/runtime/<namespace>/logs/desktop` dir that the export
   // reader never looks in. Keeping both sides on `resolveRuntimeNamespaceRoot`
   // co-locates renderer.log with the desktop log dir AND keeps it captured.
@@ -668,7 +683,9 @@ export async function runDesktopMain(
   });
   options.onDesktopReady?.({ show: () => desktop?.show() });
   disposeMenu = installDesktopMenu(runtime, options);
-  removeDiagnosticsIpc = registerDesktopDiagnosticsIpc(runtime);
+  removeDiagnosticsIpc = registerDesktopDiagnosticsIpc({
+    discoverDaemonBaseUrl: resolveDaemonBaseUrl(runtime, options),
+  });
   updateScheduler = createDesktopUpdaterScheduler(updater, {
     backoffInitialMs: updater.config.checkBackoffInitialMs,
     backoffMaxMs: updater.config.checkBackoffMaxMs,

--- a/apps/desktop/tests/main/diagnostics-export-delegates.test.ts
+++ b/apps/desktop/tests/main/diagnostics-export-delegates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchDiagnosticsBundle } from "../../src/main/diagnostics-fetch.js";
+
+describe("fetchDiagnosticsBundle", () => {
+  it("GETs the daemon's own diagnostics export endpoint and returns its bytes", async () => {
+    // Regression for the desktop-ipc export that rebuilt the bundle with a
+    // GUESSED data dir (`<namespaceRoot>/data`) and so missed the daemon's real
+    // `runs/<id>/events.jsonl` + AMR logs in dev / OD_DATA_DIR-override setups.
+    // The fix delegates to the daemon, which knows its real RUNTIME_DATA_DIR.
+    const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // "PK\x03\x04" (zip magic)
+    const fetchImpl = vi.fn(async () => new Response(bytes, { status: 200 }));
+
+    const buffer = await fetchDiagnosticsBundle("http://127.0.0.1:50022", { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:50022/api/diagnostics/export");
+    expect(Buffer.from(buffer)).toEqual(Buffer.from(bytes));
+  });
+
+  it("throws on a non-200 response so the user sees a real error, not a truncated zip", async () => {
+    const fetchImpl = vi.fn(async () => new Response("unavailable", { status: 503 }));
+
+    await expect(
+      fetchDiagnosticsBundle("http://127.0.0.1:50022", { fetchImpl }),
+    ).rejects.toThrow(/503/);
+  });
+});


### PR DESCRIPTION
## Why

A user hit an AMR / deepseek-v4-flash run that looped on read/write for ~30 min and produced nothing, then exported a diagnostics bundle to debug it — but the bundle had **no per-run event logs and no AMR logs**, exactly the data needed to explain the stuck run. The bundle did include unrelated noise (CSP font blocks, preview-iframe `replaceState` errors), so it looked like "nothing happened."

Root cause: the desktop **"Export diagnostics"** path rebuilds the bundle in the Electron main process and has to **guess** the daemon data dir from the sidecar namespace layout (`<namespaceRoot>/data`). That guess is wrong whenever the daemon's real `RUNTIME_DATA_DIR` differs:
- **tools-dev** (dev): `OD_DATA_DIR` is unset, so the daemon writes to `<projectRoot>/.od`.
- any **`OD_DATA_DIR` override**: the daemon writes wherever the override points.

The exporter then sweeps the wrong `runs/` and `amr/opencode-home` trees and silently drops the per-run `events.jsonl` (which already records every agent `stderr` chunk, tool call, and error since #3141) plus the AMR OpenCode logs.

The daemon already exposes a complete, correctly-pathed bundle at `GET /api/diagnostics/export` — it knows its own `RUNTIME_DATA_DIR` and collects run events, agent CLI logs (claude/codex/opencode/amr), sidecar daemon/web/desktop logs (incl. `renderer.log`), and host crash reports. So the desktop path should delegate to it instead of duplicating the assembly with a path guess.

## What users will see

No visible change in the happy path: **Settings → About → Export diagnostics** (and the Develop-menu equivalent) still opens a Save dialog and reveals the saved `.zip`. The difference is the bundle now actually contains the per-run `runs/<id>/events.jsonl` and AMR logs in dev / `OD_DATA_DIR`-override setups (previously empty), so support bundles can explain stuck/looping runs. If the daemon is unreachable, the export now reports a real error instead of silently writing an incomplete zip.

## Surface area

- [x] **None** — internal refactor + tests. (Desktop main-process IPC behavior change; no new UI surface, CLI flag, contract, or dependency. The daemon `/api/diagnostics/export` endpoint already exists.)

## Bug fix verification

- Test paths:
  - `apps/desktop/tests/main/diagnostics-export-delegates.test.ts` — `fetchDiagnosticsBundle` GETs `/api/diagnostics/export` and returns its bytes; surfaces non-200 as an error.
  - `apps/daemon/tests/diagnostics-export.test.ts` — warns in the manifest when `runsDir` is set but no per-run event logs were found.
- Red on `main` / green on branch? **yes** — the desktop test imports a module that doesn't exist on `main` (the old path rebuilt the bundle and never hit the endpoint); the daemon warning isn't emitted on `main`.
- Note: the daemon-side collection of `runs/<id>/events.jsonl` is already covered by the existing run-event-logs test; this PR pins the **desktop delegation** so it can't drift back to guessing paths.

## Changes

- **desktop**: new electron-free `diagnostics-fetch.ts` fetches the daemon bundle; `diagnostics.ts` keeps only the Save dialog + reveal and writes those bytes (removes all data-dir guessing — net −141 lines in `diagnostics.ts`).
- **desktop `index.ts`**: share one `resolveDaemonBaseUrl(runtime, options)` (daemon URL → web URL → sidecar web discovery) across the app-config menu actions and the diagnostics IPC, so the export targets the same daemon as everything else.
- **daemon**: emit a manifest warning when `runsDir` is set but no per-run event logs were found, so an empty bundle reads as "collection gap / persistence off" rather than "clean run with nothing to report."

## Validation

- `pnpm guard` — 63 pass
- `pnpm --filter @open-design/desktop typecheck` + `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm --filter @open-design/desktop test tests/main` — 125 pass (incl. new delegate test)
- `pnpm --filter @open-design/daemon exec vitest run tests/diagnostics-export.test.ts` — 5 pass (incl. new warning test)