### PR TITLE
[codex] Fix social template English metadata

### DIFF
--- a/plugins/_official/examples/social-media-matrix-tracker-template/open-design.json
+++ b/plugins/_official/examples/social-media-matrix-tracker-template/open-design.json
@@ -24,7 +24,7 @@
     "en": "Social Media Matrix Tracker Template"
   },
   "version": "0.1.0",
-  "description": "Social Media Matrix Tracker template.\nUse when users ask for a cinematic, data-dense social media analytics dashboard\nwith multi-platform metrics, interactive charts, hover insights, range compare,\nand dark/light theme switching in a single HTML artifact.",
+  "description": "Social Media Matrix Tracker template. Use when users ask for a cinematic, data-dense social media analytics dashboard with multi-platform metrics, interactive charts, hover insights, range compare, and dark/light theme switching in a single HTML artifact.",
   "description_i18n": {
     "zh-CN": "社媒矩阵数据追踪面板模板（Social Media Matrix Tracker）。适用于需要电影级、数据密集型社交媒体分析仪表板的场景，支持多平台指标、交互式图表、悬停洞察、范围对比和深浅主题切换，单个 HTML 文件即可实现。",
     "zh-TW": "社群媒體矩陣數據追蹤面板範本（Social Media Matrix Tracker）。適用於需要電影級、數據密集型社群媒體分析儀表板的場景，支援多平台指標、互動式圖表、懸停洞察、範圍比較和深淺主題切換，單一 HTML 檔案即可實現。",
@@ -43,7 +43,7 @@
     "ar": "قالب لوحة تتبع بيانات مصفوفة وسائل التواصل الاجتماعي (Social Media Matrix Tracker). لإنشاء لوحات تحليلية سينمائية كثيفة البيانات مع مقاييس متعددة المنصات ورسوم بيانية تفاعلية ورؤى عند التمرير ومقارنة النطاقات والتبديل بين السمة الفاتحة والداكنة في ملف HTML واحد.",
     "tr": "Sosyal medya matrisi veri takip paneli şablonu (Social Media Matrix Tracker). Multi-platform metrikler, etkileşimli grafikler, hover içgörüler, aralık karşılaştırması ve koyu/açık tema geçişi ile sinematik, veri yoğun sosyal medya analitik panoları oluşturmak için tek bir HTML dosyasında.",
     "uk": "Шаблон панелі відстеження даних матриці соціальних мереж (Social Media Matrix Tracker). Для створення кінематографічних, насичених даними аналітичних дашбордів соцмереж з мультиплатформними метриками, інтерактивними графіками, спливаючими підказками, порівнянням діапазонів та перемиканням темної/світлої теми в одному HTML-файлі.",
-    "en": "Social Media Matrix Tracker template.\nUse when users ask for a cinematic, data-dense social media analytics dashboard\nwith multi-platform metrics, interactive charts, hover insights, range compare,\nand dark/light theme switching in a single HTML artifact."
+    "en": "Social Media Matrix Tracker template. Use when users ask for a cinematic, data-dense social media analytics dashboard with multi-platform metrics, interactive charts, hover insights, range compare, and dark/light theme switching in a single HTML artifact."
   },
   "license": "MIT",
   "author": {

--- a/plugins/_official/examples/social-media-matrix-tracker-template/open-design.json
+++ b/plugins/_official/examples/social-media-matrix-tracker-template/open-design.json
@@ -24,7 +24,7 @@
     "en": "Social Media Matrix Tracker Template"
   },
   "version": "0.1.0",
