### PR TITLE
ci: add hot and full validation modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      ci_mode:
+        description: Validation strength for this manual run
+        type: choice
+        options:
+          - full
+          - hot
+        default: full
 
 permissions:
   actions: read
@@ -34,15 +42,26 @@ jobs:
     name: Detect validation scopes
     runs-on: ubuntu-latest
     outputs:
+      ci_mode: ${{ steps.detect.outputs.ci_mode }}
       daemon_tests_required: ${{ steps.detect.outputs.daemon_tests_required }}
       web_tests_required: ${{ steps.detect.outputs.web_tests_required }}
       tools_dev_tests_required: ${{ steps.detect.outputs.tools_dev_tests_required }}
       tools_pack_tests_required: ${{ steps.detect.outputs.tools_pack_tests_required }}
       nix_validation_required: ${{ steps.detect.outputs.nix_validation_required }}
-      ui_p0_pr_required: ${{ steps.detect.outputs.ui_p0_pr_required }}
+      ui_p0_validation_required: ${{ steps.detect.outputs.ui_p0_validation_required }}
       visual_validation_required: ${{ steps.detect.outputs.visual_validation_required }}
       docker_validation_required: ${{ steps.detect.outputs.docker_validation_required }}
       workspace_validation_required: ${{ steps.detect.outputs.workspace_validation_required }}
+      run_docker_build: ${{ steps.detect.outputs.run_docker_build }}
+      run_e2e_vitest: ${{ steps.detect.outputs.run_e2e_vitest }}
+      run_nix_validation: ${{ steps.detect.outputs.run_nix_validation }}
+      run_playwright_critical: ${{ steps.detect.outputs.run_playwright_critical }}
+      run_playwright_visual: ${{ steps.detect.outputs.run_playwright_visual }}
+      run_preflight: ${{ steps.detect.outputs.run_preflight }}
+      run_ui_p0: ${{ steps.detect.outputs.run_ui_p0 }}
+      run_web_workspace_tests: ${{ steps.detect.outputs.run_web_workspace_tests }}
+      run_windows_tools_pack_payload_tests: ${{ steps.detect.outputs.run_windows_tools_pack_payload_tests }}
+      run_workspace_unit_tests: ${{ steps.detect.outputs.run_workspace_unit_tests }}
       ui_p0_matrix: ${{ steps.detect.outputs.ui_p0_matrix }}
       visual_matrix: ${{ steps.detect.outputs.visual_matrix }}
 
@@ -154,7 +173,7 @@ jobs:
   nix_validation:
     name: Validate Nix flake
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.nix_validation_required == 'true' }}
+    if: ${{ needs.scopes.outputs.run_nix_validation == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     permissions:
@@ -265,7 +284,7 @@ jobs:
   preflight:
     name: Preflight
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.workspace_validation_required == 'true' }}
+    if: ${{ needs.scopes.outputs.run_preflight == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
 
@@ -311,7 +330,7 @@ jobs:
   workspace_unit_tests:
     name: Workspace unit tests
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.workspace_validation_required == 'true' }}
+    if: ${{ needs.scopes.outputs.run_workspace_unit_tests == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
 
@@ -359,7 +378,7 @@ jobs:
   windows_tools_pack_payload_tests:
     name: Windows tools-pack payload tests
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.tools_pack_tests_required == 'true' }}
+    if: ${{ needs.scopes.outputs.run_windows_tools_pack_payload_tests == 'true' }}
     runs-on: windows-latest
     timeout-minutes: 20
 
@@ -376,7 +395,7 @@ jobs:
   web_workspace_tests:
     name: Web workspace tests
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.web_tests_required == 'true' }}
+    if: ${{ needs.scopes.outputs.run_web_workspace_tests == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
 
@@ -396,7 +415,7 @@ jobs:
   e2e_vitest:
     name: E2E Vitest
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.workspace_validation_required == 'true' }}
+    if: ${{ needs.scopes.outputs.run_e2e_vitest == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
 
@@ -425,7 +444,7 @@ jobs:
   playwright_critical:
     name: Playwright critical (${{ matrix.group }})
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.workspace_validation_required == 'true' && (github.event_name != 'pull_request' || needs.scopes.outputs.ui_p0_pr_required != 'true') }}
+    if: ${{ needs.scopes.outputs.run_playwright_critical == 'true' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
@@ -468,7 +487,7 @@ jobs:
   ui_p0_smoke:
     name: UI P0 smoke
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.ui_p0_pr_required == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)) }}
+    if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
 
@@ -515,7 +534,7 @@ jobs:
   ui_p0:
     name: UI P0 (${{ matrix.name }})
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.ui_p0_pr_required == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)) }}
+    if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 45
     strategy:
