### PR TITLE
fix(daemon): detect Claude resume failure from the stream-json result event (#4275)

### DIFF
--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -76,14 +76,55 @@ export function persistCapturedAgentSession(
 
 // Signatures Claude Code prints to stderr when a `--resume <id>` target no
 // longer exists on disk (session pruned, repo moved machines, ~/.claude
-// cleared). VERIFY against the installed CLI during implementation and add
-// the exact observed string to a mocks/ fixture — these patterns are the
-// planning-time best guess, intentionally permissive.
+// cleared). Verified against the installed CLI (v2.1.178): the first pattern
+// matches its "No conversation found with session ID: <id>" string. These stay
+// as a fast path, but Claude's human-readable prose drifts across builds — when
+// it does, none of these match and the stale session id is never cleared, so
+// every turn retries the same dead `--resume` (#4275). The structured detector
+// below is the version-stable primary; treat these patterns as a complement.
 const CLAUDE_RESUME_FAILURE_PATTERNS: RegExp[] = [
   /no conversation found with session id/i,
   /no session found/i,
   /session .* not found/i,
 ];
+
+/**
+ * Version-stable structured signal that a `--resume <id>` turn failed because
+ * the target session could not be loaded. Unlike the human-readable prose
+ * (which #4275 shows can silently stop matching across Claude builds), the
+ * stream-json `result` event shape is stable: a resume whose session can't be
+ * loaded fails LOCALLY, before any API call, so the terminal result is
+ * `is_error` with zero turns and zero API time. A genuine in-turn failure
+ * (overload / network) spends real API time (`duration_api_ms > 0`) and/or
+ * completes a turn, so it is deliberately left alone — a transient blip must
+ * not drop a still-valid session.
+ */
+function hasClaudeResumeFailureResultEvent(text: string): boolean {
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{') || !trimmed.includes('"result"')) continue;
+    let event: {
+      type?: unknown;
+      is_error?: unknown;
+      num_turns?: unknown;
+      duration_api_ms?: unknown;
+    };
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (event.type !== 'result') continue;
+    if (
+      event.is_error === true
+      && Number(event.num_turns) === 0
+      && Number(event.duration_api_ms) === 0
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /** sha256 hex digest of the composed stable instruction block. */
 export function hashStableInstructions(stable: string): string {
@@ -109,5 +150,6 @@ export function computeIncludeStable(
 /** True when CLI output indicates a resume target session is missing. */
 export function isClaudeResumeFailure(text: string): boolean {
   if (!text) return false;
-  return CLAUDE_RESUME_FAILURE_PATTERNS.some((re) => re.test(text));
+  if (CLAUDE_RESUME_FAILURE_PATTERNS.some((re) => re.test(text))) return true;
+  return hasClaudeResumeFailureResultEvent(text);
 }

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -170,4 +170,75 @@ describe('isClaudeResumeFailure', () => {
     expect(isClaudeResumeFailure('rate limit exceeded')).toBe(false);
     expect(isClaudeResumeFailure('')).toBe(false);
   });
+
+  // Captured from the installed Claude Code CLI (v2.1.178) on a bogus
+  // `--resume <id>` with OD's exact stream-json flags. stderr carries the
+  // human string; stdout carries the structured result event. Locks the
+  // real-world shape as a regression guard (#4275).
+  const REAL_CLAUDE_RESUME_FAILURE_STDERR =
+    'No conversation found with session ID: 00000000-0000-0000-0000-000000000000';
+  const REAL_CLAUDE_RESUME_FAILURE_STDOUT =
+    '{"type":"result","subtype":"error_during_execution","duration_ms":0,'
+    + '"duration_api_ms":0,"is_error":true,"num_turns":0,"stop_reason":null,'
+    + '"session_id":"00000000-0000-0000-0000-000000000000","total_cost_usd":0,'
+    + '"errors":["No conversation found with session ID: 00000000-0000-0000-0000-000000000000"]}';
+
+  it('matches the real installed Claude CLI --resume failure output (#4275)', () => {
+    expect(
+      isClaudeResumeFailure(
+        `${REAL_CLAUDE_RESUME_FAILURE_STDERR}\n${REAL_CLAUDE_RESUME_FAILURE_STDOUT}`,
+      ),
+    ).toBe(true);
+  });
+
+  // #4275: the human-readable prose drifts across Claude builds, so a reworded
+  // failure ("...is unavailable" / "conversation ... not found") slips past all
+  // three legacy patterns. The stream-json result event shape is version-stable
+  // and must still flag the dead resume so the stored session id gets cleared.
+  it('detects a resume failure from the stream-json result event when the prose is reworded', () => {
+    const rewordedProse = 'Conversation 00000000-0000-0000-0000-000000000000 is unavailable';
+    // Sanity: the reworded prose alone misses every legacy pattern.
+    expect(isClaudeResumeFailure(rewordedProse)).toBe(false);
+
+    const rewordedResult = JSON.stringify({
+      type: 'result',
+      subtype: 'error_during_execution',
+      duration_ms: 0,
+      duration_api_ms: 0,
+      is_error: true,
+      num_turns: 0,
+      session_id: '00000000-0000-0000-0000-000000000000',
+      errors: [rewordedProse],
+    });
+    expect(isClaudeResumeFailure(rewordedResult)).toBe(true);
+  });
+
+  // Guard against over-clearing: a transient in-turn failure (overload /
+  // network) spends real API time and produces at least one turn, and a
+  // successful run is not an error — neither must read as a dead resume, or a
+  // blip would drop a still-valid session.
+  it('does not treat an in-turn API failure or a successful run as a resume failure', () => {
+    const inTurnApiError = JSON.stringify({
+      type: 'result',
+      subtype: 'error_during_execution',
+      duration_ms: 5200,
+      duration_api_ms: 5000,
+      is_error: true,
+      num_turns: 1,
+      session_id: 'live-session',
+      errors: ['Overloaded'],
+    });
+    expect(isClaudeResumeFailure(inTurnApiError)).toBe(false);
+
+    const success = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 4200,
+      duration_api_ms: 4000,
+      is_error: false,
+      num_turns: 2,
+      session_id: 'live-session',
+    });
+    expect(isClaudeResumeFailure(success)).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes #4275

## Why

On 0.10.x, Claude can get stuck in a brand-new conversation with "The previous Claude session could not be resumed (it may have expired). Resend your message to continue with a fresh session." — and it persists across resend / new chat. 0.9.0 works; Codex works on the same machine.

OD resumes a Claude session with `--resume <session-id>`. When the stored session no longer exists (pruned, machine moved, `~/.claude` cleared), OD clears the stale id — letting the next turn start fresh — only if the CLI output matches one of three error-string patterns in `agent-session-resume.ts`. Those patterns carried an in-source note: "planning-time best guess — VERIFY against the installed CLI." Claude's human-readable error prose drifts across builds; when it stops matching any pattern, the failure goes undetected, the dead session id stays in the DB, and every subsequent turn retries the same dead `--resume`. That's the persistent loop.

## What users will see

A Claude conversation whose stored session has expired/been pruned now reliably detects the failed resume and clears the stale session id, so the next turn starts a fresh session (seeded from the transcript) instead of retrying the dead `--resume` forever — regardless of how the installed Claude build words its error.

## What changed

The prose patterns are kept as a fast path (and the in-source TODO updated to reflect the verification below), but the primary detector is now version-stable: a `--resume` whose session can't be loaded fails *locally, before any API call*, so the terminal stream-json `result` event is `is_error` with zero turns and zero API time. An in-turn failure (overload / network) spends real API time / completes a turn and is deliberately left alone, so a transient blip never drops a still-valid session.

No `server.ts` change — the existing call site already passes the combined stderr+stdout tail, which contains the result event.

## Verifying against the installed CLI

Per the in-source "VERIFY against the installed CLI" note, I ran OD's exact Claude invocation with a bogus `--resume` target to capture the real failure output:

```
$ printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}' \
    | claude -p --input-format stream-json --output-format stream-json --verbose \
        --resume 00000000-0000-0000-0000-000000000000 --permission-mode bypassPermissions
# exit: 1
# stderr:
No conversation found with session ID: 00000000-0000-0000-0000-000000000000
# stdout (stream-json result event):
{"type":"result","subtype":"error_during_execution","duration_ms":0,"duration_api_ms":0,
 "is_error":true,"num_turns":0,"session_id":"00000000-0000-0000-0000-000000000000",
 "errors":["No conversation found with session ID: 00000000-0000-0000-0000-000000000000"]}

$ claude --version
2.1.178 (Claude Code)
```

On this build the first regex still matches the stderr string, so detection works today — the prose is the fragile part. The structured `result` event (`is_error` + zero turns + zero API time) is the version-stable signal the fix keys on, and the captured output above is locked as a regression fixture in the test.

## Surface area

- [x] None of UI / CLI / contract / i18n — daemon-internal session-resume detection; behavior fix only, no user-facing surface added.

## Bug fix verification

`apps/daemon/tests/agent-session-resume.test.ts`:

- "detects a resume failure from the stream-json result event when the prose is reworded" — red on `main` (reworded prose misses all three patterns; the structured event is ignored), green here.
- "matches the real installed Claude CLI --resume failure output (#4275)" — locks the captured v2.1.178 output as a regression fixture.
- "does not treat an in-turn API failure or a successful run as a resume failure" — guards against over-clearing a still-valid session.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/agent-session-resume.test.ts` — 17 pass
- daemon build / typecheck — pass
- `pnpm guard` — pass

## Adjacent issue (not fixed here)

The thread's second symptom — a brand-new project (no stored session to resume) failing with "OUT after 4–7s" and no visible error — is a different failure path (likely a signal / early exit before any output), not the resume-detection bug. Scoped out per the bug-follow-up workflow; worth its own issue with the failing run's stderr.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784252696&installation_id=140661819&pr_number=4438&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4438&signature=860f38a5b474970ac8ae3b5357ee490e127435577182ef82a97a7bd38eb0daef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->