### PR TITLE
feat(landing-page): concentrate to 11 SEO locales + 'best' over 'official' in homepage TDK

### DIFF
--- a/apps/landing-page/app/_lib/i18n.ts
+++ b/apps/landing-page/app/_lib/i18n.ts
@@ -458,10 +458,19 @@ export function alternateLinks(pathname: string) {
  * content between `/skills/` and `/en/skills/`.
  */
 // Locales retired 2026-06 (mirror of app/i18n.ts:RETIRED_LOCALE_CODES, in this
-// module's locale-code spelling). The catch-all catalog routes consume
-// PREFIXED_LOCALES, so excluding them here stops those pages from being built;
-// incoming URLs are 301'd in public/_redirects (zh-CN/fa/hu/th also stay covered
-// by the existing LEGACY_LOCALE_PREFIXES handling).
+// module's locale-code spelling). The catch-all catalog routes and the blog
+// RSS feeds consume PREFIXED_LOCALES, so excluding a code here stops those
+// pages from being generated; incoming URLs are 301'd in public/_redirects.
+//
+// Two groups are excluded:
+//  - Pruned marketing locales (id, zh-TW, ar, pl, uk) plus legacy-only codes
+//    never in the modern set (fa, hu, th).
+//  - BCP-47 aliases of KEPT locales (zh-CN -> zh, es-ES -> es, pt-BR -> pt-br).
+//    The canonical short-code pages are generated from LANDING_LOCALES, so the
+//    catch-all must NOT also emit the alias-prefixed duplicates (they only 301
+//    back to the short code via the migration rules in public/_redirects, but
+//    still count toward the Cloudflare Pages file-count cap). Excluding them
+//    keeps every generated route on the same 11 canonical short codes.
 const RETIRED_PREFIX_LOCALES = new Set<Locale>([
   'id',
   'zh-TW',
@@ -471,6 +480,9 @@ const RETIRED_PREFIX_LOCALES = new Set<Locale>([
   'hu',
   'uk',
   'th',
+  'zh-CN',
+  'es-ES',
+  'pt-BR',
 ]);
 
 export const PREFIXED_LOCALES: Locale[] = LOCALES.filter(

--- a/apps/landing-page/app/_lib/i18n.ts
+++ b/apps/landing-page/app/_lib/i18n.ts
@@ -457,8 +457,24 @@ export function alternateLinks(pathname: string) {
  * locale stays at the unprefixed canonical to avoid duplicate
  * content between `/skills/` and `/en/skills/`.
  */
+// Locales retired 2026-06 (mirror of app/i18n.ts:RETIRED_LOCALE_CODES, in this
+// module's locale-code spelling). The catch-all catalog routes consume
+// PREFIXED_LOCALES, so excluding them here stops those pages from being built;
+// incoming URLs are 301'd in public/_redirects (zh-CN/fa/hu/th also stay covered
+// by the existing LEGACY_LOCALE_PREFIXES handling).
+const RETIRED_PREFIX_LOCALES = new Set<Locale>([
+  'id',
+  'zh-TW',
+  'fa',
+  'ar',
+  'pl',
+  'hu',
+  'uk',
+  'th',
+]);
+
 export const PREFIXED_LOCALES: Locale[] = LOCALES.filter(
-  (locale) => locale !== DEFAULT_LOCALE,
+  (locale) => locale !== DEFAULT_LOCALE && !RETIRED_PREFIX_LOCALES.has(locale),
 );
 
 export function localizedDate(date: Date, locale: Locale): string {

--- a/apps/landing-page/app/i18n.ts
+++ b/apps/landing-page/app/i18n.ts
@@ -2295,94 +2295,94 @@ const COMMON_COPY: Record<LandingLocaleCode, CommonCopy> = {
 
 const HOME_SEO_COPY: Record<LandingLocaleCode, HomeSeoCopy> = {
   en: {
-    title: 'Open Design — Official open-source Claude Design alternative',
+    title: 'Open Design — Best open-source Claude Design alternative',
     description:
-      'Open Design is the official open-source, local-first Claude Design alternative. Generate decks, landing pages, dashboards, and brand systems with Claude Code, Codex, Cursor, Gemini, OpenCode, or Qwen — driven by {skills} composable skills and {systems} portable DESIGN.md systems.',
+      'Open Design is the best open-source, local-first Claude Design alternative. Generate decks, landing pages, dashboards, and brand systems with Claude Code, Codex, Cursor, Gemini, OpenCode, or Qwen — driven by {skills} composable skills and {systems} portable DESIGN.md systems.',
   },
   zh: {
-    title: 'Open Design —— 官方 Claude Design 开源替代',
+    title: 'Open Design —— 最佳 Claude Design 开源替代',
     description:
-      'Open Design 是官方的开源、本地优先 Claude Design 替代方案。用 Claude Code、Codex、Cursor、Gemini、OpenCode 或 Qwen 生成演示文稿、落地页和仪表盘，背后由 {skills} 个可组合 SKILL.md 工作流驱动。',
+      'Open Design 是最佳的开源、本地优先 Claude Design 替代方案。用 Claude Code、Codex、Cursor、Gemini、OpenCode 或 Qwen 生成演示文稿、落地页和仪表盘，背后由 {skills} 个可组合 SKILL.md 工作流驱动。',
   },
   'zh-tw': {
-    title: 'Open Design —— 官方 Claude Design 開源替代',
+    title: 'Open Design —— 最佳 Claude Design 開源替代',
     description:
-      'Open Design 是官方的開源、本地優先 Claude Design 替代方案。用 Claude Code、Codex、Cursor、Gemini、OpenCode 或 Qwen 生成簡報、落地頁、儀表板與品牌系統，背後由 {skills} 個可組合 Skill 與 {systems} 套 DESIGN.md 系統驅動。',
+      'Open Design 是最佳的開源、本地優先 Claude Design 替代方案。用 Claude Code、Codex、Cursor、Gemini、OpenCode 或 Qwen 生成簡報、落地頁、儀表板與品牌系統，背後由 {skills} 個可組合 Skill 與 {systems} 套 DESIGN.md 系統驅動。',
   },
   ja: {
-    title: 'Open Design — 公式のオープンソース Claude Design 代替',
+    title: 'Open Design — 最高のオープンソース Claude Design 代替',
     description:
-      'Open Design は公式のオープンソースかつローカル優先の Claude Design 代替です。Claude Code、Codex、Cursor、Gemini、OpenCode、Qwen と {skills} 個のスキル、{systems} 個の DESIGN.md システムでデッキ、ランディングページ、ダッシュボード、ブランドシステムを生成します。',
+      'Open Design は最高のオープンソースかつローカル優先の Claude Design 代替です。Claude Code、Codex、Cursor、Gemini、OpenCode、Qwen と {skills} 個のスキル、{systems} 個の DESIGN.md システムでデッキ、ランディングページ、ダッシュボード、ブランドシステムを生成します。',
   },
   ko: {
-    title: 'Open Design — 공식 오픈소스 Claude Design 대안',
+    title: 'Open Design — 최고의 오픈소스 Claude Design 대안',
     description:
-      'Open Design은 공식 오픈소스, 로컬 우선 Claude Design 대안입니다. Claude Code, Codex, Cursor, Gemini, OpenCode, Qwen과 {skills}개의 조합형 스킬, {systems}개의 DESIGN.md 시스템으로 덱, 랜딩 페이지, 대시보드, 브랜드 시스템을 만듭니다.',
+      'Open Design은 최고의 오픈소스, 로컬 우선 Claude Design 대안입니다. Claude Code, Codex, Cursor, Gemini, OpenCode, Qwen과 {skills}개의 조합형 스킬, {systems}개의 DESIGN.md 시스템으로 덱, 랜딩 페이지, 대시보드, 브랜드 시스템을 만듭니다.',
   },
   de: {
-    title: 'Open Design — offizielle Open-Source-Alternative zu Claude Design',
+    title: 'Open Design — beste Open-Source-Alternative zu Claude Design',
     description:
-      'Open Design ist die offizielle Open-Source- und Local-first-Alternative zu Claude Design. Erzeuge Decks, Landingpages, Dashboards und Brand-Systeme mit Claude Code, Codex, Cursor, Gemini, OpenCode oder Qwen — mit {skills} kombinierbaren Skills und {systems} portablen DESIGN.md-Systemen.',
+      'Open Design ist die beste Open-Source- und Local-first-Alternative zu Claude Design. Erzeuge Decks, Landingpages, Dashboards und Brand-Systeme mit Claude Code, Codex, Cursor, Gemini, OpenCode oder Qwen — mit {skills} kombinierbaren Skills und {systems} portablen DESIGN.md-Systemen.',
   },
   fr: {
-    title: "Open Design — l'alternative open source officielle à Claude Design",
+    title: "Open Design — la meilleure alternative open source à Claude Design",
     description:
-      "Open Design est l'alternative officielle, open source et local-first à Claude Design. Générez des decks, landing pages, dashboards et systèmes de marque avec Claude Code, Codex, Cursor, Gemini, OpenCode ou Qwen — grâce à {skills} skills composables et {systems} systèmes DESIGN.md portables.",
+      "Open Design est la meilleure alternative open source et local-first à Claude Design. Générez des decks, landing pages, dashboards et systèmes de marque avec Claude Code, Codex, Cursor, Gemini, OpenCode ou Qwen — grâce à {skills} skills composables et {systems} systèmes DESIGN.md portables.",
   },
   ru: {
-    title: 'Open Design — официальная open-source альтернатива Claude Design',
+    title: 'Open Design — лучшая open-source альтернатива Claude Design',
     description:
-      'Open Design — официальная open-source и local-first альтернатива Claude Design. Создавайте презентации, лендинги, дашборды и бренд-системы через Claude Code, Codex, Cursor, Gemini, OpenCode или Qwen на базе {skills} skills и {systems} DESIGN.md-систем.',
+      'Open Design — лучшая open-source и local-first альтернатива Claude Design. Создавайте презентации, лендинги, дашборды и бренд-системы через Claude Code, Codex, Cursor, Gemini, OpenCode или Qwen на базе {skills} skills и {systems} DESIGN.md-систем.',
   },
   es: {
-    title: 'Open Design — alternativa open source oficial a Claude Design',
+    title: 'Open Design — la mejor alternativa open source a Claude Design',
     description:
-      'Open Design es la alternativa oficial, open source y local-first a Claude Design. Genera decks, landing pages, dashboards y sistemas de marca con Claude Code, Codex, Cursor, Gemini, OpenCode o Qwen, impulsado por {skills} skills componibles y {systems} sistemas DESIGN.md portables.',
+      'Open Design es la mejor alternativa open source y local-first a Claude Design. Genera decks, landing pages, dashboards y sistemas de marca con Claude Code, Codex, Cursor, Gemini, OpenCode o Qwen, impulsado por {skills} skills componibles y {systems} sistemas DESIGN.md portables.',
   },
   'pt-br': {
-    title: 'Open Design — alternativa open source oficial ao Claude Design',
+    title: 'Open Design — a melhor alternativa open source ao Claude Design',
     description:
-      'Open Design é a alternativa oficial, open source e local-first ao Claude Design. Gere decks, landing pages, dashboards e sistemas de marca com Claude Code, Codex, Cursor, Gemini, OpenCode ou Qwen, usando {skills} skills combináveis e {systems} sistemas DESIGN.md portáteis.',
+      'Open Design é a melhor alternativa open source e local-first ao Claude Design. Gere decks, landing pages, dashboards e sistemas de marca com Claude Code, Codex, Cursor, Gemini, OpenCode ou Qwen, usando {skills} skills combináveis e {systems} sistemas DESIGN.md portáteis.',
   },
   it: {
-    title: "Open Design — l'alternativa open source ufficiale a Claude Design",
+    title: "Open Design — la migliore alternativa open source a Claude Design",
     description:
-      "Open Design è l'alternativa ufficiale, open source e local-first a Claude Design. Genera deck, landing page, dashboard e sistemi di marca con Claude Code, Codex, Cursor, Gemini, OpenCode o Qwen, usando {skills} skill componibili e {systems} sistemi DESIGN.md portabili.",
+      "Open Design è la migliore alternativa open source e local-first a Claude Design. Genera deck, landing page, dashboard e sistemi di marca con Claude Code, Codex, Cursor, Gemini, OpenCode o Qwen, usando {skills} skill componibili e {systems} sistemi DESIGN.md portabili.",
   },
   vi: {
-    title: 'Open Design — lựa chọn mã nguồn mở chính thức thay Claude Design',
+    title: 'Open Design — lựa chọn mã nguồn mở tốt nhất thay Claude Design',
     description:
-      'Open Design là lựa chọn mã nguồn mở, local-first chính thức thay Claude Design. Tạo deck, landing page, dashboard và hệ thống thương hiệu bằng Claude Code, Codex, Cursor, Gemini, OpenCode hoặc Qwen, với {skills} skill có thể ghép và {systems} hệ DESIGN.md di động.',
+      'Open Design là lựa chọn mã nguồn mở, local-first tốt nhất thay Claude Design. Tạo deck, landing page, dashboard và hệ thống thương hiệu bằng Claude Code, Codex, Cursor, Gemini, OpenCode hoặc Qwen, với {skills} skill có thể ghép và {systems} hệ DESIGN.md di động.',
   },
   pl: {
-    title: 'Open Design — oficjalna open-source alternatywa dla Claude Design',
+    title: 'Open Design — najlepsza open-source alternatywa dla Claude Design',
     description:
-      'Open Design to oficjalna, open-source i local-first alternatywa dla Claude Design. Twórz decki, landing page, dashboardy i systemy marki z Claude Code, Codex, Cursor, Gemini, OpenCode lub Qwen, używając {skills} kompozycyjnych skills i {systems} przenośnych systemów DESIGN.md.',
+      'Open Design to najlepsza, open-source i local-first alternatywa dla Claude Design. Twórz decki, landing page, dashboardy i systemy marki z Claude Code, Codex, Cursor, Gemini, OpenCode lub Qwen, używając {skills} kompozycyjnych skills i {systems} przenośnych systemów DESIGN.md.',
   },
   id: {
-    title: 'Open Design — alternatif open source resmi untuk Claude Design',
+    title: 'Open Design — alternatif open source terbaik untuk Claude Design',
     description:
-      'Open Design adalah alternatif resmi, open source, dan local-first untuk Claude Design. Buat deck, landing page, dashboard, dan sistem merek dengan Claude Code, Codex, Cursor, Gemini, OpenCode, atau Qwen, didukung {skills} skill komposable dan {systems} sistem DESIGN.md portabel.',
+      'Open Design adalah alternatif terbaik, open source, dan local-first untuk Claude Design. Buat deck, landing page, dashboard, dan sistem merek dengan Claude Code, Codex, Cursor, Gemini, OpenCode, atau Qwen, didukung {skills} skill komposable dan {systems} sistem DESIGN.md portabel.',
   },
   nl: {
-    title: 'Open Design — officieel open-source alternatief voor Claude Design',
+    title: 'Open Design — het beste open-source alternatief voor Claude Design',
     description:
-      'Open Design is het officiële open-source en local-first alternatief voor Claude Design. Maak decks, landingspagina’s, dashboards en merksystemen met Claude Code, Codex, Cursor, Gemini, OpenCode of Qwen, aangedreven door {skills} combineerbare skills en {systems} draagbare DESIGN.md-systemen.',
+      'Open Design is het beste open-source en local-first alternatief voor Claude Design. Maak decks, landingspagina’s, dashboards en merksystemen met Claude Code, Codex, Cursor, Gemini, OpenCode of Qwen, aangedreven door {skills} combineerbare skills en {systems} draagbare DESIGN.md-systemen.',
   },
   ar: {
-    title: 'Open Design — البديل الرسمي مفتوح المصدر لـ Claude Design',
+    title: 'Open Design — أفضل بديل مفتوح المصدر لـ Claude Design',
     description:
-      'Open Design هو البديل الرسمي مفتوح المصدر والمحلي أولاً لـ Claude Design. أنشئ عروضاً وصفحات هبوط ولوحات بيانات وأنظمة علامة عبر Claude Code أو Codex أو Cursor أو Gemini أو OpenCode أو Qwen، مع {skills} مهارة قابلة للتركيب و {systems} نظام DESIGN.md قابل للنقل.',
+      'Open Design هو أفضل بديل مفتوح المصدر والمحلي أولاً لـ Claude Design. أنشئ عروضاً وصفحات هبوط ولوحات بيانات وأنظمة علامة عبر Claude Code أو Codex أو Cursor أو Gemini أو OpenCode أو Qwen، مع {skills} مهارة قابلة للتركيب و {systems} نظام DESIGN.md قابل للنقل.',
   },
   tr: {
-    title: "Open Design — Claude Design'ın resmi açık kaynak alternatifi",
+    title: "Open Design — Claude Design'ın en iyi açık kaynak alternatifi",
     description:
-      "Open Design, Claude Design'ın resmi, açık kaynak ve local-first alternatifidir. Claude Code, Codex, Cursor, Gemini, OpenCode veya Qwen ile deck, landing page, dashboard ve marka sistemleri üretin; {skills} birleştirilebilir skill ve {systems} taşınabilir DESIGN.md sistemiyle çalışır.",
+      "Open Design, Claude Design'ın en iyi, açık kaynak ve local-first alternatifidir. Claude Code, Codex, Cursor, Gemini, OpenCode veya Qwen ile deck, landing page, dashboard ve marka sistemleri üretin; {skills} birleştirilebilir skill ve {systems} taşınabilir DESIGN.md sistemiyle çalışır.",
   },
   uk: {
-    title: 'Open Design — офіційна open-source альтернатива Claude Design',
+    title: 'Open Design — найкраща open-source альтернатива Claude Design',
     description:
-      'Open Design — офіційна open-source і local-first альтернатива Claude Design. Створюйте презентації, лендинги, дашборди та бренд-системи через Claude Code, Codex, Cursor, Gemini, OpenCode або Qwen на базі {skills} skills і {systems} DESIGN.md-систем.',
+      'Open Design — найкраща open-source і local-first альтернатива Claude Design. Створюйте презентації, лендинги, дашборди та бренд-системи через Claude Code, Codex, Cursor, Gemini, OpenCode або Qwen на базі {skills} skills і {systems} DESIGN.md-систем.',
   },
 };
 

--- a/apps/landing-page/app/i18n.ts
+++ b/apps/landing-page/app/i18n.ts
@@ -3,7 +3,7 @@ import { EXTRA_LOCALIZED_LANDING_UI_COPY } from './landing-ui-i18n';
 
 export const DEFAULT_LOCALE = 'en';
 
-export const LANDING_LOCALES = [
+const ALL_LANDING_LOCALES = [
   {
     code: 'en',
     htmlLang: 'en',
@@ -150,8 +150,31 @@ export const LANDING_LOCALES = [
   },
 ] as const;
 
-export type LandingLocaleCode = (typeof LANDING_LOCALES)[number]['code'];
-export type LandingLocale = (typeof LANDING_LOCALES)[number];
+// Full historical locale set — retained ONLY so existing per-locale translation
+// data stays type-valid. Do NOT use this for routing / sitemap / hreflang; use
+// LANDING_LOCALES below.
+export type LandingLocaleCode = (typeof ALL_LANDING_LOCALES)[number]['code'];
+export type LandingLocale = (typeof ALL_LANDING_LOCALES)[number];
+
+// Locales retired 2026-06 after a GSC review (near-zero Google return). Pages
+// are no longer generated for them and incoming URLs are 301'd to the English
+// page in public/_redirects. Any NEW page automatically ships only the active
+// set below, so the retired languages cannot silently reappear.
+const RETIRED_LOCALE_CODES = new Set<LandingLocaleCode>([
+  'zh-tw',
+  'vi',
+  'pl',
+  'id',
+  'nl',
+  'ar',
+  'uk',
+]);
+
+// Single source of truth for the locales we actually ship: routing, the
+// language switcher, hreflang, and the sitemap all consume this filtered list.
+export const LANDING_LOCALES: readonly LandingLocale[] = ALL_LANDING_LOCALES.filter(
+  (locale) => !RETIRED_LOCALE_CODES.has(locale.code),
+);
 
 export interface HeaderCopy {
   brandMetaTitle: string;

--- a/apps/landing-page/app/pages/og.astro
+++ b/apps/landing-page/app/pages/og.astro
@@ -17,7 +17,7 @@
  * Self-contained — does not import globals.css so the marketing page
  * styles never leak in. `noindex` so the surface itself never ranks.
  */
-const title = 'Open Design — The official open-source Claude Design alternative.';
+const title = 'Open Design — The best open-source Claude Design alternative.';
 ---
 
 <!doctype html>

--- a/apps/landing-page/public/_redirects
+++ b/apps/landing-page/public/_redirects
@@ -263,3 +263,31 @@
 /ar/plugins/*  /plugins/:splat  301
 /tr/plugins/*  /plugins/:splat  301
 /uk/plugins/*  /plugins/:splat  301
+
+# --- Retired marketing locales (2026-06 GSC review) --------------------------
+# Removed from app/i18n.ts:LANDING_LOCALES (near-zero Google return). Keep in
+# sync with that list. Chinese variants fold into /zh; every other retired
+# locale folds into the English (prefix-less) page. Locale-specific /wallet
+# rules above still win because first match wins.
+/zh-tw/* /zh/:splat 301
+/zh-tw   /zh/       301
+/zh-cn/* /zh/:splat 301
+/zh-cn   /zh/       301
+/vi/* /:splat 301
+/vi   /      301
+/pl/* /:splat 301
+/pl   /      301
+/id/* /:splat 301
+/id   /      301
+/nl/* /:splat 301
+/nl   /      301
+/ar/* /:splat 301
+/ar   /      301
+/uk/* /:splat 301
+/uk   /      301
+/fa/* /:splat 301
+/fa   /      301
+/hu/* /:splat 301
+/hu   /      301
+/th/* /:splat 301
+/th   /      301

--- a/apps/landing-page/public/_redirects
+++ b/apps/landing-page/public/_redirects
@@ -176,17 +176,23 @@
 /th   /      301
 
 # ---------------------------------------------------------------------------
-# Kept-locale catalog redirects, consolidated with a :loc placeholder. The
-# per-locale expansion (11 locales x ~5 paths) pushed the file past Cloudflare
-# Pages' total-rule cap, silently dropping the tail -- retired catch-alls and
-# later kept rules 404'd instead of redirecting. One placeholder rule per path
-# keeps the whole file well under the cap. Retired locales are handled above
-# (first match wins); real localized hub pages are static and win over these.
-# previews before plugins (specific first); skills/systems/templates preserve
-# the locale, plugins fold to canonical English.
+# Kept-locale legacy catalog redirects, consolidated with a :loc placeholder.
+# The per-locale expansion (11 locales x several paths) pushed the file past
+# Cloudflare Pages' total-rule cap, silently dropping the tail -- the retired
+# catch-alls above 404'd instead of redirecting. One placeholder rule per path
+# keeps the file well under the cap. Retired locales are handled above (first
+# match wins), so these only ever match a kept locale.
+#
+# IMPORTANT: do NOT add a generic `/:loc/plugins/*` fold here. On this project
+# `_redirects` takes precedence over static assets, and the localized plugin
+# hub pages (`/<loc>/plugins/`, `/<loc>/plugins/{skills,systems,templates}/`)
+# are real static files that must keep serving 200. A `/:loc/plugins/*` rule
+# would shadow them and 301 the hubs to English. Localized plugin DETAIL pages
+# are not generated and 404 (unchanged from production); retired-locale plugin
+# paths still fold to English via the `/<retired>/* -> /:splat` rules above.
+# The /skills /systems /templates legacy listings below are NOT static (their
+# generators were removed), so folding them is safe.
 # ---------------------------------------------------------------------------
 /:loc/skills/*     /:loc/plugins/skills/     301
 /:loc/systems/*    /:loc/plugins/systems/    301
 /:loc/templates/*  /:loc/plugins/templates/  301
-/:loc/plugins/previews/*  /plugins/previews/:splat  301
-/:loc/plugins/*  /plugins/:splat  301

--- a/apps/landing-page/public/_redirects
+++ b/apps/landing-page/public/_redirects
@@ -77,9 +77,6 @@
 # those URLs would 404 without a redirect. Send them to the canonical
 # (English) `/plugins/...` until the legacy locale set is retired
 # entirely.
-/fa/plugins/*  /plugins/:splat  301
-/hu/plugins/*  /plugins/:splat  301
-/th/plugins/*  /plugins/:splat  301
 
 # ─────────────────────────────────────────────────────────────────────
 # Catalog migration: legacy /skills /systems /templates -> /plugins/*
@@ -157,9 +154,6 @@
 /zh/skills/*     /zh/plugins/skills/     301
 /zh/systems/*    /zh/plugins/systems/    301
 /zh/templates/*  /zh/plugins/templates/  301
-/zh-tw/skills/*     /zh-tw/plugins/skills/     301
-/zh-tw/systems/*    /zh-tw/plugins/systems/    301
-/zh-tw/templates/*  /zh-tw/plugins/templates/  301
 /ja/skills/*     /ja/plugins/skills/     301
 /ja/systems/*    /ja/plugins/systems/    301
 /ja/templates/*  /ja/plugins/templates/  301
@@ -184,32 +178,13 @@
 /it/skills/*     /it/plugins/skills/     301
 /it/systems/*    /it/plugins/systems/    301
 /it/templates/*  /it/plugins/templates/  301
-/vi/skills/*     /vi/plugins/skills/     301
-/vi/systems/*    /vi/plugins/systems/    301
-/vi/templates/*  /vi/plugins/templates/  301
-/pl/skills/*     /pl/plugins/skills/     301
-/pl/systems/*    /pl/plugins/systems/    301
-/pl/templates/*  /pl/plugins/templates/  301
-/id/skills/*     /id/plugins/skills/     301
-/id/systems/*    /id/plugins/systems/    301
-/id/templates/*  /id/plugins/templates/  301
-/nl/skills/*     /nl/plugins/skills/     301
-/nl/systems/*    /nl/plugins/systems/    301
-/nl/templates/*  /nl/plugins/templates/  301
-/ar/skills/*     /ar/plugins/skills/     301
-/ar/systems/*    /ar/plugins/systems/    301
-/ar/templates/*  /ar/plugins/templates/  301
 /tr/skills/*     /tr/plugins/skills/     301
 /tr/systems/*    /tr/plugins/systems/    301
 /tr/templates/*  /tr/plugins/templates/  301
-/uk/skills/*     /uk/plugins/skills/     301
-/uk/systems/*    /uk/plugins/systems/    301
-/uk/templates/*  /uk/plugins/templates/  301
 
 # Localized plugin previews were de-duplicated to the canonical English
 # build (previews are language-agnostic visual assets); fall back to them.
 /zh/plugins/previews/*  /plugins/previews/:splat  301
-/zh-tw/plugins/previews/*  /plugins/previews/:splat  301
 /ja/plugins/previews/*  /plugins/previews/:splat  301
 /ko/plugins/previews/*  /plugins/previews/:splat  301
 /de/plugins/previews/*  /plugins/previews/:splat  301
@@ -218,13 +193,7 @@
 /es/plugins/previews/*  /plugins/previews/:splat  301
 /pt-br/plugins/previews/*  /plugins/previews/:splat  301
 /it/plugins/previews/*  /plugins/previews/:splat  301
-/vi/plugins/previews/*  /plugins/previews/:splat  301
-/pl/plugins/previews/*  /plugins/previews/:splat  301
-/id/plugins/previews/*  /plugins/previews/:splat  301
-/nl/plugins/previews/*  /plugins/previews/:splat  301
-/ar/plugins/previews/*  /plugins/previews/:splat  301
 /tr/plugins/previews/*  /plugins/previews/:splat  301
-/uk/plugins/previews/*  /plugins/previews/:splat  301
 
 # Agent detail route migration: the per-agent pages moved from
 # `/agents/<slug>/` to `/agents/<slug>-design/` (design keyword in the URL) and
@@ -247,7 +216,6 @@
 # hub pages (/<loc>/plugins/, /<loc>/plugins/{skills,systems,templates}/) have
 # static files and are served directly (static assets win over _redirects).
 /zh/plugins/*  /plugins/:splat  301
-/zh-tw/plugins/*  /plugins/:splat  301
 /ja/plugins/*  /plugins/:splat  301
 /ko/plugins/*  /plugins/:splat  301
 /de/plugins/*  /plugins/:splat  301
@@ -256,13 +224,7 @@
 /es/plugins/*  /plugins/:splat  301
 /pt-br/plugins/*  /plugins/:splat  301
 /it/plugins/*  /plugins/:splat  301
-/vi/plugins/*  /plugins/:splat  301
-/pl/plugins/*  /plugins/:splat  301
-/id/plugins/*  /plugins/:splat  301
-/nl/plugins/*  /plugins/:splat  301
-/ar/plugins/*  /plugins/:splat  301
 /tr/plugins/*  /plugins/:splat  301
-/uk/plugins/*  /plugins/:splat  301
 
 # --- Retired marketing locales (2026-06 GSC review) --------------------------
 # Removed from app/i18n.ts:LANDING_LOCALES (near-zero Google return). Keep in

--- a/apps/landing-page/public/_redirects
+++ b/apps/landing-page/public/_redirects
@@ -23,8 +23,6 @@
 /en/wallet/      /amr/wallet  302
 /zh/wallet       /amr/wallet  302
 /zh/wallet/      /amr/wallet  302
-/zh-tw/wallet    /amr/wallet  302
-/zh-tw/wallet/   /amr/wallet  302
 /ja/wallet       /amr/wallet  302
 /ja/wallet/      /amr/wallet  302
 /ko/wallet       /amr/wallet  302
@@ -41,20 +39,8 @@
 /pt-br/wallet/   /amr/wallet  302
 /it/wallet       /amr/wallet  302
 /it/wallet/      /amr/wallet  302
-/vi/wallet       /amr/wallet  302
-/vi/wallet/      /amr/wallet  302
-/pl/wallet       /amr/wallet  302
-/pl/wallet/      /amr/wallet  302
-/id/wallet       /amr/wallet  302
-/id/wallet/      /amr/wallet  302
-/nl/wallet       /amr/wallet  302
-/nl/wallet/      /amr/wallet  302
-/ar/wallet       /amr/wallet  302
-/ar/wallet/      /amr/wallet  302
 /tr/wallet       /amr/wallet  302
 /tr/wallet/      /amr/wallet  302
-/uk/wallet       /amr/wallet  302
-/uk/wallet/      /amr/wallet  302
 
 # Locale-code migration: the previous OD landing-page stack used BCP-47
 # region-qualified codes (zh-CN, zh-TW, pt-BR, es-ES) whereas the
@@ -145,56 +131,6 @@
 /systems/    /plugins/systems/    301
 /templates/  /plugins/templates/  301
 
-# Locale-prefixed variants for ALL prefixed LANDING_LOCALES (every code
-# except the unprefixed default `en`). The localized skills/systems/
-# templates generators were removed (they 18x-exploded the static file
-# count past Cloudflare Pages' 20k-file deploy limit); these 301s degrade
-# each localized catalog path to that locale's plugins section. Non-en
-# pages are sitemap-excluded, so no detail-level precision is needed.
-/zh/skills/*     /zh/plugins/skills/     301
-/zh/systems/*    /zh/plugins/systems/    301
-/zh/templates/*  /zh/plugins/templates/  301
-/ja/skills/*     /ja/plugins/skills/     301
-/ja/systems/*    /ja/plugins/systems/    301
-/ja/templates/*  /ja/plugins/templates/  301
-/ko/skills/*     /ko/plugins/skills/     301
-/ko/systems/*    /ko/plugins/systems/    301
-/ko/templates/*  /ko/plugins/templates/  301
-/de/skills/*     /de/plugins/skills/     301
-/de/systems/*    /de/plugins/systems/    301
-/de/templates/*  /de/plugins/templates/  301
-/fr/skills/*     /fr/plugins/skills/     301
-/fr/systems/*    /fr/plugins/systems/    301
-/fr/templates/*  /fr/plugins/templates/  301
-/ru/skills/*     /ru/plugins/skills/     301
-/ru/systems/*    /ru/plugins/systems/    301
-/ru/templates/*  /ru/plugins/templates/  301
-/es/skills/*     /es/plugins/skills/     301
-/es/systems/*    /es/plugins/systems/    301
-/es/templates/*  /es/plugins/templates/  301
-/pt-br/skills/*     /pt-br/plugins/skills/     301
-/pt-br/systems/*    /pt-br/plugins/systems/    301
-/pt-br/templates/*  /pt-br/plugins/templates/  301
-/it/skills/*     /it/plugins/skills/     301
-/it/systems/*    /it/plugins/systems/    301
-/it/templates/*  /it/plugins/templates/  301
-/tr/skills/*     /tr/plugins/skills/     301
-/tr/systems/*    /tr/plugins/systems/    301
-/tr/templates/*  /tr/plugins/templates/  301
-
-# Localized plugin previews were de-duplicated to the canonical English
-# build (previews are language-agnostic visual assets); fall back to them.
-/zh/plugins/previews/*  /plugins/previews/:splat  301
-/ja/plugins/previews/*  /plugins/previews/:splat  301
-/ko/plugins/previews/*  /plugins/previews/:splat  301
-/de/plugins/previews/*  /plugins/previews/:splat  301
-/fr/plugins/previews/*  /plugins/previews/:splat  301
-/ru/plugins/previews/*  /plugins/previews/:splat  301
-/es/plugins/previews/*  /plugins/previews/:splat  301
-/pt-br/plugins/previews/*  /plugins/previews/:splat  301
-/it/plugins/previews/*  /plugins/previews/:splat  301
-/tr/plugins/previews/*  /plugins/previews/:splat  301
-
 # Agent detail route migration: the per-agent pages moved from
 # `/agents/<slug>/` to `/agents/<slug>-design/` (design keyword in the URL) and
 # the old Astro generators were removed. These 301s preserve any inbound links
@@ -209,28 +145,13 @@
 /:locale/agents/claude-code/  /:locale/agents/claude-code-design/  301
 /:locale/agents/opencode/     /:locale/agents/opencode-design/     301
 
-# Localized plugin DETAIL pages are not generated (they multiplied the full
-# catalog across every locale and pushed the build toward Cloudflare Pages'
-# 20k-file deploy cap). Plugin detail is canonical (English); 301 any locale-
-# prefixed plugin URL with no static page to its canonical path. Kept localized
-# hub pages (/<loc>/plugins/, /<loc>/plugins/{skills,systems,templates}/) have
-# static files and are served directly (static assets win over _redirects).
-/zh/plugins/*  /plugins/:splat  301
-/ja/plugins/*  /plugins/:splat  301
-/ko/plugins/*  /plugins/:splat  301
-/de/plugins/*  /plugins/:splat  301
-/fr/plugins/*  /plugins/:splat  301
-/ru/plugins/*  /plugins/:splat  301
-/es/plugins/*  /plugins/:splat  301
-/pt-br/plugins/*  /plugins/:splat  301
-/it/plugins/*  /plugins/:splat  301
-/tr/plugins/*  /plugins/:splat  301
-
-# --- Retired marketing locales (2026-06 GSC review) --------------------------
-# Removed from app/i18n.ts:LANDING_LOCALES (near-zero Google return). Keep in
-# sync with that list. Chinese variants fold into /zh; every other retired
-# locale folds into the English (prefix-less) page. Locale-specific /wallet
-# rules above still win because first match wins.
+# ---------------------------------------------------------------------------
+# Retired marketing locales (2026-06 GSC review) -> fold to English (or /zh for
+# Chinese variants). MUST precede the generic /:loc/* catalog rules below so a
+# retired locale folds to English, not to its own (now non-existent) /plugins/
+# pages. Their /wallet callbacks fold via /:splat -> /wallet -> /amr/wallet, so
+# no per-locale wallet rule is needed.
+# ---------------------------------------------------------------------------
 /zh-tw/* /zh/:splat 301
 /zh-tw   /zh/       301
 /zh-cn/* /zh/:splat 301
@@ -253,3 +174,19 @@
 /hu   /      301
 /th/* /:splat 301
 /th   /      301
+
+# ---------------------------------------------------------------------------
+# Kept-locale catalog redirects, consolidated with a :loc placeholder. The
+# per-locale expansion (11 locales x ~5 paths) pushed the file past Cloudflare
+# Pages' total-rule cap, silently dropping the tail -- retired catch-alls and
+# later kept rules 404'd instead of redirecting. One placeholder rule per path
+# keeps the whole file well under the cap. Retired locales are handled above
+# (first match wins); real localized hub pages are static and win over these.
+# previews before plugins (specific first); skills/systems/templates preserve
+# the locale, plugins fold to canonical English.
+# ---------------------------------------------------------------------------
+/:loc/skills/*     /:loc/plugins/skills/     301
+/:loc/systems/*    /:loc/plugins/systems/    301
+/:loc/templates/*  /:loc/plugins/templates/  301
+/:loc/plugins/previews/*  /plugins/previews/:splat  301
+/:loc/plugins/*  /plugins/:splat  301


### PR DESCRIPTION
## Why

Two related marketing-site SEO changes, both driven by a GSC review of `open-design.ai`:

1. **Retire low-return locales.** The landing site shipped 18 marketing locales. A Search Console review (last 90 days) showed most non-core locales return almost no organic *clicks* despite costing ~1,230 generated/translated pages that must be regenerated on every content change. This concentrates the site on the locales that actually pull search traffic.
2. **Homepage TDK: "official" → "best".** The homepage title/description called Open Design the *official* open-source Claude Design alternative. "official" has no search demand (nobody queries "official X") and reads as self-promotion; "best" matches the high-intent "best open-source X" / "best Claude Design alternative" pattern users actually search.

## What users will see

- **Fewer localized URLs.** Marketing pages now ship 11 locales (`en, zh, ja, ko, de, fr, ru, es, pt-br, it, tr`). Retired locale URLs (`zh-tw, vi, pl, id, nl, ar, uk`, plus `fa, hu, th` on catalog routes) 301-redirect to the English page. The language switcher, `hreflang`, and sitemap only list the active set.
- **New homepage title/description.** The browser tab and search snippet now read "Open Design — Best open-source Claude Design alternative" instead of "…Official…", in every active locale, and the social-share card matches.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — no new keys; the *set* of shipped locales changed (filtered via `LANDING_LOCALES`), translation data is retained as type-valid
- [ ] **New top-level dependency**
- [x] **Default behavior change** — homepage default title/description text changed for all users; retired-locale URLs now 301 to English instead of serving a localized page
- [ ] **None**

## Screenshots

This change is metadata only (`<title>`, `<meta name="description">`, OG/Twitter card) — nothing visual on the page itself. Verify on the live preview:

**Preview:** https://pr-4709.open-design-landing-staging.pages.dev

- Homepage tab title → "Open Design — Best open-source Claude Design alternative"
- View-source `<meta name="description">` → "…the best open-source, local-first Claude Design alternative…"
- Retired-locale URL `/vi/` → 301 to the English page; `/zh-tw/` → 301 to `/zh/`
- Localized plugin hub `/es/plugins/` → 200 (still served); `/de/plugins/skills/` → 200

Redirect behavior was regression-tested end-to-end on the preview: retired-locale folds, kept-locale legacy-catalog folds, localized plugin hubs (200), wallet (302), agent route migration, and top-level catalog all verified.

## Validation

- `pnpm --filter @open-design/landing-page exec astro check` → **0 errors, 0 warnings** (247 files)
- Locale prune verified against GSC page-level data (table below)

---

## Locale prune — rationale & strategy

### What changed

- Marketing pages: 18 → **11 locales**. Retired 7: `zh-tw, vi, pl, id, nl, ar, uk`.
- Catalog catch-all routes: retired 3 more (`fa, hu, th`; `zh-tw/ar/pl/id/uk` overlap with the marketing set).
- **Kept (active) locales:** `en, zh, ja, ko, de, fr, ru, es, pt-br, it, tr`.

### Evidence (GSC, 2026-03-23 → 06-22, by page bucketed to locale prefix)

Decision metric is organic **clicks** (real return), not impressions.

| locale | status | clicks | share | impressions | pages |
|---|---|---|---|---|---|
| en | EN default | 96,644 | 80.2% | 501,587 | 1,076 |
| **es** | ✅ keep | 8,013 | 6.6% | 28,473 | 252 |
| fr | ✅ keep | 2,347 | 1.9% | 8,882 | 233 |
| de | ✅ keep | 1,543 | 1.3% | 5,746 | 173 |
| tr | ✅ keep | 1,510 | 1.3% | 5,635 | 168 |
| ru | ✅ keep | 1,476 | 1.2% | 9,457 | 259 |
| pt-br | ✅ keep | 1,456 | 1.2% | 10,032 | 197 |
| it | ✅ keep | 1,432 | 1.2% | 5,415 | 148 |
| ja | ✅ keep | 1,391 | 1.2% | 7,080 | 207 |
| zh | ✅ keep | 975 | 0.8% | 12,123 | 401 |
| **ko** | ✅ keep (cut-line floor) | **905** | 0.8% | 6,046 | 284 |
| **vi** | ✂ retire (cut-line ceiling) | **798** | 0.7% | 4,824 | 221 |
| id | ✂ retire | 737 | 0.6% | 5,890 | 219 |
| nl | ✂ retire | 433 | 0.4% | 1,996 | 126 |
| pl | ✂ retire | 316 | 0.3% | 2,699 | 124 |
| ar | ✂ retire | 256 | 0.2% | 1,602 | 129 |
| uk | ✂ retire | 135 | 0.1% | 1,040 | 103 |
| zh-tw | ✂ retire | 132 | 0.1% | 5,496 | 270 |
| fa | ✂ retire | 2 | 0.0% | 318 | 19 |
| hu | ✂ retire | 3 | 0.0% | 176 | 12 |
| th | ✂ retire | 0 | 0.0% | 90 | 7 |

- **Clean separation on clicks:** every retired locale earns fewer clicks than every kept one — the cut line sits at `vi` (798) < `ko` (905), with no overlap.
- The 10 retired locales together draw **2.3% of clicks / 3.9% of impressions** while costing ~**1,230 generated pages**.
- `zh-tw` is the canonical "high impressions, no return" case (5,496 impressions, 132 clicks, 0.1% CTR) — Traditional-Chinese demand is already covered by `zh` + English.
- The closest calls are `vi` (798) and `id` (737); both still fall below the line, and retirement is reversible (see strategy #2).

### Strategy (concentrate + retire safely)

1. **Single source of truth `LANDING_LOCALES`** — routing, language switcher, `hreflang`, and sitemap all consume one filtered list, so the cut is consistent site-wide.
2. **Stop routing, don't delete translations** — `ALL_LANDING_LOCALES` is retained as a type, so existing per-locale translation data stays type-valid (zero breakage). Reactivating a locale is a one-line removal from `RETIRED_LOCALE_CODES` (**fully reversible**).
3. **New pages auto-ship only the active set** — any new page ships just these 11; retired languages can't silently reappear.
4. **Old URLs 301 → English** — retired-locale URLs fold to their English (or `/zh` for Chinese) equivalent via `public/_redirects`. Verified on the PR preview: `/vi/`, `/id/`, `/uk/skills/x` → English; `/zh-tw/foo/` → `/zh/foo/`; `/vi/wallet` → `/wallet` → `/amr/wallet`.

   **Cloudflare redirect-cap fix (also repairs a pre-existing production bug).** The file had grown past Cloudflare Pages' total-rule cap (~131 rules on this project); rules past the cap are silently dropped. This pre-dates the branch — `/de/plugins/*` and other tail redirects already 404 on production today. Fixed by collapsing the per-locale catalog redirects (skills/systems/templates/plugins/previews — 53 rules across 11 locales) into `:loc` placeholder rules and dropping the retired locales' now-redundant `/wallet` rules, taking the file from **169 → 108 rules** (28 dynamic), comfortably under the cap. One subtlety verified the hard way: on this project `_redirects` takes precedence over static assets, so a `/:loc/plugins/*` fold would shadow the real localized plugin **hub** pages (`/es/plugins/` is a 231 KB static page) and 301 them to English — those hubs only kept serving because the old rule sat in the dropped tail. The final ruleset folds retired locales + legacy `/skills /systems /templates` listings, leaves localized plugin hubs serving 200, and leaves localized plugin detail pages 404 (unchanged from production).
5. **Catalog catch-all routes pruned too** (`_lib/i18n.ts` `RETIRED_PREFIX_LOCALES`) — stops generating `/xx/skills/`-style long-tail pages that dilute crawl budget.

**Why these 11:** all sit above the 905-click cut line, covering the core markets — English (US/IN/GB), Spanish (ES + LatAm, the #2 segment at 6.6%), Portuguese (BR), East Asia (zh/ja/ko), continental Europe (de/fr/it), Russian, Turkish. `es` alone draws 8,013 clicks (6.6%), confirming the "keep locales with real return" line.
