### PR TITLE
[codex] Fix design-system review TOC overlay

### DIFF
--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -2835,6 +2835,7 @@
   }
 
   .ds-project-toc {
+    position: static;
     z-index: 5;
     top: 0;
     max-height: none;

--- a/apps/web/tests/styles/design-system-review-density.test.ts
+++ b/apps/web/tests/styles/design-system-review-density.test.ts
@@ -39,4 +39,11 @@ describe('design-system review preview density', () => {
     expect(toc).toContain('position: sticky;');
     expect(toc).toContain('border-right: 1px solid var(--border);');
   });
+
+  it('lets the contents rail scroll with the page in the single-column review layout', () => {
+    const toc = cssDeclarations('.ds-project-toc');
+
+    expect(toc).toContain('position: static;');
+    expect(toc).toContain('border-bottom: 1px solid var(--border);');
+  });
 });


### PR DESCRIPTION
## Why

This PR fixes the narrow design-system review layout on top of #4260.

The pain being addressed is review usability: dense design-system contents need to remain scrollable in constrained layouts instead of being obscured by the table-of-contents overlay.

## What users will see

In the #4260 design-system review flow, narrow layouts allow the contents area to scroll correctly instead of being blocked by the TOC overlay.

## Surface area

- [x] **UI** — design-system review layout in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — narrow review layout scrolling changes in the #4260 flow
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. Layout behavior is covered by the branch test.

## Bug fix verification

Skipped. The branch includes focused layout test coverage, but I did not rerun it locally while opening this PR.

## Validation

- Not run locally; PR opened from the existing branch for review.
