### PR TITLE
[codex] Fix Brand Kit preview lifecycle guards

### DIFF
--- a/apps/web/src/components/BrandPreviewCard.tsx
+++ b/apps/web/src/components/BrandPreviewCard.tsx
@@ -203,18 +203,24 @@ export interface BrandPreviewCardProps {
   variant?: 'panel' | 'compact';
   /** Panel-only: called after a mutation (delete) so a parent can refresh. */
   onChanged?: () => void | Promise<void>;
+  /** Panel-only: lets a parent clear iframe-heavy detail UI before mutation. */
+  onBeforeMutation?: () => void;
   /** Panel-only: apply this brand's design system as the global default. */
   onApplyDesignSystem?: (designSystemId: string) => void;
   /** Panel-only: open the backing extraction project through the app shell. */
   onOpenProject?: (projectId: string) => Promise<boolean> | boolean | void;
+  /** Panel-only: disables actions when parent route/selection/summary are stale. */
+  actionsDisabled?: boolean;
 }
 
 export function BrandPreviewCard({
   summary,
   variant = 'panel',
   onChanged,
+  onBeforeMutation,
   onApplyDesignSystem,
   onOpenProject,
+  actionsDisabled = false,
 }: BrandPreviewCardProps) {
   const t = useT();
   const compact = variant === 'compact';
@@ -321,6 +327,7 @@ export function BrandPreviewCard({
   }, [showSystem, projectId]);
 
   const useInChat = useCallback(async () => {
+    if (actionsDisabled) return;
     const designSystemId = meta.designSystemId;
     if (!designSystemId || busy) return;
     setBusy(true);
@@ -351,13 +358,14 @@ export function BrandPreviewCard({
     } finally {
       setBusy(false);
     }
-  }, [meta.designSystemId, busy, onApplyDesignSystem, t, name]);
+  }, [actionsDisabled, meta.designSystemId, busy, onApplyDesignSystem, t, name]);
 
   useEffect(() => {
     setBackingProjectMissing(false);
   }, [projectId]);
 
   const openProject = useCallback(async () => {
+    if (actionsDisabled) return;
     if (!projectId) return;
     if (onOpenProject) {
       const opened = await onOpenProject(projectId);
@@ -365,12 +373,14 @@ export function BrandPreviewCard({
       return;
     }
     navigate({ kind: 'project', projectId, fileName: null, conversationId: null });
-  }, [onOpenProject, projectId]);
+  }, [actionsDisabled, onOpenProject, projectId]);
 
   const deleteBrand = useCallback(async () => {
+    if (actionsDisabled) return;
     if (busy) return;
     const ok = window.confirm(t('brandDetail.deleteConfirm').replace('{name}', name));
     if (!ok) return;
+    onBeforeMutation?.();
     setBusy(true);
     try {
       await fetch(`/api/brands/${encodeURIComponent(meta.id)}`, { method: 'DELETE' });
@@ -380,7 +390,7 @@ export function BrandPreviewCard({
     } catch {
       setBusy(false);
     }
-  }, [busy, meta.id, name, onChanged, t]);
+  }, [actionsDisabled, busy, meta.id, name, onBeforeMutation, onChanged, t]);
 
   const dsKitFile = dsTheme === 'dark' ? 'system/kit.dark.html' : 'system/kit.html';
 
