### PR TITLE
fix(e2e): stub /api/design-systems in /projects UI P0 tests to remove merge-queue flake

### DIFF
--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -3,6 +3,20 @@ import { ensureRailOpen } from '@/playwright/rail';
 import type { Locator, Page, Request, Route } from '@playwright/test';
 import { routeAgents } from '../lib/playwright/mock-factory.js';
 
+// The `/projects` view in `EntryShell` renders a `CenteredLoader` until
+// `projectsLoading || skillsLoading || designSystemsLoading` all clear
+// (`apps/web/src/components/EntryShell.tsx`), and `designSystemsLoading` only
+// clears once `GET /api/design-systems` resolves (`App.tsx` `dsLoading`). A test
+// that lands on `/projects` but leaves `/api/design-systems` unmocked therefore
+// gates its first assertion on the real daemon's response time — fast locally,
+// but a flaky >10s loader under CI load (this dequeued PR #4548 from the merge
+// queue). Stub the endpoint so the projects view renders deterministically.
+async function stubDesignSystemsEmpty(page: Page): Promise<void> {
+  await page.route('**/api/design-systems', async (route) => {
+    await route.fulfill({ json: { designSystems: [] } });
+  });
+}
+
 const STORAGE_KEY = 'open-design:config';
 const ACTIVE_ARTIFACT_PREVIEW_SELECTOR = '[data-testid="artifact-preview-frame"]:visible, [data-testid="artifact-preview-frame-url-load"]:visible, [data-testid="artifact-preview-frame-srcdoc"]:visible, [data-testid="live-artifact-preview-frame"]:visible';
 
@@ -218,6 +232,7 @@ test('[P0] projects empty state create action opens the new project flow', async
     await route.continue();
   });
 
+  await stubDesignSystemsEmpty(page);
   await page.goto('/projects');
   await expect(page.locator('.designs-empty-state')).toBeVisible();
   await page.locator('.designs-empty-cta').click();
@@ -1263,6 +1278,7 @@ test('[P2] projects sub tabs switch between Recent and Your designs ordering', a
     await route.fulfill({ json: { liveArtifacts: [] } });
   });
 
+  await stubDesignSystemsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
 
@@ -1418,6 +1434,7 @@ test('[P2] projects page shows the empty state when there are no projects', asyn
     await route.continue();
   });
 
+  await stubDesignSystemsEmpty(page);
   await page.goto('/projects');
   await expect(page).toHaveURL(/\/projects$/);
   await expect(page.locator('.tab-empty')).toBeVisible();
@@ -1447,6 +1464,7 @@ test('[P2] projects page shows the no-results state and recovers when search is 
     await route.fulfill({ json: { liveArtifacts: [] } });
   });
 
+  await stubDesignSystemsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
   await expect(homeDesignCard(page, 'Searchable Prototype')).toBeVisible();
@@ -1482,6 +1500,7 @@ test('[P2] projects grid overflow menu closes on outside click and Escape', asyn
     await route.fulfill({ json: { liveArtifacts: [] } });
   });
 
+  await stubDesignSystemsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
 
@@ -1552,6 +1571,7 @@ test('[P2] projects kanban view groups cards into status columns', async ({ page
     await route.fulfill({ json: { liveArtifacts: [] } });
   });
 
+  await stubDesignSystemsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
   await page.getByTestId('designs-view-kanban').click();
@@ -1642,6 +1662,7 @@ test('[P1] projects page shows live artifact cards, supports search, and opens t
     });
   });
 
+  await stubDesignSystemsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
 


### PR DESCRIPTION
## Why

The merge queue keeps dequeuing PRs on a flaky **UI P0 (project-workspace)** failure. It just dequeued the docs-only PR #4548: `project-management-flows.test.ts:203` (`[P0] projects empty state create action opens the new project flow`) timed out **twice** on `await expect(page.locator('.designs-empty-state')).toBeVisible()` (30s, retry included), while a sibling share-menu test failed once and recovered on retry. A markdown-only PR cannot cause a UI regression, so this is pure CI jitter that wastes queue cycles and blocks unrelated work.

- **Use case:** triaging why #4548 (a spec doc) was removed from the merge queue by `github-merge-queue[bot]` despite all its own checks being green.
- **Pain:** recurring merge-queue flakiness (main `ci.yml` failed on 2026-06-20 and twice on 2026-06-21) that dequeues good PRs and forces manual re-enqueues.

## Root cause

The `/projects` view in `EntryShell` renders a `CenteredLoader` until **all** of `projectsLoading || skillsLoading || designSystemsLoading` clear (`apps/web/src/components/EntryShell.tsx`). `designSystemsLoading` only clears once `GET /api/design-systems` resolves (`App.tsx` `dsLoading`, set `false` after `fetchDesignSystems()`).

Seven tests in `project-management-flows.test.ts` navigate to `/projects` but **never stub `/api/design-systems`**, so their first assertion is gated on the *real* daemon's response time. Locally that's milliseconds; on a loaded CI runner it can exceed the 10s loader window, leaving `.designs-empty-state` un-rendered → timeout. (The design-system-focused tests in the same file already stub this endpoint; the `/projects` tests just missed it.)

## What changed

Added a `stubDesignSystemsEmpty(page)` helper (with a docblock explaining the gate) and called it before each `goto('/projects')` in the seven affected tests. This removes the only unmocked gating dependency, so the projects view renders deterministically regardless of CI load. Pure test-network change — no product code touched.

## Validation

The UI P0 Playwright suite (`e2e/ui`) runs the affected `project-management-flows.test.ts` under the tools-dev runtime in CI — i.e. this PR's own checks exercise exactly the suite that was flaking. Local Playwright runs require the per-worker tools-dev daemon/web runtime (Node 24); CI is the validation gate. The change mirrors the established `/api/design-systems` stub pattern already used by the design-system tests in this same file.

## Surface area

- [x] Tests (`e2e/ui`)
- No product, contract, CLI, UI, or i18n changes.

## Adjacent

The merge-queue automation gap (bot bake PRs lacking CI, no auto-enqueue) is separate and covered by the pipeline spec in #4548.