### PR TITLE
test(daemon): cover OpenCode npm binary detection

### DIFF
--- a/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
+++ b/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
@@ -28,6 +28,19 @@ function writeCursorAgent(dir: string, statusOutput: string): void {
   chmodSync(bin, 0o755);
 }
 
+function writeOpenCode(dir: string): string {
+  const bin = join(dir, 'opencode');
+  writeFileSync(
+    bin,
+    `#!/bin/sh\n` +
+      `if [ "$1" = "--version" ]; then echo "opencode 1.17.3"; exit 0; fi\n` +
+      `if [ "$1" = "models" ]; then echo "openai/gpt-5"; exit 0; fi\n` +
+      `exit 0\n`,
+  );
+  chmodSync(bin, 0o755);
+  return bin;
+}
+
 function writeNonExecutableCursorAgent(dir: string): string {
   const bin = join(dir, 'cursor-agent');
   writeFileSync(
@@ -64,6 +77,28 @@ posixTest('detectAgents emits a not-on-path diagnostic with searched dirs + fix 
       const intents = (diagnostic?.fixActions ?? []).map((a) => a.kind);
       assert.ok(intents.includes('openInstall'), 'expected openInstall fix intent');
       assert.ok(intents.includes('rescan'), 'expected rescan fix intent');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+posixTest('detectAgents finds OpenCode when npm exposes only the opencode binary', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-opencode-npm-bin-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      const bin = writeOpenCode(dir);
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+
+      const agents = await detectAgents();
+      const opencode = agents.find((agent) => agent.id === 'opencode');
+
+      assert.equal(opencode?.available, true);
+      assert.equal(opencode?.bin, 'opencode-cli');
+      assert.equal(opencode?.path, bin);
+      assert.equal(opencode?.version, 'opencode 1.17.3');
+      assert.equal(opencode?.diagnostics, undefined);
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #4186

## Why

Docker users installing OpenCode with `npm install -g opencode-ai` get an `opencode` binary, while Open Design keeps `opencode-cli` as the public primary binary name for backwards compatibility. The daemon runtime already has the `opencode` fallback path, and this PR locks that behavior with a focused regression test so `/api/agents` does not regress to reporting OpenCode unavailable in Docker-style installs.

## What users will see

Docker deployments with only `opencode` on PATH remain detected as OpenCode available, without requiring a manual `opencode-cli` symlink.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — test-only daemon regression coverage.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/detection-diagnostics.test.ts`
- Did the test go red on `main` and green on this branch? No. The runtime fallback implementation is already present on this branch/base; this PR adds explicit regression coverage for the Docker/npm binary shape from #4186.

## Validation

- `git diff --check`
- Attempted `pnpm --filter @open-design/daemon test -- tests/runtimes/detection-diagnostics.test.ts` but the runner PATH does not provide `pnpm`.
- Attempted Node/Corepack validation setup checks; the runner PATH does not provide `node` or `corepack`.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>