### PR TITLE
fix(docker): add opt-in API auth disable flag

### DIFF
--- a/apps/daemon/src/api-token-auth.ts
+++ b/apps/daemon/src/api-token-auth.ts
@@ -1,0 +1,16 @@
+export function isTruthyEnvFlag(value: unknown): boolean {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+export function isApiAuthDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthyEnvFlag(env.OD_DISABLE_API_AUTH);
+}
+
+export function apiTokenFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  return (env.OD_API_TOKEN ?? '').trim();
+}
+
+export function isApiTokenMiddlewareEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return apiTokenFromEnv(env).length > 0 && !isApiAuthDisabled(env);
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -539,6 +539,7 @@ import {
   isAllowedBrowserOrigin,
   isLocalSameOrigin,
 } from './origin-validation.js';
+import { apiTokenFromEnv, isApiAuthDisabled, isApiTokenMiddlewareEnabled } from './api-token-auth.js';
 
 /** @typedef {import('@open-design/contracts').ApiErrorCode} ApiErrorCode */
 /** @typedef {import('@open-design/contracts').ApiError} ApiError */
@@ -4423,12 +4424,14 @@ export async function startServer({
   // purely additive: when present, every /api/* request must carry a
   // matching `Authorization: Bearer <token>` header (loopback origins
   // are exempted so the desktop UI keeps working).
-  const apiToken = (process.env.OD_API_TOKEN ?? '').trim();
-  if (!isLoopbackHostname(host) && apiToken.length === 0) {
+  const apiToken = apiTokenFromEnv();
+  const apiAuthDisabled = isApiAuthDisabled();
+  if (!isLoopbackHostname(host) && apiToken.length === 0 && !apiAuthDisabled) {
     throw new Error(
       `OD_BIND_HOST=${host} requires OD_API_TOKEN to be set. ` +
       `Generate one with \`openssl rand -hex 32\` and re-launch. ` +
-      `(Loopback hosts 127.0.0.1 / ::1 / localhost do not need a token.)`,
+      `(Loopback hosts 127.0.0.1 / ::1 / localhost do not need a token.) ` +
+      `Set OD_DISABLE_API_AUTH=1 only when a trusted reverse proxy already authenticates every request.`,
     );
   }
 
@@ -4439,7 +4442,8 @@ export async function startServer({
 
   // Plan §3.K1 — bearer-token middleware.
   //
-  // Active only when OD_API_TOKEN is set. Loopback origins skip the
+  // Active only when OD_API_TOKEN is set and API auth is not disabled.
+  // Loopback origins skip the
   // check (the desktop UI / local CLI never carry a bearer); every
   // other request must present `Authorization: Bearer <token>` with a
   // value matching `OD_API_TOKEN`. Health / readiness / version remain
@@ -4448,7 +4452,7 @@ export async function startServer({
   // browser iframes can load HTML/CSS/JS without privileged headers.
   // Rich daemon status stays authenticated because it includes local
   // runtime paths.
-  if (apiToken.length > 0) {
+  if (isApiTokenMiddlewareEnabled()) {
     const openProbePaths = new Set([
       '/health',
       '/api/health',

--- a/apps/daemon/tests/api-token-guard.test.ts
+++ b/apps/daemon/tests/api-token-guard.test.ts
@@ -14,10 +14,12 @@
 
 import type http from 'node:http';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isApiAuthDisabled, isApiTokenMiddlewareEnabled } from '../src/api-token-auth.js';
 import { startServer } from '../src/server.js';
 
 const PREVIOUS_TOKEN = process.env.OD_API_TOKEN;
 const PREVIOUS_HOST  = process.env.OD_BIND_HOST;
+const PREVIOUS_DISABLE_API_AUTH = process.env.OD_DISABLE_API_AUTH;
 
 let server: http.Server | undefined;
 let baseUrl = '';
@@ -32,6 +34,8 @@ afterEach(async () => {
   else process.env.OD_API_TOKEN = PREVIOUS_TOKEN;
   if (PREVIOUS_HOST === undefined) delete process.env.OD_BIND_HOST;
   else process.env.OD_BIND_HOST = PREVIOUS_HOST;
+  if (PREVIOUS_DISABLE_API_AUTH === undefined) delete process.env.OD_DISABLE_API_AUTH;
+  else process.env.OD_DISABLE_API_AUTH = PREVIOUS_DISABLE_API_AUTH;
 });
 
 describe('bound-API-token guard', () => {
@@ -54,6 +58,17 @@ describe('bound-API-token guard', () => {
     shutdown = started.shutdown;
     baseUrl = started.url;
     expect(baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:/);
+  });
+
+  it('starts on a public host without OD_API_TOKEN when OD_DISABLE_API_AUTH=1', async () => {
+    delete process.env.OD_API_TOKEN;
+    process.env.OD_DISABLE_API_AUTH = '1';
+    const started = (await startServer({ port: 0, host: '0.0.0.0', returnServer: true })) as {
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    server = started.server;
+    shutdown = started.shutdown;
   });
 });
 
@@ -82,5 +97,21 @@ describe('bearer middleware', () => {
       const resp = await fetch(`${baseUrl}${path}`);
       expect(resp.status).toBe(200);
     }
+  });
+
+  it('disables bearer middleware when OD_DISABLE_API_AUTH=1 even if OD_API_TOKEN is set', () => {
+    expect(
+      isApiTokenMiddlewareEnabled({
+        ...process.env,
+        OD_API_TOKEN: 'secret-test-token',
+        OD_DISABLE_API_AUTH: '1',
+      }),
+    ).toBe(false);
+    expect(
+      isApiAuthDisabled({
+        ...process.env,
+        OD_DISABLE_API_AUTH: '1',
+      }),
+    ).toBe(true);
   });
 });

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -10,10 +10,15 @@ OPEN_DESIGN_PORT=7456
 # domain, public IP, or reverse proxy, e.g. http://203.0.113.10:7456,https://od.example.com.
 OPEN_DESIGN_ALLOWED_ORIGINS=
 
-# REQUIRED. 
-# The daemon binds to 0.0.0.0 inside the container and strictly requires an API token for security.
+# Recommended unless OPEN_DESIGN_DISABLE_API_AUTH=1 is set behind a trusted,
+# already-authenticated reverse proxy.
 # Generate a secure 32-byte hex token by running `openssl rand -hex 32` and paste it below.
 OD_API_TOKEN=
+
+# Optional escape hatch for deployments whose reverse proxy already authenticates
+# every request before it reaches the daemon. Set to 1 only for trusted setups;
+# when enabled, the daemon skips OD_API_TOKEN enforcement entirely.
+OPEN_DESIGN_DISABLE_API_AUTH=
 
 # Container memory limit. The idle service has been verified around 18-22 MiB.
 # Raise this for large exports, concurrent agent runs, or heavy upload workflows.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,13 +14,15 @@ Before starting:
    cp .env.example .env
    ```
 
-2. Generate a secure token:
+2. Generate a secure token (recommended unless your reverse proxy will both authenticate every request and set `OPEN_DESIGN_DISABLE_API_AUTH=1`):
 
    ```bash
    openssl rand -hex 32
    ```
 
-3. Open `.env` in your editor, find `OD_API_TOKEN=`, and paste the generated token there.
+3. Open `.env` in your editor and choose one auth mode:
+   - default: paste the token into `OD_API_TOKEN=`
+   - trusted reverse proxy that already authenticates every request: leave `OD_API_TOKEN=` empty and set `OPEN_DESIGN_DISABLE_API_AUTH=1`
 
 Then pull and start the service:
 
@@ -47,12 +49,24 @@ bound to localhost and put an authenticated reverse proxy, SSH tunnel, or VPN in
 front of it.
 
 When exposing the service through an authenticated public IP, domain, or reverse
-proxy, set `OPEN_DESIGN_ALLOWED_ORIGINS` to the browser origins that should be
-allowed to call `/api`:
+proxy, set `OPEN_DESIGN_ALLOWED_ORIGINS` to the exact browser origins that should
+be allowed to call `/api`:
 
 ```bash
 OPEN_DESIGN_ALLOWED_ORIGINS=https://od.example.com,http://203.0.113.10:7456 docker compose up -d --no-build
 ```
+
+If the reverse proxy already authenticates every request and you do not want it
+to inject `Authorization: Bearer <OD_API_TOKEN>` upstream, set:
+
+```bash
+OPEN_DESIGN_DISABLE_API_AUTH=1
+```
+
+Use this only for trusted deployments where the daemon is reachable strictly
+through that authenticated proxy. It disables daemon-side bearer enforcement for
+all `/api/*` requests, so direct access to the daemon must remain blocked. The
+Compose variable maps to daemon env `OD_DISABLE_API_AUTH`.
 
 Pin a specific published image with a digest instead of the mutable `latest` tag:
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -15,7 +15,8 @@ services:
       OD_ALLOWED_ORIGINS: ${OPEN_DESIGN_ALLOWED_ORIGINS:-}
       OD_PORT: 7456
       OD_WEB_PORT: ${OPEN_DESIGN_PORT:-7456}
-      OD_API_TOKEN: ${OD_API_TOKEN:?Please run 'openssl rand -hex 32' to generate one, and set it in your .env file.}
+      OD_API_TOKEN: ${OD_API_TOKEN:-}
+      OD_DISABLE_API_AUTH: ${OPEN_DESIGN_DISABLE_API_AUTH:-}
       OD_CODEX_SANDBOX: ${OD_CODEX_SANDBOX:-}
     ports:
       - "127.0.0.1:${OPEN_DESIGN_PORT:-7456}:7456"

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -18,12 +18,24 @@ What this does:
 - Downloads the project
 - Moves into the folder that contains `docker-compose.yml`
 
-## Step 2: Choose an API auth mode
+## Step 2: Create `.env` and choose an API auth mode
 
-Edit `deploy/.env` and configure one of these before first start:
+Create `deploy/.env` from the tracked template:
 
-- recommended default: set `OD_API_TOKEN=` to a freshly generated token
-- trusted authenticated reverse proxy only: set `OPEN_DESIGN_DISABLE_API_AUTH=1`
+```bash
+cp .env.example .env
+```
+
+Generate a token if you want the default protected mode:
+
+```bash
+openssl rand -hex 32
+```
+
+Then edit `.env` and configure one of these before first start:
+
+- recommended default: paste the generated token into `OD_API_TOKEN=`
+- trusted authenticated reverse proxy only: leave `OD_API_TOKEN=` empty and set `OPEN_DESIGN_DISABLE_API_AUTH=1`
 
 If you expose Open Design through a reverse proxy, also set:
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -18,7 +18,20 @@ What this does:
 - Downloads the project
 - Moves into the folder that contains `docker-compose.yml`
 
-## Step 2: Start Open Design
+## Step 2: Choose an API auth mode
+
+Edit `deploy/.env` and configure one of these before first start:
+
+- recommended default: set `OD_API_TOKEN=` to a freshly generated token
+- trusted authenticated reverse proxy only: set `OPEN_DESIGN_DISABLE_API_AUTH=1`
+
+If you expose Open Design through a reverse proxy, also set:
+
+```bash
+OPEN_DESIGN_ALLOWED_ORIGINS=https://yourdomain.com
+```
+
+## Step 3: Start Open Design
 
 ```bash
 docker-compose up -d
@@ -28,7 +41,7 @@ What to expect:
 - First run can take 1-2 minutes while Docker pulls the image
 - You should see container creation and startup messages
 
-## Step 3: Confirm Container Health
+## Step 4: Confirm Container Health
 
 ```bash
 docker-compose ps
@@ -42,7 +55,7 @@ Success looks like:
 ![Docker Desktop container running](../screenshots/deployment/docker/02-docker-desktop-container-running.png)
 ![docker-compose ps healthy output (sanitized)](../screenshots/deployment/docker/04-docker-compose-ps-healthy.png)
 
-## Step 4: Verify HTTP Response
+## Step 5: Verify HTTP Response
 
 ```bash
 curl -i http://127.0.0.1:7456/
@@ -53,7 +66,7 @@ Success looks like:
 
 ![curl HTTP 200 output (sanitized)](../screenshots/deployment/docker/05-curl-http-200-proof.png)
 
-## Step 5: Open Open Design in Your Browser
+## Step 6: Open Open Design in Your Browser
 
 Open:
 - `http://localhost:7456/`
@@ -68,4 +81,5 @@ You should see the Open Design interface.
 - `failed to connect to the docker API`: Docker Desktop is not running yet
 - `address already in use`: Port `7456` is occupied by another process
 - `curl: (7) Failed to connect`: container is still starting; wait 10-20 seconds and retry
+- reverse proxy + `OD_API_TOKEN`: either inject `Authorization: Bearer <OD_API_TOKEN>` at the proxy, or set `OPEN_DESIGN_DISABLE_API_AUTH=1` only when that proxy already authenticates every request and the daemon is not directly exposed.
 - `Authorization: Bearer <OD_API_TOKEN> required` on macOS: Docker Desktop bridge networking makes the daemon see requests as non-loopback. See [Docker Desktop on macOS](../../deploy/README.md#docker-desktop-on-macos) for the host networking workaround.


### PR DESCRIPTION
## Summary
- add an explicit OD_DISABLE_API_AUTH escape hatch so trusted reverse-proxy deployments can run without upstream bearer injection
- keep the default OD_API_TOKEN protection in place, wire the new flag through Docker Compose, and cover the new auth-mode behavior in daemon tests
- update Docker deployment docs and env examples to explain the two reverse-proxy auth modes and required origin settings

## Validation
- pnpm exec vitest run -c vitest.config.ts tests/origin-validation.test.ts tests/api-token-guard.test.ts
- pnpm --filter @open-design/daemon typecheck
- pnpm guard
- pnpm typecheck

Closes #4187

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>