### PR TITLE
fix(templates): avoid system Chrome for html-ppt screenshots

### DIFF
--- a/apps/daemon/tests/skills.test.ts
+++ b/apps/daemon/tests/skills.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -41,18 +49,9 @@ function fresh(): string {
   return mkdtempSync(path.join(tmpdir(), 'od-skills-'));
 }
 
-function runHtmlPptRenderWithFakePlaywright(options: { screenshotExitCode?: number } = {}) {
-  const root = fresh();
-  const html = path.join(root, 'deck.html');
-  const out = path.join(root, 'deck.png');
-  const log = path.join(root, 'playwright.log');
-  const fakePlaywright = path.join(root, 'fake-playwright.sh');
+function writeFakePlaywrightCli(file: string) {
   writeFileSync(
-    html,
-    '<!doctype html><html><body><section class="slide">Slide</section></body></html>',
-  );
-  writeFileSync(
-    fakePlaywright,
+    file,
     [
       '#!/usr/bin/env bash',
       'set -euo pipefail',
@@ -78,7 +77,20 @@ function runHtmlPptRenderWithFakePlaywright(options: { screenshotExitCode?: numb
       '',
     ].join('\n'),
   );
-  chmodSync(fakePlaywright, 0o755);
+  chmodSync(file, 0o755);
+}
+
+function runHtmlPptRenderWithFakePlaywright(options: { screenshotExitCode?: number } = {}) {
+  const root = fresh();
+  const html = path.join(root, 'deck.html');
+  const out = path.join(root, 'deck.png');
+  const log = path.join(root, 'playwright.log');
+  const fakePlaywright = path.join(root, 'fake-playwright.sh');
+  writeFileSync(
+    html,
+    '<!doctype html><html><body><section class="slide">Slide</section></body></html>',
+  );
+  writeFakePlaywrightCli(fakePlaywright);
 
   const result = spawnSync(
     path.join(designTemplatesRoot, 'html-ppt', 'scripts', 'render.sh'),
@@ -94,6 +106,55 @@ function runHtmlPptRenderWithFakePlaywright(options: { screenshotExitCode?: numb
       },
     },
   );
+  const calls = readFileSync(log, 'utf8').trim().split('\n').filter(Boolean);
+  return { calls, result, root };
+}
+
+function runHtmlPptRenderWithLocalPlaywrightFromOutsideCwd() {
+  const root = fresh();
+  const repo = path.join(root, 'repo');
+  const script = path.join(repo, 'design-templates', 'html-ppt', 'scripts', 'render.sh');
+  const localPlaywright = path.join(repo, 'node_modules', '.bin', 'playwright');
+  const fakeBin = path.join(root, 'bin');
+  const fakeNpx = path.join(fakeBin, 'npx');
+  const outsideCwd = path.join(root, 'outside');
+  const html = path.join(root, 'input', 'deck.html');
+  const out = path.join(root, 'deck.png');
+  const log = path.join(root, 'playwright.log');
+
+  mkdirSync(path.dirname(script), { recursive: true });
+  mkdirSync(path.dirname(localPlaywright), { recursive: true });
+  mkdirSync(path.dirname(html), { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
+  mkdirSync(outsideCwd, { recursive: true });
+  copyFileSync(path.join(designTemplatesRoot, 'html-ppt', 'scripts', 'render.sh'), script);
+  chmodSync(script, 0o755);
+  writeFakePlaywrightCli(localPlaywright);
+  writeFileSync(
+    fakeNpx,
+    [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'printf "npx %s\\n" "$*" >> "$PLAYWRIGHT_CALL_LOG"',
+      'exit 66',
+      '',
+    ].join('\n'),
+  );
+  chmodSync(fakeNpx, 0o755);
+  writeFileSync(
+    html,
+    '<!doctype html><html><body><section class="slide">Slide</section></body></html>',
+  );
+
+  const result = spawnSync(script, [html, '1', out], {
+    cwd: outsideCwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}`,
+      PLAYWRIGHT_CALL_LOG: log,
+    },
+  });
   const calls = readFileSync(log, 'utf8').trim().split('\n').filter(Boolean);
   return { calls, result, root };
 }
@@ -267,6 +328,16 @@ describe('listSkills', () => {
       expect(success.calls.join('\n')).not.toContain('--remote-debugging-port');
     } finally {
       rmSync(success.root, { recursive: true, force: true });
+    }
+
+    const outsideCwd = runHtmlPptRenderWithLocalPlaywrightFromOutsideCwd();
+    try {
+      expect(outsideCwd.result.status, outsideCwd.result.stderr).toBe(0);
+      expect(outsideCwd.calls[0]).toBe('install chromium');
+      expect(outsideCwd.calls.filter((call) => call.startsWith('screenshot '))).toHaveLength(1);
+      expect(outsideCwd.calls.some((call) => call.startsWith('npx '))).toBe(false);
+    } finally {
+      rmSync(outsideCwd.root, { recursive: true, force: true });
     }
 
     const failure = runHtmlPptRenderWithFakePlaywright({ screenshotExitCode: 23 });

--- a/apps/daemon/tests/skills.test.ts
+++ b/apps/daemon/tests/skills.test.ts
@@ -1,14 +1,12 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { rmSync } from 'node:fs';
-
 import { skillCwdAliasSegment, SKILLS_CWD_ALIAS } from '../src/cwd-aliases.js';
-import { readFileSync } from 'node:fs';
 import {
   deleteUserSkill,
   importUserSkill,
@@ -41,6 +39,63 @@ type SkillCatalogEntry = {
 
 function fresh(): string {
   return mkdtempSync(path.join(tmpdir(), 'od-skills-'));
+}
+
+function runHtmlPptRenderWithFakePlaywright(options: { screenshotExitCode?: number } = {}) {
+  const root = fresh();
+  const html = path.join(root, 'deck.html');
+  const out = path.join(root, 'deck.png');
+  const log = path.join(root, 'playwright.log');
+  const fakePlaywright = path.join(root, 'fake-playwright.sh');
+  writeFileSync(
+    html,
+    '<!doctype html><html><body><section class="slide">Slide</section></body></html>',
+  );
+  writeFileSync(
+    fakePlaywright,
+    [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'printf "%s\\n" "$*" >> "$PLAYWRIGHT_CALL_LOG"',
+      'case "${1:-}" in',
+      '  install)',
+      '    [[ "${2:-}" == "chromium" ]] || exit 64',
+      '    exit 0',
+      '    ;;',
+      '  screenshot)',
+      '    if [[ "${FAKE_PLAYWRIGHT_SCREENSHOT_EXIT:-0}" != "0" ]]; then',
+      '      exit "$FAKE_PLAYWRIGHT_SCREENSHOT_EXIT"',
+      '    fi',
+      '    target="${@: -1}"',
+      '    mkdir -p "$(dirname "$target")"',
+      '    printf "png" > "$target"',
+      '    exit 0',
+      '    ;;',
+      '  *)',
+      '    exit 65',
+      '    ;;',
+      'esac',
+      '',
+    ].join('\n'),
+  );
+  chmodSync(fakePlaywright, 0o755);
+
+  const result = spawnSync(
+    path.join(designTemplatesRoot, 'html-ppt', 'scripts', 'render.sh'),
+    [html, '1', out],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PLAYWRIGHT_CLI: fakePlaywright,
+        PLAYWRIGHT_CALL_LOG: log,
+        FAKE_PLAYWRIGHT_SCREENSHOT_EXIT: String(options.screenshotExitCode ?? 0),
+      },
+    },
+  );
+  const calls = readFileSync(log, 'utf8').trim().split('\n').filter(Boolean);
+  return { calls, result, root };
 }
 
 function writeSkill(
@@ -182,7 +237,7 @@ describe('listSkills', () => {
     expect(skill.body).toContain('pkill -f -- "--user-data-dir=${CHROME_USER_DATA_DIR}"');
   });
 
-  it('keeps html-ppt PNG export off the user system Chrome path', async () => {
+  it('keeps html-ppt PNG export on one managed Chromium screenshot path', async () => {
     const skills = await listSkills(designTemplatesRoot);
     const skill = skills.find((entry: { id: string }) => entry.id === 'html-ppt');
     const renderScript = readFileSync(
@@ -194,12 +249,38 @@ describe('listSkills', () => {
     expect(skill.body).toContain("Playwright's managed Chromium");
     expect(skill.body).toContain('If the managed renderer fails once');
     expect(skill.body).not.toContain('/Applications/Google Chrome.app');
+    expect(renderScript).toContain('install chromium');
     expect(renderScript).toContain('playwright@${PLAYWRIGHT_VERSION}');
     expect(renderScript).toContain('not retrying and not falling back to system Google Chrome');
     expect(renderScript).not.toContain('/Applications/Google Chrome.app');
     expect(renderScript).not.toContain('--headless');
     expect(renderScript).not.toContain('--screenshot');
     expect(renderScript).not.toContain('--remote-debugging-port');
+
+    const success = runHtmlPptRenderWithFakePlaywright();
+    try {
+      expect(success.result.status, success.result.stderr).toBe(0);
+      expect(success.calls[0]).toBe('install chromium');
+      expect(success.calls.filter((call) => call.startsWith('screenshot '))).toHaveLength(1);
+      expect(success.calls.join('\n')).not.toContain('/Applications/Google Chrome.app');
+      expect(success.calls.join('\n')).not.toContain('--headless');
+      expect(success.calls.join('\n')).not.toContain('--remote-debugging-port');
+    } finally {
+      rmSync(success.root, { recursive: true, force: true });
+    }
+
+    const failure = runHtmlPptRenderWithFakePlaywright({ screenshotExitCode: 23 });
+    try {
+      expect(failure.result.status).not.toBe(0);
+      expect(failure.result.stderr).toContain(
+        'not retrying and not falling back to system Google Chrome',
+      );
+      expect(failure.calls[0]).toBe('install chromium');
+      expect(failure.calls.filter((call) => call.startsWith('screenshot '))).toHaveLength(1);
+      expect(failure.calls.join('\n')).not.toContain('/Applications/Google Chrome.app');
+    } finally {
+      rmSync(failure.root, { recursive: true, force: true });
+    }
   });
 
   it('includes the DCF valuation, X research, and Last30Days research skills', async () => {

--- a/apps/daemon/tests/skills.test.ts
+++ b/apps/daemon/tests/skills.test.ts
@@ -182,6 +182,26 @@ describe('listSkills', () => {
     expect(skill.body).toContain('pkill -f -- "--user-data-dir=${CHROME_USER_DATA_DIR}"');
   });
 
+  it('keeps html-ppt PNG export off the user system Chrome path', async () => {
+    const skills = await listSkills(designTemplatesRoot);
+    const skill = skills.find((entry: { id: string }) => entry.id === 'html-ppt');
+    const renderScript = readFileSync(
+      path.join(designTemplatesRoot, 'html-ppt', 'scripts', 'render.sh'),
+      'utf8',
+    );
+
+    if (!skill) throw new Error('html-ppt skill not found');
+    expect(skill.body).toContain("Playwright's managed Chromium");
+    expect(skill.body).toContain('If the managed renderer fails once');
+    expect(skill.body).not.toContain('/Applications/Google Chrome.app');
+    expect(renderScript).toContain('playwright@${PLAYWRIGHT_VERSION}');
+    expect(renderScript).toContain('not retrying and not falling back to system Google Chrome');
+    expect(renderScript).not.toContain('/Applications/Google Chrome.app');
+    expect(renderScript).not.toContain('--headless');
+    expect(renderScript).not.toContain('--screenshot');
+    expect(renderScript).not.toContain('--remote-debugging-port');
+  });
+
   it('includes the DCF valuation, X research, and Last30Days research skills', async () => {
     const skills = await listSkills(designTemplatesRoot);
     const byId = new Map(

--- a/design-templates/html-ppt/README.md
+++ b/design-templates/html-ppt/README.md
@@ -160,7 +160,7 @@ open templates/layout-showcase.html        # all 31 layouts
 open templates/animation-showcase.html     # all 47 animations
 open templates/full-decks-index.html       # all 14 full decks
 
-# Render any template to PNG via headless Chrome
+# Render any template to PNG via managed Chromium
 ./scripts/render.sh templates/theme-showcase.html
 ./scripts/render.sh examples/my-talk/index.html 12
 ```
@@ -211,7 +211,7 @@ html-ppt-skill/
 │   └── single-page/*.html        31 layout files with demo data
 ├── scripts/
 │   ├── new-deck.sh               scaffold
-│   ├── render.sh                 headless Chrome → PNG
+│   ├── render.sh                 managed Chromium → PNG
 │   └── verify-output/            56 self-test screenshots
 └── examples/demo-deck/           complete working deck
 ```

--- a/design-templates/html-ppt/README.pt-BR.md
+++ b/design-templates/html-ppt/README.pt-BR.md
@@ -162,7 +162,7 @@ open templates/layout-showcase.html        # all 31 layouts
 open templates/animation-showcase.html     # all 47 animations
 open templates/full-decks-index.html       # all 14 full decks
 
-# Render any template to PNG via headless Chrome
+# Render any template to PNG via managed Chromium
 ./scripts/render.sh templates/theme-showcase.html
 ./scripts/render.sh examples/my-talk/index.html 12
 ```
@@ -213,7 +213,7 @@ html-ppt-skill/
 │   └── single-page/*.html        31 layout files with demo data
 ├── scripts/
 │   ├── new-deck.sh               scaffold
-│   ├── render.sh                 headless Chrome → PNG
+│   ├── render.sh                 managed Chromium → PNG
 │   └── verify-output/            56 self-test screenshots
 └── examples/demo-deck/           complete working deck
 ```

--- a/design-templates/html-ppt/README.zh-CN.md
+++ b/design-templates/html-ppt/README.zh-CN.md
@@ -163,7 +163,7 @@ open templates/layout-showcase.html        # 全部 31 布局
 open templates/animation-showcase.html     # 全部 47 动效
 open templates/full-decks-index.html       # 全部 15 个完整 deck
 
-# 用 headless Chrome 导出 PNG
+# 用托管 Chromium 导出 PNG
 ./scripts/render.sh templates/theme-showcase.html
 ./scripts/render.sh examples/my-talk/index.html 12
 ```
@@ -216,7 +216,7 @@ html-ppt-skill/
 │   └── single-page/*.html        31 个布局文件（带示例数据）
 ├── scripts/
 │   ├── new-deck.sh               脚手架
-│   ├── render.sh                 headless Chrome → PNG
+│   ├── render.sh                 managed Chromium → PNG
 │   └── verify-output/            56 张自测截图
 └── examples/demo-deck/           完整可运行的示例 deck
 ```

--- a/design-templates/html-ppt/SKILL.md
+++ b/design-templates/html-ppt/SKILL.md
@@ -54,7 +54,7 @@ One command, no build. Pure static HTML/CSS/JS with only CDN webfonts.
 - **Keyboard runtime** (`assets/runtime.js`) — arrows, T (theme), A (anim), F/O, **S (presenter mode: magnetic-card popup with CURRENT / NEXT / SCRIPT / TIMER cards)**, N (notes drawer), R (reset timer in presenter)
 - **FX runtime** (`assets/animations/fx-runtime.js`) — auto-inits `[data-fx]` on slide enter, cleans up on leave
 - **Showcase decks** for themes / layouts / animations / full-decks gallery
-- **Headless Chrome render script** for PNG export
+- **Managed Chromium render script** for PNG export
 
 ## When to use
 
@@ -214,15 +214,20 @@ html-ppt/
 │   └── single-page/*.html         (31 layout files with demo data)
 ├── scripts/
 │   ├── new-deck.sh                (scaffold a deck from deck.html)
-│   └── render.sh                  (headless Chrome → PNG)
+│   └── render.sh                  (managed Chromium → PNG)
 └── examples/demo-deck/            (complete working deck)
 ```
 
 ## Rendering to PNG
 
-`scripts/render.sh` wraps headless Chrome at
-`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`. For multi-slide
-capture, runtime.js exposes `#/N` deep-links, and render.sh iterates 1..N.
+`scripts/render.sh` uses Playwright's managed Chromium renderer. Do not call the
+user's installed Google Chrome directly for PNG export, especially on macOS
+desktop builds where Crashpad/profile permissions can abort Chrome before a
+screenshot is written. If the managed renderer fails once, surface that error
+and stop instead of retrying alternate Chrome launch commands.
+
+For multi-slide capture, runtime.js exposes `#/N` deep-links, and render.sh
+iterates 1..N.
 
 ```bash
 ./scripts/render.sh templates/single-page/kpi-grid.html        # single page

--- a/design-templates/html-ppt/references/authoring-guide.md
+++ b/design-templates/html-ppt/references/authoring-guide.md
@@ -114,6 +114,11 @@ Walk through every slide with ← →. Press:
 Output is 1920×1080 by default. Change in `render.sh` if the user wants 3:4
 for 小红书图文 (1242×1660).
 
+The renderer uses Playwright's managed Chromium. Do not replace it with
+`/Applications/Google Chrome.app` or another user-profile Chrome launch on
+macOS. If the managed renderer fails once, report the error and stop instead of
+retrying alternate Chrome commands.
+
 ## 10. What to NOT do
 
 - Don't hand-author from a blank file.
@@ -138,4 +143,4 @@ for 小红书图文 (1242×1660).
 - **Fonts fall back**: make sure `fonts.css` is linked before the theme.
 - **Chart.js colors wrong**: charts read CSS vars in JS; make sure they run
   after the DOM is ready (`addEventListener('DOMContentLoaded', …)`).
-- **PNG too small**: bump `--window-size` in `scripts/render.sh`.
+- **PNG too small**: bump `--viewport-size` in `scripts/render.sh`.

--- a/design-templates/html-ppt/scripts/render.sh
+++ b/design-templates/html-ppt/scripts/render.sh
@@ -30,15 +30,21 @@ OUT="${3:-}"
 
 ABS="$(cd "$(dirname "$FILE")" && pwd)/$(basename "$FILE")"
 STEM="$(basename "${FILE%.*}")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT_DIR="$(dirname "$ABS")"
 
 find_upward_playwright() {
-  local dir="$PWD"
-  while [[ "$dir" != "/" ]]; do
-    if [[ -x "$dir/node_modules/.bin/playwright" ]]; then
-      printf '%s\n' "$dir/node_modules/.bin/playwright"
-      return 0
-    fi
-    dir="$(dirname "$dir")"
+  local start dir
+  for start in "$@"; do
+    [[ -n "$start" ]] || continue
+    dir="$(cd "$start" 2>/dev/null && pwd)" || continue
+    while [[ "$dir" != "/" ]]; do
+      if [[ -x "$dir/node_modules/.bin/playwright" ]]; then
+        printf '%s\n' "$dir/node_modules/.bin/playwright"
+        return 0
+      fi
+      dir="$(dirname "$dir")"
+    done
   done
   return 1
 }
@@ -50,7 +56,7 @@ run_playwright() {
   fi
 
   local local_playwright
-  if local_playwright="$(find_upward_playwright)"; then
+  if local_playwright="$(find_upward_playwright "$SCRIPT_DIR" "$INPUT_DIR")"; then
     "$local_playwright" "$@"
     return $?
   fi

--- a/design-templates/html-ppt/scripts/render.sh
+++ b/design-templates/html-ppt/scripts/render.sh
@@ -58,6 +58,13 @@ run_playwright() {
   npx --yes "playwright@${PLAYWRIGHT_VERSION}" "$@"
 }
 
+ensure_managed_chromium() {
+  if ! run_playwright install chromium; then
+    echo "error: failed to install Playwright managed Chromium; cannot render PNG export" >&2
+    exit 1
+  fi
+}
+
 if [[ "$COUNT" == "all" ]]; then
   COUNT="$(grep -c 'class="slide"' "$FILE" || true)"
   [[ -z "$COUNT" || "$COUNT" -lt 1 ]] && COUNT=1
@@ -69,6 +76,8 @@ if [[ -z "$OUT" ]]; then
     mkdir -p "$OUT"
   fi
 fi
+
+ensure_managed_chromium
 
 render_one() {
   local url="$1" target="$2"

--- a/design-templates/html-ppt/scripts/render.sh
+++ b/design-templates/html-ppt/scripts/render.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# html-ppt :: render.sh — headless Chrome screenshot(s)
+# html-ppt :: render.sh — managed Chromium screenshot(s)
 #
 # Usage:
 #   render.sh <html-file>                     # one PNG, slide 1
@@ -7,15 +7,13 @@
 #   render.sh <html-file> all                 # autodetect .slide count
 #   render.sh <html-file> <N> <out-dir>       # custom output dir
 #
-# Requires: Google Chrome at /Applications/Google Chrome.app (macOS).
+# Uses Playwright's managed Chromium. Do not fall back to the user's installed
+# Google Chrome on macOS; Crashpad/profile permissions can abort it inside the
+# Open Design desktop sandbox.
 
 set -euo pipefail
 
-CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-if [[ ! -x "$CHROME" ]]; then
-  echo "error: Chrome not found at $CHROME" >&2
-  exit 1
-fi
+PLAYWRIGHT_VERSION="${PLAYWRIGHT_VERSION:-1.60.0}"
 
 FILE="${1:-}"
 if [[ -z "$FILE" ]]; then
@@ -33,6 +31,33 @@ OUT="${3:-}"
 ABS="$(cd "$(dirname "$FILE")" && pwd)/$(basename "$FILE")"
 STEM="$(basename "${FILE%.*}")"
 
+find_upward_playwright() {
+  local dir="$PWD"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -x "$dir/node_modules/.bin/playwright" ]]; then
+      printf '%s\n' "$dir/node_modules/.bin/playwright"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+run_playwright() {
+  if [[ -n "${PLAYWRIGHT_CLI:-}" ]]; then
+    "$PLAYWRIGHT_CLI" "$@"
+    return $?
+  fi
+
+  local local_playwright
+  if local_playwright="$(find_upward_playwright)"; then
+    "$local_playwright" "$@"
+    return $?
+  fi
+
+  npx --yes "playwright@${PLAYWRIGHT_VERSION}" "$@"
+}
+
 if [[ "$COUNT" == "all" ]]; then
   COUNT="$(grep -c 'class="slide"' "$FILE" || true)"
   [[ -z "$COUNT" || "$COUNT" -lt 1 ]] && COUNT=1
@@ -47,15 +72,15 @@ fi
 
 render_one() {
   local url="$1" target="$2"
-  "$CHROME" \
-    --headless=new \
-    --disable-gpu \
-    --hide-scrollbars \
-    --no-sandbox \
-    --virtual-time-budget=4000 \
-    --window-size=1920,1080 \
-    --screenshot="$target" \
-    "$url" >/dev/null 2>&1
+  if ! run_playwright screenshot \
+    --browser chromium \
+    --viewport-size=1920,1080 \
+    --wait-for-timeout=4000 \
+    "$url" \
+    "$target"; then
+    echo "error: managed Chromium screenshot failed; not retrying and not falling back to system Google Chrome" >&2
+    exit 1
+  fi
   echo "  ✔ $target"
 }
 

--- a/design-templates/html-ppt/templates/single-page/arch-diagram.html
+++ b/design-templates/html-ppt/templates/single-page/arch-diagram.html
@@ -35,7 +35,7 @@
       </div>
     </div>
     <div class="tier"><div class="tname">Tooling</div>
-      <div class="cells three"><div class="cell"><div class="ic">🧪</div><h4>render.sh</h4><p>headless Chrome</p></div>
+      <div class="cells three"><div class="cell"><div class="ic">🧪</div><h4>render.sh</h4><p>managed Chromium</p></div>
         <div class="cell"><div class="ic">🆕</div><h4>new-deck.sh</h4><p>脚手架</p></div>
         <div class="cell"><div class="ic">📦</div><h4>AgentSkill</h4><p>Claude 接入点</p></div>
       </div>

--- a/design-templates/html-ppt/templates/single-page/flow-diagram.html
+++ b/design-templates/html-ppt/templates/single-page/flow-diagram.html
@@ -26,7 +26,7 @@
     <div class="arr">→</div>
     <div class="node"><div class="ic">🌐</div><h4>HTML</h4><p>运行时接管</p></div>
     <div class="arr">→</div>
-    <div class="node"><div class="ic">📸</div><h4>PNG</h4><p>headless Chrome</p></div>
+    <div class="node"><div class="ic">📸</div><h4>PNG</h4><p>managed Chromium</p></div>
   </div>
 </section></div>
 <script src="../../assets/runtime.js"></script>

--- a/design-templates/html-ppt/templates/single-page/timeline.html
+++ b/design-templates/html-ppt/templates/single-page/timeline.html
@@ -24,7 +24,7 @@
       <div class="item"><div class="year">2025 Q4</div><div class="dot"></div><h4>tokens 化</h4><p>把颜色全部收进 :root</p></div>
       <div class="item"><div class="year">2026 Q1</div><div class="dot"></div><h4>Agent 接入</h4><p>开放为 AgentSkill</p></div>
       <div class="item"><div class="year">2026 Q2</div><div class="dot"></div><h4>24 themes</h4><p>从克制到霓虹一应俱全</p></div>
-      <div class="item"><div class="year">2026 Q3</div><div class="dot"></div><h4>渲染管线</h4><p>headless Chrome PNG 出稿</p></div>
+      <div class="item"><div class="year">2026 Q3</div><div class="dot"></div><h4>渲染管线</h4><p>managed Chromium PNG 出稿</p></div>
     </div>
   </div>
 </section></div>


### PR DESCRIPTION
Closes #4228

## Why

This fixes the macOS screenshot export failure reported in #4228. The html-ppt template instructed agents to run the user's installed Google Chrome binary for PNG export, which can abort inside the packaged desktop sandbox with Crashpad/profile permission errors and trigger repeated failed launch attempts.

The pain addressed is user-visible export failure: generated HTML/deck screenshots should not crash the user's system Chrome or keep retrying alternate Chrome launch commands.

## What users will see

PNG export for html-ppt decks now uses Playwright's managed Chromium path instead of `/Applications/Google Chrome.app`. If the managed renderer cannot start, the script emits one actionable error and stops instead of falling back to system Chrome.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes a design-template export script and agent-facing docs, not UI.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/skills.test.ts` now asserts html-ppt export guidance and `render.sh` do not reference system Chrome launch flags and include the single-failure guard.
- Did the test go red on `main` and green on this branch? Not run here; this worker does not have `node`, `corepack`, or `pnpm` installed.
- Additional verification: direct shell validation covered `bash -n`, a fake successful Playwright CLI invocation, and a fake failing Playwright CLI invocation that confirmed exactly one renderer attempt before the no-fallback error.

## Validation

- `bash -n design-templates/html-ppt/scripts/render.sh`
- `git diff --check`
- Fake Playwright success path: `PLAYWRIGHT_CLI=<fake> design-templates/html-ppt/scripts/render.sh design-templates/html-ppt/templates/deck.html 1 <out.png>`
- Fake Playwright failure path: confirmed exit after one invocation with `not retrying and not falling back to system Google Chrome`
- Not run: `pnpm guard`, `pnpm typecheck`, `pnpm --filter @open-design/daemon test -- skills.test.ts` because `node`, `corepack`, and `pnpm` are unavailable in this worker image.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>