### PR TITLE
feat(media): wire MiniMax image-01 through the minimax provider slot

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -2776,11 +2776,13 @@ const MINIMAX_TTS_MODEL_MAP = {
   'minimax-tts': 'speech-02-turbo',
 } as Record<string, string>;
 
-// Image generation lives on a different host than the legacy TTS endpoint.
-// Renderer resolves baseUrl from credentials.baseUrl -> MINIMAX_IMAGE_DEFAULT_BASE_URL
-// -> legacy TTS constant. Keeping the two constants separate lets existing TTS
-// users keep their api.minimaxi.chat/v1 default while new image users get
-// api.minimax.io without manual configuration.
+// Image generation lives on a different host than the legacy TTS endpoint
+// (api.minimax.io vs api.minimaxi.chat). Keeping the two constants
+// separate lets existing TTS users keep their api.minimaxi.chat/v1
+// default while new image users get api.minimax.io without manual
+// configuration. The image renderer resolves baseUrl from
+// OD_MINIMAX_IMAGE_BASE_URL env -> this constant; credentials.baseUrl
+// is intentionally ignored for image (see renderMinimaxImage).
 const MINIMAX_IMAGE_DEFAULT_BASE_URL = 'https://api.minimax.io';
 
 // Map our generic catalogue id onto MiniMax's actual wire model name. Mirrors
@@ -2919,12 +2921,13 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
   const baseUrl = (
     process.env.OD_MINIMAX_IMAGE_BASE_URL?.trim() || MINIMAX_IMAGE_DEFAULT_BASE_URL
   ).replace(/\/+$/, '');
