### PR TITLE
feat(landing): trust/EEAT pages (about, faq, privacy, terms, 404) + footer rebuild

### DIFF
--- a/apps/landing-page/app/_components/site-footer.astro
+++ b/apps/landing-page/app/_components/site-footer.astro
@@ -24,7 +24,7 @@ const href = (path: string) => localizedHref(path, locale);
 const REPO = 'https://github.com/nexu-io/open-design';
 const DISCORD = 'https://discord.gg/9ptkbbqRu';
 const X_TWITTER = 'https://x.com/nexudotio';
-const YOUTUBE = 'https://www.youtube.com/@opendesignai';
+const YOUTUBE = 'https://www.youtube.com/channel/UChtshixMhvtgBWzoD9R_Qfg';
 
 // Footer columns mirror the top-nav sections. Hrefs are kept in lockstep
 // with header.tsx (USE_CASE_HREFS / agent routes); the labels reuse the
@@ -126,6 +126,8 @@ const l = L[locale as keyof typeof L] ?? L.en;
         <ul>
           <li><a href={href('/about/')}>{l.about}</a></li>
           <li><a href={href('/faq/')}>{l.faq}</a></li>
+          <li><a href={href('/privacy/')}>{l.privacy}</a></li>
+          <li><a href={href('/terms/')}>{l.terms}</a></li>
           <li><a href={REPO} target='_blank' rel='noopener'>{ui.footer.github}</a></li>
           <li><a href={DISCORD} target='_blank' rel='noopener'>{ui.footer.discord}</a></li>
         </ul>

