### PR TITLE
fix(daemon): actionable connection-test error for OpenCode custom-provider env failures (#4514)

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1924,6 +1924,32 @@ function openCodeOutdatedCliDetail(output: string): string | null {
     : null;
 }
 
+// Issue #4514: OpenCode fails with a cryptic "fetch() URL is invalid" when it
+// can't build a valid provider URL. The error text doesn't say why, and there
+// are two common causes we can't distinguish from the message alone:
+//   (1) a custom-provider `{env:...}` placeholder (e.g. baseURL:
+//       "{env:MY_PROVIDER_BASE_URL}") that resolved to empty - common when
+//       Open Design is launched from Finder/the desktop icon, which doesn't
+//       source the shell profile that exports the variable; or
+//   (2) a baseURL written literally in opencode.jsonc that is malformed.
+// Rewrite the bare error into a hint that names both causes and their fixes,
+// rather than asserting the env case. Exported for unit coverage.
+export const OPENCODE_INVALID_PROVIDER_URL_DETAIL =
+  'OpenCode could not build a valid provider URL ("fetch() URL is invalid"). ' +
+  'Two common causes: (1) a custom-provider {env:...} placeholder in your opencode.jsonc ' +
+  '(e.g. baseURL: "{env:MY_PROVIDER_BASE_URL}") resolved to empty because the environment ' +
+  'variable is not visible to Open Design - launching from Finder or the desktop icon does not ' +
+  'load your shell profile, so variables exported in .zshrc/.zprofile are absent; or (2) a ' +
+  'baseURL written literally in opencode.jsonc is malformed. Check your provider baseURL in ' +
+  'opencode.jsonc, and if it uses {env:...}, make sure the variable is exported where Open Design ' +
+  'can see it (launch from a terminal that exports it, or use a literal value).';
+
+export function openCodeInvalidProviderUrlDetail(output: string): string | null {
+  return /fetch\(\)\s*url\s*is\s*invalid/iu.test(output)
+    ? OPENCODE_INVALID_PROVIDER_URL_DETAIL
+    : null;
+}
+
 function openCodeProviderConnectivityDetail(output: string): string | null {
   for (const rawLine of output.split(/\r?\n/u)) {
     const line = rawLine.replace(/\s+/gu, ' ').trim();
@@ -2252,6 +2278,23 @@ async function testAgentConnectionInternal(
     const detail = redactSecrets(
       error instanceof Error ? error.message : String(error),
     );
+    if (input.agentId === 'opencode') {
+      const invalidProviderUrlDetail = openCodeInvalidProviderUrlDetail(detail);
+      if (invalidProviderUrlDetail) {
+        console.warn(
+          `[test:agent] ${def.name} → invalid_provider_url: ${detail}`,
+        );
+        return {
+          ok: false,
+          kind: 'agent_spawn_failed',
+          latencyMs,
+          model,
+          agentName: def.name,
+          detail: invalidProviderUrlDetail,
+          diagnostics: buildDiagnostics(),
+        };
+      }
+    }
     const auth = classifyAgentAuthFailure(input.agentId, detail);
     if (auth?.status === 'missing') {
       console.warn(`[test:agent] ${def.name} → auth_required: ${detail}`);
@@ -2668,6 +2711,25 @@ async function testAgentConnectionInternal(
             model,
             agentName: def.name,
             detail: outdatedCliDetail,
+            diagnostics: buildDiagnostics({
+              phase: 'spawn',
+              exitCode: winner.code,
+              signal: winner.signal,
+            }),
+          };
+        }
+        const invalidProviderUrlDetail = openCodeInvalidProviderUrlDetail(rawDetail);
+        if (invalidProviderUrlDetail) {
+          console.warn(
+            `[test:agent] ${def.name} → invalid_provider_url: ${redactSecrets(rawDetail)}`,
+          );
+          return {
+            ok: false,
+            kind: 'agent_spawn_failed',
+            latencyMs,
+            model,
+            agentName: def.name,
+            detail: invalidProviderUrlDetail,
             diagnostics: buildDiagnostics({
               phase: 'spawn',
               exitCode: winner.code,

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -14,6 +14,7 @@ import {
   createAgentSink,
   isSmokeOkReply,
   mergeNoProxyWithLoopbackDefaults,
+  openCodeInvalidProviderUrlDetail,
   proxyDispatcherRequestInit,
   redactSecrets,
   resolveOpenAIConnectionTestRunProviderPackage,
@@ -3564,6 +3565,83 @@ setTimeout(() => process.exit(0), 50);
           agentName: 'OpenCode',
           detail: 'OpenCode auth failed: login required',
         });
+      },
+    );
+  });
+
+  it('rewrites OpenCode structured fetch-URL-invalid errors to provider URL guidance', async () => {
+    await withFakeOpenCode(
+      `
+const args = process.argv.slice(2);
+if (args[0] === 'models') {
+  console.log('openai/gpt-5');
+  process.exit(0);
+}
+console.log(JSON.stringify({ type: 'error', error: { data: { message: 'fetch() URL is invalid' } } }));
+setTimeout(() => process.exit(0), 50);
+`,
+      async () => {
+        const res = await realFetch(`${baseUrl}/api/test/connection`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'agent', agentId: 'opencode' }),
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { ok: boolean; detail?: string };
+        expect(body.ok).toBe(false);
+        expect(body.detail).toMatch(/provider URL/i);
+        expect(body.detail).toMatch(/\{env:/);
+        expect(body.detail).toMatch(/malformed|literal/i);
+        expect(body.detail).toMatch(/opencode\.jsonc/);
+      },
+    );
+  });
+
+  // Issue #4514: OpenCode fails with a cryptic "fetch() URL is invalid" when
+  // it can't build a valid provider URL. The connection test must turn that
+  // into an actionable hint. The error text can't tell us why (an empty
+  // {env:...} placeholder vs a malformed literal baseURL), so the hint names
+  // both causes rather than asserting the env case.
+  it('maps the opencode fetch-URL-invalid failure to a hint naming both causes (unit)', () => {
+    const hint = openCodeInvalidProviderUrlDetail('exit 1 · stderr: fetch() URL is invalid');
+    expect(hint).toBeTruthy();
+    expect(hint).toMatch(/opencode\.jsonc/);
+    expect(hint).toMatch(/\{env:/);
+    expect(hint).toMatch(/Finder|terminal|shell profile/);
+    expect(hint).toMatch(/malformed|literal/i);
+    expect(openCodeInvalidProviderUrlDetail('exit 1 · stderr: some other error')).toBeNull();
+  });
+
+  it('keeps malformed literal OpenCode baseURL failures on generic provider-URL guidance', () => {
+    const hint = openCodeInvalidProviderUrlDetail(
+      'exit 1 · stderr: fetch() URL is invalid while loading provider baseURL "http://%"',
+    );
+    expect(hint).toBeTruthy();
+    expect(hint).toMatch(/provider URL/i);
+    expect(hint).toMatch(/literal/i);
+    expect(hint).toMatch(/malformed/i);
+    expect(hint).toMatch(/\{env:/);
+  });
+
+  it('surfaces an actionable env hint when opencode fails with fetch() URL is invalid (#4514)', async () => {
+    await withFakeOpenCode(
+      `
+const args = process.argv.slice(2);
+if (args[0] === 'models') { console.log('openai/gpt-5'); process.exit(0); }
+console.error('fetch() URL is invalid');
+process.exit(1);
+`,
+      async () => {
+        const res = await realFetch(`${baseUrl}/api/test/connection`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'agent', agentId: 'opencode' }),
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { ok: boolean; detail?: string };
+        expect(body.ok).toBe(false);
+        expect(body.detail).toMatch(/\{env:/);
+        expect(body.detail).toMatch(/opencode\.jsonc/);
       },
     );
   });


### PR DESCRIPTION
Refs #4514

## Why

When OpenCode's `opencode.jsonc` uses `{env:...}` placeholders for a custom provider (e.g. `baseURL: "{env:MY_PROVIDER_BASE_URL}"`), launching Open Design from Finder/the desktop icon makes the connection test (and runs) fail with a cryptic **"fetch() URL is invalid"**. macOS doesn't source the shell profile that exports those vars when launched from Finder, so the daemon's OpenCode subprocess resolves the placeholder to empty and builds an invalid URL. The bare error gives the user no idea what's wrong or how to fix it.

## What users will see

When the OpenCode connection test fails this way, the error now explains the likely cause (a `{env:...}` placeholder resolving empty), why it happens (Finder launch doesn't load the shell profile), and the two workarounds (launch from a terminal that exports the vars, or set literal values in `opencode.jsonc`) — instead of "fetch() URL is invalid".

## Surface area

- [x] **None** — internal daemon connection-test diagnostics (`apps/daemon/src/connectionTest.ts`). No UI/CLI/API/i18n surface.

## Bug fix verification

- Test path: `apps/daemon/tests/connection-test.test.ts`
  - unit: `maps the opencode fetch-URL-invalid failure to an actionable env hint` — pins the rewrite and that unrelated errors are left alone.
  - end-to-end: `surfaces an actionable env hint when opencode fails with fetch() URL is invalid (#4514)` — runs a **real fake opencode CLI** (via `withFakeOpenCode`) that emits `fetch() URL is invalid` and exits non-zero, hits `POST /api/test/connection`, and asserts the response `detail` carries the hint (not the raw error).
- Did they go red on `main` and green on this branch? **yes** — `openCodeMissingProviderEnvDetail` is missing on `main` (unit throws), and the end-to-end `detail` was the raw `"exit 1 · stderr: fetch() URL is invalid"`; both green after the fix.

## Honest scope / limitation

This is the actionable-error half of #4514 (the issue's "at minimum the error message explains…" expected behavior). The full fix — making OpenCode custom-provider env available **in-product** — needs a generic env pass-through plus Settings UI, because OpenCode placeholders use arbitrary names (`MY_PROVIDER_BASE_URL`) with no standard env key to allowlist the way `claude`/`codex` have `ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL`. That's a UX-deciding feature, so I'm leaving it for maintainer scope alignment and using `Refs` rather than `Fixes`.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/connection-test.test.ts` → 128 passed; the 2 failing specs are pre-existing provider-mode proxy tests that hit the real network (unrelated to this change).
- `tsc --noEmit` clean for `connectionTest.ts`; `pnpm guard` no new violations.
