### PR TITLE
test(e2e): clear Electron user-data on win onboarding smoke reset

### DIFF
--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -1361,8 +1361,31 @@ async function resetPackagedRuntimeNamespaceRoot(namespaceRoot: string): Promise
   await rm(namespaceRoot, { force: true, recursive: true });
 }
 
+// Reset every per-namespace runtime state directory before a fresh-onboarding
+// start, EXCEPT the installed app payload (`install/`). On Windows the install
+// lives UNDER the runtime namespace root, so — unlike the macOS smoke, which
+// installs to /Applications and can `rm` the whole namespace root
+// (resetPackagedMacRuntimeData) — we must preserve `install/` while wiping
+// everything else.
+//
+// Wiping only `data/` is not enough. The packaged web frontend persists its
+// config — including `onboardingCompleted` — to `localStorage`, which Electron
+// stores under the SEPARATE `user-data/` partition, not the daemon's `data/`
+// dir (see the `daemonDataRoot` vs `electronUserDataRoot` split logged on
+// boot). When `<data>/app-config.json` is absent the daemon OMITS
+// `onboardingCompleted`, so `mergeDaemonConfig` keeps the localStorage value;
+// a leftover `onboardingCompleted: true` from an earlier run (e.g. the [P2]
+// smoke that ran first in this file) then boots the app straight to Home
+// instead of onboarding, and this test times out waiting for the cloud
+// sign-in landing. Clearing `user-data/` alongside `data/` gives the same
+// true-first-run guarantee the mac smoke gets from removing the entire root.
 async function resetPackagedRuntimeDataRoot(): Promise<void> {
-  await rm(join(runtimeNamespaceRoot, 'data'), { force: true, recursive: true });
+  const entries = await readdir(runtimeNamespaceRoot).catch(() => [] as string[]);
+  await Promise.all(
+    entries
+      .filter((entry) => entry !== 'install')
+      .map((entry) => rm(join(runtimeNamespaceRoot, entry), { force: true, recursive: true })),
+  );
 }
 
 function resolveFromWorkspace(filePath: string): string {


### PR DESCRIPTION
## Why

The `[P0] @electron-smoke ... fresh packaged Windows app on onboarding` test (added in #4322, first executed once #4654 fixed the permissions bug that had kept it from running) failed deterministically on the v0.12.0 nightly — it blocks the release win x64 smoke and therefore the nightly notify run (e.g. run 27997123632). I traced the failure from the CI logs rather than the test source.

The app booted straight to **Home** instead of the onboarding cloud sign-in landing, so `waitForPackagedOnboarding` timed out (`onboardingVisible: false`, `text: null`, `href: "od://app/"`). Root cause is a Windows-specific data-isolation gap in the test, not a product bug:

- The packaged web frontend persists its config — including `onboardingCompleted` — to `localStorage`, which Electron stores under a **separate `user-data/` partition**, not the daemon's `data/` dir. The packaged boot log even splits these: `daemonDataRoot` (`…/release-nightly-win/data`) vs `electronUserDataRoot` (`…/release-nightly-win/user-data`).
- When `<data>/app-config.json` is absent the daemon **omits** `onboardingCompleted` (it's optional in `AppConfigPrefs`), so `mergeDaemonConfig` keeps the localStorage value (`config.ts` — `if (daemonConfig.onboardingCompleted != null)` is false on a fresh daemon).
- The `[P2]` smoke runs first in the same file and lands `onboardingCompleted: true`. `resetPackagedRuntimeDataRoot()` only wiped `data/`, leaving the `user-data/` localStorage flag intact → the next start reads `true` → Home.
- macOS never hit this: `resetPackagedMacRuntimeData()` removes the **entire** namespace root (the app installs to `/Applications`). On Windows the install lives **under** the namespace root, so the reset must preserve `install/` while clearing everything else.

## What users will see

No user-facing change. This only fixes test isolation for the packaged Windows onboarding smoke so the release nightly stops failing.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — test-only change.

## Bug fix verification

- Test path that reproduces the bug: `e2e/specs/win.spec.ts` → `[P0] @electron-smoke starts a fresh packaged Windows app on onboarding with AMR, Local CLI, and BYOK visible`.
- Did the test go red on `main` and green on this branch? The test is **Windows-packaged-only** (`OD_PACKAGED_E2E_WIN=1` + `OD_PACKAGED_E2E_WIN_ONBOARDING_SMOKE=1`) and cannot run on the macOS dev box. It is confirmed **red** on the current code by the nightly CI run 27997123632 (snapshot above). Green can only be confirmed by re-running the Windows packaged smoke in CI — calling that out honestly rather than claiming a local green.
- Why no cheaper red spec: the behavior is an Electron `user-data` localStorage persistence that only exists in the real packaged runtime; there is no lighter layer that can observe it.

## Validation

- `pnpm --filter @open-design/e2e typecheck` — green
- `pnpm guard` — green (60/60)
