### PR TITLE
fix(opencode): add --pure flag to default buildArgs

### DIFF
--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -42,6 +42,7 @@ export const opencodeAgentDef = {
         'run',
         '--format',
         'json',
+        '--pure',
       ];
       if (options.model && options.model !== 'default') {
         args.push('-m', options.model);


### PR DESCRIPTION
## Summary

The `--pure` flag disables CLI plugins during non-interactive `opencode run --format json` calls.
Without it, plugins like `oh-my-openagent` may silently exit under non-TTY stdout (pipe mode),
causing the daemon to report "Agent completed without producing any output."

The connection test (`connectionTest.ts`) already applies `--pure` for the same reason;
this change extends it to regular chat runs.

## Changes

- `apps/daemon/src/runtimes/defs/opencode.ts`: Added `--pure` to the default buildArgs

## Motivation

When Open Design spawns opencode via `child_process.spawn()`, stdout is a pipe
(`isTTY=false`). OpenCode's plugins (e.g. `oh-my-openagent`) detect the non-TTY
environment and exit without producing any output on stdout. The `--pure` flag
tells opencode to skip plugin loading, allowing the JSON event stream to flow
correctly.

## Testing

Tested on OpenHarmony (arm64) with opencode 1.14.33-ohos:

```bash
echo "Just say hello" | opencode run --format json --pure
# → {"type":"step_start",...}
# → {"type":"text",...,"text":"Hello",...}
# → {"type":"step_finish",...}
```

The SSE event stream now delivers `text_delta` events and the run completes with
`status: "succeeded"`.
