### PR TITLE
fix(daemon): accept the audit warning's own heading wording in skillHasReusableSections (#4435)

### DIFF
--- a/apps/daemon/src/tools-connectors-cli.ts
+++ b/apps/daemon/src/tools-connectors-cli.ts
@@ -2239,7 +2239,11 @@ function skillHasAgentFrontmatter(text: string): boolean {
 
 function skillHasReusableSections(text: string): boolean {
   if (text.trim().length < 800) return false;
-  const hasInside = (/\*\*What's inside:\*\*/iu.test(text) || /^##\s+(?:What's inside|Contents)\s*$/imu.test(text))
+  // Accept "What's inside", the skill_missing_reuse_sections warning's own
+  // "What is inside" wording, and "Contents" — the validator must accept the
+  // headings the warning tells authors to write or --fail-on-warnings loops
+  // forever re-spelling them (#4435).
+  const hasInside = (/\*\*What(?:'s| is) inside:\*\*/iu.test(text) || /^##\s+(?:What(?:'s| is) inside|Contents)\s*$/imu.test(text))
     && /\b(tokens?|assets?|fonts?|preview|ui\s*kit|components?)\b/iu.test(text);
   const hasSourceContext = (/\*\*Source context:\*\*/iu.test(text) || /^##\s+(?:Source Context|Source)\s*$/imu.test(text))
     && /\b(source|repository|github|local|based on|evidence)\b/iu.test(text);
@@ -2247,7 +2251,9 @@ function skillHasReusableSections(text: string): boolean {
     && /\b(prototypes?|mockups?|interfaces?|artifacts?|production|design|build(?:ing)?)\b/iu.test(text);
   const hasHowToUse = (/\*\*How to use:\*\*/iu.test(text) || /^##\s+(?:How to use|Usage)\s*$/imu.test(text))
     && /\b(README\.md|DESIGN\.md|colors_and_type\.css|preview\/|assets\/|build\/|fonts\/|ui_kits\/app)\b/iu.test(text);
-  const hasHighlights = (/\*\*Design system highlights:\*\*/iu.test(text) || /^##\s+(?:(?:Design System|Design) )?Highlights\s*$/imu.test(text))
+  // Accept "Design system highlights", the warning's hyphenated "design-system
+  // highlights", and bare "Highlights" so following the warning text passes (#4435).
+  const hasHighlights = (/\*\*Design[ -]system highlights:\*\*/iu.test(text) || /^##\s+(?:(?:Design[ -]System|Design) )?Highlights\s*$/imu.test(text))
     && /\b(colors?|typography|spacing|radius|shadows?|icons?|layout|interaction)\b/iu.test(text);
   return hasInside && hasSourceContext && hasWhenToUse && hasHowToUse && hasHighlights;
 }

--- a/apps/daemon/tests/tools-connectors-cli.test.ts
+++ b/apps/daemon/tests/tools-connectors-cli.test.ts
@@ -163,6 +163,15 @@ Load colors_and_type.css, inspect preview/, reuse ui_kits/app/, and preserve com
 - Interaction: subtle hover, active, focus, and disabled states for dense productivity UI.
 `;
 
+// Same complete, reusable SKILL.md as AUDIT_SKILL, but with the two reuse
+// headings worded exactly as the skill_missing_reuse_sections warning instructs
+// authors to write them — "What is inside" and "design-system highlights".
+// Following the warning text must satisfy the validator, or an agent running
+// --fail-on-warnings loops forever re-spelling these headings (#4435).
+const SKILL_WITH_WARNING_WORDED_SECTIONS = AUDIT_SKILL
+  .replace("**What's inside:**", '**What is inside:**')
+  .replace('**Design system highlights:**', '**Design-system highlights:**');
+
 const SKILL_WITHOUT_REUSE_SECTIONS = `---
 name: cherry-studio-design
 description: Use this skill when creating Open Design artifacts that should match the Cherry Studio desktop AI chat workspace.
@@ -1048,6 +1057,46 @@ exit 128
         message: expect.stringContaining('reusable Claude Design skill package'),
       }),
     ]));
