### PR TITLE
fix(web): fill card width and stabilize the Execution-mode model picker chevron (#4443)

### DIFF
--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1840,20 +1840,6 @@
   position: relative;
   overflow: visible;
 }
-/*
-  Inside an Execution-mode CLI card the model picker reuses the full-width
-  `.settings-model-select` / `.inline-switcher__select` styling, so on a wide
-  Settings dialog it stretches edge-to-edge with the chevron stranded at the
-  far right — reading like an unfinished text input rather than a dropdown
-  (#4443). Cap the control so the selected model and chevron stay grouped,
-  reusing the BYOK picker's 420px width budget (`max-width`, so it still
-  collapses to the card width on narrow dialogs). Applies to both the loaded
-  button and the loading row, which share this wrapper.
-*/
-.agent-card-config .agent-model-select-wrap {
-  max-width: 420px;
-}
-
 .settings-model-select {
   display: block;
   width: 100%;
@@ -1893,6 +1879,23 @@
 }
 .agent-card-config .agent-model-select-wrap select:hover {
   border-color: var(--border-strong);
+}
+/*
+  The model picker is a <button>, so the global `button:hover` rule
+  (primitives.css) applies — but it sets `background` as a shorthand, which
+  wipes this button's chevron (a background-image) on hover, leaving the model
+  picker without a dropdown affordance mid-interaction (#4443 read it as an
+  unfinished text input; #4547 QA flagged the unstable hover/blur affordance).
+  Re-assert the full background (hover surface + chevron) at a higher
+  specificity so exactly one dropdown affordance stays put across hover/blur.
+  The control keeps its full card width — capping it to 420px made it read as
+  clipped, noticeably narrower than the card (#4547 QA).
+*/
+.agent-card-config .agent-model-select-wrap .inline-switcher__select:hover {
+  background:
+    var(--bg-subtle)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2374716b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>")
+    no-repeat right 10px center;
 }
 .agent-model-select-chevron {
   position: absolute;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1840,6 +1840,19 @@
   position: relative;
   overflow: visible;
 }
+/*
+  Inside an Execution-mode CLI card the model picker reuses the full-width
+  `.settings-model-select` / `.inline-switcher__select` styling, so on a wide
+  Settings dialog it stretches edge-to-edge with the chevron stranded at the
+  far right — reading like an unfinished text input rather than a dropdown
+  (#4443). Cap the control so the selected model and chevron stay grouped,
+  reusing the BYOK picker's 420px width budget (`max-width`, so it still
+  collapses to the card width on narrow dialogs). Applies to both the loaded
+  button and the loading row, which share this wrapper.
+*/
+.agent-card-config .agent-model-select-wrap {
+  max-width: 420px;
+}
 
 .settings-model-select {
   display: block;

--- a/apps/web/tests/styles/settings-polish.test.ts
+++ b/apps/web/tests/styles/settings-polish.test.ts
@@ -53,4 +53,13 @@ describe('settings polish CSS', () => {
     expect(ruleValue(content, 'position')).toBe('relative');
     expect(ruleValue(content, 'z-index')).toBe('1');
   });
+
+  it('caps the Execution-mode model picker so it reads as a dropdown, not a full-width input (#4443)', () => {
+    const wrap = cssBlock(
+      expandedIndexCss,
+      '.agent-card-config .agent-model-select-wrap',
+    );
+
+    expect(ruleValue(wrap, 'max-width')).toBe('420px');
+  });
 });

--- a/apps/web/tests/styles/settings-polish.test.ts
+++ b/apps/web/tests/styles/settings-polish.test.ts
@@ -53,13 +53,4 @@ describe('settings polish CSS', () => {
     expect(ruleValue(content, 'position')).toBe('relative');
     expect(ruleValue(content, 'z-index')).toBe('1');
   });
-
-  it('caps the Execution-mode model picker so it reads as a dropdown, not a full-width input (#4443)', () => {
-    const wrap = cssBlock(
-      expandedIndexCss,
-      '.agent-card-config .agent-model-select-wrap',
-    );
-
-    expect(ruleValue(wrap, 'max-width')).toBe('420px');
-  });
 });

