### PR TITLE
feat(packaged): main-process telemetry for pre-daemon startup failures

### DIFF
--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -54,6 +54,7 @@ let startupTelemetryContext:
       appVersion: string | null;
       namespace: string;
       source: string;
+      installationRoot: string;
     }
   | null = null;
 
@@ -125,6 +126,9 @@ async function main(): Promise<void> {
     appVersion: activeConfig.appVersion,
     namespace,
     source: SIDECAR_SOURCES.PACKAGED,
+    // Pass installationRoot explicitly: OD_INSTALLATION_DIR is only set in the
+    // daemon child env, not this parent process (see startup-telemetry.ts).
+    installationRoot: paths.installationRoot,
   };
 
   await ensurePackagedNamespacePaths(paths);
@@ -273,7 +277,10 @@ void main().catch(async (error: unknown) => {
       isPathAccess,
       posthogKey: startupTelemetryContext.posthogKey,
       posthogHost: startupTelemetryContext.posthogHost,
-      distinctId: resolveStartupDistinctId(startupTelemetryContext.namespace),
+      distinctId: resolveStartupDistinctId(
+        startupTelemetryContext.namespace,
+        startupTelemetryContext.installationRoot,
+      ),
       appVersion: startupTelemetryContext.appVersion,
       namespace: startupTelemetryContext.namespace,
       source: startupTelemetryContext.source,

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -34,12 +34,28 @@ import {
 import { resolvePackagedNamespacePaths } from "./paths.js";
 import { packagedEntryUrl, registerOdProtocol } from "./protocol.js";
 import { startPackagedSidecars } from "./sidecars.js";
+import { reportStartupFailure, resolveStartupDistinctId } from "./startup-telemetry.js";
 import { resolvePackagedWindowTitle } from "./window-title.js";
 import { syncWindowsUninstallDisplayVersion } from "./windows-lifecycle.js";
 
 let packagedLogger: PackagedDesktopLogger | null = null;
 let pendingSecondInstanceFocus = false;
 let showExistingDesktop: (() => void) | null = null;
+
+// Telemetry context for the fatal-exit path. Populated once config + launcher
+// runtime are resolved so the `main().catch` below can report a startup failure
+// even though the daemon (the PostHog host) never came up. Null until then —
+// failures earlier than config resolution simply skip telemetry. See
+// `startup-telemetry.ts` for the zero-startup-side-effect contract.
+let startupTelemetryContext:
+  | {
+      posthogKey: string | null;
+      posthogHost: string | null;
+      appVersion: string | null;
+      namespace: string;
+      source: string;
+    }
+  | null = null;
 
 function createPackagedDesktopStamp(namespace: string): SidecarStamp {
   return {
@@ -99,6 +115,17 @@ async function main(): Promise<void> {
   const activeConfig = launcherRuntime.config;
   const paths = launcherRuntime.paths;
   const stamp = argvStamp ?? createPackagedDesktopStamp(namespace);
+
+  // Arm fatal-exit telemetry now that we know the channel key/version. The
+  // startPackagedSidecars call below is THE failure this covers (daemon/web
+  // dying before reporting status, e.g. issue #4638's missing better-sqlite3).
+  startupTelemetryContext = {
+    posthogKey: activeConfig.posthogKey,
+    posthogHost: activeConfig.posthogHost,
+    appVersion: activeConfig.appVersion,
+    namespace,
+    source: SIDECAR_SOURCES.PACKAGED,
+  };
 
   await ensurePackagedNamespacePaths(paths);
   packagedLogger = createPackagedDesktopLogger(paths);
@@ -224,8 +251,9 @@ async function main(): Promise<void> {
   });
 }
 
-void main().catch((error: unknown) => {
-  if (error instanceof PackagedPathAccessError) {
+void main().catch(async (error: unknown) => {
+  const isPathAccess = error instanceof PackagedPathAccessError;
+  if (isPathAccess) {
     try {
       dialog.showErrorBox(error.title, error.message);
     } catch {
@@ -234,5 +262,22 @@ void main().catch((error: unknown) => {
   }
   packagedLogger?.error("packaged runtime failed", { error });
   console.error("packaged runtime failed", error);
+  // Best-effort crash telemetry on the way out. This is the ONLY new behavior
+  // on the failure path; the happy path never reaches here. reportStartupFailure
+  // self-caps its runtime (Promise.race timeout) and swallows all errors, so it
+  // can neither block nor crash the exit. No-op when telemetry isn't armed yet
+  // or the build has no PostHog key.
+  if (startupTelemetryContext) {
+    await reportStartupFailure({
+      error,
+      isPathAccess,
+      posthogKey: startupTelemetryContext.posthogKey,
+      posthogHost: startupTelemetryContext.posthogHost,
+      distinctId: resolveStartupDistinctId(startupTelemetryContext.namespace),
+      appVersion: startupTelemetryContext.appVersion,
+      namespace: startupTelemetryContext.namespace,
+      source: startupTelemetryContext.source,
+    });
+  }
   process.exit(1);
 });

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -29,7 +29,15 @@ import { join } from "node:path";
 import { release } from "node:os";
 
 const DEFAULT_HOST = "https://us.i.posthog.com";
-const DEFAULT_TIMEOUT_MS = 1500;
+// Real-machine e2e (local packaged build → delete better-sqlite3 → launch →
+// query PostHog) proved a 1.5s cap silently DROPPED the event: a cold DNS+TLS
+// handshake to us.i.posthog.com from a fresh main process exceeds 1.5s, so the
+// race timed out and process.exit(1) killed the in-flight POST before it
+// landed. 5s gives the one request room to complete on a cold connection.
+// A genuinely offline machine still exits fast — fetch rejects on DNS failure,
+// so `send` resolves early and we don't burn the full bound; only a black-hole
+// network pays the full 5s, which on an already-crashing exit is acceptable.
+const DEFAULT_TIMEOUT_MS = 5000;
 const LOG_TAIL_MAX_BYTES = 16_384;
 
 export const STARTUP_FAILURE_EVENT = "packaged_runtime_failed";

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -42,6 +42,40 @@ const LOG_TAIL_MAX_BYTES = 16_384;
 
 export const STARTUP_FAILURE_EVENT = "packaged_runtime_failed";
 
+// Shared safety-event envelope constants. `captureSafety` in
+// apps/daemon/src/analytics.ts stamps these on every stability event; we mirror
+// them here so env/schema-filtered dashboards bucket packaged_runtime_failed
+// beside the rest of the analytics stream instead of dropping it.
+//
+// EVENT_SCHEMA_VERSION must stay in lockstep with
+// packages/contracts/src/analytics/public-params.ts. It is replicated (not
+// imported) because apps/packaged does not depend on @open-design/contracts and
+// a single integer isn't worth a new cross-package dependency that also
+// complicates the daemon-chunk externalization.
+const EVENT_SCHEMA_VERSION = 2;
+const CLIENT_TYPE = "packaged_main";
+const CAPTURE_SOURCE = "packaged/startup";
+
+// Replicates apps/daemon/src/telemetry-environment.ts (daemon src, not
+// importable here) so the packaged main process resolves the same `env` bucket
+// as daemon-emitted events for a given process environment.
+function resolveTelemetryEnv(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit =
+    env.OD_TELEMETRY_ENV?.trim() ||
+    env.OPEN_DESIGN_ENV?.trim() ||
+    env.POSTHOG_ENV?.trim() ||
+    env.LANGFUSE_ENVIRONMENT?.trim();
+  if (explicit) return explicit;
+  if (env.NODE_ENV === "production") return "production";
+  return "development";
+}
+
+// Mirrors apps/daemon/src/analytics.ts randomInsertId. $insert_id is PostHog's
+// dedup key; event_id carries the same value.
+function randomInsertId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 export type StartupFailureKind =
   | "daemon-start"
   | "web-start"
@@ -166,6 +200,7 @@ export interface CaptureDeps {
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
   now?: () => string;
+  insertId?: string;
 }
 
 // Fire a single PostHog capture over plain HTTPS. No-op without a key; never
@@ -186,16 +221,29 @@ export async function captureStartupFailure(
   const fetchImpl = deps.fetchImpl ?? fetch;
   const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const now = deps.now ?? (() => new Date().toISOString());
+  const insertId = deps.insertId ?? randomInsertId();
+  const appVersion =
+    typeof args.properties.app_version === "string" ? args.properties.app_version : null;
   const body = JSON.stringify({
     api_key: key,
     event: args.event,
     distinct_id: args.distinctId,
     properties: {
       ...args.properties,
-      // posthog-node-style manual enrichment (the SDK auto-fills these for
-      // posthog-js but not for server emits; we mirror analytics.ts).
+      // Shared safety-event envelope, mirroring captureSafety in
+      // apps/daemon/src/analytics.ts. posthog-node-style manual enrichment:
+      // the SDK auto-fills $os/$insert_id for posthog-js but not for server
+      // emits, and dashboards filter on env / event_schema_version.
+      event_id: insertId,
+      event_schema_version: EVENT_SCHEMA_VERSION,
+      env: resolveTelemetryEnv(),
+      device_id: args.distinctId,
+      client_type: CLIENT_TYPE,
+      capture_source: CAPTURE_SOURCE,
+      ui_version: appVersion,
       $os: osName(),
       $os_version: release(),
+      $insert_id: insertId,
     },
     timestamp: now(),
   });

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -72,7 +72,12 @@ export function classifyStartupFailure(
   const parsedCode = rawCode === "null" ? null : Number.parseInt(rawCode, 10);
   const exitCode = parsedCode == null || Number.isNaN(parsedCode) ? null : parsedCode;
   const signal = rawSignal === "none" ? null : rawSignal;
-  const failureKind: StartupFailureKind = logPath?.includes("/web/")
+  // `startPackagedSidecars` builds the watched log path with path.join, which is
+  // backslash-separated on Windows (`...\logs\web\latest.log`). Normalize before
+  // the segment check so a web-sidecar failure isn't misreported as daemon-start
+  // on Windows — exactly the platform split this field exists to capture.
+  const normalizedLogPath = logPath?.replace(/\\/g, "/") ?? null;
+  const failureKind: StartupFailureKind = normalizedLogPath?.includes("/web/")
     ? "web-start"
     : "daemon-start";
   return { failureKind, exitCode, signal, logPath };
@@ -114,9 +119,17 @@ function osName(platform: NodeJS.Platform = process.platform): string {
 // installationId (survives a namespace data reset); falls back to a synthetic
 // per-namespace id. Person identity is not critical for crash-distribution
 // analysis — we segment on os/version/channel, not per-user funnels.
-export function resolveStartupDistinctId(namespace: string): string {
+//
+// `installationRoot` must be passed explicitly from `paths.installationRoot`:
+// OD_INSTALLATION_DIR is only set in the daemon CHILD env, never in the packaged
+// main process, so relying on the env here would always fall through to the
+// synthetic id. The env is kept as a secondary fallback only.
+export function resolveStartupDistinctId(
+  namespace: string,
+  installationRoot?: string | null,
+): string {
+  const dir = installationRoot?.trim() || process.env.OD_INSTALLATION_DIR?.trim();
   try {
-    const dir = process.env.OD_INSTALLATION_DIR?.trim();
     if (dir) {
       const raw = readFileSync(join(dir, "installation.json"), "utf8");
       const parsed = JSON.parse(raw) as { installationId?: unknown };

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -1,0 +1,264 @@
+// Main-process direct PostHog capture for daemon/web STARTUP failures.
+//
+// Why this exists separately from apps/daemon/src/analytics.ts: the daemon is
+// the PostHog client's host. When the daemon never reports status (e.g. a
+// missing native module — see issue #4638, where `better-sqlite3` vanished
+// from the app bundle and the daemon died with ERR_MODULE_NOT_FOUND), the
+// daemon/web sidecars are not running, so NOTHING emits telemetry and the
+// whole "startup failed before the daemon came up" class is invisible on every
+// dashboard. This module lets the packaged MAIN process emit one structured
+// event on the fatal-exit path.
+//
+// ZERO startup side-effects by construction:
+//  - No work at import time (pure helpers + one async fn; no client, no I/O).
+//  - Invoked ONLY from index.ts's `main().catch(...)`, i.e. only when startup
+//    has ALREADY failed and the process is about to exit(1). The happy path
+//    never touches any of this.
+//  - capture() is fetch-based (no posthog-node SDK, no new dependency), wrapped
+//    in Promise.race with a hard timeout, and swallows every error — it can
+//    neither block nor crash the exit.
+//
+// Consent: startup-crash telemetry follows the existing `captureSafety` policy
+// in apps/daemon/src/analytics.ts — stability data is retained even for
+// opted-out users (and the main process cannot read daemon consent anyway,
+// since the daemon isn't up). The Settings → Privacy copy MUST call this out.
+
+import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { release } from "node:os";
+
+const DEFAULT_HOST = "https://us.i.posthog.com";
+const DEFAULT_TIMEOUT_MS = 1500;
+const LOG_TAIL_MAX_BYTES = 16_384;
+
+export const STARTUP_FAILURE_EVENT = "packaged_runtime_failed";
+
+export type StartupFailureKind =
+  | "daemon-start"
+  | "web-start"
+  | "path-access"
+  | "unknown";
+
+export interface StartupFailureClassification {
+  failureKind: StartupFailureKind;
+  exitCode: number | null;
+  signal: string | null;
+  logPath: string | null;
+}
+
+// `waitForStatus` (apps/packaged/src/sidecars.ts:206-208) throws:
+//   "daemon exited before reporting status (code=1, signal=none); see <logPath> for details"
+// The literal word is always "daemon" even for the web sidecar, so we
+// distinguish daemon-vs-web by the LOG PATH segment, not the message text.
+const EXIT_RE =
+  /exited before reporting status \(code=(.*?), signal=(.*?)\); see (.*?) for details/;
+
+export function classifyStartupFailure(
+  error: unknown,
+  isPathAccess: boolean,
+): StartupFailureClassification {
+  if (isPathAccess) {
+    return { failureKind: "path-access", exitCode: null, signal: null, logPath: null };
+  }
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  const match = EXIT_RE.exec(message);
+  if (!match) {
+    return { failureKind: "unknown", exitCode: null, signal: null, logPath: null };
+  }
+  const rawCode = match[1];
+  const rawSignal = match[2];
+  const logPath = match[3] && match[3] !== "<no log path>" ? match[3] : null;
+  const parsedCode = rawCode === "null" ? null : Number.parseInt(rawCode, 10);
+  const exitCode = parsedCode == null || Number.isNaN(parsedCode) ? null : parsedCode;
+  const signal = rawSignal === "none" ? null : rawSignal;
+  const failureKind: StartupFailureKind = logPath?.includes("/web/")
+    ? "web-start"
+    : "daemon-start";
+  return { failureKind, exitCode, signal, logPath };
+}
+
+// Pull the real error code + missing module out of a sidecar log tail. Pure
+// function so it can be fed the #4638 log text verbatim in tests.
+export function parseDaemonLogTail(logText: string): {
+  errorCode?: string;
+  missingModule?: string;
+} {
+  const out: { errorCode?: string; missingModule?: string } = {};
+  const errMatch = /\bERR_[A-Z0-9_]+/.exec(logText);
+  if (errMatch) out.errorCode = errMatch[0];
+  const modMatch =
+    /Cannot find package '([^']+)'|Cannot find module '([^']+)'/.exec(logText);
+  if (modMatch) out.missingModule = modMatch[1] ?? modMatch[2];
+  return out;
+}
+
+// apps/web/src/analytics/scrub.ts only rewrites paths containing an
+// apps/|packages/|tools/ segment, so it does NOT touch a user's home dir
+// (verified empirically against the #4638 log). The packaged main process
+// can't import the web module anyway, so we ship a focused scrubber here.
+export function scrubUserPaths(value: string): string {
+  return value
+    .replace(/\/(Users|home)\/[^/\s]+/g, "/$1/<redacted>")
+    .replace(/([A-Za-z]:\\Users\\)[^\\\s]+/g, "$1<redacted>");
+}
+
+function osName(platform: NodeJS.Platform = process.platform): string {
+  if (platform === "darwin") return "Mac OS X";
+  if (platform === "win32") return "Windows";
+  if (platform === "linux") return "Linux";
+  return platform;
+}
+
+// Stable-ish distinct id for the crash event. Best-effort reads the persistent
+// installationId (survives a namespace data reset); falls back to a synthetic
+// per-namespace id. Person identity is not critical for crash-distribution
+// analysis — we segment on os/version/channel, not per-user funnels.
+export function resolveStartupDistinctId(namespace: string): string {
+  try {
+    const dir = process.env.OD_INSTALLATION_DIR?.trim();
+    if (dir) {
+      const raw = readFileSync(join(dir, "installation.json"), "utf8");
+      const parsed = JSON.parse(raw) as { installationId?: unknown };
+      if (typeof parsed.installationId === "string" && parsed.installationId.length > 0) {
+        return parsed.installationId;
+      }
+    }
+  } catch {
+    // fall through to synthetic
+  }
+  return `packaged-${namespace}`;
+}
+
+async function defaultReadLogTail(path: string): Promise<string | null> {
+  try {
+    const buf = await readFile(path);
+    return buf.length > LOG_TAIL_MAX_BYTES
+      ? buf.subarray(buf.length - LOG_TAIL_MAX_BYTES).toString("utf8")
+      : buf.toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+export interface CaptureDeps {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  now?: () => string;
+}
+
+// Fire a single PostHog capture over plain HTTPS. No-op without a key; never
+// throws; never blocks longer than `timeoutMs`.
+export async function captureStartupFailure(
+  args: {
+    posthogKey: string | null;
+    posthogHost: string | null;
+    distinctId: string;
+    event: string;
+    properties: Record<string, unknown>;
+  },
+  deps: CaptureDeps = {},
+): Promise<void> {
+  const key = args.posthogKey?.trim();
+  if (!key) return; // fork builds / no key → no-op, zero network
+  const host = (args.posthogHost?.trim() || DEFAULT_HOST).replace(/\/+$/, "");
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const now = deps.now ?? (() => new Date().toISOString());
+  const body = JSON.stringify({
+    api_key: key,
+    event: args.event,
+    distinct_id: args.distinctId,
+    properties: {
+      ...args.properties,
+      // posthog-node-style manual enrichment (the SDK auto-fills these for
+      // posthog-js but not for server emits; we mirror analytics.ts).
+      $os: osName(),
+      $os_version: release(),
+    },
+    timestamp: now(),
+  });
+
+  const send = (async () => {
+    try {
+      await fetchImpl(`${host}/capture/`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      });
+    } catch {
+      // analytics failure must never look like a product error
+    }
+  })();
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  await Promise.race([send, timeout]);
+  if (timer) clearTimeout(timer);
+}
+
+export interface ReportStartupFailureArgs {
+  error: unknown;
+  isPathAccess: boolean;
+  posthogKey: string | null;
+  posthogHost: string | null;
+  distinctId: string;
+  appVersion: string | null;
+  namespace: string;
+  source: string;
+}
+
+export interface ReportDeps extends CaptureDeps {
+  readLogTail?: (path: string) => Promise<string | null>;
+}
+
+// The single entry point index.ts's fatal-exit catch calls. Orchestrates
+// classify → read log tail → parse error code → scrub → capture. Wrapped so it
+// can NEVER become a new startup-failure source.
+export async function reportStartupFailure(
+  args: ReportStartupFailureArgs,
+  deps: ReportDeps = {},
+): Promise<void> {
+  try {
+    const classification = classifyStartupFailure(args.error, args.isPathAccess);
+    let errorCode: string | undefined;
+    let missingModule: string | undefined;
+    if (classification.logPath) {
+      const tail = await (deps.readLogTail ?? defaultReadLogTail)(classification.logPath);
+      if (tail) {
+        const parsed = parseDaemonLogTail(tail);
+        errorCode = parsed.errorCode;
+        missingModule = parsed.missingModule;
+      }
+    }
+    const properties: Record<string, unknown> = {
+      failure_kind: classification.failureKind,
+      exit_code: classification.exitCode,
+      signal: classification.signal,
+      error_name: args.error instanceof Error ? args.error.name : "unknown",
+      error_code: errorCode ?? null,
+      missing_module: missingModule ?? null,
+      // Structured fields only — no raw message/stack. Scrub the one path we do
+      // send so a user's home dir never reaches PostHog.
+      log_path: classification.logPath ? scrubUserPaths(classification.logPath) : null,
+      app_version: args.appVersion,
+      namespace: args.namespace,
+      source: args.source,
+      platform: process.platform,
+    };
+    await captureStartupFailure(
+      {
+        posthogKey: args.posthogKey,
+        posthogHost: args.posthogHost,
+        distinctId: args.distinctId,
+        event: STARTUP_FAILURE_EVENT,
+        properties,
+      },
+      { fetchImpl: deps.fetchImpl, timeoutMs: deps.timeoutMs, now: deps.now },
+    );
+  } catch {
+    // Reporting a startup failure must NEVER itself break the exit path.
+  }
+}

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -161,6 +161,38 @@ describe('captureStartupFailure', () => {
     expect((body.properties as Record<string, unknown>).$os).toBeDefined();
   });
 
+  it('stamps the shared safety-event envelope so dashboards bucket it', async () => {
+    // Mirrors captureSafety in apps/daemon/src/analytics.ts. Without these,
+    // env/schema-filtered dashboards miss or mis-bucket the event even though
+    // PostHog accepts the raw payload (PerishCode review on #4696).
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await captureStartupFailure(
+      {
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'install-123',
+        event: STARTUP_FAILURE_EVENT,
+        properties: { failure_kind: 'daemon-start', app_version: '0.11.0' },
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => '2026-06-23T00:00:00.000Z',
+        insertId: 'ins-fixed',
+      },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const p = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
+      .properties;
+    expect(p.event_schema_version).toBe(2);
+    expect(p.device_id).toBe('install-123');
+    expect(p.client_type).toBe('packaged_main');
+    expect(p.capture_source).toBe('packaged/startup');
+    expect(p.ui_version).toBe('0.11.0');
+    expect(p.event_id).toBe('ins-fixed');
+    expect(p.$insert_id).toBe('ins-fixed');
+    expect(typeof p.env).toBe('string');
+  });
+
   it('never blocks past the timeout even if fetch hangs forever', async () => {
     // The critical guarantee for "no startup side-effect": a hung (offline)
     // request must not wedge the exit. Race must resolve via the timeout.

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -14,7 +14,10 @@
  *
  * @see apps/packaged/src/startup-telemetry.ts
  */
-import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   STARTUP_FAILURE_EVENT,
@@ -22,6 +25,7 @@ import {
   classifyStartupFailure,
   parseDaemonLogTail,
   reportStartupFailure,
+  resolveStartupDistinctId,
   scrubUserPaths,
 } from '../src/startup-telemetry.js';
 
@@ -65,6 +69,15 @@ describe('classifyStartupFailure', () => {
     expect(c.failureKind).toBe('web-start');
   });
 
+  it('classifies a Windows (backslash) web-start log path as web-start', () => {
+    // startPackagedSidecars uses path.join, so on Windows the watched log path
+    // is backslash-separated. A naive "/web/" check would misreport this as
+    // daemon-start — the one platform split this field exists for.
+    const winWebMessage =
+      'daemon exited before reporting status (code=1, signal=none); see C:\\Users\\Alice\\AppData\\Roaming\\Open Design\\namespaces\\release-stable\\logs\\web\\latest.log for details';
+    expect(classifyStartupFailure(new Error(winWebMessage), false).failureKind).toBe('web-start');
+  });
+
   it('marks path-access failures without inventing a log path', () => {
     const c = classifyStartupFailure(new Error('whatever'), true);
     expect(c.failureKind).toBe('path-access');
@@ -89,6 +102,29 @@ describe('scrubUserPaths', () => {
     expect(scrubUserPaths('C:\\Users\\Alice\\AppData\\Roaming')).toBe(
       'C:\\Users\\<redacted>\\AppData\\Roaming',
     );
+  });
+});
+
+describe('resolveStartupDistinctId', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    delete process.env.OD_INSTALLATION_DIR;
+  });
+
+  it('reads installationId from an explicit installationRoot (not the child-only env)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-install-'));
+    dirs.push(root);
+    writeFileSync(join(root, 'installation.json'), JSON.stringify({ installationId: 'inst-abc' }));
+    // env is intentionally unset — proving the parent process resolves via the
+    // explicit arg, the bug PerishCode flagged.
+    expect(resolveStartupDistinctId('release-stable', root)).toBe('inst-abc');
+  });
+
+  it('falls back to a synthetic per-namespace id when no installation file exists', () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-install-'));
+    dirs.push(root);
+    expect(resolveStartupDistinctId('release-stable', root)).toBe('packaged-release-stable');
   });
 });
 

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Coverage for the packaged main-process startup-failure telemetry
+ * (apps/packaged/src/startup-telemetry.ts).
+ *
+ * Background: when the daemon dies before reporting status (issue #4638:
+ * `better-sqlite3` vanished from the bundle → ERR_MODULE_NOT_FOUND), the
+ * daemon/web sidecars — which host the PostHog client — never run, so the
+ * whole crash class emits ZERO telemetry. This module emits one event from the
+ * main process on the fatal-exit path. These tests pin three guarantees:
+ *   1. it extracts the real error code / missing module from the #4638 log,
+ *   2. it scrubs the user's home dir out of anything it sends,
+ *   3. it can NEVER block the exit (timeout wins over a hung fetch) and is a
+ *      no-op without a PostHog key.
+ *
+ * @see apps/packaged/src/startup-telemetry.ts
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  STARTUP_FAILURE_EVENT,
+  captureStartupFailure,
+  classifyStartupFailure,
+  parseDaemonLogTail,
+  reportStartupFailure,
+  scrubUserPaths,
+} from '../src/startup-telemetry.js';
+
+// Verbatim daemon log tail from issue #4638.
+const ISSUE_4638_LOG = `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'better-sqlite3' imported from /Applications/Open Design.app/Contents/Resources/app/prebundled/daemon/chunks/server-PULTSXNL.mjs
+    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:301:9)
+[open-design packaged] exited app=daemon pid=45305 code=1 signal=none`;
+
+// Verbatim shape of what waitForStatus throws (sidecars.ts:206-208).
+const DAEMON_EXIT_MESSAGE =
+  'daemon exited before reporting status (code=1, signal=none); see /Users/liudetao/Library/Application Support/Open Design/namespaces/release-stable/logs/daemon/latest.log for details';
+const WEB_EXIT_MESSAGE =
+  'daemon exited before reporting status (code=1, signal=none); see /Users/liudetao/Library/Application Support/Open Design/namespaces/release-stable/logs/web/latest.log for details';
+
+describe('parseDaemonLogTail', () => {
+  it('extracts the error code and missing module from the #4638 log', () => {
+    expect(parseDaemonLogTail(ISSUE_4638_LOG)).toEqual({
+      errorCode: 'ERR_MODULE_NOT_FOUND',
+      missingModule: 'better-sqlite3',
+    });
+  });
+
+  it('returns empty when the log carries no recognizable signal', () => {
+    expect(parseDaemonLogTail('daemon started ok\nlistening on 17456')).toEqual({});
+  });
+});
+
+describe('classifyStartupFailure', () => {
+  it('classifies a daemon-start failure and pulls code/signal/logPath', () => {
+    const c = classifyStartupFailure(new Error(DAEMON_EXIT_MESSAGE), false);
+    expect(c.failureKind).toBe('daemon-start');
+    expect(c.exitCode).toBe(1);
+    expect(c.signal).toBeNull();
+    expect(c.logPath).toContain('/logs/daemon/latest.log');
+  });
+
+  it('distinguishes a web-start failure by log-path segment, not message text', () => {
+    // The thrown message still literally says "daemon" even for the web
+    // sidecar; the log path is the only honest discriminator.
+    const c = classifyStartupFailure(new Error(WEB_EXIT_MESSAGE), false);
+    expect(c.failureKind).toBe('web-start');
+  });
+
+  it('marks path-access failures without inventing a log path', () => {
+    const c = classifyStartupFailure(new Error('whatever'), true);
+    expect(c.failureKind).toBe('path-access');
+    expect(c.logPath).toBeNull();
+  });
+
+  it('falls back to unknown for an unrecognized error', () => {
+    expect(classifyStartupFailure(new Error('boom'), false).failureKind).toBe('unknown');
+  });
+});
+
+describe('scrubUserPaths', () => {
+  it('redacts the user home directory but keeps the rest of the path', () => {
+    const scrubbed = scrubUserPaths(
+      '/Users/liudetao/Library/Application Support/Open Design/namespaces/release-stable/logs/daemon/latest.log',
+    );
+    expect(scrubbed).not.toContain('liudetao');
+    expect(scrubbed).toContain('/Users/<redacted>/Library/Application Support');
+  });
+
+  it('redacts Windows user dirs too', () => {
+    expect(scrubUserPaths('C:\\Users\\Alice\\AppData\\Roaming')).toBe(
+      'C:\\Users\\<redacted>\\AppData\\Roaming',
+    );
+  });
+});
+
+describe('captureStartupFailure', () => {
+  it('is a no-op (zero network) without a PostHog key', async () => {
+    const fetchImpl = vi.fn();
+    await captureStartupFailure(
+      { posthogKey: null, posthogHost: null, distinctId: 'd', event: 'e', properties: {} },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to /capture/ with the PostHog wire shape', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await captureStartupFailure(
+      {
+        posthogKey: 'phc_test',
+        posthogHost: 'https://us.i.posthog.com',
+        distinctId: 'install-123',
+        event: STARTUP_FAILURE_EVENT,
+        properties: { failure_kind: 'daemon-start' },
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, now: () => '2026-06-23T00:00:00.000Z' },
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://us.i.posthog.com/capture/');
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.api_key).toBe('phc_test');
+    expect(body.event).toBe(STARTUP_FAILURE_EVENT);
+    expect(body.distinct_id).toBe('install-123');
+    expect((body.properties as Record<string, unknown>).failure_kind).toBe('daemon-start');
+    expect((body.properties as Record<string, unknown>).$os).toBeDefined();
+  });
+
+  it('never blocks past the timeout even if fetch hangs forever', async () => {
+    // The critical guarantee for "no startup side-effect": a hung (offline)
+    // request must not wedge the exit. Race must resolve via the timeout.
+    const hung = new Promise<Response>(() => {
+      /* never resolves */
+    });
+    const fetchImpl = vi.fn().mockReturnValue(hung);
+    const start = Date.now();
+    await captureStartupFailure(
+      { posthogKey: 'phc_test', posthogHost: null, distinctId: 'd', event: 'e', properties: {} },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 30 },
+    );
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  it('swallows a fetch that throws (analytics failure is not a product error)', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'));
+    await expect(
+      captureStartupFailure(
+        { posthogKey: 'phc_test', posthogHost: null, distinctId: 'd', event: 'e', properties: {} },
+        { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 50 },
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('reportStartupFailure', () => {
+  it('reads the log tail, enriches the event, scrubs paths, and sends once', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await reportStartupFailure(
+      {
+        error: new Error(DAEMON_EXIT_MESSAGE),
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'install-123',
+        appVersion: '0.11.0',
+        namespace: 'release-stable',
+        source: 'packaged',
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        readLogTail: async () => ISSUE_4638_LOG,
+        now: () => '2026-06-23T00:00:00.000Z',
+      },
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
+      .properties;
+    expect(props.failure_kind).toBe('daemon-start');
+    expect(props.error_code).toBe('ERR_MODULE_NOT_FOUND');
+    expect(props.missing_module).toBe('better-sqlite3');
+    expect(props.app_version).toBe('0.11.0');
+    expect(props.exit_code).toBe(1);
+    expect(props.log_path).not.toContain('liudetao');
+  });
+
+  it('never throws even when the log read blows up', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await expect(
+      reportStartupFailure(
+        {
+          error: new Error(DAEMON_EXIT_MESSAGE),
+          isPathAccess: false,
+          posthogKey: 'phc_test',
+          posthogHost: null,
+          distinctId: 'd',
+          appVersion: '0.11.0',
+          namespace: 'release-stable',
+          source: 'packaged',
+        },
+        {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          readLogTail: async () => {
+            throw new Error('disk gone');
+          },
+        },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('is a no-op without a PostHog key (fork builds)', async () => {
+    const fetchImpl = vi.fn();
+    await reportStartupFailure(
+      {
+        error: new Error(DAEMON_EXIT_MESSAGE),
+        isPathAccess: false,
+        posthogKey: null,
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.11.0',
+        namespace: 'release-stable',
+        source: 'packaged',
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, readLogTail: async () => ISSUE_4638_LOG },
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -35,11 +35,6 @@ export type AnalyticsEventName =
   // Packaged updater lifecycle
   | 'update_install_result'
   | 'update_apply_observed'
-  // Packaged startup failure — emitted by the packaged MAIN process (not the
-  // daemon) when daemon/web sidecars die before reporting status, i.e. the
-  // pre-daemon crash class that produces zero telemetry today (issue #4638).
-  // A `captureSafety`-class stability event; see apps/packaged/src/startup-telemetry.ts.
-  | 'packaged_runtime_failed'
   // File manager
   | 'file_upload_result'
   // Artifact
@@ -3061,9 +3056,44 @@ export interface SettingsConnectorAuthResultProps {
   error_code?: string;
 }
 
+// ---- Packaged startup failure --------------------------------------------
+
+export type PackagedStartupFailureKind =
+  | 'daemon-start'
+  | 'web-start'
+  | 'path-access'
+  | 'unknown';
+
+// Event-specific props for `packaged_runtime_failed`. Emitted by the packaged
+// MAIN process (apps/packaged/src/startup-telemetry.ts) over a direct PostHog
+// capture when daemon/web sidecars die before reporting status — the pre-daemon
+// crash class that otherwise produces no telemetry (issue #4638). The shared
+// safety-event envelope (event_schema_version / env / device_id / client_type /
+// capture_source / $insert_id / $os) is stamped at emit time, mirroring
+// `captureSafety` in apps/daemon/src/analytics.ts; these are the event-specific
+// fields on top of it.
+export interface PackagedRuntimeFailedProps {
+  failure_kind: PackagedStartupFailureKind;
+  exit_code: number | null;
+  signal: string | null;
+  error_name: string;
+  // Pulled from the dead sidecar's log tail (e.g. `ERR_MODULE_NOT_FOUND`).
+  error_code: string | null;
+  // The unresolved module when error_code is a module-resolution failure
+  // (e.g. `better-sqlite3` for #4638).
+  missing_module: string | null;
+  // Scrubbed of the user's home dir before send.
+  log_path: string | null;
+  app_version: string | null;
+  namespace: string;
+  source: string;
+  platform: string;
+}
+
 // ---- Discriminated union of all event payloads ---------------------------
 
 export type AnalyticsEventPayload =
+  | { event: 'packaged_runtime_failed'; props: PackagedRuntimeFailedProps }
   | { event: 'page_view'; props: PageViewProps }
   | { event: 'ui_click'; props: UiClickProps }
   | { event: 'surface_view'; props: SurfaceViewProps }

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -35,6 +35,11 @@ export type AnalyticsEventName =
   // Packaged updater lifecycle
   | 'update_install_result'
   | 'update_apply_observed'
+  // Packaged startup failure — emitted by the packaged MAIN process (not the
+  // daemon) when daemon/web sidecars die before reporting status, i.e. the
+  // pre-daemon crash class that produces zero telemetry today (issue #4638).
+  // A `captureSafety`-class stability event; see apps/packaged/src/startup-telemetry.ts.
+  | 'packaged_runtime_failed'
   // File manager
   | 'file_upload_result'
   // Artifact


### PR DESCRIPTION
<!-- This PR adds observability; it does not by itself fix #4638. Related: #4638, spec PR #4694. -->

## Why

- **Use case**: triaging #4638 (stable 0.11.0, macOS 27 Beta, M4) — "opens and crashes, nothing in Console". The crash is real and deterministic (daemon dies ~500ms in, 14 relaunches all `code=1`), but it produced **zero telemetry**, so it only surfaced because the user hand-filed an issue with logs.
- **Pain**: the daemon hosts the PostHog client. When daemon/web sidecars die **before reporting status** (here: `better-sqlite3` vanished from the bundle → `ERR_MODULE_NOT_FOUND`), neither daemon nor web is running, so this entire **pre-daemon crash class is invisible on every dashboard**. I verified the gap in code: `apps/packaged/src/index.ts`'s fatal-exit path only `logger.error` + `console.error` + `process.exit(1)` — no capture; `sidecars.ts:380-410` only *forwards* the PostHog key as env to the (dead) children.
- This is **slice B (observability)** of the crash-governance spec (#4694), pulled forward as P0 because "we can't even see it" is the worst failure mode.

> For context, I mounted the live 0.11.0 and 0.10.1 DMGs and verified `better_sqlite3.node` is correctly Developer-ID signed + hardenedRuntime + notarized (`spctl` accepted) in both — **not a packaging bug**. The file is deleted on the user's machine while the app isn't running, by something outside OD. Root cause is environmental and N=1 can't pin it — which is exactly why we need the distribution this telemetry will give us.

## What users will see

Nothing visible. This is backend telemetry only: one `packaged_runtime_failed` event emitted from the packaged **main process** when startup fails. Carries `failure_kind` (daemon-start / web-start / path-access / unknown), `error_code` (e.g. `ERR_MODULE_NOT_FOUND`), `missing_module` (e.g. `better-sqlite3`), `exit_code`, `signal`, `app_version`, `namespace`, `platform` — so "this time it's better-sqlite3" **and** any future pre-daemon crash become visible and segmentable (by OS/version/channel).

**Zero happy-path side-effects (by construction)** — the reviewer concern I designed around:
- All logic runs only inside `main().catch`, i.e. only when startup has *already* failed and the process is about to exit. The happy path never executes any of it.
- `startup-telemetry.ts` does no work at import time (pure helpers + one async fn; no client, no I/O, no new dependency — plain `fetch`, not `posthog-node`).
- `captureStartupFailure` is wrapped in `Promise.race` with a hard 1.5s timeout and swallows every error → it can neither block nor crash the exit (offline = times out and exits). No-op without a PostHog key.
- A test pins this: a fetch that *never resolves* still returns within the timeout.

## Surface area

- [x] **API / contract** — new analytics event name `packaged_runtime_failed` in `packages/contracts/src/analytics/events.ts`

## Screenshots

N/A — no UI.

## Bug fix verification

Not a bug fix — observability. New tests (`apps/packaged/tests/startup-telemetry.test.ts`, 15 cases) cover: parsing the verbatim #4638 log → `ERR_MODULE_NOT_FOUND` + `better-sqlite3`; daemon-vs-web classification by log-path segment (not the hard-coded "daemon" word in the message); home-dir scrubbing; no-op without key; and the never-blocks-past-timeout guarantee.

## Validation

- `pnpm --filter @open-design/packaged typecheck` — passes (Node 24).
- `pnpm --filter @open-design/packaged exec vitest run tests/startup-telemetry.test.ts` — **15/15 pass**.
- `pnpm guard` — the only failure is pre-existing untracked `.js` files under `3158/` in the working tree (unrelated to this branch, which adds only `.ts`).

## Follow-ups / open questions (for review)

- **Privacy copy (must-do)**: crash telemetry follows the existing `captureSafety` policy (`apps/daemon/src/analytics.ts:118-137`) — stability data is retained even for opted-out users (the main process can't read daemon consent since the daemon isn't up). That policy's own comment requires Settings → Privacy to call this out; this PR does **not** touch the 18-locale copy — needs a decision + follow-up.
- **distinctId**: best-effort reads the persistent `installationId`, falls back to a synthetic per-namespace id. Could be unified with `apps/daemon/src/installation.ts` if promoted to a pure package.
- **Slice A (the user-facing error dialog)** and **slice C (startup integrity self-check)** remain separate per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
