### PR TITLE
feat(ci): implement the plugin-preview bake pipeline (spec 4548)

### DIFF
--- a/.github/actions/bake-previews/action.yml
+++ b/.github/actions/bake-previews/action.yml
@@ -1,0 +1,111 @@
+name: Bake plugin previews
+description: >-
+  Render the home-gallery plugin previews to H.264 clips + posters into
+  .tmp/plugin-previews (content-hash skip reuses unchanged plugins) and, when
+  asked, publish the clips to the repository-assets R2 bucket. The caller owns
+  what happens to the resulting manifest (rolling PR, commit-to-branch, etc.).
+  Shared by the post-merge, pre-merge, and release-cut bake workflows so the
+  heavy render core lives in exactly one place.
+
+inputs:
+  upload:
+    description: When 'true', publish the freshly rendered clips to R2.
+    required: false
+    default: 'false'
+  r2-access-key-id:
+    description: R2 access key id (required when upload is true).
+    required: false
+    default: ''
+  r2-secret-access-key:
+    description: R2 secret access key (required when upload is true).
+    required: false
+    default: ''
+  r2-bucket:
+    description: R2 bucket name (required when upload is true).
+    required: false
+    default: ''
+  r2-endpoint:
+    description: R2 S3 endpoint URL (required when upload is true).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install ffmpeg + CJK fonts + puppeteer-core
+      shell: bash
+      run: |
+        sudo apt-get update
+        # ffmpeg encodes the clips; the Noto CJK + emoji fonts give headless
+        # Chrome a real CJK/emoji fallback so templates that rely on system
+        # fonts for 中文/日本語/한국어 (or load Noto SC from Google Fonts but
+        # race) render glyphs instead of missing-glyph tofu boxes.
+        sudo apt-get install -y ffmpeg fonts-noto-cjk fonts-noto-color-emoji
+        # npm chokes on the workspace:* root manifest; use pnpm to drop
+        # puppeteer-core into the workspace node_modules (CI-only, not committed).
+        pnpm add -w puppeteer-core
+
+    - name: Build daemon + tools
+      shell: bash
+      run: |
+        pnpm --filter "./packages/**" build
+        pnpm --filter @open-design/daemon build
+        pnpm --filter @open-design/tools-dev build
+
+    - name: Start daemon
+      shell: bash
+      run: |
+        pnpm tools-dev start daemon --namespace ci --daemon-port 17470
+        for _ in $(seq 1 60); do
+          if curl -sf -o /dev/null http://127.0.0.1:17470/api/plugins; then
+            echo "daemon ready"; exit 0
+          fi
+          sleep 2
+        done
+        echo "daemon did not become ready" >&2; exit 1
+
+    - name: Bake (content-hash skip reuses unchanged plugins)
+      shell: bash
+      env:
+        BASE_URL: http://127.0.0.1:17470
+        # The CI clips live on R2, not on disk, so trust the manifest hash.
+        PREVIEW_REMOTE: '1'
+      run: |
+        CHROME="$(which google-chrome || which google-chrome-stable || which chromium-browser)"
+        export CHROME
+        echo "resolved CHROME=$CHROME"
+        mkdir -p .tmp/plugin-previews
+        # Seed with the committed manifest so the hash skip can reuse entries.
+        cp data/plugin-previews/manifest.json .tmp/plugin-previews/manifest.json
+        node scripts/bake-plugin-previews.mjs --out .tmp/plugin-previews
+
+    - name: Upload clips to R2
+      if: ${{ inputs.upload == 'true' }}
+      shell: bash
+      # Publishes to the repository-assets R2 bucket; the deployed daemon must
+      # set OD_PLUGIN_PREVIEWS_BASE_URL to
+      # https://repo-assets.open-design.ai/plugin-previews so its bakedPreview
+      # URLs point here (CLOUDFLARE_R2_REPOSITORY_ASSETS_PUBLIC_ORIGIN).
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.r2-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.r2-secret-access-key }}
+        AWS_DEFAULT_REGION: auto
+        AWS_EC2_METADATA_DISABLED: 'true'
+        R2_BUCKET: ${{ inputs.r2-bucket }}
+        R2_ENDPOINT: ${{ inputs.r2-endpoint }}
+      run: |
+        endpoint="${R2_ENDPOINT%/}"
+        # cp (not sync --delete) so untouched clips already on R2 stay put.
+        # Keys are content-addressed (<id>/<fingerprint>/preview.mp4), so the
+        # clips are immutable — let the CDN cache them forever (a content change
+        # ships a new directory). Garbage collection is a separate scheduled job.
+        aws s3 cp .tmp/plugin-previews "s3://$R2_BUCKET/plugin-previews/" \
+          --recursive --no-progress \
+          --endpoint-url "$endpoint" \
+          --cache-control "public, max-age=31536000, immutable" \
+          --exclude manifest.json
+
+    - name: Stop daemon
+      if: always()
+      shell: bash
+      run: pnpm tools-dev stop --namespace ci || true

--- a/.github/workflows/bake-plugin-previews-gc.yml
+++ b/.github/workflows/bake-plugin-previews-gc.yml
@@ -1,0 +1,66 @@
+name: bake-plugin-previews-gc
+
+# Weekly garbage collection of orphaned plugin-preview clips on R2 (spec slice
+# 4b). Preview clips are immutable + content-addressed, so the bucket only grows;
+# this prunes clips that NO live build references. The protected set is the union
+# of object keys named by every git tag's manifest, every live release/** branch
+# HEAD, and the current main manifest — so a clip a shipped/old client still
+# points at is never deleted (see scripts/plugin-previews-gc.mjs).
+#
+# Ships in DRY-RUN: it only reports what it would delete. Arming real deletion
+# needs BOTH the `delete` input AND the GC_ENABLE_DELETE env below — flip them
+# only after eyeballing a few dry-run deletion lists.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      delete:
+        description: Actually delete orphans (default: dry-run report only).
+        type: boolean
+        default: false
+      grace-days:
+        description: Minimum age (days) before an orphan may be deleted.
+        type: string
+        default: '90'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bake-plugin-previews-gc
+  cancel-in-progress: false
+
+jobs:
+  gc:
+    name: GC orphaned preview clips
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0 # need all tags + refs to build the protected set
+
+      - name: Fetch release branches + tags
+        run: |
+          git fetch --tags --force origin '+refs/heads/release/*:refs/remotes/origin/release/*' || true
+          git fetch origin main:refs/remotes/origin/main || true
+
+      - name: Garbage-collect (dry-run unless armed)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_AK }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_SK }}
+          AWS_DEFAULT_REGION: auto
+          AWS_EC2_METADATA_DISABLED: 'true'
+          R2_BUCKET: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_BUCKET }}
+          R2_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_URL }}
+          # Second arming switch. Leave unset/empty to keep deletions disabled even
+          # if someone passes --delete; set to '1' here only when ready to prune.
+          GC_ENABLE_DELETE: ''
+        run: |
+          GRACE="${{ github.event.inputs.grace-days || '90' }}"
+          DELETE_FLAG=""
+          if [ "${{ github.event.inputs.delete }}" = "true" ]; then DELETE_FLAG="--delete"; fi
+          node scripts/plugin-previews-gc.mjs --grace-days "$GRACE" $DELETE_FLAG

