### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ docker compose up -d
 
 > **macOS users:** If the web UI shows `Authorization: Bearer <OD_API_TOKEN> required`, Docker Desktop bridge networking is the cause. See [Docker Desktop on macOS](deploy/README.md#docker-desktop-on-macos) for the fix.
 
+### 🚀 Deploy on Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://template.sealos.io/deploy?templateName=opendesign)
+
+The Sealos template runs the published Open Design Docker image with persistent workspace storage. Configure access control for any public or shared deployment, matching the Docker deployment guidance above.
+
 ### 🧑‍💻 Run from source
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-The Sealos template runs the published Open Design Docker image with persistent workspace storage. Configure access control for any public or shared deployment, matching the Docker deployment guidance above.
+The Sealos App Store template runs the published Open Design Docker image with persistent workspace storage and Basic Auth on the public proxy. For custom public or shared Docker deployments, follow the reverse-proxy and `OPEN_DESIGN_ALLOWED_ORIGINS` guidance in [`deploy/README.md`](deploy/README.md#local-compose).
 
 ### 🧑‍💻 Run from source
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 ### 🚀 Deploy on Sealos
 
-[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://template.sealos.io/deploy?templateName=opendesign)
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://template.sealos.io/deploy?templateName=open-design)
 
 The Sealos template runs the published Open Design Docker image with persistent workspace storage. Configure access control for any public or shared deployment, matching the Docker deployment guidance above.
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 ### 🚀 Deploy on Sealos
 
-[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://template.sealos.io/deploy?templateName=open-design)
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
 The Sealos template runs the published Open Design Docker image with persistent workspace storage. Configure access control for any public or shared deployment, matching the Docker deployment guidance above.
 

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -332,7 +332,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-يشغّل قالب Sealos صورة Docker المنشورة لـ Open Design مع تخزين دائم لمساحة العمل. اضبط التحكم في الوصول لأي نشر عام أو مشترك بما يتوافق مع إرشادات نشر Docker أعلاه.
+يشغّل قالب Sealos App Store صورة Docker المنشورة لـ Open Design مع تخزين دائم لمساحة العمل وBasic Auth على الوكيل العام. لعمليات نشر Docker العامة أو المشتركة المخصصة، اتبع إرشادات الوكيل العكسي و`OPEN_DESIGN_ALLOWED_ORIGINS` في [`deploy/README.md`](../../deploy/README.md#local-compose).
 
 ### 🧑‍💻 التشغيل من المصدر
 

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -328,6 +328,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 النشر على Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+يشغّل قالب Sealos صورة Docker المنشورة لـ Open Design مع تخزين دائم لمساحة العمل. اضبط التحكم في الوصول لأي نشر عام أو مشترك بما يتوافق مع إرشادات نشر Docker أعلاه.
+
 ### 🧑‍💻 التشغيل من المصدر
 
 ```bash

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Die Sealos-Vorlage führt das veröffentlichte Open-Design-Docker-Image mit persistentem Workspace-Speicher aus. Konfigurieren Sie die Zugriffskontrolle für öffentliche oder gemeinsam genutzte Deployments gemäß den Docker-Hinweisen oben.
+Die Sealos-App-Store-Vorlage führt das veröffentlichte Open-Design-Docker-Image mit persistentem Workspace-Speicher und Basic Auth am öffentlichen Proxy aus. Folgen Sie für eigene öffentliche oder gemeinsam genutzte Docker-Deployments den Reverse-Proxy- und `OPEN_DESIGN_ALLOWED_ORIGINS`-Hinweisen in [`deploy/README.md`](../../deploy/README.md#local-compose).
 
 ### 🧑‍💻 Aus dem Quellcode ausführen
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Auf Sealos bereitstellen
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Die Sealos-Vorlage führt das veröffentlichte Open-Design-Docker-Image mit persistentem Workspace-Speicher aus. Konfigurieren Sie die Zugriffskontrolle für öffentliche oder gemeinsam genutzte Deployments gemäß den Docker-Hinweisen oben.
+
 ### 🧑‍💻 Aus dem Quellcode ausführen
 
 ```bash

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Despliega en Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+La plantilla de Sealos ejecuta la imagen Docker publicada de Open Design con almacenamiento persistente para el espacio de trabajo. Configura el control de acceso para cualquier despliegue público o compartido según la guía de Docker anterior.
+
 ### 🧑‍💻 Ejecútalo desde el código fuente
 
 ```bash

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-La plantilla de Sealos ejecuta la imagen Docker publicada de Open Design con almacenamiento persistente para el espacio de trabajo. Configura el control de acceso para cualquier despliegue público o compartido según la guía de Docker anterior.
+La plantilla de Sealos App Store ejecuta la imagen Docker publicada de Open Design con almacenamiento persistente para el espacio de trabajo y Basic Auth en el proxy público. Para despliegues Docker públicos o compartidos personalizados, sigue la guía de proxy inverso y `OPEN_DESIGN_ALLOWED_ORIGINS` en [`deploy/README.md`](../../deploy/README.md#local-compose).
 
 ### 🧑‍💻 Ejecútalo desde el código fuente
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Le modèle Sealos exécute l'image Docker publiée d'Open Design avec un stockage persistant pour l'espace de travail. Configurez le contrôle d'accès pour tout déploiement public ou partagé selon les indications Docker ci-dessus.
+Le modèle Sealos App Store exécute l'image Docker publiée d'Open Design avec un stockage persistant pour l'espace de travail et une Basic Auth sur le proxy public. Pour les déploiements Docker publics ou partagés personnalisés, suivez les indications de proxy inverse et `OPEN_DESIGN_ALLOWED_ORIGINS` dans [`deploy/README.md`](../../deploy/README.md#local-compose).
 
 ### 🧑‍💻 Exécutez depuis les sources
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Déployer sur Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Le modèle Sealos exécute l'image Docker publiée d'Open Design avec un stockage persistant pour l'espace de travail. Configurez le contrôle d'accès pour tout déploiement public ou partagé selon les indications Docker ci-dessus.
+
 ### 🧑‍💻 Exécutez depuis les sources
 
 ```bash

--- a/docs/i18n/README.ja-JP.md
+++ b/docs/i18n/README.ja-JP.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Sealos テンプレートは、公開済みの Open Design Docker イメージを永続的なワークスペースストレージ付きで実行します。公開または共有デプロイでは、上記の Docker デプロイ手順に沿ってアクセス制御を設定してください。
+Sealos App Store テンプレートは、公開済みの Open Design Docker イメージを永続的なワークスペースストレージと公開プロキシの Basic Auth 付きで実行します。独自の公開または共有 Docker デプロイでは、[`deploy/README.md`](../../deploy/README.md#local-compose) のリバースプロキシと `OPEN_DESIGN_ALLOWED_ORIGINS` の手順に従ってください。
 
 ### 🧑‍💻 ソースから実行
 

--- a/docs/i18n/README.ja-JP.md
+++ b/docs/i18n/README.ja-JP.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Sealos にデプロイ
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Sealos テンプレートは、公開済みの Open Design Docker イメージを永続的なワークスペースストレージ付きで実行します。公開または共有デプロイでは、上記の Docker デプロイ手順に沿ってアクセス制御を設定してください。
+
 ### 🧑‍💻 ソースから実行
 
 ```bash

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Sealos에 배포
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Sealos 템플릿은 게시된 Open Design Docker 이미지를 영구 워크스페이스 스토리지와 함께 실행합니다. 공개 또는 공유 배포에서는 위 Docker 배포 안내에 맞춰 접근 제어를 설정하세요.
+
 ### 🧑‍💻 소스에서 실행
 
 ```bash

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Sealos 템플릿은 게시된 Open Design Docker 이미지를 영구 워크스페이스 스토리지와 함께 실행합니다. 공개 또는 공유 배포에서는 위 Docker 배포 안내에 맞춰 접근 제어를 설정하세요.
+Sealos App Store 템플릿은 게시된 Open Design Docker 이미지를 영구 워크스페이스 스토리지 및 공개 프록시의 Basic Auth와 함께 실행합니다. 사용자 지정 공개 또는 공유 Docker 배포에서는 [`deploy/README.md`](../../deploy/README.md#local-compose)의 리버스 프록시와 `OPEN_DESIGN_ALLOWED_ORIGINS` 안내를 따르세요.
 
 ### 🧑‍💻 소스에서 실행
 

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Implante no Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+O template do Sealos executa a imagem Docker publicada do Open Design com armazenamento persistente para o workspace. Configure o controle de acesso para qualquer implantação pública ou compartilhada seguindo as orientações de Docker acima.
+
 ### 🧑‍💻 Rode a partir do código-fonte
 
 ```bash

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-O template do Sealos executa a imagem Docker publicada do Open Design com armazenamento persistente para o workspace. Configure o controle de acesso para qualquer implantação pública ou compartilhada seguindo as orientações de Docker acima.
+O template da Sealos App Store executa a imagem Docker publicada do Open Design com armazenamento persistente para o workspace e Basic Auth no proxy público. Para implantações Docker públicas ou compartilhadas personalizadas, siga as orientações de proxy reverso e `OPEN_DESIGN_ALLOWED_ORIGINS` em [`deploy/README.md`](../../deploy/README.md#local-compose).
 
 ### 🧑‍💻 Rode a partir do código-fonte
 

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Шаблон Sealos запускает опубликованный Docker-образ Open Design с постоянным хранилищем рабочей области. Настройте контроль доступа для публичного или совместного развертывания согласно рекомендациям Docker выше.
+Шаблон Sealos App Store запускает опубликованный Docker-образ Open Design с постоянным хранилищем рабочей области и Basic Auth на публичном прокси. Для пользовательских публичных или совместных Docker-развертываний следуйте рекомендациям по обратному прокси и `OPEN_DESIGN_ALLOWED_ORIGINS` в [`deploy/README.md`](../../deploy/README.md#local-compose).
 
 ### 🧑‍💻 Запуск из исходников
 

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Развертывание на Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Шаблон Sealos запускает опубликованный Docker-образ Open Design с постоянным хранилищем рабочей области. Настройте контроль доступа для публичного или совместного развертывания согласно рекомендациям Docker выше.
+
 ### 🧑‍💻 Запуск из исходников
 
 ```bash

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Sealos üzerinde dağıtın
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Sealos şablonu, yayımlanmış Open Design Docker imajını kalıcı çalışma alanı depolamasıyla çalıştırır. Herkese açık veya paylaşılan dağıtımlar için erişim denetimini yukarıdaki Docker dağıtım rehberine göre yapılandırın.
+
 ### 🧑‍💻 Kaynaktan çalıştırın
 
 ```bash

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Sealos şablonu, yayımlanmış Open Design Docker imajını kalıcı çalışma alanı depolamasıyla çalıştırır. Herkese açık veya paylaşılan dağıtımlar için erişim denetimini yukarıdaki Docker dağıtım rehberine göre yapılandırın.
+Sealos App Store şablonu, yayımlanmış Open Design Docker imajını kalıcı çalışma alanı depolaması ve herkese açık proxy üzerinde Basic Auth ile çalıştırır. Özel herkese açık veya paylaşılan Docker dağıtımları için [`deploy/README.md`](../../deploy/README.md#local-compose) içindeki ters proxy ve `OPEN_DESIGN_ALLOWED_ORIGINS` rehberini izleyin.
 
 ### 🧑‍💻 Kaynaktan çalıştırın
 

--- a/docs/i18n/README.uk.md
+++ b/docs/i18n/README.uk.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Шаблон Sealos запускає опублікований Docker-образ Open Design із постійним сховищем робочої області. Налаштуйте контроль доступу для публічного або спільного розгортання згідно з рекомендаціями Docker вище.
+Шаблон Sealos App Store запускає опублікований Docker-образ Open Design із постійним сховищем робочої області та Basic Auth на публічному проксі. Для користувацьких публічних або спільних Docker-розгортань дотримуйтеся рекомендацій щодо зворотного проксі та `OPEN_DESIGN_ALLOWED_ORIGINS` у [`deploy/README.md`](../../deploy/README.md#local-compose).
 
 ### 🧑‍💻 Запуск із вихідного коду
 

--- a/docs/i18n/README.uk.md
+++ b/docs/i18n/README.uk.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 Розгортання на Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Шаблон Sealos запускає опублікований Docker-образ Open Design із постійним сховищем робочої області. Налаштуйте контроль доступу для публічного або спільного розгортання згідно з рекомендаціями Docker вище.
+
 ### 🧑‍💻 Запуск із вихідного коду
 
 ```bash

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Sealos 模板会运行已发布的 Open Design Docker 镜像，并提供持久化工作区存储。面向公开或共享部署时，请按照上方 Docker 部署指引配置访问控制。
+Sealos App Store 模板会运行已发布的 Open Design Docker 镜像，提供持久化工作区存储，并在公网代理层启用 Basic Auth。自定义公开或共享 Docker 部署请遵循 [`deploy/README.md`](../../deploy/README.md#local-compose) 中的反向代理和 `OPEN_DESIGN_ALLOWED_ORIGINS` 指引。
 
 ### 🧑‍💻 从源码运行
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -326,6 +326,12 @@ docker compose up -d
 # 打开 http://localhost:7456
 ```
 
+### 🚀 部署到 Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Sealos 模板会运行已发布的 Open Design Docker 镜像，并提供持久化工作区存储。面向公开或共享部署时，请按照上方 Docker 部署指引配置访问控制。
+
 ### 🧑‍💻 从源码运行
 
 ```bash

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -330,7 +330,7 @@ docker compose up -d
 
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
 
-Sealos 範本會執行已發布的 Open Design Docker 映像，並提供持久化工作區儲存。面向公開或共享部署時，請依照上方 Docker 部署指引設定存取控制。
+Sealos App Store 範本會執行已發布的 Open Design Docker 映像，提供持久化工作區儲存，並在公開代理層啟用 Basic Auth。自訂公開或共享 Docker 部署請遵循 [`deploy/README.md`](../../deploy/README.md#local-compose) 中的反向代理與 `OPEN_DESIGN_ALLOWED_ORIGINS` 指引。
 
 ### 🧑‍💻 從原始碼執行
 

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -326,6 +326,12 @@ docker compose up -d
 # open http://localhost:7456
 ```
 
+### 🚀 部署到 Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/open-design/)
+
+Sealos 範本會執行已發布的 Open Design Docker 映像，並提供持久化工作區儲存。面向公開或共享部署時，請依照上方 Docker 部署指引設定存取控制。
+
 ### 🧑‍💻 從原始碼執行
 
 ```bash


### PR DESCRIPTION
## Why

I use Sealos for one-click app deployments and wanted a short README entry for users who prefer that path after reading the Docker setup.

This adds a small hosted deployment option while keeping the existing Docker and source flows unchanged.

## What users will see

Users will see a new "Deploy on Sealos" section immediately after "Run with Docker" in the English README and every localized README. The section links to the Sealos App Store template, notes that the template includes Basic Auth on the public proxy, and points custom public Docker deployments to the reverse-proxy and `OPEN_DESIGN_ALLOWED_ORIGINS` guidance in `deploy/README.md`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — README-only docs change.

## Bug fix verification

N/A — docs change.

## Validation

- `git diff --check`
- `for f in README.md docs/i18n/README.*.md; do rg -c "https://sealos.io/products/app-store/open-design/" "$f"; rg -c "Basic Auth" "$f"; rg -c "deploy/README.md#local-compose" "$f"; done`
- `curl -I -L --max-time 20 https://sealos.io/Deploy-on-Sealos.svg`
- `curl -I -L --max-time 20 https://sealos.io/products/app-store/open-design/`
- `curl -I -L --max-time 20 https://raw.githubusercontent.com/nexu-io/open-design/main/deploy/README.md`

## Sealos template evidence

- Template page: https://sealos.io/products/app-store/open-design/
- Template source: https://github.com/labring-actions/templates/tree/kb-0.9/template/open-design
- Template authentication evidence: labring-actions/templates#709
- App image policy: pinned digest in the Sealos template
- Persistence: workspace data is mounted at `/app/.od` with a persistent volume
- Authentication: Basic Auth is enforced by the Sealos public Nginx proxy; unauthenticated `/` and `/api/health` returned `401`, authenticated `/` and `/api/health` returned `200` during PR #709 validation


