### PR TITLE
feat(daemon): split spawn-to-first-token into auditable subsegments (#3408 §4)

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -89,6 +89,13 @@ interface AttachAcpSessionOptions {
   clientVersion?: string;
   stageTimeoutMs?: number;
   modelUnavailableErrorCode?: 'AMR_MODEL_UNAVAILABLE';
+  // Subsegment timing markers for spawn->first-token attribution (#3408 §4).
+  // `onCliReady` fires once on the first well-formed ACP JSON-RPC message
+  // (the CLI is up and speaking the protocol); `onSessionInit` fires once when
+  // the `session/new` handshake is acknowledged (a session id is established).
+  // Both are best-effort and the caller dedupes, so extra calls are harmless.
+  onCliReady?: () => void;
+  onSessionInit?: () => void;
 }
 
 function errorMessage(err: unknown): string {
@@ -821,6 +828,8 @@ export function attachAcpSession({
   clientVersion = 'runtime-adapter',
   stageTimeoutMs = DEFAULT_STAGE_TIMEOUT_MS,
   modelUnavailableErrorCode,
+  onCliReady,
+  onSessionInit,
 }: AttachAcpSessionOptions) {
   const runStartedAt = Date.now();
   const effectiveCwd = path.resolve(cwd || process.cwd());
@@ -1021,6 +1030,9 @@ export function attachAcpSession({
     resetStageTimer('response');
     const obj = asObject(raw);
     if (!obj) return;
+    // First well-formed ACP JSON-RPC message = CLI ready (#3408 §4). Caller
+    // dedupes, so re-notifying on later messages is harmless.
+    onCliReady?.();
     const error = asObject(obj.error);
     const params = asObject(obj.params);
     const result = asObject(obj.result);
@@ -1244,6 +1256,8 @@ export function attachAcpSession({
     }
     if (expectedId === 2) {
       sessionId = typeof result.sessionId === 'string' ? result.sessionId : null;
+      // session/new acknowledged with a session id = handshake done (#3408 §4).
+      if (sessionId) onSessionInit?.();
       const modelConfig = findModelConfigOption(result.configOptions);
       modelConfigId = modelConfig?.configId ?? null;
       activeModel = currentModelFromSessionResult(result);

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -57,6 +57,17 @@ export interface RunTelemetryTimestamps {
   promptBuildEndAt?: number;
   processSpawnStartedAt?: number;
   processSpawnedAt?: number;
+  // Subsegment boundaries inside `processSpawnedAt -> firstTokenAt`. The
+  // markers are keyed by runtime family (see `noteCliReadyAt` /
+  // `noteSessionInitDoneAt` in server.ts and the ACP callbacks): `cliReadyAt`
+  // is the first well-formed adapter output (first JSONL line / first ACP
+  // JSON-RPC message / first decoded stream event / first non-empty stdout
+  // chunk), and `sessionInitDoneAt` is the resume/`session/new` ack for ACP or
+  // the first model-bound request for stream agents. Either may be absent when
+  // its declared marker cannot be observed; the unattributed time then rolls
+  // into `spawn_to_first_token_remainder_ms`.
+  cliReadyAt?: number;
+  sessionInitDoneAt?: number;
   modelCallStartAt?: number;
   firstTokenAt?: number;
   finalizeStartAt?: number;
@@ -84,6 +95,14 @@ export interface RunTimingAnalytics {
   process_spawn_duration_ms?: number;
   time_to_first_token_ms?: number;
   spawn_to_first_token_ms?: number;
+  // `spawn_to_first_token_ms` split into auditable subsegments. By construction
+  // `cli_ready_ms + session_init_ms + model_first_token_ms +
+  // spawn_to_first_token_remainder_ms === spawn_to_first_token_ms` (absent
+  // subsegments count as 0 and their time falls into the remainder).
+  cli_ready_ms?: number;
+  session_init_ms?: number;
+  model_first_token_ms?: number;
+  spawn_to_first_token_remainder_ms?: number;
   generation_duration_ms?: number;
   tool_call_count: number;
   tool_duration_ms?: number;
@@ -372,6 +391,32 @@ export function summarizeRunTimingAnalytics(args: {
   );
   if (spawnToFirstToken !== undefined) {
     result.spawn_to_first_token_ms = spawnToFirstToken;
+    // Split spawn->first-token into subsegments where the markers were
+    // observed. Each subsegment is the gap between two adjacent marks; an
+    // absent mark leaves its subsegment undefined and that time flows into the
+    // remainder so the four parts always sum back to spawn_to_first_token_ms.
+    const cliReady = durationBetween(
+      telemetry.processSpawnedAt,
+      telemetry.cliReadyAt,
+    );
+    const sessionInit = durationBetween(
+      telemetry.cliReadyAt,
+      telemetry.sessionInitDoneAt,
+    );
+    const modelFirstToken = durationBetween(
+      telemetry.sessionInitDoneAt,
+      telemetry.firstTokenAt,
+    );
+    if (cliReady !== undefined) result.cli_ready_ms = cliReady;
+    if (sessionInit !== undefined) result.session_init_ms = sessionInit;
+    if (modelFirstToken !== undefined) {
+      result.model_first_token_ms = modelFirstToken;
+    }
+    const attributed = (cliReady ?? 0) + (sessionInit ?? 0) + (modelFirstToken ?? 0);
+    result.spawn_to_first_token_remainder_ms = Math.max(
+      0,
+      spawnToFirstToken - attributed,
+    );
   }
   const generationDuration = durationBetween(telemetry.firstTokenAt, runEndAt);
   if (generationDuration !== undefined) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9262,6 +9262,30 @@ export async function startServer({
         firstTokenAt: timestamp,
       };
     };
+    // Subsegment markers inside `processSpawnedAt -> firstTokenAt` (#3408 §4).
+    // `cliReadyAt` is the first well-formed adapter output and is stamped for
+    // every runtime family from its own decode choke point: first JSONL line
+    // (claude-stream-json), first decoded stream event (json-event-stream /
+    // qoder / pi-rpc), first non-empty stdout chunk (plain), or first ACP
+    // JSON-RPC message (acp-json-rpc). `sessionInitDoneAt` is only observable
+    // for ACP (the resume/`session/new` ack); for stream/plain families that
+    // gap is folded into `spawn_to_first_token_remainder_ms` rather than
+    // anchored to a fabricated marker. Both are first-write-wins like
+    // `firstTokenAt` so a later chunk cannot move an already-stamped boundary.
+    const noteCliReadyAt = (timestamp = Date.now()) => {
+      if (run.analyticsTelemetry?.cliReadyAt) return;
+      run.analyticsTelemetry = {
+        ...(run.analyticsTelemetry ?? {}),
+        cliReadyAt: timestamp,
+      };
+    };
+    const noteSessionInitDoneAt = (timestamp = Date.now()) => {
+      if (run.analyticsTelemetry?.sessionInitDoneAt) return;
+      run.analyticsTelemetry = {
+        ...(run.analyticsTelemetry ?? {}),
+        sessionInitDoneAt: timestamp,
+      };
+    };
     const noteFirstTokenFromAgentEvent = (ev) => {
       if (ev?.type && FIRST_TOKEN_AGENT_EVENT_TYPES.has(ev.type)) {
         noteFirstTokenAt();
@@ -9398,6 +9422,9 @@ export async function startServer({
         }));
         return;
       }
+      // First well-formed decoded stream event = CLI ready for the
+      // json-event-stream / qoder / pi-rpc families (#3408 §4 marker).
+      noteCliReadyAt();
       lastAgentEventPhase = summarizeAgentEventForInactivity(ev);
       noteAgentActivity();
       // Role-marker guard for qoder / json-event-stream / pi-rpc (#3247).
@@ -9435,6 +9462,9 @@ export async function startServer({
 
     if (def.streamFormat === 'claude-stream-json') {
       const claude = createClaudeStreamHandler((ev) => {
+        // First parsed claude-stream-json event = CLI ready (#3408 §4); the
+        // init/system line arrives well before the model's first token.
+        noteCliReadyAt();
         if (ev?.type === 'error') {
           if (agentStreamError) return;
           flushVisibleAgentStderr();
@@ -9594,6 +9624,8 @@ export async function startServer({
         mcpServers,
         envFormat: def.acpMcpEnvFormat ?? 'array',
         ...(def.id === 'amr' ? { modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE' } : {}),
+        onCliReady: () => noteCliReadyAt(),
+        onSessionInit: () => noteSessionInitDoneAt(),
         send: (event, data) => {
           if (event === 'agent') {
             lastAgentEventPhase = summarizeAgentEventForInactivity(data);
@@ -9659,6 +9691,10 @@ export async function startServer({
       child.stdout.on('data', (chunk) => {
         noteAgentActivity();
         const text = typeof chunk === 'string' ? chunk : String(chunk);
+        // First non-empty stdout chunk = CLI ready for the plain family
+        // (#3408 §4 marker). A plain adapter has no structured preamble, so
+        // this typically coincides with its first model output.
+        if (text.length > 0) noteCliReadyAt();
         const visibleText = titleMarkerStripper.strip(text);
         const safe = guardTextDelta(visibleText);
         if (safe.length > 0) {

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -647,12 +647,76 @@ describe('summarizeRunTimingAnalytics', () => {
       process_spawn_duration_ms: 60,
       time_to_first_token_ms: 1300,
       spawn_to_first_token_ms: 740,
+      // No subsegment markers were observed, so the whole spawn->first-token
+      // span is unattributed and falls into the remainder.
+      spawn_to_first_token_remainder_ms: 740,
       generation_duration_ms: 5500,
       tool_call_count: 2,
       tool_duration_ms: 650,
       finalize_duration_ms: 20,
       total_duration_ms: 7020,
     });
+  });
+
+  it('splits spawn->first-token into subsegments that sum back exactly', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 8_000,
+      analyticsCapturedAt: 8_020,
+      telemetry: {
+        startChatRunStartedAt: 1_200,
+        processSpawnStartedAt: 1_700,
+        processSpawnedAt: 1_760,
+        // 1760 -> 1900 cli-ready, 1900 -> 2100 session-init, 2100 -> 2500 model.
+        cliReadyAt: 1_900,
+        sessionInitDoneAt: 2_100,
+        firstTokenAt: 2_500,
+      },
+      events: [],
+    });
+
+    expect(result.spawn_to_first_token_ms).toBe(740);
+    expect(result.cli_ready_ms).toBe(140);
+    expect(result.session_init_ms).toBe(200);
+    expect(result.model_first_token_ms).toBe(400);
+    expect(result.spawn_to_first_token_remainder_ms).toBe(0);
+    // The auditable invariant: the four parts reconstruct the parent span.
+    expect(
+      (result.cli_ready_ms ?? 0) +
+        (result.session_init_ms ?? 0) +
+        (result.model_first_token_ms ?? 0) +
+        (result.spawn_to_first_token_remainder_ms ?? 0),
+    ).toBe(result.spawn_to_first_token_ms);
+  });
+
+  it('folds an unobservable session-init boundary into the remainder', () => {
+    // Stream/plain families stamp cliReadyAt but never sessionInitDoneAt, so
+    // session_init/model_first_token stay undefined and their time rolls into
+    // the remainder while the sum invariant still holds.
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 8_000,
+      analyticsCapturedAt: 8_020,
+      telemetry: {
+        startChatRunStartedAt: 1_200,
+        processSpawnedAt: 1_760,
+        cliReadyAt: 1_900,
+        firstTokenAt: 2_500,
+      },
+      events: [],
+    });
+
+    expect(result.spawn_to_first_token_ms).toBe(740);
+    expect(result.cli_ready_ms).toBe(140);
+    expect(result.session_init_ms).toBeUndefined();
+    expect(result.model_first_token_ms).toBeUndefined();
+    expect(result.spawn_to_first_token_remainder_ms).toBe(600);
+    expect(
+      (result.cli_ready_ms ?? 0) +
+        (result.session_init_ms ?? 0) +
+        (result.model_first_token_ms ?? 0) +
+        (result.spawn_to_first_token_remainder_ms ?? 0),
+    ).toBe(result.spawn_to_first_token_ms);
   });
 
   it('drops negative timing segments and ignores orphan tool results', () => {

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -2716,6 +2716,14 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   process_spawn_duration_ms?: number;
   time_to_first_token_ms?: number;
   spawn_to_first_token_ms?: number;
+  // `spawn_to_first_token_ms` split into auditable subsegments so dashboards
+  // can separate local CLI startup from session handshake from provider
+  // first-token latency. The four parts sum back to `spawn_to_first_token_ms`
+  // (absent subsegments count as 0 and roll into the remainder).
+  cli_ready_ms?: number;
+  session_init_ms?: number;
+  model_first_token_ms?: number;
+  spawn_to_first_token_remainder_ms?: number;
   generation_duration_ms?: number;
   tool_call_count?: number;
   tool_duration_ms?: number;


### PR DESCRIPTION
## Why

Part of the reliability push tracked in #3408 (§4 main-path segment timing) and the latency-profiling spec in #4504. The run-finished telemetry currently reports the whole `processSpawnedAt -> firstTokenAt` gap as a single `spawn_to_first_token_ms`. The 0.10.0 dashboard readout on #3408 shows this span is the dominant cost for `claude_code` / `codex_cli` first-token latency, but with one opaque number there is no way to tell whether ~8–10s went to local CLI startup, the session handshake, or the provider model call — so we cannot pick the right fix (warmed process pool vs session reuse vs provider-side).

This is the Phase 1 instrumentation the spec asks to land before any fix work: split the span into auditable subsegments at one choke point, no behavior change.

## What users will see

Nothing in the product UI — this is observability only. Analytics consumers (PostHog `run_finished`, Langfuse traces) gain four new optional fields that decompose `spawn_to_first_token_ms`, so dashboards can separate local CLI startup from session handshake from provider first-token latency.

## What changed

- New `run_finished` timing fields: `cli_ready_ms`, `session_init_ms`, `model_first_token_ms`, and `spawn_to_first_token_remainder_ms`. By construction the four sum back to `spawn_to_first_token_ms` (absent subsegments count as 0 and roll into the remainder).
- Derived at the existing `summarizeRunTimingAnalytics` choke point — no new failure/telemetry emitter.
- `cli_ready_ms` marker is declared per runtime family (one auditable signal each, per the spec's contract):
  - `claude-stream-json` → first parsed JSONL event
  - `json-event-stream` (codex/gemini/cursor) → first decoded stream event
  - `acp-json-rpc` (AMR/devin/hermes) → first well-formed ACP JSON-RPC message
  - `plain` → first non-empty stdout chunk
- `session_init_ms` is only anchored where a real handshake exists (the ACP `session/new` ack, threaded out of `acp.ts` via two best-effort callbacks). For stream/plain families that have no observable session boundary, the time honestly folds into the remainder rather than a fabricated marker — matching the spec's nullable-when-unobservable principle.
- The fields ride the existing shared analytics contract, so they mirror to both PostHog props and the Langfuse trace via the existing spreads; no divergent surface.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

The only surface is the analytics contract: four optional `run_finished` timing fields added to `packages/contracts/src/analytics/events.ts`. No `/api/*` endpoint or SSE event changes. The daemon-side derivation and ACP marker plumbing are internal; there is no UI, CLI, i18n, dependency, or default-behavior change (pure observability).

## Testing

- `pnpm --filter @open-design/daemon exec vitest run tests/run-analytics-observability.test.ts` — 26/26, including the sum invariant `cli_ready + session_init + model_first_token + remainder === spawn_to_first_token` and the stream/plain fold-into-remainder case.
- `pnpm --filter @open-design/daemon exec vitest run tests/langfuse-trace.test.ts tests/langfuse-bridge.test.ts tests/acp.test.ts` — 136/136 (mirror + ACP callbacks unaffected).
- `pnpm --filter @open-design/contracts typecheck` and `pnpm --filter @open-design/daemon typecheck` — clean.

Pure observability; no runtime behavior changed.
