### PR TITLE
fix(daemon): add --print flag to kimi adapter and handle array content

### DIFF
--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -13,7 +13,7 @@ export const kimiAgentDef = {
       { id: 'moonshot-v1-32k', label: 'moonshot-v1-32k' },
     ],
     buildArgs: (prompt, _imagePaths, _extraAllowedDirs = [], options = {}) => {
-      const args = ['-p', prompt, '--output-format', 'stream-json'];
+      const args = ['--print', '-p', prompt, '--output-format', 'stream-json'];
       if (options.model && options.model !== 'default') {
         args.push('--model', options.model);
       }

--- a/apps/daemon/src/runtimes/json-event-stream.ts
+++ b/apps/daemon/src/runtimes/json-event-stream.ts
@@ -373,13 +373,21 @@ function handleKimiEvent(obj: unknown, onEvent: StreamEventHandler): boolean {
     return true;
   }
 
-  if (
-    obj.role === 'assistant' &&
-    typeof obj.content === 'string' &&
-    obj.content.length > 0
-  ) {
-    onEvent({ type: 'text_delta', delta: obj.content });
-    return true;
+  if (obj.role === 'assistant' && !Array.isArray(obj.tool_calls)) {
+    if (typeof obj.content === 'string' && obj.content.length > 0) {
+      onEvent({ type: 'text_delta', delta: obj.content });
+      return true;
+    }
+    if (Array.isArray(obj.content)) {
+      const text = obj.content
+        .filter((part) => isRecord(part) && part.type === 'text' && typeof part.text === 'string' && (part.text as string).length > 0)
+        .map((part) => (part as { text: string }).text)
+        .join('');
+      if (text.length > 0) {
+        onEvent({ type: 'text_delta', delta: text });
+      }
+      return true;
+    }
   }
 
   if (obj.role === 'meta' && obj.type === 'session.resume_hint') {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -3173,6 +3173,10 @@ if (args.includes('acp')) {
   console.error('error: too many arguments. Expected 0 arguments but got 1.');
   process.exit(1);
 }
+if (!args.includes('--print')) {
+  console.error('missing --print flag');
+  process.exit(1);
+}
 const promptIndex = args.indexOf('-p');
 if (promptIndex === -1 || args[promptIndex + 1] !== 'Reply with only: ok') {
   console.error('missing connection-test prompt');
@@ -3183,7 +3187,7 @@ if (outputFormatIndex === -1 || args[outputFormatIndex + 1] !== 'stream-json') {
   console.error('missing --output-format stream-json');
   process.exit(1);
 }
-console.log(JSON.stringify({ role: 'assistant', content: 'ok' }));
+console.log(JSON.stringify({ role: 'assistant', content: [{ type: 'text', text: 'ok' }] }));
 `,
         async () => {
           const res = await realFetch(`${baseUrl}/api/test/connection`, {
@@ -3206,6 +3210,7 @@ console.log(JSON.stringify({ role: 'assistant', content: 'ok' }));
 
           await expect(fsp.readFile(argvFile, 'utf8')).resolves.toBe(
             JSON.stringify([
+              '--print',
               '-p',
               'Reply with only: ok',
               '--output-format',

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -749,7 +749,7 @@ test('kimi args use prompt-mode JSONL instead of ACP', () => {
   const prompt = 'design a page';
   const args = kimi.buildArgs(prompt, [], [], {});
 
-  assert.deepEqual(args, ['-p', prompt, '--output-format', 'stream-json']);
+  assert.deepEqual(args, ['--print', '-p', prompt, '--output-format', 'stream-json']);
   assert.equal(args.includes('acp'), false);
   assert.equal(args.includes('--yolo'), false);
   assert.equal(kimi.streamFormat, 'json-event-stream');
@@ -762,6 +762,7 @@ test('kimi args pass explicit model selections through prompt mode', () => {
   const args = kimi.buildArgs('hello', [], [], { model: 'moonshot-v1-32k' });
 
   assert.deepEqual(args, [
+    '--print',
     '-p',
     'hello',
     '--output-format',

--- a/apps/daemon/tests/runtimes/json-event-stream.test.ts
+++ b/apps/daemon/tests/runtimes/json-event-stream.test.ts
@@ -258,6 +258,41 @@ test('kimi stream emits OpenAI-style tool calls, tool results, and assistant tex
   ]);
 });
 
+test('kimi stream extracts text from array content blocks (stream-json format)', () => {
+  const { events, handler } = collectEvents('kimi');
+
+  handler.feed(
+    JSON.stringify({
+      role: 'assistant',
+      content: [
+        { type: 'think', think: 'The user wants a greeting.', encrypted: null },
+        { type: 'text', text: 'Hello!' },
+      ],
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'Hello!' },
+  ]);
+});
+
+test('kimi stream silently drops think-only array content without emitting text_delta', () => {
+  const { events, handler } = collectEvents('kimi');
+
+  handler.feed(
+    JSON.stringify({
+      role: 'assistant',
+      content: [
+        { type: 'think', think: 'Thinking...', encrypted: null },
+      ],
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, []);
+});
+
 test('gemini stream handles real stream-json user, tool, and error frames', () => {
   const { events, handler } = collectEvents('gemini');
 


### PR DESCRIPTION
## Why

kimi CLI (`kimi-cli`) requires `--print` for `--output-format` to be accepted — enforced consistently from at least version 1.40.0 through 1.48.0. Without it every invocation exits 2 with:

> Invalid value for --output-format: Output format is only supported for print UI

This was introduced in #4191 which added the `-p`/`--output-format` invocation but omitted `--print`, making the kimi adapter non-functional on all kimi-cli versions. The symptom in Settings is "Could not start Kimi CLI: exit 2 · stderr: Output format is only supported for print UI".

A second bug was also present: kimi's `stream-json` output emits `content` as an array of typed blocks (`[{type:"text",text:"ok"},{type:"think",...}]`) rather than a plain string. `handleKimiEvent` only handled the string case, so even if the CLI had started correctly, no text would have reached the chat UI.

## What users will see

The Kimi CLI connection test in Settings passes instead of showing the exit 2 error. Kimi responds normally in chat.

## Surface area

- [x] **None** — internal bug fix in runtime adapter code

## Bug fix verification

- Verified `kimi -p "..." --output-format stream-json` exits 2 on kimi-cli 1.40.0–1.48.0 without `--print`.
- Verified `kimi --print -p "..." --output-format stream-json` succeeds and emits `{"role":"assistant","content":[{"type":"text","text":"ok"},{"type":"think",...}]}`.
- No cheap red-spec path: the kimi adapter has no mock in `mocks/`; a connection-test unit would need the mock first.

## Validation

- `pnpm guard` and `pnpm typecheck` are blocked by pre-existing failures on `main` unrelated to this change (`extractComponentsManifest` missing from contracts, `node-pty` types, etc.).
- Manually verified the invocation and output format with kimi-cli 1.44.0 and 1.48.0.
