### PR TITLE
Fix idle MCP stdio helper leaks

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -25,6 +25,7 @@ import { postCreateArtifactRequest } from './artifacts/create.js';
 
 const SERVER_NAME = 'open-design';
 const SERVER_VERSION = '0.2.0';
+const MCP_STDIO_IDLE_EXIT_MS = 30 * 60 * 1000;
 
 type JsonObject = Record<string, unknown>;
 interface RunMcpOptions { daemonUrl: string | URL }
@@ -43,6 +44,69 @@ interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; inclu
 interface ProjectFileBundleEntry { name: string; mime: string; size: number | null; content: string | null; binary: boolean }
 interface BundleInput { project: ProjectPayload | ProjectSummary; entry: string; files: ProjectFileBundleEntry[]; truncated: boolean; active: ActiveContext | null; resolved?: ResolvedProject | null }
 interface ErrorWithCode { message?: string; code?: string; cause?: { code?: string } }
+
+interface McpIdleExitControllerOptions {
+  idleMs: number;
+  onIdle: () => void;
+}
+
+export function _createMcpIdleExitController({
+  idleMs,
+  onIdle,
+}: McpIdleExitControllerOptions) {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight = 0;
+  let disposed = false;
+
+  const clear = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const schedule = () => {
+    if (disposed) return;
+    clear();
+    timer = setTimeout(() => {
+      timer = null;
+      if (disposed) return;
+      if (inFlight > 0) {
+        schedule();
+        return;
+      }
+      disposed = true;
+      onIdle();
+    }, idleMs);
+  };
+
+  schedule();
+
+  return {
+    noteActivity() {
+      schedule();
+    },
+    async trackRequest<T>(fn: () => T | Promise<T>): Promise<T> {
+      if (disposed) {
+        return fn();
+      }
+      inFlight += 1;
+      schedule();
+      try {
+        return await fn();
+      } finally {
+        inFlight -= 1;
+        if (inFlight === 0) {
+          schedule();
+        }
+      }
+    },
+    dispose() {
+      disposed = true;
+      clear();
+    },
+  };
+}
 
 // Mimes whose body we surface as MCP `text` content. Everything else
 // returns a clear error directing the caller at list_files for
@@ -434,6 +498,15 @@ const TOOL_DEFS = [
 
 export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
   const baseUrl = String(daemonUrl).replace(/\/$/, '');
+  let closeTransportForIdle: (() => void) | null = null;
+  const idleExit = _createMcpIdleExitController({
+    idleMs: MCP_STDIO_IDLE_EXIT_MS,
+    onIdle: () => closeTransportForIdle?.(),
+  });
+  const withMcpActivity =
+    <Args extends unknown[], Result>(handler: (...args: Args) => Result | Promise<Result>) =>
+      (...args: Args) =>
+        idleExit.trackRequest(() => handler(...args));
 
   const server = new Server(
     { name: SERVER_NAME, version: SERVER_VERSION },
@@ -533,11 +606,11 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
     },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  server.setRequestHandler(ListToolsRequestSchema, withMcpActivity(async () => ({
     tools: TOOL_DEFS,
-  }));
+  })));
 
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  server.setRequestHandler(ListResourcesRequestSchema, withMcpActivity(async () => {
     const [skillsData, dsData] = await Promise.all([
       getJson<SkillsPayload>(`${baseUrl}/api/skills`).catch((): SkillsPayload => ({ skills: [] })),
       getJson<DesignSystemsPayload>(`${baseUrl}/api/design-systems`).catch((): DesignSystemsPayload => ({ designSystems: [] })),
@@ -567,9 +640,9 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
       });
     }
     return { resources };
-  });
+  }));
 