@@ -566,7 +585,7 @@ jobs:
   playwright_visual:
     name: Playwright visual (${{ matrix.name }})
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.visual_validation_required == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)) }}
+    if: ${{ needs.scopes.outputs.run_playwright_visual == 'true' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
@@ -651,7 +670,7 @@ jobs:
   docker_pr:
     name: Docker image build
     needs: [scopes]
-    if: ${{ needs.scopes.outputs.docker_validation_required == 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ needs.scopes.outputs.run_docker_build == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
@@ -672,6 +691,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/od
           tags: |
             type=sha,prefix=pr-${{ github.event.pull_request.number }}-sha-,format=short,enable=${{ github.event_name == 'pull_request' }}
+            type=sha,prefix=queue-sha-,format=short,enable=${{ github.event_name == 'merge_group' }}
             type=sha,prefix=manual-sha-,format=short,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build Docker image
@@ -716,6 +736,32 @@ jobs:
           if [ -n "$failures" ]; then
             echo "Workspace validation failed:"
             echo "$failures"
+            exit 1
+          fi
+
+          required_misses="$(echo "$NEEDS_JSON" | jq -r '
+            . as $needs |
+            ($needs.scopes.outputs // {}) as $out |
+            def when($condition; $jobs): if $condition then $jobs else [] end;
+            (
+              ["scopes", "static_gate"]
+              + when($out.run_preflight == "true"; ["preflight"])
+              + when($out.run_workspace_unit_tests == "true"; ["workspace_unit_tests"])
+              + when($out.run_windows_tools_pack_payload_tests == "true"; ["windows_tools_pack_payload_tests"])
+              + when($out.run_web_workspace_tests == "true"; ["web_workspace_tests"])
+              + when($out.run_e2e_vitest == "true"; ["e2e_vitest"])
+              + when($out.run_playwright_critical == "true"; ["playwright_critical"])
+              + when($out.run_ui_p0 == "true"; ["ui_p0_smoke", "ui_p0"])
+              + when($out.run_playwright_visual == "true"; ["playwright_visual"])
+              + when($out.run_nix_validation == "true"; ["nix_validation"])
+              + when($out.run_docker_build == "true"; ["docker_pr"])
+            )[]
+            | select(($needs[.].result // "missing") != "success")
+            | "\(.)=\($needs[.].result // "missing")"
+          ')"
+          if [ -n "$required_misses" ]; then
+            echo "Required validation jobs did not succeed:"
+            echo "$required_misses"
             exit 1
           fi
 

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -19,6 +19,7 @@ const releasePreviewWorkflowPath = join(workspaceRoot, ".github", "workflows", "
 const releaseStableWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-stable.yml");
 const releaseStableScriptPath = join(workspaceRoot, "scripts", "release-stable.ts");
 const releaseBetaScriptPath = join(workspaceRoot, "scripts", "release-beta.ts");
+const scopesScriptPath = join(workspaceRoot, "scripts", "scopes.ts");
 const notifyDailyFeishuWorkflowPath = join(workspaceRoot, ".github", "workflows", "notify-daily-feishu.yml");
 const releasePublishMetadataScriptPath = join(
   workspaceRoot,
@@ -69,6 +70,38 @@ async function runReleaseStableForFailure(env: Record<string, string>): Promise<
   throw new Error("release-stable script unexpectedly succeeded");
 }
 
+async function runScopesPrint(eventName: string, eventPayload: unknown, changedFiles: string[] = []): Promise<Record<string, unknown>> {
+  const tempDir = await mkdtemp(join(tmpdir(), "od-scopes-"));
+  const eventPath = join(tempDir, "event.json");
+  const ghPath = join(tempDir, "gh");
+  await writeFile(eventPath, JSON.stringify(eventPayload));
+  await writeFile(
+    ghPath,
+    `#!/usr/bin/env node
+process.stdout.write(${JSON.stringify(changedFiles.join("\n"))});
+if (${JSON.stringify(changedFiles.length > 0)}) process.stdout.write("\\n");
+`,
+  );
+  await chmod(ghPath, 0o755);
+
+  try {
+    const { stdout } = await execFileAsync(process.execPath, ["--experimental-strip-types", scopesScriptPath, "print"], {
+      cwd: workspaceRoot,
+      env: {
+        ...process.env,
+        GITHUB_EVENT_NAME: eventName,
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_REPOSITORY: "nexu-io/open-design",
+        GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+        PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+    return JSON.parse(stdout) as Record<string, unknown>;
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
 async function writeFakeGhBin(binDir: string, releases: unknown[]): Promise<void> {
   const ghPath = join(binDir, "gh");
   await writeFile(
@@ -107,7 +140,7 @@ describe("packaged smoke workflow", () => {
     const validate = sectionBetween(workflow, "  validate:", "          if [ -n \"$failures\" ]; then");
 
     expect(job).toContain("runs-on: windows-latest");
-    expect(job).toContain("needs.scopes.outputs.tools_pack_tests_required == 'true'");
+    expect(job).toContain("needs.scopes.outputs.run_windows_tools_pack_payload_tests == 'true'");
     expect(job).toContain("pnpm --filter @open-design/tools-pack exec vitest run tests/launcher-payload.test.ts");
     expect(validate).toContain("windows_tools_pack_payload_tests");
   });
@@ -119,6 +152,39 @@ describe("packaged smoke workflow", () => {
     expect(blobGuard).toContain('${{ github.event_name }}" = "workflow_dispatch"');
     expect(blobGuard).toContain("repos/${{ github.repository }}/compare/main...${{ github.sha }}");
     expect(blobGuard).toContain("select(.status != \"removed\") | .filename");
+  });
+
+  it("[P2] keeps PR and merge queue CI separated by hot/full validation mode", async () => {
+    const workflow = await readFile(ciWorkflowPath, "utf8");
+    const scopes = sectionBetween(workflow, "  scopes:", "  static_gate:");
+    const validate = sectionBetween(workflow, "  validate:", "  runtime_summary:");
+
+    expect(workflow).toContain("ci_mode:");
+    expect(scopes).toContain("ci_mode: ${{ steps.detect.outputs.ci_mode }}");
+    expect(scopes).toContain("ui_p0_validation_required: ${{ steps.detect.outputs.ui_p0_validation_required }}");
+    expect(scopes).toContain("run_ui_p0: ${{ steps.detect.outputs.run_ui_p0 }}");
+    expect(workflow).toContain("needs.scopes.outputs.run_ui_p0 == 'true'");
+    expect(validate).toContain('when($out.run_ui_p0 == "true"; ["ui_p0_smoke", "ui_p0"])');
+
+    await expect(runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, ["apps/web/src/app/page.tsx"])).resolves.toMatchObject({
+      ci_mode: "hot",
+      run_ui_p0: true,
+      run_nix_validation: false,
+    });
+    await expect(runScopesPrint("workflow_dispatch", { inputs: {} })).resolves.toMatchObject({
+      ci_mode: "full",
+      ui_p0_validation_required: true,
+      run_docker_build: true,
+      run_nix_validation: true,
+      run_ui_p0: true,
+    });
+    await expect(runScopesPrint("merge_group", {})).resolves.toMatchObject({
+      ci_mode: "full",
+      ui_p0_validation_required: true,
+      run_docker_build: true,
+      run_nix_validation: true,
+      run_ui_p0: true,
+    });
   });
 
   it("[P2] preserves beta linux AppImage smoke reports for platform publication", async () => {

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -1237,10 +1237,15 @@ async function checkCiTopology(): Promise<boolean> {
     ...validatePlaywrightSuiteTopology(),
     ...[
       "run: node --experimental-strip-types scripts/scopes.ts github-output",
+      "ci_mode: ${{ steps.detect.outputs.ci_mode }}",
+      "ui_p0_validation_required: ${{ steps.detect.outputs.ui_p0_validation_required }}",
+      "run_ui_p0: ${{ steps.detect.outputs.run_ui_p0 }}",
+      "run_nix_validation: ${{ steps.detect.outputs.run_nix_validation }}",
       "ui_p0_matrix: ${{ steps.detect.outputs.ui_p0_matrix }}",
       "visual_matrix: ${{ steps.detect.outputs.visual_matrix }}",
       "include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}",
       "include: ${{ fromJSON(needs.scopes.outputs.visual_matrix) }}",
+      "needs.scopes.outputs.run_ui_p0 == 'true'",
       "pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group smoke",
       "pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}",
     ]

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -3,19 +3,32 @@ import { appendFileSync, readFileSync } from "node:fs";
 
 import { uiP0CiMatrix, visualCiMatrix } from "../e2e/lib/playwright/suites.ts";
 
+type CiMode = "hot" | "full";
+
 type ScopeOutputs = {
   daemon_tests_required: boolean;
   web_tests_required: boolean;
   tools_dev_tests_required: boolean;
   tools_pack_tests_required: boolean;
   nix_validation_required: boolean;
-  ui_p0_pr_required: boolean;
+  ui_p0_validation_required: boolean;
   visual_validation_required: boolean;
   docker_validation_required: boolean;
   workspace_validation_required: boolean;
 };
 
 type ScopePlan = ScopeOutputs & {
+  ci_mode: CiMode;
+  run_docker_build: boolean;
+  run_e2e_vitest: boolean;
+  run_nix_validation: boolean;
+  run_playwright_critical: boolean;
+  run_playwright_visual: boolean;
+  run_preflight: boolean;
+  run_ui_p0: boolean;
+  run_web_workspace_tests: boolean;
+  run_windows_tools_pack_payload_tests: boolean;
+  run_workspace_unit_tests: boolean;
   ui_p0_matrix: string;
   visual_matrix: string;
 };
@@ -23,6 +36,9 @@ type ScopePlan = ScopeOutputs & {
 type GitHubEvent = {
   pull_request?: {
     number?: number;
+  };
+  inputs?: {
+    ci_mode?: string;
   };
 };
 
@@ -47,13 +63,14 @@ function createScopePlan(): ScopePlan {
     tools_dev_tests_required: false,
     tools_pack_tests_required: false,
     nix_validation_required: false,
-    ui_p0_pr_required: false,
+    ui_p0_validation_required: false,
     visual_validation_required: false,
     docker_validation_required: false,
     workspace_validation_required: false,
   };
 
   const eventName = requiredEnv("GITHUB_EVENT_NAME");
+  const ciMode = resolveCiMode(eventName);
 
   if (eventName === "pull_request") {
     for (const file of changedPullRequestFiles()) {
@@ -68,6 +85,11 @@ function createScopePlan(): ScopePlan {
       outputs.tools_pack_tests_required
     ) {
       outputs.workspace_validation_required = true;
+    }
+  } else if (eventName === "workflow_dispatch" && ciMode === "hot") {
+    for (const file of changedManualFiles()) {
+      applyChangedFile(file, outputs);
+      if (allScopeOutputsTrue(outputs)) break;
     }
   } else if (eventName === "push") {
     outputs.daemon_tests_required = true;
@@ -86,9 +108,7 @@ function createScopePlan(): ScopePlan {
     outputs.tools_dev_tests_required = true;
     outputs.tools_pack_tests_required = true;
     outputs.nix_validation_required = true;
-    if (eventName === "workflow_dispatch") {
-      outputs.ui_p0_pr_required = true;
-    }
+    outputs.ui_p0_validation_required = true;
     outputs.visual_validation_required = true;
     outputs.docker_validation_required = true;
     outputs.workspace_validation_required = true;
@@ -96,8 +116,43 @@ function createScopePlan(): ScopePlan {
 
   return {
     ...outputs,
+    ...createRunPlan(outputs, ciMode, eventName),
     ui_p0_matrix: JSON.stringify(uiP0CiMatrix),
     visual_matrix: JSON.stringify(visualCiMatrix),
+  };
+}
+
+function resolveCiMode(eventName: string): CiMode {
+  if (eventName === "pull_request") return "hot";
+  if (eventName === "workflow_dispatch") {
+    const event = JSON.parse(readFileSync(requiredEnv("GITHUB_EVENT_PATH"), "utf8")) as GitHubEvent;
+    const input = event.inputs?.ci_mode ?? "full";
+    if (input === "hot" || input === "full") return input;
+    throw new Error(`Unsupported workflow_dispatch ci_mode: ${input}`);
+  }
+  return "full";
+}
+
+function createRunPlan(
+  outputs: ScopeOutputs,
+  ciMode: CiMode,
+  eventName: string,
+): Omit<ScopePlan, keyof ScopeOutputs | "ui_p0_matrix" | "visual_matrix"> {
+  const isFull = ciMode === "full";
+  const isMainPush = eventName === "push";
+
+  return {
+    ci_mode: ciMode,
+    run_docker_build: (isFull && !isMainPush) || outputs.docker_validation_required,
+    run_e2e_vitest: isFull || outputs.web_tests_required || outputs.ui_p0_validation_required,
+    run_nix_validation: (isFull && !isMainPush) || outputs.nix_validation_required,
+    run_playwright_critical: isFull || (outputs.workspace_validation_required && !outputs.ui_p0_validation_required),
+    run_playwright_visual: isFull || outputs.visual_validation_required,
+    run_preflight: true,
+    run_ui_p0: isFull || outputs.ui_p0_validation_required,
+    run_web_workspace_tests: isFull || outputs.web_tests_required,
+    run_windows_tools_pack_payload_tests: isFull || outputs.tools_pack_tests_required,
+    run_workspace_unit_tests: true,
   };
 }
 
@@ -113,6 +168,23 @@ function changedPullRequestFiles(): string[] {
   const stdout = execFileSync(
     "gh",
     ["api", "--paginate", `repos/${repository}/pulls/${prNumber}/files`, "--jq", ".[].filename"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] },
+  );
+  return stdout.split(/\r?\n/).filter(Boolean);
+}
+
+function changedManualFiles(): string[] {
+  const repository = requiredEnv("GITHUB_REPOSITORY");
+  const sha = requiredEnv("GITHUB_SHA");
+  const stdout = execFileSync(
+    "gh",
+    [
+      "api",
+      "--paginate",
+      `repos/${repository}/compare/main...${sha}`,
+      "--jq",
+      '(.files // [])[] | select(.status != "removed") | .filename',
+    ],
     { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] },
   );
   return stdout.split(/\r?\n/).filter(Boolean);
@@ -177,7 +249,7 @@ function applyChangedFile(file: string, target: ScopeOutputs): void {
   }
 
   if (isUiP0RelevantFile(file)) {
-    target.ui_p0_pr_required = true;
+    target.ui_p0_validation_required = true;
   }
 
   if (isVisualRelevantFile(file)) {
@@ -266,18 +338,6 @@ function isDockerRelevantFile(file: string): boolean {
   return (
     startsWithAny(file, [
       "deploy/",
-      "apps/daemon/",
-      "apps/web/",
-      "apps/packaged/",
-      "packages/",
-      "tools/",
-      "assets/",
-      "plugins/",
-      "skills/",
-      "design-systems/",
-      "design-templates/",
-      "craft/",
-      "prompt-templates/",
     ]) ||
     [
       "package.json",
@@ -286,7 +346,8 @@ function isDockerRelevantFile(file: string): boolean {
       ".dockerignore",
       ".github/workflows/ci.yml",
       ".github/workflows/docker-image.yml",
-    ].includes(file)
+    ].includes(file) ||
+    isWorkspaceManifestOrCiFile(file)
   );
 }
 
@@ -294,25 +355,6 @@ function isNixRelevantFile(file: string): boolean {
   return (
     startsWithAny(file, [
       "nix/",
-      "apps/daemon/",
-      "apps/web/",
-      "packages/components/",
-      "packages/contracts/",
-      "packages/registry-protocol/",
-      "packages/agui-adapter/",
-      "packages/plugin-runtime/",
-      "packages/sidecar-proto/",
-      "packages/sidecar/",
-      "packages/platform/",
-      "packages/diagnostics/",
-      "packages/host/",
-      "assets/",
-      "plugins/",
-      "skills/",
-      "design-systems/",
-      "design-templates/",
-      "craft/",
-      "prompt-templates/",
     ]) ||
     [
       "package.json",
@@ -324,7 +366,8 @@ function isNixRelevantFile(file: string): boolean {
       ".github/workflows/nix-check.yml",
       ".github/workflows/nix-hash-autofix.yml",
       "scripts/update-nix-pnpm-deps-hash.ts",
-    ].includes(file)
+    ].includes(file) ||
+    isWorkspaceManifestOrCiFile(file)
   );
 }
 


### PR DESCRIPTION
## Why

This PR continues the CI efficiency work after the topology cleanup in #4460. With merge queue enabled, running the same expensive CI shape on both `pull_request` and `merge_group` wastes time: the merge group is the authoritative "merge and run" gate, while the PR event should give fast, scoped feedback.

The pain addressed here is avoidable CI cold-start and runner cost. PR checks now plan a hot validation set from centralized scopes, while merge queue and manual full runs keep the complete validation surface.

## What users will see

No product UI changes. Contributors should see PR validation stay focused on the affected areas, while merge queue validation still runs the full authoritative CI set before merge.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

Not a product bug fix.

## Validation

- `actionlint -color .github/workflows/ci.yml`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
- `GITHUB_EVENT_NAME=merge_group GITHUB_EVENT_PATH=/tmp/nonexistent GITHUB_REPOSITORY=nexu-io/open-design node --experimental-strip-types scripts/scopes.ts print`

Remote validation:

- Hot workflow_dispatch: https://github.com/nexu-io/open-design/actions/runs/27678556265
- Full workflow_dispatch, first run: https://github.com/nexu-io/open-design/actions/runs/27678563635
  - Failed in `Playwright critical (a)` on a transient `ECONNRESET` / loading-shell timeout.
  - `Validate workspace` correctly failed because a planned job failed.
- Full workflow_dispatch, rerun: https://github.com/nexu-io/open-design/actions/runs/27678911183
  - Passed, including `Validate workspace`.

After rebasing onto latest `origin/main` (`73d07d8df`):

- `actionlint -color .github/workflows/ci.yml`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts`
