### PR TITLE
feat(daemon): split opaque execution_failed into close-reason sub-details

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -315,6 +315,48 @@ function processExitDetail(
   return 'unknown';
 }
 
+// The daemon emits a `runtime_close` diagnostic into the run's event stream at
+// finalize time (see `deriveRpcCloseReason` in server.ts) carrying the mechanism
+// that ended the child as `rpc_close_reason`. When the agent-level error code is
+// the generic `AGENT_EXECUTION_FAILED` and no text pattern matched, this close
+// reason is the only remaining signal that distinguishes a mid-stream agent
+// error from a bare non-zero exit from an ACP fatal — so we surface it instead
+// of collapsing all three into one opaque `execution_failed` bucket.
+function readRuntimeCloseReason(
+  events: RunEventForFailureClassification[] = [],
+): string | null {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const rec = events[i];
+    if (!rec || rec.event !== 'diagnostic') continue;
+    const data = rec.data && typeof rec.data === 'object'
+      ? rec.data as Record<string, unknown>
+      : null;
+    if (data?.type === 'runtime_close' && typeof data.rpc_close_reason === 'string') {
+      return data.rpc_close_reason;
+    }
+  }
+  return null;
+}
+
+// Promote the opaque `execution_failed` detail to the specific close reason when
+// one of the three currently-unclassified shapes is present. Every other reason
+// (and a missing diagnostic) keeps the opaque label so the bucket never silently
+// absorbs a reason we haven't reasoned about.
+function executionFailedDetail(
+  events: RunEventForFailureClassification[] | undefined,
+): TrackingRunFailureDetail {
+  switch (readRuntimeCloseReason(events)) {
+    case 'stream_error':
+      return 'stream_error';
+    case 'exit_nonzero':
+      return 'exit_nonzero';
+    case 'fatal_rpc_error':
+      return 'fatal_rpc_error';
+    default:
+      return 'execution_failed';
+  }
+}
+
 /**
  * Whether a terminal failure can be recovered by RESUMING the agent's existing
  * CLI session (continue from where it left off) rather than restarting from
@@ -540,9 +582,12 @@ export function classifyRunFailure(
     errorCode === 'AGENT_TERMINATED_UNKNOWN' ||
     errorCode === 'AGENT_EXECUTION_FAILED'
   ) {
+    const baseDetail = processExitDetail(errorCode, text);
     return classification(
       'process_exit',
-      processExitDetail(errorCode, text),
+      // Only the generic AGENT_EXECUTION_FAILED catch-all is refined; the
+      // specific exit_code / terminated_unknown labels already carry meaning.
+      baseDetail === 'execution_failed' ? executionFailedDetail(input.events) : baseDetail,
       'child_close',
       retryableHint ?? false,
       retryableHint ? 'retry' : 'none',

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -758,3 +758,57 @@ describe('classifyRunFailure — signal and interrupt attribution', () => {
     });
   });
 });
+
+function runtimeCloseEvent(reason: string): RunEventForFailureClassification {
+  return { event: 'diagnostic', data: { type: 'runtime_close', rpc_close_reason: reason } };
+}
+
+describe('execution_failed close-reason refinement', () => {
+  // A generic AGENT_EXECUTION_FAILED whose text matched no pattern, plus the
+  // runtime_close diagnostic the daemon stamps at finalize time.
+  const withCloseReason = (reason: string | null) =>
+    classify('AGENT_EXECUTION_FAILED', '', [
+      errorEvent('AGENT_EXECUTION_FAILED', ''),
+      ...(reason ? [runtimeCloseEvent(reason)] : []),
+    ]);
+
+  it('promotes a mid-stream agent error to stream_error', () => {
+    expect(withCloseReason('stream_error')).toMatchObject({
+      failure_category: 'process_exit',
+      failure_detail: 'stream_error',
+    });
+  });
+
+  it('promotes a bare non-zero exit to exit_nonzero', () => {
+    expect(withCloseReason('exit_nonzero')).toMatchObject({
+      failure_category: 'process_exit',
+      failure_detail: 'exit_nonzero',
+    });
+  });
+
+  it('promotes an ACP fatal close to fatal_rpc_error', () => {
+    expect(withCloseReason('fatal_rpc_error')).toMatchObject({
+      failure_category: 'process_exit',
+      failure_detail: 'fatal_rpc_error',
+    });
+  });
+
+  it('keeps the opaque execution_failed label when no runtime_close diagnostic is present', () => {
+    expect(withCloseReason(null)).toMatchObject({ failure_detail: 'execution_failed' });
+  });
+
+  it('keeps the opaque label for close reasons outside the three known shapes', () => {
+    expect(withCloseReason('unknown')).toMatchObject({ failure_detail: 'execution_failed' });
+  });
+
+  it('does not override an already-specific process_exit detail with the close reason', () => {
+    // AGENT_EXIT_1 classifies to the specific `exit_code` detail; a stream_error
+    // close reason must not relabel it — only the opaque bucket is refined.
+    expect(
+      classify('AGENT_EXIT_1', '', [
+        errorEvent('AGENT_EXIT_1', ''),
+        runtimeCloseEvent('stream_error'),
+      ]),
+    ).toMatchObject({ failure_category: 'process_exit', failure_detail: 'exit_code' });
+  });
+});

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -294,6 +294,9 @@ export type TrackingRunFailureDetail =
   | 'interrupted'
   | 'exit_code'
   | 'terminated_unknown'
+  | 'stream_error'
+  | 'exit_nonzero'
+  | 'fatal_rpc_error'
   | 'execution_failed'
   | 'user_cancelled'
   | 'unknown';


### PR DESCRIPTION
## Why

I'm taking over the run-reliability lane (#3408). Profiling current-version (0.10.0+) failures in PostHog, the single largest `failure_detail` is the opaque `execution_failed` — **~4.5k/week** across providers (opencode, codex_cli, claude_code, gemini, …). It's the `AGENT_EXECUTION_FAILED` catch-all that fires when no text pattern matched, so on the dashboard it reads as "the agent failed and we don't know why."

But the daemon *does* already know more: the `runtime_close` diagnostic carries `rpc_close_reason`, which splits this bucket into three genuinely distinct shapes — mid-stream agent error (`stream_error`, ~51%), bare non-zero exit (`exit_nonzero`, ~44%), and ACP fatal close (`fatal_rpc_error`). That split only lived on PostHog's `rpc_close_reason` field, so the canonical `failure_detail` — and therefore the **Langfuse** sink, which classifies through the same `classifyRunFailure` — stayed opaque, and the two sinks disagreed per run.

## What users will see

No user-facing UI change. This is internal failure-analytics: dashboards and Langfuse traces keyed on `failure_detail` now see `stream_error` / `exit_nonzero` / `fatal_rpc_error` instead of one undifferentiated `execution_failed`, so the largest failure bucket becomes actionable.

## How

`classifyRunFailure` already receives the run's events, so it reads the latest `runtime_close` diagnostic and promotes the generic `execution_failed` detail to the matching close reason. Only the opaque catch-all is refined — specific details (`exit_code`, `cli_not_installed`, …) and all retry behavior are untouched, so the change is observational-only. Three values added to `TrackingRunFailureDetail`.

This is the first step of the #3408 follow-up; mining the `stream_error` texts (1,082/wk carry a `langfuse_trace_id`) for real provider/tool error patterns is a Langfuse-backed follow-up PR.

## Surface area

- [x] **API / contract** — added `stream_error` / `exit_nonzero` / `fatal_rpc_error` to `TrackingRunFailureDetail` in `packages/contracts`
- [ ] UI / Keyboard shortcut / CLI / Extension point / i18n / new dependency
- [x] **Default behavior change** — none for users; changes the `failure_detail` value emitted for a subset of failed runs (analytics only)

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/run-failure-classification.test.ts` — 44/44 (6 new red specs: each close reason → its detail, plus guards that a missing/unknown diagnostic stays `execution_failed` and a specific detail is never relabeled)
- `pnpm --filter @open-design/contracts typecheck`, `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`

Relates to #3408.