### PR TITLE
fix(amr): normalize kimi-k2.7-code Vela model id

### DIFF
--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -50,6 +50,7 @@ export function normalizeVelaModelId(rawId: string): string | null {
   if (/^deepseek_v3_2$/i.test(withoutPrefix)) return 'deepseek-v3.2';
   if (/^deepseek-v3-2$/i.test(withoutPrefix)) return 'deepseek-v3.2';
   if (/^kimi_k2_6$/i.test(withoutPrefix)) return 'kimi-k2.6';
+  if (/^kimi_k2_7_code$/i.test(withoutPrefix)) return 'kimi-k2.7-code';
   if (/^glm_5_1$/i.test(withoutPrefix)) return 'glm-5.1';
   if (/^glm_5$/i.test(withoutPrefix)) return 'glm-5';
   const versioned = normalizeKnownVelaVersionId(withoutPrefix);

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -91,6 +91,7 @@ describe('AMR runtime def', () => {
   it('normalizes Vela public model ids to link-canonical ACP model ids', () => {
     expect(normalizeVelaModelId('public_model_deepseek_v3_2')).toBe('deepseek-v3.2');
     expect(normalizeVelaModelId('public_model_kimi_k2_6')).toBe('kimi-k2.6');
+    expect(normalizeVelaModelId('public_model_kimi_k2_7_code')).toBe('kimi-k2.7-code');
     expect(normalizeVelaModelId('public_model_gemini_2_5_flash')).toBe('gemini-2.5-flash');
     expect(normalizeVelaModelId('public_model_gemini_3_1_flash_lite_preview')).toBe(
       'gemini-3.1-flash-lite-preview',


### PR DESCRIPTION
## What users will see

Vela users selecting `kimi_k2_7_code` models will have the model id normalized to the canonical Open Design id `kimi-k2.7-code`, matching the behavior of existing K2.6 normalization rules.

## Why

Kimi K2.7-Code is Moonshot's coding-focused model. Without this normalization rule, Vela users routing `kimi_k2_7_code` through the AMR proxy receive a non-canonical model ID instead of `kimi-k2.7-code`. This change aligns K2.7-Code with the existing K2.6 normalization behavior and ensures consistent model routing.

## Surface area

* [x] **None**

## Bug fix verification

* Test path that reproduces the bug:
  `apps/daemon/tests/amr-acp-integration.test.ts`
* Added a normalization assertion for `public_model_kimi_k2_7_code`.
* Verified the expected normalized id is `kimi-k2.7-code`.

## Validation

* Reviewed the existing K2.6 normalization pattern.
* Added the matching K2.7-Code normalization rule.
* Added a corresponding test assertion.
* Verified only the intended files were modified.

Closes #4410