+
+    await cleanupTempDir(tmpDir);
+  });
+
+  it('accepts SKILL.md reuse sections worded exactly as the audit warning instructs (#4435)', async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'od-package-audit-skill-wording-'));
+    process.chdir(tmpDir);
+    await mkdir(path.join(tmpDir, 'preview'), { recursive: true });
+    await mkdir(path.join(tmpDir, 'ui_kits/app/components'), { recursive: true });
+    await writeFile(path.join(tmpDir, 'DESIGN.md'), AUDIT_DESIGN_MD);
+    await writeFile(path.join(tmpDir, 'README.md'), AUDIT_README);
+    await writeFile(path.join(tmpDir, 'SKILL.md'), SKILL_WITH_WARNING_WORDED_SECTIONS);
+    await writeFile(path.join(tmpDir, 'colors_and_type.css'), AUDIT_TOKENS_CSS);
+    for (const fileName of [
+      'colors-primary.html',
+      'colors-theme-light.html',
+      'typography-specimens.html',
+      'spacing-tokens.html',
+      'components-buttons.html',
+      'brand-assets.html',
+    ]) {
+      await writeFile(path.join(tmpDir, 'preview', fileName), auditHtml(fileName));
+    }
+    await writeFile(path.join(tmpDir, 'ui_kits/app/index.html'), auditUiKitIndex());
+    await writeFile(path.join(tmpDir, 'ui_kits/app/README.md'), AUDIT_UI_KIT_README);
+    for (const componentName of AUDIT_COMPONENT_FILES) {
+      await writeFile(
+        path.join(tmpDir, 'ui_kits/app/components', componentName),
+        auditUiKitComponent(componentName),
+      );
+    }
+
+    const result = await runConnectorsToolCli(['design-system-package-audit', '--path', tmpDir]);
+
+    expect(result.exitCode).toBe(0);
+    const warnings = JSON.parse(stdoutOutput.join('')).warnings ?? [];
+    const reuseWarnings = warnings.filter(
+      (warning: { code?: string }) => warning.code === 'skill_missing_reuse_sections',
+    );
+    expect(reuseWarnings).toEqual([]);
 
     await cleanupTempDir(tmpDir);
   });


### PR DESCRIPTION
Fixes #4435

## Why

`design-system-package-audit` emits a `skill_missing_reuse_sections` warning telling authors their `SKILL.md` should "include What is inside, Source context, When to use, How to use, and design-system highlights." But the validator behind it, `skillHasReusableSections`, only accepts `## What's inside` / `## Contents` and `## Design system highlights` / `## Highlights` (a space, not a hyphen). The guidance text contradicts the patterns it's checked against, so following the warning never clears it.

For a human that's a papercut; for an agent it's a trap. A coding agent (Kimi) generating a design-system package looped for ~23 minutes re-spelling `SKILL.md` headings — repeatedly running `design-system-package-audit --path . --fail-on-warnings` and never passing — because it trusted the warning text ("What is inside"), which the regex rejects. The package was otherwise complete and correct.

## What users will see

Authors (and agents) who write the `SKILL.md` sections the audit warning names now pass the audit. Writing "What is inside" / "design-system highlights" — the exact wording the warning instructs — satisfies `skillHasReusableSections` instead of looping `--fail-on-warnings` forever.

## What changed

`apps/daemon/src/tools-connectors-cli.ts`, `skillHasReusableSections`: broaden the two mismatched patterns so the validator accepts the wording the warning uses, in addition to the canonical forms it already accepted:

- "What's inside" → also "What is inside" (and still "Contents")
- "Design system highlights" → also the hyphenated "design-system highlights" (and still "Highlights")

The invariant: writing the sections the warning names must satisfy the audit. (The other three sections — Source context, When to use, How to use — already matched the warning, so they're unchanged.)

## Surface area

- [x] None of UI / CLI flag / contract / i18n — tightens an existing CLI audit validator; no new surface, behavior fix only.

## Bug fix verification

`apps/daemon/tests/tools-connectors-cli.test.ts`:

- "accepts SKILL.md reuse sections worded exactly as the audit warning instructs (#4435)" — a full, valid package whose `SKILL.md` headings use the warning's wording emits `skill_missing_reuse_sections` on `main` (red) and is clean here (green). The fixture is derived from the existing passing `AUDIT_SKILL` by swapping only those two headings, so the wording is the only variable.
- The existing "warns when SKILL.md lacks Claude-style reusable skill sections" still warns — broadening accepts the reworded headings, not missing ones.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/tools-connectors-cli.test.ts` — 39 pass
- daemon build / typecheck — pass
- `pnpm guard` — pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784253688&installation_id=140661819&pr_number=4440&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4440&signature=113e2c71eb306832908d69a832ea5750f11d584283c62a18f815568785e06212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->