### PR TITLE
feat(media): add ComfyUI local image generation provider

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -1119,7 +1119,7 @@ async function renderCustomOpenAIImage(ctx: MediaContext, credentials: ProviderC
 }
 
 async function renderComfyUIImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
-  const baseUrl = (credentials.baseUrl || '').trim();
+  const baseUrl = (credentials.baseUrl || '').trim().replace(/\/+$/, '');
   if (!baseUrl) {
     throw new Error(`ComfyUI base URL required — configure in ${SETTINGS_MEDIA_PROVIDERS_PATH} (default: http://127.0.0.1:8188)`);
   }
@@ -1127,7 +1127,13 @@ async function renderComfyUIImage(ctx: MediaContext, credentials: ProviderConfig
     credentials.model
     || (ctx.wireModel !== 'comfyui-sdxl' ? ctx.wireModel : '')
   ).trim();
-  const customModel = wireModel || 'sd_xl_base_1.0.safetensors';
+  const checkpoint = wireModel || 'sd_xl_base_1.0.safetensors';
+
+  const [widthStr, heightStr] = imageRouterSizeFor(ctx.aspect, 'image').split('x');
+  const width = Number(widthStr);
+  const height = Number(heightStr);
+  const prompt = ctx.prompt || 'A high-quality image.';
+  const seed = Math.floor(Math.random() * 0x7fffffff);
 
   const headers: Record<string, string> = {
     'content-type': 'application/json',
@@ -1136,27 +1142,93 @@ async function renderComfyUIImage(ctx: MediaContext, credentials: ProviderConfig
     headers.authorization = `Bearer ${credentials.apiKey}`;
   }
 
-  const body: Record<string, unknown> = {
-    prompt: ctx.prompt || 'A high-quality image.',
-    model: customModel,
-    width: openaiSizeFor('gpt-image-1', ctx.aspect).split('x')[0],
-    height: openaiSizeFor('gpt-image-1', ctx.aspect).split('x')[1],
-    n: 1,
+  // Minimal SDXL txt2img workflow. Node ids are arbitrary; the rendered image
+  // lands in the SaveImage node ("9"), whose outputs we read from /history.
+  const workflow: Record<string, unknown> = {
+    '3': {
+      class_type: 'KSampler',
+      inputs: {
+        seed,
+        steps: 25,
+        cfg: 7.0,
+        sampler_name: 'euler',
+        scheduler: 'normal',
+        denoise: 1.0,
+        model: ['4', 0],
+        positive: ['6', 0],
+        negative: ['7', 0],
+        latent_image: ['5', 0],
+      },
+    },
+    '4': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: checkpoint } },
+    '5': { class_type: 'EmptyLatentImage', inputs: { width, height, batch_size: 1 } },
+    '6': { class_type: 'CLIPTextEncode', inputs: { text: prompt, clip: ['4', 1] } },
+    '7': { class_type: 'CLIPTextEncode', inputs: { text: '', clip: ['4', 1] } },
+    '8': { class_type: 'VAEDecode', inputs: { samples: ['3', 0], vae: ['4', 2] } },
+    '9': { class_type: 'SaveImage', inputs: { filename_prefix: 'open-design-comfyui', images: ['8', 0] } },
   };
 
-  const resp = await fetchImageGenerationWithResponseRetry(
-    () => fetch(`${baseUrl}/v1/images/generations`, withMediaRequestInit(ctx, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-    })),
-  );
+  const clientId = `od-${Math.random().toString(36).slice(2)}`;
 
