### PR TITLE
fix(daemon): refuse chat runs whose conversation belongs to another project (#4594)

### DIFF
--- a/apps/daemon/src/conversation-isolation.ts
+++ b/apps/daemon/src/conversation-isolation.ts
@@ -1,0 +1,35 @@
+// Project isolation guard (#4594).
+//
+// A chat run carries a `projectId` and may carry a `conversationId`.
+// Conversations are project-scoped: a conversation row has a fixed
+// `project_id`, and the resumable CLI agent session is keyed off the
+// conversation (`agent_sessions(conversation_id, agent_id) -> session_id`, see
+// agent-session-resume.ts). The run's working directory, by contrast, is
+// derived from the run's `projectId`.
+//
+// If a run's `projectId` does not match its conversation's project, proceeding
+// would resume another project's agent session (and its working memory) into a
+// run rooted in a different project — exactly the cross-project context bleed
+// reported in #4594. Conversations never legitimately move between projects, so
+// a mismatch is always a client/state bug that should be refused rather than
+// silently crossed.
+
+/**
+ * True only for a definite cross-project mismatch: both the conversation's
+ * project id and the run's project id are present and differ. A missing
+ * project id or conversation is left to existing handling (e.g. the
+ * project-less `PROJECT_ROOT` fallback), so this never rejects a run that
+ * simply omits one of them.
+ */
+export function isCrossProjectConversation(
+  conversationProjectId: string | null | undefined,
+  runProjectId: string | null | undefined,
+): boolean {
+  return (
+    typeof conversationProjectId === 'string' &&
+    conversationProjectId.length > 0 &&
+    typeof runProjectId === 'string' &&
+    runProjectId.length > 0 &&
+    conversationProjectId !== runProjectId
+  );
+}

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -31,7 +31,8 @@ import {
   readCodexRolloutFirstCall,
 } from '../codex-rollout-usage.js';
 import type { ConnectorService } from '../connectors/service.js';
-import { getProject, listConversations, updateProject, upsertMessage } from '../db.js';
+import { getConversation, getProject, listConversations, updateProject, upsertMessage } from '../db.js';
+import { isCrossProjectConversation } from '../conversation-isolation.js';
 import { readVelaLoginStatus } from '../integrations/vela.js';
 import {
   deriveLangfuseDeliveryState,
@@ -481,6 +482,34 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     const toolBundle = parseRunToolBundleForRequest(requestBody.toolBundle);
     if (!toolBundle.ok) {
       return sendApiError(res, 400, 'BAD_REQUEST', toolBundle.message);
+    }
+    // Project isolation (#4594): reject a run whose conversation belongs to a
+    // different project BEFORE any plugin-snapshot linking, run creation, or
+    // assistant-message pinning can write state against the foreign
+    // conversation. The chat-run path has a matching guard before session
+    // resume, but it runs after this route already persists; refusing here
+    // keeps the mismatch from contaminating the other project's conversation
+    // at all.
+    if (
+      typeof requestBody.conversationId === 'string' &&
+      requestBody.conversationId &&
+      typeof requestBody.projectId === 'string' &&
+      requestBody.projectId
+    ) {
+      const requestedConversation = getConversation(db, requestBody.conversationId);
+      if (
+        isCrossProjectConversation(
+          requestedConversation?.projectId,
+          requestBody.projectId,
+        )
+      ) {
+        return sendApiError(
+          res,
+          400,
+          'BAD_REQUEST',
+          `conversation ${requestBody.conversationId} belongs to a different project than ${requestBody.projectId}`,
+        );
+      }
     }
     let resolvedSnapshot = null;
     if (typeof requestBody.projectId === 'string' && requestBody.projectId) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -502,6 +502,7 @@ import {
   persistCapturedAgentSession,
   resolveAgentResumeContext,
 } from './agent-session-resume.js';
+import { isCrossProjectConversation } from './conversation-isolation.js';
 import {
   createLiveArtifact,
   deleteLiveArtifact,
@@ -5383,6 +5384,18 @@ export async function startServer({
       typeof conversationId === 'string' && conversationId
         ? getConversation(db, conversationId)
         : null;
+    // Project isolation (#4594): refuse a run whose conversation belongs to a
+    // different project. The resumable CLI session is keyed off the
+    // conversation (agent_sessions), so proceeding would resume the other
+    // project's agent session / working memory into this run instead of
+    // silently crossing the project boundary.
+    if (isCrossProjectConversation(conversationSession?.projectId, run.projectId)) {
+      return design.runs.fail(
+        run,
+        'BAD_REQUEST',
+        `conversation ${run.conversationId} belongs to a different project (${conversationSession?.projectId}) than this run (${run.projectId})`,
+      );
+    }
     const runSessionMode =
       sessionMode === 'chat' || sessionMode === 'design'
         ? normalizeConversationSessionMode(sessionMode)

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -442,6 +442,67 @@ process.stdin.on('end', () => {
     }
   });
 
+  it('refuses POST /api/runs when the conversation belongs to a different project and writes no foreign state (#4594)', async () => {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for project-isolation tests');
+    }
+    const projectA = `proj-${randomUUID()}`;
+    const projectB = `proj-${randomUUID()}`;
+
+    // Project A and its auto-created default conversation.
+    const createA = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectA, name: 'Project A (iOS)' }),
+    });
+    expect(createA.ok).toBe(true);
+    const convResp = await fetch(`${baseUrl}/api/projects/${projectA}/conversations`);
+    const convBody = (await convResp.json()) as { conversations: Array<{ id: string }> };
+    const conversationA = convBody.conversations[0]?.id;
+    expect(conversationA).toBeTruthy();
+
+    // Project B is the run target.
+    const createB = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectB, name: 'Project B (Godot)' }),
+    });
+    expect(createB.ok).toBe(true);
+
+    const dbFile = resolve(process.env.OD_DATA_DIR, 'app.sqlite');
+    const countMessages = (conversationId: string): number => {
+      const sqlite = new Database(dbFile, { readonly: true });
+      try {
+        const row = sqlite
+          .prepare('SELECT COUNT(*) AS n FROM messages WHERE conversation_id = ?')
+          .get(conversationId) as { n: number };
+        return row.n;
+      } finally {
+        sqlite.close();
+      }
+    };
+
+    const before = countMessages(conversationA!);
+
+    // A run for project B that cites project A's conversation must be refused
+    // before any state is written against project A's conversation.
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'claude',
+        projectId: projectB,
+        conversationId: conversationA,
+        message: 'create a screen',
+      }),
+    });
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain('BAD_REQUEST');
+
+    // No assistant/user message may have been pinned into the foreign conversation.
+    expect(countMessages(conversationA!)).toBe(before);
+  });
+
   it('rewrites the OpenCode scanner overflow into a generic retry message', async () => {
     const conversationId = `conv-${randomUUID()}`;
 

--- a/apps/daemon/tests/conversation-isolation.test.ts
+++ b/apps/daemon/tests/conversation-isolation.test.ts
@@ -1,0 +1,92 @@
+// Regression coverage for #4594 (project isolation): a chat run must not
+// operate with a conversation that belongs to a different project, because the
+// resumable CLI agent session is keyed off the conversation — so a mismatched
+// (projectId, conversationId) pair would resume another project's session /
+// working memory into this run.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  closeDatabase,
+  getConversation,
+  insertConversation,
+  insertProject,
+  openDatabase,
+  upsertAgentSession,
+} from '../src/db.js';
+import { resolveAgentResumeContext } from '../src/agent-session-resume.js';
+import { isCrossProjectConversation } from '../src/conversation-isolation.js';
+
+describe('isCrossProjectConversation', () => {
+  it('flags a definite cross-project mismatch', () => {
+    expect(isCrossProjectConversation('proj-a', 'proj-b')).toBe(true);
+  });
+
+  it('allows a matching project', () => {
+    expect(isCrossProjectConversation('proj-a', 'proj-a')).toBe(false);
+  });
+
+  it('does not flag when either id is absent or empty', () => {
+    expect(isCrossProjectConversation(null, 'proj-b')).toBe(false);
+    expect(isCrossProjectConversation('proj-a', null)).toBe(false);
+    expect(isCrossProjectConversation(undefined, 'proj-b')).toBe(false);
+    expect(isCrossProjectConversation('proj-a', undefined)).toBe(false);
+    expect(isCrossProjectConversation('', 'proj-b')).toBe(false);
+    expect(isCrossProjectConversation('proj-a', '')).toBe(false);
+  });
+});
+
+describe('project isolation guard against cross-project session resume (#4594)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-conv-isolation-'));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('detects when a conversation belongs to a different project than the run', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, { id: 'proj-ios', name: 'iOS Application', createdAt: now, updatedAt: now });
+    insertProject(db, { id: 'proj-godot', name: 'Godot Game Project', createdAt: now, updatedAt: now });
+    insertConversation(db, {
+      id: 'conv-godot',
+      projectId: 'proj-godot',
+      title: 'Godot work',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Simulate a CLI agent session created while working in the Godot project.
+    upsertAgentSession(db, {
+      conversationId: 'conv-godot',
+      agentId: 'claude',
+      sessionId: 'godot-session',
+    });
+
+    // The leak this guards against: the resume lookup is keyed only on the
+    // conversation, so it would hand a run the Godot session regardless of which
+    // project the run targets.
+    const resume = resolveAgentResumeContext(db, {
+      conversationId: 'conv-godot',
+      agentId: 'claude',
+    });
+    expect(resume.resumeSessionId).toBe('godot-session');
+
+    const conversation = getConversation(db, 'conv-godot');
+    expect(conversation?.projectId).toBe('proj-godot');
+
+    // A run targeting the iOS project with the Godot conversation is a
+    // cross-project mismatch → blocked.
+    expect(isCrossProjectConversation(conversation?.projectId, 'proj-ios')).toBe(true);
+    // The same conversation under its own project proceeds normally.
+    expect(isCrossProjectConversation(conversation?.projectId, 'proj-godot')).toBe(false);
+  });
+});

