### PR TITLE
docs: correct PRIVACY.md to reflect telemetry is on by default (opt-out)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -17,9 +17,9 @@ It is an informed-disclosure notice with a single **I get it** acknowledgement,
 not an opt-in gate — and because telemetry is already enabled, the app may begin
 sending events (such as onboarding and UI-interaction events) from first launch.
 
-You stay in control: the banner footer and **Settings → Privacy** both expose a
-one-click opt-out, where each category below has its own toggle, and you can
-change your decision at any time.
+You stay in control: the banner footer tells you sharing is on and points you to
+**Settings → Privacy**, where you can turn telemetry off and toggle each category
+below — and you can change your decision at any time.
 
 ## What is collected
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -5,17 +5,23 @@ when it collects it, and how you stay in control. It documents the behavior
 shipped in the app — the same controls live under **Settings → Privacy**.
 
 Open Design is **local-first**. Your projects, generated files, and BYOK API
-keys stay on your machine. The app works fully offline; nothing in this page
-applies unless you explicitly turn telemetry on.
+keys stay on your machine, and the app works fully offline. Usage telemetry,
+described below, is the one category of data the app may send — it is **on by
+default**, and you can turn it off at any time under **Settings → Privacy**.
 
-## Telemetry is opt-in
+## Telemetry is opt-out
 
-Usage telemetry is **off by default**. On first run the app shows a privacy
-consent banner asking you to make a choice — it never starts sending anything
-before you do. You can change your decision at any time under
-**Settings → Privacy**, where each category below has its own toggle.
+Usage telemetry is **on by default**. On first run the app shows a privacy
+disclosure banner so you can see what is collected before doing anything else.
+It is an informed-disclosure notice with a single **I get it** acknowledgement,
+not an opt-in gate — and because telemetry is already enabled, the app may begin
+sending events (such as onboarding and UI-interaction events) from first launch.
 
-## What is collected when you opt in
+You stay in control: the banner footer and **Settings → Privacy** both expose a
+one-click opt-out, where each category below has its own toggle, and you can
+change your decision at any time.
+
+## What is collected
 
 When telemetry is enabled, the app may send the following to the Open Design
 team. Each category is independently controllable in Settings.


### PR DESCRIPTION
Closes #4558.

## Why

`PRIVACY.md` contradicted the shipped behavior, as the reporter (@UjuiUjuMandan) pinpointed and @lefarcen confirmed. The doc claimed telemetry is **opt-in / off by default** and that the app "never starts sending anything before you do" — but the code ships the opposite (opt-out / on by default).

**Verified against current `main`:**

- `apps/web/src/state/config.ts` (default config) ships `telemetry: { metrics: true, content: true }` — telemetry is **on by default**. The inline comment is explicit: *"Telemetry defaults to ON so fresh-install users emit onboarding / ui_click events from the first frame … Settings → Privacy remains the one-click opt-out."*
- `apps/web/src/components/PrivacyConsentModal.tsx` is an **informed-disclosure** banner with a single **I get it** acknowledgement (no opt-out choice inside it); its doc comment states *"the product runs with telemetry on by default"* and the `onAccept` prop *"implies default opt-in."*
- The daemon send-gate is `if (telemetry?.metrics !== true) return` — so with the default (`metrics: true`), events flow **before** the user makes any decision.
- History matches: PR #2682 flipped the default to on, PR #4131 reinforced the opt-out direction, and the revert-to-opt-in PR #3874 was **closed unmerged** — so opt-out is the current product direction. `PRIVACY.md` was simply never updated.

Per @lefarcen's guidance ("the documentation needs to accurately reflect whichever behavior actually ships"), this is a **docs-only** change — the code is the source of truth and is left untouched.

## What changed

`PRIVACY.md`:
- Intro: drop "nothing in this page applies unless you explicitly turn telemetry on"; state telemetry is **on by default** with a one-click off switch in **Settings → Privacy**.
- Heading **Telemetry is opt-in** → **Telemetry is opt-out**; rewrite the body to describe on-by-default behavior, the single **I get it** informed-disclosure banner (not an opt-in gate), and that onboarding/UI events may be sent from first launch. Keep the "you stay in control" path (banner footer + Settings → Privacy one-click opt-out, per-category toggles).
- Heading **What is collected when you opt in** → **What is collected** (the "when telemetry is enabled …" body and all collection/"never collected"/sending sections remain accurate and unchanged).

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand/flag or `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, SSE event, or contract shape
- [ ] **Extension point** — `skills/`, `design-systems/`, `design-templates/`, `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — root `package.json`
- [ ] **Default behavior change** — default model / setting / schema / auto-network / auto-install
- [x] **None** — documentation only (no code/behavior change; aligns `PRIVACY.md` with shipped behavior)

## Validation

- Cross-checked every corrected statement against the source of truth in `apps/web/src/state/config.ts`, `PrivacyConsentModal.tsx`, and the daemon analytics gate — the doc now matches the shipped opt-out model.
- The accurate sections (what is/isn't collected, how telemetry is sent, anonymous ID, deleting data, BYOK, AMR) are preserved verbatim.

## Adjacent finding (out of scope)

- `docs/roadmap.md:161` still lists "Telemetry (opt-in, …)" in a roadmap context, which is the same stale framing. Left out of this PR to keep the change scoped to the reported file (`PRIVACY.md`); happy to follow up if you'd like it aligned too. `CHANGELOG.md` references to "opt-in Langfuse telemetry" are historical entries and intentionally left as-is.