@@ -449,7 +459,7 @@ export function BrandPreviewCard({
             <Button
               variant="primary"
               onClick={() => void useInChat()}
-              disabled={busy || !meta.designSystemId}
+              disabled={actionsDisabled || busy || !meta.designSystemId}
               data-testid="brand-preview-use"
             >
               {t('brandDetail.useInChat')}
@@ -458,7 +468,7 @@ export function BrandPreviewCard({
               <Button
                 variant="ghost"
                 onClick={() => void openProject()}
-                disabled={busy || backingProjectMissing}
+                disabled={actionsDisabled || busy || backingProjectMissing}
                 data-testid="brand-preview-open-project"
               >
                 {t('brandDetail.openProject')}
@@ -467,7 +477,7 @@ export function BrandPreviewCard({
             <Button
               variant="ghost"
               onClick={() => void deleteBrand()}
-              disabled={busy}
+              disabled={actionsDisabled || busy}
               data-testid="brand-preview-delete"
             >
               {t('brandDetail.delete')}
@@ -756,7 +766,7 @@ export function BrandPreviewCard({
               <span className={styles.dsCap}>system/kit.html</span>
             </div>
             <iframe
-              key={dsKitFile}
+              key={`${meta.id}:${projectId}:${dsKitFile}`}
               className={styles.dsFrame}
               src={projectRawUrl(projectId, dsKitFile)}
               loading="lazy"
@@ -801,6 +811,7 @@ export function BrandPreviewCard({
               >
                 <div className={styles.assetFrame}>
                   <iframe
+                    key={`${meta.id}:${projectId}:${a.file}`}
                     src={projectRawUrl(projectId, a.file)}
                     loading="lazy"
                     tabIndex={-1}

--- a/apps/web/src/components/BrandPreviewCard.tsx
+++ b/apps/web/src/components/BrandPreviewCard.tsx
@@ -380,11 +380,11 @@ export function BrandPreviewCard({
     if (busy) return;
     const ok = window.confirm(t('brandDetail.deleteConfirm').replace('{name}', name));
     if (!ok) return;
-    onBeforeMutation?.();
     setBusy(true);
     try {
       await fetch(`/api/brands/${encodeURIComponent(meta.id)}`, { method: 'DELETE' });
       // Drop the now-stale `/brands/:id` selection before refreshing the list.
+      onBeforeMutation?.();
       navigate({ kind: 'home', view: 'brands' }, { replace: true });
       await onChanged?.();
     } catch {

--- a/apps/web/src/components/BrandPreviewCard.tsx
+++ b/apps/web/src/components/BrandPreviewCard.tsx
@@ -382,7 +382,8 @@ export function BrandPreviewCard({
     if (!ok) return;
     setBusy(true);
     try {
-      await fetch(`/api/brands/${encodeURIComponent(meta.id)}`, { method: 'DELETE' });
+      const resp = await fetch(`/api/brands/${encodeURIComponent(meta.id)}`, { method: 'DELETE' });
+      if (!resp.ok) throw new Error('Brand delete failed');
       // Drop the now-stale `/brands/:id` selection before refreshing the list.
       onBeforeMutation?.();
       navigate({ kind: 'home', view: 'brands' }, { replace: true });

--- a/apps/web/src/components/BrandsTab.tsx
+++ b/apps/web/src/components/BrandsTab.tsx
@@ -102,9 +102,10 @@ export function BrandsTab({ onApplyDesignSystem, onOpenProject }: BrandsTabProps
   }, [brands, query]);
 
   // Resolve which brand the preview shows. A routed brand id (deep-link / rail
-  // selection) wins when it exists; otherwise keep the current pick valid as
-  // the list refreshes (e.g. a brand finishes extracting or is removed), and
-  // fall back to the first entry only when the current pick is gone.
+  // selection) wins only when it is present in the reconciled list. If the
+  // route points at a brand that was just deleted or refreshed away, leave the
+  // detail pane empty instead of silently aiming panel actions at another
+  // brand while the URL still names the stale id.
   useEffect(() => {
     const list = brands ?? [];
     if (list.length === 0) {
@@ -112,7 +113,9 @@ export function BrandsTab({ onApplyDesignSystem, onOpenProject }: BrandsTabProps
       return;
     }
     setSelectedBrandId((cur) => {
-      if (routedBrandId && list.some((b) => b.meta.id === routedBrandId)) return routedBrandId;
+      if (routedBrandId) {
+        return list.some((b) => b.meta.id === routedBrandId) ? routedBrandId : null;
+      }
       if (cur && list.some((b) => b.meta.id === cur)) return cur;
       return list[0]?.meta.id ?? null;
     });
@@ -130,6 +133,9 @@ export function BrandsTab({ onApplyDesignSystem, onOpenProject }: BrandsTabProps
     if (!selectedBrandId) return null;
     return (brands ?? []).find((b) => b.meta.id === selectedBrandId) ?? null;
   }, [brands, selectedBrandId]);
+  const selectedIsRouteSynced = Boolean(
+    selected && selected.meta.id === selectedBrandId && (!routedBrandId || routedBrandId === selected.meta.id),
+  );
 
   const handleCreated = useCallback(
     (_brandId: string, projectId: string, conversationId: string) => {
@@ -221,8 +227,10 @@ export function BrandsTab({ onApplyDesignSystem, onOpenProject }: BrandsTabProps
             summary={selected}
             variant="panel"
             onChanged={refresh}
+            onBeforeMutation={() => setSelectedBrandId(null)}
             onApplyDesignSystem={onApplyDesignSystem}
             onOpenProject={onOpenProject}
+            actionsDisabled={!selectedIsRouteSynced}
           />
         ) : isEmpty ? (
           <div className={styles.pickerPane} data-testid="brands-picker-pane">

--- a/apps/web/tests/components/BrandPreviewCard.test.tsx
+++ b/apps/web/tests/components/BrandPreviewCard.test.tsx
@@ -125,4 +125,56 @@ describe('BrandPreviewCard', () => {
       ),
     ).toBeTruthy();
   });
+
+  it('does not mount design-system iframes for an in-progress brand', () => {
+    const extracting: BrandSummary = {
+      ...rampBrand,
+      meta: { ...rampBrand.meta, status: 'extracting' },
+    };
+
+    const { container } = render(
+      <I18nProvider initial="en">
+        <BrandPreviewCard summary={extracting} variant="panel" onApplyDesignSystem={vi.fn()} />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('Extracting…')).toBeTruthy();
+    expect(container.querySelectorAll('iframe')).toHaveLength(0);
+  });
+
+  it('clears the parent detail before deleting a brand', async () => {
+    const events: string[] = [];
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input).startsWith('/api/brands/') && init?.method === 'DELETE') {
+          events.push('fetch-delete');
+        }
+        return { ok: true, json: async () => ({}) };
+      }),
+    );
+
+    render(
+      <I18nProvider initial="en">
+        <BrandPreviewCard
+          summary={rampBrand}
+          variant="panel"
+          onBeforeMutation={() => {
+            events.push('clear-preview');
+          }}
+          onChanged={() => {
+            events.push('refresh');
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('brand-preview-delete'));
+
+    await waitFor(() => {
+      expect(events).toContain('refresh');
+    });
+    expect(events.slice(0, 2)).toEqual(['clear-preview', 'fetch-delete']);
+  });
 });

--- a/apps/web/tests/components/BrandPreviewCard.test.tsx
+++ b/apps/web/tests/components/BrandPreviewCard.test.tsx
@@ -142,7 +142,7 @@ describe('BrandPreviewCard', () => {
     expect(container.querySelectorAll('iframe')).toHaveLength(0);
   });
 
-  it('clears the parent detail before deleting a brand', async () => {
+  it('clears the parent detail after deleting a brand', async () => {
     const events: string[] = [];
     vi.stubGlobal('confirm', vi.fn(() => true));
     vi.stubGlobal(
@@ -175,6 +175,39 @@ describe('BrandPreviewCard', () => {
     await waitFor(() => {
       expect(events).toContain('refresh');
     });
-    expect(events.slice(0, 2)).toEqual(['clear-preview', 'fetch-delete']);
+    expect(events).toEqual(['fetch-delete', 'clear-preview', 'refresh']);
+  });
+
+  it('keeps the parent detail selected when deleting a brand fails', async () => {
+    const onBeforeMutation = vi.fn();
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input).startsWith('/api/brands/') && init?.method === 'DELETE') {
+          throw new Error('delete failed');
+        }
+        return { ok: true, json: async () => ({}) };
+      }),
+    );
+
+    render(
+      <I18nProvider initial="en">
+        <BrandPreviewCard
+          summary={rampBrand}
+          variant="panel"
+          onBeforeMutation={onBeforeMutation}
+          onChanged={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('brand-preview-delete'));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/brands/brand-ramp', { method: 'DELETE' });
+      expect((screen.getByTestId('brand-preview-delete') as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect(onBeforeMutation).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/components/BrandPreviewCard.test.tsx
+++ b/apps/web/tests/components/BrandPreviewCard.test.tsx
@@ -210,4 +210,40 @@ describe('BrandPreviewCard', () => {
     });
     expect(onBeforeMutation).not.toHaveBeenCalled();
   });
+
+  it('keeps the parent detail selected when deleting a brand returns an HTTP failure', async () => {
+    const onBeforeMutation = vi.fn();
+    const onChanged = vi.fn();
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input).startsWith('/api/brands/') && init?.method === 'DELETE') {
+          return { ok: false, json: async () => ({}) };
+        }
+        return { ok: true, json: async () => ({}) };
+      }),
+    );
+
+    render(
+      <I18nProvider initial="en">
+        <BrandPreviewCard
+          summary={rampBrand}
+          variant="panel"
+          onBeforeMutation={onBeforeMutation}
+          onChanged={onChanged}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('brand-preview-delete'));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/brands/brand-ramp', { method: 'DELETE' });
+      expect((screen.getByTestId('brand-preview-delete') as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect(onBeforeMutation).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/brands/brand-ramp');
+  });
 });

--- a/apps/web/tests/components/BrandsTab.refresh.test.tsx
+++ b/apps/web/tests/components/BrandsTab.refresh.test.tsx
@@ -12,6 +12,7 @@ const routerState = vi.hoisted(() => ({
   route: { kind: 'home', view: 'brands', brandId: undefined } as Record<string, unknown>,
 }));
 const fetchBrandsMock = vi.hoisted(() => vi.fn(async (): Promise<BrandSummary[]> => []));
+const previewCardMock = vi.hoisted(() => vi.fn(() => null));
 
 vi.mock('../../src/router', () => ({
   useRoute: () => routerState.route,
@@ -29,7 +30,7 @@ vi.mock('../../src/runtime/brand-intent', () => ({
 }));
 // Heavy children are out of scope for the refresh contract.
 vi.mock('../../src/components/BrandPreviewCard', () => ({
-  BrandPreviewCard: () => null,
+  BrandPreviewCard: previewCardMock,
   BrandLogo: () => null,
   hostnameOf: (url?: string) => url ?? '',
 }));
@@ -68,6 +69,7 @@ describe('BrandsTab refresh reconciliation', () => {
     routerState.route = { kind: 'home', view: 'brands', brandId: undefined };
     fetchBrandsMock.mockReset();
     fetchBrandsMock.mockResolvedValue([]);
+    previewCardMock.mockClear();
   });
   afterEach(() => {
     cleanup();
@@ -116,5 +118,15 @@ describe('BrandsTab refresh reconciliation', () => {
     const afterSettle = fetchBrandsMock.mock.calls.length;
     await vi.advanceTimersByTimeAsync(8000);
     expect(fetchBrandsMock).toHaveBeenCalledTimes(afterSettle);
+  });
+
+  it('does not aim the preview at another brand when the routed brand disappears', async () => {
+    routerState.route = { kind: 'home', view: 'brands', brandId: 'deleted-brand' };
+    fetchBrandsMock.mockResolvedValue([brandSummary('remaining-brand', 'ready')]);
+
+    renderBrandsTab();
+
+    await waitFor(() => expect(fetchBrandsMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(previewCardMock).not.toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
## Why

This PR fixes brand kit preview lifecycle guards on top of #4260.

The pain being addressed is state reliability: preview cards and the Brands tab need to avoid stale or unsafe lifecycle transitions while brand extraction and refresh state changes are in flight.

## What users will see

In the #4260 Brand Kit flow, preview cards and the Brands tab should behave more consistently as extraction and refresh lifecycle state changes.

## Surface area

- [x] **UI** — Brand Kit preview and Brands tab lifecycle handling in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — Brand Kit preview lifecycle behavior changes in the #4260 flow
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. Lifecycle behavior is covered by focused component tests.

## Bug fix verification

Skipped. The branch includes focused component test coverage, but I did not rerun it locally while opening this PR.

## Validation

- Not run locally; PR opened from the existing branch for review.