--- a/.github/workflows/bake-plugin-previews-gc.yml
+++ b/.github/workflows/bake-plugin-previews-gc.yml
@@ -17,11 +17,11 @@ on:
   workflow_dispatch:
     inputs:
       delete:
-        description: Actually delete orphans (default: dry-run report only).
+        description: 'Actually delete orphans (default: dry-run report only).'
         type: boolean
         default: false
       grace-days:
-        description: Minimum age (days) before an orphan may be deleted.
+        description: Minimum age in days before an orphan may be deleted.
         type: string
         default: '90'
 
@@ -59,8 +59,12 @@ jobs:
           # Second arming switch. Leave unset/empty to keep deletions disabled even
           # if someone passes --delete; set to '1' here only when ready to prune.
           GC_ENABLE_DELETE: ''
+          # Dispatch inputs via env (never interpolated into the script body) to
+          # avoid script injection.
+          GC_DELETE: ${{ github.event.inputs.delete }}
+          GC_GRACE_DAYS: ${{ github.event.inputs.grace-days }}
         run: |
-          GRACE="${{ github.event.inputs.grace-days || '90' }}"
+          GRACE="${GC_GRACE_DAYS:-90}"
           DELETE_FLAG=""
-          if [ "${{ github.event.inputs.delete }}" = "true" ]; then DELETE_FLAG="--delete"; fi
+          if [ "$GC_DELETE" = "true" ]; then DELETE_FLAG="--delete"; fi
           node scripts/plugin-previews-gc.mjs --grace-days "$GRACE" $DELETE_FLAG

--- a/.github/workflows/bake-plugin-previews-gc.yml
+++ b/.github/workflows/bake-plugin-previews-gc.yml
@@ -43,10 +43,14 @@ jobs:
         with:
           fetch-depth: 0 # need all tags + refs to build the protected set
 
-      - name: Fetch release branches + tags
+      - name: Fetch release branches + tags (fail closed)
+        # No `|| true`: these refs define the protected set. If we cannot fetch
+        # them, fail the job rather than GC from partial ref data — once deletion
+        # is armed, an incomplete protected set could prune clips a live release
+        # or main manifest still references.
         run: |
-          git fetch --tags --force origin '+refs/heads/release/*:refs/remotes/origin/release/*' || true
-          git fetch origin main:refs/remotes/origin/main || true
+          git fetch --tags --force origin '+refs/heads/release/*:refs/remotes/origin/release/*'
+          git fetch origin main:refs/remotes/origin/main
 
       - name: Garbage-collect (dry-run unless armed)
         env:

--- a/.github/workflows/bake-plugin-previews-pr.yml
+++ b/.github/workflows/bake-plugin-previews-pr.yml
@@ -1,0 +1,93 @@
+name: bake-plugin-previews-pr
+
+# Pre-merge bake for SAME-REPO pull requests (spec slice 2 — the coupling fix).
+# When an internal PR changes a plugin's preview source (or the bake recipe),
+# re-render the affected previews, publish the immutable clips to R2, and commit
+# the manifest update INTO THE AUTHOR'S BRANCH, so the manifest change rides with
+# the code change in the same PR and reverts atomically — instead of arriving
+# later as a detached bot PR.
+#
+# Forks are intentionally excluded: a `pull_request` from a fork has no secrets,
+# so fork manifests are refreshed post-merge by bake-plugin-previews.yml.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'plugins/_official/**'
+      - 'scripts/bake-plugin-previews.mjs'
+
+permissions:
+  contents: write # push the manifest commit back to the PR head branch
+
+concurrency:
+  group: bake-plugin-previews-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bake:
+    name: Bake plugin previews (pre-merge)
+    # Same-repo only — a fork PR cannot safely receive the R2/push secrets.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          # Token that can push back to the PR branch. PREVIEW_BAKE_TOKEN (PAT/
+          # app) also lets the pushed commit re-trigger CI; GITHUB_TOKEN can push
+          # but its commits do not start new runs.
+          token: ${{ secrets.PREVIEW_BAKE_TOKEN || github.token }}
+
+      - name: Loop guard — skip the bake bot's own manifest commit
+        id: guard
+        # A `pull_request` path filter evaluates the PR's CUMULATIVE diff, so the
+        # original plugin change keeps this workflow path-eligible even after our
+        # commit only touches data/plugin-previews/**. Without a guard the manifest
+        # commit re-triggers another bake (and loops). Note: head.user.login is the
+        # head-repo OWNER, not the commit author, so check the actual head commit
+        # author email instead.
+        run: |
+          AUTHOR="$(git log -1 --format='%ae' "${{ github.event.pull_request.head.sha }}")"
+          echo "head commit author: $AUTHOR"
+          if [ "$AUTHOR" = "bot@open-design.ai" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "head commit is the bake bot's manifest commit — skipping to break the loop"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup workspace
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/setup-workspace
+
+      - name: Render previews + publish clips to R2
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/bake-previews
+        with:
+          upload: 'true'
+          r2-access-key-id: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_AK }}
+          r2-secret-access-key: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_SK }}
+          r2-bucket: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_BUCKET }}
+          r2-endpoint: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_URL }}
+
+      - name: Commit refreshed manifest into the PR branch
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        # No-op `previews`-diff guard: an identical re-bake commits nothing, so a
+        # synchronize that only re-renders the same content does not loop.
+        run: |
+          OLD=data/plugin-previews/manifest.json
+          NEW=.tmp/plugin-previews/manifest.json
+          if [ "$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")" != "changed" ]; then
+            echo "previews unchanged — nothing to commit"
+            exit 0
+          fi
+          cp "$NEW" "$OLD"
+          git config user.name "open-design-bot"
+          git config user.email "bot@open-design.ai"
+          git add "$OLD"
+          git commit -m "chore(plugin-previews): refresh baked preview manifest"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/bake-plugin-previews-pr.yml
+++ b/.github/workflows/bake-plugin-previews-pr.yml
@@ -49,9 +49,12 @@ jobs:
         # commit only touches data/plugin-previews/**. Without a guard the manifest
         # commit re-triggers another bake (and loops). Note: head.user.login is the
         # head-repo OWNER, not the commit author, so check the actual head commit
