### PR TITLE
ci: reduce Blacksmith usage and stabilize PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,7 +453,7 @@ jobs:
     name: Workspace unit tests
     needs: [scopes]
     if: ${{ needs.scopes.outputs.run_workspace_unit_tests == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     steps:
@@ -718,8 +718,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace

--- a/.github/workflows/comment.atom.yml
+++ b/.github/workflows/comment.atom.yml
@@ -9,7 +9,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: comment-${{ github.event.workflow_run.id }}

--- a/.github/workflows/report.atom.yml
+++ b/.github/workflows/report.atom.yml
@@ -9,7 +9,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: report-${{ github.event.workflow_run.id }}
@@ -324,11 +324,29 @@ jobs:
               | tail -n 1 || true
           )"
           if [ -n "$comment_id" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" --input "$payload_file" >/dev/null
-            echo "Updated visual report comment on PR $PR_NUMBER."
+            if gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" --input "$payload_file" >/dev/null; then
+              echo "Updated visual report comment on PR $PR_NUMBER."
+            else
+              echo "::warning title=Visual report comment update failed::Generated the visual report, but GitHub rejected updating the PR comment."
+              {
+                echo "### Visual report comment update failed"
+                echo
+                echo "The visual report was generated, but GitHub rejected updating the PR comment."
+                echo "Use the uploaded visual report artifact from this run."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           else
-            gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" --input "$payload_file" >/dev/null
-            echo "Created visual report comment on PR $PR_NUMBER."
+            if gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" --input "$payload_file" >/dev/null; then
+              echo "Created visual report comment on PR $PR_NUMBER."
+            else
+              echo "::warning title=Visual report comment creation failed::Generated the visual report, but GitHub rejected creating the PR comment."
+              {
+                echo "### Visual report comment creation failed"
+                echo
+                echo "The visual report was generated, but GitHub rejected creating the PR comment."
+                echo "Use the uploaded visual report artifact from this run."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
 
       - name: Upload visual report artifact

--- a/e2e/lib/playwright/suites.ts
+++ b/e2e/lib/playwright/suites.ts
@@ -34,7 +34,7 @@ export const uiP0Groups = {
       "ui/settings-connectors-auth-recovery.test.ts",
     ],
   },
-  "project-runtime": {
+  "project-workspace": {
     grep: String.raw`\[P0\]`,
     files: [
       "ui/app.test.ts",
@@ -42,6 +42,11 @@ export const uiP0Groups = {
       "ui/app-manual-edit.test.ts",
       "ui/project-management-flows.test.ts",
       "ui/workspace-keyboard-flows.test.ts",
+    ],
+  },
+  "project-runtime": {
+    grep: String.raw`\[P0\]`,
+    files: [
       "ui/real-daemon-run.test.ts",
       "ui/amr-run-failure-recovery.test.ts",
       "ui/amr-logout-requires-relogin.test.ts",
@@ -54,6 +59,7 @@ export type UiP0GroupName = keyof typeof uiP0Groups;
 
 export const uiP0CiMatrix = [
   { name: "entry-settings", shard: "entry-settings" },
+  { name: "project-workspace", shard: "project-workspace" },
   { name: "project-runtime", shard: "project-runtime" },
   { name: "workspace-restoration", shard: "workspace-restoration" },
 ] as const satisfies readonly UiP0CiMatrixEntry[];

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -223,6 +223,19 @@ describe("packaged smoke workflow", () => {
     });
   });
 
+  it("[P2] keeps the lightweight unit workspace check on GitHub hosted runners", async () => {
+    const workflow = await readFile(ciWorkflowPath, "utf8");
+    const workspaceUnitTests = sectionBetween(workflow, "  workspace_unit_tests:", "  windows_tools_pack_payload_tests:");
+    const webWorkspaceTests = sectionBetween(workflow, "  web_workspace_tests:", "  e2e_vitest:");
+    const uiP0 = sectionBetween(workflow, "  ui_p0:", "  playwright_visual:");
+    const visual = sectionBetween(workflow, "  playwright_visual:", "  docker_pr:");
+
+    expect(workspaceUnitTests).toContain("runs-on: ubuntu-24.04");
+    expect(webWorkspaceTests).toContain("runs-on: blacksmith-4vcpu-ubuntu-2404");
+    expect(uiP0).toContain("runs-on: blacksmith-8vcpu-ubuntu-2404");
+    expect(visual).toContain("runs-on: blacksmith-8vcpu-ubuntu-2404");
+  });
+
   it("[P2] routes CI follow-ons through generic handoff workflows", async () => {
     const [ciWorkflow, commentWorkflow, autofixWorkflow, reportWorkflow, handoffScript] = await Promise.all([
       readFile(ciWorkflowPath, "utf8"),
@@ -242,11 +255,14 @@ describe("packaged smoke workflow", () => {
     expect(ciWorkflow).not.toContain("visual-pr-comment");
     expect(commentWorkflow).toContain("artifact-pattern comment");
     expect(commentWorkflow).toContain("merge-multiple: false");
+    expect(commentWorkflow).toContain("pull-requests: write");
     expect(autofixWorkflow).toContain("artifact-pattern autofix");
     expect(autofixWorkflow).toContain("allowed_paths");
     expect(reportWorkflow).toContain("artifact-pattern report");
     expect(reportWorkflow).toContain("scripts/visual-report.ts compare-pr");
     expect(reportWorkflow).toContain("R2_ACCESS_KEY_ID");
+    expect(reportWorkflow).toContain("pull-requests: write");
+    expect(reportWorkflow).toContain("Visual report comment creation failed");
     expect(reportWorkflow).toContain("jq -n --rawfile body");
     expect(reportWorkflow).toContain("--input");
     expect(reportWorkflow).not.toContain("handoff.py dir comment");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -9,6 +9,8 @@ import { promisify } from "node:util";
 
 import { describe, expect, it } from "vitest";
 
+import { uiP0CiMatrix, uiP0Groups } from "../lib/playwright/suites.ts";
+
 const execFileAsync = promisify(execFile);
 const e2eRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = dirname(e2eRoot);
@@ -233,6 +235,20 @@ describe("packaged smoke workflow", () => {
     expect(workspaceUnitTests).toContain("runs-on: ubuntu-24.04");
     expect(webWorkspaceTests).toContain("runs-on: blacksmith-4vcpu-ubuntu-2404");
     expect(uiP0).toContain("runs-on: blacksmith-8vcpu-ubuntu-2404");
+    expect(uiP0).toContain("include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}");
+    expect(uiP0CiMatrix.map((entry) => entry.name)).toEqual([
+      "entry-settings",
+      "project-workspace",
+      "project-runtime",
+      "workspace-restoration",
+    ]);
+    expect(uiP0Groups["project-workspace"].files).toEqual([
+      "ui/app.test.ts",
+      "ui/app-design-files.test.ts",
+      "ui/app-manual-edit.test.ts",
+      "ui/project-management-flows.test.ts",
+      "ui/workspace-keyboard-flows.test.ts",
+    ]);
     expect(visual).toContain("runs-on: blacksmith-8vcpu-ubuntu-2404");
   });
 

--- a/e2e/ui/amr-logout-requires-relogin.test.ts
+++ b/e2e/ui/amr-logout-requires-relogin.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { expect, test } from '@/playwright/suite';
 
 import { writeFakeVelaBin } from '@/amr';
+import { T } from '@/timeouts';
 import {
   createProjectViaApi,
   gotoProject,
@@ -13,6 +14,8 @@ import {
   seedBrowserConfig,
   sendPrompt,
 } from '@/playwright/amr';
+
+test.describe.configure({ timeout: T.long });
 
 test('[P0] after local Sign out, AMR runs require re-login and Settings keeps AMR selected', async ({ page }) => {
   const root = join(tmpdir(), `open-design-amr-logout-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -10,7 +10,7 @@ const STORAGE_KEY = 'open-design:config';
 const TINY_PNG_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=';
 
-test.describe.configure({ timeout: 30_000 });
+test.describe.configure({ timeout: T.xlong });
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript((key) => {


### PR DESCRIPTION
## Why

This PR reduces Blacksmith usage where the data showed a clear win, while keeping the delivery-critical parallel topology intact. The main cost target is low-risk CI overhead: lightweight workspace checks that do not need Blacksmith capacity, plus an expensive full-history checkout in the visual path.

It also fixes two CI reliability issues found during the run:

- `report.atom` could generate and upload a visual report, then fail the job when GitHub rejected first-time PR comment creation with `Resource not accessible by integration`.
- `UI P0 (project-runtime)` was timing out in CI when the dev server had a cold-start/high-concurrency long tail, even though the failing screenshots showed loading or partially-ready app states rather than a product regression.

## What users will see

No product UI changes. Contributors should see lower Blacksmith consumption for the affected PR validation path, faster visual checkout, and a less flaky UI P0 project-runtime shard. Visual report artifacts remain available even when the PR comment write is rejected.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the workflow hardening: `e2e/tests/packaged-smoke-workflow.test.ts`
- Test paths adjusted for UI P0 timeout stability: `e2e/ui/app-design-files.test.ts`, `e2e/ui/amr-logout-requires-relogin.test.ts`
- Did the test go red on `main` and green on this branch? no; the workflow permission failure and CI cold-start timeout are only fully observable in GitHub Actions. This branch adds topology assertions for the workflow behavior, validates the affected UI P0 tests locally at CI worker parity, then uses this PR's Actions run as live validation.

## Validation

- `actionlint -color .github/workflows/ci.yml`
- `python3 .github/scripts/handoff.py self-check`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts`
- `OD_PLAYWRIGHT_WORKERS=4 pnpm -C e2e exec playwright test -c playwright.config.ts ui/app-design-files.test.ts ui/amr-logout-requires-relogin.test.ts --grep '\[P0\]'`
- `pnpm -C e2e typecheck`
- `git diff --check`
- CI: https://github.com/nexu-io/open-design/actions/runs/27928570762
