### PR TITLE
feat(ci): auto-approve the release bot's own clean backports

### DIFF
--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write   # github-actions[bot] approves the bot's own clean backport (Approve step)
 
 jobs:
   followup:
@@ -63,6 +64,28 @@ jobs:
             echo "cross=$(printf '%s' "$row" | jq -r '.isCrossRepository')"
             echo "head_oid=$(printf '%s' "$row" | jq -r '.headRefOid')"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Approve the clean backport (release bot, CI green)
+        # release/v* requires 1 approving review. The diff was already reviewed + approved on
+        # main; this is a mechanical, conflict-free cherry-pick by the release bot with green CI.
+        # Approve as github-actions[bot] — a DIFFERENT identity than the App that authored the PR
+        # (an author can't approve its own PR) — under the SAME bot-identity + SHA + CI gates as
+        # the merge below, so only the release bot's own verified backports are auto-approved.
+        if: >-
+          ${{ steps.pr.outputs.found == 'true'
+              && steps.pr.outputs.draft == 'false'
+              && steps.pr.outputs.author == 'open-design-release-bot[bot]'
+              && steps.pr.outputs.cross == 'false'
+              && steps.pr.outputs.head_oid == github.event.workflow_run.head_sha
+              && github.event.workflow_run.conclusion == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          gh pr review "$NUM" --repo "$REPO" --approve \
+            --body "Auto-approved: clean cherry-pick by the release bot of code already reviewed on main, CI green. (release/v* requires one approval.)"
 
       - name: Auto-merge clean backport on green CI
         # Guards (release/v* has no required checks, so this workflow IS the gate):

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -236,6 +236,15 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain("--squash");
     expect(workflow).toContain("--delete-branch");
 
+    // To satisfy release/v*'s one-approval rule, the bot's own clean backport is auto-approved by
+    // github-actions[bot] (pull-requests: write) — under the same author==bot gate as the merge.
+    expect(workflow).toContain("pull-requests: write");
+    expect(workflow).toContain("gh pr review");
+    expect(workflow).toContain("--approve");
+    const approveStep = sectionBetween(workflow, "Approve the clean backport", "gh pr review");
+    expect(approveStep).toContain("steps.pr.outputs.author == 'open-design-release-bot[bot]'");
+    expect(approveStep).toContain("github.token");
+
     // The Feishu failure path carries the same identity gates, so a fork / non-bot backport-*
     // PR can't spam the release group.
     const feishuStep = sectionBetween(workflow, "Notify Feishu on failed backport CI", "FEISHU_WEBHOOK");


### PR DESCRIPTION
## What

Let `backport-automerge.yml` auto-**approve** the release bot's own clean backport PRs, so they can actually auto-merge.

## Why

`release/v*` requires **1 approving review** (ruleset). backport PRs are authored by the release App, and an app can't approve its own PR — so the auto-merge step was always blocked (`At least 1 approving review is required`). The diff was already reviewed + approved on `main`; the backport is a mechanical, conflict-free cherry-pick by the bot with green CI, so re-reviewing on the release branch is redundant.

## How (scoped strictly)

Before merging, approve as **`github-actions[bot]`** (a different identity than the authoring App, with `pull-requests: write`) — but only under the **same gates** as the merge:

- `author == open-design-release-bot[bot]` (the release bot's own PR)
- same-repo (`!isCrossRepository`), non-draft
- PR head == the exact SHA CI passed on (`workflow_run.head_sha`)
- `workflow_run.conclusion == 'success'`

So only the release bot's own verified, CI-green backports are auto-approved; everything else still needs a human. Merge then proceeds with the App token (`--match-head-commit`).

## Note for reviewers

This is intentionally a governance trade-off: it auto-satisfies the release-branch approval rule **only** for the bot's pre-reviewed backports. If the team prefers a human to approve backports, revert this one commit — the rest of the flow (auto-create + auto-CI) is unaffected and backports then just wait for a one-click approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
