### PR TITLE
fix(ci): only auto-merge a backport that is a pristine bot cherry-pick

### DIFF
--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -63,9 +63,15 @@ jobs:
           # strength of its first page; one non-bot committer anywhere fails it. Count the lines
           # that do NOT equal the literal bot login (-F/-x; the [..] is not a regex class) with
           # grep -c, whose count semantics are portable (unlike `grep -qv`, whose early-exit status
-          # is unreliable across BSD/GNU). Fail closed: empty list / lookup miss -> not pristine.
-          logins="$(gh api "repos/$REPO/pulls/$num/commits?per_page=100" --paginate \
-                      --jq '.[].committer.login // "none"' 2>/dev/null || true)"
+          # is unreliable across BSD/GNU).
+          # Fail closed on a partial/failed lookup: --paginate may emit several pages and THEN fail
+          # on a later one; `|| true` would keep that partial output and could read all-bot. Capture
+          # gh's exit status via `if !` and blank the list on any failure, so pristine needs a
+          # complete, successful enumeration of every commit.
+          if ! logins="$(gh api "repos/$REPO/pulls/$num/commits?per_page=100" --paginate \
+                          --jq '.[].committer.login // "none"' 2>/dev/null)"; then
+            logins=""
+          fi
           nonbot="$(printf '%s\n' "$logins" | grep -Fvxc 'github-actions[bot]' || true)"
           if [ -n "$logins" ] && [ "${nonbot:-1}" = "0" ]; then
             pristine=true

--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -60,12 +60,14 @@ jobs:
           # github-actions[bot], so pristine=false and the auto-approve/merge below are skipped:
           # those commits were never reviewed, so the PR must go through human review instead.
           # Paginate across ALL commits (--paginate) — a >100-commit PR must not pass on the
-          # strength of its first page; one non-bot committer anywhere fails it. -F/-x match the
-          # literal "github-actions[bot]" (the [..] is not a regex class). Fail closed: empty list
-          # or any lookup miss -> not pristine.
+          # strength of its first page; one non-bot committer anywhere fails it. Count the lines
+          # that do NOT equal the literal bot login (-F/-x; the [..] is not a regex class) with
+          # grep -c, whose count semantics are portable (unlike `grep -qv`, whose early-exit status
+          # is unreliable across BSD/GNU). Fail closed: empty list / lookup miss -> not pristine.
           logins="$(gh api "repos/$REPO/pulls/$num/commits?per_page=100" --paginate \
                       --jq '.[].committer.login // "none"' 2>/dev/null || true)"
-          if [ -n "$logins" ] && ! printf '%s\n' "$logins" | grep -Fqvx 'github-actions[bot]'; then
+          nonbot="$(printf '%s\n' "$logins" | grep -Fvxc 'github-actions[bot]' || true)"
+          if [ -n "$logins" ] && [ "${nonbot:-1}" = "0" ]; then
             pristine=true
           else
             pristine=false

--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -54,6 +54,15 @@ jobs:
           fi
           row="$(gh pr view "$num" --repo "$REPO" \
                   --json number,baseRefName,isDraft,title,author,isCrossRepository,headRefOid)"
+          # "Pristine" = every commit on the branch was committed by github-actions[bot] — the
+          # untouched korthout cherry-pick of code already reviewed on main. If a human pushed any
+          # commit (resolving a conflict, fixing a failing test), that commit's committer is NOT
+          # github-actions[bot], so pristine=false and the auto-approve/merge below are skipped:
+          # those commits were never reviewed, so the PR must go through human review instead.
+          # Fail closed: any lookup miss / empty list -> pristine=false.
+          pristine="$(gh api "repos/$REPO/pulls/$num/commits?per_page=100" \
+                        --jq 'if (length > 0) and (all(.[]; (.committer.login // "") == "github-actions[bot]")) then "true" else "false" end' \
+                        2>/dev/null || echo false)"
           {
             echo "found=true"
             echo "number=$(printf '%s' "$row" | jq -r .number)"
@@ -63,6 +72,7 @@ jobs:
             echo "author=$(printf '%s' "$row" | jq -r '.author.login')"
             echo "cross=$(printf '%s' "$row" | jq -r '.isCrossRepository')"
             echo "head_oid=$(printf '%s' "$row" | jq -r '.headRefOid')"
+            echo "pristine=$pristine"
           } >> "$GITHUB_OUTPUT"
 
       - name: Approve the clean backport (release bot, CI green)
@@ -71,9 +81,13 @@ jobs:
         # Approve as github-actions[bot] — a DIFFERENT identity than the App that authored the PR
         # (an author can't approve its own PR) — under the SAME bot-identity + SHA + CI gates as
         # the merge below, so only the release bot's own verified backports are auto-approved.
