### PR TITLE
[codex] Prevent first-run home flash before onboarding

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,6 +21,7 @@ import { PluginDetailView } from './components/PluginDetailView';
 import type { CreateInput, ImportClaudeDesignOutcome } from './components/NewProjectPanel';
 import { MemoryToast } from './components/MemoryToast';
 import { Toast } from './components/Toast';
+import { CenteredLoader } from './components/Loading';
 import { PetOverlay, type PetTaskCenter } from './components/pet/PetOverlay';
 import { buildPetTaskCenter } from './components/pet/taskCenter';
 import { migrateCustomPetAtlas } from './components/pet/pets';
@@ -2005,7 +2006,18 @@ function AppInner() {
   // EntryView / ProjectView split so the discovery surface stays
   // independent of any active project.
   let appMain: ReactNode;
-  if (route.kind === 'marketplace') {
+  const pendingFirstRunOnboardingRoute =
+    route.kind === 'home' &&
+    route.view === 'home' &&
+    config.onboardingCompleted !== true &&
+    !daemonConfigLoaded;
+  if (pendingFirstRunOnboardingRoute) {
+    appMain = (
+      <div className="entry-shell entry-shell--no-header">
+        <CenteredLoader label={t('entry.loadingWorkspace')} />
+      </div>
+    );
+  } else if (route.kind === 'marketplace') {
     appMain = <MarketplaceView />;
   } else if (route.kind === 'marketplace-detail') {
     appMain = <PluginDetailView pluginId={route.pluginId} />;

--- a/apps/web/tests/components/App.onboarding-agent-autoselect.test.tsx
+++ b/apps/web/tests/components/App.onboarding-agent-autoselect.test.tsx
@@ -186,6 +186,26 @@ describe('App first-run agent auto-select', () => {
     vi.clearAllMocks();
   });
 
+  it('does not render the Home entry before first-run onboarding routing is known', async () => {
+    let resolveDaemonConfig!: (value: {}) => void;
+    mockedLoadConfig.mockReturnValue(firstRunConfig());
+    mockedFetchDaemonConfig.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDaemonConfig = resolve;
+      }),
+    );
+
+    render(<App />);
+
+    expect(screen.queryByTestId('agent-id')).toBeNull();
+    expect(screen.getByText('Loading workspace…')).toBeTruthy();
+
+    resolveDaemonConfig({});
+    await waitFor(() => {
+      expect(screen.getByTestId('onboarding-completed').textContent).toBe('false');
+    });
+  });
+
   it('does not auto-pick a default agent while first-run onboarding is in progress', async () => {
     const { syncConfigToDaemon } = await import('../../src/state/config');
     const mockedSync = vi.mocked(syncConfigToDaemon);


### PR DESCRIPTION
## Why

This PR prevents the first-run home screen from flashing before onboarding takes over.

The pain being addressed is onboarding polish: new users should land directly in the onboarding path without briefly seeing the regular home experience first.

## What users will see

On first run, the app should avoid flashing the home screen before showing onboarding.

## Surface area

- [x] **UI** — first-run onboarding flow in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — first-run route rendering changes without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. First-run transition behavior is covered by the branch test changes.

## Bug fix verification

Skipped. Existing branch includes focused onboarding test coverage, but I did not rerun it locally while opening this PR.

## Validation

- Not run locally; PR opened from the existing branch for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784209254&installation_id=140661819&pr_number=4429&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4429&signature=6a5490a394d53f410e34662a630600ce18ef83ee77b545699a02d04d17f95c38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->