### PR TITLE
fix(ci): notify-release-feishu startup_failure — grant packages/id-token for nested docker publish

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -40,6 +40,12 @@ on:
 permissions:
   contents: write
   actions: write
+  # release-stable's publish_docker_image job (added in #4327) needs these to call
+  # docker-image.yml. A called workflow can only downgrade the caller's token, so without
+  # them this reusable-workflow chain fails at startup (permission escalation) — even though
+  # the docker job is skipped for the nightly channel. See run 27996588773.
+  packages: write
+  id-token: write
 
 concurrency:
   group: feishu-release-${{ github.ref }}

--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -40,12 +40,6 @@ on:
 permissions:
   contents: write
   actions: write
-  # release-stable's publish_docker_image job (added in #4327) needs these to call
-  # docker-image.yml. A called workflow can only downgrade the caller's token, so without
-  # them this reusable-workflow chain fails at startup (permission escalation) — even though
-  # the docker job is skipped for the nightly channel. See run 27996588773.
-  packages: write
-  id-token: write
 
 concurrency:
   group: feishu-release-${{ github.ref }}
@@ -60,6 +54,16 @@ jobs:
   build:
     name: Build nightly from release branch
     if: github.repository == 'nexu-io/open-design'
+    # Scope packages/id-token to the only job that calls release-stable. Its
+    # publish_docker_image job (added in #4327) needs them to call docker-image.yml;
+    # a called workflow can only downgrade the caller's token, so without them the chain
+    # fails at startup (permission escalation) even though the docker job is skipped for
+    # the nightly channel. The notify job below doesn't need them. See run 27996588773.
+    permissions:
+      contents: write
+      actions: write
+      packages: write
+      id-token: write
     uses: ./.github/workflows/release-stable.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Problem

`notify-release-feishu` (push to `release/**`) has been failing at **`startup_failure`** since the first time it ran after #4327 merged. Latest: [run 27996588773](https://github.com/nexu-io/open-design/actions/runs/27996588773) on `release/v0.12.0`.

## Root cause

`notify-release-feishu` calls `release-stable.yml` (`channel: nightly`). #4327 added a `publish_docker_image` job to `release-stable` that requests `packages: write` + `id-token: write` to call `docker-image.yml`.

A reusable workflow can only **downgrade** the caller's `GITHUB_TOKEN`, never escalate. `notify-release-feishu` only granted `contents: write` + `actions: write`, so that job's request is a permission escalation → the whole nested run fails at **startup**, before any job runs (which is why there are no logs/annotations).

It went unnoticed because #4327 merged (2026-06-17 12:25) **after** the last notify-triggered `release-stable` run; the successful `release-stable` runs since then were all direct `workflow_dispatch` (full token, no escalation). The push-triggered path simply hadn't run again until now.

## Fix

Grant `packages: write` + `id-token: write` to `notify-release-feishu`'s top-level `permissions`. The chain can then start. For the `nightly` channel the docker job is still skipped at runtime (`github_release_enabled != true`), so this only unblocks startup — it does not publish a Docker image on nightly.

## Note

Any other reusable-workflow caller of `release-stable` that lacks these two permissions would hit the same wall. Direct `workflow_dispatch` runs are unaffected (they carry the full token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
