### PR TITLE
fix(e2e): seed win smoke onboarding into the live daemon data dir

### DIFF
--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -2,7 +2,6 @@
 
 import { execFile } from 'node:child_process';
 import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
@@ -295,25 +294,6 @@ type DirectInstallerResult = {
   nsisLogTail: string[];
 };
 
-type InstalledPackagedConfig = {
-  namespaceBaseRoot?: unknown;
-};
-
-type InstalledRuntimeConfig = {
-  active?: {
-    entry?: {
-      cwd?: unknown;
-    };
-    root?: unknown;
-  };
-};
-
-type InstalledAppPackage = {
-  name?: unknown;
-  productName?: unknown;
-  version?: unknown;
-};
-
 const shouldRunPackagedWinSmoke = process.platform === 'win32' && process.env.OD_PACKAGED_E2E_WIN === '1';
 const winDescribe = shouldRunPackagedWinSmoke ? describe : describe.skip;
 
@@ -368,7 +348,7 @@ winDescribe('packaged windows runtime smoke', () => {
         );
       }
 
-      await seedPackagedOnboardingComplete(install.installDir);
+      await seedPackagedOnboardingComplete();
 
       const startDesktop = async (step: string): Promise<WinStartResult> => {
         const nextStart = await measureSmokeStep(timings, step, async () => runToolsPackJson<WinStartResult>('start'));
@@ -1089,86 +1069,26 @@ async function readTiming(filePath: string): Promise<TimingResult> {
   return JSON.parse(await readFile(filePath, 'utf8')) as TimingResult;
 }
 
-async function seedPackagedOnboardingComplete(installDir: string): Promise<void> {
-  const configPath = join(await resolveExpectedDataRoot(installDir), 'app-config.json');
+async function seedPackagedOnboardingComplete(): Promise<void> {
+  // Pre-mark first-run onboarding as complete so the packaged app boots
+  // straight to the home shell. Since #4389 the Connect onboarding step is
+  // required and has no Skip affordance, so the only way past it on a fresh
+  // install is an `onboardingCompleted: true` config the daemon reads on boot.
+  //
+  // Write to the SAME data dir the running daemon actually reads —
+  // `<runtimeNamespaceRoot>/data` — not a path derived from the installed
+  // app's baked config. `tools-pack win start` rewrites the launch config's
+  // `namespaceBaseRoot` to the tools-pack runtime root (see
+  // writeInstalledLaunchPackagedConfig in tools/pack/src/win/lifecycle.ts) and
+  // hands it to the runtime via OD_PACKAGED_CONFIG_PATH, so the live daemon's
+  // RUNTIME_DATA_DIR is always under runtimeNamespaceRoot regardless of what
+  // the installer baked. Deriving the path from the installed manifest landed
+  // the seed elsewhere (the AppData fallback), so the daemon never saw it and
+  // the app stuck on onboarding once the Skip button was removed. This mirrors
+  // the macOS smoke's seed, which already writes under runtimeNamespaceRoot.
+  const configPath = join(runtimeNamespaceRoot, 'data', 'app-config.json');
   await mkdir(dirname(configPath), { recursive: true });
   await writeFile(configPath, `${JSON.stringify({ onboardingCompleted: true }, null, 2)}\n`, 'utf8');
-}
-
-async function resolveExpectedDataRoot(installDir: string): Promise<string> {
-  return join(await resolveExpectedNamespaceRoot(installDir), 'data');
-}
-
-async function resolveExpectedNamespaceRoot(installDir: string): Promise<string> {
-  const installedConfig = JSON.parse(
-    await readFile(await resolveInstalledPackagedConfigPath(installDir), 'utf8'),
-  ) as InstalledPackagedConfig;
-  const configuredNamespaceBaseRoot =
-    typeof installedConfig.namespaceBaseRoot === 'string' && installedConfig.namespaceBaseRoot.length > 0
-      ? installedConfig.namespaceBaseRoot
-      : null;
-  const namespaceBaseRoot =
-    configuredNamespaceBaseRoot ?? join(defaultWindowsAppDataRoot(await readInstalledAppName(installDir)), 'namespaces');
-  return join(resolve(namespaceBaseRoot), namespace);
-}
-
-async function readInstalledAppName(installDir: string): Promise<string> {
-  const appPackage = JSON.parse(
-    await readFile(
-      join(await resolveInstalledPayloadRoot(installDir), 'resources', 'app', 'package.json'),
-      'utf8',
-    ),
-  ) as InstalledAppPackage;
-  if (typeof appPackage.productName === 'string' && appPackage.productName.length > 0) return appPackage.productName;
-  if (typeof appPackage.name === 'string' && appPackage.name.length > 0) return appPackage.name;
-  return 'Open Design';
-}
-
-async function resolveInstalledPackagedConfigPath(installDir: string): Promise<string> {
-  return join(await resolveInstalledPayloadRoot(installDir), 'resources', 'open-design-config.json');
-}
-
-async function resolveInstalledPayloadRoot(installDir: string): Promise<string> {
-  const runtimePath = join(installDir, 'runtime.json');
-  const runtimeRaw = await readFile(runtimePath, 'utf8').catch((error: NodeJS.ErrnoException) => {
-    if (error.code === 'ENOENT') return null;
-    throw error;
-  });
-  if (runtimeRaw == null) return installDir;
-
-  const runtime = JSON.parse(runtimeRaw) as InstalledRuntimeConfig;
-  const activeRoot = safeLauncherRelativePath(runtime.active?.root);
-  const activeCwd = safeLauncherRelativePath(runtime.active?.entry?.cwd);
-  if (activeRoot == null || activeCwd == null) {
-    throw new Error(`installed runtime.json does not describe an active payload root: ${runtimePath}`);
-  }
-
-  const payloadRoot = resolve(installDir, activeRoot, activeCwd);
-  if (!isPathInside(payloadRoot, installDir)) {
-    throw new Error(`installed runtime active payload root escapes install dir: ${payloadRoot}`);
-  }
-  return payloadRoot;
-}
-
-function safeLauncherRelativePath(value: unknown): string | null {
-  if (typeof value !== 'string' || value.length === 0 || isAbsolute(value)) return null;
-  const segments = value.split(/[\\/]+/);
-  if (segments.some((segment) => segment.length === 0 || segment === '.' || segment === '..')) return null;
-  return join(...segments);
-}
-
-function defaultWindowsAppDataRoot(appName: string): string {
-  return join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), appName);
-}
-
-function isPathInside(filePath: string, expectedRoot: string): boolean {
-  const normalizedPath = normalizePathForComparison(resolve(filePath));
-  const normalizedRoot = normalizePathForComparison(resolve(expectedRoot));
-  return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`);
-}
-
-function normalizePathForComparison(filePath: string): string {
-  return process.platform === 'win32' ? filePath.toLowerCase() : filePath;
 }
 
 function resolveFromWorkspace(filePath: string): string {


### PR DESCRIPTION
## Why

The `release/v0.11.0` nightly's **Build release win x64** job is failing the packaged Windows smoke (`e2e/specs/win.spec.ts`) with:

> packaged windows runtime did not reach main app shell

The app installs, starts, and reports `running`, but stays stuck on the first-run **onboarding** view (`onboardingVisible: true, homeVisible: false`) and `ensureMainAppShell()` times out — blocking the whole nightly (install/start/update/uninstall coverage all gated behind this one step).

Root cause is two things meeting:

1. The smoke pre-seeds `{ onboardingCompleted: true }` to skip onboarding, but on Windows it derived the target path from the **installed app's baked config** (`resources/open-design-config.json`), which falls back to the AppData namespace root. The **running** daemon's `RUNTIME_DATA_DIR` is somewhere else: `tools-pack win start` rewrites `namespaceBaseRoot` to the tools-pack runtime root and hands it to the runtime via `OD_PACKAGED_CONFIG_PATH` (`writeInstalledLaunchPackagedConfig`, `tools/pack/src/win/lifecycle.ts`). So the seed landed in a dir the daemon never reads → `onboardingCompleted` was never honored.
2. This was harmless until #4389 made the **Connect** onboarding step required and removed the step-0 "Skip" button. `ensureMainAppShell` previously clicked Skip to reach home, so the ineffective seed didn't matter. With Skip gone, the seed is the *only* way past onboarding — and it was missing its target.

macOS passed because the mac packaged smoke doesn't assert the home shell (only daemon health + `running`), so it never exercised the seed.

## What users will see

No user-facing change. This is a test-only fix that unblocks the Windows nightly build. End users were never affected (a real fresh install lands in onboarding by design; only the automated smoke pre-skips it).

## What changed

- `seedPackagedOnboardingComplete` now writes to `<runtimeNamespaceRoot>/data/app-config.json` — the exact data dir the running daemon reads (already asserted for `logs` at `win.spec.ts:~400`), matching the macOS smoke's approach.
- Removed the now-dead manifest-derivation helper chain (`resolveExpectedNamespaceRoot`, `resolveInstalledPayloadRoot`, `defaultWindowsAppDataRoot`, etc.) and its types/import. Net −99/+19.

## Surface area

- [x] Tests (`e2e/specs/win.spec.ts`)

No app code, contracts, CLI, i18n, or dependencies touched.

## Validation

- `pnpm --filter @open-design/e2e typecheck` ✅
- `pnpm guard` ✅ (63/63)
- The packaged Windows smoke itself only runs on `win32` with `OD_PACKAGED_E2E_WIN=1` (the nightly runner) — cannot execute on macOS locally. The fix aligns the seed path with the daemon's `RUNTIME_DATA_DIR`, which the same test already asserts via `expectPathInside(start.logPath, join(runtimeNamespaceRoot, 'logs', 'desktop'))`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nexu-io/codesmith/open-design/pr/4444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784261057&installation_id=140661819&pr_number=4444&repository=nexu-io%2Fopen-design&return_to=https%3A%2F%2Fgithub.com%2Fnexu-io%2Fopen-design%2Fpull%2F4444&signature=33661a2e214a6f52a4b11164ab0029da8f16854104a8c1b39832d3a36ba5f047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->