### PR TITLE
feat(release): automate release cut + backport + pre-release gate

### DIFF
--- a/.github/workflows/backport-label-guard.yml
+++ b/.github/workflows/backport-label-guard.yml
@@ -1,7 +1,8 @@
 name: backport-label-guard
-# 谁都能贴 label(GitHub 没法按单个 label 控权限),所以这里兜底:
-# 有人贴 backport label 时,校验贴标人是否有 write 及以上权限(含有 write 的 outside collaborator)。
-# 不够权限 → 自动撤掉 label + 评论提示。撤 label 触发 unlabeled 事件,不会死循环。
+# Anyone with triage+ can apply any label (GitHub has no per-label permission), so guard here:
+# when someone applies a backport label, verify they have write+ permission (this includes
+# outside collaborators granted write). If not, remove the label and comment. Removing a label
+# fires the "unlabeled" event, not "labeled", so there is no loop.
 
 on:
   pull_request_target:
@@ -21,7 +22,7 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - name: 校验贴标人权限
+      - name: Verify labeler permission
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           ACTOR: ${{ github.event.sender.login }}
@@ -33,10 +34,10 @@ jobs:
           perm=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null || echo none)
           case "$perm" in
             admin|maintain|write)
-              echo "✅ 授权通过: $ACTOR ($perm)";;
+              echo "Authorized: $ACTOR ($perm)";;
             *)
-              echo "⛔ $ACTOR 权限 $perm,撤销 label"
+              echo "Unauthorized: $ACTOR ($perm), removing label"
               gh pr edit "$PR" --repo "$REPO" --remove-label "$LABEL"
-              gh pr comment "$PR" --repo "$REPO" --body "ℹ️ \`$LABEL\` 需要 write 及以上权限才能贴(@$ACTOR 当前是 \`$perm\`),已自动移除。如需纳入本次发布,请 @ 维护者确认。"
+              gh pr comment "$PR" --repo "$REPO" --body "ℹ️ The \`$LABEL\` label requires write permission or above (@$ACTOR currently has \`$perm\`), so it was removed automatically. Please ask a maintainer to confirm whether this should ship in the current release."
               ;;
           esac

--- a/.github/workflows/backport-label-guard.yml
+++ b/.github/workflows/backport-label-guard.yml
@@ -1,0 +1,42 @@
+name: backport-label-guard
+# 谁都能贴 label(GitHub 没法按单个 label 控权限),所以这里兜底:
+# 有人贴 backport label 时,校验贴标人是否有 write 及以上权限(含有 write 的 outside collaborator)。
+# 不够权限 → 自动撤掉 label + 评论提示。撤 label 触发 unlabeled 事件,不会死循环。
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    if: startsWith(github.event.label.name, 'backport ') && github.repository == 'nexu-io/open-design'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: 校验贴标人权限
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          ACTOR: ${{ github.event.sender.login }}
+          LABEL: ${{ github.event.label.name }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          perm=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null || echo none)
+          case "$perm" in
+            admin|maintain|write)
+              echo "✅ 授权通过: $ACTOR ($perm)";;
+            *)
+              echo "⛔ $ACTOR 权限 $perm,撤销 label"
+              gh pr edit "$PR" --repo "$REPO" --remove-label "$LABEL"
+              gh pr comment "$PR" --repo "$REPO" --body "ℹ️ \`$LABEL\` 需要 write 及以上权限才能贴(@$ACTOR 当前是 \`$perm\`),已自动移除。如需纳入本次发布,请 @ 维护者确认。"
+              ;;
+          esac

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,8 @@
 name: backport
-# PR 合进 main 后,若带 backport release/vX.Y.Z label,自动 cherry-pick 到对应 release 分支并开 PR。
-# 用 App token 开 PR(非 GITHUB_TOKEN)→ backport PR 会正常触发 ci.yml 跑全量 CI。
-# 冲突时开 draft PR(把冲突标记一起 commit),不卡死流程,人去解。
+# When a PR merged into main carries a "backport release/vX.Y.Z" label, cherry-pick it onto
+# the matching release branch and open a PR. The App token (not GITHUB_TOKEN) opens the PR so
+# it triggers ci.yml. On conflict it opens a draft PR (conflict markers committed) so nothing
+# is silently lost and a human resolves it.
 
 on:
   pull_request_target:
@@ -30,15 +31,17 @@ jobs:
         uses: korthout/backport-action@v3
         with:
           github_token: ${{ steps.app.outputs.token }}