+        # pristine == 'true' is critical here: it means NO human commit was pushed, so the diff is
+        # exactly what was already reviewed on main. If a human resolved a conflict or fixed CI,
+        # pristine is false and this skips — that unreviewed code must get a real human review.
         if: >-
           ${{ steps.pr.outputs.found == 'true'
               && steps.pr.outputs.draft == 'false'
+              && steps.pr.outputs.pristine == 'true'
               && steps.pr.outputs.author == 'app/open-design-release-bot'
               && steps.pr.outputs.cross == 'false'
               && steps.pr.outputs.head_oid == github.event.workflow_run.head_sha
@@ -94,9 +108,13 @@ jobs:
         #  - PR head == the exact SHA CI passed on (head_oid == workflow_run.head_sha), and
         #    --match-head-commit re-checks at merge time — so a commit pushed after CI went
         #    green is never merged untested.
+        #  - pristine == 'true' — every commit was committed by github-actions[bot], i.e. nobody
+        #    pushed human commits on top of the cherry-pick. Once a human touches the branch the
+        #    diff is no longer the reviewed-on-main code, so we fall back to human review.
         if: >-
           ${{ steps.pr.outputs.found == 'true'
               && steps.pr.outputs.draft == 'false'
+              && steps.pr.outputs.pristine == 'true'
               && steps.pr.outputs.author == 'app/open-design-release-bot'
               && steps.pr.outputs.cross == 'false'
               && steps.pr.outputs.head_oid == github.event.workflow_run.head_sha

--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -59,10 +59,17 @@ jobs:
           # commit (resolving a conflict, fixing a failing test), that commit's committer is NOT
           # github-actions[bot], so pristine=false and the auto-approve/merge below are skipped:
           # those commits were never reviewed, so the PR must go through human review instead.
-          # Fail closed: any lookup miss / empty list -> pristine=false.
-          pristine="$(gh api "repos/$REPO/pulls/$num/commits?per_page=100" \
-                        --jq 'if (length > 0) and (all(.[]; (.committer.login // "") == "github-actions[bot]")) then "true" else "false" end' \
-                        2>/dev/null || echo false)"
+          # Paginate across ALL commits (--paginate) — a >100-commit PR must not pass on the
+          # strength of its first page; one non-bot committer anywhere fails it. -F/-x match the
+          # literal "github-actions[bot]" (the [..] is not a regex class). Fail closed: empty list
+          # or any lookup miss -> not pristine.
+          logins="$(gh api "repos/$REPO/pulls/$num/commits?per_page=100" --paginate \
+                      --jq '.[].committer.login // "none"' 2>/dev/null || true)"
+          if [ -n "$logins" ] && ! printf '%s\n' "$logins" | grep -Fqvx 'github-actions[bot]'; then
+            pristine=true
+          else
+            pristine=false
+          fi
           {
             echo "found=true"
             echo "number=$(printf '%s' "$row" | jq -r .number)"

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -226,6 +226,12 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain("steps.pr.outputs.draft == 'false'");
     expect(workflow).toContain('startswith("release/v")');
 
+    // A human commit pushed on top of the cherry-pick (conflict resolution, CI fix) is never
+    // reviewed, so auto-approve/merge require pristine == 'true' — every commit committed by
+    // github-actions[bot]. Otherwise the PR falls back to human review.
+    expect(workflow).toContain("steps.pr.outputs.pristine == 'true'");
+    expect(workflow).toContain('(.committer.login // "") == "github-actions[bot]"');
+
     // The PR is resolved from the run's authoritative workflow_run.pull_requests association
     // (filtered to the release/* base at exactly the run's SHA), not a branch-name guess, and the
     // merge is bound to that same SHA (no post-green commit merged untested).
@@ -243,6 +249,7 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain("--approve");
     const approveStep = sectionBetween(workflow, "Approve the clean backport", "gh pr review");
     expect(approveStep).toContain("steps.pr.outputs.author == 'app/open-design-release-bot'");
+    expect(approveStep).toContain("steps.pr.outputs.pristine == 'true'");
     expect(approveStep).toContain("github.token");
 
     // The Feishu failure path carries the same identity gates, so a fork / non-bot backport-*

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -227,10 +227,13 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain('startswith("release/v")');
 
     // A human commit pushed on top of the cherry-pick (conflict resolution, CI fix) is never
-    // reviewed, so auto-approve/merge require pristine == 'true' — every commit committed by
-    // github-actions[bot]. Otherwise the PR falls back to human review.
+    // reviewed, so auto-approve/merge require pristine == 'true': every commit's committer is
+    // github-actions[bot]. The committers are paginated across all commits and any non-bot one
+    // fails the count. Otherwise the PR falls back to human review.
     expect(workflow).toContain("steps.pr.outputs.pristine == 'true'");
-    expect(workflow).toContain('(.committer.login // "") == "github-actions[bot]"');
+    expect(workflow).toContain('.[].committer.login // "none"');
+    expect(workflow).toContain("--paginate");
+    expect(workflow).toContain("grep -Fvxc 'github-actions[bot]'");
 
     // The PR is resolved from the run's authoritative workflow_run.pull_requests association
     // (filtered to the release/* base at exactly the run's SHA), not a branch-name guess, and the


### PR DESCRIPTION
## Problem (edge case raised in review)

Auto-approve + auto-merge of a backport is justified **only** because it's the untouched cherry-pick of code already reviewed on main. That premise breaks the moment a human pushes a commit onto the backport branch:

- **conflict** → korthout opens a *draft*; a human resolves + un-drafts → CI green
- **CI failure** → a human pushes a fix → CI green

In both, the branch now carries **unreviewed** commits, but the existing gates don't catch it:

| gate | why it misses a human push |
|---|---|
| `author == app/open-design-release-bot` | PR author is unchanged by pushes — always the bot |
| `draft == false` | a conflict draft, once un-drafted by a human, clears this |
| `head_oid == CI sha` + `--match-head-commit` | only guards a *post-green* race, not bot-vs-human authorship |

→ a human-touched backport would auto-merge unreviewed code into `release/v*`.

## Fix

Add a **pristine** gate to auto-approve + auto-merge: every commit on the branch must have `committer.login == github-actions[bot]` — exactly what korthout's cherry-pick produces (the human *author* is preserved; the *committer* is the bot). Verified empirically on real clean backports (#4698, #4680).

Any human commit → committer ≠ `github-actions[bot]` → `pristine=false` → skip auto path → the PR falls back to human review (`REVIEW_REQUIRED`; `release-gate` blocks the release until it lands). **Fail closed**: any lookup miss / empty list → not pristine.

Topology test updated to assert the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)