### PR TITLE
fix: persist plain-stream artifact tags

### DIFF
--- a/apps/daemon/src/runtimes/plain-stream.ts
+++ b/apps/daemon/src/runtimes/plain-stream.ts
@@ -45,6 +45,10 @@ const MAX_ARTIFACTS_PER_RUN = 50;
 const HEADING_RE = /^#{1,4}\s+/;
 const UL_ITEM_RE = /^\s*[-*+]\s+/;
 const OL_ITEM_RE = /^\s*\d+\.\s+/;
+// Mirrors apps/web/src/artifacts/markdown-context.ts so headless plain-stream
+// persistence sees the same fence boundaries as the browser artifact parser.
+const FENCE_OPEN_RE = /^```(\w[\w+-]*)?\s*$/;
+const FENCE_CLOSE_RE = /^```\s*$/;
 
 const TYPE_TO_EXTENSION = new Map<string, SupportedArtifactExtension>([
   ['html', '.html'],
@@ -220,21 +224,29 @@ function computeMarkdownSkipRanges(text: string): Array<[number, number]> {
 
 function computeMarkdownFenceRanges(text: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
-  const fenceRe = /^ {0,3}(?:```|~~~).*$/gm;
-  let open: { marker: string; start: number } | null = null;
-  let match: RegExpExecArray | null = fenceRe.exec(text);
-  while (match) {
-    const line = match[0] ?? '';
-    const marker = line.trimStart().startsWith('~~~') ? '~~~' : '```';
-    if (!open) {
-      open = { marker, start: match.index };
-    } else if (marker === open.marker) {
-      ranges.push([open.start, fenceRe.lastIndex]);
-      open = null;
+  let pos = 0;
+  let fenceStart = -1;
+  while (pos < text.length) {
+    const eol = text.indexOf('\n', pos);
+    const lineEnd = eol === -1 ? text.length : eol;
+    const line = text.slice(pos, lineEnd);
+    const lineHasNewline = eol !== -1;
+
+    if (fenceStart === -1) {
+      if (lineHasNewline && FENCE_OPEN_RE.test(line)) {
+        fenceStart = pos;
+      }
+    } else if (lineHasNewline && FENCE_CLOSE_RE.test(line)) {
+      ranges.push([fenceStart, eol + 1]);
+      fenceStart = -1;
     }
-    match = fenceRe.exec(text);
+
+    if (!lineHasNewline) {
+      break;
+    }
+    pos = eol + 1;
   }
-  if (open) ranges.push([open.start, text.length]);
+  if (fenceStart !== -1) ranges.push([fenceStart, text.length]);
   return ranges;
 }
 

--- a/apps/daemon/src/runtimes/plain-stream.ts
+++ b/apps/daemon/src/runtimes/plain-stream.ts
@@ -212,12 +212,12 @@ function findOpenTagEnd(text: string, from: number): number {
 
 function computeMarkdownFenceRanges(text: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
-  const fenceRe = /^(?:```|~~~).*$/gm;
+  const fenceRe = /^ {0,3}(?:```|~~~).*$/gm;
   let open: { marker: string; start: number } | null = null;
   let match: RegExpExecArray | null = fenceRe.exec(text);
   while (match) {
     const line = match[0] ?? '';
-    const marker = line.startsWith('~~~') ? '~~~' : '```';
+    const marker = line.trimStart().startsWith('~~~') ? '~~~' : '```';
     if (!open) {
       open = { marker, start: match.index };
     } else if (marker === open.marker) {

--- a/apps/daemon/src/runtimes/plain-stream.ts
+++ b/apps/daemon/src/runtimes/plain-stream.ts
@@ -212,7 +212,7 @@ function findNextArtifactOpen(
 
 function isRealArtifactOpenAt(text: string, idx: number): boolean {
   const next = text.charAt(idx + OPEN_TAG.length);
-  return next === '>' || /\s/.test(next);
+  return /\s/.test(next);
 }
 
 function findOpenTagEnd(text: string, from: number): number {

--- a/apps/daemon/src/runtimes/plain-stream.ts
+++ b/apps/daemon/src/runtimes/plain-stream.ts
@@ -42,6 +42,9 @@ type ListFiles = (
 const OPEN_TAG = '<artifact';
 const CLOSE_TAG = '</artifact>';
 const MAX_ARTIFACTS_PER_RUN = 50;
+const HEADING_RE = /^#{1,4}\s+/;
+const UL_ITEM_RE = /^\s*[-*+]\s+/;
+const OL_ITEM_RE = /^\s*\d+\.\s+/;
 
 const TYPE_TO_EXTENSION = new Map<string, SupportedArtifactExtension>([
   ['html', '.html'],
@@ -240,21 +243,62 @@ function computeMarkdownInlineCodeRanges(
   fenceRanges: ReadonlyArray<[number, number]>,
 ): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
-  let i = 0;
-  while (i < text.length) {
-    if (text.charAt(i) !== '`' || rangeContains(fenceRanges, i)) {
-      i += 1;
-      continue;
+  for (const [start, end] of computeMarkdownInlineBlockRanges(text, fenceRanges)) {
+    let i = start;
+    while (i < end) {
+      const idx = text.indexOf('`', i);
+      if (idx === -1 || idx >= end) break;
+      const tickCount = countBacktickRun(text, idx);
+      const close = findMatchingBacktickRun(text, idx + tickCount, tickCount, fenceRanges, end);
+      if (close === -1) {
+        i = idx + tickCount;
+        continue;
+      }
+      ranges.push([idx, close + tickCount]);
+      i = close + tickCount;
     }
-    const tickCount = countBacktickRun(text, i);
-    const close = findMatchingBacktickRun(text, i + tickCount, tickCount, fenceRanges);
-    if (close === -1) {
-      i += tickCount;
-      continue;
-    }
-    ranges.push([i, close + tickCount]);
-    i = close + tickCount;
   }
+  return ranges;
+}
+
+function computeMarkdownInlineBlockRanges(
+  text: string,
+  fenceRanges: ReadonlyArray<[number, number]>,
+): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let pos = 0;
+  let blockStart = -1;
+
+  const closeBlockBefore = (idx: number) => {
+    if (blockStart !== -1 && idx > blockStart) ranges.push([blockStart, idx]);
+    blockStart = -1;
+  };
+
+  while (pos < text.length) {
+    const fenceRange = rangeContaining(fenceRanges, pos);
+    if (fenceRange) {
+      closeBlockBefore(pos);
+      pos = fenceRange[1];
+      continue;
+    }
+
+    const eol = text.indexOf('\n', pos);
+    const lineEnd = eol === -1 ? text.length : eol;
+    const line = text.slice(pos, lineEnd);
+
+    if (line.trim() === '') {
+      closeBlockBefore(pos);
+    } else if (HEADING_RE.test(line) || UL_ITEM_RE.test(line) || OL_ITEM_RE.test(line)) {
+      closeBlockBefore(pos);
+      ranges.push([pos, lineEnd]);
+    } else if (blockStart === -1) {
+      blockStart = pos;
+    }
+
+    pos = eol === -1 ? text.length : eol + 1;
+  }
+
+  closeBlockBefore(text.length);
   return ranges;
 }
 
@@ -269,11 +313,12 @@ function findMatchingBacktickRun(
   from: number,
   tickCount: number,
   fenceRanges: ReadonlyArray<[number, number]>,
+  until: number,
 ): number {
   let i = from;
-  while (i < text.length) {
+  while (i < until) {
     const idx = text.indexOf('`', i);
-    if (idx === -1) return -1;
+    if (idx === -1 || idx >= until) return -1;
     if (rangeContains(fenceRanges, idx)) {
       i = idx + 1;
       continue;
@@ -283,6 +328,13 @@ function findMatchingBacktickRun(
     i = idx + candidateCount;
   }
   return -1;
+}
+
+function rangeContaining(
+  ranges: ReadonlyArray<[number, number]>,
+  idx: number,
+): [number, number] | null {
+  return ranges.find(([start, end]) => idx >= start && idx < end) ?? null;
 }
 
 function rangeContains(ranges: ReadonlyArray<[number, number]>, idx: number): boolean {

--- a/apps/daemon/src/runtimes/plain-stream.ts
+++ b/apps/daemon/src/runtimes/plain-stream.ts
@@ -82,10 +82,25 @@ export function extractPlainStreamArtifacts(stdout: string): PlainStreamArtifact
   while (from < stdout.length && artifacts.length < MAX_ARTIFACTS_PER_RUN) {
     const openStart = findNextArtifactOpen(stdout, from, skipRanges);
     if (openStart === -1) break;
+    const nextOpenStart = findNextArtifactOpen(stdout, openStart + OPEN_TAG.length, skipRanges);
     const openEnd = findOpenTagEnd(stdout, openStart + OPEN_TAG.length);
-    if (openEnd === -1) break;
+    if (openEnd === -1) {
+      from = openStart + OPEN_TAG.length;
+      continue;
+    }
+    if (nextOpenStart !== -1 && nextOpenStart < openEnd) {
+      from = nextOpenStart;
+      continue;
+    }
     const closeStart = stdout.indexOf(CLOSE_TAG, openEnd);
-    if (closeStart === -1) break;
+    if (closeStart === -1) {
+      from = openStart + OPEN_TAG.length;
+      continue;
+    }
+    if (nextOpenStart !== -1 && nextOpenStart < closeStart) {
+      from = nextOpenStart;
+      continue;
+    }
 
     const attrText = stdout.slice(openStart + OPEN_TAG.length, openEnd - 1);
     const attrs = parseAttrs(attrText);

--- a/apps/daemon/src/runtimes/plain-stream.ts
+++ b/apps/daemon/src/runtimes/plain-stream.ts
@@ -68,7 +68,7 @@ export function plainStdoutFromRunEvents(events: readonly RunEventLike[]): strin
 
 export function extractPlainStreamArtifacts(stdout: string): PlainStreamArtifact[] {
   if (!stdout.includes(OPEN_TAG)) return [];
-  const skipRanges = computeMarkdownFenceRanges(stdout);
+  const skipRanges = computeMarkdownSkipRanges(stdout);
   const artifacts: PlainStreamArtifact[] = [];
   let from = 0;
 
@@ -210,6 +210,11 @@ function findOpenTagEnd(text: string, from: number): number {
   return -1;
 }
 
+function computeMarkdownSkipRanges(text: string): Array<[number, number]> {
+  const fenceRanges = computeMarkdownFenceRanges(text);
+  return [...fenceRanges, ...computeMarkdownInlineCodeRanges(text, fenceRanges)];
+}
+
 function computeMarkdownFenceRanges(text: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
   const fenceRe = /^ {0,3}(?:```|~~~).*$/gm;
@@ -228,6 +233,56 @@ function computeMarkdownFenceRanges(text: string): Array<[number, number]> {
   }
   if (open) ranges.push([open.start, text.length]);
   return ranges;
+}
+
+function computeMarkdownInlineCodeRanges(
+  text: string,
+  fenceRanges: ReadonlyArray<[number, number]>,
+): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let i = 0;
+  while (i < text.length) {
+    if (text.charAt(i) !== '`' || rangeContains(fenceRanges, i)) {
+      i += 1;
+      continue;
+    }
+    const tickCount = countBacktickRun(text, i);
+    const close = findMatchingBacktickRun(text, i + tickCount, tickCount, fenceRanges);
+    if (close === -1) {
+      i += tickCount;
+      continue;
+    }
+    ranges.push([i, close + tickCount]);
+    i = close + tickCount;
+  }
+  return ranges;
+}
+
+function countBacktickRun(text: string, from: number): number {
+  let count = 0;
+  while (text.charAt(from + count) === '`') count += 1;
+  return count;
+}
+
+function findMatchingBacktickRun(
+  text: string,
+  from: number,
+  tickCount: number,
+  fenceRanges: ReadonlyArray<[number, number]>,
+): number {
+  let i = from;
+  while (i < text.length) {
+    const idx = text.indexOf('`', i);
+    if (idx === -1) return -1;
+    if (rangeContains(fenceRanges, idx)) {
+      i = idx + 1;
+      continue;
+    }
+    const candidateCount = countBacktickRun(text, idx);
+    if (candidateCount === tickCount) return idx;
+    i = idx + candidateCount;
+  }
+  return -1;
 }
 
 function rangeContains(ranges: ReadonlyArray<[number, number]>, idx: number): boolean {

--- a/apps/daemon/src/runtimes/plain-stream.ts
+++ b/apps/daemon/src/runtimes/plain-stream.ts
@@ -1,0 +1,321 @@
+import type { ProjectFile } from '@open-design/contracts';
+import { createProjectArtifactFile } from '../artifacts/create.js';
+import {
+  listFiles as defaultListFiles,
+  writeProjectFile as defaultWriteProjectFile,
+} from '../projects.js';
+
+type JsonRecord = Record<string, unknown>;
+
+export interface PlainStreamArtifact {
+  identifier: string;
+  artifactType: string;
+  title: string;
+  content: string;
+  extension: SupportedArtifactExtension;
+  fileName: string;
+}
+
+export interface PersistedPlainStreamArtifact {
+  identifier: string;
+  artifactType: string;
+  title: string;
+  name: string;
+  file: unknown;
+}
+
+interface RunEventLike {
+  event?: string;
+  data?: unknown;
+}
+
+type SupportedArtifactExtension = '.html' | '.css' | '.svg' | '.md';
+
+type WriteProjectFile = Parameters<typeof createProjectArtifactFile>[0]['writeProjectFile'];
+
+type ListFiles = (
+  projectsRoot: string,
+  projectId: string,
+  opts?: { metadata?: unknown },
+) => Promise<ProjectFile[]>;
+
+const OPEN_TAG = '<artifact';
+const CLOSE_TAG = '</artifact>';
+const MAX_ARTIFACTS_PER_RUN = 50;
+
+const TYPE_TO_EXTENSION = new Map<string, SupportedArtifactExtension>([
+  ['html', '.html'],
+  ['text/html', '.html'],
+  ['css', '.css'],
+  ['text/css', '.css'],
+  ['svg', '.svg'],
+  ['image/svg+xml', '.svg'],
+  ['markdown', '.md'],
+  ['md', '.md'],
+  ['text/markdown', '.md'],
+  ['text/x-markdown', '.md'],
+]);
+
+export function plainStdoutFromRunEvents(events: readonly RunEventLike[]): string {
+  let stdout = '';
+  for (const rec of events) {
+    if (rec?.event !== 'stdout') continue;
+    const data = rec.data as { chunk?: unknown } | null | undefined;
+    if (typeof data?.chunk === 'string') stdout += data.chunk;
+  }
+  return stdout;
+}
+
+export function extractPlainStreamArtifacts(stdout: string): PlainStreamArtifact[] {
+  if (!stdout.includes(OPEN_TAG)) return [];
+  const skipRanges = computeMarkdownFenceRanges(stdout);
+  const artifacts: PlainStreamArtifact[] = [];
+  let from = 0;
+
+  while (from < stdout.length && artifacts.length < MAX_ARTIFACTS_PER_RUN) {
+    const openStart = findNextArtifactOpen(stdout, from, skipRanges);
+    if (openStart === -1) break;
+    const openEnd = findOpenTagEnd(stdout, openStart + OPEN_TAG.length);
+    if (openEnd === -1) break;
+    const closeStart = stdout.indexOf(CLOSE_TAG, openEnd);
+    if (closeStart === -1) break;
+
+    const attrText = stdout.slice(openStart + OPEN_TAG.length, openEnd - 1);
+    const attrs = parseAttrs(attrText);
+    const content = stdout.slice(openEnd, closeStart);
+    const artifactType = normalizeArtifactType(attrs.type, content);
+    const extension = artifactType ? TYPE_TO_EXTENSION.get(artifactType) : undefined;
+    if (artifactType && extension) {
+      const title = attrs.title ?? '';
+      const identifier = attrs.identifier ?? '';
+      artifacts.push({
+        identifier,
+        artifactType,
+        title,
+        content,
+        extension,
+        fileName: `${artifactBaseNameFor({ identifier, title })}${extension}`,
+      });
+    }
+    from = closeStart + CLOSE_TAG.length;
+  }
+
+  return artifacts;
+}
+
+export async function persistPlainStreamArtifacts(options: {
+  projectsRoot: string;
+  projectId: string;
+  stdout: string;
+  metadata?: unknown;
+  writeProjectFile?: WriteProjectFile;
+  listFiles?: ListFiles;
+}): Promise<PersistedPlainStreamArtifact[]> {
+  const artifacts = extractPlainStreamArtifacts(options.stdout);
+  if (artifacts.length === 0) return [];
+
+  const listFiles = options.listFiles ?? (defaultListFiles as ListFiles);
+  const writeProjectFile = options.writeProjectFile ?? (defaultWriteProjectFile as WriteProjectFile);
+  const existingFiles = await listFiles(options.projectsRoot, options.projectId, {
+    metadata: options.metadata,
+  });
+  const reservedNames = new Set(existingFiles.map((file) => file.name));
+  const persisted: PersistedPlainStreamArtifact[] = [];
+
+  for (const artifact of artifacts) {
+    const name = reserveUniqueArtifactFileName(artifact.fileName, reservedNames);
+    const manifest = artifactManifestFor(artifact, name);
+    const file = await createProjectArtifactFile({
+      projectsRoot: options.projectsRoot,
+      projectId: options.projectId,
+      input: {
+        name,
+        content: artifact.content,
+        artifactManifest: manifest,
+      },
+      metadata: options.metadata,
+      writeProjectFile,
+    });
+    persisted.push({
+      identifier: artifact.identifier,
+      artifactType: artifact.artifactType,
+      title: artifact.title,
+      name,
+      file,
+    });
+  }
+
+  return persisted;
+}
+
+function normalizeArtifactType(rawType: string | undefined, content: string): string | null {
+  const normalized = rawType?.trim().toLowerCase();
+  if (normalized && TYPE_TO_EXTENSION.has(normalized)) return normalized;
+  if (!normalized && looksLikeHtmlDocument(content)) return 'text/html';
+  return null;
+}
+
+function looksLikeHtmlDocument(content: string): boolean {
+  return /^\s*(?:<!doctype\s+html\b|<html\b)/i.test(content);
+}
+
+function parseAttrs(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const re = /([A-Za-z_:][\w:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+  let match: RegExpExecArray | null = re.exec(raw);
+  while (match) {
+    attrs[match[1] as string] = (match[2] ?? match[3] ?? '') as string;
+    match = re.exec(raw);
+  }
+  return attrs;
+}
+
+function findNextArtifactOpen(
+  text: string,
+  from: number,
+  skipRanges: ReadonlyArray<[number, number]>,
+): number {
+  let current = from;
+  while (current < text.length) {
+    const idx = text.indexOf(OPEN_TAG, current);
+    if (idx === -1) return -1;
+    if (!isRealArtifactOpenAt(text, idx) || rangeContains(skipRanges, idx)) {
+      current = idx + OPEN_TAG.length;
+      continue;
+    }
+    return idx;
+  }
+  return -1;
+}
+
+function isRealArtifactOpenAt(text: string, idx: number): boolean {
+  const next = text.charAt(idx + OPEN_TAG.length);
+  return next === '>' || /\s/.test(next);
+}
+
+function findOpenTagEnd(text: string, from: number): number {
+  let quote: '"' | "'" | null = null;
+  for (let i = from; i < text.length; i += 1) {
+    const ch = text.charAt(i);
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === '>') return i + 1;
+  }
+  return -1;
+}
+
+function computeMarkdownFenceRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const fenceRe = /^(?:```|~~~).*$/gm;
+  let open: { marker: string; start: number } | null = null;
+  let match: RegExpExecArray | null = fenceRe.exec(text);
+  while (match) {
+    const line = match[0] ?? '';
+    const marker = line.startsWith('~~~') ? '~~~' : '```';
+    if (!open) {
+      open = { marker, start: match.index };
+    } else if (marker === open.marker) {
+      ranges.push([open.start, fenceRe.lastIndex]);
+      open = null;
+    }
+    match = fenceRe.exec(text);
+  }
+  if (open) ranges.push([open.start, text.length]);
+  return ranges;
+}
+
+function rangeContains(ranges: ReadonlyArray<[number, number]>, idx: number): boolean {
+  return ranges.some(([start, end]) => idx >= start && idx < end);
+}
+
+function artifactBaseNameFor(input: { identifier: string; title: string }): string {
+  return (
+    (input.identifier || input.title || 'artifact')
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'artifact'
+  );
+}
+
+function reserveUniqueArtifactFileName(
+  desiredName: string,
+  reservedNames: Set<string>,
+): string {
+  if (!reservedNames.has(desiredName)) {
+    reservedNames.add(desiredName);
+    return desiredName;
+  }
+  const dot = desiredName.lastIndexOf('.');
+  const stem = dot >= 0 ? desiredName.slice(0, dot) : desiredName;
+  const ext = dot >= 0 ? desiredName.slice(dot) : '';
+  let suffix = 2;
+  while (suffix < 10_000) {
+    const candidate = `${stem}-${suffix}${ext}`;
+    if (!reservedNames.has(candidate)) {
+      reservedNames.add(candidate);
+      return candidate;
+    }
+    suffix += 1;
+  }
+  throw new Error(`could not allocate artifact filename for ${desiredName}`);
+}
+
+function artifactManifestFor(artifact: PlainStreamArtifact, entry: string): JsonRecord {
+  const title = artifact.title || artifact.identifier || entry;
+  const metadata = {
+    identifier: artifact.identifier,
+    artifactType: artifact.artifactType,
+    inferred: false,
+  };
+
+  if (artifact.extension === '.html') {
+    return {
+      kind: 'html',
+      title,
+      entry,
+      renderer: 'html',
+      status: 'complete',
+      exports: ['html', 'pdf', 'zip'],
+      primary: true,
+      metadata,
+    };
+  }
+  if (artifact.extension === '.css') {
+    return {
+      kind: 'code-snippet',
+      title,
+      entry,
+      renderer: 'code',
+      status: 'complete',
+      exports: ['txt', 'zip'],
+      metadata,
+    };
+  }
+  if (artifact.extension === '.svg') {
+    return {
+      kind: 'svg',
+      title,
+      entry,
+      renderer: 'svg',
+      status: 'complete',
+      exports: ['svg', 'zip'],
+      metadata,
+    };
+  }
+  return {
+    kind: 'markdown-document',
+    title,
+    entry,
+    renderer: 'markdown',
+    status: 'complete',
+    exports: ['md', 'html', 'pdf', 'zip'],
+    metadata,
+  };
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8745,6 +8745,7 @@ export async function startServer({
             }
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
+            const failureMessage = `Failed to persist plain-stream artifact(s): ${message}`;
             console.warn(`[plain-stream] failed to persist stdout artifact(s): ${message}`);
             send('agent', {
               type: 'diagnostic',
@@ -8752,6 +8753,11 @@ export async function startServer({
               source: 'daemon-run-finalize',
               message,
             });
+            send('error', createSseErrorPayload(
+              'AGENT_EXECUTION_FAILED',
+              failureMessage,
+            ));
+            return finishWithRetryDecision('failed', 1, null);
           }
         }
       }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -156,6 +156,10 @@ import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
 import { preparePromptFileForAgent } from './runtimes/prompt-file.js';
 import { buildOpenCodeByokProviderConfig } from './runtimes/byok-opencode.js';
 import {
+  persistPlainStreamArtifacts,
+  plainStdoutFromRunEvents,
+} from './runtimes/plain-stream.js';
+import {
   readVelaLoginStatus,
   resolveAmrProfile,
 } from './integrations/vela.js';
@@ -8704,6 +8708,52 @@ export async function startServer({
       }
       const flushedTitleMarkerText = titleMarkerStripper.flush();
       if (flushedTitleMarkerText) send('stdout', { chunk: flushedTitleMarkerText });
+      if (
+        status === 'succeeded' &&
+        (def.streamFormat ?? 'plain') === 'plain' &&
+        run.projectId
+      ) {
+        const plainStdout = plainStdoutFromRunEvents(run.events);
+        if (plainStdout.includes('<artifact')) {
+          try {
+            const project = getProject(db, run.projectId);
+            const persistedPlainArtifacts = await persistPlainStreamArtifacts({
+              projectsRoot: PROJECTS_DIR,
+              projectId: run.projectId,
+              stdout: plainStdout,
+              metadata: project?.metadata,
+              writeProjectFile,
+            });
+            if (persistedPlainArtifacts.length > 0) {
+              send('agent', {
+                type: 'artifact',
+                source: 'plain-stream',
+                files: persistedPlainArtifacts.map((artifact) => ({
+                  name: artifact.name,
+                  identifier: artifact.identifier,
+                  artifactType: artifact.artifactType,
+                })),
+              });
+              send('agent', {
+                type: 'diagnostic',
+                name: 'plain_stream_artifacts_persisted',
+                source: 'daemon-run-finalize',
+                fileCount: persistedPlainArtifacts.length,
+                files: persistedPlainArtifacts.map((artifact) => artifact.name),
+              });
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(`[plain-stream] failed to persist stdout artifact(s): ${message}`);
+            send('agent', {
+              type: 'diagnostic',
+              name: 'plain_stream_artifacts_persist_failed',
+              source: 'daemon-run-finalize',
+              message,
+            });
+          }
+        }
+      }
       // Capture the pi session file path for conversational continuity.
       // The session path is discovered by attachPiRpcSession when it
       // processes agent_end; persist it under (conversationId, agentId) so

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8725,15 +8725,16 @@ export async function startServer({
               writeProjectFile,
             });
             if (persistedPlainArtifacts.length > 0) {
-              send('agent', {
-                type: 'artifact',
-                source: 'plain-stream',
-                files: persistedPlainArtifacts.map((artifact) => ({
+              for (const artifact of persistedPlainArtifacts) {
+                send('agent', {
+                  type: 'artifact',
+                  source: 'plain-stream',
                   name: artifact.name,
+                  path: artifact.name,
                   identifier: artifact.identifier,
                   artifactType: artifact.artifactType,
-                })),
-              });
+                });
+              }
               send('agent', {
                 type: 'diagnostic',
                 name: 'plain_stream_artifacts_persisted',

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2367,6 +2367,54 @@ process.exit(0);
     );
   });
 
+  it('fails plain-stream runs when stdout artifact persistence fails', async () => {
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write('<artifact identifier="blocked" type="text/html" title="Blocked"><!doctype html><html><body>Name to confirm</body></html></artifact>\\n');
+process.exit(0);
+`,
+      async () => {
+        const projectId = `plain-artifact-fail-${randomUUID()}`;
+        const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: projectId, name: 'Plain artifact failure' }),
+        });
+        expect(createProjectResponse.ok).toBe(true);
+
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            projectId,
+            message: 'emit blocked artifact',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'event: final');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: error');
+        expect(eventsBody).toContain('plain-stream artifact');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
   it('fails Antigravity Gemini JSONL output with no visible assistant content', async () => {
     await withFakeAgent(
       'agy',

--- a/apps/daemon/tests/runtimes/plain-stream.test.ts
+++ b/apps/daemon/tests/runtimes/plain-stream.test.ts
@@ -150,4 +150,15 @@ describe('plain stream artifact extraction', () => {
     expect(artifacts[0]?.fileName).toBe('real.html');
     expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
   });
+
+  it('ignores artifact tags inside inline markdown code spans', () => {
+    const artifacts = extractPlainStreamArtifacts([
+      'Use `<artifact identifier="example" type="text/html">example</artifact>` to emit HTML.\n',
+      '<artifact identifier="real" type="text/html"><!doctype html><html><body>Real</body></html></artifact>',
+    ].join(''));
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.fileName).toBe('real.html');
+    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
+  });
 });

--- a/apps/daemon/tests/runtimes/plain-stream.test.ts
+++ b/apps/daemon/tests/runtimes/plain-stream.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  extractPlainStreamArtifacts,
+  persistPlainStreamArtifacts,
+  plainStdoutFromRunEvents,
+} from '../../src/runtimes/plain-stream.js';
+import { listFiles, writeProjectFile } from '../../src/projects.js';
+
+describe('plain stream artifact extraction', () => {
+  it('extracts and writes artifact tags from plain stdout into project files', async () => {
+    const projectsRoot = await mkdtemp(path.join(tmpdir(), 'od-plain-stream-'));
+    try {
+      const stdout = [
+        'Here is the result:\n',
+        '<artifact identifier="flowmind-landing" type="text/html" title="FlowMind Landing">',
+        '<!doctype html><html><body><h1>FlowMind</h1></body></html>',
+        '</artifact>',
+        '\nDone.',
+      ].join('');
+
+      const written = await persistPlainStreamArtifacts({
+        projectsRoot,
+        projectId: 'project-1',
+        stdout,
+        writeProjectFile: writeProjectFile as any,
+      });
+
+      expect(written).toHaveLength(1);
+      expect(written[0]).toMatchObject({
+        name: 'flowmind-landing.html',
+        identifier: 'flowmind-landing',
+        artifactType: 'text/html',
+      });
+
+      const body = await readFile(
+        path.join(projectsRoot, 'project-1', 'flowmind-landing.html'),
+        'utf8',
+      );
+      expect(body).toContain('<h1>FlowMind</h1>');
+
+      const files = await listFiles(projectsRoot, 'project-1');
+      const file = files.find((candidate) => candidate.name === 'flowmind-landing.html');
+      expect(file?.artifactManifest).toMatchObject({
+        kind: 'html',
+        renderer: 'html',
+        entry: 'flowmind-landing.html',
+        metadata: {
+          identifier: 'flowmind-landing',
+          artifactType: 'text/html',
+          inferred: false,
+        },
+      });
+    } finally {
+      await rm(projectsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write files when plain stdout contains no artifact tags', async () => {
+    const projectsRoot = await mkdtemp(path.join(tmpdir(), 'od-plain-stream-'));
+    try {
+      const written = await persistPlainStreamArtifacts({
+        projectsRoot,
+        projectId: 'project-1',
+        stdout: 'plain answer with no file output',
+        writeProjectFile: writeProjectFile as any,
+      });
+
+      expect(written).toEqual([]);
+      await expect(listFiles(projectsRoot, 'project-1')).resolves.toEqual([]);
+    } finally {
+      await rm(projectsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('infers html artifacts without a type and avoids filename collisions', async () => {
+    const projectsRoot = await mkdtemp(path.join(tmpdir(), 'od-plain-stream-'));
+    try {
+      await mkdir(path.join(projectsRoot, 'project-1'), { recursive: true });
+      await writeFile(path.join(projectsRoot, 'project-1', 'landing.html'), 'existing');
+
+      const written = await persistPlainStreamArtifacts({
+        projectsRoot,
+        projectId: 'project-1',
+        stdout: [
+          '<artifact identifier="landing" title="Landing">',
+          '<!doctype html><html><body>New</body></html>',
+          '</artifact>',
+        ].join(''),
+        writeProjectFile: writeProjectFile as any,
+      });
+
+      expect(written).toHaveLength(1);
+      expect(written[0]).toMatchObject({
+        name: 'landing-2.html',
+        artifactType: 'text/html',
+      });
+      await expect(readFile(path.join(projectsRoot, 'project-1', 'landing.html'), 'utf8'))
+        .resolves.toBe('existing');
+      await expect(readFile(path.join(projectsRoot, 'project-1', 'landing-2.html'), 'utf8'))
+        .resolves.toContain('<body>New</body>');
+    } finally {
+      await rm(projectsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('maps supported text artifact types to stable project file names', () => {
+    const artifacts = extractPlainStreamArtifacts([
+      '<artifact identifier="theme" type="text/css">body { color: red; }</artifact>',
+      '<artifact identifier="logo" type="image/svg+xml"><svg /></artifact>',
+      '<artifact identifier="brief" type="text/markdown"># Brief</artifact>',
+    ].join('\n'));
+
+    expect(artifacts.map((artifact) => ({
+      name: artifact.fileName,
+      type: artifact.artifactType,
+    }))).toEqual([
+      { name: 'theme.css', type: 'text/css' },
+      { name: 'logo.svg', type: 'image/svg+xml' },
+      { name: 'brief.md', type: 'text/markdown' },
+    ]);
+  });
+
+  it('reconstructs only plain stdout events and ignores literal code-fence examples', () => {
+    const stdout = plainStdoutFromRunEvents([
+      { event: 'agent', data: { type: 'text_delta', delta: '<artifact type="text/html">no</artifact>' } },
+      { event: 'stdout', data: { chunk: '```html\n<artifact type="text/html">example</artifact>\n```\n' } },
+      { event: 'stdout', data: { chunk: '<artifact type="text/html"><!doctype html><html></html></artifact>' } },
+    ]);
+
+    const artifacts = extractPlainStreamArtifacts(stdout);
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.content).toBe('<!doctype html><html></html>');
+  });
+});

--- a/apps/daemon/tests/runtimes/plain-stream.test.ts
+++ b/apps/daemon/tests/runtimes/plain-stream.test.ts
@@ -107,6 +107,17 @@ describe('plain stream artifact extraction', () => {
     }
   });
 
+  it('ignores bare artifact tags to match the web artifact parser', () => {
+    const artifacts = extractPlainStreamArtifacts([
+      '<artifact><!doctype html><html><body>Bare</body></html></artifact>',
+      '<artifact identifier="real" type="text/html"><!doctype html><html><body>Real</body></html></artifact>',
+    ].join('\n'));
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.fileName).toBe('real.html');
+    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
+  });
+
   it('maps supported text artifact types to stable project file names', () => {
     const artifacts = extractPlainStreamArtifacts([
       '<artifact identifier="theme" type="text/css">body { color: red; }</artifact>',

--- a/apps/daemon/tests/runtimes/plain-stream.test.ts
+++ b/apps/daemon/tests/runtimes/plain-stream.test.ts
@@ -161,4 +161,18 @@ describe('plain stream artifact extraction', () => {
     expect(artifacts[0]?.fileName).toBe('real.html');
     expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
   });
+
+  it('does not let unmatched backticks hide artifact tags in later paragraphs', () => {
+    const artifacts = extractPlainStreamArtifacts([
+      'Intro with a stray ` backtick.',
+      '',
+      '<artifact identifier="real" type="text/html"><!doctype html><html><body>Real</body></html></artifact>',
+      '',
+      'Another stray ` backtick later.',
+    ].join('\n'));
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.fileName).toBe('real.html');
+    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
+  });
 });

--- a/apps/daemon/tests/runtimes/plain-stream.test.ts
+++ b/apps/daemon/tests/runtimes/plain-stream.test.ts
@@ -178,6 +178,32 @@ describe('plain stream artifact extraction', () => {
     expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
   });
 
+  it('resyncs past prose artifact openers before a valid artifact block', () => {
+    const artifacts = extractPlainStreamArtifacts([
+      'Use <artifact type="text/html"> in prose before emitting the real artifact.\n',
+      '<artifact identifier="real" type="text/html">',
+      '<!doctype html><html><body>Real</body></html>',
+      '</artifact>',
+    ].join(''));
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.fileName).toBe('real.html');
+    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
+  });
+
+  it('resyncs past malformed artifact openers before a valid artifact block', () => {
+    const artifacts = extractPlainStreamArtifacts([
+      'Malformed protocol example: <artifact type="text/html"\n',
+      '<artifact identifier="real" type="text/html">',
+      '<!doctype html><html><body>Real</body></html>',
+      '</artifact>',
+    ].join(''));
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.fileName).toBe('real.html');
+    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
+  });
+
   it('does not let unmatched backticks hide artifact tags in later paragraphs', () => {
     const artifacts = extractPlainStreamArtifacts([
       'Intro with a stray ` backtick.',

--- a/apps/daemon/tests/runtimes/plain-stream.test.ts
+++ b/apps/daemon/tests/runtimes/plain-stream.test.ts
@@ -136,4 +136,18 @@ describe('plain stream artifact extraction', () => {
     expect(artifacts).toHaveLength(1);
     expect(artifacts[0]?.content).toBe('<!doctype html><html></html>');
   });
+
+  it('ignores artifact tags inside indented markdown code fences', () => {
+    const artifacts = extractPlainStreamArtifacts([
+      '- Literal example:\n',
+      '   ```html\n',
+      '   <artifact type="text/html"><!doctype html><html><body>Example</body></html></artifact>\n',
+      '   ```\n',
+      '<artifact identifier="real" type="text/html"><!doctype html><html><body>Real</body></html></artifact>',
+    ].join(''));
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.fileName).toBe('real.html');
+    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
+  });
 });

--- a/apps/daemon/tests/runtimes/plain-stream.test.ts
+++ b/apps/daemon/tests/runtimes/plain-stream.test.ts
@@ -137,18 +137,34 @@ describe('plain stream artifact extraction', () => {
     expect(artifacts[0]?.content).toBe('<!doctype html><html></html>');
   });
 
-  it('ignores artifact tags inside indented markdown code fences', () => {
+  it('extracts artifact tags inside indented backtick examples to match web markdown context', () => {
     const artifacts = extractPlainStreamArtifacts([
       '- Literal example:\n',
       '   ```html\n',
       '   <artifact type="text/html"><!doctype html><html><body>Example</body></html></artifact>\n',
-      '   ```\n',
       '<artifact identifier="real" type="text/html"><!doctype html><html><body>Real</body></html></artifact>',
     ].join(''));
 
-    expect(artifacts).toHaveLength(1);
-    expect(artifacts[0]?.fileName).toBe('real.html');
-    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Real</body></html>');
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts[0]?.fileName).toBe('artifact.html');
+    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Example</body></html>');
+    expect(artifacts[1]?.fileName).toBe('real.html');
+    expect(artifacts[1]?.content).toBe('<!doctype html><html><body>Real</body></html>');
+  });
+
+  it('extracts artifact tags inside tilde fences to match web markdown context', () => {
+    const artifacts = extractPlainStreamArtifacts([
+      '~~~html\n',
+      '<artifact type="text/html"><!doctype html><html><body>Tilde</body></html></artifact>\n',
+      '~~~\n',
+      '<artifact identifier="real" type="text/html"><!doctype html><html><body>Real</body></html></artifact>',
+    ].join(''));
+
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts[0]?.fileName).toBe('artifact.html');
+    expect(artifacts[0]?.content).toBe('<!doctype html><html><body>Tilde</body></html>');
+    expect(artifacts[1]?.fileName).toBe('real.html');
+    expect(artifacts[1]?.content).toBe('<!doctype html><html><body>Real</body></html>');
   });
 
   it('ignores artifact tags inside inline markdown code spans', () => {

--- a/apps/web/src/artifacts/strip.ts
+++ b/apps/web/src/artifacts/strip.ts
@@ -176,11 +176,16 @@ export interface PersistedArtifactFileRef {
 
 // Mirrors ProjectView's artifactExtensionFor: the on-disk extension the
 // persist path picks from the artifact's type/identifier.
-function artifactExtensionForAttrs(attrs: Record<string, string>): '.html' | '.jsx' | '.tsx' {
+function artifactExtensionForAttrs(
+  attrs: Record<string, string>,
+): '.html' | '.jsx' | '.tsx' | '.css' | '.svg' | '.md' {
   const type = (attrs['type'] || '').toLowerCase();
   const identifier = (attrs['identifier'] || '').toLowerCase();
   if (type.includes('tsx') || identifier.endsWith('.tsx')) return '.tsx';
   if (type.includes('jsx') || type.includes('react') || identifier.endsWith('.jsx')) return '.jsx';
+  if (type.includes('css') || identifier.endsWith('.css')) return '.css';
+  if (type.includes('svg') || identifier.endsWith('.svg')) return '.svg';
+  if (type.includes('markdown') || type === 'md' || identifier.endsWith('.md')) return '.md';
   return '.html';
 }
 

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -8474,6 +8474,12 @@ function artifactBaseNameFor(art: Artifact): string {
   );
 }
 
+function artifactFileNamePattern(baseName: string, ext: string): RegExp {
+  const escapedBaseName = baseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedExt = ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${escapedBaseName}(?:-\\d+)?${escapedExt}$`);
+}
+
 export function findExistingArtifactProjectFile(
   art: Artifact,
   projectFiles: ProjectFile[],
@@ -8504,7 +8510,16 @@ export function findExistingArtifactProjectFile(
     if (manifestMatches[0]) return manifestMatches[0];
   }
 
-  return currentRunFiles.find((file) => file.name === candidateFileName) ?? null;
+  const exactNameMatch = currentRunFiles.find((file) => file.name === candidateFileName);
+  if (exactNameMatch) return exactNameMatch;
+  if (ext !== '.html') {
+    const namePattern = artifactFileNamePattern(baseName, ext);
+    const suffixedMatches = currentRunFiles
+      .filter((file) => namePattern.test(file.name))
+      .sort((a, b) => b.mtime - a.mtime);
+    if (suffixedMatches[0]) return suffixedMatches[0];
+  }
+  return null;
 }
 
 export function findExistingNonHtmlArtifactProjectFile(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5186,7 +5186,7 @@ export function ProjectView({
               if (artifactToPersist?.html) {
                 const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
                 const sameTurnArtifactWrite =
-                  findExistingArtifactProjectFile(artifactToPersist, producedBeforeFallback);
+                  findExistingNonHtmlArtifactProjectFile(artifactToPersist, producedBeforeFallback);
                 const sameTurnHtmlWrite = sameTurnArtifactWrite
                   ? null
                   : await findSameTurnHtmlWriteForRecoveredArtifact({
@@ -8505,6 +8505,15 @@ export function findExistingArtifactProjectFile(
   }
 
   return currentRunFiles.find((file) => file.name === candidateFileName) ?? null;
+}
+
+export function findExistingNonHtmlArtifactProjectFile(
+  art: Artifact,
+  projectFiles: ProjectFile[],
+  options: { minMtime?: number } = {},
+): ProjectFile | null {
+  if (artifactExtensionFor(art) === '.html') return null;
+  return findExistingArtifactProjectFile(art, projectFiles, options);
 }
 
 function filterProjectFilesByMinMtime(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3711,12 +3711,20 @@ export function ProjectView({
               : artifactFromStandaloneHtml(replayedContent);
             let recoveredExistingArtifact: ProjectFile | null = null;
             if (artifactToPersist?.html) {
+              const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
               const runStartedAt = status.createdAt || message.startedAt || message.createdAt;
-              recoveredExistingArtifact = findExistingArtifactProjectFile(
-                artifactToPersist,
-                nextFiles,
-                { minMtime: runStartedAt },
-              );
+              recoveredExistingArtifact =
+                await findSameTurnWriteForRecoveredArtifact({
+                  artifact: artifactToPersist,
+                  sourceText: replayedContent,
+                  producedFiles: producedBeforeFallback,
+                  readProjectText: readProjectHtml,
+                }) ??
+                findExistingArtifactProjectFile(
+                  artifactToPersist,
+                  nextFiles,
+                  { minMtime: runStartedAt },
+                );
               if (recoveredExistingArtifact) {
                 savedArtifactRef.current = recoveredExistingArtifact.name;
                 requestOpenFile(recoveredExistingArtifact.name);
@@ -3973,19 +3981,18 @@ export function ProjectView({
                 if (artifactToPersist?.html) {
                   const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
                   const runStartedAt = status.createdAt || message.startedAt || message.createdAt;
-                  recoveredExistingArtifact = findExistingArtifactProjectFile(
-                    artifactToPersist,
-                    nextFiles,
-                    { minMtime: runStartedAt },
-                  ) ?? await findSameTurnHtmlWriteForRecoveredArtifact({
-                    artifactHtml: resolvePersistedArtifactHtml({
-                      artifactHtml: artifactToPersist.html,
-                      identifier: artifactToPersist.identifier,
+                  recoveredExistingArtifact =
+                    await findSameTurnWriteForRecoveredArtifact({
+                      artifact: artifactToPersist,
                       sourceText: replayedContent,
-                    }),
-                    producedFiles: producedBeforeFallback,
-                    readProjectHtml,
-                  });
+                      producedFiles: producedBeforeFallback,
+                      readProjectText: readProjectHtml,
+                    }) ??
+                    findExistingArtifactProjectFile(
+                      artifactToPersist,
+                      nextFiles,
+                      { minMtime: runStartedAt },
+                    );
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
                     requestOpenFile(recoveredExistingArtifact.name);
@@ -4064,11 +4071,19 @@ export function ProjectView({
                     );
                     const runStartedAt =
                       latestRunStatus?.createdAt || message.startedAt || message.createdAt;
-                    let recoveredExistingArtifact = findExistingArtifactProjectFile(
-                      artifactToPersist,
-                      nextFiles,
-                      { minMtime: runStartedAt },
-                    );
+                    const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+                    let recoveredExistingArtifact =
+                      await findSameTurnWriteForRecoveredArtifact({
+                        artifact: artifactToPersist,
+                        sourceText: replayedContent,
+                        producedFiles: producedBeforeFallback,
+                        readProjectText: readProjectHtml,
+                      }) ??
+                      findExistingArtifactProjectFile(
+                        artifactToPersist,
+                        nextFiles,
+                        { minMtime: runStartedAt },
+                      );
                     if (recoveredExistingArtifact) {
                       savedArtifactRef.current = recoveredExistingArtifact.name;
                       requestOpenFile(recoveredExistingArtifact.name);
@@ -4416,11 +4431,19 @@ export function ProjectView({
           );
           const runStartedAt =
             latestRunStatus?.createdAt || message.startedAt || message.createdAt;
-          let recoveredExistingArtifact = findExistingArtifactProjectFile(
-            artifactToPersist,
-            nextFiles,
-            { minMtime: runStartedAt },
-          );
+          const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+          let recoveredExistingArtifact =
+            await findSameTurnWriteForRecoveredArtifact({
+              artifact: artifactToPersist,
+              sourceText,
+              producedFiles: producedBeforeFallback,
+              readProjectText: readProjectHtml,
+            }) ??
+            findExistingArtifactProjectFile(
+              artifactToPersist,
+              nextFiles,
+              { minMtime: runStartedAt },
+            );
           if (recoveredExistingArtifact) {
             savedArtifactRef.current = recoveredExistingArtifact.name;
             requestOpenFile(recoveredExistingArtifact.name);
@@ -8514,14 +8537,9 @@ export function findExistingArtifactProjectFile(
     if (manifestMatches[0]) return manifestMatches[0];
   }
 
-  const exactNameMatch = currentRunFiles.find((file) => file.name === candidateFileName);
-  if (exactNameMatch) return exactNameMatch;
-  if (ext !== '.html') {
-    const namePattern = artifactFileNamePattern(baseName, ext);
-    const suffixedMatches = currentRunFiles
-      .filter((file) => namePattern.test(file.name))
-      .sort((a, b) => b.mtime - a.mtime);
-    if (suffixedMatches[0]) return suffixedMatches[0];
+  if (ext === '.html') {
+    const exactNameMatch = currentRunFiles.find((file) => file.name === candidateFileName);
+    if (exactNameMatch) return exactNameMatch;
   }
   return null;
 }
@@ -8568,6 +8586,34 @@ export async function findSameTurnNonHtmlWriteForRecoveredArtifact({
     if (actual === expected) return file;
   }
   return null;
+}
+
+async function findSameTurnWriteForRecoveredArtifact({
+  artifact,
+  sourceText,
+  producedFiles,
+  readProjectText,
+}: {
+  artifact: Artifact;
+  sourceText: string;
+  producedFiles: readonly ProjectFile[];
+  readProjectText: (name: string) => Promise<string | null>;
+}): Promise<ProjectFile | null> {
+  const nonHtmlWrite = await findSameTurnNonHtmlWriteForRecoveredArtifact({
+    artifact,
+    producedFiles,
+    readProjectText,
+  });
+  if (nonHtmlWrite || artifactExtensionFor(artifact) !== '.html') return nonHtmlWrite;
+  return findSameTurnHtmlWriteForRecoveredArtifact({
+    artifactHtml: resolvePersistedArtifactHtml({
+      artifactHtml: artifact.html,
+      identifier: artifact.identifier,
+      sourceText,
+    }),
+    producedFiles,
+    readProjectHtml: readProjectText,
+  });
 }
 
 function normalizeProjectTextForArtifactComparison(value: string | null | undefined): string {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5186,7 +5186,11 @@ export function ProjectView({
               if (artifactToPersist?.html) {
                 const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
                 const sameTurnArtifactWrite =
-                  findExistingNonHtmlArtifactProjectFile(artifactToPersist, producedBeforeFallback);
+                  await findSameTurnNonHtmlWriteForRecoveredArtifact({
+                    artifact: artifactToPersist,
+                    producedFiles: producedBeforeFallback,
+                    readProjectText: readProjectHtml,
+                  });
                 const sameTurnHtmlWrite = sameTurnArtifactWrite
                   ? null
                   : await findSameTurnHtmlWriteForRecoveredArtifact({
@@ -8529,6 +8533,47 @@ export function findExistingNonHtmlArtifactProjectFile(
 ): ProjectFile | null {
   if (artifactExtensionFor(art) === '.html') return null;
   return findExistingArtifactProjectFile(art, projectFiles, options);
+}
+
+export async function findSameTurnNonHtmlWriteForRecoveredArtifact({
+  artifact,
+  producedFiles,
+  readProjectText,
+}: {
+  artifact: Artifact;
+  producedFiles: readonly ProjectFile[];
+  readProjectText: (name: string) => Promise<string | null>;
+}): Promise<ProjectFile | null> {
+  const ext = artifactExtensionFor(artifact);
+  if (ext === '.html') return null;
+
+  const baseName = artifactBaseNameFor(artifact);
+  const candidateFileName = `${baseName}${ext}`;
+  const namePattern = artifactFileNamePattern(baseName, ext);
+  const identifier = artifact.identifier || '';
+  const candidates = producedFiles
+    .filter((file) => {
+      if (identifier && file.artifactManifest?.metadata?.identifier === identifier) {
+        return file.name.toLowerCase().endsWith(ext);
+      }
+      return file.name === candidateFileName || namePattern.test(file.name);
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+
+  const expected = normalizeProjectTextForArtifactComparison(artifact.html);
+  for (const file of candidates) {
+    const text = await readProjectText(file.name);
+    if (text === null) continue;
+    const actual = normalizeProjectTextForArtifactComparison(text);
+    if (actual === expected) return file;
+  }
+  return null;
+}
+
+function normalizeProjectTextForArtifactComparison(value: string | null | undefined): string {
+  return String(value || '')
+    .replace(/^\uFEFF/, '')
+    .replace(/\r\n?/g, '\n');
 }
 
 function filterProjectFilesByMinMtime(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5185,18 +5185,23 @@ export function ProjectView({
                 : artifactFromStandaloneHtml(finalText);
               if (artifactToPersist?.html) {
                 const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
-                const sameTurnHtmlWrite = await findSameTurnHtmlWriteForRecoveredArtifact({
-                  artifactHtml: resolvePersistedArtifactHtml({
-                    artifactHtml: artifactToPersist.html,
-                    identifier: artifactToPersist.identifier,
-                    sourceText: finalText,
-                  }),
-                  producedFiles: producedBeforeFallback,
-                  readProjectHtml,
-                });
-                if (sameTurnHtmlWrite) {
-                  savedArtifactRef.current = sameTurnHtmlWrite.name;
-                  requestOpenFile(sameTurnHtmlWrite.name);
+                const sameTurnArtifactWrite =
+                  findExistingArtifactProjectFile(artifactToPersist, producedBeforeFallback);
+                const sameTurnHtmlWrite = sameTurnArtifactWrite
+                  ? null
+                  : await findSameTurnHtmlWriteForRecoveredArtifact({
+                      artifactHtml: resolvePersistedArtifactHtml({
+                        artifactHtml: artifactToPersist.html,
+                        identifier: artifactToPersist.identifier,
+                        sourceText: finalText,
+                      }),
+                      producedFiles: producedBeforeFallback,
+                      readProjectHtml,
+                    });
+                const sameTurnWrite = sameTurnArtifactWrite ?? sameTurnHtmlWrite;
+                if (sameTurnWrite) {
+                  savedArtifactRef.current = sameTurnWrite.name;
+                  requestOpenFile(sameTurnWrite.name);
                 } else {
                   await persistArtifact(artifactToPersist, nextFiles, finalText);
                   nextFiles = await refreshProjectFiles();
@@ -8431,12 +8436,17 @@ export function ProjectView({
   );
 }
 
-function artifactExtensionFor(art: Artifact): '.html' | '.jsx' | '.tsx' {
+function artifactExtensionFor(art: Artifact): '.html' | '.jsx' | '.tsx' | '.css' | '.svg' | '.md' {
   const type = (art.artifactType || '').toLowerCase();
   const identifier = (art.identifier || '').toLowerCase();
   if (type.includes('tsx') || identifier.endsWith('.tsx')) return '.tsx';
   if (type.includes('jsx') || type.includes('react') || identifier.endsWith('.jsx')) {
     return '.jsx';
+  }
+  if (type.includes('css') || identifier.endsWith('.css')) return '.css';
+  if (type.includes('svg') || identifier.endsWith('.svg')) return '.svg';
+  if (type.includes('markdown') || type === 'md' || identifier.endsWith('.md')) {
+    return '.md';
   }
   return '.html';
 }

--- a/apps/web/tests/artifacts/strip.test.ts
+++ b/apps/web/tests/artifacts/strip.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { splitStreamingArtifact, stripArtifact, stripRecoveredHtmlFallbackForDisplay } from '../../src/artifacts/strip';
+import {
+  splitStreamingArtifact,
+  stripArtifact,
+  stripRecoveredHtmlFallbackForDisplay,
+  summarizeArtifactsForTranscript,
+} from '../../src/artifacts/strip';
 
 const completeHtml = '<!doctype html><html><head><title>X</title></head><body><h1>X</h1></body></html>';
 
@@ -223,5 +228,34 @@ describe('stripRecoveredHtmlFallbackForDisplay', () => {
   it('leaves multiple complete html fences unchanged instead of guessing', () => {
     const input = ['```html', completeHtml, '```', '```html', completeHtml, '```'].join('\n');
     expect(stripRecoveredHtmlFallbackForDisplay(input)).toBe(input);
+  });
+});
+
+describe('summarizeArtifactsForTranscript', () => {
+  it('summarizes persisted css, svg, and markdown artifacts', () => {
+    const input = [
+      '<artifact identifier="theme" type="text/css" title="Theme">',
+      'body { color: red; }',
+      '</artifact>',
+      '<artifact identifier="logo" type="image/svg+xml" title="Logo">',
+      '<svg viewBox="0 0 10 10"></svg>',
+      '</artifact>',
+      '<artifact identifier="brief" type="text/markdown" title="Brief">',
+      '# Brief',
+      '</artifact>',
+    ].join('\n');
+
+    const out = summarizeArtifactsForTranscript(input, [
+      { name: 'theme.css' },
+      { name: 'logo.svg' },
+      { name: 'brief.md' },
+    ]);
+
+    expect(out).toContain('project file "theme.css"');
+    expect(out).toContain('project file "logo.svg"');
+    expect(out).toContain('project file "brief.md"');
+    expect(out).not.toContain('body { color: red; }');
+    expect(out).not.toContain('<svg viewBox="0 0 10 10"></svg>');
+    expect(out).not.toContain('# Brief');
   });
 });

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -248,6 +248,18 @@ describe('terminal replay artifact recovery', () => {
     ).toBe(currentTarget);
   });
 
+  it('reuses same-turn non-html artifact files with their declared extension', () => {
+    const cssArtifact: Artifact = {
+      identifier: 'theme',
+      artifactType: 'text/css',
+      title: 'Theme',
+      html: 'body { color: red; }',
+    };
+    const cssFile = projectFile('theme.css', 'code', 1_000);
+
+    expect(findExistingArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
+  });
+
   it('treats standalone HTML terminal assistant messages as recoverable', () => {
     expect(
       hasRecoverableArtifactMessage({

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -41,6 +41,7 @@ const patchPreviewCommentStatus = vi.fn();
 const saveTabs = vi.fn();
 const writeProjectTextFile = vi.fn();
 const cancelBrandExtraction = vi.fn();
+const originalFetch = globalThis.fetch;
 
 const replayArtifact: Artifact = {
   identifier: 'real-daemon-smoke',
@@ -250,7 +251,7 @@ describe('terminal replay artifact recovery', () => {
     ).toBe(currentTarget);
   });
 
-  it('reuses same-turn non-html artifact files with their declared extension', () => {
+  it('reuses same-turn non-html artifact files with their declared extension after content matches', async () => {
     const cssArtifact: Artifact = {
       identifier: 'theme',
       artifactType: 'text/css',
@@ -259,11 +260,18 @@ describe('terminal replay artifact recovery', () => {
     };
     const cssFile = projectFile('theme.css', 'code', 1_000);
 
-    expect(findExistingArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
-    expect(findExistingNonHtmlArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
+    expect(findExistingArtifactProjectFile(cssArtifact, [cssFile])).toBeNull();
+    expect(findExistingNonHtmlArtifactProjectFile(cssArtifact, [cssFile])).toBeNull();
+    await expect(
+      findSameTurnNonHtmlWriteForRecoveredArtifact({
+        artifact: cssArtifact,
+        producedFiles: [cssFile],
+        readProjectText: async () => 'body { color: red; }',
+      }),
+    ).resolves.toBe(cssFile);
   });
 
-  it('reuses same-turn non-html artifact files with collision suffixes', () => {
+  it('reuses same-turn non-html artifact files with collision suffixes after content matches', async () => {
     const cssArtifact: Artifact = {
       identifier: '',
       artifactType: 'text/css',
@@ -272,8 +280,15 @@ describe('terminal replay artifact recovery', () => {
     };
     const cssFile = projectFile('theme-2.css', 'code', 1_000);
 
-    expect(findExistingArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
-    expect(findExistingNonHtmlArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
+    expect(findExistingArtifactProjectFile(cssArtifact, [cssFile])).toBeNull();
+    expect(findExistingNonHtmlArtifactProjectFile(cssArtifact, [cssFile])).toBeNull();
+    await expect(
+      findSameTurnNonHtmlWriteForRecoveredArtifact({
+        artifact: cssArtifact,
+        producedFiles: [cssFile],
+        readProjectText: async () => 'body { color: red; }',
+      }),
+    ).resolves.toBe(cssFile);
   });
 
   it('does not reuse same-turn non-html filename matches when contents differ', async () => {
@@ -445,12 +460,13 @@ describe('ProjectView daemon cleanup', () => {
     cancelBrandExtraction.mockResolvedValue({ ok: true, status: 'failed' });
   });
 
-afterEach(() => {
-  cleanup();
-  vi.clearAllMocks();
-  vi.useRealTimers();
-  window.sessionStorage.clear();
-});
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    globalThis.fetch = originalFetch;
+    window.sessionStorage.clear();
+  });
 
   it('does not abort daemon cancel reattach controllers during unmount cleanup', async () => {
     let seenCancelSignal: { aborted: boolean } | null = null;
@@ -3863,6 +3879,88 @@ afterEach(() => {
         expect.objectContaining({ telemetryFinalized: true }),
       );
     });
+  });
+
+  it('persists reload-recovered non-html artifacts when same-turn suffix matches have different contents', async () => {
+    const runCreatedAt = Date.now();
+    const staleCss = projectFile('theme-2.css', 'code', runCreatedAt + 1);
+    const finalCss = 'body { color: red; }';
+    const artifactContent =
+      `<artifact type="text/css" title="Theme">${finalCss}</artifact>`;
+
+    globalThis.fetch = vi.fn(async () =>
+      new Response('body { color: blue; }', { status: 200 }),
+    ) as typeof fetch;
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-css-recover',
+        role: 'assistant',
+        content: artifactContent,
+        createdAt: runCreatedAt + 1,
+        runId: 'run-css-recover',
+        runStatus: 'succeeded',
+        producedFiles: [],
+        preTurnFileNames: [],
+      },
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockImplementation(async () =>
+      writeProjectTextFile.mock.calls.length > 0
+        ? [staleCss, projectFile('theme.css', 'code', runCreatedAt + 2)]
+        : [staleCss],
+    );
+    fetchProjectDesignSystemPackageAudit.mockResolvedValue(null);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-css-recover',
+      status: 'succeeded',
+      createdAt: runCreatedAt,
+      updatedAt: runCreatedAt + 1,
+      exitCode: 0,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+    writeProjectTextFile.mockImplementation(async (_projectId, name) =>
+      projectFile(String(name), 'code', runCreatedAt + 2),
+    );
+
+    render(
+      <ProjectView
+        project={{ id: 'project-css-recover', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(writeProjectTextFile).toHaveBeenCalledTimes(1));
+    expect(writeProjectTextFile).toHaveBeenCalledWith(
+      'project-css-recover',
+      'theme.css',
+      finalCss,
+      expect.objectContaining({
+        artifactManifest: expect.objectContaining({ entry: 'theme.css' }),
+      }),
+    );
   });
 
   it('does not recover a stale pointer target when reattached artifact persistence falls back to writing', async () => {

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -8,6 +8,7 @@ import {
   clearStreamingConversationMarker,
   finalizeActiveAssistantMessagesOnStop,
   findExistingArtifactProjectFile,
+  findExistingNonHtmlArtifactProjectFile,
   hasRecoverableArtifactMessage,
   resolveRetryTarget,
   resolveSucceededRunStatus,
@@ -258,6 +259,22 @@ describe('terminal replay artifact recovery', () => {
     const cssFile = projectFile('theme.css', 'code', 1_000);
 
     expect(findExistingArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
+    expect(findExistingNonHtmlArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
+  });
+
+  it('does not reuse same-turn html files before checking recovered content', () => {
+    const htmlArtifact: Artifact = {
+      identifier: 'landing',
+      artifactType: 'text/html',
+      title: 'Landing',
+      html: '<!doctype html><html><body>final artifact</body></html>',
+    };
+    const sameNameHtmlFile = projectFile('landing.html', 'html', 1_000);
+
+    expect(findExistingArtifactProjectFile(htmlArtifact, [sameNameHtmlFile]))
+      .toBe(sameNameHtmlFile);
+    expect(findExistingNonHtmlArtifactProjectFile(htmlArtifact, [sameNameHtmlFile]))
+      .toBeNull();
   });
 
   it('treats standalone HTML terminal assistant messages as recoverable', () => {

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -9,6 +9,7 @@ import {
   finalizeActiveAssistantMessagesOnStop,
   findExistingArtifactProjectFile,
   findExistingNonHtmlArtifactProjectFile,
+  findSameTurnNonHtmlWriteForRecoveredArtifact,
   hasRecoverableArtifactMessage,
   resolveRetryTarget,
   resolveSucceededRunStatus,
@@ -273,6 +274,42 @@ describe('terminal replay artifact recovery', () => {
 
     expect(findExistingArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
     expect(findExistingNonHtmlArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
+  });
+
+  it('does not reuse same-turn non-html filename matches when contents differ', async () => {
+    const cssArtifact: Artifact = {
+      identifier: '',
+      artifactType: 'text/css',
+      title: 'Theme',
+      html: 'body { color: red; }',
+    };
+    const cssFile = projectFile('theme.css', 'code', 1_000);
+
+    await expect(
+      findSameTurnNonHtmlWriteForRecoveredArtifact({
+        artifact: cssArtifact,
+        producedFiles: [cssFile],
+        readProjectText: async () => 'body { color: blue; }',
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('reuses same-turn non-html collision suffixes only when contents match', async () => {
+    const cssArtifact: Artifact = {
+      identifier: '',
+      artifactType: 'text/css',
+      title: 'Theme',
+      html: 'body { color: red; }',
+    };
+    const cssFile = projectFile('theme-2.css', 'code', 1_000);
+
+    await expect(
+      findSameTurnNonHtmlWriteForRecoveredArtifact({
+        artifact: cssArtifact,
+        producedFiles: [cssFile],
+        readProjectText: async () => 'body { color: red; }',
+      }),
+    ).resolves.toBe(cssFile);
   });
 
   it('does not reuse same-turn html files before checking recovered content', () => {

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -262,6 +262,19 @@ describe('terminal replay artifact recovery', () => {
     expect(findExistingNonHtmlArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
   });
 
+  it('reuses same-turn non-html artifact files with collision suffixes', () => {
+    const cssArtifact: Artifact = {
+      identifier: '',
+      artifactType: 'text/css',
+      title: 'Theme',
+      html: 'body { color: red; }',
+    };
+    const cssFile = projectFile('theme-2.css', 'code', 1_000);
+
+    expect(findExistingArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
+    expect(findExistingNonHtmlArtifactProjectFile(cssArtifact, [cssFile])).toBe(cssFile);
+  });
+
   it('does not reuse same-turn html files before checking recovered content', () => {
     const htmlArtifact: Artifact = {
       identifier: 'landing',

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -244,6 +244,28 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 - Models: ships `deepseek-v4-pro` and `deepseek-v4-flash` as fallback hints (1M-token context windows, native thinking-mode streaming). Users can paste any other id (e.g. `nvidia-nim/deepseek-v4-pro`, `fireworks/deepseek-v4-flash`) via the Settings dialog's custom-model input.
 - **Gotcha — auth state is not auto-detected.** DeepSeek TUI reads its API key from `~/.deepseek/config.toml` or `DEEPSEEK_API_KEY`. If the user hasn't run `deepseek auth set --provider deepseek` (or set the env var), the first run errors out with a non-actionable message. Detection currently only reports `available: true` based on the binary being on PATH; surface auth state via `deepseek doctor --json` in a follow-up.
 
+### 5.13 Plain stream artifact handoff
+
+Adapters with `streamFormat: 'plain'` do not expose structured file-write tool calls to the daemon. Their stdout is still a valid artifact handoff when the model emits Anthropic-style source blocks:
+
+```html
+<artifact identifier="landing-page" type="text/html" title="Landing page">
+<!doctype html>
+<html>...</html>
+</artifact>
+```
+
+At run completion, the daemon scans the captured plain stdout for `<artifact>` blocks with supported text types and writes them through the normal project artifact path:
+
+| Artifact type | Project file |
+|---|---|
+| `text/html` or `html` | `<identifier>.html` |
+| `text/css` or `css` | `<identifier>.css` |
+| `image/svg+xml` or `svg` | `<identifier>.svg` |
+| `text/markdown`, `text/x-markdown`, `markdown`, or `md` | `<identifier>.md` |
+
+The identifier is slugged before use, collisions receive `-2`, `-3`, etc., and outputs without a supported `<artifact>` block are left unchanged. This daemon-side extraction keeps headless runs and web-attached runs aligned: the project file exists even when no browser is present to parse the chat stream.
+
 ## 6. Capability-driven UI
 
 The web UI reads `agents.capabilities()` and disables features that the active adapter can't support:

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -32,6 +32,16 @@ export interface LiveArtifactRefreshSsePayload {
   error?: string;
 }
 
+export interface PlainStreamArtifactSsePayload {
+  type: 'artifact';
+  source: 'plain-stream';
+  files: Array<{
+    name: string;
+    identifier: string;
+    artifactType: string;
+  }>;
+}
+
 /**
  * Emitted by the daemon on `/api/projects/:id/events` when a new
  * conversation is inserted into a project from a path the open
@@ -86,6 +96,7 @@ export type DaemonAgentPayload =
   | { type: 'thinking_start' }
   | LiveArtifactSsePayload
   | LiveArtifactRefreshSsePayload
+  | PlainStreamArtifactSsePayload
   | { type: 'tool_use'; id: string; name: string; input: unknown }
   /**
    * Live-only incremental tool-input fragment, emitted while the model is still

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -35,11 +35,10 @@ export interface LiveArtifactRefreshSsePayload {
 export interface PlainStreamArtifactSsePayload {
   type: 'artifact';
   source: 'plain-stream';
-  files: Array<{
-    name: string;
-    identifier: string;
-    artifactType: string;
-  }>;
+  name: string;
+  path?: string;
+  identifier?: string;
+  artifactType?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #4255

## Why

I picked this up after claiming #4255 because plain-stream adapters such as Qwen can finish successfully while leaving the project with no artifact files. The model output contains the deliverable inside `<artifact>` tags, but only the browser-side chat parser saw it; headless runs and web-detached runs had no daemon-side handoff.

This closes that runtime gap so plain adapters that emit supported artifact blocks land real project files through the same project artifact write path. It also keeps no-tag plain output unchanged.

## What users will see

When a plain-stream agent emits an artifact block like `<artifact identifier="flowmind-landing" type="text/html">...</artifact>`, the run finishes with `flowmind-landing.html` in the project file tree. CSS, SVG, and Markdown artifact blocks are saved as `.css`, `.svg`, and `.md` respectively, with collision suffixes such as `-2` when needed.

Web-attached runs no longer duplicate daemon-written non-HTML artifacts during the browser fallback recovery path.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no new UI surface. The visible result is the existing project file tree showing files created by plain-stream artifact extraction.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/plain-stream.test.ts`
- Did the test go red on `main` and green on this branch? yes — the new daemon test failed before the parser module existed (`Cannot find module '../../src/runtimes/plain-stream.js'`) and now passes.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/plain-stream.test.ts` — 5 tests passed
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ProjectView.run-cleanup.test.tsx` — 29 tests passed
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

All validation commands exited 0. Local shell emitted the existing engine warning because this machine is on Node `v22.14.0` while the repo targets `~24`; full typecheck also showed existing landing-page Astro hints.
