### PR TITLE
[codex] Load tools-dev env files

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -212,7 +212,7 @@ pnpm typecheck                 # workspace typecheck
 
 `pnpm tools-dev` is the only local lifecycle entry point. Do not use the removed legacy root aliases (`pnpm dev`, `pnpm dev:all`, `pnpm daemon`, `pnpm preview`, `pnpm start`).
 
-`tools-dev` automatically loads workspace env files before resolving ports, namespaces, and child process environments. Default precedence is `.env.development.local`, then `.env.local`, then `.env.development`, then `.env`; existing shell exports win. Use `--no-env-file` to disable loading or repeat `--env-file <path>` to use explicit env files instead.
+`tools-dev` automatically loads workspace env files before resolving ports, namespaces, and child process environments. Default precedence is `.env.development.local`, then `.env.local`, then `.env.development`, then `.env`; env files override ambient shell exports so project-local config wins. Use `--no-env-file` to disable loading or repeat `--env-file <path>` to use explicit env files instead.
 
 During local development, `tools-dev` starts the daemon first, passes its port into `apps/web`, and `apps/web/next.config.ts` rewrites `/api/*`, `/artifacts/*`, and `/frames/*` to that daemon port so the App Router app can talk to the sibling Express process without CORS setup.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -212,6 +212,8 @@ pnpm typecheck                 # workspace typecheck
 
 `pnpm tools-dev` is the only local lifecycle entry point. Do not use the removed legacy root aliases (`pnpm dev`, `pnpm dev:all`, `pnpm daemon`, `pnpm preview`, `pnpm start`).
 
+`tools-dev` automatically loads workspace env files before resolving ports, namespaces, and child process environments. Default precedence is `.env.development.local`, then `.env.local`, then `.env.development`, then `.env`; existing shell exports win. Use `--no-env-file` to disable loading or repeat `--env-file <path>` to use explicit env files instead.
+
 During local development, `tools-dev` starts the daemon first, passes its port into `apps/web`, and `apps/web/next.config.ts` rewrites `/api/*`, `/artifacts/*`, and `/frames/*` to that daemon port so the App Router app can talk to the sibling Express process without CORS setup.
 
 ## Media generation / agent dispatcher checks

--- a/tools/dev/src/cli-args.ts
+++ b/tools/dev/src/cli-args.ts
@@ -1,0 +1,42 @@
+const CLI_COMMANDS = new Set(["start", "run", "status", "stop", "restart", "logs", "inspect", "check", "help"]);
+const OPTIONS_WITH_VALUE = new Set([
+  "--daemon-port",
+  "--env-file",
+  "--expr",
+  "--namespace",
+  "--path",
+  "--selector",
+  "--timeout",
+  "--tools-dev-root",
+  "--update-action",
+  "--web-port",
+]);
+
+export function rewriteCliArgsForDefaultStart(args: readonly string[]): string[] {
+  const firstPositionalIndex = firstPositionalArgIndex(args);
+  const firstPositional = firstPositionalIndex >= 0 ? args[firstPositionalIndex] : undefined;
+  if (isGlobalHelpRequest(args, firstPositional) || CLI_COMMANDS.has(firstPositional ?? "")) return [...args];
+
+  const rewritten = [...args];
+  rewritten.splice(firstPositionalIndex >= 0 ? firstPositionalIndex : 0, 0, "start");
+  return rewritten;
+}
+
+function isGlobalHelpRequest(args: readonly string[], firstPositional: string | undefined): boolean {
+  return firstPositional === undefined && args.some((arg) => arg === "--help" || arg === "-h");
+}
+
+function firstPositionalArgIndex(args: readonly string[]): number {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") return index + 1 < args.length ? index + 1 : -1;
+    if (arg.startsWith("--") && arg.includes("=")) continue;
+    if (OPTIONS_WITH_VALUE.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    return index;
+  }
+  return -1;
+}

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -1080,7 +1080,7 @@ function addSharedOptions(command: ReturnType<typeof cli.command>) {
     .option("--namespace <name>", "runtime namespace (default: default)")
     .option("--tools-dev-root <path>", "tools-dev runtime root")
     .option("--env-file <path>", "load env file before resolving tools-dev config; repeatable")
-    .option("--no-env-file", "skip automatic .env file loading")
+    .option("--no-env-file", "skip automatic .env file loading", { default: false })
     .option("--json", "print JSON");
 }
 

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -64,6 +64,7 @@ import {
   waitForDesktopRuntime,
   waitForWebRuntime,
 } from "./sidecar-client.js";
