### PR TITLE
docs(windows): explain the SmartScreen 'unknown publisher' installer warning

### DIFF
--- a/docs/windows-troubleshooting.md
+++ b/docs/windows-troubleshooting.md
@@ -6,6 +6,50 @@ Open Design runs on Windows natively, but the path is less travelled than macOS,
 
 ---
 
+## Installing the desktop app: "Windows protected your PC"
+
+### Symptom
+
+When you run the downloaded installer (for example `open-design-0.11.0-win-x64-setup.exe`), a blue Windows Defender SmartScreen dialog appears:
+
+```text
+Windows protected your PC
+Microsoft Defender SmartScreen prevented an unrecognized app from starting.
+App:       open-design-x.y.z-win-x64-setup.exe
+Publisher: Unknown publisher
+```
+
+The first dialog only shows a **Don't run** button. The **Run anyway** button is hidden until you click **More info**.
+
+### Why this happens
+
+This is expected and does not mean the app is unsafe or broken. SmartScreen warns about any installer that is not signed with a code-signing certificate it already recognizes. Open Design ships unsigned Windows builds today, so the installer reports `Publisher: Unknown publisher` and SmartScreen flags it until a given signed binary builds up download reputation. The warning is about verifying who published the file, not about detecting a threat.
+
+### Fix
+
+If you downloaded the installer from an official source, you can proceed:
+
+1. Click **More info** in the dialog.
+2. Click **Run anyway**.
+3. Continue through the installer as normal.
+
+### Verify the download first
+
+Only run the installer if you got it from an official source:
+
+- [open-design.ai](https://open-design.ai/), or
+- [GitHub Releases](https://github.com/nexu-io/open-design/releases) on the `nexu-io/open-design` repository.
+
+Do not run an installer from a mirror, a re-upload, or a link you cannot trace back to one of those two sources. If a release publishes a SHA-256 checksum, you can confirm the file is intact before running it:
+
+```powershell
+Get-FileHash .\open-design-x.y.z-win-x64-setup.exe -Algorithm SHA256
+```
+
+Compare the printed hash against the checksum listed on the release page. They must match exactly.
+
+---
+
 ## Prerequisites
 
 | Tool | Version | How to verify |


### PR DESCRIPTION
## Why

New Windows users hit a blue Microsoft Defender SmartScreen dialog the first time they run the packaged installer (`open-design-x.y.z-win-x64-setup.exe`). It reads "Windows protected your PC ... Publisher: Unknown publisher", and the first dialog only shows **Don't run**, with the **Run anyway** button hidden behind **More info**. That looks alarming and stops a first-time install in its tracks.

`docs/windows-troubleshooting.md` only covered the dev/source setup (Node, pnpm, build tools), so there was no answer for the very first thing an end user actually sees. This is the first-run friction that undercuts the install-and-create promise on Windows.

## What the user sees

<table>
  <tr>
    <td width="50%" align="center">
      <img alt="SmartScreen dialog with only a Don't run button; Run anyway is hidden behind More info" src="https://github.com/user-attachments/assets/5c23be3c-6d6d-459d-a704-9a4018133c54" />
      <br /><sub><b>1. Default dialog</b>: only <b>Don't run</b> is shown. The <b>Run anyway</b> button is hidden until you click <b>More info</b>.</sub>
    </td>
    <td width="50%" align="center">
      <img alt="SmartScreen dialog after clicking More info, now showing the Run anyway button" src="https://github.com/user-attachments/assets/4f6e3e0f-d048-4b10-be56-7d2c013331df" />
      <br /><sub><b>2. After More info</b>: the <b>Run anyway</b> button appears alongside <b>Don't run</b>.</sub>
    </td>
  </tr>
</table>

## What changed

A new section at the top of `docs/windows-troubleshooting.md` that:

- shows the exact dialog text so users can match what they see,
- explains why it appears (unsigned build, so SmartScreen reports an unknown publisher) and that it is about verifying the publisher, not detecting a threat,
- gives the steps to proceed (More info, then Run anyway),
- tells users to verify the download source first (open-design.ai or the official GitHub Releases) and how to check the SHA-256 with `Get-FileHash` before running.

Docs only. No code, schema, or behavior change.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** - documentation only.

## Note

This documents the current unsigned-installer behavior so users are not blocked. The release pipeline already has Windows signing plumbed (`tools/pack/src/win/sign.ts`, `.github/scripts/release/windows-signing.ps1`), but it is gated behind a sign mode that is off by default, so public builds report an unknown publisher. Turning signing on would remove the warning at the source, but that is an infra/cost decision for the maintainers rather than something this PR changes.
