### PR TITLE
Centralize reasoning provider policy enforcement

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -35,6 +35,7 @@ import { projectKindToTracking } from '@open-design/contracts/analytics';
 import { proxyDispatcherRequestInit, validateBaseUrlResolved } from './connectionTest.js';
 import { googleStreamGenerateContentUrl } from './google-models.js';
 import { createRoleMarkerGuard } from './role-marker-guard.js';
+import { authorizeReasoningEgress, sendReasoningEgressDenial } from './reasoning-egress.js';
 
 // Allowlist for the `/feedback` route. Mirrors the
 // ChatMessageFeedbackReasonCode union in packages/contracts/src/api/chat.ts.
@@ -239,6 +240,13 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         apiKeyRequired ? 'baseUrl and apiKey are required' : 'baseUrl is required',
       );
     }
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: body.reasoningExecution,
+      routeKind: 'provider_models',
+      provider: protocol,
+      resolvedBaseUrl: body.baseUrl,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
     try {
       const proxyDispatcher = proxyDispatcherRequestInit();
       try {
@@ -308,6 +316,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
             'baseUrl, apiKey, and model are required',
           );
         }
+        const reasoningDenial = authorizeReasoningEgress({
+          policy: body.reasoningExecution,
+          routeKind: 'connection_test',
+          provider: protocol,
+          resolvedBaseUrl: body.baseUrl,
+          model: body.model,
+        });
+        if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
         try {
           const result = await testProviderConnection({
             protocol,
@@ -934,6 +950,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         validated.error,
       );
     }
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: proxyBody.reasoningExecution,
+      routeKind: 'proxy',
+      provider: 'anthropic',
+      resolvedBaseUrl: baseUrl,
+      model,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
 
     const url = appendVersionedApiPath(baseUrl, '/messages');
     console.log(
@@ -972,6 +996,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         validated.error,
       );
     }
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: proxyBody.reasoningExecution,
+      routeKind: 'proxy',
+      provider: 'openai',
+      resolvedBaseUrl: baseUrl,
+      model,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
 
     const url = appendVersionedApiPath(baseUrl, '/chat/completions');
     console.log(
@@ -1087,6 +1119,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         validated.error,
       );
     }
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: proxyBody.reasoningExecution,
+      routeKind: 'proxy',
+      provider: 'azure',
+      resolvedBaseUrl: baseUrl,
+      model,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
 
     const url = new URL(baseUrl);
     const basePath = url.pathname.replace(/\/+$/, '');
@@ -1241,6 +1281,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         validated.error,
       );
     }
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: proxyBody.reasoningExecution,
+      routeKind: 'proxy',
+      provider: 'google',
+      resolvedBaseUrl: effectiveBaseUrl,
+      model,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
 
     const url = googleStreamGenerateContentUrl(effectiveBaseUrl, model);
     console.log(
@@ -1274,6 +1322,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         validated.error,
       );
     }
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: proxyBody.reasoningExecution,
+      routeKind: 'proxy',
+      provider: 'ollama',
+      resolvedBaseUrl: effectiveBaseUrl,
+      model,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
 
     const clean = effectiveBaseUrl.replace(/\/+$/, '').replace(/\/api\/?$/, '');
     const url = `${clean}/api/chat`;
@@ -1452,6 +1508,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         validated.error,
       );
     }
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: proxyBody.reasoningExecution,
+      routeKind: 'proxy',
+      provider: opts.providerId,
+      resolvedBaseUrl: effectiveBaseUrl,
+      model,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
 
     // AIHubMix routes by model name to the native protocol wire (claude →
     // Anthropic /v1/messages, gemini/imagen → Gemini generateContent). That
@@ -2182,6 +2246,20 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     runSpeech: executeAIHubMixGenerateSpeech,
     runVideo: executeAIHubMixGenerateVideo,
     routeByModel: true,
+  });
+
+  app.post('/api/proxy/:provider/stream', (req, res) => {
+    const proxyBody = req.body || {};
+    const provider = typeof req.params.provider === 'string' ? req.params.provider : 'unknown';
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: proxyBody.reasoningExecution,
+      routeKind: 'proxy',
+      provider,
+      resolvedBaseUrl: typeof proxyBody.baseUrl === 'string' ? proxyBody.baseUrl : undefined,
+      model: typeof proxyBody.model === 'string' ? proxyBody.model : undefined,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
+    return sendApiError(res, 404, 'NOT_FOUND', 'unknown proxy provider');
   });
 
 }

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -8,6 +8,7 @@ import {
   inlineRelativeAssets,
   type InlineAssetReader,
 } from './inline-assets.js';
