### PR TITLE
fix(daemon): hide Warp open-in launcher on win32/linux until dir-targeting lands (#4544)

### DIFF
--- a/apps/daemon/src/routes/host-tools.ts
+++ b/apps/daemon/src/routes/host-tools.ts
@@ -28,10 +28,10 @@ import type { RouteDeps } from '../server-context.js';
 export interface RegisterHostToolsRoutesDeps
   extends RouteDeps<'db' | 'http' | 'paths' | 'projectStore' | 'projectFiles'> {}
 
-type RealPlatform = 'darwin' | 'win32' | 'linux';
-type Platform = RealPlatform | 'unknown';
+export type RealPlatform = 'darwin' | 'win32' | 'linux';
+export type Platform = RealPlatform | 'unknown';
 
-interface CatalogueEntry {
+export interface CatalogueEntry {
   id: HostEditorId;
   label: string;
   icon: string;
@@ -53,7 +53,7 @@ const MAC_OPEN_COMMAND = '/usr/bin/open';
 // The catalogue covers the apps shown in the user's reference screenshot
 // (image 4): Qoder, Cursor, Zed, Windsurf, Antigravity, Finder, Terminal,
 // Warp, Xcode, IntelliJ IDEA — plus a few cross-platform staples.
-const CATALOGUE: ReadonlyArray<CatalogueEntry> = [
+export const CATALOGUE: ReadonlyArray<CatalogueEntry> = [
   { id: 'cursor', label: 'Cursor', icon: 'sparkles', command: 'cursor', macOpenBundle: 'Cursor' },
   { id: 'vscode', label: 'VS Code', icon: 'file-code', command: 'code', macOpenBundle: 'Visual Studio Code' },
   { id: 'windsurf', label: 'Windsurf', icon: 'sparkles', command: 'windsurf', macOpenBundle: 'Windsurf' },
@@ -67,7 +67,10 @@ const CATALOGUE: ReadonlyArray<CatalogueEntry> = [
   { id: 'explorer', label: 'Explorer', icon: 'folder', command: 'explorer', platforms: ['win32'] },
   { id: 'file-manager', label: 'File Manager', icon: 'folder', command: 'xdg-open', platforms: ['linux'] },
   { id: 'terminal', label: 'Terminal', icon: 'sliders', macOpenBundle: 'Terminal', platforms: ['darwin'] },
-  { id: 'warp', label: 'Warp', icon: 'sliders', macOpenBundle: 'Warp' },
+  // darwin-only: Warp cold-starts ignore the cwd argument on win32/linux, so
+  // the "open in Warp" UX is broken on those platforms. Revisit if/when
+  // warpdotdev/Warp#6357 ships cross-platform cwd support. (#4544)
+  { id: 'warp', label: 'Warp', icon: 'sliders', macOpenBundle: 'Warp', platforms: ['darwin'] },
 ];
 
 function currentPlatform(): Platform {
@@ -218,7 +221,7 @@ export async function resolveHostToolLaunchPlan(
   };
 }
 
-function applicableForPlatform(entry: CatalogueEntry, platform: Platform): boolean {
+export function applicableForPlatform(entry: CatalogueEntry, platform: Platform): boolean {
   if (platform === 'unknown') return false;
   if (entry.platforms && !entry.platforms.includes(platform)) return false;
   if (entry.excludedPlatforms && entry.excludedPlatforms.includes(platform)) return false;

--- a/apps/daemon/tests/host-tools-routes.test.ts
+++ b/apps/daemon/tests/host-tools-routes.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveHostToolLaunchPlan } from '../src/routes/host-tools.js';
+import {
+  CATALOGUE,
+  applicableForPlatform,
+  resolveHostToolLaunchPlan,
+} from '../src/routes/host-tools.js';
+import type { CatalogueEntry, Platform } from '../src/routes/host-tools.js';
 
 describe('host tools open-in launch plans', () => {
   it('uses the absolute macOS open command to reveal project folders in Finder', async () => {
@@ -21,5 +26,38 @@ describe('host tools open-in launch plans', () => {
     expect(plan.available).toBe(true);
     expect(plan.command).toBe('/usr/bin/open');
     expect(plan.args).toEqual(['-a', 'Terminal', '/tmp/open-design-project']);
+  });
+});
+
+describe('platform gate — Warp is darwin-only, cross-platform tools stay available everywhere', () => {
+  it('CATALOGUE includes a warp entry', () => {
+    const warp = CATALOGUE.find((e: CatalogueEntry) => e.id === 'warp');
+    expect(warp).toBeDefined();
+  });
+
+  it('warp is not applicable on win32', () => {
+    const warp = CATALOGUE.find((e: CatalogueEntry) => e.id === 'warp')!;
+    expect(applicableForPlatform(warp, 'win32' as Platform)).toBe(false);
+  });
+
+  it('warp is not applicable on linux', () => {
+    const warp = CATALOGUE.find((e: CatalogueEntry) => e.id === 'warp')!;
+    expect(applicableForPlatform(warp, 'linux' as Platform)).toBe(false);
+  });
+
+  it('warp is applicable on darwin', () => {
+    const warp = CATALOGUE.find((e: CatalogueEntry) => e.id === 'warp')!;
+    expect(applicableForPlatform(warp, 'darwin' as Platform)).toBe(true);
+  });
+
+  it('cursor remains applicable on win32 (regression guard — no platforms restriction)', () => {
+    const cursor = CATALOGUE.find((e: CatalogueEntry) => e.id === 'cursor')!;
+    expect(cursor).toBeDefined();
+    expect(applicableForPlatform(cursor, 'win32' as Platform)).toBe(true);
+  });
+
+  it('cursor remains applicable on darwin (regression guard — no platforms restriction)', () => {
+    const cursor = CATALOGUE.find((e: CatalogueEntry) => e.id === 'cursor')!;
+    expect(applicableForPlatform(cursor, 'darwin' as Platform)).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #4544

## Why

Follow-up to #4539 / #4542, addressing @nettee's review on #4542.

#4542 made the Warp host tool detectable and launchable on Windows, but surfaced a deeper limitation: **Warp has no reliable directory-targeted launch on Windows/Linux.** Empirically verified on Windows:

- **Cold start** (Warp not running): the spawn `cwd` is **ignored** — Warp opens at its home directory.
- **Warm** (Warp already running): the relaunch **honors** `cwd` — the new tab opens at the project directory.

This cold/warm split is invisible to the user and is a bug magnet: a user who keeps Warp closed clicks "Open in Warp", lands at home instead of their project, and reports "Open in Warp ignores my project" with no way to know why. Rather than ship inconsistent behavior, hide the Warp launcher on the platforms where it can't reliably target the directory until upstream support lands (warpdotdev/Warp#6357). macOS (`open -a Warp <dir>`) is unaffected.

## What users will see

- **On Windows and Linux:** the "Open with editor" menu (project view → top-right launcher) and the `od project editors` / `od project open-in` CLI surfaces **no longer list Warp.** A direct `POST /api/projects/:id/open-in` with `editorId: "warp"` now returns `400` on these platforms.
- **On macOS:** no change — Warp still appears and launches as before.

This is a default-behavior change for existing Windows/Linux users (Warp was briefly offered via #4542's draft; it is now gated off).

## Surface area

- [x] **UI** — the Warp item is removed from the "Open with editor" menu on win32/linux
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — `od project editors` / `od project open-in` reflect the same gate (both go through `/api/editors` + `applicableForPlatform`)
- [ ] **API / contract** — no `/api/*` shape change; the `HostEditor` response is unchanged, the catalogue is just filtered
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — existing win32/linux users no longer see Warp in the launcher
- [ ] **None**

Dual-track note: this is a *filtering* change, not a capability addition. The gate lives in one place (`applicableForPlatform`) that both the UI list (`GET /api/editors`) and the launch path (`POST /api/projects/:id/open-in`) already consult, so UI and CLI stay in lockstep automatically.

## Screenshots

Verified live on Windows (win32) against the branch build. The "Open with editor" menu lists exactly: **Cursor, VS Code, Explorer** (installed) and **Windsurf, Zed, Qoder, Antigravity, WebStorm, IntelliJ IDEA** (not installed) — **Warp is absent**, matching `GET /api/editors` 1:1. The darwin-only Finder/Terminal entries are correctly absent too. 

<img width="1689" height="1221" alt="download" src="https://github.com/user-attachments/assets/c0af4434-181d-4f7d-af9a-ca2ba59895b2" />

## Bug fix verification

Test path: `apps/daemon/tests/host-tools-routes.test.ts` (new `describe` block, "platform gate — Warp is darwin-only…").

- Did the test go red on `main` and green on this branch? **yes** — red because `CATALOGUE` / `applicableForPlatform` were private (import resolved `undefined`); green after the entry gains `platforms: ['darwin']` and the two symbols are exported.
- Assertions: `applicableForPlatform(warp, 'win32'|'linux') === false`, `applicableForPlatform(warp, 'darwin') === true`, plus a regression guard that `cursor` stays applicable on all platforms (no over-broad gating).

## Validation

- `pnpm --filter @open-design/daemon test -- host-tools-routes` — **8/8 green** (the 6 new gate assertions + the 2 pre-existing finder/terminal tests).
- `pnpm --filter @open-design/daemon test` (full suite) — no new failures attributable to this change; pre-existing failures are external-dependency/env tests (provider auth keys absent, agent CLIs absent, `vela` binary unresolved, Langfuse telemetry), none touching host-tools.
- `pnpm typecheck` — **pass** (all packages).
- `pnpm --filter @open-design/daemon build` — **pass**.
- `pnpm guard` — fails on this branch **and** `main` identically (stale design-system token artifacts, unrelated to this diff; confirmed via stash/pop on the same checkout).
- Live win32 verification: `GET /api/editors` returns no `warp` id; rendered "Open with editor" menu shows no Warp (see Screenshots).

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
