### PR TITLE
Fix chat splitter overlapping scrollbar hit area

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1352,7 +1352,7 @@ a.avatar-item:visited {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -10px;
+  left: -2px;
   right: -10px;
   cursor: col-resize;
 }


### PR DESCRIPTION
## Why

When the left chat transcript is long enough to show a scrollbar, the chat/workspace splitter hit area extends too far into the chat pane. This makes the scrollbar show the column-resize cursor and interferes with dragging the scrollbar itself.

## What users will see

Users can drag the left chat scrollbar normally while still having an easy-to-grab splitter between the chat pane and workspace.

<img width="1280" height="673" alt="1aac8ad277f854777790ac933ba1effc" src="https://github.com/user-attachments/assets/00dc5c47-f257-4388-84b5-ae119eb425af" />

## Surface area

- [x] **UI** — adjusts the chat/workspace splitter hit area in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — existing users get corrected splitter/scrollbar pointer behavior
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Manual local verification: the chat scrollbar remains usable after the left transcript overflows, and the splitter still resizes the chat/workspace panes.

## Bug fix verification

- Test path that reproduces the bug: not added; this is a small CSS hit-area adjustment and the behavior is pointer/scrollbar interaction specific.
- Did the test go red on `main` and green on this branch? no
- Verification performed instead: manually reproduced the long chat scrollbar state and confirmed the scrollbar no longer gets covered by the splitter hit area.
- 
<img width="1275" height="602" alt="9f7bc22a6f250ac7ffd58ffb5790aeb0" src="https://github.com/user-attachments/assets/87b5e7ce-3370-4e99-a636-c1c92dfe239f" />

## Validation

- `git diff --check -- apps/web/src/styles/shell.css`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`
- `pnpm guard` attempted; fails on pre-existing stale `design-systems/*/manifest.json` generated asset checks unrelated to this CSS change.