### PR TITLE
feat(ci): auto-merge clean backports on green CI (+ Feishu ping on failure)

### DIFF
--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -37,14 +37,18 @@ jobs:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          row="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
-                  --json number,baseRefName,isDraft,title,author,isCrossRepository,headRefOid \
-                  --jq '[.[] | select(.baseRefName | startswith("release/v"))][0] // empty')"
+          all="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+                  --json number,baseRefName,isDraft,title,author,isCrossRepository,headRefOid)"
+          # Bind to the exact PR this CI run was for: same head branch AND head == the run's SHA,
+          # not just a branch-name match (which could resolve a different / newer PR).
+          row="$(printf '%s' "$all" | jq --arg sha "$HEAD_SHA" \
+                  '[.[] | select(.baseRefName | startswith("release/v")) | select(.headRefOid == $sha)][0] // empty')"
           if [ -z "$row" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "No open backport PR to release/* for $BRANCH"
+            echo "No open backport PR to release/* for $BRANCH at $HEAD_SHA"
             exit 0
           fi
           {

--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -31,26 +31,28 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - name: Resolve the backport PR for this branch
+      - name: Resolve the backport PR for this run
         id: pr
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           REPO: ${{ github.repository }}
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # Authoritative run -> PR association from GitHub (populated for same-repo PRs; empty
+          # for forks, which we never auto-merge anyway).
+          RUN_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
         run: |
           set -euo pipefail
-          all="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
-                  --json number,baseRefName,isDraft,title,author,isCrossRepository,headRefOid)"
-          # Bind to the exact PR this CI run was for: same head branch AND head == the run's SHA,
-          # not just a branch-name match (which could resolve a different / newer PR).
-          row="$(printf '%s' "$all" | jq --arg sha "$HEAD_SHA" \
-                  '[.[] | select(.baseRefName | startswith("release/v")) | select(.headRefOid == $sha)][0] // empty')"
-          if [ -z "$row" ]; then
+          # Pick the run's own PR that targets a release/* branch at exactly the SHA CI ran on —
+          # bound to workflow_run.pull_requests, not a branch-name guess.
+          num="$(printf '%s' "$RUN_PRS" | jq -r --arg sha "$HEAD_SHA" \
+                  '[.[] | select(.base.ref | startswith("release/v")) | select(.head.sha == $sha)][0].number // empty')"
+          if [ -z "$num" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "No open backport PR to release/* for $BRANCH at $HEAD_SHA"
+            echo "Run has no associated release/* PR at $HEAD_SHA — skipping"
             exit 0
           fi
+          row="$(gh pr view "$num" --repo "$REPO" \
+                  --json number,baseRefName,isDraft,title,author,isCrossRepository,headRefOid)"
           {
             echo "found=true"
             echo "number=$(printf '%s' "$row" | jq -r .number)"

--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -20,7 +20,9 @@ permissions:
 
 jobs:
   followup:
-    if: ${{ github.repository == 'nexu-io/open-design' && startsWith(github.event.workflow_run.head_branch, 'backport-') }}
+    # Only react to CI that ran for a *pull request* on a backport-* branch — never a push or
+    # manual dispatch — so a non-PR run can't reach the App-token / Feishu steps below.
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event.workflow_run.event == 'pull_request' && startsWith(github.event.workflow_run.head_branch, 'backport-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2
@@ -82,7 +84,9 @@ jobs:
           gh pr merge "$NUM" --repo "$REPO" --squash --delete-branch --match-head-commit "$HEAD_SHA"
 
       - name: Notify Feishu on failed backport CI
-        if: ${{ steps.pr.outputs.found == 'true' && github.event.workflow_run.conclusion == 'failure' }}
+        # Same identity gates as the merge step: only ping for a genuine bot backport from the
+        # same repo, so a fork / non-bot PR named backport-* can't spam the release group.
+        if: ${{ steps.pr.outputs.found == 'true' && steps.pr.outputs.author == 'open-design-release-bot[bot]' && steps.pr.outputs.cross == 'false' && github.event.workflow_run.conclusion == 'failure' }}
         env:
           FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
           FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}

--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -1,0 +1,93 @@
+name: backport-automerge
+# Auto-merge a clean backport PR once its CI is green — and ping Feishu if its CI fails.
+#
+# release/v* is protected (PR required) but has no required status check and no merge queue,
+# so neither GitHub auto-merge nor enqueuePullRequest applies. Instead we react to ci.yml
+# finishing for a backport-* branch:
+#   - CI success + clean (non-draft) PR  -> squash-merge it (App token, so the push to
+#     release/* re-triggers notify-release-feishu / the nightly).
+#   - CI failure                         -> Feishu ping for manual follow-up.
+#   - conflict (draft PR)                -> left for a human; release-gate blocks the release
+#                                           until it lands.
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  followup:
+    if: ${{ github.repository == 'nexu-io/open-design' && startsWith(github.event.workflow_run.head_branch, 'backport-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Resolve the backport PR for this branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          row="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+                  --json number,baseRefName,isDraft,title \
+                  --jq '[.[] | select(.baseRefName | startswith("release/v"))][0] // empty')"
+          if [ -z "$row" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No open backport PR to release/* for $BRANCH"
+            exit 0
+          fi
+          {
+            echo "found=true"
+            echo "number=$(printf '%s' "$row" | jq -r .number)"
+            echo "base=$(printf '%s' "$row" | jq -r .baseRefName)"
+            echo "draft=$(printf '%s' "$row" | jq -r .isDraft)"
+            echo "title=$(printf '%s' "$row" | jq -r .title)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Auto-merge clean backport on green CI
+        if: ${{ steps.pr.outputs.found == 'true' && steps.pr.outputs.draft == 'false' && github.event.workflow_run.conclusion == 'success' }}
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.pr.outputs.number }}
+          BASE: ${{ steps.pr.outputs.base }}
+        run: |
+          set -euo pipefail
+          echo "CI green — squash-merging clean backport PR #$NUM into $BASE"
+          gh pr merge "$NUM" --repo "$REPO" --squash --delete-branch
+
+      - name: Notify Feishu on failed backport CI
+        if: ${{ steps.pr.outputs.found == 'true' && github.event.workflow_run.conclusion == 'failure' }}
+        env:
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
+          NUM: ${{ steps.pr.outputs.number }}
+          BASE: ${{ steps.pr.outputs.base }}
+          TITLE: ${{ steps.pr.outputs.title }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          python3 - <<'PY'
+          import os, time, hmac, hashlib, base64, json, urllib.request
+          wh = os.environ.get("FEISHU_WEBHOOK", "")
+          if not wh:
+              raise SystemExit(0)
+          secret = os.environ.get("FEISHU_SIGN_SECRET", "")
+          text = (f"⚠️ backport PR #{os.environ['NUM']} CI 失败（目标 {os.environ['BASE']}）\n"
+                  f"{os.environ.get('TITLE','')}\n需要人工跟进：{os.environ.get('RUN_URL','')}")
+          body = {"msg_type": "text", "content": {"text": text}}
+          if secret:
+              ts = str(int(time.time()))
+              sign = base64.b64encode(hmac.new(f"{ts}\n{secret}".encode(), b"", hashlib.sha256).digest()).decode()
+              body = {"timestamp": ts, "sign": sign, **body}
+          req = urllib.request.Request(wh, data=json.dumps(body).encode(), headers={"Content-Type": "application/json"})
+          print(urllib.request.urlopen(req).read().decode())
+          PY

--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           row="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
-                  --json number,baseRefName,isDraft,title \
+                  --json number,baseRefName,isDraft,title,author,isCrossRepository,headRefOid \
                   --jq '[.[] | select(.baseRefName | startswith("release/v"))][0] // empty')"
           if [ -z "$row" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -51,19 +51,35 @@ jobs:
             echo "base=$(printf '%s' "$row" | jq -r .baseRefName)"
             echo "draft=$(printf '%s' "$row" | jq -r .isDraft)"
             echo "title=$(printf '%s' "$row" | jq -r .title)"
+            echo "author=$(printf '%s' "$row" | jq -r '.author.login')"
+            echo "cross=$(printf '%s' "$row" | jq -r '.isCrossRepository')"
+            echo "head_oid=$(printf '%s' "$row" | jq -r '.headRefOid')"
           } >> "$GITHUB_OUTPUT"
 
       - name: Auto-merge clean backport on green CI
-        if: ${{ steps.pr.outputs.found == 'true' && steps.pr.outputs.draft == 'false' && github.event.workflow_run.conclusion == 'success' }}
+        # Guards (release/v* has no required checks, so this workflow IS the gate):
+        #  - author == the release bot and same-repo (not a fork) — so a stranger can't get a
+        #    branch named backport-* auto-merged with the App token.
+        #  - PR head == the exact SHA CI passed on (head_oid == workflow_run.head_sha), and
+        #    --match-head-commit re-checks at merge time — so a commit pushed after CI went
+        #    green is never merged untested.
+        if: >-
+          ${{ steps.pr.outputs.found == 'true'
+              && steps.pr.outputs.draft == 'false'
+              && steps.pr.outputs.author == 'open-design-release-bot[bot]'
+              && steps.pr.outputs.cross == 'false'
+              && steps.pr.outputs.head_oid == github.event.workflow_run.head_sha
+              && github.event.workflow_run.conclusion == 'success' }}
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           REPO: ${{ github.repository }}
           NUM: ${{ steps.pr.outputs.number }}
           BASE: ${{ steps.pr.outputs.base }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          echo "CI green — squash-merging clean backport PR #$NUM into $BASE"
-          gh pr merge "$NUM" --repo "$REPO" --squash --delete-branch
+          echo "CI green on $HEAD_SHA — squash-merging clean backport PR #$NUM into $BASE"
+          gh pr merge "$NUM" --repo "$REPO" --squash --delete-branch --match-head-commit "$HEAD_SHA"
 
       - name: Notify Feishu on failed backport CI
         if: ${{ steps.pr.outputs.found == 'true' && github.event.workflow_run.conclusion == 'failure' }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -41,9 +41,7 @@ jobs:
           # Do not give up on conflicts: commit the conflict markers into the backport branch
           # and open a draft PR for a human to resolve.
           experimental: '{ "conflict_resolution": "draft_commit_conflicts" }'
-          # ── Fast lane: auto-merge clean backports (off by default) ──────────
-          # Prerequisite: branch protection on release/* requiring CI to pass, otherwise it
-          # would merge before CI finishes. Once that is set up, uncomment the two lines below
-          # to auto-merge clean backports after CI turns green:
-          # auto_merge_enabled: true
-          # auto_merge_method: squash
+          # Clean backports are auto-merged after CI passes by backport-automerge.yml
+          # (triggered by ci.yml completing on the backport-* branch). release/v* has no merge
+          # queue and no required status check, so GitHub auto-merge / enqueuePullRequest don't
+          # apply here; that workflow gates on ci.yml's own success instead.

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -221,7 +221,9 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain("steps.pr.outputs.draft == 'false'");
     expect(workflow).toContain('startswith("release/v")');
 
-    // The merge is bound to the exact SHA CI passed on (no post-green commit merged untested).
+    // The PR is resolved by binding to the run's SHA (not just the branch name), and the merge
+    // is bound to the exact SHA CI passed on (no post-green commit merged untested).
+    expect(workflow).toContain("select(.headRefOid == $sha)");
     expect(workflow).toContain("steps.pr.outputs.head_oid == github.event.workflow_run.head_sha");
     expect(workflow).toContain("--match-head-commit");
     expect(workflow).toContain("--squash");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -221,9 +221,11 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain("steps.pr.outputs.draft == 'false'");
     expect(workflow).toContain('startswith("release/v")');
 
-    // The PR is resolved by binding to the run's SHA (not just the branch name), and the merge
-    // is bound to the exact SHA CI passed on (no post-green commit merged untested).
-    expect(workflow).toContain("select(.headRefOid == $sha)");
+    // The PR is resolved from the run's authoritative workflow_run.pull_requests association
+    // (filtered to the release/* base at exactly the run's SHA), not a branch-name guess, and the
+    // merge is bound to that same SHA (no post-green commit merged untested).
+    expect(workflow).toContain("github.event.workflow_run.pull_requests");
+    expect(workflow).toContain("select(.head.sha == $sha)");
     expect(workflow).toContain("steps.pr.outputs.head_oid == github.event.workflow_run.head_sha");
     expect(workflow).toContain("--match-head-commit");
     expect(workflow).toContain("--squash");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -19,6 +19,7 @@ const commentWorkflowPath = join(workspaceRoot, ".github", "workflows", "comment
 const autofixWorkflowPath = join(workspaceRoot, ".github", "workflows", "autofix.atom.yml");
 const reportWorkflowPath = join(workspaceRoot, ".github", "workflows", "report.atom.yml");
 const dockerImageWorkflowPath = join(workspaceRoot, ".github", "workflows", "docker-image.yml");
+const backportAutomergeWorkflowPath = join(workspaceRoot, ".github", "workflows", "backport-automerge.yml");
 const handoffScriptPath = join(workspaceRoot, ".github", "scripts", "handoff.py");
 const releaseBetaWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-beta.yml");
 const releaseBetaSelfHostedWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-beta-s.yml");
@@ -199,6 +200,38 @@ describe("packaged smoke workflow", () => {
     expect(autofixWorkflow).not.toContain("ci-nix");
     expect(reportWorkflow).toContain("workflows: [ci]");
     expect(reportWorkflow).toContain("github.event.workflow_run.event == 'pull_request'");
+  });
+
+  it("[P2] gates the backport auto-merge follow-up as a trusted workflow_run consumer", async () => {
+    const workflow = await readFile(backportAutomergeWorkflowPath, "utf8");
+
+    // Triggered only by ci completing, and only for a pull_request run on a backport-* branch —
+    // never a push / manual dispatch, so a non-PR run can't reach the App-token or merge steps.
+    expect(workflow).toContain("workflows: [ci]");
+    expect(workflow).toContain("github.event.workflow_run.event == 'pull_request'");
+    expect(workflow).toContain("startsWith(github.event.workflow_run.head_branch, 'backport-')");
+
+    // It mints the privileged release App token, hence the identity + SHA gates below.
+    expect(workflow).toContain("actions/create-github-app-token");
+    expect(workflow).toContain("secrets.RELEASE_BOT_APP_ID");
+
+    // Only a non-draft, same-repo PR authored by the release bot, targeting release/v*, is merged.
+    expect(workflow).toContain("steps.pr.outputs.author == 'open-design-release-bot[bot]'");
+    expect(workflow).toContain("steps.pr.outputs.cross == 'false'");
+    expect(workflow).toContain("steps.pr.outputs.draft == 'false'");
+    expect(workflow).toContain('startswith("release/v")');
+
+    // The merge is bound to the exact SHA CI passed on (no post-green commit merged untested).
+    expect(workflow).toContain("steps.pr.outputs.head_oid == github.event.workflow_run.head_sha");
+    expect(workflow).toContain("--match-head-commit");
+    expect(workflow).toContain("--squash");
+    expect(workflow).toContain("--delete-branch");
+
+    // The Feishu failure path carries the same identity gates, so a fork / non-bot backport-*
+    // PR can't spam the release group.
+    const feishuStep = sectionBetween(workflow, "Notify Feishu on failed backport CI", "FEISHU_WEBHOOK");
+    expect(feishuStep).toContain("steps.pr.outputs.author == 'open-design-release-bot[bot]'");
+    expect(feishuStep).toContain("steps.pr.outputs.cross == 'false'");
   });
 
   it("[P2] keeps PR and merge queue CI separated by hot/full validation mode", async () => {


### PR DESCRIPTION
## What

Implements **auto-merge for clean backport PRs** once their CI is green, plus a **Feishu ping when a backport's CI fails** — without changing repo settings.

## Why this shape

`release/v*` is protected (PR required) but has **no merge queue and no required status check**, so:
- GitHub native auto-merge (`auto_merge_enabled`) would merge *before* CI, and needs repo-level "Allow auto-merge" (off).
- `enqueuePullRequest` needs a merge queue on the base branch (none on release/*).

So `backport-automerge.yml` reacts to **`ci.yml` completing** on a `backport-*` branch and gates on ci.yml's own success:

| ci.yml result | action |
|---|---|
| success + clean (non-draft) PR | squash-merge with the App token → the push to `release/*` re-triggers `notify-release-feishu` (nightly) |
| failure | Feishu ping for manual follow-up |
| conflict (draft PR) | left for a human; `release-gate` blocks the release until it lands |

Also updates `backport.yml`'s now-stale auto-merge comment to point here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
