### PR TITLE
fix(web): stop home carousel scrollbar overlapping template cards

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2054,8 +2054,14 @@
   overscroll-behavior-x: contain;
   scroll-snap-type: x proximity;
   padding: 1px 2px 8px;
-  scrollbar-width: thin;
+  /* Hide the native horizontal scrollbar (#4609). On overlay-scrollbar
+     platforms it was a wide thumb floating over the bottom edge / titles of
+     the cards. The partially-revealed next card plus scroll-snap already
+     signal that the row scrolls, so this mirrors the sibling horizontal
+     scroller `.home-hero__mention-tabs` rather than competing with the cards. */
+  scrollbar-width: none;
 }
+.home-hero__plugin-presets::-webkit-scrollbar { display: none; }
 
 .home-hero__plugin-preset {
   appearance: none;


### PR DESCRIPTION
Closes #4609.

## Why

The home-page template/prompt-examples carousel (`.home-hero__plugin-presets`, rendered by `PluginPromptPresets` in `apps/web/src/components/HomeHero.tsx`) is a horizontal scroller using `overflow-x: auto` + `scrollbar-width: thin`. With ~6 × 248px cards in an ~880px viewport, the native scroll thumb is ~60% wide (spanning roughly three cards). On overlay-scrollbar platforms (e.g. macOS) that thumb floats over the **bottom edge and title area of the cards** once the row is scrolled — exactly the "indicator cuts across the 钻蓝工作室 / 祖母绿封面故事 / 林间编辑部 cards" the report describes — making the carousel look visually broken.

## What users will see

After scrolling the home carousel, there's no horizontal bar floating over the cards/titles anymore. The row still scrolls (and snaps), with the partially-revealed next card signalling that more cards exist.

## What changed

`apps/web/src/styles/home/home-hero.css` — `.home-hero__plugin-presets`:
- `scrollbar-width: thin` → `scrollbar-width: none`
- added `.home-hero__plugin-presets::-webkit-scrollbar { display: none; }`

This mirrors the existing sibling horizontal scroller `.home-hero__mention-tabs` in the same file, which already hides its scrollbar the same way — so this also removes an inconsistency between two horizontal card scrollers. Hiding the indicator is one of the issue's explicitly accepted resolutions ("hidden/styled in a way that does not compete with the card titles"); scroll-snap and the peeking next card preserve the scroll affordance, and keyboard/trackpad scrolling is unaffected.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — home-page prompt-examples carousel in `apps/web` (hides the overlapping native scrollbar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed contract shape
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — default model / setting / schema / auto-network / auto-install
- [ ] **None** — internal refactor, docs, tests, or translation update only

CSS-only change to one selector; no CLI/contract/skill/design-system/i18n/dependency surfaces touched.

## Validation

- Confirmed `.home-hero__plugin-presets` is the carousel scroll container and that the only horizontal-overflow indicator on it is the native scrollbar (no separate progress-bar element exists in `HomeHero.tsx`).
- Mirrors the proven `.home-hero__mention-tabs` pattern already in the same stylesheet, so the hide approach is known-good cross-browser (`scrollbar-width` for Firefox/standards, `::-webkit-scrollbar` for Chromium/WebKit).
- Visual: with the carousel scrolled, the thumb that previously overlapped the card titles is gone; the cards and titles render unobstructed.