### PR TITLE
feat(daemon): populate run_devloop_iterations.tokens_used from run-level usage

### DIFF
--- a/apps/daemon/src/plugins/atoms/registry.ts
+++ b/apps/daemon/src/plugins/atoms/registry.ts
@@ -27,6 +27,10 @@ import type {
   PipelineStage,
 } from '@open-design/contracts';
 import type { UntilSignals } from '../until.js';
+import {
+  scanRunEventsForUsageAnalytics,
+  type RunEventForAnalyticsObservability,
+} from '../../run-analytics-observability.js';
 
 type SqliteDb = Database.Database;
 
@@ -38,6 +42,7 @@ export interface AtomWorkerContext {
   stage:          PipelineStage;
   iteration:      number;
   snapshot:       AppliedPluginSnapshot;
+  runEvents?:     RunEventForAnalyticsObservability[];
 }
 
 export interface AtomOutcome {
@@ -93,6 +98,7 @@ export interface StageRegistryOutcome {
   critiqueSummary: string | null;
   notes:           string[];
   observedAtoms:   string[];
+  tokensUsed?:     number | null;
 }
 
 // Walk every atom in the stage, invoke its registered worker (if
@@ -131,7 +137,16 @@ export async function runStageWithRegistry(
     critiqueSummary: notes.length > 0 ? notes.join('\n') : null,
     notes,
     observedAtoms:   observed,
+    tokensUsed:      tokensUsedFromRunEvents(ctx.runEvents),
   };
+}
+
+function tokensUsedFromRunEvents(
+  events: RunEventForAnalyticsObservability[] | undefined,
+): number | null {
+  if (!events?.length) return null;
+  const usage = scanRunEventsForUsageAnalytics(events, null, 0);
+  return usage.total_tokens ?? null;
 }
 
 // Pessimistic merge between multiple workers contributing to the

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5029,14 +5029,16 @@ export async function startServer({
           stage,
           iteration,
           snapshot:       stageSnapshot,
+          runEvents:      run.events,
         });
         return {
           signals:         outcome.signals,
           critiqueSummary: outcome.critiqueSummary,
+          tokensUsed:      outcome.tokensUsed,
         };
       };
     }
