### PR TITLE
fix(daemon): classify completed Claude startup output before exit 1

### DIFF
--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -489,7 +489,10 @@ export function createClaudeStreamHandler(
         usage: obj.usage ?? null,
         costUsd: obj.total_cost_usd ?? null,
         durationMs: obj.duration_ms ?? null,
-        stopReason: obj.stop_reason ?? null,
+        stopReason:
+          (typeof obj.stop_reason === 'string' && obj.stop_reason) ||
+          (typeof obj.terminal_reason === 'string' && obj.terminal_reason) ||
+          null,
       });
       return;
     }

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2256,11 +2256,11 @@ async function testAgentConnectionInternal(
         );
       const claudeCompletedTurn =
         input.agentId === 'claude' &&
-        !claudeResult?.isError &&
+        !!claudeResult &&
+        !claudeResult.isError &&
         (
           sink.sawTerminalCompletion() ||
           (
-            !!claudeResult &&
             isTerminalCompletionStopReason(claudeResult.stopReason)
           )
         );

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1522,14 +1522,53 @@ interface AgentSink {
   getText: () => string;
   getStderrTail: () => string;
   appendRawStdout: (chunk: string) => void;
+  getRawStdout: () => string;
   getRawStdoutTail: () => string;
+  sawTerminalCompletion: () => boolean;
   dispose: () => void;
+}
+
+function isTerminalCompletionStopReason(value: unknown): boolean {
+  return typeof value === 'string' && value.length > 0 && value !== 'tool_use';
+}
+
+function parseClaudeResultFrame(stdout: string): {
+  resultText: string;
+  stopReason: string | null;
+  isError: boolean;
+} | null {
+  let parsed: {
+    resultText: string;
+    stopReason: string | null;
+    isError: boolean;
+  } | null = null;
+  for (const line of stdout.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed) as Record<string, unknown>;
+      if (obj.type !== 'result') continue;
+      parsed = {
+        resultText: typeof obj.result === 'string' ? obj.result.trim() : '',
+        stopReason:
+          (typeof obj.stop_reason === 'string' && obj.stop_reason) ||
+          (typeof obj.terminal_reason === 'string' && obj.terminal_reason) ||
+          null,
+        isError: Boolean(obj.is_error),
+      };
+    } catch {
+      // Non-JSON stdout falls back to the normal diagnostic path.
+    }
+  }
+  return parsed;
 }
 
 export function createAgentSink(): AgentSink {
   let buffer = '';
   let stderrTail = '';
+  let rawStdout = '';
   let rawStdoutTail = '';
+  let terminalCompletionSeen = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let resolveResult!: (value: AgentSinkResult) => void;
   let resolveStreamError!: (value: Error) => void;
@@ -1576,6 +1615,7 @@ export function createAgentSink(): AgentSink {
 
   const appendRawStdout = (chunk: string) => {
     if (typeof chunk === 'string' && chunk.length > 0) {
+      rawStdout = (rawStdout + chunk).slice(-16_384);
       rawStdoutTail = (rawStdoutTail + chunk).slice(-400);
     }
   };
@@ -1606,6 +1646,11 @@ export function createAgentSink(): AgentSink {
         consumeText(delta);
       } else if (type === 'text' && typeof text === 'string') {
         consumeText(text);
+      } else if (
+        (type === 'turn_end' || type === 'usage') &&
+        isTerminalCompletionStopReason(data.stopReason)
+      ) {
+        terminalCompletionSeen = true;
       }
       return;
     }
@@ -1635,7 +1680,9 @@ export function createAgentSink(): AgentSink {
     getText: () => buffer,
     getStderrTail: () => stderrTail,
     appendRawStdout,
+    getRawStdout: () => rawStdout,
     getRawStdoutTail: () => rawStdoutTail,
+    sawTerminalCompletion: () => terminalCompletionSeen,
     dispose: () => {
       if (debounceTimer) {
         clearTimeout(debounceTimer);
@@ -2179,6 +2226,12 @@ async function testAgentConnectionInternal(
       await delay(AGENT_STDOUT_DRAIN_MS);
       const latencyMs = Date.now() - start;
       const buffered = sink.getText().trim();
+      const claudeResult = input.agentId === 'claude'
+        ? parseClaudeResultFrame(sink.getRawStdout())
+        : null;
+      const parsedClaudeResultText =
+        claudeResult && !claudeResult.isError ? claudeResult.resultText.trim() : '';
+      const visibleText = buffered || parsedClaudeResultText;
       // ACP agents that don't shut down on stdin.end() are terminated after a
       // clean prompt completion. Depending on the ACP bridge, this can surface
       // either as SIGTERM or as a normal code 130 teardown. For those exact
@@ -2201,15 +2254,25 @@ async function testAgentConnectionInternal(
           (winner.code === null && winner.signal === 'SIGTERM') ||
           (winner.code === 130 && winner.signal === null)
         );
+      const claudeCompletedTurn =
+        input.agentId === 'claude' &&
+        (
+          sink.sawTerminalCompletion() ||
+          (
+            !!claudeResult &&
+            !claudeResult.isError &&
+            isTerminalCompletionStopReason(claudeResult.stopReason)
+          )
+        );
       const exitedCleanly =
-        (winner.code === 0 && !winner.signal) || acpForcedShutdown;
-      if (buffered) {
-        const rawSample = truncateSample(buffered);
+        (winner.code === 0 && !winner.signal) || acpForcedShutdown || claudeCompletedTurn;
+      if (visibleText) {
+        const rawSample = truncateSample(visibleText);
         const exitInfo = { code: winner.code, signal: winner.signal };
         if (rawSample && isLikelyModelErrorText(rawSample)) {
-          return resultFromAgentText(buffered, exitInfo);
+          return resultFromAgentText(visibleText, exitInfo);
         }
-        if (exitedCleanly) return resultFromAgentText(buffered, exitInfo);
+        if (exitedCleanly) return resultFromAgentText(visibleText, exitInfo);
       }
       const stderrTail = sink.getStderrTail().trim();
       const rawStdoutTail = sink.getRawStdoutTail().trim();
@@ -2276,7 +2339,7 @@ async function testAgentConnectionInternal(
         exitCode: winner.code,
         signal: winner.signal,
         stderrTail,
-        stdoutTail: rawStdoutTail || buffered,
+        stdoutTail: sink.getRawStdout() || rawStdoutTail || visibleText,
         env,
         resolvedBin: executableResolution.selectedPath,
       });

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1536,11 +1536,13 @@ function parseClaudeResultFrame(stdout: string): {
   resultText: string;
   stopReason: string | null;
   isError: boolean;
+  subtype: string | null;
 } | null {
   let parsed: {
     resultText: string;
     stopReason: string | null;
     isError: boolean;
+    subtype: string | null;
   } | null = null;
   for (const line of stdout.split(/\r?\n/u)) {
     const trimmed = line.trim();
@@ -1555,6 +1557,7 @@ function parseClaudeResultFrame(stdout: string): {
           (typeof obj.terminal_reason === 'string' && obj.terminal_reason) ||
           null,
         isError: Boolean(obj.is_error),
+        subtype: typeof obj.subtype === 'string' ? obj.subtype : null,
       };
     } catch {
       // Non-JSON stdout falls back to the normal diagnostic path.
@@ -2229,8 +2232,12 @@ async function testAgentConnectionInternal(
       const claudeResult = input.agentId === 'claude'
         ? parseClaudeResultFrame(sink.getRawStdout())
         : null;
+      const claudeReportedSuccess =
+        !!claudeResult &&
+        !claudeResult.isError &&
+        claudeResult.subtype === 'success';
       const parsedClaudeResultText =
-        claudeResult && !claudeResult.isError ? claudeResult.resultText.trim() : '';
+        claudeReportedSuccess ? claudeResult.resultText.trim() : '';
       const visibleText = buffered || parsedClaudeResultText;
       // ACP agents that don't shut down on stdin.end() are terminated after a
       // clean prompt completion. Depending on the ACP bridge, this can surface
@@ -2256,8 +2263,7 @@ async function testAgentConnectionInternal(
         );
       const claudeCompletedTurn =
         input.agentId === 'claude' &&
-        !!claudeResult &&
-        !claudeResult.isError &&
+        claudeReportedSuccess &&
         (
           sink.sawTerminalCompletion() ||
           (

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2256,11 +2256,11 @@ async function testAgentConnectionInternal(
         );
       const claudeCompletedTurn =
         input.agentId === 'claude' &&
+        !claudeResult?.isError &&
         (
           sink.sawTerminalCompletion() ||
           (
             !!claudeResult &&
-            !claudeResult.isError &&
             isTerminalCompletionStopReason(claudeResult.stopReason)
           )
         );

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2236,6 +2236,10 @@ async function testAgentConnectionInternal(
         !!claudeResult &&
         !claudeResult.isError &&
         claudeResult.subtype === 'success';
+      const claudeLateExitOne =
+        input.agentId === 'claude' &&
+        winner.code === 1 &&
+        winner.signal === null;
       const parsedClaudeResultText =
         claudeReportedSuccess ? claudeResult.resultText.trim() : '';
       const visibleText = buffered || parsedClaudeResultText;
@@ -2262,7 +2266,7 @@ async function testAgentConnectionInternal(
           (winner.code === 130 && winner.signal === null)
         );
       const claudeCompletedTurn =
-        input.agentId === 'claude' &&
+        claudeLateExitOne &&
         claudeReportedSuccess &&
         (
           sink.sawTerminalCompletion() ||

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2523,6 +2523,33 @@ process.exit(1);
     );
   });
 
+  it('rejects Claude smoke tests when assistant end_turn is followed by exit 1 without a result frame', async () => {
+    await withFakeClaude(
+      `
+console.log(JSON.stringify({
+  type: 'assistant',
+  message: {
+    id: 'msg_1',
+    content: [{ type: 'text', text: 'ok' }],
+    stop_reason: 'end_turn',
+  },
+}));
+process.exit(1);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Claude Code',
+        });
+        expect(result.diagnostics?.phase).toBe('spawn');
+        expect(result.diagnostics?.exitCode).toBe(1);
+      },
+    );
+  });
+
   it('rejects Claude smoke tests when the result frame reports an error before a late exit 1', async () => {
     await withFakeClaude(
       `

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2523,6 +2523,41 @@ process.exit(1);
     );
   });
 
+  it('rejects Claude smoke tests when the result frame reports an error before a late exit 1', async () => {
+    await withFakeClaude(
+      `
+console.log(JSON.stringify({
+  type: 'assistant',
+  message: {
+    id: 'msg_1',
+    content: [{ type: 'text', text: 'ok' }],
+    stop_reason: 'end_turn',
+  },
+}));
+console.log(JSON.stringify({
+  type: 'result',
+  subtype: 'error_during_execution',
+  is_error: true,
+  result: 'tool failed',
+  terminal_reason: 'completed',
+  duration_ms: 17,
+}));
+process.exit(1);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Claude Code',
+        });
+        expect(result.diagnostics?.phase).toBe('spawn');
+        expect(result.diagnostics?.exitCode).toBe(1);
+      },
+    );
+  });
+
   it('preserves ANTHROPIC_API_KEY when Claude adapter launches the OpenClaude fallback', async () => {
     const envFile = path.join(os.tmpdir(), `od-openclaude-env-${Date.now()}-${Math.random()}.json`);
     const previousKey = process.env.ANTHROPIC_API_KEY;

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2487,6 +2487,42 @@ process.stdin.on('end', () => {
     );
   });
 
+  it('accepts Claude smoke tests that completed cleanly before a late exit 1', async () => {
+    await withFakeClaude(
+      `
+console.log(JSON.stringify({
+  type: 'assistant',
+  message: {
+    id: 'msg_1',
+    content: [{ type: 'text', text: 'ok' }],
+    stop_reason: 'end_turn',
+  },
+}));
+console.log(JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  result: 'ok',
+  terminal_reason: 'completed',
+  duration_ms: 17,
+}));
+process.exit(1);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({
+          ok: true,
+          kind: 'success',
+          agentName: 'Claude Code',
+          sample: 'ok',
+        });
+        expect(result.diagnostics?.phase).toBe('connection_smoke_test');
+        expect(result.diagnostics?.exitCode).toBe(1);
+      },
+    );
+  });
+
   it('preserves ANTHROPIC_API_KEY when Claude adapter launches the OpenClaude fallback', async () => {
     const envFile = path.join(os.tmpdir(), `od-openclaude-env-${Date.now()}-${Math.random()}.json`);
     const previousKey = process.env.ANTHROPIC_API_KEY;

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2544,7 +2544,7 @@ process.exit(1);
           kind: 'agent_spawn_failed',
           agentName: 'Claude Code',
         });
-        expect(result.diagnostics?.phase).toBe('spawn');
+        expect(result.diagnostics?.phase).toBe('output_parse');
         expect(result.diagnostics?.exitCode).toBe(1);
       },
     );
@@ -2579,7 +2579,41 @@ process.exit(1);
           kind: 'agent_spawn_failed',
           agentName: 'Claude Code',
         });
-        expect(result.diagnostics?.phase).toBe('spawn');
+        expect(result.diagnostics?.phase).toBe('output_parse');
+        expect(result.diagnostics?.exitCode).toBe(1);
+      },
+    );
+  });
+
+  it('rejects Claude smoke tests when the result subtype reports an execution error before a late exit 1', async () => {
+    await withFakeClaude(
+      `
+console.log(JSON.stringify({
+  type: 'assistant',
+  message: {
+    id: 'msg_1',
+    content: [{ type: 'text', text: 'ok' }],
+    stop_reason: 'end_turn',
+  },
+}));
+console.log(JSON.stringify({
+  type: 'result',
+  subtype: 'error_during_execution',
+  result: 'tool failed',
+  terminal_reason: 'completed',
+  duration_ms: 17,
+}));
+process.exit(1);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Claude Code',
+        });
+        expect(result.diagnostics?.phase).toBe('output_parse');
         expect(result.diagnostics?.exitCode).toBe(1);
       },
     );

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2523,6 +2523,41 @@ process.exit(1);
     );
   });
 
+  it('rejects Claude smoke tests when a successful result is followed by a different termination', async () => {
+    await withFakeClaude(
+      `
+console.log(JSON.stringify({
+  type: 'assistant',
+  message: {
+    id: 'msg_1',
+    content: [{ type: 'text', text: 'ok' }],
+    stop_reason: 'end_turn',
+  },
+}));
+console.log(JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  result: 'ok',
+  terminal_reason: 'completed',
+  duration_ms: 17,
+}));
+process.exit(137);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Claude Code',
+        });
+        expect(result.diagnostics?.phase).toBe('output_parse');
+        expect(result.diagnostics?.exitCode).toBe(137);
+      },
+    );
+  });
+
   it('rejects Claude smoke tests when assistant end_turn is followed by exit 1 without a result frame', async () => {
     await withFakeClaude(
       `

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -895,6 +895,27 @@ describe('structured agent stream fixtures', () => {
     ))).toEqual([{ type: 'thinking_delta', delta: 'Plan from wrapper.' }]);
   });
 
+  it('maps Claude result terminal_reason into usage stopReason', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+
+    handler.feed(`${JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      terminal_reason: 'completed',
+      duration_ms: 42,
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'usage',
+      usage: null,
+      costUsd: null,
+      durationMs: 42,
+      stopReason: 'completed',
+    });
+  });
+
   it('emits TodoWrite tool_use from Pi RPC tool_execution events', () => {
     const events: unknown[] = [];
     const send = (_channel: string, payload: unknown) => { events.push(payload); };


### PR DESCRIPTION
Closes #4125

## Why

A Discord report showed the Claude Code connection/startup check failing with a generic `exit 1` message even though Claude had already emitted structured completion JSON on stdout. That makes Settings misclassify a usable Claude install as a startup failure and hides the structured outcome that Open Design already has enough data to interpret.

## What users will see

When Claude Code completes the smoke request and only exits non-zero afterward, Settings now treats that startup check as successful instead of showing a generic "Could not start Claude Code" error. If Claude reports structured result metadata with `terminal_reason`, Open Design now recognizes that completion signal instead of dropping it.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts` (`accepts Claude smoke tests that completed cleanly before a late exit 1`) plus `apps/daemon/tests/structured-streams.test.ts` (`maps Claude result terminal_reason into usage stopReason`)
- Did the test go red on `main` and green on this branch? no — I added the regression spec on this branch and validated the exact scenario with a manual `testAgentConnection({ agentId: 'claude' })` harness because Vitest did not terminate cleanly in this environment.
- Additional verification: the manual harness exercised a fake `claude` binary that emitted assistant text, a `result` frame with `terminal_reason: "completed"`, then `exit 1`, and the daemon now returns `ok: true` for that smoke test.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Manual check: `pnpm exec tsx` importing `createClaudeStreamHandler` and asserting `terminal_reason` maps to usage `stopReason`
- Manual check: `pnpm exec tsx` importing `testAgentConnection`, running a fake `claude` binary that emits a completed result then exits `1`, and asserting the smoke test returns success

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>