### PR TITLE
release: Open Design 0.11.0 — The Bazaar

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -2,7 +2,6 @@
 
 import { execFile } from 'node:child_process';
 import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
@@ -295,25 +294,6 @@ type DirectInstallerResult = {
   nsisLogTail: string[];
 };
 
-type InstalledPackagedConfig = {
-  namespaceBaseRoot?: unknown;
-};
-
-type InstalledRuntimeConfig = {
-  active?: {
-    entry?: {
-      cwd?: unknown;
-    };
-    root?: unknown;
-  };
-};
-
-type InstalledAppPackage = {
-  name?: unknown;
-  productName?: unknown;
-  version?: unknown;
-};
-
 const shouldRunPackagedWinSmoke = process.platform === 'win32' && process.env.OD_PACKAGED_E2E_WIN === '1';
 const winDescribe = shouldRunPackagedWinSmoke ? describe : describe.skip;
 
@@ -368,7 +348,7 @@ winDescribe('packaged windows runtime smoke', () => {
         );
       }
 
-      await seedPackagedOnboardingComplete(install.installDir);
+      await seedPackagedOnboardingComplete();
 
       const startDesktop = async (step: string): Promise<WinStartResult> => {
         const nextStart = await measureSmokeStep(timings, step, async () => runToolsPackJson<WinStartResult>('start'));
@@ -1089,86 +1069,26 @@ async function readTiming(filePath: string): Promise<TimingResult> {
   return JSON.parse(await readFile(filePath, 'utf8')) as TimingResult;
 }
 
-async function seedPackagedOnboardingComplete(installDir: string): Promise<void> {
-  const configPath = join(await resolveExpectedDataRoot(installDir), 'app-config.json');
+async function seedPackagedOnboardingComplete(): Promise<void> {
+  // Pre-mark first-run onboarding as complete so the packaged app boots
+  // straight to the home shell. Since #4389 the Connect onboarding step is
+  // required and has no Skip affordance, so the only way past it on a fresh
+  // install is an `onboardingCompleted: true` config the daemon reads on boot.
+  //
+  // Write to the SAME data dir the running daemon actually reads —
+  // `<runtimeNamespaceRoot>/data` — not a path derived from the installed
+  // app's baked config. `tools-pack win start` rewrites the launch config's
+  // `namespaceBaseRoot` to the tools-pack runtime root (see
+  // writeInstalledLaunchPackagedConfig in tools/pack/src/win/lifecycle.ts) and
+  // hands it to the runtime via OD_PACKAGED_CONFIG_PATH, so the live daemon's
+  // RUNTIME_DATA_DIR is always under runtimeNamespaceRoot regardless of what
+  // the installer baked. Deriving the path from the installed manifest landed
+  // the seed elsewhere (the AppData fallback), so the daemon never saw it and
+  // the app stuck on onboarding once the Skip button was removed. This mirrors
+  // the macOS smoke's seed, which already writes under runtimeNamespaceRoot.
+  const configPath = join(runtimeNamespaceRoot, 'data', 'app-config.json');
   await mkdir(dirname(configPath), { recursive: true });
   await writeFile(configPath, `${JSON.stringify({ onboardingCompleted: true }, null, 2)}\n`, 'utf8');
-}
-
-async function resolveExpectedDataRoot(installDir: string): Promise<string> {
-  return join(await resolveExpectedNamespaceRoot(installDir), 'data');
-}
-
-async function resolveExpectedNamespaceRoot(installDir: string): Promise<string> {
-  const installedConfig = JSON.parse(
-    await readFile(await resolveInstalledPackagedConfigPath(installDir), 'utf8'),
-  ) as InstalledPackagedConfig;
-  const configuredNamespaceBaseRoot =
-    typeof installedConfig.namespaceBaseRoot === 'string' && installedConfig.namespaceBaseRoot.length > 0
-      ? installedConfig.namespaceBaseRoot
-      : null;
-  const namespaceBaseRoot =
-    configuredNamespaceBaseRoot ?? join(defaultWindowsAppDataRoot(await readInstalledAppName(installDir)), 'namespaces');
-  return join(resolve(namespaceBaseRoot), namespace);
-}
-
-async function readInstalledAppName(installDir: string): Promise<string> {
-  const appPackage = JSON.parse(
-    await readFile(
-      join(await resolveInstalledPayloadRoot(installDir), 'resources', 'app', 'package.json'),
-      'utf8',
-    ),
-  ) as InstalledAppPackage;
-  if (typeof appPackage.productName === 'string' && appPackage.productName.length > 0) return appPackage.productName;
-  if (typeof appPackage.name === 'string' && appPackage.name.length > 0) return appPackage.name;
-  return 'Open Design';
-}
-
-async function resolveInstalledPackagedConfigPath(installDir: string): Promise<string> {
-  return join(await resolveInstalledPayloadRoot(installDir), 'resources', 'open-design-config.json');
-}
-
-async function resolveInstalledPayloadRoot(installDir: string): Promise<string> {
-  const runtimePath = join(installDir, 'runtime.json');
-  const runtimeRaw = await readFile(runtimePath, 'utf8').catch((error: NodeJS.ErrnoException) => {
-    if (error.code === 'ENOENT') return null;
-    throw error;
-  });
-  if (runtimeRaw == null) return installDir;
-
-  const runtime = JSON.parse(runtimeRaw) as InstalledRuntimeConfig;
-  const activeRoot = safeLauncherRelativePath(runtime.active?.root);
-  const activeCwd = safeLauncherRelativePath(runtime.active?.entry?.cwd);
-  if (activeRoot == null || activeCwd == null) {
-    throw new Error(`installed runtime.json does not describe an active payload root: ${runtimePath}`);
-  }
-
-  const payloadRoot = resolve(installDir, activeRoot, activeCwd);
-  if (!isPathInside(payloadRoot, installDir)) {
-    throw new Error(`installed runtime active payload root escapes install dir: ${payloadRoot}`);
-  }
-  return payloadRoot;
-}
-
-function safeLauncherRelativePath(value: unknown): string | null {
-  if (typeof value !== 'string' || value.length === 0 || isAbsolute(value)) return null;
-  const segments = value.split(/[\\/]+/);
-  if (segments.some((segment) => segment.length === 0 || segment === '.' || segment === '..')) return null;
-  return join(...segments);
-}
-
-function defaultWindowsAppDataRoot(appName: string): string {
-  return join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), appName);
-}
-
-function isPathInside(filePath: string, expectedRoot: string): boolean {
-  const normalizedPath = normalizePathForComparison(resolve(filePath));
-  const normalizedRoot = normalizePathForComparison(resolve(expectedRoot));
-  return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`);
-}
-
-function normalizePathForComparison(filePath: string): string {
-  return process.platform === 'win32' ? filePath.toLowerCase() : filePath;
 }
 
 function resolveFromWorkspace(filePath: string): string {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -332,9 +332,9 @@ describe("packaged smoke workflow", () => {
   it("[P2] validates stable dry-run nightly metadata from a non-release ref", async () => {
     const objects: Record<string, unknown> = {};
     const fixture = await startStableNightlyMetadataServer(objects);
-    objects["nightly/versions/0.10.2.nightly.12/metadata.json"] = stableNightlyMetadataFixture(
-      "0.10.2",
-      "0.10.2.nightly.12",
+    objects["nightly/versions/0.11.0.nightly.12/metadata.json"] = stableNightlyMetadataFixture(
+      "0.11.0",
+      "0.11.0.nightly.12",
       fixture.origin,
     );
     const runnerTemp = await mkdtemp(join(tmpdir(), "od-release-stable-dry-run-"));
@@ -354,16 +354,16 @@ describe("packaged smoke workflow", () => {
           OPEN_DESIGN_RELEASE_CHANNEL: "stable",
           OPEN_DESIGN_RELEASE_DRY_RUN: "true",
           OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: fixture.origin,
-          OPEN_DESIGN_STABLE_NIGHTLY_VERSION: "0.10.2.nightly.12",
-          OPEN_DESIGN_STABLE_VERSION: "0.10.2",
+          OPEN_DESIGN_STABLE_NIGHTLY_VERSION: "0.11.0.nightly.12",
+          OPEN_DESIGN_STABLE_VERSION: "0.11.0",
           PATH: `${join(runnerTemp, "bin")}:${process.env.PATH ?? ""}`,
         },
       });
 
-      expect(result.stdout).toContain("[release-stable] validated nightly: 0.10.2.nightly.12");
+      expect(result.stdout).toContain("[release-stable] validated nightly: 0.11.0.nightly.12");
       expect(result.stdout).toContain("[release-stable] channel: stable");
       expect(result.stdout).toContain("[release-stable] dry run: true");
-      expect(result.stdout).toContain("[release-stable] version tag: open-design-v0.10.2");
+      expect(result.stdout).toContain("[release-stable] version tag: open-design-v0.11.0");
     } finally {
       await fixture.close();
       await rm(runnerTemp, { force: true, recursive: true });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "description": "Open Design renderer host bridge protocol.",

--- a/packages/launcher-proto/package.json
+++ b/packages/launcher-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/launcher-proto",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
### 🌟 Codename: *The Bazaar*

🎨 **`137 PRs` · `57 contributors` · `4 days`** — codename **“The Bazaar.”** A cathedral is built in private by a chosen few; a bazaar is built in the open, by everyone, all at once — and 0.11.0 turns Open Design into the bazaar. Walk in and start picking things up. The stalls are **a gallery of 56 official decks and 23 community slide kits**, each playing a live clip of the real output — browse the rows, grab what catches your eye, make it yours. Any vendor can set up shop: **whatever coding agent you already use — Amp, Codebuddy, Kimi, Codex, GitHub Copilot — just works**, no tool you're locked out of. And anyone can wander in off the street: a newcomer's first run is **a guided welcome, not a locked gate.** Come walk the market. 🚀

## 🔥 Highlights

- 🧩 **Use the coding agent you already love.** Whatever you've wired into your day now snaps in right beside Claude — two brand-new adapters for **Amp** and **Codebuddy Code**, a fixed **Kimi Code** runtime, **Codex** subscription media, **Antigravity** support, a roomier **GitHub Copilot** ceiling, and `reasonix` 1.x MCP env. Never switch the tool you trust again. (#3861, #3961, #4191, #4244, #4247, #2579, #4094) Thanks `@techpotatoes`, `@aleexjiang`, `@AriaShishegaran`, `@passive-book`, `@mrcfps`, `@YOMXXX`, `@AirTech-Full`.
- 🖼️ **A gallery that finally shows off.** No more guessing from a dead thumbnail — every plugin card and detail page now **plays a live clip of the real output.** All **56 official decks** got an on-brand glow-up, **23 community slide kits** from the best open-source skills joined the shelf, and the HyperFrames video templates are fresh. Browse, hit play, riff. (#4237, #4357, #4127, #4063, #4350) Thanks `@lefarcen`, `@free666799`, `@elihahah666`, `@xne998808-ai`.
- 🌐 **Open Design has a real home on the web now.** Wherever it shows up, it looks the part: **design pages for all 21 supported agents**, a full set of **trust pages** (about, FAQ, privacy, terms, a real 404) with a rebuilt footer, a **custom share card site-wide** so every link you paste looks sharp, a **rebuilt blog** with a table of contents and full i18n, a top-to-bottom **SEO + UX pass on the plugin pages**, and **two new community tutorials** to get people rolling. (#4050, #4417, #4292, #4330, #4331, #4386, #4158) Thanks `@xne998808-ai`, `@wangchenglong0001`.
- 🧭 **A welcome, not a wall.** Your first run is a guided path now — a gated Connect step (with a tooltip that explains *why* it's gated), a clean sequential stepper, smarter BYOK and CLI auto-detection, and no jarring home-screen flash before onboarding even starts. A control panel became an actual welcome. (#4389, #4418, #4425, #4426, #4429) Thanks `@free666799`, `@PerishCode`.
- 🛡️ **Rock-solid — the biggest stability pass yet.** The desktop window **heals itself** when the renderer dies or a load fails, runs **never hang** waiting on a question, the **preview stops reloading out from under you** while you mark up, screenshot, or comment, a file-descriptor leak is plugged, the updater stops spinning at zero delay, and a long tail of dialog, picker, and screenshot glitches is gone. The build you keep open all day just *stays up.* (#4179, #4277, #4365, #4163, #4143, #4159, #4173, #3909) Thanks `@portseif`, `@cbeaulieu-gt`, `@lefarcen`, `@koniaik`, `@nettee`, `@swpark3179`, `@opendorai`, `@maxmilian`.
- 🔑 **Your own keys stop fighting you.** The **Composio key gate is one click** now instead of a dead end, **Gemini BYOK models** track the current API (shut-down 2.0 out, 3.x in), and **composer model switching** finally sticks. (#4047, #3821, #4209) Thanks `@jzhishu`, `@muhsin9999`, `@AmyShang-alt`.
- 🔒 **Nothing leaks.** Preview URL handling is hardened and the local preview server binds to **loopback** by default, so a project preview never wanders onto your network. (#4226, #4227) Thanks `@VIVAAN-DHAWAN`.
- 🧱 **Built to grow.** Sandbox contract shapes and ownership guards are pinned, explicit-root imports are allowed, and model-orchestrator scratch workspaces land — the groundwork for what comes next. (#3429, #3694, #4263) Thanks `@dredozubov`.


> 📥 **Download:** assets for `open-design-v0.11.0` are built by the nightly pipeline and publish to GitHub Releases and `releases.open-design.ai` — macOS arm64/Intel `.dmg`, Windows x64 installer/portable — when the build completes.

## ✨ Added

### 🧩 Agents & runtimes
- **Amp CLI** coding-agent adapter. (#3861) Thanks `@techpotatoes`.
- **Codebuddy Code** CLI agent adapter. (#3961) Thanks `@aleexjiang`.
- **Codex subscription media provider.** (#4244) Thanks `@passive-book`.
- **`reasonix` 1.x Go MCP env** support via `envFormat` map. (#4094) Thanks `@AirTech-Full`.

### 🖼️ Plugins & gallery
- **56 official deck seeds** unified around the Open Design product narrative. (#4357) Thanks `@free666799`.
- **23 community slides/deck plugins** from top open-source slide skills. (#4127) Thanks `@elihahah666`.
- **Refreshed HyperFrames video templates** from html-video. (#4063) Thanks `@xne998808-ai`.
- **Baked plugin preview clips** on cards and detail pages. (#4237) Thanks `@lefarcen`.
- **Community slide decks surfaced on Home** with letterbox-free 16:9 previews. (#4350) Thanks `@free666799`.
- **`/deep-think` — Maximum Cognitive Effort Protocol** plugin. (#4116) Thanks `@Mallet-Dev`.
- **Zelda-style image prompt** template. (#4138) Thanks `@Tuola-waj`.

### 🚪 Landing, blog & discovery
- **Agent design pages for all 21 supported agents.** (#4050) Thanks `@xne998808-ai`.
- **Purpose-built OG card site-wide.** (#4292) Thanks `@xne998808-ai`.
- **Blog overhaul** — TOC, unified art, 0.10.0 post, full i18n. (#4330) Thanks `@xne998808-ai`.
- **SEO + UX overhaul** for /plugins/ systems & detail pages. (#4331) Thanks `@xne998808-ai`.
- **Keyword-optimized tutorial metadata** across locales. (#4353) Thanks `@xne998808-ai`.
- **Two community Open Design overview tutorials.** (#4386) Thanks `@xne998808-ai`.
- **Landing skill-spec restyle**, upstream parity, newsletter + nav updates. (#4158) Thanks `@wangchenglong0001`.
- **Giant two-tone wordmark sign-off** under the footer. (#4257) Thanks `@wangchenglong0001`.
- **Trust & EEAT pages** — about, FAQ, privacy, terms, and a real 404 — with a rebuilt footer. (#4417) Thanks `@xne998808-ai`.

### 🧭 Onboarding & accounts
- **Gated Connect step, sequential stepper, restyled progress bar** in onboarding, plus a **tooltip that explains the Connect gate**, **smarter BYOK auto-checks and CLI scan reuse**, and **no first-run home flash** before onboarding starts. (#4389, #4418, #4425, #4426, #4429) Thanks `@free666799`, `@PerishCode`.
- **Connect your Open Design and AMR accounts** across products, with handoff carried end to end. (#4310, #4280, #4396) Thanks `@NJUHua`.
- **Product analytics:** activation milestones, runnable globals, working-dir picker tracking, entry-point tagging, and real-deploy / export-share success tracking. (#4362, #4355, #4354, #4352, #4411) Thanks `@free666799`.

### 🌐 UI & web
- **Consistent tab hover tooltips.** (#3712) Thanks `@portseif`.
- **Clickable Composio API-key gate.** (#4047) Thanks `@jzhishu`.
- **Live Codex thinking status** in the chat. (#4317) Thanks `@yinjialu`.

## 🔁 Changed

- **Gemini BYOK models** updated to the current API — shut-down 2.0 models removed, 3.x added. (#3821) Thanks `@muhsin9999`.
- **Localized plugin input form labels.** (#3825) Thanks `@mcncarl`.
- **Performance:** **OpenCode bootstrap loading is now cached** to cut cold-start latency. (#4224) Thanks `@VIVAAN-DHAWAN`.
- **Internal refactors:** shared composable **dialog primitives** for web dialogs, migrated low-risk **raw buttons & form controls to shared primitives**, and split the daemon **server-bootstrap / plugin routes** with duplicate registrations removed. (#4256, #4174, #4311, #4340, #4325) Thanks `@mrcfps`.
- **CI hardening:** structured ci-gate workflow stack, visual-regression screenshot stabilization, and PR UI P0 gating. (#4083, #4290, #4142) Thanks `@PerishCode`, `@mrcfps`, `@AmyShang-alt`.

## 🐛 Fixed

### 🖥️ Desktop & updater
- **Recover the window** when the renderer dies or a load fails. (#4179) Thanks `@portseif`.
- **Prevent zero-delay idle updater polling.** (#4143) Thanks `@nettee`.
- **Scope window-chrome spec matching** to the main app window, and **parent native dialogs to the renderer window.** (#4216, #4159) Thanks `@swpark3179`.
- **Pad the macOS app icon** to the HIG safe area. (#4282) Thanks `@maxmilian`.

### 🧠 Daemon, agents & runs
- **Close stdin on AskUserQuestion tool_use** so runs don't hang. (#4277) Thanks `@cbeaulieu-gt`.
- **Destroy child stdio streams on retry** to prevent an FD leak. (#4163) Thanks `@koniaik`.
- **AMR login now tries a direct connection first and falls back to the IPv4 proxy** only when it has to, fixing sign-in behind transparent proxies. (#4409, #4210) Thanks `@lefarcen`, `@PerishCode`.
- **Keep plan + critique stages stable** for template and plugin generation, so quality stages aren't skipped. (#4360) Thanks `@lefarcen`.
- **Skip Cursor `model_call_id` replay** to prevent duplicate output. (#3777) Thanks `@zhangdongming0607`.
- **Report unavailable Codex Browser Use**, **fix the Kimi Code runtime adapter**, **prevent legacy Kimi CLI launch regressions**, and **improve the outdated OpenCode CLI connection error.** (#4156, #4191, #4312, #4233) Thanks `@TheAngryPit`, `@AriaShishegaran`, `@nettee`, `@Diyoncrz18`.
- **Strip inherited OpenCode session env** and grant project-dir permissions. (#3806) Thanks `@r3vs`.
- **Default the local preview server to loopback** and **harden preview URL handling.** (#4227, #4226) Thanks `@VIVAAN-DHAWAN`.
- **Diagnostics export delegates to the daemon** so run/AMR logs are captured. (#4405) Thanks `@lefarcen`.

### 🎨 Editing, preview & capture
- **Drop a text caret on bare `div`/`li`/`td`/`h4-6`** in edit mode. (#4382) Thanks `@lefarcen`.
- **Prevent artifact scripts from consuming keyboard events** during text editing. (#3445) Thanks `@daltonnyx`.
- **Keep screenshot capture from grabbing the hover tooltip**, **send annotations without the screenshot when capture fails**, and **fix blank/clipped desktop PDF export** by sizing the page to artifact content. (#3909, #4080, #4086) Thanks `@maxmilian`, `@fancyboi999`, `@fancy`.
- **Suppress the PDF export toast on cancel.** (#4002) Thanks `@icenfly`.
- **Stop the preview reloading out from under you** while you mark up, screenshot, or comment. (#4365) Thanks `@lefarcen`.
- **Fix composer BYOK model switching** and **composer toolbox flyout positioning.** (#4209, #3793) Thanks `@AmyShang-alt`, `@cocojojo5213`.

### 🪟 New Project, pickers & layout
- **Handle draft design systems in New Project** and **exclude them from the selection list.** (#3797, #3798) Thanks `@thongntit`, `@xxiaoxiong`.
- **Keep the design-system / Platform picker above modal chrome and later form sections** — a cluster of stacking-context fixes. (#3703, #4026, #4161, #4173, #4193) Thanks `@liuzemei`, `@sarinkuruvilla`, `@PeixuanLi`, `@opendorai`, `@jzhishu`.
- **Unify entry topbar tooltips**, **hide the back-to-projects action from the menu**, and **relax the standalone readiness probe.** (#4079, #3983, #3811) Thanks `@jzhishu`, `@Lanzhou3`.

### 🌍 Landing & docs
- **Post-#4158 landing fixes** — analytics, downloads, mobile nav, newsletter, share, live counts. (#4221) Thanks `@lefarcen`.
- **Share links use the current host**, not hardcoded production; **stop footer wordmark clipping** on narrow phones; **highlight Resources** on the download page; and **track /download/ CTA routing.** (#4236, #4258, #3611, #4326) Thanks `@lefarcen`, `@mturac`, `@elihahah666`.
- **Fix landing download release metadata** and **AMR install URL metadata.** (#4155, #4006) Thanks `@Siri-Ray`, `@TheAngryPit`.
- **Refresh the French locale** and **fix README architecture-doc table formatting.** (#3652, #3926) Thanks `@davezfr`, `@yihuishou`.
- **Tighten copy across the product** — social-share publish modal wording, social template English metadata, and the Replicate CTA. (#4428, #4427, #4424) Thanks `@PerishCode`.

### 🛠️ Build, CLI & infra
- **Replace CommonJS `require` with ESM imports** in `od files write/upload`. (#4060) Thanks `@ZCDeng`.
- **Skip build targets whose sources are absent** so the Docker image build survives. (#4039) Thanks `@maxmilian`.
- **Pin `pnpm_10` through `fetchPnpmDeps` and `pnpmConfigHook`** (Nix). (#3990) Thanks `@GodTamIt`.
- **Back off offline star-fetch logging.** (#3592) Thanks `@mturac`.
- **Unwrap cosmetic hard wraps** in bundled plugin manifest descriptions. (#4406) Thanks `@lefarcen`.
- **Build the daily beta from `main`**, not the latest release branch. (#4393) Thanks `@lefarcen`.

## 🙏 Thanks to everyone who shipped 0.11.0

`@AirTech-Full` · `@alchemistklk` · `@aleexjiang` · `@alexandre-leng` · `@AmyShang-alt` · `@AriaShishegaran` · `@cbeaulieu-gt` · `@cocojojo5213` · `@daltonnyx` · `@davezfr` · `@Diyoncrz18` · `@dredozubov` · `@elihahah666` · `@fancy` · `@fancyboi999` · `@free666799` · `@GodTamIt` · `@icenfly` · `@Jeshua09090` · `@jzhishu` · `@kokisanai` · `@koniaik` · `@Lanzhou3` · `@lefarcen` · `@liuzemei` · `@Mallet-Dev` · `@maxmilian` · `@mcncarl` · `@MFA-G` · `@mrcfps` · `@mturac` · `@muhsin9999` · `@nettee` · `@NJUHua` · `@opendorai` · `@oriengy` · `@passive-book` · `@PeixuanLi` · `@PerishCode` · `@portseif` · `@r3vs` · `@sarinkuruvilla` · `@Siri-Ray` · `@swpark3179` · `@techpotatoes` · `@TheAngryPit` · `@thongntit` · `@Tuola-waj` · `@VIVAAN-DHAWAN` · `@wangchenglong0001` · `@xne998808-ai` · `@xxiaoxiong` · `@yihuishou` · `@yinjialu` · `@YOMXXX` · `@ZCDeng` · `@zhangdongming0607`

---

> ⚠️ **Merge with a *merge commit* — never squash or rebase.** This is the `release/v0.11.0 → main` back-merge; the merge-button choice is the entire safeguard. The nightly build + Feishu card were triggered automatically by the push to `release/**`.
>
> _Scope note: the topological delta `open-design-v0.10.1..release/v0.11.0` is 140 PRs — everything on `main` after the 0.10.0 cut that shipped in neither 0.10.0 nor the 0.10.1 hotfix (0.10.1 was branched off the 0.10.0 tag and never merged back). Three of those PRs (#4198, #4202, #4203) already shipped — and were credited — in the 0.10.1 release, so they're intentionally excluded here, leaving **137 net-new PRs across 57 contributors**. There is **zero** overlap with the 0.10.0 release note._