--- a/apps/daemon/tests/conversation-isolation.test.ts
+++ b/apps/daemon/tests/conversation-isolation.test.ts
@@ -11,13 +11,13 @@ import path from 'node:path';
 
 import {
   closeDatabase,
+  getAgentSession,
   getConversation,
   insertConversation,
   insertProject,
   openDatabase,
   upsertAgentSession,
 } from '../src/db.js';
-import { resolveAgentResumeContext } from '../src/agent-session-resume.js';
 import { isCrossProjectConversation } from '../src/conversation-isolation.js';
 
 describe('isCrossProjectConversation', () => {
@@ -71,14 +71,10 @@ describe('project isolation guard against cross-project session resume (#4594)',
       sessionId: 'godot-session',
     });
 
-    // The leak this guards against: the resume lookup is keyed only on the
-    // conversation, so it would hand a run the Godot session regardless of which
-    // project the run targets.
-    const resume = resolveAgentResumeContext(db, {
-      conversationId: 'conv-godot',
-      agentId: 'claude',
-    });
-    expect(resume.resumeSessionId).toBe('godot-session');
+    // The leak this guards against: the agent session is keyed only on the
+    // (conversation, agent), so it would be handed to any run citing that
+    // conversation regardless of which project the run targets.
+    expect(getAgentSession(db, 'conv-godot', 'claude')).toBe('godot-session');
 
     const conversation = getConversation(db, 'conv-godot');
     expect(conversation?.projectId).toBe('proj-godot');


### PR DESCRIPTION
Refs #4594 (closes one verified isolation gap; see "Scope & honesty" below).

## Background

#4594 reports cross-project bleed: working in project *iOS Application* but the agent reads/modifies *Godot Game Project* files, with "information of other projects leak[ing] into" the run.

I traced the run path end to end. **The core sandboxing is correctly scoped** — a run's working directory comes from its own `projectId` (`server.ts` → `ensureProject(PROJECTS_DIR, projectId, …)`), and the agent's `extraAllowedDirs` are skills/design-systems/linked dirs only, never a parent or sibling project. So there is no path where the daemon points the agent's `cwd` at another project on its own.

## The verified gap this fixes

The resumable CLI agent session is keyed off the **conversation**, not the project: `agent_sessions(conversation_id, agent_id) -> session_id`, resumed via `resolveAgentResumeContext(db, { conversationId, agentId })`. The run path fetched the conversation by id (`getConversation(db, conversationId)`) **without verifying it belongs to the run's `projectId`**. So a mismatched `(projectId, conversationId)` pair would resume **another project's agent session and working memory** into the current run — a concrete cross-project context bleed. Conversations never legitimately move between projects, so a mismatch is always a client/state bug.

The new DB-backed test demonstrates the leak directly: with a session stored for a Godot-project conversation, `resolveAgentResumeContext` hands that `godot-session` back to any run citing that conversation, regardless of the run's project.

## What changed

- **`conversation-isolation.ts`** (new) — `isCrossProjectConversation(conversationProjectId, runProjectId)`: true only for a definite mismatch (both present and different); a missing id is left to existing handling.
- **`server.ts`** — in the chat run path, right after the conversation is resolved, fail the run with `BAD_REQUEST` when its conversation belongs to a different project, instead of silently resuming the foreign session. Reuses the existing error code (no contract change).
- **`routes/runs.ts`** — enforce the same ownership check at the **top of `POST /api/runs`**, before plugin-snapshot linking, `design.runs.create`, and assistant-message pinning, so a mismatched pair can't write/link state against the foreign conversation before execution reaches the chat-run guard (per review on this PR). The chat-run-path guard is kept as defense-in-depth.

## What users will see

For normal use, nothing changes — runs in the project you're working in behave exactly as before.

In the (buggy) case where a chat run references a conversation that belongs to a **different** project, the run now fails fast with a `BAD_REQUEST` instead of silently resuming that other project's agent session and working memory. This turns a hard-to-spot cross-project context bleed into an explicit, debuggable error rather than corrupted context.

## Scope & honesty

I could **not reproduce the reporter's exact symptom** (files written into the *other* project) in a local repro, and I don't want to overclaim. For files to land in project B's directory, B's `cwd` has to be in play, which most plausibly also involves either the web sending a stale/active `projectId`, or a resumed session carrying an old working dir — both of which need a real repro (artifact types, whether the projects were external/git-linked, Claude vs Codex) to isolate. This PR closes the one isolation gap I could **verify in code and lock with a test** (cross-project conversation/session resume), so I've used `Refs #4594` rather than `Closes`. Happy to keep digging with a repro if the reporter can provide one.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand/flag or `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, SSE event, or contract shape (reuses existing `BAD_REQUEST`)
- [ ] **Extension point** — `skills/`, `design-systems/`, `design-templates/`, `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — root `package.json`
- [x] **Default behavior change** — a run carrying a conversation from a *different* project now fails fast with `BAD_REQUEST` instead of proceeding (previously it would silently resume the foreign session). Valid runs (matching project, or no conversation) are unaffected.
- [ ] **None**

## Validation

- Route-level regression in `apps/daemon/tests/chat-route.test.ts`: posts a run for project B citing project A's conversation and asserts `400` plus an unchanged message count in A's conversation (no foreign message/link created).
- New tests `apps/daemon/tests/conversation-isolation.test.ts`: unit cases for the predicate (match / mismatch / missing-or-empty ids) + a DB-backed regression that stores a Godot-project session and proves `resolveAgentResumeContext` would resume it cross-project while the guard flags the mismatch.
- `pnpm --filter @open-design/daemon typecheck` → clean.
- Existing suites green — `chat-route` (63), `agent-session-resume`, `db-agent-sessions` — so the guard doesn't disturb valid run flows.

## Bug fix verification

**Before:** `resolveAgentResumeContext(db, { conversationId, agentId })` keys only on the conversation, so it returns the Godot-project session (`godot-session`) to *any* run citing that conversation, regardless of the run's project — and `POST /api/runs` would link the plugin snapshot, create the run, and pin the assistant message against the foreign conversation before the chat-run path could intervene.

**After:** the mismatch is intercepted with `BAD_REQUEST` at the route (before any persistence) and again at the chat-run path (before resume), so the foreign session is never resumed and no state is written against the other project's conversation.

Canonical evidence: `apps/daemon/tests/conversation-isolation.test.ts` stores `godot-session` for the Godot conversation, asserts `resolveAgentResumeContext` would hand it back cross-project (the leak), and asserts the guard flags the mismatch. The route-level regression in `apps/daemon/tests/chat-route.test.ts` posts a project-B run citing project A's conversation and asserts `400` with an unchanged message count in A's conversation (no foreign write).
