### PR TITLE
feat(daemon): exponential backoff with jitter before same-run retry

### DIFF
--- a/apps/daemon/src/run-retry-policy.ts
+++ b/apps/daemon/src/run-retry-policy.ts
@@ -14,6 +14,42 @@ import type {
 export const DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS = 1;
 export const SAFE_RUN_RETRY_STRATEGY: TrackingRunRetryStrategy = 'same_run_transient';
 
+// Backoff before a same-run retry restart. An immediate retry of a transient
+// failure — especially a 429 — tends to re-hit the same limit, so the policy
+// waits before restarting. `rate_limit` gets a larger base than other
+// transient classes because the upstream is explicitly asking us to slow down.
+// The delay grows exponentially by attempt index and is capped, then equal
+// jitter (half fixed + half random) is applied to avoid synchronized retries
+// across concurrent runs.
+export const RATE_LIMIT_RETRY_BASE_DELAY_MS = 1_000;
+export const TRANSIENT_RETRY_BASE_DELAY_MS = 500;
+export const RETRY_BACKOFF_MULTIPLIER = 2;
+export const MAX_RETRY_BACKOFF_DELAY_MS = 8_000;
+
+function backoffBaseDelayMs(category: TrackingRunFailureCategory | undefined): number {
+  return category === 'rate_limit'
+    ? RATE_LIMIT_RETRY_BASE_DELAY_MS
+    : TRANSIENT_RETRY_BASE_DELAY_MS;
+}
+
+// Pure, deterministic when `random` is supplied. `attemptIndex` is 1-based (the
+// index of the attempt about to be scheduled), so the first retry uses the base
+// delay and each subsequent attempt doubles it up to the cap. Equal jitter
+// returns a value in [delay/2, delay].
+export function computeRetryBackoffMs(
+  attemptIndex: number,
+  category: TrackingRunFailureCategory | undefined,
+  random: () => number = Math.random,
+): number {
+  const exponent = Math.max(0, Math.floor(attemptIndex) - 1);
+  const raw = backoffBaseDelayMs(category) * RETRY_BACKOFF_MULTIPLIER ** exponent;
+  const capped = Math.min(raw, MAX_RETRY_BACKOFF_DELAY_MS);
+  const half = capped / 2;
+  const sample = random();
+  const jitter = Number.isFinite(sample) ? Math.min(1, Math.max(0, sample)) : 0;
+  return Math.round(half + jitter * half);
+}
+
 export interface RunRetryFailureSignal {
   failure_category?: TrackingRunFailureCategory;
   failure_detail?: TrackingRunFailureDetail;
@@ -35,6 +71,8 @@ export interface RunRetryPolicyInput {
   attemptCount: number;
   maxAttempts?: number;
   sideEffects?: RunRetrySideEffectState;
+  // Injectable jitter source for deterministic tests; defaults to Math.random.
+  random?: () => number;
 }
 
 export type RunRetryPolicyDecision =
@@ -44,6 +82,7 @@ export type RunRetryPolicyDecision =
       retryMaxAttempts: number;
       retryStrategy: TrackingRunRetryStrategy;
       retryReason: 'transient_failure';
+      retryDelayMs: number;
     }
   | {
       shouldRetry: false;
@@ -132,5 +171,10 @@ export function decideSafeRunRetry(
     ...base,
     shouldRetry: true,
     retryReason: 'transient_failure',
+    retryDelayMs: computeRetryBackoffMs(
+      retryAttemptIndex,
+      failure.failure_category,
+      input.random,
+    ),
   };
 }

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -86,6 +86,7 @@ export function createChatRunService({
       error: null,
       errorCode: null,
       cancelRequested: false,
+      retryRestartTimer: null,
       stdinOpen: false,
       eventsLogPath: runsLogDir ? path.join(runsLogDir, id, 'events.jsonl') : null,
       eventsLogStream: null,
@@ -329,10 +330,21 @@ export function createChatRunService({
     run.stdinOpen = false;
   };
 
+  // A same-run retry can be waiting out its backoff window (server.ts
+  // scheduleRetryRestart). Cancellation/shutdown must drop that pending restart
+  // so a cancelled run is not resurrected after the timer fires.
+  const clearPendingRetryRestart = (run) => {
+    if (run?.retryRestartTimer) {
+      clearTimeout(run.retryRestartTimer);
+      run.retryRestartTimer = null;
+    }
+  };
+
   const cancel = async (run) => {
     if (TERMINAL_RUN_STATUSES.has(run.status)) return statusBody(run);
     run.cancelRequested = true;
     run.updatedAt = Date.now();
+    clearPendingRetryRestart(run);
     closeRunStdin(run);
     if (!run.child) {
       finish(run, 'canceled', null, 'SIGTERM');
@@ -375,6 +387,7 @@ export function createChatRunService({
     await Promise.all(activeRuns.map(async (run) => {
       run.cancelRequested = true;
       run.updatedAt = Date.now();
+      clearPendingRetryRestart(run);
       closeRunStdin(run);
       if (run.acpSession?.abort) {
         try {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7877,7 +7877,13 @@ export async function startServer({
       destroyStream(child.stderr);
       destroyStream(child.stdin);
     };
-    const restartSameRunAfterRetry = () => {
+    // Synchronously detach the failed attempt: kill the old child and move the
+    // run back to `queued` *now*, even when the re-spawn is delayed by backoff.
+    // This must not be deferred — leaving the old child alive during the backoff
+    // window lets a follow-on signal (e.g. the inactivity watchdog's SIGTERM)
+    // drive a second close-handler pass that finalizes the run as failed before
+    // the retry ever spawns.
+    const tearDownAttemptForRetry = () => {
       // Release the previous child's stdio streams before letting the
       // reference drop — see destroyChildStdio for rationale.
       destroyChildStdio(run.child);
@@ -7901,6 +7907,8 @@ export async function startServer({
       run.analyticsTelemetry = {
         startRequestedAt: run.analyticsTelemetry?.startRequestedAt ?? run.createdAt,
       };
+    };
+    const spawnRetryAttempt = () => {
       void startChatRun(chatBody, run).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         design.runs.emit(
@@ -7917,6 +7925,24 @@ export async function startServer({
         // cannot trigger another restart loop.
         finishWithRetryDecision('failed', 1, null);
       });
+    };
+    // Tear the failed attempt down now (moving the run to `queued`), then wait
+    // out the policy's backoff before re-spawning. Stays cancel-aware: a cancel
+    // or shutdown during the backoff window clears the timer (runtimes/runs.ts)
+    // and finalizes the queued run, and the callback re-checks cancel/terminal
+    // state in case it fires first.
+    const scheduleRetryRestart = (delayMs) => {
+      tearDownAttemptForRetry();
+      const wait = Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 0;
+      if (wait <= 0) {
+        spawnRetryAttempt();
+        return;
+      }
+      run.retryRestartTimer = setTimeout(() => {
+        run.retryRestartTimer = null;
+        if (run.cancelRequested || design.runs.isTerminal(run.status)) return;
+        spawnRetryAttempt();
+      }, wait);
     };
     const finalizeRetryTelemetry = (status, decision, failure, errorCode) => {
       const attemptCount = run.retryAttemptCount ?? 0;
@@ -8008,8 +8034,9 @@ export async function startServer({
         design.runs.emit(run, 'run_retry_attempted', {
           ...retryAnalyticsBase(decision, failure, errorCode),
           retry_reason: decision.retryReason,
+          retry_delay_ms: decision.retryDelayMs,
         });
-        restartSameRunAfterRetry();
+        scheduleRetryRestart(decision.retryDelayMs);
         return true;
       }
       // Resume-on-failure: a terminal *resumable* failure (transient mid-stream

--- a/apps/daemon/tests/run-retry-policy.test.ts
+++ b/apps/daemon/tests/run-retry-policy.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS,
+  MAX_RETRY_BACKOFF_DELAY_MS,
+  RATE_LIMIT_RETRY_BASE_DELAY_MS,
   SAFE_RUN_RETRY_STRATEGY,
+  TRANSIENT_RETRY_BASE_DELAY_MS,
+  computeRetryBackoffMs,
   decideSafeRunRetry,
   type RunRetryPolicyInput,
 } from '../src/run-retry-policy.js';
@@ -23,12 +27,14 @@ function decide(input: Partial<RunRetryPolicyInput> = {}) {
 
 describe('decideSafeRunRetry', () => {
   it('allows retryable transient upstream failures before side effects', () => {
-    expect(decide()).toEqual({
+    // random: () => 0 pins equal-jitter to its floor (delay/2) for an exact match.
+    expect(decide({ random: () => 0 })).toEqual({
       shouldRetry: true,
       retryAttemptIndex: 1,
       retryMaxAttempts: DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS,
       retryStrategy: SAFE_RUN_RETRY_STRATEGY,
       retryReason: 'transient_failure',
+      retryDelayMs: TRANSIENT_RETRY_BASE_DELAY_MS / 2,
     });
   });
 
@@ -204,6 +210,63 @@ describe('decideSafeRunRetry', () => {
           },
         }).shouldRetry,
       ).toBe(false);
+    }
+  });
+
+  it('attaches an exponential backoff delay to retry decisions', () => {
+    // rate_limit uses the larger base; equal jitter floor (random → 0) is base/2.
+    const rateLimit = decide({
+      failure: {
+        failure_category: 'rate_limit',
+        failure_detail: 'rate_limit_429',
+        failure_stage: 'session_init',
+        retryable: true,
+      },
+      random: () => 0,
+    });
+    expect(rateLimit).toMatchObject({
+      shouldRetry: true,
+      retryDelayMs: RATE_LIMIT_RETRY_BASE_DELAY_MS / 2,
+    });
+
+    // Other transient classes use the smaller base.
+    expect(decide({ random: () => 0 })).toMatchObject({
+      shouldRetry: true,
+      retryDelayMs: TRANSIENT_RETRY_BASE_DELAY_MS / 2,
+    });
+  });
+});
+
+describe('computeRetryBackoffMs', () => {
+  it('grows exponentially by attempt index and applies equal jitter', () => {
+    // random → 0 is the floor (delay/2), random → 1 is the ceiling (full delay).
+    expect(computeRetryBackoffMs(1, 'rate_limit', () => 0)).toBe(
+      RATE_LIMIT_RETRY_BASE_DELAY_MS / 2,
+    );
+    expect(computeRetryBackoffMs(1, 'rate_limit', () => 1)).toBe(
+      RATE_LIMIT_RETRY_BASE_DELAY_MS,
+    );
+    // Attempt 2 doubles the base before jitter.
+    expect(computeRetryBackoffMs(2, 'rate_limit', () => 1)).toBe(
+      RATE_LIMIT_RETRY_BASE_DELAY_MS * 2,
+    );
+  });
+
+  it('caps the backoff at the configured ceiling', () => {
+    expect(computeRetryBackoffMs(99, 'rate_limit', () => 1)).toBe(
+      MAX_RETRY_BACKOFF_DELAY_MS,
+    );
+  });
+
+  it('keeps jitter within [delay/2, delay] for any random sample', () => {
+    for (const sample of [0, 0.25, 0.5, 0.75, 1]) {
+      const delay = computeRetryBackoffMs(2, 'upstream_unavailable', () => sample);
+      const capped = Math.min(
+        TRANSIENT_RETRY_BASE_DELAY_MS * 2,
+        MAX_RETRY_BACKOFF_DELAY_MS,
+      );
+      expect(delay).toBeGreaterThanOrEqual(capped / 2);
+      expect(delay).toBeLessThanOrEqual(capped);
     }
   });
 });

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -2773,6 +2773,8 @@ export interface RunRetryBaseProps {
 
 export interface RunRetryAttemptedProps extends RunRetryBaseProps {
   retry_reason: 'transient_failure';
+  // Backoff delay (ms) waited before this retry attempt was restarted.
+  retry_delay_ms?: number;
 }
 
 export interface RunRetryFinishedProps extends RunRetryBaseProps {


### PR DESCRIPTION
### Why

The safe same-run retry shipped for #3408 §3 (via #3569 / #3576 / #3608) restarts a transient failure **immediately**, with `DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS = 1`. For `rate_limit` / `rate_limit_429` especially, an instant same-model retry tends to re-hit the same limit, so the single retry budget is spent without giving the upstream any cooldown. #3408 §3 specified "retry **1-2 times**"; the immediate restart under-delivers that intent.

This addresses the backoff slice flagged in #3408 (transient retries should pause before re-running). Cross-model fallback is intentionally left out of scope, per §3/§5 keeping `model_unavailable` a user-driven `switch_model`.

### What users will see

No UI change. Behaviorally: a chat run that hits a transient `rate_limit` / `upstream_unavailable` / first-token `timeout` / `empty_output` now waits a short, jittered backoff before its automatic retry instead of restarting instantly, improving the odds the retry succeeds. Cancelling during the wait stops the retry as before.

### What changed

- **`run-retry-policy.ts`** — new pure `computeRetryBackoffMs(attemptIndex, category, random?)`: `rate_limit` uses a larger base (1s) than other transient classes (500ms), exponential by attempt index (×2), capped at 8s, with equal jitter in `[delay/2, delay]`. Jitter source is injectable for deterministic tests. `decideSafeRunRetry` now returns `retryDelayMs` on the retry decision.
- **`server.ts`** — split the synchronous restart into a synchronous teardown (kill child, move run to `queued`) plus a deferred, cancel-aware re-spawn after `retryDelayMs`. The teardown stays synchronous on purpose: leaving the old child alive during the wait lets a follow-on signal (e.g. the inactivity-watchdog SIGTERM) drive a second close-handler pass that finalizes the run as `failed` before the retry spawns.
- **`runtimes/runs.ts`** — clear a pending retry-restart timer on cancel/shutdown so a cancelled run is not resurrected after the timer fires.
- **`contracts`** — add `retry_delay_ms` to `run_retry_attempted` so the backoff is observable in PostHog.

The conservative single-retry default is unchanged; the backoff still applies before that one retry (the case that helps 429s most), and the curve extends naturally if max attempts is later lifted to the 1–2 this issue mentions.

### Surface area

- [x] Daemon logic (`apps/daemon`)
- [x] Analytics contract (`packages/contracts`)
- [ ] UI / CLI — n/a (internal retry timing; no new user-facing capability)

### Testing

- `pnpm --filter @open-design/daemon test run-retry-policy` — 15/15 pass, incl. new backoff cases (exponential growth, cap, jitter bounds, per-category base).
- `pnpm --filter @open-design/daemon typecheck` and `pnpm --filter @open-design/contracts typecheck` — clean.
