### PR TITLE
fix(platform): discover Windows fnm-managed Node in the toolchain bin list

### DIFF
--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1002,18 +1002,26 @@ export function wellKnownUserToolchainBins(
       segments: ["installation", "bin"],
     },
   ];
-  // Windows fnm keeps Node installs under %APPDATA%\fnm\node-versions\<ver>\
-  // installation, with node.exe directly in `installation` (no POSIX-style
-  // `bin` subdir). `FNM_DIR` overrides that root. A GUI-launched packaged
-  // app inherits a stripped PATH and reads no shell rc, so without an
-  // explicit probe fnm-managed Node — and every agent CLI it runs — is
-  // silently undetected on Windows. See issue #3517.
+  // Windows fnm keeps Node installs under <fnm-root>\node-versions\<ver>\
+  // installation, with node.exe — and any `npm i -g`'d CLI shim such as
+  // codex.cmd — directly in `installation` (no POSIX-style `bin` subdir).
+  // The fnm root is %APPDATA%\fnm or %LOCALAPPDATA%\fnm depending on the
+  // install, and `FNM_DIR` overrides both. A GUI-launched packaged app
+  // inherits a stripped PATH and reads no shell rc, so without an explicit
+  // probe fnm-managed Node — and every agent CLI it runs — is silently
+  // undetected on Windows. See issues #3517 and #3062.
   if (process.platform === "win32") {
     const fnmDirOverride = typeof env.FNM_DIR === "string" ? env.FNM_DIR.trim() : "";
-    const appData = typeof env.APPDATA === "string" ? env.APPDATA.trim() : "";
-    const fnmRoot =
-      fnmDirOverride.length > 0 ? fnmDirOverride : appData.length > 0 ? join(appData, "fnm") : "";
-    if (fnmRoot.length > 0) {
+    const fnmRoots: string[] = [];
+    if (fnmDirOverride.length > 0) {
+      fnmRoots.push(fnmDirOverride);
+    } else {
+      for (const base of [env.LOCALAPPDATA, env.APPDATA]) {
+        const trimmed = typeof base === "string" ? base.trim() : "";
+        if (trimmed.length > 0) fnmRoots.push(join(trimmed, "fnm"));
+      }
+    }
+    for (const fnmRoot of fnmRoots) {
       nodeInstallRoots.push({ root: join(fnmRoot, "node-versions"), segments: ["installation"] });
     }
   }

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -984,7 +984,7 @@ export function wellKnownUserToolchainBins(
   // When MISE_DATA_DIR is set we use the same root for consistency with shims.
   const miseInstalls = join(miseData, "installs");
   dirs.push(...existingMiseNpmPackageBinDirs(miseInstalls));
-  for (const installRoot of [
+  const nodeInstallRoots: Array<{ root: string; segments: string[] }> = [
     {
       root: join(miseInstalls, "node"),
       segments: ["bin"],
@@ -1001,7 +1001,23 @@ export function wellKnownUserToolchainBins(
       root: join(home, ".fnm", "node-versions"),
       segments: ["installation", "bin"],
     },
-  ]) {
+  ];
+  // Windows fnm keeps Node installs under %APPDATA%\fnm\node-versions\<ver>\
+  // installation, with node.exe directly in `installation` (no POSIX-style
+  // `bin` subdir). `FNM_DIR` overrides that root. A GUI-launched packaged
+  // app inherits a stripped PATH and reads no shell rc, so without an
+  // explicit probe fnm-managed Node — and every agent CLI it runs — is
+  // silently undetected on Windows. See issue #3517.
+  if (process.platform === "win32") {
+    const fnmDirOverride = typeof env.FNM_DIR === "string" ? env.FNM_DIR.trim() : "";
+    const appData = typeof env.APPDATA === "string" ? env.APPDATA.trim() : "";
+    const fnmRoot =
+      fnmDirOverride.length > 0 ? fnmDirOverride : appData.length > 0 ? join(appData, "fnm") : "";
+    if (fnmRoot.length > 0) {
+      nodeInstallRoots.push({ root: join(fnmRoot, "node-versions"), segments: ["installation"] });
+    }
+  }
+  for (const installRoot of nodeInstallRoots) {
     for (const dir of existingChildBinDirs(installRoot.root, installRoot.segments)) {
       dirs.push(dir);
     }

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -682,6 +682,25 @@ describe("wellKnownUserToolchainBins Windows fnm node discovery", () => {
       rmSync(fnmDir, { recursive: true, force: true });
     }
   });
+
+  it("surfaces the Windows fnm installation dir under %LOCALAPPDATA%\\fnm", () => {
+    // fnm on Windows can keep its root under %LOCALAPPDATA%\fnm (not only
+    // %APPDATA%\fnm). A globally `npm i -g`'d CLI (e.g. Codex) lands in the
+    // node install's `installation` dir, so probing this root makes that CLI
+    // discoverable from a GUI launch. See issue #3062.
+    const home = mkdtempSync(join(tmpdir(), "od-fnm-home-"));
+    const localAppData = mkdtempSync(join(tmpdir(), "od-fnm-localappdata-"));
+    const installDir = join(localAppData, "fnm", "node-versions", "v22.13.1", "installation");
+    mkdirSync(installDir, { recursive: true });
+    setPlatform("win32");
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: { LOCALAPPDATA: localAppData } });
+      expect(dirs).toContain(installDir);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(localAppData, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("createPackageManagerInvocation", () => {

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -635,6 +635,55 @@ describe("createCommandInvocation", () => {
   });
 });
 
+describe("wellKnownUserToolchainBins Windows fnm node discovery", () => {
+  // Issue #3517: a GUI-launched packaged app on Windows inherits a stripped
+  // PATH and never sees fnm-managed Node. fnm on Windows keeps its installs
+  // under %APPDATA%\fnm\node-versions\<version>\installation, with node.exe
+  // directly in `installation` (no POSIX-style `bin` subdir). The toolchain
+  // bin list only probed ~/.fnm and ~/.local/share/fnm with [installation,
+  // bin] segments, so Windows fnm Node was silently undetected.
+  const originalPlatform = process.platform;
+  function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", { configurable: true, value });
+  }
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  });
+
+  it("surfaces the Windows fnm installation dir under %APPDATA%\\fnm", () => {
+    const home = mkdtempSync(join(tmpdir(), "od-fnm-home-"));
+    const appData = mkdtempSync(join(tmpdir(), "od-fnm-appdata-"));
+    const installDir = join(appData, "fnm", "node-versions", "v22.13.1", "installation");
+    mkdirSync(installDir, { recursive: true });
+    setPlatform("win32");
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: { APPDATA: appData } });
+      expect(dirs).toContain(installDir);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(appData, { recursive: true, force: true });
+    }
+  });
+
+  it("honors FNM_DIR over %APPDATA% for the Windows fnm root", () => {
+    const home = mkdtempSync(join(tmpdir(), "od-fnm-home-"));
+    const fnmDir = mkdtempSync(join(tmpdir(), "od-fnm-dir-"));
+    const installDir = join(fnmDir, "node-versions", "v20.11.0", "installation");
+    mkdirSync(installDir, { recursive: true });
+    setPlatform("win32");
+    try {
+      const dirs = wellKnownUserToolchainBins({
+        home,
+        env: { APPDATA: join(home, "AppData", "Roaming"), FNM_DIR: fnmDir },
+      });
+      expect(dirs).toContain(installDir);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(fnmDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("createPackageManagerInvocation", () => {
   const originalPlatform = process.platform;
   function setPlatform(value: NodeJS.Platform): void {


### PR DESCRIPTION
Refs #3517, #3062

## Why

While triaging #3517 ("cannot start a new conversation" on Windows), @lefarcen narrowed the likely cause to fnm/PATH discovery and confirmed in code that the packaged app only probes a fixed set of POSIX fnm roots. #3062 is the same failure class: Codex installed via `npm i -g` under fnm-managed Node is detected when Open Design is launched from an fnm-initialized shell, but not from the Start Menu.

The pain: a GUI-launched packaged app on Windows inherits a stripped PATH and reads no shell rc, so it depends entirely on `wellKnownUserToolchainBins` to find user toolchains. That list only probed POSIX fnm roots (`~/.fnm`, `~/.local/share/fnm`) with `[installation, bin]` segments. fnm on Windows keeps Node under `<fnm-root>\node-versions\<version>\installation` — where `<fnm-root>` is `%APPDATA%\fnm` or `%LOCALAPPDATA%\fnm` — with `node.exe` (and any `npm i -g`'d CLI shim such as `codex.cmd`) directly in `installation` and no `bin` subdir. So fnm-managed Node, and every agent CLI it runs, was invisible to the daemon even though it resolved fine from the user's shell.

## What users will see

On Windows, a packaged app whose Node is managed by fnm will now discover that Node — and the agent CLIs (Codex, etc.) installed against it via `npm i -g` — without the user adding a separate global install or hand-editing PATH.

## Surface area

- [x] **None** — internal toolchain-discovery fix. It reads the existing `FNM_DIR` env (fnm's own override) but adds no new flag or setting. No UI/CLI/API/i18n surface.

## Screenshots

N/A — no UI.

## Bug fix verification

- Test path: `packages/platform/tests/index.test.ts` → `wellKnownUserToolchainBins Windows fnm node discovery`
  - `surfaces the Windows fnm installation dir under %APPDATA%\fnm`
  - `surfaces the Windows fnm installation dir under %LOCALAPPDATA%\fnm`
  - `honors FNM_DIR over %APPDATA% for the Windows fnm root`
- Did the tests go red on `main` and green on this branch? **yes** — each assertion fails on `main` (the dir is never surfaced) and passes after the fix. Tests stub `process.platform = "win32"` and build a real fnm dir tree under tmpdir, so they run on any CI OS.
- End-to-end confirmation on a real Windows + fnm host is still valuable (the Codex repro in #3062 is the natural manual check); the unit tests pin the discovery contract. Note the Windows distro places `node.exe` and global `.cmd` shims directly in `installation` (no `bin` subdir), which the fix accounts for.

## Validation

- `pnpm --filter @open-design/platform test` → 58 passed (the 3 new specs RED→GREEN).
- `pnpm --filter @open-design/platform typecheck` → clean.
- Scope held to Windows fnm discovery; the POSIX `FNM_DIR` override remains an adjacent gap for a follow-up.
