### PR TITLE
test(e2e): match onboarding href prefix in win smoke like mac

### DIFF
--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -622,7 +622,13 @@ winOnboardingDescribe('packaged windows onboarding AMR smoke', () => {
         snapshot.byokLinkVisible,
         'fresh packaged Windows onboarding cloud sign-in landing',
       );
-      expect(initial.href).toBe('od://app/');
+      // Onboarding lives on a dedicated route since the #4513 cloud sign-in
+      // redesign, so the href is `od://app/onboarding` (packaged) — not the
+      // bare app root. Match the prefix the same lenient way the mac smoke
+      // does instead of pinning the exact root path. Before the user-data
+      // reset fix the app booted to Home and never reached this line, which
+      // is why the stale exact-match assertion went unnoticed.
+      expect(initial.href).toMatch(/^(od:\/\/app\/|http:\/\/127\.0\.0\.1:\d+\/)/);
       expect(initial.cloudSignInVisible).toBe(true);
       expect(initial.localLinkVisible).toBe(true);
       expect(initial.byokLinkVisible).toBe(true);


### PR DESCRIPTION
## Why

Follow-up to #4665 / #4668, surfaced on the v0.12.0 release nightly. Once #4665's user-data reset fix let the win onboarding smoke actually reach onboarding (it previously booted to Home and timed out earlier, masking everything downstream), the next assertion failed:

```
expected 'od://app/onboarding' to be 'od://app/'   ← e2e/specs/win.spec.ts:625
```

The win `[P0]` smoke pinned `expect(initial.href).toBe('od://app/')`, but since the #4513 cloud sign-in redesign onboarding lives on a dedicated route, so the packaged href is `od://app/onboarding`. The mac smoke already matches the prefix leniently (`/^(od:\/\/app\/|http:\/\/127\.0\.0\.1:\d+\/)/`); this aligns win with it. The assertion was effectively dead code until #4665, which is why it only fails now (nightly run 28004716716 on commit `704ec25`).

Per the release fix flow this lands on `main` and backports to `release/v0.12.0`.

## What users will see

No user-facing change. Stale test assertion fix.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — test-only change.

## Bug fix verification

- Corrects `e2e/specs/win.spec.ts` → `[P0] @electron-smoke ... fresh packaged Windows app on onboarding` (Windows-packaged-only, runs in the release nightly).
- Confirmed **red** on nightly run 28004716716 (commit `704ec25`, which carries #4665 — the app now renders onboarding at `od://app/onboarding`, proving #4665 works). Green confirmable only by the next release nightly after this backports.

## Validation

- `pnpm --filter @open-design/e2e typecheck` — green