-        # author email instead.
+        # author email instead. The head SHA goes through env (never interpolated
+        # into the script body) to avoid script injection.
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          AUTHOR="$(git log -1 --format='%ae' "${{ github.event.pull_request.head.sha }}")"
+          AUTHOR="$(git log -1 --format='%ae' "$HEAD_SHA")"
           echo "head commit author: $AUTHOR"
           if [ "$AUTHOR" = "bot@open-design.ai" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -77,7 +80,11 @@ jobs:
       - name: Commit refreshed manifest into the PR branch
         if: ${{ steps.guard.outputs.skip != 'true' }}
         # No-op `previews`-diff guard: an identical re-bake commits nothing, so a
-        # synchronize that only re-renders the same content does not loop.
+        # synchronize that only re-renders the same content does not loop. The PR
+        # head ref goes through env (not interpolated into the script) to avoid
+        # script injection.
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           OLD=data/plugin-previews/manifest.json
           NEW=.tmp/plugin-previews/manifest.json
@@ -94,4 +101,4 @@ jobs:
           git config user.email "bot@open-design.ai"
           git add "$OLD"
           git commit -m "chore(plugin-previews): refresh baked preview manifest"
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/bake-plugin-previews-pr.yml
+++ b/.github/workflows/bake-plugin-previews-pr.yml
@@ -81,10 +81,14 @@ jobs:
         run: |
           OLD=data/plugin-previews/manifest.json
           NEW=.tmp/plugin-previews/manifest.json
-          if [ "$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")" != "changed" ]; then
-            echo "previews unchanged — nothing to commit"
-            exit 0
-          fi
+          # Capture on its own line so `set -e` surfaces a helper error (exit 2)
+          # rather than command substitution swallowing it into the test.
+          diff_result="$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")"
+          case "$diff_result" in
+            changed) ;;
+            unchanged) echo "previews unchanged — nothing to commit"; exit 0 ;;
+            *) echo "unexpected diff result: '$diff_result'" >&2; exit 1 ;;
+          esac
           cp "$NEW" "$OLD"
           git config user.name "open-design-bot"
           git config user.email "bot@open-design.ai"

--- a/.github/workflows/bake-plugin-previews-release.yml
+++ b/.github/workflows/bake-plugin-previews-release.yml
@@ -1,0 +1,82 @@
+name: bake-plugin-previews-release
+
+# Release-cut full bake (spec slice 3). On a push to a release/** branch, render
+# every preview (hash-skip reuses unchanged), publish the immutable clips to R2,
+# and commit the authoritative manifest snapshot onto the release branch. The
+# manifest then flows to main via the normal non-squash release back-merge.
+#
+# Bumping BAKE_VERSION at release time is the explicit lever to refresh shared-
+# input changes (fonts / web CSS / design systems / renderer) that per-file
+# triggers cannot detect — a full sweep alone would reuse, not re-render, them.
+
+on:
+  push:
+    branches: ['release/**']
+    paths-ignore:
+      - 'data/plugin-previews/**' # our own manifest commit must not re-trigger
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # commit the authoritative manifest onto the release branch
+
+concurrency:
+  group: bake-plugin-previews-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bake:
+    name: Bake plugin previews (release cut)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.PREVIEW_BAKE_TOKEN || github.token }}
+
+      - name: Loop guard — skip the bake bot's own manifest commit
+        id: guard
+        # Belt-and-suspenders with paths-ignore above: also skip when the head
+        # commit was authored by the bake bot, so the manifest writeback cannot
+        # re-trigger this workflow.
+        run: |
+          AUTHOR="$(git log -1 --format='%ae')"
+          echo "head commit author: $AUTHOR"
+          if [ "$AUTHOR" = "bot@open-design.ai" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "head commit is the bake bot's manifest commit — skipping to break the loop"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup workspace
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/setup-workspace
+
+      - name: Render previews + publish clips to R2
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/bake-previews
+        with:
+          upload: 'true'
+          r2-access-key-id: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_AK }}
+          r2-secret-access-key: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_SK }}
+          r2-bucket: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_BUCKET }}
+          r2-endpoint: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_URL }}
+
+      - name: Commit the authoritative manifest onto the release branch
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        run: |
+          OLD=data/plugin-previews/manifest.json
+          NEW=.tmp/plugin-previews/manifest.json
+          if [ "$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")" != "changed" ]; then
+            echo "previews unchanged — nothing to commit"
+            exit 0
+          fi
+          cp "$NEW" "$OLD"
+          git config user.name "open-design-bot"
+          git config user.email "bot@open-design.ai"
+          git add "$OLD"
+          git commit -m "chore(plugin-previews): refresh baked preview manifest (release cut)"
+          git push origin "HEAD:${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/bake-plugin-previews-release.yml
+++ b/.github/workflows/bake-plugin-previews-release.yml
@@ -26,6 +26,12 @@ concurrency:
 jobs:
   bake:
     name: Bake plugin previews (release cut)
+    # `push` is already limited to release/**, but `workflow_dispatch` can be run
+    # from any ref. The commit step pushes the authoritative manifest to the
+    # triggering ref with contents:write, so a dispatch on `main` would write
+    # straight to main and bypass the release back-merge/review path. Hard-gate
+    # the whole job to release branches.
+    if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:

--- a/.github/workflows/bake-plugin-previews-release.yml
+++ b/.github/workflows/bake-plugin-previews-release.yml
@@ -70,10 +70,14 @@ jobs:
         run: |
           OLD=data/plugin-previews/manifest.json
           NEW=.tmp/plugin-previews/manifest.json
-          if [ "$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")" != "changed" ]; then
-            echo "previews unchanged — nothing to commit"
-            exit 0
-          fi
+          # Capture on its own line so `set -e` surfaces a helper error (exit 2)
+          # rather than command substitution swallowing it into the test.
+          diff_result="$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")"
+          case "$diff_result" in
+            changed) ;;
+            unchanged) echo "previews unchanged — nothing to commit"; exit 0 ;;
+            *) echo "unexpected diff result: '$diff_result'" >&2; exit 1 ;;
+          esac
           cp "$NEW" "$OLD"
           git config user.name "open-design-bot"
           git config user.email "bot@open-design.ai"

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -1,11 +1,19 @@
 name: bake-plugin-previews
 
-# Pre-render the home gallery's plugin previews to small H.264 clips + posters.
-# We bake ALL plugins every run; the script's content-hash skip (manifest hash +
-# BAKE_VERSION) makes that cheap — only plugins whose page actually changed are
-# re-rendered and re-uploaded. Runs post-merge (so fork contributions are covered
-# with full secrets) and nightly as a self-healing sweep. Until a plugin is baked
-# the gallery falls back to its live example.html iframe, so there is no gap.
+# Post-merge + nightly bake of the home gallery's plugin previews.
+#
+# Role after the pipeline rework (specs/change/20260618-plugin-preview-bake-
+# pipeline/spec.md): this workflow is the UPLOADER + FORK PATH + nightly
+# BACKSTOP, no longer the primary way a manifest lands.
+#   - Internal (same-repo) plugin changes refresh their own preview inside the
+#     author's PR via bake-plugin-previews-pr.yml, so by merge time the manifest
+#     is usually already current and this run only ensures the clips are on R2.
+#   - Fork contributions cannot bake in-PR (no secrets), so their manifest is
+#     refreshed here, post-merge.
+#   - Nightly re-runs catch transient bake failures and BAKE_VERSION bumps.
+# When it does need to land a manifest, it opens ONE rolling review PR (it cannot
+# push to protected main directly). Until a plugin is baked the gallery falls
+# back to its live example.html iframe, so there is no gap.
 
 on:
   push:
@@ -18,7 +26,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write # push the manifest branch
+  contents: write # push the rolling manifest branch
   pull-requests: write # open the review PR (gh pr create needs this; unset perms default to none)
 
 concurrency:
@@ -37,72 +45,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
 
-      - name: Install ffmpeg + CJK fonts + puppeteer-core
-        run: |
-          sudo apt-get update
-          # ffmpeg encodes the clips; the Noto CJK + emoji fonts give headless
-          # Chrome a real CJK/emoji fallback so templates that rely on system
-          # fonts for 中文/日本語/한국어 (or load Noto SC from Google Fonts but
-          # race) render glyphs instead of missing-glyph tofu boxes.
-          sudo apt-get install -y ffmpeg fonts-noto-cjk fonts-noto-color-emoji
-          # npm chokes on the workspace:* root manifest; use pnpm to drop
-          # puppeteer-core into the workspace node_modules (CI-only, not committed).
-          pnpm add -w puppeteer-core
-
-      - name: Build daemon + tools
-        run: |
-          pnpm --filter "./packages/**" build
-          pnpm --filter @open-design/daemon build
-          pnpm --filter @open-design/tools-dev build
-
-      - name: Start daemon
-        run: |
-          pnpm tools-dev start daemon --namespace ci --daemon-port 17470
-          for _ in $(seq 1 60); do
-            if curl -sf -o /dev/null http://127.0.0.1:17470/api/plugins; then
-              echo "daemon ready"; exit 0
-            fi
-            sleep 2
-          done
-          echo "daemon did not become ready" >&2; exit 1
-
-      - name: Bake (content-hash skip reuses unchanged plugins)
-        env:
-          BASE_URL: http://127.0.0.1:17470
-          # The CI clips live on R2, not on disk, so trust the manifest hash.
-          PREVIEW_REMOTE: '1'
-        run: |
-          CHROME="$(which google-chrome || which google-chrome-stable || which chromium-browser)"
-          export CHROME
-          echo "resolved CHROME=$CHROME"
-          mkdir -p .tmp/plugin-previews
-          # Seed with the committed manifest so the hash skip can reuse entries.
-          cp data/plugin-previews/manifest.json .tmp/plugin-previews/manifest.json
-          node scripts/bake-plugin-previews.mjs --out .tmp/plugin-previews
-
-      - name: Upload clips to R2
-        if: ${{ github.ref == 'refs/heads/main' }} # only publish from main
-        # Publishes to the repository-assets R2 bucket; the deployed daemon must
-        # set OD_PLUGIN_PREVIEWS_BASE_URL to
-        # https://repo-assets.open-design.ai/plugin-previews so its bakedPreview
-        # URLs point here (CLOUDFLARE_R2_REPOSITORY_ASSETS_PUBLIC_ORIGIN).
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_AK }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_SK }}
-          AWS_DEFAULT_REGION: auto
-          AWS_EC2_METADATA_DISABLED: 'true'
-          R2_BUCKET: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_BUCKET }}
-          R2_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_URL }}
-        run: |
-          endpoint="${R2_ENDPOINT%/}"
-          # cp (not sync --delete) so untouched clips already on R2 stay put.
-          # Filenames are content-hashed, so the clips are immutable — let the
-          # CDN cache them forever (a content change ships a new filename).
-          aws s3 cp .tmp/plugin-previews "s3://$R2_BUCKET/plugin-previews/" \
-            --recursive --no-progress \
-            --endpoint-url "$endpoint" \
-            --cache-control "public, max-age=31536000, immutable" \
-            --exclude manifest.json
+      - name: Render previews + publish clips to R2 (main only)
+        uses: ./.github/actions/bake-previews
+        with:
+          upload: ${{ github.ref == 'refs/heads/main' }}
+          r2-access-key-id: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_AK }}
+          r2-secret-access-key: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_SK }}
+          r2-bucket: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_BUCKET }}
+          r2-endpoint: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_URL }}
 
       - name: Open or update the rolling manifest PR for review
         if: ${{ github.ref == 'refs/heads/main' }} # branch debug runs skip publishing
@@ -110,8 +60,7 @@ jobs:
         # with the build), so it must land on main through a reviewed PR rather
         # than a direct push to protected main.
         #
-        # Two guards keep this quiet and tidy (see specs/change/
-        # 20260618-plugin-preview-bake-pipeline/spec.md, slice 1):
+        # Two guards keep this quiet and tidy (spec slice 1):
         #   1. Open a PR only when a `previews` entry actually changed. The
         #      manifest's `generatedAt` timestamp moves every run, so the old
         #      whole-file `git diff` opened a noise PR every time (e.g. #4261).
@@ -120,7 +69,7 @@ jobs:
         #   2. Use ONE rolling branch (`chore/plugin-previews`) and force-update
         #      the existing open PR in place, instead of stacking a fresh
         #      `chore/plugin-previews-<run_id>` branch + PR per run (which built
-        #      the 6-deep backlog this slice removes).
+        #      the backlog this rework removes).
         #
         # NOTE: a GITHUB_TOKEN-authored PR does not trigger pull_request CI; set a
         # PAT/app token secret PREVIEW_BAKE_TOKEN so the PR runs checks + can be
@@ -155,7 +104,3 @@ jobs:
               --reviewer lefarcen \
               --body "Automated by the bake-plugin-previews workflow: preview clips were re-rendered and uploaded to R2; this updates data/plugin-previews/manifest.json to match (the clips live on R2 and are not committed). This is a single **rolling** PR — each bake force-updates it in place rather than stacking a new PR per run. @lefarcen please review and merge."
           fi
-
-      - name: Stop daemon
-        if: always()
-        run: pnpm tools-dev stop --namespace ci || true

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -104,12 +104,23 @@ jobs:
             --cache-control "public, max-age=31536000, immutable" \
             --exclude manifest.json
 
-      - name: Open manifest PR for review
+      - name: Open or update the rolling manifest PR for review
         if: ${{ github.ref == 'refs/heads/main' }} # branch debug runs skip publishing
         # The clips are already on R2; the manifest is version-pinned (it ships
         # with the build), so it must land on main through a reviewed PR rather
