### PR TITLE
fix(maxTokens): correct cogito-2.1:671b output cap to 65536

### DIFF
--- a/apps/web/src/state/maxTokens.ts
+++ b/apps/web/src/state/maxTokens.ts
@@ -36,7 +36,8 @@ const OVERRIDES: Record<string, number> = {
   // ids (many with `-cloud` suffixes), so the bare model-id lookups never
   // match. Add overrides so chat doesn't silently clip at 8192 tokens.
   // 131072 (128k) is a safe floor for all Ollama Cloud models.
-  'cogito-2.1:671b': 131072,
+  // Exception: cogito-2.1:671b caps at 65536 (confirmed via upstream 400).
+  'cogito-2.1:671b': 65536,
   'deepseek-v3.1:671b': 163840,
   'deepseek-v3.2': 163840,
   'devstral-2:123b': 131072,


### PR DESCRIPTION
## Why
The previous value caused every generation request using this model to fail with:
upstream error: 400 {"error":"max_tokens (131072) exceeds model's maximum output tokens (65536) for model cogito-2.1:671b"}

Fixes #4373

## What users will see
No visible UI change. Generation requests using the `cogito-2.1:671b` model via BYOK/Ollama Cloud will now succeed instead of failing with a 400 error.

## Surface area
- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification
Confirmed via daemon logs from a real failing run (see #4373) showing the exact 400 response with the model's real cap.

## Validation
Ran `pnpm guard` (60/60 tests passing) and `pnpm typecheck` (0 errors across all workspace projects). Change is a single value correction in a static lookup table — no behavioral code path affected.