+import { authorizeReasoningEgress, sendReasoningEgressDenial } from './reasoning-egress.js';
 import { sandboxImportedProjectRootUnavailableReason } from './sandbox-mode.js';
 import { parseOrchestratorWorkspace } from './workspace-contract.js';
 
@@ -961,7 +962,7 @@ export function registerFinalizeRoutes(app: Express, ctx: RegisterFinalizeRoutes
     redactSecrets,
   } = ctx.finalize;
   app.post('/api/projects/:id/finalize/:provider', async (req, res) => {
-    const { apiKey, baseUrl, model, maxTokens, apiVersion, protocol: bodyProtocol } = req.body || {};
+    const { apiKey, baseUrl, model, maxTokens, apiVersion, protocol: bodyProtocol, reasoningExecution } = req.body || {};
     try {
       // Centralized path-traversal guard. `isSafeId` (apps/daemon/src/projects.ts)
       // rejects pure-dot ids (`.`, `..`, etc.) which would otherwise pass
@@ -1011,6 +1012,14 @@ export function registerFinalizeRoutes(app: Express, ctx: RegisterFinalizeRoutes
           validated.error,
         );
       }
+      const reasoningDenial = authorizeReasoningEgress({
+        policy: reasoningExecution,
+        routeKind: 'finalize',
+        provider: protocol,
+        resolvedBaseUrl: effectiveBaseUrl,
+        model,
+      });
+      if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
       if (maxTokens !== undefined && (typeof maxTokens !== 'number' || maxTokens <= 0)) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'maxTokens must be a positive number when provided');
       }

--- a/apps/daemon/src/reasoning-egress.ts
+++ b/apps/daemon/src/reasoning-egress.ts
@@ -3,6 +3,7 @@ import type {
   ReasoningExecutionMode,
   ReasoningExecutionPolicy,
 } from '@open-design/contracts/api/reasoningExecution';
+import { normalizeGoogleModelId } from './google-models.js';
 
 export type ReasoningEgressRouteKind =
   | 'proxy'
@@ -132,12 +133,18 @@ function allowedBaseUrlSet(policy: Partial<ReasoningExecutionPolicy>): Set<strin
   );
 }
 
-function allowedModelSet(policy: Partial<ReasoningExecutionPolicy>): Set<string> {
+function normalizeReasoningModelId(provider: string, model: string): string {
+  const trimmed = model.trim();
+  if (provider === 'google') return normalizeGoogleModelId(trimmed);
+  return trimmed;
+}
+
+function allowedModelSet(policy: Partial<ReasoningExecutionPolicy>, provider: string): Set<string> {
   const values: unknown[] = Array.isArray(policy.allowedModels) ? policy.allowedModels : [];
   return new Set(
     values
       .filter((value: unknown): value is string => typeof value === 'string')
-      .map((value: string) => value.trim())
+      .map((value: string) => normalizeReasoningModelId(provider, value))
       .filter(Boolean),
   );
 }
@@ -158,7 +165,10 @@ export function authorizeReasoningEgress(args: ReasoningEgressRequest): Reasonin
     return allowlistDenial(args);
   }
 
