### PR TITLE
fix(imagegen): keep single-image Codex runs to one final file

### DIFF
--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -1037,6 +1037,13 @@ Only if the built-in result does not return a usable path should you search
 \`\${CODEX_HOME:-$HOME/.codex}/generated_images/.../ig_*.png\` as a fallback
 source. Never leave a project-referenced asset only under \`$CODEX_HOME\`.
 
+When the user asked for one image, produce exactly one final project image
+file. If Codex built-in imagegen returns multiple candidate files, previews, or
+variants, select the single best match and import only that file into
+\`$OD_PROJECT_DIR\`. Do not copy every generated variant, do not keep multiple
+final image files, and do not present multiple outputs unless the user
+explicitly asked for variants or more than one image.
+
 Copy or move the selected generated file into \`$OD_PROJECT_DIR\` with a short
 descriptive filename, then verify the exact destination file exists under
 \`$OD_PROJECT_DIR\` before claiming success. If reading the source path,

--- a/apps/daemon/tests/system-prompt-template.test.ts
+++ b/apps/daemon/tests/system-prompt-template.test.ts
@@ -261,6 +261,10 @@ describe('composeSystemPrompt — metadata.promptTemplate', () => {
       /actual\s+output path returned by the built-in imagegen result/,
     );
     expect(out).toContain('${CODEX_HOME:-$HOME/.codex}/generated_images/.../ig_*.png');
+    expect(out).toContain('When the user asked for one image, produce exactly one final project image');
+    expect(out).toContain('If Codex built-in imagegen returns multiple candidate files, previews, or');
+    expect(out).toContain('select the single best match and import only that file into');
+    expect(out).toContain('Do not copy every generated variant');
     expect(out).toContain('verify the exact destination file exists under');
     expect(out).toMatch(
       /report the exact source path, destination path, and access\/copy\s+error/,


### PR DESCRIPTION
Closes #4208

## Why

This issue came from an image-generation project where the user asked for a single image, but the Codex built-in imagegen flow left two generated PNGs in the project. That makes the result ambiguous, wastes generation/storage work, and breaks the expectation that a one-image prompt should yield one final deliverable.

## What users will see

For Codex-backed `gpt-image` image projects, a request for one image now stays a one-file result. If Codex produces multiple candidate files internally, the agent is instructed to pick the single best match and import only that one final image into the project unless the user explicitly asks for variants or multiple images.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the regression guard: `apps/daemon/tests/system-prompt-template.test.ts`
- Did the test go red on `main` and green on this branch? no
- Why not: the issue is a prompt-contract gap in the Codex imagegen override, and the cheapest reliable regression guard here was to add an assertion on the generated prompt text rather than recreate the full end-to-end Codex imagegen session in test.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/system-prompt-template.test.ts` (from `apps/daemon/`)
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>