+import { rewriteCliArgsForDefaultStart } from "./cli-args.js";
 import { ensureDaemonGateForDesktop } from "./desktop-auth-gate.js";
 import { loadWorkspaceLocalEnv } from "./local-env.js";
 import { resolveSharedPortsFromRunningState } from "./shared-ports.js";
@@ -1073,19 +1074,6 @@ async function runForeground(config: ToolDevConfig, appName: string | undefined,
 }
 
 const cli = cac("tools-dev");
-const CLI_COMMANDS = new Set(["start", "run", "status", "stop", "restart", "logs", "inspect", "check", "help"]);
-const OPTIONS_WITH_VALUE = new Set([
-  "--daemon-port",
-  "--env-file",
-  "--expr",
-  "--namespace",
-  "--path",
-  "--selector",
-  "--timeout",
-  "--tools-dev-root",
-  "--update-action",
-  "--web-port",
-]);
 
 function addSharedOptions(command: ReturnType<typeof cli.command>) {
   return command
@@ -1192,27 +1180,6 @@ loadWorkspaceLocalEnv({
   log: (message) => process.stderr.write(`${message}\n`),
   workspaceRoot: WORKSPACE_ROOT,
 });
-process.argv.splice(2, process.argv.length - 2, ...cliArgs);
-
-function firstPositionalArgIndex(args: readonly string[]): number {
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--") return index + 1 < args.length ? index + 1 : -1;
-    if (arg.startsWith("--") && arg.includes("=")) continue;
-    if (OPTIONS_WITH_VALUE.has(arg)) {
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith("-")) continue;
-    return index;
-  }
-  return -1;
-}
-
-const firstPositionalIndex = firstPositionalArgIndex(cliArgs);
-const firstPositional = firstPositionalIndex >= 0 ? cliArgs[firstPositionalIndex] : undefined;
-if (firstPositional !== "--help" && firstPositional !== "-h" && !CLI_COMMANDS.has(firstPositional ?? "")) {
-  process.argv.splice(firstPositionalIndex >= 0 ? 2 + firstPositionalIndex : 2, 0, "start");
-}
+process.argv.splice(2, process.argv.length - 2, ...rewriteCliArgsForDefaultStart(cliArgs));
 
 cli.parse();

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -69,7 +69,9 @@ import { loadWorkspaceLocalEnv } from "./local-env.js";
 import { resolveSharedPortsFromRunningState } from "./shared-ports.js";
 
 type CliOptions = ToolDevOptions & {
+  envFile?: string | string[];
   expr?: string;
+  noEnvFile?: boolean;
   parentPid?: number;
   path?: string;
   selector?: string;
@@ -90,8 +92,6 @@ function exitWithError(error: unknown): never {
 
 process.on("uncaughtException", exitWithError);
 process.on("unhandledRejection", exitWithError);
-
-loadWorkspaceLocalEnv({ workspaceRoot: WORKSPACE_ROOT });
 
 function printJson(payload: unknown): void {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
@@ -1073,11 +1073,26 @@ async function runForeground(config: ToolDevConfig, appName: string | undefined,
 }
 
 const cli = cac("tools-dev");
+const CLI_COMMANDS = new Set(["start", "run", "status", "stop", "restart", "logs", "inspect", "check", "help"]);
+const OPTIONS_WITH_VALUE = new Set([
+  "--daemon-port",
+  "--env-file",
+  "--expr",
+  "--namespace",
+  "--path",
+  "--selector",
+  "--timeout",
+  "--tools-dev-root",
+  "--update-action",
+  "--web-port",
+]);
 
 function addSharedOptions(command: ReturnType<typeof cli.command>) {
   return command
     .option("--namespace <name>", "runtime namespace (default: default)")
     .option("--tools-dev-root <path>", "tools-dev runtime root")
+    .option("--env-file <path>", "load env file before resolving tools-dev config; repeatable")
+    .option("--no-env-file", "skip automatic .env file loading")
     .option("--json", "print JSON");
 }
 
@@ -1172,10 +1187,32 @@ cli.help();
 
 const rawCliArgs = process.argv.slice(2);
 const cliArgs = rawCliArgs[0] === "--" ? rawCliArgs.slice(1) : rawCliArgs;
+loadWorkspaceLocalEnv({
+  args: cliArgs,
+  log: (message) => process.stderr.write(`${message}\n`),
+  workspaceRoot: WORKSPACE_ROOT,
+});
 process.argv.splice(2, process.argv.length - 2, ...cliArgs);
 
-if (cliArgs.length === 0 || (cliArgs[0]?.startsWith("-") && cliArgs[0] !== "--help" && cliArgs[0] !== "-h")) {
-  process.argv.splice(2, 0, "start");
+function firstPositionalArgIndex(args: readonly string[]): number {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") return index + 1 < args.length ? index + 1 : -1;
+    if (arg.startsWith("--") && arg.includes("=")) continue;
+    if (OPTIONS_WITH_VALUE.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    return index;
+  }
+  return -1;
+}
+
+const firstPositionalIndex = firstPositionalArgIndex(cliArgs);
+const firstPositional = firstPositionalIndex >= 0 ? cliArgs[firstPositionalIndex] : undefined;
+if (firstPositional !== "--help" && firstPositional !== "-h" && !CLI_COMMANDS.has(firstPositional ?? "")) {
+  process.argv.splice(firstPositionalIndex >= 0 ? 2 + firstPositionalIndex : 2, 0, "start");
 }
 
 cli.parse();

--- a/tools/dev/src/local-env.ts
+++ b/tools/dev/src/local-env.ts
@@ -39,7 +39,7 @@ export function loadWorkspaceLocalEnv(options: {
 
     const parsed = parseDotEnvLocal(readFileSync(envPath, "utf8"));
     for (const [key, value] of Object.entries(parsed)) {
-      if (env[key] !== undefined) continue;
+      if (loadedKeys.has(key)) continue;
       env[key] = value;
       loadedKeys.add(key);
     }

--- a/tools/dev/src/local-env.ts
+++ b/tools/dev/src/local-env.ts
@@ -1,32 +1,127 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
-export const LOCAL_ENV_FILE_NAME = ".env.local";
+export const DEFAULT_LOCAL_ENV_FILE_NAMES = [".env.development.local", ".env.local", ".env.development", ".env"] as const;
 export const LOCAL_DEVELOPMENT_TELEMETRY_ENV = "local_development";
 export const TELEMETRY_ENV_KEY = "OD_TELEMETRY_ENV";
 
 export interface LoadWorkspaceLocalEnvResult {
-  envPath: string;
+  envPath: string | null;
   loaded: boolean;
+  loadedFiles: string[];
   keys: string[];
+  skippedFiles: string[];
 }
 
 export function loadWorkspaceLocalEnv(options: {
+  args?: readonly string[];
   workspaceRoot: string;
   env?: NodeJS.ProcessEnv;
+  log?: (message: string) => void;
 }): LoadWorkspaceLocalEnvResult {
-  const env = options.env ?? process.env;
-  const envPath = path.join(options.workspaceRoot, LOCAL_ENV_FILE_NAME);
-  if (!existsSync(envPath)) return { envPath, loaded: false, keys: [] };
+  const flags = parseLocalEnvFlags(options.args ?? []);
+  if (flags.disabled || flags.help) return { envPath: null, loaded: false, loadedFiles: [], keys: [], skippedFiles: [] };
 
-  const parsed = parseDotEnvLocal(readFileSync(envPath, "utf8"));
-  for (const [key, value] of Object.entries(parsed)) {
-    env[key] = value;
+  const env = options.env ?? process.env;
+  const envFileNames = flags.explicitFiles.length > 0 ? flags.explicitFiles : [...DEFAULT_LOCAL_ENV_FILE_NAMES];
+  const explicit = flags.explicitFiles.length > 0;
+  const loadedFiles: string[] = [];
+  const skippedFiles: string[] = [];
+  const loadedKeys = new Set<string>();
+
+  for (const fileName of envFileNames) {
+    const envPath = resolveEnvFilePath(options.workspaceRoot, fileName);
+    if (!isReadableFile(envPath)) {
+      if (explicit) throw new Error(`env file not found: ${fileName}`);
+      skippedFiles.push(fileName);
+      continue;
+    }
+
+    const parsed = parseDotEnvLocal(readFileSync(envPath, "utf8"));
+    for (const [key, value] of Object.entries(parsed)) {
+      if (env[key] !== undefined) continue;
+      env[key] = value;
+      loadedKeys.add(key);
+    }
+    loadedFiles.push(fileName);
   }
+
+  if (loadedFiles.length === 0) {
+    return { envPath: null, loaded: false, loadedFiles, keys: [], skippedFiles };
+  }
+
   if (env[TELEMETRY_ENV_KEY] == null || env[TELEMETRY_ENV_KEY]?.trim() === "") {
     env[TELEMETRY_ENV_KEY] = LOCAL_DEVELOPMENT_TELEMETRY_ENV;
+    loadedKeys.add(TELEMETRY_ENV_KEY);
   }
-  return { envPath, loaded: true, keys: Object.keys(parsed).sort() };
+  if (!flags.json) {
+    options.log?.(`tools-dev env: loaded ${loadedFiles.join(", ")}`);
+  }
+
+  return {
+    envPath: resolveEnvFilePath(options.workspaceRoot, loadedFiles[0]!),
+    loaded: true,
+    loadedFiles,
+    keys: [...loadedKeys].sort(),
+    skippedFiles,
+  };
+}
+
+function parseLocalEnvFlags(args: readonly string[]): {
+  disabled: boolean;
+  explicitFiles: string[];
+  help: boolean;
+  json: boolean;
+} {
+  const explicitFiles: string[] = [];
+  let disabled = false;
+  let help = false;
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") break;
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h" || arg === "help") {
+      help = true;
+      continue;
+    }
+    if (arg === "--no-env-file") {
+      disabled = true;
+      continue;
+    }
+    if (arg === "--env-file") {
+      const value = args[index + 1];
+      if (value == null || value.startsWith("-")) throw new Error("--env-file requires a path");
+      explicitFiles.push(value);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--env-file=")) {
+      const value = arg.slice("--env-file=".length);
+      if (value.length === 0) throw new Error("--env-file requires a path");
+      explicitFiles.push(value);
+    }
+  }
+
+  return { disabled, explicitFiles, help, json };
+}
+
+function resolveEnvFilePath(workspaceRoot: string, filePath: string): string {
+  return path.isAbsolute(filePath) ? filePath : path.join(workspaceRoot, filePath);
+}
+
+function isReadableFile(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    throw error;
+  }
 }
 
 export function parseDotEnvLocal(content: string): Record<string, string> {

--- a/tools/dev/tests/cli-args.test.ts
+++ b/tools/dev/tests/cli-args.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { rewriteCliArgsForDefaultStart } from "../src/cli-args.js";
+
+const toolsDevRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("tools-dev CLI argument rewriting", () => {
   it("preserves global help before applying the default start command", () => {
@@ -35,5 +40,16 @@ describe("tools-dev CLI argument rewriting", () => {
   it("preserves explicit commands", () => {
     assert.deepEqual(rewriteCliArgsForDefaultStart(["status", "--json"]), ["status", "--json"]);
     assert.deepEqual(rewriteCliArgsForDefaultStart(["--namespace", "demo", "logs"]), ["--namespace", "demo", "logs"]);
+  });
+
+  it("does not require --env-file when parsing shared command options", () => {
+    const result = spawnSync(process.execPath, ["--import", "tsx", "src/index.ts", "status", "not-an-app"], {
+      cwd: toolsDevRoot,
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /unsupported tools-dev app: not-an-app/);
+    assert.doesNotMatch(result.stderr, /option `--env-file <path>` value is missing/);
   });
 });

--- a/tools/dev/tests/cli-args.test.ts
+++ b/tools/dev/tests/cli-args.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { rewriteCliArgsForDefaultStart } from "../src/cli-args.js";
+
+describe("tools-dev CLI argument rewriting", () => {
+  it("preserves global help before applying the default start command", () => {
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["--help"]), ["--help"]);
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["-h"]), ["-h"]);
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["--namespace", "demo", "--help"]), ["--namespace", "demo", "--help"]);
+  });
+
+  it("inserts the default start command without stealing option values", () => {
+    assert.deepEqual(rewriteCliArgsForDefaultStart([]), ["start"]);
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["--namespace", "demo", "--json"]), [
+      "start",
+      "--namespace",
+      "demo",
+      "--json",
+    ]);
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["--env-file=local.env", "--web-port", "17573"]), [
+      "start",
+      "--env-file=local.env",
+      "--web-port",
+      "17573",
+    ]);
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["--namespace", "demo", "daemon"]), [
+      "--namespace",
+      "demo",
+      "start",
+      "daemon",
+    ]);
+  });
+
+  it("preserves explicit commands", () => {
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["status", "--json"]), ["status", "--json"]);
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["--namespace", "demo", "logs"]), ["--namespace", "demo", "logs"]);
+  });
+});

