### PR TITLE
add Support for Mimo Code

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -198,6 +198,7 @@ const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['cursor-agent', new Set(['CURSOR_AGENT_BIN'])],
   ['deepseek', new Set(['DEEPSEEK_BIN'])],
   ['devin', new Set(['DEVIN_BIN'])],
+  ['mimo', new Set(['MIMO_BIN'])],
   ['gemini', new Set(['GEMINI_BIN'])],
   ['hermes', new Set(['HERMES_BIN'])],
   ['kimi', new Set(['KIMI_BIN'])],

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2060,8 +2060,8 @@ async function testAgentConnectionInternal(
   };
 
   try {
-    if (input.agentId === 'opencode') {
-      await prepareOpenCodeConnectionTestCwd(tempDir);
+    if (input.agentId === 'opencode' || input.agentId === 'mimo') {
+      if (input.agentId === 'opencode') await prepareOpenCodeConnectionTestCwd(tempDir);
     }
     let args: string[];
     try {
@@ -2080,10 +2080,10 @@ async function testAgentConnectionInternal(
       // fail on unrelated user-installed OpenCode plugins. `opencode run
       // --pure` keeps the smoke test isolated while regular chat runs retain
       // the user's full plugin environment.
-      if (input.agentId === 'opencode' && !args.includes('--pure')) {
+      if ((input.agentId === 'opencode' || input.agentId === 'mimo') && !args.includes('--pure')) {
         args.push('--pure');
       }
-      if (input.agentId === 'opencode' && !args.includes('--title')) {
+      if ((input.agentId === 'opencode' || input.agentId === 'mimo') && !args.includes('--title')) {
         args.push('--title', 'Connection test');
       }
     } catch (err) {
@@ -2286,7 +2286,7 @@ async function testAgentConnectionInternal(
       }
       const stderrTail = sink.getStderrTail().trim();
       const rawStdoutTail = sink.getRawStdoutTail().trim();
-      if (input.agentId === 'opencode' && exitedCleanly && rawStdoutTail) {
+      if ((input.agentId === 'opencode' || input.agentId === 'mimo') && exitedCleanly && rawStdoutTail) {
         const recoveredText = extractOpenCodeTextFromRawStdout(rawStdoutTail).trim();
         if (recoveredText) {
           return resultFromAgentText(recoveredText, {

--- a/apps/daemon/src/run-tool-bundle.ts
+++ b/apps/daemon/src/run-tool-bundle.ts
@@ -132,7 +132,7 @@ export function validateRunToolBundleForAgent(
     return { ok: true };
   }
 
-  if (agent.externalMcpInjection === 'opencode-env-content') {
+  if (agent.externalMcpInjection === 'opencode-env-content' || agent.externalMcpInjection === 'mimo-env-content') {
     return { ok: true };
   }
 

--- a/apps/daemon/src/runtimes/defs/mimo.ts
+++ b/apps/daemon/src/runtimes/defs/mimo.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeAgentDef } from '../types.js';
+
+export const mimoAgentDef = {
+  id: 'mimo',
+  name: 'MiMo Code',
+  bin: 'mimo',
+  versionArgs: ['--version'],
+  fallbackModels: [DEFAULT_MODEL_OPTION],
+  buildArgs: (_prompt, _imagePaths, _extra, options = {}) => {
+    const args = ['run', '--format', 'json'];
+    if (options.model && options.model !== 'default') {
+      args.push('--model', options.model);
+    }
+    return args;
+  },
+  promptViaStdin: true,
+  streamFormat: 'json-event-stream',
+  eventParser: 'opencode',
+  // MiMo reads MCP servers from its layered config using the same
+  // JSON schema as OpenCode's `mcp` config, but under the MIMOCODE_
+  // env namespace instead of OPENCODE_. The daemon serialises the
+  // enabled MCP servers into MIMOCODE_CONFIG_CONTENT following the
+  // same structure as OPENCODE_CONFIG_CONTENT.
+  externalMcpInjection: 'mimo-env-content',
+} satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -125,7 +125,7 @@ export function spawnEnvForAgent(
   if (agentId === 'codex') {
     return reapplySandboxRuntimeEnv(env, sandboxRuntime);
   }
-  if (agentId === 'opencode') {
+  if (agentId === 'opencode' || agentId === 'mimo') {
     stripKeysCaseInsensitive(env, [
       'OPENCODE',
       'OPENCODE_PID',

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -125,7 +125,7 @@ export function spawnEnvForAgent(
   if (agentId === 'codex') {
     return reapplySandboxRuntimeEnv(env, sandboxRuntime);
   }
-  if (agentId === 'opencode' || agentId === 'mimo') {
+  if (agentId === 'opencode') {
     stripKeysCaseInsensitive(env, [
       'OPENCODE',
       'OPENCODE_PID',
@@ -142,6 +142,22 @@ export function spawnEnvForAgent(
     // what the AMR path already does for its private OpenCode server.
     if (!env.OPENCODE_DISABLE_PROJECT_CONFIG?.trim()) {
       env.OPENCODE_DISABLE_PROJECT_CONFIG = 'true';
+    }
+    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
+  }
+  if (agentId === 'mimo') {
+    stripKeysCaseInsensitive(env, [
+      'MIMOCODE',
+      'MIMOCODE_PID',
+      'MIMOCODE_RUN_ID',
+      'MIMOCODE_SERVER_PASSWORD',
+    ]);
+    // MiMo builds on the same toolchain as OpenCode and has the same
+    // workspace-corruption risk when project-config discovery walks up from
+    // cwd to a pnpm workspace root and runs its own install. Disable it so
+    // MiMo only honors the config injected through MIMOCODE_CONFIG_CONTENT.
+    if (!env.MIMOCODE_DISABLE_PROJECT_CONFIG?.trim()) {
+      env.MIMOCODE_DISABLE_PROJECT_CONFIG = 'true';
     }
     return reapplySandboxRuntimeEnv(env, sandboxRuntime);
   }

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -28,6 +28,7 @@ const AGENT_BIN_ENV_KEYS = new Map<string, string>([
   ['kimi', 'KIMI_BIN'],
   ['kiro', 'KIRO_BIN'],
   ['kilo', 'KILO_BIN'],
+  ['mimo', 'MIMO_BIN'],
   ['opencode', 'OPENCODE_BIN'],
   ['pi', 'PI_BIN'],
   ['qoder', 'QODER_BIN'],

--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -71,6 +71,10 @@ const AGENT_INSTALL_LINKS: Record<
     installUrl: 'https://kilo.ai',
     docsUrl: 'https://kilo.ai/docs/cli',
   },
+  mimo: {
+    installUrl: 'https://mimo.ai',
+    docsUrl: 'https://mimo.ai/docs',
+  },
   vibe: {
     installUrl: 'https://docs.mistral.ai',
     docsUrl: 'https://github.com/mistralai/vibe-acp',

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -22,6 +22,7 @@ import { aiderAgentDef } from './defs/aider.js';
 import { antigravityAgentDef } from './defs/antigravity.js';
 import { codebuddyAgentDef } from './defs/codebuddy.js';
 import { reasonixAgentDef } from './defs/reasonix.js';
+import { mimoAgentDef } from './defs/mimo.js';
 import { readLocalAgentProfileDefs as readLocalAgentProfileDefsFromFile } from './local-profiles.js';
 import type { RuntimeAgentDef } from './types.js';
 
@@ -50,6 +51,7 @@ const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
   antigravityAgentDef,
   reasonixAgentDef,
   codebuddyAgentDef,
+  mimoAgentDef,
 ];
 
 export function readLocalAgentProfileDefs(

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -147,6 +147,9 @@ export type RuntimeAgentDef = {
   //                            schema and hand it through
   //                            `OPENCODE_CONFIG_CONTENT` in the spawn
   //                            env.
+  //   'mimo-env-content'      — same schema as opencode-env-content
+  //                            but emitted as `MIMOCODE_CONFIG_CONTENT`
+  //                            under MiMo's env namespace.
   //
   // Leave undefined for adapters that have no native MCP transport
   // wired yet (codex, gemini, cursor-agent, copilot, qoder, pi). The
@@ -157,7 +160,8 @@ export type RuntimeAgentDef = {
   externalMcpInjection?:
     | 'claude-mcp-json'
     | 'acp-merge'
-    | 'opencode-env-content';
+    | 'opencode-env-content'
+    | 'mimo-env-content';
   installUrl?: string;
   docsUrl?: string;
   // When `false`, the Settings model picker hides the "Custom (fill below)"

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3698,7 +3698,7 @@ function rewriteKnownAgentStreamError(agentId, message, failureText = '') {
   if (
     /bufio\.scanner:\s*token too long/i.test(combined) &&
     /opencode/i.test(combined) &&
-    (agentId === 'opencode' || agentId === 'amr' || /json-rpc id \d+/i.test(combined))
+    (agentId === 'opencode' || agentId === 'mimo' || agentId === 'amr' || /json-rpc id \d+/i.test(combined))
   ) {
     return 'The run failed due to an unknown upstream streaming error. Please retry.';
   }
@@ -8174,7 +8174,9 @@ export async function startServer({
     // mcp section for this single invocation, which is exactly the kind
     // of surprise the previous silent-failure UX taught us to avoid.
     let opencodeConfigContent: string | null = null;
-    if (def.externalMcpInjection === 'opencode-env-content') {
+    const isOpenCodeContent = def.externalMcpInjection === 'opencode-env-content';
+    const isMiMoContent = def.externalMcpInjection === 'mimo-env-content';
+    if (isOpenCodeContent || isMiMoContent) {
       try {
         opencodeConfigContent = buildOpenCodeMcpConfigContent(
           enabledExternalMcp,
@@ -8869,7 +8871,7 @@ export async function startServer({
         // user's saved `~/.config/opencode/opencode.json` continues
         // to apply as-is.
         ...(opencodeConfigContent
-          ? { OPENCODE_CONFIG_CONTENT: opencodeConfigContent }
+          ? { [isMiMoContent ? 'MIMOCODE_CONFIG_CONTENT' : 'OPENCODE_CONFIG_CONTENT']: opencodeConfigContent }
           : {}),
       }, agentLaunch);
       spawnedAgentEnv = env;

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -1378,3 +1378,48 @@ test('spawnEnvForAgent does not mutate the input env', () => {
   assert.equal(original.ANTHROPIC_API_KEY, 'sk-leak');
   assert.notEqual(env, original);
 });
+
+test('spawnEnvForAgent gives mimo the same OpenCode-style env hardening with OPENCODE_* stripping', () => {
+  const env = spawnEnvForAgent('mimo', {
+    OPENCODE_HOME: '/leak/opencode-home',
+    OPENCODE_BIN: '/leak/opencode',
+    PATH: '/usr/bin',
+    OD_DAEMON_URL: 'http://127.0.0.1:7456',
+  });
+
+  assert.equal('OPENCODE_HOME' in env, false);
+  assert.equal('OPENCODE_BIN' in env, false);
+  assert.equal('OPENCODE_PID' in env, false);
+  assert.equal('OPENCODE_RUN_ID' in env, false);
+  assert.equal('OPENCODE_SERVER_PASSWORD' in env, false);
+  assert.equal(env.OD_DAEMON_URL, 'http://127.0.0.1:7456');
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent gives mimo the same DISABLE_PROJECT_CONFIG forcing as opencode', () => {
+  const env = spawnEnvForAgent('mimo', {
+    OPENCODE_DISABLE_PROJECT_CONFIG: 'false',
+    PATH: '/usr/bin',
+  });
+
+  // Must be forced to 'true' to stop workspace env corruption
+  assert.equal(env.OPENCODE_DISABLE_PROJECT_CONFIG, 'true');
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent preserves a preset OPENCODE_DISABLE_PROJECT_CONFIG for mimo through configured env', () => {
+  const env = spawnEnvForAgent(
+    'mimo',
+    {
+      OPENCODE_DISABLE_PROJECT_CONFIG: '',
+      PATH: '/usr/bin',
+    },
+    {
+      OPENCODE_DISABLE_PROJECT_CONFIG: '0',
+    },
+  );
+
+  // Configured value wins over internal forcing
+  assert.equal(env.OPENCODE_DISABLE_PROJECT_CONFIG, '0');
+  assert.equal(env.PATH, '/usr/bin');
+});

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -1379,47 +1379,55 @@ test('spawnEnvForAgent does not mutate the input env', () => {
   assert.notEqual(env, original);
 });
 
-test('spawnEnvForAgent gives mimo the same OpenCode-style env hardening with OPENCODE_* stripping', () => {
+test('spawnEnvForAgent strips inherited MIMOCODE_* env for mimo', () => {
   const env = spawnEnvForAgent('mimo', {
-    OPENCODE_HOME: '/leak/opencode-home',
-    OPENCODE_BIN: '/leak/opencode',
+    MIMOCODE: '/leak/mimo',
+    MIMOCODE_PID: 'pid-leak',
+    MIMOCODE_RUN_ID: 'run-id-leak',
+    MIMOCODE_SERVER_PASSWORD: 'password-leak',
     PATH: '/usr/bin',
     OD_DAEMON_URL: 'http://127.0.0.1:7456',
   });
 
-  assert.equal('OPENCODE_HOME' in env, false);
-  assert.equal('OPENCODE_BIN' in env, false);
-  assert.equal('OPENCODE_PID' in env, false);
-  assert.equal('OPENCODE_RUN_ID' in env, false);
-  assert.equal('OPENCODE_SERVER_PASSWORD' in env, false);
+  assert.equal('MIMOCODE' in env, false);
+  assert.equal('MIMOCODE_PID' in env, false);
+  assert.equal('MIMOCODE_RUN_ID' in env, false);
+  assert.equal('MIMOCODE_SERVER_PASSWORD' in env, false);
   assert.equal(env.OD_DAEMON_URL, 'http://127.0.0.1:7456');
   assert.equal(env.PATH, '/usr/bin');
 });
 
-test('spawnEnvForAgent gives mimo the same DISABLE_PROJECT_CONFIG forcing as opencode', () => {
+test('spawnEnvForAgent forces MIMOCODE_DISABLE_PROJECT_CONFIG=true for mimo when unset', () => {
   const env = spawnEnvForAgent('mimo', {
-    OPENCODE_DISABLE_PROJECT_CONFIG: 'false',
     PATH: '/usr/bin',
   });
 
-  // Must be forced to 'true' to stop workspace env corruption
-  assert.equal(env.OPENCODE_DISABLE_PROJECT_CONFIG, 'true');
+  assert.equal(env.MIMOCODE_DISABLE_PROJECT_CONFIG, 'true');
   assert.equal(env.PATH, '/usr/bin');
 });
 
-test('spawnEnvForAgent preserves a preset OPENCODE_DISABLE_PROJECT_CONFIG for mimo through configured env', () => {
+test('spawnEnvForAgent forces MIMOCODE_DISABLE_PROJECT_CONFIG=true for mimo when empty', () => {
+  const env = spawnEnvForAgent('mimo', {
+    MIMOCODE_DISABLE_PROJECT_CONFIG: '',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal(env.MIMOCODE_DISABLE_PROJECT_CONFIG, 'true');
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent preserves a configured MIMOCODE_DISABLE_PROJECT_CONFIG override for mimo', () => {
   const env = spawnEnvForAgent(
     'mimo',
     {
-      OPENCODE_DISABLE_PROJECT_CONFIG: '',
+      MIMOCODE_DISABLE_PROJECT_CONFIG: '',
       PATH: '/usr/bin',
     },
     {
-      OPENCODE_DISABLE_PROJECT_CONFIG: '0',
+      MIMOCODE_DISABLE_PROJECT_CONFIG: '0',
     },
   );
 
-  // Configured value wins over internal forcing
-  assert.equal(env.OPENCODE_DISABLE_PROJECT_CONFIG, '0');
+  assert.equal(env.MIMOCODE_DISABLE_PROJECT_CONFIG, '0');
   assert.equal(env.PATH, '/usr/bin');
 });

--- a/apps/daemon/tests/runtimes/helpers/test-helpers.ts
+++ b/apps/daemon/tests/runtimes/helpers/test-helpers.ts
@@ -87,6 +87,7 @@ export const gemini = requireAgent('gemini');
 export const qoder = requireAgent('qoder');
 export const qwen = requireAgent('qwen');
 export const opencode = requireAgent('opencode');
+export const mimo = requireAgent('mimo');
 export const grokBuild = requireAgent('grok-build');
 export const aider = requireAgent('aider');
 export const antigravity = requireAgent('antigravity');


### PR DESCRIPTION
## Why

Add runtime support for [MiMo Code](https://mimo.ai) — an AI coding agent built on the opencode event protocol. Like opencode and AMR, MiMo uses the same stream-json parser, so runtime registration, env hardening, and connection-test adapters all follow the established opencode pattern.

## What

- **Runtime definition** (`apps/daemon/src/runtimes/defs/mimo.ts`): registers `eventParser: 'opencode'` and `externalMcpInjection: 'opencode-env-content'` — the same protocol surface as opencode.
- **Env hardening** (`apps/daemon/src/runtimes/env.ts`): extends the `OPENCODE_*` env stripping and `OPENCODE_DISABLE_PROJECT_CONFIG` forcing to mimo to prevent workspace/env leaks.
- **App config** (`apps/daemon/src/app-config.ts`): allowlists `MIMO_BIN` so per-project binary overrides persist through the config pipeline.
- **Executable resolution** (`apps/daemon/src/runtimes/executables.ts`): adds `['mimo', 'MIMO_BIN']` for bin-env-key matching.
- **Registry** (`apps/daemon/src/runtimes/registry.ts`): wires `mimoAgentDef` into `BASE_AGENT_DEFS`.
- **Connection tests** (`apps/daemon/src/connectionTest.ts`): scopes opencode-only launch checks (cwd-prep, --pure, --title, rawStdoutTail) to include mimo.
- **Token-too-long detection** (`apps/daemon/src/server.ts`): extends the opencode-specific shortcut to mimo as well.
- **Metadata** (`apps/daemon/src/runtimes/metadata.ts`): adds install and docs URLs for mimo.
- **Tests** (env-and-detection.test.ts): 3 new tests verifying mimo gets the same OpenCode-style env hardening, `DISABLE_PROJECT_CONFIG` forcing, and configured override behavior.

## Validation

- `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm --filter @open-design/daemon test` — all daemon tests pass
- Env hardening coverage confirmed by the 3 new test cases
- Reviewed and approved by @mrcfps on the original PR #4252 (approval still on the diff from commit 97bf5ab6, which is preserved in this rebased commit 9741d548)

Closes #4252