### PR TITLE
fix(web): improve dark-mode contrast for in-tab present exit button

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -823,18 +823,23 @@
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  background: var(--bg);
-  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-md);
   color: var(--text-muted);
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 .viewer .present-exit-btn:hover {
-  background: var(--bg-subtle);
+  background: var(--bg-muted);
   color: var(--text);
+}
+.viewer .present-exit-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .live-artifact-preview-frame-host {
   width: 100%;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -5516,6 +5516,23 @@ describe('LiveArtifactViewer', () => {
     expect(rule).toContain('align-items: center;');
   });
 
+  it('gives the in-tab present exit button a distinct elevated surface for dark-mode contrast', () => {
+    const css = readExpandedIndexCss();
+    const rule = css.match(/\.viewer\s+\.present-exit-btn\s*\{[^}]+\}/)?.[0] ?? '';
+
+    expect(rule).toContain('background: var(--bg-elevated)');
+    expect(rule).toContain('border: 1px solid var(--border-strong)');
+    expect(rule).toContain('box-shadow: var(--shadow-md)');
+  });
+
+  it('adds a keyboard focus ring to the in-tab present exit button', () => {
+    const css = readExpandedIndexCss();
+    const rule = css.match(/\.viewer\s+\.present-exit-btn:focus-visible\s*\{[^}]+\}/)?.[0] ?? '';
+
+    expect(rule).toContain('outline:');
+    expect(rule).toContain('var(--accent)');
+  });
+
   it('keeps in-tab presentation overlays anchored to the inherited workspace tab height', () => {
     const css = readExpandedIndexCss();
     const overlayRule = css.match(/\.present-overlay\s*\{[^}]+\}/)?.[0] ?? '';

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -5529,8 +5529,8 @@ describe('LiveArtifactViewer', () => {
     const css = readExpandedIndexCss();
     const rule = css.match(/\.viewer\s+\.present-exit-btn:focus-visible\s*\{[^}]+\}/)?.[0] ?? '';
 
-    expect(rule).toContain('outline:');
-    expect(rule).toContain('var(--accent)');
+    expect(rule).toContain('outline: 2px solid var(--accent)');
+    expect(rule).toContain('outline-offset: 2px');
   });
 
   it('keeps in-tab presentation overlays anchored to the inherited workspace tab height', () => {


### PR DESCRIPTION
Fixes #4118

## Why

In dark mode, the in-tab present close button (`.present-exit-btn`) used `var(--bg)` for its background — the same token as the page background (#1a1917). This made the button blend into the preview content, with an almost-invisible border (`--border`) and a shadow too dark to register against the dark surface. The hover state (`--bg-subtle`) was similarly indistinguishable from the base background.

## What users will see

In dark mode, the close button now has a distinctly elevated surface (`--bg-elevated`, #2a2825) with a stronger border (`--border-strong`) and a medium shadow (`--shadow-md`), making it read as part of the preview chrome rather than floating on page content. Hover produces a clearer state change (`--bg-muted`), and keyboard users get a focus ring (`--accent` outline).

Light-mode appearance is preserved — the same token swap simply maps to different values (e.g. `--bg-elevated` = #fffefc, nearly identical to the previous `--bg` = #faf9f7).

## Surface area

- [x] **UI** — adjusted in-tab present close button styling/focus treatment in `apps/web`
- `apps/web/src/styles/shell.css` — `.viewer .present-exit-btn` base, `:hover`, new `:focus-visible`
- `apps/web/tests/components/FileViewer.test.tsx` — 2 regression tests

## Screenshots

Dark mode before: button background = `--bg` (#1a1917), indistinguishable from page.
Dark mode after: button background = `--bg-elevated` (#2a2825), clearly elevated above content.

(Screenshots to be added from Playwright capture.)

## Bug fix verification

**Red test**: `tests/components/FileViewer.test.tsx` — new tests assert `background: var(--bg-elevated)`, `border: 1px solid var(--border-strong)`, `box-shadow: var(--shadow-md)`, and `:focus-visible` with exact `outline: 2px solid var(--accent)` + `outline-offset: 2px`. Reverting the CSS to `var(--bg)` / `var(--border)` / `var(--shadow-sm)` causes both tests to fail.

**Green test**: With the fix applied, both tests pass:
```
✓ tests/components/FileViewer.test.tsx (2 passed | 165 skipped)
```

## Validation

- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` (targeted) — 2/2 pass