-        # than a direct push to protected main. Fires only when a plugin actually
-        # changed (hash skip + diff guard), so this is quiet in steady state.
+        # than a direct push to protected main.
+        #
+        # Two guards keep this quiet and tidy (see specs/change/
+        # 20260618-plugin-preview-bake-pipeline/spec.md, slice 1):
+        #   1. Open a PR only when a `previews` entry actually changed. The
+        #      manifest's `generatedAt` timestamp moves every run, so the old
+        #      whole-file `git diff` opened a noise PR every time (e.g. #4261).
+        #      scripts/plugin-previews-diff.mjs compares only the `previews`
+        #      subtree.
+        #   2. Use ONE rolling branch (`chore/plugin-previews`) and force-update
+        #      the existing open PR in place, instead of stacking a fresh
+        #      `chore/plugin-previews-<run_id>` branch + PR per run (which built
+        #      the 6-deep backlog this slice removes).
         #
         # NOTE: a GITHUB_TOKEN-authored PR does not trigger pull_request CI; set a
         # PAT/app token secret PREVIEW_BAKE_TOKEN so the PR runs checks + can be
@@ -117,21 +128,33 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PREVIEW_BAKE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          cp .tmp/plugin-previews/manifest.json data/plugin-previews/manifest.json
-          if git diff --quiet -- data/plugin-previews/manifest.json; then
-            echo "manifest unchanged — nothing to review"; exit 0
+          OLD=data/plugin-previews/manifest.json
+          NEW=.tmp/plugin-previews/manifest.json
+          if [ "$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")" != "changed" ]; then
+            echo "previews unchanged (only generatedAt moved) — nothing to review"
+            exit 0
           fi
-          BRANCH="chore/plugin-previews-${{ github.run_id }}"
+          cp "$NEW" "$OLD"
+          BRANCH="chore/plugin-previews"
           git config user.name "open-design-bot"
           git config user.email "bot@open-design.ai"
-          git checkout -b "$BRANCH"
-          git add data/plugin-previews/manifest.json
+          # Rebuild the rolling branch from the current main HEAD + this manifest,
+          # so it always carries exactly the freshest manifest on top of main.
+          git checkout -B "$BRANCH"
+          git add "$OLD"
           git commit -m "chore(plugin-previews): refresh baked preview manifest"
-          git push origin "$BRANCH"
-          gh pr create --base main --head "$BRANCH" \
-            --title "chore(plugin-previews): refresh baked preview manifest" \
-            --reviewer lefarcen \
-            --body "Automated by the bake-plugin-previews workflow: preview clips were re-rendered and uploaded to R2; this updates data/plugin-previews/manifest.json to match (the clips live on R2 and are not committed). @lefarcen please review and merge."
+          # Bot-owned branch; force-push is safe (nobody else writes it).
+          git push --force origin "$BRANCH"
+          # Reuse the existing open PR (force-push already refreshed it); only
+          # create one if none is open.
+          if [ "$(gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null)" = "OPEN" ]; then
+            echo "rolling PR already open for $BRANCH — force-push refreshed it in place"
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore(plugin-previews): refresh baked preview manifest" \
+              --reviewer lefarcen \
+              --body "Automated by the bake-plugin-previews workflow: preview clips were re-rendered and uploaded to R2; this updates data/plugin-previews/manifest.json to match (the clips live on R2 and are not committed). This is a single **rolling** PR — each bake force-updates it in place rather than stacking a new PR per run. @lefarcen please review and merge."
+          fi
 
       - name: Stop daemon
         if: always()

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -79,10 +79,15 @@ jobs:
         run: |
           OLD=data/plugin-previews/manifest.json
           NEW=.tmp/plugin-previews/manifest.json
-          if [ "$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")" != "changed" ]; then
-            echo "previews unchanged (only generatedAt moved) — nothing to review"
-            exit 0
-          fi
+          # Capture on its own line so `set -e` surfaces a helper error (the diff
+          # script exits 2 on bad args / unreadable manifest) instead of command
+          # substitution swallowing it into the test and silently skipping the PR.
+          diff_result="$(node scripts/plugin-previews-diff.mjs "$OLD" "$NEW")"
+          case "$diff_result" in
+            changed) ;;
+            unchanged) echo "previews unchanged (only generatedAt moved) — nothing to review"; exit 0 ;;
+            *) echo "unexpected diff result: '$diff_result'" >&2; exit 1 ;;
+          esac
           cp "$NEW" "$OLD"
           BRANCH="chore/plugin-previews"
           git config user.name "open-design-bot"

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -424,13 +424,22 @@ async function bakeOne(browser, id, hash, motion) {
   const listPath = path.join(frameDir, 'list.txt');
   writeFileSync(listPath, lines.join('\n'));
 
-  // Content-hashed filenames so a re-bake publishes a NEW URL the daemon points
-  // at via the manifest, instead of overwriting the same key — which the CDN
-  // edge would keep serving stale until its TTL expired. New name => new cache
-  // entry => safe to cache immutably forever.
-  const slug = hash ? `${id}.${hash}` : id;
-  const video = path.join(OUT, `${slug}.mp4`);
-  const poster = path.join(OUT, `${slug}.poster.jpg`);
+  // Directory-layered, content-addressed keys: `<id>/<fingerprint>/preview.mp4`
+  // (+ `poster.jpg`). Immutable — a content change yields a NEW `<fingerprint>`
+  // directory (hence a new URL the CDN can cache forever), while a re-bake of the
+  // same source resolves to the same keys. The manifest stores these
+  // PREFIX-RELATIVE keys; it must NOT repeat the `plugin-previews/` segment that
+  // the base URL already carries, or `${base}/${key}` would double it and 404
+  // (see specs/change/20260618-plugin-preview-bake-pipeline/spec.md §0). The
+  // daemon resolves both `${base}/${key}` and `path.join(dir, key)`, which handle
+  // the nested path transparently — no consumer change needed. Existing flat
+  // `<id>.<hash>.mp4` entries are left untouched on reuse (additive migration).
+  const dirKey = hash ? `${id}/${hash}` : id;
+  const videoKey = `${dirKey}/preview.mp4`;
+  const posterKey = `${dirKey}/poster.jpg`;
+  const video = path.join(OUT, videoKey);
+  const poster = path.join(OUT, posterKey);
+  mkdirSync(path.dirname(video), { recursive: true });
   const ff = (a) => execFileSync('ffmpeg', ['-y', ...a], { stdio: 'ignore' });
   // H.264 MP4, constant frame rate (the fps filter resamples the concat's
   // real-time timeline to a constant FPS). H.264 decodes reliably in both
@@ -444,7 +453,7 @@ async function bakeOne(browser, id, hash, motion) {
     '-q:v', '5', '-frames:v', '1', poster]);
   rmSync(frameDir, { recursive: true, force: true });
 
