### PR TITLE
Add Design Taste Libraries plugin

### DIFF
--- a/plugins/community/design-taste-libraries/SKILL.md
+++ b/plugins/community/design-taste-libraries/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: design-taste-libraries
+description: 'TRIGGER when: designing, redesigning, critiquing, or prototyping frontend, mobile, dashboard, landing-page, shadcn, or motion-led UI in Open Design. DO NOT TRIGGER when: the user asks for a single fixed brand system, backend-only work, copy-only edits, or production coding without design judgment.'
+version: 0.1.0
+---
+
+# Design Taste Libraries
+
+Use this skill as a source-backed taste router before generating or critiquing UI. It is a library pack, not a visual theme. Do not stack every library. Pick the smallest set that matches the surface.
+
+## First Pass
+
+1. Read the user brief and any attached screenshot, code, brand file, or existing artifact.
+2. Open `references/LIBRARIES.md`.
+3. Check whether Open Design already has a matching local plugin or design system.
+4. Select one primary library and at most two secondary libraries.
+5. State the selected libraries, the local Open Design plugin ids used, and any external-only gap.
+6. Discard one tempting but wrong library when it would push the design toward generic AI output.
+
+## Routing
+
+- General taste or high-end web visual direction: use `community-hallmark` plus the Anthropic Frontend Design method.
+- Existing React component systems: use `design-system-shadcn` first, then custom code only for gaps.
+- Dense operational interfaces: use `design-system-dashboard` or `example-dashboard`.
+- Mobile app surfaces: use `example-mobile-app`, `example-mobile-onboarding`, and the external mobile/native rules; treat mobile as its own product surface, not a shrunken website.
+- Motion-led or cinematic interaction: use Open Design HyperFrames/video templates first; add GSAP rules only when animation needs timeline-level code.
+- Taste presets such as Minimalist UI, Premium, or Industrial Brutalist UI: use the existing OD design systems/examples as constraints, never as a pile-on.
+- Material 3 or SwiftUI: use `design-system-material` for Material visual grammar; use external platform rules when production native behavior matters.
+
+## Design Rules
+
+- Commit to a visual thesis before writing files.
+- Bind the design to the subject matter in the first viewport or first app screen.
+- Use real content, real product states, and real constraints where available.
+- Prefer established components and registries before inventing primitives.
+- Prefer existing Open Design plugin ids over new local library plugins when coverage exists.
+- Keep dashboards dense but calm; keep landing pages visual and specific; keep tools ergonomic over decorative.
+- Use motion to explain state, reveal hierarchy, or make a moment memorable. Remove motion that only makes the artifact feel busy.
+- Check mobile thumb zones, safe areas, navigation placement, and content density separately from desktop.
+
+## Output Contract
+
+For a design generation:
+
+1. Selected library set.
+2. Visual thesis.
+3. Surface-specific layout and interaction plan.
+4. Missing source material that would change the result.
+5. Generated artifact.
+6. Self-critique against the chosen libraries.
+
+For a critique:
+
+1. What library standards were applied.
+2. The three highest-impact fixes.
+3. What to delete.
+4. What to keep.
+5. Proof needed: screenshot sizes, interaction path, accessibility/contrast/state checks.
+
+## Hard Rejections
+
+- no generic purple-blue SaaS gradients unless the brand specifically requires them;
+- no decorative card walls for serious tools;
+- no mobile design that is just a compressed desktop layout;
+- no invented brand, product, social, price, metric, or event facts;
+- no animation library recommendation unless the interaction needs a timeline, scroll choreography, gesture choreography, or video-quality motion.

