### PR TITLE
fix(daemon): stop retrying hard quota failures

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -621,17 +621,19 @@ export function classifyRunFailure(
   }
 
   if (errorCode === 'RATE_LIMITED' || serviceFailure === 'RATE_LIMITED' || isHardQuotaText(text) || isRateLimitText(text)) {
-    const retryable = retryableHint ?? !isHardQuotaText(text);
+    const hardQuota = isHardQuotaText(text);
+    const workspaceCredits = isWorkspaceCreditsText(text);
+    const retryable = hardQuota ? false : (retryableHint ?? true);
     return classification(
       'rate_limit',
-      isWorkspaceCreditsText(text)
+      workspaceCredits
         ? 'workspace_credits_exhausted'
-        : isHardQuotaText(text)
+        : hardQuota
           ? 'hard_quota'
           : 'rate_limit_429',
       'session_init',
       retryable,
-      retryable ? 'retry' : isWorkspaceCreditsText(text) ? 'recharge' : 'none',
+      retryable ? 'retry' : workspaceCredits ? 'recharge' : 'none',
     );
   }
 

--- a/apps/daemon/src/runtimes/opencode-log.ts
+++ b/apps/daemon/src/runtimes/opencode-log.ts
@@ -13,6 +13,7 @@ import { classifyAgentServiceFailure, type AgentServiceFailureCode } from './aut
 export interface OpenCodeServiceFailure {
   code: AgentServiceFailureCode;
   message: string;
+  retryable: boolean;
   statusCode: number | null;
 }
 
@@ -84,6 +85,9 @@ export function readLatestOpenCodeLogTail(
 const SERVICE_ERROR_MESSAGE_RE =
   /usage limit|rate[ _-]?limit|quota|limit reached|insufficient|credit|balance|overloaded|unavailable|unauthor|authenticat|invalid[ _-]?(?:api[ _-]?)?key|api key|\/login|exhaust|too many requests/i;
 
+const HARD_QUOTA_MESSAGE_RE =
+  /\b(session limit|usage limit|limit reached|quota|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|funds)|exceeded your current quota)\b/i;
+
 function pickServiceErrorMessage(line: string): string | null {
   const re = /"message":"((?:[^"\\]|\\.)*)"/g;
   let fallback: string | null = null;
@@ -151,8 +155,11 @@ export function extractOpenCodeServiceFailure(
     statusCode != null ? codeFromStatus(statusCode) : null;
   if (!code && message) code = classifyAgentServiceFailure(message);
   if (!code) return null;
+  const retryable = code === 'UPSTREAM_UNAVAILABLE' || (
+    code === 'RATE_LIMITED' && !HARD_QUOTA_MESSAGE_RE.test(message ?? '')
+  );
 
-  return { code, message: message || defaultMessageForCode(code), statusCode };
+  return { code, message: message || defaultMessageForCode(code), retryable, statusCode };
 }
 
 // Convenience for the run close handler / inactivity watchdog: resolve the

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6739,7 +6739,7 @@ export async function startServer({
           stallPayload = createSseErrorPayload(
             logFailure.code,
             logFailure.message,
-            { retryable: true },
+            { retryable: logFailure.retryable },
           );
         }
       }
@@ -8162,7 +8162,7 @@ export async function startServer({
             send('error', createSseErrorPayload(
               openCodeFailure.code,
               openCodeFailure.message,
-              { retryable: true },
+              { retryable: openCodeFailure.retryable },
             ));
           } else {
             const rewritten = rewriteKnownAgentStreamError(

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -252,6 +252,27 @@ describe('classifyRunFailure', () => {
     });
   });
 
+  it('does not let retryable hints override session-limit hard quota text', () => {
+    expect(
+      classify(
+        'RATE_LIMITED',
+        "You've hit your session limit; resets at 3:10am.",
+        [
+          errorEvent(
+            'RATE_LIMITED',
+            "You've hit your session limit; resets at 3:10am.",
+            true,
+          ),
+        ],
+      ),
+    ).toMatchObject({
+      failure_category: 'rate_limit',
+      failure_detail: 'hard_quota',
+      retryable: false,
+      user_action: 'none',
+    });
+  });
+
   it('maps upstream failures to retry guidance', () => {
     expect(classify('UPSTREAM_UNAVAILABLE', 'HTTP 503 upstream unavailable')).toMatchObject({
       failure_category: 'upstream_unavailable',

--- a/apps/daemon/tests/runtimes/opencode-log-failure.test.ts
+++ b/apps/daemon/tests/runtimes/opencode-log-failure.test.ts
@@ -30,6 +30,7 @@ describe('extractOpenCodeServiceFailure', () => {
     const failure = extractOpenCodeServiceFailure(USAGE_LIMIT_LINE);
     expect(failure).not.toBeNull();
     expect(failure!.code).toBe('RATE_LIMITED');
+    expect(failure!.retryable).toBe(false);
     expect(failure!.statusCode).toBe(429);
     expect(failure!.message).toContain('Monthly usage limit reached');
     expect(failure!.message).toContain('Resets in 6 days');


### PR DESCRIPTION
Fixes #4388

## Why

I am opening this PR for issue #4388 after the attached diagnostics showed excessive token consumption caused by retry loops around usage/session limits.

The user-facing pain is that OpenCode can surface a provider usage/session limit from its own log after the daemon sees a silent stall, but Open Design was re-emitting that recovered `RATE_LIMITED` error as retryable. That allowed the safe same-run retry path to treat a hard quota as recoverable, wasting more input tokens instead of stopping and showing the user the real limit condition.

## What users will see

When OpenCode hits a hard quota / usage limit / session limit, the chat run now stops with a non-retryable rate-limit error instead of automatically retrying the same run. Ordinary transient 429 rate limits remain retryable.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — daemon retry/error-classification behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/run-failure-classification.test.ts`, `apps/daemon/tests/runtimes/opencode-log-failure.test.ts`
- Did the test go red on `main` and green on this branch? yes — added tests first and confirmed failure before implementation:
  - `opencode-log-failure.test.ts`: `failure!.retryable` was `undefined` instead of `false`
  - `run-failure-classification.test.ts`: session-limit hard quota with a retryable hint was classified as `retryable: true`

## Validation

- [x] `PATH=/Users/xu/.nvm/versions/node/v24.16.0/bin:$PATH corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/opencode-log-failure.test.ts tests/run-failure-classification.test.ts tests/run-retry-policy.test.ts` — passed, 64 tests
- [x] `PATH=/Users/xu/.nvm/versions/node/v24.16.0/bin:$PATH corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/run-retry-runtime.test.ts` — passed, 2 tests
- [x] `PATH=/Users/xu/.nvm/versions/node/v24.16.0/bin:$PATH corepack pnpm --filter @open-design/daemon typecheck` — passed
- [x] `PATH=/Users/xu/.nvm/versions/node/v24.16.0/bin:$PATH corepack pnpm guard` — passed

Note: running the four Vitest files in one command exposed an existing test isolation issue where `run-retry-runtime.test.ts` reused a temporary fake CLI path from a prior test when run concurrently. The file passes when run by itself, and the directly related daemon logic tests pass together.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784253681&installation_id=140661819&pr_number=4439&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4439&signature=fcf8324ab9ff08a8a374f0e9676ba317daf89fb22db61fab4e1196bc83ae3eda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->