### PR TITLE
fix(daemon): detect and launch Warp on Windows for the open-in host tool (#4539)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.worktrees/
 dist/
 out/
 .next/

--- a/apps/daemon/src/routes/host-tools.ts
+++ b/apps/daemon/src/routes/host-tools.ts
@@ -200,7 +200,7 @@ async function probeMacBundle(name: string | readonly string[]): Promise<{ name:
 async function resolveEntry(entry: CatalogueEntry): Promise<{
   available: boolean;
   resolvedPath?: string;
-  launch?: { command: string; argsForDir: (resolvedDir: string) => string[]; cwdForDir?: (resolvedDir: string) => string };
+  launch?: { command: string; argsForDir: (resolvedDir: string) => string[]; cwdForDir?: (resolvedDir: string) => string; shell?: boolean };
 }> {
   if (entry.command) {
     const resolved = await probeCommandOnPath(entry.command);
@@ -224,6 +224,9 @@ async function resolveEntry(entry: CatalogueEntry): Promise<{
           argsForDir: () => [],
           // Best-effort: set cwd so Warp opens in the project directory.
           cwdForDir: (resolvedDir) => resolvedDir,
+          // shell:false so Node uses CreateProcess directly — cmd.exe mis-parses
+          // forward-slash exe paths (fix #4539).
+          shell: false,
         },
       };
     }
@@ -253,6 +256,8 @@ export interface HostToolLaunchPlan {
   args?: string[];
   /** Working directory for spawn; set when the tool has no dir CLI arg (e.g. Warp on Windows). */
   cwd?: string;
+  /** When false, bypass cmd.exe and use CreateProcess directly (win32 install-path entries). Unset for PATH/shim entries. */
+  shell?: boolean;
 }
 
 export async function resolveHostToolLaunchPlan(
@@ -275,6 +280,7 @@ export async function resolveHostToolLaunchPlan(
     command: probe.launch.command,
     args: probe.launch.argsForDir(resolvedDir),
     ...(cwd ? { cwd } : {}),
+    ...(probe.launch.shell !== undefined ? { shell: probe.launch.shell } : {}),
   };
 }
 
@@ -373,7 +379,7 @@ export function registerHostToolsRoutes(app: Express, ctx: RegisterHostToolsRout
       const child = spawn(launchPlan.command, launchPlan.args, {
         detached: true,
         stdio: 'ignore',
-        shell: process.platform === 'win32',
+        shell: launchPlan.shell ?? (process.platform === 'win32'),
         ...(launchPlan.cwd ? { cwd: launchPlan.cwd } : {}),
       });
       child.on('error', () => {

--- a/apps/daemon/src/routes/host-tools.ts
+++ b/apps/daemon/src/routes/host-tools.ts
@@ -44,6 +44,10 @@ interface CatalogueEntry {
   // to also install their CLI shim.
   macOpenBundle?: string | readonly string[];
   macOpenArgs?: (bundleName: string, resolvedDir: string) => string[];
+  // Windows-only fallback: absolute exe paths (may contain %VAR% tokens)
+  // probed in order when the CLI shim is not on $PATH. Lets us detect
+  // apps like Warp that have no `warp` CLI shim on Windows.
+  winInstallPaths?: string[];
   platforms?: RealPlatform[];
   excludedPlatforms?: RealPlatform[];
 }
@@ -67,7 +71,8 @@ const CATALOGUE: ReadonlyArray<CatalogueEntry> = [
   { id: 'explorer', label: 'Explorer', icon: 'folder', command: 'explorer', platforms: ['win32'] },
   { id: 'file-manager', label: 'File Manager', icon: 'folder', command: 'xdg-open', platforms: ['linux'] },
   { id: 'terminal', label: 'Terminal', icon: 'sliders', macOpenBundle: 'Terminal', platforms: ['darwin'] },
-  { id: 'warp', label: 'Warp', icon: 'sliders', macOpenBundle: 'Warp' },
+  { id: 'warp', label: 'Warp', icon: 'sliders', macOpenBundle: 'Warp',
+    winInstallPaths: ['%LOCALAPPDATA%\\Programs\\Warp\\warp.exe', '%PROGRAMFILES%\\Warp\\warp.exe'] },
 ];
 
 function currentPlatform(): Platform {
@@ -124,6 +129,41 @@ async function probeCommandOnPath(command: string): Promise<string | null> {
   return null;
 }
 
+/**
+ * Expand %VAR% tokens in a Windows-style path template using process.env,
+ * then return the resolved path if it exists and is accessible, else null.
+ *
+ * OS-agnostic: does not branch on process.platform. If a referenced %VAR%
+ * is unset or empty, that candidate is skipped (falls through to the next).
+ * Both \ and / separators are accepted.
+ */
+export async function resolveFirstExistingExecutable(candidatePaths: string[]): Promise<string | null> {
+  for (const candidate of candidatePaths) {
+    // Expand all %VAR% tokens from process.env.
+    let expanded = candidate;
+    let skipCandidate = false;
+    expanded = candidate.replace(/%([^%]+)%/g, (_match, varName: string) => {
+      const value = process.env[varName];
+      if (!value) {
+        skipCandidate = true;
+        return '';
+      }
+      return value;
+    });
+    if (skipCandidate) continue;
+
+    // Normalize separators (\ → /) for consistency; Node fs handles both on Windows.
+    const normalized = expanded.replace(/\\/g, '/');
+    try {
+      await access(normalized, fsConstants.X_OK);
+      return normalized;
+    } catch {
+      // not accessible — try next candidate
+    }
+  }
+  return null;
+}
+
 async function resolveMacOpenCommand(): Promise<string> {
   try {
     await access(MAC_OPEN_COMMAND, fsConstants.X_OK);
@@ -160,7 +200,7 @@ async function probeMacBundle(name: string | readonly string[]): Promise<{ name:
 async function resolveEntry(entry: CatalogueEntry): Promise<{
   available: boolean;
   resolvedPath?: string;
-  launch?: { command: string; argsForDir: (resolvedDir: string) => string[] };
+  launch?: { command: string; argsForDir: (resolvedDir: string) => string[]; cwdForDir?: (resolvedDir: string) => string };
 }> {
   if (entry.command) {
     const resolved = await probeCommandOnPath(entry.command);
@@ -169,6 +209,22 @@ async function resolveEntry(entry: CatalogueEntry): Promise<{
         available: true,
         resolvedPath: resolved,
         launch: { command: resolved, argsForDir: entry.commandArgs ?? ((resolvedDir) => [resolvedDir]) },
+      };
+    }
+  }
+  if (entry.winInstallPaths && process.platform === 'win32') {
+    const resolved = await resolveFirstExistingExecutable(entry.winInstallPaths);
+    if (resolved) {
+      return {
+        available: true,
+        resolvedPath: resolved,
+        launch: {
+          command: resolved,
+          // Warp has no open-directory CLI argument (warpdotdev/warp#6357); pass no args.
+          argsForDir: () => [],
+          // Best-effort: set cwd so Warp opens in the project directory.
+          cwdForDir: (resolvedDir) => resolvedDir,
+        },
       };
     }
   }
@@ -195,6 +251,8 @@ export interface HostToolLaunchPlan {
   resolvedPath?: string;
   command?: string;
   args?: string[];
+  /** Working directory for spawn; set when the tool has no dir CLI arg (e.g. Warp on Windows). */
+  cwd?: string;
 }
 
 export async function resolveHostToolLaunchPlan(
@@ -210,11 +268,13 @@ export async function resolveHostToolLaunchPlan(
       ...(probe.resolvedPath ? { resolvedPath: probe.resolvedPath } : {}),
     };
   }
+  const cwd = probe.launch.cwdForDir?.(resolvedDir);
   return {
     available: true,
     ...(probe.resolvedPath ? { resolvedPath: probe.resolvedPath } : {}),
     command: probe.launch.command,
     args: probe.launch.argsForDir(resolvedDir),
+    ...(cwd ? { cwd } : {}),
   };
 }
 
@@ -314,6 +374,7 @@ export function registerHostToolsRoutes(app: Express, ctx: RegisterHostToolsRout
         detached: true,
         stdio: 'ignore',
         shell: process.platform === 'win32',
+        ...(launchPlan.cwd ? { cwd: launchPlan.cwd } : {}),
       });
       child.on('error', () => {
         // Swallow — best-effort; the client will see ok:true but the OS

--- a/apps/daemon/tests/host-tools-routes.test.ts
+++ b/apps/daemon/tests/host-tools-routes.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { resolveHostToolLaunchPlan } from '../src/routes/host-tools.js';
+import { resolveFirstExistingExecutable, resolveHostToolLaunchPlan } from '../src/routes/host-tools.js';
 
 describe('host tools open-in launch plans', () => {
   it('uses the absolute macOS open command to reveal project folders in Finder', async () => {
@@ -21,5 +24,121 @@ describe('host tools open-in launch plans', () => {
     expect(plan.available).toBe(true);
     expect(plan.command).toBe('/usr/bin/open');
     expect(plan.args).toEqual(['-a', 'Terminal', '/tmp/open-design-project']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFirstExistingExecutable — pure helper, no platform gate.
+// Runs on Linux CI and Windows alike; must never branch on process.platform.
+// ---------------------------------------------------------------------------
+
+describe('resolveFirstExistingExecutable', () => {
+  // Env-var key used across all tests in this suite. Chosen to be obviously
+  // test-scoped and absent from any real environment.
+  const TEST_VAR = 'OD_TEST_EXEC_TMPDIR_4539';
+  let tmpDir = '';
+  let realFile = '';
+
+  beforeEach(async () => {
+    // Create an isolated temp directory and place a real file inside it.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-host-tools-4539-'));
+    realFile = path.join(tmpDir, 'fake-warp.exe');
+    fs.writeFileSync(realFile, '');
+    // Make it executable on POSIX (no-op on Windows; fs.access X_OK succeeds for any existing file).
+    fs.chmodSync(realFile, 0o755);
+    process.env[TEST_VAR] = tmpDir;
+  });
+
+  afterEach(() => {
+    delete process.env[TEST_VAR];
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns the expanded absolute path when a forward-slash candidate exists', async () => {
+    // Candidate uses %VAR%/filename — forward-slash form.
+    const candidate = `%${TEST_VAR}%/fake-warp.exe`;
+
+    const result = await resolveFirstExistingExecutable([candidate]);
+
+    // Normalise separators for comparison so the test is platform-agnostic.
+    expect(result?.replace(/\\/g, '/')).toBe(realFile.replace(/\\/g, '/'));
+  });
+
+  it('returns the expanded absolute path when a back-slash candidate exists', async () => {
+    // Candidate uses %VAR%\filename — Windows-separator form.
+    // This is the exact shape the Warp catalogue entry will use.
+    const candidate = `%${TEST_VAR}%\\fake-warp.exe`;
+
+    const result = await resolveFirstExistingExecutable([candidate]);
+
+    expect(result?.replace(/\\/g, '/')).toBe(realFile.replace(/\\/g, '/'));
+  });
+
+  it('returns null when no candidate path exists on disk', async () => {
+    const result = await resolveFirstExistingExecutable([
+      `%${TEST_VAR}%/does-not-exist.exe`,
+    ]);
+
+    expect(result).toBeNull();
+  });
+
+  it('skips candidates whose env var is unset and falls through to a real path', async () => {
+    // Guarantee the sentinel var is absent (should be, but be explicit).
+    const UNSET_VAR = 'OD_DEFINITELY_UNSET_XYZ_4539';
+    delete process.env[UNSET_VAR];
+
+    const result = await resolveFirstExistingExecutable([
+      `%${UNSET_VAR}%/nope.exe`,         // unset var → must be skipped, not throw
+      `%${TEST_VAR}%/fake-warp.exe`,      // real file → should be returned
+    ]);
+
+    expect(result?.replace(/\\/g, '/')).toBe(realFile.replace(/\\/g, '/'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Warp resolves as available on Windows
+// ---------------------------------------------------------------------------
+
+describe('Warp host tool on Windows', () => {
+  it('reports available=true with executable path and no dir arg when LOCALAPPDATA Warp install is present', async () => {
+    // This test only makes sense on Windows — gate it explicitly.
+    if (process.platform !== 'win32') return;
+
+    // Build a fake LOCALAPPDATA tree with a real warp.exe file.
+    const fakeLOCALAPPDATA = fs.mkdtempSync(path.join(os.tmpdir(), 'od-fake-localappdata-'));
+    const warpDir = path.join(fakeLOCALAPPDATA, 'Programs', 'Warp');
+    fs.mkdirSync(warpDir, { recursive: true });
+    const fakeWarpExe = path.join(warpDir, 'warp.exe');
+    fs.writeFileSync(fakeWarpExe, '');
+
+    const originalLOCALAPPDATA = process.env.LOCALAPPDATA;
+
+    try {
+      process.env.LOCALAPPDATA = fakeLOCALAPPDATA;
+
+      const plan = await resolveHostToolLaunchPlan('warp', 'C:\\some\\project\\dir');
+
+      // Core contract: Warp must be detected as available.
+      expect(plan.available).toBe(true);
+
+      // The resolved command must point at the fake warp.exe.
+      // Normalise separators before comparing.
+      expect(plan.command?.replace(/\//g, '\\')).toBe(fakeWarpExe.replace(/\//g, '\\'));
+
+      // Warp has no open-directory CLI argument (upstream gap warpdotdev/warp#6357).
+      // The launch plan must pass an empty args array — no path argument.
+      expect(plan.args).toEqual([]);
+
+      // Working directory is passed as cwd so the OS opens Warp in the right place.
+      expect(plan.cwd).toBe('C:\\some\\project\\dir');
+    } finally {
+      if (originalLOCALAPPDATA === undefined) {
+        delete process.env.LOCALAPPDATA;
+      } else {
+        process.env.LOCALAPPDATA = originalLOCALAPPDATA;
+      }
+      fs.rmSync(fakeLOCALAPPDATA, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/daemon/tests/host-tools-routes.test.ts
+++ b/apps/daemon/tests/host-tools-routes.test.ts
@@ -141,4 +141,73 @@ describe('Warp host tool on Windows', () => {
       fs.rmSync(fakeLOCALAPPDATA, { recursive: true, force: true });
     }
   });
+
+  // ---------------------------------------------------------------------------
+  // Regression: #4539 — Warp Windows launch must set shell:false
+  //
+  // cmd.exe mis-parses forward-slash exe paths (C:/Users/.../warp.exe) when
+  // the route spawns with shell:true.  The fix: install-path launches set
+  // shell:false so Node's CreateProcess handles the exe path directly.
+  // ---------------------------------------------------------------------------
+
+  it('sets shell:false on the launch plan so cmd.exe never parses the exe path', async () => {
+    // Windows-only: shell:false vs shell:true is a win32 spawn distinction.
+    if (process.platform !== 'win32') return;
+
+    const fakeLOCALAPPDATA = fs.mkdtempSync(path.join(os.tmpdir(), 'od-fake-localappdata-shell-'));
+    const warpDir = path.join(fakeLOCALAPPDATA, 'Programs', 'Warp');
+    fs.mkdirSync(warpDir, { recursive: true });
+    fs.writeFileSync(path.join(warpDir, 'warp.exe'), '');
+
+    const originalLOCALAPPDATA = process.env.LOCALAPPDATA;
+
+    try {
+      process.env.LOCALAPPDATA = fakeLOCALAPPDATA;
+
+      const plan = await resolveHostToolLaunchPlan('warp', 'C:\\some\\project\\dir');
+
+      // Detection must still succeed — this is a combined regression guard.
+      expect(plan.available).toBe(true);
+
+      // KEY ASSERTION (currently RED): install-path Warp launch must carry
+      // shell:false so the resolved forward-slash exe path is passed directly
+      // to CreateProcess rather than through cmd.exe, which would ENOENT it.
+      expect(plan.shell).toBe(false);
+    } finally {
+      if (originalLOCALAPPDATA === undefined) {
+        delete process.env.LOCALAPPDATA;
+      } else {
+        process.env.LOCALAPPDATA = originalLOCALAPPDATA;
+      }
+      fs.rmSync(fakeLOCALAPPDATA, { recursive: true, force: true });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Counter-spec: PATH-shim entries must NOT force shell:false
+  //
+  // Bare-command entries (explorer, code, cursor …) rely on cmd.exe PATH
+  // resolution to find .cmd shims and wrappers.  Setting shell:false on those
+  // would break them.  This test locks the fix as *selective*: a future
+  // "set shell:false everywhere" change must fail here.
+  // ---------------------------------------------------------------------------
+
+  it('leaves shell unset for PATH-shim entries so cmd.exe can resolve .cmd wrappers', async () => {
+    // Shell-selection semantics are win32-specific.
+    if (process.platform !== 'win32') return;
+
+    // explorer.exe is always present on any Windows host via PATH; it is a
+    // safe representative of a bare-command (non-install-path) entry.
+    const plan = await resolveHostToolLaunchPlan('explorer', 'C:\\some\\dir');
+
+    if (!plan.available) {
+      // If the host's catalogue doesn't include explorer as an available tool,
+      // skip rather than fail — the absence itself can't tell us about shell.
+      return;
+    }
+
+    // Shell must be absent (undefined) — not false — for PATH-shim entries.
+    // The route's existing win32 default (shell:true) handles .cmd resolution.
+    expect(plan.shell).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Fixes #4539

## Why

- **Use case:** I run Open Design on Windows with Warp installed (`%LOCALAPPDATA%\Programs\Warp\warp.exe`). In the Hand-off "Open in…" menu, Warp showed as **"Warp - not detected on $PATH"** and couldn't be used. I wanted "Open in Warp" to actually work.
- **Pain:** The Warp host-tool entry was macOS-only. On Windows (and Linux) it was *shown but permanently undetectable*, and even once detected the launch silently failed — so the feature was unusable off-macOS.

## What users will see

On Windows, the Hand-off "Open in…" menu now lists **Warp as available** (previously greyed out as "not detected on $PATH"), and clicking it **launches the Warp terminal**.

Note: Warp opens in its default working directory, not the project folder — Warp has no CLI/working-dir launch argument yet (upstream warpdotdev/Warp#6357). This PR passes the project dir as the spawn `cwd` as a best-effort nudge.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — Windows (and Linux) users now see Warp as an available "Open in…" target; on Windows clicking it launches Warp. No contract or new-surface change — the existing Hand-off menu item simply resolves correctly now.
- [ ] **None**

(Warp was already a menu item; this changes its detected/launchable state, not the UI surface. Both the web Hand-off button and the daemon `open-in` route share the same `/api/editors` + `/api/projects/:id/open-in` path, so the fix reaches both surfaces.)

## Screenshots

Verified live rather than by screenshot (headless dev daemon). `GET /api/editors` on Windows before vs after:

```diff
- {"id":"warp","label":"Warp","available":false}     // "not detected on $PATH"
+ {"id":"warp","label":"Warp","available":true,
+  "resolvedPath":"C:/Users/.../AppData/Local/Programs/Warp/warp.exe"}
```

Clicking "Open in Warp" launches a Warp window (confirmed on a clean, zero-instance Windows machine).

## Bug fix verification

- **Test path:** `apps/daemon/tests/host-tools-routes.test.ts`
- **Red on `main`, green on branch:** yes.
  - Detection: a pure, OS-agnostic helper test (`resolveFirstExistingExecutable`) runs on all platforms (CI is Linux) and is the load-bearing red. Plus a win32-gated integration test for the Warp launch plan.
  - Launch: a win32-gated test pins `plan.shell === false`, with a companion test asserting PATH-shim entries keep the default — so the selective fix can't regress into "shell off everywhere" (which would break `.cmd` shims).

### Root cause (two layers)

1. **Detection** — `apps/daemon/src/routes/host-tools.ts` Warp entry declared only `macOpenBundle` (macOS); the `$PATH` probe never finds Warp's Windows install (no PATH shim), and the bundle branch is `process.platform === 'darwin'`-gated. Fix: a `winInstallPaths` probe (`%LOCALAPPDATA%\Programs\Warp\warp.exe`, `%PROGRAMFILES%\Warp\warp.exe`) via a new `resolveFirstExistingExecutable` helper.
2. **Launch** — the `open-in` route spawned with `shell: true` on win32; `cmd.exe` mis-parses the resolved forward-slash exe path → silent `ENOENT` (the route swallows the child `error`). Fix: the install-path launch carries `shell: false` (direct `CreateProcess`), threaded through as `shell: launchPlan.shell ?? (process.platform === 'win32')` so PATH/`.cmd` shims keep their existing `shell: true` default.

## Validation

- `pnpm --filter @open-design/daemon build` — pass
- `pnpm --filter @open-design/daemon run typecheck` — pass (0 errors)
- `pnpm i18n:check` — pass
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/host-tools-routes.test.ts` — **9/9 pass**
- Live: `GET /api/editors` shows Warp `available:true`; "Open in Warp" launches a Warp window on a clean Windows host
- Scope: change is confined to `apps/daemon/src/routes/host-tools.ts` (+ tests). No `packages/contracts` change.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_