-  if (args.model !== undefined && !allowedModelSet(policy).has(args.model)) {
+  if (
+    args.model !== undefined
+    && !allowedModelSet(policy, args.provider).has(normalizeReasoningModelId(args.provider, args.model))
+  ) {
     return allowlistDenial(args);
   }
 

--- a/apps/daemon/src/reasoning-egress.ts
+++ b/apps/daemon/src/reasoning-egress.ts
@@ -1,0 +1,144 @@
+import type { Response } from 'express';
+import type {
+  ReasoningExecutionMode,
+  ReasoningExecutionPolicy,
+} from '@open-design/contracts/api/reasoningExecution';
+
+export type ReasoningEgressRouteKind =
+  | 'proxy'
+  | 'provider_models'
+  | 'connection_test'
+  | 'finalize';
+
+export interface ReasoningEgressRequest {
+  policy: unknown;
+  routeKind: ReasoningEgressRouteKind;
+  provider: string;
+  resolvedBaseUrl?: string;
+  model?: string;
+}
+
+export interface ReasoningEgressDenial {
+  status: 403;
+  code: 'reasoning_execution_disabled' | 'reasoning_execution_not_allowlisted';
+  message: string;
+  data: {
+    routeKind: ReasoningEgressRouteKind;
+    provider: string;
+    policyMode: Exclude<ReasoningExecutionMode, 'enabled'>;
+    resolvedBaseUrl?: string;
+    model?: string;
+  };
+}
+
+function isReasoningPolicy(value: unknown): value is Partial<ReasoningExecutionPolicy> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function policyMode(policy: unknown): ReasoningExecutionMode {
+  if (!isReasoningPolicy(policy)) return 'enabled';
+  return policy.mode === 'enabled' || policy.mode === 'disabled' || policy.mode === 'allowlist'
+    ? policy.mode
+    : 'disabled';
+}
+
+export function normalizeReasoningBaseUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    url.hash = '';
+    url.search = '';
+    url.pathname = url.pathname.replace(/\/+$/, '');
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return null;
+  }
+}
+
+function disabledDenial(args: ReasoningEgressRequest): ReasoningEgressDenial {
+  return {
+    status: 403,
+    code: 'reasoning_execution_disabled',
+    message: 'Reasoning provider egress is disabled for this run.',
+    data: {
+      routeKind: args.routeKind,
+      provider: args.provider,
+      policyMode: 'disabled',
+      ...(args.resolvedBaseUrl ? { resolvedBaseUrl: args.resolvedBaseUrl } : {}),
+      ...(args.model ? { model: args.model } : {}),
+    },
+  };
+}
+
+function allowlistDenial(args: ReasoningEgressRequest): ReasoningEgressDenial {
+  return {
+    status: 403,
+    code: 'reasoning_execution_not_allowlisted',
+    message: 'Reasoning provider egress is not allowlisted for this run.',
+    data: {
+      routeKind: args.routeKind,
+      provider: args.provider,
+      policyMode: 'allowlist',
+      ...(args.resolvedBaseUrl ? { resolvedBaseUrl: args.resolvedBaseUrl } : {}),
+      ...(args.model ? { model: args.model } : {}),
+    },
+  };
+}
+
+function routeIsDeniedByFlag(policy: Partial<ReasoningExecutionPolicy>, routeKind: ReasoningEgressRouteKind): boolean {
+  if (routeKind === 'provider_models') return policy.denyProviderDiscovery === true;
+  if (routeKind === 'connection_test') return policy.denyConnectionTests === true;
+  if (routeKind === 'finalize') return policy.denyFinalize === true;
+  return false;
+}
+
+function allowedBaseUrlSet(policy: Partial<ReasoningExecutionPolicy>): Set<string> {
+  const values: unknown[] = Array.isArray(policy.allowedBaseUrls) ? policy.allowedBaseUrls : [];
+  return new Set(
+    values
+      .filter((value: unknown): value is string => typeof value === 'string')
+      .map(normalizeReasoningBaseUrl)
+      .filter((value: string | null): value is string => Boolean(value)),
+  );
+}
+
+function allowedModelSet(policy: Partial<ReasoningExecutionPolicy>): Set<string> {
+  const values: unknown[] = Array.isArray(policy.allowedModels) ? policy.allowedModels : [];
+  return new Set(
+    values
+      .filter((value: unknown): value is string => typeof value === 'string')
+      .map((value: string) => value.trim())
+      .filter(Boolean),
+  );
+}
+
+export function authorizeReasoningEgress(args: ReasoningEgressRequest): ReasoningEgressDenial | null {
+  const mode = policyMode(args.policy);
+  if (mode === 'enabled') return null;
+  if (mode === 'disabled') return disabledDenial(args);
+
+  const policy = isReasoningPolicy(args.policy) ? args.policy : {};
+  if (routeIsDeniedByFlag(policy, args.routeKind)) return allowlistDenial(args);
+
+  const normalizedBaseUrl = args.resolvedBaseUrl
+    ? normalizeReasoningBaseUrl(args.resolvedBaseUrl)
+    : null;
+  if (!normalizedBaseUrl || !allowedBaseUrlSet(policy).has(normalizedBaseUrl)) {
+    return allowlistDenial(args);
+  }
+
+  if (args.model !== undefined && !allowedModelSet(policy).has(args.model)) {
+    return allowlistDenial(args);
+  }
+
+  return null;
+}
+
+export function sendReasoningEgressDenial(res: Response, denial: ReasoningEgressDenial): void {
+  res.status(denial.status).json({
+    error: {
+      code: denial.code,
+      message: denial.message,
+      data: denial.data,
+    },
+  });
+}

