### PR TITLE
fix(web): make full-screen present-exit button dark-mode aware

### DIFF
--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -331,12 +331,12 @@
   align-items: center;
   padding: 6px 12px;
   font-size: 12px;
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   cursor: pointer;
 }
-.present-exit:hover { background: white; }
+.present-exit:hover { background: var(--bg-muted); }
 
 /* Picker (legacy in some surfaces) */
 .picker {


### PR DESCRIPTION
Closes #4592.

## Why

The full-screen presentation exit button (`.present-exit` in `apps/web/src/styles/viewer/composio.css`) hardcoded `rgba(255, 255, 255, 0.92)` as its background (and `white` on hover). In dark theme it renders as a bright white rectangle floating over dark content — visually jarring and inconsistent with the in-tab exit button, which was already fixed in #4590.

## What users will see

In dark mode, the full-screen present-exit button now blends with the theme (dark elevated surface) instead of appearing as a glaring white box; in light mode it looks the same as before. Hover uses the muted surface token.

## What changed

`apps/web/src/styles/viewer/composio.css` — `.present-exit`:
- `background: rgba(255, 255, 255, 0.92)` → `background: var(--bg-elevated)`
- `:hover { background: white }` → `:hover { background: var(--bg-muted) }`

This mirrors the #4590 fix for the sibling `.present-exit-btn`. Both tokens are defined for light and dark themes in `apps/web/src/styles/tokens.css` (`--bg-elevated`: `#fffefc` / `#2a2825`, `--bg-muted`: `#eef1f5` / `#2e2c29`), so the button is now theme-aware in both directions and keeps using the existing `var(--border)` border.

## Surface area

- [x] `apps/web` UI styling (viewer/present overlay)
- No CLI/contract/test/i18n/dependency surfaces touched (CSS-only token swap).

## Validation

CSS-only change; verified the `.present-exit` rule matches the issue, the swapped tokens exist and are theme-aware in `tokens.css`, and the approach is identical to the merged #4590 fix. (No behavioral/JS surface, so no unit test; a quick dark-mode visual check on the full-screen present overlay confirms the white box is gone.)