### PR TITLE
fix(telemetry): default content (raw prompt text) telemetry to off

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -600,20 +600,23 @@ function filterAllowedKeys(obj: Record<string, unknown>): AppConfigPrefs {
 }
 
 // Fill in telemetry defaults when the saved config has no `telemetry`
-// field at all (fresh install, pre-disclosure). `metrics` / `content`
-// default to true so onboarding-funnel events emit from the first
-// render — without these defaults the gate at
-// `analytics.ts` (`if (cfg.telemetry?.metrics !== true) return`)
-// dropped every event a user fired before the post-onboarding
-// disclosure modal had a chance to set them. An EXPLICIT `false`
-// the user previously saved is preserved (only `undefined` gets
-// the new default), so opt-out users stay opted out across the
-// 0.7.x → 0.8.0 upgrade.
+// field at all (fresh install, pre-disclosure). `metrics` defaults to
+// true so anonymous onboarding-funnel events emit from the first render
+// — without it the gate at `analytics.ts`
+// (`if (cfg.telemetry?.metrics !== true) return`) dropped every event a
+// user fired before the post-onboarding disclosure modal had a chance
+// to set them. `content` (raw prompt / output text) defaults to FALSE:
+// a fresh install must never ship a user's prompt content before they
+// make an explicit choice — the single "I get it" disclosure banner is
+// not consent for that. Turning content on requires an explicit opt-in
+// under Settings → Privacy. An EXPLICIT `false` the user previously
+// saved is preserved (only `undefined` gets the new default), so
+// opt-out users stay opted out across upgrades.
 function applyTelemetryDefaults(prefs: AppConfigPrefs): AppConfigPrefs {
   if (prefs.telemetry === undefined) {
     return {
       ...prefs,
-      telemetry: { metrics: true, content: true },
+      telemetry: { metrics: true, content: false },
     };
   }
   return prefs;

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -24,7 +24,7 @@ import { isLocalSameOrigin } from '../src/origin-validation.js';
 // "user opted out → stays opted out" assert on `metrics: false`.
 const DEFAULT_TELEMETRY = {
   metrics: true,
-  content: true,
+  content: false,
 } as const;
 
 describe('app-config', () => {
@@ -643,6 +643,16 @@ describe('app-config telemetry prefs', () => {
       content: true,
       artifactManifest: false,
     });
+  });
+
+  it('never enables content telemetry for a fresh install (no consent yet)', async () => {
+    // Privacy invariant: raw prompt / output text must not be sent
+    // before the user makes an explicit choice. A brand-new install has
+    // no `telemetry` field on disk, so the read path backfills the
+    // default — `content` must be false there. Anonymous `metrics` may
+    // stay on for the onboarding funnel; `content` may not.
+    const cfg = await readAppConfig(dataDir);
+    expect(cfg.telemetry?.content).not.toBe(true);
   });
 
   it('persists partial telemetry prefs and omits absent keys', async () => {

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -87,16 +87,20 @@ export const DEFAULT_CONFIG: AppConfig = {
   orbit: DEFAULT_ORBIT,
   projectLocations: [],
   defaultProjectLocationId: 'default',
-  // Telemetry defaults to ON so fresh-install users emit onboarding /
-  // ui_click events from the first frame. The disclosure modal still
-  // appears after `onboardingCompleted` flips, and Settings → Privacy
-  // remains the one-click opt-out. Without these defaults the gate at
-  // `daemon/src/analytics.ts` (`if (telemetry?.metrics !== true) return`)
-  // dropped every event fired during onboarding because no consent
-  // existed yet — observed live on the nightly.10 QA run, which left
-  // zero `page_view pn=onboarding` rows on PostHog despite the user
+  // `metrics` defaults to ON so fresh-install users emit anonymous
+  // onboarding / ui_click events from the first frame. The disclosure
+  // modal still appears after `onboardingCompleted` flips, and
+  // Settings → Privacy remains the one-click opt-out. Without this the
+  // gate at `daemon/src/analytics.ts`
+  // (`if (telemetry?.metrics !== true) return`) dropped every event
+  // fired during onboarding because no consent existed yet — observed
+  // live on the nightly.10 QA run, which left zero
+  // `page_view pn=onboarding` rows on PostHog despite the user
   // completing the flow.
-  telemetry: { metrics: true, content: true },
+  // `content` (raw prompt / output text) defaults to OFF: it must never
+  // be sent before the user makes an explicit choice. Enabling it is an
+  // opt-in under Settings → Privacy.
+  telemetry: { metrics: true, content: false },
 };
 
 /** Well-known providers with pre-filled base URLs. */
@@ -752,25 +756,25 @@ export function mergeDaemonConfig(
   }
   // Default-on reporting. Unless the user has explicitly opted out
   // (Settings → "Don't share", which persists telemetry.metrics === false
-  // together with installationId: null), an install reports with the
-  // product's default telemetry channels on and carries a stable
-  // installationId. This is the single source of the "Opted out" state:
-  // previously an upgraded or never-prompted install could sit with
-  // telemetry on but no id (the daemon ships a metrics+content default but
-  // never mints an id), which the Settings → Privacy field rendered as
-  // "Opted out" even though the user never declined. We mint the id and
-  // keep the default channels on so the displayed state matches the product
-  // default — the same metrics+content surface the first-run banner's "I
-  // get it" opt-in enables (artifactManifest stays off, as it does there).
-  // This does NOT override an explicit opt-out: metrics === false short-
-  // circuits the whole block, and any channel the user already turned off
-  // is preserved via the nullish-coalesce.
+  // together with installationId: null), an install reports anonymous
+  // metrics and carries a stable installationId. This is the single
+  // source of the "Opted out" state: previously an upgraded or
+  // never-prompted install could sit with metrics on but no id (the
+  // daemon ships a metrics default but never mints an id), which the
+  // Settings → Privacy field rendered as "Opted out" even though the
+  // user never declined. We mint the id and keep metrics on so the
+  // displayed state matches the product default. `content` (raw prompt
+  // text) is NOT defaulted on here — it stays off unless the user has
+  // already turned it on, matching the fresh-install default. This does
+  // NOT override an explicit opt-out: metrics === false short-circuits
+  // the whole block, and any channel the user already set is preserved
+  // via the nullish-coalesce.
   const explicitlyOptedOut = next.telemetry?.metrics === false;
   if (!explicitlyOptedOut && !next.installationId) {
     next.installationId = randomUUID();
     next.telemetry = {
       metrics: true,
-      content: next.telemetry?.content ?? true,
+      content: next.telemetry?.content ?? false,
       artifactManifest: next.telemetry?.artifactManifest ?? false,
     };
   }

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -251,16 +251,16 @@ describe('mergeDaemonConfig', () => {
     expect(typeof merged.privacyDecisionAt).toBe('number');
   });
 
-  it('defaults reporting on and mints an installationId when the install never opted out', () => {
-    // Brand-new install: the daemon has no privacy state at all. The product
-    // default telemetry channels (metrics + content) are on and an anonymous
-    // id is assigned so events have a stable distinct id. This mirrors the
-    // first-run banner's "I get it" opt-in payload; artifactManifest stays
-    // off, matching that surface.
+  it('defaults metrics on but content off, minting an installationId when the install never opted out', () => {
+    // Brand-new install: the daemon has no privacy state at all. Anonymous
+    // `metrics` is on (onboarding funnel) and an anonymous id is assigned so
+    // events have a stable distinct id. `content` (raw prompt text) stays
+    // OFF — it must never flow before the user makes an explicit choice.
+    // artifactManifest stays off too.
     const merged = mergeDaemonConfig(DEFAULT_CONFIG, {});
 
     expect(merged.telemetry?.metrics).toBe(true);
-    expect(merged.telemetry?.content).toBe(true);
+    expect(merged.telemetry?.content).toBe(false);
     expect(merged.telemetry?.artifactManifest).toBe(false);
     expect(typeof merged.installationId).toBe('string');
     expect(merged.installationId).toBeTruthy();


### PR DESCRIPTION
Closes #4558.

## Why

#4558 (by @UjuiUjuMandan) surfaced that the privacy docs claimed opt-in/off-by-default while the app ships opt-out/on-by-default. #4631 makes the docs honest — but it does not fix the part that actually matters: a fresh install ships `telemetry: { metrics: true, content: true }`, and the `content` channel releases **raw prompt / output / generated-artifact text** to Langfuse.

Because the default is deliberately on "from the first frame", that raw content can be sent **before** the first-run disclosure banner — which carries only a single **I get it** acknowledgement, not a choice — is even seen. A one-button notice is not consent for shipping someone's prompt content off their machine. This is the substantive fix behind the docs correction, and it is what closes the reporter's issue.

## What changed

Flip `content` to default **OFF** at all three default sites; leave anonymous `metrics` default **ON** (the onboarding-funnel reason the default was originally flipped — metrics and content are separate channels):

- `apps/daemon/src/app-config.ts` — `applyTelemetryDefaults` (the authoritative fresh-install default the daemon send-gate reads).
- `apps/web/src/state/config.ts` — `DEFAULT_CONFIG` and the reporting-default backfill in `mergeDaemonConfig` (`content ?? false`).

An explicit prior choice in either direction is still preserved (only an absent value gets the new default), so existing opt-out **and** opt-in users keep what they had. Turning content on is now an opt-in under **Settings → Privacy**.

### What this stops sending (by default, for users who have not opted in)

- Raw prompt text, raw model output / generation text, generated-artifact bodies, and free-text feedback reasons to Langfuse.

### What is unaffected

- All PostHog product analytics (onboarding funnel, `page_view`, `ui_click`, `run_finished`, counts, durations, error categories, token counts, runtime type) — gated on `metrics`, which stays on.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand/flag or `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, SSE event, or contract shape
- [ ] **Extension point** — `skills/`, `design-systems/`, `design-templates/`, `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — root `package.json`
- [x] **Default behavior change** — content telemetry now defaults off (was on)
- [ ] **None**

## Validation

- `pnpm guard` — green (60 pass).
- `pnpm --filter @open-design/daemon --filter @open-design/web typecheck` — green.
- `apps/daemon/tests/app-config.test.ts` — updated `DEFAULT_TELEMETRY` to `content: false` and added a named privacy invariant: *"never enables content telemetry for a fresh install (no consent yet)"*. Green.
- `apps/web/tests/state/config.test.ts` — fresh-install merge now asserts `metrics: true, content: false`. Green.

## Adjacent issues (out of scope)

- `apps/daemon/tests/runtimes/run-failure-telemetry-smoke.test.ts > drives representative failed runs through analytics and Langfuse diagnostics` fails with `expected 'invalid_api_key' to be 'auth_required'`. Verified this fails **identically on `main`** (stash-diff baseline) — a pre-existing stale auth-categorization assertion, unrelated to this change. Worth its own follow-up.
- A real opt-in checkbox in the first-run banner (so users who *want* to share prompt content can turn it on up front, recovering some Langfuse observability) is a sensible follow-up; kept out to keep this change minimal and focused on the default.
- `docs/roadmap.md` / `CHANGELOG.md` "opt-in" framing — doc alignment tracked alongside #4631.