--- a/apps/daemon/src/reasoning-egress.ts
+++ b/apps/daemon/src/reasoning-egress.ts
@@ -18,7 +18,23 @@ export interface ReasoningEgressRequest {
   model?: string;
 }
 
-export interface ReasoningEgressDenial {
+export type ReasoningEgressDenial =
+  | ReasoningEgressInvalidPolicyDenial
+  | ReasoningEgressPolicyDenial;
+
+export interface ReasoningEgressInvalidPolicyDenial {
+  status: 400;
+  code: 'reasoning_execution_invalid_policy';
+  message: string;
+  data: {
+    routeKind: ReasoningEgressRouteKind;
+    provider: string;
+    resolvedBaseUrl?: string;
+    model?: string;
+  };
+}
+
+export interface ReasoningEgressPolicyDenial {
   status: 403;
   code: 'reasoning_execution_disabled' | 'reasoning_execution_not_allowlisted';
   message: string;
@@ -35,11 +51,12 @@ function isReasoningPolicy(value: unknown): value is Partial<ReasoningExecutionP
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
-function policyMode(policy: unknown): ReasoningExecutionMode {
-  if (!isReasoningPolicy(policy)) return 'enabled';
+function policyMode(policy: unknown): ReasoningExecutionMode | 'invalid' {
+  if (policy === undefined) return 'enabled';
+  if (!isReasoningPolicy(policy)) return 'invalid';
   return policy.mode === 'enabled' || policy.mode === 'disabled' || policy.mode === 'allowlist'
     ? policy.mode
-    : 'disabled';
+    : 'invalid';
 }
 
 export function normalizeReasoningBaseUrl(value: string): string | null {
@@ -52,6 +69,20 @@ export function normalizeReasoningBaseUrl(value: string): string | null {
   } catch {
     return null;
   }
+}
+
+function invalidPolicyDenial(args: ReasoningEgressRequest): ReasoningEgressInvalidPolicyDenial {
+  return {
+    status: 400,
+    code: 'reasoning_execution_invalid_policy',
+    message: 'reasoningExecution.mode must be one of enabled, disabled, or allowlist.',
+    data: {
+      routeKind: args.routeKind,
+      provider: args.provider,
+      ...(args.resolvedBaseUrl ? { resolvedBaseUrl: args.resolvedBaseUrl } : {}),
+      ...(args.model ? { model: args.model } : {}),
+    },
+  };
 }
 
 function disabledDenial(args: ReasoningEgressRequest): ReasoningEgressDenial {
@@ -114,6 +145,7 @@ function allowedModelSet(policy: Partial<ReasoningExecutionPolicy>): Set<string>
 export function authorizeReasoningEgress(args: ReasoningEgressRequest): ReasoningEgressDenial | null {
   const mode = policyMode(args.policy);
   if (mode === 'enabled') return null;
+  if (mode === 'invalid') return invalidPolicyDenial(args);
   if (mode === 'disabled') return disabledDenial(args);
 
   const policy = isReasoningPolicy(args.policy) ? args.policy : {};

--- a/apps/daemon/tests/reasoning-egress-policy.test.ts
+++ b/apps/daemon/tests/reasoning-egress-policy.test.ts
@@ -57,11 +57,11 @@ describe('reasoningExecution egress policy', () => {
   async function expectReasoningDenied(
     path: string,
     body: Record<string, unknown>,
-    expected: { routeKind: string; provider: string; code?: string },
+    expected: { routeKind: string; provider: string; code?: string; status?: number },
   ) {
     const fetchMock = stubUnexpectedUpstreamFetch();
     const res = await postJson(path, body);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(expected.status ?? 403);
     const payload = await res.json() as {
       error: {
         code: string;
@@ -80,6 +80,30 @@ describe('reasoningExecution egress policy', () => {
   }
 
   const disabledPolicy = { mode: 'disabled' };
+
+  it.each([
+    { label: 'missing mode object', reasoningExecution: {} },
+    { label: 'invalid mode object', reasoningExecution: { mode: 'off' } },
+    { label: 'null value', reasoningExecution: null },
+    { label: 'array value', reasoningExecution: [] },
+  ])('rejects malformed reasoningExecution before upstream fetch: $label', async ({ reasoningExecution }) => {
+    await expectReasoningDenied(
+      '/api/proxy/openai/stream',
+      {
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        model: 'gpt-test',
+        messages: [{ role: 'user', content: 'hello' }],
+        reasoningExecution,
+      },
+      {
+        status: 400,
+        routeKind: 'proxy',
+        provider: 'openai',
+        code: 'reasoning_execution_invalid_policy',
+      },
+    );
+  });
 
   it.each([
     {

--- a/apps/daemon/tests/reasoning-egress-policy.test.ts
+++ b/apps/daemon/tests/reasoning-egress-policy.test.ts
@@ -266,6 +266,34 @@ describe('reasoningExecution egress policy', () => {
     );
   });
 
+  it('canonicalizes Google proxy model ids before checking the allowlist', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: {"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await postJson('/api/proxy/google/stream', {
+      baseUrl: 'https://generativelanguage.googleapis.com',
+      apiKey: 'google-key',
+      model: 'models/gemini-test',
+      messages: [{ role: 'user', content: 'hello' }],
+      reasoningExecution: {
+        mode: 'allowlist',
+        allowedBaseUrls: ['https://generativelanguage.googleapis.com'],
+        allowedModels: ['gemini-test'],
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toContain('event: end');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-test:streamGenerateContent?alt=sse',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
   it('denies allowlist proxy egress when the resolved base URL is not allowlisted', async () => {
     await expectReasoningDenied(
       '/api/proxy/openai/stream',

--- a/apps/daemon/tests/reasoning-egress-policy.test.ts
+++ b/apps/daemon/tests/reasoning-egress-policy.test.ts
@@ -73,6 +73,9 @@ describe('reasoningExecution egress policy', () => {
       routeKind: expected.routeKind,
       provider: expected.provider,
     });
+    if (typeof body.apiKey === 'string') {
+      expect(JSON.stringify(payload)).not.toContain(body.apiKey);
+    }
     expect(fetchMock).not.toHaveBeenCalled();
   }
 

--- a/apps/daemon/tests/reasoning-egress-policy.test.ts
+++ b/apps/daemon/tests/reasoning-egress-policy.test.ts
@@ -1,0 +1,342 @@
+import type http from 'node:http';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { startServer } from '../src/server.js';
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+const realFetch = globalThis.fetch;
+
+function sseResponse(body: string): Response {
+  return new Response(new TextEncoder().encode(body), {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+describe('reasoningExecution egress policy', () => {
+  let baseUrl: string;
+  let server: http.Server | null = null;
+
+  beforeAll(async () => {
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterAll(() => new Promise<void>((resolve) => {
+    if (!server) return resolve();
+    server.close(() => resolve());
+  }));
+
+  function stubUnexpectedUpstreamFetch() {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      throw new Error(`unexpected upstream fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  async function postJson(path: string, body: unknown): Promise<Response> {
+    return realFetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function expectReasoningDenied(
+    path: string,
+    body: Record<string, unknown>,
+    expected: { routeKind: string; provider: string; code?: string },
+  ) {
+    const fetchMock = stubUnexpectedUpstreamFetch();
+    const res = await postJson(path, body);
+    expect(res.status).toBe(403);
+    const payload = await res.json() as {
+      error: {
+        code: string;
+        data: Record<string, unknown>;
+      };
+    };
+    expect(payload.error.code).toBe(expected.code ?? 'reasoning_execution_disabled');
+    expect(payload.error.data).toMatchObject({
+      routeKind: expected.routeKind,
+      provider: expected.provider,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  }
+
+  const disabledPolicy = { mode: 'disabled' };
+
+  it.each([
+    {
+      provider: 'anthropic',
+      path: '/api/proxy/anthropic/stream',
+      body: {
+        baseUrl: 'https://api.anthropic.com',
+        apiKey: 'sk-ant',
+        model: 'claude-test',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    },
+    {
+      provider: 'openai',
+      path: '/api/proxy/openai/stream',
+      body: {
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        model: 'gpt-test',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    },
+    {
+      provider: 'azure',
+      path: '/api/proxy/azure/stream',
+      body: {
+        baseUrl: 'https://resource.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'deployment-one',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    },
+    {
+      provider: 'google',
+      path: '/api/proxy/google/stream',
+      body: {
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        apiKey: 'google-key',
+        model: 'gemini-test',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    },
+    {
+      provider: 'ollama',
+      path: '/api/proxy/ollama/stream',
+      body: {
+        baseUrl: 'https://ollama.example.com',
+        apiKey: 'ollama-key',
+        model: 'llama3',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    },
+    {
+      provider: 'senseaudio',
+      path: '/api/proxy/senseaudio/stream',
+      body: {
+        baseUrl: 'https://api.senseaudio.cn',
+        apiKey: 'senseaudio-key',
+        model: 'senseaudio-s2',
+        projectId: 'project-1',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    },
+    {
+      provider: 'aihubmix',
+      path: '/api/proxy/aihubmix/stream',
+      body: {
+        baseUrl: 'https://aihubmix.com/v1',
+        apiKey: 'aihubmix-key',
+        model: 'gpt-test',
+        projectId: 'project-1',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    },
+    {
+      provider: 'newprovider',
+      path: '/api/proxy/newprovider/stream',
+      body: {
+        baseUrl: 'https://newprovider.example.com/v1',
+        apiKey: 'newprovider-key',
+        model: 'new-model',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    },
+  ])('blocks disabled proxy egress for $provider before upstream fetch', async ({ path, provider, body }) => {
+    await expectReasoningDenied(
+      path,
+      { ...body, reasoningExecution: disabledPolicy },
+      { routeKind: 'proxy', provider },
+    );
+  });
+
+  it('blocks disabled provider model discovery before upstream fetch', async () => {
+    await expectReasoningDenied(
+      '/api/provider/models',
+      {
+        protocol: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        reasoningExecution: disabledPolicy,
+      },
+      { routeKind: 'provider_models', provider: 'openai' },
+    );
+  });
+
+  it('blocks disabled provider connection tests before upstream fetch', async () => {
+    await expectReasoningDenied(
+      '/api/test/connection',
+      {
+        mode: 'provider',
+        protocol: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        model: 'gpt-test',
+        reasoningExecution: disabledPolicy,
+      },
+      { routeKind: 'connection_test', provider: 'openai' },
+    );
+  });
+
+  it('blocks disabled finalize egress before project lookup or upstream fetch', async () => {
+    await expectReasoningDenied(
+      '/api/projects/project-1/finalize/openai',
+      {
+        protocol: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        model: 'gpt-test',
+        reasoningExecution: disabledPolicy,
+      },
+      { routeKind: 'finalize', provider: 'openai' },
+    );
+  });
+
+  it('allows proxy egress only when base URL and model are allowlisted', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await postJson('/api/proxy/openai/stream', {
+      baseUrl: 'http://localhost:1234/v1/',
+      apiKey: 'sk-openai',
+      model: 'gpt-test',
+      messages: [{ role: 'user', content: 'hello' }],
+      reasoningExecution: {
+        mode: 'allowlist',
+        allowedBaseUrls: ['http://localhost:1234/v1'],
+        allowedModels: ['gpt-test'],
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toContain('event: end');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:1234/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('denies allowlist proxy egress when the resolved base URL is not allowlisted', async () => {
+    await expectReasoningDenied(
+      '/api/proxy/openai/stream',
+      {
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        model: 'gpt-test',
+        messages: [{ role: 'user', content: 'hello' }],
+        reasoningExecution: {
+          mode: 'allowlist',
+          allowedBaseUrls: ['http://localhost:1234/v1'],
+          allowedModels: ['gpt-test'],
+        },
+      },
+      {
+        routeKind: 'proxy',
+        provider: 'openai',
+        code: 'reasoning_execution_not_allowlisted',
+      },
+    );
+  });
+
+  it('denies allowlist proxy egress when the model is not allowlisted', async () => {
+    await expectReasoningDenied(
+      '/api/proxy/openai/stream',
+      {
+        baseUrl: 'http://localhost:1234/v1',
+        apiKey: 'sk-openai',
+        model: 'gpt-other',
+        messages: [{ role: 'user', content: 'hello' }],
+        reasoningExecution: {
+          mode: 'allowlist',
+          allowedBaseUrls: ['http://localhost:1234/v1'],
+          allowedModels: ['gpt-test'],
+        },
+      },
+      {
+        routeKind: 'proxy',
+        provider: 'openai',
+        code: 'reasoning_execution_not_allowlisted',
+      },
+    );
+  });
+
+  it('honors explicit allowlist denial flags for discovery, tests, and finalize', async () => {
+    const policy = {
+      mode: 'allowlist',
+      allowedBaseUrls: ['http://localhost:1234/v1'],
+      allowedModels: ['gpt-test'],
+      denyProviderDiscovery: true,
+      denyConnectionTests: true,
+      denyFinalize: true,
+    };
+
+    await expectReasoningDenied(
+      '/api/provider/models',
+      {
+        protocol: 'openai',
+        baseUrl: 'http://localhost:1234/v1',
+        apiKey: 'sk-openai',
+        reasoningExecution: policy,
+      },
+      {
+        routeKind: 'provider_models',
+        provider: 'openai',
+        code: 'reasoning_execution_not_allowlisted',
+      },
+    );
+    await expectReasoningDenied(
+      '/api/test/connection',
+      {
+        mode: 'provider',
+        protocol: 'openai',
+        baseUrl: 'http://localhost:1234/v1',
+        apiKey: 'sk-openai',
+        model: 'gpt-test',
+        reasoningExecution: policy,
+      },
+      {
+        routeKind: 'connection_test',
+        provider: 'openai',
+        code: 'reasoning_execution_not_allowlisted',
+      },
+    );
+    await expectReasoningDenied(
+      '/api/projects/project-1/finalize/openai',
+      {
+        protocol: 'openai',
+        baseUrl: 'http://localhost:1234/v1',
+        apiKey: 'sk-openai',
+        model: 'gpt-test',
+        reasoningExecution: policy,
+      },
+      {
+        routeKind: 'finalize',
+        provider: 'openai',
+        code: 'reasoning_execution_not_allowlisted',
+      },
+    );
+  });
+});

--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -11,6 +11,7 @@ await build({
     "./src/api/finalize.ts",
     "./src/api/handoff.ts",
     "./src/api/providerModels.ts",
+    "./src/api/reasoningExecution.ts",
     "./src/api/research.ts",
     "./src/design-systems/components-manifest.ts",
     "./src/design-systems/derived-token-outputs.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/api/providerModels.d.ts",
       "default": "./dist/api/providerModels.mjs"
     },
+    "./api/reasoningExecution": {
+      "types": "./dist/api/reasoningExecution.d.ts",
+      "default": "./dist/api/reasoningExecution.mjs"
+    },
     "./api/research": {
       "types": "./dist/api/research.d.ts",
       "default": "./dist/api/research.mjs"

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -3,6 +3,7 @@
 // and returns it inside a JSON envelope (always HTTP 200 — see notes in the
 // daemon module for why).
 import type { AgentCliEnvPrefs } from './app-config';
+import type { ReasoningExecutionRequestFields } from './reasoningExecution';
 
 export interface BaseUrlValidationResult {
   parsed?: ParsedBaseUrl;
@@ -180,7 +181,7 @@ export interface ConnectionTestDiagnostics {
 
 export type ConnectionTestProtocol = 'anthropic' | 'openai' | 'azure' | 'google' | 'ollama' | 'senseaudio' | 'aihubmix';
 
-export interface ProviderTestRequest {
+export interface ProviderTestRequest extends ReasoningExecutionRequestFields {
   protocol: ConnectionTestProtocol;
   baseUrl: string;
   apiKey: string;

--- a/packages/contracts/src/api/finalize.ts
+++ b/packages/contracts/src/api/finalize.ts
@@ -1,4 +1,5 @@
 import type { ConnectionTestProtocol } from './connectionTest';
+import type { ReasoningExecutionRequestFields } from './reasoningExecution';
 
 // Shared DTOs for the `/api/projects/:id/finalize/<provider>` family of
 // synthesis endpoints. `/finalize/anthropic` was introduced first; the
@@ -28,7 +29,7 @@ export type FinalizeProviderProtocol = ConnectionTestProtocol;
  * the proxy, which requires it for some providers) — standard provider
  * defaults are applied by the daemon when possible.
  */
-export interface FinalizeProviderRequest {
+export interface FinalizeProviderRequest extends ReasoningExecutionRequestFields {
   /**
    * BYOK protocol selected in Settings. Omitted means `anthropic` for
    * backward compatibility with the original `/finalize/anthropic` caller.

--- a/packages/contracts/src/api/providerModels.ts
+++ b/packages/contracts/src/api/providerModels.ts
@@ -1,4 +1,5 @@
 import type { ConnectionTestKind, ConnectionTestProtocol } from './connectionTest';
+import type { ReasoningExecutionRequestFields } from './reasoningExecution';
 import type { AgentModelOption } from './registry';
 
 export type ProviderModelsKind =
@@ -6,7 +7,7 @@ export type ProviderModelsKind =
   | 'no_models'
   | 'unsupported_protocol';
 
-export interface ProviderModelsRequest {
+export interface ProviderModelsRequest extends ReasoningExecutionRequestFields {
   protocol: ConnectionTestProtocol;
   baseUrl: string;
   apiKey: string;

--- a/packages/contracts/src/api/proxy.ts
+++ b/packages/contracts/src/api/proxy.ts
@@ -1,3 +1,5 @@
+import type { ReasoningExecutionRequestFields } from './reasoningExecution';
+
 export type ProxyMessageRole = 'system' | 'user' | 'assistant' | 'tool';
 
 export type ProxyMessageContent =
@@ -23,7 +25,7 @@ export interface ProxyMessage {
   content: ProxyMessageContent;
 }
 
-export interface ProxyStreamRequest {
+export interface ProxyStreamRequest extends ReasoningExecutionRequestFields {
   baseUrl: string;
   apiKey: string;
   model: string;

--- a/packages/contracts/src/api/reasoningExecution.ts
+++ b/packages/contracts/src/api/reasoningExecution.ts
@@ -1,0 +1,14 @@
+export type ReasoningExecutionMode = 'enabled' | 'disabled' | 'allowlist';
+
+export interface ReasoningExecutionPolicy {
+  mode: ReasoningExecutionMode;
+  allowedBaseUrls?: string[];
+  allowedModels?: string[];
+  denyProviderDiscovery?: boolean;
+  denyConnectionTests?: boolean;
+  denyFinalize?: boolean;
+}
+
+export interface ReasoningExecutionRequestFields {
+  reasoningExecution?: ReasoningExecutionPolicy;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -27,6 +27,7 @@ export * from './api/proxy.js';
 export * from './api/routines.js';
 export * from './api/registry.js';
 export * from './api/research.js';
+export * from './api/reasoningExecution.js';
 export * from './api/social-share.js';
 export * from './api/terminals.js';
 export * from './api/version.js';


### PR DESCRIPTION
## Why

OpenDesign has several server paths that can initiate reasoning-provider traffic. This PR centralizes the deployment policy check for those paths so managed and enterprise deployments can apply consistent provider governance across proxy chat, provider model discovery, connection tests, and finalize.

Today that policy is route-local. As the provider surface grows, centralizing it makes the behavior easier to audit, test, and evolve without depending on each route to remember the same enforcement details.

## What users will see

Default behavior is unchanged. API callers can pass `reasoningExecution` with `mode: "disabled"` or `mode: "allowlist"` on provider proxy, model discovery, connection-test, and finalize requests. Denied requests return HTTP 403 with stable `reasoning_execution_disabled` or `reasoning_execution_not_allowlisted` codes.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [x] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

N/A. No UI surface changed.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/reasoning-egress-policy.test.ts`
- `pnpm --filter @open-design/daemon typecheck`

Both were run under local Node v26.0.0, which emits the repo engine warning.