--- a/tools/dev/tests/local-env.test.ts
+++ b/tools/dev/tests/local-env.test.ts
@@ -40,14 +40,14 @@ describe("tools-dev local env loading", () => {
     const result = loadWorkspaceLocalEnv({ workspaceRoot, env });
 
     assert.equal(result.loaded, true);
-    assert.equal(env.POSTHOG_KEY, "phc_from_parent");
+    assert.equal(env.POSTHOG_KEY, "phc_from_file");
     assert.equal(env.LANGFUSE_PUBLIC_KEY, "pk_from_file");
     assert.equal(env[TELEMETRY_ENV_KEY], LOCAL_DEVELOPMENT_TELEMETRY_ENV);
     assert.deepEqual(result.loadedFiles, [".env.local"]);
-    assert.deepEqual(result.keys, ["LANGFUSE_PUBLIC_KEY", TELEMETRY_ENV_KEY]);
+    assert.deepEqual(result.keys, ["LANGFUSE_PUBLIC_KEY", TELEMETRY_ENV_KEY, "POSTHOG_KEY"]);
   });
 
-  it("loads workspace env files in precedence order without overriding earlier values", async () => {
+  it("loads workspace env files in precedence order without overriding higher-priority files", async () => {
     const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "od-local-env-"));
     await writeFile(path.join(workspaceRoot, ".env"), "FROM_BASE=base\nSHARED=base\n");
     await writeFile(path.join(workspaceRoot, ".env.development"), "FROM_DEV=dev\nSHARED=dev\n");

--- a/tools/dev/tests/local-env.test.ts
+++ b/tools/dev/tests/local-env.test.ts
@@ -40,10 +40,80 @@ describe("tools-dev local env loading", () => {
     const result = loadWorkspaceLocalEnv({ workspaceRoot, env });
 
     assert.equal(result.loaded, true);
-    assert.equal(env.POSTHOG_KEY, "phc_from_file");
+    assert.equal(env.POSTHOG_KEY, "phc_from_parent");
     assert.equal(env.LANGFUSE_PUBLIC_KEY, "pk_from_file");
     assert.equal(env[TELEMETRY_ENV_KEY], LOCAL_DEVELOPMENT_TELEMETRY_ENV);
-    assert.deepEqual(result.keys, ["LANGFUSE_PUBLIC_KEY", "POSTHOG_KEY"]);
+    assert.deepEqual(result.loadedFiles, [".env.local"]);
+    assert.deepEqual(result.keys, ["LANGFUSE_PUBLIC_KEY", TELEMETRY_ENV_KEY]);
+  });
+
+  it("loads workspace env files in precedence order without overriding earlier values", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "od-local-env-"));
+    await writeFile(path.join(workspaceRoot, ".env"), "FROM_BASE=base\nSHARED=base\n");
+    await writeFile(path.join(workspaceRoot, ".env.development"), "FROM_DEV=dev\nSHARED=dev\n");
+    await writeFile(path.join(workspaceRoot, ".env.local"), "FROM_LOCAL=local\nSHARED=local\n");
+    await writeFile(path.join(workspaceRoot, ".env.development.local"), "FROM_DEV_LOCAL=dev-local\nSHARED=dev-local\n");
+    const logs: string[] = [];
+    const env: NodeJS.ProcessEnv = {};
+
+    const result = loadWorkspaceLocalEnv({ workspaceRoot, env, log: (message) => logs.push(message) });
+
+    assert.deepEqual(result.loadedFiles, [".env.development.local", ".env.local", ".env.development", ".env"]);
+    assert.equal(env.FROM_DEV_LOCAL, "dev-local");
+    assert.equal(env.FROM_LOCAL, "local");
+    assert.equal(env.FROM_DEV, "dev");
+    assert.equal(env.FROM_BASE, "base");
+    assert.equal(env.SHARED, "dev-local");
+    assert.deepEqual(logs, ["tools-dev env: loaded .env.development.local, .env.local, .env.development, .env"]);
+  });
+
+  it("uses explicit env files instead of default env files", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "od-local-env-"));
+    await writeFile(path.join(workspaceRoot, ".env.local"), "DEFAULT_ONLY=yes\n");
+    await writeFile(path.join(workspaceRoot, "custom.env"), "CUSTOM_ONLY=yes\n");
+    const env: NodeJS.ProcessEnv = {};
+
+    const result = loadWorkspaceLocalEnv({ args: ["--env-file", "custom.env"], workspaceRoot, env });
+
+    assert.deepEqual(result.loadedFiles, ["custom.env"]);
+    assert.equal(env.CUSTOM_ONLY, "yes");
+    assert.equal(env.DEFAULT_ONLY, undefined);
+  });
+
+  it("can be disabled with --no-env-file", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "od-local-env-"));
+    await writeFile(path.join(workspaceRoot, ".env.local"), "SHOULD_NOT_LOAD=yes\n");
+    const env: NodeJS.ProcessEnv = {};
+
+    const result = loadWorkspaceLocalEnv({ args: ["--no-env-file"], workspaceRoot, env });
+
+    assert.equal(result.loaded, false);
+    assert.equal(env.SHOULD_NOT_LOAD, undefined);
+  });
+
+  it("does not load env files for help output and suppresses logs for json output", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "od-local-env-"));
+    await writeFile(path.join(workspaceRoot, ".env.local"), "VALUE=yes\n");
+    const helpEnv: NodeJS.ProcessEnv = {};
+
+    const helpResult = loadWorkspaceLocalEnv({ args: ["--help"], workspaceRoot, env: helpEnv });
+
+    assert.equal(helpResult.loaded, false);
+    assert.equal(helpEnv.VALUE, undefined);
+
+    const logs: string[] = [];
+    loadWorkspaceLocalEnv({ args: ["status", "--json"], workspaceRoot, env: {}, log: (message) => logs.push(message) });
+
+    assert.deepEqual(logs, []);
+  });
+
+  it("requires explicitly requested env files to exist", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "od-local-env-"));
+
+    assert.throws(
+      () => loadWorkspaceLocalEnv({ args: ["--env-file", "missing.env"], workspaceRoot, env: {} }),
+      /env file not found: missing\.env/,
+    );
   });
 
   it("preserves an explicit telemetry environment from .env.local", async () => {


### PR DESCRIPTION
## Why

This PR lets `tools-dev` load environment files and makes those values override the shell environment where intended.

The pain being addressed is local development setup drift: contributors should be able to put repeatable tool configuration in env files instead of re-exporting values by hand for each shell session.

## What users will see

Developers running `tools-dev` can use env-file based configuration for local lifecycle commands, with documented behavior in the quickstart.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — `tools-dev` env-file loading behavior
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — `tools-dev` environment resolution changes when env files are present
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

Skipped. This is a tools-dev behavior update, not a bug fix follow-up.

## Validation

- Not run locally; PR opened from the existing branch for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784209883&installation_id=140661819&pr_number=4430&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4430&signature=8eb4fbbb8500268819d5fb81f0d5c7fd932914d391d188895aba710fc55010b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->