-          # label 形如 "backport release/v0.12.0" → 捕获 release/v0.12.0 作为目标分支
+          # A label like "backport release/v0.12.0" -> captures release/v0.12.0 as the target branch
           label_pattern: '^backport ([^ ]+)$'
           merge_commits: skip
           pull_title: '[backport ${target_branch}] ${pull_title}'
-          pull_description: '回灌 #${pull_number} 到 `${target_branch}`。\n\n> 干净 pick → CI 绿即可合;冲突 → 这是 draft,解完冲突再合。'
-          # 冲突不放弃:把冲突标记 commit 进 backport 分支并开 draft PR,人接手解
+          pull_description: 'Backport of #${pull_number} to `${target_branch}`.\n\n> Clean pick -> merge once CI is green. Conflict -> this is a draft, resolve conflicts then merge.'
+          # Do not give up on conflicts: commit the conflict markers into the backport branch
+          # and open a draft PR for a human to resolve.
           experimental: '{ "conflict_resolution": "draft_commit_conflicts" }'
-          # ── 干净 pick 自动合的快车道(默认关)──────────────────────────────
-          # 开启前提:release/* 分支保护「要求 CI 通过才能合」,否则会在 CI 跑完前就合。
-          # 配好分支保护后,取消下面两行注释即可让干净 backport CI 绿后自动合:
+          # ── Fast lane: auto-merge clean backports (off by default) ──────────
+          # Prerequisite: branch protection on release/* requiring CI to pass, otherwise it
+          # would merge before CI finishes. Once that is set up, uncomment the two lines below
+          # to auto-merge clean backports after CI turns green:
           # auto_merge_enabled: true
           # auto_merge_method: squash

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,8 +31,10 @@ jobs:
         uses: korthout/backport-action@v3
         with:
           github_token: ${{ steps.app.outputs.token }}
-          # A label like "backport release/v0.12.0" -> captures release/v0.12.0 as the target branch
-          label_pattern: '^backport ([^ ]+)$'
+          # A label like "backport release/v0.12.0" -> captures release/v0.12.0 as the target branch.
+          # Constrained to the release/vX.Y.Z contract so a typo like "backport main" or
+          # "backport feat/foo" does not match and is ignored (never handed to the release bot).
+          label_pattern: '^backport (release/v[0-9]+\.[0-9]+\.[0-9]+)$'
           merge_commits: skip
           pull_title: '[backport ${target_branch}] ${pull_title}'
           pull_description: 'Backport of #${pull_number} to `${target_branch}`.\n\n> Clean pick -> merge once CI is green. Conflict -> this is a draft, resolve conflicts then merge.'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,44 @@
+name: backport
+# PR 合进 main 后,若带 backport release/vX.Y.Z label,自动 cherry-pick 到对应 release 分支并开 PR。
+# 用 App token 开 PR(非 GITHUB_TOKEN)→ backport PR 会正常触发 ci.yml 跑全量 CI。
+# 冲突时开 draft PR(把冲突标记一起 commit),不卡死流程,人去解。
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged == true && github.repository == 'nexu-io/open-design'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app.outputs.token }}
+
+      - name: Backport
+        uses: korthout/backport-action@v3
+        with:
+          github_token: ${{ steps.app.outputs.token }}
+          # label 形如 "backport release/v0.12.0" → 捕获 release/v0.12.0 作为目标分支
+          label_pattern: '^backport ([^ ]+)$'
+          merge_commits: skip
+          pull_title: '[backport ${target_branch}] ${pull_title}'
+          pull_description: '回灌 #${pull_number} 到 `${target_branch}`。\n\n> 干净 pick → CI 绿即可合;冲突 → 这是 draft,解完冲突再合。'
+          # 冲突不放弃:把冲突标记 commit 进 backport 分支并开 draft PR,人接手解
+          experimental: '{ "conflict_resolution": "draft_commit_conflicts" }'
+          # ── 干净 pick 自动合的快车道(默认关)──────────────────────────────
+          # 开启前提:release/* 分支保护「要求 CI 通过才能合」,否则会在 CI 跑完前就合。
+          # 配好分支保护后,取消下面两行注释即可让干净 backport CI 绿后自动合:
+          # auto_merge_enabled: true
+          # auto_merge_method: squash

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,22 +1,23 @@
 name: cut-release
