### PR TITLE
[codex] Improve onboarding BYOK auto checks

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1417,6 +1417,13 @@ function OnboardingView({
     void onConfigPersist(nextConfig);
   }
 
+  function selectFirstProviderModelWhenEmpty(models: readonly ProviderModelOption[]) {
+    const firstModel = models[0];
+    if (!firstModel || config.model.trim()) return;
+    onApiModelChange(firstModel.id);
+    updateApiConfig({ model: firstModel.id });
+  }
+
   function clearAgentRevealTimers() {
     agentRevealTimersRef.current.forEach((timer) => clearTimeout(timer));
     agentRevealTimersRef.current = [];
@@ -1781,6 +1788,7 @@ function OnboardingView({
     providerModelsAutoFetchKeyRef.current = inputKey;
     const cachedModels = activeProviderModelsCache[inputKey];
     if (cachedModels) {
+      selectFirstProviderModelWhenEmpty(cachedModels);
       setProviderModelsState({
         status: 'done',
         inputKey,
@@ -1801,11 +1809,7 @@ function OnboardingView({
         apiKey: config.apiKey,
       });
       if (result.ok && result.models?.length) {
-        const firstModel = result.models[0];
-        if (firstModel && !config.model.trim()) {
-          onApiModelChange(firstModel.id);
-          updateApiConfig({ model: firstModel.id });
-        }
+        selectFirstProviderModelWhenEmpty(result.models);
         activeSetProviderModelsCache((current) => ({
           ...current,
           [inputKey]: result.models ?? [],

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -188,6 +188,8 @@ const ONBOARDING_DROPDOWN_OPEN_EVENT = 'open-design:onboarding-dropdown-open';
 const NEWSLETTER_SUBSCRIBE_URL =
   process.env.NEXT_PUBLIC_NEWSLETTER_URL ?? 'https://open-design.ai/subscribe';
 const NEWSLETTER_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ONBOARDING_BYOK_AUTO_FETCH_DELAY_MS = 300;
+const ONBOARDING_BYOK_AUTO_TEST_DELAY_MS = 500;
 
 const ONBOARDING_AMR_MODEL_OPTIONS: NonNullable<AgentInfo['models']> = [
   { id: 'claude-opus-4.8', label: 'Claude Opus 4.8' },
@@ -1003,6 +1005,8 @@ function OnboardingView({
   const cliScanTokenRef = useRef(0);
   const amrLoginPollCancelledRef = useRef(false);
   const amrAgentRefreshAttemptedRef = useRef(false);
+  const providerModelsAutoFetchKeyRef = useRef<string | null>(null);
+  const providerAutoTestKeyRef = useRef<string | null>(null);
   const apiProtocol = config.apiProtocol ?? 'anthropic';
   const providerTestInputKey = [
     apiProtocol,
@@ -1742,6 +1746,7 @@ function OnboardingView({
   async function testProviderInline() {
     if (!canTestProvider || providerTestState.status === 'running') return;
     const inputKey = providerTestInputKey;
+    providerAutoTestKeyRef.current = inputKey;
     setProviderTestState({ status: 'running', inputKey });
     try {
       const result = await testApiProvider({
@@ -1773,6 +1778,7 @@ function OnboardingView({
   async function fetchProviderModelsInline() {
     if (!canFetchProviderModels || providerModelsState.status === 'running') return;
     const inputKey = providerModelsInputKey;
+    providerModelsAutoFetchKeyRef.current = inputKey;
     const cachedModels = activeProviderModelsCache[inputKey];
     if (cachedModels) {
       setProviderModelsState({
@@ -1795,6 +1801,11 @@ function OnboardingView({
         apiKey: config.apiKey,
       });
       if (result.ok && result.models?.length) {
+        const firstModel = result.models[0];
+        if (firstModel && !config.model.trim()) {
+          onApiModelChange(firstModel.id);
+          updateApiConfig({ model: firstModel.id });
+        }
         activeSetProviderModelsCache((current) => ({
           ...current,
           [inputKey]: result.models ?? [],
@@ -1814,6 +1825,40 @@ function OnboardingView({
       });
     }
   }
+
+  useEffect(() => {
+    if (runtime !== 'byok' || step !== 0) return;
+    if (!canFetchProviderModels) return;
+    if (providerModelsState.status === 'running') return;
+    if (providerModelsAutoFetchKeyRef.current === providerModelsInputKey) return;
+    const timer = window.setTimeout(() => {
+      void fetchProviderModelsInline();
+    }, ONBOARDING_BYOK_AUTO_FETCH_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [
+    canFetchProviderModels,
+    providerModelsInputKey,
+    providerModelsState.status,
+    runtime,
+    step,
+  ]);
+
+  useEffect(() => {
+    if (runtime !== 'byok' || step !== 0) return;
+    if (!canTestProvider) return;
+    if (providerTestState.status === 'running') return;
+    if (providerAutoTestKeyRef.current === providerTestInputKey) return;
+    const timer = window.setTimeout(() => {
+      void testProviderInline();
+    }, ONBOARDING_BYOK_AUTO_TEST_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [
+    canTestProvider,
+    providerTestInputKey,
+    providerTestState.status,
+    runtime,
+    step,
+  ]);
 
   const onboardingNavigationLocked = newsletterSubmitting;
   const primaryActionLabel = isLastStep && newsletterSubmitting

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1007,6 +1007,10 @@ function OnboardingView({
   const amrAgentRefreshAttemptedRef = useRef(false);
   const providerModelsAutoFetchKeyRef = useRef<string | null>(null);
   const providerAutoTestKeyRef = useRef<string | null>(null);
+  const providerModelAutoSelectRef = useRef({
+    model: config.model,
+    providerModelsInputKey: '',
+  });
   const apiProtocol = config.apiProtocol ?? 'anthropic';
   const providerTestInputKey = [
     apiProtocol,
@@ -1021,6 +1025,10 @@ function OnboardingView({
     config.apiKey,
     config.apiVersion ?? '',
   );
+  providerModelAutoSelectRef.current = {
+    model: config.model,
+    providerModelsInputKey,
+  };
   const canTestProvider =
     Boolean(config.apiKey.trim()) &&
     Boolean(config.baseUrl.trim()) &&
@@ -1417,9 +1425,19 @@ function OnboardingView({
     void onConfigPersist(nextConfig);
   }
 
-  function selectFirstProviderModelWhenEmpty(models: readonly ProviderModelOption[]) {
+  function selectFirstProviderModelWhenEmpty(
+    models: readonly ProviderModelOption[],
+    expectedInputKey: string,
+  ) {
     const firstModel = models[0];
-    if (!firstModel || config.model.trim()) return;
+    const current = providerModelAutoSelectRef.current;
+    if (
+      !firstModel ||
+      current.providerModelsInputKey !== expectedInputKey ||
+      current.model.trim()
+    ) {
+      return;
+    }
     onApiModelChange(firstModel.id);
     updateApiConfig({ model: firstModel.id });
   }
@@ -1788,7 +1806,7 @@ function OnboardingView({
     providerModelsAutoFetchKeyRef.current = inputKey;
     const cachedModels = activeProviderModelsCache[inputKey];
     if (cachedModels) {
-      selectFirstProviderModelWhenEmpty(cachedModels);
+      selectFirstProviderModelWhenEmpty(cachedModels, inputKey);
       setProviderModelsState({
         status: 'done',
         inputKey,
@@ -1809,7 +1827,7 @@ function OnboardingView({
         apiKey: config.apiKey,
       });
       if (result.ok && result.models?.length) {
-        selectFirstProviderModelWhenEmpty(result.models);
+        selectFirstProviderModelWhenEmpty(result.models, inputKey);
         activeSetProviderModelsCache((current) => ({
           ...current,
           [inputKey]: result.models ?? [],

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1010,6 +1010,8 @@ function OnboardingView({
   const providerModelAutoSelectRef = useRef({
     model: config.model,
     providerModelsInputKey: '',
+    runtime,
+    step,
   });
   const apiProtocol = config.apiProtocol ?? 'anthropic';
   const providerTestInputKey = [
@@ -1028,6 +1030,8 @@ function OnboardingView({
   providerModelAutoSelectRef.current = {
     model: config.model,
     providerModelsInputKey,
+    runtime,
+    step,
   };
   const canTestProvider =
     Boolean(config.apiKey.trim()) &&
@@ -1433,6 +1437,8 @@ function OnboardingView({
     const current = providerModelAutoSelectRef.current;
     if (
       !firstModel ||
+      current.runtime !== 'byok' ||
+      current.step !== 0 ||
       current.providerModelsInputKey !== expectedInputKey ||
       current.model.trim()
     ) {

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EntryShell } from '../../src/components/EntryShell';
 import { AMR_LOGIN_TIMEOUT_MS } from '../../src/components/amrLoginPolling';
+import { providerModelsCacheKey } from '../../src/components/providerModelsCache';
 import { I18nProvider } from '../../src/i18n';
 import type { AgentInfo, AppConfig } from '../../src/types';
 
@@ -960,6 +961,61 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     );
     expect(providerModelCalls).toHaveLength(1);
     expect(connectionTestCalls).toHaveLength(1);
+    expect(JSON.parse(String(connectionTestCalls[0]?.[1]?.body))).toMatchObject({
+      protocol: 'anthropic',
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'test-api-key',
+      model: 'claude-opus-4-8',
+    });
+  });
+
+  it('automatically selects a cached BYOK model before testing in onboarding', async () => {
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 12,
+          model: 'claude-opus-4-8',
+          sample: 'Connected',
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    const props = renderOnboarding({
+      providerModelsCache: {
+        [providerModelsCacheKey('anthropic', 'https://api.anthropic.com', 'test-api-key')]: [
+          { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+          { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+        ],
+      },
+      onProviderModelsCacheChange: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Bring your own key/i }));
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'test-api-key' } });
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://api.anthropic.com' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Fetched 2 models.')).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Connected\. Replied in 12 ms/i)).toBeTruthy();
+    });
+    const providerModelCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith('/api/provider/models'),
+    );
+    const connectionTestCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith('/api/test/connection'),
+    );
+    expect(providerModelCalls).toHaveLength(0);
+    expect(connectionTestCalls).toHaveLength(1);
+    expect(props.onApiModelChange).toHaveBeenCalledWith('claude-opus-4-8');
     expect(JSON.parse(String(connectionTestCalls[0]?.[1]?.body))).toMatchObject({
       protocol: 'anthropic',
       baseUrl: 'https://api.anthropic.com',

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -856,8 +856,8 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
           kind: 'success',
           latencyMs: 10,
           models: [
-            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
             { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
           ],
         });
       }
@@ -908,6 +908,63 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
       baseUrl: 'https://api.anthropic.com',
       model: 'claude-opus-4-8',
       apiProviderBaseUrl: null,
+    });
+  });
+
+  it('automatically fetches BYOK models and tests the selected model in onboarding', async () => {
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/provider/models') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 10,
+          models: [
+            { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+          ],
+        });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 12,
+          model: 'claude-opus-4-8',
+          sample: 'Connected',
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    renderOnboarding();
+
+    fireEvent.click(screen.getByRole('button', { name: /Bring your own key/i }));
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'test-api-key' } });
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://api.anthropic.com' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Fetched 2 models.')).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Connected\. Replied in 12 ms/i)).toBeTruthy();
+    });
+    const providerModelCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith('/api/provider/models'),
+    );
+    const connectionTestCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith('/api/test/connection'),
+    );
+    expect(providerModelCalls).toHaveLength(1);
+    expect(connectionTestCalls).toHaveLength(1);
+    expect(JSON.parse(String(connectionTestCalls[0]?.[1]?.body))).toMatchObject({
+      protocol: 'anthropic',
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'test-api-key',
+      model: 'claude-opus-4-8',
     });
   });
 

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -1024,6 +1024,68 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     });
   });
 
+  it('ignores stale BYOK model fetch responses after onboarding inputs change', async () => {
+    let resolveFirstModelFetch: ((response: Response) => void) | null = null;
+    let providerModelRequestCount = 0;
+    const fetchMock = vi.fn((input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return Promise.resolve(
+          jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),
+        );
+      }
+      if (url.endsWith('/api/provider/models') && init?.method === 'POST') {
+        providerModelRequestCount += 1;
+        if (providerModelRequestCount === 1) {
+          return new Promise<Response>((resolve) => {
+            resolveFirstModelFetch = resolve;
+          });
+        }
+        return new Promise<Response>(() => {});
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    const props = renderOnboarding();
+
+    fireEvent.click(screen.getByRole('button', { name: /Bring your own key/i }));
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'old-api-key' } });
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://api.anthropic.com' } });
+
+    await waitFor(() => {
+      expect(providerModelRequestCount).toBe(1);
+    });
+
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'new-api-key' } });
+
+    await act(async () => {
+      resolveFirstModelFetch?.(
+        jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 10,
+          models: [
+            { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+          ],
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(props.onApiModelChange).not.toHaveBeenCalled();
+    expect((props.onConfigPersist as ReturnType<typeof vi.fn>).mock.calls).not.toContainEqual([
+      expect.objectContaining({
+        apiKey: 'old-api-key',
+        model: 'claude-opus-4-8',
+      }),
+    ]);
+    expect((props.onConfigPersist as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0]).toMatchObject({
+      apiKey: 'new-api-key',
+      model: '',
+    });
+  });
+
   it('shows the AMR cloud card as a skeleton while agent detection is still in flight', async () => {
     // Before this fix, the AMR cloud card was simply absent for the several
     // seconds AMR's probe takes to settle (showAmrCloudOption was false once

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -1086,6 +1086,63 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     });
   });
 
+  it('ignores stale BYOK model fetch responses after switching to Local CLI', async () => {
+    let resolveModelFetch: ((response: Response) => void) | null = null;
+    let providerModelRequestCount = 0;
+    const fetchMock = vi.fn((input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return Promise.resolve(
+          jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),
+        );
+      }
+      if (url.endsWith('/api/provider/models') && init?.method === 'POST') {
+        providerModelRequestCount += 1;
+        return new Promise<Response>((resolve) => {
+          resolveModelFetch = resolve;
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    const props = renderOnboarding();
+
+    fireEvent.click(screen.getByRole('button', { name: /Bring your own key/i }));
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'test-api-key' } });
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://api.anthropic.com' } });
+
+    await waitFor(() => {
+      expect(providerModelRequestCount).toBe(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Local coding agent/i }));
+    await act(async () => {});
+
+    await act(async () => {
+      resolveModelFetch?.(
+        jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 10,
+          models: [
+            { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+          ],
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(props.onApiModelChange).not.toHaveBeenCalledWith('claude-opus-4-8');
+    expect((props.onConfigPersist as ReturnType<typeof vi.fn>).mock.calls).not.toContainEqual([
+      expect.objectContaining({
+        mode: 'api',
+        model: 'claude-opus-4-8',
+      }),
+    ]);
+    expect(props.onModeChange).toHaveBeenCalledWith('daemon');
+  });
+
   it('shows the AMR cloud card as a skeleton while agent detection is still in flight', async () => {
     // Before this fix, the AMR cloud card was simply absent for the several
     // seconds AMR's probe takes to settle (showAmrCloudOption was false once


### PR DESCRIPTION
## Why

This PR improves the onboarding BYOK auto-check flow.

The pain being addressed is onboarding friction: provider readiness checks should update automatically so users get accurate setup feedback without manually re-driving the flow.

## What users will see

During onboarding, BYOK setup status updates more reliably as the app checks provider configuration.

## Surface area

- [x] **UI** — onboarding flow behavior in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — onboarding readiness checks update automatically
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is an onboarding behavior update.

## Bug fix verification

Skipped. This is an onboarding behavior improvement, not a bug fix follow-up.

## Validation

- Not run locally; PR opened from the existing branch for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784208624&installation_id=140661819&pr_number=4425&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4425&signature=a102a41b2b27823c2187825c1812e83c4c98669ece6d92b3271e7a9e265abaed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->