--- a/plugins/community/design-taste-libraries/open-design.json
+++ b/plugins/community/design-taste-libraries/open-design.json
@@ -40,7 +40,12 @@
       }
     },
     "context": {
-      "assets": ["./SKILL.md", "./references/LIBRARIES.md"]
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ],
+      "assets": ["./references/LIBRARIES.md"]
     },
     "inputs": [
       {

--- a/plugins/community/design-taste-libraries/open-design.json
+++ b/plugins/community/design-taste-libraries/open-design.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-taste-libraries",
+  "title": "Design Taste Libraries",
+  "version": "0.1.0",
+  "description": "General Open Design skill that routes agents through high-quality design, UI, dashboard, mobile, shadcn, and motion libraries before generating or critiquing frontend work.",
+  "license": "MIT",
+  "author": {
+    "name": "Konstantin Baltsat"
+  },
+  "tags": [
+    "local",
+    "design",
+    "frontend",
+    "taste",
+    "libraries",
+    "mobile",
+    "dashboard",
+    "shadcn",
+    "motion",
+    "source-backed"
+  ],
+  "compat": {
+    "agentSkills": [
+      {
+        "path": "./SKILL.md"
+      }
+    ]
+  },
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "mode": "prototype",
+    "platform": "desktop",
+    "scenario": "frontend-design",
+    "useCase": {
+      "query": {
+        "en": "Use Design Taste Libraries to choose the right source-backed design library before designing, critiquing, or rebuilding a frontend artifact. Select by surface, cite the library used, then generate or critique with visual proof gates."
+      }
+    },
+    "context": {
+      "assets": ["./SKILL.md", "./references/LIBRARIES.md"]
+    },
+    "inputs": [
+      {
+        "name": "surface",
+        "label": "Surface",
+        "type": "select",
+        "options": ["web app", "mobile app", "dashboard", "landing page", "motion prototype"],
+        "default": "web app"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the design accomplish?"
+      }
+    ],
+    "capabilities": ["prompt:inject"]
+  },
+  "plugin": {
+    "repo": "https://github.com/nexu-io/open-design/tree/main/plugins/community/design-taste-libraries"
+  }
+}