-# 每周二 09:00(北京)从 main HEAD 切下一个 minor 的 release 分支:
-#   1. 算版本(最高 release/vX.Y.Z → bump minor → X.(Y+1).0;0.11.0 → 0.12.0)
-#   2. 切 release/vX.Y.Z + bump apps/packaged/package.json + push
-#   3. 建 backport release/vX.Y.Z label
-# push 用 App token(非 GITHUB_TOKEN),会自动触发 notify-release-feishu → 打 nightly 包 + 发飞书群。
+# Every Tuesday 09:00 Asia/Shanghai, cut the next minor release branch from main HEAD:
+#   1. Compute version (highest release/vX.Y.Z -> bump minor -> X.(Y+1).0; e.g. 0.11.0 -> 0.12.0)
+#   2. Create release/vX.Y.Z, bump apps/packaged/package.json, push
+#   3. Create the "backport release/vX.Y.Z" label
+# The push uses the App token (not GITHUB_TOKEN), so it triggers notify-release-feishu
+# -> builds a nightly package and posts the Feishu card.
 
 on:
   schedule:
-    - cron: '0 1 * * 2'        # 01:00 UTC = 北京周二 09:00
+    - cron: '0 1 * * 2'        # 01:00 UTC = 09:00 Asia/Shanghai, Tuesday
   workflow_dispatch:
     inputs:
       version:
-        description: '完整版本号 x.y.z(留空 = 最高 release 版本 bump minor)'
+        description: 'Full version x.y.z (empty = bump minor of the highest release branch)'
         required: false
         default: ''
 
 permissions:
-  contents: read               # 实际写操作走下面的 App token
+  contents: read               # actual writes go through the App token below
 
 jobs:
   cut:
@@ -38,7 +39,7 @@ jobs:
         with:
           node-version: 24
 
-      - name: 计算下一个版本号
+      - name: Compute next version
         id: ver
         run: |
           set -euo pipefail
@@ -53,16 +54,16 @@ jobs:
           fi
           echo "version=$V"          >> "$GITHUB_OUTPUT"
           echo "branch=release/v$V"  >> "$GITHUB_OUTPUT"
-          echo "切出版本 v$V (分支 release/v$V)"
+          echo "Cutting v$V (branch release/v$V)"
 
-      - name: 防重复(分支已存在则退出)
+      - name: Bail out if the branch already exists
         run: |
           if git ls-remote --exit-code --heads origin "${{ steps.ver.outputs.branch }}" >/dev/null 2>&1; then
-            echo "::error::${{ steps.ver.outputs.branch }} 已存在,跳过"
+            echo "::error::${{ steps.ver.outputs.branch }} already exists, skipping"
             exit 1
           fi
 
-      - name: 切分支 + bump 版本 + push
+      - name: Create branch + bump version + push
         run: |
           set -euo pipefail
           git config user.name  'open-design-release-bot[bot]'
@@ -70,14 +71,14 @@ jobs:
           git switch -c "${{ steps.ver.outputs.branch }}"
           ( cd apps/packaged && npm pkg set version="${{ steps.ver.outputs.version }}" )
           git commit -am "chore(release): v${{ steps.ver.outputs.version }}"
-          git push origin "${{ steps.ver.outputs.branch }}"   # App token push → 触发 notify-release-feishu(nightly + 飞书)
+          git push origin "${{ steps.ver.outputs.branch }}"   # App token push -> triggers notify-release-feishu (nightly + Feishu)
 
-      - name: 建 backport label
+      - name: Create backport label
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
         run: |
           gh label create "backport release/v${{ steps.ver.outputs.version }}" \
             --repo nexu-io/open-design \
             --color 0E8A16 \
-            --description "回灌本修复到 release/v${{ steps.ver.outputs.version }}" \
+            --description "Backport this fix to release/v${{ steps.ver.outputs.version }}" \
             --force

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -32,6 +32,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          ref: main            # always cut from main HEAD, even on a manual dispatch from another branch
           fetch-depth: 0
           token: ${{ steps.app.outputs.token }}
 

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -41,44 +41,62 @@ jobs:
 
       - name: Compute next version
         id: ver
