### PR TITLE
fix(e2e): stop packaged Windows onboarding smoke racing the onboarding redirect

### DIFF
--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -658,9 +658,15 @@ winOnboardingDescribe('packaged windows onboarding AMR smoke', () => {
 
       const inspect = await measureSmokeStep(timings, 'wait healthy inspect eval', async () => waitForHealthyDesktop());
       expect(inspect.status?.state).toBe('running');
-      expect(inspect.status?.url).toBe('od://app/');
+      // A fresh install boots at `od://app/` and the SPA immediately redirects to the dedicated
+      // onboarding route (`od://app/onboarding`, since the #4513 cloud sign-in redesign). Whether
+      // the desktop is reported healthy just before or just after that redirect is a race, so the
+      // healthy URL/href may be either — match the prefix leniently exactly as the mac smoke and
+      // the onboarding-landing assertion below do, instead of pinning the bare root (which flaked
+      // ~3 of 4 nightly Windows builds when the redirect won the race).
+      expect(inspect.status?.url).toMatch(/^(od:\/\/app\/|http:\/\/127\.0\.0\.1:\d+\/)/);
       const health = assertHealthEvalValue(inspect.eval?.value);
-      expect(health.href).toBe('od://app/');
+      expect(health.href).toMatch(/^(od:\/\/app\/|http:\/\/127\.0\.0\.1:\d+\/)/);
       expect(health.status).toBe(200);
       expect(health.health.ok).toBe(true);
 


### PR DESCRIPTION
## Symptom

The nightly Windows release build fails ~3 of 4 runs on:

```
FAIL specs/win.spec.ts > packaged windows onboarding AMR smoke > [P0] @electron-smoke ...
AssertionError: expected 'od://app/onboarding' to be 'od://app/'
```

## Root cause — a race, not a product bug

A fresh install boots at `od://app/` and the SPA **immediately redirects** to the dedicated onboarding route `od://app/onboarding` (since the #4513 cloud sign-in redesign). `waitForHealthyDesktop()` can report healthy just **before or after** that redirect, so the healthy URL/href is legitimately either value.

But the smoke pinned the exact bare root:

```ts
expect(inspect.status?.url).toBe('od://app/');   // races the redirect
expect(health.href).toBe('od://app/');           // races the redirect
```

These exact-match assertions (from #4322) went stale after #4513 moved onboarding to its own route. The **same test already matches leniently** a few lines below (the onboarding-landing `initial.href`), and **mac.spec.ts** uses the lenient prefix at the equivalent spot — Windows was just the one left pinned.

## Fix

Relax lines 661/663 to the same prefix match used by mac.spec.ts:328/331 and this test's own landing assertion:

```ts
expect(...).toMatch(/^(od:\/\/app\/|http:\/\/127\.0\.0\.1:\d+\/)/);
```

`od://app/onboarding` matches `^od://app/`, so both the pre- and post-redirect states pass. **Test-only; no product change.** Validates on the next nightly Windows build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Not a recurrence of the "Home flashes before onboarding" bug

Confirmed before relaxing the assertion: the first-run Home-flash fix (#4429, `a8d18b8c2`) is present on **both main and release/v0.12.0**. For a fresh un-onboarded user at `od://app/`, the `pendingFirstRunOnboardingRoute` guard (`apps/web/src/App.tsx`) renders a loading spinner — **not Home** — and the redirect to `/onboarding` is a synchronous `navigate({ replace: true })` done before `daemonConfigLoaded` flips. So Home never paints.

Both URL states this assertion now accepts (`od://app/` = spinner moment, `od://app/onboarding` = redirect done) are **post-#4429** states; neither is a rendered Home. This URL assertion never tested for the flash anyway — that is covered by #4429's own unit test and by this smoke's later `waitForPackagedOnboarding(...)`. Relaxing it does not reduce flash-regression coverage.

(The "booted to Home" note elsewhere in this spec refers to a separate Windows-only test-data isolation bug — stale `onboardingCompleted` in the Electron user-data partition — fixed in #4665, which surfaces as an onboarding-wait timeout, not this href mismatch.)