### PR TITLE
fix: ignore stale output comment bridge readiness

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -401,6 +401,9 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   }
   function relativePoint(ev){ return { x: Math.round(ev.clientX), y: Math.round(ev.clientY) }; }
   function postStroke(type){ window.parent.postMessage({ type: type, points: stroke.slice() }, '*'); }
+  function postReady(){
+    window.parent.postMessage({ type: 'od:url-selection-bridge-ready', href: window.location.href }, '*');
+  }
   function schedulePostStroke(){
     if (strokeFrame !== null) return;
     strokeFrame = requestAnimationFrame(function(){
@@ -412,7 +415,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
     var data = ev && ev.data;
     if (!data || !data.type) return;
     if (data.type === 'od:url-selection-bridge-probe') {
-      window.parent.postMessage({ type: 'od:url-selection-bridge-ready' }, '*');
+      postReady();
       return;
     }
     if (data.type === 'od:comment-mode') {
@@ -538,7 +541,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   var mo = new MutationObserver(schedulePostTargets);
   mo.observe(document.documentElement, { subtree: true, childList: true });
   ensureStyle();
-  window.parent.postMessage({ type: 'od:url-selection-bridge-ready' }, '*');
+  postReady();
 })();
 </script>`;
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5464,8 +5464,17 @@ function HtmlViewer({
       const frame = urlPreviewIframeRef.current;
       if (ev.source !== frame?.contentWindow) return;
       if (frame.getAttribute('src') === 'about:blank') return;
-      const data = ev.data as { type?: string } | null;
+      const data = ev.data as { type?: string; href?: string } | null;
       if (data?.type !== 'od:url-selection-bridge-ready') return;
+      if (data.href) {
+        try {
+          const expectedHref = new URL(frame.getAttribute('src') ?? '', window.location.href).href;
+          const readyHref = new URL(data.href, window.location.href).href;
+          if (readyHref !== expectedHref) return;
+        } catch {
+          return;
+        }
+      }
       setUrlSelectionBridgeReady(true);
     }
     window.addEventListener('message', onMessage);

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -3327,6 +3327,54 @@ describe('FileViewer tweaks toolbar', () => {
     expect(srcDocFrame.srcdoc).toContain('data-od-selection-bridge');
   });
 
+  it('ignores stale URL selection bridge readiness after the output URL changes', async () => {
+    function Harness() {
+      const [mtime, setMtime] = useState(1710000000);
+      return (
+        <>
+          <button type="button" onClick={() => setMtime(1710000001)}>Refresh output</button>
+          <FileViewer
+            projectId="project-1"
+            projectKind="prototype"
+            file={htmlPreviewFile({ mtime })}
+            liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const oldHref = new URL(frame.getAttribute('src') ?? '', window.location.href).href;
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: frame.contentWindow,
+        data: { type: 'od:url-selection-bridge-ready', href: oldHref },
+      }));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh output' }));
+    await waitFor(() => {
+      expect(frame.getAttribute('src')).toContain('v=1710000001');
+    });
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: frame.contentWindow,
+        data: { type: 'od:url-selection-bridge-ready', href: oldHref },
+      }));
+    });
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+
+    const srcDocFrame = await waitFor(() => {
+      const activeFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(activeFrame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+      return activeFrame;
+    });
+    expect(srcDocFrame.srcdoc).toContain('data-od-selection-bridge');
+  });
+
   it('lets Draw direct send emit a queued annotation while a task is running', async () => {
     const annotationSpy = vi.fn();
     installCanvasSnapshotMocks();


### PR DESCRIPTION
Closes #4126

## Why

A Discord report suggested that commenting on generated outputs could be broken in 0.9.0. The output viewer can URL-load HTML artifacts and rely on an injected selection bridge for comments. A late `od:url-selection-bridge-ready` message from an older raw output URL could mark the current output as comment-ready before its own bridge had responded, leaving Comment mode on the URL-loaded iframe without a live selection bridge.

## What users will see

Commenting on generated HTML outputs should reliably fall back to the srcDoc comment bridge until the current URL-loaded output reports that its own selection bridge is ready.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no visual UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx` (`ignores stale URL selection bridge readiness after the output URL changes`)
- Did the test go red on `main` and green on this branch? Not run locally; this environment does not have `node`, `pnpm`, `npm`, or `mise` on PATH. The test is written to fail before the href check because a stale ready message would keep comments on URL-load instead of falling back to srcDoc.

## Validation

- `git diff --check`
- Attempted `pnpm --filter @open-design/web test -- FileViewer.test.tsx file-viewer-render-mode.test.ts` (blocked: `pnpm: command not found`)
- Attempted `pnpm --filter @open-design/daemon test -- project-file-range.test.ts` (blocked: `pnpm: command not found`)
- Attempted `node --version`, `corepack --version`, `mise --version` (blocked: commands not found)

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>