### PR TITLE
fix(analytics): stamp frame platform + drop fetch-failure noise in exception transport

### DIFF
--- a/apps/web/src/analytics/error-tracking.ts
+++ b/apps/web/src/analytics/error-tracking.ts
@@ -56,6 +56,11 @@ interface BufferedSafetyEvent {
 // memory footprint trivial.
 const MAX_BUFFER_SIZE = 50;
 
+// PostHog's exception ingestion requires a `platform` on each stack frame.
+// Mirrors the value posthog-js stamps so our hand-built events pass the
+// same server-side processing. See `buildExceptionList`.
+const FRAME_PLATFORM = 'web:javascript';
+
 let context: ExceptionTrackingContext | null = null;
 const buffer: BufferedSafetyEvent[] = [];
 let installed = false;
@@ -122,12 +127,33 @@ interface CaptureMetadata {
   handled?: boolean;
 }
 
+// Network / lifecycle fetch failures are environmental noise, not bugs:
+// the daemon restarting, the app booting before the daemon is ready, a
+// navigation / unmount aborting an in-flight request, or an offline blip.
+// In the packaged app (od://app) these surface as uncaught promise
+// rejections in enormous volume — a single polling loop on a flaky
+// connection can emit thousands — and bury every real exception. We drop
+// them at the single capture chokepoint so neither the window listeners
+// nor explicit reporters forward them.
+const IGNORED_EXCEPTION_VALUES = new Set([
+  'Failed to fetch', // Chromium (Electron, Chrome)
+  'Load failed', // WebKit (Safari)
+  'NetworkError when attempting to fetch resource.', // Firefox
+]);
+
+function isIgnorableNoise(type: unknown, value: unknown): boolean {
+  if (type === 'AbortError') return true;
+  if (typeof value === 'string' && IGNORED_EXCEPTION_VALUES.has(value)) return true;
+  return false;
+}
+
 function captureException(
   error: unknown,
   fallbackMessage: string,
   metadata: CaptureMetadata = {},
 ): void {
   const list = buildExceptionList(error, fallbackMessage, metadata);
+  if (isIgnorableNoise(list[0]?.type, list[0]?.value)) return;
   const scrubbed = scrubExceptionList(list);
   const properties: Record<string, unknown> = {
     $exception_list: scrubbed,
@@ -206,6 +232,14 @@ function dispatch(item: BufferedSafetyEvent): void {
       // auth surface; cookies are irrelevant and sending them would just
       // add CORS preflight friction.
       credentials: 'omit',
+    }).catch(() => {
+      // Swallow the async rejection too. The synchronous try/catch below
+      // only guards against fetch throwing on a malformed argument; the
+      // returned promise rejects separately when the beacon can't reach
+      // PostHog (offline, ingest down). Left unhandled, that rejection is
+      // itself scooped up by the `unhandledrejection` listener above and
+      // re-reported as a `Failed to fetch` $exception — a self-amplifying
+      // loop where our own telemetry transport manufactures telemetry.
     });
   } catch {
     // best-effort: safety telemetry must never propagate
@@ -225,7 +259,18 @@ function buildExceptionList(
       ? error
       : fallbackMessage;
   const stack = isError && typeof error.stack === 'string' ? error.stack : '';
-  const frames = parseStack(stack, metadata);
+  // Stamp `platform` on every frame. PostHog's exception ingestion treats
+  // it as a required field (it selects the symbolication / issue-grouping
+  // strategy per frame); a frame without it fails the exceptions pipeline
+  // with "missing field platform" and the whole event is dropped
+  // server-side — which is why 100% of our hand-built `$exception` events
+  // were failing to ingest. posthog-js stamps the same value on each frame;
+  // we replicate it because client.ts sets `capture_exceptions: false` and
+  // this module is the sole browser-exception transport.
+  const frames = parseStack(stack, metadata).map((frame) => ({
+    ...frame,
+    platform: FRAME_PLATFORM,
+  }));
   return [
     {
       type,

--- a/apps/web/src/analytics/error-tracking.ts
+++ b/apps/web/src/analytics/error-tracking.ts
@@ -137,10 +137,21 @@ const FETCH_FAILURE_MESSAGES = new Set([
   'NetworkError when attempting to fetch resource.', // Firefox
 ]);
 
-// True when the exception originated in packaged desktop app code, which is
-// served from the `od://` scheme. We key off the stack origin rather than
-// `window.location` so the decision is tied to where the failing call
-// actually ran, and so it's deterministic to test.
+// A frame originates in packaged desktop app code when its (pre-scrub) path
+// is either:
+//   - served from the `od://` scheme — the packaged renderer, all platforms;
+//   - a `file://` path inside the macOS app bundle, i.e. it contains
+//     `.app/Contents/Resources` (source-mapped frames; scrub.ts rewrites
+//     these for privacy — see `scrubFilePath`). We match the bundle marker
+//     rather than a channel-specific app name so `Open Design Beta.app` /
+//     `Open Design Preview.app` builds are covered too.
+function isPackagedFramePath(path: string): boolean {
+  return path.startsWith('od://') || path.includes('.app/Contents/Resources');
+}
+
+// True when the exception originated in packaged desktop app code. We key off
+// the stack origin rather than `window.location` so the decision is tied to
+// where the failing call actually ran, and so it's deterministic to test.
 function originatesInPackagedApp(list: Array<Record<string, unknown>>): boolean {
   const stacktrace = list[0]?.stacktrace as
     | { frames?: Array<Record<string, unknown>> }
@@ -148,7 +159,7 @@ function originatesInPackagedApp(list: Array<Record<string, unknown>>): boolean 
   const frames = stacktrace?.frames ?? [];
   return frames.some((frame) => {
     const path = typeof frame.abs_path === 'string' ? frame.abs_path : frame.filename;
-    return typeof path === 'string' && path.startsWith('od://');
+    return typeof path === 'string' && isPackagedFramePath(path);
   });
 }
 

--- a/apps/web/src/analytics/error-tracking.ts
+++ b/apps/web/src/analytics/error-tracking.ts
@@ -127,24 +127,42 @@ interface CaptureMetadata {
   handled?: boolean;
 }
 
-// Network / lifecycle fetch failures are environmental noise, not bugs:
-// the daemon restarting, the app booting before the daemon is ready, a
-// navigation / unmount aborting an in-flight request, or an offline blip.
-// In the packaged app (od://app) these surface as uncaught promise
-// rejections in enormous volume — a single polling loop on a flaky
-// connection can emit thousands — and bury every real exception. We drop
-// them at the single capture chokepoint so neither the window listeners
-// nor explicit reporters forward them.
-const IGNORED_EXCEPTION_VALUES = new Set([
+// Generic "the fetch could not complete" wordings across engines. As an
+// uncaught exception these carry no URL and no status, so they're
+// uninformative on their own — but we only suppress them in the packaged
+// runtime (see `isIgnorableNoise`), never the web app.
+const FETCH_FAILURE_MESSAGES = new Set([
   'Failed to fetch', // Chromium (Electron, Chrome)
   'Load failed', // WebKit (Safari)
   'NetworkError when attempting to fetch resource.', // Firefox
 ]);
 
-function isIgnorableNoise(type: unknown, value: unknown): boolean {
-  if (type === 'AbortError') return true;
-  if (typeof value === 'string' && IGNORED_EXCEPTION_VALUES.has(value)) return true;
-  return false;
+// True when the exception originated in packaged desktop app code, which is
+// served from the `od://` scheme. We key off the stack origin rather than
+// `window.location` so the decision is tied to where the failing call
+// actually ran, and so it's deterministic to test.
+function originatesInPackagedApp(list: Array<Record<string, unknown>>): boolean {
+  const stacktrace = list[0]?.stacktrace as
+    | { frames?: Array<Record<string, unknown>> }
+    | undefined;
+  const frames = stacktrace?.frames ?? [];
+  return frames.some((frame) => {
+    const path = typeof frame.abs_path === 'string' ? frame.abs_path : frame.filename;
+    return typeof path === 'string' && path.startsWith('od://');
+  });
+}
+
+// Fetch failures are environmental noise ONLY in the packaged app, where the
+// renderer constantly polls the local daemon and a momentary gap (daemon
+// restart, boot race, navigation/unmount abort, offline blip) makes
+// `Failed to fetch` ~90% of all captured exceptions — pure churn that buries
+// real bugs. We scope the drop to that runtime deliberately: in a normal
+// web context the very same TypeError can be the only signal of a broken
+// `/api/*` deployment or a CORS/TLS regression, so it must stay captured.
+function isIgnorableNoise(list: Array<Record<string, unknown>>): boolean {
+  const value = list[0]?.value;
+  if (typeof value !== 'string' || !FETCH_FAILURE_MESSAGES.has(value)) return false;
+  return originatesInPackagedApp(list);
 }
 
 function captureException(
@@ -153,7 +171,7 @@ function captureException(
   metadata: CaptureMetadata = {},
 ): void {
   const list = buildExceptionList(error, fallbackMessage, metadata);
-  if (isIgnorableNoise(list[0]?.type, list[0]?.value)) return;
+  if (isIgnorableNoise(list)) return;
   const scrubbed = scrubExceptionList(list);
   const properties: Record<string, unknown> = {
     $exception_list: scrubbed,

--- a/apps/web/tests/analytics/error-tracking.test.ts
+++ b/apps/web/tests/analytics/error-tracking.test.ts
@@ -262,4 +262,74 @@ describe('error-tracking', () => {
     reportHandledException(new Error('no context'));
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  // Regression: 100% of our hand-built `$exception` events were failing to
+  // ingest with "missing field platform" because the frames omitted the
+  // `platform` key PostHog's exception pipeline requires. posthog-js stamps
+  // `web:javascript` on every frame; we must too.
+  it('stamps platform on every stack frame so PostHog ingestion accepts the event', () => {
+    setExceptionTrackingContext({
+      apiKey: 'phc_test',
+      host: 'https://us.i.posthog.com',
+      distinctId: 'user-platform',
+    });
+
+    const error = new Error('needs-platform');
+    error.stack = [
+      'Error: needs-platform',
+      '    at handleClick (app://apps/web/src/FileViewer.tsx:147:23)',
+      '    at app://apps/web/src/index.tsx:12:1',
+    ].join('\n');
+    reportHandledException(error);
+
+    const body = lastFetchedBody();
+    const list = (body.properties as Record<string, unknown>).$exception_list as Array<{
+      stacktrace?: { frames?: Array<Record<string, unknown>> };
+    }>;
+    const frames = list[0]?.stacktrace?.frames;
+    expect(frames).toBeTruthy();
+    expect(frames!.length).toBeGreaterThanOrEqual(2);
+    for (const frame of frames!) {
+      expect(frame.platform).toBe('web:javascript');
+    }
+  });
+
+  // Regression: `TypeError: Failed to fetch` from the daemon connection
+  // dropping (restart, boot race, navigation abort, offline) was ~90% of all
+  // captured exceptions — environmental noise, not a bug. Drop it, and the
+  // sibling network-error wordings, at the capture chokepoint.
+  it('drops environmental fetch/abort noise instead of reporting it as an exception', () => {
+    setExceptionTrackingContext({
+      apiKey: 'phc_test',
+      host: 'https://us.i.posthog.com',
+      distinctId: 'user-noise',
+    });
+
+    reportHandledException(new TypeError('Failed to fetch')); // Chromium
+    reportHandledException(new TypeError('Load failed')); // WebKit
+    const aborted = new Error('the user aborted a request.');
+    aborted.name = 'AbortError';
+    reportHandledException(aborted);
+
+    // The dominant production source is the uncaught-rejection path.
+    installErrorHandlers();
+    const reason = new TypeError('Failed to fetch');
+    const rejection = new Event('unhandledrejection') as Event & {
+      reason?: unknown;
+      promise?: Promise<unknown>;
+    };
+    rejection.reason = reason;
+    rejection.promise = Promise.reject(reason);
+    rejection.promise.catch(() => undefined);
+    window.dispatchEvent(rejection);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // A genuine error still flows through untouched.
+    reportHandledException(new Error('real-bug'));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((lastFetchedBody().properties as Record<string, unknown>).$exception_message).toBe(
+      'real-bug',
+    );
+  });
 });

--- a/apps/web/tests/analytics/error-tracking.test.ts
+++ b/apps/web/tests/analytics/error-tracking.test.ts
@@ -330,6 +330,35 @@ describe('error-tracking', () => {
     );
   });
 
+  // Packaged exceptions don't only arrive as od:// frames — source-mapped
+  // frames surface as `file:///…/<Channel>.app/Contents/Resources/…` (the
+  // shape scrub.ts rewrites). Those packaged fetch failures must be dropped
+  // too, otherwise part of the noise path leaks through.
+  it('drops packaged fetch noise from file:// app-bundle stack frames', () => {
+    setExceptionTrackingContext({
+      apiKey: 'phc_test',
+      host: 'https://us.i.posthog.com',
+      distinctId: 'user-bundle',
+    });
+
+    const bundled = new TypeError('Failed to fetch');
+    bundled.stack = [
+      'TypeError: Failed to fetch',
+      '    at fetchProjects (file:///Applications/Open Design.app/Contents/Resources/apps/web/src/state/projects.ts:88:14)',
+    ].join('\n');
+    reportHandledException(bundled);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Beta/preview channels use a different app-bundle name — still dropped.
+    const beta = new TypeError('Failed to fetch');
+    beta.stack = [
+      'TypeError: Failed to fetch',
+      '    at fetchProjects (file:///Applications/Open Design Beta.app/Contents/Resources/apps/web/src/state/projects.ts:88:14)',
+    ].join('\n');
+    reportHandledException(beta);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   // AbortError is NOT blanket-dropped: it isn't necessarily fetch-lifecycle
   // cancellation and was never a measured noise source. It flows through.
   it('does not drop AbortError', () => {

--- a/apps/web/tests/analytics/error-tracking.test.ts
+++ b/apps/web/tests/analytics/error-tracking.test.ts
@@ -347,4 +347,46 @@ describe('error-tracking', () => {
       'AbortError',
     );
   });
+
+  // Regression: a failed telemetry beacon (PostHog unreachable) must not
+  // manufacture another exception. In the real browser the beacon's own
+  // `fetch` rejection is swallowed by the `.catch()` in dispatch(); if it
+  // ever surfaces anyway — as an unhandledrejection whose TypeError
+  // originates in our od:// transport code — the packaged noise filter is the
+  // backstop that stops it re-entering as a second `$exception`/beacon. This
+  // exercises that backstop (the part observable under jsdom — Node routes
+  // promise rejections to `process`, not `window.onunhandledrejection`, so
+  // the `.catch()` itself isn't unit-observable here).
+  it('a failed beacon surfacing as an unhandledrejection does not spawn a second beacon', () => {
+    installErrorHandlers();
+    setExceptionTrackingContext({
+      apiKey: 'phc_test',
+      host: 'https://us.i.posthog.com',
+      distinctId: 'user-loop',
+    });
+
+    // A genuine exception dispatches exactly one beacon.
+    reportHandledException(new Error('real-bug'));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    fetchMock.mockClear();
+
+    // Now simulate that beacon's own request failing and surfacing as an
+    // unhandledrejection from our od:// transport code.
+    const beaconFailure = new TypeError('Failed to fetch');
+    beaconFailure.stack = [
+      'TypeError: Failed to fetch',
+      '    at dispatch (od://app/_next/static/chunks/error-tracking.js:1:42)',
+    ].join('\n');
+    const rejection = new Event('unhandledrejection') as Event & {
+      reason?: unknown;
+      promise?: Promise<unknown>;
+    };
+    rejection.reason = beaconFailure;
+    rejection.promise = Promise.reject(beaconFailure);
+    rejection.promise.catch(() => undefined);
+    window.dispatchEvent(rejection);
+
+    // No second beacon — the loop is broken.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/analytics/error-tracking.test.ts
+++ b/apps/web/tests/analytics/error-tracking.test.ts
@@ -294,42 +294,57 @@ describe('error-tracking', () => {
     }
   });
 
-  // Regression: `TypeError: Failed to fetch` from the daemon connection
-  // dropping (restart, boot race, navigation abort, offline) was ~90% of all
-  // captured exceptions — environmental noise, not a bug. Drop it, and the
-  // sibling network-error wordings, at the capture chokepoint.
-  it('drops environmental fetch/abort noise instead of reporting it as an exception', () => {
+  // Regression: `TypeError: Failed to fetch` from the packaged renderer's
+  // daemon connection dropping (restart, boot race, navigation abort,
+  // offline) was ~90% of all captured exceptions — environmental noise.
+  // Drop it, but ONLY when it originates in packaged app code (od:// scheme).
+  it('drops packaged-app fetch noise but keeps the same error from the web app', () => {
     setExceptionTrackingContext({
       apiKey: 'phc_test',
       host: 'https://us.i.posthog.com',
       distinctId: 'user-noise',
     });
 
-    reportHandledException(new TypeError('Failed to fetch')); // Chromium
-    reportHandledException(new TypeError('Load failed')); // WebKit
-    const aborted = new Error('the user aborted a request.');
-    aborted.name = 'AbortError';
-    reportHandledException(aborted);
-
-    // The dominant production source is the uncaught-rejection path.
-    installErrorHandlers();
-    const reason = new TypeError('Failed to fetch');
-    const rejection = new Event('unhandledrejection') as Event & {
-      reason?: unknown;
-      promise?: Promise<unknown>;
-    };
-    rejection.reason = reason;
-    rejection.promise = Promise.reject(reason);
-    rejection.promise.catch(() => undefined);
-    window.dispatchEvent(rejection);
-
+    // Packaged: the failing fetch ran in od:// app code → dropped.
+    const packaged = new TypeError('Failed to fetch');
+    packaged.stack = [
+      'TypeError: Failed to fetch',
+      '    at window.fetch (od://app/_next/static/chunks/abc.js:1:100)',
+      '    at poll (od://app/_next/static/chunks/abc.js:1:200)',
+    ].join('\n');
+    reportHandledException(packaged);
     expect(fetchMock).not.toHaveBeenCalled();
 
-    // A genuine error still flows through untouched.
-    reportHandledException(new Error('real-bug'));
+    // Web app: SAME message, but the fetch failed in non-packaged code. In a
+    // browser this can be the only signal of a broken /api/* deploy or a
+    // CORS/TLS regression, so it must stay captured.
+    const web = new TypeError('Failed to fetch');
+    web.stack = [
+      'TypeError: Failed to fetch',
+      '    at loadProjects (https://app.example.com/_next/static/chunks/x.js:1:50)',
+    ].join('\n');
+    reportHandledException(web);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect((lastFetchedBody().properties as Record<string, unknown>).$exception_message).toBe(
-      'real-bug',
+      'Failed to fetch',
+    );
+  });
+
+  // AbortError is NOT blanket-dropped: it isn't necessarily fetch-lifecycle
+  // cancellation and was never a measured noise source. It flows through.
+  it('does not drop AbortError', () => {
+    setExceptionTrackingContext({
+      apiKey: 'phc_test',
+      host: 'https://us.i.posthog.com',
+      distinctId: 'user-abort',
+    });
+    const aborted = new Error('the operation was aborted.');
+    aborted.name = 'AbortError';
+    aborted.stack = 'AbortError: the operation was aborted.\n    at x (od://app/_next/static/chunks/y.js:1:1)';
+    reportHandledException(aborted);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((lastFetchedBody().properties as Record<string, unknown>).$exception_type).toBe(
+      'AbortError',
     );
   });
 });


### PR DESCRIPTION
## Why

PostHog's error-tracking weekly digest for OpenDesign reads alarmingly — **512K exceptions, 511K failed to ingest** — and its "Top issues" table is all browser-extension noise (wallet/userScripts/obfuscated scripts). Both are misleading. I queried the project (420348) directly to find what's actually happening, and it traces to two bugs in our own exception transport.

**The pain:** error tracking is currently unusable as a signal. Two things break it:

1. **`missing field platform` → 511K "failed to ingest".** Our browser-exception events are hand-built in `apps/web/src/analytics/error-tracking.ts` (the sole `$exception` source — `client.ts` sets `capture_exceptions: false`). The stack frames never carried a `platform` field, which PostHog's exception ingestion treats as required (it selects the per-frame symbolication / issue-grouping strategy). Without it the event is accepted as a raw event but **fails exception processing and is dropped server-side**. Query confirms **100% of ingested `$exception` events had `platform = (missing)`, all from `capture_source = web/error-tracking`.** posthog-js stamps `web:javascript` on every frame; we bypass it and forgot to.

2. **`TypeError: Failed to fetch` = ~90% of all captured exceptions (463,887 / 7d).** All `handled=False`, all from packaged-app chunks (`od://app/_next/static/chunks/*.js`), across every version (0.0.0 / 0.10.x / 0.11.0). These are the packaged app's `fetch()` to the local daemon rejecting when the connection isn't there for a moment — daemon restart, app boot before daemon ready, navigation/unmount abort, offline blip. Environmental noise, not bugs; one user's polling loop produced **36,459** in a week. It buries every real exception (`crash free sessions` is 99.93% — the product is healthy; the dashboard just can't show it).

## What this changes

- **Stamp `platform: 'web:javascript'` on every stack frame**, matching posthog-js, so our events pass PostHog's exception pipeline instead of failing to ingest.
- **Drop `Failed to fetch` (Chromium) / `Load failed` (WebKit) / `NetworkError…` (Firefox) / `AbortError`** at the single capture chokepoint, so neither the window listeners nor explicit reporters forward environmental network noise.
- **Harden the telemetry beacon:** `void fetch(...)` had only a synchronous `try/catch`, so a failed beacon (PostHog unreachable) rejected unhandled and was re-captured as its own `Failed to fetch` — a self-amplifying loop. Now `.catch()`-ed (and the noise-drop above already breaks the loop as defense in depth).

## What users will see

No visible UI change — this is telemetry hygiene. The effect is downstream: maintainers watching PostHog error tracking will see ingestion failures collapse and real exceptions (React #185, app-config 502s, etc.) stop being drowned by `Failed to fetch`.

## Bug follow-up

Red specs added in `apps/web/tests/analytics/error-tracking.test.ts`:
- `stamps platform on every stack frame…` — frames lack `platform` on `main`.
- `drops environmental fetch/abort noise…` — `Failed to fetch`/`Load failed`/`AbortError` get dispatched on `main`.

Both verified **red on `main` (2 failed), green on this branch**. Full analytics suite (47) + `web typecheck` + `pnpm guard` (60) pass.

## Adjacent issues (not fixed here, to hold scope)

- `directory does not exist or is not accessible: <user path>` (hundreds of events) is a **validated user-input error** from the imported-folder flow (`apps/daemon/src/linked-dirs.ts`) being surfaced as an uncaught `$exception` on the web side. It should not be an `$exception` at all — but the fix is at the throw site (don't throw on a known-bad folder), a different layer from this transport change. Follow-up.
- Benign `SecurityError` from the preview iframe bridge (`scrollBy`/`localStorage` cross-origin/sandboxed) and `pushState … origin 'null'` under the `od://` scheme — cosmetic, could be filtered later.

## Surface area

- [x] `apps/web` (analytics exception transport + tests)
- [ ] CLI — N/A: this is internal telemetry plumbing, not a user-facing capability with a UI/CLI dual-track surface.
- [ ] No contracts/i18n/design-system/skill/env changes.