### PR TITLE
fix(daemon): make argv prompt-budget platform-aware so POSIX isn't capped at Windows' limit (#4473)

### DIFF
--- a/apps/daemon/src/runtimes/prompt-budget.ts
+++ b/apps/daemon/src/runtimes/prompt-budget.ts
@@ -3,34 +3,58 @@ import type { RuntimeAgentDef, RuntimePromptBudgetError } from './types.js';
 function promptArgvBudgetMessage(
   def: RuntimeAgentDef,
   bytes: number,
+  limit: number,
 ): string {
   if (def.id === 'deepseek') {
     return (
-      `${def.name} currently accepts prompts only as a command-line argument, and this run's composed prompt exceeds the safe size (${bytes} > ${def.maxPromptArgBytes} bytes). ` +
+      `${def.name} currently accepts prompts only as a command-line argument, and this run's composed prompt exceeds the safe size (${bytes} > ${limit} bytes). ` +
       'Reduce the selected skills/design-system context or conversation length, or use DeepSeek through an API/provider model connection for large contexts. Pick a stdin-capable adapter when the prompt must include large local context.'
     );
   }
   return (
-    `${def.name} requires the prompt as a command-line argument and this run's composed prompt exceeds the safe size (${bytes} > ${def.maxPromptArgBytes} bytes). ` +
+    `${def.name} requires the prompt as a command-line argument and this run's composed prompt exceeds the safe size (${bytes} > ${limit} bytes). ` +
     'Reduce the selected skills/design-system context, shorten the conversation, or pick an adapter with stdin support.'
   );
+}
+
+// `maxPromptArgBytes` is sized for Windows' ~32 KB CreateProcess
+// command-line limit (see deepseek.ts). On POSIX the per-arg ceiling is far
+// higher — Linux's MAX_ARG_STRLEN is 128 KB and macOS's ARG_MAX is 256 KB
+// (total argv+env) — and the *real* Windows command-line cap is guarded
+// precisely post-buildArgs by checkWindowsCmdShim/DirectExeCommandLineBudget.
+// So applying the conservative Windows byte budget unconditionally on
+// macOS/Linux false-positives on normal projects (system prompt + DESIGN.md +
+// skills ≈ 50-70 KB) with a confusing "prompt too long" (issue #4473). On
+// POSIX we keep a much larger guard — headroom under Linux's 128 KB per-arg
+// ceiling — purely so a runaway prompt still fails fast with the actionable
+// message instead of a generic spawn E2BIG.
+const POSIX_ARGV_PROMPT_BUDGET = 100_000;
+
+function resolveArgvPromptBudget(
+  maxPromptArgBytes: number,
+  platform: NodeJS.Platform,
+): number {
+  if (platform === 'win32') return maxPromptArgBytes;
+  return Math.max(maxPromptArgBytes, POSIX_ARGV_PROMPT_BUDGET);
 }
 
 export function checkPromptArgvBudget(
   def: RuntimeAgentDef | null | undefined,
   composed: unknown,
+  platform: NodeJS.Platform = process.platform,
 ): RuntimePromptBudgetError | null {
   if (!def || typeof def.maxPromptArgBytes !== 'number') return null;
   const bytes = Buffer.byteLength(
     typeof composed === 'string' ? composed : '',
     'utf8',
   );
-  if (bytes <= def.maxPromptArgBytes) return null;
+  const limit = resolveArgvPromptBudget(def.maxPromptArgBytes, platform);
+  if (bytes <= limit) return null;
   return {
     code: 'AGENT_PROMPT_TOO_LARGE',
-    message: promptArgvBudgetMessage(def, bytes),
+    message: promptArgvBudgetMessage(def, bytes, limit),
     bytes,
-    limit: def.maxPromptArgBytes,
+    limit,
   };
 }
 

--- a/apps/daemon/tests/runtimes/prompt-budget.test.ts
+++ b/apps/daemon/tests/runtimes/prompt-budget.test.ts
@@ -67,7 +67,7 @@ test('deepseek declares a conservative argv-byte budget for the prompt', () => {
 // real spawn would surface a generic ENAMETOOLONG / E2BIG.
 test('checkPromptArgvBudget flags oversized DeepSeek prompts and lets short prompts through', () => {
   const oversized = 'x'.repeat(deepseekMaxPromptArgBytes + 1);
-  const flagged = checkPromptArgvBudget(deepseek, oversized);
+  const flagged = checkPromptArgvBudget(deepseek, oversized, 'win32');
   assert.ok(flagged, 'oversized prompts must trip the argv-byte guard');
   assert.equal(flagged.code, 'AGENT_PROMPT_TOO_LARGE');
   assert.equal(flagged.limit, deepseekMaxPromptArgBytes);
@@ -91,14 +91,53 @@ test('checkPromptArgvBudget flags oversized DeepSeek prompts and lets short prom
   const cjkOversized = '汉'.repeat(
     Math.ceil(deepseekMaxPromptArgBytes / 3) + 1,
   );
-  const cjkFlagged = checkPromptArgvBudget(deepseek, cjkOversized);
+  const cjkFlagged = checkPromptArgvBudget(deepseek, cjkOversized, 'win32');
   assert.ok(cjkFlagged, 'byte-counted UTF-8 prompts must also trip the guard');
   assert.equal(cjkFlagged.code, 'AGENT_PROMPT_TOO_LARGE');
 });
 
+// Issue #4473: `maxPromptArgBytes` (30 KB) is derived from Windows'
+// ~32 KB CreateProcess command-line limit. On POSIX the per-arg ceiling is
+// far higher (Linux MAX_ARG_STRLEN 128 KB; macOS ARG_MAX 256 KB total), and
+// the *real* Windows command-line cap is guarded precisely post-buildArgs by
+// checkWindowsCmdShim/DirectExeCommandLineBudget. Applying the conservative
+// Windows byte budget unconditionally on macOS/Linux false-positives on
+// normal design projects (system prompt + DESIGN.md + skills ≈ 50-70 KB),
+// surfacing as a confusing "prompt too long" even though the OS would accept
+// the argv. The budget must be platform-aware.
+test('checkPromptArgvBudget does not false-positive on POSIX where argv ceilings are far higher (#4473)', () => {
+  // 50 KB: over the Windows-derived 30 KB budget, far under POSIX ceilings.
+  const fiftyKb = 'x'.repeat(50_000);
+  assert.equal(
+    checkPromptArgvBudget(deepseek, fiftyKb, 'linux'),
+    null,
+    'Linux must not flag a 50 KB argv prompt (well under MAX_ARG_STRLEN)',
+  );
+  assert.equal(
+    checkPromptArgvBudget(deepseek, fiftyKb, 'darwin'),
+    null,
+    'macOS must not flag a 50 KB argv prompt (well under ARG_MAX)',
+  );
+
+  // Windows still enforces the conservative budget — its real command-line
+  // cap is ~32 KB, so a 50 KB argv prompt genuinely cannot spawn there.
+  const win = checkPromptArgvBudget(deepseek, fiftyKb, 'win32');
+  assert.ok(win, 'Windows must still flag a 50 KB argv prompt');
+  assert.equal(win.code, 'AGENT_PROMPT_TOO_LARGE');
+
+  // POSIX still guards a genuinely enormous prompt near the per-arg ceiling,
+  // so a runaway prompt fails fast with the actionable message instead of a
+  // generic spawn E2BIG.
+  const huge = 'x'.repeat(200_000);
+  assert.ok(
+    checkPromptArgvBudget(deepseek, huge, 'linux'),
+    'POSIX must still flag a 200 KB argv prompt near MAX_ARG_STRLEN',
+  );
+});
+
 test('checkPromptArgvBudget gives DeepSeek-specific guidance for large contexts', () => {
   const oversized = 'x'.repeat(deepseekMaxPromptArgBytes + 1);
-  const flagged = checkPromptArgvBudget(deepseek, oversized);
+  const flagged = checkPromptArgvBudget(deepseek, oversized, 'win32');
 
   assert.ok(flagged, 'oversized DeepSeek prompts must return a diagnostic');
   assert.match(flagged.message, /DeepSeek TUI/);
@@ -111,7 +150,7 @@ test('Kimi prompt mode declares and enforces an argv-byte budget', () => {
   assert.equal(kimi.maxPromptArgBytes, 30_000);
 
   const oversized = 'x'.repeat(kimi.maxPromptArgBytes + 1);
-  const flagged = checkPromptArgvBudget(kimi, oversized);
+  const flagged = checkPromptArgvBudget(kimi, oversized, 'win32');
   assert.ok(flagged, 'oversized Kimi prompts must trip the argv-byte guard');
   assert.equal(flagged.code, 'AGENT_PROMPT_TOO_LARGE');
   assert.equal(flagged.limit, kimi.maxPromptArgBytes);


### PR DESCRIPTION
Fixes #4473

## Why

A user hit "Prompt is too long" while their own input was small (<2k tokens). The error comes from the daemon's `checkPromptArgvBudget`, which guards argv-bound adapters (DeepSeek/Kimi) against an oversized command line. Its budget, `maxPromptArgBytes` (30 KB), is deliberately sized for **Windows'** ~32 KB CreateProcess command-line limit — but it was applied on **every** platform.

On macOS/Linux the per-arg ceiling is far higher (Linux `MAX_ARG_STRLEN` 128 KB; macOS `ARG_MAX` 256 KB total), and the *real* Windows command-line cap is already guarded precisely **after** buildArgs by `checkWindowsCmdShimCommandLineBudget` / `checkWindowsDirectExeCommandLineBudget`. So applying the conservative Windows byte budget unconditionally on POSIX false-positived on a normal design project — the composed prompt is system prompt + DESIGN.md + selected skills + the user message (~50-70 KB), not just what the user typed — surfacing as a confusing "prompt too long".

## What users will see

On macOS/Linux, running DeepSeek/Kimi on a normal project (large DESIGN.md + a couple of skills) no longer fails with "prompt too long" when the OS would happily accept the argv. The error text now reports the platform-resolved limit.

## Surface area

- [x] **None** — internal daemon prompt-budget logic (`apps/daemon/src/runtimes/prompt-budget.ts`). No UI/CLI/API/i18n surface.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/prompt-budget.test.ts` → `checkPromptArgvBudget does not false-positive on POSIX where argv ceilings are far higher (#4473)`.
- Did it go red on `main` and green on this branch? **yes** — a 50 KB prompt on `'linux'`/`'darwin'` returns null on the branch but flagged on `main`; `'win32'` still flags it; a 200 KB prompt is still flagged on POSIX. Existing Windows-budget specs were made explicit by passing `'win32'`.
- **Honest caveat:** on Windows the 30 KB budget is a *real* OS constraint (CreateProcess ~32 KB), so a genuinely large composed prompt there still can't spawn — that path keeps the existing actionable message (reduce skills/design-system context, or use a stdin-capable adapter). This PR removes the POSIX false-positive, which is the reported symptom.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/prompt-budget.test.ts` → 23 passed.
- `tsc --noEmit` clean for `prompt-budget.ts`.