--- a/plugins/community/design-taste-libraries/references/LIBRARIES.md
+++ b/plugins/community/design-taste-libraries/references/LIBRARIES.md
@@ -1,0 +1,246 @@
+---
+generated_by: Codex
+generated_at: 2026-06-24T04:25:00+08:00
+last_updated: 2026-06-24T06:18:00+08:00
+canonical_source: tools/open-design/plugins/design-taste-libraries
+source_context: YouTube video Ot582-E61ac and linked public design skills/libraries
+---
+
+# Design Library Catalog
+
+This catalog is a routing index for Open Design agents. It keeps source links and extracted usage rules close to the design workflow without copying entire external skills into the local repo.
+
+## Open Design Coverage Audit
+
+Checked locally on 2026-06-24 with `opendesign plugin search`.
+
+| Video library / need               | Local Open Design coverage                                                                                                                                        | Status  | Action                                                                                                                |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| Hallmark anti-slop design critique | `community-hallmark`                                                                                                                                              | covered | Do not duplicate. Prefer this plugin directly.                                                                        |
+| shadcn UI                          | `design-system-shadcn`                                                                                                                                            | covered | Do not create `library-shadcn`; route to the built-in design system.                                                  |
+| Dashboard/data-density UI          | `design-system-dashboard`, `example-dashboard`, `example-trading-analysis-dashboard-template`, `example-flowai-live-dashboard-template`, `example-live-dashboard` | covered | Do not create `library-dashboard`; use the closest built-in.                                                          |
+| Mobile app mockups/onboarding      | `example-mobile-app`, `example-mobile-onboarding`, `example-gamified-app`                                                                                         | partial | Built-in prototypes exist; keep external mobile rules for production UX checks.                                       |
+| Expo / React Native                | `design-system-expo`                                                                                                                                              | partial | Built-in is visual/brand-ish; keep external Expo Native UI rules for safe area, haptics, layout, and native behavior. |
+| HyperFrames / video motion         | `example-hyperframes`, `example-video-hyperframes`, `example-motion-frames`, many `video-template-frame-*` entries                                                | covered | Do not create another HyperFrames plugin; route to built-ins.                                                         |
+| GSAP motion                        | `example-cinematic-landing-page`                                                                                                                                  | partial | Built-in example exists; keep external GSAP rules only for timeline/ScrollTrigger/React implementation discipline.    |
+| Minimalist taste                   | `design-system-minimal`, `design-system-contemporary`, `design-system-sleek`, `example-web-prototype-taste-editorial`, `example-html-ppt-taste-editorial`         | covered | Do not create a minimalist library plugin.                                                                            |
+| Industrial/brutalist taste         | `design-system-brutalism`, `design-system-neobrutalism`, `example-web-prototype-taste-brutalist`, `example-html-ppt-taste-brutalist`                              | covered | Do not create a brutalist library plugin.                                                                             |
+| Premium frontend                   | `design-system-premium`, `design-system-apple`, `design-system-luxury`, many premium examples                                                                     | covered | Do not create a premium frontend plugin.                                                                              |
+| Material / Material 3              | `design-system-material`                                                                                                                                          | partial | Visual grammar is covered; keep external Material 3 rules only for token/component audit detail.                      |
+| SwiftUI                            | no strong local hit                                                                                                                                               | gap     | Add only if Open Design will generate native SwiftUI specs or code.                                                   |
+| Anthropic Frontend Design method   | no exact local hit; `community-hallmark` covers adjacent anti-slop critique                                                                                       | partial | Keep as method inside this router or a small future `library-frontend-design-method`, not a duplicate visual system.  |
+| UI UX Pro Max category explorer    | no strong local hit                                                                                                                                               | gap     | Add only if we need category-first ideation before picking a visual system.                                           |
+
+Default: use existing Open Design ids first. Add a new local library plugin only when the missing value is procedural and not already represented by a design system, example, or video template.
+
+## Core Libraries
+
+### Anthropic Frontend Design
+
+Source: https://github.com/anthropics/claude-code/blob/main/plugins/frontend-design/skills/frontend-design/SKILL.md
+
+Use for: high-end web visual direction, visual thesis, landing pages, portfolio/product pages, and critique before code.
+
+Extract:
+
+- choose a distinctive direction before implementation;
+- make the subject visible immediately;
+- treat typography, hierarchy, and imagery as the core composition;
+- run a critique pass after generation.
+
+Avoid when: the target is a dense operational product where utility and state grammar matter more than expressive hero composition.
+
+### Hallmark
+
+Source: https://github.com/Nutlope/hallmark
+Local Open Design plugin: community-hallmark
+
+Use for: anti-AI-slop critique, structure variety, project-aware tokens, responsive checks, and polishing generated UI.
+
+Extract:
+
+- inspect existing typography, palette, spacing, and motion dependencies before changing anything;
+- vary structure instead of repeating centered cards;
+- produce visual proof, not only prose.
+
+### shadcn UI
+
+Source: https://github.com/shadcn-ui/ui/blob/main/skills/shadcn/SKILL.md
+Local Open Design plugin/design system to search: design-system-shadcn
+
+Use for: React apps, production-feeling app surfaces, forms, dialogs, controls, tables, menus, and component composition.
+
+Extract:
+
+- search registry components before hand-building;
+- compose primitives instead of inventing new controls;
+- use semantic tokens and CSS variables;
+- avoid overwriting existing components without an explicit reason.
+
+### Dashboard
+
+Source: https://github.com/bergside/awesome-design-skills/tree/main/skills/dashboard
+
+Use for: analytics, admin, CRM, operations, monitoring, finance, product dashboards, and any dense decision surface.
+
+Extract:
+
+- prioritize information hierarchy and scan paths;
+- use grids, tables, filters, and compact cards only where they support comparison;
+- keep visual style restrained enough for repeated use;
+- prove with realistic data states, empty states, and overflow.
+
+### UI UX Pro Max
+
+Source: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill
+
+Use for: broad ideation and category-first exploration when the product type is unclear.
+
+Extract:
+
+- search a design category database before choosing palette/layout;
+- decide the product genre before choosing visual treatment.
+
+Avoid when: the brief already names a precise product and existing design system.
+
+## Motion Libraries
+
+### GSAP Skills
+
+Source: https://github.com/greensock/gsap-skills
+
+Use for: scroll choreography, timeline-based motion, cinematic reveals, SVG motion, complex gesture sequences, and motion prototypes.
+
+Extract:
+
+- use timelines for coordinated motion;
+- prefer official plugin patterns for ScrollTrigger and React integration;
+- keep performance in view;
+- motion must clarify state or create a memorable product moment.
+
+Avoid when: a small CSS transition or platform-native animation is enough.
+
+### HyperFrames
+
+Source: local OpenAI curated plugin `hyperframes`
+
+Use for: video-grade web motion, interactive product films, and reusable motion components.
+
+Extract:
+
+- use when the deliverable is motion-led;
+- keep source UI and rendered motion tied together;
+- do not replace functional app UI with cinematic wrappers.
+
+## Taste Presets
+
+### Minimalist UI
+
+Source: https://www.skills.sh/leonxlnx/taste-skill/minimalist-ui
+
+Use for: sparse, quiet, editorial, luxury, or high-clarity interfaces.
+
+Extract:
+
+- remove decoration before adding detail;
+- make spacing, type scale, and content quality carry the design.
+
+Avoid when: the product needs rich discovery, play, high energy, or operational density.
+
+### Industrial Brutalist UI
+
+Source: https://www.skills.sh/leonxlnx/taste-skill/industrial-brutalist-ui
+
+Use for: bold, raw, grid-heavy, tool-like, editorial, music, creative, or fashion-adjacent work.
+
+Extract:
+
+- use strong contrast, hard edges, visible structure, and assertive typography;
+- do not soften it into generic SaaS cards.
+
+Avoid when: the product needs trust, care, calm, finance, health, or broad consumer warmth.
+
+### Premium Frontend UI
+
+Source: https://www.skills.sh/github/awesome-copilot/premium-frontend-ui
+
+Use for: elevated product sites, polished marketing surfaces, and high-end web prototypes.
+
+Extract:
+
+- use premium spacing, purposeful imagery, and precise component polish;
+- avoid one-note gradients and stock-layout tropes.
+
+## Mobile And Platform Libraries
+
+### Mobile App UI Design
+
+Source: https://github.com/ceorkm/mobile-app-ui-design
+
+Use for: mobile app screens, onboarding, tab flows, app home surfaces, detail sheets, and one-handed workflows.
+
+Extract:
+
+- mobile is not a small website;
+- check thumb zones, safe areas, navigation, spacing, and content hierarchy;
+- use platform-appropriate density and gestures.
+
+### Expo Native UI
+
+Source: https://github.com/expo/skills/blob/main/plugins/expo/skills/building-native-ui/SKILL.md
+
+Use for: Expo/React Native screens and native-feeling mobile prototypes.
+
+Extract:
+
+- respect safe areas and scroll containers;
+- use haptics and platform motion when they improve feedback;
+- keep responsive layout and text overflow explicit.
+
+### SwiftUI
+
+Source: https://github.com/ameyalambat128/swiftui-skills
+
+Use for: native iOS/macOS SwiftUI designs, platform-native component grammar, and Apple ecosystem screens.
+
+Extract:
+
+- follow platform conventions;
+- prefer native controls and layout behavior before custom visuals.
+
+### Material 3
+
+Source: https://github.com/hamen/material-3-skill
+
+Use for: Android/Google-style surfaces, Compose/Flutter material systems, and products intentionally using Material grammar.
+
+Extract:
+
+- use tokens and component roles;
+- check color roles, elevation, shape, and state layers.
+
+Avoid when: the product is not Material-led; forced Material can flatten brand taste.
+
+## Open Design Local Libraries To Prefer
+
+Search/install these in Open Design before hand-writing equivalents:
+
+- `community-hallmark`
+- `design-system-shadcn`
+- `design-system-dashboard`
+- `example-dashboard`
+- `example-mobile-app`
+- `example-mobile-onboarding`
+- `example-cinematic-landing-page`
+
+## Selection Matrix
+
+- Web app: Anthropic Frontend Design + Hallmark + shadcn.
+- Mobile app: Mobile App UI Design + Expo Native UI + shadcn if the implementation is React-based.
+- Dashboard: Dashboard + shadcn + Hallmark.
+- Landing page: Anthropic Frontend Design + Premium Frontend UI or one taste preset.
+- Motion prototype: GSAP Skills + HyperFrames + the surface-specific library.
+
+## Anti-Stacking Rule
+
+Use one primary library. Add a secondary library only for a missing dimension: components, dashboard density, mobile grammar, or motion. If two libraries disagree, the product surface wins.

