### PR TITLE
feat(daemon): AMR native session resume across turns

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -89,6 +89,12 @@ interface AttachAcpSessionOptions {
   clientVersion?: string;
   stageTimeoutMs?: number;
   modelUnavailableErrorCode?: 'AMR_MODEL_UNAVAILABLE';
+  // When set, resume an existing upstream session instead of creating a new
+  // one: the handshake sends `session/load { sessionId }` (the durable handle
+  // captured from a prior run via `getDurableSessionId()`) rather than
+  // `session/new`. The agent verifies the session and, if it is gone, returns a
+  // structured `resume_failed` error the caller maps to its reseed path.
+  resumeSessionId?: string | null;
   // Subsegment timing markers for spawn->first-token attribution (#3408 §4).
   // `onCliReady` fires once on the first well-formed ACP JSON-RPC message
   // (the CLI is up and speaking the protocol); `onSessionInit` fires once when
@@ -828,6 +834,7 @@ export function attachAcpSession({
   clientVersion = 'runtime-adapter',
   stageTimeoutMs = DEFAULT_STAGE_TIMEOUT_MS,
   modelUnavailableErrorCode,
+  resumeSessionId,
   onCliReady,
   onSessionInit,
 }: AttachAcpSessionOptions) {
@@ -843,6 +850,11 @@ export function attachAcpSession({
   let promptRequestId: JsonRpcId | null = null;
   let setModelRequestId: JsonRpcId | null = null;
   let sessionId: string | null = null;
+  // The durable upstream session handle reported by the agent on session/new or
+  // session/load (vela's `openCodeSessionId`). The caller stores it per
+  // conversation to resume next turn. Distinct from `sessionId`, which is the
+  // ACP wrapper id ("vela-opencode-1").
+  let durableSessionId: string | null = null;
   let activeModel: string | null = null;
   let modelConfigId: string | null = null;
   let emittedThinkingStart = false;
@@ -1242,20 +1254,33 @@ export function attachAcpSession({
     }
     if (expectedId === 1) {
       expectedId = nextId;
-      writeRpc(
-        nextId,
-        'session/new',
-        buildAcpSessionNewParams(
-          effectiveCwd,
-          mcpServers ? { mcpServers, envFormat } : { envFormat },
-        ),
-        'session/new',
-      );
+      if (resumeSessionId) {
+        // Resume the prior upstream session instead of creating a fresh one.
+        writeRpc(
+          nextId,
+          'session/load',
+          { sessionId: resumeSessionId, cwd: effectiveCwd },
+          'session/load',
+        );
+      } else {
+        writeRpc(
+          nextId,
+          'session/new',
+          buildAcpSessionNewParams(
+            effectiveCwd,
+            mcpServers ? { mcpServers, envFormat } : { envFormat },
+          ),
+          'session/new',
+        );
+      }
       nextId += 1;
       return;
     }
     if (expectedId === 2) {
       sessionId = typeof result.sessionId === 'string' ? result.sessionId : null;
+      // The durable handle for resuming this session on the next turn.
+      durableSessionId =
+        typeof result.openCodeSessionId === 'string' ? result.openCodeSessionId : null;
       // session/new acknowledged with a session id = handshake done (#3408 §4).
       if (sessionId) onSessionInit?.();
       const modelConfig = findModelConfigOption(result.configOptions);
@@ -1325,6 +1350,12 @@ export function attachAcpSession({
   return {
     hasFatalError() {
       return fatal;
+    },
+    // The durable upstream session handle to persist for resume, or null when
+    // none was reported (older agents, or a handshake that never established a
+    // session). Mirrors pi-rpc's getLastSessionPath().
+    getDurableSessionId() {
+      return durableSessionId;
     },
     completedSuccessfully() {
       // Returns true when the prompt request resolved without a fatal error

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -171,6 +171,23 @@ export function isCodexResumeFailure(text: string): boolean {
   return CODEX_RESUME_FAILURE_PATTERNS.some((re) => re.test(text));
 }
 
+// Signature OpenCode prints when `run -s <id>` targets a session whose store is
+// gone (deleted, corrupted, different machine). Verified against the installed
+// OpenCode CLI: `run -s <well-formed-but-missing-id>` prints `Error: Session
+// not found` to stderr (and the HTTP path returns a `NotFoundError`). Like the
+// other CLIs this fails before any model call, so clearing the stale handle and
+// re-seeding the transcript next turn is the correct, lossless recovery.
+const OPENCODE_RESUME_FAILURE_PATTERNS: RegExp[] = [
+  /session not found/i,
+  /NotFoundError/,
+];
+
+/** True when OpenCode CLI output indicates a resume target session is missing. */
+export function isOpencodeResumeFailure(text: string): boolean {
+  if (!text) return false;
+  return OPENCODE_RESUME_FAILURE_PATTERNS.some((re) => re.test(text));
+}
+
 /**
  * Per-agent dispatch for "the session/thread I asked to resume is gone".
  * Generalizes the resume-fallback so every `resumesSessionViaCli` adapter
@@ -180,6 +197,7 @@ export function isCodexResumeFailure(text: string): boolean {
 export function isAgentResumeFailure(agentId: string, text: string): boolean {
   if (!text) return false;
   if (agentId === 'codex') return isCodexResumeFailure(text);
+  if (agentId === 'opencode') return isOpencodeResumeFailure(text);
   // claude + codebuddy share Claude Code's stream-json result shape.
   return isClaudeResumeFailure(text);
 }

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -153,3 +153,33 @@ export function isClaudeResumeFailure(text: string): boolean {
   if (CLAUDE_RESUME_FAILURE_PATTERNS.some((re) => re.test(text))) return true;
   return hasClaudeResumeFailureResultEvent(text);
 }
+
+// Signature codex prints when `exec resume <thread_id>` targets a thread whose
+// rollout file is gone (pruned, ~/.codex/sessions cleared, machine moved):
+//   Error: thread/resume: thread/resume failed: no rollout found for thread id <id>
+// Verified against the installed Codex CLI. Like the Claude case this fails
+// locally before any model call, so clearing the stale handle and re-seeding
+// the transcript next turn is the correct, lossless recovery.
+const CODEX_RESUME_FAILURE_PATTERNS: RegExp[] = [
+  /no rollout found for thread id/i,
+  /thread\/resume failed/i,
+];
+
+/** True when codex CLI output indicates a resume target thread is missing. */
+export function isCodexResumeFailure(text: string): boolean {
+  if (!text) return false;
+  return CODEX_RESUME_FAILURE_PATTERNS.some((re) => re.test(text));
+}
+
+/**
+ * Per-agent dispatch for "the session/thread I asked to resume is gone".
+ * Generalizes the resume-fallback so every `resumesSessionViaCli` adapter
+ * routes through one decision point in server.ts. Unknown agents return false
+ * (no fallback) — a new resume-capable adapter must opt in here explicitly.
+ */
+export function isAgentResumeFailure(agentId: string, text: string): boolean {
+  if (!text) return false;
+  if (agentId === 'codex') return isCodexResumeFailure(text);
+  // claude + codebuddy share Claude Code's stream-json result shape.
+  return isClaudeResumeFailure(text);
+}

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -301,6 +301,19 @@ export function isAgentResumeFailure(
 ): boolean {
   if (agentId === 'codex') return isCodexResumeFailure(stderr);
   if (agentId === 'opencode') return isOpencodeResumeFailure(stderr);
+  if (agentId === 'amr') return isAmrResumeFailure(stdout);
   // claude + codebuddy share Claude Code's stream-json result shape.
   return isClaudeResumeFailure(stderr, stdout);
+}
+
+// vela (AMR) reports a missing resumed session as a structured ACP JSON-RPC
+// error `{"error":{"data":{"kind":"resume_failed",...}}}` on stdout (the
+// protocol channel). Match the structured marker — not a bare word — so a
+// model reply that merely mentions "resume_failed" cannot trip it.
+const AMR_RESUME_FAILURE_PATTERN = /"kind"\s*:\s*"resume_failed"/;
+
+/** True when vela's ACP output carries a resume_failed signal. */
+export function isAmrResumeFailure(stdout: string): boolean {
+  if (!stdout) return false;
+  return AMR_RESUME_FAILURE_PATTERN.test(stdout);
 }

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -131,6 +131,13 @@ export function persistCapturedAgentSession(
     agentId: string;
     sessionId: string | null;
     stablePromptHash?: string | null;
+    // Resume identity (see resolveAgentResumeContext). Must be stored alongside
+    // the captured session so the next turn can verify the session is still
+    // safe to resume; omitting them leaves a null cursor that the guard treats
+    // as `missing_cursor` and reseeds every turn.
+    model?: string | null;
+    cwd?: string | null;
+    lastMessageId?: string | null;
   },
 ): CapturedAgentSessionResult {
   if (!input.conversationId) return 'skipped';
@@ -140,6 +147,9 @@ export function persistCapturedAgentSession(
       agentId: input.agentId,
       sessionId: input.sessionId,
       stablePromptHash: input.stablePromptHash ?? null,
+      model: input.model ?? null,
+      cwd: input.cwd ?? null,
+      lastMessageId: input.lastMessageId ?? null,
     });
     return 'stored';
   }

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -99,10 +99,15 @@ export function resolveAgentResumeContext(
           storedLastMessageId: record?.lastMessageId ?? null,
           currentModel: input.currentModel ?? null,
           currentCwd: input.currentCwd ?? null,
+          // Admit the stored session's own last message id through the cursor
+          // filter so a resume-on-failure session (whose last turn FAILED but is
+          // resumable) still matches its cursor; a different later failed turn
+          // stays excluded and genuine advancement is still detected.
           latestCompletedAssistantId: latestCompletedAssistantMessageId(
             db,
             input.conversationId,
             input.currentAssistantMessageId ?? '',
+            record?.lastMessageId ?? null,
           ),
         })
       : null;

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -5,41 +5,114 @@ import type Database from 'better-sqlite3';
 import {
   clearAgentSession,
   getAgentSessionRecord,
+  latestCompletedAssistantMessageId,
   upsertAgentSession,
 } from './db.js';
 
 type SqliteDb = Database.Database;
+
+/**
+ * Why a stored session was NOT resumed this turn. `null` means it WAS resumed
+ * (or there was no stored session to begin with). Surfaced for tests and
+ * analytics; the daemon reseeds the full transcript for every non-null reason.
+ */
+export type ResumeInvalidationReason =
+  | 'model_changed'
+  | 'cwd_changed'
+  | 'conversation_advanced'
+  | 'missing_cursor';
 
 export interface AgentResumeContext {
   /** Stored CLI session id to resume, or null when starting fresh. */
   resumeSessionId: string | null;
   /** Freshly minted UUID to open a new session with when not resuming. */
   newSessionId: string;
-  /** True when a prior session id exists for this (conversation, agent). */
+  /** True when a prior session id exists AND it is still safe to resume. */
   isResuming: boolean;
   /** Hash of the stable instruction block last sent on this session, or null. */
   storedStablePromptHash: string | null;
+  /** Set when a stored session existed but was rejected; see the type. */
+  invalidationReason: ResumeInvalidationReason | null;
 }
 
 export type CapturedAgentSessionResult = 'stored' | 'cleared' | 'skipped';
 
 /**
+ * Resume identity guard. A stored upstream session is only safe to continue
+ * (and to `skipTranscript` for) when the conversation has not changed shape
+ * under it. We reject the resume — forcing a fresh session reseeded with the
+ * full transcript — when:
+ *  - the model changed (the session was built under a different model),
+ *  - the cwd changed (different workspace identity), or
+ *  - the conversation advanced under the session: the assistant message the
+ *    session last produced is no longer the latest completed assistant turn
+ *    (another agent ran in between, or the message was edited/removed).
+ *
+ * The cursor is the session's own last assistant message id. At the next turn's
+ * resolve time the latest completed assistant message — excluding the current
+ * run's in-flight placeholder — must still be that id. A null stored cursor (row
+ * written before this guard shipped) cannot be verified, so it is treated as
+ * unsafe and reseeded once.
+ */
+export function evaluateResumeInvalidation(input: {
+  storedModel: string | null;
+  storedCwd: string | null;
+  storedLastMessageId: string | null;
+  currentModel: string | null;
+  currentCwd: string | null;
+  latestCompletedAssistantId: string | null;
+}): ResumeInvalidationReason | null {
+  if ((input.storedModel ?? null) !== (input.currentModel ?? null)) return 'model_changed';
+  if ((input.storedCwd ?? null) !== (input.currentCwd ?? null)) return 'cwd_changed';
+  if (input.storedLastMessageId == null) return 'missing_cursor';
+  if (input.latestCompletedAssistantId !== input.storedLastMessageId) {
+    return 'conversation_advanced';
+  }
+  return null;
+}
+
+/**
  * Decide whether a resume-capable adapter should continue its stored CLI
  * session or start a new one for this (conversation, agent). Pure read +
- * mint; the caller is responsible for persisting `newSessionId` when it
- * actually spawns a create turn.
+ * mint; the caller is responsible for persisting `newSessionId` (and the
+ * current model/cwd/cursor) when it actually spawns a create turn.
  */
 export function resolveAgentResumeContext(
   db: SqliteDb,
-  input: { conversationId: string; agentId: string },
+  input: {
+    conversationId: string;
+    agentId: string;
+    currentModel?: string | null;
+    currentCwd?: string | null;
+    /** The current run's in-flight assistant placeholder id, excluded from the
+     *  "latest completed assistant" cursor lookup. */
+    currentAssistantMessageId?: string | null;
+  },
 ): AgentResumeContext {
   const record = getAgentSessionRecord(db, input.conversationId, input.agentId);
-  const resumeSessionId = record?.sessionId ?? null;
+  const storedSessionId = record?.sessionId ?? null;
+  const invalidationReason =
+    storedSessionId != null
+      ? evaluateResumeInvalidation({
+          storedModel: record?.model ?? null,
+          storedCwd: record?.cwd ?? null,
+          storedLastMessageId: record?.lastMessageId ?? null,
+          currentModel: input.currentModel ?? null,
+          currentCwd: input.currentCwd ?? null,
+          latestCompletedAssistantId: latestCompletedAssistantMessageId(
+            db,
+            input.conversationId,
+            input.currentAssistantMessageId ?? '',
+          ),
+        })
+      : null;
+  const resumable = storedSessionId != null && invalidationReason == null;
   return {
-    resumeSessionId,
+    resumeSessionId: resumable ? storedSessionId : null,
     newSessionId: randomUUID(),
-    isResuming: resumeSessionId != null,
-    storedStablePromptHash: record?.stablePromptHash ?? null,
+    isResuming: resumable,
+    storedStablePromptHash: resumable ? (record?.stablePromptHash ?? null) : null,
+    invalidationReason,
   };
 }
 

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -230,11 +230,17 @@ export function computeIncludeStable(
   return !isResuming || storedStableHash !== currentStableHash;
 }
 
-/** True when CLI output indicates a resume target session is missing. */
-export function isClaudeResumeFailure(text: string): boolean {
-  if (!text) return false;
-  if (CLAUDE_RESUME_FAILURE_PATTERNS.some((re) => re.test(text))) return true;
-  return hasClaudeResumeFailureResultEvent(text);
+/**
+ * True when CLI output indicates a resume target session is missing. Prose
+ * signatures are matched on `stderr` (where Claude prints the failure); the
+ * version-stable structured `result` event is matched on `stdout` (the
+ * stream-json channel). We deliberately do NOT scan ordinary assistant stdout
+ * for the prose phrases — a successful turn whose model text happens to contain
+ * "session not found" must not be mistaken for a resume failure.
+ */
+export function isClaudeResumeFailure(stderr: string, stdout = ''): boolean {
+  if (stderr && CLAUDE_RESUME_FAILURE_PATTERNS.some((re) => re.test(stderr))) return true;
+  return stdout ? hasClaudeResumeFailureResultEvent(stdout) : false;
 }
 
 // Signature codex prints when `exec resume <thread_id>` targets a thread whose
@@ -276,11 +282,20 @@ export function isOpencodeResumeFailure(text: string): boolean {
  * Generalizes the resume-fallback so every `resumesSessionViaCli` adapter
  * routes through one decision point in server.ts. Unknown agents return false
  * (no fallback) — a new resume-capable adapter must opt in here explicitly.
+ *
+ * Detection scans only the CLI's FAILURE channel, never successful assistant
+ * output: codex/opencode print their resume-miss to `stderr` (a generic phrase
+ * like OpenCode's "Session not found" must not be matched against the model's
+ * stdout, or a turn that merely *mentions* it would be falsely failed); Claude's
+ * prose is on stderr and its structured `result` marker on stdout.
  */
-export function isAgentResumeFailure(agentId: string, text: string): boolean {
-  if (!text) return false;
-  if (agentId === 'codex') return isCodexResumeFailure(text);
-  if (agentId === 'opencode') return isOpencodeResumeFailure(text);
+export function isAgentResumeFailure(
+  agentId: string,
+  stderr: string,
+  stdout = '',
+): boolean {
+  if (agentId === 'codex') return isCodexResumeFailure(stderr);
+  if (agentId === 'opencode') return isOpencodeResumeFailure(stderr);
   // claude + codebuddy share Claude Code's stream-json result shape.
-  return isClaudeResumeFailure(text);
+  return isClaudeResumeFailure(stderr, stdout);
 }

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1188,33 +1188,41 @@ export function getAgentSessionRecord(
 }
 
 // Conversation cursor for the resume identity guard: the id of the latest
-// SUCCESSFULLY COMPLETED assistant message in the conversation, EXCLUDING the
-// current run's in-flight placeholder (`excludeMessageId`). At resolve time the
-// session is in sync iff this equals the assistant message the session last
-// produced — otherwise another agent completed a turn in between, or the
-// session's own last message was edited/removed, and the session is behind.
-// Returns null when there is no prior completed assistant turn.
+// COMPLETED assistant message in the conversation, EXCLUDING the current run's
+// in-flight placeholder (`excludeMessageId`). At resolve time the session is in
+// sync iff this equals the assistant message the session last produced —
+// otherwise another agent completed a turn in between, or the session's own last
+// message was edited/removed, and the session is behind. Returns null when there
+// is no prior completed assistant turn.
 //
-// The `run_status = 'succeeded'` filter is load-bearing: a run stamps its
-// assistant message with the terminal status on finish (server.ts), so an
-// intervening agent run that FAILED or was CANCELED leaves a placeholder that
-// produced no completed turn. Counting it as advancement would force a needless
-// cold reseed (silently disabling this PR's resume perf path) even though the
-// stored session is still the latest completed turn. In-flight placeholders have
-// a null run_status and are likewise excluded.
+// "Completed" means run_status = 'succeeded' — a run stamps its assistant
+// message with the terminal status on finish (server.ts), so an intervening
+// agent run that FAILED or was CANCELED leaves a placeholder that produced no
+// completed turn; counting it as advancement would force a needless cold reseed
+// (silently disabling the resume perf path) even though the stored session is
+// still the latest completed turn. In-flight placeholders have a null run_status
+// and are likewise excluded.
+//
+// `resumableMessageId` is the one allowed exception: the resume-on-failure path
+// persists a session whose own last assistant turn FAILED transiently (the CLI
+// session already committed a tool/artifact block and is resumable). That stored
+// id is admitted through the filter so the session it owns still matches its
+// cursor — while a DIFFERENT later failed/canceled turn (a different id) stays
+// excluded, so genuine advancement by a later succeeded turn is still detected.
 export function latestCompletedAssistantMessageId(
   db: SqliteDb,
   conversationId: string,
   excludeMessageId: string,
+  resumableMessageId: string | null = null,
 ): string | null {
   const row = db
     .prepare(
       `SELECT id FROM messages
         WHERE conversation_id = ? AND role = 'assistant' AND id != ?
-          AND run_status = 'succeeded'
+          AND (run_status = 'succeeded' OR id = ?)
         ORDER BY position DESC LIMIT 1`,
     )
-    .get(conversationId, excludeMessageId) as DbRow | undefined;
+    .get(conversationId, excludeMessageId, resumableMessageId) as DbRow | undefined;
   return row && typeof row.id === 'string' ? row.id : null;
 }
 

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -91,6 +91,16 @@ function migrate(db: SqliteDb): void {
       agent_id        TEXT NOT NULL,
       session_id      TEXT NOT NULL,
       stable_prompt_hash TEXT,
+      -- Resume identity guard: the session is only safe to resume when the
+      -- conversation has not changed shape under it. model/cwd are the runtime
+      -- identity the upstream session was created with; a change forces a fresh
+      -- session. last_message_id is the assistant message this session produced
+      -- on its last turn -- if it is no longer the latest completed assistant
+      -- turn (another agent ran in between, or it was edited away), the session
+      -- is behind and we reseed the full transcript.
+      model           TEXT,
+      cwd             TEXT,
+      last_message_id TEXT,
       updated_at      INTEGER NOT NULL,
       PRIMARY KEY (conversation_id, agent_id),
       FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
@@ -342,6 +352,16 @@ function migrate(db: SqliteDb): void {
   const agentSessionCols = db.prepare(`PRAGMA table_info(agent_sessions)`).all() as DbRow[];
   if (agentSessionCols.length > 0 && !agentSessionCols.some((c: DbRow) => c.name === 'stable_prompt_hash')) {
     db.exec(`ALTER TABLE agent_sessions ADD COLUMN stable_prompt_hash TEXT`);
+  }
+  // Resume identity guard columns (see agent_sessions CREATE TABLE comment).
+  if (agentSessionCols.length > 0 && !agentSessionCols.some((c: DbRow) => c.name === 'model')) {
+    db.exec(`ALTER TABLE agent_sessions ADD COLUMN model TEXT`);
+  }
+  if (agentSessionCols.length > 0 && !agentSessionCols.some((c: DbRow) => c.name === 'cwd')) {
+    db.exec(`ALTER TABLE agent_sessions ADD COLUMN cwd TEXT`);
+  }
+  if (agentSessionCols.length > 0 && !agentSessionCols.some((c: DbRow) => c.name === 'last_message_id')) {
+    db.exec(`ALTER TABLE agent_sessions ADD COLUMN last_message_id TEXT`);
   }
   const tabsStateCols = db.prepare(`PRAGMA table_info(tabs_state)`).all() as DbRow[];
   if (tabsStateCols.length > 0 && !tabsStateCols.some((c: DbRow) => c.name === 'state_json')) {
@@ -1111,20 +1131,30 @@ export function upsertAgentSession(
     agentId: string;
     sessionId: string;
     stablePromptHash?: string | null;
+    model?: string | null;
+    cwd?: string | null;
+    lastMessageId?: string | null;
   },
 ): void {
   db.prepare(
-    `INSERT INTO agent_sessions (conversation_id, agent_id, session_id, stable_prompt_hash, updated_at)
-       VALUES (?, ?, ?, ?, ?)
+    `INSERT INTO agent_sessions
+       (conversation_id, agent_id, session_id, stable_prompt_hash, model, cwd, last_message_id, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(conversation_id, agent_id)
        DO UPDATE SET session_id = excluded.session_id,
                      stable_prompt_hash = excluded.stable_prompt_hash,
+                     model = excluded.model,
+                     cwd = excluded.cwd,
+                     last_message_id = excluded.last_message_id,
                      updated_at = excluded.updated_at`,
   ).run(
     input.conversationId,
     input.agentId,
     input.sessionId,
     input.stablePromptHash ?? null,
+    input.model ?? null,
+    input.cwd ?? null,
+    input.lastMessageId ?? null,
     Date.now(),
   );
 }
@@ -1133,10 +1163,16 @@ export function getAgentSessionRecord(
   db: SqliteDb,
   conversationId: string,
   agentId: string,
-): { sessionId: string; stablePromptHash: string | null } | null {
+): {
+  sessionId: string;
+  stablePromptHash: string | null;
+  model: string | null;
+  cwd: string | null;
+  lastMessageId: string | null;
+} | null {
   const row = db
     .prepare(
-      `SELECT session_id, stable_prompt_hash FROM agent_sessions
+      `SELECT session_id, stable_prompt_hash, model, cwd, last_message_id FROM agent_sessions
         WHERE conversation_id = ? AND agent_id = ?`,
     )
     .get(conversationId, agentId) as DbRow | undefined;
@@ -1145,7 +1181,32 @@ export function getAgentSessionRecord(
     sessionId: row.session_id,
     stablePromptHash:
       typeof row.stable_prompt_hash === 'string' ? row.stable_prompt_hash : null,
+    model: typeof row.model === 'string' ? row.model : null,
+    cwd: typeof row.cwd === 'string' ? row.cwd : null,
+    lastMessageId: typeof row.last_message_id === 'string' ? row.last_message_id : null,
   };
+}
+
+// Conversation cursor for the resume identity guard: the id of the latest
+// assistant message in the conversation, EXCLUDING the current run's in-flight
+// placeholder (`excludeMessageId`). At resolve time the session is in sync iff
+// this equals the assistant message the session last produced — otherwise
+// another agent completed a turn in between, or the session's own last message
+// was edited/removed, and the session is behind. Returns null when there is no
+// prior assistant turn.
+export function latestCompletedAssistantMessageId(
+  db: SqliteDb,
+  conversationId: string,
+  excludeMessageId: string,
+): string | null {
+  const row = db
+    .prepare(
+      `SELECT id FROM messages
+        WHERE conversation_id = ? AND role = 'assistant' AND id != ?
+        ORDER BY position DESC LIMIT 1`,
+    )
+    .get(conversationId, excludeMessageId) as DbRow | undefined;
+  return row && typeof row.id === 'string' ? row.id : null;
 }
 
 export function updateAgentSessionStableHash(

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1188,12 +1188,20 @@ export function getAgentSessionRecord(
 }
 
 // Conversation cursor for the resume identity guard: the id of the latest
-// assistant message in the conversation, EXCLUDING the current run's in-flight
-// placeholder (`excludeMessageId`). At resolve time the session is in sync iff
-// this equals the assistant message the session last produced — otherwise
-// another agent completed a turn in between, or the session's own last message
-// was edited/removed, and the session is behind. Returns null when there is no
-// prior assistant turn.
+// SUCCESSFULLY COMPLETED assistant message in the conversation, EXCLUDING the
+// current run's in-flight placeholder (`excludeMessageId`). At resolve time the
+// session is in sync iff this equals the assistant message the session last
+// produced — otherwise another agent completed a turn in between, or the
+// session's own last message was edited/removed, and the session is behind.
+// Returns null when there is no prior completed assistant turn.
+//
+// The `run_status = 'succeeded'` filter is load-bearing: a run stamps its
+// assistant message with the terminal status on finish (server.ts), so an
+// intervening agent run that FAILED or was CANCELED leaves a placeholder that
+// produced no completed turn. Counting it as advancement would force a needless
+// cold reseed (silently disabling this PR's resume perf path) even though the
+// stored session is still the latest completed turn. In-flight placeholders have
+// a null run_status and are likewise excluded.
 export function latestCompletedAssistantMessageId(
   db: SqliteDb,
   conversationId: string,
@@ -1203,6 +1211,7 @@ export function latestCompletedAssistantMessageId(
     .prepare(
       `SELECT id FROM messages
         WHERE conversation_id = ? AND role = 'assistant' AND id != ?
+          AND run_status = 'succeeded'
         ORDER BY position DESC LIMIT 1`,
     )
     .get(conversationId, excludeMessageId) as DbRow | undefined;

--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -271,6 +271,11 @@ export const amrAgentDef = {
   fallbackModels: [] as RuntimeModelOption[],
   buildArgs: () => ['agent', 'run', '--runtime', 'opencode'],
   streamFormat: 'acp-json-rpc',
+  // vela resumes the upstream OpenCode session via ACP session/load across
+  // turns (the OpenCode session store persists per conversation), so the daemon
+  // captures the durable handle, skips the transcript resend on resume, and
+  // maps vela's resume_failed onto the reseed path. See resumesSessionViaAcpLoad.
+  resumesSessionViaAcpLoad: true,
   // Vela routes model selection through ACP's `session/set_model` and only
   // accepts ids that survived the `vela models` preflight check, so a
   // free-text "Custom" id silently fails at spawn. The model picker

--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -117,17 +117,43 @@ export const codexAgentDef = {
       // and Linux (Landlock+seccomp) keep workspace-write because their
       // sandbox enforcement permits shell while restricting writes.
       const needsDangerFullAccess = codexNeedsDangerFullAccessSandbox();
-      const args = needsDangerFullAccess
-        ? ['exec', '--json', '--skip-git-repo-check', '--sandbox', 'danger-full-access']
-        : [
-            'exec',
-            '--json',
-            '--skip-git-repo-check',
-            '--sandbox',
-            'workspace-write',
-            '-c',
-            'sandbox_workspace_write.network_access=true',
-          ];
+      // Capture-style resume: when the daemon has a stored Codex thread id for
+      // this conversation it asks the CLI to continue that session with
+      // `exec resume <thread_id>` instead of `exec` (a fresh session). Codex
+      // mints its own id, so the daemon does not specify one — it captures the
+      // id from the create turn's `thread.started.thread_id` event (see the
+      // json-event-stream `codex` parser) and replays it here on resume.
+      const resumeSessionId =
+        typeof runtimeContext.resumeSessionId === 'string' &&
+        runtimeContext.resumeSessionId.length > 0
+          ? runtimeContext.resumeSessionId
+          : null;
+      // `codex exec resume` rejects `--sandbox` (only valid on a fresh
+      // `exec`); the sandbox mode must be passed as a `-c sandbox_mode=...`
+      // config override. We mirror the exact same effective sandbox policy as
+      // the create turn so Codex's per-turn `turn_context` block byte-matches
+      // across turns and does not break the upstream prefix cache the resume
+      // is meant to reuse.
+      const sandboxArgs = needsDangerFullAccess
+        ? resumeSessionId
+          ? ['-c', 'sandbox_mode="danger-full-access"']
+          : ['--sandbox', 'danger-full-access']
+        : resumeSessionId
+          ? [
+              '-c',
+              'sandbox_mode="workspace-write"',
+              '-c',
+              'sandbox_workspace_write.network_access=true',
+            ]
+          : [
+              '--sandbox',
+              'workspace-write',
+              '-c',
+              'sandbox_workspace_write.network_access=true',
+            ];
+      const args = resumeSessionId
+        ? ['exec', 'resume', '--json', '--skip-git-repo-check', ...sandboxArgs]
+        : ['exec', '--json', '--skip-git-repo-check', ...sandboxArgs];
       if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
         args.push('--disable', 'plugins');
       }
@@ -149,9 +175,23 @@ export const codexAgentDef = {
         // is exposed as `model_reasoning_effort`.
         args.push('-c', `model_reasoning_effort="${effort}"`);
       }
+      // The resume thread id is the positional SESSION_ID argument of
+      // `codex exec resume`; it must come after the flags. The prompt is
+      // delivered via stdin (promptViaStdin), so the thread id is the final
+      // argv entry.
+      if (resumeSessionId) {
+        args.push(resumeSessionId);
+      }
       return args;
     },
     promptViaStdin: true,
+    // Codex's CLI carries its own session across spawns: on a follow-up turn
+    // the daemon resumes the captured thread id instead of re-sending the
+    // flattened transcript, so the first upstream call reuses the warm prefix
+    // cache. Capture-style: the resume handle is the `thread.started.thread_id`
+    // captured from the stream, not a daemon-minted id.
+    resumesSessionViaCli: true,
+    capturesSessionIdFromStream: true,
     streamFormat: 'json-event-stream',
     eventParser: 'codex',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -157,14 +157,24 @@ export const codexAgentDef = {
       if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
         args.push('--disable', 'plugins');
       }
-      if (runtimeContext.cwd) {
-        args.push('-C', runtimeContext.cwd);
-      }
-      const dirs = (extraAllowedDirs || []).filter(
-        (d) => typeof d === 'string' && d.length > 0,
-      );
-      for (const d of dirs) {
-        args.push('--add-dir', d);
+      // `-C <cwd>` and `--add-dir <dir>` are CREATE-only flags: `codex exec
+      // resume` rejects both (`error: unexpected argument '-C' found`), so
+      // appending them on a resume turn would make the follow-up turn die
+      // before the first event. The daemon already spawns the child with
+      // `cwd: effectiveCwd`, and resuming by explicit SESSION_ID does not use
+      // codex's cwd-based session filtering, so the resumed turn still runs in
+      // the right workspace without `-C`. The extra writable dirs were granted
+      // when the session was created and are carried by the resumed session.
+      if (!resumeSessionId) {
+        if (runtimeContext.cwd) {
+          args.push('-C', runtimeContext.cwd);
+        }
+        const dirs = (extraAllowedDirs || []).filter(
+          (d) => typeof d === 'string' && d.length > 0,
+        );
+        for (const d of dirs) {
+          args.push('--add-dir', d);
+        }
       }
       if (options.model && options.model !== 'default') {
         args.push('--model', options.model);

--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -37,18 +37,38 @@ export const opencodeAgentDef = {
     // avoid Windows `spawn ENAMETOOLONG` while preserving OpenCode's
     // structured stream. A literal `-` is parsed as a positional message by
     // OpenCode 1.14.x and can surface as "Session not found".
-    buildArgs: (_prompt, _imagePaths, _extra, options = {}) => {
+    buildArgs: (_prompt, _imagePaths, _extra, options = {}, runtimeContext = {}) => {
       const args = [
         'run',
         '--format',
         'json',
       ];
+      // Capture-style resume: OpenCode mints its own session id (reported on
+      // the stream as `sessionID`, e.g. `ses_...`). On a follow-up turn the
+      // daemon continues that session with `-s <id>` instead of re-sending the
+      // flattened transcript, so the first upstream call reuses the warm prefix
+      // cache. `-s` continues an EXISTING session (the create turn passes no id
+      // and we capture the one OpenCode generated), mirroring codex.
+      const resumeSessionId =
+        typeof runtimeContext.resumeSessionId === 'string' &&
+        runtimeContext.resumeSessionId.length > 0
+          ? runtimeContext.resumeSessionId
+          : null;
+      if (resumeSessionId) {
+        args.push('-s', resumeSessionId);
+      }
       if (options.model && options.model !== 'default') {
         args.push('-m', options.model);
       }
       return args;
     },
     promptViaStdin: true,
+    // OpenCode's CLI carries its own session across spawns: on a follow-up turn
+    // the daemon resumes the captured session id (`-s <id>`) instead of
+    // re-flattening the transcript. Capture-style — the resume handle is the
+    // `sessionID` captured from the stream, not a daemon-minted id.
+    resumesSessionViaCli: true,
+    capturesSessionIdFromStream: true,
     streamFormat: 'json-event-stream',
     eventParser: 'opencode',
     // OpenCode reads MCP servers from its layered config (global ~/.config

--- a/apps/daemon/src/runtimes/json-event-stream.ts
+++ b/apps/daemon/src/runtimes/json-event-stream.ts
@@ -675,7 +675,16 @@ function handleCodexEvent(obj: unknown, onEvent: StreamEventHandler, state: Pars
   }
 
   if (obj.type === 'thread.started') {
-    onEvent({ type: 'status', label: 'initializing' });
+    // `thread_id` is Codex's own session handle (capture-style resume). Surface
+    // it on the status event so the daemon can persist it to `agent_sessions`
+    // and replay it as `exec resume <thread_id>` on the next turn. Codex emits
+    // this both for a fresh `exec` and for `exec resume` (echoing the resumed
+    // id), so it is a stable capture point either way.
+    const threadId =
+      typeof obj.thread_id === 'string' && obj.thread_id.length > 0
+        ? obj.thread_id
+        : null;
+    onEvent({ type: 'status', label: 'initializing', sessionId: threadId });
     return true;
   }
 

--- a/apps/daemon/src/runtimes/json-event-stream.ts
+++ b/apps/daemon/src/runtimes/json-event-stream.ts
@@ -152,7 +152,16 @@ function handleOpenCodeEvent(obj: unknown, onEvent: StreamEventHandler, state: P
   const part = isRecord(obj.part) ? obj.part : {};
 
   if (obj.type === 'step_start') {
-    onEvent({ type: 'status', label: 'running' });
+    // `sessionID` is OpenCode's own session handle (capture-style resume).
+    // Surface it on the step-start status so the daemon can persist it to
+    // `agent_sessions` and replay it as `run -s <id>` next turn. OpenCode
+    // stamps it on every stream event; step_start is the turn opener, so a
+    // create turn always exposes it here.
+    const sessionId =
+      typeof obj.sessionID === 'string' && obj.sessionID.length > 0
+        ? obj.sessionID
+        : null;
+    onEvent({ type: 'status', label: 'running', sessionId });
     return true;
   }
 

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -175,6 +175,17 @@ export type RuntimeAgentDef = {
   // RuntimeContext.hasPriorAssistantTurn comment for why double-context
   // is the discovery-form loop's root cause.
   resumesSessionViaCli?: boolean;
+  // How the resumable session id is obtained, for `resumesSessionViaCli`
+  // adapters. The default (undefined/false) is "specify-style": the daemon
+  // mints `RuntimeContext.newSessionId` and the CLI is told to use it (claude
+  // `--session-id`), so the id the daemon stores is the id it generated. When
+  // `true` the adapter is "capture-style": the CLI generates its OWN session
+  // id and reports it on the stream (codex `thread.started.thread_id`), so the
+  // daemon must capture that id from the parsed stream (surfaced as a
+  // `status` event's `sessionId`) and persist THAT as the resume handle —
+  // `newSessionId` is not passed to the CLI. See server.ts capture-and-store
+  // path and `agent-cli-session-resume.md`.
+  capturesSessionIdFromStream?: boolean;
   // Optional name of a daemon-process environment variable that overrides
   // the default model id when the chat run reaches the spawn layer with
   // null or the synthetic 'default'. Used by adapters whose CLI rejects

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -186,6 +186,15 @@ export type RuntimeAgentDef = {
   // `newSessionId` is not passed to the CLI. See server.ts capture-and-store
   // path and `agent-cli-session-resume.md`.
   capturesSessionIdFromStream?: boolean;
+  // ACP-runtime analogue of capture-style resume: the agent talks `acp-json-rpc`
+  // (today only AMR/vela) and supports resuming via `session/load`. The daemon
+  // captures the durable upstream session handle from the ACP session
+  // (`getDurableSessionId()`) and persists THAT, drives `session/load` on a
+  // resume turn, and maps the agent's structured `resume_failed` error onto the
+  // reseed path. Kept distinct from `resumesSessionViaCli` /
+  // `capturesSessionIdFromStream` because the capture + resume transport is the
+  // ACP result, not a `--session-id` flag or a stream `status` event.
+  resumesSessionViaAcpLoad?: boolean;
   // Optional name of a daemon-process environment variable that overrides
   // the default model id when the chat run reaches the spawn layer with
   // null or the synthetic 'default'. Used by adapters whose CLI rejects

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5521,7 +5521,9 @@ export async function startServer({
     // prompt-composition skipTranscript choice, the buildArgs flags, and the
     // create-turn persistence below.
     const agentSupportsSessionResume =
-      def.resumesSessionViaCli === true || def.streamFormat === 'pi-rpc';
+      def.resumesSessionViaCli === true ||
+      def.streamFormat === 'pi-rpc' ||
+      def.resumesSessionViaAcpLoad === true;
     // Capture-style adapters (codex) mint their OWN session id and report it on
     // the stream; the daemon captures it here and persists THAT as the resume
     // handle instead of `agentResumeCtx.newSessionId` (which such CLIs ignore).
@@ -7699,6 +7701,11 @@ export async function startServer({
         mcpServers,
         envFormat: def.acpMcpEnvFormat ?? 'array',
         ...(def.id === 'amr' ? { modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE' } : {}),
+        // Resume the prior upstream session (drives `session/load`) when the
+        // resume-identity guard says it is safe; otherwise a fresh session/new.
+        ...(def.resumesSessionViaAcpLoad === true && agentResumeCtx.isResuming && agentResumeCtx.resumeSessionId
+          ? { resumeSessionId: agentResumeCtx.resumeSessionId }
+          : {}),
         onCliReady: () => noteCliReadyAt(),
         onSessionInit: () => noteSessionInitDoneAt(),
         send: (event, data) => {
@@ -7841,7 +7848,7 @@ export async function startServer({
       // broken conversation.
       if (
         !run.cancelRequested &&
-        def.resumesSessionViaCli === true &&
+        (def.resumesSessionViaCli === true || def.resumesSessionViaAcpLoad === true) &&
         agentResumeCtx.isResuming &&
         run.conversationId &&
         isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
@@ -8173,6 +8180,27 @@ export async function startServer({
             lastMessageId: run.assistantMessageId ?? null,
           });
         }
+      }
+      // ACP session/load adapters (AMR/vela) report a durable upstream handle
+      // from the ACP session; persist it (under the resume-identity guard) so
+      // the next turn resumes via session/load. A missing handle clears the row
+      // (so a fresh session is opened next turn), mirroring the capture-style
+      // adapters.
+      if (
+        def.resumesSessionViaAcpLoad === true &&
+        status === 'succeeded' &&
+        acpSession &&
+        typeof acpSession.getDurableSessionId === 'function'
+      ) {
+        persistCapturedAgentSession(db, {
+          conversationId: run.conversationId,
+          agentId: def.id,
+          sessionId: acpSession.getDurableSessionId(),
+          stablePromptHash: currentStableHash,
+          model: run.model ?? null,
+          cwd: effectiveCwd,
+          lastMessageId: run.assistantMessageId ?? null,
+        });
       }
       if (status === 'succeeded') {
         persistDeliveredAgentSessionState();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -488,7 +488,7 @@ import {
 import {
   computeIncludeStable,
   hashStableInstructions,
-  isClaudeResumeFailure,
+  isAgentResumeFailure,
   persistCapturedAgentSession,
   resolveAgentResumeContext,
 } from './agent-session-resume.js';
@@ -5523,6 +5523,12 @@ export async function startServer({
     // create-turn persistence below.
     const agentSupportsSessionResume =
       def.resumesSessionViaCli === true || def.streamFormat === 'pi-rpc';
+    // Capture-style adapters (codex) mint their OWN session id and report it on
+    // the stream; the daemon captures it here and persists THAT as the resume
+    // handle instead of `agentResumeCtx.newSessionId` (which such CLIs ignore).
+    // Set from the `status` event's `sessionId` in `sendAgentEvent` below.
+    const agentCapturesSessionId = def.capturesSessionIdFromStream === true;
+    let capturedSessionId: string | null = null;
     const agentResumeCtx =
       agentSupportsSessionResume && run.conversationId
         ? resolveAgentResumeContext(db, {
@@ -5991,7 +5997,9 @@ export async function startServer({
       );
       const liveSessionId = agentResumeCtx.isResuming
         ? agentResumeCtx.resumeSessionId
-        : agentResumeCtx.newSessionId;
+        : agentCapturesSessionId
+          ? capturedSessionId
+          : agentResumeCtx.newSessionId;
       const resumableFailure =
         result === 'failed' &&
         def.resumesSessionViaCli === true &&
@@ -6475,11 +6483,20 @@ export async function startServer({
       persistDeliveredAgentSessionState = () => {
         if (persisted) return;
         persisted = true;
-        if (!agentResumeCtx.isResuming && agentResumeCtx.newSessionId) {
+        // The id to persist for a create turn: capture-style adapters store the
+        // session id the CLI minted and reported on the stream; specify-style
+        // adapters store the daemon-minted id they passed to the CLI. A
+        // capture-style run that never reported an id (CLI died before
+        // `thread.started`) leaves nothing to resume — correct, the next turn
+        // starts fresh and re-seeds the transcript.
+        const createTurnSessionId = agentCapturesSessionId
+          ? capturedSessionId
+          : agentResumeCtx.newSessionId;
+        if (!agentResumeCtx.isResuming && createTurnSessionId) {
           upsertAgentSession(db, {
             conversationId: run.conversationId,
             agentId: def.id,
-            sessionId: agentResumeCtx.newSessionId,
+            sessionId: createTurnSessionId,
             stablePromptHash: currentStableHash,
           });
           return;
@@ -7450,6 +7467,18 @@ export async function startServer({
       // First well-formed decoded stream event = CLI ready for the
       // json-event-stream / qoder / pi-rpc families (#3408 §4 marker).
       noteCliReadyAt();
+      // Capture-style resume: codex reports its own thread id on the
+      // `thread.started` status event. Persist the most recent non-empty id we
+      // see so the create-turn store (and the resumable-failure store) use the
+      // CLI's real session handle, not the unused daemon-minted `newSessionId`.
+      if (
+        agentCapturesSessionId &&
+        ev?.type === 'status' &&
+        typeof ev.sessionId === 'string' &&
+        ev.sessionId.length > 0
+      ) {
+        capturedSessionId = ev.sessionId;
+      }
       lastAgentEventPhase = summarizeAgentEventForInactivity(ev);
       noteAgentActivity();
       // Role-marker guard for qoder / json-event-stream / pi-rpc (#3247).
@@ -7781,6 +7810,29 @@ export async function startServer({
       }
       parseBufferedAntigravityGeminiJsonEventStream();
       flushAgentTitleMarkerBuffer();
+      // Resume-target-missing recovery runs BEFORE the generic stream-error
+      // short-circuit: some CLIs (codex `exec resume`) report "no rollout found
+      // for thread id" as a stream `error` event, which would otherwise be
+      // swallowed by the stream_error path and leave the dead session id stored
+      // — every later turn would retry the same broken resume (#4275 class).
+      // Clearing the stale handle here lets the next turn start fresh + re-seed
+      // the full transcript, so a missing session costs one cold turn, never a
+      // broken conversation.
+      if (
+        !run.cancelRequested &&
+        def.resumesSessionViaCli === true &&
+        agentResumeCtx.isResuming &&
+        run.conversationId &&
+        isAgentResumeFailure(def.id, `${agentStderrTail}\n${agentStdoutTail}`)
+      ) {
+        clearAgentSession(db, run.conversationId, def.id);
+        send('error', createSseErrorPayload(
+          'AGENT_EXECUTION_FAILED',
+          'The previous session could not be resumed (it may have expired). Resend your message to continue with a fresh session.',
+          { retryable: true },
+        ));
+        return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+      }
       if (agentStreamError) {
         markRpcCloseReason('stream_error');
         return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
@@ -7810,26 +7862,6 @@ export async function startServer({
           ));
           return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
         }
-      }
-      if (
-        code !== 0 &&
-        !run.cancelRequested &&
-        def.resumesSessionViaCli === true &&
-        agentResumeCtx.isResuming &&
-        run.conversationId &&
-        isClaudeResumeFailure(`${agentStderrTail}\n${agentStdoutTail}`)
-      ) {
-        // The stored session id no longer resolves (pruned / machine moved
-        // / ~/.claude cleared). Drop it so the next turn starts a fresh
-        // session seeded with the full transcript, and surface a retryable
-        // error rather than a confusing hard failure.
-        clearAgentSession(db, run.conversationId, def.id);
-        send('error', createSseErrorPayload(
-          'AGENT_EXECUTION_FAILED',
-          'The previous Claude session could not be resumed (it may have expired). Resend your message to continue with a fresh session.',
-          { retryable: true },
-        ));
-        return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
       }
       // Empty-output guard: a clean `code === 0` exit with no visible
       // output means the run silently finished without producing anything.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8168,6 +8168,9 @@ export async function startServer({
             agentId: def.id,
             sessionId: sessionPath,
             stablePromptHash: currentStableHash,
+            model: run.model ?? null,
+            cwd: effectiveCwd,
+            lastMessageId: run.assistantMessageId ?? null,
           });
         }
       }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -479,7 +479,6 @@ import {
   updateRoutine,
   updateRoutineRun,
   clearAgentSession,
-  updateAgentSessionStableHash,
   upsertAgentSession,
   upsertDeployment,
   upsertMessage,
@@ -5534,8 +5533,11 @@ export async function startServer({
         ? resolveAgentResumeContext(db, {
             conversationId: run.conversationId,
             agentId: def.id,
+            currentModel: run.model ?? null,
+            currentCwd: effectiveCwd,
+            currentAssistantMessageId: run.assistantMessageId ?? null,
           })
-        : { resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null };
+        : { resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null, invalidationReason: null };
     const userRequestPrompt = composeChatUserRequestForAgent(
       message,
       currentPrompt,
@@ -6014,6 +6016,9 @@ export async function startServer({
           agentId: def.id,
           sessionId: liveSessionId,
           stablePromptHash: currentStableHash,
+          model: run.model ?? null,
+          cwd: effectiveCwd,
+          lastMessageId: run.assistantMessageId ?? null,
         });
       }
       finalizeRetryTelemetry(status, decision, failure, errorCode);
@@ -6498,11 +6503,27 @@ export async function startServer({
             agentId: def.id,
             sessionId: createTurnSessionId,
             stablePromptHash: currentStableHash,
+            model: run.model ?? null,
+            cwd: effectiveCwd,
+            lastMessageId: run.assistantMessageId ?? null,
           });
           return;
         }
-        if (agentResumeCtx.isResuming && includeStableInstructions) {
-          updateAgentSessionStableHash(db, run.conversationId, def.id, currentStableHash);
+        if (agentResumeCtx.isResuming && agentResumeCtx.resumeSessionId) {
+          // Advance the resume identity guard after a successful resume turn:
+          // the conversation grew by this turn, so the cursor must move to the
+          // new max position (otherwise the next turn sees `cursor + 4` and
+          // falsely reseeds). model/cwd are unchanged (they matched on resume);
+          // refresh the stable hash to what the session now holds.
+          upsertAgentSession(db, {
+            conversationId: run.conversationId,
+            agentId: def.id,
+            sessionId: agentResumeCtx.resumeSessionId,
+            stablePromptHash: currentStableHash,
+            model: run.model ?? null,
+            cwd: effectiveCwd,
+            lastMessageId: run.assistantMessageId ?? null,
+          });
         }
       };
     }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7844,7 +7844,7 @@ export async function startServer({
         def.resumesSessionViaCli === true &&
         agentResumeCtx.isResuming &&
         run.conversationId &&
-        isAgentResumeFailure(def.id, `${agentStderrTail}\n${agentStdoutTail}`)
+        isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
       ) {
         clearAgentSession(db, run.conversationId, def.id);
         send('error', createSseErrorPayload(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7832,20 +7832,15 @@ export async function startServer({
       }
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
-      if (acpSession?.hasFatalError()) {
-        markRpcCloseReason('fatal_rpc_error');
-        return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
-      }
-      parseBufferedAntigravityGeminiJsonEventStream();
-      flushAgentTitleMarkerBuffer();
-      // Resume-target-missing recovery runs BEFORE the generic stream-error
-      // short-circuit: some CLIs (codex `exec resume`) report "no rollout found
-      // for thread id" as a stream `error` event, which would otherwise be
-      // swallowed by the stream_error path and leave the dead session id stored
-      // — every later turn would retry the same broken resume (#4275 class).
-      // Clearing the stale handle here lets the next turn start fresh + re-seed
-      // the full transcript, so a missing session costs one cold turn, never a
-      // broken conversation.
+      // Resume-target-missing recovery runs BEFORE the generic fatal/stream-error
+      // short-circuits. The signal arrives differently per adapter: codex reports
+      // "no rollout found for thread id" as a stream `error` event, while AMR/vela
+      // reports a structured `resume_failed` JSON-RPC error that the ACP bridge
+      // turns into a FATAL. Either would otherwise be swallowed by the
+      // `fatal_rpc_error` / `stream_error` paths below and leave the dead session
+      // id stored — so every later turn would retry the same broken resume (#4275
+      // class). Clearing the stale handle here lets the next turn start fresh +
+      // re-seed the full transcript: one cold turn, never a broken conversation.
       if (
         !run.cancelRequested &&
         (def.resumesSessionViaCli === true || def.resumesSessionViaAcpLoad === true) &&
@@ -7861,6 +7856,12 @@ export async function startServer({
         ));
         return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
       }
+      if (acpSession?.hasFatalError()) {
+        markRpcCloseReason('fatal_rpc_error');
+        return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
+      }
+      parseBufferedAntigravityGeminiJsonEventStream();
+      flushAgentTitleMarkerBuffer();
       if (agentStreamError) {
         markRpcCloseReason('stream_error');
         return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -1425,3 +1425,43 @@ test('attachAcpSession preserves structured OpenCode session error details from 
     },
   });
 });
+
+test('attachAcpSession resumes via session/load when resumeSessionId is set', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'oc-prev',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {}); // initialize ack -> drives the resume handshake
+
+  const requests = parseRpcWrites(writes);
+  const loadReq = requests.find((entry) => entry.method === 'session/load');
+  assert.ok(loadReq, 'expected a session/load request on resume');
+  assert.deepEqual(loadReq?.params, {
+    sessionId: 'oc-prev',
+    cwd: path.resolve('/tmp/od-project'),
+  });
+  assert.equal(requests.some((entry) => entry.method === 'session/new'), false);
+});
+
+test('attachAcpSession captures the durable session handle from the result', () => {
+  const child = new FakeAcpChild();
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'vela-opencode-1', openCodeSessionId: 'oc-handle' });
+
+  assert.equal(session.getDurableSessionId(), 'oc-handle');
+});

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -16,6 +16,7 @@ import {
   computeIncludeStable,
   hashStableInstructions,
   isAgentResumeFailure,
+  isAmrResumeFailure,
   isClaudeResumeFailure,
   isCodexResumeFailure,
   isOpencodeResumeFailure,
@@ -451,7 +452,30 @@ describe('isOpencodeResumeFailure', () => {
   });
 });
 
+describe('isAmrResumeFailure', () => {
+  it('matches vela\'s structured resume_failed ACP error on stdout', () => {
+    expect(
+      isAmrResumeFailure('{"jsonrpc":"2.0","id":4,"error":{"code":-32600,"message":"the resumed session could not be loaded","data":{"kind":"resume_failed","phase":"session_load","retryable":true}}}'),
+    ).toBe(true);
+  });
+
+  it('does not match a bare mention of resume_failed in assistant prose', () => {
+    expect(isAmrResumeFailure('The build step logged resume_failed as a warning.')).toBe(false);
+    expect(isAmrResumeFailure('')).toBe(false);
+  });
+});
+
 describe('isAgentResumeFailure dispatch', () => {
+  it('routes amr to the resume_failed structured detector on stdout', () => {
+    // AMR's signal arrives on stdout (the ACP JSON-RPC channel), not stderr.
+    expect(
+      isAgentResumeFailure('amr', '', '{"error":{"data":{"kind":"resume_failed"}}}'),
+    ).toBe(true);
+    expect(
+      isAgentResumeFailure('amr', '{"error":{"data":{"kind":"resume_failed"}}}', ''),
+    ).toBe(false);
+  });
+
   it('routes codex to the rollout-not-found detector', () => {
     expect(
       isAgentResumeFailure('codex', 'no rollout found for thread id abc'),

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -17,6 +17,7 @@ import {
   isAgentResumeFailure,
   isClaudeResumeFailure,
   isCodexResumeFailure,
+  isOpencodeResumeFailure,
   persistCapturedAgentSession,
   resolveAgentResumeContext,
 } from '../src/agent-session-resume.js';
@@ -265,6 +266,21 @@ describe('isCodexResumeFailure', () => {
   });
 });
 
+describe('isOpencodeResumeFailure', () => {
+  it('matches the OpenCode "Session not found" resume error', () => {
+    expect(isOpencodeResumeFailure('Error: Session not found')).toBe(true);
+    expect(
+      isOpencodeResumeFailure('{"name":"NotFoundError","data":{"message":"Session not found: ses_x"}}'),
+    ).toBe(true);
+  });
+
+  it('ignores unrelated OpenCode errors and empty input', () => {
+    expect(isOpencodeResumeFailure('OpenCode auth failed: login required')).toBe(false);
+    expect(isOpencodeResumeFailure('rate limit exceeded')).toBe(false);
+    expect(isOpencodeResumeFailure('')).toBe(false);
+  });
+});
+
 describe('isAgentResumeFailure dispatch', () => {
   it('routes codex to the rollout-not-found detector', () => {
     expect(
@@ -273,6 +289,14 @@ describe('isAgentResumeFailure dispatch', () => {
     // A Claude-style signature must NOT count as a codex resume failure.
     expect(
       isAgentResumeFailure('codex', 'No conversation found with session ID: abc'),
+    ).toBe(false);
+  });
+
+  it('routes opencode to the session-not-found detector', () => {
+    expect(isAgentResumeFailure('opencode', 'Error: Session not found')).toBe(true);
+    // codex prose is not an OpenCode resume failure.
+    expect(
+      isAgentResumeFailure('opencode', 'no rollout found for thread id abc'),
     ).toBe(false);
   });
 

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -14,7 +14,9 @@ import {
 import {
   computeIncludeStable,
   hashStableInstructions,
+  isAgentResumeFailure,
   isClaudeResumeFailure,
+  isCodexResumeFailure,
   persistCapturedAgentSession,
   resolveAgentResumeContext,
 } from '../src/agent-session-resume.js';
@@ -240,5 +242,52 @@ describe('isClaudeResumeFailure', () => {
       session_id: 'live-session',
     });
     expect(isClaudeResumeFailure(success)).toBe(false);
+  });
+});
+
+describe('isCodexResumeFailure', () => {
+  it('matches the codex "no rollout found" resume error', () => {
+    expect(
+      isCodexResumeFailure(
+        'Error: thread/resume: thread/resume failed: no rollout found for thread id 019eef4f-7409-7c82-bebe-30504eed3959',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches the generic thread/resume-failed signature', () => {
+    expect(isCodexResumeFailure('thread/resume failed: something else')).toBe(true);
+  });
+
+  it('ignores unrelated codex errors and empty input', () => {
+    expect(isCodexResumeFailure('stream disconnected before first event')).toBe(false);
+    expect(isCodexResumeFailure('rate limit exceeded')).toBe(false);
+    expect(isCodexResumeFailure('')).toBe(false);
+  });
+});
+
+describe('isAgentResumeFailure dispatch', () => {
+  it('routes codex to the rollout-not-found detector', () => {
+    expect(
+      isAgentResumeFailure('codex', 'no rollout found for thread id abc'),
+    ).toBe(true);
+    // A Claude-style signature must NOT count as a codex resume failure.
+    expect(
+      isAgentResumeFailure('codex', 'No conversation found with session ID: abc'),
+    ).toBe(false);
+  });
+
+  it('routes claude (and unknown resume-capable agents) to the Claude detector', () => {
+    expect(
+      isAgentResumeFailure('claude', 'No conversation found with session ID: abc'),
+    ).toBe(true);
+    // codex prose is not a Claude resume failure.
+    expect(
+      isAgentResumeFailure('claude', 'no rollout found for thread id abc'),
+    ).toBe(false);
+  });
+
+  it('never reports a failure for empty output', () => {
+    expect(isAgentResumeFailure('codex', '')).toBe(false);
+    expect(isAgentResumeFailure('claude', '')).toBe(false);
   });
 });

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -235,6 +235,36 @@ describe('persistCapturedAgentSession', () => {
     expect(resolveAgentResumeContext(db, { conversationId: 'conv-1', agentId: 'pi' }).isResuming)
       .toBe(false);
   });
+
+  // Regression for the resume identity guard: pi-rpc persists via this capture
+  // path, so it must store model/cwd/lastMessageId too — otherwise the next pi
+  // turn sees a null cursor (`missing_cursor`) and reseeds forever, silently
+  // disabling pi's existing follow-up-session path (reported by @nettee).
+  it('persists the resume identity so a successful pi turn still resumes next turn', () => {
+    const db = seed();
+    upsertMessage(db, 'conv-1', { id: 'asst-1', role: 'assistant', content: 'pi reply' });
+
+    const result = persistCapturedAgentSession(db, {
+      conversationId: 'conv-1',
+      agentId: 'pi',
+      sessionId: '/tmp/current.jsonl',
+      stablePromptHash: 'hash-1',
+      model: null,
+      cwd: '/work/proj',
+      lastMessageId: 'asst-1',
+    });
+    expect(result).toBe('stored');
+
+    const ctx = resolveAgentResumeContext(db, {
+      conversationId: 'conv-1',
+      agentId: 'pi',
+      currentModel: null,
+      currentCwd: '/work/proj',
+    });
+    expect(ctx.isResuming).toBe(true);
+    expect(ctx.resumeSessionId).toBe('/tmp/current.jsonl');
+    expect(ctx.invalidationReason).toBeNull();
+  });
 });
 
 describe('hashStableInstructions', () => {

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -161,6 +161,49 @@ describe('resolveAgentResumeContext', () => {
     expect(ctx.invalidationReason).toBe('conversation_advanced');
   });
 
+  it('still resumes when the stored cursor is the session own failed turn (resume-on-failure)', () => {
+    const db = seed();
+    // Turn 1 committed work then FAILED transiently; the resume-on-failure path
+    // persisted the session pointing at that failed assistant turn.
+    seedMessage(db, 'asst-1', 'assistant', 'failed');
+    upsertAgentSession(db, {
+      conversationId: 'conv-1',
+      agentId: 'claude',
+      sessionId: 'sess-A',
+      lastMessageId: 'asst-1',
+      model: null,
+      cwd: null,
+      stablePromptHash: null,
+    });
+    // Turn 2 must continue the same session — the failed turn it owns is a valid
+    // resume cursor, not conversation advancement.
+    const ctx = resolveAgentResumeContext(db, { conversationId: 'conv-1', agentId: 'claude' });
+    expect(ctx.isResuming).toBe(true);
+    expect(ctx.resumeSessionId).toBe('sess-A');
+    expect(ctx.invalidationReason).toBeNull();
+  });
+
+  it('reseeds (conversation_advanced) when a later succeeded turn follows the stored failed turn', () => {
+    const db = seed();
+    // Stored session owns a failed turn (asst-1)...
+    seedMessage(db, 'asst-1', 'assistant', 'failed');
+    upsertAgentSession(db, {
+      conversationId: 'conv-1',
+      agentId: 'claude',
+      sessionId: 'sess-A',
+      lastMessageId: 'asst-1',
+      model: null,
+      cwd: null,
+      stablePromptHash: null,
+    });
+    // ...but a different agent then COMPLETED a turn (asst-2 succeeded). That is
+    // genuine advancement the session never saw — must reseed, not resume.
+    seedMessage(db, 'asst-2', 'assistant'); // succeeded
+    const ctx = resolveAgentResumeContext(db, { conversationId: 'conv-1', agentId: 'claude' });
+    expect(ctx.isResuming).toBe(false);
+    expect(ctx.invalidationReason).toBe('conversation_advanced');
+  });
+
   it('reseeds (missing_cursor) for a legacy row written without an identity', () => {
     const db = seed();
     seedMessage(db, 'asst-1', 'assistant');

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -10,6 +10,7 @@ import {
   insertProject,
   openDatabase,
   upsertAgentSession,
+  upsertMessage,
 } from '../src/db.js';
 import {
   computeIncludeStable,
@@ -45,34 +46,120 @@ describe('resolveAgentResumeContext', () => {
     return db;
   }
 
+  function seedMessage(db: ReturnType<typeof seed>, id: string, role: 'user' | 'assistant') {
+    upsertMessage(db, 'conv-1', { id, role, content: `${role} ${id}` });
+  }
+
+  // A session row whose identity (model/cwd/last assistant id) matches what the
+  // next resolve will present, so the guard allows the resume.
+  function storeInSyncSession(
+    db: ReturnType<typeof seed>,
+    over: { stablePromptHash?: string | null; model?: string | null; cwd?: string | null } = {},
+  ) {
+    upsertAgentSession(db, {
+      conversationId: 'conv-1',
+      agentId: 'claude',
+      sessionId: 'sess-A',
+      lastMessageId: 'asst-1',
+      model: over.model ?? null,
+      cwd: over.cwd ?? null,
+      stablePromptHash: over.stablePromptHash ?? null,
+    });
+  }
+
   it('creates a new session (minted uuid, not resuming) when none stored', () => {
     const db = seed();
     const ctx = resolveAgentResumeContext(db, { conversationId: 'conv-1', agentId: 'claude' });
     expect(ctx.isResuming).toBe(false);
     expect(ctx.resumeSessionId).toBeNull();
     expect(ctx.newSessionId).toMatch(UUID_RE);
+    expect(ctx.invalidationReason).toBeNull();
   });
 
-  it('resumes the stored session when one exists', () => {
+  it('resumes the stored session when the identity still matches', () => {
     const db = seed();
-    upsertAgentSession(db, { conversationId: 'conv-1', agentId: 'claude', sessionId: 'sess-A' });
+    seedMessage(db, 'asst-1', 'assistant');
+    storeInSyncSession(db);
     const ctx = resolveAgentResumeContext(db, { conversationId: 'conv-1', agentId: 'claude' });
+    expect(ctx.isResuming).toBe(true);
+    expect(ctx.resumeSessionId).toBe('sess-A');
+    expect(ctx.invalidationReason).toBeNull();
+  });
+
+  it('still resumes when only the current run placeholder is newer (normal follow-up)', () => {
+    const db = seed();
+    seedMessage(db, 'asst-1', 'assistant');
+    storeInSyncSession(db);
+    // The next turn's user message + assistant placeholder are already inserted.
+    seedMessage(db, 'user-2', 'user');
+    seedMessage(db, 'asst-2', 'assistant');
+    const ctx = resolveAgentResumeContext(db, {
+      conversationId: 'conv-1',
+      agentId: 'claude',
+      currentAssistantMessageId: 'asst-2',
+    });
     expect(ctx.isResuming).toBe(true);
     expect(ctx.resumeSessionId).toBe('sess-A');
   });
 
-  it('returns null storedStablePromptHash when none stored, and the value when present', () => {
+  it('returns the stored stable hash when resuming', () => {
     const db = seed();
-    const fresh = resolveAgentResumeContext(db, { conversationId: 'conv-1', agentId: 'claude' });
-    expect(fresh.storedStablePromptHash).toBeNull();
-
-    upsertAgentSession(db, {
-      conversationId: 'conv-1', agentId: 'claude', sessionId: 'sess-A', stablePromptHash: 'h-1',
-    });
+    seedMessage(db, 'asst-1', 'assistant');
+    storeInSyncSession(db, { stablePromptHash: 'h-1' });
     const resumed = resolveAgentResumeContext(db, { conversationId: 'conv-1', agentId: 'claude' });
     expect(resumed.isResuming).toBe(true);
-    expect(resumed.resumeSessionId).toBe('sess-A');
     expect(resumed.storedStablePromptHash).toBe('h-1');
+  });
+
+  it('reseeds (model_changed) when the model differs from the stored session', () => {
+    const db = seed();
+    seedMessage(db, 'asst-1', 'assistant');
+    storeInSyncSession(db, { model: 'gpt-5.1' });
+    const ctx = resolveAgentResumeContext(db, {
+      conversationId: 'conv-1', agentId: 'claude', currentModel: 'gpt-5-codex',
+    });
+    expect(ctx.isResuming).toBe(false);
+    expect(ctx.resumeSessionId).toBeNull();
+    expect(ctx.invalidationReason).toBe('model_changed');
+  });
+
+  it('reseeds (cwd_changed) when the cwd differs from the stored session', () => {
+    const db = seed();
+    seedMessage(db, 'asst-1', 'assistant');
+    storeInSyncSession(db, { cwd: '/work/a' });
+    const ctx = resolveAgentResumeContext(db, {
+      conversationId: 'conv-1', agentId: 'claude', currentCwd: '/work/b',
+    });
+    expect(ctx.isResuming).toBe(false);
+    expect(ctx.invalidationReason).toBe('cwd_changed');
+  });
+
+  it('reseeds (conversation_advanced) when another agent completed a turn in between', () => {
+    const db = seed();
+    seedMessage(db, 'asst-1', 'assistant');
+    storeInSyncSession(db);
+    // A different agent ran: a newer completed assistant turn now exists.
+    seedMessage(db, 'user-2', 'user');
+    seedMessage(db, 'asst-other', 'assistant');
+    // This agent comes back; its placeholder is asst-3.
+    seedMessage(db, 'user-3', 'user');
+    seedMessage(db, 'asst-3', 'assistant');
+    const ctx = resolveAgentResumeContext(db, {
+      conversationId: 'conv-1', agentId: 'claude', currentAssistantMessageId: 'asst-3',
+    });
+    expect(ctx.isResuming).toBe(false);
+    expect(ctx.resumeSessionId).toBeNull();
+    expect(ctx.invalidationReason).toBe('conversation_advanced');
+  });
+
+  it('reseeds (missing_cursor) for a legacy row written without an identity', () => {
+    const db = seed();
+    seedMessage(db, 'asst-1', 'assistant');
+    // Old-style upsert: no model/cwd/lastMessageId.
+    upsertAgentSession(db, { conversationId: 'conv-1', agentId: 'claude', sessionId: 'sess-A' });
+    const ctx = resolveAgentResumeContext(db, { conversationId: 'conv-1', agentId: 'claude' });
+    expect(ctx.isResuming).toBe(false);
+    expect(ctx.invalidationReason).toBe('missing_cursor');
   });
 });
 
@@ -121,7 +208,7 @@ describe('persistCapturedAgentSession', () => {
       stablePromptHash: 'hash-1',
     });
     expect(result).toBe('stored');
-    expect(getAgentSessionRecord(db, 'conv-1', 'pi')).toEqual({
+    expect(getAgentSessionRecord(db, 'conv-1', 'pi')).toMatchObject({
       sessionId: '/tmp/current.jsonl',
       stablePromptHash: 'hash-1',
     });

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -46,8 +46,17 @@ describe('resolveAgentResumeContext', () => {
     return db;
   }
 
-  function seedMessage(db: ReturnType<typeof seed>, id: string, role: 'user' | 'assistant') {
-    upsertMessage(db, 'conv-1', { id, role, content: `${role} ${id}` });
+  // A completed turn stamps its assistant message run_status='succeeded' at
+  // finish (server.ts). The resume cursor only counts succeeded assistant turns,
+  // so completed turns default to 'succeeded'; pass runStatus=null for an
+  // in-flight placeholder (the current run's own not-yet-finished message).
+  function seedMessage(
+    db: ReturnType<typeof seed>,
+    id: string,
+    role: 'user' | 'assistant',
+    runStatus: string | null = role === 'assistant' ? 'succeeded' : null,
+  ) {
+    upsertMessage(db, 'conv-1', { id, role, content: `${role} ${id}`, runStatus });
   }
 
   // A session row whose identity (model/cwd/last assistant id) matches what the
@@ -92,7 +101,7 @@ describe('resolveAgentResumeContext', () => {
     storeInSyncSession(db);
     // The next turn's user message + assistant placeholder are already inserted.
     seedMessage(db, 'user-2', 'user');
-    seedMessage(db, 'asst-2', 'assistant');
+    seedMessage(db, 'asst-2', 'assistant', null); // in-flight placeholder
     const ctx = resolveAgentResumeContext(db, {
       conversationId: 'conv-1',
       agentId: 'claude',
@@ -143,7 +152,7 @@ describe('resolveAgentResumeContext', () => {
     seedMessage(db, 'asst-other', 'assistant');
     // This agent comes back; its placeholder is asst-3.
     seedMessage(db, 'user-3', 'user');
-    seedMessage(db, 'asst-3', 'assistant');
+    seedMessage(db, 'asst-3', 'assistant', null); // in-flight placeholder
     const ctx = resolveAgentResumeContext(db, {
       conversationId: 'conv-1', agentId: 'claude', currentAssistantMessageId: 'asst-3',
     });
@@ -242,7 +251,7 @@ describe('persistCapturedAgentSession', () => {
   // disabling pi's existing follow-up-session path (reported by @nettee).
   it('persists the resume identity so a successful pi turn still resumes next turn', () => {
     const db = seed();
-    upsertMessage(db, 'conv-1', { id: 'asst-1', role: 'assistant', content: 'pi reply' });
+    upsertMessage(db, 'conv-1', { id: 'asst-1', role: 'assistant', content: 'pi reply', runStatus: 'succeeded' });
 
     const result = persistCapturedAgentSession(db, {
       conversationId: 'conv-1',

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -330,7 +330,8 @@ describe('isClaudeResumeFailure', () => {
       session_id: '00000000-0000-0000-0000-000000000000',
       errors: [rewordedProse],
     });
-    expect(isClaudeResumeFailure(rewordedResult)).toBe(true);
+    // The structured result event arrives on stdout (the stream-json channel).
+    expect(isClaudeResumeFailure('', rewordedResult)).toBe(true);
   });
 
   // Guard against over-clearing: a transient in-turn failure (overload /
@@ -348,7 +349,7 @@ describe('isClaudeResumeFailure', () => {
       session_id: 'live-session',
       errors: ['Overloaded'],
     });
-    expect(isClaudeResumeFailure(inTurnApiError)).toBe(false);
+    expect(isClaudeResumeFailure('', inTurnApiError)).toBe(false);
 
     const success = JSON.stringify({
       type: 'result',
@@ -359,7 +360,7 @@ describe('isClaudeResumeFailure', () => {
       num_turns: 2,
       session_id: 'live-session',
     });
-    expect(isClaudeResumeFailure(success)).toBe(false);
+    expect(isClaudeResumeFailure('', success)).toBe(false);
   });
 });
 
@@ -409,11 +410,24 @@ describe('isAgentResumeFailure dispatch', () => {
     ).toBe(false);
   });
 
-  it('routes opencode to the session-not-found detector', () => {
-    expect(isAgentResumeFailure('opencode', 'Error: Session not found')).toBe(true);
+  it('routes opencode to the session-not-found detector (on stderr only)', () => {
+    // The CLI prints the miss to stderr (2nd positional is stdout).
+    expect(isAgentResumeFailure('opencode', 'Error: Session not found', '')).toBe(true);
     // codex prose is not an OpenCode resume failure.
     expect(
       isAgentResumeFailure('opencode', 'no rollout found for thread id abc'),
+    ).toBe(false);
+  });
+
+  it('does NOT treat a generic phrase in successful assistant stdout as a resume miss (#4629 nettee)', () => {
+    // A turn that SUCCEEDS but whose model output literally says "session not
+    // found" must not be failed + have its session cleared — the phrase is only
+    // a resume miss when it comes from the CLI's stderr failure channel.
+    expect(
+      isAgentResumeFailure('opencode', '', 'Sure — your previous session was not found in the list, here it is...'),
+    ).toBe(false);
+    expect(
+      isAgentResumeFailure('codex', '', 'The logs mention "no rollout found for thread id" as an example.'),
     ).toBe(false);
   });
 

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -445,6 +445,54 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
     expect(thinkingDeltas.join('')).toBe('thinking-chunk');
   });
 
+  it('resumes a prior session via session/load and captures the durable handle', async () => {
+    const child = spawnFakeVela({ FAKE_VELA_TEXT: 'Resumed.' });
+    try {
+      const session = attachAcpSession({
+        child: child as never,
+        prompt: 'continue',
+        cwd: process.cwd(),
+        model: 'deepseek-v3.2',
+        // A stored durable handle drives session/load instead of session/new.
+        resumeSessionId: 'oc-prev-handle',
+        mcpServers: [],
+        send: () => {},
+      });
+      await waitForExit(child);
+      expect(session.hasFatalError()).toBe(false);
+      expect(session.completedSuccessfully()).toBe(true);
+      // The fake echoes the requested handle back as the durable id; the daemon
+      // would persist this to resume again next turn.
+      expect(session.getDurableSessionId()).toBe('oc-prev-handle');
+    } finally {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }
+  });
+
+  it('surfaces resume_failed (no completion) when the resumed session is gone', async () => {
+    const child = spawnFakeVela({ FAKE_VELA_RESUME_FAILED: '1' });
+    const events: Array<{ event: string; payload: unknown }> = [];
+    try {
+      const session = attachAcpSession({
+        child: child as never,
+        prompt: 'continue',
+        cwd: process.cwd(),
+        model: 'deepseek-v3.2',
+        resumeSessionId: 'oc-gone',
+        mcpServers: [],
+        send: (event, payload) => events.push({ event, payload }),
+      });
+      await waitForExit(child);
+      expect(session.completedSuccessfully()).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }
+    // The structured resume_failed marker reaches the host (the daemon matches
+    // it on stdout to clear the stale handle and reseed). It must never look
+    // like a successful turn.
+    expect(JSON.stringify(events)).toContain('resume_failed');
+  });
+
   it('regression: stub mirrors real vela by rejecting session/prompt before session/set_model', async () => {
     const child = spawnFakeVela({ FAKE_VELA_TEXT: 'unused' });
     const errors: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/amr-session-resume.test.ts
+++ b/apps/daemon/tests/amr-session-resume.test.ts
@@ -1,0 +1,334 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+// End-to-end coverage for AMR (vela) ACP session resume through the FULL server
+// close handler — not just `attachAcpSession` in isolation.
+//
+// AMR is `resumesSessionViaAcpLoad`: turn 1 issues `session/new` and the daemon
+// captures vela's durable `openCodeSessionId`; the next turn in the same
+// conversation issues `session/load <handle>` to resume the upstream OpenCode
+// session instead of re-paying the whole transcript cache-cold.
+//
+// The headline guard is the dead-handle fallback. When the resumed upstream
+// session is gone, vela returns a structured `resume_failed` JSON-RPC error,
+// which the ACP bridge turns into a FATAL. The daemon must STILL recognize it as
+// a resume failure, clear the stale handle, surface a retryable error, and let
+// the NEXT turn start a fresh `session/new` (re-seeded with the full transcript)
+// — one cold turn, never a conversation wedged retrying a dead `session/load`.
+//
+// Regression note: turn-2's error code is `AGENT_EXECUTION_FAILED` whether or
+// not the handle is cleared, so the load-bearing assertions are turn-3 (must
+// SUCCEED via a fresh session) and the session-bind sequence
+// (['new','load','new'], not ['new','load','load']). Before the close-handler
+// ordering fix — where `hasFatalError()` short-circuited BEFORE the
+// resume-failure reseed block — the dead handle was never cleared, so turn-3
+// resumed it again, going ['new','load','load'] and failing.
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  error: string | null;
+  errorCode: string | null;
+  eventsLogPath: string;
+};
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FAKE_VELA = path.join(HERE, 'fixtures', 'fake-vela.mjs');
+
+describe('AMR (vela) ACP session resume — full server cycle', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await removeTempDir(binDir);
+    binDir = null;
+    restoreEnv(originalEnv);
+  });
+
+  it('captures the durable handle on turn 1 and resumes it via session/load on turn 2', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-amr-resume-bin-'));
+    const logPath = path.join(binDir, 'invocations.jsonl');
+    const bin = await writeVelaWrapper(binDir, 'vela-resume', { logPath });
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'amr',
+      agentCliEnv: { amr: { VELA_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    const turn1 = await sendRunAndWait(started.url, conversationId, 'first request');
+    expect(turn1.status).toBe('succeeded');
+
+    const turn2 = await sendRunAndWait(started.url, conversationId, 'second request');
+    expect(turn2.status).toBe('succeeded');
+
+    // Turn 1 binds a fresh session; turn 2 resumes the captured durable handle.
+    expect(await readInvocations(logPath)).toEqual(['new', 'load']);
+  });
+
+  it('clears the dead handle on resume_failed and reseeds a fresh session next turn', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-amr-deadresume-bin-'));
+    const logPath = path.join(binDir, 'invocations.jsonl');
+    // The resumed session is gone: any session/load turn fails with the
+    // structured resume_failed; a fresh session/new turn still succeeds.
+    const bin = await writeVelaWrapper(binDir, 'vela-deadresume', { logPath, resumeFailed: true });
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'amr',
+      agentCliEnv: { amr: { VELA_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    // Turn 1 creates + persists the durable handle.
+    const turn1 = await sendRunAndWait(started.url, conversationId, 'first request');
+    expect(turn1.status).toBe('succeeded');
+
+    // Turn 2 resumes (session/load), but the upstream session is gone → vela
+    // returns resume_failed → retryable failure, stale handle cleared.
+    const turn2 = await sendRunAndWait(started.url, conversationId, 'second request');
+    expect(turn2.status).toBe('failed');
+    expect(turn2.errorCode).toBe('AGENT_EXECUTION_FAILED');
+    expect(turn2.error ?? '').toMatch(/could not be resumed/i);
+
+    // Turn 3 must NOT retry the dead resume — the cleared handle forces a fresh
+    // session/new (reseeded with the full transcript), which succeeds.
+    const turn3 = await sendRunAndWait(started.url, conversationId, 'third request');
+    expect(turn3.status).toBe('succeeded');
+
+    // The session-bind sequence is the regression signal: fixed = new/load/new;
+    // buggy (handle never cleared) would be new/load/load with turn-3 failing.
+    expect(await readInvocations(logPath)).toEqual(['new', 'load', 'new']);
+  });
+
+  it('opens a fresh session next turn when turn 1 yields no durable handle', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-amr-nohandle-bin-'));
+    const logPath = path.join(binDir, 'invocations.jsonl');
+    // vela never reports openCodeSessionId → the daemon captures null and must
+    // clear the row, so the next turn cannot attempt a session/load.
+    const bin = await writeVelaWrapper(binDir, 'vela-nohandle', { logPath, omitHandle: true });
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'amr',
+      agentCliEnv: { amr: { VELA_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    expect((await sendRunAndWait(started.url, conversationId, 'first request')).status)
+      .toBe('succeeded');
+    expect((await sendRunAndWait(started.url, conversationId, 'second request')).status)
+      .toBe('succeeded');
+
+    // No handle was ever stored, so BOTH turns open a fresh session — never a
+    // session/load against a non-existent upstream session.
+    expect(await readInvocations(logPath)).toEqual(['new', 'new']);
+  });
+
+  it('reseeds a fresh session (no resume) when the model changes between turns', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-amr-modelchange-bin-'));
+    const logPath = path.join(binDir, 'invocations.jsonl');
+    const bin = await writeVelaWrapper(binDir, 'vela-modelchange', { logPath });
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'amr',
+      agentCliEnv: { amr: { VELA_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    // Turn 1 binds a session under one model and captures the durable handle.
+    expect((await sendRunAndWait(started.url, conversationId, 'first request', 'deepseek-v3.2')).status)
+      .toBe('succeeded');
+    // Turn 2 switches model: the resume-identity guard must invalidate (the
+    // upstream session was seeded under the old model) and open a FRESH session
+    // rather than session/load the mismatched one.
+    expect((await sendRunAndWait(started.url, conversationId, 'second request', 'gemini-2.5-flash')).status)
+      .toBe('succeeded');
+
+    expect(await readInvocations(logPath)).toEqual(['new', 'new']);
+  });
+});
+
+// A tiny executable shim that forwards to fake-vela.mjs under the current node,
+// so VELA_BIN resolves to a real executable regardless of the fixture's mode.
+// The daemon's `agentCliEnv` is allowlisted (only VELA_BIN survives for AMR), so
+// behavior knobs are baked into the wrapper's OWN env here instead of passed
+// through config — the wrapper exports them before exec'ing fake-vela.
+async function writeVelaWrapper(
+  dir: string,
+  name: string,
+  opts: { logPath: string; resumeFailed?: boolean; omitHandle?: boolean },
+): Promise<string> {
+  const bin = path.join(dir, name);
+  const lines = [
+    '#!/bin/sh',
+    `export FAKE_VELA_INVOCATION_LOG=${JSON.stringify(opts.logPath)}`,
+    // Isolate the resume cycle from the set_model gate; the strict-set_model
+    // contract is covered by amr-acp-integration.test.ts.
+    'export FAKE_VELA_REQUIRE_SET_MODEL=0',
+  ];
+  if (opts.resumeFailed) lines.push('export FAKE_VELA_RESUME_FAILED=1');
+  if (opts.omitHandle) lines.push('export FAKE_VELA_OMIT_OPENCODE_SESSION_ID=1');
+  lines.push(`exec ${JSON.stringify(process.execPath)} ${JSON.stringify(FAKE_VELA)} "$@"`, '');
+  await writeFile(bin, lines.join('\n'), 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function readInvocations(logPath: string): Promise<string[]> {
+  let raw = '';
+  try {
+    raw = await readFile(logPath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => (JSON.parse(line) as { method: string }).method);
+}
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.POSTHOG_KEY;
+  delete process.env.POSTHOG_HOST;
+  delete process.env.LANGFUSE_PUBLIC_KEY;
+  delete process.env.LANGFUSE_SECRET_KEY;
+  delete process.env.LANGFUSE_BASE_URL;
+  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createConversation(url: string): Promise<string> {
+  const projectId = `amr_resume_${randomUUID()}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'AMR resume smoke',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const projectBody = (await projectResponse.json()) as { conversationId: string; id: string };
+  return `${projectId}::${projectBody.conversationId}`;
+}
+
+async function sendRunAndWait(
+  url: string,
+  encoded: string,
+  message: string,
+  model?: string,
+): Promise<RunStatus> {
+  const [projectId, conversationId] = encoded.split('::');
+  const assistantMessageId = `assistant_amr_${randomUUID()}`;
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'amr-resume-test',
+      'x-od-analytics-session-id': 'amr-resume-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId,
+      assistantMessageId,
+      clientRequestId: `client_amr_${randomUUID()}`,
+      agentId: 'amr',
+      message,
+      currentPrompt: message,
+      ...(model ? { model } : {}),
+    }),
+  });
+  expect(runResponse.status).toBe(202);
+  const body = (await runResponse.json()) as { runId: string };
+  return await waitForRun(url, body.runId);
+}
+
+async function waitForRun(url: string, runId: string): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 15_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+    expect(response.status).toBe(200);
+    const run = (await response.json()) as RunStatus;
+    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
+      return run;
+    }
+    await delay(100);
+  }
+  throw new Error(`run ${runId} did not finish`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+}

--- a/apps/daemon/tests/codex-session-resume.test.ts
+++ b/apps/daemon/tests/codex-session-resume.test.ts
@@ -1,0 +1,368 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+// End-to-end coverage for codex native (capture-style) session resume.
+//
+// codex mints its OWN session id and reports it on the first stream event
+// `{"type":"thread.started","thread_id":...}`. The daemon must:
+//   1. capture that thread id from the stream and persist it (NOT the
+//      daemon-minted `newSessionId`, which codex ignores),
+//   2. on the next turn in the same conversation, resume with
+//      `codex exec resume <thread_id>` and send ONLY the new turn (no
+//      flattened-history resend), and
+//   3. when the stored thread is gone (`no rollout found for thread id`),
+//      clear the stale handle, surface a retryable error, and let the next
+//      turn start a fresh session re-seeded with the full transcript.
+//
+// On origin/main codex is not `resumesSessionViaCli`, so it always runs plain
+// `exec` and re-pays the whole transcript — turn-2 here would carry no
+// `resume` and would include the prior reply, going red.
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  error: string | null;
+  errorCode: string | null;
+  eventsLogPath: string;
+  resumable?: boolean;
+};
+
+type ExecInvocation = { argv: string[]; stdin: string };
+
+const THREAD = '019eef4f-0000-7000-8000-000000000abc';
+const FIRST_REPLY_SENTINEL = 'FIRST_TURN_REPLY_SENTINEL_8af31';
+
+describe('codex native session resume', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await removeTempDir(binDir);
+    binDir = null;
+    restoreEnv(originalEnv);
+  });
+
+  it('captures the thread id on turn 1 and resumes it (without resending history) on turn 2', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-resume-bin-'));
+    const { bin, logPath } = await writeCapturingCodex(binDir, 'codex-capture');
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: { codex: { CODEX_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    const turn1 = await sendRunAndWait(started.url, conversationId, 'first user request');
+    expect(turn1.status).toBe('succeeded');
+
+    const turn2 = await sendRunAndWait(started.url, conversationId, 'second user request please');
+    expect(turn2.status).toBe('succeeded');
+
+    // Filter to this conversation's chat-turn `exec` calls (cwd points at its
+    // project dir). codex is also used as the daemon's background memory-llm and
+    // for `login status` / `debug models` probes — those run from the repo root
+    // and must not be counted as chat turns.
+    const runs = await readChatTurnExecs(logPath, conversationId);
+    expect(runs).toHaveLength(2);
+    const [create, resume] = runs as [ExecInvocation, ExecInvocation];
+
+    // Turn 1 is a fresh `exec` — no resume, no leaked id.
+    expect(create.argv).toContain('exec');
+    expect(create.argv).not.toContain('resume');
+    expect(create.argv).not.toContain(THREAD);
+
+    // Turn 2 resumes the captured thread id as the trailing positional arg.
+    expect(resume.argv.slice(0, 2)).toEqual(['exec', 'resume']);
+    expect(resume.argv[resume.argv.length - 1]).toBe(THREAD);
+    // Resume must pass sandbox via `-c`, never the `--sandbox` flag (rejected
+    // by `exec resume`).
+    expect(resume.argv).not.toContain('--sandbox');
+
+    // The turn-2 prompt must NOT re-send turn-1's assistant reply (history is
+    // carried by the resumed session), but must carry the new user message.
+    expect(resume.stdin).not.toContain(FIRST_REPLY_SENTINEL);
+    expect(resume.stdin).toContain('second user request please');
+  });
+
+  it('clears a dead thread on `no rollout found` and starts fresh next turn', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-fallback-bin-'));
+    const { bin, logPath } = await writeMissingRolloutCodex(binDir, 'codex-fallback');
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: { codex: { CODEX_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    // Turn 1 creates + persists the thread.
+    const turn1 = await sendRunAndWait(started.url, conversationId, 'first request');
+    expect(turn1.status).toBe('succeeded');
+
+    // Turn 2 resumes, but the rollout is gone → retryable failure, stale
+    // handle cleared.
+    const turn2 = await sendRunAndWait(started.url, conversationId, 'second request');
+    expect(turn2.status).toBe('failed');
+    expect(turn2.errorCode).toBe('AGENT_EXECUTION_FAILED');
+
+    // Turn 3 must NOT retry the dead resume — the cleared session forces a
+    // fresh `exec` (re-seeded with the full transcript).
+    const turn3 = await sendRunAndWait(started.url, conversationId, 'third request');
+    expect(turn3.status).toBe('succeeded');
+
+    const runs = await readChatTurnExecs(logPath, conversationId);
+    expect(runs).toHaveLength(3);
+    const [create, deadResume, fresh] = runs as [
+      ExecInvocation,
+      ExecInvocation,
+      ExecInvocation,
+    ];
+    expect(create.argv).not.toContain('resume');
+    expect(deadResume.argv.slice(0, 2)).toEqual(['exec', 'resume']);
+    expect(fresh.argv).not.toContain('resume');
+  });
+});
+
+// Fake codex CLI: mints a FIXED thread id on a create turn and echoes it on a
+// resume turn. Logs `{argv, stdin}` per invocation so the test can assert the
+// resume shape and the skipped transcript.
+async function writeCapturingCodex(
+  dir: string,
+  name: string,
+): Promise<{ bin: string; logPath: string }> {
+  const bin = path.join(dir, name);
+  const logPath = path.join(dir, `${name}-log.jsonl`);
+  await writeFile(
+    bin,
+    fakeCodexSource({
+      logPath,
+      body: `
+  const isResume = argv.includes('resume');
+  console.log(JSON.stringify({ type: 'thread.started', thread_id: THREAD }));
+  console.log(JSON.stringify({ type: 'turn.started' }));
+  const text = isResume ? 'Resumed reply.' : ${JSON.stringify(FIRST_REPLY_SENTINEL)};
+  console.log(JSON.stringify({ type: 'item.completed', item: { id: 'item-1', type: 'agent_message', text } }));
+  console.log(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, cached_input_tokens: 4, output_tokens: 3 } }));
+  setTimeout(() => process.exit(0), 10);`,
+    }),
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return { bin, logPath };
+}
+
+// Fake codex CLI: succeeds on a create turn (persisting the thread), but a
+// resume turn fails with codex's real "no rollout found" error and exits 1.
+async function writeMissingRolloutCodex(
+  dir: string,
+  name: string,
+): Promise<{ bin: string; logPath: string }> {
+  const bin = path.join(dir, name);
+  const logPath = path.join(dir, `${name}-log.jsonl`);
+  await writeFile(
+    bin,
+    fakeCodexSource({
+      logPath,
+      body: `
+  if (argv.includes('resume')) {
+    process.stderr.write('Error: thread/resume: thread/resume failed: no rollout found for thread id ' + THREAD + '\\n');
+    setTimeout(() => process.exit(1), 10);
+    return;
+  }
+  console.log(JSON.stringify({ type: 'thread.started', thread_id: THREAD }));
+  console.log(JSON.stringify({ type: 'turn.started' }));
+  console.log(JSON.stringify({ type: 'item.completed', item: { id: 'item-1', type: 'agent_message', text: 'Created reply.' } }));
+  console.log(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 8, cached_input_tokens: 0, output_tokens: 2 } }));
+  setTimeout(() => process.exit(0), 10);`,
+    }),
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return { bin, logPath };
+}
+
+function fakeCodexSource(opts: { logPath: string; body: string }): string {
+  return `#!/usr/bin/env node
+const fs = require('node:fs');
+const logPath = ${JSON.stringify(opts.logPath)};
+const THREAD = ${JSON.stringify(THREAD)};
+const argv = process.argv.slice(2);
+if (argv.includes('--version')) { console.log('codex-cli 0.133.0'); process.exit(0); }
+if (argv.includes('--help')) { console.log('Usage: codex exec [--sandbox MODE]'); process.exit(0); }
+let stdin = '';
+let done = false;
+function finish() {
+  if (done) return; done = true;
+  try { fs.appendFileSync(logPath, JSON.stringify({ argv, stdin }) + '\\n'); } catch {}
+  run();
+}
+function run() {${opts.body}
+}
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (d) => { stdin += d; });
+process.stdin.on('end', finish);
+process.stdin.on('error', finish);
+setTimeout(finish, 1500);
+`;
+}
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.POSTHOG_KEY;
+  delete process.env.POSTHOG_HOST;
+  delete process.env.LANGFUSE_PUBLIC_KEY;
+  delete process.env.LANGFUSE_SECRET_KEY;
+  delete process.env.LANGFUSE_BASE_URL;
+  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createConversation(url: string): Promise<string> {
+  const projectId = `codex_resume_${randomUUID()}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Codex resume smoke',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const projectBody = (await projectResponse.json()) as {
+    conversationId: string;
+    id: string;
+  };
+  return `${projectId}::${projectBody.conversationId}`;
+}
+
+async function sendRunAndWait(
+  url: string,
+  encoded: string,
+  message: string,
+): Promise<RunStatus> {
+  const [projectId, conversationId] = encoded.split('::');
+  const assistantMessageId = `assistant_codex_${randomUUID()}`;
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'codex-resume-test',
+      'x-od-analytics-session-id': 'codex-resume-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId,
+      assistantMessageId,
+      clientRequestId: `client_codex_${randomUUID()}`,
+      agentId: 'codex',
+      message,
+      currentPrompt: message,
+    }),
+  });
+  expect(runResponse.status).toBe(202);
+  const body = (await runResponse.json()) as { runId: string };
+  return await waitForRun(url, body.runId);
+}
+
+async function waitForRun(url: string, runId: string): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+    expect(response.status).toBe(200);
+    const run = (await response.json()) as RunStatus;
+    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
+      return run;
+    }
+    await delay(100);
+  }
+  throw new Error(`run ${runId} did not finish`);
+}
+
+// Chat-turn `exec` invocations for this conversation, in call order. Identified
+// by the project id appearing in argv (the `-C <projectDir>` cwd) — this drops
+// the background memory-llm exec (repo-root cwd) and the login/models probes.
+async function readChatTurnExecs(
+  logPath: string,
+  encoded: string,
+): Promise<ExecInvocation[]> {
+  const projectId = encoded.split('::')[0] ?? encoded;
+  let raw = '';
+  try {
+    raw = await readFile(logPath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as ExecInvocation)
+    .filter(
+      (rec) =>
+        rec.argv[0] === 'exec' &&
+        rec.argv.some((a) => typeof a === 'string' && a.includes(projectId)),
+    );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+}

--- a/apps/daemon/tests/codex-session-resume.test.ts
+++ b/apps/daemon/tests/codex-session-resume.test.ts
@@ -148,7 +148,69 @@ describe('codex native session resume', () => {
     expect(deadResume.argv.slice(0, 2)).toEqual(['exec', 'resume']);
     expect(fresh.argv).not.toContain('resume');
   });
+
+  it('reseeds (no resume) when another agent ran in the conversation between codex turns', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-intervene-bin-'));
+    const { bin, logPath } = await writeCapturingCodex(binDir, 'codex-intervene');
+    const claudeBin = await writeMinimalClaude(binDir, 'claude-intervene');
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: { codex: { CODEX_BIN: bin }, claude: { CLAUDE_BIN: claudeBin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    // Turn 1: codex creates + persists its session.
+    expect((await sendRunAndWait(started.url, conversationId, 'codex first', 'codex')).status)
+      .toBe('succeeded');
+    // Turn 2: a DIFFERENT agent runs, adding a completed assistant turn that the
+    // codex session never saw.
+    expect((await sendRunAndWait(started.url, conversationId, 'now claude', 'claude')).status)
+      .toBe('succeeded');
+    // Turn 3: codex returns. Its stored session is behind, so the daemon must
+    // start a fresh `exec` (and reseed the full transcript) — NOT resume the
+    // stale session and silently drop the intervening claude turn.
+    expect((await sendRunAndWait(started.url, conversationId, 'codex again', 'codex')).status)
+      .toBe('succeeded');
+
+    const runs = await readChatTurnExecs(logPath, conversationId);
+    expect(runs).toHaveLength(2); // only the two codex turns hit the codex bin
+    const [create, afterIntervening] = runs as [ExecInvocation, ExecInvocation];
+    expect(create.argv).not.toContain('resume');
+    // The headline guard (issue raised by @nettee): after a different agent
+    // completed a turn the codex session never saw, codex must NOT resume that
+    // stale session — it starts a fresh `exec` so the run is reseeded with the
+    // full transcript instead of silently dropping the intervening turn.
+    expect(afterIntervening.argv).not.toContain('resume');
+    expect(afterIntervening.argv[0]).toBe('exec');
+  });
 });
+
+// Minimal fake Claude CLI (claude-stream-json): emits an init frame + one
+// assistant text reply and exits 0. Used only to inject an intervening
+// completed turn from a different agent.
+async function writeMinimalClaude(dir: string, name: string): Promise<string> {
+  const bin = path.join(dir, name);
+  await writeFile(
+    bin,
+    `#!/usr/bin/env node
+const argv = process.argv.slice(2);
+if (argv.includes('--version')) { console.log('claude-code 1.0.0-intervene'); process.exit(0); }
+if (argv.includes('--help')) { console.log('Usage: claude -p'); process.exit(0); }
+console.log(JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-intervene' }));
+console.log(JSON.stringify({ type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'CLAUDE_INTERVENING_REPLY' }], stop_reason: 'end_turn' } }));
+setTimeout(() => process.exit(0), 10);
+`,
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return bin;
+}
 
 // Fake codex CLI: mints a FIXED thread id on a create turn and echoes it on a
 // resume turn. Logs `{argv, stdin}` per invocation so the test can assert the
@@ -301,6 +363,7 @@ async function sendRunAndWait(
   url: string,
   encoded: string,
   message: string,
+  agentId = 'codex',
 ): Promise<RunStatus> {
   const [projectId, conversationId] = encoded.split('::');
   const assistantMessageId = `assistant_codex_${randomUUID()}`;
@@ -317,7 +380,7 @@ async function sendRunAndWait(
       conversationId,
       assistantMessageId,
       clientRequestId: `client_codex_${randomUUID()}`,
-      agentId: 'codex',
+      agentId,
       message,
       currentPrompt: message,
     }),

--- a/apps/daemon/tests/codex-session-resume.test.ts
+++ b/apps/daemon/tests/codex-session-resume.test.ts
@@ -39,7 +39,7 @@ type RunStatus = {
   resumable?: boolean;
 };
 
-type ExecInvocation = { argv: string[]; stdin: string };
+type ExecInvocation = { argv: string[]; stdin: string; cwd: string };
 
 const THREAD = '019eef4f-0000-7000-8000-000000000abc';
 const FIRST_REPLY_SENTINEL = 'FIRST_TURN_REPLY_SENTINEL_8af31';
@@ -220,10 +220,18 @@ let stdin = '';
 let done = false;
 function finish() {
   if (done) return; done = true;
-  try { fs.appendFileSync(logPath, JSON.stringify({ argv, stdin }) + '\\n'); } catch {}
+  try { fs.appendFileSync(logPath, JSON.stringify({ argv, stdin, cwd: process.cwd() }) + '\\n'); } catch {}
   run();
 }
-function run() {${opts.body}
+function run() {
+  // Faithful to the real CLI: codex exec resume rejects the create-only
+  // -C / --add-dir flags. If the daemon ever appends them on a resume turn,
+  // die exactly like the real binary so the e2e catches the regression.
+  if (argv.includes('resume') && (argv.includes('-C') || argv.includes('--add-dir'))) {
+    process.stderr.write("error: unexpected argument '-C' found\\n");
+    setTimeout(() => process.exit(2), 10);
+    return;
+  }${opts.body}
 }
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', (d) => { stdin += d; });
@@ -334,8 +342,10 @@ async function waitForRun(url: string, runId: string): Promise<RunStatus> {
 }
 
 // Chat-turn `exec` invocations for this conversation, in call order. Identified
-// by the project id appearing in argv (the `-C <projectDir>` cwd) — this drops
-// the background memory-llm exec (repo-root cwd) and the login/models probes.
+// by the chat turn's cwd (the project working dir, which contains the project
+// id) — this drops the background memory-llm exec (repo-root cwd) and the
+// login/models probes. The cwd is set via the spawn, not an argv flag, and on a
+// resume turn there is no `-C` to key off, so cwd is the reliable discriminator.
 async function readChatTurnExecs(
   logPath: string,
   encoded: string,
@@ -355,7 +365,8 @@ async function readChatTurnExecs(
     .filter(
       (rec) =>
         rec.argv[0] === 'exec' &&
-        rec.argv.some((a) => typeof a === 'string' && a.includes(projectId)),
+        typeof rec.cwd === 'string' &&
+        rec.cwd.includes(projectId),
     );
 }
 

--- a/apps/daemon/tests/db-agent-sessions.test.ts
+++ b/apps/daemon/tests/db-agent-sessions.test.ts
@@ -95,7 +95,7 @@ describe('agent_sessions stable_prompt_hash', () => {
     upsertAgentSession(db, {
       conversationId: 'conv-1', agentId: 'claude', sessionId: 'sess-A', stablePromptHash: 'hash-1',
     });
-    expect(getAgentSessionRecord(db, 'conv-1', 'claude')).toEqual({
+    expect(getAgentSessionRecord(db, 'conv-1', 'claude')).toMatchObject({
       sessionId: 'sess-A', stablePromptHash: 'hash-1',
     });
   });
@@ -103,7 +103,7 @@ describe('agent_sessions stable_prompt_hash', () => {
   it('stores null stable hash when omitted', () => {
     const db = seed();
     upsertAgentSession(db, { conversationId: 'conv-1', agentId: 'claude', sessionId: 'sess-A' });
-    expect(getAgentSessionRecord(db, 'conv-1', 'claude')).toEqual({
+    expect(getAgentSessionRecord(db, 'conv-1', 'claude')).toMatchObject({
       sessionId: 'sess-A', stablePromptHash: null,
     });
   });
@@ -114,7 +114,7 @@ describe('agent_sessions stable_prompt_hash', () => {
       conversationId: 'conv-1', agentId: 'claude', sessionId: 'sess-A', stablePromptHash: 'hash-1',
     });
     updateAgentSessionStableHash(db, 'conv-1', 'claude', 'hash-2');
-    expect(getAgentSessionRecord(db, 'conv-1', 'claude')).toEqual({
+    expect(getAgentSessionRecord(db, 'conv-1', 'claude')).toMatchObject({
       sessionId: 'sess-A', stablePromptHash: 'hash-2',
     });
   });

--- a/apps/daemon/tests/db-agent-sessions.test.ts
+++ b/apps/daemon/tests/db-agent-sessions.test.ts
@@ -10,9 +10,11 @@ import {
   getAgentSessionRecord,
   insertConversation,
   insertProject,
+  latestCompletedAssistantMessageId,
   openDatabase,
   updateAgentSessionStableHash,
   upsertAgentSession,
+  upsertMessage,
 } from '../src/db.js';
 
 describe('agent_sessions persistence', () => {
@@ -68,6 +70,70 @@ describe('agent_sessions persistence', () => {
     clearAgentSession(db, 'conv-1', 'claude');
     expect(getAgentSession(db, 'conv-1', 'claude')).toBeNull();
     expect(getAgentSession(db, 'conv-1', 'codex')).toBe('sess-B');
+  });
+});
+
+describe('latestCompletedAssistantMessageId (resume-identity cursor)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-resume-cursor-'));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function seed() {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, { id: 'proj-1', name: 'P', createdAt: now, updatedAt: now });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'C',
+      createdAt: now,
+      updatedAt: now,
+    });
+    return db;
+  }
+
+  function addAssistant(db: ReturnType<typeof seed>, id: string, runStatus: string | null) {
+    upsertMessage(db, 'conv-1', { id, role: 'assistant', content: 'x', runStatus });
+  }
+
+  it('returns null when there is no prior completed assistant turn', () => {
+    const db = seed();
+    expect(latestCompletedAssistantMessageId(db, 'conv-1', 'in-flight')).toBeNull();
+  });
+
+  it('does NOT advance the cursor across an intervening failed/canceled assistant run', () => {
+    const db = seed();
+    // A resumable session was last produced by m-1 (a succeeded turn).
+    addAssistant(db, 'm-1', 'succeeded');
+    expect(latestCompletedAssistantMessageId(db, 'conv-1', 'in-flight')).toBe('m-1');
+
+    // Another agent runs and FAILS, then one is CANCELED, before producing any
+    // completed turn. These must not read as conversation advancement — the
+    // stored session (m-1) is still the latest completed turn, so an otherwise
+    // resumable session stays resumable. (Pre-fix this query ignored run_status
+    // and returned the failed placeholder, forcing a needless cold reseed.)
+    addAssistant(db, 'm-2-failed', 'failed');
+    addAssistant(db, 'm-3-canceled', 'canceled');
+    expect(latestCompletedAssistantMessageId(db, 'conv-1', 'in-flight')).toBe('m-1');
+
+    // A genuinely completed intervening turn DOES advance the cursor.
+    addAssistant(db, 'm-4', 'succeeded');
+    expect(latestCompletedAssistantMessageId(db, 'conv-1', 'in-flight')).toBe('m-4');
+  });
+
+  it('excludes the current run in-flight placeholder (null run_status)', () => {
+    const db = seed();
+    addAssistant(db, 'm-1', 'succeeded');
+    // The current turn's own placeholder is the latest by position but in-flight.
+    addAssistant(db, 'm-current', null);
+    expect(latestCompletedAssistantMessageId(db, 'conv-1', 'm-current')).toBe('m-1');
   });
 });
 

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -56,6 +56,12 @@ import { dirname, join } from 'node:path';
 import { argv, stdin, stdout, stderr, env, exit } from 'node:process';
 
 const SESSION_ID = env.FAKE_VELA_SESSION_ID || 'fake-vela-session-1';
+// Durable upstream (OpenCode) session handle reported on session/new and
+// session/load — the value the daemon captures and replays to resume.
+const OPENCODE_SESSION_ID = env.FAKE_VELA_OPENCODE_SESSION_ID || 'oc-fake-1';
+// When set, a resumed session/prompt fails with the structured resume_failed
+// error (modelling vela's pre-prompt probe finding the session gone).
+const RESUME_FAILED = env.FAKE_VELA_RESUME_FAILED || '';
 const ASSISTANT_TEXT = Object.prototype.hasOwnProperty.call(env, 'FAKE_VELA_TEXT')
   ? env.FAKE_VELA_TEXT
   : 'Hello from fake vela.';
@@ -190,12 +196,21 @@ function handleMessage(msg) {
       }
       writeResult(id, {
         sessionId: SESSION_ID,
+        openCodeSessionId: OPENCODE_SESSION_ID,
         models: {
           currentModelId,
           availableModels: AVAILABLE_MODELS,
         },
       });
       return;
+    case 'session/load': {
+      // Resume: bind the prior upstream session, echoing back the durable
+      // handle. (vela validates existence before the first prompt, so a missing
+      // session surfaces as resume_failed on session/prompt, not here.)
+      const durable = typeof params?.sessionId === 'string' ? params.sessionId : OPENCODE_SESSION_ID;
+      writeResult(id, { sessionId: SESSION_ID, openCodeSessionId: durable });
+      return;
+    }
     case 'session/set_model': {
       if (SET_MODEL_ERROR) {
         writeError(id, SET_MODEL_ERROR, -32099);
@@ -218,6 +233,20 @@ function handleMessage(msg) {
       return;
     }
     case 'session/prompt': {
+      if (RESUME_FAILED) {
+        // Structured resume-miss: the resumed session is gone. Mirrors vela's
+        // pre-prompt probe emitting resume_failed BEFORE any model call.
+        writeMessage({
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: -32600,
+            message: 'the resumed session could not be loaded',
+            data: { kind: 'resume_failed', phase: 'session_load', retryable: true },
+          },
+        });
+        return;
+      }
       if (PROMPT_ERROR) {
         writeError(id, PROMPT_ERROR, -32602);
         return;

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -50,7 +50,7 @@
  *                                   session/set_model (legacy behaviour)
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { argv, stdin, stdout, stderr, env, exit } from 'node:process';
@@ -128,6 +128,13 @@ const DEFAULT_MODEL_LIST_JSON = JSON.stringify({
 let currentModelId = null;
 const sessionsWithModel = new Set();
 const STRICT_SET_MODEL = process.env.FAKE_VELA_REQUIRE_SET_MODEL !== '0';
+// Whether THIS process bound a resumed upstream session via session/load.
+// vela spawns one process per turn, so a fresh session/new turn and a resumed
+// session/load turn are distinct processes — `didLoad` lets the RESUME_FAILED
+// branch fire ONLY on the resume turn (mirroring a session that vanished
+// upstream), so a daemon that clears the dead handle and reseeds with a fresh
+// session/new on the next turn recovers instead of failing forever.
+let didLoad = false;
 
 function writeMessage(obj) {
   stdout.write(`${JSON.stringify(obj)}\n`);
@@ -151,6 +158,19 @@ function writeError(id, message, code = -32603) {
 
 function logDiag(line) {
   stderr.write(`[fake-vela] ${line}\n`);
+}
+
+// Append one line per session-bind method (`new` / `load`) to the file named by
+// FAKE_VELA_INVOCATION_LOG, so a multi-turn server test can assert the resume
+// sequence across the separate per-turn vela processes (e.g. ['new','load','new']).
+function logInvocation(method) {
+  const file = env.FAKE_VELA_INVOCATION_LOG;
+  if (!file) return;
+  try {
+    appendFileSync(file, `${JSON.stringify({ method })}\n`);
+  } catch {
+    /* best-effort diagnostics only */
+  }
 }
 
 function emitSessionUpdates(sessionId) {
@@ -190,13 +210,18 @@ function handleMessage(msg) {
       });
       return;
     case 'session/new':
+      logInvocation('new');
       if (SESSION_NEW_ERROR) {
         writeError(id, SESSION_NEW_ERROR);
         return;
       }
       writeResult(id, {
         sessionId: SESSION_ID,
-        openCodeSessionId: OPENCODE_SESSION_ID,
+        // FAKE_VELA_OMIT_OPENCODE_SESSION_ID models an older vela (or a handshake
+        // that never surfaced the durable handle): the daemon captures a null
+        // handle, which must CLEAR the row so the next turn opens a fresh session
+        // instead of resuming a non-existent one.
+        ...(env.FAKE_VELA_OMIT_OPENCODE_SESSION_ID ? {} : { openCodeSessionId: OPENCODE_SESSION_ID }),
         models: {
           currentModelId,
           availableModels: AVAILABLE_MODELS,
@@ -208,6 +233,8 @@ function handleMessage(msg) {
       // handle. (vela validates existence before the first prompt, so a missing
       // session surfaces as resume_failed on session/prompt, not here.)
       const durable = typeof params?.sessionId === 'string' ? params.sessionId : OPENCODE_SESSION_ID;
+      logInvocation('load');
+      didLoad = true;
       writeResult(id, { sessionId: SESSION_ID, openCodeSessionId: durable });
       return;
     }
@@ -233,9 +260,11 @@ function handleMessage(msg) {
       return;
     }
     case 'session/prompt': {
-      if (RESUME_FAILED) {
+      if (RESUME_FAILED && didLoad) {
         // Structured resume-miss: the resumed session is gone. Mirrors vela's
-        // pre-prompt probe emitting resume_failed BEFORE any model call.
+        // pre-prompt probe emitting resume_failed BEFORE any model call. Gated on
+        // `didLoad` so it fires only on a resume turn — a fresh session/new turn
+        // (e.g. the daemon reseeding after it cleared the dead handle) succeeds.
         writeMessage({
           jsonrpc: '2.0',
           id,
@@ -386,6 +415,13 @@ function loginAndExit() {
   stdout.write('Code: FAKE-CODE\n');
   if (delayMs > 0) setTimeout(finish, delayMs);
   else finish();
+}
+
+// `vela --version`: the daemon's executable-resolution probe (def.versionArgs)
+// expects a version string and a clean exit, NOT the ACP stdio loop.
+if (argv[2] === '--version' || (argv.includes('--version') && argv[2] !== 'agent')) {
+  stdout.write('vela 0.0.0-fake\n');
+  exit(0);
 }
 
 if (argv[2] === 'login') {

--- a/apps/daemon/tests/opencode-session-resume.test.ts
+++ b/apps/daemon/tests/opencode-session-resume.test.ts
@@ -1,0 +1,362 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+// End-to-end coverage for OpenCode native (capture-style) session resume.
+//
+// OpenCode mints its own session id and stamps it on every stream event as
+// `sessionID` (e.g. `ses_...`). The daemon must:
+//   1. capture that id from the stream and persist it (NOT the daemon-minted
+//      `newSessionId`, which OpenCode ignores),
+//   2. continue it next turn with `opencode run -s <id>` and send ONLY the new
+//      turn (no flattened-history resend), and
+//   3. when the session store is gone (`Session not found`), clear the stale
+//      handle, surface a retryable error, and let the next turn start fresh
+//      re-seeded with the full transcript.
+//
+// On origin/main OpenCode is not `resumesSessionViaCli`, so it always runs
+// plain `run` and re-pays the whole transcript — turn-2 here would carry no
+// `-s` and would include the prior reply, going red.
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  error: string | null;
+  errorCode: string | null;
+  eventsLogPath: string;
+  resumable?: boolean;
+};
+
+type RunInvocation = { argv: string[]; stdin: string; cwd: string };
+
+const SESSION = 'ses_e2e0000resume0000';
+const FIRST_REPLY_SENTINEL = 'FIRST_TURN_REPLY_SENTINEL_0c7d2';
+
+describe('opencode native session resume', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await removeTempDir(binDir);
+    binDir = null;
+    restoreEnv(originalEnv);
+  });
+
+  it('captures the session id on turn 1 and resumes it (without resending history) on turn 2', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-opencode-resume-bin-'));
+    const { bin, logPath } = await writeCapturingOpencode(binDir, 'opencode-capture');
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'opencode',
+      agentCliEnv: { opencode: { OPENCODE_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    const turn1 = await sendRunAndWait(started.url, conversationId, 'first user request');
+    expect(turn1.status).toBe('succeeded');
+
+    const turn2 = await sendRunAndWait(started.url, conversationId, 'second user request please');
+    expect(turn2.status).toBe('succeeded');
+
+    const runs = await readChatTurnRuns(logPath, conversationId);
+    expect(runs).toHaveLength(2);
+    const [create, resume] = runs as [RunInvocation, RunInvocation];
+
+    // Turn 1 is a fresh `run` — no `-s`, no leaked id.
+    expect(create.argv[0]).toBe('run');
+    expect(create.argv).not.toContain('-s');
+    expect(create.argv).not.toContain(SESSION);
+
+    // Turn 2 continues the captured session id.
+    expect(resume.argv).toContain('-s');
+    expect(resume.argv[resume.argv.indexOf('-s') + 1]).toBe(SESSION);
+
+    // The turn-2 prompt must NOT re-send turn-1's assistant reply (history is
+    // carried by the resumed session), but must carry the new user message.
+    expect(resume.stdin).not.toContain(FIRST_REPLY_SENTINEL);
+    expect(resume.stdin).toContain('second user request please');
+  });
+
+  it('clears a dead session on `Session not found` and starts fresh next turn', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-opencode-fallback-bin-'));
+    const { bin, logPath } = await writeMissingSessionOpencode(binDir, 'opencode-fallback');
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'opencode',
+      agentCliEnv: { opencode: { OPENCODE_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    const turn1 = await sendRunAndWait(started.url, conversationId, 'first request');
+    expect(turn1.status).toBe('succeeded');
+
+    // Turn 2 resumes, but the session store is gone → retryable failure, stale
+    // handle cleared. OpenCode prints "Session not found" and exits 0, so this
+    // exercises the exit-0 resume-failure path too.
+    const turn2 = await sendRunAndWait(started.url, conversationId, 'second request');
+    expect(turn2.status).toBe('failed');
+    expect(turn2.errorCode).toBe('AGENT_EXECUTION_FAILED');
+
+    // Turn 3 must NOT retry the dead resume — the cleared session forces a
+    // fresh `run` (re-seeded with the full transcript).
+    const turn3 = await sendRunAndWait(started.url, conversationId, 'third request');
+    expect(turn3.status).toBe('succeeded');
+
+    const runs = await readChatTurnRuns(logPath, conversationId);
+    expect(runs).toHaveLength(3);
+    const [create, deadResume, fresh] = runs as [
+      RunInvocation,
+      RunInvocation,
+      RunInvocation,
+    ];
+    expect(create.argv).not.toContain('-s');
+    expect(deadResume.argv).toContain('-s');
+    expect(fresh.argv).not.toContain('-s');
+  });
+});
+
+// Fake opencode CLI: stamps a FIXED session id on a create turn and echoes it
+// on a resume turn. Logs `{argv, stdin}` per invocation.
+async function writeCapturingOpencode(
+  dir: string,
+  name: string,
+): Promise<{ bin: string; logPath: string }> {
+  const bin = path.join(dir, name);
+  const logPath = path.join(dir, `${name}-log.jsonl`);
+  await writeFile(
+    bin,
+    fakeOpencodeSource({
+      logPath,
+      body: `
+  const isResume = argv.includes('-s');
+  const text = isResume ? 'Resumed reply.' : ${JSON.stringify(FIRST_REPLY_SENTINEL)};
+  console.log(JSON.stringify({ type: 'step_start', sessionID: SESSION, part: { type: 'step-start' } }));
+  console.log(JSON.stringify({ type: 'text', sessionID: SESSION, part: { type: 'text', text } }));
+  console.log(JSON.stringify({ type: 'step_finish', sessionID: SESSION, part: { type: 'step-finish', tokens: { input: 11, output: 7, reasoning: 0, cache: { read: 5, write: 2 } }, cost: 0 } }));
+  setTimeout(() => process.exit(0), 10);`,
+    }),
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return { bin, logPath };
+}
+
+// Fake opencode CLI: succeeds on a create turn (persisting the session), but a
+// resume turn (`-s`) prints "Session not found" to stderr and exits 0 — the
+// real OpenCode behavior for a missing session.
+async function writeMissingSessionOpencode(
+  dir: string,
+  name: string,
+): Promise<{ bin: string; logPath: string }> {
+  const bin = path.join(dir, name);
+  const logPath = path.join(dir, `${name}-log.jsonl`);
+  await writeFile(
+    bin,
+    fakeOpencodeSource({
+      logPath,
+      body: `
+  if (argv.includes('-s')) {
+    process.stderr.write('Error: Session not found\\n');
+    setTimeout(() => process.exit(0), 10);
+    return;
+  }
+  console.log(JSON.stringify({ type: 'step_start', sessionID: SESSION, part: { type: 'step-start' } }));
+  console.log(JSON.stringify({ type: 'text', sessionID: SESSION, part: { type: 'text', text: 'Created reply.' } }));
+  console.log(JSON.stringify({ type: 'step_finish', sessionID: SESSION, part: { type: 'step-finish', tokens: { input: 8, output: 2, reasoning: 0, cache: { read: 0, write: 0 } }, cost: 0 } }));
+  setTimeout(() => process.exit(0), 10);`,
+    }),
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return { bin, logPath };
+}
+
+function fakeOpencodeSource(opts: { logPath: string; body: string }): string {
+  return `#!/usr/bin/env node
+const fs = require('node:fs');
+const logPath = ${JSON.stringify(opts.logPath)};
+const SESSION = ${JSON.stringify(SESSION)};
+const argv = process.argv.slice(2);
+if (argv.includes('--version')) { console.log('1.17.7'); process.exit(0); }
+if (argv.includes('--help')) { console.log('opencode run [message..]'); process.exit(0); }
+if (argv[0] === 'models') { console.log('anthropic/claude-sonnet-4-5'); process.exit(0); }
+let stdin = '';
+let done = false;
+function finish() {
+  if (done) return; done = true;
+  try { fs.appendFileSync(logPath, JSON.stringify({ argv, stdin, cwd: process.cwd() }) + '\\n'); } catch {}
+  run();
+}
+function run() {${opts.body}
+}
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (d) => { stdin += d; });
+process.stdin.on('end', finish);
+process.stdin.on('error', finish);
+setTimeout(finish, 1500);
+`;
+}
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.POSTHOG_KEY;
+  delete process.env.POSTHOG_HOST;
+  delete process.env.LANGFUSE_PUBLIC_KEY;
+  delete process.env.LANGFUSE_SECRET_KEY;
+  delete process.env.LANGFUSE_BASE_URL;
+  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createConversation(url: string): Promise<string> {
+  const projectId = `opencode_resume_${randomUUID()}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'OpenCode resume smoke',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const projectBody = (await projectResponse.json()) as {
+    conversationId: string;
+    id: string;
+  };
+  return `${projectId}::${projectBody.conversationId}`;
+}
+
+async function sendRunAndWait(
+  url: string,
+  encoded: string,
+  message: string,
+): Promise<RunStatus> {
+  const [projectId, conversationId] = encoded.split('::');
+  const assistantMessageId = `assistant_opencode_${randomUUID()}`;
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'opencode-resume-test',
+      'x-od-analytics-session-id': 'opencode-resume-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId,
+      assistantMessageId,
+      clientRequestId: `client_opencode_${randomUUID()}`,
+      agentId: 'opencode',
+      message,
+      currentPrompt: message,
+    }),
+  });
+  expect(runResponse.status).toBe(202);
+  const body = (await runResponse.json()) as { runId: string };
+  return await waitForRun(url, body.runId);
+}
+
+async function waitForRun(url: string, runId: string): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+    expect(response.status).toBe(200);
+    const run = (await response.json()) as RunStatus;
+    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
+      return run;
+    }
+    await delay(100);
+  }
+  throw new Error(`run ${runId} did not finish`);
+}
+
+// Chat-turn `run` invocations for this conversation, in call order. OpenCode is
+// also used as the daemon's background memory-llm and for `models` probes;
+// those run from the repo root, so filter by the chat turn's cwd (the project
+// working dir, which contains the project id). OpenCode receives its cwd via
+// the spawn `cwd`, not an argv flag.
+async function readChatTurnRuns(
+  logPath: string,
+  encoded: string,
+): Promise<RunInvocation[]> {
+  const projectId = encoded.split('::')[0] ?? encoded;
+  let raw = '';
+  try {
+    raw = await readFile(logPath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as RunInvocation)
+    .filter(
+      (rec) =>
+        rec.argv[0] === 'run' &&
+        typeof rec.cwd === 'string' &&
+        rec.cwd.includes(projectId),
+    );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+}

--- a/apps/daemon/tests/runtimes/codex-resume-args.test.ts
+++ b/apps/daemon/tests/runtimes/codex-resume-args.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { codexAgentDef } from '../../src/runtimes/defs/codex.js';
+
+// codex is capture-style: it mints its own thread id (reported on the stream's
+// `thread.started` event) rather than accepting a daemon-minted one. So a
+// create turn passes NO id (plain `exec`) and a resume turn replays the stored
+// thread id as `exec resume <id>`. The id daemon-side `newSessionId` is ignored
+// by codex on purpose.
+describe('codex buildArgs session resume', () => {
+  const THREAD = '019eef4f-7409-7c82-bebe-30504eed3959';
+
+  it('uses plain `exec` (no resume, no id) on a create turn', () => {
+    const args = codexAgentDef.buildArgs('prompt', [], [], {}, {
+      newSessionId: '11111111-1111-4111-8111-111111111111',
+      resumeSessionId: null,
+    });
+    expect(args[0]).toBe('exec');
+    expect(args).not.toContain('resume');
+    // The minted daemon id must NOT leak into argv — codex would reject/ignore.
+    expect(args).not.toContain('11111111-1111-4111-8111-111111111111');
+    // Create turn keeps the `--sandbox` flag form.
+    expect(args).toContain('--sandbox');
+  });
+
+  it('uses `exec resume <thread_id>` with the stored id on a resume turn', () => {
+    const args = codexAgentDef.buildArgs('prompt', [], [], {}, {
+      newSessionId: '22222222-2222-4222-8222-222222222222',
+      resumeSessionId: THREAD,
+    });
+    expect(args.slice(0, 2)).toEqual(['exec', 'resume']);
+    // The thread id is the trailing positional SESSION_ID arg.
+    expect(args[args.length - 1]).toBe(THREAD);
+  });
+
+  it('passes sandbox via `-c sandbox_mode` on resume (never `--sandbox`, which resume rejects)', () => {
+    const args = codexAgentDef.buildArgs('prompt', [], [], {}, {
+      resumeSessionId: THREAD,
+    });
+    expect(args).not.toContain('--sandbox');
+    expect(args.some((a) => a.startsWith('sandbox_mode='))).toBe(true);
+    // The `-c key=value` override carries the value (workspace-write default).
+    expect(args).toContain('-c');
+    expect(args.some((a) => a.includes('sandbox_mode="workspace-write"'))).toBe(true);
+  });
+
+  it('keeps model + reasoning overrides ahead of the trailing thread id on resume', () => {
+    const args = codexAgentDef.buildArgs(
+      'prompt',
+      [],
+      [],
+      { model: 'gpt-5.1-codex', reasoning: 'high' },
+      { resumeSessionId: THREAD },
+    );
+    const idIndex = args.indexOf(THREAD);
+    expect(idIndex).toBe(args.length - 1);
+    const modelIndex = args.indexOf('--model');
+    expect(modelIndex).toBeGreaterThan(-1);
+    // Flags precede the positional session id.
+    expect(modelIndex).toBeLessThan(idIndex);
+  });
+
+  it('uses plain `exec` when no session context is supplied (back-compat)', () => {
+    const args = codexAgentDef.buildArgs('prompt', [], [], {}, {});
+    expect(args[0]).toBe('exec');
+    expect(args).not.toContain('resume');
+  });
+
+  it('declares CLI-managed, capture-style session resume', () => {
+    expect(codexAgentDef.resumesSessionViaCli).toBe(true);
+    expect(codexAgentDef.capturesSessionIdFromStream).toBe(true);
+  });
+});

--- a/apps/daemon/tests/runtimes/codex-resume-args.test.ts
+++ b/apps/daemon/tests/runtimes/codex-resume-args.test.ts
@@ -59,6 +59,35 @@ describe('codex buildArgs session resume', () => {
     expect(modelIndex).toBeLessThan(idIndex);
   });
 
+  it('excludes the create-only `-C` and `--add-dir` flags on resume (rejected by `exec resume`)', () => {
+    const args = codexAgentDef.buildArgs(
+      'prompt',
+      [],
+      ['/extra/writable/dir'],
+      {},
+      { resumeSessionId: THREAD, cwd: '/some/project/dir' },
+    );
+    // `codex exec resume` errors with "unexpected argument '-C' found" / same
+    // for `--add-dir`, so a resume turn must not carry either — the daemon
+    // spawns the child in the right cwd and the resumed session keeps its dirs.
+    expect(args).not.toContain('-C');
+    expect(args).not.toContain('--add-dir');
+    expect(args).not.toContain('/some/project/dir');
+    expect(args).not.toContain('/extra/writable/dir');
+  });
+
+  it('still passes `-C` and `--add-dir` on a create turn', () => {
+    const args = codexAgentDef.buildArgs(
+      'prompt',
+      [],
+      ['/extra/writable/dir'],
+      {},
+      { resumeSessionId: null, cwd: '/some/project/dir' },
+    );
+    expect(args[args.indexOf('-C') + 1]).toBe('/some/project/dir');
+    expect(args[args.indexOf('--add-dir') + 1]).toBe('/extra/writable/dir');
+  });
+
   it('uses plain `exec` when no session context is supplied (back-compat)', () => {
     const args = codexAgentDef.buildArgs('prompt', [], [], {}, {});
     expect(args[0]).toBe('exec');

--- a/apps/daemon/tests/runtimes/json-event-stream.test.ts
+++ b/apps/daemon/tests/runtimes/json-event-stream.test.ts
@@ -1108,10 +1108,28 @@ test('codex json stream emits status text and usage events', () => {
   );
 
   assert.deepEqual(events, [
-    { type: 'status', label: 'initializing' },
+    { type: 'status', label: 'initializing', sessionId: 'thr-1' },
     { type: 'status', label: 'thinking' },
     { type: 'text_delta', delta: 'hello' },
     { type: 'usage', usage: { input_tokens: 12, output_tokens: 3, cached_read_tokens: 4 } },
+  ]);
+});
+
+test('codex thread.started surfaces the thread id as the status sessionId (capture-style resume handle)', () => {
+  const { events, handler } = collectEvents('codex');
+  handler.feed(
+    JSON.stringify({ type: 'thread.started', thread_id: '019eef4f-7409-7c82-bebe-30504eed3959' }) + '\n',
+  );
+  assert.deepEqual(events, [
+    { type: 'status', label: 'initializing', sessionId: '019eef4f-7409-7c82-bebe-30504eed3959' },
+  ]);
+});
+
+test('codex thread.started without a thread id reports a null sessionId (no spurious capture)', () => {
+  const { events, handler } = collectEvents('codex');
+  handler.feed(JSON.stringify({ type: 'thread.started' }) + '\n');
+  assert.deepEqual(events, [
+    { type: 'status', label: 'initializing', sessionId: null },
   ]);
 });
 
@@ -1550,7 +1568,7 @@ test('codex json stream treats reconnect errors as status warnings not fatal (re
   );
 
   assert.deepEqual(events, [
-    { type: 'status', label: 'initializing' },
+    { type: 'status', label: 'initializing', sessionId: 'thr-1' },
     { type: 'status', label: 'thinking' },
     { type: 'status', label: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' },
     { type: 'text_delta', delta: 'OK' },
@@ -1573,7 +1591,7 @@ test('codex json stream treats stream disconnect reconnect errors as status warn
   );
 
   assert.deepEqual(events, [
-    { type: 'status', label: 'initializing' },
+    { type: 'status', label: 'initializing', sessionId: 'thr-1' },
     { type: 'status', label: 'thinking' },
     {
       type: 'status',

--- a/apps/daemon/tests/runtimes/json-event-stream.test.ts
+++ b/apps/daemon/tests/runtimes/json-event-stream.test.ts
@@ -20,7 +20,7 @@ test('opencode json stream emits text and usage events', () => {
   );
 
   assert.deepEqual(events, [
-    { type: 'status', label: 'running' },
+    { type: 'status', label: 'running', sessionId: 'ses-1' },
     { type: 'text_delta', delta: 'hello' },
     {
       type: 'usage',
@@ -33,6 +33,22 @@ test('opencode json stream emits text and usage events', () => {
       },
       costUsd: 0,
     },
+  ]);
+});
+
+test('opencode step_start surfaces the session id as the status sessionId (capture-style resume handle)', () => {
+  const { events, handler } = collectEvents('opencode');
+  handler.feed('{"type":"step_start","sessionID":"ses_4af9c2","part":{"type":"step-start"}}\n');
+  assert.deepEqual(events, [
+    { type: 'status', label: 'running', sessionId: 'ses_4af9c2' },
+  ]);
+});
+
+test('opencode step_start without a session id reports a null sessionId (no spurious capture)', () => {
+  const { events, handler } = collectEvents('opencode');
+  handler.feed('{"type":"step_start","part":{"type":"step-start"}}\n');
+  assert.deepEqual(events, [
+    { type: 'status', label: 'running', sessionId: null },
   ]);
 });
 

--- a/apps/daemon/tests/runtimes/opencode-resume-args.test.ts
+++ b/apps/daemon/tests/runtimes/opencode-resume-args.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { opencodeAgentDef } from '../../src/runtimes/defs/opencode.js';
+
+// OpenCode is capture-style: it mints its own session id (reported on the
+// stream's `step_start.sessionID`) rather than accepting a daemon-minted one.
+// A create turn passes NO id (plain `run`); a resume turn continues the stored
+// session with `-s <id>`.
+describe('opencode buildArgs session resume', () => {
+  const SESSION = 'ses_4af9c2e1b0';
+
+  it('uses plain `run` (no `-s`) on a create turn', () => {
+    const args = opencodeAgentDef.buildArgs('prompt', [], [], {}, {
+      newSessionId: '11111111-1111-4111-8111-111111111111',
+      resumeSessionId: null,
+    });
+    expect(args.slice(0, 3)).toEqual(['run', '--format', 'json']);
+    expect(args).not.toContain('-s');
+    // The minted daemon id must NOT leak into argv.
+    expect(args).not.toContain('11111111-1111-4111-8111-111111111111');
+  });
+
+  it('continues the stored session with `-s <id>` on a resume turn', () => {
+    const args = opencodeAgentDef.buildArgs('prompt', [], [], {}, {
+      resumeSessionId: SESSION,
+    });
+    expect(args).toContain('-s');
+    expect(args[args.indexOf('-s') + 1]).toBe(SESSION);
+  });
+
+  it('keeps the model flag alongside the resume flag', () => {
+    const args = opencodeAgentDef.buildArgs(
+      'prompt',
+      [],
+      [],
+      { model: 'anthropic/claude-sonnet-4-5' },
+      { resumeSessionId: SESSION },
+    );
+    expect(args[args.indexOf('-s') + 1]).toBe(SESSION);
+    expect(args[args.indexOf('-m') + 1]).toBe('anthropic/claude-sonnet-4-5');
+  });
+
+  it('uses plain `run` when no session context is supplied (back-compat)', () => {
+    const args = opencodeAgentDef.buildArgs('prompt', [], [], {}, {});
+    expect(args.slice(0, 3)).toEqual(['run', '--format', 'json']);
+    expect(args).not.toContain('-s');
+  });
+
+  it('declares CLI-managed, capture-style session resume', () => {
+    expect(opencodeAgentDef.resumesSessionViaCli).toBe(true);
+    expect(opencodeAgentDef.capturesSessionIdFromStream).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

AMR follow-up turns re-pay the entire conversation as cache-cold input because each turn opened a fresh upstream session. This extends the native session-resume path to AMR so a follow-up turn continues the existing session instead of reseeding the whole transcript — the same win #4629 lands for codex/opencode, now for AMR.

> **Base note:** this builds on the resume-identity foundation from #4629 (codex/opencode native resume) and is opened against `main` intentionally. Until #4629 merges, this PR's diff includes those commits; whichever lands first, the other rebases/resolves the overlap. The AMR-specific change is the top 3 commits (`feat/test/fix(daemon): AMR …`).

## What users will see

Nothing new to click — it is a transparent latency/cost improvement: multi-turn AMR conversations resume the same session instead of restarting, so follow-up turns are faster and cheaper. If the upstream session has expired, the user gets a clear retryable "previous session could not be resumed — resend" message and the next turn starts fresh (no stuck conversation).

## What changed (daemon)

- New runtime flag `resumesSessionViaAcpLoad` (AMR). On a follow-up turn the daemon drives ACP `session/load` with the durable session handle captured on the first turn, reusing #4629's resume-identity guard (model / cwd / conversation-advance invalidation) to decide when a fresh session is required instead.
- A structured `resume_failed` signal from the agent is recognized (`isAmrResumeFailure`) and routed through the same reseed path as codex/opencode: clear the stale handle, surface a retryable error, reseed the full transcript next turn.
- **Fix:** the resume-failure reseed now runs **before** the ACP fatal short-circuit in the run close handler. AMR reports a missing session as a structured *fatal* ACP error, which the prior ordering swallowed (`fatal_rpc_error`) so the dead handle was never cleared and every later turn retried the same broken resume. Hoisting the recovery fixes both the codex stream-error shape and the AMR structured-fatal shape.

## Verification

- Daemon resume suite green, incl. 4 new `startServer` full-cycle AMR tests (happy `session/load` resume; dead-resume → reseed, red-checked against the fix; null durable handle → fresh session; model-change → fresh session) + ACP integration + `isAmrResumeFailure` unit coverage.
- `pnpm guard` + `pnpm --filter @open-design/daemon typecheck` green.
- **Real end-to-end:** real daemon + real vela + a prod AMR account + native opencode (deepseek-v4-flash), 4 turns. Turn 2 resumes via `session/load`; the upstream session is then deleted to force a miss → turn 3 surfaces the retryable reseed error → turn 4 opens a fresh session. On-the-wire ACP bind sequence: `["new","load","load","new"]`.

## Surface area

- [x] Daemon runtime (AMR adapter, run close handler, resume guard)
- [x] Tests (unit + integration + full-cycle)
- [ ] CLI / UI: none — transparent optimization, no new user-facing surface or flag

Depends on the daemon-side counterpart in vela (OpenCode session reuse).