-  return { id, durationMs: durMs, holdMs: HOLD_MS, video: `${slug}.mp4`, poster: `${slug}.poster.jpg`,
+  return { id, durationMs: durMs, holdMs: HOLD_MS, video: videoKey, poster: posterKey,
     bytes: statSync(video).size, posterBytes: statSync(poster).size };
 }
 

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -94,6 +94,11 @@ const residualAllowedExactPaths = new Set([
   // runtime deps (puppeteer-core + a headless Chrome + ffmpeg) are provided by
   // the CI environment and never pulled into the daemon/web TS build or bundle.
   "scripts/bake-plugin-previews.mjs",
+  // Manifest diff guard + its node:test coverage. Run directly by Node from the
+  // bake workflows (no TS build step there) to decide whether a `previews` entry
+  // actually changed, ignoring the per-run `generatedAt` timestamp.
+  "scripts/plugin-previews-diff.mjs",
+  "scripts/plugin-previews-diff.test.mjs",
   "scripts/scaffold-html-ppt-skills.mjs",
   "scripts/sync-hyperframes-skill.mjs",
   "scripts/verify-media-models.mjs",

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -99,6 +99,9 @@ const residualAllowedExactPaths = new Set([
   // actually changed, ignoring the per-run `generatedAt` timestamp.
   "scripts/plugin-previews-diff.mjs",
   "scripts/plugin-previews-diff.test.mjs",
+  // CI-only R2 garbage collector for orphaned preview clips + its node:test.
+  "scripts/plugin-previews-gc.mjs",
+  "scripts/plugin-previews-gc.test.mjs",
   "scripts/scaffold-html-ppt-skills.mjs",
   "scripts/sync-hyperframes-skill.mjs",
   "scripts/verify-media-models.mjs",

--- a/scripts/plugin-previews-diff.mjs
+++ b/scripts/plugin-previews-diff.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Decide whether two plugin-preview manifests differ in a way that matters —
+// i.e. whether their `previews` subtree changed.
+//
+// The manifest also carries a `generatedAt` timestamp that moves on EVERY bake
+// run. Comparing the whole file (as the workflow's old `git diff --quiet` did)
+// therefore always reports a change and opens a noise review PR even when no
+// clip actually changed — this is what produced timestamp-only PRs like #4261
+// and the stacked backlog. The bake workflows use this helper to open/update a
+// review PR only when a real preview entry changed.
+//
+// CLI:
+//   node scripts/plugin-previews-diff.mjs <oldManifest.json> <newManifest.json>
+//   → prints "changed" or "unchanged" to stdout; exit 0 on success, 2 on error.
+//   A missing/unreadable OLD manifest is treated as "no previews yet", so any
+//   entry in NEW counts as a change.
+
+import { readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Stable, key-order-independent serialization of a JSON value, so reordering the
+// keys inside a preview entry is not mistaken for a content change.
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+// True when the `previews` subtree differs between the two manifests, ignoring
+// `generatedAt` and any other top-level metadata.
+export function previewsChanged(oldManifest, newManifest) {
+  const oldPreviews = (oldManifest && oldManifest.previews) || {};
+  const newPreviews = (newManifest && newManifest.previews) || {};
+  return canonical(oldPreviews) !== canonical(newPreviews);
+}
+
+function readJsonOrEmpty(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+// CLI entry — only when this file is the process entrypoint, not when a test
+// imports `previewsChanged`.
+const invokedDirectly =
+  process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const [oldPath, newPath] = process.argv.slice(2);
+  if (!oldPath || !newPath) {
+    console.error('usage: plugin-previews-diff.mjs <oldManifest.json> <newManifest.json>');
+    process.exit(2);
+  }
+  let newManifest;
+  try {
+    newManifest = JSON.parse(readFileSync(newPath, 'utf8'));
+  } catch (e) {
+    console.error(`failed to read new manifest ${newPath}: ${e.message}`);
+    process.exit(2);
+  }
+  const oldManifest = readJsonOrEmpty(oldPath);
+  process.stdout.write(previewsChanged(oldManifest, newManifest) ? 'changed\n' : 'unchanged\n');
+}

--- a/scripts/plugin-previews-diff.test.mjs
+++ b/scripts/plugin-previews-diff.test.mjs
@@ -1,0 +1,33 @@
+// Unit coverage for the plugin-preview manifest diff guard. Run with:
+//   node --test scripts/plugin-previews-diff.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { previewsChanged } from './plugin-previews-diff.mjs';
+
+test('timestamp-only delta is NOT a change (the #4261 noise case)', () => {
+  const a = { generatedAt: '2026-01-01T00:00:00Z', previews: { x: { hash: 'h1' } } };
+  const b = { generatedAt: '2026-02-02T00:00:00Z', previews: { x: { hash: 'h1' } } };
+  assert.equal(previewsChanged(a, b), false);
+});
+
+test('a changed previews entry IS a change', () => {
+  const a = { generatedAt: 't', previews: { x: { hash: 'h1' } } };
+  const b = { generatedAt: 't', previews: { x: { hash: 'h2' } } };
+  assert.equal(previewsChanged(a, b), true);
+});
+
+test('an added or removed entry IS a change', () => {
+  assert.equal(previewsChanged({ previews: {} }, { previews: { y: { hash: 'h' } } }), true);
+  assert.equal(previewsChanged({ previews: { y: { hash: 'h' } } }, { previews: {} }), true);
+});
+
+test('reordering keys within an entry is NOT a change', () => {
+  const a = { previews: { x: { hash: 'h', video: 'v', poster: 'p' } } };
+  const b = { previews: { x: { poster: 'p', video: 'v', hash: 'h' } } };
+  assert.equal(previewsChanged(a, b), false);
+});
+
+test('a missing/empty old manifest makes any new entry a change', () => {
+  assert.equal(previewsChanged({}, { previews: { y: { hash: 'h' } } }), true);
+  assert.equal(previewsChanged({}, { previews: {} }), false);
+});

--- a/scripts/plugin-previews-gc.mjs
+++ b/scripts/plugin-previews-gc.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// Garbage-collect orphaned plugin-preview clips from the repository-assets R2
+// bucket (spec slice 4b). Preview clips are immutable and content-addressed, so
+// the bucket only ever grows: a content change ships a NEW <id>/<fingerprint>/
+// directory and the old one is left behind. This job deletes the leftovers —
+// but ONLY ones no live build still references.
+//
+// Source of truth = the object keys named by every PROTECTED manifest, NOT
+// filename parsing. A clip stays protected while ANY of these reference it:
+//   - any git tag's manifest          (shipped stable/preview releases)
+//   - any live release/** branch HEAD  (feeds the non-tagged nightly + preview)
+//   - the current main manifest        (beta / staging / the next build)
+// Anything outside that set AND older than a grace window is an orphan.
+//
+// SAFETY: dry-run by default — it prints what it WOULD delete and deletes
+// nothing. Real deletion requires BOTH `--delete` and GC_ENABLE_DELETE=1, so the
+// scheduled workflow can run in report-only mode for a while before anyone arms
+// it. Deletions are also recoverable: re-running the bake at a clip's source
+// state regenerates the identical <id>/<fingerprint>/ keys.
+//
+// Usage:
+//   node scripts/plugin-previews-gc.mjs [--delete] [--grace-days N] [--prefix plugin-previews/]
+// Env (only needed for the live R2 list/delete, not for the pure unit tests):
+//   R2_BUCKET, R2_ENDPOINT, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION
+//   GC_ENABLE_DELETE=1   (second arming switch, with --delete)
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { realpathSync } from 'node:fs';
+
+const MANIFEST_PATH = 'data/plugin-previews/manifest.json';
+const DEFAULT_PREFIX = 'plugin-previews/';
+const DEFAULT_GRACE_DAYS = 90;
+
+// ---- pure helpers (unit-tested) -------------------------------------------
+
+// The prefix-relative object keys a single manifest references (video + poster
+// of every preview entry). Tolerant of partial/legacy entries.
+export function keysFromManifest(manifest) {
+  const previews = (manifest && manifest.previews) || {};
+  const keys = [];
+  for (const entry of Object.values(previews)) {
+    if (entry && typeof entry.video === 'string') keys.push(entry.video);
+    if (entry && typeof entry.poster === 'string') keys.push(entry.poster);
+  }
+  return keys;
+}
+
+// Union of referenced keys across every protected manifest.
+export function protectedKeys(manifests) {
+  const set = new Set();
+  for (const m of manifests) for (const k of keysFromManifest(m)) set.add(k);
+  return set;
+}
+
+// Orphans = listed objects whose key is not protected AND older than the grace
+// window. `objects` is [{ key, lastModifiedMs }]; `protectedSet` holds
+// prefix-relative keys; `nowMs`/`graceDays` bound the age gate.
+export function selectOrphans(objects, protectedSet, { nowMs, graceDays }) {
+  const graceMs = graceDays * 24 * 60 * 60 * 1000;
+  return objects
+    .filter((o) => !protectedSet.has(o.key))
+    .filter((o) => nowMs - o.lastModifiedMs > graceMs)
+    .map((o) => o.key);
+}
+
+// ---- IO (live run) ---------------------------------------------------------
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' });
+}
+
+// Manifest JSON at a git ref, or null when the ref has no manifest yet.
+function manifestAtRef(ref) {
+  try {
+    return JSON.parse(git(['show', `${ref}:${MANIFEST_PATH}`]));
+  } catch {
+    return null;
+  }
+}
+
+// Every ref whose manifest must protect its clips: all tags + main + each live
+// release/** branch HEAD.
+function protectedRefs() {
+  const refs = new Set(['origin/main']);
+  const tags = git(['tag']).split('\n').map((s) => s.trim()).filter(Boolean);
+  for (const t of tags) refs.add(t);
+  const branches = git(['for-each-ref', '--format=%(refname)', 'refs/remotes/origin/release'])
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((r) => r.replace('refs/remotes/', ''));
+  for (const b of branches) refs.add(b);
+  return [...refs];
+}
+
+// List the bucket's preview objects as [{ key, lastModifiedMs }] (key is
+// prefix-relative). `aws s3 ls --recursive` lines: "DATE TIME  SIZE  full/key".
+function listR2(prefix) {
+  const bucket = process.env.R2_BUCKET;
+  const endpoint = (process.env.R2_ENDPOINT || '').replace(/\/+$/, '');
+  if (!bucket || !endpoint) throw new Error('R2_BUCKET and R2_ENDPOINT are required to list R2');
+  const out = execFileSync(
+    'aws',
+    ['s3', 'ls', `s3://${bucket}/${prefix}`, '--recursive', '--endpoint-url', endpoint],
+    { encoding: 'utf8' },
+  );
+  const objects = [];
+  for (const line of out.split('\n')) {
+    const m = line.match(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})\s+\d+\s+(.+)$/);
+    if (!m) continue;
+    const fullKey = m[3];
+    if (!fullKey.startsWith(prefix)) continue;
+    const key = fullKey.slice(prefix.length);
+    if (!key || key.endsWith('/')) continue; // skip the manifest pointer / dir markers
+    if (key === 'manifest.json') continue;
+    objects.push({ key, lastModifiedMs: Date.parse(`${m[1]}T${m[2]}Z`) });
+  }
+  return objects;
+}
+
+function deleteR2(prefix, keys) {
+  const bucket = process.env.R2_BUCKET;
+  const endpoint = (process.env.R2_ENDPOINT || '').replace(/\/+$/, '');
+  for (const key of keys) {
+    execFileSync(
+      'aws',
+      ['s3', 'rm', `s3://${bucket}/${prefix}${key}`, '--endpoint-url', endpoint],
+      { stdio: 'inherit' },
+    );
+  }
+}
+
+function parseArgs(argv) {
+  const args = { delete: false, graceDays: DEFAULT_GRACE_DAYS, prefix: DEFAULT_PREFIX };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--delete') args.delete = true;
+    else if (argv[i] === '--grace-days') args.graceDays = Number(argv[(i += 1)]);
+    else if (argv[i] === '--prefix') args.prefix = argv[(i += 1)];
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const refs = protectedRefs();
+  const manifests = refs.map(manifestAtRef).filter(Boolean);
+  const protectedSet = protectedKeys(manifests);
+  console.log(`protected by ${manifests.length}/${refs.length} refs → ${protectedSet.size} live keys`);
+
+  const objects = listR2(args.prefix);
+  const orphans = selectOrphans(objects, protectedSet, { nowMs: Date.now(), graceDays: args.graceDays });
+  console.log(
+    `${objects.length} objects under ${args.prefix}; ${orphans.length} orphan(s) older than ${args.graceDays}d`,
+  );
+  for (const k of orphans) console.log(`  orphan: ${k}`);
+
+  const armed = args.delete && process.env.GC_ENABLE_DELETE === '1';
+  if (!orphans.length) return;
+  if (!armed) {
+    console.log(
+      `DRY RUN — deleting nothing. Re-run with --delete and GC_ENABLE_DELETE=1 to remove the ${orphans.length} orphan(s).`,
+    );
+    return;
+  }
+  console.log(`deleting ${orphans.length} orphan(s)…`);
+  deleteR2(args.prefix, orphans);
+}
+
+const invokedDirectly =
+  process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) main();

--- a/scripts/plugin-previews-gc.mjs
+++ b/scripts/plugin-previews-gc.mjs
@@ -157,6 +157,15 @@ function main() {
 
   const armed = args.delete && process.env.GC_ENABLE_DELETE === '1';
   if (!orphans.length) return;
+  // Fail closed: never delete from a protected set built on partial ref data
+  // (e.g. main's manifest could not be read). An empty/main-less protected set
+  // would mark live clips as orphans.
+  if (armed && (protectedSet.size === 0 || !manifestAtRef('origin/main'))) {
+    console.error(
+      'refusing to delete: protected set is empty or origin/main manifest is unreadable — fail-closed',
+    );
+    process.exit(1);
+  }
   if (!armed) {
     console.log(
       `DRY RUN — deleting nothing. Re-run with --delete and GC_ENABLE_DELETE=1 to remove the ${orphans.length} orphan(s).`,

--- a/scripts/plugin-previews-gc.test.mjs
+++ b/scripts/plugin-previews-gc.test.mjs
@@ -1,0 +1,60 @@
+// Unit coverage for the plugin-preview GC protected-set + orphan selection.
+//   node --test scripts/plugin-previews-gc.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { keysFromManifest, protectedKeys, selectOrphans } from './plugin-previews-gc.mjs';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+test('keysFromManifest collects video + poster of every entry', () => {
+  const m = {
+    previews: {
+      a: { video: 'a/h1/preview.mp4', poster: 'a/h1/poster.jpg' },
+      b: { video: 'b/h2/preview.mp4', poster: 'b/h2/poster.jpg' },
+    },
+  };
+  assert.deepEqual(keysFromManifest(m).sort(), [
+    'a/h1/poster.jpg',
+    'a/h1/preview.mp4',
+    'b/h2/poster.jpg',
+    'b/h2/preview.mp4',
+  ]);
+});
+
+test('keysFromManifest tolerates empty / partial manifests', () => {
+  assert.deepEqual(keysFromManifest(null), []);
+  assert.deepEqual(keysFromManifest({}), []);
+  assert.deepEqual(keysFromManifest({ previews: { a: { video: 'a/h/preview.mp4' } } }), [
+    'a/h/preview.mp4',
+  ]);
+});
+
+test('protectedKeys unions across manifests (tag + release branch + main)', () => {
+  const tag = { previews: { a: { video: 'a/old/preview.mp4', poster: 'a/old/poster.jpg' } } };
+  const main = { previews: { a: { video: 'a/new/preview.mp4', poster: 'a/new/poster.jpg' } } };
+  const set = protectedKeys([tag, main]);
+  // The old clip is still protected because a shipped tag references it.
+  assert.ok(set.has('a/old/preview.mp4'));
+  assert.ok(set.has('a/new/preview.mp4'));
+  assert.equal(set.size, 4);
+});
+
+test('selectOrphans keeps protected keys and keys inside the grace window', () => {
+  const now = 1_000 * DAY;
+  const objects = [
+    { key: 'a/old/preview.mp4', lastModifiedMs: now - 200 * DAY }, // protected → keep
+    { key: 'a/stale/preview.mp4', lastModifiedMs: now - 200 * DAY }, // orphan + old → delete
+    { key: 'a/recent/preview.mp4', lastModifiedMs: now - 10 * DAY }, // orphan but young → keep
+  ];
+  const protectedSet = new Set(['a/old/preview.mp4']);
+  const orphans = selectOrphans(objects, protectedSet, { nowMs: now, graceDays: 90 });
+  assert.deepEqual(orphans, ['a/stale/preview.mp4']);
+});
+
+test('a clip referenced only by a live release branch is never an orphan', () => {
+  const releaseBranch = { previews: { z: { video: 'z/r/preview.mp4', poster: 'z/r/poster.jpg' } } };
+  const set = protectedKeys([releaseBranch]);
+  const now = 1_000 * DAY;
+  const objects = [{ key: 'z/r/preview.mp4', lastModifiedMs: now - 500 * DAY }];
+  assert.deepEqual(selectOrphans(objects, set, { nowMs: now, graceDays: 90 }), []);
+});


### PR DESCRIPTION
## Why

Implements the plugin-preview bake pipeline spec (`specs/change/20260618-plugin-preview-bake-pipeline/spec.md`, #4548) — the fix for the stacked / detached bake-PR backlog you flagged. All slices in one PR; the GC slice ships **dry-run** so the spec's staged *enablement* still holds.

- **Pain:** the bake workflow opened a fresh `chore/plugin-previews-<run_id>` branch + PR every run (stacking 6-deep), its whole-file `git diff` fired every run because `generatedAt` moves each bake, and the manifest arrived as a detached bot PR decoupled from the code change that caused it.

## What changed (by spec slice)

1. **Diff guard + single rolling PR** — `scripts/plugin-previews-diff.mjs` decides whether the `previews` subtree actually changed (ignoring `generatedAt`); the post-merge workflow opens **one rolling** `chore/plugin-previews` PR, force-updated in place, only on a real change.
2. **Pre-merge coupling** — `bake-plugin-previews-pr.yml`: for **same-repo** PRs, render + upload + commit the manifest **into the author's branch** so it rides with the code change and reverts atomically. Loop guard checks the head **commit** author (`git log -1 %ae` of `head.sha`, full checkout) + a no-op diff guard. Forks fall through to post-merge.
3. **Release-cut full bake** — `bake-plugin-previews-release.yml`: on `release/**`, full bake → commit authoritative manifest onto the release branch (flows to main via the non-squash back-merge). `paths-ignore` + bot-author loop guards. Bump `BAKE_VERSION` here to refresh shared-input changes.
4. **Directory keys + GC** — `bake-plugin-previews.mjs` now writes content-addressed `<id>/<fingerprint>/preview.mp4` (+ `poster.jpg`) prefix-relative keys (daemon consumer already resolves `base+key`, no change; reused flat entries left untouched = additive). `scripts/plugin-previews-gc.mjs` + `bake-plugin-previews-gc.yml`: weekly R2 GC, protected set = keys referenced by every tag + live `release/**` HEAD + main, deletes orphans older than 90d. **Dry-run by default** (needs `--delete` *and* `GC_ENABLE_DELETE=1`).

Shared render+upload core extracted to a composite action `.github/actions/bake-previews` so the three workflows don't duplicate it.

## What users will see

No end-user change. For maintainers: at most one rolling bake PR (no more stacks / timestamp noise); internal plugin changes refresh their preview inside the author's own PR; R2 growth is bounded by GC without ever deleting a clip a live release references.

## Validation

`node --test scripts/plugin-previews-diff.test.mjs scripts/plugin-previews-gc.test.mjs` → 10/10 pass (timestamp-only no-op, entry change, add/remove, key-order; GC protected-set union across tag/release/main, grace window, live-release protection). Workflow YAML + `guard`/`typecheck` run in this PR's CI; the bake jobs themselves run post-merge / on PRs / on release / weekly.

## Surface area

- [x] CI / workflows (`.github/workflows/`, `.github/actions/`)
- [x] Scripts (`scripts/`)
- No product, contract, CLI, UI, or i18n changes (daemon consumer is already key-shape-agnostic).

## Open questions resolved per spec recommendations

Pre-merge **uploads** to R2 (orphans GC'd); GC grace **90d** (covers beta/main staleness); R2-existence self-heal deferred (deterministic re-bake recovers a deleted clip).