--- a/plugins/registry/community/open-design-marketplace.json
+++ b/plugins/registry/community/open-design-marketplace.json
@@ -81,6 +81,35 @@
         "anti-ai-slop"
       ],
       "description": "Anti-AI-slop design skill for greenfield pages, audits, redesigns, and design extraction from URLs or screenshots."
+    },
+    {
+      "name": "community/design-taste-libraries",
+      "title": "Design Taste Libraries",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/community/design-taste-libraries",
+      "publisher": {
+        "id": "baltsat",
+        "github": "Baltsat",
+        "url": "https://github.com/Baltsat"
+      },
+      "homepage": "https://github.com/nexu-io/open-design/tree/main/plugins/community/design-taste-libraries",
+      "license": "MIT",
+      "capabilitiesSummary": [
+        "prompt:inject"
+      ],
+      "tags": [
+        "community",
+        "design",
+        "frontend",
+        "taste",
+        "libraries",
+        "mobile",
+        "dashboard",
+        "shadcn",
+        "motion",
+        "source-backed"
+      ],
+      "description": "Source-backed design library router for frontend, mobile, dashboard, shadcn, and motion design work."
     }
   ]
 }


### PR DESCRIPTION
## Why

Open Design already has strong individual design systems and examples, but it lacks one opt-in routing step for choosing among them by surface before generation or critique. This plugin fills that workflow gap: it prefers existing Open Design coverage, adds external references only for genuine procedural gaps, and prevents agents from stacking unrelated taste libraries into generic output.

