### PR TITLE
fix(web): stop MCP server snippet code from inheriting the inline-code chip

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -7274,7 +7274,22 @@ function IntegrationsSection() {
             }}
             data-lang={snippetLang}
           >
-            <code>
+            <code
+              style={{
+                // Neutralize the global inline-`code` chip style (background,
+                // padding, rounded corners, color, size) so it doesn't paint a
+                // light rounded rectangle behind every wrapped segment of the
+                // dark snippet block — which read as permanent selection
+                // highlights on the wrapped `claude mcp add-json` one-liner.
+                // Issue #4509.
+                background: 'transparent',
+                padding: 0,
+                borderRadius: 0,
+                color: 'inherit',
+                fontFamily: 'inherit',
+                fontSize: 'inherit',
+              }}
+            >
               {snippet ||
                 (infoError
                   ? t('settings.mcpResolvingFailed')

--- a/e2e/ui/settings-mcp-snippet-chip.test.ts
+++ b/e2e/ui/settings-mcp-snippet-chip.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@/playwright/suite';
+import { T } from '@/timeouts';
+
+// Regression for #4509: the MCP server setup snippet renders inside a dark
+// `<pre><code>` block, but the inner `<code>` used to inherit the global
+// inline-`code` chip style (light background + padding + rounded corners). On
+// a wrapped `claude mcp add-json` one-liner that painted a light rounded
+// rectangle behind every wrapped segment — reading as permanent selection
+// highlights. The inner `<code>` must stay transparent.
+
+const STORAGE_KEY = 'open-design:config';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(key, JSON.stringify({
+      mode: 'api', apiProtocol: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-chat', agentId: null, skillId: null, designSystemId: null,
+      onboardingCompleted: true, agentModels: {}, privacyDecisionAt: 1,
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+    }));
+  }, STORAGE_KEY);
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    await route.fulfill({ json: { config: { onboardingCompleted: true, agentId: null, skillId: null, designSystemId: null, agentModels: {}, privacyDecisionAt: 1, telemetry: { metrics: false, content: false, artifactManifest: false } } } });
+  });
+});
+
+test('[P1] MCP server snippet code stays transparent, not the inline-code chip (#4509)', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: T.medium });
+  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
+  if (await privacyDialog.isVisible()) {
+    await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
+  }
+
+  const shortcut = process.platform === 'darwin' ? 'Meta+Comma' : 'Control+Comma';
+  await page.keyboard.press(shortcut);
+  await expect(page.locator('.modal-backdrop .modal-settings')).toBeVisible({ timeout: T.short });
+
+  // Open the "MCP server" section — Claude Code is the default client, so its
+  // `claude mcp add-json` snippet renders without further interaction.
+  await page.locator('.settings-nav-item', { hasText: 'MCP server' }).click();
+
+  const code = page.locator('.modal-settings pre code').first();
+  await expect(code).toBeVisible({ timeout: T.short });
+
+  const style = await code.evaluate((el: Element) => {
+    const cs = getComputedStyle(el);
+    return { background: cs.backgroundColor, padding: cs.padding };
+  });
+
+  // Transparent (Chromium reports `rgba(0, 0, 0, 0)`) — the inline-code chip
+  // background must not leak in. Before the fix this was the light
+  // `--bg-subtle` (e.g. `rgb(244, 245, 247)`) with `1px 5px` padding.
+  expect(style.background).toBe('rgba(0, 0, 0, 0)');
+  expect(style.padding).toBe('0px');
+});


### PR DESCRIPTION
Fixes #4509

## Why

Scratching the issue's itch (reported by @NightGlowww, root cause confirmed with @lefarcen). In **Settings → MCP server**, the generated CLI command (`claude mcp add-json …` for Claude Code, and the other clients) renders inside a dark `<pre><code>` block. The inner `<code>` had no style of its own, so it inherited the global inline-`code` chip rule from `primitives.css` (`background: var(--bg-subtle)` + `padding: 1px 5px` + rounded corners). On the wrapped bash one-liner (`white-space: pre-wrap; word-break: break-all`) each wrapped segment painted its own light rounded rectangle — which reads as the command being permanently selected, and makes the MCP setup UI look broken.

## What users will see

The MCP server setup command now renders as clean monospaced code on the dark block — no light rectangles behind wrapped lines, stable contrast, and no selection-like highlights unless you actually select text. Applies to every CLI client (Claude Code / Codex / …) since they share the snippet block.

## Surface area

- [x] **UI** — fixes the MCP server snippet rendering in Settings (`apps/web`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Settings → MCP server, Claude Code snippet (the wrapped `claude mcp add-json` one-liner):

| Before | After |
| --- | --- |
| light rounded rectangles behind every wrapped segment (selection-like) | clean monospaced code, no highlight artifacts |

<img width="602" height="165" alt="mcpsnippet-before" src="https://github.com/user-attachments/assets/395ed045-8ac5-42aa-a4da-e145cbcee573" />

<img width="602" height="165" alt="mcpsnippet-after" src="https://github.com/user-attachments/assets/02db66ff-9013-41fd-ba93-c3241c5a6825" />

## Bug fix verification

- Test path: `e2e/ui/settings-mcp-snippet-chip.test.ts` → `MCP server snippet code stays transparent, not the inline-code chip (#4509)`
- Did the test go red on `main` and green on this branch? **yes** — the test navigates to Settings → MCP server and reads the snippet `<code>` computed style. On `main` it fails: `background` is `rgb(244, 245, 247)` (the `--bg-subtle` chip) with `1px 5px` padding. On this branch it passes: `background` is `rgba(0, 0, 0, 0)` (transparent), `padding` `0px`.

## Validation

- `pnpm typecheck` — clean (`apps/web` Done)
- New Playwright UI test passes; verified the real `claude mcp add-json` snippet renders against the e2e mock daemon and the `<code>` no longer carries the chip background (before/after screenshots above)

Implementation note: the fix is a small inline-style reset on the snippet's inner `<code>` (`background: transparent; padding: 0; border-radius: 0; color/font: inherit`) so it stops inheriting the global inline-code chip styling and instead inherits the dark block's own color and monospace font. Nothing else in the MCP setup card changes.
