### PR TITLE
[codex] Fix onboarding brand extraction flow

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -483,6 +483,7 @@ import { registerMemoryRoutes } from './routes/memory.js';
 import { registerTelemetryRoutes } from './routes/telemetry.js';
 import { registerAtomRoutes, registerStaticResourceRoutes } from './routes/static-resource.js';
 import { registerRoutineRoutes, routineDbRowToContract } from './routes/routine.js';
+import { registerBrandRoutes } from './brand-routes.js';
 import { resolveAmrModelProbe } from './runtimes/amr-model-probe.js';
 import { createPluginInstallationHelpers, normalizeProjectPluginFolderPath, resolveProjectChildDirectory } from './services/plugin-installation.js';
 import { createPluginShareTaskStore } from './services/plugin-share-tasks.js';
@@ -1556,6 +1557,7 @@ const ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'artifacts');
 // read path so project-membership, size, and CSP guards cannot be bypassed.
 const CRITIQUE_ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'critique-artifacts');
 const PROJECTS_DIR = path.join(RUNTIME_DATA_DIR, 'projects');
+const BRANDS_DIR = path.join(RUNTIME_DATA_DIR, 'brands');
 const USER_SKILLS_DIR = path.join(RUNTIME_DATA_DIR, 'skills');
 const USER_DESIGN_SYSTEMS_DIR = path.join(RUNTIME_DATA_DIR, 'design-systems');
 const PLUGIN_REGISTRY_ROOTS = registryRootsForDataDir(RUNTIME_DATA_DIR);
@@ -1583,6 +1585,7 @@ const ALL_SKILL_LIKE_ROOTS = [
   DESIGN_TEMPLATES_DIR,
 ];
 fs.mkdirSync(PROJECTS_DIR, { recursive: true });
+fs.mkdirSync(BRANDS_DIR, { recursive: true });
 for (const dir of [USER_SKILLS_DIR, USER_DESIGN_SYSTEMS_DIR, USER_DESIGN_TEMPLATES_DIR, PLUGIN_REGISTRY_ROOTS.userPluginsRoot]) {
   fs.mkdirSync(dir, { recursive: true });
 }
