### PR TITLE
test(e2e): harden win onboarding smoke reset + match onboarding href like mac

### DIFF
--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -1380,7 +1380,15 @@ async function resetPackagedRuntimeNamespaceRoot(namespaceRoot: string): Promise
 // sign-in landing. Clearing `user-data/` alongside `data/` gives the same
 // true-first-run guarantee the mac smoke gets from removing the entire root.
 async function resetPackagedRuntimeDataRoot(): Promise<void> {
-  const entries = await readdir(runtimeNamespaceRoot).catch(() => [] as string[]);
+  // A missing root means the namespace has no runtime state yet — already a
+  // fresh first-run, nothing to wipe. Any OTHER readdir failure (permissions,
+  // I/O) is a real problem that must surface loudly: swallowing it would turn
+  // the reset into a silent no-op and let stale state through, defeating the
+  // very guarantee this helper exists to make.
+  const entries = await readdir(runtimeNamespaceRoot).catch((error: NodeJS.ErrnoException) => {
+    if (error?.code === 'ENOENT') return [] as string[];
+    throw error;
+  });
   await Promise.all(
     entries
       .filter((entry) => entry !== 'install')


### PR DESCRIPTION
## Why

Follow-ups to #4665, both surfaced on the v0.12.0 release nightly once the user-data reset fix let the win onboarding smoke actually reach onboarding (it previously booted to Home and timed out earlier, masking everything downstream).

**1. Only swallow `ENOENT` in the namespace reset** (@nettee review on backport #4667). `resetPackagedRuntimeDataRoot()` guarded its `readdir` with `.catch(() => [])`, swallowing **any** error — a real failure (permissions, I/O) would silently turn the reset into a no-op and let stale state through, defeating the fresh-first-run guarantee. Now: missing root → already fresh; any other error rethrows.

**2. Match the onboarding href prefix like the mac smoke.** win [P0] pinned `expect(initial.href).toBe('od://app/')`, but since the #4513 cloud sign-in redesign onboarding lives on a dedicated route, so the packaged href is `od://app/onboarding`. The mac smoke already matches the prefix leniently; align win with it. This assertion was dead code until #4665 let the app reach onboarding, which is why it only failed now (nightly run 28004716716, `expected 'od://app/onboarding' to be 'od://app/'`).

Per the release fix flow both land on `main` first and backport to `release/v0.12.0`, keeping `main` the superset.

## What users will see

No user-facing change. Test-helper robustness + a stale assertion fix.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — test-only change.

## Bug fix verification

- Both changes harden / correct `e2e/specs/win.spec.ts` → `[P0] @electron-smoke ... fresh packaged Windows app on onboarding`, which is Windows-packaged-only and runs in the release nightly.
- The href fix is confirmed **red** on the nightly (run 28004716716 on commit `704ec25`, which already carries the #4665 user-data fix — proving that fix works since the app now renders onboarding instead of Home). Green can only be confirmed by the next release nightly after this backports.

## Validation

- `pnpm --filter @open-design/e2e typecheck` — green
