### PR TITLE
AMR: normalize Vela's kimi_k2_7_code id to kimi-k2.7-code

### DIFF
--- a/CLAIM-COMMENT.md
+++ b/CLAIM-COMMENT.md
@@ -1,0 +1,5 @@
+<!-- Plak dit als reactie op het issue om te claimen. Check eerst de exacte regels van het programma (Algora gebruikt vaak /attempt). -->
+
+/attempt
+
+I'd like to work on this. Planning to submit a focused PR with tests.

--- a/PR-DESCRIPTION.md
+++ b/PR-DESCRIPTION.md
@@ -1,0 +1,32 @@
+## What
+
+Adds a Vela AMR proxy model-id normalization rule so that `vela/public_model_kimi_k2_7_code` (→ `kimi_k2_7_code`) is mapped to the canonical model id Open Design uses everywhere else: `kimi-k2.7-code`.
+
+## Why
+
+Moonshot released **Kimi K2.7-Code**. The Vela AMR proxy exposes it via the same `<model>_<variant>` shape as previous Kimi variants, but the normalizer in `apps/daemon/src/runtimes/defs/amr.ts` only knew about K2.6. As a result, a Vela user selecting K2.7 was routed through the unnormalized raw id (`kimi_k2_7_code`, or `kimi-k2-7-code` after the generic underscore replacement) instead of the canonical `kimi-k2.7-code`.
+
+This is the inbound-routing side and is independent from the picker-side fallback list (#4376 / PR #4375), which surfaces the new id in the web UI on discovery failure. Different code paths, independent landing risk.
+
+## How
+
+Added a single sibling rule right after the existing K2.6 line in `normalizeVelaModelId`:
+
+```ts
+if (/^kimi_k2_6$/i.test(withoutPrefix)) return 'kimi-k2.6';
+if (/^kimi_k2_7_code$/i.test(withoutPrefix)) return 'kimi-k2.7-code'; // NEW
+```
+
+The new rule is matched before the generic `_` → `-` fallback, so the canonical dotted id is returned.
+
+## Testing
+
+Mirrored the existing K2.6 normalization assertion in `apps/daemon/tests/amr-acp-integration.test.ts`:
+
+```ts
+expect(normalizeVelaModelId('public_model_kimi_k2_7_code')).toBe('kimi-k2.7-code');
+```
+
+No other code paths are affected; the change is additive and scoped to a single normalization branch.
+
+Fixes #4410

--- a/PR-TITLE.md
+++ b/PR-TITLE.md
@@ -1,0 +1,1 @@
+AMR: normalize Vela's kimi_k2_7_code id to kimi-k2.7-code

--- a/SOLVE_BRIEF.md
+++ b/SOLVE_BRIEF.md
@@ -1,0 +1,50 @@
+# Solve-brief: AMR: normalize Vela's kimi_k2_7_code id to kimi-k2.7-code
+
+> Autopilot-taak voor bounty github:nexu-io/open-design#4410.
+
+## De opdracht
+- **Repo:** nexu-io/open-design
+- **Issue:** #4410 -> https://github.com/nexu-io/open-design/issues/4410
+- **Bedrag:** onbekend
+- **Triage:** Triviale, afgebakende bugfix: één regex-regel toevoegen en één test-case spiegelen in TypeScript. Duidelijke precedent (K2.6-regel), minimale landing-risk, perfekte 'good first issue'.
+
+## Issue-omschrijving
+### What
+
+\`apps/daemon/src/runtimes/defs/amr.ts\` carries a small table of Vela AMR proxy model-id normalizers, including the existing K2.6 rule:
+
+\`\`\`ts
+if (/^kimi_k2_6$/i.test(withoutPrefix)) return 'kimi-k2.6';
+\`\`\`
+
+When Moonshot releases a new Kimi model variant, the Vela AMR proxy typically exposes it via the same \`<model>_<variant>\` shape, and Open Design needs a matching normalization rule so the Vela-prefixed id (\`vela/public_model_kimi_k2_7_code\` → \`kimi_k2_7_code\`) gets mapped to the canonical model id Open Design uses everywhere else (\`kimi-k2.7-code\`).
+
+Moonshot released **Kimi K2.7-Code** on 2026-06-12. PR #4375 lists it in the Kimi runtime's \`fallbackModels\`, but the AMR normalization rule still only knows about K2.6 — so a Vela user selecting K2.7 today still gets routed through the unnormalized raw id.
+
+### Repro
+
+1. Run an Open Design daemon configured to route Kimi through the Vela AMR proxy.
+2. Trigger a chat/run with a Vela K2.7 model id (e.g. \`vela/public_model_kimi_k2_7_code\`).
+3. Observe that the normalized model id used downstream is \`kimi_k2_7_code\` (or \`kimi-k2-7-code\` after the generic underscore replacement) instead of the canonical \`kimi-k2.7-code\`.
+
+### Proposed fix
+
+Add a single sibling rule right after the K2.6 line:
+
+\`\`\`ts
+if (/^kimi_k2_6$/i.test(withoutPrefix)) return 'kimi-k2.6';
+if (/^kimi_k2_7_code$/i.test(withoutPrefix)) return 'kimi-k2.7-code'; // NEW
+\`\`\`
+
+Plus a test case mirroring the existing K2.6 normalization assertion in \`apps/daemon/tests/amr-acp-integration.test.ts\`.
+
+### Why this is a separate issue from #4376
+
+#4376 / PR #4375 is the picker-side fallback list (web UI surfaces the new model id when discovery fails). This is the inbound-routing side (Vela ids get mapped to the canonical id Open Design uses). Different code paths, independent landing risk. Splitting keeps the picker change reviewable on its own and lets the AMR rule ship behind whichever timeline Vela confirms K2.7 support
+
+## Aanpak
+1. Lees het issue volledig + bestaande code.
+2. Implementeer de kleinst mogelijke nette fix in de stijl van de repo.
+3. Schrijf of update tests. Draai de testsuite tot groen.
+4. Houd de diff klein. Geen ongerelateerde wijzigingen.
+5. Dien NIETS in: geen git push, geen PR. De Autopilot doet dat.

--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -50,6 +50,7 @@ export function normalizeVelaModelId(rawId: string): string | null {
   if (/^deepseek_v3_2$/i.test(withoutPrefix)) return 'deepseek-v3.2';
   if (/^deepseek-v3-2$/i.test(withoutPrefix)) return 'deepseek-v3.2';
   if (/^kimi_k2_6$/i.test(withoutPrefix)) return 'kimi-k2.6';
+  if (/^kimi_k2_7_code$/i.test(withoutPrefix)) return 'kimi-k2.7-code';
   if (/^glm_5_1$/i.test(withoutPrefix)) return 'glm-5.1';
   if (/^glm_5$/i.test(withoutPrefix)) return 'glm-5';
   const versioned = normalizeKnownVelaVersionId(withoutPrefix);

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -91,6 +91,7 @@ describe('AMR runtime def', () => {
   it('normalizes Vela public model ids to link-canonical ACP model ids', () => {
     expect(normalizeVelaModelId('public_model_deepseek_v3_2')).toBe('deepseek-v3.2');
     expect(normalizeVelaModelId('public_model_kimi_k2_6')).toBe('kimi-k2.6');
+    expect(normalizeVelaModelId('public_model_kimi_k2_7_code')).toBe('kimi-k2.7-code');
     expect(normalizeVelaModelId('public_model_gemini_2_5_flash')).toBe('gemini-2.5-flash');
     expect(normalizeVelaModelId('public_model_gemini_3_1_flash_lite_preview')).toBe(
       'gemini-3.1-flash-lite-preview',


### PR DESCRIPTION
## What

Adds a Vela AMR proxy model-id normalization rule so that `vela/public_model_kimi_k2_7_code` (→ `kimi_k2_7_code`) is mapped to the canonical model id Open Design uses everywhere else: `kimi-k2.7-code`.

## Why

Moonshot released **Kimi K2.7-Code**. The Vela AMR proxy exposes it via the same `<model>_<variant>` shape as previous Kimi variants, but the normalizer in `apps/daemon/src/runtimes/defs/amr.ts` only knew about K2.6. As a result, a Vela user selecting K2.7 was routed through the unnormalized raw id (`kimi_k2_7_code`, or `kimi-k2-7-code` after the generic underscore replacement) instead of the canonical `kimi-k2.7-code`.

This is the inbound-routing side and is independent from the picker-side fallback list (#4376 / PR #4375), which surfaces the new id in the web UI on discovery failure. Different code paths, independent landing risk.

## How

Added a single sibling rule right after the existing K2.6 line in `normalizeVelaModelId`:

```ts
if (/^kimi_k2_6$/i.test(withoutPrefix)) return 'kimi-k2.6';
if (/^kimi_k2_7_code$/i.test(withoutPrefix)) return 'kimi-k2.7-code'; // NEW
```

The new rule is matched before the generic `_` → `-` fallback, so the canonical dotted id is returned.

## Testing

Mirrored the existing K2.6 normalization assertion in `apps/daemon/tests/amr-acp-integration.test.ts`:

```ts
expect(normalizeVelaModelId('public_model_kimi_k2_7_code')).toBe('kimi-k2.7-code');
```

No other code paths are affected; the change is additive and scoped to a single normalization branch.

Fixes #4410
