### PR TITLE
BE daemon: mount brand extraction routes

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -524,6 +524,7 @@ import { registerDesignSystemToolRoutes } from './routes/design-system-tool.js';
 import { registerDeployRoutes, registerDeploymentCheckRoutes } from './routes/deploy.js';
 import { registerMediaRoutes } from './routes/media.js';
 import { registerProjectRoutes, registerProjectArtifactRoutes, registerProjectFileRoutes, registerProjectUploadRoutes } from './routes/project/index.js';
+import { registerBrandRoutes } from './brand-routes.js';
 import { registerVelaRoutes } from './routes/vela.js';
 import { registerFinalizeRoutes, registerImportRoutes, registerProjectExportRoutes } from './import-export-routes.js';
 import { registerHandoffRoutes } from './routes/handoff.js';
@@ -805,6 +806,7 @@ const CRITIQUE_ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'critique-artifacts')
 const PROJECTS_DIR = path.join(RUNTIME_DATA_DIR, 'projects');
 const USER_SKILLS_DIR = path.join(RUNTIME_DATA_DIR, 'skills');
 const USER_DESIGN_SYSTEMS_DIR = path.join(RUNTIME_DATA_DIR, 'design-systems');
+const BRANDS_DIR = path.join(RUNTIME_DATA_DIR, 'brands');
 const PLUGIN_REGISTRY_ROOTS = registryRootsForDataDir(RUNTIME_DATA_DIR);
 // Disk cache + same-origin proxy for external preview media (cross-border CDN
 // images/videos referenced by plugin example.html). See plugin-asset-cache.ts.
@@ -4060,6 +4062,15 @@ export async function startServer({
       updateUserDesignSystemRevisionStatus,
     },
     generationJobs: designSystemGenerationJobs,
+  });
+  registerBrandRoutes(app, {
+    brandsRoot: BRANDS_DIR,
+    userDesignSystemsRoot: USER_DESIGN_SYSTEMS_DIR,
+    projectsRoot: PROJECTS_DIR,
+    skillsRoot: SKILLS_DIR,
+    dataDir: RUNTIME_DATA_DIR,
+    db,
+    randomId,
   });
   registerProjectArtifactRoutes(app, {
     http: httpDeps,


### PR DESCRIPTION
## Why

Hit this while setting up Open Design locally and trying the onboarding
**"Extract your design system"** flow on first run: every attempt failed with
`Extraction request failed (404)`. Contributor scratching a real first-run itch.

Root cause is wiring, not logic. The brand-extraction HTTP surface is fully
implemented and unit-tested in `apps/daemon/src/brand-routes.ts`
(`registerBrandRoutes` → `GET/POST /api/brands`, `/api/brands/:id/finalize`,
`/preview`, `/logo`, `DELETE`, etc.), but `registerBrandRoutes` is **never
invoked in `apps/daemon/src/server.ts`**. The router is defined and exported,
two callers depend on it -

- onboarding UI: `apps/web/src/runtime/useBrandExtract.ts` → `POST /api/brands`
- CLI: `apps/daemon/src/cli.ts` (`od brand`) → `GET/POST /api/brands`

- but the routes are not mounted, so every request 404s. `server.ts` mounts
~30 routers via explicit static `registerXxxRoutes(app, …)` calls; this one was
simply missing from that list. The existing `brand-routes.test.ts` stays green
because it mounts the router itself, so it can't observe the missing wiring.

## What this fixes

| | `/api/brands` | `od brand` CLI | Onboarding "Extract design system" |
|---|---|---|---|
| Before | 404 | broken | `Extraction request failed (404)` |
| After | 200 | works | starts an extraction |

## Changes

| File | Intent |
|---|---|
| `apps/daemon/src/server.ts` | import `registerBrandRoutes`; add `BRANDS_DIR = <data>/brands`; mount the router next to `registerDesignSystemRoutes` |

All data roots derive from `RUNTIME_DATA_DIR` per the daemon data directory
contract (`BRANDS_DIR`, reusing `PROJECTS_DIR`, `USER_DESIGN_SYSTEMS_DIR`,
`SKILLS_DIR`, `RUNTIME_DATA_DIR`, `db`, `randomId`). The optional in-memory
`runs` registry is omitted; brand status reconciliation falls back to the DB via
`listLatestProjectRunStatuses`, which the route already handles
(`deps.runs?.list() ?? []`).

## What users will see

Onboarding → "Extract your design system" (paste a brand URL → "Extract design
system") now starts an extraction instead of erroring with
`Extraction request failed (404)`. The `od brand` subcommands work for the same
reason.

## Surface area

- [x] **API / contract** - restores the existing `/api/brands*` endpoints. No
  shape change; they were defined but never mounted. `od brand` CLI is unblocked
  as a side effect.

## Bug fix verification

No new red spec in this PR. The defect is wiring-level (router not mounted), and
`apps/daemon/tests/brand-routes.test.ts` mounts the router directly so it cannot
see the regression. Verified manually against a live daemon:

```
# before (main)
POST /api/brands {"url":"https://orkait.com"}  -> 404
GET  /api/brands                                -> 404

# after (this branch)
GET  /api/brands  -> 200 {"brands":[]}
POST /api/brands {"url":"https://orkait.com"}
                  -> 200 {"id":"orkait-…","projectId":"brand-orkait-…",
                          "conversationId":"…","sourceUrl":"https://orkait.com/"}
```

Recommended follow-up (happy to add here if preferred): an integration spec that
boots the real server and asserts `/api/brands` is mounted, so a future drop of
the registration goes red.

## Validation

- `pnpm --filter @open-design/daemon typecheck` - clean
- `pnpm --filter @open-design/daemon build` - clean
- live daemon curl, before/after above
