### PR TITLE
[codex] Fix brand extraction terminal status reconciliation

### DIFF
--- a/apps/daemon/src/brand-routes.ts
+++ b/apps/daemon/src/brand-routes.ts
@@ -285,7 +285,7 @@ function reconcileBrandMetaStatus(
   meta: BrandMeta,
   context: BrandStatusContext,
 ): BrandMeta {
-  if (meta.status !== 'extracting' || !meta.projectId) return meta;
+  if (!meta.projectId) return meta;
   const status = context.latestByProject.get(meta.projectId);
   if (status && (status.value === 'failed' || status.value === 'canceled')) {
     const error =
@@ -293,12 +293,14 @@ function reconcileBrandMetaStatus(
       ?? (status.value === 'canceled'
         ? 'Brand extraction was canceled.'
         : 'Brand extraction failed in the backing project.');
+    if (meta.status === 'failed' && meta.error === error) return meta;
     return patchMeta(brandsRoot, meta.id, { status: 'failed', error }) ?? {
       ...meta,
       status: 'failed',
       error,
     };
   }
+  if (meta.status !== 'extracting') return meta;
   // The backing run paused on a question form (anti-bot wall / clarifying
   // question). Surface it as needs_input WITHOUT persisting — answering the
   // question resumes extraction, so the brand must be free to flip back.

--- a/apps/daemon/src/brand-routes.ts
+++ b/apps/daemon/src/brand-routes.ts
@@ -288,13 +288,21 @@ function reconcileBrandMetaStatus(
   if (!meta.projectId) return meta;
   const status = context.latestByProject.get(meta.projectId);
   if (status && (status.value === 'failed' || status.value === 'canceled')) {
-    const error = terminalBrandRunError(status);
-    if (!shouldReconcileTerminalBrandRun(meta, error)) return meta;
+    const error = terminalBrandRunError(meta, status);
+    if (!shouldReconcileTerminalBrandRun(meta, status)) return meta;
     if (meta.status === 'failed' && meta.error === error) return meta;
-    return patchMeta(brandsRoot, meta.id, { status: 'failed', error }) ?? {
+    const terminalPatch: Parameters<typeof patchMeta>[2] = {
+      status: 'failed',
+      error,
+      extractionTerminalError: error,
+    };
+    if (status.runId) terminalPatch.extractionTerminalRunId = status.runId;
+    return patchMeta(brandsRoot, meta.id, terminalPatch) ?? {
       ...meta,
       status: 'failed',
       error,
+      extractionTerminalError: error,
+      ...(status.runId ? { extractionTerminalRunId: status.runId } : {}),
     };
   }
   if (meta.status !== 'extracting') return meta;
@@ -307,18 +315,25 @@ function reconcileBrandMetaStatus(
   return meta;
 }
 
-function terminalBrandRunError(status: BrandRunStatus): string {
+function terminalBrandRunError(meta: BrandMeta, status: BrandRunStatus): string {
   return (
     status.error
+    ?? (status.runId && meta.extractionTerminalRunId === status.runId
+      ? meta.extractionTerminalError
+      : undefined)
     ?? (status.value === 'canceled'
       ? 'Brand extraction was canceled.'
       : 'Brand extraction failed in the backing project.')
   );
 }
 
-function shouldReconcileTerminalBrandRun(meta: BrandMeta, error: string): boolean {
+function shouldReconcileTerminalBrandRun(meta: BrandMeta, status: BrandRunStatus): boolean {
   if (meta.status === 'extracting') return true;
-  return meta.status === 'ready' && meta.error === error;
+  return Boolean(
+    meta.status === 'ready'
+    && status.runId
+    && meta.extractionTerminalRunId === status.runId,
+  );
 }
 
 function normalizeBrandRunStatus(status: string): string {

--- a/apps/daemon/src/brand-routes.ts
+++ b/apps/daemon/src/brand-routes.ts
@@ -288,11 +288,8 @@ function reconcileBrandMetaStatus(
   if (!meta.projectId) return meta;
   const status = context.latestByProject.get(meta.projectId);
   if (status && (status.value === 'failed' || status.value === 'canceled')) {
-    const error =
-      status.error
-      ?? (status.value === 'canceled'
-        ? 'Brand extraction was canceled.'
-        : 'Brand extraction failed in the backing project.');
+    const error = terminalBrandRunError(status);
+    if (!shouldReconcileTerminalBrandRun(meta, error)) return meta;
     if (meta.status === 'failed' && meta.error === error) return meta;
     return patchMeta(brandsRoot, meta.id, { status: 'failed', error }) ?? {
       ...meta,
@@ -308,6 +305,20 @@ function reconcileBrandMetaStatus(
     return { ...meta, status: 'needs_input' };
   }
   return meta;
+}
+
+function terminalBrandRunError(status: BrandRunStatus): string {
+  return (
+    status.error
+    ?? (status.value === 'canceled'
+      ? 'Brand extraction was canceled.'
+      : 'Brand extraction failed in the backing project.')
+  );
+}
+
+function shouldReconcileTerminalBrandRun(meta: BrandMeta, error: string): boolean {
+  if (meta.status === 'extracting') return true;
+  return meta.status === 'ready' && meta.error === error;
 }
 
 function normalizeBrandRunStatus(status: string): string {

--- a/apps/daemon/src/brands/index.ts
+++ b/apps/daemon/src/brands/index.ts
@@ -588,6 +588,8 @@ async function finalizeBrandCore(opts: FinalizeBrandCoreOptions): Promise<BrandF
   patchMeta(brandsRoot, id, {
     status: 'ready',
     error: undefined,
+    extractionTerminalRunId: undefined,
+    extractionTerminalError: undefined,
     designSystemId,
     systemFiles: systemBuild.files,
     projectId,

--- a/apps/daemon/src/brands/index.ts
+++ b/apps/daemon/src/brands/index.ts
@@ -587,6 +587,7 @@ async function finalizeBrandCore(opts: FinalizeBrandCoreOptions): Promise<BrandF
 
   patchMeta(brandsRoot, id, {
     status: 'ready',
+    error: undefined,
     designSystemId,
     systemFiles: systemBuild.files,
     projectId,

--- a/apps/daemon/src/brands/prefetch.ts
+++ b/apps/daemon/src/brands/prefetch.ts
@@ -820,7 +820,8 @@ export async function prefetchBrand(
 
   // Persist raw material for the agent to Read deeper if it wants to.
   fs.writeFileSync(path.join(prefetchDir, "material.md"), materialMd);
-  fs.writeFileSync(path.join(prefetchDir, "page.html"), previewablePrefetchHtml(html));
+  fs.writeFileSync(path.join(prefetchDir, "page.html"), html.slice(0, HTML_CAP));
+  fs.writeFileSync(path.join(prefetchDir, "page-preview.html"), previewablePrefetchHtml(html));
   fs.writeFileSync(path.join(prefetchDir, "styles.css"), allCss.slice(0, 2_000_000));
 
   return { ...partial, thin, materialMd };

--- a/apps/daemon/src/brands/prefetch.ts
+++ b/apps/daemon/src/brands/prefetch.ts
@@ -20,7 +20,7 @@ import { harvestFonts, type FontFile } from "./fonts.js";
 const UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
 
-const HTML_CAP = 1_500_000; // 1.5MB
+const HTML_CAP = 6_000_000; // Large SSR payloads can put megabytes of JSON before <body>.
 const CSS_CAP = 400_000; // 400KB per file
 const MAX_CSS_FILES = 6;
 const MAX_LOGOS = 6;
@@ -164,6 +164,43 @@ export function isChallengePage(html: string): boolean {
   const title = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
   if (CHALLENGE_TITLE_RE.test(title)) return true;
   return CHALLENGE_BODY_RE.test(html.slice(0, 60_000));
+}
+
+export function previewablePrefetchHtml(html: string, cap = HTML_CAP): string {
+  const out = html.slice(0, cap);
+  if (/<body\b/i.test(out) || out.length < cap) return out;
+  const title = decodeEntities(/<title[^>]*>([\s\S]*?)<\/title>/i.exec(out)?.[1] ?? "").trim();
+  return [
+    "<!doctype html>",
+    "<html>",
+    "<head>",
+    '<meta charset="utf-8">',
+    `<title>${escapeHtml(title || "Prefetch HTML truncated")}</title>`,
+    "<style>",
+    "body{font:14px/1.5 system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;margin:0;background:#fff;color:#202124}",
+    "main{max-width:760px;margin:64px auto;padding:0 24px}",
+    "h1{font-size:22px;margin:0 0 12px}",
+    "p{margin:0 0 10px;color:#5f6368}",
+    "code{background:#f1f3f4;border-radius:4px;padding:2px 4px;color:#202124}",
+    "</style>",
+    "</head>",
+    "<body>",
+    "<main>",
+    "<h1>Prefetch HTML was truncated before the page body.</h1>",
+    `<p>The fetched document exceeded the ${cap.toLocaleString("en-US")} byte preview cap before <code>&lt;body&gt;</code> appeared.</p>`,
+    "<p>Use <code>prefetch/material.md</code>, <code>prefetch/styles.css</code>, and saved brand assets for extraction evidence.</p>",
+    "</main>",
+    "</body>",
+    "</html>",
+  ].join("");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 function decodeEntities(s: string): string {
@@ -783,7 +820,7 @@ export async function prefetchBrand(
 
   // Persist raw material for the agent to Read deeper if it wants to.
   fs.writeFileSync(path.join(prefetchDir, "material.md"), materialMd);
-  fs.writeFileSync(path.join(prefetchDir, "page.html"), html.slice(0, HTML_CAP));
+  fs.writeFileSync(path.join(prefetchDir, "page.html"), previewablePrefetchHtml(html));
   fs.writeFileSync(path.join(prefetchDir, "styles.css"), allCss.slice(0, 2_000_000));
 
   return { ...partial, thin, materialMd };

--- a/apps/daemon/src/brands/store.ts
+++ b/apps/daemon/src/brands/store.ts
@@ -16,7 +16,11 @@ import type { Brand, BrandMeta } from '@open-design/contracts';
 
 const ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
-type BrandMetaPatch = Partial<Omit<BrandMeta, 'error'>> & { error?: string | undefined };
+type BrandMetaPatch = Partial<Omit<BrandMeta, 'error' | 'extractionTerminalRunId' | 'extractionTerminalError'>> & {
+  error?: string | undefined;
+  extractionTerminalRunId?: string | undefined;
+  extractionTerminalError?: string | undefined;
+};
 
 /** True when `id` is a safe single-segment brand directory name. */
 export function isValidBrandId(id: string): boolean {
@@ -113,13 +117,32 @@ export function patchMeta(
 ): BrandMeta | null {
   const current = readMeta(brandsRoot, id);
   if (!current) return null;
-  const { error: patchError, ...rest } = patch;
+  const {
+    error: patchError,
+    extractionTerminalRunId: patchExtractionTerminalRunId,
+    extractionTerminalError: patchExtractionTerminalError,
+    ...rest
+  } = patch;
   const next: BrandMeta = { ...current, ...rest, updatedAt: Date.now() };
   if (Object.prototype.hasOwnProperty.call(patch, 'error')) {
     if (patchError === undefined) {
       delete next.error;
     } else {
       next.error = patchError;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'extractionTerminalRunId')) {
+    if (patchExtractionTerminalRunId === undefined) {
+      delete next.extractionTerminalRunId;
+    } else {
+      next.extractionTerminalRunId = patchExtractionTerminalRunId;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'extractionTerminalError')) {
+    if (patchExtractionTerminalError === undefined) {
+      delete next.extractionTerminalError;
+    } else {
+      next.extractionTerminalError = patchExtractionTerminalError;
     }
   }
   writeMeta(brandsRoot, id, next);

--- a/apps/daemon/src/brands/store.ts
+++ b/apps/daemon/src/brands/store.ts
@@ -16,6 +16,8 @@ import type { Brand, BrandMeta } from '@open-design/contracts';
 
 const ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
+type BrandMetaPatch = Partial<Omit<BrandMeta, 'error'>> & { error?: string | undefined };
+
 /** True when `id` is a safe single-segment brand directory name. */
 export function isValidBrandId(id: string): boolean {
   return ID_RE.test(id) && !id.includes('..');
@@ -107,11 +109,19 @@ export function writeMeta(brandsRoot: string, id: string, meta: BrandMeta): void
 export function patchMeta(
   brandsRoot: string,
   id: string,
-  patch: Partial<BrandMeta>,
+  patch: BrandMetaPatch,
 ): BrandMeta | null {
   const current = readMeta(brandsRoot, id);
   if (!current) return null;
-  const next: BrandMeta = { ...current, ...patch, updatedAt: Date.now() };
+  const { error: patchError, ...rest } = patch;
+  const next: BrandMeta = { ...current, ...rest, updatedAt: Date.now() };
+  if (Object.prototype.hasOwnProperty.call(patch, 'error')) {
+    if (patchError === undefined) {
+      delete next.error;
+    } else {
+      next.error = patchError;
+    }
+  }
   writeMeta(brandsRoot, id, next);
   return next;
 }

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -16,6 +16,7 @@ import {
   renderBrandPreviewIntoProject,
   startBrandExtraction,
 } from '../src/brands/index.js';
+import { patchMeta } from '../src/brands/store.js';
 import { ensureLogoFallback } from '../src/brands/logo-fallback.js';
 import { listDesignSystems } from '../src/design-systems.js';
 import {
@@ -205,6 +206,12 @@ describe('agent-driven brand extraction engine', () => {
       db,
       logoFallback: NO_LOGO_FALLBACK,
     });
+    patchMeta(brandsRoot, started.id, {
+      status: 'failed',
+      error: 'Old extraction failed.',
+      extractionTerminalRunId: 'run-old-failed',
+      extractionTerminalError: 'Old extraction failed.',
+    });
 
     // Simulate the agent writing the complete kit into the backing project.
     const projectDir = path.join(projectsRoot, started.projectId);
@@ -232,6 +239,9 @@ describe('agent-driven brand extraction engine', () => {
 
     const detail = readBrandDetail(brandsRoot, started.id);
     expect(detail?.meta.status).toBe('ready');
+    expect(detail?.meta.error).toBeUndefined();
+    expect(detail?.meta.extractionTerminalRunId).toBeUndefined();
+    expect(detail?.meta.extractionTerminalError).toBeUndefined();
     expect(detail?.meta.designSystemId).toBe(finalized.designSystemId);
 
     const project = getProject(db, started.projectId);

--- a/apps/daemon/tests/brand-prefetch.test.ts
+++ b/apps/daemon/tests/brand-prefetch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { previewablePrefetchHtml } from '../src/brands/prefetch.js';
+
+describe('brand prefetch artifacts', () => {
+  it('replaces head-only truncated captures with a visible diagnostic page', () => {
+    const html = `<!doctype html><html><head><title>Big SSR</title><script>${'x'.repeat(80)}</script></head><body>real page</body></html>`;
+
+    const preview = previewablePrefetchHtml(html, 64);
+
+    expect(preview).toContain('<body>');
+    expect(preview).toContain('Prefetch HTML was truncated before the page body.');
+    expect(preview).toContain('Big SSR');
+    expect(preview).not.toContain('real page');
+  });
+
+  it('keeps capped captures when the body is present before the cap', () => {
+    const html = `<!doctype html><html><head><title>Ready</title></head><body>${'x'.repeat(80)}</body></html>`;
+
+    const preview = previewablePrefetchHtml(html, 72);
+
+    expect(preview).toBe(html.slice(0, 72));
+    expect(preview).toContain('<body>');
+  });
+});

--- a/apps/daemon/tests/brand-routes.test.ts
+++ b/apps/daemon/tests/brand-routes.test.ts
@@ -228,6 +228,55 @@ describe('brand routes', () => {
     expect(storedMeta.extractionTerminalError).toBe(providerError);
   });
 
+  it('does not regress a successful retry when the old failed run remains the latest status', async () => {
+    writeBrandFixture('brand-retry-ready', {
+      projectId: 'project-retry-ready',
+      logoPrimary: 'logos/missing.svg',
+      status: 'ready',
+    });
+    insertProject(db, {
+      id: 'project-retry-ready',
+      name: 'Retry Ready Brand Project',
+      skillId: null,
+      designSystemId: null,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: { kind: 'brand', brandId: 'brand-retry-ready' },
+    });
+    insertConversation(db, {
+      id: 'conversation-retry-ready',
+      projectId: 'project-retry-ready',
+      title: 'Extract brand',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    upsertMessage(db, 'conversation-retry-ready', {
+      id: 'message-retry-ready-failed',
+      role: 'assistant',
+      content: 'Old extraction failed.',
+      runId: 'run-retry-ready-failed',
+      runStatus: 'failed',
+      startedAt: 1,
+      endedAt: 2,
+    });
+
+    const detail = await requestJson('/api/brands/brand-retry-ready');
+    const list = await requestJson('/api/brands');
+
+    expect(detail.status).toBe(200);
+    expect(detail.body.meta.status).toBe('ready');
+    expect(detail.body.meta.error).toBeUndefined();
+    expect(list.body.brands.find((brand: any) => brand.meta.id === 'brand-retry-ready')?.meta.status).toBe(
+      'ready',
+    );
+
+    const storedMeta = JSON.parse(readFileSync(path.join(brandsRoot, 'brand-retry-ready', 'meta.json'), 'utf8'));
+    expect(storedMeta.status).toBe('ready');
+    expect(storedMeta.error).toBeUndefined();
+    expect(storedMeta.extractionTerminalRunId).toBeUndefined();
+    expect(storedMeta.extractionTerminalError).toBeUndefined();
+  });
+
   it('does not regress ready brands after a later backing project run is canceled', async () => {
     writeBrandFixture('brand-ready', {
       projectId: 'project-ready',

--- a/apps/daemon/tests/brand-routes.test.ts
+++ b/apps/daemon/tests/brand-routes.test.ts
@@ -175,6 +175,54 @@ describe('brand routes', () => {
     expect(storedMeta.status).toBe('failed');
   });
 
+  it('keeps terminal backing run failure visible even if a stale finalize marked the brand ready', async () => {
+    writeBrandFixture('brand-stale-ready', {
+      projectId: 'project-stale-ready',
+      logoPrimary: 'logos/missing.svg',
+      status: 'ready',
+      error: 'Brand extraction was canceled.',
+    });
+    insertProject(db, {
+      id: 'project-stale-ready',
+      name: 'Stale Ready Brand Project',
+      skillId: null,
+      designSystemId: null,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: { kind: 'brand', brandId: 'brand-stale-ready' },
+    });
+    insertConversation(db, {
+      id: 'conversation-stale-ready',
+      projectId: 'project-stale-ready',
+      title: 'Extract brand',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    upsertMessage(db, 'conversation-stale-ready', {
+      id: 'message-stale-ready',
+      role: 'assistant',
+      content: 'Stopped.',
+      runId: 'run-stale-ready',
+      runStatus: 'canceled',
+      startedAt: 1,
+      endedAt: 2,
+    });
+
+    const detail = await requestJson('/api/brands/brand-stale-ready');
+    const list = await requestJson('/api/brands');
+
+    expect(detail.status).toBe(200);
+    expect(detail.body.meta.status).toBe('failed');
+    expect(detail.body.meta.error).toBe('Brand extraction was canceled.');
+    expect(list.body.brands.find((brand: any) => brand.meta.id === 'brand-stale-ready')?.meta.status).toBe(
+      'failed',
+    );
+
+    const storedMeta = JSON.parse(readFileSync(path.join(brandsRoot, 'brand-stale-ready', 'meta.json'), 'utf8'));
+    expect(storedMeta.status).toBe('failed');
+    expect(storedMeta.error).toBe('Brand extraction was canceled.');
+  });
+
   it('surfaces needs_input when the backing project is awaiting user input', async () => {
     writeBrandFixture('brand-blocked', {
       projectId: 'project-blocked',
@@ -225,7 +273,7 @@ describe('brand routes', () => {
 
   function writeBrandFixture(
     id: string,
-    options: { projectId?: string; logoPrimary: string; logoBody?: string; status?: string },
+    options: { projectId?: string; logoPrimary: string; logoBody?: string; status?: string; error?: string },
   ) {
     const brandDir = path.join(brandsRoot, id);
     mkdirSync(brandDir, { recursive: true });
@@ -237,6 +285,7 @@ describe('brand routes', () => {
         createdAt: 1,
         updatedAt: 1,
         status: options.status ?? 'ready',
+        ...(options.error ? { error: options.error } : {}),
         ...(options.projectId ? { projectId: options.projectId } : {}),
       }),
     );

--- a/apps/daemon/tests/brand-routes.test.ts
+++ b/apps/daemon/tests/brand-routes.test.ts
@@ -175,7 +175,7 @@ describe('brand routes', () => {
     expect(storedMeta.status).toBe('failed');
   });
 
-  it('keeps terminal backing run failure visible even if a stale finalize marked the brand ready', async () => {
+  it('keeps terminal backing run failure visible when a stale finalize left the terminal error', async () => {
     writeBrandFixture('brand-stale-ready', {
       projectId: 'project-stale-ready',
       logoPrimary: 'logos/missing.svg',
@@ -221,6 +221,51 @@ describe('brand routes', () => {
     const storedMeta = JSON.parse(readFileSync(path.join(brandsRoot, 'brand-stale-ready', 'meta.json'), 'utf8'));
     expect(storedMeta.status).toBe('failed');
     expect(storedMeta.error).toBe('Brand extraction was canceled.');
+  });
+
+  it('does not regress ready brands after a later backing project run is canceled', async () => {
+    writeBrandFixture('brand-ready', {
+      projectId: 'project-ready',
+      logoPrimary: 'logos/missing.svg',
+      status: 'ready',
+    });
+    insertProject(db, {
+      id: 'project-ready',
+      name: 'Ready Brand Project',
+      skillId: null,
+      designSystemId: null,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: { kind: 'brand', brandId: 'brand-ready' },
+    });
+    insertConversation(db, {
+      id: 'conversation-ready',
+      projectId: 'project-ready',
+      title: 'Iterate ready brand',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    upsertMessage(db, 'conversation-ready', {
+      id: 'message-ready-canceled',
+      role: 'assistant',
+      content: 'Stopped unrelated follow-up.',
+      runId: 'run-ready-canceled',
+      runStatus: 'canceled',
+      startedAt: 1,
+      endedAt: 2,
+    });
+
+    const detail = await requestJson('/api/brands/brand-ready');
+    const list = await requestJson('/api/brands');
+
+    expect(detail.status).toBe(200);
+    expect(detail.body.meta.status).toBe('ready');
+    expect(detail.body.meta.error).toBeUndefined();
+    expect(list.body.brands.find((brand: any) => brand.meta.id === 'brand-ready')?.meta.status).toBe('ready');
+
+    const storedMeta = JSON.parse(readFileSync(path.join(brandsRoot, 'brand-ready', 'meta.json'), 'utf8'));
+    expect(storedMeta.status).toBe('ready');
+    expect(storedMeta.error).toBeUndefined();
   });
 
   it('surfaces needs_input when the backing project is awaiting user input', async () => {

--- a/apps/daemon/tests/brand-routes.test.ts
+++ b/apps/daemon/tests/brand-routes.test.ts
@@ -176,11 +176,14 @@ describe('brand routes', () => {
   });
 
   it('keeps terminal backing run failure visible when a stale finalize left the terminal error', async () => {
+    const providerError = 'Provider timed out while reading the target site.';
     writeBrandFixture('brand-stale-ready', {
       projectId: 'project-stale-ready',
       logoPrimary: 'logos/missing.svg',
       status: 'ready',
-      error: 'Brand extraction was canceled.',
+      error: providerError,
+      extractionTerminalRunId: 'run-stale-ready',
+      extractionTerminalError: providerError,
     });
     insertProject(db, {
       id: 'project-stale-ready',
@@ -201,9 +204,9 @@ describe('brand routes', () => {
     upsertMessage(db, 'conversation-stale-ready', {
       id: 'message-stale-ready',
       role: 'assistant',
-      content: 'Stopped.',
+      content: 'Timed out.',
       runId: 'run-stale-ready',
-      runStatus: 'canceled',
+      runStatus: 'failed',
       startedAt: 1,
       endedAt: 2,
     });
@@ -213,14 +216,16 @@ describe('brand routes', () => {
 
     expect(detail.status).toBe(200);
     expect(detail.body.meta.status).toBe('failed');
-    expect(detail.body.meta.error).toBe('Brand extraction was canceled.');
+    expect(detail.body.meta.error).toBe(providerError);
     expect(list.body.brands.find((brand: any) => brand.meta.id === 'brand-stale-ready')?.meta.status).toBe(
       'failed',
     );
 
     const storedMeta = JSON.parse(readFileSync(path.join(brandsRoot, 'brand-stale-ready', 'meta.json'), 'utf8'));
     expect(storedMeta.status).toBe('failed');
-    expect(storedMeta.error).toBe('Brand extraction was canceled.');
+    expect(storedMeta.error).toBe(providerError);
+    expect(storedMeta.extractionTerminalRunId).toBe('run-stale-ready');
+    expect(storedMeta.extractionTerminalError).toBe(providerError);
   });
 
   it('does not regress ready brands after a later backing project run is canceled', async () => {
@@ -318,7 +323,15 @@ describe('brand routes', () => {
 
   function writeBrandFixture(
     id: string,
-    options: { projectId?: string; logoPrimary: string; logoBody?: string; status?: string; error?: string },
+    options: {
+      projectId?: string;
+      logoPrimary: string;
+      logoBody?: string;
+      status?: string;
+      error?: string;
+      extractionTerminalRunId?: string;
+      extractionTerminalError?: string;
+    },
   ) {
     const brandDir = path.join(brandsRoot, id);
     mkdirSync(brandDir, { recursive: true });
@@ -331,6 +344,8 @@ describe('brand routes', () => {
         updatedAt: 1,
         status: options.status ?? 'ready',
         ...(options.error ? { error: options.error } : {}),
+        ...(options.extractionTerminalRunId ? { extractionTerminalRunId: options.extractionTerminalRunId } : {}),
+        ...(options.extractionTerminalError ? { extractionTerminalError: options.extractionTerminalError } : {}),
         ...(options.projectId ? { projectId: options.projectId } : {}),
       }),
     );

--- a/packages/contracts/src/api/brands.ts
+++ b/packages/contracts/src/api/brands.ts
@@ -117,6 +117,10 @@ export interface BrandMeta {
   status: BrandStatus;
   /** Human-readable failure reason when status === "failed". */
   error?: string;
+  /** Backing extraction run that last drove this brand into a terminal failure. */
+  extractionTerminalRunId?: string;
+  /** Original terminal failure reason for that extraction run, preserved across daemon restarts. */
+  extractionTerminalError?: string;
   /** The `user:<id>` design-system id this brand registered, so selecting the
    *  brand in the composer applies it through the existing design-system flow. */
   designSystemId?: string;


### PR DESCRIPTION
## Why

This PR fixes brand extraction terminal status reconciliation on top of #4260.

The pain being addressed is lifecycle correctness: brand extraction records need to settle into accurate terminal states when the backing run has completed, failed, or been canceled, instead of leaving stale in-progress state behind.

## What users will see

In the #4260 Brand Kit flow, completed or failed extraction runs should reconcile to the correct brand status more consistently.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — daemon brand extraction status behavior
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — Brand Kit terminal extraction status reconciliation changes in the #4260 flow
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

Skipped. The branch includes focused daemon brand routes coverage, but I did not rerun it locally while opening this PR.

## Validation

- Not run locally; PR opened from the existing branch for review.