--- a/apps/landing-page/app/_components/site-footer.astro
+++ b/apps/landing-page/app/_components/site-footer.astro
@@ -3,6 +3,7 @@ import type { HeaderProps } from './header';
 import {
   DEFAULT_LOCALE,
   getCommonCopy,
+  getHeaderProductMenuCopy,
   getLandingUiCopy,
   isLandingLocale,
   localizedHref,
@@ -13,45 +14,92 @@ interface Props {
   locale?: string;
 }
 
-const { counts, locale: rawLocale = DEFAULT_LOCALE } = Astro.props as Props;
+const { locale: rawLocale = DEFAULT_LOCALE } = Astro.props as Props;
 const locale = isLandingLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
 const copy = getCommonCopy(locale).header;
 const ui = getLandingUiCopy(locale);
+const menu = getHeaderProductMenuCopy(locale);
 const href = (path: string) => localizedHref(path, locale);
+
 const REPO = 'https://github.com/nexu-io/open-design';
 const DISCORD = 'https://discord.gg/9ptkbbqRu';
 const X_TWITTER = 'https://x.com/nexudotio';
+const YOUTUBE = 'https://www.youtube.com/@opendesignai';
+
+// Footer columns mirror the top-nav sections. Hrefs are kept in lockstep
+// with header.tsx (USE_CASE_HREFS / agent routes); the labels reuse the
+// already-localized nav dropdown copy so we don't fork translations.
+const USE_CASE_HREFS = [
+  '/solutions/prototype/',
+  '/solutions/dashboard/',
+  '/solutions/slides/',
+  '/solutions/image/',
+  '/solutions/video/',
+  '/solutions/design-system/',
+] as const;
+
+// A short, recognisable subset of the agent roster for the footer; the
+// column header links to the full /agents/ hub.
+const FOOTER_AGENTS = [
+  { name: 'Claude Code', route: 'claude-code-design' },
+  { name: 'Codex', route: 'codex-design' },
+  { name: 'Cursor', route: 'cursor-design' },
+  { name: 'Gemini CLI', route: 'gemini-design' },
+  { name: 'OpenCode', route: 'opencode-design' },
+] as const;
+
+// Legal / company labels — small inline map (en/zh/zh-tw, fallback en) so
+// this stays out of the larger footer i18n surface.
+const L = {
+  en: { company: 'Company', about: 'About', faq: 'FAQ', privacy: 'Privacy Policy', terms: 'Terms', allAgents: 'All agents', allSolutions: 'All use cases' },
+  zh: { company: '公司', about: '关于', faq: '常见问题', privacy: '隐私政策', terms: '服务条款', allAgents: '全部 Agent', allSolutions: '全部场景' },
+  'zh-tw': { company: '公司', about: '關於', faq: '常見問題', privacy: '隱私政策', terms: '服務條款', allAgents: '全部 Agent', allSolutions: '全部場景' },
+} satisfies Record<string, Record<string, string>>;
+const l = L[locale as keyof typeof L] ?? L.en;
 ---
 
 <footer class='sub-footer' data-od-id='footer'>
   <div class='container sub-footer-inner'>
     <div class='sub-footer-grid'>
       <div class='sub-footer-col'>
-        <h5>{ui.footer.products}</h5>
+        <h5>{menu.product}</h5>
         <ul>
           <li><a href={href('/')}>Open Design</a></li>
           <li><a href={href('/html-anything/')}>{ui.footer.htmlAnything}</a></li>
           <li><a href={href('/html-video/')}>{ui.footer.htmlVideo}</a></li>
         </ul>
       </div>
+
       <div class='sub-footer-col'>
-        <h5>{copy.nav.plugins}</h5>
+        <h5><a href={href('/solutions/')}>{menu.solution}</a></h5>
+        <ul>
+          {menu.useCaseItems.map((name, i) => (
+            <li><a href={href(USE_CASE_HREFS[i]!)}>{name}</a></li>
+          ))}
+        </ul>
+      </div>
+
+      <div class='sub-footer-col'>
+        <h5><a href={href('/agents/')}>{menu.agent}</a></h5>
+        <ul>
+          {FOOTER_AGENTS.map((a) => (
+            <li><a href={href(`/agents/${a.route}/`)}>{a.name}</a></li>
+          ))}
+          <li><a href={href('/agents/')}>{l.allAgents} →</a></li>
+        </ul>
+      </div>
+
+      <div class='sub-footer-col'>
+        <h5><a href={href('/plugins/')}>{copy.nav.plugins}</a></h5>
         <ul>
           <li><a href={href('/plugins/templates/')}>{copy.nav.templates}</a></li>
           <li><a href={href('/plugins/skills/')}>{copy.nav.skills}</a></li>
           <li><a href={href('/plugins/systems/')}>{copy.nav.systems}</a></li>
         </ul>
       </div>
+
       <div class='sub-footer-col'>
-        <h5>{ui.footer.resources}</h5>
-        <ul>
-          <li><a href={href('/official/')}>{ui.footer.official}</a></li>
-          <li><a href={href('/quickstart/')}>{ui.footer.quickstart}</a></li>
-          <li><a href={href('/agents/')}>{ui.footer.agents}</a></li>
-        </ul>
-      </div>
-      <div class='sub-footer-col'>
-        <h5>{ui.footer.compare}</h5>
+        <h5><a href={href('/compare/')}>{ui.footer.compare}</a></h5>
         <ul>
           <li><a href={href('/alternatives/claude-design/')}>Claude Design</a></li>
           <li><a href={href('/alternatives/figma/')}>Figma</a></li>
@@ -61,24 +109,100 @@ const X_TWITTER = 'https://x.com/nexudotio';
           <li><a href={href('/alternatives/framer/')}>Framer</a></li>
         </ul>
       </div>
+
       <div class='sub-footer-col'>
-        <h5>{ui.footer.connect}</h5>
+        <h5>{menu.resources}</h5>
         <ul>
+          <li><a href={href('/blog/')}>{menu.resourceItems.blog}</a></li>
+          <li><a href={href('/tutorials/')}>{menu.resourceItems.tutorials}</a></li>
+          <li><a href={href('/download/')}>{menu.resourceItems.download}</a></li>
+          <li><a href={href('/quickstart/')}>{ui.footer.quickstart}</a></li>
+          <li><a href={href('/official/')}>{ui.footer.official}</a></li>
+        </ul>
+      </div>
+
+      <div class='sub-footer-col'>
+        <h5>{l.company}</h5>
+        <ul>
+          <li><a href={href('/about/')}>{l.about}</a></li>
+          <li><a href={href('/faq/')}>{l.faq}</a></li>
           <li><a href={REPO} target='_blank' rel='noopener'>{ui.footer.github}</a></li>
-          <li><a href={`${REPO}/issues`} target='_blank' rel='noopener'>{ui.footer.issues}</a></li>
-          <li><a href={`${REPO}/releases`} target='_blank' rel='noopener'>{ui.footer.releases}</a></li>
           <li><a href={DISCORD} target='_blank' rel='noopener'>{ui.footer.discord}</a></li>
-          <li><a href={X_TWITTER} target='_blank' rel='noopener'>{ui.footer.xTwitter}</a></li>
-          <li><a href='/blog/rss.xml'>{ui.footer.rss}</a></li>
-          <li><a href={href('/#contact')}>{copy.nav.contact}</a></li>
         </ul>
       </div>
     </div>
-    {/* Masthead sign-off — the giant two-tone wordmark, nothing else. */}
+
+    <div class='foot-bar'>
+      <div class='foot-bar-left'>
+        <span class='foot-copy'>© 2026 Powerformer, Inc. · Apache-2.0</span>
+        <a href={href('/privacy/')}>{l.privacy}</a>
+        <span class='foot-dot' aria-hidden='true'>·</span>
+        <a href={href('/terms/')}>{l.terms}</a>
+      </div>
+      <div class='foot-social'>
+        <a href={X_TWITTER} target='_blank' rel='noopener' aria-label='X'>
+          <svg viewBox='0 0 24 24' width='18' height='18' fill='currentColor' aria-hidden='true'><path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.65l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25h6.815l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z'/></svg>
+        </a>
+        <a href={DISCORD} target='_blank' rel='noopener' aria-label='Discord'>
+          <svg viewBox='0 0 24 24' width='18' height='18' fill='currentColor' aria-hidden='true'><path d='M20.317 4.369a19.79 19.79 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.6 12.6 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.74 19.74 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .078.009c.12.099.246.198.373.292a.077.077 0 0 1-.006.127c-.598.349-1.22.645-1.873.891a.076.076 0 0 0-.04.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.056c.5-5.177-.838-9.674-3.549-13.66a.06.06 0 0 0-.031-.028zM8.02 15.331c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z'/></svg>
+        </a>
+        <a href={REPO} target='_blank' rel='noopener' aria-label='GitHub'>
+          <svg viewBox='0 0 24 24' width='18' height='18' fill='currentColor' aria-hidden='true'><path d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.5 11.5 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/></svg>
+        </a>
+        <a href={YOUTUBE} target='_blank' rel='noopener' aria-label='YouTube'>
+          <svg viewBox='0 0 24 24' width='18' height='18' fill='currentColor' aria-hidden='true'><path d='M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z'/></svg>
+        </a>
+      </div>
+    </div>
+
+    {/* Masthead sign-off — the giant two-tone wordmark. */}
     <div class='foot-masthead' data-od-id='footer-masthead'>
       <p class='foot-masthead-wordmark'>
         Open <span class='foot-masthead-accent'>Design</span><span class='foot-masthead-period'>.</span>
       </p>
     </div>
   </div>
+
+  <style>
+    .foot-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      flex-wrap: wrap;
+      margin-top: 40px;
+      padding-top: 24px;
+      border-top: 1px solid var(--line, #d9d9d9);
+    }
+    .foot-bar-left {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      flex-wrap: wrap;
+      font-size: 13px;
+      color: var(--ink-mute, #8c8c8c);
+    }
+    .foot-bar-left a {
+      color: var(--ink-soft, #595959);
+      text-decoration: none;
+    }
+    .foot-bar-left a:hover {
+      text-decoration: underline;
+    }
+    .foot-dot {
+      opacity: 0.5;
+    }
+    .foot-social {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+    .foot-social a {
+      color: var(--ink-mute, #8c8c8c);
+      display: inline-flex;
+    }
+    .foot-social a:hover {
+      color: var(--ink, #262626);
+    }
+  </style>
 </footer>

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -4773,6 +4773,9 @@ footer .container {
 /* Column headers that double as links (Solution / Agent / Plugins /
    Compare) keep the eyebrow styling but become clickable. */
 .sub-footer-col h5 a {
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
   color: inherit;
   text-decoration: none;
   transition: color 0.16s ease;

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -4757,8 +4757,8 @@ footer .container {
 }
 .sub-footer-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 40px;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 28px;
   margin-bottom: 36px;
 }
 .sub-footer-col h5 {
@@ -4770,6 +4770,14 @@ footer .container {
   margin-bottom: 14px;
   font-weight: 500;
 }
+/* Column headers that double as links (Solution / Agent / Plugins /
+   Compare) keep the eyebrow styling but become clickable. */
+.sub-footer-col h5 a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.16s ease;
+}
+.sub-footer-col h5 a:hover { color: var(--coral); }
 .sub-footer-col ul {
   list-style: none;
   padding: 0;
@@ -4785,6 +4793,52 @@ footer .container {
   transition: color 0.16s ease;
 }
 .sub-footer-col a:hover { color: var(--coral); }
+
+/* ---------- footer bottom bar ----------
+ *
+ * Legal sign-off + social row under the link columns. One class contract
+ * shared by `site-footer.astro` (sub-pages, scoped style) and the homepage
+ * footer in `page.tsx` (these global rules).
+ */
+.foot-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid var(--line, #d9d9d9);
+}
+.foot-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: var(--ink-mute, #8c8c8c);
+}
+.foot-bar-left a {
+  color: var(--ink-soft, #595959);
+  text-decoration: none;
+}
+.foot-bar-left a:hover { text-decoration: underline; }
+.foot-dot { opacity: 0.5; }
+.foot-social {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.foot-social a {
+  color: var(--ink-mute, #8c8c8c);
+  display: inline-flex;
+}
+.foot-social a:hover { color: var(--ink, #262626); }
+
+/* Tablet: 7 columns get cramped — drop to a 4-wide grid. */
+@media (max-width: 1080px) {
+  .sub-footer-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
 
 /* ---------- footer masthead ----------
  *

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -167,7 +167,7 @@ const REPO_SKILLS = `${REPO}/tree/main/skills`;
 const REPO_DOCS = `${REPO}#readme`;
 const DISCORD = 'https://discord.gg/9ptkbbqRu';
 const X_TWITTER = 'https://x.com/nexudotio';
-const YOUTUBE = 'https://www.youtube.com/@opendesignai';
+const YOUTUBE = 'https://www.youtube.com/channel/UChtshixMhvtgBWzoD9R_Qfg';
 
 // Footer columns mirror the top-nav sections + `site-footer.astro` (the
 // sub-page footer) so the homepage and every sub-page share one footer
@@ -1127,6 +1127,8 @@ export default function Page({
                 <ul>
                   <li><a href={href('/about/')}>{footL.about}</a></li>
                   <li><a href={href('/faq/')}>{footL.faq}</a></li>
+                  <li><a href={href('/privacy/')}>{footL.privacy}</a></li>
+                  <li><a href={href('/terms/')}>{footL.terms}</a></li>
                   <li><a href={REPO} target='_blank' rel='noopener'>{ui.footer.github}</a></li>
                   <li><a href={DISCORD} target='_blank' rel='noopener'>{ui.footer.discord}</a></li>
                 </ul>

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_LOCALE,
   LANDING_LOCALES,
   getCommonCopy,
+  getHeaderProductMenuCopy,
   getHomePageCopy,
   getLandingUiCopy,
   getLocaleDefinition,
@@ -165,6 +166,37 @@ const REPO_DAEMON = `${REPO}/tree/main/apps/daemon`;
 const REPO_SKILLS = `${REPO}/tree/main/skills`;
 const REPO_DOCS = `${REPO}#readme`;
 const DISCORD = 'https://discord.gg/9ptkbbqRu';
+const X_TWITTER = 'https://x.com/nexudotio';
+const YOUTUBE = 'https://www.youtube.com/@opendesignai';
+
+// Footer columns mirror the top-nav sections + `site-footer.astro` (the
+// sub-page footer) so the homepage and every sub-page share one footer
+// contract. Hrefs stay in lockstep with header.tsx (USE_CASE_HREFS / agent
+// routes); labels reuse the already-localized nav dropdown copy.
+const FOOTER_USE_CASE_HREFS = [
+  '/solutions/prototype/',
+  '/solutions/dashboard/',
+  '/solutions/slides/',
+  '/solutions/image/',
+  '/solutions/video/',
+  '/solutions/design-system/',
+] as const;
+
+const FOOTER_AGENTS = [
+  { name: 'Claude Code', route: 'claude-code-design' },
+  { name: 'Codex', route: 'codex-design' },
+  { name: 'Cursor', route: 'cursor-design' },
+  { name: 'Gemini CLI', route: 'gemini-design' },
+  { name: 'OpenCode', route: 'opencode-design' },
+] as const;
+
+// Legal / company labels — small inline map (en/zh/zh-tw, fallback en) kept
+// identical to `site-footer.astro` so the two footers never drift.
+const FOOTER_LEGAL = {
+  en: { company: 'Company', about: 'About', faq: 'FAQ', privacy: 'Privacy Policy', terms: 'Terms', allAgents: 'All agents' },
+  zh: { company: '公司', about: '关于', faq: '常见问题', privacy: '隐私政策', terms: '服务条款', allAgents: '全部 Agent' },
+  'zh-tw': { company: '公司', about: '關於', faq: '常見問題', privacy: '隱私政策', terms: '服務條款', allAgents: '全部 Agent' },
+} satisfies Record<string, Record<string, string>>;
 
 const ext = {
   target: '_blank',
@@ -296,6 +328,9 @@ export default function Page({
   const commonCopy = getCommonCopy(locale);
   const home = getHomePageCopy(locale);
   const ui = getLandingUiCopy(locale);
+  const menu = getHeaderProductMenuCopy(locale);
+  const footL =
+    FOOTER_LEGAL[locale as keyof typeof FOOTER_LEGAL] ?? FOOTER_LEGAL.en;
   const localeDef = getLocaleDefinition(locale);
   const localeOptions = LANDING_LOCALES.map((entry) => ({
     ...entry,
@@ -1024,55 +1059,48 @@ export default function Page({
           <div className='container sub-footer-inner'>
             <div className='sub-footer-grid'>
               <div className='sub-footer-col'>
-                <h5>{ui.footer.products}</h5>
+                <h5>{menu.product}</h5>
                 <ul>
-                  <li>
-                    <a href={href('/')}>Open Design</a>
-                  </li>
-                  <li>
-                    <a href={href('/html-anything/')}>{ui.footer.htmlAnything}</a>
-                  </li>
-                  <li>
-                    <a href={href('/html-video/')}>{ui.footer.htmlVideo}</a>
-                  </li>
+                  <li><a href={href('/')}>Open Design</a></li>
+                  <li><a href={href('/html-anything/')}>{ui.footer.htmlAnything}</a></li>
+                  <li><a href={href('/html-video/')}>{ui.footer.htmlVideo}</a></li>
                 </ul>
               </div>
+
               <div className='sub-footer-col'>
-                <h5>{commonCopy.header.nav.plugins}</h5>
+                <h5><a href={href('/solutions/')}>{menu.solution}</a></h5>
                 <ul>
-                  <li>
-                    <a href={href('/plugins/templates/')}>
-                      {commonCopy.header.nav.templates}
-                    </a>
-                  </li>
-                  <li>
-                    <a href={href('/plugins/skills/')}>
-                      {commonCopy.header.nav.skills}
-                    </a>
-                  </li>
-                  <li>
-                    <a href={href('/plugins/systems/')}>
-                      {commonCopy.header.nav.systems}
-                    </a>
-                  </li>
+                  {menu.useCaseItems.map((name, i) => (
+                    <li key={FOOTER_USE_CASE_HREFS[i]}>
+                      <a href={href(FOOTER_USE_CASE_HREFS[i]!)}>{name}</a>
+                    </li>
+                  ))}
                 </ul>
               </div>
+
               <div className='sub-footer-col'>
-                <h5>{ui.footer.resources}</h5>
+                <h5><a href={href('/agents/')}>{menu.agent}</a></h5>
                 <ul>
-                  <li>
-                    <a href={href('/official/')}>{ui.footer.official}</a>
-                  </li>
-                  <li>
-                    <a href={href('/quickstart/')}>{ui.footer.quickstart}</a>
-                  </li>
-                  <li>
-                    <a href={href('/agents/')}>{ui.footer.agents}</a>
-                  </li>
+                  {FOOTER_AGENTS.map((a) => (
+                    <li key={a.route}>
+                      <a href={href(`/agents/${a.route}/`)}>{a.name}</a>
+                    </li>
+                  ))}
+                  <li><a href={href('/agents/')}>{footL.allAgents} →</a></li>
                 </ul>
               </div>
+
               <div className='sub-footer-col'>
-                <h5>{ui.footer.compare}</h5>
+                <h5><a href={href('/plugins/')}>{commonCopy.header.nav.plugins}</a></h5>
+                <ul>
+                  <li><a href={href('/plugins/templates/')}>{commonCopy.header.nav.templates}</a></li>
+                  <li><a href={href('/plugins/skills/')}>{commonCopy.header.nav.skills}</a></li>
+                  <li><a href={href('/plugins/systems/')}>{commonCopy.header.nav.systems}</a></li>
+                </ul>
+              </div>
+
+              <div className='sub-footer-col'>
+                <h5><a href={href('/compare/')}>{ui.footer.compare}</a></h5>
                 <ul>
                   <li><a href={href('/alternatives/claude-design/')}>Claude Design</a></li>
                   <li><a href={href('/alternatives/figma/')}>Figma</a></li>
@@ -1082,17 +1110,49 @@ export default function Page({
                   <li><a href={href('/alternatives/framer/')}>Framer</a></li>
                 </ul>
               </div>
+
               <div className='sub-footer-col'>
-                <h5>{ui.footer.connect}</h5>
+                <h5>{menu.resources}</h5>
                 <ul>
-                  <li><a href={REPO} target='_blank' rel='noopener'>{ui.footer.github}</a></li>
-                  <li><a href={REPO_ISSUES} target='_blank' rel='noopener'>{ui.footer.issues}</a></li>
-                  <li><a href={REPO_RELEASES} target='_blank' rel='noopener'>{ui.footer.releases}</a></li>
-                  <li><a href={DISCORD} target='_blank' rel='noopener'>{ui.footer.discord}</a></li>
-                  <li><a href='https://x.com/nexudotio' target='_blank' rel='noopener'>{ui.footer.xTwitter}</a></li>
-                  <li><a href='/blog/rss.xml'>{ui.footer.rss}</a></li>
-                  <li><a href={href('/#contact')}>{commonCopy.header.nav.contact}</a></li>
+                  <li><a href={href('/blog/')}>{menu.resourceItems.blog}</a></li>
+                  <li><a href={href('/tutorials/')}>{menu.resourceItems.tutorials}</a></li>
+                  <li><a href={href('/download/')}>{menu.resourceItems.download}</a></li>
+                  <li><a href={href('/quickstart/')}>{ui.footer.quickstart}</a></li>
+                  <li><a href={href('/official/')}>{ui.footer.official}</a></li>
                 </ul>
+              </div>
+
+              <div className='sub-footer-col'>
+                <h5>{footL.company}</h5>
+                <ul>
+                  <li><a href={href('/about/')}>{footL.about}</a></li>
+                  <li><a href={href('/faq/')}>{footL.faq}</a></li>
+                  <li><a href={REPO} target='_blank' rel='noopener'>{ui.footer.github}</a></li>
+                  <li><a href={DISCORD} target='_blank' rel='noopener'>{ui.footer.discord}</a></li>
+                </ul>
+              </div>
+            </div>
+
+            <div className='foot-bar'>
+              <div className='foot-bar-left'>
+                <span className='foot-copy'>© 2026 Powerformer, Inc. · Apache-2.0</span>
+                <a href={href('/privacy/')}>{footL.privacy}</a>
+                <span className='foot-dot' aria-hidden='true'>·</span>
+                <a href={href('/terms/')}>{footL.terms}</a>
+              </div>
+              <div className='foot-social'>
+                <a href={X_TWITTER} target='_blank' rel='noopener' aria-label='X'>
+                  <svg viewBox='0 0 24 24' width='18' height='18' fill='currentColor' aria-hidden='true'><path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.65l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25h6.815l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z' /></svg>
+                </a>
+                <a href={DISCORD} target='_blank' rel='noopener' aria-label='Discord'>
+                  <svg viewBox='0 0 24 24' width='18' height='18' fill='currentColor' aria-hidden='true'><path d='M20.317 4.369a19.79 19.79 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.6 12.6 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.74 19.74 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .078.009c.12.099.246.198.373.292a.077.077 0 0 1-.006.127c-.598.349-1.22.645-1.873.891a.076.076 0 0 0-.04.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.056c.5-5.177-.838-9.674-3.549-13.66a.06.06 0 0 0-.031-.028zM8.02 15.331c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z' /></svg>
+                </a>
+                <a href={REPO} target='_blank' rel='noopener' aria-label='GitHub'>
+                  <svg viewBox='0 0 24 24' width='18' height='18' fill='currentColor' aria-hidden='true'><path d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.5 11.5 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12' /></svg>
+                </a>
+                <a href={YOUTUBE} target='_blank' rel='noopener' aria-label='YouTube'>
+                  <svg viewBox='0 0 24 24' width='18' height='18' fill='currentColor' aria-hidden='true'><path d='M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z' /></svg>
+                </a>
               </div>
             </div>
             {/* Masthead sign-off — same markup contract as

--- a/apps/landing-page/app/pages/404.astro
+++ b/apps/landing-page/app/pages/404.astro
@@ -1,0 +1,66 @@
+---
+/*
+ * 404 — not found.
+ *
+ * Astro emits this as `404.html`; Cloudflare Pages serves it with a real
+ * 404 status for any unmatched route, replacing the previous soft-404
+ * (unknown URLs were returning the homepage with a 200). Single static
+ * file, so the copy stays in English.
+ */
+import Layout from '../_components/sub-page-layout.astro';
+import { localizedHref } from '../i18n';
+
+const href = (path: string) => localizedHref(path, 'en');
+---
+
+<Layout
+  title="Page not found — Open Design"
+  description="The page you’re looking for doesn’t exist. Explore Open Design’s tutorials, plugins, and docs instead."
+>
+  <article class="notfound">
+    <span class="notfound-code">404</span>
+    <h1 class="notfound-h1">This page wandered off.</h1>
+    <p class="notfound-lead">
+      The page you’re looking for doesn’t exist or has moved. Here’s where to head next.
+    </p>
+    <div class="notfound-links">
+      <a class="btn btn-primary" href={href('/')}>Back to home →</a>
+      <a class="btn btn-ghost" href={href('/plugins/')}>Browse plugins</a>
+      <a class="btn btn-ghost" href={href('/tutorials/')}>Tutorials</a>
+    </div>
+  </article>
+
+  <style>
+    .notfound {
+      max-width: 640px;
+      padding: 40px 0 80px;
+    }
+    .notfound-code {
+      display: block;
+      font-size: 80px;
+      font-weight: 800;
+      line-height: 1;
+      letter-spacing: -0.03em;
+      color: var(--ui-brand, #63fe13);
+    }
+    .notfound-h1 {
+      margin: 16px 0 0;
+      font-size: 36px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--ink, #262626);
+    }
+    .notfound-lead {
+      margin: 16px 0 0;
+      font-size: 17px;
+      line-height: 1.6;
+      color: var(--ink-soft, #434343);
+    }
+    .notfound-links {
+      display: flex;
+      gap: 14px;
+      margin-top: 32px;
+      flex-wrap: wrap;
+    }
+  </style>
+</Layout>

--- a/apps/landing-page/app/pages/[locale]/about/index.astro
+++ b/apps/landing-page/app/pages/[locale]/about/index.astro
@@ -1,0 +1,12 @@
+---
+import AboutPage from '../../about/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<AboutPage />

--- a/apps/landing-page/app/pages/[locale]/faq/index.astro
+++ b/apps/landing-page/app/pages/[locale]/faq/index.astro
@@ -1,0 +1,12 @@
+---
+import FaqPage from '../../faq/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<FaqPage />

--- a/apps/landing-page/app/pages/[locale]/privacy/index.astro
+++ b/apps/landing-page/app/pages/[locale]/privacy/index.astro
@@ -1,0 +1,12 @@
+---
+import PrivacyPage from '../../privacy/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<PrivacyPage />

--- a/apps/landing-page/app/pages/[locale]/terms/index.astro
+++ b/apps/landing-page/app/pages/[locale]/terms/index.astro
@@ -1,0 +1,12 @@
+---
+import TermsPage from '../../terms/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<TermsPage />

--- a/apps/landing-page/app/pages/about/index.astro
+++ b/apps/landing-page/app/pages/about/index.astro
@@ -1,0 +1,178 @@
+---
+/*
+ * /about/ — short, vision-led company page.
+ *
+ * Deliberately light: who builds Open Design (Powerformer, Inc.) and a
+ * line of open-source products before it (Refly, Nexu), then the vision.
+ * No named individuals. en / zh / zh-tw authored; other locales fall
+ * back to en. Localized routes are produced by `[locale]/about/`.
+ */
+import Layout from '../../_components/sub-page-layout.astro';
+import { localeFromPath, localizedHref } from '../../i18n';
+
+const locale = localeFromPath(Astro.url.pathname);
+const href = (path: string) => localizedHref(path, locale);
+
+type AboutCopy = {
+  metaTitle: string;
+  metaDescription: string;
+  eyebrow: string;
+  h1: string;
+  lead: string;
+  visionHead: string;
+  vision: string[];
+  closing: string;
+};
+
+const COPY = {
+  en: {
+    metaTitle: 'About — Open Design',
+    metaDescription:
+      'Open Design is built by Powerformer, Inc. — a team behind a line of open-source products including Refly and Nexu, and, in 2026, Open Design.',
+    eyebrow: 'About',
+    h1: 'About Open Design',
+    lead: 'Open Design is built by Powerformer, Inc. We have shipped open-source tools for years — a line of products including Refly and Nexu — and in 2026 we released Open Design: a one-stop, agent-native design platform.',
+    visionHead: 'Our vision',
+    vision: [
+      'For decades, design barely changed: you open an app and drag shapes around a canvas by hand. Figma, Sketch, Photoshop — all variations of the same manual loop. We think that is about to shift. Design is becoming a capability every agent can call — woven into how products get built, the way coding already is.',
+      '2026 is the inflection point: models finally have real aesthetic judgment. World-class design no longer has to be a scarce resource locked behind specialists and expensive seats — paired with the right design system, it can be a default anyone can reach.',
+      'Open Design takes the coding agent already on your laptop and lets it step out of the code window to actually design, produce, and ship — local-first, open-source, BYOK at every layer, and neutral to any agent runtime. Skills, design systems, and templates are shared freely and get better with every use.',
+      'Our goal is to rekindle the curiosity for beauty — so people who are not designers can still make things that look great. An open, agent-native design ecosystem: design that evolves with you, not design you rent.',
+    ],
+    closing: 'Open Design is Apache-2.0 and built in the open.',
+  },
+  zh: {
+    metaTitle: '关于 — Open Design',
+    metaDescription:
+      'Open Design 由 Powerformer, Inc. 打造——我们做过一系列开源产品,包括 Refly、Nexu,并于 2026 年发布 Open Design。',
+    eyebrow: '关于',
+    h1: '关于 Open Design',
+    lead: 'Open Design 由 Powerformer, Inc. 打造。我们做开源产品已有多年——包括 Refly、Nexu,并在 2026 年发布了 Open Design:一站式的 agent-native 设计平台。',
+    visionHead: '我们的愿景',
+    vision: [
+      '过去几十年,设计这件事几乎没变过:打开一个软件,在画布上用鼠标一个个拖图形。Figma、Sketch、Photoshop,本质都是同一套"人在画布上手动操作"。我们判断,这正在改变——设计会从"一个要打开的软件",变成"每个 agent 都能随时调用的能力",像今天的 coding 一样融进生产流程。',
+      '2026 是拐点:模型第一次真正有了审美。世界级的"好看"不再是锁在少数专业设计师和昂贵席位里的稀缺资源——配上一套设计系统,它可以成为人人都能调用的默认能力。',
+      'Open Design 让你电脑里已有的 coding agent 走出代码窗口,真正去做设计、做产品、做交付——本地优先、开源、每一层都支持 BYOK,且对任何 agent runtime 保持中立。Skill、设计系统、模板自由共享,越用越好。',
+      '我们想做的,是把对美的好奇心重新点亮——让不只是设计师的人,也能做出好看的东西。一个开放、agent-native 的设计生态:设计与你一起进化,而不是租来的设计。',
+    ],
+    closing: 'Open Design 采用 Apache-2.0,完全开源构建。',
+  },
+  'zh-tw': {
+    metaTitle: '關於 — Open Design',
+    metaDescription:
+      'Open Design 由 Powerformer, Inc. 打造——我們做過一系列開源產品,包括 Refly、Nexu,並於 2026 年發布 Open Design。',
+    eyebrow: '關於',
+    h1: '關於 Open Design',
+    lead: 'Open Design 由 Powerformer, Inc. 打造。我們做開源產品已有多年——包括 Refly、Nexu,並在 2026 年發布了 Open Design:一站式的 agent-native 設計平台。',
+    visionHead: '我們的願景',
+    vision: [
+      '過去幾十年,設計這件事幾乎沒變過:打開一個軟體,在畫布上用滑鼠一個個拖圖形。Figma、Sketch、Photoshop,本質都是同一套「人在畫布上手動操作」。我們判斷,這正在改變——設計會從「一個要打開的軟體」,變成「每個 agent 都能隨時呼叫的能力」,像今天的 coding 一樣融進生產流程。',
+      '2026 是拐點:模型第一次真正有了審美。世界級的「好看」不再是鎖在少數專業設計師和昂貴席位裡的稀缺資源——配上一套設計系統,它可以成為人人都能呼叫的預設能力。',
+      'Open Design 讓你電腦裡已有的 coding agent 走出程式碼視窗,真正去做設計、做產品、做交付——本地優先、開源、每一層都支援 BYOK,且對任何 agent runtime 保持中立。Skill、設計系統、範本自由共享,越用越好。',
+      '我們想做的,是把對美的好奇心重新點亮——讓不只是設計師的人,也能做出好看的東西。一個開放、agent-native 的設計生態:設計與你一起進化,而不是租來的設計。',
+    ],
+    closing: 'Open Design 採用 Apache-2.0,完全開源建構。',
+  },
+} satisfies Record<string, AboutCopy>;
+
+const c = COPY[locale as keyof typeof COPY] ?? COPY.en;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'AboutPage',
+  name: c.metaTitle,
+  description: c.metaDescription,
+  url: new URL('/about/', Astro.site).toString(),
+  mainEntity: {
+    '@type': 'Organization',
+    name: 'Powerformer, Inc.',
+    brand: 'Open Design',
+    url: Astro.site?.toString(),
+    sameAs: [
+      'https://github.com/nexu-io/open-design',
+      'https://nexu.io',
+      'https://refly.ai',
+    ],
+  },
+};
+---
+
+<Layout title={c.metaTitle} description={c.metaDescription} jsonLd={jsonLd}>
+  <article class="about-page">
+    <span class="about-eyebrow">{c.eyebrow}</span>
+    <h1 class="about-h1">{c.h1}<span class="about-dot">.</span></h1>
+    <p class="about-lead">{c.lead}</p>
+
+    <section class="about-block">
+      <h2 class="about-h2">{c.visionHead}</h2>
+      {c.vision.map((p) => <p class="about-p">{p}</p>)}
+      <p class="about-closing">{c.closing}</p>
+    </section>
+
+    <div class="about-actions">
+      <a class="btn btn-primary" href="https://github.com/nexu-io/open-design" target="_blank" rel="noopener">GitHub ↗</a>
+      <a class="btn btn-ghost" href={href('/plugins/')}>Open Design plugins →</a>
+    </div>
+  </article>
+
+  <style>
+    .about-page {
+      max-width: 680px;
+    }
+    .about-eyebrow {
+      display: inline-block;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--ink-mute, #595959);
+      margin-bottom: 18px;
+    }
+    .about-h1 {
+      margin: 0;
+      font-size: 40px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      line-height: 1.1;
+      color: var(--ink, #262626);
+    }
+    .about-dot {
+      color: var(--ui-brand, #63fe13);
+    }
+    .about-lead {
+      margin: 18px 0 0;
+      font-size: 18px;
+      line-height: 1.6;
+      color: var(--ink-soft, #434343);
+    }
+    .about-block {
+      margin-top: 44px;
+      padding-top: 36px;
+      border-top: 1px solid var(--line);
+    }
+    .about-h2 {
+      margin: 0 0 18px;
+      font-size: 26px;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      color: var(--ink, #262626);
+    }
+    .about-p {
+      margin: 0 0 16px;
+      font-size: 16px;
+      line-height: 1.7;
+      color: var(--ink-soft, #434343);
+    }
+    .about-closing {
+      margin: 24px 0 0;
+      font-size: 14px;
+      color: var(--ink-mute, #595959);
+    }
+    .about-actions {
+      display: flex;
+      gap: 14px;
+      margin-top: 40px;
+      flex-wrap: wrap;
+    }
+  </style>
+</Layout>

--- a/apps/landing-page/app/pages/faq/index.astro
+++ b/apps/landing-page/app/pages/faq/index.astro
@@ -1,0 +1,121 @@
+---
+/*
+ * /faq/ — standalone FAQ page.
+ *
+ * Reuses the localized homepage FAQ (`getHomeFaq`) as a single source of
+ * truth so the dedicated page and the homepage never drift, and adds a
+ * FAQPage JSON-LD block (AI/GEO citability + rich results). Localized
+ * routes come from `[locale]/faq/`.
+ */
+import Layout from '../../_components/sub-page-layout.astro';
+import { getHomeFaq, localeFromPath } from '../../i18n';
+
+const locale = localeFromPath(Astro.url.pathname);
+const faq = getHomeFaq(locale, {
+  origin: 'open-design.ai',
+  repo: 'github.com/nexu-io/open-design',
+});
+
+const HEAD = {
+  en: {
+    eyebrow: 'FAQ',
+    h1: 'Open Design FAQ',
+    lead: 'Common questions about Open Design — what it is, how it works, and how to get started.',
+    title: 'FAQ — Open Design',
+    desc: 'Frequently asked questions about Open Design: what it is, how to use it, pricing, models, and getting started.',
+  },
+  zh: {
+    eyebrow: '常见问题',
+    h1: 'Open Design 常见问题',
+    lead: '关于 Open Design 的常见问题——它是什么、怎么用、如何上手。',
+    title: '常见问题 — Open Design',
+    desc: 'Open Design 常见问题:它是什么、如何使用、模型与上手方式。',
+  },
+  'zh-tw': {
+    eyebrow: '常見問題',
+    h1: 'Open Design 常見問題',
+    lead: '關於 Open Design 的常見問題——它是什麼、怎麼用、如何上手。',
+    title: '常見問題 — Open Design',
+    desc: 'Open Design 常見問題:它是什麼、如何使用、模型與上手方式。',
+  },
+} satisfies Record<string, { eyebrow: string; h1: string; lead: string; title: string; desc: string }>;
+const h = HEAD[locale as keyof typeof HEAD] ?? HEAD.en;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  url: new URL('/faq/', Astro.site).toString(),
+  mainEntity: faq.map(({ q, a }) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a },
+  })),
+};
+---
+
+<Layout title={h.title} description={h.desc} jsonLd={jsonLd}>
+  <article class="faq-page">
+    <span class="faq-eyebrow">{h.eyebrow}</span>
+    <h1 class="faq-h1">{h.h1}<span class="faq-dot">.</span></h1>
+    <p class="faq-lead">{h.lead}</p>
+
+    <dl class="faq-list">
+      {faq.map(({ q, a }) => (
+        <div class="faq-item">
+          <dt class="faq-q">{q}</dt>
+          <dd class="faq-a">{a}</dd>
+        </div>
+      ))}
+    </dl>
+  </article>
+
+  <style>
+    .faq-page {
+      max-width: 720px;
+    }
+    .faq-eyebrow {
+      display: inline-block;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--ink-mute, #595959);
+      margin-bottom: 18px;
+    }
+    .faq-h1 {
+      margin: 0;
+      font-size: 40px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--ink, #262626);
+    }
+    .faq-dot {
+      color: var(--ui-brand, #63fe13);
+    }
+    .faq-lead {
+      margin: 16px 0 40px;
+      font-size: 18px;
+      line-height: 1.6;
+      color: var(--ink-soft, #434343);
+    }
+    .faq-list {
+      margin: 0;
+    }
+    .faq-item {
+      padding: 24px 0;
+      border-top: 1px solid var(--line);
+    }
+    .faq-q {
+      margin: 0 0 10px;
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--ink, #262626);
+    }
+    .faq-a {
+      margin: 0;
+      font-size: 16px;
+      line-height: 1.7;
+      color: var(--ink-soft, #434343);
+    }
+  </style>
+</Layout>

--- a/apps/landing-page/app/pages/privacy/index.astro
+++ b/apps/landing-page/app/pages/privacy/index.astro
@@ -1,0 +1,108 @@
+---
+/*
+ * /privacy/ — Privacy Policy.
+ *
+ * Standard policy for the open-design.ai marketing site + the local-first
+ * product. English single page (legal text). DRAFT — should be reviewed
+ * by counsel before relying on it. Covers: who we are, what the website
+ * collects (analytics/cookies), the local-first/BYOK product stance,
+ * third parties, rights, contact.
+ */
+import Layout from '../../_components/sub-page-layout.astro';
+
+const updated = 'June 16, 2026';
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'Privacy Policy — Open Design',
+  url: new URL('/privacy/', Astro.site).toString(),
+  isPartOf: { '@type': 'WebSite', name: 'Open Design', url: Astro.site?.toString() },
+};
+---
+
+<Layout
+  title="Privacy Policy — Open Design"
+  description="How Open Design (Powerformer, Inc.) handles data on open-design.ai and in the local-first Open Design app."
+  jsonLd={jsonLd}
+>
+  <article class="legal">
+    <h1 class="legal-h1">Privacy Policy</h1>
+    <p class="legal-meta">Last updated: {updated}</p>
+
+    <p>This Privacy Policy explains how <strong>Powerformer, Inc.</strong> (“Open Design”, “we”, “us”) handles information in connection with the website <a href="https://open-design.ai">open-design.ai</a> and the Open Design application.</p>
+
+    <h2>1. Open Design is local-first</h2>
+    <p>The Open Design application runs on your own machine. Your projects, prompts, designs, and the API keys you provide (BYOK — “bring your own key”) stay on your device and are sent directly to the model providers you configure. We do not proxy, collect, or store your design content or your keys on our servers.</p>
+
+    <h2>2. Information the website collects</h2>
+    <p>When you visit open-design.ai we collect limited, standard analytics to understand traffic and improve the site:</p>
+    <ul>
+      <li><strong>Usage analytics</strong> — pages viewed, referrer, approximate location (from IP), device and browser type, via privacy-respecting analytics providers.</li>
+      <li><strong>Cookies / local storage</strong> — used for analytics and to remember preferences such as your language. You can control cookies through your browser and our cookie notice.</li>
+    </ul>
+    <p>We do not sell your personal information.</p>
+
+    <h2>3. Third-party services</h2>
+    <p>The website may use third-party analytics and infrastructure providers (for example, web analytics and hosting/CDN). These providers process data on our behalf under their own terms. Outbound links (GitHub, Discord, YouTube, etc.) are governed by those services’ own privacy policies.</p>
+
+    <h2>4. Your choices and rights</h2>
+    <p>Depending on your location, you may have the right to access, correct, or delete personal data we hold, and to object to or restrict certain processing. You can also disable cookies in your browser. To exercise any of these, contact us (below).</p>
+
+    <h2>5. Data retention &amp; security</h2>
+    <p>We retain website analytics only as long as needed for the purposes above, and apply reasonable technical and organizational measures to protect data. No method of transmission or storage is completely secure.</p>
+
+    <h2>6. Children</h2>
+    <p>Open Design is not directed to children under 13 (or the age required by your jurisdiction), and we do not knowingly collect their personal information.</p>
+
+    <h2>7. Changes</h2>
+    <p>We may update this policy from time to time. Material changes will be reflected by the “Last updated” date above.</p>
+
+    <h2>8. Contact</h2>
+    <p>Questions about this policy? Reach us via the <a href="https://github.com/nexu-io/open-design">Open Design GitHub repository</a> or the community <a href="https://discord.gg/9ptkbbqRu">Discord</a>.</p>
+  </article>
+
+  <style>
+    .legal {
+      max-width: 720px;
+    }
+    .legal-h1 {
+      margin: 0;
+      font-size: 40px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--ink, #262626);
+    }
+    .legal-meta {
+      margin: 10px 0 32px;
+      font-size: 14px;
+      color: var(--ink-mute, #595959);
+    }
+    .legal h2 {
+      margin: 32px 0 12px;
+      font-size: 20px;
+      font-weight: 700;
+      color: var(--ink, #262626);
+    }
+    .legal p,
+    .legal li {
+      font-size: 16px;
+      line-height: 1.7;
+      color: var(--ink-soft, #434343);
+    }
+    .legal p {
+      margin: 0 0 14px;
+    }
+    .legal ul {
+      margin: 0 0 14px;
+      padding-left: 1.4em;
+    }
+    .legal li {
+      margin: 0 0 8px;
+    }
+    .legal a {
+      color: var(--ink, #262626);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+  </style>
+</Layout>

--- a/apps/landing-page/app/pages/terms/index.astro
+++ b/apps/landing-page/app/pages/terms/index.astro
@@ -1,0 +1,96 @@
+---
+/*
+ * /terms/ — Terms of Service.
+ *
+ * Standard terms for the open-design.ai site + Open Design software.
+ * English single page. DRAFT — review by counsel before relying on it.
+ */
+import Layout from '../../_components/sub-page-layout.astro';
+
+const updated = 'June 16, 2026';
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'Terms of Service — Open Design',
+  url: new URL('/terms/', Astro.site).toString(),
+  isPartOf: { '@type': 'WebSite', name: 'Open Design', url: Astro.site?.toString() },
+};
+---
+
+<Layout
+  title="Terms of Service — Open Design"
+  description="The terms that govern use of the open-design.ai website and the open-source Open Design software."
+  jsonLd={jsonLd}
+>
+  <article class="legal">
+    <h1 class="legal-h1">Terms of Service</h1>
+    <p class="legal-meta">Last updated: {updated}</p>
+
+    <p>These Terms govern your use of the website <a href="https://open-design.ai">open-design.ai</a> and the Open Design software provided by <strong>Powerformer, Inc.</strong> (“Open Design”, “we”, “us”). By using the site or the software, you agree to these Terms.</p>
+
+    <h2>1. The software is open source</h2>
+    <p>Open Design is released under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>. Your use, modification, and distribution of the software are governed by that license. These Terms cover the website and our hosted services; the Apache-2.0 license controls the software itself and prevails in any conflict regarding the code.</p>
+
+    <h2>2. Bring your own keys</h2>
+    <p>Open Design is local-first and BYOK: you connect your own model-provider credentials, and your use of those providers is subject to their terms and pricing. You are responsible for the keys you configure and the costs they incur.</p>
+
+    <h2>3. Acceptable use</h2>
+    <p>You agree not to use the site or software to break the law, infringe others’ rights, distribute malware, or disrupt the service. Community spaces (GitHub, Discord) are also governed by their respective codes of conduct.</p>
+
+    <h2>4. Content &amp; contributions</h2>
+    <p>You retain ownership of what you create with Open Design. Contributions you submit to the open-source project are licensed under the project’s license as described in its CONTRIBUTING guide.</p>
+
+    <h2>5. Trademarks</h2>
+    <p>“Open Design”, “Powerformer”, and related logos are marks of Powerformer, Inc. Third-party names and brands referenced on the site (e.g., for comparisons) belong to their respective owners and are used for identification only.</p>
+
+    <h2>6. No warranty</h2>
+    <p>The site and software are provided “as is,” without warranties of any kind, to the fullest extent permitted by law. We do not warrant that the site or software will be uninterrupted, error-free, or fit for a particular purpose.</p>
+
+    <h2>7. Limitation of liability</h2>
+    <p>To the maximum extent permitted by law, Powerformer, Inc. will not be liable for any indirect, incidental, or consequential damages arising from your use of the site or software.</p>
+
+    <h2>8. Changes</h2>
+    <p>We may update these Terms from time to time; the “Last updated” date reflects the latest version. Continued use after changes means you accept them.</p>
+
+    <h2>9. Contact</h2>
+    <p>Questions? Reach us via the <a href="https://github.com/nexu-io/open-design">Open Design GitHub repository</a> or the community <a href="https://discord.gg/9ptkbbqRu">Discord</a>.</p>
+  </article>
+
+  <style>
+    .legal {
+      max-width: 720px;
+    }
+    .legal-h1 {
+      margin: 0;
+      font-size: 40px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--ink, #262626);
+    }
+    .legal-meta {
+      margin: 10px 0 32px;
+      font-size: 14px;
+      color: var(--ink-mute, #595959);
+    }
+    .legal h2 {
+      margin: 32px 0 12px;
+      font-size: 20px;
+      font-weight: 700;
+      color: var(--ink, #262626);
+    }
+    .legal p,
+    .legal li {
+      font-size: 16px;
+      line-height: 1.7;
+      color: var(--ink-soft, #434343);
+    }
+    .legal p {
+      margin: 0 0 14px;
+    }
+    .legal a {
+      color: var(--ink, #262626);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+  </style>
+</Layout>

--- a/apps/landing-page/app/sub-pages.css
+++ b/apps/landing-page/app/sub-pages.css
@@ -1061,6 +1061,9 @@ body.sub-page {
   font-weight: 500;
 }
 .sub-footer-col h5 a {
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
   color: inherit;
   text-decoration: none;
   transition: color 0.16s ease;

--- a/apps/landing-page/app/sub-pages.css
+++ b/apps/landing-page/app/sub-pages.css
@@ -1047,8 +1047,8 @@ body.sub-page {
 }
 .sub-footer-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 40px;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 28px;
   margin-bottom: 36px;
 }
 .sub-footer-col h5 {
@@ -1060,6 +1060,12 @@ body.sub-page {
   margin-bottom: 14px;
   font-weight: 500;
 }
+.sub-footer-col h5 a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.16s ease;
+}
+.sub-footer-col h5 a:hover { color: var(--coral); }
 .sub-footer-col ul {
   list-style: none;
   padding: 0;
@@ -1075,6 +1081,9 @@ body.sub-page {
   transition: color 0.16s ease;
 }
 .sub-footer-col a:hover { color: var(--coral); }
+@media (max-width: 1080px) {
+  .sub-footer-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
 @media (max-width: 720px) {
   .sub-footer-inner { padding-inline: 24px; }
   .sub-footer-grid { grid-template-columns: 1fr; gap: 32px; }


### PR DESCRIPTION
## Why

The landing site was missing the trust/EEAT baseline that Google and AI answer
engines expect from a credible product site, and the footer had drifted from
the top-nav information architecture.

- No **Privacy Policy**, **Terms**, **FAQ**, or **About** pages — these are the
  pages users (and AI Overviews / ChatGPT) look for to judge legitimacy, and
  their absence weakens E-E-A-T signals.
- Unknown URLs were served the homepage with a `200` (soft-404) — bad for both
  users and crawlers; there was no real `404` page.
- The footer was a stale 5-column layout (Products / Plugins / Resources /
  Compare / Connect) with dead links (RSS feed, `/#contact`) and no legal /
  company section. The homepage footer (`page.tsx`) and the sub-page footer
  (`site-footer.astro`) were two separate, divergent copies.

Benchmarked against `seo-skills/seo-audit-skill` and `AgricIDaniel/claude-seo`
(Google EEAT checklist) plus the Kuse footer pattern.

## What users will see

- New **/about/** — a vision-led company page (Powerformer, Inc.; prior
  open-source products; the 2026 Open Design launch and the agent-native design
  thesis). Localized routes under `/[locale]/about/`.
- New **/faq/** — reuses the homepage FAQ as a single source of truth, adds
  `FAQPage` JSON-LD for rich results / AI citability.
- New **/privacy/** and **/terms/** — standard legal pages (DRAFT — see note
  below).
- A real **404 page** instead of the homepage being returned for unknown URLs.
- A **rebuilt footer**, identical on the homepage and every sub-page, whose
  columns mirror the top nav — Product / Solution / Agent / Plugins / Compare /
  Resources / Company — plus a legal bottom bar (© Powerformer, Inc. ·
  Apache-2.0 · Privacy · Terms) and X / Discord / GitHub / YouTube icons. Dead
  RSS and contact links removed; column headers render at a uniform size.

## Surface area

- [x] i18n keys / localized copy (footer + new-page heads in en/zh/zh-tw, others
      fall back to en per the landing DeepPartial merge)
- [x] New routes / pages (`/about/`, `/faq/`, `/privacy/`, `/terms/`, `404`)
- [ ] CLI
- [ ] Contracts / protocol

## Validation

- `astro check` → 0 errors (241 files).
- Local dev server: `/`, `/about/`, `/zh/about/`, `/faq/`, `/privacy/`,
  `/terms/`, and an unknown path (404) all render; footer verified on both the
  homepage and sub-pages in en and zh, column headers uniform, Privacy/Terms
  present in both the Company column and the bottom bar, YouTube icon points at
  the real channel.

## Note

`/privacy/` and `/terms/` are first-draft legal text and should get a counsel
review before they are treated as final.
