### PR TITLE
[codex] fix linux AppImage launcher startup

### DIFF
--- a/tools/pack/resources/linux/open-design.desktop.template
+++ b/tools/pack/resources/linux/open-design.desktop.template
@@ -3,7 +3,7 @@ Type=Application
 Name=Open Design (@@NAMESPACE@@)
 GenericName=Open Design
 Comment=Open Design packaged build (@@NAMESPACE@@)
-Exec=env OD_PACKAGED_NAMESPACE=@@NAMESPACE@@ @@EXEC_PATH@@ --appimage-extract-and-run %U
+Exec=env -u ELECTRON_RUN_AS_NODE OD_PACKAGED_NAMESPACE=@@NAMESPACE@@ @@EXEC_PATH@@ --appimage-extract-and-run %U
 Icon=@@ICON_PATH@@
 Categories=Development;Utility;
 StartupWMClass=Open Design

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -332,8 +332,16 @@ export function matchesAppImageProcess(
   // In both cases the AppImage runtime sets $APPIMAGE to the original install path.
   const isMountedRunner = /^\/tmp\/\.mount_[^/]+\/AppRun$/.test(snapshot.executable);
   const isExtractedRunner = /^\/tmp\/appimage_extracted_[^/]+\/[^/]+$/.test(snapshot.executable);
-  if (!isMountedRunner && !isExtractedRunner) return false;
-  return snapshot.env.APPIMAGE === installPath;
+  if ((isMountedRunner || isExtractedRunner) && snapshot.env.APPIMAGE === installPath) {
+    return true;
+  }
+
+  // Direct AppRun launches do not know the installed .AppImage path. Our AppRun
+  // fallback sets $APPIMAGE to the sibling AppRun before execing Electron.
+  return (
+    basename(snapshot.executable) === PRODUCT_NAME &&
+    snapshot.env.APPIMAGE === join(dirname(snapshot.executable), "AppRun")
+  );
 }
 
 // --- Step 1: LinuxPaths type and resolveLinuxPaths ---

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -982,6 +982,21 @@ function linuxDesktopStamp(config: ToolPackConfig): SidecarStamp {
   };
 }
 
+export function createLinuxDesktopLaunchEnv(
+  config: ToolPackConfig,
+  stamp: SidecarStamp,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env = createSidecarLaunchEnv({
+    base: join(config.roots.runtime.namespaceRoot, "runtime"),
+    contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+    extraEnv: { ...baseEnv, [DESKTOP_LOG_ECHO_ENV]: "0" },
+    stamp,
+  });
+  delete env.ELECTRON_RUN_AS_NODE;
+  return env;
+}
+
 async function waitForMarker(markerPath: string, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -1037,12 +1052,7 @@ export async function startPackedLinuxApp(config: ToolPackConfig): Promise<Linux
     args,
     command: appImagePath,
     cwd: dirname(appImagePath),
-    env: createSidecarLaunchEnv({
-      base: join(config.roots.runtime.namespaceRoot, "runtime"),
-      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
-      extraEnv: { ...process.env, [DESKTOP_LOG_ECHO_ENV]: "0" },
-      stamp,
-    }),
+    env: createLinuxDesktopLaunchEnv(config, stamp),
     logFd: null,
   });
 

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -264,6 +264,8 @@ export function renderLinuxPackagedMainEntry(): string {
   return 'import("@open-design/packaged").catch((error) => {\n  console.error("packaged entry failed", error);\n  process.exit(1);\n});\n';
 }
 
+export const LINUX_APPIMAGE_EXECUTABLE_ARGS = ["--"] as const;
+
 export type AppImageProcessSnapshot = {
   pid: number;
   executable: string;
@@ -576,6 +578,14 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
       category: "Development",
       synopsis: "Open Design",
       maintainer: "Open Design Contributors",
+    },
+    // electron-builder's AppImage target injects `--no-sandbox` when
+    // executableArgs is unset. AppImageLauncher copies that embedded Exec line
+    // into its generated desktop entry, which breaks when the launch environment
+    // includes ELECTRON_RUN_AS_NODE. A non-empty end-of-options marker suppresses
+    // the default while still letting electron-builder append its `%U` placeholder.
+    appImage: {
+      executableArgs: [...LINUX_APPIMAGE_EXECUTABLE_ARGS],
     },
     nodeGypRebuild: false,
     npmRebuild: false,

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -307,7 +307,7 @@ atexit()
 }
 
 if [ -z "$APPIMAGE" ] ; then