--- a/e2e/ui/settings-execution-model-picker.test.ts
+++ b/e2e/ui/settings-execution-model-picker.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+// Regression guard for #4443 / #4547: the Execution-mode CLI card model picker.
+//
+// #4443 reported the picker reading like an unfinished text input. Capping its
+// width to 420px (the first fix attempt) instead made it read as clipped —
+// noticeably narrower than the card (#4547 manual QA). It is also a <button>,
+// so the global `button:hover` rule applies; that rule sets `background` as a
+// shorthand, which wiped the button's chevron (a background-image) on hover,
+// leaving the affordance unstable across hover/blur (#4547 QA).
+//
+// This guards both: the picker fills the card width, and its single chevron
+// affordance survives hover.
+
+const STORAGE_KEY = 'open-design:config';
+const LOCALE_KEY = 'open-design:locale';
+const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定|Account & settings/i;
+const SETTINGS_MENU_LABEL = /Settings|设置|設定/i;
+const LOCAL_CLI_LABEL = /Local CLI|本机 CLI|本地 CLI/i;
+
+const AGENT = {
+  id: 'codex',
+  name: 'Codex CLI',
+  bin: 'codex',
+  available: true,
+  version: '0.130.0',
+  models: [
+    { id: 'gpt-5', label: 'gpt-5' },
+    { id: 'gpt-5-mini', label: 'gpt-5-mini' },
+    { id: 'o4', label: 'o4' },
+  ],
+};
+
+async function openExpandedCliCard(page: Page) {
+  await page.setViewportSize({ width: 1680, height: 1050 });
+  await page.addInitScript(
+    ({ key, value, localeKey, localeValue }) => {
+      window.localStorage.setItem(key, JSON.stringify(value));
+      window.localStorage.setItem(localeKey, localeValue);
+    },
+    {
+      key: STORAGE_KEY,
+      value: {
+        mode: 'daemon',
+        agentId: 'codex',
+        onboardingCompleted: true,
+        mediaProviders: {},
+        agentModels: {},
+        agentCliEnv: {},
+      },
+      localeKey: LOCALE_KEY,
+      localeValue: 'en',
+    },
+  );
+  await page.route('**/api/health', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
+  );
+  await page.route('**/api/app-config', (r) => {
+    if (r.request().method() === 'GET') {
+      return r.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          config: {
+            onboardingCompleted: true,
+            agentId: 'codex',
+            agentCliEnv: {},
+            agentModels: {},
+            skillId: null,
+            designSystemId: null,
+            disabledSkills: [],
+            disabledDesignSystems: [],
+          },
+        }),
+      });
+    }
+    return r.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+  });
+  await page.route('**/api/agents', (r) => r.fulfill({ json: { agents: [AGENT] } }));
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByText('Loading Open Design…')).toHaveCount(0, { timeout: 15_000 });
+  const privacy = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
+  if (await privacy.isVisible().catch(() => false)) {
+    await privacy.getByRole('button', { name: /not now/i }).click();
+  }
+
+  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).first().click();
+  const dialog = page.getByRole('dialog');
+  const menu = page.getByRole('menu');
+  await expect
+    .poll(async () => {
+      if (await dialog.isVisible().catch(() => false)) return 'dialog';
+      if (await menu.isVisible().catch(() => false)) return 'menu';
+      return 'pending';
+    })
+    .not.toBe('pending');
+  if (await menu.isVisible().catch(() => false)) {
+    await menu.getByRole('menuitem', { name: SETTINGS_MENU_LABEL }).click();
+  }
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('tab', { name: LOCAL_CLI_LABEL }).click();
+  const card = dialog.getByRole('button', { name: /Codex CLI/i });
+  await expect(card).toBeVisible();
+  await card.click();
+  return dialog;
+}
+
+test.describe('Settings Execution-mode model picker (#4443 / #4547)', () => {
+  test('[P2] fills the card width instead of reading as a clipped 420px control', async ({
+    page,
+  }) => {
+    const dialog = await openExpandedCliCard(page);
+    const wrap = dialog.locator('.agent-card-config .agent-model-select-wrap').first();
+    await expect(wrap).toBeVisible();
+
+    const { wrapW, contentW } = await wrap.evaluate((el) => {
+      const card = el.closest('.agent-card-config') as HTMLElement;
+      const cs = getComputedStyle(card);
+      const contentW =
+        card.getBoundingClientRect().width -
+        parseFloat(cs.paddingLeft) -
+        parseFloat(cs.paddingRight);
+      return { wrapW: el.getBoundingClientRect().width, contentW };
+    });
+
+    // The picker should track the card content width (the 420px cap left a
+    // ~160px gap on a wide dialog, which QA read as clipped).
+    expect(wrapW).toBeGreaterThan(contentW - 2);
+    expect(wrapW).toBeGreaterThan(480);
+  });
+
+  test('[P2] keeps a single chevron affordance that survives hover', async ({ page }) => {
+    const dialog = await openExpandedCliCard(page);
+    const btn = dialog
+      .locator('.agent-card-config .agent-model-select-wrap .inline-switcher__select')
+      .first();
+    await expect(btn).toBeVisible();
+
+    const restBg = await btn.evaluate((el) => getComputedStyle(el).backgroundImage);
+    expect(restBg).toContain('svg');
+
+    await btn.hover();
+    await page.waitForTimeout(150);
+    const hoverBg = await btn.evaluate((el) => getComputedStyle(el).backgroundImage);
+    // Without the re-asserted background, the global `button:hover` shorthand
+    // wipes this to `none` mid-interaction.
+    expect(hoverBg).toContain('svg');
+  });
+});