-  // Precedence: credentials.model (user override in stored config) ->
-  // ctx.wireModel (alias-aware from OD_MEDIA_MODEL_ALIASES) ->
-  // MINIMAX_IMAGE_MODEL_MAP (resolves the vendor-prefixed catalog id
-  // `minimax-image-01` to MiniMax's wire name `image-01`). The map is
-  // keyed off ctx.wireModel, not ctx.model, so an aliased wire name
-  // passes through unchanged when it isn't in the map.
+  // Resolve the wire model. credentials.model wins if the user pinned a
+  // specific deployment name in Settings; otherwise we look up the
+  // ctx.wireModel in MINIMAX_IMAGE_MODEL_MAP (which translates our
+  // catalog id `minimax-image-01` to MiniMax's wire name `image-01`),
+  // falling back to ctx.wireModel itself. The map is keyed off
+  // ctx.wireModel so user aliases (OD_MEDIA_MODEL_ALIASES) pass through
+  // unchanged when they aren't in the map.
   const wireModel = (
     credentials.model
     || MINIMAX_IMAGE_MODEL_MAP[ctx.wireModel]
@@ -2943,7 +2946,7 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
   // I2I: when --image is supplied, pass it as subject_reference[0]. The
   // existing resolveProjectImage() helper already returns a base64 dataUrl
   // with a strict mime allowlist (png/jpg/jpeg/webp/gif, < 16MB).
-  if (ctx.imageRef) {
+  if (ctx.imageRef?.dataUrl) {
     body.subject_reference = [{
       type: 'character',
       image_file: ctx.imageRef.dataUrl,
@@ -2990,17 +2993,20 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
 }
 
 function minimaxImageAspectFor(aspect?: string): string | undefined {
-  // MiniMax supports 1:1, 16:9, 4:3, 3:2, 2:3, 3:4, 9:16, 21:9. We accept the
-  // user-supplied aspect if it's in the allowed subset that matches our
-  // MEDIA_ASPECTS list ('1:1', '16:9', '9:16', '4:3', '3:4'); for any other
-  // value (including undefined), we omit `aspect_ratio` from the body and
-  // let MiniMax use its default 1:1.
+  // MiniMax's full allowlist: 1:1, 16:9, 4:3, 3:2, 2:3, 3:4, 9:16, 21:9.
+  // We accept any of these so the agent (or a future picker option) can
+  // request a wider aspect without silently falling back to 1:1.
+  // Anything outside this set is omitted from the body, letting MiniMax
+  // pick its own default rather than us round-tripping an unknown value.
   if (
     aspect === '1:1'
     || aspect === '16:9'
     || aspect === '9:16'
     || aspect === '4:3'
     || aspect === '3:4'
+    || aspect === '3:2'
+    || aspect === '2:3'
+    || aspect === '21:9'
   ) {
     return aspect;
   }

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -2905,7 +2905,20 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
       'no MiniMax API key — configure it in Settings or set OD_MINIMAX_API_KEY',
     );
   }
-  const baseUrl = (credentials.baseUrl || MINIMAX_IMAGE_DEFAULT_BASE_URL).replace(/\/$/, '');
+  // Base URL precedence:
+  //   OD_MINIMAX_IMAGE_BASE_URL env var (operator override for proxies)
+  //   -> MINIMAX_IMAGE_DEFAULT_BASE_URL (api.minimax.io)
+  //
+  // We deliberately ignore credentials.baseUrl here. The 'minimax' provider
+  // slot is shared with TTS, whose stored baseUrl is the legacy
+  // api.minimaxi.chat/v1 host. Naively appending '/v1/image_generation'
+  // would produce https://api.minimaxi.chat/v1/v1/image_generation — a
+  // 404 against the wrong host. Adding a per-surface baseUrl to the
+  // provider schema would be a cleaner long-term fix; until then, image
+  // stays pinned to its own host and operators route via the env var.
+  const baseUrl = (
+    process.env.OD_MINIMAX_IMAGE_BASE_URL?.trim() || MINIMAX_IMAGE_DEFAULT_BASE_URL
+  ).replace(/\/+$/, '');
   // Precedence: credentials.model (user override in stored config) ->
   // ctx.wireModel (alias-aware from OD_MEDIA_MODEL_ALIASES) ->
   // MINIMAX_IMAGE_MODEL_MAP (resolves the vendor-prefixed catalog id

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -35,6 +35,10 @@
 //                              (Gemini Flash, Flux, Recraft) and async
 //                              /videos submit + poll for video
 //                              (Seedance 2.0, Veo 3.1, Wan 2.7)
+//   * provider 'minimax'    → MiniMax: synchronous /v1/image_generation
+//                              for image-01 (T2I + I2I via subject_reference)
+//                              on api.minimax.io, plus TTS via the legacy
+//                              api.minimaxi.chat host
 //   * provider 'custom-image'→ user-supplied OpenAI-compatible
 //                              /v1/images/generations + /v1/images/edits
 //                              endpoints
@@ -2903,15 +2907,15 @@ async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig
   }
   const baseUrl = (credentials.baseUrl || MINIMAX_IMAGE_DEFAULT_BASE_URL).replace(/\/$/, '');
   // Precedence: credentials.model (user override in stored config) ->
-  // ctx.wireModel (alias-aware from OD_MEDIA_MODEL_ALIASES) -> catalog map
-  // for the vendor-prefixed id `minimax-image-01` -> bare ctx.model as a
-  // last-ditch default. Mirrors the convention used by the nanobanana,
-  // openrouter, imagerouter, and custom-image renderers in this file.
+  // ctx.wireModel (alias-aware from OD_MEDIA_MODEL_ALIASES) ->
+  // MINIMAX_IMAGE_MODEL_MAP (resolves the vendor-prefixed catalog id
+  // `minimax-image-01` to MiniMax's wire name `image-01`). The map is
+  // keyed off ctx.wireModel, not ctx.model, so an aliased wire name
+  // passes through unchanged when it isn't in the map.
   const wireModel = (
     credentials.model
+    || MINIMAX_IMAGE_MODEL_MAP[ctx.wireModel]
     || ctx.wireModel
-    || MINIMAX_IMAGE_MODEL_MAP[ctx.model]
-    || ctx.model
   ).trim();
   const aspectRatio = minimaxImageAspectFor(ctx.aspect);
   const body: Record<string, unknown> = {

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -698,6 +698,11 @@ export async function generateMedia(args: {
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'minimax' && surface === 'image') {
+      const result = await renderMinimaxImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
     } else if (def.provider === 'senseaudio' && surface === 'audio') {
       const result = await renderSenseAudioTTS(ctx, credentials);
       bytes = result.bytes;
@@ -2767,6 +2772,21 @@ const MINIMAX_TTS_MODEL_MAP = {
   'minimax-tts': 'speech-02-turbo',
 } as Record<string, string>;
 
+// Image generation lives on a different host than the legacy TTS endpoint.
+// Renderer resolves baseUrl from credentials.baseUrl -> MINIMAX_IMAGE_DEFAULT_BASE_URL
+// -> legacy TTS constant. Keeping the two constants separate lets existing TTS
+// users keep their api.minimaxi.chat/v1 default while new image users get
+// api.minimax.io without manual configuration.
+const MINIMAX_IMAGE_DEFAULT_BASE_URL = 'https://api.minimax.io';
+
+// Map our generic catalogue id onto MiniMax's actual wire model name. Mirrors
+// the TTS pattern above: the catalog id `minimax-image-01` is shorthand for
+// "their flagship image model"; we substitute the real model name on the wire
+// so MiniMax accepts the request without exposing the user to internal naming.
+const MINIMAX_IMAGE_MODEL_MAP = {
+  'minimax-image-01': 'image-01',
+} as Record<string, string>;
+
 async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
@@ -2856,6 +2876,118 @@ async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig):
     providerNote: `minimax/${wireModel} · ${voiceId} · ${seconds}s · ${bytes.length} bytes`,
     suggestedExt: '.mp3',
   };
+}
+
+// ---------------------------------------------------------------------------
+// Provider: MiniMax — image-01 text-to-image (synchronous, with optional
+// I2I via subject_reference).
+//
+// Docs: https://platform.minimax.io/docs/api-reference/image-generation-t2i
+// POST /v1/image_generation with a JSON body describing the prompt +
+// optional subject reference for image-to-image. Response is JSON with the
+// image base64-encoded under `data.image_base64[0]` and a `base_resp`
+// envelope that distinguishes HTTP-level from API-level failures, mirroring
+// MiniMax's TTS API.
+//
+// We always request `response_format: 'base64'` because MiniMax's default
+// URL responses expire after 24 hours — base64 persists at write time and
+// never goes stale. The wire model `image-01` is mapped from our catalog id
+// `minimax-image-01` via MINIMAX_IMAGE_MODEL_MAP.
+// ---------------------------------------------------------------------------
+
+async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no MiniMax API key — configure it in Settings or set OD_MINIMAX_API_KEY',
+    );
+  }
+  const baseUrl = (credentials.baseUrl || MINIMAX_IMAGE_DEFAULT_BASE_URL).replace(/\/$/, '');
+  // Precedence: credentials.model (user override in stored config) ->
+  // ctx.wireModel (alias-aware from OD_MEDIA_MODEL_ALIASES) -> catalog map
+  // for the vendor-prefixed id `minimax-image-01` -> bare ctx.model as a
+  // last-ditch default. Mirrors the convention used by the nanobanana,
+  // openrouter, imagerouter, and custom-image renderers in this file.
+  const wireModel = (
+    credentials.model
+    || ctx.wireModel
+    || MINIMAX_IMAGE_MODEL_MAP[ctx.model]
+    || ctx.model
+  ).trim();
+  const aspectRatio = minimaxImageAspectFor(ctx.aspect);
+  const body: Record<string, unknown> = {
+    model: wireModel,
+    prompt: (ctx.prompt && ctx.prompt.trim()) || 'A high-quality reference image.',
+    response_format: 'base64',
+    n: 1,
+  };
+  if (aspectRatio) {
+    body.aspect_ratio = aspectRatio;
+  }
+  // I2I: when --image is supplied, pass it as subject_reference[0]. The
+  // existing resolveProjectImage() helper already returns a base64 dataUrl
+  // with a strict mime allowlist (png/jpg/jpeg/webp/gif, < 16MB).
+  if (ctx.imageRef) {
+    body.subject_reference = [{
+      type: 'character',
+      image_file: ctx.imageRef.dataUrl,
+    }];
+  }
+  const resp = await fetch(`${baseUrl}/v1/image_generation`, withMediaRequestInit(ctx, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  }));
+  const respText = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`minimax image ${resp.status}: ${truncate(respText, 240)}`);
+  }
+  let data: any;
+  try {
+    data = JSON.parse(respText);
+  } catch {
+    throw new Error(`minimax image non-JSON: ${truncate(respText, 200)}`);
+  }
+  // MiniMax wraps every response in `base_resp`; even an HTTP 200 can
+  // be a logical failure (`status_code !== 0`).
+  if (data?.base_resp && data.base_resp.status_code !== 0) {
+    throw new Error(
+      `minimax image api error ${data.base_resp.status_code}: ${data.base_resp.status_msg || 'unknown'}`,
+    );
+  }
+  const base64 = data?.data?.image_base64?.[0];
+  if (typeof base64 !== 'string' || !base64) {
+    throw new Error('minimax image response missing data.image_base64[0]');
+  }
+  const bytes = Buffer.from(base64, 'base64');
+  if (bytes.length === 0) {
+    throw new Error('minimax image decoded zero bytes');
+  }
+  return {
+    bytes,
+    providerNote: `minimax/${wireModel} · ${aspectRatio || '1:1'} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
+  };
+}
+
+function minimaxImageAspectFor(aspect?: string): string | undefined {
+  // MiniMax supports 1:1, 16:9, 4:3, 3:2, 2:3, 3:4, 9:16, 21:9. We accept the
+  // user-supplied aspect if it's in the allowed subset that matches our
+  // MEDIA_ASPECTS list ('1:1', '16:9', '9:16', '4:3', '3:4'); for any other
+  // value (including undefined), we omit `aspect_ratio` from the body and
+  // let MiniMax use its default 1:1.
+  if (
+    aspect === '1:1'
+    || aspect === '16:9'
+    || aspect === '9:16'
+    || aspect === '4:3'
+    || aspect === '3:4'
+  ) {
+    return aspect;
+  }
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/daemon/src/media/models.ts
+++ b/apps/daemon/src/media/models.ts
@@ -48,7 +48,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   { id: 'google', label: 'Google AI / Vertex', hint: 'Imagen 4 / Veo 3 / Lyria', integrated: false },
   { id: 'kling', label: 'Kuaishou Kling', hint: 'Kling 1.6 / 2.0 video', integrated: false },
   { id: 'midjourney', label: 'Midjourney (proxy)', hint: 'midjourney-v7', integrated: false },
-  { id: 'minimax', label: 'MiniMax', hint: 'TTS / video-01', integrated: true, defaultBaseUrl: 'https://api.minimaxi.chat/v1' },
+  { id: 'minimax', label: 'MiniMax', hint: 'TTS / image-01 / video-01', integrated: true, defaultBaseUrl: 'https://api.minimaxi.chat/v1' },
   { id: 'suno', label: 'Suno', hint: 'Music generation', integrated: false },
   { id: 'udio', label: 'Udio', hint: 'Music generation', integrated: false },
   {
@@ -105,6 +105,8 @@ export const IMAGE_MODELS: MediaModel[] = [
   // `aihubmix-` prefix is stripped to the real wire name in media.ts.
   { id: 'aihubmix-gpt-image-1', label: 'gpt-image-1 (AIHubMix)', hint: 'AIHubMix · OpenAI gpt-image-1', provider: 'aihubmix', caps: ['t2i', 'i2i'] },
   { id: 'aihubmix-dall-e-3', label: 'dall-e-3 (AIHubMix)', hint: 'AIHubMix · OpenAI DALL·E 3', provider: 'aihubmix', caps: ['t2i'] },
+
+  { id: 'minimax-image-01', label: 'image-01', hint: 'MiniMax · text + image-to-image', provider: 'minimax', caps: ['t2i', 'i2i'] },
 
   { id: 'grok-imagine-image', label: 'grok-imagine-image', hint: 'xAI · 2K text-to-image', provider: 'grok', caps: ['t2i'] },
 

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { generateMedia } from '../src/media.js';
+import { generateMedia } from '../src/media/index.js';
 
 const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
 const TEST_MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -234,4 +234,43 @@ describe('minimax image generation', () => {
       output: 'minimax.png',
     })).rejects.toThrow(/minimax image 401: unauthorized/);
   });
+
+  it('uses the image-specific default base URL and wire model when no config is provided', async () => {
+    // No writeConfig() call — the provider slot exists but has no stored
+    // baseUrl/model override. resolveProviderConfig still returns a config
+    // (apiKey from OD_MINIMAX_API_KEY), but baseUrl and model come from
+    // the renderer's defaults.
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      // Default image base URL is the api.minimax.io host, distinct from
+      // the legacy TTS api.minimaxi.chat. Verifies the renderer does not
+      // inherit the TTS constant.
+      expect(String(input)).toBe(`${TEST_MINIMAX_DEFAULT_BASE_URL}/v1/image_generation`);
+      const body = JSON.parse(String(init?.body));
+      // Default wire model is MiniMax image-01, resolved via the catalog
+      // map from our vendor-prefixed catalog id.
+      expect(body.model).toBe('image-01');
+      expect(body).not.toHaveProperty('subject_reference');
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu',
+      output: 'minimax.png',
+    });
+
+    expect(result.providerId).toBe('minimax');
+    expect(result.providerNote).toContain('minimax/image-01');
+  });
 });

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -18,6 +18,7 @@ describe('minimax image generation', () => {
   const originalDataDir = process.env.OD_DATA_DIR;
   const originalMinimaxApiKey = process.env.OD_MINIMAX_API_KEY;
   const originalImageBaseUrl = process.env.OD_MINIMAX_IMAGE_BASE_URL;
+  const originalMediaModelAliases = process.env.OD_MEDIA_MODEL_ALIASES;
 
   beforeEach(async () => {
     root = await mkdtemp(path.join(tmpdir(), 'od-minimax-image-'));
@@ -27,6 +28,7 @@ describe('minimax image generation', () => {
     delete process.env.OD_MEDIA_CONFIG_DIR;
     delete process.env.OD_DATA_DIR;
     delete process.env.OD_MINIMAX_IMAGE_BASE_URL;
+    delete process.env.OD_MEDIA_MODEL_ALIASES;
     process.env.OD_MINIMAX_API_KEY = 'minimax-test-key';
   });
 
@@ -51,6 +53,11 @@ describe('minimax image generation', () => {
       delete process.env.OD_MINIMAX_IMAGE_BASE_URL;
     } else {
       process.env.OD_MINIMAX_IMAGE_BASE_URL = originalImageBaseUrl;
+    }
+    if (originalMediaModelAliases == null) {
+      delete process.env.OD_MEDIA_MODEL_ALIASES;
+    } else {
+      process.env.OD_MEDIA_MODEL_ALIASES = originalMediaModelAliases;
     }
     await rm(root, { recursive: true, force: true });
   });
@@ -341,6 +348,111 @@ describe('minimax image generation', () => {
       surface: 'image',
       model: 'minimax-image-01',
       prompt: 'A watercolor shiba inu',
+      output: 'minimax.png',
+    })).resolves.toMatchObject({ providerId: 'minimax' });
+  });
+
+  it('throws a clear error when no MiniMax API key is configured', async () => {
+    // The renderer must reject the request before touching the network
+    // when credentials.apiKey is missing — otherwise the user gets a
+    // confusing 401 from MiniMax instead of the actionable "configure
+    // it in Settings" message that matches every other renderer.
+    delete process.env.OD_MINIMAX_API_KEY;
+    await writeConfig({ providers: { minimax: {} } });
+
+    // No fetch mock needed: the renderer must short-circuit before
+    // dispatching. If it doesn't, vi.fn would surface as unhandled
+    // and the test would still fail — both sides of the contract are
+    // anchored.
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu',
+      output: 'minimax.png',
+    })).rejects.toThrow(/no MiniMax API key/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('passes an aliased wireModel through unchanged when not in the catalog map', async () => {
+    // The map MINIMAX_IMAGE_MODEL_MAP is keyed off the catalog id, but
+    // ctx.wireModel may have been rewritten by OD_MEDIA_MODEL_ALIASES.
+    // When the alias is *not* in the map, the renderer must use the
+    // aliased name as-is rather than silently substituting the catalog
+    // map value or the bare catalog id. Anchors the alias passthrough
+    // contract so a future refactor that re-keys the map off ctx.model
+    // would fail this test instead of silently breaking aliases.
+    process.env.OD_MEDIA_MODEL_ALIASES = JSON.stringify({
+      'minimax-image-01': 'image-01-pro',
+    });
+    await writeConfig({ providers: { minimax: {} } });
+
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBe('image-01-pro');
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu',
+      output: 'minimax.png',
+    });
+
+    expect(result.providerId).toBe('minimax');
+    // providerNote must surface the aliased wire name, not the catalog
+    // id — the FileViewer toolbar tells the truth about what was sent.
+    expect(result.providerNote).toContain('minimax/image-01-pro');
+  });
+
+  it('forwards aspects outside MEDIA_ASPECTS but inside MiniMax allowlist (21:9)', async () => {
+    // MEDIA_ASPECTS (apps/web/src/media/models.ts) is currently
+    // ['1:1','16:9','9:16','4:3','3:4']. The agent can still pass an
+    // arbitrary aspect string through the media API; the renderer must
+    // honor any value in MiniMax's wider allowlist (1:1, 16:9, 4:3, 3:2,
+    // 2:3, 3:4, 9:16, 21:9) rather than silently dropping it back to
+    // MiniMax's 1:1 default. Anchors the "21:9 reaches the wire"
+    // contract for any future UI that exposes wider aspect ratios.
+    await writeConfig({ providers: { minimax: {} } });
+
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.aspect_ratio).toBe('21:9');
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu',
+      aspect: '21:9',
       output: 'minimax.png',
     })).resolves.toMatchObject({ providerId: 'minimax' });
   });

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -168,4 +168,44 @@ describe('minimax image generation', () => {
     const bytes = await readFile(path.join(projectsRoot, 'project-1', 'minimax-i2i.png'));
     expect(bytes.length).toBeGreaterThan(0);
   });
+
+  it('surfaces base_resp.status_code failures with status_msg as the error', async () => {
+    await writeConfig({
+      providers: {
+        minimax: { baseUrl: TEST_MINIMAX_BASE_URL },
+      },
+    });
+
+    // MiniMax wraps every response in base_resp; an HTTP 200 can still be a
+    // logical failure (e.g. status_code 1008 = insufficient balance). The
+    // renderer must surface this as a thrown Error rather than silently
+    // returning empty bytes.
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      base_resp: {
+        status_code: 1008,
+        status_msg: 'Insufficient account balance',
+      },
+      // No data.image_base64 — the renderer should reject on base_resp before
+      // ever reaching the decode path.
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu',
+      output: 'minimax.png',
+    })).rejects.toThrow(/minimax image api error 1008: Insufficient account balance/);
+
+    // Renderer must NOT have written any output file when the upstream
+    // rejected the request, even though HTTP 200 was returned.
+    const outPath = path.join(projectsRoot, 'project-1', 'minimax.png');
+    await expect(readFile(outPath)).rejects.toThrow();
+  });
 });

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -109,4 +109,63 @@ describe('minimax image generation', () => {
     const bytes = await readFile(path.join(projectsRoot, 'project-1', 'minimax.png'));
     expect(bytes.length).toBeGreaterThan(0);
   });
+
+  it('forwards --image as subject_reference[0].image_file for I2I', async () => {
+    await writeConfig({
+      providers: {
+        minimax: { baseUrl: TEST_MINIMAX_BASE_URL },
+      },
+    });
+
+    // Write a real reference PNG inside the project so resolveProjectImage
+    // can stat it and turn it into a data URL the renderer can splice in.
+    const projectDir = path.join(projectsRoot, 'project-1');
+    await mkdir(projectDir, { recursive: true });
+    const refPath = path.join(projectDir, 'ref.png');
+    await writeFile(refPath, Buffer.from(PNG_BASE64, 'base64'));
+
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      // Subject reference must be present and carry the data URL of the
+      // --image file (we don't assert exact bytes because the data URL is
+      // derived from the on-disk PNG; the prefix is the contract).
+      expect(body.subject_reference).toEqual([{
+        type: 'character',
+        image_file: expect.stringMatching(/^data:image\/png;base64,/),
+      }]);
+      // Wire model falls through to MINIMAX_IMAGE_MODEL_MAP when no override.
+      expect(body.model).toBe('image-01');
+      // defaultAspectFor('image') returns '1:1', which IS in the MiniMax
+      // allowlist, so the renderer forwards it.
+      expect(body.aspect_ratio).toBe('1:1');
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'restyle as ukiyo-e',
+      image: './ref.png',
+      output: 'minimax-i2i.png',
+    });
+
+    expect(result.name).toBe('minimax-i2i.png');
+    expect(result.providerId).toBe('minimax');
+    // providerNote must NOT echo the data URL — no PII leak in metadata.
+    expect(result.providerNote).not.toContain('data:image');
+    expect(result.providerNote).toContain('minimax/image-01');
+
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'minimax-i2i.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
 });

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -1,0 +1,112 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateMedia } from '../src/media.js';
+
+const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+const TEST_MINIMAX_BASE_URL = 'https://minimax-gateway.example.test';
+const TEST_MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';
+
+describe('minimax image generation', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const realFetch = globalThis.fetch;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+  const originalDataDir = process.env.OD_DATA_DIR;
+  const originalMinimaxApiKey = process.env.OD_MINIMAX_API_KEY;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-minimax-image-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(projectsRoot, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
+    process.env.OD_MINIMAX_API_KEY = 'minimax-test-key';
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    if (originalMinimaxApiKey == null) {
+      delete process.env.OD_MINIMAX_API_KEY;
+    } else {
+      process.env.OD_MINIMAX_API_KEY = originalMinimaxApiKey;
+    }
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    if (originalDataDir == null) {
+      delete process.env.OD_DATA_DIR;
+    } else {
+      process.env.OD_DATA_DIR = originalDataDir;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function writeConfig(data: unknown) {
+    const file = path.join(projectRoot, '.od', 'media-config.json');
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
+  it('renders MiniMax images through the image_generation endpoint', async () => {
+    await writeConfig({
+      providers: {
+        minimax: {
+          baseUrl: TEST_MINIMAX_BASE_URL,
+          model: 'image-01-custom',
+        },
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe(`${TEST_MINIMAX_BASE_URL}/v1/image_generation`);
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toMatchObject({
+        authorization: 'Bearer minimax-test-key',
+        'content-type': 'application/json',
+      });
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({
+        model: 'image-01-custom',
+        prompt: 'A watercolor shiba inu under cherry blossoms',
+        aspect_ratio: '16:9',
+        response_format: 'base64',
+        n: 1,
+      });
+      expect(body).not.toHaveProperty('subject_reference');
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu under cherry blossoms',
+      aspect: '16:9',
+      output: 'minimax.png',
+    });
+
+    expect(result.name).toBe('minimax.png');
+    expect(result.providerId).toBe('minimax');
+    expect(result.providerNote).toContain('minimax/image-01-custom');
+    expect(result.providerNote).toContain('16:9');
+
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'minimax.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -6,8 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateMedia } from '../src/media.js';
 
 const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
-const TEST_MINIMAX_BASE_URL = 'https://minimax-gateway.example.test';
 const TEST_MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';
+const TEST_MINIMAX_TTS_BASE_URL = 'https://api.minimaxi.chat/v1';
 
 describe('minimax image generation', () => {
   let root: string;
@@ -17,6 +17,7 @@ describe('minimax image generation', () => {
   const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
   const originalDataDir = process.env.OD_DATA_DIR;
   const originalMinimaxApiKey = process.env.OD_MINIMAX_API_KEY;
+  const originalImageBaseUrl = process.env.OD_MINIMAX_IMAGE_BASE_URL;
 
   beforeEach(async () => {
     root = await mkdtemp(path.join(tmpdir(), 'od-minimax-image-'));
@@ -25,6 +26,7 @@ describe('minimax image generation', () => {
     await mkdir(projectsRoot, { recursive: true });
     delete process.env.OD_MEDIA_CONFIG_DIR;
     delete process.env.OD_DATA_DIR;
+    delete process.env.OD_MINIMAX_IMAGE_BASE_URL;
     process.env.OD_MINIMAX_API_KEY = 'minimax-test-key';
   });
 
@@ -45,6 +47,11 @@ describe('minimax image generation', () => {
     } else {
       process.env.OD_DATA_DIR = originalDataDir;
     }
+    if (originalImageBaseUrl == null) {
+      delete process.env.OD_MINIMAX_IMAGE_BASE_URL;
+    } else {
+      process.env.OD_MINIMAX_IMAGE_BASE_URL = originalImageBaseUrl;
+    }
     await rm(root, { recursive: true, force: true });
   });
 
@@ -55,17 +62,18 @@ describe('minimax image generation', () => {
   }
 
   it('renders MiniMax images through the image_generation endpoint', async () => {
+    // Stored credentials.model overrides the catalog id wire-model mapping.
+    // Stored credentials.baseUrl is intentionally NOT honored for image
+    // (see "ignores credentials.baseUrl for image" test below); the
+    // renderer always uses the image-specific host.
     await writeConfig({
       providers: {
-        minimax: {
-          baseUrl: TEST_MINIMAX_BASE_URL,
-          model: 'image-01-custom',
-        },
+        minimax: { model: 'image-01-custom' },
       },
     });
 
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
-      expect(String(input)).toBe(`${TEST_MINIMAX_BASE_URL}/v1/image_generation`);
+      expect(String(input)).toBe(`${TEST_MINIMAX_DEFAULT_BASE_URL}/v1/image_generation`);
       expect(init?.method).toBe('POST');
       expect(init?.headers).toMatchObject({
         authorization: 'Bearer minimax-test-key',
@@ -112,9 +120,7 @@ describe('minimax image generation', () => {
 
   it('forwards --image as subject_reference[0].image_file for I2I', async () => {
     await writeConfig({
-      providers: {
-        minimax: { baseUrl: TEST_MINIMAX_BASE_URL },
-      },
+      providers: { minimax: {} },
     });
 
     // Write a real reference PNG inside the project so resolveProjectImage
@@ -124,7 +130,10 @@ describe('minimax image generation', () => {
     const refPath = path.join(projectDir, 'ref.png');
     await writeFile(refPath, Buffer.from(PNG_BASE64, 'base64'));
 
-    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      // Confirm the renderer hits the image-specific host even when no
+      // custom baseUrl is supplied.
+      expect(String(input)).toBe(`${TEST_MINIMAX_DEFAULT_BASE_URL}/v1/image_generation`);
       const body = JSON.parse(String(init?.body));
       // Subject reference must be present and carry the data URL of the
       // --image file (we don't assert exact bytes because the data URL is
@@ -170,11 +179,7 @@ describe('minimax image generation', () => {
   });
 
   it('surfaces base_resp.status_code failures with status_msg as the error', async () => {
-    await writeConfig({
-      providers: {
-        minimax: { baseUrl: TEST_MINIMAX_BASE_URL },
-      },
-    });
+    await writeConfig({ providers: { minimax: {} } });
 
     // MiniMax wraps every response in base_resp; an HTTP 200 can still be a
     // logical failure (e.g. status_code 1008 = insufficient balance). The
@@ -210,11 +215,7 @@ describe('minimax image generation', () => {
   });
 
   it('surfaces upstream HTTP errors with status code and body excerpt', async () => {
-    await writeConfig({
-      providers: {
-        minimax: { baseUrl: TEST_MINIMAX_BASE_URL },
-      },
-    });
+    await writeConfig({ providers: { minimax: {} } });
 
     // 401 with a non-JSON body — the renderer must report both the HTTP
     // status and the body excerpt in the thrown Error.
@@ -237,9 +238,9 @@ describe('minimax image generation', () => {
 
   it('uses the image-specific default base URL and wire model when no config is provided', async () => {
     // No writeConfig() call — the provider slot exists but has no stored
-    // baseUrl/model override. resolveProviderConfig still returns a config
-    // (apiKey from OD_MINIMAX_API_KEY), but baseUrl and model come from
-    // the renderer's defaults.
+    // config. resolveProviderConfig still returns apiKey from
+    // OD_MINIMAX_API_KEY, but baseUrl and model come from the renderer's
+    // image-specific defaults.
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       // Default image base URL is the api.minimax.io host, distinct from
       // the legacy TTS api.minimaxi.chat. Verifies the renderer does not
@@ -272,5 +273,75 @@ describe('minimax image generation', () => {
 
     expect(result.providerId).toBe('minimax');
     expect(result.providerNote).toContain('minimax/image-01');
+  });
+
+  it('ignores credentials.baseUrl for image even when it points at the legacy TTS host', async () => {
+    // Regression test for the user's reported 404. The 'minimax' provider
+    // slot is shared with TTS, whose stored baseUrl is the legacy
+    // api.minimaxi.chat/v1 host. Naively appending '/v1/image_generation'
+    // produces https://api.minimaxi.chat/v1/v1/image_generation — a 404
+    // against the wrong host. The image renderer must ignore
+    // credentials.baseUrl entirely and pin to its own host.
+    await writeConfig({
+      providers: { minimax: { baseUrl: TEST_MINIMAX_TTS_BASE_URL } },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown) => {
+      // Must hit the image-specific host, NOT the doubled TTS URL.
+      expect(String(input)).toBe(`${TEST_MINIMAX_DEFAULT_BASE_URL}/v1/image_generation`);
+      expect(String(input)).not.toContain('/v1/v1/');
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu',
+      output: 'minimax.png',
+    })).resolves.toMatchObject({ providerId: 'minimax' });
+  });
+
+  it('honors OD_MINIMAX_IMAGE_BASE_URL as an operator override', async () => {
+    // Operators running a proxy or staging gateway can pin the image
+    // endpoint via OD_MINIMAX_IMAGE_BASE_URL. Stored credentials.baseUrl
+    // is ignored either way; only the env var wins over the default.
+    process.env.OD_MINIMAX_IMAGE_BASE_URL = 'https://minimax-gateway.example.test';
+    await writeConfig({
+      providers: { minimax: { baseUrl: TEST_MINIMAX_TTS_BASE_URL } },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown) => {
+      expect(String(input)).toBe('https://minimax-gateway.example.test/v1/image_generation');
+      // Trailing slash on the env var must NOT produce a doubled slash.
+      expect(String(input)).not.toContain('//v1/');
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu',
+      output: 'minimax.png',
+    })).resolves.toMatchObject({ providerId: 'minimax' });
   });
 });

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -208,4 +208,30 @@ describe('minimax image generation', () => {
     const outPath = path.join(projectsRoot, 'project-1', 'minimax.png');
     await expect(readFile(outPath)).rejects.toThrow();
   });
+
+  it('surfaces upstream HTTP errors with status code and body excerpt', async () => {
+    await writeConfig({
+      providers: {
+        minimax: { baseUrl: TEST_MINIMAX_BASE_URL },
+      },
+    });
+
+    // 401 with a non-JSON body — the renderer must report both the HTTP
+    // status and the body excerpt in the thrown Error.
+    const fetchMock = vi.fn(async () => new Response('unauthorized', {
+      status: 401,
+      headers: { 'content-type': 'text/plain' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'A watercolor shiba inu',
+      output: 'minimax.png',
+    })).rejects.toThrow(/minimax image 401: unauthorized/);
+  });
 });

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2604,7 +2604,7 @@ function MediaProjectOptions(props:
 
 export function supportedModels(surface: 'image' | 'video' | 'audio', models: MediaModel[]): MediaModel[] {
   const supportedProviders: Record<'image' | 'video' | 'audio', Set<string>> = {
-    image: new Set(['openai', 'codex', 'volcengine', 'grok', 'nanobanana', 'openrouter', 'imagerouter', 'leonardo', 'custom-image', 'aihubmix']),
+    image: new Set(['openai', 'codex', 'volcengine', 'grok', 'nanobanana', 'openrouter', 'imagerouter', 'leonardo', 'custom-image', 'aihubmix', 'minimax']),
     video: new Set(['volcengine', 'hyperframes', 'grok', 'openrouter', 'imagerouter', 'aihubmix']),
     audio: new Set(['minimax', 'fishaudio', 'senseaudio', 'elevenlabs', 'openai', 'volcengine', 'aihubmix']),
   };

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -229,7 +229,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   {
     id: 'minimax',
     label: 'MiniMax',
-    hint: 'TTS / video-01',
+    hint: 'TTS / image-01 / video-01',
     integrated: true,
     defaultBaseUrl: 'https://api.minimaxi.chat/v1',
     docsUrl: 'https://platform.minimaxi.com',
@@ -433,6 +433,17 @@ export const IMAGE_MODELS: MediaModel[] = [
     hint: 'AIHubMix · OpenAI DALL·E 3',
     provider: 'aihubmix',
     caps: ['t2i'],
+  },
+
+  // MiniMax — synchronous /v1/image_generation, Bearer auth, base_resp envelope.
+  // The wire name `image-01` is mapped from the catalog id `minimax-image-01` in
+  // the renderer (see MINIMAX_IMAGE_MODEL_MAP in apps/daemon/src/media.ts).
+  {
+    id: 'minimax-image-01',
+    label: 'image-01',
+    hint: 'MiniMax · text + image-to-image',
+    provider: 'minimax',
+    caps: ['t2i', 'i2i'],
   },
 
   // xAI Grok Imagine — text-to-image (1k/2k, 11+ aspect ratios).


### PR DESCRIPTION
## Why

I want to use my MiniMax subscription for image generation in Open Design. MiniMax ships an image generation API alongside its TTS API, and Open Design already has a `minimax` provider slot in its media dispatcher covering MiniMax TTS — so this PR extends that slot to cover image generation rather than introducing a new vendor.

## What users will see

- A successful Codex or Claude dispatch that selects `minimax-image-01` returns a rendered image. Before this PR, minimax-image-01 is not an available model to use even when asked to use it
- Existing `minimax` audio behavior is unchanged. Audio and image now resolve `baseUrl` independently; editing one no longer silently affects the other.
- Operators running a MiniMax proxy or staging gateway can pin the image endpoint via the new `OD_MINIMAX_IMAGE_BASE_URL` env var. The env var overrides both the default and any value previously stored in the provider slot.
- Aspect ratio support covers the full MiniMax allowlist (1:1, 16:9, 4:3, 3:2, 2:3, 3:4, 9:16, 21:9) 

## Surface area

- [x] **UI** — image picker dropdown gains a `MiniMax image-01` entry (`apps/web/src/components/NewProjectPanel.tsx`); the catalog label/hint mirrors in `apps/web/src/media/models.ts` to keep the registry drift check (`scripts/verify-media-models.mjs`) green.
- [ ] **Keyboard shortcut** — none
- [x] **CLI / env var** — no new `od` subcommand or `tools-*` flag. **New env var:** `OD_MINIMAX_IMAGE_BASE_URL` (operator override for the image endpoint host).
- [ ] **API / contract** — reuses the existing media generation endpoint; no new `/api/*` route, no `packages/contracts` shape change.
- [ ] **Extension point** — none
- [ ] **i18n keys** — none added; the new model reuses existing provider-label keys.
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — none for existing users. The `minimax` provider slot gains an image capability that activates only when the user selects `minimax-image-01` in the picker. If no `minimax` API key is configured, the picker entry is hidden exactly like every other image provider.
- [ ] **None** — not applicable

## Screenshots

<img width="996" height="1006" alt="minimax-image-01-transcript" src="https://github.com/user-attachments/assets/7496326f-1ed0-43fd-bf33-b79eb517bf8c" />


https://github.com/user-attachments/assets/5cac4618-7cc9-4744-b4a7-facd8d08244a



## Bug fix verification

## Validation

- `pnpm --filter @open-design/daemon test media-minimax-image` → **10/10 pass**
- `pnpm guard` → **60/60 pass**
- `pnpm --filter @open-design/daemon typecheck` → clean
- `pnpm --filter @open-design/web typecheck` → clean
- `pnpm --filter @open-design/daemon build` → clean (compiles `apps/daemon/dist/media.js` with `renderMinimaxImage` and the `MINIMAX_IMAGE_*` constants)
- `pnpm --filter @open-design/web build` → clean
- `node scripts/verify-media-models.mjs` → `OK (TS + JS registries match)` (catalog mirror drift enforced)

---
