### PR TITLE
fix(web): gate PDF print-ready handshake on a usable content size (#4458)

### DIFF
--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -1035,6 +1035,67 @@ export async function exportAsPdf(
   setTimeout(() => URL.revokeObjectURL(url), 60_000);
 }
 
+/**
+ * A reported print size is only usable when both dimensions are positive,
+ * finite numbers. The desktop bridge (apps/desktop/src/main/pdf-export.ts
+ * inferPageSize) sizes the PDF page to this; a zero/invalid size makes it
+ * fall back to measuring the wrapper viewport, which — per that function's
+ * own docs — blanks artifacts whose visible content sits below the fold.
+ * Exported so the injected handshake/cache scripts and unit tests share one
+ * definition. See issue #4458.
+ */
+export function isUsablePrintSize(width: unknown, height: unknown): boolean {
+  return (
+    typeof width === 'number' &&
+    typeof height === 'number' &&
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width > 0 &&
+    height > 0
+  );
+}
+
+/**
+ * Poll `measure` once per animation frame until it returns a usable
+ * (positive, finite) size, then call `report` with it. Bounded by
+ * `maxFrames`: a genuinely empty artifact never gains a usable size, so the
+ * last measurement is reported best-effort rather than hanging the desktop
+ * readiness handshake forever.
+ *
+ * This fixes one #4458 blank-PDF path: the in-iframe handshake used to
+ * report the content size after a fixed two animation frames, which can fire
+ * before a heavier artifact has finished layout (size still 0). The desktop
+ * bridge then has no usable `__odPrintSize`, falls back to the wrapper
+ * viewport, and prints a blank page. Waiting for a non-zero size avoids that.
+ *
+ * Injected into the handshake via `toString()`; the function is self-contained
+ * (no references to other module symbols) so production minification cannot
+ * break the injected copy. The `raf` seam keeps it unit-testable.
+ */
+export function reportPrintSizeWhenStable(
+  measure: () => { width: number; height: number },
+  report: (size: { width: number; height: number }) => void,
+  maxFrames: number,
+  raf: (cb: () => void) => void = (cb) => requestAnimationFrame(() => cb()),
+): void {
+  const usable = (w: number, h: number): boolean =>
+    typeof w === 'number' &&
+    typeof h === 'number' &&
+    Number.isFinite(w) &&
+    Number.isFinite(h) &&
+    w > 0 &&
+    h > 0;
+  const step = (remaining: number): void => {
+    const size = measure();
+    if (usable(size.width, size.height) || remaining <= 0) {
+      report(size);
+      return;
+    }
+    raf(() => step(remaining - 1));
+  };
+  step(maxFrames);
+}
+
 function injectPrintScript(doc: string, title: string): string {
   const safeTitle = JSON.stringify(title || 'artifact');
   // Browser fallback PDF export shares the same print-readiness signal as the
@@ -1071,7 +1132,7 @@ function injectPrintReadyHandshake(doc: string, nonce: string): string {
   // The nonce is a per-export random UUID that verifies the readiness signal
   // came from our injected handshake, not a spoofed message from untrusted
   // artifact code.
-  const script = `<script data-od-print-ready>(function(){window.parent.postMessage({type:'OD_PRINT_READY_STARTED',nonce:'${nonce}'},'*');function waitForImages(){var imgs=Array.from(document.images).filter(function(img){if(img.loading==='lazy')img.loading='eager';return !img.complete});return Promise.all(imgs.map(function(img){return new Promise(function(r){img.addEventListener('load',r,{once:true});img.addEventListener('error',r,{once:true});if(img.complete)r()})}))}function cssUrlValues(value){var urls=[];if(!value||value==='none')return urls;value.replace(/url\\((['"]?)(.*?)\\1\\)/g,function(_,q,rawUrl){if(rawUrl&&!/^data:/i.test(rawUrl))urls.push(rawUrl);return''});return urls}function waitForCssBackgroundImages(){var urls=new Set();Array.from(document.querySelectorAll('*')).forEach(function(el){var style=window.getComputedStyle(el);cssUrlValues(style.backgroundImage).forEach(function(url){urls.add(url)});cssUrlValues(style.borderImageSource).forEach(function(url){urls.add(url)});cssUrlValues(style.listStyleImage).forEach(function(url){urls.add(url)})});return Promise.all(Array.from(urls).map(function(url){return new Promise(function(r){var img=new Image();img.onload=r;img.onerror=r;img.src=url})}))}function nextFrame(){return new Promise(function(r){requestAnimationFrame(function(){r(true)})})}Promise.all([document.fonts&&document.fonts.ready?document.fonts.ready.catch(function(){}):Promise.resolve(),new Promise(function(r){if(document.readyState==='complete')r();else window.addEventListener('load',r,{once:true})})]).then(function(){return Promise.all([waitForImages(),waitForCssBackgroundImages()])}).then(nextFrame).then(nextFrame).then(function(){var de=document.documentElement;var b=document.body||de;var w=Math.max(de.scrollWidth,b.scrollWidth,de.offsetWidth,b.offsetWidth);var h=Math.max(de.scrollHeight,b.scrollHeight,de.offsetHeight,b.offsetHeight);window.parent.postMessage({type:'OD_PRINT_READY',nonce:'${nonce}',width:w,height:h},'*')})})();<\/script>`;
+  const script = `<script data-od-print-ready>(function(){window.parent.postMessage({type:'OD_PRINT_READY_STARTED',nonce:'${nonce}'},'*');function waitForImages(){var imgs=Array.from(document.images).filter(function(img){if(img.loading==='lazy')img.loading='eager';return !img.complete});return Promise.all(imgs.map(function(img){return new Promise(function(r){img.addEventListener('load',r,{once:true});img.addEventListener('error',r,{once:true});if(img.complete)r()})}))}function cssUrlValues(value){var urls=[];if(!value||value==='none')return urls;value.replace(/url\\((['"]?)(.*?)\\1\\)/g,function(_,q,rawUrl){if(rawUrl&&!/^data:/i.test(rawUrl))urls.push(rawUrl);return''});return urls}function waitForCssBackgroundImages(){var urls=new Set();Array.from(document.querySelectorAll('*')).forEach(function(el){var style=window.getComputedStyle(el);cssUrlValues(style.backgroundImage).forEach(function(url){urls.add(url)});cssUrlValues(style.borderImageSource).forEach(function(url){urls.add(url)});cssUrlValues(style.listStyleImage).forEach(function(url){urls.add(url)})});return Promise.all(Array.from(urls).map(function(url){return new Promise(function(r){var img=new Image();img.onload=r;img.onerror=r;img.src=url})}))}function nextFrame(){return new Promise(function(r){requestAnimationFrame(function(){r(true)})})}Promise.all([document.fonts&&document.fonts.ready?document.fonts.ready.catch(function(){}):Promise.resolve(),new Promise(function(r){if(document.readyState==='complete')r();else window.addEventListener('load',r,{once:true})})]).then(function(){return Promise.all([waitForImages(),waitForCssBackgroundImages()])}).then(nextFrame).then(nextFrame).then(function(){var __odReport=${reportPrintSizeWhenStable.toString()};function measure(){var de=document.documentElement;var b=document.body||de;return {width:Math.max(de.scrollWidth,b.scrollWidth,de.offsetWidth,b.offsetWidth),height:Math.max(de.scrollHeight,b.scrollHeight,de.offsetHeight,b.offsetHeight)}}__odReport(measure,function(size){window.parent.postMessage({type:'OD_PRINT_READY',nonce:'${nonce}',width:size.width,height:size.height},'*')},30)})})();<\/script>`;
   if (/<\/head>/i.test(doc)) return doc.replace(/<\/head>/i, `${script}</head>`);
   if (/<\/body>/i.test(doc)) return doc.replace(/<\/body>/i, `${script}</body>`);
   return doc + script;
@@ -1087,7 +1148,7 @@ function injectParentPrintReadyCache(doc: string, nonce: string): string {
   // either signal. window.__odPrintReadyStarted distinguishes a live handshake
   // from a CSP-blocked one so the browser fallback can preserve the historical
   // quick print path when the inner script never runs.
-  const script = `<script>window.__odPrintReady=false;window.__odPrintReadyStarted=false;window.__odPrintSize=null;window.addEventListener('message',function(e){if(e.data&&e.data.nonce==='${nonce}'&&(e.source===window||(window.frames&&e.source===window.frames[0]))){if(e.data.type==='OD_PRINT_READY_STARTED'){window.__odPrintReadyStarted=true;return}if(e.data.type==='OD_PRINT_READY'){window.__odPrintReady=true;if(Number.isFinite(e.data.width)&&Number.isFinite(e.data.height)&&e.data.width>0&&e.data.height>0)window.__odPrintSize={width:e.data.width,height:e.data.height}}}});<\/script>`;
+  const script = `<script>window.__odPrintReady=false;window.__odPrintReadyStarted=false;window.__odPrintSize=null;var __odUsable=${isUsablePrintSize.toString()};window.addEventListener('message',function(e){if(e.data&&e.data.nonce==='${nonce}'&&(e.source===window||(window.frames&&e.source===window.frames[0]))){if(e.data.type==='OD_PRINT_READY_STARTED'){window.__odPrintReadyStarted=true;return}if(e.data.type==='OD_PRINT_READY'){window.__odPrintReady=true;if(__odUsable(e.data.width,e.data.height))window.__odPrintSize={width:e.data.width,height:e.data.height}}}});<\/script>`;
   if (/<head>/i.test(doc)) return doc.replace(/<head>/i, `<head>${script}`);
   return script + doc;
 }

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -10,6 +10,8 @@ import {
   exportAsImage,
   exportAsMd,
   exportAsPdf,
+  isUsablePrintSize,
+  reportPrintSizeWhenStable,
   exportProjectAsHtml,
   exportProjectAsPdf,
   openSandboxedPreviewInNewTab,
@@ -20,6 +22,58 @@ import {
 function mockResponse(headers: Record<string, string>): Response {
   return { headers: new Headers(headers) } as Response;
 }
+
+describe('isUsablePrintSize (#4458)', () => {
+  // The print-ready handshake reports the artifact's own content size so the
+  // desktop bridge can size the PDF page to it. When that size is zero or
+  // invalid, the desktop path falls back to measuring the wrapper viewport,
+  // which (per inferPageSize's own docs) blanks artifacts whose visible
+  // content sits below the fold. Gating on a usable size prevents that.
+  it('treats positive finite dimensions as usable', () => {
+    expect(isUsablePrintSize(1440, 2000)).toBe(true);
+    expect(isUsablePrintSize(1, 1)).toBe(true);
+  });
+
+  it('rejects zero, negative, non-finite, or non-number dimensions', () => {
+    expect(isUsablePrintSize(0, 2000)).toBe(false);
+    expect(isUsablePrintSize(1440, 0)).toBe(false);
+    expect(isUsablePrintSize(-5, 100)).toBe(false);
+    expect(isUsablePrintSize(Number.NaN, 100)).toBe(false);
+    expect(isUsablePrintSize(Number.POSITIVE_INFINITY, 100)).toBe(false);
+    expect(isUsablePrintSize('1440' as unknown as number, 2000)).toBe(false);
+    expect(isUsablePrintSize(undefined as unknown as number, undefined as unknown as number)).toBe(false);
+  });
+});
+
+describe('reportPrintSizeWhenStable (#4458)', () => {
+  it('reports only once the content has a usable size, polling animation frames', () => {
+    // Simulate content that has not finished layout: size is 0 for the first
+    // frames, then becomes positive once laid out. The handshake must not
+    // report the early zero size (which would blank the PDF).
+    const sizes = [
+      { width: 0, height: 0 },
+      { width: 0, height: 0 },
+      { width: 1440, height: 2000 },
+    ];
+    let call = 0;
+    const measure = (): { width: number; height: number } => sizes[Math.min(call++, sizes.length - 1)]!;
+    const reported: Array<{ width: number; height: number }> = [];
+    const raf = (cb: () => void): void => cb(); // run synchronously
+    reportPrintSizeWhenStable(measure, (s) => reported.push(s), 30, raf);
+    expect(reported).toEqual([{ width: 1440, height: 2000 }]);
+  });
+
+  it('reports the last measured size when frames are exhausted (genuinely empty content)', () => {
+    // A truly empty artifact never gains a usable size; rather than hang
+    // forever, report best-effort after the frame budget so the desktop
+    // path is not left waiting on the readiness handshake indefinitely.
+    const measure = (): { width: number; height: number } => ({ width: 0, height: 0 });
+    const reported: Array<{ width: number; height: number }> = [];
+    const raf = (cb: () => void): void => cb();
+    reportPrintSizeWhenStable(measure, (s) => reported.push(s), 3, raf);
+    expect(reported).toEqual([{ width: 0, height: 0 }]);
+  });
+});
 
 describe('archiveRootFromFilePath', () => {
   it('returns the top-level directory name when present', () => {
@@ -669,17 +723,25 @@ describe('sandboxed preview Blob exports', () => {
     expect(htmlArg).toContain('document.documentElement');
     expect(htmlArg).toContain('scrollHeight');
     expect(htmlArg).toContain('offsetHeight');
-    // ...and it ships the size alongside the readiness signal.
-    expect(htmlArg).toContain('width:w');
-    expect(htmlArg).toContain('height:h');
+    // ...and it ships that size to the parent, but only once the content has a
+    // usable (non-zero) size, by driving the measurement through
+    // reportPrintSizeWhenStable. The polling/gating behavior itself is covered
+    // by the reportPrintSizeWhenStable unit tests above (real-logic behavior
+    // assertions, not string presence); here we assert the handshake is wired
+    // to it so a heavier artifact that lays out late is not reported at size 0,
+    // which would blank the PDF (#4458).
+    expect(htmlArg).toContain('reportPrintSizeWhenStable');
+    expect(htmlArg).toContain('width:size.width');
+    expect(htmlArg).toContain('height:size.height');
     // The parent wrapper caches the reported size for inferPageSize() to read,
-    // validating it as a positive finite number so a malformed/oversized message
+    // gating it through isUsablePrintSize so a malformed/oversized message
     // cannot poison the page size. The finite check matters: `Infinity > 0` is
     // true, so a bare `typeof === 'number'` guard would cache a non-finite
-    // dimension and let it leak into the page size.
+    // dimension and let it leak into the page size. (isUsablePrintSize's own
+    // boundary behavior is covered by its unit tests above.)
     expect(htmlArg).toContain('window.__odPrintSize');
-    expect(htmlArg).toContain('Number.isFinite(e.data.width)');
-    expect(htmlArg).toContain('Number.isFinite(e.data.height)');
+    expect(htmlArg).toContain('__odUsable(e.data.width,e.data.height)');
+    expect(htmlArg).toContain('Number.isFinite(width)');
   });
 
   it('injects the readiness cache for non-sandboxed desktop exports too', async () => {

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -75,6 +75,98 @@ describe('reportPrintSizeWhenStable (#4458)', () => {
   });
 });
 
+describe('injected print-ready parent cache script — runtime behavior (#4458)', () => {
+  // Issue #4458 calls out that the existing coverage only proves script
+  // *strings* are injected, never that the injected script *behaves*. These
+  // specs extract the real parent-cache <script> from a live export, run it,
+  // and drive it with postMessage to assert the runtime size gate: a usable
+  // size is cached for the desktop inferPageSize(); a zero or non-finite size
+  // is rejected so it cannot blank the page (viewport fallback) or poison it.
+  async function extractCacheScript(): Promise<{ body: string; nonce: string }> {
+    const printPdfMock = vi.fn().mockResolvedValue({ ok: true });
+    const restoreHost = installMockOpenDesignHost({ host: { pdf: { print: printPdfMock } } });
+    try {
+      await exportAsPdf('<div style="height:4000px">tall artifact</div>', 'Cache Eval');
+    } finally {
+      restoreHost();
+    }
+    const htmlArg = printPdfMock.mock.calls[0]![0] as string;
+    const match = /<script>(window\.__odPrintReady=false;[\s\S]*?)<\/script>/.exec(htmlArg);
+    if (!match) throw new Error('parent cache script not found in exported HTML');
+    const body = match[1]!;
+    const nonceMatch = /nonce===['"]([^'"]+)['"]/.exec(body);
+    if (!nonceMatch) throw new Error('nonce not found in parent cache script');
+    return { body, nonce: nonceMatch[1]! };
+  }
+
+  // This suite runs in the node environment (no DOM), so we drive the real
+  // injected script against a minimal fake `window`: a plain object with a
+  // message-listener registry. The script wires its handler through
+  // `window.addEventListener('message', …)`, so dispatching a message means
+  // invoking the registered handler with a `{ data, source }` event — exactly
+  // what a real `postMessage` delivers, including the source-identity check.
+  type FakeWindow = Record<string, unknown> & {
+    __odPrintReady?: unknown;
+    __odPrintSize?: unknown;
+  };
+
+  function loadCache(body: string): { win: FakeWindow; fire: (event: unknown) => void } {
+    const handlers: Array<(event: unknown) => void> = [];
+    const win: FakeWindow = {
+      addEventListener: (type: string, fn: (event: unknown) => void) => {
+        if (type === 'message') handlers.push(fn);
+      },
+      removeEventListener: () => undefined,
+    };
+    win.frames = [win];
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    new Function('window', body)(win);
+    return { win, fire: (event) => handlers.slice().forEach((h) => h(event)) };
+  }
+
+  function readyEvent(
+    nonce: string,
+    width: unknown,
+    height: unknown,
+    source: unknown,
+  ): { data: unknown; source: unknown } {
+    return { data: { type: 'OD_PRINT_READY', nonce, width, height }, source };
+  }
+
+  it('caches a usable content size so the desktop bridge sizes the page to the artifact', async () => {
+    const { body, nonce } = await extractCacheScript();
+    const { win, fire } = loadCache(body);
+    fire(readyEvent(nonce, 1440, 2000, win));
+    expect(win.__odPrintReady).toBe(true);
+    expect(win.__odPrintSize).toEqual({ width: 1440, height: 2000 });
+  });
+
+  it('rejects a zero size so the page does not fall back to the wrapper viewport and blank', async () => {
+    const { body, nonce } = await extractCacheScript();
+    const { win, fire } = loadCache(body);
+    fire(readyEvent(nonce, 0, 0, win));
+    // Readiness still resolves (so the desktop bridge never hangs), but the
+    // size is withheld so inferPageSize cannot adopt a blank wrapper viewport.
+    expect(win.__odPrintReady).toBe(true);
+    expect(win.__odPrintSize).toBeNull();
+  });
+
+  it('rejects a non-finite size so Infinity cannot poison the page size', async () => {
+    const { body, nonce } = await extractCacheScript();
+    const { win, fire } = loadCache(body);
+    fire(readyEvent(nonce, Number.POSITIVE_INFINITY, 100, win));
+    expect(win.__odPrintSize).toBeNull();
+  });
+
+  it('ignores a print-ready message carrying the wrong nonce (anti-spoof)', async () => {
+    const { body } = await extractCacheScript();
+    const { win, fire } = loadCache(body);
+    fire(readyEvent('not-the-real-nonce', 1440, 2000, win));
+    expect(win.__odPrintReady).toBe(false);
+    expect(win.__odPrintSize).toBeNull();
+  });
+});
+
 describe('archiveRootFromFilePath', () => {
   it('returns the top-level directory name when present', () => {
     expect(archiveRootFromFilePath('ui-design/index.html')).toBe('ui-design');


### PR DESCRIPTION
Refs #4458

## Why

#4458 reports PDF export still producing a one-page, all-white PDF even though the artifact visibly rendered in Open Design. @lefarcen's triage pointed at the desktop `printToPDF` readiness path, and reading it confirmed one concrete, non-speculative blank path:

For the sandboxed-preview export, the desktop bridge prints a wrapper document whose `<body>` is `overflow:hidden` around a `sandbox="allow-scripts"` iframe it cannot read. It therefore depends on the in-iframe print-ready handshake reporting the artifact's content size (`__odPrintSize`). That handshake measured the size after a fixed two animation frames — which can fire before a heavier artifact has finished layout, so it reports `width/height = 0`. The parent cache only stores a positive-finite size, so `__odPrintSize` stays null, and `inferPageSize` then falls back to measuring the wrapper viewport — which, per that function's own docstring, "blanks … artifacts whose visible content sits below the fold".

## What users will see

A heavier or slower-laying-out artifact that previously exported as a blank page is more likely to export with its real content, because the desktop PDF bridge now receives the artifact's true content size instead of falling back to the wrapper viewport.

## Surface area

- [x] **None** — internal change to the PDF export print-ready handshake in `apps/web/src/runtime/exports.ts`. No UI/CLI/API/i18n surface.

## Screenshots

N/A — no UI. (Visual confirmation requires a real desktop PDF export; see Bug fix verification.)

## Bug fix verification

- Test path: `apps/web/tests/runtime/exports.test.ts`
  - `reportPrintSizeWhenStable (#4458)` — reports only once content has a usable (non-zero) size by polling animation frames; reports best-effort when the frame budget is exhausted (genuinely empty content).
  - `isUsablePrintSize (#4458)` — rejects zero / negative / non-finite / non-number dimensions.
  - The existing #4067 size-reporting test is updated to assert the handshake is wired to `reportPrintSizeWhenStable` and the cache gates on `isUsablePrintSize`.
- Did the tests go red on `main` and green on this branch? **yes** — both new functions are missing on `main` (import is `undefined`, tests throw); green after the fix. These are real-logic behavior assertions on the exact functions injected into the handshake (via `toString()`), not string-presence checks.
- **Honest scope / limitation:** this fixes one root-cause path (late layout → size 0 → viewport fallback → blank). #4458 may also cover a second mode where `__odPrintSize` is valid but Electron's `printToPDF` captures before the iframe composites a paint; distinguishing/validating that needs a real-Electron repro with an artifact that reproduces the blank (the reporter noted it was hard to recreate), which this PR does not attempt. Hence `Refs` rather than `Fixes` — leaving the issue open for end-to-end confirmation.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/runtime/exports.test.ts` → 55 passed (4 new/updated specs RED→GREEN).
- `tsc --noEmit` clean for `exports.ts`.
- `pnpm guard` → no new violations.