+        env:
+          # Never interpolate the raw input into the shell; pass via env and validate.
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [ -n "${{ inputs.version }}" ]; then
-            V="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            # Strict x.y.z, digits only — rejects shell metacharacters, newlines, etc.
+            if ! printf '%s' "$INPUT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error::Invalid version '$INPUT_VERSION' (expected x.y.z, digits only)"
+              exit 1
+            fi
+            V="$INPUT_VERSION"
           else
             latest=$(git ls-remote --heads origin 'release/v*' \
               | sed -E 's#.*/release/v##' \
+              | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
               | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
             major=${latest%%.*}; rest=${latest#*.}; minor=${rest%%.*}
             V="${major}.$((minor+1)).0"
           fi
+          # V is now guaranteed to match ^[0-9]+\.[0-9]+\.[0-9]+$
           echo "version=$V"          >> "$GITHUB_OUTPUT"
           echo "branch=release/v$V"  >> "$GITHUB_OUTPUT"
           echo "Cutting v$V (branch release/v$V)"
 
       - name: Bail out if the branch already exists
+        env:
+          BRANCH: ${{ steps.ver.outputs.branch }}
         run: |
-          if git ls-remote --exit-code --heads origin "${{ steps.ver.outputs.branch }}" >/dev/null 2>&1; then
-            echo "::error::${{ steps.ver.outputs.branch }} already exists, skipping"
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::error::$BRANCH already exists, skipping"
             exit 1
           fi
 
       - name: Create branch + bump version + push
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
         run: |
           set -euo pipefail
           git config user.name  'open-design-release-bot[bot]'
           git config user.email 'open-design-release-bot[bot]@users.noreply.github.com'
-          git switch -c "${{ steps.ver.outputs.branch }}"
-          ( cd apps/packaged && npm pkg set version="${{ steps.ver.outputs.version }}" )
-          git commit -am "chore(release): v${{ steps.ver.outputs.version }}"
-          git push origin "${{ steps.ver.outputs.branch }}"   # App token push -> triggers notify-release-feishu (nightly + Feishu)
+          git switch -c "$BRANCH"
+          ( cd apps/packaged && npm pkg set version="$VERSION" )
+          git commit -am "chore(release): v$VERSION"
+          git push origin "$BRANCH"   # App token push -> triggers notify-release-feishu (nightly + Feishu)
 
       - name: Create backport label
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          gh label create "backport release/v${{ steps.ver.outputs.version }}" \
+          set -euo pipefail
+          gh label create "backport release/v$VERSION" \
             --repo nexu-io/open-design \
             --color 0E8A16 \
-            --description "Backport this fix to release/v${{ steps.ver.outputs.version }}" \
+            --description "Backport this fix to release/v$VERSION" \
             --force

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,83 @@
+name: cut-release
+# 每周二 09:00(北京)从 main HEAD 切下一个 minor 的 release 分支:
+#   1. 算版本(最高 release/vX.Y.Z → bump minor → X.(Y+1).0;0.11.0 → 0.12.0)
+#   2. 切 release/vX.Y.Z + bump apps/packaged/package.json + push
+#   3. 建 backport release/vX.Y.Z label
+# push 用 App token(非 GITHUB_TOKEN),会自动触发 notify-release-feishu → 打 nightly 包 + 发飞书群。
+
+on:
+  schedule:
+    - cron: '0 1 * * 2'        # 01:00 UTC = 北京周二 09:00
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '完整版本号 x.y.z(留空 = 最高 release 版本 bump minor)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read               # 实际写操作走下面的 App token
+
+jobs:
+  cut:
+    if: github.repository == 'nexu-io/open-design'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app.outputs.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: 计算下一个版本号
+        id: ver
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.version }}" ]; then
+            V="${{ inputs.version }}"
+          else
+            latest=$(git ls-remote --heads origin 'release/v*' \
+              | sed -E 's#.*/release/v##' \
+              | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+            major=${latest%%.*}; rest=${latest#*.}; minor=${rest%%.*}
+            V="${major}.$((minor+1)).0"
+          fi
+          echo "version=$V"          >> "$GITHUB_OUTPUT"
+          echo "branch=release/v$V"  >> "$GITHUB_OUTPUT"
+          echo "切出版本 v$V (分支 release/v$V)"
+
+      - name: 防重复(分支已存在则退出)
+        run: |
+          if git ls-remote --exit-code --heads origin "${{ steps.ver.outputs.branch }}" >/dev/null 2>&1; then
+            echo "::error::${{ steps.ver.outputs.branch }} 已存在,跳过"
+            exit 1
+          fi
+
+      - name: 切分支 + bump 版本 + push
+        run: |
+          set -euo pipefail
+          git config user.name  'open-design-release-bot[bot]'
+          git config user.email 'open-design-release-bot[bot]@users.noreply.github.com'
+          git switch -c "${{ steps.ver.outputs.branch }}"
+          ( cd apps/packaged && npm pkg set version="${{ steps.ver.outputs.version }}" )
+          git commit -am "chore(release): v${{ steps.ver.outputs.version }}"
+          git push origin "${{ steps.ver.outputs.branch }}"   # App token push → 触发 notify-release-feishu(nightly + 飞书)
+
+      - name: 建 backport label
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+        run: |
+          gh label create "backport release/v${{ steps.ver.outputs.version }}" \
+            --repo nexu-io/open-design \
+            --color 0E8A16 \
+            --description "回灌本修复到 release/v${{ steps.ver.outputs.version }}" \
+            --force

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,18 +1,19 @@
 name: release-gate
-# 发版前的准入闸:确认目标 release 分支上没有「没落地的 backport」。
-# 非空就失败 → 提醒别 tag。建议在 tag/发版前手动跑(或接成 release 流程的前置 required job)。
+# Pre-release gate: confirm the target release branch has no un-landed backports.
+# Fails if any -> do not tag. Run it before tagging (or wire it as a required pre-release job).
 #
-# 判据 = 还开着、base = 该 release 分支的 PR。这一条就够覆盖所有「没落地」的情况:
-#   - 冲突 → backport-action 开的是 draft PR(state open,被这里抓到)
-#   - 干净但还没合 / 还在跑 CI → 同样是 open PR,被抓到
-# 全部合进去后,base=该分支的 open PR 归零 → 闸门放行。
-# (korthout 没有「失败打 label」的功能,所以不依赖任何 *-failed label。)
+# The check = open PRs whose base is the release branch. That single check covers every
+# "not landed yet" case:
+#   - Conflict -> backport-action opens a draft PR (state open, caught here)
+#   - Clean but not merged / CI still running -> also an open PR, caught here
+# Once everything is merged, open PRs targeting the branch hit zero -> the gate passes.
+# (korthout has no "label on failure" feature, so this does not rely on any *-failed label.)
 
 on:
   workflow_dispatch:
     inputs:
       release_branch:
-        description: 'release 分支,如 release/v0.12.0'
+        description: 'Release branch, e.g. release/v0.12.0'
         required: true
 
 permissions:
@@ -24,20 +25,20 @@ jobs:
     if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     steps:
-      - name: 检查未落地的 backport
+      - name: Check for un-landed backports
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           BR: ${{ inputs.release_branch }}
         run: |
           set -euo pipefail
-          echo "检查 $BR 是否还有没落地的 backport(open PR)…"
+          echo "Checking $BR for un-landed backports (open PRs)…"
           open=$(gh pr list --repo "$REPO" --base "$BR" --state open \
                   --json number,title,isDraft \
-                  --jq '.[] | "  #\(.number) \(.title)\(if .isDraft then "  [draft/冲突]" else "" end)"')
+                  --jq '.[] | "  #\(.number) \(.title)\(if .isDraft then "  [draft/conflict]" else "" end)"')
           if [ -n "$open" ]; then
-            echo "::error::$BR 还有未落地的 backport,禁止发版:"
+            echo "::error::$BR has un-landed backports, do not release:"
             echo "$open"
             exit 1
           fi
-          echo "✅ $BR 没有悬着的 backport,可以 tag 发版。"
+          echo "✅ $BR has no pending backports, safe to tag and release."

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -32,6 +32,12 @@ jobs:
           BR: ${{ inputs.release_branch }}
         run: |
           set -euo pipefail
+          # Constrain the input to the release/vX.Y.Z grammar first. Any other branch (e.g. main)
+          # must never pass the gate, even if it exists and happens to have no open PRs targeting it.
+          if ! printf '%s' "$BR" | grep -Eq '^release/v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid release branch '$BR' (expected release/vX.Y.Z)"
+            exit 1
+          fi
           # Fail closed: the branch must actually exist. A mistyped or not-yet-cut branch makes
           # `gh pr list` return an empty list, which would otherwise look like "clean / safe".
           if ! gh api "repos/$REPO/git/ref/heads/$BR" >/dev/null 2>&1; then

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -32,6 +32,12 @@ jobs:
           BR: ${{ inputs.release_branch }}
         run: |
           set -euo pipefail
+          # Fail closed: the branch must actually exist. A mistyped or not-yet-cut branch makes
+          # `gh pr list` return an empty list, which would otherwise look like "clean / safe".
+          if ! gh api "repos/$REPO/git/ref/heads/$BR" >/dev/null 2>&1; then
+            echo "::error::Release branch '$BR' does not exist — failing closed (refusing to pass the gate)."
+            exit 1
+          fi
           echo "Checking $BR for un-landed backports (open PRs)…"
           open=$(gh pr list --repo "$REPO" --base "$BR" --state open \
                   --json number,title,isDraft \

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,43 @@
+name: release-gate
+# 发版前的准入闸:确认目标 release 分支上没有「没落地的 backport」。
+# 非空就失败 → 提醒别 tag。建议在 tag/发版前手动跑(或接成 release 流程的前置 required job)。
+#
+# 判据 = 还开着、base = 该 release 分支的 PR。这一条就够覆盖所有「没落地」的情况:
+#   - 冲突 → backport-action 开的是 draft PR(state open,被这里抓到)
+#   - 干净但还没合 / 还在跑 CI → 同样是 open PR,被抓到
+# 全部合进去后,base=该分支的 open PR 归零 → 闸门放行。
+# (korthout 没有「失败打 label」的功能,所以不依赖任何 *-failed label。)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'release 分支,如 release/v0.12.0'
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate:
+    if: github.repository == 'nexu-io/open-design'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检查未落地的 backport
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BR: ${{ inputs.release_branch }}
+        run: |
+          set -euo pipefail
+          echo "检查 $BR 是否还有没落地的 backport(open PR)…"
+          open=$(gh pr list --repo "$REPO" --base "$BR" --state open \
+                  --json number,title,isDraft \
+                  --jq '.[] | "  #\(.number) \(.title)\(if .isDraft then "  [draft/冲突]" else "" end)"')
+          if [ -n "$open" ]; then
+            echo "::error::$BR 还有未落地的 backport,禁止发版:"
+            echo "$open"
+            exit 1
+          fi
+          echo "✅ $BR 没有悬着的 backport,可以 tag 发版。"


### PR DESCRIPTION
## What this is

A GitHub Actions–based automation for the release flow (companion to the internal "Handling fix PRs during a release" doc). Four workflows:

| workflow | what it does | trigger |
|---|---|---|
| **cut-release** | Every Tue 09:00 (Asia/Shanghai), cut `release/vX.Y.Z` from main HEAD (bump minor of the highest release branch, e.g. 0.11.0 → 0.12.0) + bump `apps/packaged/package.json` + create the `backport release/vX.Y.Z` label | `schedule` + manual `workflow_dispatch` |
| **backport** | A PR merged into main that carries a `backport release/vX.Y.Z` label is cherry-picked onto the matching release branch as a PR; on conflict it opens a draft PR (conflict markers committed for a human to resolve) | PR `closed` (merged) |
| **backport-label-guard** | If the person applying a backport label lacks write+ permission, the label is removed automatically with a comment (outside collaborators with write are allowed) | PR `labeled` |
| **release-gate** | Before release, checks the target release branch for un-landed backports (open PRs incl. drafts/conflicts) → fails to block tagging | manual `workflow_dispatch` |

## Dependencies (already in place)

- GitHub App **`open-design-release-bot`** is installed on `nexu-io/open-design`; secrets `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY` are configured.
- **Why an App token instead of `GITHUB_TOKEN`**: GitHub's anti-recursion rule means events produced by `GITHUB_TOKEN` don't trigger other workflows. An App token is not subject to that, so:
  - cut-release pushing `release/**` → triggers the existing **notify-release-feishu** (builds a nightly + posts the Feishu card).
  - backport's PR → triggers **ci.yml** for the full CI run.

## How it chains together

```
Tue 09:00 cut-release ──push──▶ notify-release-feishu (nightly + Feishu)
PR merged to main + backport label ──▶ backport (cherry-pick to release, draft on conflict)
before release ──▶ release-gate (no un-landed backports) ──▶ tag → release-stable
```

## Rollout notes / follow-ups

- **First run: trigger cut-release manually via `workflow_dispatch`** to validate the whole chain (no need to wait for Tuesday).
- **release-gate is manual for now**; it can later be wired as a required pre-release job.
- **backport's auto-merge fast lane is off by default** (see comment in backport.yml); before enabling it, add branch protection on `release/*` requiring CI, otherwise it would merge before CI finishes.
- korthout/backport-action inputs verified against its action.yml (`experimental.conflict_resolution`, `merge_commits`, `label_pattern`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
