### PR TITLE
add EvoLink provider preset

### DIFF
--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -165,6 +165,22 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     models: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
   },
   {
+    label: 'EvoLink',
+    protocol: 'openai',
+    baseUrl: 'https://direct.evolink.ai/v1',
+    model: 'gpt-5.2',
+    models: [
+      'gpt-5.2',
+      'gpt-5.4',
+      'gpt-5.5',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'glm-5.2',
+      'minimax-m2.5',
+      'minimax-m3',
+    ],
+  },
+  {
     label: 'OpenRouter',
     protocol: 'openai',
     baseUrl: 'https://openrouter.ai/api/v1',

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -5,6 +5,7 @@ import {
   fetchMediaProvidersFromDaemon,
   isStoredMediaProviderEntryEmpty,
   isStoredMediaProviderEntryPresent,
+  KNOWN_PROVIDERS,
   loadConfig,
   mergeDaemonConfig,
   mergeDaemonMediaProviders,
@@ -826,6 +827,27 @@ describe('buildMediaProvidersForDaemonSave', () => {
     ).toEqual({
       providers: {},
       force: false,
+    });
+  });
+});
+
+describe('KNOWN_PROVIDERS', () => {
+  it('includes EvoLink as an OpenAI-compatible provider preset', () => {
+    expect(KNOWN_PROVIDERS).toContainEqual({
+      label: 'EvoLink',
+      protocol: 'openai',
+      baseUrl: 'https://direct.evolink.ai/v1',
+      model: 'gpt-5.2',
+      models: [
+        'gpt-5.2',
+        'gpt-5.4',
+        'gpt-5.5',
+        'deepseek-v4-flash',
+        'deepseek-v4-pro',
+        'glm-5.2',
+        'minimax-m2.5',
+        'minimax-m3',
+      ],
     });
   });
 });


### PR DESCRIPTION
## Why

I use Open Design's BYOK API mode with OpenAI-compatible gateways, and EvoLink exposes a compatible chat-completions endpoint. Without a preset, users have to manually enter the endpoint and model IDs even though this matches the existing provider-preset pattern.

This keeps the integration small: it does not add a runtime, credential, new protocol, or outbound behavior. It only adds a user-selected BYOK preset that reuses the existing OpenAI-compatible proxy path.

## What users will see

Settings / BYOK provider selection includes a new `EvoLink` preset. Selecting it fills `https://direct.evolink.ai/v1`, uses the existing OpenAI-compatible protocol, and suggests EvoLink language model IDs with `gpt-5.2` as the default.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a provider-preset row in the existing searchable Settings / BYOK provider picker, with no new layout or visual component.

## Bug fix verification

-

## Validation

- `pnpm install` to restore local workspace dependencies before validation. Lockfile stayed unchanged. Local environment warning: this machine is currently on Node v22.22.3 while the repo requests Node `~24`; pnpm also reported `node-pty` build scripts ignored by the local approve-builds policy.
- `pnpm --filter @open-design/web test -- tests/state/config.test.ts` passed. The package script ran the web Vitest suite: 335 test files passed, 3344 tests passed, 1 skipped.
- Live EvoLink endpoint smoke check: `POST https://direct.evolink.ai/v1/chat/completions` with model `gpt-5.2` returned HTTP 200 and a chat response.
