### PR TITLE
fix(ci): backport auto-merge gated on wrong App author login

### DIFF
--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -74,7 +74,7 @@ jobs:
         if: >-
           ${{ steps.pr.outputs.found == 'true'
               && steps.pr.outputs.draft == 'false'
-              && steps.pr.outputs.author == 'open-design-release-bot[bot]'
+              && steps.pr.outputs.author == 'app/open-design-release-bot'
               && steps.pr.outputs.cross == 'false'
               && steps.pr.outputs.head_oid == github.event.workflow_run.head_sha
               && github.event.workflow_run.conclusion == 'success' }}
@@ -97,7 +97,7 @@ jobs:
         if: >-
           ${{ steps.pr.outputs.found == 'true'
               && steps.pr.outputs.draft == 'false'
-              && steps.pr.outputs.author == 'open-design-release-bot[bot]'
+              && steps.pr.outputs.author == 'app/open-design-release-bot'
               && steps.pr.outputs.cross == 'false'
               && steps.pr.outputs.head_oid == github.event.workflow_run.head_sha
               && github.event.workflow_run.conclusion == 'success' }}
@@ -115,7 +115,7 @@ jobs:
       - name: Notify Feishu on failed backport CI
         # Same identity gates as the merge step: only ping for a genuine bot backport from the
         # same repo, so a fork / non-bot PR named backport-* can't spam the release group.
-        if: ${{ steps.pr.outputs.found == 'true' && steps.pr.outputs.author == 'open-design-release-bot[bot]' && steps.pr.outputs.cross == 'false' && github.event.workflow_run.conclusion == 'failure' }}
+        if: ${{ steps.pr.outputs.found == 'true' && steps.pr.outputs.author == 'app/open-design-release-bot' && steps.pr.outputs.cross == 'false' && github.event.workflow_run.conclusion == 'failure' }}
         env:
           FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
           FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -221,7 +221,7 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain("secrets.RELEASE_BOT_APP_ID");
 
     // Only a non-draft, same-repo PR authored by the release bot, targeting release/v*, is merged.
-    expect(workflow).toContain("steps.pr.outputs.author == 'open-design-release-bot[bot]'");
+    expect(workflow).toContain("steps.pr.outputs.author == 'app/open-design-release-bot'");
     expect(workflow).toContain("steps.pr.outputs.cross == 'false'");
     expect(workflow).toContain("steps.pr.outputs.draft == 'false'");
     expect(workflow).toContain('startswith("release/v")');
@@ -242,13 +242,13 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain("gh pr review");
     expect(workflow).toContain("--approve");
     const approveStep = sectionBetween(workflow, "Approve the clean backport", "gh pr review");
-    expect(approveStep).toContain("steps.pr.outputs.author == 'open-design-release-bot[bot]'");
+    expect(approveStep).toContain("steps.pr.outputs.author == 'app/open-design-release-bot'");
     expect(approveStep).toContain("github.token");
 
     // The Feishu failure path carries the same identity gates, so a fork / non-bot backport-*
     // PR can't spam the release group.
     const feishuStep = sectionBetween(workflow, "Notify Feishu on failed backport CI", "FEISHU_WEBHOOK");
-    expect(feishuStep).toContain("steps.pr.outputs.author == 'open-design-release-bot[bot]'");
+    expect(feishuStep).toContain("steps.pr.outputs.author == 'app/open-design-release-bot'");
     expect(feishuStep).toContain("steps.pr.outputs.cross == 'false'");
   });
 


### PR DESCRIPTION
## Bug

The backport auto-approve/merge gates check `steps.pr.outputs.author == 'open-design-release-bot[bot]'`, but the resolve step gets the author via `gh pr view --json author --jq .author.login`, which returns **`app/open-design-release-bot`** for an App-authored PR (gh's `app/<slug>` form), not `...[bot]`.

So the gate never matched → the Approve and Auto-merge steps were always skipped → clean backports sat open and unmerged despite green CI (surfaced by the end-to-end test: **#4697** and **#4698** both CI-green, 0 approval, BLOCKED).

## Fix

Match the value gh actually returns (`app/open-design-release-bot`) in all three gates (approve, merge, Feishu) + the topology test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)