### PR TITLE
fix(daemon): stop local CLI auth probes misclassifying valid API-key and profile-based auth

### DIFF
--- a/apps/daemon/src/codex-config-normalize.ts
+++ b/apps/daemon/src/codex-config-normalize.ts
@@ -56,6 +56,101 @@ export function resolveCodexConfigPath(
 }
 
 /**
+ * Strip a trailing TOML comment from a line, honoring quoted strings so a `#`
+ * inside a quoted value (e.g. `env_key = "A#B"`) is preserved.
+ */
+function stripTomlComment(line: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    else if (ch === '"' && !inSingle) inDouble = !inDouble;
+    else if (ch === '#' && !inSingle && !inDouble) return line.slice(0, i);
+  }
+  return line;
+}
+
+/** Read a `key = "value"` (single- or double-quoted) string, or null. */
+function matchQuotedValue(line: string, key: string): string | null {
+  const match = new RegExp(`^${key}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`).exec(line);
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? '').trim();
+  return value.length > 0 ? value : null;
+}
+
+/**
+ * Resolve the `env_key` of the currently-selected Codex provider from a
+ * config.toml string, or null when there is no custom provider / env_key.
+ *
+ * Codex custom providers name the environment variable holding their API key
+ * via `env_key`, e.g.:
+ *
+ *   model_provider = "azure"
+ *   [model_providers.azure]
+ *   env_key = "AZURE_OPENAI_API_KEY"
+ *
+ * Consumed by the auth probe (`runtimes/auth.ts`) so a working custom-provider
+ * Codex install isn't reported as unauthenticated just because
+ * `codex login status` (a ChatGPT/OpenAI-login check) exits non-zero.
+ *
+ * Deliberately a narrow line scanner rather than a full TOML parse — matching
+ * this module's regex-scoped handling of config.toml (the daemon ships no TOML
+ * parser); it reads only the two fields it needs.
+ */
+export function extractCodexProviderEnvKey(toml: string): string | null {
+  const lines = String(toml || '').split(/\r?\n/);
+
+  // The selected provider is a root-table key, which in TOML must appear before
+  // the first `[table]` header.
+  let provider: string | null = null;
+  for (const raw of lines) {
+    const line = stripTomlComment(raw).trim();
+    if (line.startsWith('[')) break;
+    const value = matchQuotedValue(line, 'model_provider');
+    if (value) {
+      provider = value;
+      break;
+    }
+  }
+  if (!provider) return null;
+
+  // Walk the `[model_providers.<provider>]` table and return its `env_key`.
+  const headerRe =
+    /^\[\s*model_providers\.\s*(?:"([^"]*)"|'([^']*)'|([A-Za-z0-9_.-]+))\s*\]$/;
+  let inSelectedTable = false;
+  for (const raw of lines) {
+    const line = stripTomlComment(raw).trim();
+    if (line.startsWith('[')) {
+      const match = headerRe.exec(line);
+      const name = match ? (match[1] ?? match[2] ?? match[3]) : null;
+      inSelectedTable = name === provider;
+      continue;
+    }
+    if (!inSelectedTable) continue;
+    const value = matchQuotedValue(line, 'env_key');
+    if (value) return value;
+  }
+  return null;
+}
+
+/**
+ * Read the selected Codex provider's `env_key` from the on-disk config.toml
+ * (honoring CODEX_HOME). Returns null when the file is absent/unreadable or
+ * declares no custom provider env_key.
+ */
+export async function readCodexProviderEnvKey(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
+  try {
+    const toml = await readFile(resolveCodexConfigPath(env), 'utf8');
+    return extractCodexProviderEnvKey(toml);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The only `service_tier` values the Codex CLI accepts. Anything else makes
  * the CLI exit on config load, so the normalizer removes it.
  */

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -1,4 +1,5 @@
 import { execAgentFile } from './invocation.js';
+import { readCodexProviderEnvKey } from '../codex-config-normalize.js';
 import type { RuntimeAgentDef, RuntimeEnv } from './types.js';
 
 export type AgentAuthProbeResult = {
@@ -319,14 +320,11 @@ function hasNonEmptyEnv(env: RuntimeEnv, keys: string[]): boolean {
   });
 }
 
-function hasProbeSatisfyingApiKey(
-  def: Pick<RuntimeAgentDef, 'id'>,
-  env: RuntimeEnv,
-): boolean {
-  if (def.id === 'codex') {
+function hasProbeSatisfyingApiKey(agentId: string, env: RuntimeEnv): boolean {
+  if (agentId === 'codex') {
     return hasNonEmptyEnv(env, ['CODEX_API_KEY', 'OPENAI_API_KEY']);
   }
-  if (def.id === 'claude') {
+  if (agentId === 'claude') {
     return hasNonEmptyEnv(env, ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN']);
   }
   return false;
@@ -339,14 +337,15 @@ function hasProbeSatisfyingApiKey(
 // HTTP/text classifier so it still gets a usable signal without bespoke
 // regexes.
 function classifyProbedAuthFailure(
-  def: Pick<RuntimeAgentDef, 'id' | 'name'>,
+  classifierId: string,
+  agentName: string,
   text: string,
 ): AgentAuthProbeResult | null {
-  if (TAILORED_AUTH_AGENTS.has(def.id)) {
-    return classifyAgentAuthFailure(def.id, text);
+  if (TAILORED_AUTH_AGENTS.has(classifierId)) {
+    return classifyAgentAuthFailure(classifierId, text);
   }
   if (classifyAgentServiceFailure(text) === 'AGENT_AUTH_REQUIRED') {
-    return { status: 'missing', message: genericAuthGuidance(def.name || def.id) };
+    return { status: 'missing', message: genericAuthGuidance(agentName) };
   }
   return null;
 }
@@ -362,7 +361,23 @@ export async function probeAgentAuthStatus(
 ): Promise<AgentAuthProbeResult | null> {
   const probe = def.authProbe;
   if (!probe) return null;
-  if (hasProbeSatisfyingApiKey(def, env)) return { status: 'ok' };
+  // Local profiles inherit a base adapter's authProbe but run under the profile
+  // id; use the base adapter's classifier identity when present so its tailored
+  // auth parsing / API-key short-circuit is preserved instead of falling
+  // through to the generic classifier (#4456).
+  const classifierId = probe.classifierAgentId ?? def.id;
+  const agentName = def.name || def.id;
+  if (hasProbeSatisfyingApiKey(classifierId, env)) return { status: 'ok' };
+  // Codex custom providers authenticate via a provider-specific `env_key` (e.g.
+  // AZURE_OPENAI_API_KEY) declared in config.toml, even when `codex login
+  // status` (a ChatGPT/OpenAI-login check) exits non-zero. Honor that key so a
+  // working custom-provider install isn't misreported as missing auth (#4456).
+  if (classifierId === 'codex') {
+    const providerEnvKey = await readCodexProviderEnvKey(env);
+    if (providerEnvKey && hasNonEmptyEnv(env, [providerEnvKey])) {
+      return { status: 'ok' };
+    }
+  }
   try {
     const { stdout, stderr } = await execAgentFile(resolvedBin, probe.args, {
       env,
@@ -372,7 +387,7 @@ export async function probeAgentAuthStatus(
     const stdoutText = typeof stdout === 'string' ? stdout : '';
     const stderrText = typeof stderr === 'string' ? stderr : '';
     const output = `${stdoutText}\n${stderrText}`;
-    const failure = classifyProbedAuthFailure(def, output);
+    const failure = classifyProbedAuthFailure(classifierId, agentName, output);
     if (failure) {
       return withProbeTails(
         { ...failure, exitCode: 0, signal: null },
@@ -397,7 +412,7 @@ export async function probeAgentAuthStatus(
     // is meaningful as an exit code.
     const numericExit = typeof err.code === 'number' ? err.code : null;
     const childSignal = typeof err.signal === 'string' ? err.signal : null;
-    const failure = classifyProbedAuthFailure(def, output);
+    const failure = classifyProbedAuthFailure(classifierId, agentName, output);
     if (failure) {
       return withProbeTails(
         { ...failure, exitCode: numericExit, signal: childSignal },

--- a/apps/daemon/src/runtimes/local-profiles.ts
+++ b/apps/daemon/src/runtimes/local-profiles.ts
@@ -177,7 +177,11 @@ function createLocalAgentDef(
     ...(helpArgs.length > 0 ? { helpArgs } : {}),
     fallbackModels,
     env,
-    ...(prefixArgs.length === 0 && baseAuthProbe ? { authProbe: baseAuthProbe } : {}),
+    // Carry the base adapter's classifier identity so an inherited probe keeps
+    // its tailored auth parsing under the profile id (#4456).
+    ...(prefixArgs.length === 0 && baseAuthProbe
+      ? { authProbe: { ...baseAuthProbe, classifierAgentId: base.id } }
+      : {}),
     buildArgs: (prompt, imagePaths, extraAllowedDirs, options, runtimeContext) => [
       ...prefixArgs,
       ...base.buildArgs(

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -203,6 +203,13 @@ export type RuntimeAgentDef = {
   authProbe?: {
     args: string[];
     timeoutMs?: number;
+    // Agent id whose tailored auth classifier + API-key short-circuit should
+    // be used for this probe when it differs from the runtime agent id. Local
+    // profiles (local-profiles.ts) inherit a base adapter's `authProbe` but run
+    // under the profile id; carrying the base id here keeps the base adapter's
+    // auth semantics (e.g. Claude's JSON-aware parser) instead of falling
+    // through to the generic classifier. Defaults to the def id when unset.
+    classifierAgentId?: string;
   };
   // Format for the `env` field in ACP `session/new` → `mcpServers[].env`.
   // `'array'` (default) emits `[{name, value}]` — used by Hermes, Kimi,

--- a/apps/daemon/tests/codex-provider-env-key.test.ts
+++ b/apps/daemon/tests/codex-provider-env-key.test.ts
@@ -1,0 +1,84 @@
+// Regression coverage for #4456 (Case 1): the Codex auth probe must recognize
+// a working custom provider whose API key lives in a provider-specific
+// `env_key` (e.g. AZURE_OPENAI_API_KEY) declared in ~/.codex/config.toml, not
+// just CODEX_API_KEY / OPENAI_API_KEY. `extractCodexProviderEnvKey` resolves
+// the selected provider's `env_key` from the config text.
+
+import { describe, expect, it } from 'vitest';
+
+import { extractCodexProviderEnvKey } from '../src/codex-config-normalize.js';
+
+describe('extractCodexProviderEnvKey', () => {
+  it('resolves the selected custom provider env_key', () => {
+    const toml = [
+      'model_provider = "azure"',
+      '',
+      '[model_providers.azure]',
+      'base_url = "https://example.openai.azure.com/openai/v1"',
+      'env_key = "AZURE_OPENAI_API_KEY"',
+    ].join('\n');
+    expect(extractCodexProviderEnvKey(toml)).toBe('AZURE_OPENAI_API_KEY');
+  });
+
+  it('picks the env_key of the SELECTED provider among several', () => {
+    const toml = [
+      'model_provider = "azure"',
+      '[model_providers.openai]',
+      'env_key = "OPENAI_API_KEY"',
+      '[model_providers.azure]',
+      'env_key = "AZURE_OPENAI_API_KEY"',
+    ].join('\n');
+    expect(extractCodexProviderEnvKey(toml)).toBe('AZURE_OPENAI_API_KEY');
+  });
+
+  it('honors single quotes and trailing comments', () => {
+    const toml = [
+      "model_provider = 'azure'  # selected",
+      '[model_providers.azure]',
+      "env_key = 'AZURE_OPENAI_API_KEY' # the key var",
+    ].join('\n');
+    expect(extractCodexProviderEnvKey(toml)).toBe('AZURE_OPENAI_API_KEY');
+  });
+
+  it('handles a quoted provider table header', () => {
+    const toml = [
+      'model_provider = "azure"',
+      '[model_providers."azure"]',
+      'env_key = "AZURE_OPENAI_API_KEY"',
+    ].join('\n');
+    expect(extractCodexProviderEnvKey(toml)).toBe('AZURE_OPENAI_API_KEY');
+  });
+
+  it('returns null when no provider is selected', () => {
+    const toml = [
+      '[model_providers.azure]',
+      'env_key = "AZURE_OPENAI_API_KEY"',
+    ].join('\n');
+    expect(extractCodexProviderEnvKey(toml)).toBeNull();
+  });
+
+  it('returns null when the selected provider declares no env_key', () => {
+    const toml = [
+      'model_provider = "azure"',
+      '[model_providers.azure]',
+      'base_url = "https://example.openai.azure.com/openai/v1"',
+    ].join('\n');
+    expect(extractCodexProviderEnvKey(toml)).toBeNull();
+  });
+
+  it('does not leak an env_key from a non-selected provider table', () => {
+    const toml = [
+      'model_provider = "azure"',
+      '[model_providers.openai]',
+      'env_key = "OPENAI_API_KEY"',
+      '[model_providers.azure]',
+      'base_url = "https://example.openai.azure.com/openai/v1"',
+    ].join('\n');
+    expect(extractCodexProviderEnvKey(toml)).toBeNull();
+  });
+
+  it('returns null for empty or non-provider config', () => {
+    expect(extractCodexProviderEnvKey('')).toBeNull();
+    expect(extractCodexProviderEnvKey('model = "gpt-5"\n')).toBeNull();
+  });
+});

--- a/apps/daemon/tests/runtimes/auth-probe-4456.test.ts
+++ b/apps/daemon/tests/runtimes/auth-probe-4456.test.ts
@@ -1,0 +1,133 @@
+// Regression coverage for #4456: local CLI auth probes can misclassify valid
+// API-key and profile-based auth.
+//
+//   Case 1 — Codex custom-provider env_key: a working custom provider (e.g.
+//     Azure via AZURE_OPENAI_API_KEY in ~/.codex/config.toml) must not be
+//     reported as missing auth just because `codex login status` exits
+//     non-zero. The probe should short-circuit to `ok` when the selected
+//     provider's env_key is present, without running the probe at all.
+//
+//   Case 2 — inherited Claude profile classifier: a local profile that
+//     inherits Claude's authProbe runs under the profile id. With the base
+//     classifier identity carried on the probe, healthy Claude output
+//     (`{"authenticated": true}`) is parsed by Claude's JSON-aware classifier
+//     (→ ok). WITHOUT it the generic classifier matches the word
+//     "authenticated" and misreports `missing` — the bug this fixes.
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execAgentFileMock = vi.fn();
+
+vi.mock('../../src/runtimes/invocation.js', () => ({
+  execAgentFile: (...args: unknown[]) =>
+    (execAgentFileMock as unknown as (...args: unknown[]) => unknown)(...args),
+}));
+
+const { probeAgentAuthStatus } = await import('../../src/runtimes/auth.js');
+
+const HEALTHY_CLAUDE = '{"authenticated": true, "source": "claude.ai"}';
+
+describe('probeAgentAuthStatus (#4456)', () => {
+  beforeEach(() => {
+    execAgentFileMock.mockReset();
+  });
+
+  describe('Case 2 — inherited Claude profile classifier', () => {
+    it('uses the base Claude classifier when classifierAgentId is carried', async () => {
+      execAgentFileMock.mockResolvedValue({ stdout: HEALTHY_CLAUDE, stderr: '' });
+      const result = await probeAgentAuthStatus(
+        {
+          id: 'my-claude-profile',
+          name: 'Claude (profile)',
+          authProbe: { args: ['auth', 'status'], classifierAgentId: 'claude' },
+        },
+        '/fake/bin/claude',
+        {},
+      );
+      expect(result).toEqual({ status: 'ok' });
+    });
+
+    it('regression: without classifierAgentId the generic classifier misreads healthy output as missing', async () => {
+      execAgentFileMock.mockResolvedValue({ stdout: HEALTHY_CLAUDE, stderr: '' });
+      const result = await probeAgentAuthStatus(
+        {
+          id: 'my-claude-profile',
+          name: 'Claude (profile)',
+          authProbe: { args: ['auth', 'status'] },
+        },
+        '/fake/bin/claude',
+        {},
+      );
+      expect(result?.status).toBe('missing');
+    });
+
+    it('still flags a real Claude auth failure under the inherited classifier', async () => {
+      execAgentFileMock.mockResolvedValue({
+        stdout: '{"authenticated": false}',
+        stderr: '',
+      });
+      const result = await probeAgentAuthStatus(
+        {
+          id: 'my-claude-profile',
+          name: 'Claude (profile)',
+          authProbe: { args: ['auth', 'status'], classifierAgentId: 'claude' },
+        },
+        '/fake/bin/claude',
+        {},
+      );
+      expect(result?.status).toBe('missing');
+    });
+  });
+
+  describe('Case 1 — Codex custom-provider env_key', () => {
+    let codexHome: string;
+
+    beforeEach(async () => {
+      codexHome = await mkdtemp(path.join(os.tmpdir(), 'od-codex-4456-'));
+      await writeFile(
+        path.join(codexHome, 'config.toml'),
+        [
+          'model_provider = "azure"',
+          '[model_providers.azure]',
+          'base_url = "https://example.openai.azure.com/openai/v1"',
+          'env_key = "AZURE_OPENAI_API_KEY"',
+        ].join('\n'),
+        'utf8',
+      );
+    });
+
+    afterEach(async () => {
+      await rm(codexHome, { recursive: true, force: true });
+    });
+
+    it('short-circuits to ok when the selected provider env_key is set (no probe run)', async () => {
+      const result = await probeAgentAuthStatus(
+        { id: 'codex', name: 'Codex CLI', authProbe: { args: ['login', 'status'] } },
+        '/fake/bin/codex',
+        { CODEX_HOME: codexHome, AZURE_OPENAI_API_KEY: 'secret-value' },
+      );
+      expect(result).toEqual({ status: 'ok' });
+      expect(execAgentFileMock).not.toHaveBeenCalled();
+    });
+
+    it('falls through to the probe when the provider env_key is absent', async () => {
+      const loginFailure = Object.assign(new Error('Not logged in. Run `codex login`.'), {
+        stdout: '',
+        stderr: 'Not logged in',
+        code: 1,
+      });
+      execAgentFileMock.mockRejectedValue(loginFailure);
+      const result = await probeAgentAuthStatus(
+        { id: 'codex', name: 'Codex CLI', authProbe: { args: ['login', 'status'] } },
+        '/fake/bin/codex',
+        { CODEX_HOME: codexHome },
+      );
+      expect(execAgentFileMock).toHaveBeenCalledTimes(1);
+      expect(result?.status).toBe('missing');
+    });
+  });
+});


### PR DESCRIPTION
Closes #4456.

## Why

Two Local-CLI auth-probe edge cases (the follow-ups #4456 tracked from the Codex review on #4453) report a working CLI as **unauthenticated**, blocking Settings connection tests / runs. I verified on current `main` that **both gaps are still present** — #4453 added the `authProbe` inheritance and the `CODEX_API_KEY`/`OPENAI_API_KEY` short-circuit, which is exactly what introduced these cases; the two follow-ups themselves did not land.

### Case 1 — Codex custom-provider `env_key`
Codex custom providers name the env var holding their API key via `env_key` in `~/.codex/config.toml`:

```toml
model_provider = "azure"
[model_providers.azure]
env_key = "AZURE_OPENAI_API_KEY"
```

`codex exec` authenticates fine through that provider even when `codex login status` (a ChatGPT/OpenAI-login check) exits non-zero. But `hasProbeSatisfyingApiKey` only treated `CODEX_API_KEY`/`OPENAI_API_KEY` as API-key auth, so these installs surfaced `authStatus: "missing"`.

### Case 2 — inherited Claude profile classifier
Local profiles (`local-profiles.ts`) inherit a base adapter's `authProbe` but run under the **profile id**. Both `classifyProbedAuthFailure` and `hasProbeSatisfyingApiKey` key off the agent id, so an inherited Claude probe fell through to the **generic** classifier. The generic auth regex matches the word `authenticat(?:e|ed|ion)`, so healthy Claude output `{"authenticated": true, "source": "claude.ai"}` was misread as an auth failure (Claude's own JSON-aware parser correctly returns "authenticated").

## What users will see

In **Settings → Local CLI**, a working CLI is no longer falsely shown as "not authenticated":

- Users whose Codex CLI authenticates through a **custom provider** (e.g. Azure via `AZURE_OPENAI_API_KEY` declared in `~/.codex/config.toml`) now see the correct authenticated status, instead of a false "missing auth" that blocked the Settings connection test and runs.
- Users running a **local profile that wraps Claude** (inheriting Claude's auth probe) now have their real Claude auth status reported, instead of a healthy, signed-in session being misread as "unauthenticated".

## What changed

- **`runtimes/types.ts`** — add optional `authProbe.classifierAgentId` (the base adapter's id to use for tailored classification when it differs from the runtime id).
- **`runtimes/local-profiles.ts`** — when a profile inherits a base `authProbe`, carry `classifierAgentId: base.id`.
- **`runtimes/auth.ts`** — `probeAgentAuthStatus` derives `classifierId = probe.classifierAgentId ?? def.id` and routes both the tailored classifier and the API-key short-circuit through it; for Codex it also honors the selected provider's `env_key`. `hasProbeSatisfyingApiKey` / `classifyProbedAuthFailure` now take the classifier id explicitly.
- **`codex-config-normalize.ts`** — add `extractCodexProviderEnvKey(toml)` + `readCodexProviderEnvKey(env)`. Deliberately a **narrow line scanner**, not a new TOML-parser dependency — matching this module's existing regex-scoped handling of `config.toml` (the daemon ships no TOML parser); it reads only `model_provider` and the selected `[model_providers.<name>].env_key`.

`probeAgentAuthStatus`'s signature is unchanged, so its two callers (`detection.ts`, `connectionTest.ts`) need no changes.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand/flag or `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, SSE event, or contract shape
- [ ] **Extension point** — `skills/`, `design-systems/`, `design-templates/`, `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — root `package.json`
- [x] **Default behavior change** — local-CLI auth detection now reports `ok` for valid custom-provider Codex installs and inherited Claude profiles that were previously misreported as `missing` (bug fix; no config/schema/model-default change)
- [ ] **None**

## Validation

- New unit tests: `apps/daemon/tests/codex-provider-env-key.test.ts` (8 cases for the env_key extractor — selection among providers, quoting, comments, missing fields, no leak from non-selected tables).
- New probe tests: `apps/daemon/tests/runtimes/auth-probe-4456.test.ts` — Case 2 (inherited classifier → `ok`; **regression assertion** that without `classifierAgentId` the same healthy output is misread as `missing`; real failure still flagged) and Case 1 (env_key set → `ok` with the probe never spawned; env_key absent → falls through to the probe).
- `pnpm --filter @open-design/daemon typecheck` → clean.
- Re-ran existing related suites — `codex-config-normalize`, `runtimes/probe-ghost-cli`, `runtimes/registry-and-args` — all green (no regressions).

## Bug fix verification

Red→green is pinned by `apps/daemon/tests/auth-probe-4456.test.ts`, which holds both states side by side:

- **Case 2 (classifier identity):** the fixed path — an inherited probe with `classifierAgentId: 'claude'` parsing healthy `{"authenticated": true}` output — returns `ok`. A sibling **regression test that omits `classifierAgentId`** exercises the *original* code path (classify off `def.id`), where the generic classifier matches the word "authenticated" and returns `missing`. That asserted `missing` is the pre-fix red state, captured permanently — flip the `probe.classifierAgentId ?? def.id` line back to `def.id` and the fixed-path test fails the same way.
- **Case 1 (Codex env_key):** with the selected provider's `env_key` (e.g. `AZURE_OPENAI_API_KEY`) present, the run returns `ok` and **never spawns the probe**; with it absent, the run correctly falls through and the probe runs. Before the fix only `CODEX_API_KEY`/`OPENAI_API_KEY` were checked, so the env_key-present case took that same fall-through to `codex login status` and was misreported as `missing` — the false negative this closes.

All daemon auth/codex suites stay green and `pnpm --filter @open-design/daemon typecheck` is clean.
