### PR TITLE
[codex] Refresh local CLI auth state after API key switches

### DIFF
--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -52,6 +52,9 @@ const ANTIGRAVITY_QUOTA_GUIDANCE =
 const REASONIX_AUTH_GUIDANCE =
   'DeepSeek Reasonix is installed but is not authenticated. Add your API key in `~/.reasonix/config.json` under `apiKey`, or expose DEEPSEEK_API_KEY to the Open Design daemon process, then retry. If Open Design is launched outside an interactive shell, shell rc files such as ~/.zshrc may not be loaded.';
 
+const CLAUDE_AUTH_GUIDANCE =
+  'Claude Code is installed but is not authenticated. Run `claude auth login` or open `claude` and complete login in a terminal, then rescan. If Open Design was launched outside an interactive shell, your shell rc files (e.g. ~/.zshrc) may not be loaded into its environment.';
+
 export function cursorAuthGuidance(): string {
   return CURSOR_AUTH_GUIDANCE;
 }
@@ -70,6 +73,10 @@ export function antigravityQuotaGuidance(): string {
 
 export function reasonixAuthGuidance(): string {
   return REASONIX_AUTH_GUIDANCE;
+}
+
+export function claudeAuthGuidance(): string {
+  return CLAUDE_AUTH_GUIDANCE;
 }
 
 export function isCursorAuthFailureText(text: string): boolean {
@@ -130,10 +137,40 @@ export function isReasonixAuthFailureText(text: string): boolean {
   );
 }
 
+export function isClaudeAuthFailureText(text: string): boolean {
+  const value = String(text || '');
+  if (!value.trim()) return false;
+  try {
+    const parsed = JSON.parse(value) as { authenticated?: unknown; loggedIn?: unknown };
+    if (parsed.authenticated === true || parsed.loggedIn === true) return false;
+    if (parsed.authenticated === false || parsed.loggedIn === false) return true;
+  } catch {
+    // Fall through to text matching below.
+  }
+  if (/"authenticated"\s*:\s*true/i.test(value) || /"loggedIn"\s*:\s*true/i.test(value)) {
+    return false;
+  }
+  return (
+    /"authenticated"\s*:\s*false/i.test(value) ||
+    /"loggedIn"\s*:\s*false/i.test(value) ||
+    /not authenticated/i.test(value) ||
+    /not logged[ _-]?in/i.test(value) ||
+    /authentication required/i.test(value) ||
+    /please (?:sign|log)[ _-]?in/i.test(value)
+  );
+}
+
 export function classifyAgentAuthFailure(
   agentId: string,
   text: string,
 ): AgentAuthProbeResult | null {
+  if (agentId === 'claude') {
+    if (!isClaudeAuthFailureText(text)) return null;
+    return {
+      status: 'missing',
+      message: claudeAuthGuidance(),
+    };
+  }
   if (agentId === 'cursor-agent') {
     if (!isCursorAuthFailureText(text)) return null;
     return {
@@ -268,6 +305,7 @@ function genericAuthGuidance(agentName: string): string {
 // ways the generic matcher would misread). The generic classifier is only a
 // fallback for adapters with no tailored classifier of their own.
 const TAILORED_AUTH_AGENTS = new Set([
+  'claude',
   'cursor-agent',
   'deepseek',
   'antigravity',

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -312,6 +312,26 @@ const TAILORED_AUTH_AGENTS = new Set([
   'reasonix',
 ]);
 
+function hasNonEmptyEnv(env: RuntimeEnv, keys: string[]): boolean {
+  return keys.some((key) => {
+    const value = env[key];
+    return typeof value === 'string' && value.trim().length > 0;
+  });
+}
+
+function hasProbeSatisfyingApiKey(
+  def: Pick<RuntimeAgentDef, 'id'>,
+  env: RuntimeEnv,
+): boolean {
+  if (def.id === 'codex') {
+    return hasNonEmptyEnv(env, ['CODEX_API_KEY', 'OPENAI_API_KEY']);
+  }
+  if (def.id === 'claude') {
+    return hasNonEmptyEnv(env, ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN']);
+  }
+  return false;
+}
+
 // Classify an auth-probe's combined output into a missing-auth result, or
 // null when the output does not look like an auth failure. Agents with a
 // tailored classifier use only that (null === authenticated); every other
@@ -342,6 +362,7 @@ export async function probeAgentAuthStatus(
 ): Promise<AgentAuthProbeResult | null> {
   const probe = def.authProbe;
   if (!probe) return null;
+  if (hasProbeSatisfyingApiKey(def, env)) return { status: 'ok' };
   try {
     const { stdout, stderr } = await execAgentFile(resolvedBin, probe.args, {
       env,

--- a/apps/daemon/src/runtimes/defs/claude.ts
+++ b/apps/daemon/src/runtimes/defs/claude.ts
@@ -23,6 +23,10 @@ export const claudeAgentDef = {
     // — issue #235) get auto-detected without writing wrapper scripts.
     fallbackBins: ['openclaude'],
     versionArgs: ['--version'],
+    authProbe: {
+      args: ['auth', 'status'],
+      timeoutMs: 5000,
+    },
     helpArgs: ['-p', '--help'],
     capabilityFlags: {
       // Flag string -> capability key. After probing `--help`, we set

--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -70,6 +70,10 @@ export const codexAgentDef = {
       parse: parseCodexDebugModels,
       timeoutMs: 5000,
     },
+    authProbe: {
+      args: ['login', 'status'],
+      timeoutMs: 5000,
+    },
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       { id: 'gpt-5.5', label: 'gpt-5.5' },

--- a/apps/daemon/src/runtimes/local-profiles.ts
+++ b/apps/daemon/src/runtimes/local-profiles.ts
@@ -166,9 +166,10 @@ function createLocalAgentDef(
   const versionArgs = normalizeStringList(profile.versionArgs);
   const helpArgs = normalizeStringList(profile.helpArgs);
   const defaultModel = normalizeDefaultModel(profile.defaultModel);
+  const { authProbe: baseAuthProbe, ...baseWithoutAuthProbe } = base;
 
   return {
-    ...base,
+    ...baseWithoutAuthProbe,
     id,
     name,
     bin,
@@ -176,6 +177,7 @@ function createLocalAgentDef(
     ...(helpArgs.length > 0 ? { helpArgs } : {}),
     fallbackModels,
     env,
+    ...(prefixArgs.length === 0 && baseAuthProbe ? { authProbe: baseAuthProbe } : {}),
     buildArgs: (prompt, imagePaths, extraAllowedDirs, options, runtimeContext) => [
       ...prefixArgs,
       ...base.buildArgs(

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -3356,6 +3356,18 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
       await withFakeCodex(
         `
 const fs = require('node:fs');
+if (process.argv[2] === '--version') {
+  console.log('codex-cli 9.9.9');
+  process.exit(0);
+}
+if (process.argv[2] === 'debug' && process.argv[3] === 'models') {
+  console.log(JSON.stringify({ models: [] }));
+  process.exit(0);
+}
+if (process.argv[2] === 'login' && process.argv[3] === 'status') {
+  console.log('Logged in using ChatGPT');
+  process.exit(0);
+}
 fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
 process.on('SIGTERM', () => {
   fs.writeFileSync(${JSON.stringify(termFile)}, 'term');

--- a/apps/daemon/tests/runtimes/helpers/test-helpers.ts
+++ b/apps/daemon/tests/runtimes/helpers/test-helpers.ts
@@ -71,6 +71,7 @@ export function minimalAgentDef(
 }
 
 export const amp = requireAgent('amp');
+export const claude = requireAgent('claude');
 export const codex = requireAgent('codex');
 export const hermes = requireAgent('hermes');
 export const kimi = requireAgent('kimi');
@@ -79,7 +80,6 @@ export const cursorAgent = requireAgent('cursor-agent');
 export const kiro = requireAgent('kiro');
 export const kilo = requireAgent('kilo');
 export const vibe = requireAgent('vibe');
-export const claude = requireAgent('claude');
 export const devin = requireAgent('devin');
 export const pi = requireAgent('pi');
 export const deepseek = requireAgent('deepseek');

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  AGENT_DEFS, amp, assert, chmodSync, codex, cursorAgent, detectAgents, grokBuild, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
+  AGENT_DEFS, amp, assert, chmodSync, claude, codex, cursorAgent, detectAgents, grokBuild, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 import { codexNeedsDangerFullAccessSandbox } from '../../src/runtimes/defs/codex.js';
 import { readLocalAgentProfileDefs } from '../../src/runtimes/registry.js';
@@ -365,6 +365,42 @@ test('codex model picker includes current OpenAI choices in priority order', asy
       assert.equal(detected.available, true);
       assert.equal(detected.version, 'codex 1.0.0');
       assert.deepEqual(detected.models.map((m: { id: string }) => m.id), expectedModels);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('claude probes auth status so rescans reflect CLI auth changes', async () => {
+  assert.deepEqual(claude.authProbe, {
+    args: ['auth', 'status'],
+    timeoutMs: 5000,
+  });
+
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-claude-auth-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CLAUDE_BIN'], async () => {
+      const claudeBin = join(dir, 'claude');
+      writeFileSync(
+        claudeBin,
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "2.1.168 (Claude Code)"; exit 0; fi
+if [ "$1" = "-p" ] && [ "$2" = "--help" ]; then echo "--include-partial-messages --add-dir"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo '{"authenticated":true,"source":"claude.ai"}'; exit 0; fi
+exit 0
+`,
+      );
+      chmodSync(claudeBin, 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+      delete process.env.CLAUDE_BIN;
+
+      const agents = await detectAgents();
+      const detected = agents.find((agent) => agent.id === 'claude');
+
+      assert.ok(detected);
+      assert.equal(detected.available, true);
+      assert.equal(detected.authStatus, 'ok');
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -60,6 +60,7 @@ test('local agent profiles inherit a base adapter and can pin the default model'
         ZCODE_ROUTE: 'design',
         RETRIES: '2',
       });
+      assert.equal(profile.authProbe, undefined);
 
       const defaultArgs = profile.buildArgs('', [], [], {});
       assert.deepEqual(defaultArgs.slice(0, 2), ['run', '-p']);
@@ -407,6 +408,38 @@ exit 0
   }
 });
 
+test('claude API key env satisfies auth probe without requiring local login', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-claude-api-key-auth-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CLAUDE_BIN', 'ANTHROPIC_API_KEY'], async () => {
+      const claudeBin = join(dir, 'claude');
+      writeFileSync(
+        claudeBin,
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "2.1.168 (Claude Code)"; exit 0; fi
+if [ "$1" = "-p" ] && [ "$2" = "--help" ]; then echo "--include-partial-messages --add-dir"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo '{"authenticated":false}'; exit 1; fi
+exit 0
+`,
+      );
+      chmodSync(claudeBin, 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+      process.env.ANTHROPIC_API_KEY = 'sk-anthropic';
+      delete process.env.CLAUDE_BIN;
+
+      const agents = await detectAgents();
+      const detected = agents.find((agent) => agent.id === 'claude');
+
+      assert.ok(detected);
+      assert.equal(detected.available, true);
+      assert.equal(detected.authStatus, 'ok');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('codex probes login status so rescans reflect CLI auth changes', async () => {
   assert.deepEqual(codex.authProbe, {
     args: ['login', 'status'],
@@ -428,6 +461,38 @@ exit 0
       chmodSync(codexBin, 0o755);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
+      delete process.env.CODEX_BIN;
+
+      const agents = await detectAgents();
+      const detected = agents.find((agent) => agent.id === 'codex');
+
+      assert.ok(detected);
+      assert.equal(detected.available, true);
+      assert.equal(detected.authStatus, 'ok');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('codex API key env satisfies auth probe without requiring local login', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-api-key-auth-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN', 'CODEX_API_KEY'], async () => {
+      const codexBin = join(dir, 'codex');
+      writeFileSync(
+        codexBin,
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "codex-cli 9.9.9"; exit 0; fi
+if [ "$1" = "debug" ] && [ "$2" = "models" ]; then echo '{"models":[]}'; exit 0; fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Not logged in"; exit 1; fi
+exit 0
+`,
+      );
+      chmodSync(codexBin, 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+      process.env.CODEX_API_KEY = 'sk-codex';
       delete process.env.CODEX_BIN;
 
       const agents = await detectAgents();

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -371,6 +371,41 @@ test('codex model picker includes current OpenAI choices in priority order', asy
   }
 });
 
+test('codex probes login status so rescans reflect CLI auth changes', async () => {
+  assert.deepEqual(codex.authProbe, {
+    args: ['login', 'status'],
+    timeoutMs: 5000,
+  });
+
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-auth-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN'], async () => {
+      const codexBin = join(dir, 'codex');
+      writeFileSync(
+        codexBin,
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "codex-cli 9.9.9"; exit 0; fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Logged in using ChatGPT"; exit 0; fi
+exit 0
+`,
+      );
+      chmodSync(codexBin, 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+      delete process.env.CODEX_BIN;
+
+      const agents = await detectAgents();
+      const detected = agents.find((agent) => agent.id === 'codex');
+
+      assert.ok(detected);
+      assert.equal(detected.available, true);
+      assert.equal(detected.authStatus, 'ok');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('codex parses live model catalog from debug models JSON', () => {
   assert.ok(codex.listModels, 'codex must define live model discovery');
   const parsed = codex.listModels.parse(JSON.stringify({
@@ -413,6 +448,7 @@ if [ "$1" = "debug" ] && [ "$2" = "models" ]; then
   printf '%s\\n' '{"models":[{"slug":"gpt-6-codex","display_name":"GPT-6 Codex","visibility":"list"}]}'
   exit 0
 fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Logged in using ChatGPT"; exit 0; fi
 exit 2
 `,
       );

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -370,7 +370,7 @@ function AppInner() {
   const amrModelsRef = useRef<AmrModelsResponse | null>(null);
   const amrPollGenerationRef = useRef(0);
   const agentStreamRequestSeqRef = useRef(0);
-  const agentFocusRefreshLastRunRef = useRef(0);
+  const agentFocusRefreshLastRunRef = useRef(Date.now());
   const [amrPollRestartToken, setAmrPollRestartToken] = useState(0);
   const [providerModelsCache, setProviderModelsCache] = useState<
     Record<string, ProviderModelOption[]>
@@ -1809,17 +1809,30 @@ function AppInner() {
     });
   }, []);
 
-  const activeProject =
+  const loadedActiveProject =
     route.kind === 'project'
       ? (projects.find((p) => p.id === route.projectId) ?? null)
       : null;
+  const routeProjectPlaceholder = useMemo<Project | null>(() => {
+    if (route.kind !== 'project') return null;
+    const now = Date.now();
+    return {
+      id: route.projectId,
+      name: 'Untitled',
+      skillId: null,
+      designSystemId: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }, [route]);
+  const activeProject = loadedActiveProject ?? routeProjectPlaceholder;
 
   // Deep-linked route to a project we don't have yet (e.g. after a refresh
   // that finishes after the project list comes back). Fetch it in the
   // background so the view can render rather than bouncing to home.
   useEffect(() => {
     if (route.kind !== 'project') return;
-    if (activeProject) return;
+    if (loadedActiveProject) return;
     if (!projects.length && !daemonLive) return;
     if (projects.some((p) => p.id === route.projectId)) return;
     let cancelled = false;
@@ -1854,7 +1867,7 @@ function AppInner() {
     return () => {
       cancelled = true;
     };
-  }, [route, activeProject, projects, daemonLive, beginProjectListRequest, reconcileFetchedProjects]);
+  }, [route, loadedActiveProject, projects, daemonLive, beginProjectListRequest, reconcileFetchedProjects]);
 
   const openSettings = useCallback((
     section: SettingsSection = 'execution',

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -120,6 +120,7 @@ import type {
 const APP_CONFIG_CHANGED_EVENT = 'open-design:app-config-changed';
 const AMR_AGENT_ID = 'amr';
 const AMR_PROFILE_ENV_KEY = 'OPEN_DESIGN_AMR_PROFILE';
+const AGENT_FOCUS_REFRESH_THROTTLE_MS = 10_000;
 
 export function shouldSyncMediaProvidersOnSave(
   mediaProviders: AppConfig['mediaProviders'],
@@ -369,6 +370,7 @@ function AppInner() {
   const amrModelsRef = useRef<AmrModelsResponse | null>(null);
   const amrPollGenerationRef = useRef(0);
   const agentStreamRequestSeqRef = useRef(0);
+  const agentFocusRefreshLastRunRef = useRef(0);
   const [amrPollRestartToken, setAmrPollRestartToken] = useState(0);
   const [providerModelsCache, setProviderModelsCache] = useState<
     Record<string, ProviderModelOption[]>
@@ -1276,6 +1278,29 @@ function AppInner() {
     },
     [beginAgentStreamRequest, config, isCurrentAgentStreamRequest],
   );
+
+  useEffect(() => {
+    if (!daemonLive || agentsLoading) return;
+
+    const refreshIfDue = () => {
+      if (document.visibilityState === 'hidden') return;
+      const now = Date.now();
+      if (now - agentFocusRefreshLastRunRef.current < AGENT_FOCUS_REFRESH_THROTTLE_MS) return;
+      agentFocusRefreshLastRunRef.current = now;
+      void refreshAgents();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refreshIfDue();
+    };
+
+    window.addEventListener('focus', refreshIfDue);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('focus', refreshIfDue);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [agentsLoading, daemonLive, refreshAgents]);
 
   useEffect(() => {
     const handleAppConfigChanged = () => {

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -670,7 +670,12 @@ const DAEMON_OWNED_KEYS = new Set<keyof AppConfig>([
   'privacyDecisionAt',
 ]);
 
-const AGENT_CLI_SECRET_ENV_KEYS = new Set(['ANTHROPIC_API_KEY', 'CODEX_API_KEY', 'OPENAI_API_KEY']);
+const AGENT_CLI_SECRET_ENV_KEYS = new Set([
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'CODEX_API_KEY',
+  'OPENAI_API_KEY',
+]);
 
 function sanitizeAgentCliEnv(agentCliEnv: AppConfig['agentCliEnv']): AppConfig['agentCliEnv'] {
   if (!agentCliEnv) return agentCliEnv;

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -310,6 +310,7 @@ describe('App AMR polling', () => {
   });
 
   it('rescans agents on window focus so external CLI auth changes are detected', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(0);
     mockedFetchAmrModels.mockReset();
     mockedFetchAmrModels.mockResolvedValue({
       source: 'preset',
@@ -340,18 +341,26 @@ describe('App AMR polling', () => {
         },
       ]);
 
-    render(<App />);
+    try {
+      render(<App />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('codex-auth').textContent).toBe('missing');
-    });
+      await waitFor(() => {
+        expect(screen.getByTestId('codex-auth').textContent).toBe('missing');
+      });
 
-    fireEvent(window, new Event('focus'));
+      fireEvent(window, new Event('focus'));
+      expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => {
-      expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(2);
-      expect(screen.getByTestId('codex-auth').textContent).toBe('ok');
-    });
+      nowSpy.mockReturnValue(10_001);
+      fireEvent(window, new Event('focus'));
+
+      await waitFor(() => {
+        expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(2);
+        expect(screen.getByTestId('codex-auth').textContent).toBe('ok');
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it('restarts AMR polling after sign-in when preset refresh previously stopped on a remote error', {

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -28,7 +28,7 @@ vi.mock('../../src/components/EntryView', () => ({
     config,
     onOpenSettings,
   }: {
-    agents: Array<{ id: string; models?: Array<{ id: string }> }>;
+    agents: Array<{ id: string; models?: Array<{ id: string }>; authStatus?: string }>;
     config: AppConfig;
     onOpenSettings: () => void;
   }) => (
@@ -41,6 +41,9 @@ vi.mock('../../src/components/EntryView', () => ({
       </div>
       <div data-testid="amr-profile">
         {config.agentCliEnv?.amr?.OPEN_DESIGN_AMR_PROFILE ?? 'none'}
+      </div>
+      <div data-testid="codex-auth">
+        {agents.find((agent) => agent.id === 'codex')?.authStatus ?? 'none'}
       </div>
       <button onClick={() => onOpenSettings()}>open settings</button>
     </>
@@ -303,6 +306,51 @@ describe('App AMR polling', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('amr-model').textContent).toBe('preset-a');
+    });
+  });
+
+  it('rescans agents on window focus so external CLI auth changes are detected', async () => {
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'preset',
+      refreshing: false,
+      models: [{ id: 'preset-a', label: 'preset-a' }],
+    });
+    mockedFetchAgentsStream
+      .mockResolvedValueOnce([
+        {
+          id: 'codex',
+          name: 'Codex CLI',
+          bin: 'codex',
+          available: true,
+          version: 'codex-cli 9.9.9',
+          authStatus: 'missing',
+          models: [],
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'codex',
+          name: 'Codex CLI',
+          bin: 'codex',
+          available: true,
+          version: 'codex-cli 9.9.9',
+          authStatus: 'ok',
+          models: [],
+        },
+      ]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('codex-auth').textContent).toBe('missing');
+    });
+
+    fireEvent(window, new Event('focus'));
+
+    await waitFor(() => {
+      expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(2);
+      expect(screen.getByTestId('codex-auth').textContent).toBe('ok');
     });
   });
 

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -1099,6 +1099,7 @@ describe('saveConfig', () => {
       agentCliEnv: {
         claude: {
           ANTHROPIC_API_KEY: 'sk-anthropic',
+          ANTHROPIC_AUTH_TOKEN: 'sk-auth-token',
           ANTHROPIC_BASE_URL: 'https://proxy.example/anthropic',
           CLAUDE_CONFIG_DIR: '~/.claude-2',
         },

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -558,7 +558,10 @@ test('[P0] sending preview comments opens the refreshed follow-up artifact', asy
   expect(revisedFileName).not.toBe('');
   await page.goto(`/projects/${projectId}/files/${revisedFileName}`, { waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
-  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}/files/${revisedFileName.replace('.', '\\.')}$`));
+  const escapedRevisedFileName = revisedFileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  await expect(page).toHaveURL(
+    new RegExp(`/projects/${projectId}(?:/conversations/[^/]+)?/files/${escapedRevisedFileName}$`),
+  );
   await expect(artifactPreview(page)).toBeVisible();
   await expectProjectFileToContain(page, projectId, revisedFileName, 'Revised headline');
   await expectProjectFileToContain(page, projectId, revisedFileName, 'Preview copy refreshed after comment send.');


### PR DESCRIPTION
## Summary

- Rebuild the local CLI auth-state fix on top of the latest `origin/main`.
- Refresh Codex auth status after Local CLI config changes so API → OAuth → API transitions are reflected without stale UI state.
- Add Claude Code auth-status probing so Claude follows the same local CLI detection path.
- Keep API-key auth recognized during CLI probes instead of treating every missing login as an OAuth failure.
- Stabilize the project route during agent refreshes so UI refreshes do not navigate away unexpectedly.

## Notes

This branch was recreated from the latest `main`. The earlier Local CLI env precedence, API-key intent, copy, and test-label commits are already present in `main`, so this PR contains only the remaining four commits needed on top.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/registry-and-args.test.ts tests/runtimes/service-failure-classification.test.ts tests/connection-test.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/components/App.amr-polling.test.tsx tests/state/config.test.ts` from `apps/web`
- `pnpm --filter @open-design/e2e typecheck`
- `git diff --check origin/main..HEAD`

One unrelated full web-suite run via `pnpm --filter @open-design/web test -- App.amr-polling.test.tsx config.test.ts` also executed most of the web suite and exposed an existing `FileViewer.test.tsx` iframe-download timeout; the targeted Local CLI/web state tests above pass.