### PR TITLE
fix(web): show seven recent projects on wide home layouts

### DIFF
--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -55,15 +55,17 @@ export function RecentProjectsStrip({
   const rowRef = useRef<HTMLDivElement | null>(null);
   const [responsiveLimit, setResponsiveLimit] = useState(DEFAULT_RECENT_PROJECT_LIMIT);
   const resolvedLimit = limit ?? responsiveLimit;
+  const hasRecentProjects = projects.length > 0;
 
   useEffect(() => {
     if (limit !== undefined) return;
 
-    const node = rowRef.current;
     const update = () => {
-      const rowWidth =
-        node?.getBoundingClientRect().width ??
-        (typeof window === 'undefined' ? 0 : window.innerWidth);
+      const rowWidth = rowRef.current?.getBoundingClientRect().width;
+      if (rowWidth === undefined) {
+        setResponsiveLimit(DEFAULT_RECENT_PROJECT_LIMIT);
+        return;
+      }
       setResponsiveLimit(
         rowWidth >= WIDE_RECENT_PROJECT_MIN_ROW_WIDTH
           ? WIDE_RECENT_PROJECT_LIMIT
@@ -72,15 +74,18 @@ export function RecentProjectsStrip({
     };
 
     update();
+    const node = rowRef.current;
     if (node && typeof ResizeObserver !== 'undefined') {
       const observer = new ResizeObserver(update);
       observer.observe(node);
       return () => observer.disconnect();
     }
 
+    if (typeof window === 'undefined') return;
+
     window.addEventListener('resize', update);
     return () => window.removeEventListener('resize', update);
-  }, [limit]);
+  }, [hasRecentProjects, limit]);
 
   const recent = useMemo(
     () => [...projects]

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -35,6 +35,10 @@ const EMPTY_DESIGN_SYSTEMS: DesignSystemSummary[] = [];
 
 const DECK_PREVIEW_WIDTH = 1280;
 const DECK_PREVIEW_HEIGHT = 720;
+const DEFAULT_RECENT_PROJECT_LIMIT = 6;
+const WIDE_RECENT_PROJECT_LIMIT = 7;
+// 7 * 180px cards + 6 * 12px gaps, matching recent-projects.css.
+const WIDE_RECENT_PROJECT_MIN_ROW_WIDTH = 1332;
 const deckCoverCache = new Map<string, string>();
 const deckCoverInflight = new Map<string, Promise<string>>();
 
@@ -45,14 +49,44 @@ export function RecentProjectsStrip({
   onViewAll,
   onDelete,
   onRename,
-  limit = 6,
+  limit,
 }: Props) {
   const t = useT();
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const [responsiveLimit, setResponsiveLimit] = useState(DEFAULT_RECENT_PROJECT_LIMIT);
+  const resolvedLimit = limit ?? responsiveLimit;
+
+  useEffect(() => {
+    if (limit !== undefined) return;
+
+    const node = rowRef.current;
+    const update = () => {
+      const rowWidth =
+        node?.getBoundingClientRect().width ??
+        (typeof window === 'undefined' ? 0 : window.innerWidth);
+      setResponsiveLimit(
+        rowWidth >= WIDE_RECENT_PROJECT_MIN_ROW_WIDTH
+          ? WIDE_RECENT_PROJECT_LIMIT
+          : DEFAULT_RECENT_PROJECT_LIMIT,
+      );
+    };
+
+    update();
+    if (node && typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(update);
+      observer.observe(node);
+      return () => observer.disconnect();
+    }
+
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [limit]);
+
   const recent = useMemo(
     () => [...projects]
       .sort((a, b) => b.updatedAt - a.updatedAt)
-      .slice(0, limit),
-    [projects, limit],
+      .slice(0, resolvedLimit),
+    [projects, resolvedLimit],
   );
   const [coverByProject, setCoverByProject] = useState<
     Record<string, { kind: 'html' | 'image' | 'video' | 'logo'; name: string } | null>
@@ -201,6 +235,7 @@ export function RecentProjectsStrip({
         </button>
       </header>
       <div
+        ref={rowRef}
         className={`recent-projects__row${menuOpenId ? ' recent-projects__row--menu-open' : ''}`}
         role="list"
       >

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -51,6 +51,7 @@ vi.mock('../../src/providers/registry', () => ({
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -67,7 +68,71 @@ function project(overrides: Partial<Project>): Project {
   };
 }
 
+function projects(count: number): Project[] {
+  return Array.from({ length: count }, (_, index) =>
+    project({
+      id: `project-${index + 1}`,
+      name: `Project ${index + 1}`,
+      updatedAt: count - index,
+    }),
+  );
+}
+
 describe('RecentProjectsStrip', () => {
+  it('shows seven projects when the row has room for a seventh card', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getRect(this: HTMLElement) {
+      return {
+        x: 0,
+        y: 0,
+        width: this.classList.contains('recent-projects__row') ? 1332 : 180,
+        height: 100,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      };
+    });
+
+    const { container } = render(
+      <RecentProjectsStrip
+        projects={projects(8)}
+        onOpen={() => {}}
+        onViewAll={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.recent-projects__card')).toHaveLength(7);
+    });
+  });
+
+  it('keeps six projects when the row is below the wide-card threshold', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getRect(this: HTMLElement) {
+      return {
+        x: 0,
+        y: 0,
+        width: this.classList.contains('recent-projects__row') ? 1331 : 180,
+        height: 100,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      };
+    });
+
+    const { container } = render(
+      <RecentProjectsStrip
+        projects={projects(8)}
+        onOpen={() => {}}
+        onViewAll={() => {}}
+      />,
+    );
+
+    expect(container.querySelectorAll('.recent-projects__card')).toHaveLength(6);
+  });
+
   it('matches project cards with previews and design-system tags', async () => {
     const { container } = render(
       <RecentProjectsStrip

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -133,6 +133,45 @@ describe('RecentProjectsStrip', () => {
     expect(container.querySelectorAll('.recent-projects__card')).toHaveLength(6);
   });
 
+  it('remeasures when projects arrive after the initial empty render', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1400,
+    });
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getRect(this: HTMLElement) {
+      return {
+        x: 0,
+        y: 0,
+        width: this.classList.contains('recent-projects__row') ? 1331 : 180,
+        height: 100,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      };
+    });
+
+    const { container, rerender } = render(
+      <RecentProjectsStrip
+        projects={[]}
+        onOpen={() => {}}
+        onViewAll={() => {}}
+      />,
+    );
+
+    rerender(
+      <RecentProjectsStrip
+        projects={projects(8)}
+        onOpen={() => {}}
+        onViewAll={() => {}}
+      />,
+    );
+
+    expect(container.querySelectorAll('.recent-projects__card')).toHaveLength(6);
+  });
+
   it('matches project cards with previews and design-system tags', async () => {
     const { container } = render(
       <RecentProjectsStrip


### PR DESCRIPTION
Supersedes #4110.

This PR carries forward the same change from #4110, rebased onto the current `main`.

I wasn’t able to reopen the original PR from my side, so I opened this follow-up PR to keep the review moving. The implementation intent, screenshots, and focused test coverage remain the same as in #4110.

Fixes #4076

## Why

I hit the Home `Recent Projects` row looking under-filled on wide fullscreen layouts. The grid had enough room for a seventh card, but the strip still rendered six, leaving an empty slot on the right.

This keeps the common smaller layout compact while using the extra space when the row is actually wide enough.

## What users will see

On wide Home layouts, can show seven project cards in the first row.

Below the seven-card width threshold, it still shows six cards so most layouts do not gain an extra row.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

<img width="3480" height="1740" alt="image" src="https://github.com/user-attachments/assets/f90607e4-477c-46c2-a78c-062d355154ba" />
<img width="2860" height="1984" alt="image" src="https://github.com/user-attachments/assets/7b1afe6a-28af-44f3-9f2b-bed5b8bb0310" />




## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/RecentProjectsStrip.test.tsx`
- Red/green: yes. With the old fixed-six behavior restored temporarily, the wide-row test failed with `expected length 7 but got 6`; restoring this change made it pass.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/RecentProjectsStrip.test.tsx`