### PR TITLE
[codex] Make same copy

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1789,7 +1789,7 @@ export const en: Dict = {
   'preview.usePlugin': 'Use plugin',
   'preview.usePluginOnly': 'Use plugin only',
   'preview.usePluginOnlyDesc': 'Use the plugin structure and write the content yourself',
-  'preview.replicateContent': 'Replicate this content',
+  'preview.replicateContent': 'Make same',
   'preview.replicateContentDesc': 'Use the example prompt to recreate the preview',
   'preview.shareMenu': 'Share',
   'preview.exportMenu': 'Export',


### PR DESCRIPTION
## Why

This PR updates the replicate CTA copy so the action text matches the intended "make same" wording.

The pain being addressed is product copy clarity: users should see CTA language that reflects the action they are taking rather than inconsistent wording.

## What users will see

Users will see updated CTA copy for the replicate action.

## Surface area

- [x] **UI** — copy shown in the web experience
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes existing CTA text without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. Copy-only CTA update.

## Bug fix verification

Skipped. This is a copy update, not a bug fix.

## Validation

- Not run locally; PR opened from the existing branch for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784207380&installation_id=140661819&pr_number=4424&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4424&signature=cb5d5bca3dcb82666c77e8e0ca3b38f0d0ac0d8ec7919163bdc17b80909d1b5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->