### PR TITLE
Add Reusable Workflow Builder plugin

### DIFF
--- a/plugins/community/reusable-workflow-builder/SKILL.md
+++ b/plugins/community/reusable-workflow-builder/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: reusable-workflow-builder
+description: Convert a user's reusable workflow goal into a scoped Open Design generation workflow with discovery, planning, artifact creation, and review.
+od:
+  kind: scenario
+  mode: scenario
+  taskKind: new-generation
+---
+
+# Reusable Workflow Builder
+
+Use this skill when the user wants to turn a concise workflow goal into a repeatable Open Design generation flow. The workflow can target HTML prototypes, decks, dashboards, marketing pages, image-led concepts, or plugin/workflow packages.
+
+## Primary outcome
+
+Create a usable artifact or workflow package that directly matches the user's stated goal. Keep the output local-user friendly: files should work in the active project workspace without marketplace publishing, private team setup, or external services unless the user explicitly asks for them.
+
+## Inputs to honor
+
+- `workflowGoal`: the core reusable workflow the user wants.
+- `audience`: who the artifact or workflow is for.
+- `artifactKind`: the intended output type, such as prototype, dashboard, deck, image, video, plugin, or other.
+- `platform`: target surface or device family.
+- `constraints`: hard requirements, references, copy, brand rules, and things to avoid.
+
+If a required input is missing, ask the smallest possible set of questions that unblocks the work. Do not re-ask fields already supplied by plugin inputs, project metadata, attachments, or the current brief.
+
+## Workflow
+
+1. Inspect the current project files before editing when the request refers to existing work or asks to continue a previous run.
+2. Resolve the requested workflow goal into a concrete deliverable, output surface, audience, and completion criteria.
+3. If the user provides a brand guide, screenshot, or reference URL, extract visible colors, typography, spacing, and layout posture before writing files.
+4. Commit to a short todo plan before authoring files, then update it as each item lands.
+5. Create the minimum useful file set for the deliverable. Prefer one canonical entry file for a single surface and separate HTML files for distinct user-facing screens.
+6. Use real, specific copy from the brief. If a value is unknown, use a short honest placeholder instead of invented metrics.
+7. Include meaningful interactions when the requested screen has inputs, generation, filtering, copying, validation, playback, checkout, login, or other action verbs.
+8. Run a self-review before handoff:
+   - Clarity: the workflow goal is obvious.
+   - Hierarchy: one primary action or idea leads each screen or slide.
+   - Specificity: labels, states, and examples fit this user's brief.
+   - Implementation readiness: CSS, JS, and file structure are readable.
+   - Restraint: one visual flourish or accent role, not competing decorations.
+
+## Output guidance by artifact type
+
+- **Prototype or app UI:** build real product screens, not designer controls. Include domain-specific modules such as forms, status panels, charts, carts, editors, players, or workflows when appropriate.
+- **Dashboard or tool UI:** prioritize density, scanning, filters, states, and table/chart behavior.
+- **Landing or marketing page:** create a focused hero plus the requested sections, with concrete copy and one clear conversion action.
+- **Deck:** use the fixed 1920 x 1080 deck framework when available. Keep one idea per slide and preserve slide navigation behavior.
+- **Plugin or workflow package:** create a local folder with `SKILL.md`, `open-design.json`, and only useful supporting files such as `examples/` or `assets/`.
+
+## Handoff
+
+Finish with a concise readiness summary:
+
+- Files created or changed.
+- What is ready to use.
+- Any validation that was run.
+- Remaining follow-up, if any.
+- Next action choices that fit the deliverable.

--- a/plugins/community/reusable-workflow-builder/examples/review-checklist.md
+++ b/plugins/community/reusable-workflow-builder/examples/review-checklist.md
@@ -1,0 +1,21 @@
+# Review checklist
+
+Use this checklist when reviewing output created through the Reusable Workflow Builder plugin.
+
+## Required
+
+- The output directly serves the supplied `workflowGoal`.
+- Any missing required context was requested in the smallest useful question set.
+- Existing project files were inspected before continuation work.
+- The plan was updated as files landed.
+- Files are local and usable from the active project workspace.
+- Unknown numbers, claims, or customer names were not invented.
+- Interactive screens include meaningful working behavior for their primary actions.
+
+## Quality bar
+
+- Clear first impression: the user can tell what the workflow produced within five seconds.
+- Strong hierarchy: each screen, slide, or page has one dominant idea.
+- Specific copy: labels and examples reflect the actual brief.
+- Implementation-ready structure: CSS, JavaScript, and file names are readable.
+- Restrained visual system: accent colors and decorative flourishes are used deliberately.

