### PR TITLE
feat(daemon): stabilize cacheable prompt prefix (#4679)

### DIFF
--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -26,6 +26,7 @@ export type PromptTelemetrySectionKind =
   | 'runContextPrompt'
   | 'browserUsePromptGuard'
   | 'titleGenerationPrompt'
+  | 'connectedExternalMcpReference'
   | 'clientSystemPrompt'
   | 'echoGuard'
   | 'userRequest'
@@ -76,6 +77,7 @@ export const PROMPT_SECTION_CACHE_CLASS: Record<
   runContextPrompt: 'volatile',
   browserUsePromptGuard: 'volatile',
   titleGenerationPrompt: 'volatile',
+  connectedExternalMcpReference: 'volatile',
   echoGuard: 'volatile',
   userRequest: 'volatile',
   cwdHint: 'volatile',
@@ -234,6 +236,7 @@ const REDACTED_CONTENT_KINDS = new Set<PromptTelemetrySectionKind>([
   'runContextPrompt',
   'browserUsePromptGuard',
   'titleGenerationPrompt',
+  'connectedExternalMcpReference',
   'clientSystemPrompt',
   'echoGuard',
   'userRequest',
@@ -256,6 +259,7 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
   ['runContextPrompt', 7],
   ['browserUsePromptGuard', 8],
   ['titleGenerationPrompt', 8],
+  ['connectedExternalMcpReference', 8],
   ['echoGuard', 8],
   ['userRequest', 9],
 ]);
@@ -359,12 +363,12 @@ function stripRuntimeToolPromptTokens(input: string): string {
     .map((line) => {
       if (line.includes('OD_TOOL_TOKEN')) {
         if (line.includes('is available')) {
-          return '- [OD_TOOL_TOKEN_AVAILABLE]';
+          return '- [TOKEN_AVAILABLE]';
         }
         if (line.includes('is not available') || line.includes('unavailable')) {
-          return '- [OD_TOOL_TOKEN_UNAVAILABLE]';
+          return '- [TOKEN_UNAVAILABLE]';
         }
-        return '- [OD_TOOL_TOKEN_REDACTED]';
+        return '- [TOKEN_REDACTED]';
       }
       return line;
     })

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -675,7 +675,19 @@ export function assertOdNextExactSendPromptEvidence(input: {
     persisted: input.persisted,
     stage: input.stage,
   });
-  if (!isDeepStrictEqual(input.telemetry, expected)) {
+
+  // Tolerate legacy pre-4681 snapshots that lack additive cacheablePrefix fields
+  const normalizedTelemetry: PromptStackTelemetry = {
+    ...input.telemetry,
+    cacheablePrefixFingerprint:
+      input.telemetry.cacheablePrefixFingerprint ?? expected.cacheablePrefixFingerprint,
+    cacheablePrefixSectionCount:
+      input.telemetry.cacheablePrefixSectionCount ?? expected.cacheablePrefixSectionCount,
+    cacheablePrefixContiguous:
+      input.telemetry.cacheablePrefixContiguous ?? expected.cacheablePrefixContiguous,
+  };
+
+  if (!isDeepStrictEqual(normalizedTelemetry, expected)) {
     throw new InvalidOdNextExactSendPromptError(
       'Persisted OD Next exact-send Prompt evidence no longer matches its authoritative task mapping.',
     );

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -69,6 +69,7 @@ export const PROMPT_SECTION_CACHE_CLASS: Record<
   skillPrompt: 'stable',
   designSystemPrompt: 'stable',
   pluginStagePrompt: 'stable',
+  odNextExactFinalText: 'volatile',
   // Volatile tail: per-turn inputs that must not break the stable prefix.
   formOverride: 'volatile',
   researchCommandContract: 'volatile',

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -136,9 +136,12 @@ export interface PromptStackTelemetry {
   /** Number of stable sections folded into `cacheablePrefixFingerprint`. */
   cacheablePrefixSectionCount: number;
   /**
-   * True when the stable sections occupy a single contiguous run in composed
-   * order (no volatile block splits them). A regression that reorders a volatile
-   * block back into the middle of the stable trio flips this to false.
+   * True only when the stable sections form the actual prefix-cacheable run:
+   * they start at the first present section (no volatile preamble such as a
+   * question-form `formOverride` ahead of them) and occupy a single contiguous
+   * run with no volatile block wedged in. A volatile block reordered into — or
+   * prepended ahead of — the stable trio flips this to false, so those turns
+   * surface as not prefix-cacheable rather than as a false cache hit.
    */
   cacheablePrefixContiguous: boolean;
   rawBytes: number;
@@ -448,24 +451,33 @@ function perSectionLimit(kind: PromptTelemetrySectionKind): number {
 
 /**
  * Derive the cacheable-prefix signal (#4679) from the present sections in
- * composed order. The fingerprint covers only `stable` sections so it stays
- * byte-identical when volatile inputs change; `contiguous` is false when a
- * volatile section is interleaved between two stable ones (the regression the
- * reorder fixed: a volatile block splitting the stable trio).
+ * composed order. Absent sections contribute no bytes to the request, so they
+ * are filtered out before reasoning about order. The fingerprint covers only
+ * `stable` sections so it stays byte-identical when volatile inputs change.
+ *
+ * `contiguous` is the actual prefix-cacheable signal: provider prompt caching
+ * only reuses a byte-identical run from the very start of the request, so the
+ * stable sections must (a) start at the first present section — no volatile
+ * preamble such as a question-form `formOverride` may precede them — and (b)
+ * form a single unbroken run (no volatile block wedged into the stable trio).
+ * Either a leading volatile section or an interleaved one flips it to false so
+ * those turns surface as not prefix-cacheable instead of a false cache hit.
  */
 function computeCacheablePrefix(
   sections: PromptTelemetrySection[],
 ): { fingerprint: string; sectionCount: number; contiguous: boolean } {
+  const present = sections.filter((section) => section.present);
   const stable: PromptTelemetrySection[] = [];
   const stablePositions: number[] = [];
-  sections.forEach((section, position) => {
+  present.forEach((section, position) => {
     if (classifyPromptSectionCacheClass(section.kind) === 'stable') {
       stable.push(section);
       stablePositions.push(position);
     }
   });
   const contiguous =
-    stablePositions.length === 0 ||
+    stablePositions.length > 0 &&
+    stablePositions[0] === 0 &&
     stablePositions[stablePositions.length - 1]! - stablePositions[0]! ===
       stablePositions.length - 1;
   const fingerprintSource = stable.map((section) => ({

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -97,11 +97,10 @@ export const PROMPT_SECTION_CACHE_CLASS: Record<
 export function classifyPromptSectionCacheClass(
   kind: PromptTelemetrySectionKind,
 ): PromptSectionCacheClass {
-  const cacheClass = PROMPT_SECTION_CACHE_CLASS[kind];
-  if (cacheClass === undefined) {
+  if (!Object.hasOwn(PROMPT_SECTION_CACHE_CLASS, kind)) {
     throw new Error(`unclassified prompt-stack section kind: ${String(kind)}`);
   }
-  return cacheClass;
+  return PROMPT_SECTION_CACHE_CLASS[kind];
 }
 
 export interface PromptTelemetryInputSection {

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -356,7 +356,18 @@ export function buildSafeChildPromptTelemetry(
 function stripRuntimeToolPromptTokens(input: string): string {
   return input
     .split(/\r?\n/)
-    .filter((line) => !line.includes('OD_TOOL_TOKEN'))
+    .map((line) => {
+      if (line.includes('OD_TOOL_TOKEN')) {
+        if (line.includes('is available')) {
+          return '- [OD_TOOL_TOKEN_AVAILABLE]';
+        }
+        if (line.includes('is not available') || line.includes('unavailable')) {
+          return '- [OD_TOOL_TOKEN_UNAVAILABLE]';
+        }
+        return '- [OD_TOOL_TOKEN_REDACTED]';
+      }
+      return line;
+    })
     .join('\n');
 }
 

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -231,6 +231,8 @@ const REDACTED_CONTENT_KINDS = new Set<PromptTelemetrySectionKind>([
   'runtimeToolPrompt',
   'researchCommandContract',
   'runContextPrompt',
+  'browserUsePromptGuard',
+  'titleGenerationPrompt',
   'clientSystemPrompt',
   'echoGuard',
   'userRequest',
@@ -251,6 +253,8 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
   ['odNextExactFinalText', 1],
   ['researchCommandContract', 6],
   ['runContextPrompt', 7],
+  ['browserUsePromptGuard', 8],
+  ['titleGenerationPrompt', 8],
   ['echoGuard', 8],
   ['userRequest', 9],
 ]);

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -24,6 +24,8 @@ export type PromptTelemetrySectionKind =
   | 'runtimeToolPrompt'
   | 'researchCommandContract'
   | 'runContextPrompt'
+  | 'browserUsePromptGuard'
+  | 'titleGenerationPrompt'
   | 'clientSystemPrompt'
   | 'echoGuard'
   | 'userRequest'
@@ -36,6 +38,68 @@ export type PromptTelemetrySectionKind =
   | 'attachments'
   | 'commentAttachments'
   | 'promptImagePaths';
+
+/**
+ * Cacheable-prefix classification (#4679, reliability epic #3408).
+ *
+ * Every prompt-stack section is declared `stable` or `volatile` at the point it
+ * is added to the union — there is no implicit default. `stable` sections are
+ * the cacheable prefix the model provider can reuse across turns of a
+ * conversation (daemon system prompt, tool contract, and the big system prompt =
+ * design system / skills / memory). `volatile` sections change per turn (run
+ * context, research contract, browser-use guard, title task, the user request,
+ * attachments, cwd) and MUST sit after the stable block so they never split it.
+ *
+ * Because this is a `Record` over the full `PromptTelemetrySectionKind` union,
+ * adding a new section kind without classifying it is a compile error — the
+ * one-choke-point guard #3408 asks for. The runtime fingerprint
+ * (`cacheablePrefixFingerprint`) plus `cacheablePrefixContiguous` then prove the
+ * stable block actually stayed contiguous in the composed byte order.
+ */
+export type PromptSectionCacheClass = 'stable' | 'volatile';
+
+export const PROMPT_SECTION_CACHE_CLASS: Record<
+  PromptTelemetrySectionKind,
+  PromptSectionCacheClass
+> = {
+  // Stable cacheable prefix: identical across turns in the common case.
+  daemonSystemPrompt: 'stable',
+  runtimeToolPrompt: 'stable',
+  clientSystemPrompt: 'stable',
+  skillPrompt: 'stable',
+  designSystemPrompt: 'stable',
+  pluginStagePrompt: 'stable',
+  // Volatile tail: per-turn inputs that must not break the stable prefix.
+  formOverride: 'volatile',
+  researchCommandContract: 'volatile',
+  runContextPrompt: 'volatile',
+  browserUsePromptGuard: 'volatile',
+  titleGenerationPrompt: 'volatile',
+  echoGuard: 'volatile',
+  userRequest: 'volatile',
+  cwdHint: 'volatile',
+  linkedDirsHint: 'volatile',
+  attachments: 'volatile',
+  commentAttachments: 'volatile',
+  promptImagePaths: 'volatile',
+};
+
+/**
+ * Classify a section kind, throwing on an unknown kind. The throw is the
+ * runtime mirror of the compile-time exhaustiveness of
+ * `PROMPT_SECTION_CACHE_CLASS`: a fixture or caller that invents a kind outside
+ * the declared union fails loudly instead of silently landing in the cacheable
+ * prefix.
+ */
+export function classifyPromptSectionCacheClass(
+  kind: PromptTelemetrySectionKind,
+): PromptSectionCacheClass {
+  const cacheClass = PROMPT_SECTION_CACHE_CLASS[kind];
+  if (cacheClass === undefined) {
+    throw new Error(`unclassified prompt-stack section kind: ${String(kind)}`);
+  }
+  return cacheClass;
+}
 
 export interface PromptTelemetryInputSection {
   kind: PromptTelemetrySectionKind;
@@ -62,6 +126,21 @@ export interface PromptStackTelemetry {
   redactionVersion: typeof PROMPT_STACK_REDACTION_VERSION;
   promptFingerprint: string;
   stackFingerprint: string;
+  /**
+   * Fingerprint of just the `stable`-classified sections (#4679). Byte-identical
+   * across turns whenever the cacheable prefix content is unchanged, regardless
+   * of which volatile blocks (run context, research, title task, user request)
+   * vary — the signal the provider prefix cache can be reused.
+   */
+  cacheablePrefixFingerprint: string;
+  /** Number of stable sections folded into `cacheablePrefixFingerprint`. */
+  cacheablePrefixSectionCount: number;
+  /**
+   * True when the stable sections occupy a single contiguous run in composed
+   * order (no volatile block splits them). A regression that reorders a volatile
+   * block back into the middle of the stable trio flips this to false.
+   */
+  cacheablePrefixContiguous: boolean;
   rawBytes: number;
   redactedBytes: number;
   sectionCount: number;
@@ -93,6 +172,9 @@ export interface StructuredPromptStackInput {
   redactionVersion: typeof PROMPT_STACK_REDACTION_VERSION;
   promptFingerprint: string;
   stackFingerprint: string;
+  cacheablePrefixFingerprint: string;
+  cacheablePrefixSectionCount: number;
+  cacheablePrefixContiguous: boolean;
   sectionCount: number;
   redactedContentBytes: number;
   redactedContentBudgetBytes: number;
@@ -364,6 +446,39 @@ function perSectionLimit(kind: PromptTelemetrySectionKind): number {
     : SECTION_MAX_BYTES;
 }
 
+/**
+ * Derive the cacheable-prefix signal (#4679) from the present sections in
+ * composed order. The fingerprint covers only `stable` sections so it stays
+ * byte-identical when volatile inputs change; `contiguous` is false when a
+ * volatile section is interleaved between two stable ones (the regression the
+ * reorder fixed: a volatile block splitting the stable trio).
+ */
+function computeCacheablePrefix(
+  sections: PromptTelemetrySection[],
+): { fingerprint: string; sectionCount: number; contiguous: boolean } {
+  const stable: PromptTelemetrySection[] = [];
+  const stablePositions: number[] = [];
+  sections.forEach((section, position) => {
+    if (classifyPromptSectionCacheClass(section.kind) === 'stable') {
+      stable.push(section);
+      stablePositions.push(position);
+    }
+  });
+  const contiguous =
+    stablePositions.length === 0 ||
+    stablePositions[stablePositions.length - 1]! - stablePositions[0]! ===
+      stablePositions.length - 1;
+  const fingerprintSource = stable.map((section) => ({
+    kind: section.kind,
+    fingerprint: section.fingerprint,
+  }));
+  return {
+    fingerprint: sha256(JSON.stringify(fingerprintSource)),
+    sectionCount: stable.length,
+    contiguous,
+  };
+}
+
 export function buildPromptStackTelemetry({
   composedPrompt,
   sections,
@@ -448,10 +563,14 @@ export function buildPromptStackTelemetry({
     (total, section) => total + byteLength(section.redactedContent ?? ''),
     0,
   );
+  const cacheablePrefix = computeCacheablePrefix(outputSections);
   return {
     redactionVersion: PROMPT_STACK_REDACTION_VERSION,
     promptFingerprint: sha256(normalizedComposed),
     stackFingerprint: sha256(JSON.stringify(stackFingerprintSource)),
+    cacheablePrefixFingerprint: cacheablePrefix.fingerprint,
+    cacheablePrefixSectionCount: cacheablePrefix.sectionCount,
+    cacheablePrefixContiguous: cacheablePrefix.contiguous,
     rawBytes,
     redactedBytes,
     sectionCount: outputSections.length,
@@ -549,6 +668,9 @@ export function structuredPromptStackInput(
     redactionVersion: telemetry.redactionVersion,
     promptFingerprint: telemetry.promptFingerprint,
     stackFingerprint: telemetry.stackFingerprint,
+    cacheablePrefixFingerprint: telemetry.cacheablePrefixFingerprint,
+    cacheablePrefixSectionCount: telemetry.cacheablePrefixSectionCount,
+    cacheablePrefixContiguous: telemetry.cacheablePrefixContiguous,
     sectionCount: telemetry.sectionCount,
     redactedContentBytes: telemetry.redactedContentBytes,
     redactedContentBudgetBytes: telemetry.redactedContentBudgetBytes,
@@ -578,6 +700,9 @@ export function buildPromptStackFlatMetadata(
     promptStack_redactionVersion: telemetry.redactionVersion,
     promptStack_promptFingerprint: telemetry.promptFingerprint,
     promptStack_stackFingerprint: telemetry.stackFingerprint,
+    promptStack_cacheablePrefixFingerprint: telemetry.cacheablePrefixFingerprint,
+    promptStack_cacheablePrefixSectionCount: telemetry.cacheablePrefixSectionCount,
+    promptStack_cacheablePrefixContiguous: telemetry.cacheablePrefixContiguous,
     promptStack_sectionCount: telemetry.sectionCount,
     promptStack_redactedContentBytes: telemetry.redactedContentBytes,
     promptStack_redactedContentBudgetBytes: telemetry.redactedContentBudgetBytes,

--- a/apps/daemon/src/runtimes/chat-prompt-inputs.ts
+++ b/apps/daemon/src/runtimes/chat-prompt-inputs.ts
@@ -68,14 +68,27 @@ type CommentAttachmentInput = {
   source?: InputValue;
 };
 
+/**
+ * Compose the live instruction block in cacheable-prefix order (#4679).
+ *
+ * The stable trio — `daemonSystemPrompt`, `runtimeToolPrompt`, and the big
+ * `clientStableSystemPrompt` (design system / skills / memory) — is emitted
+ * first and contiguously so a provider can reuse it as a cached prefix across
+ * turns. The per-turn `clientSystemPrompt` (run context, research contract,
+ * browser-use guard, title task) follows as a volatile tail, and any
+ * `finalPromptOverride` (the codex imagegen override) is appended last so it
+ * stays semantically volatile and never lands inside the cacheable prefix.
+ */
 export function composeLiveInstructionPrompt({
   daemonSystemPrompt,
   runtimeToolPrompt,
+  clientStableSystemPrompt,
   clientSystemPrompt,
   finalPromptOverride,
 }: {
   daemonSystemPrompt?: string | null;
   runtimeToolPrompt?: string | null;
+  clientStableSystemPrompt?: string | null;
   clientSystemPrompt?: string | null;
   finalPromptOverride?: string | null;
 }) {
@@ -83,7 +96,12 @@ export function composeLiveInstructionPrompt({
     typeof finalPromptOverride === 'string'
       ? finalPromptOverride.trim()
       : '';
-  const parts = [daemonSystemPrompt, runtimeToolPrompt, clientSystemPrompt]
+  const parts = [
+    daemonSystemPrompt,
+    runtimeToolPrompt,
+    clientStableSystemPrompt,
+    clientSystemPrompt,
+  ]
     .map((part) => (typeof part === 'string' ? part.trim() : ''))
     .map((part) =>
       override && part.includes(override)

--- a/apps/daemon/src/runtimes/chat-prompt-inputs.ts
+++ b/apps/daemon/src/runtimes/chat-prompt-inputs.ts
@@ -286,13 +286,19 @@ export function composeChatAgentTextPayload({
 
   assertOdNextLegacyTextContributorCoverage(Object.keys(contributors), strategyInputStage);
 
-  const clientInstructionPrompt = [
+  const clientVolatileSystemPrompt = [
     researchCommandContract,
     runContextPrompt,
     connectedExternalMcpReference,
     browserUnavailableGuard,
     titleGenerationDirective,
+  ]
+    .map((part) => (typeof part === 'string' ? part.trim() : ''))
+    .filter(Boolean)
+    .join('\n\n---\n\n');
+  const clientInstructionPrompt = [
     clientSystemPrompt,
+    clientVolatileSystemPrompt,
   ]
     .map((part) => (typeof part === 'string' ? part.trim() : ''))
     .filter(Boolean)
@@ -300,7 +306,8 @@ export function composeChatAgentTextPayload({
   const instructionPrompt = composeLiveInstructionPrompt({
     daemonSystemPrompt,
     runtimeToolPrompt,
-    clientSystemPrompt: clientInstructionPrompt,
+    clientStableSystemPrompt: clientSystemPrompt,
+    clientSystemPrompt: clientVolatileSystemPrompt,
     finalPromptOverride: null,
   });
   const composedPrompt = [

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11581,6 +11581,10 @@ export async function startServer({
             },
             { kind: 'researchCommandContract', content: researchCommandContract },
             { kind: 'runContextPrompt', content: runContextPrompt },
+            {
+              kind: 'connectedExternalMcpReference',
+              content: mcpConnectedDirective,
+            },
             { kind: 'browserUsePromptGuard', content: browserUsePromptGuard },
             { kind: 'titleGenerationPrompt', content: titleGenerationPrompt },
             { kind: 'echoGuard', content: agentEchoGuard },

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11543,23 +11543,48 @@ export async function startServer({
             // Phase 1 explicitly needs redactedContent for these aggregate prompts:
             // they are the quickest way to inspect the system context sent to the
             // model when diagnosing Langfuse traces.
-            { kind: 'daemonSystemPrompt', content: daemonSystemPrompt },
-            { kind: 'runtimeToolPrompt', content: runtimeToolPrompt },
-            { kind: 'researchCommandContract', content: researchCommandContract },
-            { kind: 'runContextPrompt', content: runContextPrompt },
-            { kind: 'browserUsePromptGuard', content: browserUsePromptGuard },
-            { kind: 'clientSystemPrompt', content: clientInstructionPrompt },
-            { kind: 'echoGuard', content: ECHO_GUARD },
-            { kind: 'userRequest', content: userRequestPrompt },
-            { kind: 'skillPrompt', content: promptTelemetryParts?.skillPrompt },
+            //
+            // The stable block is gated by `includeStableForPayload` exactly like
+            // the composed bytes above (the resume/session-reuse token-skip path):
+            // on a resumed turn these sections are NOT resent, so the telemetry must
+            // omit them too — otherwise cacheablePrefix* would hash a stable prefix
+            // that never reached the model. Mirror the same gate here.
+            {
+              kind: 'daemonSystemPrompt',
+              content: includeStableForPayload ? daemonSystemPrompt : '',
+            },
+            {
+              kind: 'runtimeToolPrompt',
+              content: includeStableForPayload ? runtimeToolPrompt : '',
+            },
+            {
+              kind: 'clientSystemPrompt',
+              content: includeStableForPayload ? systemPrompt : '',
+            },
+            {
+              kind: 'skillPrompt',
+              content: includeStableForPayload
+                ? promptTelemetryParts?.skillPrompt
+                : '',
+            },
             {
               kind: 'designSystemPrompt',
-              content: promptTelemetryParts?.designSystemPrompt,
+              content: includeStableForPayload
+                ? promptTelemetryParts?.designSystemPrompt
+                : '',
             },
             {
               kind: 'pluginStagePrompt',
-              content: promptTelemetryParts?.pluginStagePrompt,
+              content: includeStableForPayload
+                ? promptTelemetryParts?.pluginStagePrompt
+                : '',
             },
+            { kind: 'researchCommandContract', content: researchCommandContract },
+            { kind: 'runContextPrompt', content: runContextPrompt },
+            { kind: 'browserUsePromptGuard', content: browserUsePromptGuard },
+            { kind: 'titleGenerationPrompt', content: titleGenerationPrompt },
+            { kind: 'echoGuard', content: agentEchoGuard },
+            { kind: 'userRequest', content: userRequestPrompt },
             { kind: 'cwdHint', content: cwdHint, metadata: cwd ? [cwd] : [] },
             {
               kind: 'linkedDirsHint',

--- a/apps/daemon/tests/cacheable-prefix.test.ts
+++ b/apps/daemon/tests/cacheable-prefix.test.ts
@@ -20,6 +20,7 @@ function buildSections({
   formOverride = '',
   researchCommandContract = '',
   runContextPrompt = '',
+  browserUsePromptGuard = '',
   titleGenerationPrompt = '',
   userRequest = 'do the thing',
 }: Partial<Record<string, string>> = {}): PromptTelemetryInputSection[] {
@@ -30,6 +31,7 @@ function buildSections({
     { kind: 'clientSystemPrompt', content: systemPrompt },
     { kind: 'researchCommandContract', content: researchCommandContract },
     { kind: 'runContextPrompt', content: runContextPrompt },
+    { kind: 'browserUsePromptGuard', content: browserUsePromptGuard },
     { kind: 'titleGenerationPrompt', content: titleGenerationPrompt },
     { kind: 'userRequest', content: userRequest },
   ];
@@ -95,6 +97,48 @@ describe('cacheable-prefix fingerprint invariant (#4679)', () => {
     expect(stableChanged.cacheablePrefixFingerprint).not.toBe(
       base.cacheablePrefixFingerprint,
     );
+  });
+
+  it('fingerprints volatile split sections by their redacted text (#4679 review)', () => {
+    // browserUsePromptGuard and titleGenerationPrompt are emitted as their own
+    // sections. They are content-bearing, so mutating just one of them must move
+    // the section fingerprint and the whole-stack fingerprint — otherwise the
+    // metadata-only fallback collapses every non-empty string to one fingerprint
+    // and the telemetry silently misses the byte change.
+    const base = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({
+        browserUsePromptGuard: 'do not click suspicious links',
+        titleGenerationPrompt: 'emit a concise title',
+      }),
+    });
+    const guardChanged = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({
+        browserUsePromptGuard: 'a completely different browser-use guard body',
+        titleGenerationPrompt: 'emit a concise title',
+      }),
+    });
+    const titleChanged = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({
+        browserUsePromptGuard: 'do not click suspicious links',
+        titleGenerationPrompt: 'produce a totally different title instruction',
+      }),
+    });
+
+    const guardFp = (t: typeof base) =>
+      t.sections.find((s) => s.kind === 'browserUsePromptGuard')?.fingerprint;
+    const titleFp = (t: typeof base) =>
+      t.sections.find((s) => s.kind === 'titleGenerationPrompt')?.fingerprint;
+
+    expect(guardFp(guardChanged)).not.toBe(guardFp(base));
+    expect(titleFp(guardChanged)).toBe(titleFp(base));
+    expect(guardChanged.stackFingerprint).not.toBe(base.stackFingerprint);
+
+    expect(titleFp(titleChanged)).not.toBe(titleFp(base));
+    expect(guardFp(titleChanged)).toBe(guardFp(base));
+    expect(titleChanged.stackFingerprint).not.toBe(base.stackFingerprint);
   });
 
   it('flags a volatile preamble ahead of the stable block (#4679 review)', () => {

--- a/apps/daemon/tests/cacheable-prefix.test.ts
+++ b/apps/daemon/tests/cacheable-prefix.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import { composeLiveInstructionPrompt } from '../src/runtimes/chat-prompt-inputs.js';
+import {
+  PROMPT_SECTION_CACHE_CLASS,
+  buildPromptStackTelemetry,
+  classifyPromptSectionCacheClass,
+  type PromptTelemetryInputSection,
+  type PromptTelemetrySectionKind,
+} from '../src/prompt-telemetry.js';
+
+// Mirror of the composed section order built in server.ts after the
+// cacheable-prefix reorder (#4679): a volatile formOverride preamble, the
+// contiguous stable block (daemon prompt, tool contract, the system prompt and
+// its sub-sections), then the volatile tail.
+function buildSections({
+  daemonSystemPrompt = 'DAEMON',
+  runtimeToolPrompt = 'TOOLS',
+  systemPrompt = 'SYSTEM (design system / skills / memory)',
+  formOverride = '',
+  researchCommandContract = '',
+  runContextPrompt = '',
+  titleGenerationPrompt = '',
+  userRequest = 'do the thing',
+}: Partial<Record<string, string>> = {}): PromptTelemetryInputSection[] {
+  return [
+    { kind: 'formOverride', content: formOverride },
+    { kind: 'daemonSystemPrompt', content: daemonSystemPrompt },
+    { kind: 'runtimeToolPrompt', content: runtimeToolPrompt },
+    { kind: 'clientSystemPrompt', content: systemPrompt },
+    { kind: 'researchCommandContract', content: researchCommandContract },
+    { kind: 'runContextPrompt', content: runContextPrompt },
+    { kind: 'titleGenerationPrompt', content: titleGenerationPrompt },
+    { kind: 'userRequest', content: userRequest },
+  ];
+}
+
+describe('cacheable-prefix classification (#4679)', () => {
+  it('classifies every section kind (no unclassified default)', () => {
+    for (const kind of Object.keys(
+      PROMPT_SECTION_CACHE_CLASS,
+    ) as PromptTelemetrySectionKind[]) {
+      expect(['stable', 'volatile']).toContain(
+        classifyPromptSectionCacheClass(kind),
+      );
+    }
+  });
+
+  it('throws on an unclassified section kind', () => {
+    expect(() =>
+      classifyPromptSectionCacheClass(
+        'totallyNewSection' as PromptTelemetrySectionKind,
+      ),
+    ).toThrow(/unclassified prompt-stack section kind/);
+  });
+});
+
+describe('cacheable-prefix fingerprint invariant (#4679)', () => {
+  it('stays byte-identical when only volatile inputs change', () => {
+    const base = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({ runContextPrompt: 'turn 1 context' }),
+    });
+    const volatileChanged = buildPromptStackTelemetry({
+      composedPrompt: 'b',
+      sections: buildSections({
+        runContextPrompt: 'turn 2 totally different context',
+        researchCommandContract: 'research now enabled',
+        titleGenerationPrompt: 'emit a title',
+        userRequest: 'a different request',
+      }),
+    });
+
+    expect(volatileChanged.cacheablePrefixContiguous).toBe(true);
+    expect(volatileChanged.cacheablePrefixSectionCount).toBe(
+      base.cacheablePrefixSectionCount,
+    );
+    // The whole-stack fingerprint differs (volatile content changed) but the
+    // cacheable prefix is unchanged — the provider can reuse the cached prefix.
+    expect(volatileChanged.stackFingerprint).not.toBe(base.stackFingerprint);
+    expect(volatileChanged.cacheablePrefixFingerprint).toBe(
+      base.cacheablePrefixFingerprint,
+    );
+  });
+
+  it('changes when stable content changes', () => {
+    const base = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections(),
+    });
+    const stableChanged = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({ systemPrompt: 'SYSTEM with a new memory line' }),
+    });
+    expect(stableChanged.cacheablePrefixFingerprint).not.toBe(
+      base.cacheablePrefixFingerprint,
+    );
+  });
+
+  it('flags non-contiguous stable sections (regression guard)', () => {
+    // A volatile block wedged between two stable sections — the exact bug the
+    // reorder fixed (run context splitting the tool prompt from the system
+    // prompt).
+    const split = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: [
+        { kind: 'daemonSystemPrompt', content: 'DAEMON' },
+        { kind: 'runtimeToolPrompt', content: 'TOOLS' },
+        { kind: 'runContextPrompt', content: 'VOLATILE WEDGE' },
+        { kind: 'clientSystemPrompt', content: 'SYSTEM' },
+        { kind: 'userRequest', content: 'go' },
+      ],
+    });
+    expect(split.cacheablePrefixContiguous).toBe(false);
+  });
+});
+
+describe('composeLiveInstructionPrompt cacheable order (#4679)', () => {
+  it('puts the stable trio ahead of volatile blocks and the override', () => {
+    const composed = composeLiveInstructionPrompt({
+      daemonSystemPrompt: 'DAEMON',
+      runtimeToolPrompt: 'TOOLS',
+      clientStableSystemPrompt: 'SYSTEM',
+      clientSystemPrompt: 'RUN-CONTEXT',
+      finalPromptOverride: 'OVERRIDE',
+    });
+    expect(composed.indexOf('DAEMON')).toBeLessThan(composed.indexOf('TOOLS'));
+    expect(composed.indexOf('TOOLS')).toBeLessThan(composed.indexOf('SYSTEM'));
+    expect(composed.indexOf('SYSTEM')).toBeLessThan(
+      composed.indexOf('RUN-CONTEXT'),
+    );
+    // The codex imagegen override stays semantically volatile: last, never
+    // inside the cacheable prefix.
+    expect(composed.indexOf('RUN-CONTEXT')).toBeLessThan(
+      composed.indexOf('OVERRIDE'),
+    );
+  });
+
+  it('keeps the stable prefix byte-identical when only volatile input varies', () => {
+    const stableArgs = {
+      daemonSystemPrompt: 'DAEMON',
+      runtimeToolPrompt: 'TOOLS',
+      clientStableSystemPrompt: 'SYSTEM',
+    } as const;
+    const a = composeLiveInstructionPrompt({
+      ...stableArgs,
+      clientSystemPrompt: 'context A',
+    });
+    const b = composeLiveInstructionPrompt({
+      ...stableArgs,
+      clientSystemPrompt: 'a much longer and different context B',
+    });
+    const prefixA = a.slice(0, a.indexOf('context A'));
+    const prefixB = b.slice(0, b.indexOf('a much longer'));
+    expect(prefixA).toBe(prefixB);
+  });
+});

--- a/apps/daemon/tests/cacheable-prefix.test.ts
+++ b/apps/daemon/tests/cacheable-prefix.test.ts
@@ -97,6 +97,25 @@ describe('cacheable-prefix fingerprint invariant (#4679)', () => {
     );
   });
 
+  it('flags a volatile preamble ahead of the stable block (#4679 review)', () => {
+    // A question-form FORM_ANSWERED_*_OVERRIDE is prepended before the stable
+    // trio. The stable sections are still consecutive among themselves, but the
+    // request no longer *starts* with them, so the provider cannot reuse the
+    // prefix cache — the signal must report not-cacheable, not a healthy hit.
+    const withOverride = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({ formOverride: 'FORM_ANSWERED_TASK_TYPE_OVERRIDE' }),
+    });
+    expect(withOverride.cacheablePrefixContiguous).toBe(false);
+
+    // The same turn without the override leads with the stable trio → cacheable.
+    const withoutOverride = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections(),
+    });
+    expect(withoutOverride.cacheablePrefixContiguous).toBe(true);
+  });
+
   it('flags non-contiguous stable sections (regression guard)', () => {
     // A volatile block wedged between two stable sections — the exact bug the
     // reorder fixed (run context splitting the tool prompt from the system

--- a/apps/daemon/tests/cacheable-prefix.test.ts
+++ b/apps/daemon/tests/cacheable-prefix.test.ts
@@ -105,6 +105,35 @@ describe('cacheable-prefix fingerprint invariant (#4679)', () => {
     );
   });
 
+  it('distinguishes available and unavailable runtime tool prompts while keeping token redacted (#4679 review)', () => {
+    const availablePrompt = [
+      '## Runtime tool environment',
+      '- `OD_TOOL_TOKEN` is available in your environment for this run. Use it only through project wrapper commands; do not print, persist, or override it.',
+    ].join('\n');
+    const unavailablePrompt = [
+      '## Runtime tool environment',
+      '- `OD_TOOL_TOKEN` is not available for this run, so `/api/tools/*` wrapper commands may be unavailable.',
+    ].join('\n');
+
+    const available = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({ runtimeToolPrompt: availablePrompt }),
+    });
+    const unavailable = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({ runtimeToolPrompt: unavailablePrompt }),
+    });
+
+    const availSec = available.sections.find((s) => s.kind === 'runtimeToolPrompt');
+    const unavailSec = unavailable.sections.find((s) => s.kind === 'runtimeToolPrompt');
+
+    expect(availSec?.fingerprint).not.toBe(unavailSec?.fingerprint);
+    expect(available.cacheablePrefixFingerprint).not.toBe(unavailable.cacheablePrefixFingerprint);
+    expect(availSec?.redactedContent).toContain('[OD_TOOL_TOKEN_AVAILABLE]');
+    expect(unavailSec?.redactedContent).toContain('[OD_TOOL_TOKEN_UNAVAILABLE]');
+    expect(availSec?.redactedContent).not.toContain('secret');
+  });
+
   it('fingerprints volatile split sections by their redacted text (#4679 review)', () => {
     // browserUsePromptGuard and titleGenerationPrompt are emitted as their own
     // sections. They are content-bearing, so mutating just one of them must move

--- a/apps/daemon/tests/cacheable-prefix.test.ts
+++ b/apps/daemon/tests/cacheable-prefix.test.ts
@@ -66,6 +66,16 @@ describe('cacheable-prefix classification (#4679)', () => {
       ),
     ).toThrow(/unclassified prompt-stack section kind/);
   });
+
+  it('throws on inherited Object.prototype property names', () => {
+    for (const inheritedKey of ['toString', 'constructor', '__proto__', 'valueOf', 'hasOwnProperty']) {
+      expect(() =>
+        classifyPromptSectionCacheClass(
+          inheritedKey as PromptTelemetrySectionKind,
+        ),
+      ).toThrow(/unclassified prompt-stack section kind/);
+    }
+  });
 });
 
 describe('cacheable-prefix fingerprint invariant (#4679)', () => {

--- a/apps/daemon/tests/cacheable-prefix.test.ts
+++ b/apps/daemon/tests/cacheable-prefix.test.ts
@@ -25,6 +25,7 @@ function buildSections({
   runContextPrompt = '',
   browserUsePromptGuard = '',
   titleGenerationPrompt = '',
+  connectedExternalMcpReference = '',
   userRequest = 'do the thing',
 }: Partial<Record<string, string>> = {}): PromptTelemetryInputSection[] {
   return [
@@ -37,6 +38,10 @@ function buildSections({
     { kind: 'pluginStagePrompt', content: pluginStagePrompt },
     { kind: 'researchCommandContract', content: researchCommandContract },
     { kind: 'runContextPrompt', content: runContextPrompt },
+    {
+      kind: 'connectedExternalMcpReference',
+      content: connectedExternalMcpReference,
+    },
     { kind: 'browserUsePromptGuard', content: browserUsePromptGuard },
     { kind: 'titleGenerationPrompt', content: titleGenerationPrompt },
     { kind: 'userRequest', content: userRequest },
@@ -129,22 +134,22 @@ describe('cacheable-prefix fingerprint invariant (#4679)', () => {
 
     expect(availSec?.fingerprint).not.toBe(unavailSec?.fingerprint);
     expect(available.cacheablePrefixFingerprint).not.toBe(unavailable.cacheablePrefixFingerprint);
-    expect(availSec?.redactedContent).toContain('[OD_TOOL_TOKEN_AVAILABLE]');
-    expect(unavailSec?.redactedContent).toContain('[OD_TOOL_TOKEN_UNAVAILABLE]');
+    expect(availSec?.redactedContent).toContain('[TOKEN_AVAILABLE]');
+    expect(unavailSec?.redactedContent).toContain('[TOKEN_UNAVAILABLE]');
     expect(availSec?.redactedContent).not.toContain('secret');
   });
 
   it('fingerprints volatile split sections by their redacted text (#4679 review)', () => {
-    // browserUsePromptGuard and titleGenerationPrompt are emitted as their own
-    // sections. They are content-bearing, so mutating just one of them must move
-    // the section fingerprint and the whole-stack fingerprint — otherwise the
-    // metadata-only fallback collapses every non-empty string to one fingerprint
-    // and the telemetry silently misses the byte change.
+    // browserUsePromptGuard, titleGenerationPrompt, and connectedExternalMcpReference
+    // are emitted as their own sections. They are content-bearing, so mutating just
+    // one of them must move the section fingerprint and the whole-stack fingerprint
+    // without invalidating the stable cacheable prefix.
     const base = buildPromptStackTelemetry({
       composedPrompt: 'a',
       sections: buildSections({
         browserUsePromptGuard: 'do not click suspicious links',
         titleGenerationPrompt: 'emit a concise title',
+        connectedExternalMcpReference: 'use mcp tools for jira',
       }),
     });
     const guardChanged = buildPromptStackTelemetry({
@@ -152,6 +157,7 @@ describe('cacheable-prefix fingerprint invariant (#4679)', () => {
       sections: buildSections({
         browserUsePromptGuard: 'a completely different browser-use guard body',
         titleGenerationPrompt: 'emit a concise title',
+        connectedExternalMcpReference: 'use mcp tools for jira',
       }),
     });
     const titleChanged = buildPromptStackTelemetry({
@@ -159,6 +165,15 @@ describe('cacheable-prefix fingerprint invariant (#4679)', () => {
       sections: buildSections({
         browserUsePromptGuard: 'do not click suspicious links',
         titleGenerationPrompt: 'produce a totally different title instruction',
+        connectedExternalMcpReference: 'use mcp tools for jira',
+      }),
+    });
+    const mcpChanged = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({
+        browserUsePromptGuard: 'do not click suspicious links',
+        titleGenerationPrompt: 'emit a concise title',
+        connectedExternalMcpReference: 'use mcp tools for github',
       }),
     });
 
@@ -166,14 +181,26 @@ describe('cacheable-prefix fingerprint invariant (#4679)', () => {
       t.sections.find((s) => s.kind === 'browserUsePromptGuard')?.fingerprint;
     const titleFp = (t: typeof base) =>
       t.sections.find((s) => s.kind === 'titleGenerationPrompt')?.fingerprint;
+    const mcpFp = (t: typeof base) =>
+      t.sections.find((s) => s.kind === 'connectedExternalMcpReference')?.fingerprint;
 
     expect(guardFp(guardChanged)).not.toBe(guardFp(base));
     expect(titleFp(guardChanged)).toBe(titleFp(base));
+    expect(mcpFp(guardChanged)).toBe(mcpFp(base));
     expect(guardChanged.stackFingerprint).not.toBe(base.stackFingerprint);
+    expect(guardChanged.cacheablePrefixFingerprint).toBe(base.cacheablePrefixFingerprint);
 
     expect(titleFp(titleChanged)).not.toBe(titleFp(base));
     expect(guardFp(titleChanged)).toBe(guardFp(base));
+    expect(mcpFp(titleChanged)).toBe(mcpFp(base));
     expect(titleChanged.stackFingerprint).not.toBe(base.stackFingerprint);
+    expect(titleChanged.cacheablePrefixFingerprint).toBe(base.cacheablePrefixFingerprint);
+
+    expect(mcpFp(mcpChanged)).not.toBe(mcpFp(base));
+    expect(guardFp(mcpChanged)).toBe(guardFp(base));
+    expect(titleFp(mcpChanged)).toBe(titleFp(base));
+    expect(mcpChanged.stackFingerprint).not.toBe(base.stackFingerprint);
+    expect(mcpChanged.cacheablePrefixFingerprint).toBe(base.cacheablePrefixFingerprint);
   });
 
   it('flags a volatile preamble ahead of the stable block (#4679 review)', () => {

--- a/apps/daemon/tests/cacheable-prefix.test.ts
+++ b/apps/daemon/tests/cacheable-prefix.test.ts
@@ -17,6 +17,9 @@ function buildSections({
   daemonSystemPrompt = 'DAEMON',
   runtimeToolPrompt = 'TOOLS',
   systemPrompt = 'SYSTEM (design system / skills / memory)',
+  skillPrompt = '',
+  designSystemPrompt = '',
+  pluginStagePrompt = '',
   formOverride = '',
   researchCommandContract = '',
   runContextPrompt = '',
@@ -29,6 +32,9 @@ function buildSections({
     { kind: 'daemonSystemPrompt', content: daemonSystemPrompt },
     { kind: 'runtimeToolPrompt', content: runtimeToolPrompt },
     { kind: 'clientSystemPrompt', content: systemPrompt },
+    { kind: 'skillPrompt', content: skillPrompt },
+    { kind: 'designSystemPrompt', content: designSystemPrompt },
+    { kind: 'pluginStagePrompt', content: pluginStagePrompt },
     { kind: 'researchCommandContract', content: researchCommandContract },
     { kind: 'runContextPrompt', content: runContextPrompt },
     { kind: 'browserUsePromptGuard', content: browserUsePromptGuard },
@@ -158,6 +164,46 @@ describe('cacheable-prefix fingerprint invariant (#4679)', () => {
       sections: buildSections(),
     });
     expect(withoutOverride.cacheablePrefixContiguous).toBe(true);
+  });
+
+  it('drops the stable sections on a resumed token-skip turn (#4679 review)', () => {
+    // On a resumed turn server.ts gates the stable trio + its skill/design/plugin
+    // subsections with `includeStableInstructions === false`, so those bytes are
+    // NOT resent to the model. The telemetry must mirror that gate: the stable
+    // sections disappear and cacheablePrefixSectionCount drops to 0 — otherwise
+    // cacheablePrefix* would hash a stable prefix that never reached the model.
+    const fresh = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({
+        skillPrompt: 'SKILL',
+        designSystemPrompt: 'DESIGN',
+        pluginStagePrompt: 'PLUGIN',
+      }),
+    });
+    expect(fresh.cacheablePrefixSectionCount).toBeGreaterThan(0);
+
+    // Resume: every stable-gated input is empty (omitted from the sent bytes).
+    const resumed = buildPromptStackTelemetry({
+      composedPrompt: 'a',
+      sections: buildSections({
+        daemonSystemPrompt: '',
+        runtimeToolPrompt: '',
+        systemPrompt: '',
+        skillPrompt: '',
+        designSystemPrompt: '',
+        pluginStagePrompt: '',
+      }),
+    });
+    expect(resumed.cacheablePrefixSectionCount).toBe(0);
+    expect(resumed.cacheablePrefixContiguous).toBe(false);
+    expect(
+      resumed.sections.some(
+        (s) =>
+          s.kind === 'daemonSystemPrompt' ||
+          s.kind === 'runtimeToolPrompt' ||
+          s.kind === 'clientSystemPrompt',
+      ),
+    ).toBe(false);
   });
 
   it('flags non-contiguous stable sections (regression guard)', () => {

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -9,6 +9,8 @@ import {
   buildSafeChildPromptTelemetry,
   buildPromptStackTelemetry,
   bindOdNextExactSendPromptEvidence,
+  assertOdNextExactSendPromptEvidence,
+  type PromptStackTelemetry,
   promptStackWithoutContent,
   redactLocalPaths,
 } from '../src/prompt-telemetry.js';
@@ -74,6 +76,42 @@ describe('prompt telemetry builder', () => {
       },
       stage: 'contract_repair',
     })).toThrow(/does not match its persisted SHA-256/u);
+  });
+
+  it('tolerates pre-4681 legacy durable telemetry without additive cacheablePrefix keys in assertOdNextExactSendPromptEvidence', () => {
+    const finalText = '<open_design_request_turn>review</open_design_request_turn>';
+    const persisted = {
+      kind: 'bundle' as const,
+      schema: 'open-design.od-next-prompt-bundle/v2' as const,
+      text: finalText,
+      utf8Bytes: Buffer.byteLength(finalText, 'utf8'),
+      sha256: createHash('sha256').update(finalText, 'utf8').digest('hex'),
+    };
+    const fullTelemetry = bindOdNextExactSendPromptEvidence({
+      telemetry: buildPromptStackTelemetry({
+        composedPrompt: finalText,
+        sections: [{ kind: 'odNextExactFinalText', content: finalText }],
+      }),
+      finalText,
+      persisted,
+      stage: 'request',
+    });
+
+    // Simulate pre-4681 durable state which omitted additive cacheablePrefix* properties
+    const {
+      cacheablePrefixFingerprint: _fp,
+      cacheablePrefixSectionCount: _sc,
+      cacheablePrefixContiguous: _cc,
+      ...legacyTelemetry
+    } = fullTelemetry;
+
+    expect(() =>
+      assertOdNextExactSendPromptEvidence({
+        telemetry: legacyTelemetry as unknown as PromptStackTelemetry,
+        persisted,
+        stage: 'request',
+      }),
+    ).not.toThrow();
   });
 
   it('builds bounded child-injected Prompt telemetry with the shared secret and path redaction', () => {

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -426,6 +426,9 @@ describe('prompt telemetry builder', () => {
 
     const flat = buildPromptStackFlatMetadata(telemetry);
     expect(Object.keys(flat).sort()).toEqual([
+      'promptStack_cacheablePrefixContiguous',
+      'promptStack_cacheablePrefixFingerprint',
+      'promptStack_cacheablePrefixSectionCount',
       'promptStack_promptFingerprint',
       'promptStack_redactedContentBudgetBytes',
       'promptStack_redactedContentBytes',

--- a/apps/daemon/tests/runtimes/od-next-exact-input.test.ts
+++ b/apps/daemon/tests/runtimes/od-next-exact-input.test.ts
@@ -280,17 +280,22 @@ describe('chat Agent exact-text production choke point', () => {
     });
 
     const clientInstruction = [
+      'client system',
       'research contract',
       'run context',
       'connected MCP: figma',
       'browser unavailable',
       'emit title marker',
-      'client system',
     ].join('\n\n---\n\n');
     const instruction = [
       'daemon system',
       'runtime tools',
-      clientInstruction,
+      'client system',
+      'research contract',
+      'run context',
+      'connected MCP: figma',
+      'browser unavailable',
+      'emit title marker',
     ].join('\n\n---\n\n');
     expect(result.clientInstructionPrompt).toBe(clientInstruction);
     expect(result.instructionPrompt).toBe(instruction);


### PR DESCRIPTION
Fixes #4679

## Why

I'm building reliability/latency work on top of OD's chat run path (epic #3408, following my per-request usage and TTFT-subsegment slices). While mapping the composed prompt for the resume/session-reuse line, I hit this: the big stable system prompt (design system / skills / memory) was appended at the **tail** of the client instruction parts, behind the volatile `researchCommandContract` / `runContextPrompt` / `browserUsePromptGuard` / `titleGenerationPrompt` blocks.

That means the provider's prefix cache breaks at the first volatile block every turn, so the largest stable chunk re-tokenizes on every message of a conversation — wasted input tokens and latency for the ~22 non-resumable agents that can't lean on upstream session resume. @lefarcen green-lit this as a clean standalone slice to land before the resume work expands.

## What users will see

No visible UI change. For long conversations, repeat turns send a byte-identical cacheable instruction prefix, so providers that cache prompt prefixes can reuse it instead of re-tokenizing the system prompt each turn — lower input-token cost and faster time-to-first-token on follow-up messages. Langfuse/PostHog traces gain `cacheablePrefixFingerprint` / `cacheablePrefixSectionCount` / `cacheablePrefixContiguous` on the prompt-stack telemetry.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — `PromptStackTelemetry` / structured prompt-stack input / flat metadata gain `cacheablePrefixFingerprint`, `cacheablePrefixSectionCount`, `cacheablePrefixContiguous` (daemon-internal telemetry shape, surfaced to Langfuse/PostHog).
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the composed instruction prompt is reordered (stable trio contiguous at front, volatile blocks as a tail). The bytes every agent receives change; the codex imagegen override stays appended last, outside the cacheable prefix.
- [ ] **None**

## Screenshots

N/A — no UI surface.

## Bug fix verification

Not a bug fix; this is an enhancement. Encoded as an invariant instead of a red spec:

- `apps/daemon/tests/cacheable-prefix.test.ts` — the cacheable prefix fingerprint is byte-identical when only volatile inputs change, changes when stable content changes, and `cacheablePrefixContiguous` flips false when a volatile block is wedged between two stable sections (the exact pre-reorder bug).
- Classification is exhaustive at compile time: `PROMPT_SECTION_CACHE_CLASS` is a `Record` over the full section-kind union, so adding a new unclassified section kind is a type error (per #3408's one-choke-point principle). A runtime `classifyPromptSectionCacheClass` throws on an unknown kind.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/cacheable-prefix.test.ts tests/prompt-telemetry.test.ts` — green (new suite + updated flat-metadata assertion).
- `pnpm --filter @open-design/daemon typecheck` — green.
- `tests/chat-route.test.ts` / `tests/langfuse-trace.test.ts` — no new failures; the 5 red chat-route cases (opencode config, plugin skill staging, DeepSeek/Claude auth diagnostics) fail identically on `main` (agent-binary/auth env on this box), not touched by this change.
- `pnpm guard` failure is the pre-existing design-systems `design-tokens.json` / `tailwind-v4.css` staleness on this box; no design-system files are touched here.
