### PR TITLE
fix(daemon): quiet shutdown for cursor-agent post-usage idle stall (#3372)

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5779,6 +5779,11 @@ export async function startServer({
     // "agent finished the deliverable and went idle" rather than
     // "agent stalled with nothing to show" (issue #1451).
     let artifactRegistered = false;
+    // Tracks whether any stream routed through `sendAgentEvent` emitted user-
+    // visible content or a deliverable. ACP sessions and plain stdout streams
+    // are covered by their own success/failure paths, and the empty-output
+    // guard below skips them via `trackingSubstantiveOutput`.
+    let agentProducedOutput = false;
     // Only daemon-initiated quiet-period termination should be treated
     // as `succeeded` in the close handler. A later unrelated SIGTERM /
     // SIGKILL (external `kill`, OOM, container shutdown) must keep its
@@ -5868,6 +5873,17 @@ export async function startServer({
         // daemon-initiated so an unrelated later signal (external
         // kill, OOM) is NOT silently reclassified to `succeeded` —
         // only signals from this watchdog branch should be.
+        artifactQuietShutdownRequested = true;
+        if (acpSession?.abort) {
+          acpSession.abort();
+        }
+        if (child && !child.killed) design.runs.signalChild(run, 'SIGTERM');
+        scheduleForcedChildShutdown();
+        return;
+      }
+      // cursor-agent / prompt-via-stdin: turn finished (usage) but child
+      // may idle on open stdin until the watchdog fires (#3372 family).
+      if (run.turnCompletedCleanly && agentProducedOutput) {
         artifactQuietShutdownRequested = true;
         if (acpSession?.abort) {
           acpSession.abort();
@@ -6467,12 +6483,6 @@ export async function startServer({
     // printed to stdout), no token ever reaches the user, so TTFT must not
     // be recorded for that failure mode. See PR #3412.
     let firstBufferedStdoutAt: number | null = null;
-    // Tracks whether any stream the run is using actually emitted user-
-    // visible content or a deliverable. Only the streams routed through
-    // `sendAgentEvent` contribute to this flag; ACP sessions and plain stdout
-    // streams are covered by their own success/failure paths and the
-    // empty-output guard below skips them via `trackingSubstantiveOutput`.
-    let agentProducedOutput = false;
     let trackingSubstantiveOutput = false;
     // Event types that count as "the agent actually produced a response or a
     // deliverable." Lifecycle markers (`status`), meter readings (`usage`),
@@ -6770,6 +6780,13 @@ export async function startServer({
         agentProducedOutput = true;
       }
       emitAgentEvent(ev);
+      // json-event-stream adapters (cursor-agent) keep stdin open; close on
+      // terminal usage so the child exits instead of idle-stalling (#3372).
+      if (def.promptViaStdin || def.id === 'cursor-agent') {
+        try {
+          applyClaudeStreamJsonRunBookkeeping(run, ev);
+        } catch {}
+      }
     };
     const parseBufferedAntigravityGeminiJsonEventStream = () => {
       if (

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -571,6 +571,28 @@ describe('applyClaudeStreamJsonRunBookkeeping', () => {
     expect(run.child.stdin.end).not.toHaveBeenCalled();
   });
 
+  it('closes stdin on cursor-agent terminal usage (single-shot stream-json, #3372)', () => {
+    const run = {
+      stdinOpen: true,
+      turnCompletedCleanly: false,
+      child: {
+        stdin: {
+          destroyed: false,
+          end: vi.fn(),
+        },
+      },
+    };
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'usage',
+      usage: { input_tokens: 1200, output_tokens: 400 },
+    });
+
+    expect(run.turnCompletedCleanly).toBe(true);
+    expect(run.stdinOpen).toBe(false);
+    expect(run.child.stdin.end).toHaveBeenCalled();
+  });
+
   it('closes stdin and records clean completion after an AskUserQuestion tool_use followed by end_turn (#4273)', () => {
     // Regression test: the dead AskUserQuestion detection branch used to add
     // the tool_use id to pendingHostAnswers and return early, preventing stdin


### PR DESCRIPTION
## Summary

- Apply `applyClaudeStreamJsonRunBookkeeping` in `sendAgentEvent` when the agent is `cursor-agent` or uses `promptViaStdin`, so terminal stream-json usage events close stdin after the turn completes.
- In `failForInactivity`, treat a clean turn with substantive output as artifact quiet shutdown instead of a 600s stall failure (same family as #3372).
- Hoist `agentProducedOutput` into watchdog scope so the inactivity path can see prior substantive output.

## Problem

On Windows, `cursor-agent` runs can emit a visible response and a terminal `usage` event, then idle with stdin open until the 600s watchdog fires with a false stall. Observed on runs such as:

- `294d1556-ba79-4686-9bd8-ec7358c39d57` — usage then 600s stall (~1.4M input tokens)
- `ab3c0060-c741-4890-b9c5-8e632137e39e` — usage then 600s stall after visible response

## Test plan

- [x] `pnpm --filter @open-design/daemon test -- chat-run-artifact-quiet-period run-failure-classification` — **76 passed**
- [x] New case: `closes stdin on cursor-agent terminal usage (single-shot stream-json, #3372)`

## Related

- #3372 (post-completion / stream-json bookkeeping family)