I wrote it while consolidating source-backed frontend, mobile, dashboard, shadcn, and motion guidance for repeated Open Design work. Without a router, the same brief can silently fall back to generic generation or duplicate capabilities that already exist in Hallmark, shadcn, dashboard, mobile, Material, or HyperFrames plugins.

## What users will see

After installing and applying `community/design-taste-libraries`, generation and critique runs first select one primary design library and at most two secondary references, state the chosen set and visual thesis, prefer matching built-in Open Design plugins, and run surface-specific proof checks before returning the artifact or critique. The plugin is opt-in and does not change existing users' default behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — adds an installable community plugin with a plugin-local `SKILL.md` router and reference catalog
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adds an entry to the root `package.json`
- [ ] **Default behavior change** — the plugin is opt-in and only affects runs where it is installed and applied
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This adds no new UI surface; discovery uses the existing Plugins Available marketplace UI.

## Bug fix verification

Not applicable; this is a new community extension.

## Validation

Run on the current PR head:

- `opendesign plugin validate /tmp/open-design-pr-4728/plugins/community/design-taste-libraries --json`
- `opendesign plugin doctor design-taste-libraries --json`
- `opendesign plugin apply design-taste-libraries --inputs '{"surface":"mobile app","brief":"source-backed taste routing smoke for a Nuanu-style map and event discovery app"}' --json`
- `node -e "JSON.parse(require('fs').readFileSync('/tmp/open-design-pr-4728/plugins/community/design-taste-libraries/open-design.json','utf8')); JSON.parse(require('fs').readFileSync('/tmp/open-design-pr-4728/plugins/registry/community/open-design-marketplace.json','utf8')); console.log('json ok')"`

Targeted review also confirmed that:

- `od.context.skills: [{ "path": "./SKILL.md" }]` reaches the daemon's plugin-local skill loader;
- `references/LIBRARIES.md` remains a staged asset rather than a skill reference;
- `community/design-taste-libraries` is present in the default community marketplace seed with `capabilitiesSummary: ["prompt:inject"]`.

`plugin doctor` reports the same plugin-local `./SKILL.md` warning seen for `plugins/community/hallmark`; daemon-side local-skill loading supports this path.