@@ -5012,6 +5015,7 @@ export async function startServer({
     PROJECT_ROOT,
     PROJECTS_DIR,
     ARTIFACTS_DIR,
+    BRANDS_DIR,
     RUNTIME_DATA_DIR,
     RUNTIME_DATA_DIR_CANONICAL,
     DESIGN_SYSTEMS_DIR,
@@ -5378,6 +5382,16 @@ export async function startServer({
       updateUserDesignSystemRevisionStatus,
     },
     generationJobs: designSystemGenerationJobs,
+  });
+  registerBrandRoutes(app, {
+    brandsRoot: BRANDS_DIR,
+    userDesignSystemsRoot: USER_DESIGN_SYSTEMS_DIR,
+    projectsRoot: PROJECTS_DIR,
+    skillsRoot: SKILLS_DIR,
+    dataDir: RUNTIME_DATA_DIR,
+    db,
+    runs: design.runs,
+    randomId,
   });
   registerProjectArtifactRoutes(app, {
     http: httpDeps,

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2491,29 +2491,6 @@ function OnboardingView({
                   }}
                 />
               </div>
-              <div className="onboarding-view__memory-callout">
-                <span className="onboarding-view__memory-callout-icon" aria-hidden>
-                  <Icon name="sparkles" size={16} />
-                </span>
-                <div className="onboarding-view__memory-callout-body">
-                  <strong>{t('settings.onboardingMemoryCalloutTitle')}</strong>
-                  <p>{t('settings.onboardingMemoryCalloutBody')}</p>
-                  <ul className="onboarding-view__memory-benefits">
-                    <li>
-                      <Icon name="check" size={13} aria-hidden />
-                      <span>{t('settings.onboardingMemoryBenefitIntent')}</span>
-                    </li>
-                    <li>
-                      <Icon name="check" size={13} aria-hidden />
-                      <span>{t('settings.onboardingMemoryBenefitFewerQuestions')}</span>
-                    </li>
-                    <li>
-                      <Icon name="check" size={13} aria-hidden />
-                      <span>{t('settings.onboardingMemoryBenefitPersonalized')}</span>
-                    </li>
-                  </ul>
-                </div>
-              </div>
             </div>
           ) : null}
 
@@ -2553,6 +2530,15 @@ function OnboardingView({
 
           {step === 3 ? (
             <div className="onboarding-view__panel onboarding-view__panel--newsletter">
+              <button
+                type="button"
+                className="onboarding-view__back-to-cloud"
+                onClick={handleBackWithTracking}
+                disabled={onboardingNavigationLocked}
+              >
+                <Icon name="chevron-left" size={14} />
+                <span>{t('settings.onboardingBack')}</span>
+              </button>
               <OnboardingPanelHeader
                 title={t('onboarding.brandTitle')}
                 body={t('onboarding.brandSubtitle')}
@@ -2582,7 +2568,7 @@ function OnboardingView({
                   }}
                 />
               </label>
-              <div className="onboarding-view__email-field">
+              <div className="onboarding-view__brand-action-row">
                 <button
                   type="button"
                   className={`onboarding-view__mini-button${brandExtractActive ? ' is-loading' : ''}`}
@@ -2594,6 +2580,15 @@ function OnboardingView({
                   {brandExtractActive
                     ? t('brand.extracting')
                     : t('newBrand.extract')}
+                </button>
+                <button
+                  type="button"
+                  className="onboarding-view__secondary"
+                  onClick={handlePrimaryAction}
+                  disabled={newsletterSubmitting}
+                  aria-busy={newsletterSubmitting ? true : undefined}
+                >
+                  <span>{t('onboarding.brandSkip')}</span>
                 </button>
                 {brandExtractActive ? (
                   <span
@@ -2638,6 +2633,7 @@ function OnboardingView({
             </div>
           ) : null}
 
+          {!isLastStep ? (
           <div className="onboarding-view__actions">
             {step === 0 && amrLoginError ? (
               <span className="onboarding-view__action-status is-error" role="alert">
@@ -2673,6 +2669,7 @@ function OnboardingView({
               <span>{primaryActionLabel}</span>
             </button>
           </div>
+          ) : null}
         </div>
       </div>
     </section>

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2588,7 +2588,7 @@ function OnboardingView({
                   disabled={newsletterSubmitting}
                   aria-busy={newsletterSubmitting ? true : undefined}
                 >
-                  <span>{t('onboarding.brandSkip')}</span>
+                  <span>{t('settings.onboardingFinish')}</span>
                 </button>
                 {brandExtractActive ? (
                   <span

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5819,6 +5819,7 @@ export function ProjectView({
     const pendingPrompt = project.pendingPrompt;
     if (!pendingPrompt) return;
     if (autoSendFirstMessageRef.current) {
+      autoSendSeedRef.current = pendingPrompt;
       onClearPendingPrompt();
       return;
     }
@@ -6019,8 +6020,6 @@ export function ProjectView({
     ).trim();
     const attachments = autoSendAttachmentsRef.current ?? [];
     if (!seed && attachments.length === 0) {
-      autoSentRef.current = true;
-      clearAutoSendSession(project.id);
       return;
     }
     autoSentRef.current = true;

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -3247,6 +3247,29 @@
   margin-top: 16px;
 }
 
+.onboarding-view__brand-action-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  column-gap: 12px;
+  row-gap: 8px;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.onboarding-view__brand-action-row .onboarding-view__mini-button {
+  grid-column: 2;
+  width: 360px;
+  max-width: 100%;
+  min-height: 44px;
+  padding: 0 28px;
+  font-size: 13px;
+}
+
+.onboarding-view__brand-action-row .onboarding-view__secondary {
+  grid-column: 3;
+  justify-self: end;
+}
+
 .onboarding-view__email-label {
   color: var(--text-strong);
   font-size: 12px;

--- a/apps/web/tests/components/App.onboarding-amr-e2e.test.tsx
+++ b/apps/web/tests/components/App.onboarding-amr-e2e.test.tsx
@@ -254,16 +254,16 @@ describe('onboarding -> home AMR selection (end to end)', () => {
     fireEvent.click(cloudContinue);
 
     // About-you step is no longer the final step: advance past it to the
-    // newsletter step, then the brand step that hosts Finish setup.
+    // newsletter step, then the brand step that hosts Skip.
     const aboutYouContinue = await screen.findByRole('button', { name: /^Continue$/i });
     fireEvent.click(aboutYouContinue);
 
-    // Newsletter step -> Brand step -> finish.
+    // Newsletter step -> Brand step -> skip.
     const newsletterContinue = await screen.findByRole('button', { name: /^Continue$/i });
     fireEvent.click(newsletterContinue);
 
-    const finish = await screen.findByRole('button', { name: /Finish setup/i });
-    fireEvent.click(finish);
+    const skip = await screen.findByRole('button', { name: /Skip for now/i });
+    fireEvent.click(skip);
 
     // Now on home: the inline model switcher chip must reflect AMR, not the
     // Claude default the App-level auto-select used to snap to while AMR was

--- a/apps/web/tests/components/App.onboarding-amr-e2e.test.tsx
+++ b/apps/web/tests/components/App.onboarding-amr-e2e.test.tsx
@@ -254,16 +254,16 @@ describe('onboarding -> home AMR selection (end to end)', () => {
     fireEvent.click(cloudContinue);
 
     // About-you step is no longer the final step: advance past it to the
-    // newsletter step, then the brand step that hosts Skip.
+    // newsletter step, then the brand step that hosts Finish setup.
     const aboutYouContinue = await screen.findByRole('button', { name: /^Continue$/i });
     fireEvent.click(aboutYouContinue);
 
-    // Newsletter step -> Brand step -> skip.
+    // Newsletter step -> Brand step -> finish.
     const newsletterContinue = await screen.findByRole('button', { name: /^Continue$/i });
     fireEvent.click(newsletterContinue);
 
-    const skip = await screen.findByRole('button', { name: /Skip for now/i });
-    fireEvent.click(skip);
+    const finish = await screen.findByRole('button', { name: /Finish setup/i });
+    fireEvent.click(finish);
 
     // Now on home: the inline model switcher chip must reflect AMR, not the
     // Claude default the App-level auto-select used to snap to while AMR was

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -812,6 +812,52 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
   });
 
+  it('does not show a memory-saved callout on the About you step before choices are submitted', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        loggedIn: true,
+        profile: 'prod',
+        configPath: '/x',
+        user: { id: 'u', email: 'user@example.com' },
+      }),
+    ) as typeof fetch;
+    renderOnboarding();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Continue \(signed in\)/i }));
+
+    expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
+    expect(screen.queryByText('Saved to your Memory')).toBeNull();
+  });
+
+  it('shows a Back control on the brand extraction onboarding step', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        loggedIn: true,
+        profile: 'prod',
+        configPath: '/x',
+        user: { id: 'u', email: 'user@example.com' },
+      }),
+    ) as typeof fetch;
+    renderOnboarding();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Continue \(signed in\)/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Stay in the loop' })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: /^Back$/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Skip for now/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Finish setup/i })).toBeNull();
+  });
+
   it('tracks onboarding page views and about-you submission payload on completion', async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({
@@ -845,7 +891,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
 
     expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
 
@@ -951,7 +997,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
 
     const subscribeCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/subscribe'));
     expect(subscribeCall).toBeTruthy();
@@ -998,7 +1044,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
 
     expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/subscribe'))).toBe(false);
   });
@@ -1083,7 +1129,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
 
     // Advance to the newsletter step via Continue (the stepper no longer
     // allows forward jumps past the current step). The survey snapshot must
-    // still fire exactly once — on the final Finish — not zero times.
+    // still fire exactly once — on the final Skip — not zero times.
     fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Stay in the loop' })).toBeTruthy();
@@ -1092,7 +1138,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
 
     const aboutYouSubmits = trackedEvents('ui_click')
       .map(([, payload]) => payload as Record<string, unknown>)
@@ -1130,7 +1176,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
     });
-    // Continue -> Newsletter again, then Brand and finish.
+    // Continue -> Newsletter again, then Brand and skip.
     fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Stay in the loop' })).toBeTruthy();
@@ -1139,7 +1185,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
 
     // The detour crosses the About-you step twice, but the snapshot must
     // not double-fire.
@@ -1204,7 +1250,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
 
     expect(props.onModeChange).toHaveBeenCalledWith('api');
     expect(props.onApiModelChange).toHaveBeenCalledWith('claude-opus-4-8');

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -854,8 +854,8 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
     expect(screen.getByRole('button', { name: /^Back$/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /Skip for now/i })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /Finish setup/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /Finish setup/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Skip for now/i })).toBeNull();
   });
 
   it('tracks onboarding page views and about-you submission payload on completion', async () => {
@@ -891,7 +891,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
 
     expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
 
@@ -997,7 +997,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
 
     const subscribeCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/subscribe'));
     expect(subscribeCall).toBeTruthy();
@@ -1044,7 +1044,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
 
     expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/subscribe'))).toBe(false);
   });
@@ -1129,7 +1129,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
 
     // Advance to the newsletter step via Continue (the stepper no longer
     // allows forward jumps past the current step). The survey snapshot must
-    // still fire exactly once — on the final Skip — not zero times.
+    // still fire exactly once — on the final Finish — not zero times.
     fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Stay in the loop' })).toBeTruthy();
@@ -1138,7 +1138,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
 
     const aboutYouSubmits = trackedEvents('ui_click')
       .map(([, payload]) => payload as Record<string, unknown>)
@@ -1176,7 +1176,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
     });
-    // Continue -> Newsletter again, then Brand and skip.
+    // Continue -> Newsletter again, then Brand and finish.
     fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Stay in the loop' })).toBeTruthy();
@@ -1185,7 +1185,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
 
     // The detour crosses the About-you step twice, but the snapshot must
     // not double-fire.
@@ -1250,7 +1250,7 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Extract your design system' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Finish setup/i }));
 
     expect(props.onModeChange).toHaveBeenCalledWith('api');
     expect(props.onApiModelChange).toHaveBeenCalledWith('claude-opus-4-8');

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import type { ComponentProps } from 'react';
 import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -706,6 +707,91 @@ describe('ProjectView daemon cleanup', () => {
       expect(seededCall).toBeUndefined();
     } finally {
       window.sessionStorage.removeItem('od:auto-send-first:project-2');
+    }
+  });
+
+  it('waits for pendingPrompt hydration before consuming an auto-send flag', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockResolvedValue(undefined);
+
+    chatPaneSpy.mockClear();
+    const onClearPendingPrompt = vi.fn();
+    window.sessionStorage.setItem('od:auto-send-first:project-hydrating', '1');
+
+    const baseProps = {
+      project: {
+        id: 'project-hydrating',
+        name: 'Ramp.com Design System',
+        skillId: null,
+        designSystemId: null,
+      } as never,
+      routeFileName: null,
+      config: { mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never,
+      agents: [{ id: 'agent-1', name: 'OpenCode', models: [] } as never],
+      skills: [],
+      designTemplates: [],
+      designSystems: [],
+      daemonLive: true,
+      onModeChange: () => {},
+      onAgentChange: () => {},
+      onAgentModelChange: () => {},
+      onRefreshAgents: () => {},
+      onOpenSettings: () => {},
+      onBack: () => {},
+      onClearPendingPrompt,
+      onTouchProject: () => {},
+      onProjectChange: () => {},
+      onProjectsRefresh: () => {},
+    } satisfies ComponentProps<typeof ProjectView>;
+
+    try {
+      const view = render(<ProjectView {...baseProps} />);
+
+      await waitFor(() => {
+        expect(chatPaneSpy).toHaveBeenCalled();
+        expect(chatPaneSpy.mock.calls.at(-1)?.[0]?.sendDisabled).toBe(false);
+      });
+      expect(streamViaDaemon).not.toHaveBeenCalled();
+      expect(onClearPendingPrompt).not.toHaveBeenCalled();
+      expect(window.sessionStorage.getItem('od:auto-send-first:project-hydrating')).toBe('1');
+
+      view.rerender(
+        <ProjectView
+          {...baseProps}
+          project={{
+            id: 'project-hydrating',
+            name: 'Ramp.com Design System',
+            skillId: null,
+            designSystemId: null,
+            createdAt: 1,
+            updatedAt: 1,
+            pendingPrompt: 'Extract ramp.com into a design system.',
+          }}
+        />,
+      );
+
+      await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+      expect(onClearPendingPrompt).toHaveBeenCalledTimes(1);
+      expect(streamViaDaemon.mock.calls[0]?.[0]).toMatchObject({
+        history: [
+          expect.objectContaining({
+            role: 'user',
+            content: 'Extract ramp.com into a design system.',
+          }),
+        ],
+      });
+      expect(window.sessionStorage.getItem('od:auto-send-first:project-hydrating')).toBeNull();
+    } finally {
+      window.sessionStorage.removeItem('od:auto-send-first:project-hydrating');
     }
   });
 


### PR DESCRIPTION
## Why

This PR fixes the onboarding brand extraction flow on `main`.

The pain being addressed is first-run setup correctness: onboarding should route brand extraction and related handoff state through the current mainline flow without stale or missing state.

## What users will see

Users going through onboarding should see a more reliable brand extraction path and related setup behavior.

## Surface area

- [x] **UI** — onboarding and artifact handoff surfaces in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — daemon runtime/static resource paths touched
- [x] **Extension point** — design template documentation/scripts touched
- [x] **i18n keys** — localized link/text values updated
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — onboarding brand extraction behavior changes
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached.

## Bug fix verification

Skipped. The branch includes focused test updates, but I did not rerun them locally while opening this PR.

## Validation

- Not run locally; PR opened from the existing branch for review.
