### PR TITLE
fix(web): restore onboarding Local CLI test control

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -133,7 +133,7 @@ import {
 import { KNOWN_PROVIDERS } from '../state/config';
 import type { KnownProvider } from '../state/config';
 import { saveOnboardingProfile } from '../state/onboarding-profile';
-import { testApiProvider } from '../providers/connection-test';
+import { testAgent, testApiProvider } from '../providers/connection-test';
 import { fetchProviderModels } from '../providers/provider-models';
 import {
   cancelVelaLogin,
@@ -182,6 +182,11 @@ function writeStoredRailOpen(open: boolean): void {
 const DISCORD_URL = 'https://discord.gg/mHAjSMV6gz';
 const X_URL = 'https://x.com/OpenDesignHQ';
 const ONBOARDING_DROPDOWN_OPEN_EVENT = 'open-design:onboarding-dropdown-open';
+
+type OnboardingAgentTestState =
+  | { status: 'idle' }
+  | { status: 'running'; inputKey: string }
+  | { status: 'done'; inputKey: string; result: ConnectionTestResponse };
 
 // The topbar chips (GitHub star, model switcher, Use everywhere)
 // collapse into the settings dropdown when the viewport gets
@@ -1045,6 +1050,9 @@ function OnboardingView({
     | { status: 'running'; inputKey: string }
     | { status: 'done'; inputKey: string; result: ConnectionTestResponse }
   >({ status: 'idle' });
+  const [agentTestState, setAgentTestState] = useState<OnboardingAgentTestState>({
+    status: 'idle',
+  });
   const [providerModelsState, setProviderModelsState] = useState<
     | { status: 'idle' }
     | { status: 'running'; inputKey: string }
@@ -1152,6 +1160,20 @@ function OnboardingView({
   const amrSelectedAndSignedOut = runtime === 'amr' && !amrSignedIn;
   const selectedAgent = visibleAgents.find((agent) => agent.id === config.agentId) ?? null;
   const selectedAgentChoice = selectedAgent ? (config.agentModels?.[selectedAgent.id] ?? {}) : {};
+  const selectedAgentTestModel = selectedAgentChoice.model ?? selectedAgent?.models?.[0]?.id ?? '';
+  const selectedAgentTestReasoning = selectedAgentChoice.reasoning ?? '';
+  const agentTestInputKey = [
+    selectedAgent?.id ?? '',
+    selectedAgentTestModel,
+    selectedAgentTestReasoning,
+    JSON.stringify(config.agentCliEnv ?? {}),
+  ].join('\n');
+  const visibleAgentTestState =
+    agentTestState.status === 'running' ||
+    (agentTestState.status !== 'idle' && agentTestState.inputKey === agentTestInputKey)
+      ? agentTestState
+      : { status: 'idle' as const };
+  const canTestAgent = Boolean(selectedAgent) && daemonLive;
   // Connect-step (step 0) gate. Continue may only advance once the selected
   // runtime is actually usable: AMR signed in, an available local CLI chosen,
   // or a BYOK provider whose connection test passed. AMR-selected-but-signed-out
@@ -2066,6 +2088,37 @@ function OnboardingView({
     }
   }
 
+  async function testAgentInline() {
+    if (!selectedAgent || !canTestAgent || agentTestState.status === 'running') return;
+    const inputKey = agentTestInputKey;
+    const agent = selectedAgent;
+    const model = selectedAgentTestModel;
+    const reasoning = selectedAgentTestReasoning;
+    setAgentTestState({ status: 'running', inputKey });
+    try {
+      const result = await testAgent({
+        agentId: agent.id,
+        model: model || undefined,
+        reasoning: reasoning || undefined,
+        agentCliEnv: config.agentCliEnv ?? {},
+      });
+      setAgentTestState({ status: 'done', inputKey, result });
+    } catch (error) {
+      setAgentTestState({
+        status: 'done',
+        inputKey,
+        result: {
+          ok: false,
+          kind: 'unknown',
+          latencyMs: 0,
+          model: model || 'default',
+          agentName: agent.name,
+          detail: error instanceof Error ? error.message : 'Test request failed',
+        },
+      });
+    }
+  }
+
   async function fetchProviderModelsInline() {
     if (!canFetchProviderModels || providerModelsState.status === 'running') return;
     const inputKey = providerModelsInputKey;
@@ -2347,6 +2400,9 @@ function OnboardingView({
                       if (!selectedAgent) return;
                       onAgentModelChange(selectedAgent.id, { model });
                     }}
+                    testState={visibleAgentTestState}
+                    canTest={canTestAgent}
+                    onTest={() => void testAgentInline()}
                   />
                 ) : null}
                 {connectExpanded === 'byok' ? (
@@ -2658,6 +2714,9 @@ function OnboardingCliSetupPanel({
   onRefresh,
   onSelectAgent,
   onSelectModel,
+  testState,
+  canTest,
+  onTest,
 }: {
   agents: AgentInfo[];
   daemonLive: boolean;
@@ -2669,9 +2728,13 @@ function OnboardingCliSetupPanel({
   onRefresh: () => void;
   onSelectAgent: (agentId: string) => void;
   onSelectModel: (model: string) => void;
+  testState: OnboardingAgentTestState;
+  canTest: boolean;
+  onTest: () => void;
 }) {
   const t = useT();
   const scanning = scanStatus === 'scanning';
+  const running = testState.status === 'running';
   const showEmpty = scanStatus === 'done' && agents.length === 0;
   return (
     <div className="onboarding-view__setup-panel">
@@ -2680,14 +2743,25 @@ function OnboardingCliSetupPanel({
           <strong>{t('settings.localCli')}</strong>
           <p>{daemonLive ? t('settings.codeAgentHint') : t('settings.modeDaemonOffline')}</p>
         </div>
-        <button
-          type="button"
-          className={`onboarding-view__mini-button${scanning ? ' is-loading' : ''}`}
-          onClick={onRefresh}
-          disabled={scanning}
-        >
-          {scanning ? t('settings.rescanRunning') : t('settings.rescan')}
-        </button>
+        <div className="onboarding-view__setup-head-actions">
+          <button
+            type="button"
+            className={`onboarding-view__mini-button${scanning ? ' is-loading' : ''}`}
+            onClick={onRefresh}
+            disabled={scanning}
+          >
+            {scanning ? t('settings.rescanRunning') : t('settings.rescan')}
+          </button>
+          <button
+            type="button"
+            className={`onboarding-view__mini-button${running ? ' is-loading' : ''}`}
+            onClick={onTest}
+            disabled={running || !canTest}
+            title={t('settings.testTitle')}
+          >
+            {running ? t('settings.testRunning') : t('settings.test')}
+          </button>
+        </div>
       </div>
       {scanning ? (
         <div className="onboarding-view__scan-copy" role="status">
@@ -2737,6 +2811,24 @@ function OnboardingCliSetupPanel({
           searchable
           searchPlaceholder={t('newproj.modelSearch')}
         />
+      ) : null}
+      {testState.status === 'running' ? (
+        <p className="onboarding-view__test-status is-running" role="status">
+          {t('settings.testRunning')}
+        </p>
+      ) : testState.status === 'done' ? (
+        <p
+          className={`onboarding-view__test-status is-${onboardingTestVariant(
+            testState.result,
+          )}`}
+          role={testState.result.ok ? 'status' : 'alert'}
+        >
+          {renderOnboardingAgentTestMessage(
+            t,
+            testState.result,
+            selectedAgent?.name ?? '',
+          )}
+        </p>
       ) : null}
     </div>
   );
@@ -3082,6 +3174,37 @@ function renderOnboardingProviderTestMessage(
       return t('settings.testRateLimited');
     case 'upstream_unavailable':
       return t('settings.testUpstream', { status: result.status ?? 0 });
+    case 'timeout':
+      return t('settings.testTimeout', { ms });
+    default:
+      return t('settings.testUnknown', { detail: result.detail ?? '' });
+  }
+}
+
+function renderOnboardingAgentTestMessage(
+  t: ReturnType<typeof useT>,
+  result: ConnectionTestResponse,
+  fallbackAgentName: string,
+): string {
+  const ms = Math.max(0, Math.round(result.latencyMs));
+  const sample = result.sample ?? '';
+  const agentName = result.agentName ?? fallbackAgentName;
+  if (result.ok) {
+    const baseMessage = t('settings.testSuccessCli', { agentName, ms, sample });
+    return result.detail ? `${baseMessage} ${result.detail}` : baseMessage;
+  }
+  switch (result.kind) {
+    case 'agent_not_installed':
+      return t('settings.testAgentMissing', { agentName });
+    case 'agent_auth_required':
+      return result.detail || 'Agent authentication is required.';
+    case 'agent_spawn_failed':
+      return t('settings.testAgentSpawn', {
+        agentName,
+        detail: result.detail ?? '',
+      });
+    case 'rate_limited':
+      return t('settings.testRateLimited');
     case 'timeout':
       return t('settings.testTimeout', { ms });
     default:

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -442,6 +442,90 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     expect(localPanel?.textContent).not.toContain('AMR');
   });
 
+  it('tests the selected Local CLI agent from onboarding', async () => {
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 12,
+          model: 'sonnet',
+          sample: 'pong',
+          agentName: 'Claude Code',
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    renderOnboarding({
+      config: baseConfig({
+        agentId: 'claude-code',
+        agentCliEnv: { 'claude-code': { OPEN_DESIGN_TEST: '1' } },
+        agentModels: { 'claude-code': { model: 'sonnet', reasoning: 'high' } },
+      }),
+      agents: [amrAgent(), cliAgent()],
+      onRefreshAgents: vi.fn(() => [amrAgent(), cliAgent()]),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Local coding agent/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Claude Code')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Claude Code replied in 12 ms/i)).toBeTruthy();
+    });
+    const connectionTestCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith('/api/test/connection'),
+    );
+    expect(connectionTestCalls).toHaveLength(1);
+    expect(JSON.parse(String(connectionTestCalls[0]?.[1]?.body))).toMatchObject({
+      mode: 'agent',
+      agentId: 'claude-code',
+      model: 'sonnet',
+      reasoning: 'high',
+      agentCliEnv: { 'claude-code': { OPEN_DESIGN_TEST: '1' } },
+    });
+  });
+
+  it('renders Local CLI test failures as alerts in onboarding', async () => {
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: false,
+          kind: 'agent_not_installed',
+          latencyMs: 0,
+          agentName: 'Claude Code',
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    renderOnboarding({
+      config: baseConfig({ agentId: 'claude-code' }),
+      agents: [amrAgent(), cliAgent()],
+      onRefreshAgents: vi.fn(() => [amrAgent(), cliAgent()]),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Local coding agent/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Claude Code')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Claude Code is not installed or not in PATH.');
+  });
+
   it('keeps AMR login pending while device authorization is waiting', async () => {
     const fetchMock = vi.fn(async (input, init) => {
       const url = String(input);


### PR DESCRIPTION
Fixes #4664

## Why

The onboarding Local CLI setup panel lost its connection-test control during the Connect-step redesign. That leaves new users able to choose a detected local agent, but unable to verify that the selected CLI/model can actually run before continuing.

## What users will see

The onboarding Local CLI panel now shows a `Test` button next to `Rescan`, mirroring the BYOK setup panel. Clicking it sends the selected local agent/model through the existing connection-test endpoint and renders the same running/success/failure status copy inline. A running Local CLI test remains visibly in progress even if the selected agent/model/env changes before it settles.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The onboarding Local CLI visual states are attached in the follow-up comment: https://github.com/nexu-io/open-design/pull/4686#issuecomment-4779056063

**Test button + Rescan**

![Local CLI onboarding panel showing Test next to Rescan](https://raw.githubusercontent.com/roian6/open-design/pr-4686-screenshots/pr-4686/local-cli-onboarding/01-local-cli-test-button.png)

**Running state after clicking Test**

![Local CLI onboarding panel showing Testing connection running state](https://raw.githubusercontent.com/roian6/open-design/pr-4686-screenshots/pr-4686/local-cli-onboarding/02-local-cli-test-running.png)

**Success state**

![Local CLI onboarding panel showing successful Codex CLI test](https://raw.githubusercontent.com/roian6/open-design/pr-4686-screenshots/pr-4686/local-cli-onboarding/03-local-cli-test-success.png)

**Failure alert state**

![Local CLI onboarding panel showing agent not installed failure alert](https://raw.githubusercontent.com/roian6/open-design/pr-4686-screenshots/pr-4686/local-cli-onboarding/04-local-cli-test-failure.png)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.onboarding.test.tsx` → `tests the selected Local CLI agent from onboarding`
- Did the test go red on `main` and green on this branch? yes. On `main`, the test failed because the Local CLI panel had no accessible `Test` button. On this branch, it passes and asserts the `/api/test/connection` request body uses `mode: 'agent'`, the selected `agentId`, selected model, reasoning option, and saved `agentCliEnv`. A second regression test covers Local CLI failure alert rendering.

## Validation

- `pnpm install --frozen-lockfile`
- Rebased onto current `origin/main` (`aad9771a6fddb359d3247b58c7b99bd0acf5650f`) and resolved the `apps/web/tests/components/EntryShell.onboarding.test.tsx` conflict
- No conflict markers in the changed files
- `git diff --check origin/main...HEAD` — passed
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding.test.tsx` — 27 passed
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx` — 118 passed
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/providers/connection-test.test.ts` — 4 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm --filter @open-design/web build` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- Earlier full web Vitest run before the latest rebase: `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts` — 342 files passed, 3421 tests passed, 1 skipped; after the latest rebase, the focused onboarding/related suites and type/build/guard/typecheck gates above were re-run