-  "description": "社媒矩阵数据追踪面板模板（Social Media Matrix Tracker）。 Use when users ask for a cinematic, data-dense social media analytics dashboard with multi-platform metrics, interactive charts, hover insights, range compare, and dark/light theme switching in a single HTML artifact.",
+  "description": "Social Media Matrix Tracker template.\nUse when users ask for a cinematic, data-dense social media analytics dashboard\nwith multi-platform metrics, interactive charts, hover insights, range compare,\nand dark/light theme switching in a single HTML artifact.",
   "description_i18n": {
     "zh-CN": "社媒矩阵数据追踪面板模板（Social Media Matrix Tracker）。适用于需要电影级、数据密集型社交媒体分析仪表板的场景，支持多平台指标、交互式图表、悬停洞察、范围对比和深浅主题切换，单个 HTML 文件即可实现。",
     "zh-TW": "社群媒體矩陣數據追蹤面板範本（Social Media Matrix Tracker）。適用於需要電影級、數據密集型社群媒體分析儀表板的場景，支援多平台指標、互動式圖表、懸停洞察、範圍比較和深淺主題切換，單一 HTML 檔案即可實現。",
@@ -43,7 +43,7 @@
     "ar": "قالب لوحة تتبع بيانات مصفوفة وسائل التواصل الاجتماعي (Social Media Matrix Tracker). لإنشاء لوحات تحليلية سينمائية كثيفة البيانات مع مقاييس متعددة المنصات ورسوم بيانية تفاعلية ورؤى عند التمرير ومقارنة النطاقات والتبديل بين السمة الفاتحة والداكنة في ملف HTML واحد.",
     "tr": "Sosyal medya matrisi veri takip paneli şablonu (Social Media Matrix Tracker). Multi-platform metrikler, etkileşimli grafikler, hover içgörüler, aralık karşılaştırması ve koyu/açık tema geçişi ile sinematik, veri yoğun sosyal medya analitik panoları oluşturmak için tek bir HTML dosyasında.",
     "uk": "Шаблон панелі відстеження даних матриці соціальних мереж (Social Media Matrix Tracker). Для створення кінематографічних, насичених даними аналітичних дашбордів соцмереж з мультиплатформними метриками, інтерактивними графіками, спливаючими підказками, порівнянням діапазонів та перемиканням темної/світлої теми в одному HTML-файлі.",
-    "en": "社媒矩阵数据追踪面板模板（Social Media Matrix Tracker）。 Use when users ask for a cinematic, data-dense social media analytics dashboard with multi-platform metrics, interactive charts, hover insights, range compare, and dark/light theme switching in a single HTML artifact."
+    "en": "Social Media Matrix Tracker template.\nUse when users ask for a cinematic, data-dense social media analytics dashboard\nwith multi-platform metrics, interactive charts, hover insights, range compare,\nand dark/light theme switching in a single HTML artifact."
   },
   "license": "MIT",
   "author": {

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -7681,7 +7681,7 @@
         "prompt:inject",
         "fs:write"
       ],
-      "description": "Social Media Matrix Tracker template.\nUse when users ask for a cinematic, data-dense social media analytics dashboard\nwith multi-platform metrics, interactive charts, hover insights, range compare,\nand dark/light theme switching in a single HTML artifact.",
+      "description": "Social Media Matrix Tracker template. Use when users ask for a cinematic, data-dense social media analytics dashboard with multi-platform metrics, interactive charts, hover insights, range compare, and dark/light theme switching in a single HTML artifact.",
       "tags": [
         "example",
         "first-party",

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -7681,7 +7681,7 @@
         "prompt:inject",
         "fs:write"
       ],
-      "description": "社媒矩阵数据追踪面板模板（Social Media Matrix Tracker）。\nUse when users ask for a cinematic, data-dense social media analytics dashboard\nwith multi-platform metrics, interactive charts, hover insights, range compare,\nand dark/light theme switching in a single HTML artifact.",
+      "description": "Social Media Matrix Tracker template.\nUse when users ask for a cinematic, data-dense social media analytics dashboard\nwith multi-platform metrics, interactive charts, hover insights, range compare,\nand dark/light theme switching in a single HTML artifact.",
       "tags": [
         "example",
         "first-party",


### PR DESCRIPTION
## Why

This PR fixes the English metadata for the official social media matrix tracker template.

The pain being addressed is marketplace clarity: users browsing official templates should see polished English copy that accurately describes the template.

## What users will see

The social media matrix tracker template has corrected English metadata in the official plugin registry.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — official plugin/template metadata update
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. Metadata-only template copy update.

## Bug fix verification

Skipped. This is a metadata copy fix.

## Validation

- Not run locally; PR opened from the existing branch for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784209245&installation_id=140661819&pr_number=4427&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4427&signature=b664827bd926af16a88ac639d207ed3de8ab3e91dc830ff3b853bc9001d901e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->