### PR TITLE
[codex] implement AMR Cloud Recovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,10 @@ _Avoid_: Open Design supported platforms, release channel, future platform promi
 Whether the user has authenticated the account needed to use AMR Cloud.
 _Avoid_: profile badge, environment, CLI version
 
+**AMR Cloud Recovery**:
+The user-visible continuity path for an AMR Cloud run that pauses because AMR billing requires payment, auto top-up, or retry coordination before the run can continue.
+_Avoid_: billing recovery, account recovery, run retry
+
 **AMR Environment Profile**:
 The target AMR service environment a packaged runtime is configured to use.
 _Avoid_: release channel, account status, app identity
@@ -94,6 +98,19 @@ _Avoid_: continue, finish setup, passive close
 - The **AMR CLI Distribution Contract** is owned separately from Open Design; Open Design release packaging consumes it instead of defining the native CLI release itself.
 - The first **AMR CLI Distribution Slice** is mac arm64 only.
 - **AMR Account Status** describes account readiness for **AMR Cloud**, not the environment profile or CLI installation state.
+- **AMR Cloud Recovery** belongs to **AMR Cloud** continuity and does not make Open Design the owner of AMR billing state.
+- **AMR Cloud Recovery** resumes automatically after automatic top-up and requires user-initiated recovery after manual top-up.
+- Manual **AMR Cloud Recovery** is initiated from Open Design, while payment state and balance readiness remain owned by AMR Cloud.
+- **AMR Cloud Recovery** preserves operation continuity across daemon restarts without becoming a complete replay archive for the original run.
+- When the original local run can no longer be resumed, **AMR Cloud Recovery** presents a restart path rather than treating the AMR payment or operation as failed.
+- **AMR Cloud Recovery** is a normal AMR Cloud continuity state, not a generic run failure category.
+- Multiple **AMR Cloud Recovery** operations may exist at once, but each is presented through its originating run or conversation rather than through a global recovery inbox.
+- Manual **AMR Cloud Recovery** continues the same user request rather than presenting a new unrelated task.
+- Canceling **AMR Cloud Recovery** means the user no longer wants to continue that request; it does not imply a refund or payment reversal.
+- **AMR Cloud Recovery** covers balance-related top-up and resume continuity; risk, refund, and dispute blocks are AMR Cloud blocks rather than recovery states.
+- **AMR Cloud Recovery** is bound to the AMR Cloud user that created the recovery operation, not to a local device or Project.
+- Returning to the correct AMR Cloud user does not change the recovery mode: automatic top-up may auto-resume, while manual top-up still requires user initiation.
+- **AMR Cloud Recovery** is presented through the originating run, conversation, and run surfaces rather than a separate recovery center.
 - An **AMR Environment Profile** is independent from release channel identity; a beta, preview, nightly, or stable package can target different AMR service environments when explicitly configured.
 - **Onboarding Skip** bypasses setup completion requirements that belong to the normal onboarding continue path.
 

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -5389,6 +5389,7 @@ async function runRun(args) {
   od run redesign [--path <folder>] [--message "<text>" | --prompt-file <path|->]
                [--agent claude] [--model <id>] [--follow] [--json]
   od run watch  <runId>                     ND-JSON event stream on stdout.
+  od run recover <runId>                    Continue an AMR Cloud Recovery run.
   od run cancel <runId>                     Request cancellation.
   od run list   [--project <id>]            List recent runs.
   od run info   <runId>                     One run's status.
@@ -5464,6 +5465,26 @@ Common options:
       const resp = await fetch(`${base}/api/runs/${encodeURIComponent(id)}/cancel`, { method: 'POST' });
       if (!resp.ok) return structuredHttpFailure(resp, 'run-not-found');
       console.log(`[run] cancelled ${id}`);
+      return;
+    }
+    case 'recover': {
+      const id = rest.find((a) => !a.startsWith('-'));
+      if (!id) {
+        console.error('Usage: od run recover <runId>');
+        process.exit(2);
+      }
+      const resp = await fetch(`${base}/api/runs/${encodeURIComponent(id)}/amr-recovery/resume`, { method: 'POST' });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+        console.error(`AMR Cloud Recovery failed: ${resp.status} ${JSON.stringify(data)}`);
+        process.exit(1);
+      }
+      if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      console.log(`[run] AMR Cloud Recovery updated ${id}`);
+      if (data?.amrRecovery) {
+        console.log(JSON.stringify(data.amrRecovery, null, 2));
+      }
       return;
     }
     case 'watch': {

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -286,6 +286,9 @@ function migrate(db: SqliteDb): void {
   if (!messageCols.some((c: DbRow) => c.name === 'applied_plugin_snapshot_json')) {
     db.exec(`ALTER TABLE messages ADD COLUMN applied_plugin_snapshot_json TEXT`);
   }
+  if (!messageCols.some((c: DbRow) => c.name === 'amr_recovery_json')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN amr_recovery_json TEXT`);
+  }
   if (!messageCols.some((c: DbRow) => c.name === 'telemetry_finalized_at')) {
     db.exec(`ALTER TABLE messages ADD COLUMN telemetry_finalized_at INTEGER`);
   }
@@ -1187,6 +1190,7 @@ export function listMessages(db: SqliteDb, conversationId: string) {
               session_mode AS sessionMode,
               run_context_json AS runContextJson,
               applied_plugin_snapshot_json AS appliedPluginSnapshotJson,
+              amr_recovery_json AS amrRecoveryJson,
               created_at AS createdAt, started_at AS startedAt, ended_at AS endedAt,
               position
          FROM messages
@@ -1211,6 +1215,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
               produced_files_json = ?, feedback_json = ?,
               pre_turn_file_names_json = ?,
               session_mode = ?, run_context_json = ?, applied_plugin_snapshot_json = ?,
+              amr_recovery_json = ?,
               telemetry_finalized_at = CASE
                 WHEN ? THEN COALESCE(telemetry_finalized_at, ?)
                 ELSE telemetry_finalized_at
@@ -1234,6 +1239,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       normalizeMessageSessionModeForStorage(m.sessionMode),
       m.runContext ? JSON.stringify(m.runContext) : null,
       m.appliedPluginSnapshot ? JSON.stringify(m.appliedPluginSnapshot) : null,
+      m.amrRecovery ? JSON.stringify(m.amrRecovery) : null,
       m.telemetryFinalized === true ? 1 : 0,
       now,
       m.startedAt ?? null,
@@ -1251,8 +1257,8 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
     // run_id, run_status, last_run_event_id, events_json, attachments_json,
     // comment_attachments_json, produced_files_json, feedback_json,
     // pre_turn_file_names_json, session_mode, run_context_json,
-    // applied_plugin_snapshot_json, telemetry_finalized_at, started_at,
-    // ended_at, position, created_at.
+    // applied_plugin_snapshot_json, amr_recovery_json,
+    // telemetry_finalized_at, started_at, ended_at, position, created_at.
     db.prepare(
       `INSERT INTO messages
          (id, conversation_id, role, content, agent_id, agent_name,
@@ -1260,8 +1266,8 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
           attachments_json, comment_attachments_json, produced_files_json,
           feedback_json, pre_turn_file_names_json,
           session_mode, run_context_json, applied_plugin_snapshot_json,
-          telemetry_finalized_at, started_at, ended_at, position, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          amr_recovery_json, telemetry_finalized_at, started_at, ended_at, position, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       m.id,
       conversationId,
@@ -1281,6 +1287,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       normalizeMessageSessionModeForStorage(m.sessionMode),
       m.runContext ? JSON.stringify(m.runContext) : null,
       m.appliedPluginSnapshot ? JSON.stringify(m.appliedPluginSnapshot) : null,
+      m.amrRecovery ? JSON.stringify(m.amrRecovery) : null,
       m.telemetryFinalized === true ? now : null,
       m.startedAt ?? null,
       m.endedAt ?? null,
@@ -1307,6 +1314,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
               session_mode AS sessionMode,
               run_context_json AS runContextJson,
               applied_plugin_snapshot_json AS appliedPluginSnapshotJson,
+              amr_recovery_json AS amrRecoveryJson,
               created_at AS createdAt, started_at AS startedAt, ended_at AS endedAt,
               position
          FROM messages WHERE id = ?`,
@@ -1357,6 +1365,13 @@ export function appendMessageStatusEvent(db: SqliteDb, messageId: string, event:
   db.prepare(`UPDATE messages SET events_json = ? WHERE id = ?`)
     .run(JSON.stringify(next), messageId);
   return next;
+}
+
+export function updateMessageAmrRecovery(db: SqliteDb, messageId: string, amrRecovery: unknown | null) {
+  db.prepare(`UPDATE messages SET amr_recovery_json = ? WHERE id = ?`).run(
+    amrRecovery ? JSON.stringify(amrRecovery) : null,
+    messageId,
+  );
 }
 
 export function appendMessageAgentEvent(db: SqliteDb, messageId: string, event: DbRow) {
@@ -1685,6 +1700,7 @@ function normalizeMessage(row: DbRow) {
     sessionMode: normalizeMessageSessionMode(row.sessionMode),
     runContext: parseJsonOrUndef(row.runContextJson),
     appliedPluginSnapshot: parseJsonOrUndef(row.appliedPluginSnapshotJson),
+    amrRecovery: parseJsonOrUndef(row.amrRecoveryJson),
     createdAt: row.createdAt ?? undefined,
     startedAt: row.startedAt ?? undefined,
     endedAt: row.endedAt ?? undefined,

--- a/apps/daemon/src/integrations/amr-cloud-recovery.ts
+++ b/apps/daemon/src/integrations/amr-cloud-recovery.ts
@@ -1,0 +1,698 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { AmrCloudRecoveryOverlay } from '@open-design/contracts';
+
+import {
+  readVelaApiContext,
+  type VelaApiContext,
+} from './vela.js';
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+type RecoverySourceStatus =
+  | 'active'
+  | 'waiting_payment'
+  | 'waiting_auto_topup'
+  | 'retry_available'
+  | 'resuming'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'blocked';
+
+type RecoveryMode =
+  | 'automatic_topup'
+  | 'manual_topup'
+  | 'manual_topup_required'
+  | 'unknown';
+
+interface StoredRecoveryContext {
+  operationId: string;
+  retryToken: string | null;
+  status: RecoverySourceStatus;
+  version: number | string | null;
+  userId: string;
+  runId: string;
+  projectId: string | null;
+  conversationId: string | null;
+  assistantMessageId: string | null;
+  mode: RecoveryMode;
+  userVisible: boolean;
+  resumeAttempts: number;
+  pollAttempts: number;
+  recoveryUrl: string | null;
+  blockReason: string | null;
+  restartAvailable: boolean;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number | null;
+}
+
+export interface AmrRecoveryRunRef {
+  id: string;
+  projectId?: string | null;
+  conversationId?: string | null;
+  assistantMessageId?: string | null;
+}
+
+export interface AmrCloudRecoveryService {
+  prepareRun(input: {
+    run: AmrRecoveryRunRef;
+    env?: NodeJS.ProcessEnv;
+    configuredEnv?: Record<string, string>;
+    model?: string | null;
+  }): Promise<AmrCloudRecoveryOverlay | null>;
+  pauseForInsufficientBalance(input: {
+    runId: string;
+    env?: NodeJS.ProcessEnv;
+    configuredEnv?: Record<string, string>;
+  }): Promise<AmrCloudRecoveryOverlay | null>;
+  refreshRun(input: {
+    runId: string;
+    env?: NodeJS.ProcessEnv;
+    configuredEnv?: Record<string, string>;
+  }): Promise<AmrCloudRecoveryOverlay | null>;
+  resumeRun(input: {
+    runId: string;
+    env?: NodeJS.ProcessEnv;
+    configuredEnv?: Record<string, string>;
+  }): Promise<AmrCloudRecoveryOverlay | null>;
+  markTerminal(input: {
+    runId: string;
+    terminal: 'complete' | 'fail' | 'cancel';
+    env?: NodeJS.ProcessEnv;
+    configuredEnv?: Record<string, string>;
+  }): Promise<AmrCloudRecoveryOverlay | null>;
+  cancelRun(input: {
+    runId: string;
+    env?: NodeJS.ProcessEnv;
+    configuredEnv?: Record<string, string>;
+  }): Promise<AmrCloudRecoveryOverlay | null>;
+  rebindRun(input: {
+    fromRunId: string;
+    toRun: AmrRecoveryRunRef;
+  }): AmrCloudRecoveryOverlay | null;
+  markRestartAvailable(input: {
+    runId: string;
+    message?: string;
+  }): AmrCloudRecoveryOverlay | null;
+  getOverlayForRun(runId: string): AmrCloudRecoveryOverlay | null;
+  getContextForRun(runId: string): StoredRecoveryContext | null;
+}
+
+export interface CreateAmrCloudRecoveryServiceDeps {
+  dataDir: string;
+  fetchImpl?: FetchLike;
+  now?: () => number;
+  logger?: Pick<Console, 'warn'>;
+}
+
+const STORE_DIR_NAME = 'amr-cloud-recovery';
+const DEFAULT_EXPIRES_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_AUTO_POLL_ATTEMPTS = 12;
+const MAX_RESUME_ATTEMPTS = 2;
+
+function recoveryDir(dataDir: string): string {
+  return path.join(dataDir, STORE_DIR_NAME);
+}
+
+function contextPath(dataDir: string, operationId: string): string {
+  return path.join(recoveryDir(dataDir), `${encodeURIComponent(operationId)}.json`);
+}
+
+function ensureStore(dataDir: string): void {
+  fs.mkdirSync(recoveryDir(dataDir), { recursive: true, mode: 0o700 });
+}
+
+function readJsonFile(file: string): unknown | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8')) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function writeContext(dataDir: string, context: StoredRecoveryContext): void {
+  ensureStore(dataDir);
+  const tmp = `${contextPath(dataDir, context.operationId)}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(context, null, 2), { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(tmp, contextPath(dataDir, context.operationId));
+}
+
+function deleteContext(dataDir: string, operationId: string): void {
+  try {
+    fs.unlinkSync(contextPath(dataDir, operationId));
+  } catch {
+    // best effort
+  }
+}
+
+function readContexts(dataDir: string): StoredRecoveryContext[] {
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(recoveryDir(dataDir));
+  } catch {
+    return [];
+  }
+  const contexts: StoredRecoveryContext[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    const parsed = readJsonFile(path.join(recoveryDir(dataDir), entry));
+    const normalized = normalizeStoredContext(parsed);
+    if (normalized) contexts.push(normalized);
+  }
+  return contexts;
+}
+
+function normalizeStoredContext(value: unknown): StoredRecoveryContext | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const operationId = readNonEmptyString(raw.operationId);
+  const userId = readNonEmptyString(raw.userId);
+  const runId = readNonEmptyString(raw.runId);
+  if (!operationId || !userId || !runId) return null;
+  const status = normalizeSourceStatus(raw.status);
+  return {
+    operationId,
+    retryToken: readNullableString(raw.retryToken),
+    status,
+    version: readVersion(raw.version),
+    userId,
+    runId,
+    projectId: readNullableString(raw.projectId),
+    conversationId: readNullableString(raw.conversationId),
+    assistantMessageId: readNullableString(raw.assistantMessageId),
+    mode: normalizeMode(raw.mode),
+    userVisible: raw.userVisible === true,
+    resumeAttempts: readNonNegativeInt(raw.resumeAttempts),
+    pollAttempts: readNonNegativeInt(raw.pollAttempts),
+    recoveryUrl: readNullableString(raw.recoveryUrl),
+    blockReason: readNullableString(raw.blockReason),
+    restartAvailable: raw.restartAvailable === true,
+    createdAt: readTimestamp(raw.createdAt),
+    updatedAt: readTimestamp(raw.updatedAt),
+    expiresAt: typeof raw.expiresAt === 'number' && Number.isFinite(raw.expiresAt)
+      ? raw.expiresAt
+      : null,
+  };
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function readNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function readVersion(value: unknown): number | string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  return null;
+}
+
+function readTimestamp(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : Date.now();
+}
+
+function readNonNegativeInt(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : 0;
+}
+
+function normalizeSourceStatus(value: unknown): RecoverySourceStatus {
+  switch (value) {
+    case 'active':
+    case 'waiting_payment':
+    case 'waiting_auto_topup':
+    case 'retry_available':
+    case 'resuming':
+    case 'completed':
+    case 'failed':
+    case 'canceled':
+    case 'blocked':
+      return value;
+    default:
+      return 'blocked';
+  }
+}
+
+function normalizeMode(value: unknown): RecoveryMode {
+  switch (value) {
+    case 'automatic_topup':
+    case 'manual_topup':
+    case 'manual_topup_required':
+    case 'unknown':
+      return value;
+    default:
+      return 'unknown';
+  }
+}
+
+function modeFromResponse(value: Record<string, unknown>): RecoveryMode {
+  if (value.manualTopupRequired === true || value.manual_topup_required === true) {
+    return 'manual_topup_required';
+  }
+  const rawMode = value.mode ?? value.recoveryMode ?? value.recovery_mode ?? value.topupMode ?? value.topup_mode;
+  const normalized = normalizeMode(rawMode);
+  if (normalized !== 'unknown') return normalized;
+  if (value.autoTopup === true || value.auto_topup === true || value.automaticTopup === true) {
+    return 'automatic_topup';
+  }
+  if (value.status === 'waiting_auto_topup') return 'automatic_topup';
+  if (value.status === 'waiting_payment') return 'manual_topup';
+  return 'unknown';
+}
+
+function responseObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const raw = value as Record<string, unknown>;
+  const data = raw.data;
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    return { ...raw, ...(data as Record<string, unknown>) };
+  }
+  return raw;
+}
+
+function contextFromResponse(input: {
+  response: unknown;
+  run: AmrRecoveryRunRef;
+  userId: string;
+  now: number;
+  previous?: StoredRecoveryContext | null;
+}): StoredRecoveryContext {
+  const raw = responseObject(input.response);
+  const operationId =
+    readNonEmptyString(raw.operationId) ??
+    readNonEmptyString(raw.operation_id) ??
+    input.previous?.operationId;
+  if (!operationId) throw new Error('AMR recovery response missing operationId');
+  const retryToken =
+    readNullableString(raw.retryToken) ??
+    readNullableString(raw.retry_token) ??
+    input.previous?.retryToken ??
+    null;
+  const status = normalizeSourceStatus(raw.status ?? input.previous?.status ?? 'active');
+  const mode = modeFromResponse(raw);
+  const previousMode = input.previous?.mode ?? 'unknown';
+  return {
+    operationId,
+    retryToken,
+    status,
+    version: readVersion(raw.version) ?? input.previous?.version ?? null,
+    userId:
+      readNonEmptyString(raw.userId) ??
+      readNonEmptyString(raw.user_id) ??
+      input.userId,
+    runId: input.run.id,
+    projectId: input.run.projectId ?? input.previous?.projectId ?? null,
+    conversationId: input.run.conversationId ?? input.previous?.conversationId ?? null,
+    assistantMessageId: input.run.assistantMessageId ?? input.previous?.assistantMessageId ?? null,
+    mode: mode !== 'unknown' ? mode : previousMode,
+    userVisible: input.previous?.userVisible === true || status !== 'active',
+    resumeAttempts: input.previous?.resumeAttempts ?? 0,
+    pollAttempts: input.previous?.pollAttempts ?? 0,
+    recoveryUrl:
+      readNullableString(raw.recoveryUrl) ??
+      readNullableString(raw.recovery_url) ??
+      readNullableString(raw.walletUrl) ??
+      input.previous?.recoveryUrl ??
+      null,
+    blockReason:
+      readNullableString(raw.blockReason) ??
+      readNullableString(raw.block_reason) ??
+      readNullableString(raw.reason) ??
+      input.previous?.blockReason ??
+      null,
+    restartAvailable: input.previous?.restartAvailable === true,
+    createdAt: input.previous?.createdAt ?? input.now,
+    updatedAt: input.now,
+    expiresAt:
+      typeof raw.expiresAt === 'number' && Number.isFinite(raw.expiresAt)
+        ? raw.expiresAt
+        : input.previous?.expiresAt ?? input.now + DEFAULT_EXPIRES_AFTER_MS,
+  };
+}
+
+function stateFor(context: StoredRecoveryContext): AmrCloudRecoveryOverlay['state'] {
+  if (context.restartAvailable) return 'recovering_restart_available';
+  if (context.status === 'waiting_payment') return 'recovering_waiting_payment';
+  if (context.status === 'waiting_auto_topup') return 'recovering_waiting_auto_topup';
+  if (context.status === 'retry_available') return 'recovering_retry_available';
+  if (context.status === 'resuming') return 'recovering_resuming';
+  if (context.status === 'completed') return 'recovering_completed';
+  if (context.status === 'canceled') return 'recovering_canceled';
+  return 'recovering_blocked';
+}
+
+function actionFor(context: StoredRecoveryContext): AmrCloudRecoveryOverlay['userAction'] {
+  if (context.restartAvailable) return 'restart_request';
+  if (context.status === 'waiting_payment') return 'open_wallet';
+  if (context.status === 'retry_available') {
+    return context.mode === 'automatic_topup' ? 'none' : 'continue_request';
+  }
+  if (context.status === 'blocked') {
+    return context.blockReason === 'wrong_user' ? 'switch_amr_user' : 'contact_support';
+  }
+  return 'none';
+}
+
+function messageFor(context: StoredRecoveryContext): string {
+  if (context.restartAvailable) {
+    return 'This AMR Cloud operation can no longer continue the original local run. Restart the request to continue.';
+  }
+  if (context.status === 'waiting_payment') {
+    return 'AMR Cloud needs a manual top-up before this request can continue.';
+  }
+  if (context.status === 'waiting_auto_topup') {
+    return 'AMR Cloud automatic top-up is in progress. Open Design will continue this request when retry is available.';
+  }
+  if (context.status === 'retry_available') {
+    return context.mode === 'automatic_topup'
+      ? 'AMR Cloud retry is available and Open Design is preparing to continue.'
+      : 'AMR Cloud retry is available. Continue this request from Open Design; continuing may use AMR Cloud balance.';
+  }
+  if (context.status === 'resuming') return 'Open Design is continuing this AMR Cloud request.';
+  if (context.status === 'canceled') return 'AMR Cloud Recovery was canceled for this request.';
+  if (context.status === 'completed') return 'AMR Cloud Recovery completed.';
+  return 'AMR Cloud blocked recovery for this request.';
+}
+
+function overlayFromContext(context: StoredRecoveryContext): AmrCloudRecoveryOverlay {
+  const userAction = actionFor(context);
+  const canResume =
+    context.status === 'retry_available' &&
+    context.mode !== 'automatic_topup' &&
+    context.restartAvailable !== true;
+  return {
+    operationId: context.operationId,
+    state: stateFor(context),
+    sourceStatus: context.status,
+    mode: context.mode,
+    userAction,
+    userActionRequired: userAction !== 'none',
+    recoveryUrl: context.recoveryUrl,
+    message: messageFor(context),
+    blockReason: context.blockReason,
+    restartAvailable: context.restartAvailable,
+    canResume,
+    canCancel:
+      context.status !== 'completed' &&
+      context.status !== 'failed' &&
+      context.status !== 'canceled',
+    updatedAt: context.updatedAt,
+    expiresAt: context.expiresAt,
+  };
+}
+
+async function postJson(
+  fetchImpl: FetchLike,
+  api: VelaApiContext,
+  endpoint: string,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const base = api.apiUrl.replace(/\/$/, '');
+  const resp = await fetchImpl(`${base}${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${api.runtimeKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const parsed = await resp.json().catch(() => null);
+  if (!resp.ok) {
+    const message =
+      responseObject(parsed).message ??
+      responseObject(parsed).error ??
+      `AMR Cloud recovery request failed with HTTP ${resp.status}`;
+    throw new Error(String(message));
+  }
+  return parsed;
+}
+
+async function getJson(fetchImpl: FetchLike, api: VelaApiContext, endpoint: string): Promise<unknown> {
+  const base = api.apiUrl.replace(/\/$/, '');
+  const resp = await fetchImpl(`${base}${endpoint}`, {
+    headers: { authorization: `Bearer ${api.runtimeKey}` },
+  });
+  const parsed = await resp.json().catch(() => null);
+  if (!resp.ok) {
+    const message =
+      responseObject(parsed).message ??
+      responseObject(parsed).error ??
+      `AMR Cloud recovery request failed with HTTP ${resp.status}`;
+    throw new Error(String(message));
+  }
+  return parsed;
+}
+
+function endpoint(operationId: string, suffix = ''): string {
+  return `/api/v1/billing/recoveries/${encodeURIComponent(operationId)}${suffix}`;
+}
+
+function contextForRun(dataDir: string, runId: string): StoredRecoveryContext | null {
+  return readContexts(dataDir)
+    .filter((context) => context.runId === runId)
+    .sort((a, b) => b.updatedAt - a.updatedAt)[0] ?? null;
+}
+
+function runRefFromContext(context: StoredRecoveryContext): AmrRecoveryRunRef {
+  return {
+    id: context.runId,
+    projectId: context.projectId,
+    conversationId: context.conversationId,
+    assistantMessageId: context.assistantMessageId,
+  };
+}
+
+function apiContextOrThrow(env?: NodeJS.ProcessEnv, configuredEnv?: Record<string, string>): VelaApiContext {
+  const api = readVelaApiContext(env, configuredEnv);
+  if (!api) throw new Error('AMR Cloud sign-in is required before recovery can be used.');
+  return api;
+}
+
+function apiUserId(api: VelaApiContext): string {
+  return api.user?.id || api.user?.email || 'env-auth-user';
+}
+
+export function createAmrCloudRecoveryService(
+  deps: CreateAmrCloudRecoveryServiceDeps,
+): AmrCloudRecoveryService {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? (() => Date.now());
+  const logger = deps.logger ?? console;
+  const dataDir = deps.dataDir;
+
+  async function refreshContext(
+    context: StoredRecoveryContext,
+    env?: NodeJS.ProcessEnv,
+    configuredEnv?: Record<string, string>,
+  ): Promise<StoredRecoveryContext> {
+    const api = apiContextOrThrow(env, configuredEnv);
+    if (context.userId && apiUserId(api) !== context.userId) {
+      const next = {
+        ...context,
+        status: 'blocked' as RecoverySourceStatus,
+        blockReason: 'wrong_user',
+        updatedAt: now(),
+      };
+      writeContext(dataDir, next);
+      return next;
+    }
+    const response = await getJson(fetchImpl, api, endpoint(context.operationId));
+    const next = contextFromResponse({
+      response,
+      run: runRefFromContext(context),
+      userId: context.userId,
+      now: now(),
+      previous: context,
+    });
+    writeContext(dataDir, next);
+    return next;
+  }
+
+  return {
+    async prepareRun(input) {
+      const api = apiContextOrThrow(input.env, input.configuredEnv);
+      const userId = apiUserId(api);
+      const createdAt = now();
+      const response = await postJson(fetchImpl, api, '/api/v1/billing/recoveries', {
+        sourceProduct: 'open_design',
+        runId: input.run.id,
+        projectId: input.run.projectId ?? null,
+        conversationId: input.run.conversationId ?? null,
+        assistantMessageId: input.run.assistantMessageId ?? null,
+        model: input.model ?? null,
+      });
+      const context = contextFromResponse({
+        response,
+        run: input.run,
+        userId,
+        now: createdAt,
+      });
+      writeContext(dataDir, { ...context, userVisible: false });
+      return null;
+    },
+
+    async pauseForInsufficientBalance(input) {
+      const context = contextForRun(dataDir, input.runId);
+      if (!context) return null;
+      const api = apiContextOrThrow(input.env, input.configuredEnv);
+      const response = await postJson(fetchImpl, api, endpoint(context.operationId, '/insufficient-balance'), {
+        version: context.version,
+        retryToken: context.retryToken,
+      });
+      const next = contextFromResponse({
+        response,
+        run: runRefFromContext(context),
+        userId: context.userId,
+        now: now(),
+        previous: { ...context, userVisible: true },
+      });
+      writeContext(dataDir, { ...next, userVisible: true });
+      return overlayFromContext({ ...next, userVisible: true });
+    },
+
+    async refreshRun(input) {
+      const context = contextForRun(dataDir, input.runId);
+      if (!context) return null;
+      try {
+        return overlayFromContext(await refreshContext(context, input.env, input.configuredEnv));
+      } catch (err) {
+        logger.warn('[amr-recovery] refresh failed', err);
+        return overlayFromContext(context);
+      }
+    },
+
+    async resumeRun(input) {
+      const context = contextForRun(dataDir, input.runId);
+      if (!context) return null;
+      const latest = await refreshContext(context, input.env, input.configuredEnv);
+      if (latest.status !== 'retry_available') return overlayFromContext(latest);
+      if (latest.resumeAttempts >= MAX_RESUME_ATTEMPTS) {
+        const restart = {
+          ...latest,
+          restartAvailable: true,
+          updatedAt: now(),
+        };
+        writeContext(dataDir, restart);
+        return overlayFromContext(restart);
+      }
+      const api = apiContextOrThrow(input.env, input.configuredEnv);
+      const response = await postJson(fetchImpl, api, endpoint(latest.operationId, '/resume'), {
+        version: latest.version,
+        retryToken: latest.retryToken,
+      });
+      const next = contextFromResponse({
+        response,
+        run: runRefFromContext(latest),
+        userId: latest.userId,
+        now: now(),
+        previous: {
+          ...latest,
+          resumeAttempts: latest.resumeAttempts + 1,
+          status: 'resuming',
+        },
+      });
+      writeContext(dataDir, {
+        ...next,
+        status: next.status === 'retry_available' ? 'resuming' : next.status,
+        userVisible: true,
+        resumeAttempts: latest.resumeAttempts + 1,
+      });
+      return overlayFromContext(contextForRun(dataDir, input.runId)!);
+    },
+
+    async markTerminal(input) {
+      const context = contextForRun(dataDir, input.runId);
+      if (!context) return null;
+      const terminalStatus =
+        input.terminal === 'complete'
+          ? 'completed'
+          : input.terminal === 'cancel'
+            ? 'canceled'
+            : 'failed';
+      try {
+        const api = apiContextOrThrow(input.env, input.configuredEnv);
+        await postJson(fetchImpl, api, endpoint(context.operationId, `/${input.terminal}`), {
+          version: context.version,
+          retryToken: context.retryToken,
+        });
+      } catch (err) {
+        logger.warn('[amr-recovery] terminal update failed', err);
+      }
+      const next = {
+        ...context,
+        status: terminalStatus as RecoverySourceStatus,
+        updatedAt: now(),
+      };
+      if (context.userVisible) {
+        writeContext(dataDir, next);
+        return overlayFromContext(next);
+      }
+      deleteContext(dataDir, context.operationId);
+      return null;
+    },
+
+    async cancelRun(input) {
+      const context = contextForRun(dataDir, input.runId);
+      if (!context) return null;
+      try {
+        const api = apiContextOrThrow(input.env, input.configuredEnv);
+        await postJson(fetchImpl, api, endpoint(context.operationId, '/cancel'), {
+          version: context.version,
+          retryToken: context.retryToken,
+        });
+      } catch (err) {
+        logger.warn('[amr-recovery] cancel update failed', err);
+      }
+      const next = {
+        ...context,
+        status: 'canceled' as RecoverySourceStatus,
+        updatedAt: now(),
+      };
+      writeContext(dataDir, next);
+      return overlayFromContext(next);
+    },
+
+    rebindRun(input) {
+      const context = contextForRun(dataDir, input.fromRunId);
+      if (!context) return null;
+      const next = {
+        ...context,
+        runId: input.toRun.id,
+        projectId: input.toRun.projectId ?? context.projectId,
+        conversationId: input.toRun.conversationId ?? context.conversationId,
+        assistantMessageId: input.toRun.assistantMessageId ?? context.assistantMessageId,
+        updatedAt: now(),
+      };
+      writeContext(dataDir, next);
+      return overlayFromContext(next);
+    },
+
+    markRestartAvailable(input) {
+      const context = contextForRun(dataDir, input.runId);
+      if (!context) return null;
+      const next = {
+        ...context,
+        status: 'blocked' as RecoverySourceStatus,
+        blockReason: input.message ?? context.blockReason,
+        restartAvailable: true,
+        userVisible: true,
+        updatedAt: now(),
+      };
+      writeContext(dataDir, next);
+      return overlayFromContext(next);
+    },
+
+    getOverlayForRun(runId) {
+      const context = contextForRun(dataDir, runId);
+      return context && context.userVisible ? overlayFromContext(context) : null;
+    },
+
+    getContextForRun(runId) {
+      return contextForRun(dataDir, runId);
+    },
+  };
+}

--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -228,6 +228,13 @@ export interface VelaCredentialRevision {
   configMtimeMs: number | null;
 }
 
+export interface VelaApiContext {
+  profile: string;
+  apiUrl: string;
+  runtimeKey: string;
+  user: VelaUser | null;
+}
+
 interface VelaProfileShape {
   controlKey?: string;
   runtimeKey?: string;
@@ -345,6 +352,35 @@ export function readVelaCredentialRevision(
       hasEnvCredentials || !existsSync(status.configPath)
         ? null
         : statSync(status.configPath).mtimeMs,
+  };
+}
+
+export function readVelaApiContext(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): VelaApiContext | null {
+  const mergedEnv = mergeVelaEnv(env, configuredEnv);
+  const profile = resolveAmrProfile(mergedEnv);
+  const envRuntimeKey = mergedEnv.VELA_RUNTIME_KEY?.trim() ?? '';
+  const envApiUrl = mergedEnv.VELA_API_URL?.trim() ?? '';
+  if (envRuntimeKey) {
+    const status = readVelaLoginStatus(env, configuredEnv);
+    return {
+      profile,
+      apiUrl: envApiUrl || 'https://amr-api.open-design.ai',
+      runtimeKey: envRuntimeKey,
+      user: status.user,
+    };
+  }
+  const file = readConfigFile();
+  const stored = file?.profiles?.[profile];
+  const runtimeKey = stored?.runtimeKey?.trim() ?? '';
+  if (!runtimeKey) return null;
+  return {
+    profile,
+    apiUrl: stored?.apiUrl?.trim() || envApiUrl || 'https://amr-api.open-design.ai',
+    runtimeKey,
+    user: stored?.user ?? null,
   };
 }
 

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -85,6 +85,7 @@ export function createChatRunService({
       signal: null,
       error: null,
       errorCode: null,
+      amrRecovery: null,
       cancelRequested: false,
       retryRestartTimer: null,
       stdinOpen: false,
@@ -144,6 +145,9 @@ export function createChatRunService({
       if (details.error) run.error = details.error;
       if (details.errorCode) run.errorCode = details.errorCode;
     }
+    if (event === 'amr_recovery' && data?.recovery) {
+      run.amrRecovery = data.recovery;
+    }
     const id = run.nextEventId++;
     const record = { id, event, data, timestamp: Date.now() };
     run.events.push(record);
@@ -186,6 +190,7 @@ export function createChatRunService({
     signal: run.signal,
     error: run.error ?? null,
     errorCode: run.errorCode ?? null,
+    amrRecovery: run.amrRecovery ?? null,
     resumable: run.resumable ?? false,
     eventsLogPath: run.eventsLogPath ?? null,
     workspace: run.workspace ?? projectWorkspaceProvenance(run.projectMetadata),

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -298,6 +298,7 @@ import { subscribe as subscribeFileEvents } from './project-watchers.js';
 import { renderDesignSystemPreview } from './design-systems/preview.js';
 import { renderDesignSystemShowcase } from './design-systems/showcase.js';
 import { createChatRunService } from './runtimes/runs.js';
+import { createAmrCloudRecoveryService } from './integrations/amr-cloud-recovery.js';
 import { deriveRunErrorCode, runResultFromStatus } from './run-result.js';
 import { classifyRunFailure, isResumableFailure } from './run-failure-classification.js';
 import { decideSafeRunRetry } from './run-retry-policy.js';
@@ -478,6 +479,7 @@ import {
   updateProject,
   updateRoutine,
   updateRoutineRun,
+  updateMessageAmrRecovery,
   clearAgentSession,
   updateAgentSessionStableHash,
   upsertAgentSession,
@@ -1751,6 +1753,42 @@ function assistantMessageEmittedQuestionForm(db, assistantMessageId) {
   if (!assistantMessageId) return false;
   const row = db.prepare(`SELECT content FROM messages WHERE id = ?`).get(assistantMessageId);
   return emittedRenderableQuestionForm(row?.content);
+}
+
+function replayRequestForAssistantMessage(db, context) {
+  if (!context?.projectId || !context?.conversationId || !context?.assistantMessageId) {
+    return { ok: false, reason: 'missing recovery replay coordinates' };
+  }
+  const messages = listMessages(db, context.conversationId);
+  const assistantIndex = messages.findIndex((message) => message.id === context.assistantMessageId);
+  if (assistantIndex < 0) {
+    return { ok: false, reason: 'assistant message not found' };
+  }
+  const assistant = messages[assistantIndex];
+  const user = messages
+    .slice(0, assistantIndex)
+    .reverse()
+    .find((message) =>
+      message.role === 'user' &&
+      typeof message.content === 'string' &&
+      message.content.trim().length > 0,
+    );
+  if (!user) return { ok: false, reason: 'user request not found' };
+  return {
+    ok: true,
+    projectId: context.projectId,
+    conversationId: context.conversationId,
+    assistantMessageId: context.assistantMessageId,
+    message: user.content,
+    attachments: Array.isArray(user.attachments) ? user.attachments.map((attachment) => attachment.path).filter(Boolean) : [],
+    commentAttachments: Array.isArray(user.commentAttachments) ? user.commentAttachments : [],
+    sessionMode: user.sessionMode ?? assistant.sessionMode,
+    context: assistant.runContext,
+    appliedPluginSnapshotId:
+      typeof assistant.appliedPluginSnapshot?.snapshotId === 'string'
+        ? assistant.appliedPluginSnapshot.snapshotId
+        : null,
+  };
 }
 
 function deferredSkillPluginCandidateForRun(db, run) {
@@ -3605,6 +3643,21 @@ export async function startServer({
     analytics: analyticsService,
     getAppVersion: () => telemetry.getCachedAppVersion()?.version ?? '0.0.0',
     readAnalyticsContext,
+  };
+  const amrCloudRecovery = createAmrCloudRecoveryService({
+    dataDir: RUNTIME_DATA_DIR,
+  });
+  const persistAmrRecoveryOverlay = (run, overlay) => {
+    if (!overlay) return;
+    run.amrRecovery = overlay;
+    design.runs.emit(run, 'amr_recovery', { recovery: overlay });
+    if (run.assistantMessageId) {
+      updateMessageAmrRecovery(db, run.assistantMessageId, overlay);
+    }
+  };
+  const clearAmrRecoveryOverlay = (run) => {
+    run.amrRecovery = null;
+    if (run.assistantMessageId) updateMessageAmrRecovery(db, run.assistantMessageId, null);
   };
 
   // Interactive Terminal sessions (node-pty). In-memory, process-local, and
@@ -5865,6 +5918,73 @@ export async function startServer({
         spawnRetryAttempt();
       }, wait);
     };
+    const scheduleAmrAutomaticRecovery = () => {
+      if (run.amrAutoRecoveryScheduled) return true;
+      const initial = run.amrRecovery;
+      if (
+        !initial ||
+        initial.mode !== 'automatic_topup' ||
+        (initial.state !== 'recovering_waiting_auto_topup' &&
+          initial.state !== 'recovering_retry_available')
+      ) {
+        return false;
+      }
+      run.amrAutoRecoveryScheduled = true;
+      run.status = 'queued';
+      run.updatedAt = Date.now();
+      const poll = async (attempt) => {
+        if (run.cancelRequested || design.runs.isTerminal(run.status)) return;
+        try {
+          const refreshed = await amrCloudRecovery.refreshRun({
+            runId: run.id,
+            env: spawnedAgentEnv ?? agentSpawnEnv,
+            configuredEnv: configuredAgentEnv,
+          });
+          if (refreshed) persistAmrRecoveryOverlay(run, refreshed);
+          const current = refreshed ?? run.amrRecovery;
+          if (current?.state === 'recovering_retry_available') {
+            const resuming = await amrCloudRecovery.resumeRun({
+              runId: run.id,
+              env: spawnedAgentEnv ?? agentSpawnEnv,
+              configuredEnv: configuredAgentEnv,
+            });
+            if (resuming) persistAmrRecoveryOverlay(run, resuming);
+            tearDownAttemptForRetry();
+            spawnRetryAttempt();
+            return;
+          }
+          if (
+            current?.state === 'recovering_waiting_auto_topup' &&
+            attempt < 12
+          ) {
+            setTimeout(() => void poll(attempt + 1), 1_000).unref?.();
+            return;
+          }
+          if (current) {
+            persistAmrRecoveryOverlay(run, {
+              ...current,
+              state: 'recovering_restart_available',
+              userAction: 'restart_request',
+              userActionRequired: true,
+              restartAvailable: true,
+              message:
+                'AMR Cloud automatic top-up did not become retryable in time. Restart the request to continue.',
+              updatedAt: Date.now(),
+            });
+          }
+          design.runs.finish(run, 'failed', 1, null);
+        } catch (err) {
+          console.warn('[amr-recovery] automatic recovery poll failed', err);
+          if (attempt < 12) {
+            setTimeout(() => void poll(attempt + 1), 1_000).unref?.();
+            return;
+          }
+          design.runs.finish(run, 'failed', 1, null);
+        }
+      };
+      setTimeout(() => void poll(0), 1_000).unref?.();
+      return true;
+    };
     const finalizeRetryTelemetry = (status, decision, failure, errorCode) => {
       const attemptCount = run.retryAttemptCount ?? 0;
       const result = runResultFromStatus(status);
@@ -5948,6 +6068,13 @@ export async function startServer({
         attemptCount: run.retryAttemptCount ?? 0,
         sideEffects,
       });
+      if (
+        def.id === 'amr' &&
+        result === 'failed' &&
+        scheduleAmrAutomaticRecovery()
+      ) {
+        return true;
+      }
       if (decision.shouldRetry && !design.runs.isTerminal(run.status)) {
         run.retryAttemptCount = decision.retryAttemptIndex;
         run.retryFinalResult = undefined;
@@ -6018,6 +6145,23 @@ export async function startServer({
         ...(signal ? { signal } : {}),
       });
       pendingRpcCloseReason = null;
+      if (def.id === 'amr') {
+        const terminal =
+          status === 'succeeded'
+            ? 'complete'
+            : status === 'canceled' || run.cancelRequested
+              ? 'cancel'
+              : 'fail';
+        void amrCloudRecovery.markTerminal({
+          runId: run.id,
+          terminal,
+          env: spawnedAgentEnv ?? agentSpawnEnv,
+          configuredEnv: configuredAgentEnv,
+        }).then((overlay) => {
+          if (overlay) persistAmrRecoveryOverlay(run, overlay);
+          else clearAmrRecoveryOverlay(run);
+        });
+      }
       design.runs.finish(run, status, code, signal);
       return false;
     };
@@ -6737,6 +6881,27 @@ export async function startServer({
         });
         return design.runs.finish(run, 'failed', 1, null);
       }
+      if (!amrCloudRecovery.getContextForRun(run.id)) {
+        try {
+          await amrCloudRecovery.prepareRun({
+            run,
+            env: agentSpawnEnv,
+            configuredEnv: configuredAgentEnv,
+            model: safeModel,
+          });
+        } catch (err) {
+          cleanupPromptFile();
+          revokeToolToken('child_exit');
+          unregisterChatAgentEventSink();
+          const message = err instanceof Error ? err.message : String(err);
+          send('error', createSseErrorPayload(
+            'AMR_CLOUD_RECOVERY_UNAVAILABLE',
+            `AMR Cloud Recovery could not start for this run: ${message}`,
+            { retryable: true },
+          ));
+          return design.runs.finish(run, 'failed', 1, null);
+        }
+      }
     }
     const odMediaEnv = {
       OD_BIN,
@@ -6777,6 +6942,25 @@ export async function startServer({
     let spawnedAgentEnv = null;
     let agentStdoutTail = '';
     let agentStderrTail = '';
+    const sendAmrRecoveryOrAccountFailure = async (failure) => {
+      if (failure?.code === 'AMR_INSUFFICIENT_BALANCE') {
+        try {
+          const overlay = await amrCloudRecovery.pauseForInsufficientBalance({
+            runId: run.id,
+            env: spawnedAgentEnv ?? agentSpawnEnv,
+            configuredEnv: configuredAgentEnv,
+          });
+          if (overlay) {
+            persistAmrRecoveryOverlay(run, overlay);
+            return overlay;
+          }
+        } catch (err) {
+          console.warn('[amr-recovery] insufficient-balance pause failed', err);
+        }
+      }
+      sendAmrAccountFailure(failure);
+      return null;
+    };
     const agentStderrFilter = createAgentStderrVisibilityFilter(agentId);
     const emitVisibleAgentStderr = (chunk: unknown) => {
       const visibleChunk = agentStderrFilter.write(chunk);
@@ -7668,7 +7852,7 @@ export async function startServer({
               ].join('\n'),
             );
             if (failure) {
-              sendAmrAccountFailure(failure);
+              void sendAmrRecoveryOrAccountFailure(failure);
               return;
             }
           }
@@ -7794,7 +7978,7 @@ export async function startServer({
             `${agentStderrTail}\n${agentStdoutTail}`,
           );
           if (amrFailure) {
-            sendAmrAccountFailure(amrFailure);
+            await sendAmrRecoveryOrAccountFailure(amrFailure);
             return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
           }
         }
@@ -8350,6 +8534,131 @@ export async function startServer({
       pinAssistantMessageOnRunCreate,
       reconcileAssistantMessageOnRunEnd,
     },
+  });
+
+  app.post('/api/runs/:id/amr-recovery/cancel', async (req, res) => {
+    const run = design.runs.get(req.params.id);
+    const overlay = await amrCloudRecovery.cancelRun({ runId: req.params.id });
+    if (!overlay) return sendApiError(res, 404, 'NOT_FOUND', 'AMR Cloud Recovery not found');
+    if (run) persistAmrRecoveryOverlay(run, overlay);
+    else if (amrCloudRecovery.getContextForRun(req.params.id)?.assistantMessageId) {
+      updateMessageAmrRecovery(
+        db,
+        amrCloudRecovery.getContextForRun(req.params.id).assistantMessageId,
+        overlay,
+      );
+    }
+    res.json({ ok: true, amrRecovery: overlay });
+  });
+
+  app.post('/api/runs/:id/amr-recovery/resume', async (req, res) => {
+    const run = design.runs.get(req.params.id);
+    const overlay = await amrCloudRecovery.resumeRun({ runId: req.params.id });
+    if (!overlay) return sendApiError(res, 404, 'NOT_FOUND', 'AMR Cloud Recovery not found');
+    if (run) persistAmrRecoveryOverlay(run, overlay);
+    const context = amrCloudRecovery.getContextForRun(req.params.id);
+    if (!run && context?.assistantMessageId) {
+      updateMessageAmrRecovery(db, context.assistantMessageId, overlay);
+    }
+    if (overlay.state !== 'recovering_resuming') {
+      res.status(409).json({
+        ok: false,
+        code: 'AMR_RECOVERY_NOT_RESUMABLE',
+        amrRecovery: overlay,
+      });
+      return;
+    }
+    if (run && overlay.state === 'recovering_resuming') {
+      run.status = 'queued';
+      run.updatedAt = Date.now();
+      run.cancelRequested = false;
+      run.exitCode = null;
+      run.signal = null;
+      run.error = null;
+      run.errorCode = null;
+      void startChatRun({
+        agentId: 'amr',
+        message: run.userPrompt ?? '',
+        projectId: run.projectId,
+        conversationId: run.conversationId,
+        assistantMessageId: run.assistantMessageId,
+        model: run.model,
+        reasoning: run.reasoning,
+      }, run).catch((err) => {
+        design.runs.emit(
+          run,
+          'error',
+          createSseErrorPayload(
+            'AGENT_EXECUTION_FAILED',
+            err instanceof Error ? err.message : String(err),
+          ),
+        );
+        design.runs.finish(run, 'failed', 1, null);
+      });
+      res.json({ ok: true, amrRecovery: overlay, run: design.runs.statusBody(run), runId: run.id });
+      return;
+    }
+
+    const replay = replayRequestForAssistantMessage(db, context);
+    if (!replay.ok) {
+      const restartOverlay = amrCloudRecovery.markRestartAvailable({
+        runId: req.params.id,
+        message: replay.reason,
+      }) ?? overlay;
+      if (context?.assistantMessageId) {
+        updateMessageAmrRecovery(db, context.assistantMessageId, restartOverlay);
+      }
+      res.status(409).json({
+        ok: false,
+        code: 'AMR_RECOVERY_RESTART_AVAILABLE',
+        amrRecovery: restartOverlay,
+      });
+      return;
+    }
+
+    const recoveredRun = design.runs.create({
+      agentId: 'amr',
+      projectId: replay.projectId,
+      conversationId: replay.conversationId,
+      assistantMessageId: replay.assistantMessageId,
+      clientRequestId: `amr-recovery-${randomUUID()}`,
+      mediaExecution: defaultMediaExecutionPolicy(),
+      ...(replay.sessionMode ? { sessionMode: replay.sessionMode } : {}),
+      ...(replay.context ? { context: replay.context } : {}),
+      ...(replay.appliedPluginSnapshotId ? { appliedPluginSnapshotId: replay.appliedPluginSnapshotId } : {}),
+    });
+    const reboundOverlay = amrCloudRecovery.rebindRun({
+      fromRunId: req.params.id,
+      toRun: recoveredRun,
+    }) ?? overlay;
+    recoveredRun.amrRecovery = reboundOverlay;
+    db.prepare(
+      `UPDATE messages
+          SET run_id = ?, run_status = 'queued',
+              last_run_event_id = NULL,
+              amr_recovery_json = ?,
+              ended_at = NULL
+        WHERE id = ?`,
+    ).run(recoveredRun.id, JSON.stringify(reboundOverlay), replay.assistantMessageId);
+    design.runs.start(recoveredRun, () => startChatRun({
+      agentId: 'amr',
+      message: replay.message,
+      projectId: replay.projectId,
+      conversationId: replay.conversationId,
+      assistantMessageId: replay.assistantMessageId,
+      clientRequestId: recoveredRun.clientRequestId,
+      attachments: replay.attachments,
+      commentAttachments: replay.commentAttachments,
+      ...(replay.sessionMode ? { sessionMode: replay.sessionMode } : {}),
+      ...(replay.context ? { context: replay.context } : {}),
+      ...(replay.appliedPluginSnapshotId ? { appliedPluginSnapshotId: replay.appliedPluginSnapshotId } : {}),
+    }, recoveredRun));
+    res.json({
+      ok: true,
+      amrRecovery: reboundOverlay,
+      run: design.runs.statusBody(recoveredRun),
+      runId: recoveredRun.id,
+    });
   });
 
   // Each routine fire resolves an agent, prepares project/conversation state,

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -1,4 +1,5 @@
 import type http from 'node:http';
+import { createServer } from 'node:http';
 import Database from 'better-sqlite3';
 import { randomUUID } from 'node:crypto';
 import {
@@ -68,6 +69,70 @@ async function withFakeAgent<T>(
     process.env.PATH = oldPath;
     killProcessesUsingPath(dir);
     await fsp.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function readRequestJson(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  if (chunks.length === 0) return {};
+  try {
+    const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function withFakeAmrRecoveryApi<T>(run: () => Promise<T>): Promise<T> {
+  const previousApiUrl = process.env.VELA_API_URL;
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const body = req.method === 'POST' ? await readRequestJson(req) : {};
+    res.setHeader('content-type', 'application/json');
+    if (req.method === 'POST' && url.pathname === '/api/v1/billing/recoveries') {
+      res.end(JSON.stringify({
+        operationId: `op-${body.runId ?? randomUUID()}`,
+        retryToken: 'test-retry-token',
+        status: 'active',
+        mode: 'unknown',
+        version: 1,
+        userId: 'env-auth-user',
+      }));
+      return;
+    }
+    const terminalMatch = url.pathname.match(/^\/api\/v1\/billing\/recoveries\/([^/]+)\/(complete|fail|cancel)$/);
+    const terminalOperationId = terminalMatch?.[1];
+    const terminalAction = terminalMatch?.[2];
+    if (req.method === 'POST' && terminalOperationId && terminalAction) {
+      res.end(JSON.stringify({
+        operationId: decodeURIComponent(terminalOperationId),
+        status: terminalAction === 'complete' ? 'completed' : terminalAction === 'cancel' ? 'canceled' : 'failed',
+        mode: 'unknown',
+        version: 2,
+        userId: 'env-auth-user',
+      }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('fake AMR recovery API did not bind a TCP port');
+  }
+  process.env.VELA_API_URL = `http://127.0.0.1:${address.port}`;
+  try {
+    return await run();
+  } finally {
+    if (previousApiUrl == null) delete process.env.VELA_API_URL;
+    else process.env.VELA_API_URL = previousApiUrl;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 }
 
@@ -299,17 +364,16 @@ process.stdin.on('end', () => {
         };
 
         const externalDirectory = parsed.permission?.external_directory ?? {};
-        const cwdAliases = new Set([effectiveCwd]);
-        if (effectiveCwd.startsWith('/private/var/')) {
-          cwdAliases.add(effectiveCwd.replace(/^\/private\/var\//, '/var/'));
-        }
-        const allowedCwd = [...cwdAliases].find(
-          (cwd) =>
-            externalDirectory[cwd] === 'allow' &&
+        const cwdCandidates = Array.from(new Set([
+          effectiveCwd,
+          realpathSync(effectiveCwd),
+          effectiveCwd.replace(/^\/private\/var\//, '/var/'),
+        ]));
+        expect(cwdCandidates.some((cwd) =>
+          externalDirectory[cwd] === 'allow' &&
             externalDirectory[`${cwd}/*`] === 'allow' &&
             externalDirectory[`${cwd}/**`] === 'allow',
-        );
-        expect(allowedCwd).toBeTruthy();
+        )).toBe(true);
       },
     );
   });
@@ -487,7 +551,7 @@ process.exit(1);
       process.env.VELA_RUNTIME_KEY = `fake-runtime-key-${randomUUID()}`;
       process.env.VELA_LINK_URL = 'https://amr-link.open-design.ai/v1';
 
-      await withFakeAgent(
+      await withFakeAmrRecoveryApi(() => withFakeAgent(
         'vela',
         `
 const { existsSync, readFileSync, writeFileSync } = require('node:fs');
@@ -539,7 +603,7 @@ child.on('exit', (code, signal) => {
           const attempts = JSON.parse(readFileSync(stateFile, 'utf8')) as { attempts: number };
           expect(attempts.attempts).toBeGreaterThanOrEqual(1);
         },
-      );
+      ));
     } finally {
       rmSync(stateFile, { force: true });
       if (previousRuntimeKey == null) delete process.env.VELA_RUNTIME_KEY;
@@ -570,7 +634,7 @@ child.on('exit', (code, signal) => {
       process.env.VELA_RUNTIME_KEY = `fake-runtime-key-${randomUUID()}`;
       process.env.VELA_LINK_URL = 'https://amr-link.open-design.ai/v1';
 
-      await withFakeAgent(
+      await withFakeAmrRecoveryApi(() => withFakeAgent(
         'vela',
         `
 const { spawn } = require('node:child_process');
@@ -617,7 +681,7 @@ child.on('exit', (code, signal) => {
           expect(body).toContain('"type":"text_delta","delta":"Hello from fake "');
           expect(body).toContain('"type":"text_delta","delta":"vela."');
         },
-      );
+      ));
     } finally {
       if (previousRuntimeKey == null) delete process.env.VELA_RUNTIME_KEY;
       else process.env.VELA_RUNTIME_KEY = previousRuntimeKey;

--- a/apps/daemon/tests/integrations/amr-cloud-recovery.test.ts
+++ b/apps/daemon/tests/integrations/amr-cloud-recovery.test.ts
@@ -1,0 +1,170 @@
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { createAmrCloudRecoveryService } from '../../src/integrations/amr-cloud-recovery.js';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function tempDataDir(): string {
+  return mkdtempSync(path.join(tmpdir(), 'od-amr-recovery-'));
+}
+
+function recoveryFiles(dataDir: string): unknown[] {
+  const dir = path.join(dataDir, 'amr-cloud-recovery');
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => JSON.parse(readFileSync(path.join(dir, name), 'utf8')) as unknown);
+}
+
+describe('AMR Cloud Recovery service', () => {
+  it('registers and pauses with minimal private context while public overlay excludes secrets', async () => {
+    const dataDir = tempDataDir();
+    const calls: Array<{ url: string; body?: unknown }> = [];
+    const responses = [
+      {
+        operationId: 'op-1',
+        retryToken: 'retry-secret',
+        status: 'active',
+        version: 1,
+        userId: 'env-auth-user',
+      },
+      {
+        operationId: 'op-1',
+        status: 'waiting_payment',
+        version: 2,
+        recoveryUrl: 'https://open-design.ai/wallet/recovery?operation_id=op-1',
+      },
+    ];
+    const service = createAmrCloudRecoveryService({
+      dataDir,
+      fetchImpl: async (url, init) => {
+        calls.push({
+          url,
+          body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        });
+        return jsonResponse(responses.shift());
+      },
+      now: () => 1_000,
+    });
+
+    const env = {
+      VELA_RUNTIME_KEY: 'runtime-secret',
+      VELA_API_URL: 'https://amr.example',
+    } as NodeJS.ProcessEnv;
+    await service.prepareRun({
+      run: {
+        id: 'run-1',
+        projectId: 'project-1',
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-1',
+      },
+      env,
+      model: 'chat-model',
+    });
+    const overlay = await service.pauseForInsufficientBalance({ runId: 'run-1', env });
+
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://amr.example/api/v1/billing/recoveries',
+      'https://amr.example/api/v1/billing/recoveries/op-1/insufficient-balance',
+    ]);
+    expect(calls[1]?.body).toMatchObject({ retryToken: 'retry-secret', version: 1 });
+    expect(overlay).toMatchObject({
+      operationId: 'op-1',
+      state: 'recovering_waiting_payment',
+      userAction: 'open_wallet',
+    });
+    expect(JSON.stringify(overlay)).not.toContain('retry-secret');
+    expect(JSON.stringify(overlay)).not.toContain('env-auth-user');
+
+    const stored = recoveryFiles(dataDir)[0] as Record<string, unknown>;
+    expect(stored.retryToken).toBe('retry-secret');
+    expect(stored).not.toHaveProperty('message');
+    expect(stored).not.toHaveProperty('cwd');
+    expect(stored).not.toHaveProperty('env');
+  });
+
+  it('keeps manual top-up user initiated and preserves retry token when status reads omit it', async () => {
+    const dataDir = tempDataDir();
+    const responses = [
+      { operationId: 'op-2', retryToken: 'retry-token', status: 'active', version: 1 },
+      { operationId: 'op-2', status: 'waiting_payment', version: 2, manualTopupRequired: true },
+      { operationId: 'op-2', status: 'retry_available', version: 3, manualTopupRequired: true },
+      { operationId: 'op-2', status: 'resuming', version: 4 },
+    ];
+    const bodies: unknown[] = [];
+    const service = createAmrCloudRecoveryService({
+      dataDir,
+      fetchImpl: async (_url, init) => {
+        if (init?.body) bodies.push(JSON.parse(String(init.body)));
+        return jsonResponse(responses.shift());
+      },
+      now: () => 2_000,
+    });
+    const env = { VELA_RUNTIME_KEY: 'rt', VELA_API_URL: 'https://amr.example' } as NodeJS.ProcessEnv;
+
+    await service.prepareRun({ run: { id: 'run-2' }, env });
+    const waiting = await service.pauseForInsufficientBalance({ runId: 'run-2', env });
+    expect(waiting).toMatchObject({
+      state: 'recovering_waiting_payment',
+      mode: 'manual_topup_required',
+      canResume: false,
+    });
+
+    const resuming = await service.resumeRun({ runId: 'run-2', env });
+    expect(resuming).toMatchObject({ state: 'recovering_resuming' });
+    expect(bodies.at(-1)).toMatchObject({ retryToken: 'retry-token', version: 3 });
+  });
+
+  it('blocks wrong AMR Cloud users instead of resuming', async () => {
+    const dataDir = tempDataDir();
+    const service = createAmrCloudRecoveryService({
+      dataDir,
+      fetchImpl: async () => jsonResponse({
+        operationId: 'op-3',
+        retryToken: 'token',
+        status: 'active',
+        version: 1,
+        userId: 'user-a',
+      }),
+      now: () => 3_000,
+    });
+
+    await service.prepareRun({
+      run: { id: 'run-3' },
+      env: { VELA_RUNTIME_KEY: 'rt', VELA_API_URL: 'https://amr.example' } as NodeJS.ProcessEnv,
+    });
+    const overlay = await service.resumeRun({
+      runId: 'run-3',
+      env: { VELA_RUNTIME_KEY: 'rt', VELA_API_URL: 'https://amr.example' } as NodeJS.ProcessEnv,
+    });
+
+    expect(overlay).toMatchObject({
+      state: 'recovering_blocked',
+      userAction: 'switch_amr_user',
+      blockReason: 'wrong_user',
+    });
+  });
+
+  it('cleans invisible pre-registered operations on terminal failure', async () => {
+    const dataDir = tempDataDir();
+    const service = createAmrCloudRecoveryService({
+      dataDir,
+      fetchImpl: async () => jsonResponse({ operationId: 'op-4', retryToken: 't', status: 'active', version: 1 }),
+    });
+    const env = { VELA_RUNTIME_KEY: 'rt', VELA_API_URL: 'https://amr.example' } as NodeJS.ProcessEnv;
+
+    await service.prepareRun({ run: { id: 'run-4' }, env });
+    const overlay = await service.markTerminal({ runId: 'run-4', terminal: 'fail', env });
+
+    expect(overlay).toBeNull();
+    expect(service.getContextForRun('run-4')).toBeNull();
+  });
+});

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -312,6 +312,8 @@ interface Props {
   // assistant message. Omitting them hides the affordance entirely (e.g. in
   // tests that don't wire chat send).
   onArtifactShare?: (fileName: string) => void;
+  onAmrRecoveryResume?: () => void;
+  onAmrRecoveryCancel?: () => void;
   // Featured design-toolbox follow-up rows on the "next step" card. Seeding the
   // composer with an action / opening the toolbox both route through the
   // composer; see ChatPane's composer ref wiring.
@@ -416,6 +418,8 @@ function AssistantMessageImpl({
   suppressDirectionForms = false,
   hasDesignSystemContext = false,
   onArtifactShare,
+  onAmrRecoveryResume,
+  onAmrRecoveryCancel,
   onToolboxAction,
   onPickSkill,
   onArtifactDownload,
@@ -629,6 +633,13 @@ function AssistantMessageImpl({
             onRequestOpenFile={onRequestOpenFile}
           />
         ) : null}
+        {message.amrRecovery ? (
+          <AmrCloudRecoveryCard
+            recovery={message.amrRecovery}
+            onResume={onAmrRecoveryResume}
+            onCancel={onAmrRecoveryCancel}
+          />
+        ) : null}
         {blocks.map((b, i) => {
           if (b.kind === "text")
             return (
@@ -806,6 +817,58 @@ function AssistantMessageImpl({
             onShareToOpenDesign={showOpenDesignSubmission ? onShareToOpenDesign : undefined}
             shareToOpenDesignBusy={shareToOpenDesignBusy}
           />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function AmrCloudRecoveryCard({
+  recovery,
+  onResume,
+  onCancel,
+}: {
+  recovery: NonNullable<ChatMessage["amrRecovery"]>;
+  onResume?: () => void;
+  onCancel?: () => void;
+}) {
+  const title =
+    recovery.state === "recovering_waiting_payment"
+      ? "AMR Cloud payment needed"
+      : recovery.state === "recovering_waiting_auto_topup"
+        ? "AMR Cloud automatic top-up"
+        : recovery.state === "recovering_retry_available"
+          ? "AMR Cloud request ready to continue"
+          : recovery.state === "recovering_resuming"
+            ? "Continuing AMR Cloud request"
+            : recovery.state === "recovering_restart_available"
+              ? "Restart AMR Cloud request"
+              : recovery.state === "recovering_canceled"
+                ? "AMR Cloud recovery canceled"
+                : recovery.state === "recovering_completed"
+                  ? "AMR Cloud recovery completed"
+                  : "AMR Cloud recovery blocked";
+  const showResume = recovery.canResume && onResume;
+  const showCancel = recovery.canCancel && onCancel;
+  return (
+    <div className="plugin-action-orphan-notice" role="status">
+      <div className="plugin-action-card__notice">
+        <strong>{title}</strong>
+        <div>{recovery.message ?? "This AMR Cloud request has recovery context."}</div>
+        {recovery.recoveryUrl && recovery.userAction === "open_wallet" ? (
+          <a className="chat-error-action" href={recovery.recoveryUrl} target="_blank" rel="noreferrer">
+            Open AMR wallet
+          </a>
+        ) : null}
+        {showResume ? (
+          <button type="button" className="chat-error-action" onClick={onResume}>
+            Continue this AMR request
+          </button>
+        ) : null}
+        {showCancel ? (
+          <button type="button" className="chat-error-action secondary" onClick={onCancel}>
+            Cancel recovery
+          </button>
         ) : null}
       </div>
     </div>

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -466,6 +466,8 @@ interface Props {
   ) => void;
   onRetry?: (assistantMessage: ChatMessage) => void;
   onResumeRun?: (assistantMessage: ChatMessage) => void;
+  onAmrRecoveryResume?: (assistantMessage: ChatMessage) => void;
+  onAmrRecoveryCancel?: (assistantMessage: ChatMessage) => void;
   onStop: () => void;
   // Skills available for @-mention assembly. ProjectView filters out the
   // user's disabled set before passing them in here.
@@ -675,6 +677,8 @@ export function ChatPane({
   onSend,
   onRetry,
   onResumeRun,
+  onAmrRecoveryResume,
+  onAmrRecoveryCancel,
   onStop,
   onRemoveQueuedSend,
   onUpdateQueuedSend,
@@ -826,6 +830,8 @@ export function ChatPane({
     onArtifactShare,
     onForkFromMessage,
     onShareToOpenDesign,
+    onAmrRecoveryResume,
+    onAmrRecoveryCancel,
   });
   assistantCallbacksRef.current = {
     onContinueRemainingTasks,
@@ -833,6 +839,8 @@ export function ChatPane({
     onArtifactShare,
     onForkFromMessage,
     onShareToOpenDesign,
+    onAmrRecoveryResume,
+    onAmrRecoveryCancel,
   };
   // Featured design-toolbox follow-up rows on the assistant "next step" card.
   // The toolbox left the "+" menu, so these route straight into the composer
@@ -2032,6 +2040,8 @@ export function ChatPane({
                 assistantCallbacksRef={assistantCallbacksRef}
                 onContinueRemainingTasks={onContinueRemainingTasks}
                 onArtifactShare={onArtifactShare}
+                onAmrRecoveryResume={onAmrRecoveryResume}
+                onAmrRecoveryCancel={onAmrRecoveryCancel}
                 onToolboxAction={handleToolboxAction}
                 onPickSkill={handlePickSkill}
                 onArtifactDownload={onArtifactDownload}
@@ -2321,6 +2331,8 @@ interface AssistantCallbacks {
   onArtifactShare: ((fileName: string) => void) | undefined;
   onForkFromMessage: ((message: ChatMessage) => void) | undefined;
   onShareToOpenDesign: ((assistantMessageId: string) => void) | undefined;
+  onAmrRecoveryResume: ((message: ChatMessage) => void) | undefined;
+  onAmrRecoveryCancel: ((message: ChatMessage) => void) | undefined;
 }
 
 type ChatRenderItem = {
@@ -2376,6 +2388,8 @@ function ChatRows({
   assistantCallbacksRef,
   onContinueRemainingTasks,
   onArtifactShare,
+  onAmrRecoveryResume,
+  onAmrRecoveryCancel,
   onToolboxAction,
   onPickSkill,
   onArtifactDownload,
@@ -2416,6 +2430,8 @@ function ChatRows({
   assistantCallbacksRef: MutableRefObject<AssistantCallbacks>;
   onContinueRemainingTasks?: (assistantMessage: ChatMessage, todos: TodoItem[]) => void;
   onArtifactShare?: (fileName: string) => void;
+  onAmrRecoveryResume?: (message: ChatMessage) => void;
+  onAmrRecoveryCancel?: (message: ChatMessage) => void;
   onToolboxAction?: (id: DesignToolboxActionId) => void;
   onPickSkill?: (skillId: string) => void;
   onArtifactDownload?: (fileName: string) => void;
@@ -2535,6 +2551,16 @@ function ChatRows({
         onArtifactShare={
           onArtifactShare
             ? (fileName) => assistantCallbacksRef.current.onArtifactShare?.(fileName)
+            : undefined
+        }
+        onAmrRecoveryResume={
+          onAmrRecoveryResume
+            ? () => assistantCallbacksRef.current.onAmrRecoveryResume?.(m)
+            : undefined
+        }
+        onAmrRecoveryCancel={
+          onAmrRecoveryCancel
+            ? () => assistantCallbacksRef.current.onAmrRecoveryCancel?.(m)
             : undefined
         }
         onToolboxAction={onToolboxAction}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -135,7 +135,7 @@ import {
   type SaveMessageOptions,
   waitGeneratedPluginShareTask,
 } from '../state/projects';
-import type { AppliedPluginSnapshot, ChatAnalyticsEntryFrom, ChatSessionMode, InstalledPluginRecord, WorkspaceContextItem } from '@open-design/contracts';
+import type { AmrCloudRecoveryOverlay, AppliedPluginSnapshot, ChatAnalyticsEntryFrom, ChatSessionMode, InstalledPluginRecord, WorkspaceContextItem } from '@open-design/contracts';
 import type {
   AgentEvent,
   AgentInfo,
@@ -2697,6 +2697,7 @@ export function ProjectView({
             ...prev,
             runStatus: status.status,
             ...(status.resumable !== undefined ? { resumable: status.resumable } : {}),
+            ...(status.amrRecovery ? { amrRecovery: status.amrRecovery } : {}),
           }),
           true,
         );
@@ -3089,6 +3090,13 @@ export function ProjectView({
               clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
               persistNow({ telemetryFinalized: true });
               scheduleConversationMessageRefresh(reattachConversationId);
+            },
+            onAmrRecovery: (amrRecovery) => {
+              updateMessageById(
+                message.id,
+                (prev) => ({ ...prev, amrRecovery }),
+                true,
+              );
             },
           },
           onRunStatus: (runStatus) => {
@@ -4051,6 +4059,10 @@ export function ProjectView({
           });
           void refreshProjectFiles();
         },
+        onAmrRecovery: (amrRecovery: AmrCloudRecoveryOverlay) => {
+          updateAssistant((prev) => ({ ...prev, amrRecovery }));
+          persistAssistantSoon();
+        },
       };
 
       if (config.mode === 'daemon') {
@@ -4564,6 +4576,57 @@ export function ProjectView({
       void handleSend(RESUME_CONTINUE_PROMPT, [], [], { entryFrom: 'resume_continue' });
     },
     [currentConversationActionDisabled, handleSend],
+  );
+
+  const handleAmrRecoveryResume = useCallback(
+    (assistantMessage: ChatMessage) => {
+      if (!assistantMessage.runId || currentConversationActionDisabled) return;
+      void (async () => {
+        const resp = await fetch(`/api/runs/${encodeURIComponent(assistantMessage.runId!)}/amr-recovery/resume`, {
+          method: 'POST',
+        });
+        const body = await resp.json().catch(() => null) as {
+          amrRecovery?: ChatMessage['amrRecovery'];
+          runId?: string;
+          run?: { id?: string; status?: ChatMessage['runStatus'] };
+        } | null;
+        if (!resp.ok || !body?.amrRecovery) return;
+        updateMessageById(
+          assistantMessage.id,
+          (prev) => ({
+            ...prev,
+            amrRecovery: body.amrRecovery,
+            runId: body.run?.id ?? body.runId ?? prev.runId,
+            runStatus: body.run?.status ?? prev.runStatus,
+            endedAt: body.run?.status === 'queued' || body.run?.status === 'running'
+              ? undefined
+              : prev.endedAt,
+          }),
+          true,
+        );
+      })();
+    },
+    [currentConversationActionDisabled, updateMessageById],
+  );
+
+  const handleAmrRecoveryCancel = useCallback(
+    (assistantMessage: ChatMessage) => {
+      if (!assistantMessage.runId) return;
+      void (async () => {
+        const resp = await fetch(`/api/runs/${encodeURIComponent(assistantMessage.runId!)}/amr-recovery/cancel`, {
+          method: 'POST',
+        });
+        const body = await resp.json().catch(() => null) as { amrRecovery?: ChatMessage['amrRecovery'] } | null;
+        if (!resp.ok || !body?.amrRecovery) return;
+        updateMessageById(
+          assistantMessage.id,
+          (prev) => ({ ...prev, amrRecovery: body.amrRecovery, runStatus: 'canceled' }),
+          true,
+          { telemetryFinalized: true },
+        );
+      })();
+    },
+    [updateMessageById],
   );
 
   // "Switch to AMR & retry" from the failed-run card: switch the run to AMR,
@@ -6165,6 +6228,8 @@ export function ProjectView({
               onSend={handleSend}
               onRetry={handleRetry}
               onResumeRun={handleResumeRun}
+              onAmrRecoveryResume={handleAmrRecoveryResume}
+              onAmrRecoveryCancel={handleAmrRecoveryCancel}
               onStop={handleStop}
               onRemoveQueuedSend={removeQueuedChatSend}
               onUpdateQueuedSend={updateQueuedChatSend}

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -23,6 +23,7 @@ import type {
   ChatSseStartPayload,
   DaemonAgentPayload,
   AmrModelsResponse,
+  AmrCloudRecoveryOverlay,
   MediaExecutionPolicy,
   ResearchOptions,
   RunContextSelection,
@@ -245,6 +246,7 @@ export interface DaemonStreamHandlers extends StreamHandlers {
    * tool name so the UI can gate the live preview to code-writing tools.
    */
   onToolInputDelta?: (id: string, name: string, delta: string) => void;
+  onAmrRecovery?: (recovery: AmrCloudRecoveryOverlay) => void;
 }
 
 export interface DaemonStreamOptions {
@@ -1028,6 +1030,15 @@ async function consumeDaemonRun({
             continue;
           }
 
+          if (event.event === 'amr_recovery') {
+            const recovery = (event.data as { recovery?: AmrCloudRecoveryOverlay }).recovery;
+            if (recovery) {
+              handlers.onAmrRecovery?.(recovery);
+              notifyRunsChanged();
+            }
+            continue;
+          }
+
           if (event.event === 'error') {
             const data = event.data as SseErrorPayload;
             const structuredError = daemonSseError(data);
@@ -1049,6 +1060,10 @@ async function consumeDaemonRun({
             //    `end` frame resolves it (succeeded -> onDone; failed ->
             //    the failure path below, carrying `end`'s resumable bit).
             const status = await fetchChatRunStatus(runId).catch(() => null);
+            if (status?.amrRecovery) {
+              handlers.onAmrRecovery?.(status.amrRecovery);
+              continue;
+            }
             if (status && (status.status === 'failed' || status.status === 'canceled')) {
               onRunStatus?.('failed');
               handlers.onError(

--- a/docs/adr/0002-amr-cloud-recovery-continuity.md
+++ b/docs/adr/0002-amr-cloud-recovery-continuity.md
@@ -1,0 +1,15 @@
+# AMR Cloud Recovery is continuity, not billing ownership
+
+Open Design treats AMR Cloud Recovery as continuity for an AMR Cloud run paused by billing readiness, while AMR Cloud remains the owner of payment and balance state. Automatic top-up can resume automatically; manual top-up resumes from Open Design by user action. If the local run can no longer be resumed, Open Design presents a restart path rather than treating the AMR payment operation as failed.
+
+AMR Cloud Recovery is exposed as recovery state attached to the originating run or conversation, not as a new top-level run status or a global recovery center.
+
+Open Design may register the AMR Cloud operation before the run starts so AMR Cloud can correlate billing and resume state, but the user-visible recovery state begins only when a balance-related pause occurs.
+
+Pre-registered operations that end because of local runtime failures are closed as terminal operations without showing AMR Cloud Recovery to the user.
+
+Automatic recovery is bounded: automatic top-up may resume a paused request, but repeated balance pauses or resume failures must surface a user-visible boundary instead of looping indefinitely.
+
+Recovery state has two surfaces: a live overlay on run status for current observation and a persisted summary on the originating assistant message so the conversation can still present recovery or restart context after the live run expires.
+
+Manual recovery should make clear that continuing the request may use AMR Cloud balance; automatic recovery does not require extra confirmation because it follows the user's automatic top-up mode.

--- a/e2e/lib/amr.ts
+++ b/e2e/lib/amr.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from 'node:crypto';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
@@ -15,6 +18,27 @@ export type VelaEndpoints = {
   linkUrl: string;
 };
 
+export type FakeAmrRecoveryRequest = {
+  body: Record<string, unknown>;
+  method: string;
+  pathname: string;
+};
+
+export type FakeAmrRecoveryApi = {
+  close: () => Promise<void>;
+  requests: FakeAmrRecoveryRequest[];
+  url: string;
+};
+
+type FakeRecoveryContext = {
+  mode: 'manual_topup';
+  operationId: string;
+  recoveryUrl: string | null;
+  retryToken: string;
+  status: 'active' | 'waiting_payment' | 'retry_available' | 'resuming' | 'completed' | 'failed' | 'canceled';
+  version: number;
+};
+
 const DEFAULT_ASSISTANT_TEXT = 'Hello from the e2e fake vela.';
 const PRESET_MODELS_JSON = JSON.stringify({
   source: 'preset',
@@ -28,6 +52,8 @@ const REMOTE_MODELS_JSON = JSON.stringify({
     { id: 'glm-5' },
   ],
 });
+const DEFAULT_RECOVERY_URL =
+  'https://open-design.ai/amr/wallet?source=open_design&od_origin=open_design&od_entry_source=chat_error_recharge';
 
 export async function writeFakeVelaBin(root: string, options: FakeVelaOptions = {}): Promise<string> {
   await mkdir(root, { recursive: true });
@@ -37,18 +63,142 @@ export async function writeFakeVelaBin(root: string, options: FakeVelaOptions = 
   return bin;
 }
 
+export async function startFakeAmrRecoveryApi(endpoints?: VelaEndpoints): Promise<FakeAmrRecoveryApi> {
+  const requests: FakeAmrRecoveryRequest[] = [];
+  const contexts = new Map<string, FakeRecoveryContext>();
+  const listenUrl = endpoints ? new URL(endpoints.apiUrl) : null;
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const body = await readJsonBody(req);
+    requests.push({ body, method: req.method ?? 'GET', pathname: url.pathname });
+
+    if (req.method === 'POST' && url.pathname === '/api/v1/billing/recoveries') {
+      const operationId = `op-${readString(body.runId) ?? randomUUID()}`;
+      const context: FakeRecoveryContext = {
+        mode: 'manual_topup',
+        operationId,
+        recoveryUrl: null,
+        retryToken: 'test-retry-token',
+        status: 'active',
+        version: 1,
+      };
+      contexts.set(operationId, context);
+      writeJson(res, 200, context);
+      return;
+    }
+
+    const match = /^\/api\/v1\/billing\/recoveries\/([^/]+)(?:\/([^/]+))?$/.exec(url.pathname);
+    if (!match) {
+      writeJson(res, 404, { error: 'not_found' });
+      return;
+    }
+
+    const operationId = decodeURIComponent(match[1] ?? '');
+    const action = match[2] ?? null;
+    const context = contexts.get(operationId);
+    if (!context) {
+      writeJson(res, 404, { error: 'unknown_recovery_operation' });
+      return;
+    }
+
+    if (req.method === 'GET' && !action) {
+      writeJson(res, 200, context);
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      writeJson(res, 405, { error: 'method_not_allowed' });
+      return;
+    }
+
+    if (action === 'insufficient-balance') {
+      const next = {
+        ...context,
+        recoveryUrl: DEFAULT_RECOVERY_URL,
+        status: 'waiting_payment' as const,
+        version: context.version + 1,
+      };
+      contexts.set(operationId, next);
+      writeJson(res, 200, next);
+      return;
+    }
+
+    if (action === 'resume') {
+      const next = {
+        ...context,
+        status: 'resuming' as const,
+        version: context.version + 1,
+      };
+      contexts.set(operationId, next);
+      writeJson(res, 200, next);
+      return;
+    }
+
+    if (action === 'complete' || action === 'fail' || action === 'cancel') {
+      const status: FakeRecoveryContext['status'] =
+        action === 'complete'
+          ? 'completed'
+          : action === 'cancel'
+            ? 'canceled'
+            : 'failed';
+      const next = {
+        ...context,
+        status,
+        version: context.version + 1,
+      };
+      contexts.set(operationId, next);
+      writeJson(res, 200, next);
+      return;
+    }
+
+    writeJson(res, 404, { error: 'unknown_recovery_action' });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(
+      listenUrl?.port ? Number(listenUrl.port) : 0,
+      listenUrl?.hostname || '127.0.0.1',
+      () => {
+        server.off('error', reject);
+        resolve();
+      },
+    );
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+    requests,
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
 export async function seedVelaLoginConfig(
   homeDir: string,
   options: {
     endpoints?: VelaEndpoints;
+    apiUrl?: string;
     profile?: string;
     email?: string;
+    linkUrl?: string;
     runtimeKey?: string;
     controlKey?: string;
   } = {},
 ): Promise<string> {
   const profile = options.profile ?? 'local';
-  const endpoints = options.endpoints ?? defaultVelaEndpoints();
+  const fallbackEndpoints = defaultVelaEndpoints();
+  const endpoints = options.endpoints ?? {
+    apiUrl: options.apiUrl ?? fallbackEndpoints.apiUrl,
+    linkUrl: options.linkUrl ?? fallbackEndpoints.linkUrl,
+  };
   const configDir = join(homeDir, '.amr');
   const file = join(configDir, 'config.json');
   await mkdir(configDir, { recursive: true });
@@ -80,6 +230,31 @@ export async function seedVelaLoginConfig(
 
 export async function clearVelaLoginConfig(homeDir: string): Promise<void> {
   await rm(join(homeDir, '.amr', 'config.json'), { force: true });
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  if (chunks.length === 0) return {};
+  try {
+    const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function writeJson(res: ServerResponse, status: number, body: Record<string, unknown>): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
 }
 
 function renderFakeVelaScript(options: FakeVelaOptions): string {
@@ -136,8 +311,8 @@ if (argv[2] === 'login') {
       [profile]: {
         runtimeKey: 'fake-runtime-key-0000000000000000000000',
         controlKey: 'fake-control-key-0000000000000000000000',
-        apiUrl: ${JSON.stringify(endpoints.apiUrl)},
-        linkUrl: ${JSON.stringify(endpoints.linkUrl)},
+        apiUrl: env.VELA_API_URL || ${JSON.stringify(endpoints.apiUrl)},
+        linkUrl: env.VELA_LINK_URL || ${JSON.stringify(endpoints.linkUrl)},
         user: { id: 'fake-user-id', email: env.FAKE_VELA_LOGIN_USER_EMAIL || 'e2e@example.com', plan: 'free' },
       },
     },

--- a/e2e/lib/vitest/suite.ts
+++ b/e2e/lib/vitest/suite.ts
@@ -105,6 +105,7 @@ export async function createSmokeSuite(name: string): Promise<SmokeSuite> {
       linkUrl: `http://127.0.0.1:${amrLinkPort}`,
       runtimeEnv(overrides = {}) {
         return normalizeDefinedEnv({
+          VELA_API_URL: `http://127.0.0.1:${amrApiPort}`,
           VELA_LINK_URL: `http://127.0.0.1:${amrLinkPort}`,
           VELA_RUNTIME_KEY: 'fake-runtime-key',
           ...overrides,

--- a/e2e/tests/amr/auth-error-convergence.test.ts
+++ b/e2e/tests/amr/auth-error-convergence.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
-import { writeFakeVelaBin } from '@/amr';
+import { startFakeAmrRecoveryApi, writeFakeVelaBin } from '@/amr';
 import { createAmrProject, putAmrAppConfig } from '@/vitest/amr';
 import { listMessages } from '@/vitest/messages';
 import { readRunEvents, startRun, waitForRunTerminal } from '@/vitest/runs';
@@ -13,47 +13,52 @@ import { createSmokeSuite } from '@/vitest/suite';
 describe('AMR auth error convergence', () => {
   test('marks the run and assistant message as failed when fake vela returns an auth error during prompt', { timeout: 180_000 }, async () => {
     const suite = await createSmokeSuite('amr-auth-error-convergence');
+    const recoveryApi = await startFakeAmrRecoveryApi(suite.amr);
 
-    await suite.with.toolsDev(async ({ webUrl }) => {
-      const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-auth-error'), {
-        endpoints: suite.amr,
-        failAuthAtPrompt: true,
-        requireLoginConfig: false,
-      });
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-auth-error'), {
+          endpoints: suite.amr,
+          failAuthAtPrompt: true,
+          requireLoginConfig: false,
+        });
 
-      await putAmrAppConfig(webUrl, {
-        agentId: 'amr',
-        agentCliEnv: {
-          amr: {
-            VELA_BIN: velaBin,
-            ...suite.amr.runtimeEnv(),
+        await putAmrAppConfig(webUrl, {
+          agentId: 'amr',
+          agentCliEnv: {
+            amr: {
+              VELA_BIN: velaBin,
+              ...suite.amr.runtimeEnv(),
+            },
           },
-        },
+        });
+
+        const project = await createAmrProject(webUrl, 'AMR auth error convergence');
+        const assistantMessageId = `assistant-${Date.now()}`;
+
+        const run = await startRun(webUrl, {
+          agentId: 'amr',
+          assistantMessageId,
+          clientRequestId: `req-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'Simulate an AMR auth expiry during session/prompt.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+
+        const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
+        expect(terminal.status).toBe('failed');
+
+        const messages = await listMessages(webUrl, project.project.id, project.conversationId);
+        const assistant = messages.find((message) => message.id === assistantMessageId);
+        expect(assistant?.runStatus).toBe('failed');
+        await expect(readRunEvents(webUrl, run.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
       });
-
-      const project = await createAmrProject(webUrl, 'AMR auth error convergence');
-      const assistantMessageId = `assistant-${Date.now()}`;
-
-      const run = await startRun(webUrl, {
-        agentId: 'amr',
-        assistantMessageId,
-        clientRequestId: `req-${Date.now()}`,
-        conversationId: project.conversationId,
-        designSystemId: null,
-        message: 'Simulate an AMR auth expiry during session/prompt.',
-        model: 'default',
-        projectId: project.project.id,
-        reasoning: 'default',
-        skillId: null,
-      });
-
-      const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
-      expect(terminal.status).toBe('failed');
-
-      const messages = await listMessages(webUrl, project.project.id, project.conversationId);
-      const assistant = messages.find((message) => message.id === assistantMessageId);
-      expect(assistant?.runStatus).toBe('failed');
-      await expect(readRunEvents(webUrl, run.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
-    });
+    } finally {
+      await recoveryApi.close();
+    }
   });
 });

--- a/e2e/tests/amr/insufficient-balance.test.ts
+++ b/e2e/tests/amr/insufficient-balance.test.ts
@@ -4,60 +4,64 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
-import { writeFakeVelaBin } from '@/amr';
+import { startFakeAmrRecoveryApi, writeFakeVelaBin } from '@/amr';
 import { createAmrProject, putAmrAppConfig } from '@/vitest/amr';
 import { listMessages } from '@/vitest/messages';
 import { readRunEvents, startRun, waitForRunTerminal } from '@/vitest/runs';
 import { createSmokeSuite } from '@/vitest/suite';
 
 describe('AMR insufficient balance run failures', () => {
-  test('fails the run with a recharge-facing AMR error when fake vela reports insufficient balance', { timeout: 180_000 }, async () => {
+  test('fails the run with a recovery overlay when fake vela reports insufficient balance', { timeout: 180_000 }, async () => {
     const suite = await createSmokeSuite('amr-insufficient-balance');
+    const recoveryApi = await startFakeAmrRecoveryApi(suite.amr);
 
-    await suite.with.toolsDev(async ({ webUrl }) => {
-      const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-balance'), {
-        endpoints: suite.amr,
-        failBalanceAtPrompt: true,
-        requireLoginConfig: false,
-      });
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-balance'), {
+          endpoints: suite.amr,
+          failBalanceAtPrompt: true,
+          requireLoginConfig: false,
+        });
 
-      await putAmrAppConfig(webUrl, {
-        agentId: 'amr',
-        agentCliEnv: {
-          amr: {
-            VELA_BIN: velaBin,
-            ...suite.amr.runtimeEnv(),
+        await putAmrAppConfig(webUrl, {
+          agentId: 'amr',
+          agentCliEnv: {
+            amr: {
+              VELA_BIN: velaBin,
+              ...suite.amr.runtimeEnv(),
+            },
           },
-        },
+        });
+
+        const project = await createAmrProject(webUrl, 'AMR insufficient balance');
+        const assistantMessageId = `assistant-${Date.now()}`;
+        const run = await startRun(webUrl, {
+          agentId: 'amr',
+          assistantMessageId,
+          clientRequestId: `req-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'This should surface a recharge link.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+
+        const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
+        expect(terminal.status).toBe('failed');
+
+        const events = await readRunEvents(webUrl, run.runId);
+        expect(events).toContain('amr_recovery');
+        expect(events).toContain('recovering_waiting_payment');
+        expect(events).toContain('https://open-design.ai/amr/wallet?source=open_design');
+
+        const messages = await listMessages(webUrl, project.project.id, project.conversationId);
+        const assistant = messages.find((message) => message.id === assistantMessageId);
+        expect(assistant?.runStatus).toBe('failed');
       });
-
-      const project = await createAmrProject(webUrl, 'AMR insufficient balance');
-      const assistantMessageId = `assistant-${Date.now()}`;
-      const run = await startRun(webUrl, {
-        agentId: 'amr',
-        assistantMessageId,
-        clientRequestId: `req-${Date.now()}`,
-        conversationId: project.conversationId,
-        designSystemId: null,
-        message: 'This should surface a recharge link.',
-        model: 'default',
-        projectId: project.project.id,
-        reasoning: 'default',
-        skillId: null,
-      });
-
-      const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
-      expect(terminal.status).toBe('failed');
-
-      const events = await readRunEvents(webUrl, run.runId);
-      expect(events).toContain('AMR_INSUFFICIENT_BALANCE');
-      expect(events).toContain(
-        'https://open-design.ai/amr/wallet?source=open_design',
-      );
-
-      const messages = await listMessages(webUrl, project.project.id, project.conversationId);
-      const assistant = messages.find((message) => message.id === assistantMessageId);
-      expect(assistant?.runStatus).toBe('failed');
-    });
+    } finally {
+      await recoveryApi.close();
+    }
   });
 });

--- a/e2e/tests/amr/logout-state-persistence.test.ts
+++ b/e2e/tests/amr/logout-state-persistence.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
-import { writeFakeVelaBin } from '@/amr';
+import { startFakeAmrRecoveryApi, writeFakeVelaBin } from '@/amr';
 import { createAmrProject, putAmrAppConfig } from '@/vitest/amr';
 import { requestJson } from '@/vitest/http';
 import { readRunEvents, startRun, waitForRunStatus, waitForRunTerminal } from '@/vitest/runs';
@@ -13,77 +13,82 @@ import { createSmokeSuite } from '@/vitest/suite';
 describe('AMR logout state persistence', () => {
   test('a previously working AMR session stops working after local logout and requires re-login', { timeout: 180_000 }, async () => {
     const suite = await createSmokeSuite('amr-logout-state-persistence');
+    const recoveryApi = await startFakeAmrRecoveryApi(suite.amr);
     const homeDir = join(suite.scratchDir, 'home-logout-state');
 
-    await suite.with.env({ HOME: homeDir, OPEN_DESIGN_AMR_PROFILE: 'local' }, async () => {
-      await suite.with.toolsDev(async ({ webUrl }) => {
-        const successVelaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-logout-success'), {
-          assistantText: 'AMR logout persistence success',
-          endpoints: suite.amr,
-          requireLoginConfig: false,
-        });
-        const strictVelaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-logout-strict'), {
-          assistantText: 'AMR logout persistence strict',
-          endpoints: suite.amr,
-        });
+    try {
+      await suite.with.env({ HOME: homeDir, OPEN_DESIGN_AMR_PROFILE: 'local' }, async () => {
+        await suite.with.toolsDev(async ({ webUrl }) => {
+          const successVelaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-logout-success'), {
+            assistantText: 'AMR logout persistence success',
+            endpoints: suite.amr,
+            requireLoginConfig: false,
+          });
+          const strictVelaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-logout-strict'), {
+            assistantText: 'AMR logout persistence strict',
+            endpoints: suite.amr,
+          });
 
-        await putAmrAppConfig(webUrl, {
-          agentId: 'amr',
-          agentCliEnv: {
-            amr: {
-              VELA_BIN: successVelaBin,
-              OPEN_DESIGN_AMR_PROFILE: 'local',
-              ...suite.amr.runtimeEnv(),
+          await putAmrAppConfig(webUrl, {
+            agentId: 'amr',
+            agentCliEnv: {
+              amr: {
+                VELA_BIN: successVelaBin,
+                OPEN_DESIGN_AMR_PROFILE: 'local',
+                ...suite.amr.runtimeEnv(),
+              },
             },
-          },
-        });
+          });
 
-        const project = await createAmrProject(webUrl, 'AMR logout state persistence');
+          const project = await createAmrProject(webUrl, 'AMR logout state persistence');
 
-        const firstRun = await startRun(webUrl, {
-          agentId: 'amr',
-          assistantMessageId: `assistant-success-${Date.now()}`,
-          clientRequestId: `req-success-${Date.now()}`,
-          conversationId: project.conversationId,
-          designSystemId: null,
-          message: 'First AMR run should succeed before logout.',
-          model: 'default',
-          projectId: project.project.id,
-          reasoning: 'default',
-          skillId: null,
-        });
-        await waitForRunStatus(webUrl, firstRun.runId, 'succeeded', { timeoutMs: 20_000 });
+          const firstRun = await startRun(webUrl, {
+            agentId: 'amr',
+            assistantMessageId: `assistant-success-${Date.now()}`,
+            clientRequestId: `req-success-${Date.now()}`,
+            conversationId: project.conversationId,
+            designSystemId: null,
+            message: 'First AMR run should succeed before logout.',
+            model: 'default',
+            projectId: project.project.id,
+            reasoning: 'default',
+            skillId: null,
+          });
+          await waitForRunStatus(webUrl, firstRun.runId, 'succeeded', { timeoutMs: 20_000 });
 
-        await putAmrAppConfig(webUrl, {
-          agentId: 'amr',
-          agentCliEnv: {
-            amr: {
-              VELA_BIN: strictVelaBin,
-              OPEN_DESIGN_AMR_PROFILE: 'local',
+          await putAmrAppConfig(webUrl, {
+            agentId: 'amr',
+            agentCliEnv: {
+              amr: {
+                VELA_BIN: strictVelaBin,
+                OPEN_DESIGN_AMR_PROFILE: 'local',
+              },
             },
-          },
-        });
-        await requestJson(webUrl, '/api/integrations/vela/logout', { body: {}, method: 'POST' });
-        const status = await requestJson<{ loggedIn: boolean }>(webUrl, '/api/integrations/vela/status');
-        expect(status.loggedIn).toBe(false);
+          });
+          await requestJson(webUrl, '/api/integrations/vela/logout', { body: {}, method: 'POST' });
+          const status = await requestJson<{ loggedIn: boolean }>(webUrl, '/api/integrations/vela/status');
+          expect(status.loggedIn).toBe(false);
 
-        const secondRun = await startRun(webUrl, {
-          agentId: 'amr',
-          assistantMessageId: `assistant-fail-${Date.now()}`,
-          clientRequestId: `req-fail-${Date.now()}`,
-          conversationId: project.conversationId,
-          designSystemId: null,
-          message: 'Second AMR run should require login again.',
-          model: 'default',
-          projectId: project.project.id,
-          reasoning: 'default',
-          skillId: null,
-        });
-        const terminal = await waitForRunTerminal(webUrl, secondRun.runId, { timeoutMs: 20_000 });
-        expect(terminal.status).toBe('failed');
+          const secondRun = await startRun(webUrl, {
+            agentId: 'amr',
+            assistantMessageId: `assistant-fail-${Date.now()}`,
+            clientRequestId: `req-fail-${Date.now()}`,
+            conversationId: project.conversationId,
+            designSystemId: null,
+            message: 'Second AMR run should require login again.',
+            model: 'default',
+            projectId: project.project.id,
+            reasoning: 'default',
+            skillId: null,
+          });
+          const terminal = await waitForRunTerminal(webUrl, secondRun.runId, { timeoutMs: 20_000 });
+          expect(terminal.status).toBe('failed');
 
-        await expect(readRunEvents(webUrl, secondRun.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
+          await expect(readRunEvents(webUrl, secondRun.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
+        });
       });
-    });
+    } finally {
+      await recoveryApi.close();
+    }
   });
 });

--- a/e2e/tests/amr/relogin-required.test.ts
+++ b/e2e/tests/amr/relogin-required.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
-import { seedVelaLoginConfig, writeFakeVelaBin } from '@/amr';
+import { seedVelaLoginConfig, startFakeAmrRecoveryApi, writeFakeVelaBin } from '@/amr';
 import { createAmrProject, putAmrAppConfig } from '@/vitest/amr';
 import { readRunEvents, startRun, waitForRunStatus, waitForRunTerminal } from '@/vitest/runs';
 import { createSmokeSuite } from '@/vitest/suite';
@@ -55,59 +55,15 @@ describe('AMR relogin-required run failures', () => {
 
   test('uses configured AMR profile env for pre-run login status', { timeout: 180_000 }, async () => {
     const suite = await createSmokeSuite('amr-configured-profile-preflight');
+    const recoveryApi = await startFakeAmrRecoveryApi(suite.amr);
     const homeDir = join(suite.scratchDir, 'home-configured-profile');
 
-    await suite.with.env({ HOME: homeDir, OPEN_DESIGN_AMR_PROFILE: 'prod' }, async () => {
-      await seedVelaLoginConfig(homeDir, { endpoints: suite.amr, profile: 'local' });
-      await suite.with.toolsDev(async ({ webUrl }) => {
-        const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-configured-profile'), {
-          endpoints: suite.amr,
-        });
-
-        await putAmrAppConfig(webUrl, {
-          agentId: 'amr',
-          agentCliEnv: {
-            amr: {
-              VELA_BIN: velaBin,
-              OPEN_DESIGN_AMR_PROFILE: 'local',
-            },
-          },
-        });
-
-        const project = await createAmrProject(webUrl, 'AMR configured profile preflight');
-        const run = await startRun(webUrl, {
-          agentId: 'amr',
-          assistantMessageId: `assistant-configured-profile-${Date.now()}`,
-          clientRequestId: `req-configured-profile-${Date.now()}`,
-          conversationId: project.conversationId,
-          designSystemId: null,
-          message: 'This should use the configured AMR profile.',
-          model: 'default',
-          projectId: project.project.id,
-          reasoning: 'default',
-          skillId: null,
-        });
-
-        await waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 20_000 });
-      });
-    });
-  });
-
-  test('uses daemon AMR runtime credentials for pre-run login status', { timeout: 180_000 }, async () => {
-    const suite = await createSmokeSuite('amr-daemon-env-credentials-preflight');
-    const homeDir = join(suite.scratchDir, 'home-daemon-env-credentials');
-
-    await suite.with.env(
-      {
-        HOME: homeDir,
-        OPEN_DESIGN_AMR_PROFILE: 'local',
-        ...suite.amr.runtimeEnv({ VELA_RUNTIME_KEY: 'fake-runtime-key-from-daemon-env' }),
-      },
-      async () => {
+    try {
+      await suite.with.env({ HOME: homeDir, OPEN_DESIGN_AMR_PROFILE: 'prod' }, async () => {
+        await seedVelaLoginConfig(homeDir, { endpoints: suite.amr, profile: 'local' });
         await suite.with.toolsDev(async ({ webUrl }) => {
-          const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-daemon-env-credentials'), {
+          const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-configured-profile'), {
             endpoints: suite.amr,
-            requireLoginConfig: false,
           });
 
           await putAmrAppConfig(webUrl, {
@@ -120,14 +76,14 @@ describe('AMR relogin-required run failures', () => {
             },
           });
 
-          const project = await createAmrProject(webUrl, 'AMR daemon env credentials preflight');
+          const project = await createAmrProject(webUrl, 'AMR configured profile preflight');
           const run = await startRun(webUrl, {
             agentId: 'amr',
-            assistantMessageId: `assistant-daemon-env-credentials-${Date.now()}`,
-            clientRequestId: `req-daemon-env-credentials-${Date.now()}`,
+            assistantMessageId: `assistant-configured-profile-${Date.now()}`,
+            clientRequestId: `req-configured-profile-${Date.now()}`,
             conversationId: project.conversationId,
             designSystemId: null,
-            message: 'This should use daemon AMR runtime credentials.',
+            message: 'This should use the configured AMR profile.',
             model: 'default',
             projectId: project.project.id,
             reasoning: 'default',
@@ -136,7 +92,61 @@ describe('AMR relogin-required run failures', () => {
 
           await waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 20_000 });
         });
-      },
-    );
+      });
+    } finally {
+      await recoveryApi.close();
+    }
+  });
+
+  test('uses daemon AMR runtime credentials for pre-run login status', { timeout: 180_000 }, async () => {
+    const suite = await createSmokeSuite('amr-daemon-env-credentials-preflight');
+    const recoveryApi = await startFakeAmrRecoveryApi(suite.amr);
+    const homeDir = join(suite.scratchDir, 'home-daemon-env-credentials');
+
+    try {
+      await suite.with.env(
+        {
+          HOME: homeDir,
+          OPEN_DESIGN_AMR_PROFILE: 'local',
+          ...suite.amr.runtimeEnv({ VELA_RUNTIME_KEY: 'fake-runtime-key-from-daemon-env' }),
+        },
+        async () => {
+          await suite.with.toolsDev(async ({ webUrl }) => {
+            const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-daemon-env-credentials'), {
+              endpoints: suite.amr,
+              requireLoginConfig: false,
+            });
+
+            await putAmrAppConfig(webUrl, {
+              agentId: 'amr',
+              agentCliEnv: {
+                amr: {
+                  VELA_BIN: velaBin,
+                  OPEN_DESIGN_AMR_PROFILE: 'local',
+                },
+              },
+            });
+
+            const project = await createAmrProject(webUrl, 'AMR daemon env credentials preflight');
+            const run = await startRun(webUrl, {
+              agentId: 'amr',
+              assistantMessageId: `assistant-daemon-env-credentials-${Date.now()}`,
+              clientRequestId: `req-daemon-env-credentials-${Date.now()}`,
+              conversationId: project.conversationId,
+              designSystemId: null,
+              message: 'This should use daemon AMR runtime credentials.',
+              model: 'default',
+              projectId: project.project.id,
+              reasoning: 'default',
+              skillId: null,
+            });
+
+            await waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 20_000 });
+          });
+        },
+      );
+    } finally {
+      await recoveryApi.close();
+    }
   });
 });

--- a/e2e/tests/amr/turn.test.ts
+++ b/e2e/tests/amr/turn.test.ts
@@ -33,6 +33,7 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
+import { startFakeAmrRecoveryApi } from '@/amr';
 import { requestJson } from '@/vitest/http';
 import { listMessages } from '@/vitest/messages';
 import { startRun, waitForRunStatus } from '@/vitest/runs';
@@ -88,8 +89,8 @@ if (argv[2] === 'login') {
       [profile]: {
         runtimeKey: 'fake-runtime-key-0000000000000000000000',
         controlKey: 'fake-control-key-0000000000000000000000',
-        apiUrl: env.FAKE_VELA_API_URL || 'http://localhost:18080',
-        linkUrl: env.FAKE_VELA_LINK_URL || 'http://localhost:18081',
+        apiUrl: env.VELA_API_URL || env.FAKE_VELA_API_URL || 'http://localhost:18080',
+        linkUrl: env.VELA_LINK_URL || env.FAKE_VELA_LINK_URL || 'http://localhost:18081',
         user: { id: 'fake-user-id', email: 'e2e@example.com', plan: 'free' },
       },
     },
@@ -200,120 +201,125 @@ describe('AMR chat-run end-to-end', () => {
     // tools-dev daemon boot + chat run lifecycle needs the same headroom
     // as the dialog/* smoke specs (~3 minutes for cold spawn + run).
     const suite = await createSmokeSuite('amr-turn');
+    const recoveryApi = await startFakeAmrRecoveryApi(suite.amr);
 
-    await suite.with.toolsDev(async ({ webUrl }) => {
-      const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela'));
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela'));
 
-      // Pre-seed `~/.amr/config.json` so `vela agent run` (the fake) does
-      // not need to negotiate device-auth. Production AMR works the same
-      // way: once login has happened once, the runtime reads the file.
-      const velaConfigDir = join(suite.scratchDir, 'home', '.amr');
-      await mkdir(velaConfigDir, { recursive: true });
-      await writeFile(
-        join(velaConfigDir, 'config.json'),
-        JSON.stringify(
-          {
-            profiles: {
-              local: {
-                runtimeKey: 'fake-runtime-key',
-                controlKey: 'fake-control-key',
-                apiUrl: suite.amr.apiUrl,
-                linkUrl: suite.amr.linkUrl,
-                user: { id: 'fake-user-id', email: 'e2e@example.com', plan: 'free' },
+        // Pre-seed `~/.amr/config.json` so `vela agent run` (the fake) does
+        // not need to negotiate device-auth. Production AMR works the same
+        // way: once login has happened once, the runtime reads the file.
+        const velaConfigDir = join(suite.scratchDir, 'home', '.amr');
+        await mkdir(velaConfigDir, { recursive: true });
+        await writeFile(
+          join(velaConfigDir, 'config.json'),
+          JSON.stringify(
+            {
+              profiles: {
+                local: {
+                  runtimeKey: 'fake-runtime-key',
+                  controlKey: 'fake-control-key',
+                  apiUrl: suite.amr.apiUrl,
+                  linkUrl: suite.amr.linkUrl,
+                  user: { id: 'fake-user-id', email: 'e2e@example.com', plan: 'free' },
+                },
               },
             },
-          },
-          null,
-          2,
-        ),
-      );
-
-      // Persist agentCliEnv so the daemon's runtime resolver picks up the
-      // fake binary and the pre-run AMR status guard sees configured runtime
-      // credentials without touching the developer's real ~/.amr config.
-      await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
-        body: {
-          agentCliEnv: {
-            amr: {
-              FAKE_VELA_API_URL: suite.amr.apiUrl,
-              FAKE_VELA_LINK_URL: suite.amr.linkUrl,
-              VELA_BIN: velaBin,
-              ...suite.amr.runtimeEnv(),
-            },
-          },
-          agentId: 'amr',
-          agentModels: { amr: { model: 'default', reasoning: 'default' } },
-          designSystemId: null,
-          onboardingCompleted: true,
-          skillId: null,
-          telemetry: { artifactManifest: true, content: false, metrics: false },
-        },
-        method: 'PUT',
-      });
-
-      const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
-        body: {
-          designSystemId: null,
-          id: randomUUID(),
-          metadata: { kind: 'prototype' },
-          name: 'AMR turn e2e',
-          pendingPrompt: null,
-          skillId: null,
-        },
-      });
-      const projectId = project.project.id;
-      const conversationId = project.conversationId;
-
-      const t0 = Date.now();
-      const userMessageId = `user-${t0}`;
-      const assistantMessageId = `assistant-${t0}`;
-
-      const run = await startRun(webUrl, {
-        agentId: 'amr',
-        assistantMessageId,
-        clientRequestId: `req-${t0}`,
-        conversationId,
-        designSystemId: null,
-        message: PROMPT,
-        // 'default' must be resolved through AMR's live `vela models`
-        // preflight; if that helper regressed, the fake vela would reject
-        // session/prompt with the `set_model must be called before
-        // session/prompt` error encoded above.
-        model: 'default',
-        projectId,
-        reasoning: 'default',
-        skillId: null,
-      });
-      expect(run.runId).toMatch(/[a-z0-9-]/i);
-
-      // Override the per-process FAKE_VELA_TEXT so the assertion below is
-      // tied to a stable canned reply. The runtime spawn inherits the
-      // daemon's process.env, so setting it after startRun would race with
-      // spawn; instead we set it on `process.env` for the test process —
-      // but tools-dev orchestrates a separate daemon child, so this only
-      // takes effect when the fake script reads its own env. The fake
-      // ships with a default 'Hello from the e2e fake vela.' literal, so
-      // we assert on a substring instead of pinning the full text here.
-      void ASSISTANT_TEXT;
-
-      const finalStatus = await waitForRunStatus(webUrl, run.runId, 'succeeded', {
-        timeoutMs: 30_000,
-      });
-      expect(finalStatus.status).toBe('succeeded');
-
-      const messages = await listMessages(webUrl, projectId, conversationId);
-      const assistantMessage = messages.find((m) => m.id === assistantMessageId);
-      if (assistantMessage) {
-        expect(assistantMessage.content).toContain('Hello from the e2e fake vela');
-      } else {
-        // Some chat flows save the assistant message under a daemon-assigned
-        // id rather than the client-provided one. Fall back to checking any
-        // assistant message captured the fake's text.
-        const anyAssistant = messages.find(
-          (m) => m.role === 'assistant' && m.content.includes('Hello from the e2e fake vela'),
+            null,
+            2,
+          ),
         );
-        expect(anyAssistant).toBeTruthy();
-      }
-    });
+
+        // Persist agentCliEnv so the daemon's runtime resolver picks up the
+        // fake binary and the pre-run AMR status guard sees configured runtime
+        // credentials without touching the developer's real ~/.amr config.
+        await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+          body: {
+            agentCliEnv: {
+              amr: {
+                FAKE_VELA_API_URL: suite.amr.apiUrl,
+                FAKE_VELA_LINK_URL: suite.amr.linkUrl,
+                VELA_BIN: velaBin,
+                ...suite.amr.runtimeEnv(),
+              },
+            },
+            agentId: 'amr',
+            agentModels: { amr: { model: 'default', reasoning: 'default' } },
+            designSystemId: null,
+            onboardingCompleted: true,
+            skillId: null,
+            telemetry: { artifactManifest: true, content: false, metrics: false },
+          },
+          method: 'PUT',
+        });
+
+        const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+          body: {
+            designSystemId: null,
+            id: randomUUID(),
+            metadata: { kind: 'prototype' },
+            name: 'AMR turn e2e',
+            pendingPrompt: null,
+            skillId: null,
+          },
+        });
+        const projectId = project.project.id;
+        const conversationId = project.conversationId;
+
+        const t0 = Date.now();
+        const userMessageId = `user-${t0}`;
+        const assistantMessageId = `assistant-${t0}`;
+
+        const run = await startRun(webUrl, {
+          agentId: 'amr',
+          assistantMessageId,
+          clientRequestId: `req-${t0}`,
+          conversationId,
+          designSystemId: null,
+          message: PROMPT,
+          // 'default' must be resolved through AMR's live `vela models`
+          // preflight; if that helper regressed, the fake vela would reject
+          // session/prompt with the `set_model must be called before
+          // session/prompt` error encoded above.
+          model: 'default',
+          projectId,
+          reasoning: 'default',
+          skillId: null,
+        });
+        expect(run.runId).toMatch(/[a-z0-9-]/i);
+
+        // Override the per-process FAKE_VELA_TEXT so the assertion below is
+        // tied to a stable canned reply. The runtime spawn inherits the
+        // daemon's process.env, so setting it after startRun would race with
+        // spawn; instead we set it on `process.env` for the test process —
+        // but tools-dev orchestrates a separate daemon child, so this only
+        // takes effect when the fake script reads its own env. The fake
+        // ships with a default 'Hello from the e2e fake vela.' literal, so
+        // we assert on a substring instead of pinning the full text here.
+        void ASSISTANT_TEXT;
+
+        const finalStatus = await waitForRunStatus(webUrl, run.runId, 'succeeded', {
+          timeoutMs: 30_000,
+        });
+        expect(finalStatus.status).toBe('succeeded');
+
+        const messages = await listMessages(webUrl, projectId, conversationId);
+        const assistantMessage = messages.find((m) => m.id === assistantMessageId);
+        if (assistantMessage) {
+          expect(assistantMessage.content).toContain('Hello from the e2e fake vela');
+        } else {
+          // Some chat flows save the assistant message under a daemon-assigned
+          // id rather than the client-provided one. Fall back to checking any
+          // assistant message captured the fake's text.
+          const anyAssistant = messages.find(
+            (m) => m.role === 'assistant' && m.content.includes('Hello from the e2e fake vela'),
+          );
+          expect(anyAssistant).toBeTruthy();
+        }
+      });
+    } finally {
+      await recoveryApi.close();
+    }
   }, 180_000);
 });

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { expect, test } from '@/playwright/suite';
 import type { Page } from '@playwright/test';
 
-import { writeFakeVelaBin, seedVelaLoginConfig } from '@/amr';
+import { seedVelaLoginConfig, startFakeAmrRecoveryApi, writeFakeVelaBin } from '@/amr';
 import { createFakeAgentRuntimes } from '@/playwright/fake-agents';
 import {
   createProjectViaApi,
@@ -36,8 +36,8 @@ test.beforeAll(async () => {
   codexRuntime = runtimes.codex;
 });
 
-test('[P0] @critical AMR insufficient-balance failures surface Top up AMR and keep Retry available', async ({ page }) => {
-  const profile = 'local';
+test('[P0] @critical AMR insufficient-balance failures surface AMR Cloud Recovery wallet action', async ({ page }) => {
+  const profile = `balance-${Date.now()}`;
   await page.route('**/api/integrations/vela/status', async (route) => {
     await route.fulfill({
       status: 200,
@@ -51,16 +51,6 @@ test('[P0] @critical AMR insufficient-balance failures surface Top up AMR and ke
     });
   });
 
-  await page.addInitScript(() => {
-    const opened: string[] = [];
-    (window as Window & { __openedUrls?: string[] }).__openedUrls = opened;
-    const originalOpen = window.open.bind(window);
-    window.open = ((...args: Parameters<typeof window.open>) => {
-      if (typeof args[0] === 'string') opened.push(args[0]);
-      return originalOpen(...args);
-    }) as typeof window.open;
-  });
-
   const amr = await setupAmrWorkspace(page, {
     failBalanceAtPrompt: true,
     profile,
@@ -68,32 +58,20 @@ test('[P0] @critical AMR insufficient-balance failures surface Top up AMR and ke
     selectedAgentId: 'amr',
   });
 
-  await gotoProject(page, amr.projectId);
-  await sendPrompt(page, 'AMR insufficient balance recovery smoke');
+  try {
+    await gotoProject(page, amr.projectId);
+    await sendPrompt(page, 'AMR insufficient balance recovery smoke');
 
-  const topUp = page.getByRole('button', { name: /Top up AMR|前往充值|前往儲值/i }).first();
-  const retry = page.getByRole('button', { name: /^Retry$|^重试$|^重試$/i }).first();
-  await expect(topUp).toBeVisible({ timeout: 15_000 });
-  await expect(retry).toBeVisible();
-
-  await topUp.click();
-
-  await expect
-    .poll(async () =>
-      page.evaluate(() => {
-        const opened = (window as Window & { __openedUrls?: string[] }).__openedUrls ?? [];
-        return opened.find((href) => {
-          const url = new URL(href, window.location.href);
-          return (
-            url.pathname.endsWith('/wallet') &&
-            url.searchParams.get('source') === 'open_design' &&
-            url.searchParams.get('od_origin') === 'open_design' &&
-            url.searchParams.get('od_entry_source') === 'chat_error_recharge'
-          );
-        }) ?? null;
-      }),
-    )
-    .toBeTruthy();
+    await expect(page.getByText(/AMR Cloud payment needed/i)).toBeVisible({ timeout: 15_000 });
+    const wallet = page.getByRole('link', { name: /Open AMR wallet/i }).first();
+    await expect(wallet).toBeVisible();
+    await expect(wallet).toHaveAttribute(
+      'href',
+      /^https:\/\/open-design\.ai\/amr\/wallet\?.*source=open_design.*od_origin=open_design.*od_entry_source=chat_error_recharge/,
+    );
+  } finally {
+    await amr.recoveryApi.close();
+  }
 });
 
 test('[P0] @critical AMR auth failures offer inline Authorize & retry sign-in', async ({ page }) => {
@@ -135,18 +113,21 @@ test('[P0] @critical AMR auth failures offer inline Authorize & retry sign-in', 
     selectedAgentId: 'amr',
   });
 
-  await gotoProject(page, amr.projectId);
-  await sendPrompt(page, 'AMR auth failure recovery smoke');
+  try {
+    await gotoProject(page, amr.projectId);
+    await sendPrompt(page, 'AMR auth failure recovery smoke');
 
-  const authorizeAndRetry = page.getByRole('button', { name: /Authorize.*retry|授权并重试/i }).first();
-  await expect(authorizeAndRetry).toBeVisible({ timeout: 15_000 });
-  await authorizeAndRetry.click();
+    const authorizeAndRetry = page.getByRole('button', { name: /Authorize.*retry|授权并重试/i }).first();
+    await expect(authorizeAndRetry).toBeVisible({ timeout: 15_000 });
+    await authorizeAndRetry.click();
 
-  // New inline flow: clicking Authorize & retry starts vela login in place (it
-  // POSTs /login directly) instead of bouncing the user out to the Settings
-  // dialog. The run then auto-retries once /status reports signed in.
-  await expect.poll(() => loginRequested, { timeout: 10_000 }).toBe(true);
-  await expect(page.getByRole('dialog')).toHaveCount(0);
+    // New inline flow: clicking Authorize & retry starts vela login in place
+    // instead of bouncing the user out to the Settings dialog.
+    await expect.poll(() => loginRequested, { timeout: 10_000 }).toBe(true);
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  } finally {
+    await amr.recoveryApi.close();
+  }
 });
 
 test('[P0] @critical AMR model catalog invalid-key failures route to authorization recovery', async ({ page }) => {
@@ -382,32 +363,36 @@ test('[P0] after an AMR failure the user can switch to Codex and complete a fres
 
   const amr = await setupAmrWorkspace(page, { failAuthAtPrompt: true, selectedAgentId: 'amr' });
 
-  await gotoProject(page, amr.projectId);
-  await sendPrompt(page, 'AMR auth failure before switch smoke');
-  await expect(page.locator('.msg.error')).toContainText(
-    /isn't authorized yet|Authorize it and this run retries automatically/i,
-    { timeout: 15_000 },
-  );
-  await expect(page.getByRole('button', { name: /Authorize.*retry|授权并重试/i }).first()).toBeVisible();
+  try {
+    await gotoProject(page, amr.projectId);
+    await sendPrompt(page, 'AMR auth failure before switch smoke');
+    await expect(page.locator('.msg.error')).toContainText(
+      /isn't authorized yet|Authorize it and this run retries automatically/i,
+      { timeout: 15_000 },
+    );
+    await expect(page.getByRole('button', { name: /Authorize.*retry|授权并重试/i }).first()).toBeVisible();
 
-  const settings = await openSettingsDialog(page);
-  await settings.getByTestId('settings-agent-select-codex').click();
-  await expect
-    .poll(async () => {
-      const raw = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY);
-      return raw ? JSON.parse(raw).agentId : null;
-    })
-    .toBe('codex');
-  await page.keyboard.press('Escape');
-  await expect(settings).toHaveCount(0);
+    const settings = await openSettingsDialog(page);
+    await settings.getByTestId('settings-agent-select-codex').click();
+    await expect
+      .poll(async () => {
+        const raw = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY);
+        return raw ? JSON.parse(raw).agentId : null;
+      })
+      .toBe('codex');
+    await page.keyboard.press('Escape');
+    await expect(settings).toHaveCount(0);
 
-  await sendPrompt(page, 'Create a deterministic smoke artifact');
-  await expect(artifactPreview(page)).toBeVisible({ timeout: 20_000 });
-  await expect(
-    artifactPreviewFrame(page).getByRole('heading', {
-      name: 'Real Daemon Smoke',
-    }),
-  ).toBeVisible();
+    await sendPrompt(page, 'Create a deterministic smoke artifact');
+    await expect(artifactPreview(page)).toBeVisible({ timeout: 20_000 });
+    await expect(
+      artifactPreviewFrame(page).getByRole('heading', {
+        name: 'Real Daemon Smoke',
+      }),
+    ).toBeVisible();
+  } finally {
+    await amr.recoveryApi.close();
+  }
 });
 
 test('[P0] upstream outages keep Retry available without promoting AMR', async ({ page }) => {
@@ -582,6 +567,7 @@ async function setupAmrWorkspace(
 ) {
   const root = join(tmpdir(), `open-design-amr-ui-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const homeDir = join(root, 'home');
+  const recoveryApi = await startFakeAmrRecoveryApi();
   const velaBin = await writeFakeVelaBin(join(root, 'bin'), {
     ...(options.assistantText !== undefined ? { assistantText: options.assistantText } : {}),
     ...(options.failAuthAtPrompt !== undefined ? { failAuthAtPrompt: options.failAuthAtPrompt } : {}),
@@ -593,7 +579,11 @@ async function setupAmrWorkspace(
   });
   await mkdir(homeDir, { recursive: true });
   if (options.seedLoginConfig !== false) {
-    await seedVelaLoginConfig(homeDir, { email: 'ui-amr@example.com', profile: options.profile ?? 'local' });
+    await seedVelaLoginConfig(homeDir, {
+      apiUrl: recoveryApi.url,
+      email: 'ui-amr@example.com',
+      profile: options.profile ?? 'local',
+    });
   }
 
   const config = {
@@ -612,6 +602,7 @@ async function setupAmrWorkspace(
     },
     agentCliEnv: {
       amr: {
+        VELA_API_URL: recoveryApi.url,
         VELA_BIN: velaBin,
         HOME: homeDir,
         VELA_LINK_URL: 'http://localhost:18081',
@@ -627,5 +618,5 @@ async function setupAmrWorkspace(
 
   const projectId = `amr-ui-${Date.now()}`.replace(/[^A-Za-z0-9._-]/g, '-');
   const { conversationId } = await createProjectViaApi(page, projectId, 'AMR UI failure smoke');
-  return { projectId, conversationId, homeDir, root, velaBin };
+  return { projectId, conversationId, homeDir, recoveryApi, root, velaBin };
 }

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -249,6 +249,58 @@ export const CHAT_RUN_STATUSES = [
 
 export type ChatRunStatus = (typeof CHAT_RUN_STATUSES)[number];
 
+export type AmrCloudRecoverySourceStatus =
+  | 'active'
+  | 'waiting_payment'
+  | 'waiting_auto_topup'
+  | 'retry_available'
+  | 'resuming'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'blocked';
+
+export type AmrCloudRecoveryMode =
+  | 'automatic_topup'
+  | 'manual_topup'
+  | 'manual_topup_required'
+  | 'unknown';
+
+export type AmrCloudRecoveryState =
+  | 'recovering_waiting_payment'
+  | 'recovering_waiting_auto_topup'
+  | 'recovering_retry_available'
+  | 'recovering_resuming'
+  | 'recovering_restart_available'
+  | 'recovering_blocked'
+  | 'recovering_canceled'
+  | 'recovering_completed';
+
+export type AmrCloudRecoveryUserAction =
+  | 'open_wallet'
+  | 'continue_request'
+  | 'restart_request'
+  | 'switch_amr_user'
+  | 'contact_support'
+  | 'none';
+
+export interface AmrCloudRecoveryOverlay {
+  operationId: string;
+  state: AmrCloudRecoveryState;
+  sourceStatus: AmrCloudRecoverySourceStatus;
+  mode: AmrCloudRecoveryMode;
+  userAction: AmrCloudRecoveryUserAction;
+  userActionRequired: boolean;
+  recoveryUrl?: string | null;
+  message?: string | null;
+  blockReason?: string | null;
+  restartAvailable?: boolean;
+  canResume?: boolean;
+  canCancel?: boolean;
+  updatedAt: number;
+  expiresAt?: number | null;
+}
+
 export type ChatMessageFeedbackRating = 'positive' | 'negative';
 
 export type ChatMessageFeedbackReasonCode =
@@ -341,6 +393,7 @@ export interface ChatRunStatusResponse {
   signal?: string | null;
   error?: string | null;
   errorCode?: string | null;
+  amrRecovery?: AmrCloudRecoveryOverlay | null;
   /** True when this terminal failure can be recovered by resuming the agent's
    *  existing CLI session (a transient upstream drop / inactivity timeout on a
    *  session-resuming runtime), rather than only restarting from scratch. The
@@ -472,6 +525,7 @@ export interface ChatMessage {
    *  session-resuming runtime). Drives the chat's Continue affordance; mirrors
    *  ChatRunStatusResponse.resumable. */
   resumable?: boolean;
+  amrRecovery?: AmrCloudRecoveryOverlay | null;
   lastRunEventId?: string;
   startedAt?: number;
   endedAt?: number;

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -1,4 +1,5 @@
 import type { LiveArtifactRefreshStatus } from '../api/live-artifacts.js';
+import type { AmrCloudRecoveryOverlay } from '../api/chat.js';
 import type { SseErrorPayload } from '../errors.js';
 import type { SseTransportEvent } from './common.js';
 
@@ -78,6 +79,10 @@ export interface ChatSseEndPayload {
   resumable?: boolean;
 }
 
+export interface ChatSseAmrRecoveryPayload {
+  recovery: AmrCloudRecoveryOverlay;
+}
+
 export type DaemonAgentPayload =
   | { type: 'status'; label: string; model?: string; ttftMs?: number; detail?: string }
   | { type: 'text_delta'; delta: string }
@@ -121,5 +126,6 @@ export type ChatSseEvent =
   | SseTransportEvent<'agent', DaemonAgentPayload>
   | SseTransportEvent<'stdout', ChatSseChunkPayload>
   | SseTransportEvent<'stderr', ChatSseChunkPayload>
+  | SseTransportEvent<'amr_recovery', ChatSseAmrRecoveryPayload>
   | SseTransportEvent<'error', SseErrorPayload>
   | SseTransportEvent<'end', ChatSseEndPayload>;

--- a/specs/current/amr-cloud-recovery.md
+++ b/specs/current/amr-cloud-recovery.md
@@ -1,0 +1,544 @@
+# AMR Cloud Recovery
+
+## Purpose
+
+AMR Cloud Recovery is the Open Design continuity path for an AMR Cloud run that
+pauses because AMR Cloud billing requires balance readiness before the request
+can continue.
+
+This spec turns the recovery handoff into Open Design product and engineering
+requirements. It follows the domain language in
+[`CONTEXT.md`](../../CONTEXT.md) and the architectural decision in
+[`docs/adr/0002-amr-cloud-recovery-continuity.md`](../../docs/adr/0002-amr-cloud-recovery-continuity.md).
+
+## Problem Statement
+
+Today Open Design treats AMR insufficient balance as a normal agent failure:
+the run receives an `AMR_INSUFFICIENT_BALANCE` error and the user is sent to a
+generic recharge URL. That loses the recovery operation that AMR Cloud/Vela can
+provide: payment state, retry coordination, automatic top-up continuation, and
+safe resume semantics.
+
+Open Design must integrate with the AMR Cloud recovery contract without taking
+ownership of AMR billing state and without turning local replay context into a
+second task system.
+
+## Goals
+
+- Register AMR Cloud recovery operations before billable AMR Cloud runs begin.
+- Pause a run into AMR Cloud Recovery when AMR Cloud reports insufficient
+  balance.
+- Automatically resume after automatic top-up when AMR Cloud marks the
+  operation retryable.
+- Require user-initiated recovery after manual top-up.
+- Preserve recovery continuity across daemon restarts using minimal local
+  replay context.
+- Keep payment, balance, risk, refund, and dispute truth owned by AMR Cloud.
+- Present recovery through the originating run, conversation, and existing run
+  surfaces.
+- Support multiple concurrent recovery operations without introducing a global
+  recovery center.
+- Make recovery visible through both web UI and `od run` CLI surfaces.
+- Provide a restart path when the AMR Cloud operation is valid but the local
+  run can no longer be resumed.
+- Close or cancel pre-registered AMR Cloud operations on normal terminal paths
+  so AMR Cloud does not retain stale active operations.
+
+## Non-Goals
+
+- Do not implement Open Design billing state, wallet balance state, payment
+  checkout, refund handling, dispute handling, or risk resolution.
+- Do not make AMR Cloud Recovery a generic run retry system.
+- Do not expand the top-level `ChatRunStatus` union for the first version.
+- Do not add a Recovery Center, global recovery inbox, or standalone recovery
+  product surface.
+- Do not store the original prompt, working directory, command arguments,
+  environment, provider credentials, or full AMR Cloud payload in replay
+  context.
+- Do not let AMR Cloud call back into the user's local daemon to resume a run.
+- Do not treat local recovery loss as payment failure.
+- Do not auto-resume manual top-up operations without user action.
+
+## Existing Context
+
+### Current Open Design Behavior
+
+- AMR runs use the local AMR CLI adapter behind the AMR Cloud product option.
+- AMR insufficient balance is classified as `AMR_INSUFFICIENT_BALANCE`.
+- The current user action is a generic recharge link.
+- Run state is exposed through `ChatRunStatus` values:
+  `queued`, `running`, `succeeded`, `failed`, and `canceled`.
+- Run status is consumed broadly by the web UI, CLI, analytics, message
+  persistence, and active-run recovery.
+
+### Domain Decisions
+
+- AMR Cloud Recovery is continuity for AMR Cloud, not Open Design billing
+  ownership.
+- Automatic top-up users auto-resume when AMR Cloud allows retry.
+- Manual top-up users initiate recovery from Open Design after payment.
+- AMR Cloud Recovery is bound to the AMR Cloud user that created the recovery
+  operation.
+- Risk, refund, and dispute blocks are not recovery states.
+- Recovery appears through the originating run or conversation, not through a
+  separate recovery center.
+- Recovery state is an overlay attached to the run/message, not a new top-level
+  run status.
+
+## AMR Cloud Contract
+
+Open Design consumes the AMR Cloud/Vela recovery contract. AMR Cloud remains the
+source of truth for payment, balance readiness, automatic top-up, manual top-up,
+risk blocking, refund guardrails, dispute guardrails, operation versioning, and
+retry authorization.
+
+### Required Endpoints
+
+Open Design must integrate with these AMR Cloud endpoints:
+
+```http
+POST /api/v1/billing/recoveries
+GET  /api/v1/billing/recoveries/:operationId
+POST /api/v1/billing/recoveries/:operationId/insufficient-balance
+POST /api/v1/billing/recoveries/:operationId/resume
+POST /api/v1/billing/recoveries/:operationId/complete
+POST /api/v1/billing/recoveries/:operationId/fail
+POST /api/v1/billing/recoveries/:operationId/cancel
+```
+
+The exact request authentication and transport details belong to the AMR Cloud
+integration layer. Open Design must not fork the payment state machine locally.
+
+### Recovery Statuses
+
+Open Design must understand these AMR Cloud recovery statuses:
+
+| Status | Meaning for Open Design |
+|---|---|
+| `active` | Operation was registered but has not become user-visible recovery. |
+| `waiting_payment` | Manual payment is required or in progress; show recovery payment path and wait for user action after top-up. |
+| `waiting_auto_topup` | AMR Cloud is handling automatic top-up; Open Design may poll within bounded limits. |
+| `retry_available` | AMR Cloud says the operation can be resumed. |
+| `resuming` | A resume attempt is in progress. |
+| `completed` | Operation finished successfully and local recovery context can be cleared. |
+| `failed` | Operation cannot continue; local recovery context can be cleared or converted to restart guidance. |
+| `canceled` | User no longer wants to continue this request; local recovery context can be cleared. |
+
+### Recovery Modes
+
+Open Design must distinguish automatic and manual recovery behavior:
+
+| Mode | Trigger | Open Design behavior |
+|---|---|---|
+| Automatic top-up | AMR Cloud reports automatic top-up is active or waiting | Poll within bounded limits and resume automatically when `retry_available`. |
+| Manual top-up | AMR Cloud requires user payment or manual top-up | Show a payment/recovery path and require user-initiated resume from Open Design after top-up. |
+| Manual top-up required | AMR Cloud explicitly requires manual top-up | Never auto-resume. |
+
+## Product Model
+
+### User-Visible States
+
+Open Design should present these user-facing recovery states as a run/message
+overlay:
+
+| Open Design state | Source status | User meaning |
+|---|---|---|
+| `recovering_waiting_payment` | `waiting_payment` | The request is paused until the user completes manual top-up. |
+| `recovering_waiting_auto_topup` | `waiting_auto_topup` | Automatic top-up is in progress and Open Design is waiting to resume. |
+| `recovering_retry_available` | `retry_available` | The request can be continued from Open Design. |
+| `recovering_resuming` | `resuming` | Open Design is continuing the paused request. |
+| `recovering_restart_available` | AMR Cloud operation valid but local run not resumable | The user can restart the request, but Open Design cannot continue the original local run. |
+| `recovering_blocked` | risk, refund, dispute, wrong user, malformed context, or non-recoverable AMR response | The user must resolve the block or restart; Open Design must not imply payment failure. |
+
+The names above are spec names, not required API enum names.
+
+### Run Status Relationship
+
+The top-level run status remains:
+
+```ts
+'queued' | 'running' | 'succeeded' | 'failed' | 'canceled'
+```
+
+AMR Cloud Recovery is represented as recovery metadata attached to:
+
+- live run status responses;
+- run SSE/error/diagnostic payloads where appropriate;
+- the originating assistant message's persisted recovery summary.
+
+User-facing UI must prefer the recovery overlay over generic failed-run copy
+when a run has active or recoverable AMR Cloud Recovery state.
+
+### Message Persistence
+
+The originating assistant message should persist a recovery summary sufficient
+to render the user's next action after the live daemon run expires.
+
+The persisted summary may include:
+
+- operation id;
+- recovery status;
+- recovery mode;
+- whether user action is required;
+- recovery or wallet URL;
+- whether restart is available;
+- user-facing block reason;
+- timestamps relevant to display and expiry.
+
+The persisted summary must not include prompt text, command data, environment,
+credentials, or full AMR Cloud payloads.
+
+## Local Replay Context
+
+Open Design must store only the minimum local context needed to resume or
+restart the recovery operation.
+
+Allowed replay context fields:
+
+- `operationId`;
+- `retryToken`;
+- `status`;
+- `version`;
+- `userId`;
+- originating `runId`;
+- originating `projectId`;
+- originating `conversationId`;
+- originating `assistantMessageId`;
+- recovery mode;
+- created, updated, and expiry timestamps.
+
+Forbidden replay context fields:
+
+- user prompt;
+- current prompt;
+- system prompt;
+- working directory;
+- command line;
+- environment;
+- provider credentials;
+- AMR Cloud auth secrets;
+- full AMR Cloud request or response payload;
+- attached file contents.
+
+Replay context is daemon-managed data and must derive from the daemon's resolved
+data root. This spec deliberately does not define concrete filesystem paths;
+follow root `AGENTS.md` → **Daemon data directory contract**.
+
+## Required Flows
+
+### 1. Pre-Register AMR Operation
+
+Before starting a billable AMR Cloud run, Open Design must register a recovery
+operation with AMR Cloud.
+
+```mermaid
+sequenceDiagram
+  participant OD as Open Design
+  participant AMR as AMR Cloud
+  participant CLI as AMR CLI
+
+  OD->>AMR: POST /api/v1/billing/recoveries
+  AMR-->>OD: operationId, retryToken, status=active, version, userId
+  OD->>OD: Store minimal replay context
+  OD->>CLI: Start AMR run
+```
+
+Pre-registration does not make recovery user-visible. If the run succeeds,
+fails locally, or is canceled without a balance pause, Open Design must close
+the AMR Cloud operation without showing AMR Cloud Recovery.
+
+### 2. Pause on Insufficient Balance
+
+When the AMR CLI or ACP session reports insufficient balance, Open Design must
+pause the registered operation instead of only emitting a generic failure.
+
+```mermaid
+sequenceDiagram
+  participant CLI as AMR CLI
+  participant OD as Open Design
+  participant AMR as AMR Cloud
+  participant UI as Web/CLI Surfaces
+
+  CLI-->>OD: insufficient balance signal
+  OD->>AMR: POST /recoveries/:operationId/insufficient-balance
+  AMR-->>OD: waiting_payment or waiting_auto_topup
+  OD->>OD: Update replay context and message recovery summary
+  OD-->>UI: Show AMR Cloud Recovery overlay
+```
+
+The recovery overlay must include a recovery URL shaped around the operation,
+for example a wallet recovery destination with the operation id. The generic
+wallet recharge URL is not enough for recovery.
+
+### 3. Automatic Top-Up Recovery
+
+For automatic top-up, Open Design may poll AMR Cloud within bounded limits.
+
+```mermaid
+sequenceDiagram
+  participant OD as Open Design
+  participant AMR as AMR Cloud
+  participant CLI as AMR CLI
+
+  OD->>AMR: GET /recoveries/:operationId
+  AMR-->>OD: waiting_auto_topup
+  OD->>AMR: GET /recoveries/:operationId
+  AMR-->>OD: retry_available
+  OD->>AMR: POST /recoveries/:operationId/resume with retryToken/version
+  AMR-->>OD: resuming/accepted
+  OD->>CLI: Continue the same user request as a recovery attempt
+```
+
+Automatic recovery must be bounded. Repeated balance pauses, repeated resume
+failures, or status polling exhaustion must surface a user-visible boundary
+instead of looping indefinitely.
+
+### 4. Manual Top-Up Recovery
+
+For manual top-up, Open Design must wait for user initiation.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant OD as Open Design
+  participant AMR as AMR Cloud
+
+  OD-->>User: Show payment/recovery path
+  User->>AMR: Complete manual top-up
+  User->>OD: Continue this AMR request
+  OD->>AMR: GET /recoveries/:operationId
+  AMR-->>OD: retry_available
+  OD->>AMR: POST /recoveries/:operationId/resume
+```
+
+The manual continue action should make clear that continuing the request may
+use AMR Cloud balance. It should not imply a free retry.
+
+### 5. Daemon Restart Reconciliation
+
+On daemon startup, Open Design must reconcile stored replay contexts:
+
+- discard malformed contexts;
+- discard terminal contexts after local cleanup;
+- verify the current AMR Cloud user matches the context user;
+- fetch current AMR Cloud status for valid non-terminal contexts;
+- automatically resume only automatic top-up contexts that are retryable;
+- show manual recovery affordances only after user action;
+- convert locally non-resumable contexts into restart guidance.
+
+Wrong-user contexts must not be resumed. They should either be hidden until the
+correct AMR Cloud user returns or shown as requiring the correct account,
+depending on the surrounding UI.
+
+### 6. Cancel Recovery
+
+Canceling recovery means the user no longer wants to continue that request. It
+does not imply refund, payment reversal, or AMR Cloud balance change.
+
+If the AMR Cloud operation is non-terminal, Open Design must best-effort call
+the cancel endpoint. If AMR Cloud cancel fails, Open Design may stop local
+waiting but must not claim the AMR Cloud operation was canceled.
+
+### 7. Terminal Cleanup
+
+Open Design must mark the AMR Cloud operation terminal when the originating run
+or recovery attempt reaches a terminal condition:
+
+| Local outcome | AMR Cloud terminal action |
+|---|---|
+| Run/recovery succeeds | `complete` |
+| Run fails after entering recovery | `fail` |
+| Pre-registered run fails before user-visible recovery | `fail` |
+| User cancels run or recovery | `cancel` |
+| Operation already terminal in AMR Cloud | No-op locally except cleanup |
+
+Terminal cleanup must clear local replay context when it is no longer needed.
+
+## Blocked and Restart Paths
+
+### Local Run No Longer Resumable
+
+When AMR Cloud says the operation can continue but Open Design no longer has
+enough local context to continue the original local run, the product state is
+restart available.
+
+Open Design must not describe this as:
+
+- payment failure;
+- AMR Cloud failure;
+- refund/dispute status;
+- generic agent crash.
+
+### Risk, Refund, and Dispute Blocks
+
+Risk, refund, and dispute guardrails are AMR Cloud blocks, not AMR Cloud
+Recovery states. Open Design may surface account or support guidance, but it
+must not show a recovery resume affordance unless AMR Cloud explicitly returns
+a recoverable status.
+
+## Surfaces
+
+### Web UI
+
+The web UI must show AMR Cloud Recovery through the originating assistant
+message/run area:
+
+- payment required state;
+- automatic top-up waiting state;
+- manual continue action;
+- resuming state;
+- restart available state;
+- canceled or blocked state;
+- link to the AMR Cloud recovery wallet path when payment is required.
+
+The web UI must not add a global recovery center in the first version.
+
+### CLI
+
+The `od` CLI must expose recovery through existing run surfaces:
+
+- `od run info` should include recovery overlay fields when present.
+- `od run watch` should show recovery transitions and terminal outcome.
+- A standalone `od recovery` command is not required for the first version.
+
+If a future standalone recovery command is added, it must not become the only
+surface for recovery.
+
+### API and Contracts
+
+Shared contracts should add AMR Cloud Recovery metadata to run and message
+shapes instead of changing the top-level run status union.
+
+The recovery metadata should be safe for both web and CLI callers and should
+exclude secrets and full AMR Cloud payloads.
+
+### Analytics and Observability
+
+Open Design should distinguish:
+
+- pre-registered operation closed without user-visible recovery;
+- balance pause entered;
+- waiting manual payment;
+- waiting automatic top-up;
+- automatic resume attempted;
+- manual resume attempted;
+- restart path shown;
+- recovery canceled;
+- recovery completed;
+- recovery failed or blocked.
+
+Analytics must not require storing forbidden replay fields.
+
+## Acceptance Criteria
+
+- An AMR run registers an AMR Cloud recovery operation before the AMR CLI starts
+  the billable run.
+- A successful AMR run completes the AMR Cloud operation and clears local replay
+  context.
+- A local AMR runtime failure before balance pause closes the AMR Cloud
+  operation without showing AMR Cloud Recovery.
+- An insufficient-balance signal pauses the operation and shows AMR Cloud
+  Recovery instead of only generic recharge guidance.
+- Manual top-up shows a recovery payment path and requires a user action from
+  Open Design before resume.
+- Automatic top-up can resume automatically after AMR Cloud returns
+  `retry_available`.
+- `manualTopupRequired` never auto-resumes.
+- Resume uses AMR Cloud operation versioning and retry token semantics.
+- Missing retry token in a read response does not erase a previously stored
+  retry token from create or pause responses.
+- Wrong-user replay context does not resume.
+- Malformed replay context does not resume.
+- Terminal AMR Cloud operations are cleaned locally.
+- Multiple recovery operations can exist concurrently.
+- Repeated automatic recovery attempts are bounded.
+- Local non-resumability produces restart guidance, not payment-failure copy.
+- Risk/refund/dispute responses do not show recovery resume affordances.
+- Canceling recovery best-effort cancels the AMR Cloud operation and never
+  implies refund or payment reversal.
+- Run status responses expose recovery overlay data without adding a top-level
+  `ChatRunStatus`.
+- The originating assistant message persists enough recovery summary to render
+  recovery or restart context after live run expiry.
+- `od run info/watch` can show recovery state.
+
+## Test Plan
+
+### Unit Tests
+
+Add focused daemon integration tests for AMR Cloud Recovery:
+
+- register operation and store minimal replay context;
+- reject forbidden replay context fields;
+- preserve retry token when later read responses omit it;
+- discard malformed context;
+- refuse wrong-user resume;
+- clear terminal context;
+- map AMR Cloud statuses to Open Design recovery overlay states;
+- enforce manual top-up user initiation;
+- enforce automatic top-up bounded polling;
+- enforce bounded resume attempts;
+- map local non-resumable context to restart guidance;
+- map risk/refund/dispute responses to blocked guidance.
+
+### Run Integration Tests
+
+Cover AMR run lifecycle behavior:
+
+- success completes pre-registered operation;
+- local pre-recovery failure fails pre-registered operation without recovery UI;
+- insufficient balance pauses and persists recovery summary;
+- automatic top-up resumes;
+- manual top-up waits for user action;
+- cancel best-effort cancels AMR Cloud operation;
+- daemon restart reconciles active contexts.
+
+### Contract Tests
+
+Cover shared run/message DTOs:
+
+- recovery overlay is present when expected;
+- top-level `ChatRunStatus` remains unchanged;
+- recovery DTOs contain no forbidden fields;
+- example payloads include web/CLI-safe recovery metadata.
+
+### UI/CLI Tests
+
+Cover user surfaces:
+
+- assistant message renders payment required, waiting auto top-up, continue,
+  resuming, restart, blocked, and canceled states;
+- manual continue copy makes AMR Cloud balance usage clear;
+- generic failed-run copy is not shown when recovery overlay is active;
+- `od run info` prints recovery metadata;
+- `od run watch` prints recovery transitions.
+
+## Implementation Shape
+
+Implement as a vertical slice before any broad directory reorganization:
+
+1. Add AMR Cloud Recovery contracts and DTOs.
+2. Add a deep daemon integration module for AMR Cloud Recovery.
+3. Add minimal replay-context persistence under the daemon data-root contract.
+4. Hook AMR run pre-registration into the run start path.
+5. Hook insufficient-balance pause into the existing AMR account failure path.
+6. Add bounded polling and resume behavior for automatic top-up.
+7. Add manual continue behavior for manual top-up.
+8. Add terminal cleanup for success, failure, and cancel.
+9. Add startup reconciliation.
+10. Add run overlay and assistant message persisted summary.
+11. Add web and CLI presentation.
+12. Add tests from this spec.
+
+The integration module should hide AMR Cloud recovery state-machine details from
+the general run orchestration path. `server.ts` should receive narrow hooks, not
+inline the full recovery workflow.
+
+## Open Questions
+
+None for the first implementation slice. Future work may revisit:
+
+- whether a global recovery inbox is warranted after real usage;
+- whether AMR Cloud blocks deserve a separate domain term;
+- whether recovery should become a first-class run status if multiple runtime
+  families adopt the same continuity model.


### PR DESCRIPTION
## Why

This replaces the closed PR #4455 with a fresh branch rebuilt directly from the latest `main` (`ab8dde83d`) and only the AMR Cloud Recovery feature commits cherry-picked over. The previous branch had gone through several conflict-resolution rounds; this PR keeps the history clean and removes the stale merge/rebase state.

The user-facing pain is still the same: recoverable AMR account/balance failures should not collapse into generic failed-run behavior. Users need clear recovery state, bounded resume behavior, and matching web/CLI affordances.

## What users will see

AMR insufficient-balance/recovery states surface as AMR Cloud Recovery status instead of plain failed-run copy. Web assistant messages show recovery states and manual continue actions, while `od run info`, `od run watch`, and `od run recover <runId>` expose the same recovery overlay through the CLI. Automatic top-up contexts can resume automatically within bounded attempts; manual top-up waits for the user to continue and indicates AMR Cloud balance will be used.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached in this draft. The recovery UI entry points are covered by focused Playwright/Vitest flows in the AMR e2e suite.

## Bug fix verification

N/A — this is a feature vertical slice with regression coverage for AMR recovery and relogin flows.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --dir e2e typecheck`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/integrations/amr-cloud-recovery.test.ts`
- `pnpm --dir e2e test tests/amr/auth-error-convergence.test.ts tests/amr/insufficient-balance.test.ts tests/amr/logout-state-persistence.test.ts tests/amr/relogin-required.test.ts tests/amr/turn.test.ts`

## Notes

This branch contains only two commits on top of current `origin/main`:

- `8450a708a implement amr cloud recovery`
- `1ef480982 fix amr recovery e2e mocks`

Supersedes #4455.