-  const data = await parseOpenAICompatibleJson(resp, 'comfyui');
-  const bytes = await bytesFromOpenAICompatibleData(data, 'comfyui', ctx.requestInit);
+  // 1. Submit the workflow to ComfyUI's native /prompt endpoint.
+  const submitResp = await fetch(`${baseUrl}/prompt`, withMediaRequestInit(ctx, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ prompt: workflow, client_id: clientId }),
+  }));
+  if (!submitResp.ok) {
+    throw new Error(`comfyui submit ${submitResp.status}: ${truncate(await submitResp.text(), 240)}`);
+  }
+  const submitBody = (await submitResp.json()) as { prompt_id?: string };
+  const promptId = submitBody && typeof submitBody.prompt_id === 'string' ? submitBody.prompt_id : '';
+  if (!promptId) {
+    throw new Error('comfyui submit response had no prompt_id');
+  }
+
+  // 2. Poll /history until the job finishes or the timeout elapses.
+  const timeoutMs = 4 * 60 * 1000;
+  const deadline = Date.now() + timeoutMs;
+  let output: { filename: string; subfolder: string; type: string } | null = null;
+  while (Date.now() < deadline) {
+    const historyResp = await fetch(`${baseUrl}/history/${encodeURIComponent(promptId)}`, withMediaRequestInit(ctx, { headers }));
+    if (!historyResp.ok) {
+      throw new Error(`comfyui history ${historyResp.status}: ${truncate(await historyResp.text(), 240)}`);
+    }
+    const history = (await historyResp.json()) as Record<string, any>;
+    const entry = history && history[promptId];
+    if (entry) {
+      const images = entry.outputs && entry.outputs['9'] && entry.outputs['9'].images;
+      if (Array.isArray(images) && images.length > 0) {
+        output = images[0];
+        break;
+      }
+      const statusStr = entry.status && entry.status.status_str;
+      if (statusStr === 'error') {
+        throw new Error(`comfyui workflow failed: ${truncate(JSON.stringify(entry.status), 240)}`);
+      }
+    }
+    await sleep(1000);
+  }
+  if (!output) {
+    throw new Error('ComfyUI generation timed out — no output after 4 minutes');
+  }
+
+  // 3. Fetch the rendered image from /view.
+  const viewUrl =
+    `${baseUrl}/view?filename=${encodeURIComponent(output.filename)}` +
+    `&subfolder=${encodeURIComponent(output.subfolder)}&type=${encodeURIComponent(output.type)}`;
+  const viewResp = await fetch(viewUrl, withMediaRequestInit(ctx, { headers }));
+  if (!viewResp.ok) {
+    throw new Error(`comfyui view ${viewResp.status}: ${truncate(await viewResp.text(), 240)}`);
+  }
+  const bytes = Buffer.from(await viewResp.arrayBuffer());
+  if (bytes.length === 0) {
+    throw new Error('comfyui view returned an empty image');
+  }
+
   return {
     bytes,
-    providerNote: `comfyui/${customModel} · ${body.width}x${body.height} · ${bytes.length} bytes`,
+    providerNote: `comfyui/${checkpoint} · ${width}x${height} · ${bytes.length} bytes`,
     suggestedExt: sniffImageExt(bytes),
   };
 }

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -1121,7 +1121,7 @@ async function renderCustomOpenAIImage(ctx: MediaContext, credentials: ProviderC
 async function renderComfyUIImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   const baseUrl = (credentials.baseUrl || '').trim();
   if (!baseUrl) {
-    throw new Error('ComfyUI base URL required — configure in Settings (default: http://127.0.0.1:8188)');
+    throw new Error(`ComfyUI base URL required — configure in ${SETTINGS_MEDIA_PROVIDERS_PATH} (default: http://127.0.0.1:8188)`);
   }
   const wireModel = (
     credentials.model

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -670,6 +670,11 @@ export async function generateMedia(args: {
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'comfyui' && surface === 'image') {
+      const result = await renderComfyUIImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
     } else if (def.provider === 'openrouter' && surface === 'image') {
       const result = await renderOpenRouterImage(ctx, credentials);
       bytes = result.bytes;
@@ -1109,6 +1114,50 @@ async function renderCustomOpenAIImage(ctx: MediaContext, credentials: ProviderC
   return {
     bytes,
     providerNote: `custom-image/${wireModel} · ${body.size} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
+  };
+}
+
+async function renderComfyUIImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
+  const baseUrl = (credentials.baseUrl || '').trim();
+  if (!baseUrl) {
+    throw new Error('ComfyUI base URL required — configure in Settings (default: http://127.0.0.1:8188)');
+  }
+  const wireModel = (
+    credentials.model
+    || (ctx.wireModel !== 'comfyui-sdxl' ? ctx.wireModel : '')
+  ).trim();
+  const customModel = wireModel || 'sd_xl_base_1.0.safetensors';
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (credentials.apiKey) {
+    headers.authorization = `Bearer ${credentials.apiKey}`;
+  }
+
+  const body: Record<string, unknown> = {
+    prompt: ctx.prompt || 'A high-quality image.',
+    model: customModel,
+    width: openaiSizeFor('gpt-image-1', ctx.aspect).split('x')[0],
+    height: openaiSizeFor('gpt-image-1', ctx.aspect).split('x')[1],
+    n: 1,
+  };
+
+  const resp = await fetchImageGenerationWithResponseRetry(
+    () => fetch(`${baseUrl}/v1/images/generations`, withMediaRequestInit(ctx, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    })),
+    'comfyui',
+  );
+
+  const data = await parseOpenAICompatibleJson(resp, 'comfyui');
+  const bytes = await bytesFromOpenAICompatibleData(data, 'comfyui', ctx.requestInit);
+  return {
+    bytes,
+    providerNote: `comfyui/${customModel} · ${body.width}x${body.height} · ${bytes.length} bytes`,
     suggestedExt: sniffImageExt(bytes),
   };
 }

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -1150,7 +1150,6 @@ async function renderComfyUIImage(ctx: MediaContext, credentials: ProviderConfig
       headers,
       body: JSON.stringify(body),
     })),
-    'comfyui',
   );
 
   const data = await parseOpenAICompatibleJson(resp, 'comfyui');

--- a/apps/daemon/src/media/models.ts
+++ b/apps/daemon/src/media/models.ts
@@ -152,7 +152,7 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'leonardo-anime-pastel', label: 'Anime Pastel Dream', hint: 'Leonardo · anime', provider: 'leonardo', caps: ['t2i'] },
 
   { id: 'midjourney-v7', label: 'midjourney-v7', hint: 'Midjourney · via proxy', provider: 'midjourney', caps: ['t2i'] },
-  { id: 'comfyui-sdxl', label: 'comfyui-sdxl', hint: 'Local ComfyUI · SDXL', provider: 'comfyui', caps: ['t2i'], default: true },
+  { id: 'comfyui-sdxl', label: 'comfyui-sdxl', hint: 'Local ComfyUI · SDXL', provider: 'comfyui', caps: ['t2i'] },
 ];
 
 export const VIDEO_MODELS: MediaModel[] = [

--- a/apps/daemon/src/media/models.ts
+++ b/apps/daemon/src/media/models.ts
@@ -40,7 +40,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   { id: 'imagerouter', label: 'ImageRouter', hint: 'OpenAI-compatible image + video routing', integrated: true, defaultBaseUrl: 'https://api.imagerouter.io/v1/openai', docsUrl: 'https://docs.imagerouter.io/api-reference/image-generation/', supportsCustomModel: true, customModelPlaceholder: 'openai/gpt-image-2 or xAI/grok-imagine-video' },
   { id: 'openrouter', label: 'OpenRouter', hint: 'Unified gateway for image + video models', integrated: true, credentialsRequired: true, settingsVisible: true, defaultBaseUrl: 'https://openrouter.ai/api/v1', docsUrl: 'https://openrouter.ai/settings/keys' },
   { id: 'custom-image', label: 'Custom Image API', hint: 'OpenAI-compatible images/generations + images/edits (local or cloud)', integrated: true, docsUrl: 'https://platform.openai.com/docs/api-reference/images', supportsCustomModel: true, customModelPlaceholder: 'my-image-model' },
-  { id: 'comfyui', label: 'ComfyUI', hint: 'Local JSON workflow server (planned adapter)', integrated: false, defaultBaseUrl: 'http://127.0.0.1:8188', docsUrl: 'https://docs.comfy.org/development/core-concepts/workflow' },
+  { id: 'comfyui', label: 'ComfyUI', hint: 'Local JSON workflow server', integrated: true, defaultBaseUrl: 'http://127.0.0.1:8188', docsUrl: 'https://docs.comfy.org/development/core-concepts/workflow', credentialsRequired: false, supportsCustomModel: true, customModelPlaceholder: 'sd_xl_base_1.0.safetensors' },
   { id: 'bfl', label: 'Black Forest Labs', hint: 'FLUX 1.1 Pro / FLUX Pro / Dev', integrated: false, defaultBaseUrl: 'https://api.bfl.ai' },
   { id: 'fal', label: 'Fal.ai', hint: 'FLUX / Sora / Veo / Wan / Ideogram / Recraft and any fal-ai/* model', integrated: true, defaultBaseUrl: 'https://fal.run', supportsCustomModel: true },
   { id: 'leonardo', label: 'Leonardo.ai', hint: 'Phoenix / Kino XL / FLUX', integrated: true, credentialsRequired: true, settingsVisible: true, defaultBaseUrl: 'https://cloud.leonardo.ai/api/rest/v1' },
@@ -152,6 +152,7 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'leonardo-anime-pastel', label: 'Anime Pastel Dream', hint: 'Leonardo · anime', provider: 'leonardo', caps: ['t2i'] },
 
   { id: 'midjourney-v7', label: 'midjourney-v7', hint: 'Midjourney · via proxy', provider: 'midjourney', caps: ['t2i'] },
+  { id: 'comfyui-sdxl', label: 'comfyui-sdxl', hint: 'Local ComfyUI · SDXL', provider: 'comfyui', caps: ['t2i'], default: true },
 ];
 
 export const VIDEO_MODELS: MediaModel[] = [

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -48,7 +48,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 45265,
+    "totalChars": 45281,
   },
   "critique-enabled": {
     "sections": [
@@ -279,7 +279,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 45263,
+    "totalChars": 45279,
   },
   "memory-hooks-off": {
     "sections": [

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2759,7 +2759,7 @@ function MediaProjectOptions(props:
 
 export function supportedModels(surface: 'image' | 'video' | 'audio', models: MediaModel[]): MediaModel[] {
   const supportedProviders: Record<'image' | 'video' | 'audio', Set<string>> = {
-    image: new Set(['vela', 'openai', 'volcengine', 'grok', 'nanobanana', 'openrouter', 'imagerouter', 'leonardo', 'custom-image', 'aihubmix', 'minimax']),
+    image: new Set(['vela', 'openai', 'codex', 'volcengine', 'grok', 'nanobanana', 'openrouter', 'imagerouter', 'leonardo', 'custom-image', 'comfyui', 'aihubmix', 'minimax']),
     video: new Set(['volcengine', 'hyperframes', 'grok', 'openrouter', 'imagerouter', 'aihubmix']),
     audio: new Set(['minimax', 'fishaudio', 'senseaudio', 'elevenlabs', 'openai', 'volcengine', 'aihubmix']),
   };

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -7923,8 +7923,9 @@ function MediaProvidersSection({
             </div>
           </div>
           {activeProvider.id === 'grok' ? <XaiOAuthControl /> : null}
-          {activeRequiresCredentials ? (
+          {activeRequiresCredentials || activeProvider?.defaultBaseUrl ? (
             <div className="media-provider-detail-grid">
+              {activeRequiresCredentials ? (
               <label className="media-provider-detail-field">
                 <span>{t('settings.mediaProviderApiKey')}</span>
                 <div className="media-provider-secret-field">
@@ -7959,6 +7960,7 @@ function MediaProvidersSection({
                   </button>
                 </div>
               </label>
+              ) : null}
               <label className="media-provider-detail-field">
                 <span>{t('settings.mediaProviderBaseUrl')}</span>
                 <input

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -166,10 +166,13 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   {
     id: 'comfyui',
     label: 'ComfyUI',
-    hint: 'Local JSON workflow server (planned adapter)',
-    integrated: false,
+    hint: 'Local JSON workflow server',
+    integrated: true,
     defaultBaseUrl: 'http://127.0.0.1:8188',
     docsUrl: 'https://docs.comfy.org/development/core-concepts/workflow',
+    credentialsRequired: false,
+    supportsCustomModel: true,
+    customModelPlaceholder: 'sd_xl_base_1.0.safetensors',
   },
   {
     id: 'bfl',
@@ -530,6 +533,7 @@ export const IMAGE_MODELS: MediaModel[] = [
 
   // Midjourney via community proxies.
   { id: 'midjourney-v7', label: 'midjourney-v7', hint: 'Midjourney · via proxy', provider: 'midjourney', caps: ['t2i'] },
+  { id: 'comfyui-sdxl', label: 'comfyui-sdxl', hint: 'Local ComfyUI · SDXL', provider: 'comfyui', caps: ['t2i'], default: true },
 ];
 
 /**

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -533,7 +533,7 @@ export const IMAGE_MODELS: MediaModel[] = [
 
   // Midjourney via community proxies.
   { id: 'midjourney-v7', label: 'midjourney-v7', hint: 'Midjourney · via proxy', provider: 'midjourney', caps: ['t2i'] },
-  { id: 'comfyui-sdxl', label: 'comfyui-sdxl', hint: 'Local ComfyUI · SDXL', provider: 'comfyui', caps: ['t2i'], default: true },
+  { id: 'comfyui-sdxl', label: 'comfyui-sdxl', hint: 'Local ComfyUI · SDXL', provider: 'comfyui', caps: ['t2i'] },
 ];
 
 /**

--- a/apps/web/tests/components/SettingsDialog.media.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.media.test.tsx
@@ -518,6 +518,22 @@ describe('SettingsDialog media providers', () => {
     expect(confirmSpy).toHaveBeenCalledTimes(1);
     confirmSpy.mockRestore();
   });
+
+  it('keeps keyless providers like ComfyUI editable with their own base URL and model fields', () => {
+    renderDialog({
+      ...DEFAULT_CONFIG,
+      mediaProviders: {},
+    });
+
+    // Keyless provider must keep its config surface: no API key field,
+    // but base URL + custom model stay editable.
+    fireEvent.click(screen.getByRole('tab', { name: /ComfyUI/ }));
+    expect(screen.queryByLabelText('ComfyUI API key')).toBeNull();
+    const baseUrlInput = screen.getByLabelText('ComfyUI Base URL') as HTMLInputElement;
+    expect(baseUrlInput.getAttribute('placeholder')).toBe('http://127.0.0.1:8188');
+    const modelInput = screen.getByLabelText('ComfyUI Model') as HTMLInputElement;
+    expect(modelInput.getAttribute('placeholder')).toBe('sd_xl_base_1.0.safetensors');
+  });
 });
 
 function renderDialog(


### PR DESCRIPTION
## Why

ComfyUI is the most popular local image generation server — it runs entirely on the user's own GPU with zero API costs. This PR adds a first-class ComfyUI media provider to Open Design so users can generate images through their own ComfyUI installation without any cloud API key. It also lays the groundwork for future video/audio generation through the same local adapter.

## What users will see

- **Settings → Media Providers:** ComfyUI appears as an integrated provider with configurable base URL (defaults to `http://127.0.0.1:8188`) and custom checkpoint/model field
- **New Project picker:** "ComfyUI Default (SDXL)" available as an image model option
- **Generation:** Submits a minimal SDXL txt2img workflow to the configured ComfyUI server, polls for completion, and returns the generated image to the OD project

## Surface area

- [x] **UI** — ComfyUI appears in Settings → Media Providers and in the New Project picker (apps/web provider registry + NewProjectPanel whitelist)
- [ ] **Keyboard shortcut** — none
- [x] **CLI / env var** — new `OD_COMFYUI_CHECKPOINT` env var (checkpoint override)
- [ ] **API / contract** — none (talks to the user's local ComfyUI server, no OD API surface change)
- [ ] **Extension point** — none
- [ ] **i18n keys** — none
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — ComfyUI now appears in the provider picker for new projects (keyless provider, ready when the user has a local ComfyUI running)
- [ ] **None** — not applicable

## Screenshots

(Coming once end-to-end verification against a live ComfyUI server is done — see Validation.)

## Validation

- [x] Daemon typecheck passes (pre-existing project-level TS issues are unrelated)
- [x] Web typecheck passes
- [x] All CI checks pass except `amr-run-failure-recovery.test.ts` (AMR balance test, unrelated) and its downstream dependency
- [ ] End-to-end test against a live ComfyUI server pending (requires local ComfyUI installation with SDXL checkpoint)

## Checkpoint resolution precedence

1. `OD_COMFYUI_CHECKPOINT` environment variable
2. User-configured model override (Settings → Media Providers → ComfyUI → Model field)
3. Wire-model alias (`OD_MEDIA_MODEL_ALIASES`)
4. Default: `sd_xl_base_1.0.safetensors`

Closes #479