### PR TITLE
[codex] keep AMR wallet balance stable during refresh

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3862,7 +3862,6 @@ export function SettingsDialog({
                                   <button
                                     type="button"
                                     className="agent-card-amr-wallet-refresh"
-                                    title={t('settings.amrWalletRefreshTitle')}
                                     aria-label={t('settings.amrWalletRefreshTitle')}
                                     disabled={amrWalletRefreshing}
                                     onClick={() => void refreshAmrWallet(true)}

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -961,8 +961,8 @@ export function amrWalletValueLabel(input: {
   snapshot: AmrWalletSnapshot | null;
   unavailableLabel: string;
 }): string {
-  if (!input.ready) return input.loadingLabel;
   if (input.balance) return input.balance;
+  if (!input.ready) return input.loadingLabel;
   const code = input.snapshot?.error?.code;
   if (code === 'missing_control_key' || code === 'unauthorized') {
     const message = input.snapshot?.error?.message?.trim();

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -295,6 +295,27 @@ describe('SettingsDialog custom model picker state', () => {
 });
 
 describe('SettingsDialog AMR wallet display state', () => {
+  it('keeps the last balance visible while a refresh is pending', () => {
+    expect(
+      amrWalletValueLabel({
+        balance: '$0.10',
+        loadingLabel: 'Loading',
+        ready: false,
+        snapshot: {
+          status: 'available',
+          profile: 'local',
+          user: { id: 'user-1', email: 'amr@example.com' },
+          balanceUsd: '0.1000',
+          updatedAt: '2026-06-23T06:05:18.782Z',
+          fetchedAt: '2026-06-23T06:05:19.000Z',
+          stale: false,
+          source: 'daemon_cache',
+        },
+        unavailableLabel: 'Balance temporarily unavailable',
+      }),
+    ).toBe('$0.10');
+  });
+
   it('shows re-auth guidance when the daemon reports missing or rejected wallet credentials', () => {
     expect(
       amrWalletValueLabel({


### PR DESCRIPTION
## Why

While validating the AMR wallet balance card in Settings, the balance row visibly flickered during refresh. The UI already had a previous balance snapshot, but the display helper preferred the loading state whenever `ready` was false, so a background refresh briefly replaced the amount with Loading.

This PR keeps the last known balance visible while the refresh is in flight and removes the browser-native hover tooltip from the refresh icon, which was appearing as a clipped `Refresh` label in the compact card layout.

This PR is intentionally based on `codex/amr-wallet-balance` so the wallet-balance work can be tested as one unified development branch before targeting `main`.

## What users will see

Settings -> Execution mode -> AMR wallet balance keeps showing the current balance during a refresh instead of flashing to Loading. Hovering the refresh icon no longer shows the browser-native `Refresh` tooltip; the button keeps its accessible label.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this terminal flow. The visible change is removing the transient Loading flicker and clipped native tooltip on the existing AMR wallet row.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.test.ts`
- Did the test go red on `main` and green on this branch? Not run on `main`; the added assertion covers the previous `ready=false` + existing balance case that returned Loading before this change.

## Validation

After retargeting/replaying this PR onto `codex/amr-wallet-balance`:

- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
