### PR TITLE
[codex] Improve onboarding CLI scan reuse

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1163,14 +1163,14 @@ function OnboardingView({
       (agent) => agent.available && agent.id !== 'amr',
     );
     if (currentAvailableAgents.length > 0) {
-      selectDefaultCliAgent(currentAvailableAgents);
+      const selectedCliAgent = selectDefaultCliAgent(currentAvailableAgents);
       showCliAgents(scanToken, currentAvailableAgents, { stagger: false });
       setCliScanStatus('done');
       emitPendingCliScanResult(scanToken, {
         result: 'success',
         detected: agents.length,
         available: currentAvailableAgents.length,
-        selectedCliId: agentIdToTracking(currentAvailableAgents[0]!.id),
+        selectedCliId: selectedCliAgent ? agentIdToTracking(selectedCliAgent.id) : undefined,
       });
       return;
     }
@@ -1512,10 +1512,14 @@ function OnboardingView({
     agentRevealTimersRef.current = [];
   }
 
-  function selectDefaultCliAgent(availableAgents: AgentInfo[]): void {
-    if (availableAgents.length === 0) return;
-    if (availableAgents.some((agent) => agent.id === config.agentId)) return;
-    onAgentChange(availableAgents[0]!.id);
+  function selectDefaultCliAgent(availableAgents: AgentInfo[]): AgentInfo | null {
+    const selectedAgent =
+      availableAgents.find((agent) => agent.id === config.agentId) ?? availableAgents[0] ?? null;
+    if (!selectedAgent) return null;
+    if (selectedAgent.id !== config.agentId) {
+      onAgentChange(selectedAgent.id);
+    }
+    return selectedAgent;
   }
 
   function emitPendingCliScanResult(
@@ -1845,14 +1849,14 @@ function OnboardingView({
       (agent) => agent.available && agent.id !== 'amr',
     );
     if (options.preferExisting && currentAvailableAgents.length > 0) {
-      selectDefaultCliAgent(currentAvailableAgents);
+      const selectedCliAgent = selectDefaultCliAgent(currentAvailableAgents);
       showCliAgents(scanToken, currentAvailableAgents, { stagger: false });
       setCliScanStatus('done');
       emitPendingCliScanResult(scanToken, {
         result: 'success',
         detected: agents.length,
         available: currentAvailableAgents.length,
-        selectedCliId: agentIdToTracking(currentAvailableAgents[0]!.id),
+        selectedCliId: selectedCliAgent ? agentIdToTracking(selectedCliAgent.id) : undefined,
       });
       return currentAvailableAgents;
     }
@@ -1866,7 +1870,7 @@ function OnboardingView({
       if (cliScanTokenRef.current !== scanToken) return;
       cliRefreshPendingTokenRef.current = null;
       const availableAgents = nextAgents.filter((agent) => agent.available && agent.id !== 'amr');
-      selectDefaultCliAgent(availableAgents);
+      const selectedCliAgent = selectDefaultCliAgent(availableAgents);
       // Scan-result semantics: zero available CLIs is a `failed` outcome
       // because the user's runtime path is blocked, even though the
       // detect call itself returned successfully. `detected_cli_count`
@@ -1886,8 +1890,8 @@ function OnboardingView({
         result: 'success',
         detected: nextAgents.length,
         available: availableAgents.length,
-        ...(availableAgents[0]
-          ? { selectedCliId: agentIdToTracking(availableAgents[0].id) }
+        ...(selectedCliAgent
+          ? { selectedCliId: agentIdToTracking(selectedCliAgent.id) }
           : {}),
       });
       showCliAgents(scanToken, availableAgents, { stagger: true });

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1020,6 +1020,12 @@ function OnboardingView({
   }, [profile]);
   const agentRevealTimersRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
   const cliScanTokenRef = useRef(0);
+  const cliScanTelemetryRef = useRef<{
+    token: number;
+    startedAt: number;
+    onboardingSessionId: string;
+  } | null>(null);
+  const cliRefreshPendingTokenRef = useRef<number | null>(null);
   const amrLoginPollCancelledRef = useRef(false);
   const amrAgentRefreshAttemptedRef = useRef(false);
   const apiProtocol = config.apiProtocol ?? 'anthropic';
@@ -1061,9 +1067,8 @@ function OnboardingView({
       provider.protocol === apiProtocol &&
       provider.baseUrl === (config.apiProviderBaseUrl ?? config.baseUrl),
   ) ?? null;
-  const visibleAgents = agents.filter(
-    (agent) => agent.available && agent.id !== 'amr' && visibleAgentIds.includes(agent.id),
-  );
+  const availableCliAgents = agents.filter((agent) => agent.available && agent.id !== 'amr');
+  const visibleAgents = availableCliAgents.filter((agent) => visibleAgentIds.includes(agent.id));
   const amrAgent = agents.find((agent) => agent.id === 'amr' && agent.available) ?? null;
   // AMR availability is still undecided while the cold-start stream runs or
   // the one-shot re-probe is in flight. During that window we show the AMR
@@ -1149,6 +1154,36 @@ function OnboardingView({
     onModeChange('daemon');
     onAgentChange('amr');
   }, [amrAgent, onAgentChange, onModeChange, runtime]);
+
+  useEffect(() => {
+    if (runtime !== 'local') return;
+    const scanToken = cliScanTokenRef.current;
+    if (cliRefreshPendingTokenRef.current === scanToken) return;
+    const currentAvailableAgents = agents.filter(
+      (agent) => agent.available && agent.id !== 'amr',
+    );
+    if (currentAvailableAgents.length > 0) {
+      selectDefaultCliAgent(currentAvailableAgents);
+      showCliAgents(scanToken, currentAvailableAgents, { stagger: false });
+      setCliScanStatus('done');
+      emitPendingCliScanResult(scanToken, {
+        result: 'success',
+        detected: agents.length,
+        available: currentAvailableAgents.length,
+        selectedCliId: agentIdToTracking(currentAvailableAgents[0]!.id),
+      });
+      return;
+    }
+    if (!agentsLoading && cliScanStatus === 'scanning') {
+      setCliScanStatus('done');
+      emitPendingCliScanResult(scanToken, {
+        result: 'failed',
+        detected: agents.length,
+        available: 0,
+        errorCode: 'NO_AVAILABLE_CLI',
+      });
+    }
+  }, [agents, agentsLoading, cliScanStatus, config.agentId, runtime]);
 
   useEffect(() => {
     // The cold-start stream finished without AMR. Re-probe once before we
@@ -1360,7 +1395,7 @@ function OnboardingView({
         emitOnboardingClick('local_coding_agent', 'select_runtime', {
           runtime_type: 'local_cli',
         });
-        void scanCliAgents();
+        void scanCliAgents({ preferExisting: true });
       },
     },
     {
@@ -1475,6 +1510,86 @@ function OnboardingView({
   function clearAgentRevealTimers() {
     agentRevealTimersRef.current.forEach((timer) => clearTimeout(timer));
     agentRevealTimersRef.current = [];
+  }
+
+  function selectDefaultCliAgent(availableAgents: AgentInfo[]): void {
+    if (availableAgents.length === 0) return;
+    if (availableAgents.some((agent) => agent.id === config.agentId)) return;
+    onAgentChange(availableAgents[0]!.id);
+  }
+
+  function emitPendingCliScanResult(
+    token: number,
+    args: {
+      result: 'success' | 'failed';
+      detected: number;
+      available: number;
+      selectedCliId?: TrackingCliProviderId;
+      errorCode?: string;
+    },
+  ): void {
+    const telemetry = cliScanTelemetryRef.current;
+    if (!telemetry || telemetry.token !== token) return;
+    cliScanTelemetryRef.current = null;
+    trackOnboardingRuntimeScanResult(analytics.track, {
+      page_name: 'onboarding',
+      area: 'runtime',
+      runtime_type: 'local_cli',
+      result: args.result,
+      detected_cli_count: args.detected,
+      available_cli_count: args.available,
+      ...(args.selectedCliId ? { selected_cli_id: args.selectedCliId } : {}),
+      ...(args.errorCode ? { error_code: args.errorCode } : {}),
+      duration_ms: Math.max(0, Date.now() - telemetry.startedAt),
+      onboarding_session_id: telemetry.onboardingSessionId,
+    });
+  }
+
+  function beginCliScan(options: { clearVisible: boolean }): number {
+    const scanToken = cliScanTokenRef.current + 1;
+    cliScanTokenRef.current = scanToken;
+    clearAgentRevealTimers();
+    setRuntime('local');
+    onModeChange('daemon');
+    setCliScanStatus('scanning');
+    if (options.clearVisible) setVisibleAgentIds([]);
+    const onboardingSessionId = onboardingSessionIdRef.current;
+    cliScanTelemetryRef.current = onboardingSessionId
+      ? {
+          token: scanToken,
+          startedAt: Date.now(),
+          onboardingSessionId,
+        }
+      : null;
+    return scanToken;
+  }
+
+  function showCliAgents(
+    token: number,
+    availableAgents: AgentInfo[],
+    options: { stagger: boolean },
+  ): void {
+    if (!options.stagger) {
+      const nextIds = availableAgents.map((agent) => agent.id);
+      setVisibleAgentIds((current) =>
+        current.length === nextIds.length && current.every((id, index) => id === nextIds[index])
+          ? current
+          : nextIds,
+      );
+      return;
+    }
+    availableAgents.forEach((agent, index) => {
+      const timer = setTimeout(() => {
+        if (cliScanTokenRef.current !== token) return;
+        setVisibleAgentIds((current) =>
+          current.includes(agent.id) ? current : [...current, agent.id],
+        );
+        if (index === availableAgents.length - 1) {
+          setCliScanStatus('done');
+        }
+      }, 110 * (index + 1));
+      agentRevealTimersRef.current.push(timer);
+    });
   }
 
   function handleBackWithTracking(): void {
@@ -1724,52 +1839,34 @@ function OnboardingView({
     }
   }
 
-  async function scanCliAgents() {
-    const scanToken = cliScanTokenRef.current + 1;
-    cliScanTokenRef.current = scanToken;
-    clearAgentRevealTimers();
-    setRuntime('local');
-    onModeChange('daemon');
-    setCliScanStatus('scanning');
-    setVisibleAgentIds([]);
-    const scanStartedAt = Date.now();
-    const onboardingSessionId = onboardingSessionIdRef.current;
-    const emitScanResult = (
-      args: {
-        result: 'success' | 'failed';
-        detected: number;
-        available: number;
-        selectedCliId?: TrackingCliProviderId;
-        errorCode?: string;
-      },
-    ): void => {
-      if (!onboardingSessionId) return;
-      trackOnboardingRuntimeScanResult(analytics.track, {
-        page_name: 'onboarding',
-        area: 'runtime',
-        runtime_type: 'local_cli',
-        result: args.result,
-        detected_cli_count: args.detected,
-        available_cli_count: args.available,
-        ...(args.selectedCliId ? { selected_cli_id: args.selectedCliId } : {}),
-        ...(args.errorCode ? { error_code: args.errorCode } : {}),
-        duration_ms: Math.max(0, Date.now() - scanStartedAt),
-        onboarding_session_id: onboardingSessionId,
+  async function scanCliAgents(options: { preferExisting?: boolean } = {}) {
+    const scanToken = beginCliScan({ clearVisible: !options.preferExisting });
+    const currentAvailableAgents = agents.filter(
+      (agent) => agent.available && agent.id !== 'amr',
+    );
+    if (options.preferExisting && currentAvailableAgents.length > 0) {
+      selectDefaultCliAgent(currentAvailableAgents);
+      showCliAgents(scanToken, currentAvailableAgents, { stagger: false });
+      setCliScanStatus('done');
+      emitPendingCliScanResult(scanToken, {
+        result: 'success',
+        detected: agents.length,
+        available: currentAvailableAgents.length,
+        selectedCliId: agentIdToTracking(currentAvailableAgents[0]!.id),
       });
-    };
+      return currentAvailableAgents;
+    }
+    if (options.preferExisting && agentsLoading) {
+      showCliAgents(scanToken, currentAvailableAgents, { stagger: false });
+      return currentAvailableAgents;
+    }
+    cliRefreshPendingTokenRef.current = scanToken;
     try {
       const nextAgents = await onRefreshAgents();
       if (cliScanTokenRef.current !== scanToken) return;
+      cliRefreshPendingTokenRef.current = null;
       const availableAgents = nextAgents.filter((agent) => agent.available && agent.id !== 'amr');
-      // If the user previously had AMR selected (e.g. it was auto-picked once
-      // we detected vela) and they have now chosen the Local CLI path, the
-      // persisted agentId is still 'amr' and would survive Continue without
-      // an explicit click on a local agent card. Switch the selection to the
-      // first available local agent as soon as we have one, so the runtime
-      // and the persisted agent always agree.
-      if (config.agentId === 'amr' && availableAgents[0]) {
-        onAgentChange(availableAgents[0].id);
-      }
+      selectDefaultCliAgent(availableAgents);
       // Scan-result semantics: zero available CLIs is a `failed` outcome
       // because the user's runtime path is blocked, even though the
       // detect call itself returned successfully. `detected_cli_count`
@@ -1777,7 +1874,7 @@ function OnboardingView({
       // "user has no CLI installed" from "detect crashed".
       if (availableAgents.length === 0) {
         setCliScanStatus('done');
-        emitScanResult({
+        emitPendingCliScanResult(scanToken, {
           result: 'failed',
           detected: nextAgents.length,
           available: 0,
@@ -1785,7 +1882,7 @@ function OnboardingView({
         });
         return;
       }
-      emitScanResult({
+      emitPendingCliScanResult(scanToken, {
         result: 'success',
         detected: nextAgents.length,
         available: availableAgents.length,
@@ -1793,22 +1890,12 @@ function OnboardingView({
           ? { selectedCliId: agentIdToTracking(availableAgents[0].id) }
           : {}),
       });
-      availableAgents.forEach((agent, index) => {
-        const timer = setTimeout(() => {
-          if (cliScanTokenRef.current !== scanToken) return;
-          setVisibleAgentIds((current) =>
-            current.includes(agent.id) ? current : [...current, agent.id],
-          );
-          if (index === availableAgents.length - 1) {
-            setCliScanStatus('done');
-          }
-        }, 110 * (index + 1));
-        agentRevealTimersRef.current.push(timer);
-      });
+      showCliAgents(scanToken, availableAgents, { stagger: true });
     } catch (err) {
       if (cliScanTokenRef.current === scanToken) {
+        cliRefreshPendingTokenRef.current = null;
         setCliScanStatus('done');
-        emitScanResult({
+        emitPendingCliScanResult(scanToken, {
           result: 'failed',
           detected: 0,
           available: 0,

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -78,7 +78,35 @@ function renderOnboarding(
   overrides: Partial<React.ComponentProps<typeof EntryShell>> = {},
 ) {
   window.history.replaceState(null, '', '/onboarding');
-  const props: React.ComponentProps<typeof EntryShell> = {
+  const props = onboardingProps(overrides);
+
+  function Harness() {
+    const [config, setConfig] = useState(props.config);
+    return (
+      <I18nProvider initial="en">
+        <EntryShell
+          {...props}
+          config={config}
+          onConfigPersist={(next) => {
+            props.onConfigPersist(next);
+            setConfig(next as AppConfig);
+          }}
+        />
+      </I18nProvider>
+    );
+  }
+
+  render(
+    <Harness />,
+  );
+
+  return props;
+}
+
+function onboardingProps(
+  overrides: Partial<React.ComponentProps<typeof EntryShell>> = {},
+): React.ComponentProps<typeof EntryShell> {
+  return {
     skills: [],
     designTemplates: [],
     designSystems: [],
@@ -112,28 +140,6 @@ function renderOnboarding(
     onCompleteOnboarding: vi.fn(),
     ...overrides,
   };
-
-  function Harness() {
-    const [config, setConfig] = useState(props.config);
-    return (
-      <I18nProvider initial="en">
-        <EntryShell
-          {...props}
-          config={config}
-          onConfigPersist={(next) => {
-            props.onConfigPersist(next);
-            setConfig(next as AppConfig);
-          }}
-        />
-      </I18nProvider>
-    );
-  }
-
-  render(
-    <Harness />,
-  );
-
-  return props;
 }
 
 function renderHome(
@@ -343,6 +349,117 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     const localPanel = screen.getByText('Local CLI').closest('.onboarding-view__setup-panel');
     expect(localPanel?.textContent).toContain('Claude Code');
     expect(localPanel?.textContent).not.toContain('AMR');
+  });
+
+  it('reuses cached available CLI agents without refreshing and reports the preserved selection', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),
+    ) as typeof fetch;
+    const refreshAgents = vi.fn(() => {
+      throw new Error('refresh should not run for cached agents');
+    });
+    const cursorAgent = cliAgent({
+      id: 'cursor-agent',
+      name: 'Cursor Agent',
+      bin: 'cursor-agent',
+    });
+    const props = renderOnboarding({
+      config: baseConfig({ agentId: 'cursor-agent' }),
+      agents: [
+        amrAgent(),
+        cliAgent({ id: 'codex', name: 'Codex CLI', bin: 'codex' }),
+        cursorAgent,
+      ],
+      onRefreshAgents: refreshAgents,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Local coding agent/i }));
+
+    await waitFor(() => {
+      expect(trackedEvents('onboarding_runtime_scan_result')).toHaveLength(1);
+    });
+    expect(refreshAgents).not.toHaveBeenCalled();
+    expect(props.onAgentChange).not.toHaveBeenCalledWith('codex');
+    expect(latestTrackedEvent('onboarding_runtime_scan_result')).toMatchObject({
+      result: 'success',
+      detected_cli_count: 3,
+      available_cli_count: 2,
+      selected_cli_id: 'cursor_agent',
+    });
+  });
+
+  it('resolves cached CLI reuse through the loading effect without duplicate scan telemetry', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),
+    ) as typeof fetch;
+    const refreshAgents = vi.fn(() => {
+      throw new Error('refresh should not run while cached agents are still loading');
+    });
+    const props = onboardingProps({
+      agents: [amrAgent()],
+      agentsLoading: true,
+      onRefreshAgents: refreshAgents,
+    });
+    const view = render(
+      <I18nProvider initial="en">
+        <EntryShell {...props} />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Local coding agent/i }));
+    await act(async () => {});
+    expect(refreshAgents).not.toHaveBeenCalled();
+    expect(trackedEvents('onboarding_runtime_scan_result')).toHaveLength(0);
+
+    view.rerender(
+      <I18nProvider initial="en">
+        <EntryShell
+          {...props}
+          agents={[amrAgent(), cliAgent({ id: 'codex', name: 'Codex CLI', bin: 'codex' })]}
+          agentsLoading={false}
+        />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(trackedEvents('onboarding_runtime_scan_result')).toHaveLength(1);
+    });
+    expect(refreshAgents).not.toHaveBeenCalled();
+    expect(latestTrackedEvent('onboarding_runtime_scan_result')).toMatchObject({
+      result: 'success',
+      detected_cli_count: 2,
+      available_cli_count: 1,
+      selected_cli_id: 'codex_cli',
+    });
+  });
+
+  it('refreshes exactly once when the cached CLI list is empty', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),
+    ) as typeof fetch;
+    const refreshAgents = vi.fn(() => [
+      amrAgent(),
+      cliAgent({ id: 'codex', name: 'Codex CLI', bin: 'codex' }),
+    ]);
+    renderOnboarding({
+      agents: [amrAgent()],
+      agentsLoading: false,
+      onRefreshAgents: refreshAgents,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Local coding agent/i }));
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(trackedEvents('onboarding_runtime_scan_result')).toHaveLength(1);
+    });
+    expect(refreshAgents).toHaveBeenCalledTimes(1);
+    expect(latestTrackedEvent('onboarding_runtime_scan_result')).toMatchObject({
+      result: 'success',
+      detected_cli_count: 2,
+      available_cli_count: 1,
+      selected_cli_id: 'codex_cli',
+    });
   });
 
   it('keeps AMR login pending while device authorization is waiting', async () => {


### PR DESCRIPTION
## Why

This PR improves reuse of cached CLI scan results during onboarding.

The pain being addressed is onboarding latency and repeated work: when CLI scan information is already available, the onboarding UI should reuse it instead of acting like every check starts from scratch.

## What users will see

During onboarding, CLI detection should feel more consistent because previously scanned CLI status can be reused.

## Surface area

- [x] **UI** — onboarding flow behavior in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — onboarding CLI scan status can be reused
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is an onboarding behavior update.

## Bug fix verification

Skipped. This is an onboarding behavior improvement, not a bug fix follow-up.

## Validation

- Not run locally; PR opened from the existing branch for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784208629&installation_id=140661819&pr_number=4426&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4426&signature=34be0bd5ce89a399d69b19b3a80cd85f215967937d04c43dd8ff362947e61890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->