### PR TITLE
fix(web): keep the pinned Home tab opaque on hover so crowded tabs don't bleed through (#4446)

### DIFF
--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -831,6 +831,21 @@
     inset 0 0 0 1px color-mix(in srgb, var(--border) 58%, transparent),
     0 1px 2px color-mix(in srgb, var(--text) 5%, transparent);
 }
+/* The sticky Home tab must stay opaque on hover/focus: the translucent panel
+   wash above (color-mix(… 78%, transparent)) would otherwise let horizontally
+   scrolled project tabs bleed through the pinned tab when the strip is crowded.
+   Re-lay the opaque tab-bar background under that same wash so the hover/focus
+   affordance is preserved while the tab keeps blocking what scrolls behind it. */
+.workspace-shell .workspace-tab.is-pinned:not(.is-active):hover,
+.workspace-shell .workspace-tab.is-pinned:not(.is-active):focus-within {
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--bg-panel) 78%, transparent),
+      color-mix(in srgb, var(--bg-panel) 78%, transparent)
+    )
+    0 0 / 100% calc(100% - 2px) no-repeat,
+    var(--workspace-tab-bar-bg);
+}
 .workspace-shell .workspace-tab.is-dragging {
   background: var(--bg-panel);
   box-shadow: 0 14px 30px color-mix(in srgb, var(--text) 16%, transparent);

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -141,6 +141,32 @@ describe('workspace tabs chrome styles', () => {
     expect(ruleValue(hoverTab, 'box-shadow')).toContain('inset 0 0 0 1px');
   });
 
+  it('keeps the pinned Home tab opaque on hover/focus so crowded tabs cannot bleed through (#4446)', () => {
+    // The generic inactive-hover rule paints a translucent panel wash
+    // (color-mix(… 78%, transparent)) sized to calc(100% - 2px). Its specificity
+    // (0,4,0) outranks the pinned base rule (0,3,0) and sits later in the
+    // cascade, so without a pinned-specific override the sticky Home tab loses
+    // its opaque background on hover/focus and horizontally-scrolled project
+    // tabs bleed through it. The pinned tab needs its own hover/focus rule that
+    // re-lays the opaque tab-bar background under that wash.
+    const pinnedHover = cssDeclarations(
+      routinesCss,
+      '.workspace-shell .workspace-tab.is-pinned:not(.is-active):hover',
+    );
+    const pinnedFocus = cssDeclarations(
+      routinesCss,
+      '.workspace-shell .workspace-tab.is-pinned:not(.is-active):focus-within',
+    );
+
+    for (const block of [pinnedHover, pinnedFocus]) {
+      const background = ruleValue(block, 'background');
+      // Opaque base layer keeps scrolled tabs from bleeding through…
+      expect(background).toContain('var(--workspace-tab-bar-bg)');
+      // …while the translucent hover wash still rides on top for the affordance.
+      expect(background).toContain('calc(100% - 2px)');
+    }
+  });
+
   it('gives dragged tabs physical collision feedback', () => {
     const tab = cssDeclarations(shellCss, '.workspace-tab');
     const dragging = cssDeclarations(shellCss, '.workspace-tab.is-dragging');


### PR DESCRIPTION
Fixes #4446

## Why

I run Open Design with a lot of projects open, and once the tab strip gets crowded enough to scroll horizontally, hovering (or focusing) the pinned Home tab let the scrolled project tabs bleed through it — the Home tab stopped reading as a clean, opaque top layer and the strip looked visually broken. The Home tab is the primary navigation anchor, so it needs to stay solid exactly when the strip is busiest.

## Root cause

The pinned Home tab (`.workspace-shell .workspace-tab.is-pinned` in `viewer/routines.css`) is given an opaque `var(--workspace-tab-bar-bg)` background on purpose, so horizontally-scrolled project tabs pass behind it. But the generic inactive-hover rule `.workspace-shell .workspace-tab:not(.is-active):hover, …:focus-within` paints a translucent panel wash (`color-mix(… 78%, transparent)`) sized to `calc(100% - 2px)`. That rule's specificity (0,4,0) outranks the pinned base rule (0,3,0) and sits later in the cascade, so on hover/focus the Home tab loses its opaque base and the tabs behind it show through.

## What users will see

When the tab strip is crowded and scrolled, hovering or keyboard-focusing the Home tab now keeps it fully opaque — scrolled project tabs no longer bleed through. The hover/focus highlight itself is unchanged; only the bleed-through is fixed.

## Surface area

- [x] **Default behavior change** — the pinned Home tab stays opaque on hover/focus in the project workspace chrome.

## Screenshots

Project workspace, ~18 tabs open and the strip scrolled so project tabs sit behind the pinned Home tab, Home focused:

**Before** — scrolled tabs bleed through the translucent Home tab

<img width="900" src="https://github.com/user-attachments/assets/38e90507-1a63-4d79-b61f-722a4e9575b9" />

**After** — Home tab stays opaque

<img width="900" src="https://github.com/user-attachments/assets/d4bf67e7-832d-4646-ab81-dbb69a32a05b" />

## Bug fix verification

- Test path: `apps/web/tests/styles/workspace-tabs-chrome.test.ts`
- Red on `main`, green on this branch: yes. The new guard resolves the pinned Home tab's hover/focus rule and asserts it re-lays the opaque `var(--workspace-tab-bar-bg)` base under the translucent wash. On `main` there is no pinned-specific hover rule, so the assertion fails (the generic translucent wash wins); after adding the rule it passes.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test -- run workspace-tabs-chrome` (red → green)