-  APPIMAGE="$APPDIR/AppRun"
+  export APPIMAGE="$APPDIR/AppRun"
   # not running from within an AppImage; hence using the AppRun for Exec=
 fi
 `;

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -260,6 +260,10 @@ export function renderDesktopTemplate(template: string, values: DesktopTemplateV
     .replace(/@@ICON_PATH@@/g, values.iconName);
 }
 
+export function renderLinuxPackagedMainEntry(): string {
+  return 'import("@open-design/packaged").catch((error) => {\n  console.error("packaged entry failed", error);\n  process.exit(1);\n});\n';
+}
+
 export type AppImageProcessSnapshot = {
   pid: number;
   executable: string;
@@ -505,8 +509,7 @@ async function writeAssembledApp(
   };
   await writeFile(paths.assembledPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
 
-  const mainStub = `"use strict";\n// Keep Electron's main process alive while the ESM packaged entry imports and\n// reaches app.whenReady(). Dynamic import alone is not a libuv handle.\nsetTimeout(() => {}, 60_000);\nimport("@open-design/packaged").catch((error) => {\n  console.error("packaged entry failed", error);\n  process.exit(1);\n});\n`;
-  await writeFile(paths.assembledMainEntryPath, mainStub, "utf8");
+  await writeFile(paths.assembledMainEntryPath, renderLinuxPackagedMainEntry(), "utf8");
 
   await writeFile(
     paths.packagedConfigPath,

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -264,7 +264,56 @@ export function renderLinuxPackagedMainEntry(): string {
   return 'import("@open-design/packaged").catch((error) => {\n  console.error("packaged entry failed", error);\n  process.exit(1);\n});\n';
 }
 
-export const LINUX_APPIMAGE_EXECUTABLE_ARGS = ["--"] as const;
+export function renderLinuxAppImageAppRun(): string {
+  return `#!/bin/bash
+set -e
+
+THIS="$0"
+args=("$@")
+NUMBER_OF_ARGS="$#"
+
+if [ -z "$APPDIR" ] ; then
+  path="$(dirname "$(readlink -f "\${THIS}")")"
+  while [[ "$path" != "" && ! -e "$path/AppRun" ]]; do
+    path=\${path%/*}
+  done
+  APPDIR="$path"
+fi
+
+export PATH="\${APPDIR}:\${APPDIR}/usr/sbin:\${PATH}"
+export XDG_DATA_DIRS="./share/:/usr/share/gnome:/usr/local/share/:/usr/share/:\${XDG_DATA_DIRS}"
+export LD_LIBRARY_PATH="\${APPDIR}/usr/lib:\${LD_LIBRARY_PATH}"
+export XDG_DATA_DIRS="\${APPDIR}"/usr/share/:"\${XDG_DATA_DIRS}":/usr/share/gnome/:/usr/local/share/:/usr/share/
+export GSETTINGS_SCHEMA_DIR="\${APPDIR}/usr/share/glib-2.0/schemas:\${GSETTINGS_SCHEMA_DIR}"
+
+BIN="$APPDIR/${PRODUCT_NAME}"
+
+if [ -z "$APPIMAGE_EXIT_AFTER_INSTALL" ] ; then
+  trap atexit EXIT
+fi
+
+isEulaAccepted=1
+
+atexit()
+{
+  if [ $isEulaAccepted == 1 ] ; then
+    unset ELECTRON_RUN_AS_NODE
+    if [ $NUMBER_OF_ARGS -eq 0 ] ; then
+      exec "$BIN"
+    else
+      exec "$BIN" "\${args[@]}"
+    fi
+  fi
+}
+
+if [ -z "$APPIMAGE" ] ; then
+  APPIMAGE="$APPDIR/AppRun"
+  # not running from within an AppImage; hence using the AppRun for Exec=
+fi
+`;
+}
+
+export const LINUX_APPIMAGE_EXECUTABLE_ARGS = ["--no-sandbox"] as const;
 
 export type AppImageProcessSnapshot = {
   pid: number;
@@ -292,6 +341,7 @@ export function matchesAppImageProcess(
 type LinuxPaths = {
   appBuilderConfigPath: string;
   appBuilderOutputRoot: string;
+  appImageAppRunPath: string;
   appImagePath: string;
   assembledAppRoot: string;
   assembledMainEntryPath: string;
@@ -323,6 +373,7 @@ function resolveLinuxPaths(config: ToolPackConfig): LinuxPaths {
   return {
     appBuilderConfigPath: join(namespaceRoot, "builder-config.json"),
     appBuilderOutputRoot,
+    appImageAppRunPath: join(namespaceRoot, "appimage", "AppRun"),
     appImagePath: "",
     assembledAppRoot: join(namespaceRoot, "assembled", "app"),
     assembledMainEntryPath: join(namespaceRoot, "assembled", "app", "main.cjs"),
@@ -535,6 +586,12 @@ async function writeAssembledApp(
   await runProductionInstall(paths.assembledAppRoot);
 }
 
+async function writeLinuxAppImageAppRun(paths: LinuxPaths): Promise<void> {
+  await mkdir(dirname(paths.appImageAppRunPath), { recursive: true });
+  await writeFile(paths.appImageAppRunPath, renderLinuxAppImageAppRun(), "utf8");
+  await chmod(paths.appImageAppRunPath, 0o755);
+}
+
 // --- Step 5: writeLinuxBuilderConfig helper ---
 
 async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths): Promise<void> {
@@ -570,6 +627,16 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
       { from: paths.resourceRoot, to: "open-design" },
       { from: paths.packagedConfigPath, to: "open-design-config.json" },
     ],
+    ...(config.to === "dir"
+      ? {}
+      : {
+          extraFiles: [
+            {
+              from: paths.appImageAppRunPath,
+              to: "AppRun",
+            },
+          ],
+        }),
     files: ["**/*", "!**/node_modules/.bin", "!**/node_modules/electron{,/**/*}"],
     icon: linuxResources.icon,
     linux: {
@@ -579,11 +646,9 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
       synopsis: "Open Design",
       maintainer: "Open Design Contributors",
     },
-    // electron-builder's AppImage target injects `--no-sandbox` when
-    // executableArgs is unset. AppImageLauncher copies that embedded Exec line
-    // into its generated desktop entry, which breaks when the launch environment
-    // includes ELECTRON_RUN_AS_NODE. A non-empty end-of-options marker suppresses
-    // the default while still letting electron-builder append its `%U` placeholder.
+    // Keep the AppImage launch fallback explicit. Our top-level AppRun wrapper
+    // clears ELECTRON_RUN_AS_NODE before these Chromium flags reach Electron,
+    // including for AppImageLauncher-generated desktop entries.
     appImage: {
       executableArgs: [...LINUX_APPIMAGE_EXECUTABLE_ARGS],
     },
@@ -655,6 +720,9 @@ export async function packLinux(config: ToolPackConfig): Promise<LinuxPackResult
   await copyResourceTree(config, paths);
   const tarballs = await collectWorkspaceTarballs(config, paths);
   await writeAssembledApp(config, paths, tarballs);
+  if (config.to !== "dir") {
+    await writeLinuxAppImageAppRun(paths);
+  }
   await writeLinuxBuilderConfig(config, paths);
   await runElectronBuilderLinux(config, paths);
 

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -505,7 +505,7 @@ async function writeAssembledApp(
   };
   await writeFile(paths.assembledPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
 
-  const mainStub = `"use strict";\nrequire("@open-design/packaged");\n`;
+  const mainStub = `"use strict";\n// Keep Electron's main process alive while the ESM packaged entry imports and\n// reaches app.whenReady(). Dynamic import alone is not a libuv handle.\nsetTimeout(() => {}, 60_000);\nimport("@open-design/packaged").catch((error) => {\n  console.error("packaged entry failed", error);\n  process.exit(1);\n});\n`;
   await writeFile(paths.assembledMainEntryPath, mainStub, "utf8");
 
   await writeFile(

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -33,6 +33,7 @@ import {
   LINUX_APPIMAGE_EXECUTABLE_ARGS,
   matchesAppImageProcess,
   renderDesktopTemplate,
+  renderLinuxAppImageAppRun,
   renderLinuxPackagedMainEntry,
   resolveLinuxLifecycleMode,
   resolveProductionInstallCommand,
@@ -626,8 +627,38 @@ describe("renderLinuxPackagedMainEntry", () => {
 });
 
 describe("LINUX_APPIMAGE_EXECUTABLE_ARGS", () => {
-  it("uses an end-of-options marker so electron-builder does not inject --no-sandbox", () => {
-    expect([...LINUX_APPIMAGE_EXECUTABLE_ARGS]).toEqual(["--"]);
+  it("keeps the AppImage no-sandbox fallback explicit for constrained Linux hosts", () => {
+    expect([...LINUX_APPIMAGE_EXECUTABLE_ARGS]).toEqual(["--no-sandbox"]);
+  });
+});
+
+describe("renderLinuxAppImageAppRun", () => {
+  it("unsets ELECTRON_RUN_AS_NODE before execing the Electron binary", () => {
+    const out = renderLinuxAppImageAppRun();
+
+    expect(out).toContain("unset ELECTRON_RUN_AS_NODE");
+    expect(out.indexOf("unset ELECTRON_RUN_AS_NODE")).toBeLessThan(out.indexOf('exec "$BIN"'));
+    expect(out).toContain('BIN="$APPDIR/Open Design"');
+  });
+
+  it("preserves AppImageLauncher install-only behavior", () => {
+    const out = renderLinuxAppImageAppRun();
+
+    expect(out).toContain('if [ -z "$APPIMAGE_EXIT_AFTER_INSTALL" ] ; then');
+    expect(out).toContain("trap atexit EXIT");
+  });
+
+  it("passes desktop Exec arguments through to Electron", () => {
+    const out = renderLinuxAppImageAppRun();
+
+    expect(out).toContain('args=("$@")');
+    expect(out).toContain('exec "$BIN" "${args[@]}"');
+  });
+
+  it("sets APPIMAGE when running an extracted AppRun directly", () => {
+    const out = renderLinuxAppImageAppRun();
+
+    expect(out).toContain('APPIMAGE="$APPDIR/AppRun"');
   });
 });
 

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -32,6 +32,7 @@ import {
   inspectPackedLinuxApp,
   matchesAppImageProcess,
   renderDesktopTemplate,
+  renderLinuxPackagedMainEntry,
   resolveLinuxLifecycleMode,
   resolveProductionInstallCommand,
   shouldRejectLinuxHeadlessInspectOptions,
@@ -610,6 +611,16 @@ MimeType=x-scheme-handler/od;
       iconName: "open-design-ns",
     });
     expect(out).toContain("MimeType=x-scheme-handler/od;");
+  });
+});
+
+describe("renderLinuxPackagedMainEntry", () => {
+  it("loads the ESM packaged entry without require or temporary keepalive handles", () => {
+    const out = renderLinuxPackagedMainEntry();
+
+    expect(out).toContain('import("@open-design/packaged")');
+    expect(out).not.toContain('require("@open-design/packaged")');
+    expect(out).not.toContain("setTimeout");
   });
 });
 

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { access, chmod, copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { posix } from "node:path";
@@ -771,6 +771,50 @@ describe("renderLinuxAppImageAppRun", () => {
     const out = renderLinuxAppImageAppRun();
 
     expect(out).toContain('APPIMAGE="$APPDIR/AppRun"');
+  });
+
+  linuxOnlyIt("exports APPIMAGE fallback to the execed Electron process", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-linux-apprun-export-"));
+    const appDir = join(root, "AppDir");
+    const appRunPath = join(appDir, "AppRun");
+    const observedEnvPath = join(root, "observed-env.txt");
+    const electronPath = join(appDir, "Open Design");
+
+    try {
+      await mkdir(appDir, { recursive: true });
+      await writeFile(appRunPath, renderLinuxAppImageAppRun(), "utf8");
+      await chmod(appRunPath, 0o755);
+      await writeFile(
+        electronPath,
+        `#!/bin/bash
+{
+  printf 'APPIMAGE=%s\\n' "$APPIMAGE"
+  printf 'ELECTRON_RUN_AS_NODE=%s\\n' "\${ELECTRON_RUN_AS_NODE-unset}"
+} > ${JSON.stringify(observedEnvPath)}
+`,
+        "utf8",
+      );
+      await chmod(electronPath, 0o755);
+
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        APPDIR: appDir,
+        ELECTRON_RUN_AS_NODE: "1",
+      };
+      delete env.APPIMAGE;
+      const child = spawn(appRunPath, [], { env, stdio: "ignore" });
+      const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("exit", (code, signal) => resolve({ code, signal }));
+      });
+
+      expect(exit).toEqual({ code: 0, signal: null });
+      expect(await readFile(observedEnvPath, "utf8")).toBe(
+        `APPIMAGE=${appRunPath}\nELECTRON_RUN_AS_NODE=unset\n`,
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
   });
 });
 

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -1,5 +1,6 @@
+import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, chmod, copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { posix } from "node:path";
@@ -38,6 +39,7 @@ import {
   resolveLinuxLifecycleMode,
   resolveProductionInstallCommand,
   shouldRejectLinuxHeadlessInspectOptions,
+  stopPackedLinuxApp,
   sanitizeNamespace,
   stopPackedLinuxHeadless,
 } from "../src/linux.js";
@@ -86,6 +88,19 @@ function makeConfig(): ToolPackConfig {
     webOutputMode: "server",
     workspaceRoot: "/work",
   };
+}
+
+const linuxOnlyIt = process.platform === "linux" ? it : it.skip;
+
+async function waitForChildExit(child: ChildProcess, timeoutMs = 5000): Promise<void> {
+  if (child.exitCode != null || child.signalCode != null) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
 }
 
 describe("buildDockerArgs", () => {
@@ -502,6 +517,103 @@ describe("stopPackedLinuxHeadless", () => {
   });
 });
 
+describe("stopPackedLinuxApp", () => {
+  linuxOnlyIt("treats a direct AppRun-launched Electron process as owned", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-linux-direct-apprun-"));
+    const namespace = "direct-apprun";
+    const outputNamespaceRoot = join(root, "out", "linux", "namespaces", namespace);
+    const runtimeNamespaceBaseRoot = join(root, "runtime", "linux", "namespaces");
+    const runtimeNamespaceRoot = join(runtimeNamespaceBaseRoot, namespace);
+    const config: ToolPackConfig = {
+      ...makeConfig(),
+      namespace,
+      roots: {
+        ...makeConfig().roots,
+        output: {
+          ...makeConfig().roots.output,
+          appBuilderRoot: join(outputNamespaceRoot, "builder"),
+          namespaceRoot: outputNamespaceRoot,
+        },
+        runtime: {
+          namespaceBaseRoot: runtimeNamespaceBaseRoot,
+          namespaceRoot: runtimeNamespaceRoot,
+        },
+      },
+    };
+    const appDir = join(root, "AppDir");
+    const executablePath = join(appDir, "Open Design");
+    const appRunPath = join(appDir, "AppRun");
+    const markerPath = join(runtimeNamespaceRoot, "runtime", "desktop-root.json");
+    const stamp = {
+      app: APP_KEYS.DESKTOP,
+      ipc: resolveAppIpcPath({
+        app: APP_KEYS.DESKTOP,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        namespace,
+      }),
+      mode: SIDECAR_MODES.RUNTIME,
+      namespace,
+      source: SIDECAR_SOURCES.PACKAGED,
+    };
+    let child: ChildProcess | null = null;
+
+    try {
+      await mkdir(appDir, { recursive: true });
+      await copyFile(process.execPath, executablePath);
+      await chmod(executablePath, 0o755);
+      await writeFile(appRunPath, "#!/bin/sh\n", "utf8");
+      await mkdir(config.roots.output.appBuilderRoot, { recursive: true });
+      await writeFile(join(config.roots.output.appBuilderRoot, "Open-Design.direct-apprun.AppImage"), "", "utf8");
+
+      child = spawn(executablePath, ["-e", "setInterval(() => {}, 1000)"], {
+        env: { ...process.env, APPIMAGE: appRunPath },
+        stdio: "ignore",
+      });
+      await new Promise<void>((resolve, reject) => {
+        child?.once("spawn", resolve);
+        child?.once("error", reject);
+      });
+      expect(child.pid).toEqual(expect.any(Number));
+      await access(`/proc/${child.pid}/exe`);
+
+      await mkdir(dirname(markerPath), { recursive: true });
+      await writeFile(
+        markerPath,
+        `${JSON.stringify({
+          appPath: "/",
+          executablePath,
+          logPath: join(runtimeNamespaceRoot, "logs", "desktop", "latest.log"),
+          namespaceRoot: runtimeNamespaceRoot,
+          pid: child.pid,
+          ppid: process.pid,
+          stamp,
+          startedAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+          version: 1,
+        })}\n`,
+        "utf8",
+      );
+
+      vi.mocked(requestJsonIpc).mockRejectedValue(new Error("shutdown unavailable in test"));
+      const result = await stopPackedLinuxApp(config);
+
+      expect(result.status).toBe("stopped");
+      expect(result.stoppedPids).toContain(child.pid);
+      expect(result.remainingPids).toEqual([]);
+    } finally {
+      if (child?.pid != null && child.exitCode == null && child.signalCode == null) {
+        try {
+          process.kill(child.pid, "SIGKILL");
+        } catch {
+          // Already gone.
+        }
+        await waitForChildExit(child, 1000);
+      }
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
 describe("resolveProductionInstallCommand", () => {
   it("defaults to npm install --omit=dev --no-package-lock when OD_TOOLS_PACK_PNPM_BIN is unset", () => {
     expect(resolveProductionInstallCommand({})).toEqual({
@@ -801,6 +913,30 @@ describe("matchesAppImageProcess", () => {
   it("rejects extracted-mode when APPIMAGE env is missing", () => {
     const ok = matchesAppImageProcess(
       { pid: 1234, executable: "/tmp/.mount_abc123/AppRun", env: {} },
+      installPath,
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("matches direct AppRun fallback when APPIMAGE points to the sibling AppRun", () => {
+    const ok = matchesAppImageProcess(
+      {
+        pid: 1234,
+        executable: "/tmp/appimage_extracted_fe548e54/Open Design",
+        env: { APPIMAGE: "/tmp/appimage_extracted_fe548e54/AppRun" },
+      },
+      installPath,
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("rejects direct AppRun fallback when APPIMAGE points outside the executable directory", () => {
+    const ok = matchesAppImageProcess(
+      {
+        pid: 1234,
+        executable: "/tmp/appimage_extracted_fe548e54/Open Design",
+        env: { APPIMAGE: "/tmp/other/AppRun" },
+      },
       installPath,
     );
     expect(ok).toBe(false);

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -28,6 +28,7 @@ import type { ToolPackConfig } from "../src/config.js";
 import {
   buildDockerArgs,
   cleanupPackedLinuxNamespace,
+  createLinuxDesktopLaunchEnv,
   inspectPackedLinuxApp,
   matchesAppImageProcess,
   renderDesktopTemplate,
@@ -609,6 +610,30 @@ MimeType=x-scheme-handler/od;
       iconName: "open-design-ns",
     });
     expect(out).toContain("MimeType=x-scheme-handler/od;");
+  });
+});
+
+describe("createLinuxDesktopLaunchEnv", () => {
+  it("strips ELECTRON_RUN_AS_NODE before spawning the Electron AppImage", () => {
+    const config = makeConfig();
+    const stamp = {
+      app: APP_KEYS.DESKTOP,
+      ipc: "/tmp/open-design/ipc/default/desktop.sock",
+      mode: SIDECAR_MODES.RUNTIME,
+      namespace: "default",
+      source: SIDECAR_SOURCES.TOOLS_PACK,
+    };
+
+    const env = createLinuxDesktopLaunchEnv(config, stamp, {
+      ELECTRON_RUN_AS_NODE: "1",
+      KEEP_ME: "yes",
+    });
+
+    expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    expect(env.KEEP_ME).toBe("yes");
+    expect(env.OD_SIDECAR_BASE).toBe(
+      "/work/.tmp/tools-pack/runtime/linux/namespaces/default/runtime",
+    );
   });
 });
 

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -547,7 +547,7 @@ describe("renderDesktopTemplate", () => {
   const template = `[Desktop Entry]
 Type=Application
 Name=Open Design (@@NAMESPACE@@)
-Exec=env OD_PACKAGED_NAMESPACE=@@NAMESPACE@@ @@EXEC_PATH@@ --appimage-extract-and-run %U
+Exec=env -u ELECTRON_RUN_AS_NODE OD_PACKAGED_NAMESPACE=@@NAMESPACE@@ @@EXEC_PATH@@ --appimage-extract-and-run %U
 Icon=@@ICON_PATH@@
 MimeType=x-scheme-handler/od;
 `;
@@ -560,7 +560,7 @@ MimeType=x-scheme-handler/od;
     });
     expect(out).toContain("Name=Open Design (default)");
     expect(out).toContain(
-      "Exec=env OD_PACKAGED_NAMESPACE=default /home/u/.local/bin/Open-Design.default.AppImage --appimage-extract-and-run %U",
+      "Exec=env -u ELECTRON_RUN_AS_NODE OD_PACKAGED_NAMESPACE=default /home/u/.local/bin/Open-Design.default.AppImage --appimage-extract-and-run %U",
     );
     expect(out).toContain("Icon=open-design-default");
   });
@@ -571,8 +571,17 @@ MimeType=x-scheme-handler/od;
       execPath: "/x",
       iconName: "open-design-ns",
     });
-    expect(out).toMatch(/^Exec=env OD_PACKAGED_NAMESPACE=ns /m);
+    expect(out).toMatch(/^Exec=env -u ELECTRON_RUN_AS_NODE OD_PACKAGED_NAMESPACE=ns /m);
     expect(out).not.toMatch(/OD_NAMESPACE=/);
+  });
+
+  it("unsets ELECTRON_RUN_AS_NODE on the Exec= line so desktop launches run Electron normally", () => {
+    const out = renderDesktopTemplate(template, {
+      namespace: "ns",
+      execPath: "/x",
+      iconName: "open-design-ns",
+    });
+    expect(out).toMatch(/^Exec=env -u ELECTRON_RUN_AS_NODE /m);
   });
 
   it("preserves --appimage-extract-and-run on the Exec= line so menu launches bypass FUSE", () => {

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -30,6 +30,7 @@ import {
   cleanupPackedLinuxNamespace,
   createLinuxDesktopLaunchEnv,
   inspectPackedLinuxApp,
+  LINUX_APPIMAGE_EXECUTABLE_ARGS,
   matchesAppImageProcess,
   renderDesktopTemplate,
   renderLinuxPackagedMainEntry,
@@ -621,6 +622,12 @@ describe("renderLinuxPackagedMainEntry", () => {
     expect(out).toContain('import("@open-design/packaged")');
     expect(out).not.toContain('require("@open-design/packaged")');
     expect(out).not.toContain("setTimeout");
+  });
+});
+
+describe("LINUX_APPIMAGE_EXECUTABLE_ARGS", () => {
+  it("uses an end-of-options marker so electron-builder does not inject --no-sandbox", () => {
+    expect([...LINUX_APPIMAGE_EXECUTABLE_ARGS]).toEqual(["--"]);
   });
 });
 


### PR DESCRIPTION
## Why

Linux AppImage launches can inherit `ELECTRON_RUN_AS_NODE=1` from Electron-based shells, which makes the Electron binary behave like Node instead of starting the desktop app. The generated AppImage entry also tried to `require()` an ESM-only package, which fails during packaged startup.

This follow-up also keeps tools-pack lifecycle ownership intact for direct `$APPDIR/AppRun` launches: when `$APPIMAGE` is missing, the wrapper exports `APPIMAGE=$APPDIR/AppRun`, and `tools-pack linux stop` / `uninstall` must still recognize the running desktop process as ours.

## What users will see

Linux AppImage desktop/menu launches start the packaged Open Design app normally instead of starting as Node. Direct `AppRun` launches remain manageable by `tools-pack linux stop`, `uninstall`, and cleanup.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — packaging/lifecycle-only fix.

## Bug fix verification

- Test path that reproduces the lifecycle bug: `tools/pack/tests/linux.test.ts`
- Before: AppImage launches could inherit `ELECTRON_RUN_AS_NODE=1` and start as Node; direct `$APPDIR/AppRun` launches set `APPIMAGE=$APPDIR/AppRun` only as a shell-local variable, so the execed Electron process could still miss `APPIMAGE` and be misclassified as unmanaged by lifecycle validation.
- Now: the AppRun wrapper unsets `ELECTRON_RUN_AS_NODE` before exec and exports `APPIMAGE=$APPDIR/AppRun`; IPC verification reports `state: running`; and the direct-AppRun regression tests verify both the wrapper-exported child environment and `stopPackedLinuxApp()` ownership.
- Red/green: not rerun on `main` during this takeover pass; this branch adds regression coverage for the reviewer-flagged lifecycle shapes.

## Validation

- `git diff --check`
- `pnpm --filter @open-design/tools-pack test -- tests/linux.test.ts`
- `pnpm --filter @open-design/tools-pack build`
- built Linux AppImage under Node 24.14.1
- relaunched the integrated AppImage locally and verified desktop IPC reports `state: running`, `title: Open Design`, `url: od://app/`
- `pnpm -C tools/pack test linux.test.ts` (this takeover pass; passed 61 tests, with local Node engine warning for v26 vs expected ~24)

## Follow-up

- #4642 fixes the develop-menu shortcut dialog observed during Linux AppImage testing. On affected sessions, startup paused until the user dismissed `Develop menu shortcut unavailable`, even though the app could continue normally.
