### PR TITLE
[codex] Fix brand extraction incomplete states

### DIFF
--- a/apps/daemon/src/brands/index.ts
+++ b/apps/daemon/src/brands/index.ts
@@ -205,7 +205,10 @@ export async function startBrandExtraction(
     brandSourceUrl: url,
   };
   const name = `${host} Design System`;
-  const pendingPrompt = brandExtractionPrompt({ url, brandId: id, host });
+  const runProgrammatic = Boolean(opts.userDesignSystemsRoot);
+  const pendingPrompt = runProgrammatic
+    ? brandExtractionFallbackPrompt({ url, brandId: id, host })
+    : brandExtractionPrompt({ url, brandId: id, host });
   insertProject(db, {
     id: projectId,
     name,
@@ -239,7 +242,6 @@ export async function startBrandExtraction(
   // network harvest here would only add latency. Otherwise (legacy / tests),
   // run the bounded parallel seed harvest so the first paint already shows a
   // real logo / palette / fonts / cover imagery before the agent measures.
-  const runProgrammatic = Boolean(opts.userDesignSystemsRoot);
   const seedBrand: Record<string, unknown> = { name: host, sourceUrl: url, colors: [], typography: {} };
   if (!runProgrammatic) {
     try {
@@ -649,7 +651,15 @@ export async function runProgrammaticExtraction(
 
   const brand = brandFromMaterial(material, meta.sourceUrl);
   const guideMd = brandGuideMd(brand);
-  return finalizeBrandCore({ ...opts, brand, guideMd });
+  const finalized = await finalizeBrandCore({ ...opts, brand, guideMd });
+  updateProject(opts.db, opts.projectId, {
+    pendingPrompt: brandExtractionPrompt({
+      url: meta.sourceUrl,
+      brandId: id,
+      host: hostnameOf(meta.sourceUrl),
+    }),
+  });
+  return finalized;
 }
 
 export interface RenderBrandPreviewOptions {
@@ -759,6 +769,27 @@ function brandExtractionPrompt(input: { url: string; brandId: string; host: stri
     '3. REBUILD & RE-REGISTER — when `brand.json` is enriched, run `od brand finalize ' + input.brandId + '` (add `--json` for machine output). That re-validates it, re-derives the light/dark/compact design tokens and the six design-system artifacts (landing, deck, poster, email, newsletter, form), and UPDATES the already-registered design system in place (same id — never a duplicate), so every template that already uses it picks up the sharper result. Fix `brand.json` and re-run if it reports a validation error.',
     '',
     'Finish by pointing the user at the enriched brand.html (logo, palette, typography, voice) and the design-system assets they can now preview, and confirm the design system was updated.',
+  ].join('\n');
+}
+
+/** Prompt used while the programmatic harvest is not known-good yet. It must
+ * not claim the design system is already ready: blocked/thin sites stay on
+ * this path and need the agent to do the initial extraction from the scaffold. */
+function brandExtractionFallbackPrompt(input: { url: string; brandId: string; host: string }): string {
+  return [
+    `This is a DESIGN SYSTEM EXTRACTION task for ${input.host}.`,
+    `Source URL: ${input.url}`,
+    `Brand id: ${input.brandId}`,
+    '',
+    'The daemon opened a live extraction scaffold (`brand.html`) in the project, but a ready design system is NOT guaranteed yet. Treat the page as an empty/in-progress workspace until you have measured the target site and written `brand.json`; do not assume a registered `brand.json` or design system already exists.',
+    '',
+    'Use the `brand-extract` skill and the `agent-browser` tool to drive and observe the target site. Measure before you synthesize: capture the real colors, fonts, logo candidates, representative imagery, voice, and layout posture. If the page is an anti-bot verification interstitial, emit a `<question-form>` asking the user to complete verification in the browser, then continue after they respond.',
+    '',
+    'Write `brand.json` as soon as you have the name, a couple of measured colors, and a logo candidate, then run `od brand preview ' + input.brandId + '` so the scaffold fills in progressively. Keep updating `brand.json`, `BRAND.md`, saved `logos/`, fonts, and `imagery/` samples as you measure each field group.',
+    '',
+    'When the kit is complete and validates, run `od brand finalize ' + input.brandId + '` (add `--json` for machine output). Fix validation errors and re-run finalize until the brand is registered and the design-system assets are ready.',
+    '',
+    'Finish by pointing the user at the completed brand.html and the reusable design-system assets.',
   ].join('\n');
 }
 

--- a/apps/daemon/src/brands/index.ts
+++ b/apps/daemon/src/brands/index.ts
@@ -633,8 +633,8 @@ export interface RunProgrammaticExtractionOptions {
  * "aha". The async AI enrichment pass then refines it to full fidelity and
  * re-finalizes in place (reusing the same `user:<id>` design system).
  *
- * Best-effort: a fully blocked / unreachable origin (prefetch returns null)
- * yields `null` and the brand stays `extracting`, so the AI pass can take over.
+ * Best-effort: a blocked, too-thin, or unreachable origin yields `null` and
+ * the brand stays `extracting`, so the AI pass can take over.
  */
 export async function runProgrammaticExtraction(
   opts: RunProgrammaticExtractionOptions,
@@ -645,6 +645,7 @@ export async function runProgrammaticExtraction(
 
   const material = await prefetch(meta.sourceUrl, brandDir);
   if (!material) return null;
+  if (material.blocked || material.thin) return null;
 
   const brand = brandFromMaterial(material, meta.sourceUrl);
   const guideMd = brandGuideMd(brand);

--- a/apps/daemon/src/brands/prefetch.ts
+++ b/apps/daemon/src/brands/prefetch.ts
@@ -155,7 +155,7 @@ async function fetchBinary(
 const CHALLENGE_TITLE_RE =
   /just a moment|attention required|access denied|verifying you are human|checking your browser|security check|please verify|are you a robot|ddos[- ]guard|captcha/i;
 const CHALLENGE_BODY_RE =
-  /challenges\.cloudflare\.com|cf-browser-verification|_cf_chl_opt|cf-turnstile|this website uses a security service|enable javascript and cookies to continue|verify you are human|px-captcha|datadome|_incapsula_/i;
+  /challenges\.cloudflare\.com|cf-browser-verification|_cf_chl_opt|cf-turnstile|this website uses a security service|enable javascript and cookies to continue|verify you are human|px-captcha|datadome|_incapsula_|EO_Bot_Ssid|__tst_status/i;
 
 /** True when the HTML is a bot-protection interstitial (Cloudflare, DataDome,
  *  PerimeterX, …) rather than the real site. Harvesting one of these poisons

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -896,6 +896,12 @@ describe('agent-driven brand extraction engine', () => {
       expect(detail?.meta.designSystemId).toBeUndefined();
       const html = readFileSync(path.join(projectsRoot, result.projectId, 'brand.html'), 'utf8');
       expect(html).toContain('"status":"extracting"');
+
+      const project = getProject(db, result.projectId);
+      expect(project?.pendingPrompt ?? '').toContain('DESIGN SYSTEM EXTRACTION');
+      expect(project?.pendingPrompt ?? '').toContain('ready design system is NOT guaranteed yet');
+      expect(project?.pendingPrompt ?? '').not.toContain('DESIGN SYSTEM ENRICHMENT');
+      expect(project?.pendingPrompt ?? '').not.toContain('ALREADY been extracted programmatically');
     }
 
     const systems = await listDesignSystems(userDesignSystemsRoot, {

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -24,6 +24,7 @@ import {
   imageSize,
   type ImagerySlot,
 } from '../src/brands/imagery-fallback.js';
+import { isChallengePage } from '../src/brands/prefetch.js';
 
 // Real repo skills root so the bundled brand-kit template resolves.
 const SKILLS_ROOT = path.resolve(
@@ -833,6 +834,79 @@ describe('agent-driven brand extraction engine', () => {
 
     const html = readFileSync(path.join(projectsRoot, result.projectId, 'brand.html'), 'utf8');
     expect(html).toContain('"status":"extracting"');
+  });
+
+  it('does not finalize blocked or thin programmatic harvests as ready', async () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+
+    for (const [host, flags] of [
+      ['blocked.example', { blocked: true, thin: true }],
+      ['thin.example', { blocked: false, thin: true }],
+    ] as const) {
+      const result = await startBrandExtraction({
+        url: host,
+        brandsRoot,
+        projectsRoot,
+        skillsRoot: SKILLS_ROOT,
+        db,
+        userDesignSystemsRoot,
+        prefetch: async () => ({
+          url: `https://${host}/`,
+          finalUrl: `https://${host}/`,
+          siteName: 'Fallback',
+          title: '',
+          description: '',
+          colors: [
+            { hex: '#ffffff', count: 50, extreme: true },
+            { hex: '#111111', count: 30, extreme: true },
+          ],
+          fonts: [],
+          fontFaceFamilies: [],
+          googleFontsUrls: [],
+          fontFiles: [],
+          logos: [],
+          headings: [],
+          paragraphs: [],
+          navLabels: [],
+          extraPages: [],
+          screenshot: null,
+          materialMd: '',
+          ...flags,
+        }),
+        logoFallback: NO_LOGO_FALLBACK,
+        imageryFallback: NO_IMAGERY_FALLBACK,
+      });
+
+      const detail = readBrandDetail(brandsRoot, result.id);
+      expect(detail?.meta.status).toBe('extracting');
+      expect(detail?.meta.designSystemId).toBeUndefined();
+      const html = readFileSync(path.join(projectsRoot, result.projectId, 'brand.html'), 'utf8');
+      expect(html).toContain('"status":"extracting"');
+    }
+
+    const systems = await listDesignSystems(userDesignSystemsRoot, {
+      idPrefix: 'user:',
+      source: 'user',
+      isEditable: true,
+      defaultStatus: 'draft',
+    });
+    expect(systems).toHaveLength(0);
+  });
+
+  it('classifies EO_Bot_Ssid verification pages as anti-bot challenges', () => {
+    expect(isChallengePage(`
+      <!doctype html>
+      <html>
+        <head><title>旺旺集团</title></head>
+        <body>
+          <script>
+            document.cookie = "EO_Bot_Ssid=abc123";
+            window.__tst_status = "verify";
+            location.reload();
+          </script>
+        </body>
+      </html>
+    `)).toBe(true);
   });
 
   it('returns fast without blocking on a slow programmatic harvest, then finalizes in the background', async () => {

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -40,6 +40,20 @@ const NO_LOGO_FALLBACK = async () => ({ changed: false });
 // real fallback fetches the site's cover/hero images over the network).
 const NO_IMAGERY_FALLBACK = async () => ({ changed: false });
 
+// Injected palette/typography harvester that does nothing — keeps the engine
+// tests offline except for cases that explicitly stub a harvester behavior.
+const NO_SEED_FALLBACK = async () => ({ changed: false });
+
+function startOfflineBrandExtraction(
+  opts: Parameters<typeof startBrandExtraction>[0],
+): ReturnType<typeof startBrandExtraction> {
+  return startBrandExtraction({
+    seedFallback: NO_SEED_FALLBACK,
+    imageryFallback: NO_IMAGERY_FALLBACK,
+    ...opts,
+  });
+}
+
 /** Build a tiny but structurally-valid PNG buffer with the given dimensions so
  *  the imagery size gate decodes a real width/height (header-only). */
 function pngBuffer(width: number, height: number): Buffer {
@@ -98,7 +112,7 @@ describe('agent-driven brand extraction engine', () => {
   it('startBrandExtraction reserves the brand and seeds a live brand.html tab', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
 
-    const result = await startBrandExtraction({
+    const result = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -139,13 +153,13 @@ describe('agent-driven brand extraction engine', () => {
   it('rejects a non-http(s) URL', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
     await expect(
-      startBrandExtraction({ url: 'ftp://nope', brandsRoot, projectsRoot, skillsRoot: SKILLS_ROOT, db }),
+      startOfflineBrandExtraction({ url: 'ftp://nope', brandsRoot, projectsRoot, skillsRoot: SKILLS_ROOT, db }),
     ).rejects.toThrow(/valid http/i);
   });
 
   it('renderBrandPreviewIntoProject re-renders brand.html from a partial brand.json', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -183,7 +197,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('finalizeBrand registers the kit, marks it ready, and lights up the assets', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -236,7 +250,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('finalizeBrand is idempotent — re-finalizing reuses the brand design system', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -288,7 +302,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('finalizeBrand fails clearly when the agent has not written brand.json yet', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -311,7 +325,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('preview renders the imagery gallery + font tiles from imagery.samples', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -359,7 +373,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('preview falls back to a logo alternate when logo.primary is empty', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -409,7 +423,7 @@ describe('agent-driven brand extraction engine', () => {
       return { changed: true };
     };
 
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -427,7 +441,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('finalizeBrand adopts on-disk logo files when the agent left logo.primary empty', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -493,7 +507,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('preview adopts on-disk project logos so the live page is never logo-less', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -536,7 +550,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('finalizeBrand mirrors imagery/ and renders the gallery on the ready page', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -655,7 +669,7 @@ describe('agent-driven brand extraction engine', () => {
 
   it('finalizeBrand runs the imagery fallback when the agent saved no samples', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
-    const started = await startBrandExtraction({
+    const started = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -766,7 +780,7 @@ describe('agent-driven brand extraction engine', () => {
       };
     };
 
-    const result = await startBrandExtraction({
+    const result = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -816,7 +830,7 @@ describe('agent-driven brand extraction engine', () => {
 
     // Prefetch returns null (fully blocked / unreachable origin) → no design
     // system is built and the agent takes over from the scaffold.
-    const result = await startBrandExtraction({
+    const result = await startOfflineBrandExtraction({
       url: 'acme.com',
       brandsRoot,
       projectsRoot,
@@ -843,7 +857,7 @@ describe('agent-driven brand extraction engine', () => {
       ['blocked.example', { blocked: true, thin: true }],
       ['thin.example', { blocked: false, thin: true }],
     ] as const) {
-      const result = await startBrandExtraction({
+      const result = await startOfflineBrandExtraction({
         url: host,
         brandsRoot,
         projectsRoot,
@@ -955,7 +969,7 @@ describe('agent-driven brand extraction engine', () => {
 
     let background: Promise<unknown> | null = null;
     const startedAt = Date.now();
-    const result = await startBrandExtraction({
+    const result = await startOfflineBrandExtraction({
       url: 'slow.com',
       brandsRoot,
       projectsRoot,

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -1669,13 +1669,10 @@ export function DesignSystemDetailView({
                 );
               }
               const repairPrompt = audit ? buildDesignSystemPackageAuditRepairPrompt(audit) : null;
-              if (repairPrompt) {
-                setChatSeed({ id: `audit-${Date.now()}`, text: repairPrompt });
-              }
               if (auditSummary) {
                 setStatusLine(
                   repairPrompt
-                    ? `${auditSummary} The next repair prompt is ready in chat.`
+                    ? `${auditSummary} Review the audit details before running a repair.`
                     : `Workspace updated. ${auditSummary}`,
                 );
               } else {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2429,9 +2429,9 @@ export function ProjectView({
         );
         const repairPrompt = buildDesignSystemPackageAuditRepairPrompt(audit);
         if (repairPrompt) {
-          const seed = { id: `audit-${Date.now()}`, value: repairPrompt };
-          setChatSeed(seed);
           if (consumeDesignSystemAuditAutoRepair(project.id)) {
+            const seed = { id: `audit-${Date.now()}`, value: repairPrompt };
+            setChatSeed(seed);
             setAutoAuditRepairSeed(seed);
           }
         } else {

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -44,15 +44,18 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../../src/components/ChatPane', () => ({
   ChatPane: ({
     error,
+    initialDraft,
     onNewConversation,
     onSend,
   }: {
     error?: string | null;
+    initialDraft?: string;
     onNewConversation?: () => void;
     onSend: (prompt: string, attachments: unknown[], commentAttachments: unknown[]) => void;
   }) => (
     <>
       {error ? <div role="alert">{error}</div> : null}
+      {initialDraft ? <div data-testid="chat-initial-draft">{initialDraft}</div> : null}
       <button
         type="button"
         data-testid="new-conversation"
@@ -1957,6 +1960,93 @@ describe('DesignSystemCreationFlow', () => {
 });
 
 describe('DesignSystemDetailView', () => {
+  it('does not silently seed audit repair prompts into the composer after manual runs', async () => {
+    const system: DesignSystemDetail = {
+      id: 'user:acme-design-system',
+      title: 'Acme Design System',
+      category: 'Custom',
+      summary: 'Acme product workspace.',
+      swatches: [],
+      surface: 'web',
+      body: '# Acme Design System\n',
+      source: 'user',
+      status: 'draft',
+      isEditable: true,
+      projectId: 'ds-acme-design-system',
+    };
+    const project: Project = {
+      id: 'ds-acme-design-system',
+      name: 'Acme Design System',
+      skillId: null,
+      designSystemId: system.id,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: {
+        kind: 'other',
+        importedFrom: 'design-system',
+        entryFile: 'DESIGN.md',
+        sourceFileName: system.id,
+      },
+    };
+    const config: AppConfig = {
+      mode: 'daemon',
+      apiKey: '',
+      baseUrl: '',
+      model: '',
+      agentId: 'agent-1',
+      agentModels: {},
+      skillId: null,
+      designSystemId: null,
+    };
+
+    mocks.fetchDesignSystem.mockResolvedValue(system);
+    mocks.ensureDesignSystemWorkspace.mockResolvedValue({ project, files: [] });
+    mocks.listConversations.mockResolvedValue([
+      { id: 'conv-design-system', projectId: project.id, title: 'Design system', createdAt: 1, updatedAt: 1 },
+    ]);
+    mocks.fetchProjectDesignSystemPackageAudit.mockResolvedValue({
+      ok: false,
+      projectPath: '/tmp/ds',
+      filesInspected: 12,
+      errors: [{
+        severity: 'error',
+        code: 'missing_required_file',
+        message: 'README.md is missing.',
+        path: 'README.md',
+      }],
+      warnings: [],
+    });
+    mocks.streamViaDaemon.mockImplementation(async (options: {
+      handlers: { onDone: () => void };
+      onRunCreated?: (runId: string) => void;
+    }) => {
+      options.onRunCreated?.('run-design-system');
+      options.handlers.onDone();
+    });
+
+    render(
+      <DesignSystemDetailView
+        id={system.id}
+        selectedId={system.id}
+        config={config}
+        agents={[{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }]}
+        onBack={() => {}}
+        onSetDefault={() => {}}
+      />,
+    );
+
+    await screen.findByText('Acme Design System');
+    fireEvent.click(screen.getByTestId('design-system-chat-send'));
+
+    await waitFor(() => expect(mocks.fetchProjectDesignSystemPackageAudit).toHaveBeenCalledWith(project.id));
+    await waitFor(() =>
+      expect(screen.getAllByText(/Package audit found 1 error/).length).toBeGreaterThan(0),
+    );
+    expect(screen.queryByTestId('chat-initial-draft')?.textContent ?? '').not.toContain(
+      'Fix the design-system package audit findings below.',
+    );
+  });
+
   it('opens the Design Files workspace when the detail payload omits the optional source field', async () => {
     const system = {
       id: 'user:acme-design-system',

--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -66,6 +66,10 @@ async function openManualMemoryTab() {
   fireEvent.click(await screen.findByRole('tab', { name: 'Add manually' }));
 }
 
+async function openAdvancedMemoryModal() {
+  fireEvent.click(await screen.findByRole('button', { name: 'Advanced' }));
+}
+
 // The top-level "Memories" / "How it works" tabs render their label plus a
 // caption, so their accessible name is composite. Match by the leading label.
 const howItWorksTopTab = { name: /^How it works/ } as const;
@@ -203,7 +207,6 @@ describe('MemorySection', () => {
     await waitFor(() => {
       expect(screen.getByText('UI preferences')).toBeTruthy();
     });
-    expect(screen.getByText('✓ Memory created')).toBeTruthy();
     expect(createBodies).toEqual([
       {
         name: 'UI preferences',
@@ -290,9 +293,7 @@ describe('MemorySection', () => {
 
     renderMemorySection();
 
-    // The entry editor opened from a tree node renders inside the Add-manually
-    // sub-tab.
-    await openManualMemoryTab();
+    await openAdvancedMemoryModal();
     const treeSummary = await screen.findByText('Memory tree');
     const treeDetails = treeSummary.closest('details')!;
     expect(within(treeDetails).getByText('/project')).toBeTruthy();
@@ -378,6 +379,7 @@ describe('MemorySection', () => {
 
     renderMemorySection();
 
+    await openAdvancedMemoryModal();
     const treeDetails = (await screen.findByText('Memory tree')).closest('details')!;
     const childRow = within(treeDetails)
       .getByText('Design agent goal')
@@ -427,9 +429,7 @@ describe('MemorySection', () => {
 
     renderMemorySection();
 
-    // The "✓ Index saved" flash toast renders inside the Add-manually sub-tab,
-    // so open it before saving the index.
-    await openManualMemoryTab();
+    await openAdvancedMemoryModal();
     fireEvent.click(await screen.findByText('MEMORY.md (index)'));
     const indexArea = await findMemoryIndexTextarea();
     fireEvent.change(indexArea, {
@@ -440,9 +440,8 @@ describe('MemorySection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save index' }));
 
     await waitFor(() => {
-      expect(screen.getByText('✓ Index saved')).toBeTruthy();
+      expect(putBodies).toEqual(['# Memory\n\n- Existing bullet\n- New bullet\n']);
     });
-    expect(putBodies).toEqual(['# Memory\n\n- Existing bullet\n- New bullet\n']);
   });
 
   it('reveals the editor after editing an existing memory entry', async () => {
@@ -563,6 +562,7 @@ describe('MemorySection', () => {
     const savedRow = await screen.findByText('UI preferences');
     const extractionRow = await screen.findByText('Remember I prefer dark mode');
     await openAddMemories();
+    await openAdvancedMemoryModal();
     const indexSummary = screen.getByText('MEMORY.md (index)')
       .closest('summary') as HTMLElement;
 
@@ -572,7 +572,8 @@ describe('MemorySection', () => {
     expect(extractionRow.closest('.library-card')?.className).toContain(
       'memory-extraction-card',
     );
-    expect(indexSummary.closest('.memory-advanced-section')).toBeTruthy();
+    expect(indexSummary.closest('.memory-action-modal--advanced')).toBeTruthy();
+    expect(indexSummary.closest('.memory-advanced-card')).toBeTruthy();
     expect(indexSummary.closest('.memory-records-section')).toBeNull();
 	    expect(screen.queryByText('Extraction history')).toBeNull();
 	    expect(indexSummary.className).toContain('memory-details-summary');
@@ -1490,7 +1491,7 @@ describe('MemorySection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(screen.getByText('✓ Memory saved')).toBeTruthy();
+      expect(screen.getByText('Updated preference')).toBeTruthy();
     });
     expect(putBodies).toEqual([
       {
@@ -1501,7 +1502,6 @@ describe('MemorySection', () => {
         body: '- Prefer spacious layouts',
       },
     ]);
-    expect(screen.getByText('Updated preference')).toBeTruthy();
   });
 
   it('keeps the expanded preview control visually distinct from delete', async () => {
@@ -1706,6 +1706,7 @@ describe('MemorySection', () => {
 
     renderMemorySection();
 
+    await openAdvancedMemoryModal();
     fireEvent.click(await screen.findByText('MEMORY.md (index)'));
     const indexArea = await findMemoryIndexTextarea();
     fireEvent.change(indexArea, {

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -924,6 +924,93 @@ describe('ProjectView daemon cleanup', () => {
     )).toBe(true);
   });
 
+  it('does not seed audit repair prompt for manual design-system runs without auto-repair budget', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    fetchProjectDesignSystemPackageAudit.mockResolvedValue({
+      ok: false,
+      projectPath: '/tmp/ds',
+      filesInspected: 12,
+      errors: [{
+        severity: 'error',
+        code: 'ui_kit_index_missing_runtime_bootstrap',
+        message: 'ui_kits/app/index.html must mount the kit.',
+        path: 'ui_kits/app/index.html',
+      }],
+      warnings: [],
+    });
+    streamViaDaemon.mockImplementation(async (options: {
+      handlers: { onDone: () => void };
+      onRunCreated?: (runId: string) => void;
+    }) => {
+      options.onRunCreated?.('run-ds-manual');
+      options.handlers.onDone();
+    });
+
+    chatPaneSpy.mockClear();
+
+    render(
+      <ProjectView
+        project={{
+          id: 'project-ds-manual',
+          name: 'Manual Design System',
+          skillId: null,
+          designSystemId: 'user:manual-ds',
+          metadata: {
+            importedFrom: 'design-system',
+            entryFile: 'DESIGN.md',
+            sourceFileName: 'user:manual-ds',
+          },
+        } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    const chatProps = await waitForReadyChatPaneProps();
+    await chatProps.onSend!('Update the design system', [], []);
+
+    await waitFor(() => expect(fetchProjectDesignSystemPackageAudit).toHaveBeenCalledWith('project-ds-manual'));
+    await waitFor(() => {
+      expect(saveMessage.mock.calls.some((call) =>
+        call[2]?.role === 'assistant'
+        && call[2]?.events?.some((event: { kind?: string; label?: string; detail?: string }) =>
+          event.kind === 'status'
+          && event.label === 'audit'
+          && event.detail?.includes('Package audit found 1 error'),
+        ),
+      )).toBe(true);
+    });
+    expect(window.sessionStorage.getItem('od:design-system-audit-auto-repair:project-ds-manual')).toBeNull();
+    expect(chatPaneSpy.mock.calls.some(
+      (call) => typeof call[0]?.initialDraft === 'string'
+        && call[0].initialDraft.includes('Fix the design-system package audit findings below.'),
+    )).toBe(false);
+  });
+
   it('clears design-system auto-repair budget when the first audit passes', async () => {
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([]);

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -47,10 +47,10 @@ test('[P0] @critical onboarding lets AMR Cloud sign in and complete setup after 
   await expect
     .poll(() => page.evaluate(() => window.__amrOnboardingStatusCalls ?? 0))
     .toBeGreaterThanOrEqual(2);
-  // Login success lands on the About-you step; advance past it to the
-  // newsletter step, which is now the final step that hosts Finish setup.
+  // Login success lands on the About-you step; advance past newsletter to the
+  // final brand step that hosts Finish setup.
   await expect(page.getByRole('button', { name: /^Continue$/i })).toBeVisible({ timeout: 10_000 });
-  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await advanceFromAboutYouToBrand(page);
   await expect(page.getByRole('button', { name: /Finish setup/i })).toBeVisible({ timeout: 10_000 });
   await expectOnboardingFinished(page);
   await pollStoredConfig(page).toMatchObject({
@@ -119,10 +119,9 @@ test('[P0] onboarding recovers from a transient AMR status failure and still con
 
   await page.getByRole('button', { name: /sign in to continue/i }).click();
 
-  // Recovery lands on About you; step through to the newsletter step where
-  // Finish setup now lives.
+  // Recovery lands on About you; step through newsletter to the final brand step.
   await expect(page.getByRole('button', { name: /^Continue$/i })).toBeVisible({ timeout: 12_000 });
-  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await advanceFromAboutYouToBrand(page);
   await expect(page.getByRole('button', { name: /Finish setup/i })).toBeVisible({ timeout: 12_000 });
 });
 
@@ -253,7 +252,7 @@ test('[P0] @critical onboarding signed-in AMR path finishes setup with the selec
 
   await page.getByRole('button', { name: /^Continue$/i }).click();
   await expect(page.getByText(/Optional details for better defaults/i)).toBeVisible();
-  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await advanceFromAboutYouToBrand(page);
   await page.getByRole('button', { name: /Finish setup/i }).click();
 
   await expect(page).not.toHaveURL(/\/onboarding$/);
@@ -307,9 +306,8 @@ test('[P0] onboarding about-you step accepts profile selections and completes se
   await expect(expectOnboardingTrigger(page, 'Use case')).toContainText('Prototype / app UI');
   await expect(expectOnboardingTrigger(page, 'Where did you hear about us?')).toContainText('Search');
 
-  // About you is no longer the final step; advance to the newsletter step
-  // before finishing.
-  await page.getByRole('button', { name: /^Continue$/i }).click();
+  // About you is no longer the final step; advance through newsletter before finishing.
+  await advanceFromAboutYouToBrand(page);
   await page.getByRole('button', { name: /Finish setup/i }).click();
 
   await expectOnboardingFinished(page);
@@ -367,8 +365,8 @@ test('[P0] @critical onboarding BYOK path can fetch models, test the provider, a
 
   await page.getByRole('button', { name: /^Continue$/i }).click();
   await expect(page.getByText(/Optional details for better defaults/i)).toBeVisible();
-  // Advance from About you to the newsletter step, then finish.
-  await page.getByRole('button', { name: /^Continue$/i }).click();
+  // Advance from About you through newsletter to the brand step, then finish.
+  await advanceFromAboutYouToBrand(page);
   await page.getByRole('button', { name: /Finish setup/i }).click();
 
   await expectOnboardingFinished(page);
@@ -573,6 +571,13 @@ async function expectOnboardingFinished(page: Page) {
   }
   await expect(page).not.toHaveURL(/\/onboarding$/);
   await expect(page.getByText('What do you want to design?')).toBeVisible();
+}
+
+async function advanceFromAboutYouToBrand(page: Page) {
+  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await expect(page.getByRole('heading', { name: /Stay in the loop/i })).toBeVisible();
+  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await expect(page.getByRole('heading', { name: /Extract your design system/i })).toBeVisible();
 }
 
 function pollStoredConfig(page: Page) {


### PR DESCRIPTION
## Why

This PR fixes incomplete-state handling in the brand extraction flow on top of #4260.

The pain being addressed is state correctness: brand extraction can leave daemon and web surfaces in incomplete or stale states, which makes the two-loop extraction flow harder to reason about and can confuse cleanup/retry behavior.

## What users will see

Users exercising the #4260 brand extraction flow should see more consistent incomplete-state handling across extraction, prefetch, design-system flow UI, and project cleanup behavior.

## Surface area

- [x] **UI** — brand extraction/design-system flow state handling in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — incomplete extraction state handling changes in the #4260 flow
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. State-handling fix with focused daemon/web tests.

## Bug fix verification

Skipped. The branch includes focused regression coverage, but I did not rerun it locally while opening this PR.

## Validation

- Not run locally; PR opened from the existing branch for review.
