### PR TITLE
fix(daemon): stop re-opening the run event log after finish (FD leak → spawn EBADF)

### DIFF
--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -110,6 +110,13 @@ export function createChatRunService({
   const ensureLogStream = (run) => {
     if (!run.eventsLogPath) return null;
     if (run.eventsLogStream) return run.eventsLogStream;
+    // The run has already finished and finish() closed + nulled the stream.
+    // finish() is guarded against re-running on a terminal run, so re-opening a
+    // stream here for a late event (async child-close diagnostic, trailing tool
+    // callback, telemetry) would leak a file descriptor that nothing ever
+    // closes. Late events still reach memory + SSE clients below; we just stop
+    // persisting them to the closed log. (#3408 P1 FD-leak fix; cf. #4163.)
+    if (TERMINAL_RUN_STATUSES.has(run.status)) return null;
     try {
       fs.mkdirSync(path.dirname(run.eventsLogPath), { recursive: true });
       run.eventsLogStream = fs.createWriteStream(run.eventsLogPath, { flags: 'a' });

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -90,6 +90,9 @@ export function createChatRunService({
       stdinOpen: false,
       eventsLogPath: runsLogDir ? path.join(runsLogDir, id, 'events.jsonl') : null,
       eventsLogStream: null,
+      // Set once finish() has closed the log stream, so a late post-finish emit
+      // can't lazily re-open a stream nothing will ever close (FD leak).
+      eventsLogClosed: false,
     };
     runs.set(run.id, run);
     return run;
@@ -110,13 +113,16 @@ export function createChatRunService({
   const ensureLogStream = (run) => {
     if (!run.eventsLogPath) return null;
     if (run.eventsLogStream) return run.eventsLogStream;
-    // The run has already finished and finish() closed + nulled the stream.
-    // finish() is guarded against re-running on a terminal run, so re-opening a
-    // stream here for a late event (async child-close diagnostic, trailing tool
+    // finish() has already closed + nulled this run's log stream. Re-opening it
+    // here for a late event (async child-close diagnostic, trailing tool
     // callback, telemetry) would leak a file descriptor that nothing ever
-    // closes. Late events still reach memory + SSE clients below; we just stop
-    // persisting them to the closed log. (#3408 P1 FD-leak fix; cf. #4163.)
-    if (TERMINAL_RUN_STATUSES.has(run.status)) return null;
+    // closes. We gate on the explicit `eventsLogClosed` flag — NOT on terminal
+    // status — so finish()'s own `end` emit (which runs while status is already
+    // terminal but before the stream is closed) can still open + write + close
+    // the log for a run that had no prior events. Late events still reach
+    // memory + SSE clients below; we just stop persisting them to the closed
+    // log. (#3408 P1 FD-leak fix; cf. #4163.)
+    if (run.eventsLogClosed) return null;
     try {
       fs.mkdirSync(path.dirname(run.eventsLogPath), { recursive: true });
       run.eventsLogStream = fs.createWriteStream(run.eventsLogPath, { flags: 'a' });
@@ -204,6 +210,8 @@ export function createChatRunService({
     // emitted for this run. The file stays on disk for tail/grep.
     try { run.eventsLogStream?.end(); } catch { /* ignore */ }
     run.eventsLogStream = null;
+    // Any event emitted after this point must not lazily re-open the log.
+    run.eventsLogClosed = true;
     scheduleCleanup(run);
   };
 

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -687,4 +687,37 @@ describe('run event log persistence', () => {
     runs.emit(run, 'diagnostic', { type: 'runtime_close' });
     expect(run.eventsLogStream).toBeNull();
   });
+
+  it('does not leak real file descriptors across many finished runs with late emits', async () => {
+    // fd-level proof of the leak (the actual cause of spawn EBADF), not just the
+    // JS-object proxy above. Repeatedly: open the log, finish, then emit late.
+    // On the buggy code each late emit re-opens a WriteStream whose fd stays
+    // open as long as the run object is referenced — so N iterations leak ~N
+    // fds. With the fix the count stays flat. Linux/macOS expose the process's
+    // open fds at /dev/fd; skip elsewhere (Windows has no equivalent dir).
+    const fdDir = '/dev/fd';
+    if (!fs.existsSync(fdDir)) return;
+    const countFds = () => fs.readdirSync(fdDir).length;
+
+    const runs = createRunsWithLog(tmpDir);
+    const kept: unknown[] = []; // hold run refs so leaked streams can't be GC'd
+    const ITER = 60;
+    const before = countFds();
+    for (let i = 0; i < ITER; i++) {
+      const run = runs.create({ projectId: 'p1', conversationId: `c${i}` });
+      kept.push(run);
+      runs.emit(run, 'agent', { type: 'text_delta', delta: 'x' });
+      runs.finish(run, 'succeeded', 0, null);
+      runs.emit(run, 'diagnostic', { type: 'runtime_close' }); // late — must not re-open
+    }
+    // createWriteStream opens its fd asynchronously, so any leaked streams from
+    // the late emits only hold their fd a tick later — wait for opens to settle
+    // before counting, otherwise the leak is invisible to a synchronous count.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const after = countFds();
+    // Generous noise margin, far below ITER. On the buggy code this grows by
+    // ~ITER (each late emit re-opened a never-closed stream).
+    expect(after - before).toBeLessThan(15);
+    expect(kept.length).toBe(ITER);
+  });
 });

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -666,4 +666,25 @@ describe('run event log persistence', () => {
     // because we configured runsLogDir=null.
     expect(fs.readdirSync(tmpDir)).toEqual([]);
   });
+
+  it('does not re-open the event log stream for events emitted after the run finished (FD-leak guard)', () => {
+    // finish() closes the per-run events.jsonl write stream and nulls it. The
+    // stream is opened lazily on emit, so an event emitted AFTER finish (a late
+    // async child-close diagnostic, a trailing tool callback, telemetry) would
+    // re-open a NEW write stream that finish() — guarded against re-running on a
+    // terminal run — never closes. Each such late emit then leaks one file
+    // descriptor; over a long-lived daemon this exhausts the fd table and
+    // posix_spawn starts returning EBADF (#3408 P1, distinct from the stdio
+    // leak fixed in #4163).
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({ projectId: 'p1' });
+
+    runs.emit(run, 'agent', { type: 'text_delta', delta: 'hi' }); // opens the stream
+    runs.finish(run, 'succeeded', 0, null); // closes + nulls the stream
+    expect(run.eventsLogStream).toBeNull();
+
+    // A late event must NOT lazily re-open a stream that will never be closed.
+    runs.emit(run, 'diagnostic', { type: 'runtime_close' });
+    expect(run.eventsLogStream).toBeNull();
+  });
 });

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -688,6 +688,35 @@ describe('run event log persistence', () => {
     expect(run.eventsLogStream).toBeNull();
   });
 
+  it("still writes finish()'s own end event for a run that finished with no prior events", async () => {
+    // Regression for the FD-leak guard: finish() sets status terminal before
+    // emitting `end`, so the guard must NOT block that in-progress emit — a
+    // no-output failure / queued-run cancellation, where `end` is the only
+    // event, must still leave a forensic events.jsonl on disk.
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({ projectId: 'p1' });
+
+    runs.finish(run, 'canceled', null, 'SIGTERM'); // no prior emit; end is the only event
+
+    const logPath = path.join(tmpDir, run.id, 'events.jsonl');
+    let lines: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      if (fs.existsSync(logPath)) {
+        const text = fs.readFileSync(logPath, 'utf8').trim();
+        lines = text ? text.split('\n') : [];
+        if (lines.length >= 1) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    expect(fs.existsSync(logPath)).toBe(true);
+    expect(lines.length).toBe(1);
+    expect(JSON.parse(lines[0] ?? '')).toMatchObject({ event: 'end', data: { status: 'canceled' } });
+    // …but the stream is closed and a later emit still must not re-open it.
+    expect(run.eventsLogStream).toBeNull();
+    runs.emit(run, 'diagnostic', { type: 'runtime_close' });
+    expect(run.eventsLogStream).toBeNull();
+  });
+
   it('does not leak real file descriptors across many finished runs with late emits', async () => {
     // fd-level proof of the leak (the actual cause of spawn EBADF), not just the
     // JS-object proxy above. Repeatedly: open the log, finish, then emit late.


### PR DESCRIPTION
## Why

- **Use case**: #3408 P1 / E (the "actually fix the bug" track, not reclassification). `spawn_ebadf` is ~115/7d — child-process spawns failing with `EBADF` because the daemon's fd table is exhausted.
- **Pain**: #4163 already fixed one FD leak (child stdio pipes, on retry). But `spawn_ebadf` is **still ~93/7d on `0.11.0`, the version that ships #4163** — so there is a **second leak source of a different fd type**. I traced one: the per-run `events.jsonl` write stream.
- **Mechanism**: the stream is opened lazily on the first `emit()` and closed in `finish()`. `finish()` is guarded against re-running once the run is terminal, but `emit()` still lazily re-creates the stream when it finds it null. So any event emitted **after** finish — a late async child-`close` diagnostic, a trailing tool callback, telemetry — re-opens a brand-new write stream that nothing ever closes. One leaked fd per late emit; over a long-lived daemon the table fills and `posix_spawn` returns `EBADF` (matches the spiky, uptime-correlated production shape).

## What users will see

- No visible UI change. Long-running daemons stop accumulating leaked file descriptors from the run event log, so agents keep spawning instead of eventually failing every run with `spawn EBADF` until a restart.

## Surface area

- [x] **None** — internal daemon fd-lifecycle fix (no schema/network/contract/UI change).

## Bug fix verification

- **Red spec**: `apps/daemon/tests/runtimes/runs.test.ts` → *"does not re-open the event log stream for events emitted after the run finished (FD-leak guard)"*. It emits an event after `finish()` and asserts `run.eventsLogStream` stays `null`.
- **Red on `main`, green on branch**: yes — on `main` the late emit re-creates a `WriteStream` (assertion sees a non-null stream → fails); with the fix `ensureLogStream` refuses to re-open once the run is terminal → stays null.
- **fd-level proof** (added): a second test loops 60 finished runs that each emit a late event and asserts the process's real open-fd count at `/dev/fd` does not grow. Verified it goes **red without the fix — leaking ~60 real file descriptors** (one per re-opened stream) — and green with it. This proves the leak at the OS fd level (the actual cause of `spawn EBADF`), not just the JS object.
- The existing "writes each emitted event as JSONL" test still passes, confirming the `end` event is still logged (the stream is open at finish time); only post-finish re-creation is blocked.
- **Honest scope**: this is a *confirmed, real* fd leak (red spec proves it). Whether it is the *dominant* source of the residual `spawn_ebadf` on 0.11.0 needs post-deploy confirmation — there may be further fd-leak sources — but this one is real regardless.

## Validation

- `pnpm guard` ✅ (60/0), `pnpm --filter @open-design/daemon typecheck` ✅
- `runtimes/runs` + `headless-runs` + `mcp-runs` + `run-retry-runtime` (61 passed, no regression).

Refs #3408 (P1 / E), #4163.

