### PR TITLE
fix(packaged): reclaim stale namespace sidecars before launch (#4441)

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -294,19 +294,22 @@ export async function reclaimStaleNamespaceSidecars(
   const processes = await listProcesses();
   const protectedPids = new Set(collectProcessTreePids(processes, [selfPid]));
   const reclaimApps: AppKey[] = [APP_KEYS.DAEMON, APP_KEYS.WEB];
+  const reclaimSources = [SIDECAR_SOURCES.PACKAGED, SIDECAR_SOURCES.TOOLS_PACK] as const;
   const reclaimedPids = processes
     .filter((processInfo) => !protectedPids.has(processInfo.pid))
     .filter((processInfo) =>
       reclaimApps.some((app) =>
-        matchesStampedProcess(
-          processInfo,
-          {
-            app,
-            mode: SIDECAR_MODES.RUNTIME,
-            namespace,
-            source: SIDECAR_SOURCES.PACKAGED,
-          },
-          OPEN_DESIGN_SIDECAR_CONTRACT,
+        reclaimSources.some((source) =>
+          matchesStampedProcess(
+            processInfo,
+            {
+              app,
+              mode: SIDECAR_MODES.RUNTIME,
+              namespace,
+              source,
+            },
+            OPEN_DESIGN_SIDECAR_CONTRACT,
+          ),
         ),
       ),
     )

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -33,6 +33,7 @@ import {
   waitForProcessExit,
   wellKnownUserToolchainBins,
   type ProcessSnapshot,
+  type StopProcessesResult,
 } from "@open-design/platform";
 
 import type { PackagedWebOutputMode } from "./config.js";
@@ -256,7 +257,7 @@ async function removeNamespaceIpcSockets(namespace: string): Promise<void> {
 
 export type ReclaimStaleNamespaceSidecarsDeps = {
   listProcesses?: () => Promise<ProcessSnapshot[]>;
-  stop?: (pids: number[]) => Promise<void>;
+  stop?: (pids: number[]) => Promise<Pick<StopProcessesResult, "remainingPids"> | void>;
   cleanupSockets?: () => Promise<void>;
   selfPid?: number;
 };
@@ -285,11 +286,7 @@ export async function reclaimStaleNamespaceSidecars(
   deps: ReclaimStaleNamespaceSidecarsDeps = {},
 ): Promise<{ reclaimedPids: number[] }> {
   const listProcesses = deps.listProcesses ?? listProcessSnapshots;
-  const stop =
-    deps.stop ??
-    (async (pids: number[]): Promise<void> => {
-      await stopProcesses(pids);
-    });
+  const stop = deps.stop ?? stopProcesses;
   const cleanupSockets =
     deps.cleanupSockets ?? (async (): Promise<void> => removeNamespaceIpcSockets(namespace));
   const selfPid = deps.selfPid ?? process.pid;
@@ -317,7 +314,14 @@ export async function reclaimStaleNamespaceSidecars(
 
   if (reclaimedPids.length === 0) return { reclaimedPids: [] };
 
-  await stop(reclaimedPids);
+  const stopResult = await stop(reclaimedPids);
+  const remainingPids = stopResult?.remainingPids ?? [];
+  if (remainingPids.length > 0) {
+    throw new Error(
+      `stale packaged sidecars still running after stop: ${remainingPids.join(", ")}`,
+    );
+  }
+
   await cleanupSockets();
   return { reclaimedPids };
 }

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { access, appendFile, mkdir, open, type FileHandle } from "node:fs/promises";
+import { access, appendFile, mkdir, open, rm, type FileHandle } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { delimiter, dirname, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -10,6 +10,7 @@ import {
   SIDECAR_ENV,
   SIDECAR_MESSAGES,
   SIDECAR_MODES,
+  SIDECAR_SOURCES,
   type AppKey,
   type DaemonStatusSnapshot,
   type SidecarStamp,
@@ -22,12 +23,16 @@ import {
   type SidecarRuntimeContext,
 } from "@open-design/sidecar";
 import {
+  collectProcessTreePids,
   createProcessStampArgs,
+  listProcessSnapshots,
+  matchesStampedProcess,
   mergeProxyAwareEnv,
   resolveSystemProxyEnv,
   stopProcesses,
   waitForProcessExit,
   wellKnownUserToolchainBins,
+  type ProcessSnapshot,
 } from "@open-design/platform";
 
 import type { PackagedWebOutputMode } from "./config.js";
@@ -181,6 +186,7 @@ export async function waitForStatus<T>(
   isReady: (status: T) => boolean,
   timeoutMs = DAEMON_STATUS_TIMEOUT_MS,
   watch: { child: { exitCode: number | null; signalCode: NodeJS.Signals | null; once: (event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void) => void; off: (event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void) => void }; logPath: string } | null = null,
+  appLabel = "daemon",
 ): Promise<T> {
   const startedAt = Date.now();
   let lastError: unknown;
@@ -202,7 +208,7 @@ export async function waitForStatus<T>(
     while (Date.now() - startedAt < timeoutMs) {
       if (childExited !== null) {
         throw new Error(
-          `daemon exited before reporting status (code=${childExited.code}, signal=${childExited.signal ?? 'none'}); see ${watch?.logPath ?? '<no log path>'} for details`,
+          `${appLabel} exited before reporting status (code=${childExited.code}, signal=${childExited.signal ?? 'none'}); see ${watch?.logPath ?? '<no log path>'} for details`,
         );
       }
       try {
@@ -231,6 +237,89 @@ export async function waitForStatus<T>(
 function extractPort(url: string): string {
   const parsed = new URL(url);
   return parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+}
+
+/**
+ * Remove every POSIX IPC socket file under a namespace's
+ * `/tmp/open-design/ipc/<namespace>` directory. Windows named pipes have
+ * no filesystem entry to clean, so this is a no-op there.
+ */
+async function removeNamespaceIpcSockets(namespace: string): Promise<void> {
+  if (process.platform === "win32") return;
+  const webIpcPath = resolveAppIpcPath({
+    app: APP_KEYS.WEB,
+    contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+    namespace,
+  });
+  await rm(dirname(webIpcPath), { recursive: true, force: true });
+}
+
+export type ReclaimStaleNamespaceSidecarsDeps = {
+  listProcesses?: () => Promise<ProcessSnapshot[]>;
+  stop?: (pids: number[]) => Promise<void>;
+  cleanupSockets?: () => Promise<void>;
+  selfPid?: number;
+};
+
+/**
+ * Reclaim a packaged runtime namespace before starting fresh sidecars.
+ *
+ * Issue #4441: a still-alive daemon or web sidecar from an older packaged
+ * runtime keeps its `/tmp/open-design/ipc/<namespace>/<app>.sock` bound and
+ * answers the new sidecar's stale-socket probe, so the probe judges the
+ * socket healthy, never unlinks it, and the new sidecar dies with
+ * EADDRINUSE while the launcher times out waiting for status.
+ *
+ * The launcher owns the namespace, so the correct upgrade semantics are to
+ * stop leftover same-namespace sidecars (and clear their sockets) before
+ * spawning, regardless of whether the old process still answers a probe.
+ * Once the old process is gone, the new sidecar's own stale-socket check in
+ * `prepareIpcPath` can unlink the dead socket cleanly.
+ *
+ * Only daemon/web sidecars are reclaimed — a leftover desktop process is
+ * handled by the single-instance lock, not here. The current process tree
+ * is always excluded so a just-spawned child can never be torn down.
+ */
+export async function reclaimStaleNamespaceSidecars(
+  namespace: string,
+  deps: ReclaimStaleNamespaceSidecarsDeps = {},
+): Promise<{ reclaimedPids: number[] }> {
+  const listProcesses = deps.listProcesses ?? listProcessSnapshots;
+  const stop =
+    deps.stop ??
+    (async (pids: number[]): Promise<void> => {
+      await stopProcesses(pids);
+    });
+  const cleanupSockets =
+    deps.cleanupSockets ?? (async (): Promise<void> => removeNamespaceIpcSockets(namespace));
+  const selfPid = deps.selfPid ?? process.pid;
+
+  const processes = await listProcesses();
+  const protectedPids = new Set(collectProcessTreePids(processes, [selfPid]));
+  const reclaimApps: AppKey[] = [APP_KEYS.DAEMON, APP_KEYS.WEB];
+  const reclaimedPids = processes
+    .filter((processInfo) => !protectedPids.has(processInfo.pid))
+    .filter((processInfo) =>
+      reclaimApps.some((app) =>
+        matchesStampedProcess(
+          processInfo,
+          {
+            app,
+            mode: SIDECAR_MODES.RUNTIME,
+            namespace,
+            source: SIDECAR_SOURCES.PACKAGED,
+          },
+          OPEN_DESIGN_SIDECAR_CONTRACT,
+        ),
+      ),
+    )
+    .map((processInfo) => processInfo.pid);
+
+  if (reclaimedPids.length === 0) return { reclaimedPids: [] };
+
+  await stop(reclaimedPids);
+  await cleanupSockets();
+  return { reclaimedPids };
 }
 
 // Hardcoded POSIX system bins the packaged daemon must always be able to
@@ -478,6 +567,15 @@ export async function startPackagedSidecars(
   await mkdir(paths.electronUserDataRoot, { recursive: true });
   await mkdir(paths.electronSessionDataRoot, { recursive: true });
 
+  // Issue #4441: stop any still-alive sidecar from an older packaged
+  // runtime that still owns this namespace's IPC sockets, otherwise the
+  // new web/daemon sidecar dies with EADDRINUSE on a socket the probe
+  // mistook for healthy. Best-effort: a discovery/stop failure must not
+  // block the launch we are about to attempt.
+  await reclaimStaleNamespaceSidecars(runtime.namespace).catch((error: unknown) => {
+    console.error("failed to reclaim stale namespace sidecars", error);
+  });
+
   const children: ManagedSidecarChild[] = [];
 
   try {
@@ -533,6 +631,13 @@ export async function startPackagedSidecars(
     const webStatus = await waitForStatus<WebStatusSnapshot>(
       web.ipcPath,
       (status) => status.url != null,
+      DAEMON_STATUS_TIMEOUT_MS,
+      // Race the web child's exit too: a web sidecar that dies on
+      // EADDRINUSE (issue #4441) must surface its real failure and log
+      // path immediately instead of timing out after 35s while pointing
+      // at the wrong process.
+      { child: web.child, logPath: logPathFor(paths, APP_KEYS.WEB) },
+      "web",
     );
     if (webStatus.url == null) throw new Error("web did not report a URL");
     options.onPhase?.("web-ready");

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildPackagedDaemonSpawnEnv,
+  reclaimStaleNamespaceSidecars,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
   resolvePackagedElectronNodeCommand,
@@ -30,6 +31,51 @@ import {
   waitForStatus,
 } from '../src/sidecars.js';
 import type { PackagedNamespacePaths } from '../src/paths.js';
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_MODES,
+  SIDECAR_SOURCES,
+  type AppKey,
+  type SidecarStamp,
+} from '@open-design/sidecar-proto';
+import { resolveAppIpcPath } from '@open-design/sidecar';
+import { createProcessStampArgs, type ProcessSnapshot } from '@open-design/platform';
+
+/**
+ * Build a runtime sidecar stamp for a given app + namespace, mirroring
+ * what `spawnSidecarChild` stamps onto packaged sidecar children.
+ */
+function packagedSidecarStamp(app: AppKey, namespace: string): SidecarStamp {
+  return {
+    app,
+    ipc: resolveAppIpcPath({ app, contract: OPEN_DESIGN_SIDECAR_CONTRACT, namespace }),
+    mode: SIDECAR_MODES.RUNTIME,
+    namespace,
+    source: SIDECAR_SOURCES.PACKAGED,
+  } satisfies SidecarStamp;
+}
+
+/**
+ * Render a process command line that carries the OD process stamp flags,
+ * so `matchesStampedProcess` can recover the stamp the same way it would
+ * from a real `ps`/`wmic` snapshot.
+ */
+function stampedProcessSnapshot(
+  pid: number,
+  ppid: number,
+  stamp: SidecarStamp,
+): ProcessSnapshot {
+  return {
+    pid,
+    ppid,
+    command: [
+      '/opt/node',
+      'sidecar.js',
+      ...createProcessStampArgs(stamp, OPEN_DESIGN_SIDECAR_CONTRACT),
+    ].join(' '),
+  };
+}
 
 describe('resolveDaemonStatusTimeoutMs', () => {
   it('uses the default 35-second budget for normal cold boots', () => {
@@ -499,5 +545,122 @@ describe('waitForStatus child-exit fast-fail', () => {
     expect((captured as Error).message).toMatch(/daemon exited before reporting status/);
     expect((captured as Error).message).toContain('code=2');
     expect(elapsed).toBeLessThan(2_000);
+  });
+});
+
+describe('reclaimStaleNamespaceSidecars', () => {
+  // Issue #4441: an older packaged runtime can leave a still-alive daemon
+  // or web sidecar bound to /tmp/open-design/ipc/<namespace>/<app>.sock.
+  // Because the leftover process answers a probe connection, the new
+  // sidecar's stale-socket check treats it as healthy and never unlinks,
+  // so the new sidecar dies with EADDRINUSE. The launcher must reclaim
+  // the namespace by stopping the leftover same-namespace sidecars (and
+  // clearing their sockets) before spawning new ones.
+
+  it('stops leftover same-namespace daemon and web sidecars and clears their sockets', async () => {
+    const namespace = 'release-nightly';
+    const processes: ProcessSnapshot[] = [
+      stampedProcessSnapshot(4002, 1, packagedSidecarStamp(APP_KEYS.WEB, namespace)),
+      stampedProcessSnapshot(4001, 1, packagedSidecarStamp(APP_KEYS.DAEMON, namespace)),
+      { pid: 999, ppid: 1, command: '/usr/bin/node some-unrelated-server.js' },
+    ];
+    const stopped: number[][] = [];
+    let cleanups = 0;
+
+    const result = await reclaimStaleNamespaceSidecars(namespace, {
+      selfPid: 1234,
+      listProcesses: async () => processes,
+      stop: async (pids) => {
+        stopped.push(pids);
+      },
+      cleanupSockets: async () => {
+        cleanups += 1;
+      },
+    });
+
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0]).toEqual(expect.arrayContaining([4001, 4002]));
+    expect(stopped[0]).not.toContain(999);
+    expect(cleanups).toBe(1);
+    expect(result.reclaimedPids).toEqual(expect.arrayContaining([4001, 4002]));
+    expect(result.reclaimedPids).toHaveLength(2);
+  });
+
+  it('ignores sidecars stamped for a different namespace', async () => {
+    const processes: ProcessSnapshot[] = [
+      stampedProcessSnapshot(5001, 1, packagedSidecarStamp(APP_KEYS.WEB, 'release-beta')),
+    ];
+    const stopped: number[][] = [];
+    let cleanups = 0;
+
+    const result = await reclaimStaleNamespaceSidecars('release-nightly', {
+      selfPid: 1234,
+      listProcesses: async () => processes,
+      stop: async (pids) => {
+        stopped.push(pids);
+      },
+      cleanupSockets: async () => {
+        cleanups += 1;
+      },
+    });
+
+    expect(stopped).toHaveLength(0);
+    expect(cleanups).toBe(0);
+    expect(result.reclaimedPids).toHaveLength(0);
+  });
+
+  it('never stops the current process or its descendants', async () => {
+    const namespace = 'release-nightly';
+    const processes: ProcessSnapshot[] = [
+      // The current desktop process and a sidecar it just spawned both
+      // carry the same namespace stamp; reclaim must not target them.
+      stampedProcessSnapshot(7000, 1, packagedSidecarStamp(APP_KEYS.DESKTOP, namespace)),
+      stampedProcessSnapshot(7001, 7000, packagedSidecarStamp(APP_KEYS.DAEMON, namespace)),
+    ];
+    const stopped: number[][] = [];
+
+    const result = await reclaimStaleNamespaceSidecars(namespace, {
+      selfPid: 7000,
+      listProcesses: async () => processes,
+      stop: async (pids) => {
+        stopped.push(pids);
+      },
+      cleanupSockets: async () => undefined,
+    });
+
+    expect(stopped).toHaveLength(0);
+    expect(result.reclaimedPids).toHaveLength(0);
+  });
+});
+
+describe('waitForStatus app label', () => {
+  // Issue #4441: the web sidecar's waitForStatus call previously passed no
+  // child watch and the error text was hardcoded to "daemon", so a web
+  // sidecar that died on EADDRINUSE surfaced as a generic 35s timeout that
+  // named the wrong process. The exit error must name the failing app.
+
+  it('names the web sidecar when its child exits before reporting status', async () => {
+    const child = fakeChild();
+    const logPath = '/tmp/od-test-web.log';
+
+    const promise = waitForStatus<{ url: string | null }>(
+      '/tmp/od-test-no-such-ipc-web-' + Date.now(),
+      (status) => status.url != null,
+      30 * 60 * 1000,
+      { child, logPath },
+      'web',
+    );
+    setTimeout(() => child.fireExit(1, null), 50);
+
+    let captured: unknown;
+    try {
+      await promise;
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error).message).toMatch(/web exited before reporting status/);
+    expect((captured as Error).message).toContain(logPath);
   });
 });

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -609,6 +609,32 @@ describe('reclaimStaleNamespaceSidecars', () => {
     expect(result.reclaimedPids).toHaveLength(0);
   });
 
+  it('does not clear sockets when requested stale sidecars are still running', async () => {
+    const namespace = 'release-nightly';
+    const processes: ProcessSnapshot[] = [
+      stampedProcessSnapshot(6001, 1, packagedSidecarStamp(APP_KEYS.DAEMON, namespace)),
+    ];
+    const stopped: number[][] = [];
+    let cleanups = 0;
+
+    await expect(
+      reclaimStaleNamespaceSidecars(namespace, {
+        selfPid: 1234,
+        listProcesses: async () => processes,
+        stop: async (pids) => {
+          stopped.push(pids);
+          return { remainingPids: [6001] };
+        },
+        cleanupSockets: async () => {
+          cleanups += 1;
+        },
+      }),
+    ).rejects.toThrow(/still running/);
+
+    expect(stopped).toEqual([[6001]]);
+    expect(cleanups).toBe(0);
+  });
+
   it('never stops the current process or its descendants', async () => {
     const namespace = 'release-nightly';
     const processes: ProcessSnapshot[] = [

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -586,6 +586,39 @@ describe('reclaimStaleNamespaceSidecars', () => {
     expect(result.reclaimedPids).toHaveLength(2);
   });
 
+  it('stops leftover same-namespace daemon and web sidecars launched by tools-pack', async () => {
+    const namespace = 'release-nightly';
+    const processes: ProcessSnapshot[] = [
+      stampedProcessSnapshot(4102, 1, {
+        ...packagedSidecarStamp(APP_KEYS.WEB, namespace),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      }),
+      stampedProcessSnapshot(4101, 1, {
+        ...packagedSidecarStamp(APP_KEYS.DAEMON, namespace),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      }),
+    ];
+    const stopped: number[][] = [];
+    let cleanups = 0;
+
+    const result = await reclaimStaleNamespaceSidecars(namespace, {
+      selfPid: 1234,
+      listProcesses: async () => processes,
+      stop: async (pids) => {
+        stopped.push(pids);
+      },
+      cleanupSockets: async () => {
+        cleanups += 1;
+      },
+    });
+
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0]).toEqual(expect.arrayContaining([4101, 4102]));
+    expect(cleanups).toBe(1);
+    expect(result.reclaimedPids).toEqual(expect.arrayContaining([4101, 4102]));
+    expect(result.reclaimedPids).toHaveLength(2);
+  });
+
   it('ignores sidecars stamped for a different namespace', async () => {
     const processes: ProcessSnapshot[] = [
       stampedProcessSnapshot(5001, 1, packagedSidecarStamp(APP_KEYS.WEB, 'release-beta')),


### PR DESCRIPTION
Fixes #4441

## Why

I hit this while exercising packaged Nightly upgrade/reinstall flows: the app appeared to crash on launch, and the desktop log only showed a generic `timed out waiting for sidecar status` against `web.sock`. Digging in, the real cause was a still-alive web sidecar from the previous build (`0.10.1`) still bound to `/tmp/open-design/ipc/release-nightly/web.sock`.

The pain: the existing stale-socket cleanup (`prepareIpcPath`/`staleUnixSocketExists`) only handles a socket left behind by a **dead** process — it probes with a connection and, when a leftover process is still alive and answers, judges the socket "healthy" and never unlinks it. The new sidecar then dies with `EADDRINUSE`, and because the web `waitForStatus` call passed no child watch, it sat through the full 35s timeout and reported the wrong process. This is the P1/risk-high startup robustness gap in #4441: a live older-version sidecar is semantically stale for the namespace but was never reclaimed.

## What users will see

Upgrading or reinstalling a packaged build no longer fails to open when an older runtime left a sidecar running. The launcher now reclaims the namespace on startup (stops the leftover daemon/web sidecars and clears their sockets) before spawning fresh ones. If a sidecar still can't start, the desktop log now names the failing process and points at its log instead of a generic 35s timeout.

## Surface area

- [x] **None** — internal packaged-launcher startup robustness fix; no UI/CLI/API/i18n surface. (It does change startup behavior in that a leftover *same-namespace* sidecar is now stopped — but that is the fix for the crash, not an opt-in behavior, and a leftover desktop process is still left to the single-instance lock.)

## Screenshots

N/A — no UI.

## Bug fix verification

- Test path that reproduces the bug: `apps/packaged/tests/sidecars.test.ts`
  - `reclaimStaleNamespaceSidecars > stops leftover same-namespace daemon and web sidecars and clears their sockets` (+ different-namespace and self-tree-exclusion cases)
  - `waitForStatus app label > names the web sidecar when its child exits before reporting status`
- Did the test go red on `main` and green on this branch? **yes** — red as `reclaimStaleNamespaceSidecars is not a function` and as the exit error naming `daemon` instead of `web`; green after the fix.
- End-to-end "packaged app no longer crashes" needs a packaged build to confirm by eye. To reproduce the live-leftover state from the issue: start an older packaged runtime, leave its web sidecar bound to `/tmp/open-design/ipc/<namespace>/web.sock`, then launch the new build — it should reclaim and start instead of timing out.

## Validation

- `pnpm --filter @open-design/packaged test` → `tests/sidecars.test.ts` 28 passed (the 4 new specs RED→GREEN).
- `tsc -p tsconfig.json --noEmit` / `tsconfig.tests.json` → no errors in `sidecars.ts`.
- Scope held to #4441's startup path; the macOS AppTranslocation/quarantine diagnostic suggested in the issue is left as a follow-up.
