### PR TITLE
[codex] Clarify social share publish modal copy

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4650,8 +4650,10 @@ function HtmlViewer({
   const [deployment, setDeployment] = useState<WebDeploymentInfo | null>(null);
   const [deploymentsByProvider, setDeploymentsByProvider] = useState<Partial<Record<WebDeployProviderId, WebDeploymentInfo>>>({});
   const [deployModalOpen, setDeployModalOpen] = useState(false);
+  const [deployModalIntent, setDeployModalIntent] = useState<'deploy' | 'social-share'>('deploy');
   const closeDeployModal = useCallback(() => {
     setDeployModalOpen(false);
+    setDeployModalIntent('deploy');
   }, []);
   const [deployConfig, setDeployConfig] = useState<WebDeployConfigResponse | null>(null);
   const [deploying, setDeploying] = useState(false);
@@ -6650,9 +6652,13 @@ function HtmlViewer({
     }
   }
 
-  async function openDeployModal(nextProviderId: WebDeployProviderId = deployProviderId) {
+  async function openDeployModal(
+    nextProviderId: WebDeployProviderId = deployProviderId,
+    intent: 'deploy' | 'social-share' = 'deploy',
+  ) {
     setDeployMenuOpen(false);
     setDeployModalOpen(true);
+    setDeployModalIntent(intent);
     setDeployError(null);
     setDeployActionToast(null);
     setCopiedDeployLink(null);
@@ -6664,7 +6670,7 @@ function HtmlViewer({
     const providerWithDeployment = DEPLOY_PROVIDER_OPTIONS.find(
       (option) => deploymentsByProvider[option.id]?.url?.trim(),
     )?.id;
-    await openDeployModal(providerWithDeployment ?? deployProviderId);
+    await openDeployModal(providerWithDeployment ?? deployProviderId, 'social-share');
   }
 
   async function changeDeployProvider(nextProviderId: WebDeployProviderId) {
@@ -7685,12 +7691,24 @@ function HtmlViewer({
         : t('fileViewer.copyShareLink');
   const shareMenuLabel = t('fileViewer.shareLabel');
   const deployMenuLabel = t('fileViewer.deployModalTitle') || 'Deploy';
+  const isSocialShareDeployModal = deployModalIntent === 'social-share';
+  const deployModalKicker = isSocialShareDeployModal
+    ? t('socialShare.projectSection')
+    : deployProviderLabel;
+  const deployModalTitle = isSocialShareDeployModal
+    ? t('socialShare.publishPageTitle')
+    : t('fileViewer.deployToProvider', { provider: deployProviderLabel });
+  const deployModalSubtitle = isSocialShareDeployModal
+    ? t('socialShare.publishPageSubtitle')
+    : t('fileViewer.deployModalSubtitle');
   const deployButtonLabel =
     deployPhase === 'deploying'
       ? t('fileViewer.deployingToProvider', { provider: deployProviderLabel })
       : deployPhase === 'preparing-link'
         ? t('fileViewer.preparingPublicLink')
-        : deployMenuLabel;
+        : isSocialShareDeployModal
+          ? t('socialShare.publishPageTitle')
+          : deployMenuLabel;
   const copyDeployLabel = (url: string) =>
     copiedDeployLink === url.trim()
       ? t('fileViewer.copied')
@@ -9010,9 +9028,9 @@ function HtmlViewer({
           <div className="modal deploy-modal deploy-flow-modal" role="dialog" aria-modal="true">
             <div className="deploy-flow-modal__scroll">
               <div className="modal-head">
-                <div className="kicker">{deployProviderLabel}</div>
-                <h2>{t('fileViewer.deployToProvider', { provider: deployProviderLabel })}</h2>
-                <p className="subtitle">{t('fileViewer.deployModalSubtitle')}</p>
+                <div className="kicker">{deployModalKicker}</div>
+                <h2>{deployModalTitle}</h2>
+                <p className="subtitle">{deployModalSubtitle}</p>
               </div>
               <div className="deploy-form">
                 <div className={`deploy-social-share${activeProjectSocialShare ? '' : ' is-locked'}${socialShareBlockedState ? ` is-${socialShareBlockedState}` : ''}`}>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1418,6 +1418,8 @@ export const ar: Dict = {
   'socialShare.openDesignText': 'Open Design هي مساحة عمل مفتوحة المصدر لإنشاء عناصر التصميم وتحريرها ونشرها وتسليمها.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'المشاركة الاجتماعية',
+  'socialShare.publishPageTitle': 'نشر صفحة المشاركة',
+  'socialShare.publishPageSubtitle': 'انشر هذه المعاينة حتى يمكن مشاركتها على منصات التواصل الاجتماعي.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'تم الإنشاء باستخدام Open Design: {title}. اعرض العنصر المنشور وامنح نجمة للمستودع: {repo}',
   'socialShare.projectCopyText': 'تم الإنشاء باستخدام Open Design: {title}\n{url}\nمستودع Open Design: {repo}',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1418,6 +1418,8 @@ export const de: Dict = {
   'socialShare.openDesignText': 'Open Design ist ein Open-Source-Workspace zum Erstellen, Bearbeiten, Bereitstellen und Übergeben von Design-Artefakten.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'IN SOZIALEN NETZWERKEN TEILEN',
+  'socialShare.publishPageTitle': 'Teileseite veröffentlichen',
+  'socialShare.publishPageSubtitle': 'Veröffentliche diese Vorschau, damit sie auf sozialen Plattformen geteilt werden kann.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Erstellt mit Open Design: {title}. Sieh dir das bereitgestellte Artefakt an und gib dem Repo einen Stern: {repo}',
   'socialShare.projectCopyText': 'Erstellt mit Open Design: {title}\n{url}\nOpen Design-Repo: {repo}',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1418,6 +1418,8 @@ export const en: Dict = {
   'socialShare.openDesignText': 'Open Design is an open-source workspace for creating, editing, deploying, and handing off design artifacts.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'SOCIAL SHARE',
+  'socialShare.publishPageTitle': 'Publish share page',
+  'socialShare.publishPageSubtitle': 'Publish this preview so it can be shared on social platforms.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Built with Open Design: {title}. View the deployed artifact and star the repo: {repo}',
   'socialShare.projectCopyText': 'Built with Open Design: {title}\n{url}\nOpen Design repo: {repo}',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1418,6 +1418,8 @@ export const esES: Dict = {
   'socialShare.openDesignText': 'Open Design es un espacio de trabajo de código abierto para crear, editar, desplegar y entregar artefactos de diseño.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'COMPARTIR EN REDES SOCIALES',
+  'socialShare.publishPageTitle': 'Publicar página para compartir',
+  'socialShare.publishPageSubtitle': 'Publica esta vista previa para poder compartirla en redes sociales.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Creado con Open Design: {title}. Consulta el artefacto desplegado y dale una estrella al repositorio: {repo}',
   'socialShare.projectCopyText': 'Creado con Open Design: {title}\n{url}\nRepositorio de Open Design: {repo}',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1418,6 +1418,8 @@ export const fa: Dict = {
   'socialShare.openDesignText': 'Open Design یک فضای کاری متن‌باز برای ساخت، ویرایش، استقرار و تحویل آرتیفکت‌های طراحی است.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'اشتراک‌گذاری در شبکه‌های اجتماعی',
+  'socialShare.publishPageTitle': 'انتشار صفحه اشتراک‌گذاری',
+  'socialShare.publishPageSubtitle': 'این پیش‌نمایش را منتشر کنید تا بتوان آن را در شبکه‌های اجتماعی به اشتراک گذاشت.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'ساخته‌شده با Open Design: {title}. آرتیفکت مستقرشده را ببینید و به مخزن ستاره بدهید: {repo}',
   'socialShare.projectCopyText': 'ساخته‌شده با Open Design: {title}\n{url}\nمخزن Open Design: {repo}',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1418,6 +1418,8 @@ export const fr: Dict = {
   'socialShare.openDesignText': 'Open Design est un workspace open source pour créer, modifier, déployer et transmettre des artefacts de design.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'PARTAGE SOCIAL',
+  'socialShare.publishPageTitle': 'Publier la page de partage',
+  'socialShare.publishPageSubtitle': 'Publiez cet aperçu pour pouvoir le partager sur les plateformes sociales.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Créé avec Open Design : {title}. Voir l’artefact déployé et mettre une étoile au dépôt : {repo}',
   'socialShare.projectCopyText': 'Créé avec Open Design : {title}\n{url}\nDépôt Open Design : {repo}',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1418,6 +1418,8 @@ export const hu: Dict = {
   'socialShare.openDesignText': 'Az Open Design egy nyílt forráskódú munkaterület tervezési elemek létrehozásához, szerkesztéséhez, telepítéséhez és átadásához.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'MEGOSZTÁS KÖZÖSSÉGI MÉDIÁN',
+  'socialShare.publishPageTitle': 'Megosztási oldal közzététele',
+  'socialShare.publishPageSubtitle': 'Tedd közzé ezt az előnézetet, hogy megosztható legyen közösségi platformokon.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Open Design segítségével készült: {title}. Tekintsd meg a telepített elemet, és csillagozd a repót: {repo}',
   'socialShare.projectCopyText': 'Open Design segítségével készült: {title}\n{url}\nOpen Design repó: {repo}',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1418,6 +1418,8 @@ export const id: Dict = {
   'socialShare.openDesignText': 'Open Design adalah ruang kerja sumber terbuka untuk membuat, mengedit, men-deploy, dan menyerahkan artefak desain.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'BAGIKAN KE MEDIA SOSIAL',
+  'socialShare.publishPageTitle': 'Publikasikan halaman berbagi',
+  'socialShare.publishPageSubtitle': 'Publikasikan pratinjau ini agar dapat dibagikan di platform sosial.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Dibuat dengan Open Design: {title}. Lihat artefak yang telah di-deploy dan beri bintang pada repo: {repo}',
   'socialShare.projectCopyText': 'Dibuat dengan Open Design: {title}\n{url}\nRepo Open Design: {repo}',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1418,6 +1418,8 @@ export const it: Dict = {
   'socialShare.openDesignText': 'Open Design è uno spazio di lavoro open-source per creare, modificare, distribuire e consegnare artifact di design.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'CONDIVISIONE SOCIAL',
+  'socialShare.publishPageTitle': 'Pubblica pagina di condivisione',
+  'socialShare.publishPageSubtitle': 'Pubblica questa anteprima per condividerla sulle piattaforme social.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Creato con Open Design: {title}. Visualizza l\'artifact distribuito e metti una stella al repo: {repo}',
   'socialShare.projectCopyText': 'Creato con Open Design: {title}\n{url}\nRepo di Open Design: {repo}',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1418,6 +1418,8 @@ export const ja: Dict = {
   'socialShare.openDesignText': 'Open Design は、デザイン成果物の作成・編集・デプロイ・引き継ぎを行うためのオープンソースのワークスペースです。',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'ソーシャル共有',
+  'socialShare.publishPageTitle': '共有ページを公開',
+  'socialShare.publishPageSubtitle': 'このプレビューを公開して、ソーシャルプラットフォームで共有できるようにします。',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Open Design で作成: {title}。デプロイされた成果物を見て、リポジトリにスターを付けてください: {repo}',
   'socialShare.projectCopyText': 'Open Design で作成: {title}\n{url}\nOpen Design リポジトリ: {repo}',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1418,6 +1418,8 @@ export const ko: Dict = {
   'socialShare.openDesignText': 'Open Design은 디자인 아티팩트를 생성, 편집, 배포 및 인수인계하기 위한 오픈소스 워크스페이스입니다.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': '소셜 공유',
+  'socialShare.publishPageTitle': '공유 페이지 게시',
+  'socialShare.publishPageSubtitle': '소셜 플랫폼에 공유할 수 있도록 이 미리보기를 게시합니다.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Open Design으로 제작: {title}. 배포된 아티팩트를 확인하고 저장소에 스타를 남겨주세요: {repo}',
   'socialShare.projectCopyText': 'Open Design으로 제작: {title}\n{url}\nOpen Design 저장소: {repo}',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1418,6 +1418,8 @@ export const pl: Dict = {
   'socialShare.openDesignText': 'Open Design to otwartoźródłowe środowisko pracy do tworzenia, edytowania, wdrażania i przekazywania artefaktów projektowych.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'UDOSTĘPNIANIE W MEDIACH SPOŁECZNOŚCIOWYCH',
+  'socialShare.publishPageTitle': 'Opublikuj stronę udostępniania',
+  'socialShare.publishPageSubtitle': 'Opublikuj ten podgląd, aby można było udostępniać go w mediach społecznościowych.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Stworzone w Open Design: {title}. Zobacz wdrożony artefakt i daj gwiazdkę repozytorium: {repo}',
   'socialShare.projectCopyText': 'Stworzone w Open Design: {title}\n{url}\nRepozytorium Open Design: {repo}',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1418,6 +1418,8 @@ export const ptBR: Dict = {
   'socialShare.openDesignText': 'Open Design é um espaço de trabalho de código aberto para criar, editar, implantar e entregar artefatos de design.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'COMPARTILHAMENTO SOCIAL',
+  'socialShare.publishPageTitle': 'Publicar página de compartilhamento',
+  'socialShare.publishPageSubtitle': 'Publique esta prévia para que ela possa ser compartilhada nas plataformas sociais.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Feito com Open Design: {title}. Veja o artefato implantado e dê uma estrela no repositório: {repo}',
   'socialShare.projectCopyText': 'Feito com Open Design: {title}\n{url}\nRepositório do Open Design: {repo}',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1418,6 +1418,8 @@ export const ru: Dict = {
   'socialShare.openDesignText': 'Open Design — это рабочее пространство с открытым исходным кодом для создания, редактирования, развёртывания и передачи дизайн-артефактов.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'ПОДЕЛИТЬСЯ В СОЦСЕТЯХ',
+  'socialShare.publishPageTitle': 'Опубликовать страницу для публикации',
+  'socialShare.publishPageSubtitle': 'Опубликуйте этот предпросмотр, чтобы им можно было поделиться в социальных сетях.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Создано с помощью Open Design: {title}. Посмотрите развёрнутый артефакт и поставьте звезду репозиторию: {repo}',
   'socialShare.projectCopyText': 'Создано с помощью Open Design: {title}\n{url}\nРепозиторий Open Design: {repo}',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1418,6 +1418,8 @@ export const th: Dict = {
   'socialShare.openDesignText': 'Open Design คือพื้นที่ทำงานแบบโอเพนซอร์สสำหรับการสร้าง แก้ไข เผยแพร่ และส่งต่อชิ้นงานออกแบบ',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'แชร์ลงโซเชียล',
+  'socialShare.publishPageTitle': 'เผยแพร่หน้าแชร์',
+  'socialShare.publishPageSubtitle': 'เผยแพร่ตัวอย่างนี้เพื่อแชร์บนแพลตฟอร์มโซเชียลได้',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'สร้างด้วย Open Design: {title} ดูชิ้นงานที่เผยแพร่และกดดาวให้ repo: {repo}',
   'socialShare.projectCopyText': 'สร้างด้วย Open Design: {title}\n{url}\nrepo ของ Open Design: {repo}',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1418,6 +1418,8 @@ export const tr: Dict = {
   'socialShare.openDesignText': 'Open Design; tasarım yapıtları oluşturmak, düzenlemek, dağıtmak ve devretmek için açık kaynaklı bir çalışma alanıdır.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'SOSYAL PAYLAŞIM',
+  'socialShare.publishPageTitle': 'Paylaşım sayfasını yayınla',
+  'socialShare.publishPageSubtitle': 'Bu önizlemeyi sosyal platformlarda paylaşılabilir hale getirmek için yayınlayın.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Open Design ile oluşturuldu: {title}. Dağıtılan yapıtı görüntüleyin ve depoya yıldız verin: {repo}',
   'socialShare.projectCopyText': 'Open Design ile oluşturuldu: {title}\n{url}\nOpen Design deposu: {repo}',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1418,6 +1418,8 @@ export const uk: Dict = {
   'socialShare.openDesignText': 'Open Design — це робочий простір з відкритим кодом для створення, редагування, розгортання та передавання дизайн-артефактів.',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': 'ПОДІЛИТИСЯ В СОЦМЕРЕЖАХ',
+  'socialShare.publishPageTitle': 'Опублікувати сторінку для поширення',
+  'socialShare.publishPageSubtitle': 'Опублікуйте цей перегляд, щоб ним можна було поділитися в соцмережах.',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': 'Створено за допомогою Open Design: {title}. Перегляньте розгорнутий артефакт і поставте зірку репозиторію: {repo}',
   'socialShare.projectCopyText': 'Створено за допомогою Open Design: {title}\n{url}\nРепозиторій Open Design: {repo}',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1418,6 +1418,8 @@ export const zhCN: Dict = {
   'socialShare.openDesignText': 'Open Design 是开源的设计智能工作区，可以生成、编辑、部署并交付设计产物。',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': '社媒分享',
+  'socialShare.publishPageTitle': '发布分享页',
+  'socialShare.publishPageSubtitle': '发布当前预览，以便分享到社媒平台。',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': '我用 Open Design 做了 {title}。查看已部署产物，也推荐收藏仓库：{repo}',
   'socialShare.projectCopyText': '我用 Open Design 做了 {title}\n{url}\nOpen Design 仓库：{repo}',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1418,6 +1418,8 @@ export const zhTW: Dict = {
   'socialShare.openDesignText': 'Open Design 是開源的設計智慧工作區，可以生成、編輯、部署並交付設計產物。',
   'socialShare.openDesignCopyText': '{text}\n{url}',
   'socialShare.projectSection': '社群分享',
+  'socialShare.publishPageTitle': '發布分享頁',
+  'socialShare.publishPageSubtitle': '發布目前預覽，以便分享到社群平台。',
   'socialShare.projectTitle': '{title} · Open Design',
   'socialShare.projectText': '我用 Open Design 做了 {title}。查看已部署產物，也推薦收藏倉庫：{repo}',
   'socialShare.projectCopyText': '我用 Open Design 做了 {title}\n{url}\nOpen Design 倉庫：{repo}',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1948,6 +1948,8 @@ export interface Dict {
   'socialShare.openDesignText': string;
   'socialShare.openDesignCopyText': string;
   'socialShare.projectSection': string;
+  'socialShare.publishPageTitle': string;
+  'socialShare.publishPageSubtitle': string;
   'socialShare.projectTitle': string;
   'socialShare.projectText': string;
   'socialShare.projectCopyText': string;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1466,7 +1466,10 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.getByRole('menuitem', { name: /Deploy to Vercel/i })).toBeTruthy();
     fireEvent.click(screen.getByRole('menuitem', { name: /Deploy to Cloudflare Pages/i }));
 
-    expect(await screen.findByRole('dialog')).toBeTruthy();
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(within(dialog).getByRole('heading', { name: /Deploy to Cloudflare Pages/i })).toBeTruthy();
+    expect(within(dialog).queryByRole('heading', { name: /Publish share page/i })).toBeNull();
     const backdrop = document.body.querySelector('.viewer-modal-backdrop.deploy-flow-backdrop');
     expect(backdrop).toBeTruthy();
     expect(backdrop?.parentElement).toBe(document.body);
@@ -2535,7 +2538,10 @@ describe('FileViewer SVG artifacts', () => {
     expect(document.querySelector('.share-menu-social-grid')).toBeNull();
     fireEvent.click(socialShareItem);
 
-    expect(await screen.findByRole('dialog')).toBeTruthy();
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(within(dialog).getByRole('heading', { name: /Publish share page/i })).toBeTruthy();
+    expect(within(dialog).getByRole('button', { name: /Publish share page/i })).toBeTruthy();
     expect(await screen.findByRole('link', { name: 'X' })).toBeTruthy();
     expect(screen.getAllByText('https://vercel.example').length).toBeGreaterThan(0);
   });
@@ -2599,8 +2605,9 @@ describe('FileViewer SVG artifacts', () => {
 
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toBeTruthy();
+    expect(within(dialog).getByRole('heading', { name: /Publish share page/i })).toBeTruthy();
     expect(screen.queryByRole('link', { name: 'X' })).toBeNull();
-    const deployButtons = within(dialog).getAllByRole('button', { name: /^Deploy$/i });
+    const deployButtons = within(dialog).getAllByRole('button', { name: /Publish share page/i });
     fireEvent.click(deployButtons[deployButtons.length - 1]!);
 
     expect(await screen.findByRole('link', { name: 'X' })).toBeTruthy();
@@ -2665,7 +2672,9 @@ describe('FileViewer SVG artifacts', () => {
     const socialShareItem = await screen.findByRole('menuitem', { name: /social share/i });
     fireEvent.click(socialShareItem);
 
-    expect(await screen.findByRole('dialog')).toBeTruthy();
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(within(dialog).getByRole('heading', { name: /Publish share page/i })).toBeTruthy();
     expect(await screen.findByRole('link', { name: 'X' })).toBeTruthy();
     expect(screen.getAllByText(/requiring authentication/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText('https://protected.vercel.example').length).toBeGreaterThan(0);


### PR DESCRIPTION
## Why

This PR clarifies the copy in the social share publish modal.

The pain being addressed is user-facing clarity: the publish flow should explain the social sharing action in direct language and keep the localized strings aligned.

## What users will see

Users opening the social share publish modal will see clearer publish copy across supported locales.

## Surface area

- [x] **UI** — publish modal copy in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — localized publish modal copy updated
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — existing modal copy changes without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. Copy-only modal update.

## Bug fix verification

Skipped. This is a copy clarity update.

## Validation

- Not run locally; PR opened from the existing branch for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784209249&installation_id=140661819&pr_number=4428&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4428&signature=cd7870a296b4181228a4b0395764d216800da9fe13cea2dfc004c48c824fa593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->