### PR TITLE
feat(analytics): first-call cache-hit + is_followup_turn telemetry (session-reuse baseline)

### DIFF
--- a/apps/daemon/src/codex-rollout-usage.ts
+++ b/apps/daemon/src/codex-rollout-usage.ts
@@ -1,0 +1,165 @@
+// codex reports only a cumulative `turn.completed` usage on the exec/json
+// stream the daemon consumes, so the stream cannot tell us the cache-hit rate
+// of a turn's OPENING model call — the signal session-reuse moves. codex does
+// record per-call usage in its rollout JSONL though: each `token_count`
+// `event_msg` carries `info.last_token_usage` (the most recent single call,
+// OpenAI-style where `input_tokens` INCLUDES the `cached_input_tokens` subset).
+//
+// A rollout accumulates every turn of a session, one `task_started` per turn.
+// The first `token_count` after the LAST `task_started` is the opening call of
+// the turn the daemon just finished — exactly the first-call number we want.
+// This module is the pure extractor; locating the rollout file for a run lives
+// at the call site (it needs CODEX_HOME + the captured session id).
+
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+interface CodexFirstCallUsage {
+  first_call_input_tokens: number;
+  first_call_cache_read_input_tokens: number;
+  first_call_cache_hit_ratio: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Recover the codex thread/session uuid captured for a run from its stored
+ * event stream. json-event-stream emits it as `sessionId` on the first
+ * `initializing` status event (mirroring claude). Returns the first one found,
+ * or null. Matches the `{ event: 'agent', data: {...} }` envelope the run uses.
+ */
+export function codexSessionIdFromRunEvents(events: unknown): string | null {
+  if (!Array.isArray(events)) return null;
+  for (const ev of events) {
+    const record = asRecord(ev);
+    const data = asRecord(record?.data);
+    if (record?.event !== 'agent' || data?.type !== 'status') continue;
+    const sessionId = data.sessionId;
+    if (typeof sessionId === 'string' && sessionId.trim()) return sessionId;
+  }
+  return null;
+}
+
+/**
+ * Extract the first-call usage of the rollout's LAST turn — the turn the daemon
+ * has just finished. Returns null when the rollout has no completed first call
+ * to read (no `last_token_usage`, or an empty/zero-input call), so callers can
+ * cleanly fall back to leaving the codex first-call fields unset rather than
+ * reporting a bogus ratio.
+ */
+export function extractCodexLastTurnFirstCallUsage(
+  rolloutJsonl: string,
+): CodexFirstCallUsage | null {
+  let firstCall: CodexFirstCallUsage | null = null;
+
+  for (const line of rolloutJsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const record = asRecord(parsed);
+    if (!record) continue;
+    const payload = asRecord(record.payload);
+    const payloadType = payload?.type;
+
+    if (payloadType === 'task_started') {
+      // A new turn opens; reset so we capture THIS turn's opening call and let
+      // the last turn in the file win.
+      firstCall = null;
+      continue;
+    }
+
+    if (payloadType !== 'token_count' || firstCall !== null) continue;
+
+    const info = asRecord(payload?.info);
+    const last = asRecord(info?.last_token_usage);
+    if (!last) continue;
+    const input = finiteNumber(last.input_tokens);
+    // codex's input_tokens already includes the cached subset; a zero-input
+    // token_count is a placeholder (e.g. an interrupted call) with no usable
+    // ratio, so skip it and keep scanning for the turn's real first call.
+    if (input === undefined || input <= 0) continue;
+    const cached = finiteNumber(last.cached_input_tokens) ?? 0;
+
+    firstCall = {
+      first_call_input_tokens: input,
+      first_call_cache_read_input_tokens: cached,
+      first_call_cache_hit_ratio: cached / input,
+    };
+  }
+
+  return firstCall;
+}
+
+// codex names each rollout `rollout-<timestamp>-<thread_id>.jsonl` under
+// `$CODEX_HOME/sessions/<year>/<month>/<day>/`. We match on the thread id
+// suffix (captured from the run's `thread.started`) so concurrent runs can't
+// collide.
+function rolloutFileMatchesSession(fileName: string, sessionId: string): boolean {
+  return fileName.startsWith('rollout-') && fileName.endsWith(`-${sessionId}.jsonl`);
+}
+
+async function findCodexRolloutPath(
+  codexHome: string,
+  sessionId: string,
+): Promise<string | null> {
+  const sessionsDir = path.join(codexHome, 'sessions');
+  // Walk year/month/day newest-first so this run's just-written rollout is hit
+  // almost immediately instead of scanning the whole history.
+  const descend = async (dir: string): Promise<string[]> => {
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    return entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => b.localeCompare(a));
+  };
+  for (const year of await descend(sessionsDir)) {
+    const yearDir = path.join(sessionsDir, year);
+    for (const month of await descend(yearDir)) {
+      const monthDir = path.join(yearDir, month);
+      for (const day of await descend(monthDir)) {
+        const dayDir = path.join(monthDir, day);
+        const files = await readdir(dayDir).catch(() => []);
+        const match = files.find((f) => rolloutFileMatchesSession(f, sessionId));
+        if (match) return path.join(dayDir, match);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Locate and read this run's codex rollout, returning the first-call usage of
+ * its last turn. Fully best-effort: any failure (no CODEX_HOME, no session id,
+ * missing rollout, unreadable file, partial turn) resolves to null so the
+ * run_finished analytics path simply omits codex first-call fields rather than
+ * failing the capture.
+ */
+export async function readCodexRolloutFirstCall(opts: {
+  codexHome: string | null | undefined;
+  sessionId: string | null | undefined;
+}): Promise<CodexFirstCallUsage | null> {
+  const codexHome = opts.codexHome?.trim();
+  const sessionId = opts.sessionId?.trim();
+  if (!codexHome || !sessionId) return null;
+  try {
+    const rolloutPath = await findCodexRolloutPath(codexHome, sessionId);
+    if (!rolloutPath) return null;
+    const contents = await readFile(rolloutPath, 'utf8');
+    return extractCodexLastTurnFirstCallUsage(contents);
+  } catch {
+    return null;
+  }
+}

--- a/apps/daemon/src/codex-rollout-usage.ts
+++ b/apps/daemon/src/codex-rollout-usage.ts
@@ -126,6 +126,13 @@ async function findCodexRolloutPath(
       .map((e) => e.name)
       .sort((a, b) => b.localeCompare(a));
   };
+  // The rollout we want was written by the run that just finished, so it lives
+  // in one of the most recent day-dirs. Cap how many we scan: on a HIT we stop
+  // at the first match (today, usually the first dir), and on a MISS (session
+  // captured but file relocated/deleted) this bounds the walk to a handful of
+  // readdirs instead of the user's entire codex history.
+  const MAX_DAY_DIRS = 8;
+  let dayDirsScanned = 0;
   for (const year of await descend(sessionsDir)) {
     const yearDir = path.join(sessionsDir, year);
     for (const month of await descend(yearDir)) {
@@ -135,6 +142,7 @@ async function findCodexRolloutPath(
         const files = await readdir(dayDir).catch(() => []);
         const match = files.find((f) => rolloutFileMatchesSession(f, sessionId));
         if (match) return path.join(dayDir, match);
+        if (++dayDirsScanned >= MAX_DAY_DIRS) return null;
       }
     }
   }

--- a/apps/daemon/src/codex-rollout-usage.ts
+++ b/apps/daemon/src/codex-rollout-usage.ts
@@ -11,6 +11,7 @@
 // This module is the pure extractor; locating the rollout file for a run lives
 // at the call site (it needs CODEX_HOME + the captured session id).
 
+import os from 'node:os';
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -151,9 +152,13 @@ export async function readCodexRolloutFirstCall(opts: {
   codexHome: string | null | undefined;
   sessionId: string | null | undefined;
 }): Promise<CodexFirstCallUsage | null> {
-  const codexHome = opts.codexHome?.trim();
+  // codex resolves its home as `$CODEX_HOME || ~/.codex`. The daemon only sets
+  // CODEX_HOME when sandbox mode relocates it; with sandbox off the resolver
+  // returns empty and codex writes under ~/.codex, so mirror that default here
+  // rather than giving up (which silently dropped every non-sandboxed run).
+  const codexHome = opts.codexHome?.trim() || path.join(os.homedir(), '.codex');
   const sessionId = opts.sessionId?.trim();
-  if (!codexHome || !sessionId) return null;
+  if (!sessionId) return null;
   try {
     const rolloutPath = await findCodexRolloutPath(codexHome, sessionId);
     if (!rolloutPath) return null;

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -21,7 +21,12 @@ import {
 import type { OdNativeEvent } from '@open-design/agui-adapter';
 import { newInsertId, readAnalyticsContext } from '../analytics.js';
 import type { AnalyticsContext } from '../analytics.js';
+import { spawnEnvForAgent } from '../agents.js';
 import { agentCliEnvForAgent, readAppConfig } from '../app-config.js';
+import {
+  codexSessionIdFromRunEvents,
+  readCodexRolloutFirstCall,
+} from '../codex-rollout-usage.js';
 import type { ConnectorService } from '../connectors/service.js';
 import { getProject, listConversations, upsertMessage } from '../db.js';
 import { readVelaLoginStatus } from '../integrations/vela.js';
@@ -914,13 +919,44 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
                 .get(run.conversationId, run.assistantMessageId ?? ''),
             )
           : false;
-        // codex reports a single cumulative `turn.completed` usage, so the
-        // first stream usage event is the whole-session aggregate, not the
-        // turn's opening call — its per-call first-call number must come from
-        // the rollout `last_token_usage` (follow-up). Every other coding agent
-        // (claude / opencode / codebuddy / pi) reports per-call usage, so the
-        // first stream usage event IS the opening call.
-        const firstCallUsageReliable = run.agentId !== 'codex';
+        // Resolve the turn's first-call usage (cache-hit of the OPENING model
+        // call — the signal session reuse moves). Every coding agent except
+        // codex reports per-call usage on the stream, so the forward-scanned
+        // first usage event IS the opening call. codex reports only a single
+        // cumulative `turn.completed` usage on the stream, so its first stream
+        // event is the whole-session aggregate; its real per-call number lives
+        // in the rollout `last_token_usage`, read here best-effort.
+        const firstCallUsage = await (async (): Promise<{
+          first_call_input_tokens?: number;
+          first_call_cache_read_input_tokens?: number;
+          first_call_cache_hit_ratio?: number;
+        } | null> => {
+          if (run.agentId === 'codex') {
+            const sessionId = codexSessionIdFromRunEvents(run.events);
+            const codexHome = spawnEnvForAgent(
+              'codex',
+              { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
+              agentCliEnvForAgent(
+                (appCfgAtFinish as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
+                'codex',
+              ),
+            ).CODEX_HOME;
+            return readCodexRolloutFirstCall({ codexHome, sessionId });
+          }
+          if (usageAnalytics.first_call_input_tokens === undefined) return null;
+          return {
+            first_call_input_tokens: usageAnalytics.first_call_input_tokens,
+            ...(usageAnalytics.first_call_cache_read_input_tokens !== undefined
+              ? {
+                  first_call_cache_read_input_tokens:
+                    usageAnalytics.first_call_cache_read_input_tokens,
+                }
+              : {}),
+            ...(usageAnalytics.first_call_cache_hit_ratio !== undefined
+              ? { first_call_cache_hit_ratio: usageAnalytics.first_call_cache_hit_ratio }
+              : {}),
+          };
+        })();
         const analyticsCapturedAt = Date.now();
         const timingAnalytics = summarizeRunTimingAnalytics({
           runCreatedAt: run.createdAt,
@@ -1062,27 +1098,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             ...(usageAnalytics.cache_hit_ratio !== undefined
               ? { cache_hit_ratio: usageAnalytics.cache_hit_ratio }
               : {}),
-            // The first-call fields come from the FIRST stream usage event,
-            // which is the turn's opening model call ONLY for agents that report
-            // per-call usage (claude / opencode / codebuddy / pi). codex reports
-            // a single cumulative `turn.completed` usage, so its first stream
-            // event is NOT the first call — gate it out here; codex's per-call
-            // first-call number must come from the rollout `last_token_usage`
-            // (tracked as a follow-up), not these stream fields.
-            ...(firstCallUsageReliable && usageAnalytics.first_call_input_tokens !== undefined
-              ? { first_call_input_tokens: usageAnalytics.first_call_input_tokens }
-              : {}),
-            ...(firstCallUsageReliable &&
-            usageAnalytics.first_call_cache_read_input_tokens !== undefined
-              ? {
-                  first_call_cache_read_input_tokens:
-                    usageAnalytics.first_call_cache_read_input_tokens,
-                }
-              : {}),
-            ...(firstCallUsageReliable &&
-            usageAnalytics.first_call_cache_hit_ratio !== undefined
-              ? { first_call_cache_hit_ratio: usageAnalytics.first_call_cache_hit_ratio }
-              : {}),
+            // First-call cache-hit of the turn's opening model call (per-call
+            // usage for claude/opencode/codebuddy/pi from the stream; codex from
+            // its rollout). Sliced by is_followup_turn, this isolates the
+            // session-reuse cache win on non-first turns.
+            ...(firstCallUsage ?? {}),
             is_followup_turn: isFollowupTurn,
             cache_token_source: usageAnalytics.cache_token_source,
             token_count_source: usageAnalytics.token_count_source,

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -932,16 +932,23 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           first_call_cache_hit_ratio?: number;
         } | null> => {
           if (run.agentId === 'codex') {
-            const sessionId = codexSessionIdFromRunEvents(run.events);
-            const codexHome = spawnEnvForAgent(
-              'codex',
-              { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
-              agentCliEnvForAgent(
-                (appCfgAtFinish as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
+            // Best-effort: a throw anywhere here (env resolution, rollout read)
+            // must degrade to "no codex first-call fields", never bubble to the
+            // outer run_finished .catch and drop the whole completion event.
+            try {
+              const sessionId = codexSessionIdFromRunEvents(run.events);
+              const codexHome = spawnEnvForAgent(
                 'codex',
-              ),
-            ).CODEX_HOME;
-            return readCodexRolloutFirstCall({ codexHome, sessionId });
+                { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
+                agentCliEnvForAgent(
+                  (appCfgAtFinish as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
+                  'codex',
+                ),
+              ).CODEX_HOME;
+              return await readCodexRolloutFirstCall({ codexHome, sessionId });
+            } catch {
+              return null;
+            }
           }
           if (usageAnalytics.first_call_input_tokens === undefined) return null;
           return {

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -895,6 +895,32 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           reqBody.model,
           userQueryTokens,
         );
+        // Whether this run is a non-first turn in its conversation — i.e. a
+        // prior completed assistant turn exists (excluding this run's own
+        // placeholder). The session-reuse cache win only applies to follow-up
+        // turns, so slicing `first_call_cache_hit_ratio` by this flag is the
+        // baseline-vs-optimized comparison. Mirrors server.ts hasPriorAssistantTurn.
+        const isFollowupTurn = run.conversationId
+          ? Boolean(
+              db
+                .prepare(
+                  `SELECT 1 FROM messages
+                     WHERE conversation_id = ?
+                       AND role = 'assistant'
+                       AND COALESCE(content, '') <> ''
+                       AND id <> COALESCE(?, '')
+                     LIMIT 1`,
+                )
+                .get(run.conversationId, run.assistantMessageId ?? ''),
+            )
+          : false;
+        // codex reports a single cumulative `turn.completed` usage, so the
+        // first stream usage event is the whole-session aggregate, not the
+        // turn's opening call — its per-call first-call number must come from
+        // the rollout `last_token_usage` (follow-up). Every other coding agent
+        // (claude / opencode / codebuddy / pi) reports per-call usage, so the
+        // first stream usage event IS the opening call.
+        const firstCallUsageReliable = run.agentId !== 'codex';
         const analyticsCapturedAt = Date.now();
         const timingAnalytics = summarizeRunTimingAnalytics({
           runCreatedAt: run.createdAt,
@@ -1036,6 +1062,28 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             ...(usageAnalytics.cache_hit_ratio !== undefined
               ? { cache_hit_ratio: usageAnalytics.cache_hit_ratio }
               : {}),
+            // The first-call fields come from the FIRST stream usage event,
+            // which is the turn's opening model call ONLY for agents that report
+            // per-call usage (claude / opencode / codebuddy / pi). codex reports
+            // a single cumulative `turn.completed` usage, so its first stream
+            // event is NOT the first call — gate it out here; codex's per-call
+            // first-call number must come from the rollout `last_token_usage`
+            // (tracked as a follow-up), not these stream fields.
+            ...(firstCallUsageReliable && usageAnalytics.first_call_input_tokens !== undefined
+              ? { first_call_input_tokens: usageAnalytics.first_call_input_tokens }
+              : {}),
+            ...(firstCallUsageReliable &&
+            usageAnalytics.first_call_cache_read_input_tokens !== undefined
+              ? {
+                  first_call_cache_read_input_tokens:
+                    usageAnalytics.first_call_cache_read_input_tokens,
+                }
+              : {}),
+            ...(firstCallUsageReliable &&
+            usageAnalytics.first_call_cache_hit_ratio !== undefined
+              ? { first_call_cache_hit_ratio: usageAnalytics.first_call_cache_hit_ratio }
+              : {}),
+            is_followup_turn: isFollowupTurn,
             cache_token_source: usageAnalytics.cache_token_source,
             token_count_source: usageAnalytics.token_count_source,
           },

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -281,6 +281,7 @@ export function scanRunEventsForUsageAnalytics(
   // signal from within-turn prefix caching; see the type docs.
   let firstCallInputTokens: number | undefined;
   let firstCallCacheReadInputTokens: number | undefined;
+  let firstCallCacheCreationInputTokens: number | undefined;
   let firstCallCacheTokenSource: 'anthropic' | 'openai' | undefined;
   for (let i = 0; i < events.length; i += 1) {
     const ev = events[i];
@@ -300,6 +301,9 @@ export function scanRunEventsForUsageAnalytics(
     const normRead = firstNumber(usage, ['cached_input_tokens', 'cache_read_tokens', 'cached_read_tokens']);
     const oaiRead = readNestedNumber(usage, ['prompt_tokens_details', 'cached_tokens']);
     firstCallCacheReadInputTokens = anthRead ?? normRead ?? oaiRead;
+    firstCallCacheCreationInputTokens =
+      firstNumber(usage, ['cache_creation_input_tokens']) ??
+      firstNumber(usage, ['cached_write_tokens']);
     firstCallCacheTokenSource = anthRead !== undefined
       ? 'anthropic'
       : (normRead ?? oaiRead) !== undefined
@@ -307,13 +311,17 @@ export function scanRunEventsForUsageAnalytics(
         : undefined;
     break;
   }
-  // Anthropic reports input_tokens as the UNCACHED portion (cache_read is
-  // separate), so the effective input is their sum; OpenAI folds cached into
-  // input_tokens. Mirrors the last-call effective computation below.
+  // Anthropic reports input_tokens as the UNCACHED portion (cache_read and
+  // cache_creation are separate), so the effective input is their sum; OpenAI
+  // folds cached into input_tokens. Mirrors the last-call effective computation
+  // below exactly, including cache_creation, so the first-call and last-call
+  // ratios share one denominator definition.
   const firstCallInputEffective =
     firstCallInputTokens !== undefined
       ? firstCallCacheTokenSource === 'anthropic'
-        ? firstCallInputTokens + (firstCallCacheReadInputTokens ?? 0)
+        ? firstCallInputTokens +
+          (firstCallCacheReadInputTokens ?? 0) +
+          (firstCallCacheCreationInputTokens ?? 0)
         : firstCallInputTokens
       : undefined;
   const firstCallCacheHitRatio =

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -171,6 +171,69 @@ function durationBetween(
   return Math.round(end - start);
 }
 
+interface UsageCacheFields {
+  inputTokens: number | undefined;
+  outputTokens: number | undefined;
+  totalTokens: number | undefined;
+  cacheReadInputTokens: number | undefined;
+  cacheCreationInputTokens: number | undefined;
+  cacheTokenSource: 'anthropic' | 'openai' | undefined;
+}
+
+// Single source of truth for the provider/runtime cache-token alias matrix.
+// Both the last-call (reverse) scan and the first-call (forward) scan extract
+// usage through this so their effective-input denominators — and therefore
+// `cache_hit_ratio` vs `first_call_cache_hit_ratio` — can never drift apart as
+// new aliases are added.
+function extractUsageCacheFields(usage: Record<string, unknown>): UsageCacheFields {
+  const inputTokens = firstNumber(usage, ['input_tokens', 'prompt_tokens']);
+  const outputTokens = firstNumber(usage, ['output_tokens', 'completion_tokens']);
+  const totalTokens = firstNumber(usage, ['total_tokens', 'totalTokens']);
+  const anthropicCacheReadInputTokens = firstNumber(usage, ['cache_read_input_tokens']);
+  const normalizedCachedReadInputTokens = firstNumber(usage, [
+    'cached_input_tokens',
+    'cache_read_tokens',
+    'cached_read_tokens',
+  ]);
+  const openAiCachedInputTokens = readNestedNumber(usage, [
+    'prompt_tokens_details',
+    'cached_tokens',
+  ]);
+  const cacheReadInputTokens =
+    anthropicCacheReadInputTokens ??
+    normalizedCachedReadInputTokens ??
+    openAiCachedInputTokens;
+  const anthropicCacheCreationInputTokens = firstNumber(
+    usage,
+    ['cache_creation_input_tokens', 'cache_write_input_tokens', 'cache_creation_tokens'],
+    [['cache_creation', 'input_tokens']],
+  );
+  const normalizedCachedWriteInputTokens = firstNumber(usage, ['cached_write_tokens']);
+  const cacheCreationInputTokens =
+    anthropicCacheCreationInputTokens ?? normalizedCachedWriteInputTokens;
+  let cacheTokenSource: 'anthropic' | 'openai' | undefined;
+  if (
+    anthropicCacheReadInputTokens !== undefined ||
+    anthropicCacheCreationInputTokens !== undefined
+  ) {
+    cacheTokenSource = 'anthropic';
+  } else if (
+    normalizedCachedReadInputTokens !== undefined ||
+    normalizedCachedWriteInputTokens !== undefined ||
+    openAiCachedInputTokens !== undefined
+  ) {
+    cacheTokenSource = 'openai';
+  }
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cacheReadInputTokens,
+    cacheCreationInputTokens,
+    cacheTokenSource,
+  };
+}
+
 export function scanRunEventsForUsageAnalytics(
   events: RunEventForAnalyticsObservability[],
   reqBodyModel: unknown,
@@ -206,52 +269,13 @@ export function scanRunEventsForUsageAnalytics(
           ? data.modelUsage
           : null;
       if (usage) {
-        inputTokens = firstNumber(usage, ['input_tokens', 'prompt_tokens']);
-        outputTokens = firstNumber(usage, ['output_tokens', 'completion_tokens']);
-        providerTotalTokens = firstNumber(usage, ['total_tokens', 'totalTokens']);
-        const anthropicCacheReadInputTokens = firstNumber(
-          usage,
-          ['cache_read_input_tokens'],
-        );
-        const normalizedCachedReadInputTokens = firstNumber(
-          usage,
-          ['cached_input_tokens', 'cache_read_tokens', 'cached_read_tokens'],
-        );
-        const openAiCachedInputTokens = readNestedNumber(
-          usage,
-          ['prompt_tokens_details', 'cached_tokens'],
-        );
-        cacheReadInputTokens =
-          anthropicCacheReadInputTokens ??
-          normalizedCachedReadInputTokens ??
-          openAiCachedInputTokens;
-        const anthropicCacheCreationInputTokens = firstNumber(
-          usage,
-          [
-            'cache_creation_input_tokens',
-            'cache_write_input_tokens',
-            'cache_creation_tokens',
-          ],
-          [['cache_creation', 'input_tokens']],
-        );
-        const normalizedCachedWriteInputTokens = firstNumber(
-          usage,
-          ['cached_write_tokens'],
-        );
-        cacheCreationInputTokens =
-          anthropicCacheCreationInputTokens ?? normalizedCachedWriteInputTokens;
-        if (
-          anthropicCacheReadInputTokens !== undefined ||
-          anthropicCacheCreationInputTokens !== undefined
-        ) {
-          cacheTokenSource = 'anthropic';
-        } else if (
-          normalizedCachedReadInputTokens !== undefined ||
-          normalizedCachedWriteInputTokens !== undefined ||
-          openAiCachedInputTokens !== undefined
-        ) {
-          cacheTokenSource = 'openai';
-        }
+        const fields = extractUsageCacheFields(usage);
+        inputTokens = fields.inputTokens;
+        outputTokens = fields.outputTokens;
+        providerTotalTokens = fields.totalTokens;
+        cacheReadInputTokens = fields.cacheReadInputTokens;
+        cacheCreationInputTokens = fields.cacheCreationInputTokens;
+        if (fields.cacheTokenSource) cacheTokenSource = fields.cacheTokenSource;
         haveUsageTokens = inputTokens !== undefined || outputTokens !== undefined;
       }
     }
@@ -296,19 +320,13 @@ export function scanRunEventsForUsageAnalytics(
         ? data.modelUsage
         : null;
     if (!usage) continue;
-    firstCallInputTokens = firstNumber(usage, ['input_tokens', 'prompt_tokens']);
-    const anthRead = firstNumber(usage, ['cache_read_input_tokens']);
-    const normRead = firstNumber(usage, ['cached_input_tokens', 'cache_read_tokens', 'cached_read_tokens']);
-    const oaiRead = readNestedNumber(usage, ['prompt_tokens_details', 'cached_tokens']);
-    firstCallCacheReadInputTokens = anthRead ?? normRead ?? oaiRead;
-    firstCallCacheCreationInputTokens =
-      firstNumber(usage, ['cache_creation_input_tokens']) ??
-      firstNumber(usage, ['cached_write_tokens']);
-    firstCallCacheTokenSource = anthRead !== undefined
-      ? 'anthropic'
-      : (normRead ?? oaiRead) !== undefined
-        ? 'openai'
-        : undefined;
+    // Same extraction as the last-call scan above, so the two denominators
+    // stay locked across the full provider alias matrix.
+    const fields = extractUsageCacheFields(usage);
+    firstCallInputTokens = fields.inputTokens;
+    firstCallCacheReadInputTokens = fields.cacheReadInputTokens;
+    firstCallCacheCreationInputTokens = fields.cacheCreationInputTokens;
+    firstCallCacheTokenSource = fields.cacheTokenSource;
     break;
   }
   // Anthropic reports input_tokens as the UNCACHED portion (cache_read and

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -84,6 +84,17 @@ export interface RunUsageAnalytics {
   uncached_input_tokens?: number;
   estimated_context_tokens?: number;
   cache_hit_ratio?: number;
+  // The turn's FIRST model call (forward scan), as opposed to the fields above
+  // which reflect the LAST usage event (reverse scan). The first call is the
+  // session-reuse signal: for per-call-usage agents (claude / opencode /
+  // codebuddy / pi) it is the turn's opening request, whose cached input shows
+  // whether the resumed session's prior context was reused. The last/aggregate
+  // call is saturated by within-turn prefix caching and masks the resume win.
+  // (codex emits only a cumulative `turn.completed` usage, so its first-call
+  // number is sourced from the rollout separately, not from these stream fields.)
+  first_call_input_tokens?: number;
+  first_call_cache_read_input_tokens?: number;
+  first_call_cache_hit_ratio?: number;
   cache_token_source: 'anthropic' | 'openai' | 'unavailable';
   token_count_source: 'provider_usage' | 'estimated' | 'unknown';
   agent_reported_model: string | null;
@@ -265,6 +276,53 @@ export function scanRunEventsForUsageAnalytics(
     if (haveUsageTokens && (!needAgentModel || agentReportedModel)) break;
   }
 
+  // Forward scan for the turn's FIRST model-call usage (the reverse loop above
+  // captured the LAST). For per-call-usage agents this isolates the resume
+  // signal from within-turn prefix caching; see the type docs.
+  let firstCallInputTokens: number | undefined;
+  let firstCallCacheReadInputTokens: number | undefined;
+  let firstCallCacheTokenSource: 'anthropic' | 'openai' | undefined;
+  for (let i = 0; i < events.length; i += 1) {
+    const ev = events[i];
+    const data = ev?.data as
+      | { type?: string; usage?: Record<string, unknown> | null; modelUsage?: Record<string, unknown> | null }
+      | null
+      | undefined;
+    if (ev?.event !== 'agent' || data?.type !== 'usage') continue;
+    const usage = data.usage && typeof data.usage === 'object'
+      ? data.usage
+      : data.modelUsage && typeof data.modelUsage === 'object'
+        ? data.modelUsage
+        : null;
+    if (!usage) continue;
+    firstCallInputTokens = firstNumber(usage, ['input_tokens', 'prompt_tokens']);
+    const anthRead = firstNumber(usage, ['cache_read_input_tokens']);
+    const normRead = firstNumber(usage, ['cached_input_tokens', 'cache_read_tokens', 'cached_read_tokens']);
+    const oaiRead = readNestedNumber(usage, ['prompt_tokens_details', 'cached_tokens']);
+    firstCallCacheReadInputTokens = anthRead ?? normRead ?? oaiRead;
+    firstCallCacheTokenSource = anthRead !== undefined
+      ? 'anthropic'
+      : (normRead ?? oaiRead) !== undefined
+        ? 'openai'
+        : undefined;
+    break;
+  }
+  // Anthropic reports input_tokens as the UNCACHED portion (cache_read is
+  // separate), so the effective input is their sum; OpenAI folds cached into
+  // input_tokens. Mirrors the last-call effective computation below.
+  const firstCallInputEffective =
+    firstCallInputTokens !== undefined
+      ? firstCallCacheTokenSource === 'anthropic'
+        ? firstCallInputTokens + (firstCallCacheReadInputTokens ?? 0)
+        : firstCallInputTokens
+      : undefined;
+  const firstCallCacheHitRatio =
+    firstCallInputEffective !== undefined &&
+    firstCallInputEffective > 0 &&
+    firstCallCacheReadInputTokens !== undefined
+      ? firstCallCacheReadInputTokens / firstCallInputEffective
+      : undefined;
+
   const inputTokensEffective =
     inputTokens !== undefined
       ? cacheTokenSource === 'anthropic'
@@ -316,6 +374,18 @@ export function scanRunEventsForUsageAnalytics(
       ? { estimated_context_tokens: estimatedContextTokens }
       : {}),
     ...(cacheHitRatio !== undefined ? { cache_hit_ratio: cacheHitRatio } : {}),
+    // The first-call group is only meaningful when we have a real opening-call
+    // input total; gate cache_read on that so cache-only alias payloads don't
+    // emit a dangling first_call_cache_read with no input to ratio against.
+    ...(firstCallInputTokens !== undefined
+      ? { first_call_input_tokens: firstCallInputTokens }
+      : {}),
+    ...(firstCallInputTokens !== undefined && firstCallCacheReadInputTokens !== undefined
+      ? { first_call_cache_read_input_tokens: firstCallCacheReadInputTokens }
+      : {}),
+    ...(firstCallCacheHitRatio !== undefined
+      ? { first_call_cache_hit_ratio: firstCallCacheHitRatio }
+      : {}),
     cache_token_source: cacheTokenSource,
     token_count_source: haveUsageTokens ? 'provider_usage' : 'unknown',
     agent_reported_model: agentReportedModel,

--- a/apps/daemon/src/runtimes/json-event-stream.ts
+++ b/apps/daemon/src/runtimes/json-event-stream.ts
@@ -675,7 +675,16 @@ function handleCodexEvent(obj: unknown, onEvent: StreamEventHandler, state: Pars
   }
 
   if (obj.type === 'thread.started') {
-    onEvent({ type: 'status', label: 'initializing' });
+    // Surface codex's thread/session uuid on the same `sessionId` status
+    // channel claude uses (claude-stream.ts). It identifies this run's rollout
+    // file (`$CODEX_HOME/sessions/**/rollout-*-<thread_id>.jsonl`), which is the
+    // only place codex records per-call usage — run_finished reads it to recover
+    // the turn's first-call cache hit (codex's stream usage is cumulative only).
+    onEvent({
+      type: 'status',
+      label: 'initializing',
+      ...(typeof obj.thread_id === 'string' ? { sessionId: obj.thread_id } : {}),
+    });
     return true;
   }
 

--- a/apps/daemon/tests/codex-rollout-usage.test.ts
+++ b/apps/daemon/tests/codex-rollout-usage.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  codexSessionIdFromRunEvents,
+  extractCodexLastTurnFirstCallUsage,
+} from '../src/codex-rollout-usage.js';
+
+// Shapes mirror real codex 0.133.0 rollout JSONL (`~/.codex/sessions/**/rollout-*.jsonl`):
+// each turn opens with a `task_started` event_msg, and every model call emits a
+// `token_count` event_msg whose `info.last_token_usage` is that single call's
+// usage (OpenAI-style: input_tokens INCLUDES the cached_input_tokens subset).
+function taskStarted(): string {
+  return JSON.stringify({ type: 'event_msg', payload: { type: 'task_started' } });
+}
+function tokenCount(input: number | null, cached: number | null): string {
+  return JSON.stringify({
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info:
+        input === null
+          ? { last_token_usage: null }
+          : { last_token_usage: { input_tokens: input, cached_input_tokens: cached } },
+    },
+  });
+}
+
+describe('extractCodexLastTurnFirstCallUsage', () => {
+  it('reports the first call of the LAST turn, not the whole-session aggregate', () => {
+    // Real numbers from a 3-turn session: turn-1 is a cold open (18.5%), turn-2
+    // a warm resume (96.2%). The daemon just finished turn-3 (95%).
+    const rollout = [
+      taskStarted(),
+      tokenCount(13137, 2432), // turn-1 first call
+      tokenCount(13160, 2560), // within-turn-1 follow-up — must be ignored
+      taskStarted(),
+      tokenCount(13171, 12672), // turn-2 first call (the 96% spec number)
+      taskStarted(),
+      tokenCount(13342, 12672), // turn-3 first call — this is what we want
+      tokenCount(20000, 18000), // within-turn-3 follow-up — must be ignored
+    ].join('\n');
+
+    const result = extractCodexLastTurnFirstCallUsage(rollout);
+    expect(result).toEqual({
+      first_call_input_tokens: 13342,
+      first_call_cache_read_input_tokens: 12672,
+      first_call_cache_hit_ratio: 12672 / 13342,
+    });
+  });
+
+  it('skips zero-input placeholder calls and uses the turn’s real first call', () => {
+    const rollout = [
+      taskStarted(),
+      tokenCount(0, 0), // interrupted/placeholder call — no usable ratio
+      tokenCount(40318, 15744), // the turn’s real opening call
+    ].join('\n');
+
+    const result = extractCodexLastTurnFirstCallUsage(rollout);
+    expect(result?.first_call_input_tokens).toBe(40318);
+    expect(result?.first_call_cache_hit_ratio).toBeCloseTo(15744 / 40318);
+  });
+
+  it('treats a missing cached subset as a zero cache hit on a cold open', () => {
+    const rollout = [taskStarted(), tokenCount(15761, null)].join('\n');
+    const result = extractCodexLastTurnFirstCallUsage(rollout);
+    expect(result).toEqual({
+      first_call_input_tokens: 15761,
+      first_call_cache_read_input_tokens: 0,
+      first_call_cache_hit_ratio: 0,
+    });
+  });
+
+  it('returns null when the last turn produced no usable token_count yet', () => {
+    const rollout = [
+      taskStarted(),
+      tokenCount(13171, 12672),
+      taskStarted(), // a fresh turn opened but no call has landed
+      tokenCount(null, null),
+    ].join('\n');
+    expect(extractCodexLastTurnFirstCallUsage(rollout)).toBeNull();
+  });
+
+  it('tolerates blank lines and non-JSON noise without throwing', () => {
+    const rollout = ['', 'not json', taskStarted(), '   ', tokenCount(13342, 12672)].join('\n');
+    const result = extractCodexLastTurnFirstCallUsage(rollout);
+    expect(result?.first_call_cache_hit_ratio).toBeCloseTo(12672 / 13342);
+  });
+});
+
+describe('codexSessionIdFromRunEvents', () => {
+  const statusEvent = (extra: Record<string, unknown>) => ({
+    event: 'agent',
+    data: { type: 'status', label: 'initializing', ...extra },
+  });
+
+  it('returns the thread id from the initializing status event', () => {
+    const events = [
+      statusEvent({ sessionId: '019eef4f-7409-7c82-bebe-30504eed3959' }),
+      { event: 'agent', data: { type: 'status', label: 'thinking' } },
+    ];
+    expect(codexSessionIdFromRunEvents(events)).toBe(
+      '019eef4f-7409-7c82-bebe-30504eed3959',
+    );
+  });
+
+  it('ignores status events without a session id and non-status events', () => {
+    const events = [
+      { event: 'agent', data: { type: 'usage', usage: { input_tokens: 1 } } },
+      statusEvent({ label: 'thinking' }),
+    ];
+    expect(codexSessionIdFromRunEvents(events)).toBeNull();
+  });
+
+  it('returns null for malformed input', () => {
+    expect(codexSessionIdFromRunEvents(null)).toBeNull();
+    expect(codexSessionIdFromRunEvents('nope')).toBeNull();
+    expect(codexSessionIdFromRunEvents([{ event: 'agent' }, 42])).toBeNull();
+  });
+});

--- a/apps/daemon/tests/codex-rollout-usage.test.ts
+++ b/apps/daemon/tests/codex-rollout-usage.test.ts
@@ -1,8 +1,12 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
   codexSessionIdFromRunEvents,
   extractCodexLastTurnFirstCallUsage,
+  readCodexRolloutFirstCall,
 } from '../src/codex-rollout-usage.js';
 
 // Shapes mirror real codex 0.133.0 rollout JSONL (`~/.codex/sessions/**/rollout-*.jsonl`):
@@ -115,5 +119,51 @@ describe('codexSessionIdFromRunEvents', () => {
     expect(codexSessionIdFromRunEvents(null)).toBeNull();
     expect(codexSessionIdFromRunEvents('nope')).toBeNull();
     expect(codexSessionIdFromRunEvents([{ event: 'agent' }, 42])).toBeNull();
+  });
+});
+
+describe('readCodexRolloutFirstCall', () => {
+  // Plants a rollout under <home>/sessions/<y>/<m>/<d>/ exactly as codex names
+  // them, so the locate-and-read layer is covered (not just the pure extractor).
+  function plantRollout(sessionId: string, lines: string[]): string {
+    const home = mkdtempSync(path.join(tmpdir(), 'codex-home-'));
+    const dayDir = path.join(home, 'sessions', '2026', '06', '24');
+    mkdirSync(dayDir, { recursive: true });
+    writeFileSync(
+      path.join(dayDir, `rollout-2026-06-24T12-00-00-${sessionId}.jsonl`),
+      lines.join('\n'),
+    );
+    return home;
+  }
+  const rollout = (sid: string) => [
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_started' } }),
+    JSON.stringify({
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: { last_token_usage: { input_tokens: 13342, cached_input_tokens: 12672 } },
+      },
+    }),
+  ];
+
+  it('locates the rollout by session id under CODEX_HOME and extracts first-call', async () => {
+    const sid = '019eef4f-7409-7c82-bebe-30504eed3959';
+    const home = plantRollout(sid, rollout(sid));
+    const result = await readCodexRolloutFirstCall({ codexHome: home, sessionId: sid });
+    expect(result?.first_call_input_tokens).toBe(13342);
+    expect(result?.first_call_cache_hit_ratio).toBeCloseTo(12672 / 13342);
+  });
+
+  it('returns null (never throws) when the session id has no matching rollout', async () => {
+    const home = plantRollout('some-other-session', rollout('some-other-session'));
+    await expect(
+      readCodexRolloutFirstCall({ codexHome: home, sessionId: 'missing-session' }),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when no session id is given', async () => {
+    await expect(
+      readCodexRolloutFirstCall({ codexHome: '/nonexistent', sessionId: null }),
+    ).resolves.toBeNull();
   });
 });

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -475,6 +475,37 @@ describe('scanRunEventsForUsageAnalytics', () => {
     expect(result.cache_read_input_tokens).toBe(8_400);
   });
 
+  it('includes anthropic cache_creation in the first-call denominator (matches last-call)', () => {
+    // A cold opening call writes a large cache (cache_creation) while reading
+    // little. The first-call denominator must be input + cache_read +
+    // cache_creation — identical to the last-call definition — so the two
+    // ratios are comparable. A single usage event makes first == last.
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 1_000,
+              output_tokens: 20,
+              cache_read_input_tokens: 500,
+              cache_creation_input_tokens: 8_500,
+            },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    // denominator = 1000 + 500 + 8500 = 10000, not 1500.
+    expect(result.first_call_input_tokens).toBe(1_000);
+    expect(result.first_call_cache_read_input_tokens).toBe(500);
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(500 / 10_000);
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(result.cache_hit_ratio ?? 0);
+  });
+
   it('mirrors first-call onto last-call for a single-call turn', () => {
     const result = scanRunEventsForUsageAnalytics(
       [

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -506,6 +506,36 @@ describe('scanRunEventsForUsageAnalytics', () => {
     expect(result.first_call_cache_hit_ratio).toBeCloseTo(result.cache_hit_ratio ?? 0);
   });
 
+  it('honors the full cache-creation alias matrix on the first call (nested cache_creation)', () => {
+    // A provider that emits cache creation only via the nested
+    // `cache_creation.input_tokens` alias (not the flat key) must still land in
+    // the first-call denominator — otherwise it overstates the cache hit. This
+    // locks the first-call extraction to the same alias matrix the last-call
+    // path already supports.
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 1_000,
+              output_tokens: 20,
+              cache_read_input_tokens: 500,
+              cache_creation: { input_tokens: 8_500 },
+            },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(500 / 10_000);
+    // Locked to the last-call definition, which also reads the nested alias.
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(result.cache_hit_ratio ?? 0);
+  });
+
   it('mirrors first-call onto last-call for a single-call turn', () => {
     const result = scanRunEventsForUsageAnalytics(
       [

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -423,6 +423,80 @@ describe('scanRunEventsForUsageAnalytics', () => {
       agent_reported_model: 'claude-opus-4-1',
     });
     expect(result.cache_hit_ratio).toBeCloseTo(60 / 240);
+    // The reverse scan above takes the LAST usage event (240 / cache_read 60).
+    // The forward first-call scan must instead surface the turn's OPENING call
+    // (120 / cache_read 20) — the session-reuse signal that the within-turn
+    // aggregate masks.
+    expect(result.first_call_input_tokens).toBe(120);
+    expect(result.first_call_cache_read_input_tokens).toBe(20);
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(20 / 120);
+  });
+
+  it('reports the anthropic first-call cache hit independently of later within-turn calls', () => {
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        // Opening call of a resumed turn: tiny uncached delta over a fully
+        // cached prefix — the cache-hit signal session reuse produces.
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 100,
+              output_tokens: 10,
+              cache_read_input_tokens: 8_000,
+              cache_creation_input_tokens: 0,
+            },
+          },
+        },
+        // A later within-turn call grows the prefix; the reverse scan lands here.
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 300,
+              output_tokens: 30,
+              cache_read_input_tokens: 8_400,
+              cache_creation_input_tokens: 200,
+            },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    // Anthropic input_tokens is the UNCACHED portion, so effective = input + cache_read.
+    expect(result.first_call_input_tokens).toBe(100);
+    expect(result.first_call_cache_read_input_tokens).toBe(8_000);
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(8_000 / 8_100);
+    // Last-call aggregate stays distinct from the first-call signal.
+    expect(result.cache_read_input_tokens).toBe(8_400);
+  });
+
+  it('mirrors first-call onto last-call for a single-call turn', () => {
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 500,
+              output_tokens: 50,
+              cache_read_input_tokens: 100,
+            },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    expect(result.first_call_input_tokens).toBe(500);
+    expect(result.first_call_cache_read_input_tokens).toBe(100);
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(result.cache_hit_ratio ?? 0);
   });
 
   it('falls back to modelUsage and totalTokens aliases when usage is nested under modelUsage', () => {

--- a/apps/daemon/tests/runtimes/json-event-stream.test.ts
+++ b/apps/daemon/tests/runtimes/json-event-stream.test.ts
@@ -1108,7 +1108,7 @@ test('codex json stream emits status text and usage events', () => {
   );
 
   assert.deepEqual(events, [
-    { type: 'status', label: 'initializing' },
+    { type: 'status', label: 'initializing', sessionId: 'thr-1' },
     { type: 'status', label: 'thinking' },
     { type: 'text_delta', delta: 'hello' },
     { type: 'usage', usage: { input_tokens: 12, output_tokens: 3, cached_read_tokens: 4 } },
@@ -1550,7 +1550,7 @@ test('codex json stream treats reconnect errors as status warnings not fatal (re
   );
 
   assert.deepEqual(events, [
-    { type: 'status', label: 'initializing' },
+    { type: 'status', label: 'initializing', sessionId: 'thr-1' },
     { type: 'status', label: 'thinking' },
     { type: 'status', label: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' },
     { type: 'text_delta', delta: 'OK' },
@@ -1573,7 +1573,7 @@ test('codex json stream treats stream disconnect reconnect errors as status warn
   );
 
   assert.deepEqual(events, [
-    { type: 'status', label: 'initializing' },
+    { type: 'status', label: 'initializing', sessionId: 'thr-1' },
     { type: 'status', label: 'thinking' },
     {
       type: 'status',

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -2720,6 +2720,18 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   uncached_input_tokens?: number;
   estimated_context_tokens?: number;
   cache_hit_ratio?: number;
+  // Cache-hit of the turn's FIRST model call (vs `cache_hit_ratio`, which is the
+  // last/aggregate call). The first call is the session-reuse signal: within a
+  // turn, later calls re-read the growing cached prefix and inflate the
+  // aggregate regardless of reuse. Per-call-usage agents (claude/opencode/
+  // codebuddy/pi) source this from the stream; codex from its rollout.
+  first_call_input_tokens?: number;
+  first_call_cache_read_input_tokens?: number;
+  first_call_cache_hit_ratio?: number;
+  // Whether this run is a non-first turn (a prior completed assistant turn
+  // exists). Slice first_call_cache_hit_ratio by this to isolate the turns
+  // where session reuse applies.
+  is_followup_turn?: boolean;
   cache_token_source?: 'anthropic' | 'openai' | 'unavailable';
   queue_duration_ms?: number;
   pre_spawn_duration_ms?: number;


### PR DESCRIPTION
## Why

**Use case:** I'm shipping the OpenCode/codex session-reuse optimization (the resume-keeps-the-session-warm work) across two releases, and I need to *prove* it moves the needle rather than assert it. The plan is telemetry-first: land instrumentation in v0.12.0 as a baseline, ship the optimization in v0.13.0, and compare cache-hit rates between the two.

**Pain being addressed:** Our existing `run_finished` usage scan is a *reverse* scan — it takes the **last** usage event of a turn. Within a single turn, every model call after the first re-reads the growing cached prefix, so the last/aggregate `cache_hit_ratio` is high *regardless* of whether the conversation's session was reused. It masks exactly the signal we want to measure. Session reuse shows up only on the **opening call of a follow-up turn**: a warm session reads ~95% cache hit there, a cold re-send ~15-18%. Without first-call measurement we can't tell the two releases apart.

## What users will see

No user-facing change. This is pure read-only analytics on the existing `run_finished` event. Three new fields ride along for our own dashboards:

- `first_call_input_tokens`, `first_call_cache_read_input_tokens`, `first_call_cache_hit_ratio` — the cache hit of the turn's **opening** model call.
- `is_followup_turn` — whether a prior completed assistant turn exists, so the ratio can be sliced to the turns where session reuse actually applies.

## Surface area

- [x] **API / contract** — new properties on the `run_finished` analytics event (no contract DTO; these are PostHog/Langfuse capture props, consistent with the existing `cache_hit_ratio`).
- [x] **None** — otherwise internal analytics only.

## How it works per agent

- **claude / opencode / codebuddy / pi** report **per-call** usage on the stream, so a forward scan of the first usage event *is* the opening call. Mirrors the existing anthropic-vs-openai cache accounting.
- **codex** reports only a single **cumulative** `turn.completed` usage on the exec/json stream, so its first stream event is the whole-session aggregate, not the opening call. codex *does* record per-call usage in its rollout JSONL (`token_count.info.last_token_usage`), so `run_finished` reads it best-effort: it surfaces codex's `thread.started` thread_id on the same `sessionId` status channel claude uses, locates `$CODEX_HOME/sessions/**/rollout-*-<thread_id>.jsonl` (newest-first, drift-proof `spawnEnvForAgent('codex')` for CODEX_HOME), and extracts the first `token_count` after the last `task_started`. Any failure (no session id, missing rollout, partial turn) cleanly omits the codex fields — it can never fail the capture or a run.

## Validation

- `pnpm guard`, `pnpm --filter @open-design/daemon typecheck` — clean.
- New unit tests: `apps/daemon/tests/run-analytics-observability.test.ts` (first-call diverges from last-call; anthropic/openai/single-call cases), `apps/daemon/tests/codex-rollout-usage.test.ts` (extractor + session-id helper, multi-turn / zero-input / noise cases).
- **Validated the codex extractor against real codex 0.133.0 rollouts**: a warm-resume turn reads 96.2% / a cold open 18.5% (matches the measured numbers from the session-resume spec); the live extractor on a real 3-turn rollout returns 0.9497 for the last turn.
- Full daemon suite: **4861 passed**. The only failures (3 sub-cases of `run-failure-telemetry-smoke.test.ts`, `auth_required` vs `invalid_api_key`) are a pre-existing env-dependent flake in failure *classification* — untouched by this diff (verified `git diff --name-only` excludes any failure-classification file) and green in CI.
