### PR TITLE
test(e2e): de-flake manual-edit bridge element selection

### DIFF
--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -164,9 +164,19 @@ async function selectPreviewElementThroughBridge(
   section: string,
 ) {
   await expect(frame.locator('html[data-od-edit-mode]')).toHaveCount(1);
-  await frame.locator(selector).click();
+  // Entering manual-edit mode re-injects the edit bridge and re-emits its targets
+  // for a beat (`setTimeout(postTargets, 0)` in edit-mode/bridge.ts), and the
+  // preview iframe can still settle (srcDoc swap / target re-emit) at the moment we
+  // click. That occasionally swallows the first click, which then hangs on
+  // Playwright's post-click stability check until the 30s test timeout. Retry the
+  // click until the element is actually marked selected, with a short per-attempt
+  // timeout so a single dropped click rides through the settle window instead of
+  // failing the whole run.
+  await expect(async () => {
+    await frame.locator(selector).click({ timeout: 5_000 });
+    await expect(frame.locator(`${selector}[data-od-edit-selected="true"]`)).toHaveCount(1, { timeout: 2_000 });
+  }).toPass({ timeout: 30_000 });
   await expect(page.locator('.manual-edit-modal')).toContainText(section);
-  await expect(frame.locator(`${selector}[data-od-edit-selected="true"]`)).toHaveCount(1);
 }
 
 test('[P0] @critical preview toolbar keeps share, download, comment, and zoom actions reachable', async ({ page }) => {


### PR DESCRIPTION
## Why

The P0 manual-edit UI tests are flaky and have started dequeuing **unrelated** PRs from the merge queue. While merging #4497 (landing-page only) I watched `github-merge-queue[bot]` remove it ~5 min after enqueue because the merge-group `ci` run failed on:

```
e2e/ui/app-manual-edit.test.ts › [P0] manual edit ... (selectPreviewElementThroughBridge)
  locator.click: Test timeout of 30000ms exceeded
  waiting for …artifact-preview-frame…[data-od-id="hero-title"]  (element was visible/enabled/stable)
```

The same run shows #4501 (docs-only) dequeued in the same window on a *different* UI P0 domain — i.e. this is queue-wide flakiness in this test, not a real regression in either PR. Neither PR touches `apps/web`, the artifact preview, or edit mode.

## What users will see

Nothing — test-only change. The merge queue stops randomly evicting green PRs on this test.

## Surface area

- [x] **None** — e2e test stabilization only.

## Bug fix verification

Flaky by nature (a CI timing race), so there is no deterministic red spec that goes red on `main` and green here — a red run only reproduces intermittently in the merge-group runner.

Root cause (not a product bug): entering manual-edit mode re-injects the edit bridge and re-emits its targets a tick later (`setTimeout(postTargets, 0)` in `apps/web/src/edit-mode/bridge.ts`) while the preview iframe is still settling. The first `click()` is occasionally swallowed during that window and then hangs on Playwright's post-click stability check until the 30s test timeout.

Fix: in `selectPreviewElementThroughBridge`, wrap the click + the `[data-od-edit-selected="true"]` assertion in `expect(...).toPass()` with a short per-attempt `click` timeout, so a single dropped click is retried through the settle window instead of failing the run. The final assertions (selection marker + modal section text) are unchanged. This is the shared bridge-selection path both reported P0 failures go through.

## Validation

- `pnpm --filter @open-design/e2e typecheck` — green.
- Confirmed the wrapped assertions are identical to the originals (no assertion weakened; only the click is made retry-through-settle).
- Did **not** run the full Playwright UI stack locally: it needs Node 24 + the tools-dev app stack + browsers, and the timing flake doesn't reliably reproduce locally. CI's `UI P0 (project-runtime)` exercises the live path on this PR.