### PR DESCRIPTION
## Problem

In **Settings → Execution mode → (a CLI card)**, the model selector didn't read as a deliberate dropdown (#4443). The first attempt — capping it to `max-width: 420px` — was caught in manual QA (#4547) as two regressions:

1. **Reads as clipped.** On a wide Settings dialog the 420px cap leaves the control noticeably narrower than the card (~160px gap), so it looks cut off rather than intentional.
2. **Unstable dropdown affordance on hover.** The picker is a `<button>`, so the global `button:hover` rule applies — and that rule sets `background` as a *shorthand*, which wipes the button's chevron (a `background-image`) on hover. Mid-hover the control loses its chevron entirely and looks like a plain text input.

## What users will see

Each Execution-mode CLI card's model selector now fills the card width — aligned with the sibling reasoning picker and the card layout — and keeps exactly one clean chevron affordance at rest **and** on hover. Visual-only: no new setting, no default change, no behavioral difference.

## Root cause

- **Width:** the 420px cap was a fixed pixel value unrelated to the card, so on a wide dialog it read as clipped.
- **Chevron:** `button:hover:not(:disabled) { background: var(--bg-subtle); … }` (`primitives.css`) outranks `.inline-switcher__select` (specificity 0,2,1 vs 0,1,0) and, being a `background` shorthand, resets `background-image` to `none` — dropping the chevron on hover. The sibling reasoning picker is a native `<select>` with a separate icon element, so it was unaffected; only the model `<button>` lost its chevron.

## Fix

- Drop the 420px cap so the control tracks the card content width like its sibling reasoning picker.
- Re-assert the full hover background (hover surface + chevron) for the model button at a higher specificity, so exactly one dropdown affordance survives hover/blur.

CSS-only, scoped to `.agent-card-config` — no TSX changes; BYOK and other selects untouched.

## Surface area

- [x] **UI** — visual fix to the existing Execution-mode model selector in `apps/web` Settings (no new control; existing control restyled)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

_Wide Settings dialog (1680px). Before = the 420px cap from the prior revision; After = this revision._

**Before — the `max-width: 420px` revision:** reads clipped (~160px gap to the card edge), and the chevron disappears on hover so it looks like a plain text input.

| At rest | On hover |
|---|---|
| <img width="642" height="279" alt="01-before-rest-420px-clipped" src="https://github.com/user-attachments/assets/3caf256d-b783-4fdc-ad08-63a8a86e3142" /> | <img width="642" height="279" alt="02-before-hover-chevron-gone" src="https://github.com/user-attachments/assets/c23a218a-a141-4753-9cee-db434f6cdd4b" /> |

**After — this revision:** fills the card width (aligned with the reasoning picker below it), and keeps exactly one chevron affordance on hover.

| At rest | On hover |
|---|---|
| <img width="642" height="279" alt="03-after-rest-fills-card" src="https://github.com/user-attachments/assets/4c8da50e-0598-47da-82f3-901c3e1d3940" /> | <img width="642" height="279" alt="04-after-hover-chevron-kept" src="https://github.com/user-attachments/assets/79209557-a3dd-494c-9d74-3957e7696415" /> |

## Bug fix verification

- **Test path:** `e2e/ui/settings-execution-model-picker.test.ts` (a rendered e2e guard, matching the repo's existing `settings-hover-contrast.test.ts` hover-regression pattern — the prior static CSS-rule assertion in `settings-polish.test.ts` couldn't capture the cascade interaction, so it's removed).
- **Did it go red on the old build and green on this one?** **yes** — verified both guards against the prior `399b71d0d` head:
  - *Fills the card width:* on the capped head `wrapW = 420 < cardContent` → fails; on this head the picker fills the card content width → passes.
  - *Chevron survives hover:* on the capped head the button's hover `background-image` computes to `none` → fails; on this head the chevron persists → passes.

## Validation

- `pnpm typecheck` (all packages) → exit 0
- `pnpm --filter @open-design/web test` → **3048 passed, 1 skipped** (incl. `settings-polish`)
- `e2e/ui/settings-execution-model-picker.test.ts` → **2 passed** (and red on `399b71d0d`)
- Node 24.16 + pnpm 10.33.2

Fixes #4443