### PR TITLE
fix(web): hide empty tool_call/tool_call_update status rows in assistant process

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -2754,7 +2754,15 @@ function buildBlocks(events: AgentEvent[]): Block[] {
         ev.label === "running" ||
         ev.label === "requesting" ||
         ev.label === "thinking" ||
-        ev.label === "empty_response"
+        ev.label === "empty_response" ||
+        // Transient ACP tool-call markers (#4618). On the live SSE path the
+        // daemon normalizes these to `running` (TRANSIENT_ACP_STATUS_LABELS in
+        // providers/daemon.ts), which is already skipped above; the persisted-
+        // events path does not normalize, so they arrive here as bare labels
+        // with no tool name/input/output/detail and would otherwise render as
+        // empty, expandable "tool ran but produced no output" status pills.
+        ev.label === "tool_call" ||
+        ev.label === "tool_call_update"
       )
         continue;
       const last = out[out.length - 1];

--- a/apps/web/tests/components/assistant-message-tool-status.test.tsx
+++ b/apps/web/tests/components/assistant-message-tool-status.test.tsx
@@ -207,6 +207,44 @@ describe('AssistantMessage tool status', () => {
     expect(container.querySelector('.op-status-ok')).toBeNull();
   });
 
+  it('hides empty tool_call / tool_call_update status rows (no displayable detail) (#4618)', () => {
+    const { container } = render(
+      <AssistantMessage
+        projectKind="prototype"
+        conversationId="conv-1"
+        message={messageWithEvents([
+          { kind: 'status', label: 'tool_call' },
+          { kind: 'status', label: 'tool_call_update' },
+        ])}
+        streaming={false}
+        projectId="project-1"
+      />,
+    );
+
+    // These persisted ACP markers carry no tool name/input/output, so they must
+    // not surface as empty, expandable status pills.
+    expect(container.querySelector('[data-status="tool_call"]')).toBeNull();
+    expect(container.querySelector('[data-status="tool_call_update"]')).toBeNull();
+    expect(container.querySelector('.status-pill')).toBeNull();
+  });
+
+  it('still renders status rows that carry a displayable detail', () => {
+    const { container } = render(
+      <AssistantMessage
+        projectKind="prototype"
+        conversationId="conv-1"
+        message={messageWithEvents([
+          { kind: 'status', label: 'model', detail: 'claude-opus-4-7-high' },
+        ])}
+        streaming={false}
+        projectId="project-1"
+      />,
+    );
+
+    expect(container.querySelector('[data-status="model"]')).not.toBeNull();
+    expect(container.querySelector('.status-detail')?.textContent).toContain('claude-opus-4-7-high');
+  });
+
   it('renders URLs in JSON-like status details without trailing structural characters', () => {
     const { container } = render(
       <AssistantMessage


### PR DESCRIPTION
Closes #4618.

## Why

During manual QA of #4399, the assistant process panel showed internal empty status rows (`tool_call`, `tool_call_update`) that expand to nothing — making it look like "a tool ran but produced no output." The persisted events only carry `{ "kind": "status", "label": "tool_call" }` with no tool name, args, output, error, or detail.

Root cause (confirmed): `buildBlocks()` in `apps/web/src/components/AssistantMessage.tsx` filters a fixed list of internal status labels (`streaming`, `starting`, `running`, `requesting`, `thinking`, `empty_response`) before they reach `StatusPill`, but `tool_call`/`tool_call_update` aren't in it, so they render as raw label pills. These are **transient ACP markers**: on the live SSE path the daemon already normalizes them to `running` via `TRANSIENT_ACP_STATUS_LABELS` (`apps/web/src/providers/daemon.ts`) — which `buildBlocks()` skips — but the **persisted-events path doesn't normalize**, so the bare labels survive into the UI.

## What users will see

In the assistant process / trace panel, the empty `tool_call` and `tool_call_update` rows no longer appear. There's nothing to expand on them, so removing them eliminates the misleading "tool ran but produced no output" entries. Status rows that carry real content (e.g. `model: …`, publish URLs) are unaffected.

## What changed

- `AssistantMessage.tsx` — added `tool_call` and `tool_call_update` to the existing status-skip list in `buildBlocks()`, with a comment pointing at the daemon's `TRANSIENT_ACP_STATUS_LABELS` source of truth (chose **Option A (hide)** from the issue, as recommended — these events carry no displayable detail, so humanizing would still produce an empty, expandable row).
- `tests/components/assistant-message-tool-status.test.tsx` — red-spec test asserting the two empty rows render no `status-pill`, plus a guard that a status row with a real `detail` still renders.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — assistant process / trace panel rendering in `apps/web` (hides the empty `tool_call` / `tool_call_update` status rows)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — default model / setting / schema / auto-network / auto-install
- [ ] **None** — internal refactor, docs, tests, or translation update only

Tests: added a red→green spec in `apps/web/tests/components/assistant-message-tool-status.test.tsx`. No CLI/contract/skill/design-system/i18n/dependency surfaces touched.

## Screenshots

This is a "remove an erroneous row" fix, so the visual result is the *absence* of an element. Concretely, at the rendered-DOM level for a persisted `{ kind: "status", label: "tool_call" }` event in the assistant process panel:

- **Before:** a status pill renders for the bare label —
  `<… class="status-pill" data-status="tool_call">tool_call</…>` — an empty, expandable row with nothing inside it (same for `tool_call_update`).
- **After:** no element with `.status-pill` / `[data-status="tool_call"]` / `[data-status="tool_call_update"]` is emitted for those events; the row is gone. Rows that carry real `detail` (e.g. `model: …`) still render unchanged.

I've described this at the DOM level rather than attach a doctored image, since reproducing the *persisted-events* path in a screenshot needs a specific runtime state. The regression test below encodes exactly this before/after. Happy to add a Playwright capture/fixture for the assistant-process panel if you'd like it as a gate.

## Validation

- Red→green confirmed per the repo's bug-follow-up playbook: with the fix removed, the new `#4618` test fails (`status-pill` renders for `tool_call`); with the fix, it passes.
- **Regression coverage — added 2 tests** in `apps/web/tests/components/assistant-message-tool-status.test.tsx`: (1) the empty-row case — asserts a persisted `tool_call` / `tool_call_update` status renders no `.status-pill` / `[data-status="tool_call"]` / `[data-status="tool_call_update"]`; (2) the guard — a status row carrying displayable `detail` (`{ label: "model", detail: "claude-opus-4-7-high" }`) still renders, proving the skip list doesn't over-filter.
- `pnpm --filter @open-design/web exec vitest run tests/components/assistant-message-tool-status.test.tsx` → **10 passed** (8 existing + 2 new).
- `pnpm --filter @open-design/web typecheck` → clean.

## Adjacent issues (out of scope, noted per playbook)

- `TRANSIENT_ACP_STATUS_LABELS` in `providers/daemon.ts` also lists `waiting_for_first_output` and `session_update`. If those ever land on the persisted-events path, they'd hit the identical "raw empty pill" bug. A future refactor could export that set as the single source of truth and have `buildBlocks()` consume it, instead of maintaining two overlapping label lists. Kept out of this fix to stay scoped to the reported labels.