-  server.setRequestHandler(ReadResourceRequestSchema, async (req) => {
+  server.setRequestHandler(ReadResourceRequestSchema, withMcpActivity(async (req) => {
     const uri = req.params?.uri;
     if (uri === 'od://focus/active') {
       const data = await getJson<ActiveContext>(`${baseUrl}/api/active`);
@@ -609,27 +682,54 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
         },
       ],
     };
-  });
+  }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  server.setRequestHandler(CallToolRequestSchema, withMcpActivity(async (req) => {
     const name = req.params?.name;
     const args: McpArgs = (req.params?.arguments ?? {}) as McpArgs;
     return handleMcpToolCall(baseUrl, name, args);
-  });
+  }));
 
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  try {
+    closeTransportForIdle = () => {
+      void transport.close().catch(() => {});
+    };
+    await server.connect(transport);
 
-  // server.connect() only *starts* the transport; it resolves once the
-  // stdio reader is wired up, not when the stream closes. Hold the
-  // process open until the client disconnects (stdin EOF) so the cli.ts
-  // top-level `process.exit(0)` doesn't kill us mid-handshake.
-  await new Promise<void>((resolve) => {
-    const done = () => resolve();
-    transport.onclose = done;
-    process.stdin.once('end', done);
-    process.stdin.once('close', done);
-  });
+    const sdkOnMessage = transport.onmessage;
+    transport.onmessage = (...args) => {
+      idleExit.noteActivity();
+      sdkOnMessage?.(...args);
+    };
+
+    // server.connect() only *starts* the transport; it resolves once the
+    // stdio reader is wired up, not when the stream closes. Hold the
+    // process open until the client disconnects (stdin EOF) so the cli.ts
+    // top-level `process.exit(0)` doesn't kill us mid-handshake.
+    await new Promise<void>((resolve) => {
+      const sdkOnClose = transport.onclose;
+      let finished = false;
+      const done = () => {
+        if (finished) return;
+        finished = true;
+        idleExit.dispose();
+        resolve();
+      };
+      transport.onclose = () => {
+        sdkOnClose?.();
+        done();
+      };
+      const closeTransportForStdin = () => {
+        void transport.close().catch(() => done());
+      };
+      process.stdin.once('end', closeTransportForStdin);
+      process.stdin.once('close', closeTransportForStdin);
+    });
+  } finally {
+    idleExit.dispose();
+    closeTransportForIdle = null;
+  }
 }
 
 function ok(payload: unknown) {

--- a/apps/daemon/tests/mcp-stdio-idle.test.ts
+++ b/apps/daemon/tests/mcp-stdio-idle.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { _createMcpIdleExitController } from '../src/mcp.js';
+
+describe('MCP stdio idle exit controller', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('exits after the idle window elapses', () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    _createMcpIdleExitController({ idleMs: 1_000, onIdle });
+
+    vi.advanceTimersByTime(999);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1_000);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the idle window when activity arrives', () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const idleExit = _createMcpIdleExitController({ idleMs: 1_000, onIdle });
+
+    vi.advanceTimersByTime(750);
+    idleExit.noteActivity();
+
+    vi.advanceTimersByTime(999);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not exit while a request is in flight', async () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const idleExit = _createMcpIdleExitController({ idleMs: 1_000, onIdle });
+    let resolveRequest!: () => void;
+
+    const request = idleExit.trackRequest(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    resolveRequest();
+    await request;
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the pending exit when disposed', () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const idleExit = _createMcpIdleExitController({ idleMs: 1_000, onIdle });
+
+    idleExit.dispose();
+    vi.advanceTimersByTime(1_000);
+
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #4400

## Why

I picked this up from the open bug report: abandoned Open Design MCP stdio helper processes can stay alive when a client does not close stdio cleanly. That leaves stale helper processes behind for users working through Codex Desktop or other MCP clients.

This PR adds a defensive idle exit inside the `od mcp` stdio bridge so Open Design can clean itself up even when the client side never sends EOF.

## What users will see

Users should no longer accumulate abandoned `od mcp` helper processes indefinitely. A helper with no MCP traffic for 30 minutes closes its stdio transport and exits cleanly; active tool calls are tracked so long-running requests are not interrupted mid-flight.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI change.

## Bug fix verification

- Test path that reproduces/guards the bug: `apps/daemon/tests/mcp-stdio-idle.test.ts`
- Did the test go red on `main` and green on this branch? Not run separately on `main`; the full leak requires an abandoned MCP stdio client. The new fake-timer unit coverage isolates the defensive behavior: idle exits after the window, activity resets the timer, in-flight calls block exit, and dispose cancels the timer.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/daemon exec vitest run tests/mcp-stdio-idle.test.ts tests/mcp-resolve-project.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