--- a/plugins/community/reusable-workflow-builder/examples/use-case.md
+++ b/plugins/community/reusable-workflow-builder/examples/use-case.md
@@ -1,0 +1,22 @@
+# Example use case
+
+Use this plugin when a user wants a repeatable Open Design workflow from a short goal.
+
+## Example input
+
+- `workflowGoal`: Turn a product positioning brief into a launch landing page.
+- `artifactKind`: Landing page prototype.
+- `audience`: Product marketers and founder-led teams.
+- `platform`: Responsive web.
+- `constraints`: Use the supplied brand copy, avoid invented metrics, include a hero, proof section, feature narrative, pricing prompt, and final CTA.
+
+## Expected behavior
+
+The agent should:
+
+1. Ask only for missing hard requirements.
+2. Inspect existing project files before editing if this is a continuation.
+3. Plan the page structure and file work before writing.
+4. Create a local HTML artifact with clear tokens, responsive sections, and working CTA or form behavior when requested.
+5. Review the result for clarity, hierarchy, specificity, implementation readiness, and restraint.
+6. Finish with a concise readiness summary.

--- a/plugins/community/reusable-workflow-builder/open-design.json
+++ b/plugins/community/reusable-workflow-builder/open-design.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "reusable-workflow-builder",
+  "title": "Reusable Workflow Builder",
+  "version": "0.1.0",
+  "description": "A local Open Design scenario that turns a short workflow goal into a scoped artifact workflow with discovery, planning, generation, and review.",
+  "license": "MIT",
+  "author": {
+    "name": "Local user",
+    "url": "https://github.com/workspaccode"
+  },
+  "tags": [
+    "scenario",
+    "workflow",
+    "generation",
+    "my-plugins"
+  ],
+  "compat": {
+    "agentSkills": [
+      {
+        "path": "./SKILL.md"
+      }
+    ]
+  },
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "scenario": "reusable-workflow-builder",
+    "mode": "scenario",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "discovery",
+          "atoms": [
+            "discovery-question-form"
+          ]
+        },
+        {
+          "id": "plan",
+          "atoms": [
+            "todo-write"
+          ]
+        },
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        },
+        {
+          "id": "review",
+          "atoms": [
+            "critique-theater"
+          ],
+          "repeat": true,
+          "until": "critique.score>=4 || iterations>=3"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ],
+    "useCase": {
+      "query": {
+        "en": "Create a reusable Open Design workflow for {{workflowGoal}}. Target {{artifactKind}} for {{audience}} on {{platform}}. Use the supplied constraints, produce the appropriate local files, and finish with a readiness summary."
+      },
+      "exampleOutputs": [
+        {
+          "path": "./examples/use-case.md",
+          "title": "Example reusable workflow brief"
+        }
+      ]
+    },
+    "inputs": [
+      {
+        "name": "workflowGoal",
+        "type": "string",
+        "required": true,
+        "label": "Workflow goal",
+        "placeholder": "turn a brand brief into a launch landing page workflow"
+      },
+      {
+        "name": "artifactKind",
+        "type": "string",
+        "required": false,
+        "default": "prototype",
+        "label": "Artifact kind",
+        "placeholder": "prototype, deck, dashboard, landing page, plugin, image, video"
+      },
+      {
+        "name": "audience",
+        "type": "string",
+        "required": false,
+        "default": "the intended users or reviewers",
+        "label": "Audience",
+        "placeholder": "product evaluators, internal team, customers, investors"
+      },
+      {
+        "name": "platform",
+        "type": "string",
+        "required": false,
+        "default": "responsive web",
+        "label": "Platform",
+        "placeholder": "responsive web, desktop web, iOS app, Android app, tablet app"
+      },
+      {
+        "name": "constraints",
+        "type": "string",
+        "required": false,
+        "default": "Use the current project context and ask only for missing hard requirements.",
+        "label": "Constraints",
+        "placeholder": "brand rules, required sections, files to preserve, references, things to avoid"
+      }
+    ]
+  },
+  "plugin": {
+    "repo": "https://github.com/workspaccode/reusable-workflow-builder"
+  },
+  "homepage": "https://github.com/workspaccode/reusable-workflow-builder"
+}


### PR DESCRIPTION
Add Reusable Workflow Builder (reusable-workflow-builder) plugin.
Version: 0.1.0
Description: A local Open Design scenario that turns a short workflow goal into a scoped artifact workflow with discovery, planning, generation, and review.