### PR TITLE
[codex] Fix Brand Kit modal intent handling

### DIFF
--- a/apps/web/src/components/BrandsTab.tsx
+++ b/apps/web/src/components/BrandsTab.tsx
@@ -80,15 +80,27 @@ export function BrandsTab({ onApplyDesignSystem, onOpenProject }: BrandsTabProps
   }, [isBrandsView, hasExtracting, refresh]);
 
   // The "Create Brand Kit" home chip routes here and asks the tab to open its
-  // New Brand Kit modal. BrandsTab stays mounted across view switches, so we
-  // react to the intent event; a pending latch left before mount is drained
-  // once on first render as a fallback.
+  // New Brand Kit modal. EntryShell keeps BrandsTab mounted while hidden, so
+  // only consume the one-shot intent when the Brands view is actually active.
   useEffect(() => {
-    const openModal = () => setModalOpen(true);
-    if (consumePendingNewBrandKit()) openModal();
+    if (isBrandsView && consumePendingNewBrandKit()) setModalOpen(true);
+  }, [isBrandsView]);
+
+  useEffect(() => {
+    if (!isBrandsView) {
+      setModalOpen(false);
+    }
+  }, [isBrandsView]);
+
+  useEffect(() => {
+    const openModal = () => {
+      if (!isBrandsView) return;
+      consumePendingNewBrandKit();
+      setModalOpen(true);
+    };
     window.addEventListener(NEW_BRAND_KIT_INTENT_EVENT, openModal);
     return () => window.removeEventListener(NEW_BRAND_KIT_INTENT_EVENT, openModal);
-  }, []);
+  }, [isBrandsView]);
 
   const filtered = useMemo(() => {
     const list = brands ?? [];

--- a/apps/web/tests/components/BrandsTab.refresh.test.tsx
+++ b/apps/web/tests/components/BrandsTab.refresh.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { BrandSummary } from '@open-design/contracts';
@@ -12,6 +12,9 @@ const routerState = vi.hoisted(() => ({
   route: { kind: 'home', view: 'brands', brandId: undefined } as Record<string, unknown>,
 }));
 const fetchBrandsMock = vi.hoisted(() => vi.fn(async (): Promise<BrandSummary[]> => []));
+const brandIntentState = vi.hoisted(() => ({
+  pending: false,
+}));
 
 vi.mock('../../src/router', () => ({
   useRoute: () => routerState.route,
@@ -25,7 +28,11 @@ vi.mock('../../src/runtime/useBrandExtract', () => ({
 }));
 vi.mock('../../src/runtime/brand-intent', () => ({
   NEW_BRAND_KIT_INTENT_EVENT: 'od:new-brand-kit-intent',
-  consumePendingNewBrandKit: () => false,
+  consumePendingNewBrandKit: () => {
+    const wasPending = brandIntentState.pending;
+    brandIntentState.pending = false;
+    return wasPending;
+  },
 }));
 // Heavy children are out of scope for the refresh contract.
 vi.mock('../../src/components/BrandPreviewCard', () => ({
@@ -37,7 +44,8 @@ vi.mock('../../src/components/BrandReferencePicker', () => ({
   BrandReferencePicker: () => null,
 }));
 vi.mock('../../src/components/NewBrandModal', () => ({
-  NewBrandModal: () => null,
+  NewBrandModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="new-brand-modal" /> : null,
 }));
 
 import { BrandsTab } from '../../src/components/BrandsTab';
@@ -66,6 +74,7 @@ function brandSummary(id: string, status: BrandSummary['meta']['status']): Brand
 describe('BrandsTab refresh reconciliation', () => {
   beforeEach(() => {
     routerState.route = { kind: 'home', view: 'brands', brandId: undefined };
+    brandIntentState.pending = false;
     fetchBrandsMock.mockReset();
     fetchBrandsMock.mockResolvedValue([]);
   });
@@ -95,6 +104,52 @@ describe('BrandsTab refresh reconciliation', () => {
     );
 
     await waitFor(() => expect(fetchBrandsMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not open the New Brand Kit modal from an intent while Brands is hidden', async () => {
+    routerState.route = { kind: 'home', view: 'home' };
+    renderBrandsTab();
+
+    brandIntentState.pending = true;
+    window.dispatchEvent(new CustomEvent('od:new-brand-kit-intent'));
+
+    expect(screen.queryByTestId('new-brand-modal')).toBeNull();
+    expect(brandIntentState.pending).toBe(true);
+  });
+
+  it('consumes the pending New Brand Kit intent only on active Brands entry', async () => {
+    routerState.route = { kind: 'home', view: 'home' };
+    const { rerender } = renderBrandsTab();
+
+    brandIntentState.pending = true;
+    window.dispatchEvent(new CustomEvent('od:new-brand-kit-intent'));
+    expect(screen.queryByTestId('new-brand-modal')).toBeNull();
+
+    routerState.route = { kind: 'home', view: 'brands', brandId: undefined };
+    rerender(
+      <I18nProvider initial="en">
+        <BrandsTab />
+      </I18nProvider>,
+    );
+
+    expect(await screen.findByTestId('new-brand-modal')).toBeTruthy();
+    expect(brandIntentState.pending).toBe(false);
+
+    routerState.route = { kind: 'project', projectId: 'p1', conversationId: null, fileName: null };
+    rerender(
+      <I18nProvider initial="en">
+        <BrandsTab />
+      </I18nProvider>,
+    );
+    expect(screen.queryByTestId('new-brand-modal')).toBeNull();
+
+    routerState.route = { kind: 'home', view: 'brands', brandId: undefined };
+    rerender(
+      <I18nProvider initial="en">
+        <BrandsTab />
+      </I18nProvider>,
+    );
+    expect(screen.queryByTestId('new-brand-modal')).toBeNull();
   });
 
   it('polls while a brand is extracting and stops once it settles', async () => {


### PR DESCRIPTION
## Why

This PR fixes Brand Kit modal intent handling on top of #4260.

The pain being addressed is interaction correctness: modal-triggered Brand Kit intents should route through the Brands tab consistently instead of being dropped or handled at the wrong time.

## What users will see

In the #4260 Brand Kit flow, modal intent handling should be more reliable when opening or refreshing the Brands tab path.

## Surface area

- [x] **UI** — Brand Kit modal intent handling in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — Brand Kit modal intent behavior changes in the #4260 flow
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. Intent handling is covered by the branch test changes.

## Bug fix verification

Skipped. The branch includes focused component test coverage, but I did not rerun it locally while opening this PR.

## Validation

- Not run locally; PR opened from the existing branch for review.
