### PR TITLE
fix(desktop): treat payload updates as in-app installs

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -455,16 +455,19 @@ function isSupportedPackageLauncherPlatform(platform: string): boolean {
   return platform === "darwin" || platform === "win32";
 }
 
-function capabilitiesFor(status: { mode: DesktopUpdateMode; platform: string; supported: boolean }) {
+function capabilitiesFor(status: { artifactType?: string; mode: DesktopUpdateMode; platform: string; supported: boolean }) {
   const packageLauncher =
     status.mode === DESKTOP_UPDATE_MODES.PACKAGE_LAUNCHER &&
     isSupportedPackageLauncherPlatform(status.platform) &&
     status.supported;
+  const payloadUpdate = status.artifactType === "payload";
+  const hasSelectedArtifact = status.artifactType != null && status.artifactType.length > 0;
+  const manualInstaller = packageLauncher && (!hasSelectedArtifact || !payloadUpdate);
   return {
-    canApplyInPlace: false,
+    canApplyInPlace: packageLauncher && payloadUpdate,
     canDownload: packageLauncher,
-    canOpenInstaller: packageLauncher,
-    requiresManualInstall: packageLauncher,
+    canOpenInstaller: manualInstaller,
+    requiresManualInstall: manualInstaller,
   };
 }
 
@@ -2343,6 +2346,7 @@ export function createDesktopUpdater(
     const statusSupported = supported();
     const active = activeRelease == null ? undefined : releaseSnapshot(activeRelease);
     const activeArtifact = activeRelease?.ref.artifact ?? (state === DESKTOP_UPDATE_STATES.AVAILABLE ? candidate?.artifact : undefined);
+    const capabilityArtifactType = activeArtifact?.type ?? incomingRelease?.artifact.type ?? candidate?.artifact.type;
     const activeChecksum = activeRelease?.ref.checksum ?? (state === DESKTOP_UPDATE_STATES.AVAILABLE ? candidate?.checksum : undefined);
     const availableVersion = activeRelease?.ref.version ?? candidate?.version;
     const downloadPath = activeRelease?.path;
@@ -2354,7 +2358,12 @@ export function createDesktopUpdater(
       ...(activeArtifact?.url == null ? {} : { artifactUrl: activeArtifact.url }),
       ...(availableVersion == null ? {} : { availableVersion }),
       ...(lifecycleSummary == null ? {} : { cache: { lifecycle: lifecycleSummary } }),
-      capabilities: capabilitiesFor({ mode: config.mode, platform: config.platform, supported: statusSupported }),
+      capabilities: capabilitiesFor({
+        artifactType: capabilityArtifactType,
+        mode: config.mode,
+        platform: config.platform,
+        supported: statusSupported,
+      }),
       channel: config.channel,
       ...(activeChecksum == null ? {} : { checksum: activeChecksum }),
       currentVersion: config.currentVersion,

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -573,6 +573,9 @@ describe("desktop updater", () => {
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.artifact?.type).toBe("payload");
       expect(checked.artifact?.name).toBe("open-design-1.0.0-beta.2-win-x64-payload.7z");
+      expect(checked.capabilities.canApplyInPlace).toBe(true);
+      expect(checked.capabilities.canOpenInstaller).toBe(false);
+      expect(checked.capabilities.requiresManualInstall).toBe(false);
       expect(await readFile(checked.downloadPath ?? "", "utf8")).toBe("open design windows payload fixture");
       expect(extractCount).toBe(1);
       expect(await readFile(join(root, "launcher", "channels", "beta", "namespaces", "release-beta-win", "versions", "1.0.0-beta.2", "manifest.json"), "utf8")).toContain("1.0.0-beta.2");
@@ -923,6 +926,9 @@ describe("desktop updater", () => {
 
       const checked = await updater.checkForUpdates();
       expect(checked.artifact?.type).toBe("payload");
+      expect(checked.capabilities.canApplyInPlace).toBe(true);
+      expect(checked.capabilities.canOpenInstaller).toBe(false);
+      expect(checked.capabilities.requiresManualInstall).toBe(false);
 
       const installed = await updater.installUpdate();
 
@@ -1020,6 +1026,9 @@ describe("desktop updater", () => {
 
       const checked = await updater.checkForUpdates();
       expect(checked.artifact?.type).toBe("payload");
+      expect(checked.capabilities.canApplyInPlace).toBe(true);
+      expect(checked.capabilities.canOpenInstaller).toBe(false);
+      expect(checked.capabilities.requiresManualInstall).toBe(false);
 
       const installed = await updater.installUpdate();
 

--- a/apps/web/src/lib/updater.ts
+++ b/apps/web/src/lib/updater.ts
@@ -30,6 +30,7 @@ export type UpdaterActionResult =
 export type UpdaterModel = {
   availableVersion: string | null;
   busy: boolean;
+  canApplyInPlace: boolean;
   canCheck: boolean;
   canDownload: boolean;
   canOpenInstaller: boolean;
@@ -43,6 +44,7 @@ export type UpdaterModel = {
   installerOpened: boolean;
   updateKind: 'installer' | 'payload' | 'unknown';
   promptKey: string | null;
+  requiresManualInstall: boolean;
   upToDate: boolean;
   shouldShowControl: boolean;
   shouldPrompt: boolean;
@@ -101,6 +103,13 @@ export function deriveUpdaterModel(
     status.supported &&
     status.capabilities.canOpenInstaller,
   );
+  const canApplyInPlace = Boolean(
+    hostAvailable &&
+    status?.enabled &&
+    status.supported &&
+    status.capabilities.canApplyInPlace,
+  );
+  const canInstallUpdate = canOpenInstaller || canApplyInPlace;
   const hasDownloadedInstaller = Boolean(
     state === OPEN_DESIGN_HOST_UPDATER_STATES.DOWNLOADED &&
     status?.downloadPath,
@@ -122,11 +131,11 @@ export function deriveUpdaterModel(
           status.downloadPath ?? status.artifactUrl ?? status.artifact?.url ?? 'unknown-artifact',
         ].join(':');
   const canQuitAfterInstallerOpen = hostAvailable && installerOpened;
-  const shouldShowControl = Boolean(canOpenInstaller && hasDownloadedInstaller && !installerOpened);
 
   return {
     availableVersion,
     busy,
+    canApplyInPlace,
     canCheck: hostAvailable && Boolean(status?.enabled) && !busy,
     canDownload: hostAvailable && Boolean(status?.enabled && status.capabilities.canDownload) && !busy,
     canOpenInstaller,
@@ -140,9 +149,10 @@ export function deriveUpdaterModel(
     installerOpened,
     updateKind,
     promptKey,
+    requiresManualInstall: Boolean(status?.capabilities.requiresManualInstall),
     upToDate,
-    shouldShowControl,
-    shouldPrompt: canOpenInstaller && hasDownloadedInstaller && !installerOpened,
+    shouldShowControl: canInstallUpdate && hasDownloadedInstaller && !installerOpened,
+    shouldPrompt: canInstallUpdate && hasDownloadedInstaller && !installerOpened,
     status,
     supported: Boolean(status?.supported),
   };

--- a/apps/web/tests/components/UpdaterPopup.test.tsx
+++ b/apps/web/tests/components/UpdaterPopup.test.tsx
@@ -47,6 +47,12 @@ function payloadDownloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusS
       type: 'payload',
       url: 'https://example.test/payload.zip',
     },
+    capabilities: {
+      canApplyInPlace: true,
+      canDownload: true,
+      canOpenInstaller: false,
+      requiresManualInstall: false,
+    },
     downloadPath: '/tmp/open-design-updater/open-design-1.2.3-beta.4-mac-arm64-payload.zip',
     ...overrides,
   });

--- a/apps/web/tests/lib/updater.test.ts
+++ b/apps/web/tests/lib/updater.test.ts
@@ -40,6 +40,25 @@ function downloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusSnapshot
   };
 }
 
+function payloadDownloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusSnapshot> = {}): OpenDesignHostUpdaterStatusSnapshot {
+  return downloadedStatus({
+    artifact: {
+      name: 'open-design-1.2.3-beta.4-mac-arm64-payload.zip',
+      platformKey: 'mac',
+      type: 'payload',
+      url: 'https://fixture.test/open-design-1.2.3-beta.4-mac-arm64-payload.zip',
+    },
+    capabilities: {
+      canApplyInPlace: true,
+      canDownload: true,
+      canOpenInstaller: false,
+      requiresManualInstall: false,
+    },
+    downloadPath: '/tmp/open-design-updater/open-design-1.2.3-beta.4-mac-arm64-payload.zip',
+    ...overrides,
+  });
+}
+
 describe('web updater model', () => {
   let restoreHost: (() => void) | null = null;
 
@@ -64,6 +83,17 @@ describe('web updater model', () => {
     expect(model.canOpenInstaller).toBe(true);
     expect(model.shouldShowControl).toBe(true);
     expect(model.promptKey).toContain('1.2.3-beta.4');
+  });
+
+  it('derives a desktop prompt for payload updates without manual installer capability', () => {
+    const model = deriveUpdaterModel(payloadDownloadedStatus(), { hostAvailable: true });
+    expect(model.environment).toBe('desktop');
+    expect(model.updateKind).toBe('payload');
+    expect(model.canApplyInPlace).toBe(true);
+    expect(model.canOpenInstaller).toBe(false);
+    expect(model.requiresManualInstall).toBe(false);
+    expect(model.shouldPrompt).toBe(true);
+    expect(model.shouldShowControl).toBe(true);
   });
 
   it('keeps downloading progress internal without showing the updater control', () => {


### PR DESCRIPTION
Part of #4467

## Why

Aegis here, working with @TheAngryPit.

We hit the macOS update path where Open Design downloaded/mounted the DMG and left the user to drag/replace the app manually, even though current release metadata already ships launcher payload artifacts. The selector already prefers payloads when launcher runtime context is valid, but the updater status still exposed downloaded payloads as manual installer flows because the capabilities were not artifact-aware.

This PR keeps the scope focused on that mismatch: payload updates should be treated as in-place app updates; DMG/installer artifacts remain the manual fallback path. The advanced Settings preference proposed in #4467 is intentionally left for follow-up UX alignment.

## What users will see

When the packaged app has a valid launcher payload context and release metadata provides a compatible payload, the existing update prompt can show the install-and-restart payload flow instead of requiring the manual open-installer path.

Manual DMG/installer behavior is unchanged when payload context is missing or payload metadata is unavailable.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI surface. The existing updater prompt copy is reused; this changes when the prompt becomes eligible for payload updates.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/desktop/tests/main/updater.test.ts`
  - `apps/web/tests/lib/updater.test.ts`
  - `apps/web/tests/components/UpdaterPopup.test.tsx`
- Did the test go red on `main` and green on this branch? No. I did not switch the checkout back to `main` for a red run. The added assertions encode the previous mismatch: downloaded payload snapshots must expose `canApplyInPlace: true`, `canOpenInstaller: false`, `requiresManualInstall: false`, and the web model must still show the payload prompt without manual installer capability.

## Validation

- `git diff --check`
- `pnpm exec vitest run -c vitest.config.ts tests/main/updater.test.ts` from `apps/desktop`, 53 passed
- `pnpm exec vitest run -c vitest.config.ts tests/lib/updater.test.ts tests/components/UpdaterPopup.test.tsx` from `apps/web`, 17 passed
- `pnpm --filter @open-design/desktop typecheck`, passed
- `pnpm --filter @open-design/web typecheck`, failed on existing unrelated `src/components/DesignsTab.tsx(286,6): Type '"refresh"' is not assignable...`; this branch does not touch `DesignsTab.tsx`
- `/Users/vitorcepedalopes/.agents/skills/openclaw-autoreview/scripts/autoreview --mode local`, clean with no accepted/actionable findings