-    void runPipelineForRun({
+    const pipelineDone = runPipelineForRun({
       db: dbHandle,
       runId:           run.id,
       projectId:       projectIdForRun,
@@ -5056,6 +5058,17 @@ export async function startServer({
         });
       } catch { /* ignore */ }
     });
+    void Promise.all([runs.wait(run), pipelineDone])
+      .then(() => {
+        const tokensUsed = scanRunEventsForUsageAnalytics(run.events, null, 0).total_tokens ?? null;
+        if (tokensUsed === null) return;
+        dbHandle.prepare(
+          'UPDATE run_devloop_iterations SET tokens_used = ? WHERE run_id = ?',
+        ).run(tokensUsed, run.id);
+      })
+      .catch((err) => {
+        console.warn('[plugins] devloop tokens_used reconciliation failed', err);
+      });
   };
 
   const startChatRun = async (chatBody, run) => {

--- a/apps/daemon/tests/plugins-pipeline-runner.test.ts
+++ b/apps/daemon/tests/plugins-pipeline-runner.test.ts
@@ -28,6 +28,7 @@ import { runPipelineForRun } from '../src/plugins/pipeline-runner.js';
 import { listIterationsForRun } from '../src/plugins/pipeline.js';
 import { respondSurface } from '../src/genui/registry.js';
 import { findPendingByRunAndSurfaceId } from '../src/genui/store.js';
+import type { RunEventForAnalyticsObservability } from '../src/run-analytics-observability.js';
 import {
   clearAtomWorkers,
   registerAtomWorker,
@@ -255,6 +256,66 @@ describe('pipeline-runner: Stage D registry runner integration', () => {
     expect(outcomes[0]?.converged).toBe(true);
     expect(outcomes[0]?.iterations).toBe(1);
     expect(outcomes[0]?.termination).toBe('no-loop');
+  });
+
+  it('persists registry run-level usage totals and leaves no-usage runs null', async () => {
+    const snap = snapshotWith({
+      pipeline: {
+        stages: [{ id: 'compose', atoms: ['unknown-atom'] }],
+      },
+    });
+    const usageEvents: RunEventForAnalyticsObservability[] = [{
+      id:        1,
+      event:     'agent',
+      data:      {
+        type:  'usage',
+        usage: { input_tokens: 17, output_tokens: 23, total_tokens: 45 },
+      },
+      timestamp: Date.now(),
+    }];
+
+    await runPipelineForRun({
+      db,
+      runId: 'run-with-usage',
+      projectId: 'project-1',
+      conversationId: 'conv-A',
+      snapshot: snap,
+      pipeline: snap.pipeline!,
+      env: { maxIterations: 1 },
+      runStage: async ({ stage, iteration, snapshot: snap2 }) => runStageWithRegistry({
+        db,
+        runId: 'run-with-usage',
+        projectId: 'project-1',
+        conversationId: 'conv-A',
+        stage,
+        iteration,
+        snapshot:  snap2,
+        runEvents: usageEvents,
+      }),
+    });
+
+    await runPipelineForRun({
+      db,
+      runId: 'run-without-usage',
+      projectId: 'project-1',
+      conversationId: 'conv-A',
+      snapshot: snap,
+      pipeline: snap.pipeline!,
+      env: { maxIterations: 1 },
+      runStage: async ({ stage, iteration, snapshot: snap2 }) => runStageWithRegistry({
+        db,
+        runId: 'run-without-usage',
+        projectId: 'project-1',
+        conversationId: 'conv-A',
+        stage,
+        iteration,
+        snapshot:  snap2,
+        runEvents: [],
+      }),
+    });
+
+    expect(listIterationsForRun(db, 'run-with-usage')[0]?.tokensUsed).toBe(45);
+    expect(listIterationsForRun(db, 'run-without-usage')[0]?.tokensUsed).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #4643.

## Why

I hit this while looking at where local token usage is and isn't visible in OD: `run_devloop_iterations.tokens_used` is always NULL even though the column and its write path are fully wired. Nothing upstream of `recordIteration` ever produces a value (`StageRegistryOutcome` has no token field, and the `server.ts` registry `runStage` closure maps only `{ signals, critiqueSummary }`), so the audit column is effectively dead. The usage data already exists in `run.events` and is already reduced by `scanRunEventsForUsageAnalytics` for Langfuse / PostHog, so this is a small plumbing gap rather than missing data. Discussed and aligned on semantics in #4643.

## What users will see

No UI change. API consumers of `GET /api/runs/:runId/devloop-iterations` now see a non-null `tokens_used` (the run-level token total) on devloop iteration rows for runs whose runtime reports usage. It is strictly additive: rows that were NULL now carry the final run total, and runtimes that report no usage (e.g. aider / deepseek / qwen / grok / antigravity) still leave `tokens_used` NULL. Semantics are run-level total stamped on each iteration row (last-write-wins via a run-end reconciliation pass), not per-iteration attribution, and complementary to the per-request work in #4620.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract** (no new endpoint / SSE / contract shape change; `tokens_used` was already typed `number | null`, this only populates it)
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** - API consumers of an existing endpoint now see a populated `tokens_used` (previously always NULL) without opting in. No schema migration (the column already exists), no auto-network, no auto-install.
- [ ] **None**

## Screenshots

None (no UI surface).

## Bug fix verification

This fills a never-populated column rather than fixing a regression, but it is covered by a falsifiable test:
- Test path: `apps/daemon/tests/plugins-pipeline-runner.test.ts` (a run whose events carry a `usage` frame records a non-null `tokens_used`; a run with no usage events leaves it NULL).
- Red on `main` / green on this branch: yes. On `main` the registry path produces no token value and the reconciliation does not exist, so `listIterationsForRun(...)[0].tokensUsed` is NULL and the new assertion fails; on this branch it is the run total.
- Verification: `pnpm --filter @open-design/daemon test` (touched suites `plugins-pipeline-runner` + `plugins-atom-registry`) pass; `pnpm --filter @open-design/daemon typecheck` exits 0.

## Validation

- `pnpm guard`: 60 pass, 0 fail.
- `pnpm --filter @open-design/daemon typecheck`: exit 0.
- `pnpm --filter @open-design/daemon test` (touched suites `plugins-pipeline-runner` + `plugins-atom-registry`): 19 pass.
