### PR TITLE
fix(onboarding): surface unavailable-agent install cards in the Local CLI empty state (#4662)

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -182,6 +182,7 @@ import {
   type OptimisticProjectOwnershipWitnesses,
 } from '../collab/optimistic-project-ownership';
 import type { ModelCapabilityTag } from './modelCapabilityTags';
+import { UnavailableAgentGrid } from './UnavailableAgentGrid';
 import { LanguageMenu } from './LanguageMenu';
 import { IntegrationsView, type IntegrationTab } from './IntegrationsView';
 import { InlineModelSwitcher } from './InlineModelSwitcher';
@@ -208,7 +209,7 @@ import { defaultKnownProviderModel, KNOWN_PROVIDERS } from '../state/config';
 import type { KnownProvider } from '../state/config';
 import { testAgent, testApiProvider } from '../providers/connection-test';
 import { fetchProviderModels } from '../providers/provider-models';
-import { invalidateProjectFilesCache } from '../providers/registry';
+import { invalidateProjectFilesCache, openExternalUrl } from '../providers/registry';
 import {
   cancelVelaLogin,
   fetchVelaLoginStatus,
@@ -2178,6 +2179,19 @@ function OnboardingView({
   const candidateCliAgents = agents.filter(
     (agent) => agent.id !== 'amr' && (agent.available || deepSeekHarnessNeedsSetup(agent)),
   );
+  // The complement of the candidates, not simply `!agent.available`.
+  // `deepSeekHarnessNeedsSetup` requires `!agent.available`, so such an agent
+  // satisfies both predicates: it is a candidate (surfaced so the user can
+  // finish setup) and would also read as "not installed" here. Today that
+  // cannot produce two visible cards — the panel's empty state is gated on
+  // `visibleAgents.length === 0`, and a setup-pending agent is visible, so the
+  // unavailable grid does not render at all. It would still be the wrong list
+  // to be on: an install card for an agent that is already installed. Deriving
+  // this from candidateCliAgents keeps the two in step if either the predicate
+  // or that gate changes.
+  const unavailableCliAgents = agents.filter(
+    (agent) => agent.id !== 'amr' && !candidateCliAgents.includes(agent),
+  );
   const visibleAgents = candidateCliAgents.filter((agent) => visibleAgentIds.includes(agent.id));
   const amrSignedIn = isAmrSessionAuthenticated(amrStatus);
   const selectedAgent = visibleAgents.find((agent) => agent.id === config.agentId) ?? null;
@@ -3538,6 +3552,7 @@ function OnboardingView({
               {runtime === 'local' ? (
                 <OnboardingCliSetupPanel
                   agents={visibleAgents}
+                  unavailableAgents={unavailableCliAgents}
                   daemonLive={daemonLive}
                   selectedAgentId={config.agentId}
                   selectedAgent={selectedAgent}
@@ -3649,6 +3664,7 @@ function OnboardingView({
 
 function OnboardingCliSetupPanel({
   agents,
+  unavailableAgents,
   daemonLive,
   selectedAgentId,
   selectedAgent,
@@ -3663,6 +3679,7 @@ function OnboardingCliSetupPanel({
   onTest,
 }: {
   agents: AgentInfo[];
+  unavailableAgents: AgentInfo[];
   daemonLive: boolean;
   selectedAgentId: string | null;
   selectedAgent: AgentInfo | null;
@@ -3747,6 +3764,14 @@ function OnboardingCliSetupPanel({
       {showEmpty ? (
         <div className="onboarding-view__empty-slice">
           {t('settings.noAgentsDetected')}
+          {unavailableAgents.length > 0 ? (
+            <UnavailableAgentGrid
+              agents={unavailableAgents}
+              onInstallIntent={() => {}}
+              onRescan={onRefresh}
+              onOpenFixUrl={(url) => void openExternalUrl(url)}
+            />
+          ) : null}
         </div>
       ) : null}
       {selectedAgent && modelOptions.length > 0 ? (

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -44,6 +44,7 @@ import type { Dict } from '../i18n/types';
 import { AgentIcon } from './AgentIcon';
 import { AgentDiagnosticRow } from './AgentDiagnosticRow';
 import { DeepSeekHarnessSetupDialog } from './DeepSeekHarnessSetupDialog';
+import { UnavailableAgentGrid } from './UnavailableAgentGrid';
 import { AmrLoginPill } from './AmrLoginPill';
 import { PlanBadge } from './PlanBadge';
 import { orderAgentsWithOpenDesignFirst } from './agentOrdering';
@@ -5126,98 +5127,18 @@ export function SettingsDialog({
                           })}
                         </span>
                       </summary>
-                      <div className="agent-grid agent-grid-unavailable">
-                        {unavailableAgents.map((a) => {
-                          const installUrl = sanitizeHttpsUrl(a.installUrl);
-                          const docsUrl = sanitizeHttpsUrl(a.docsUrl);
-                          const description = AGENT_SHORT_DESCRIPTIONS[a.id];
-                          const agentName = displayAgentName(a);
-                          const diagnosticHandlers = diagnosticHandlersForAgent(a);
-                          const cardLabel = `${agentName} · ${t('common.notInstalled')}`;
-                          return (
-                            <div
-                              key={a.id}
-                              className="agent-card disabled agent-card-unavailable"
-                              role="group"
-                              aria-label={cardLabel}
-                            >
-                              <div className="agent-card-unavailable-row">
-                                <AgentIcon id={a.id} size={30} />
-                                <div className="agent-card-body">
-                                  <div className="agent-card-name">
-                                    {agentName}
-                                  </div>
-                                  {description ? (
-                                    <div className="agent-card-description">
-                                      {description}
-                                    </div>
-                                  ) : null}
-                                </div>
-                              </div>
-                              {/* Why is it unavailable? not-on-path vs a broken
-                                  shim vs a bad *_BIN override each get a
-                                  distinct, actionable line, full-width below the
-                                  logo/name. Rendered message-only: the fix
-                                  actions are hoisted into the shared footer bar
-                                  so every control lives on one row. */}
-                              {(a.diagnostics ?? []).map((diagnostic, i) => (
-                                <AgentDiagnosticRow
-                                  key={`${diagnostic.reason}-${i}`}
-                                  diagnostic={diagnostic}
-                                />
-                              ))}
-                              {/* Every action for the card collapses into one
-                                  horizontal bar at the foot, fenced from the
-                                  content above by a hair divider: Docs + Rescan
-                                  as quiet icon buttons, Install as the primary
-                                  labelled CTA holding the right edge. */}
-                              <div className="agent-card-footer">
-                                {docsUrl ? (
-                                  <a
-                                    href={docsUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="agent-card-link agent-card-link--muted agent-card-link--icon"
-                                    onClick={markAgentInstallIntent}
-                                    title={t('settings.agentInstall.docs')}
-                                    aria-label={t('settings.agentInstall.docs')}
-                                  >
-                                    <Icon name="file" size={15} />
-                                  </a>
-                                ) : null}
-                                <button
-                                  type="button"
-                                  className="agent-card-link agent-card-link--muted agent-card-link--icon"
-                                  onClick={() => diagnosticHandlers.onRescan?.()}
-                                  title={t('settings.rescan')}
-                                  aria-label={t('settings.rescan')}
-                                >
-                                  <Icon name="reload" size={15} />
-                                </button>
-                                {installUrl ? (
-                                  <a
-                                    href={installUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="agent-card-link agent-card-link--ghost"
-                                    onClick={(event) => {
-                                      markAgentInstallIntent();
-                                      if (a.id === 'amr') {
-                                        event.currentTarget.href = attributedAmrSettingsUrl(
-                                          installUrl,
-                                          'settings_amr_install',
-                                        );
-                                      }
-                                    }}
-                                  >
-                                    {t('settings.agentInstall.install')}
-                                  </a>
-                                ) : null}
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
+                      {/* No onOpenFixUrl: Settings keeps the plain
+                          target="_blank" anchors this section has always used.
+                          Only onboarding overrides them, because the packaged
+                          app needs links to leave its own window. */}
+                      <UnavailableAgentGrid
+                        agents={unavailableAgents}
+                        onInstallIntent={markAgentInstallIntent}
+                        onRescan={() => void handleRefreshAgents()}
+                        attributeAmrInstallUrl={(url) =>
+                          attributedAmrSettingsUrl(url, 'settings_amr_install')
+                        }
+                      />
                     </details>
                   ) : null}
                   {/*

--- a/apps/web/src/components/UnavailableAgentGrid.tsx
+++ b/apps/web/src/components/UnavailableAgentGrid.tsx
@@ -1,0 +1,186 @@
+import { useT } from '../i18n';
+import type { AgentInfo } from '../types';
+import { AgentIcon } from './AgentIcon';
+import { AgentDiagnosticRow } from './AgentDiagnosticRow';
+import { Icon } from './Icon';
+
+// Short, vendor-neutral one-liners shown under each unavailable agent's name.
+// Duplicated (rather than imported) from SettingsDialog to keep this shared
+// grid self-contained; the map is tiny and the host file follows the same
+// "local copy" convention for these labels.
+const AGENT_SHORT_DESCRIPTIONS: Record<string, string> = {
+  claude: 'Anthropic official CLI',
+  codex: 'OpenAI official CLI',
+  'cursor-agent': 'Cursor command line',
+  gemini: 'Google official CLI',
+  opencode: 'Open-source agent CLI',
+  qwen: 'Qwen coding CLI',
+  copilot: 'GitHub coding CLI',
+  devin: 'Cognition terminal CLI',
+  kimi: 'Moonshot Kimi CLI',
+  qoder: 'Alibaba coding CLI',
+  pi: 'Inflection chat CLI',
+  kiro: 'Kiro agent CLI',
+  kilo: 'Kilo Code CLI',
+  vibe: 'Mistral open-source CLI',
+  deepseek: 'DeepSeek terminal UI',
+  hermes: 'ACP agent CLI',
+  'grok-build': 'xAI coding CLI',
+  reasonix: 'DeepSeek native coding CLI',
+};
+
+function sanitizeHttpsUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' ? parsed.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function displayAgentName(agent: Pick<AgentInfo, 'id' | 'name'>): string {
+  return agent.id === 'amr' ? 'Open Design AMR' : agent.name;
+}
+
+export interface UnavailableAgentGridProps {
+  /** The unavailable agents to render as install cards. */
+  agents: AgentInfo[];
+  /**
+   * Called whenever the user clicks an Install/Docs affordance (inline link or
+   * diagnostic fix button). The Settings host uses this to arm a rescan for
+   * when the user returns to the app after installing; onboarding may pass a
+   * no-op.
+   */
+  onInstallIntent: () => void;
+  /** Re-run agent detection (the "Rescan" affordance in the card footer). */
+  onRescan: () => void;
+  /**
+   * Open a fix URL (docs or install) instead of letting the anchor navigate.
+   * Onboarding wires this to `openExternalUrl` so links leave the packaged
+   * app's window; Settings omits it and keeps plain `target="_blank"` anchors.
+   */
+  onOpenFixUrl?: (url: string, agent: AgentInfo, kind: 'docs' | 'install') => void;
+  /**
+   * Rewrite the inline Install anchor's href for the AMR agent so the handoff
+   * carries Settings attribution. Only the Settings host passes this; onboarding
+   * never renders AMR here, so it can omit it.
+   */
+  attributeAmrInstallUrl?: (url: string) => string;
+}
+
+/**
+ * The inner grid of "not installed" agent cards (icon + name + short
+ * description + Docs/Install links + per-diagnostic fix rows). Extracted from
+ * SettingsDialog so the onboarding empty-state can surface the same install
+ * affordances instead of a bare "no agents detected" sentence (issue #4662).
+ *
+ * Renders only the grid — callers wrap it (e.g. Settings keeps its
+ * `<details>` collapse) however they like.
+ */
+export function UnavailableAgentGrid({
+  agents,
+  onInstallIntent,
+  onRescan,
+  onOpenFixUrl,
+  attributeAmrInstallUrl,
+}: UnavailableAgentGridProps) {
+  const t = useT();
+  return (
+    <div className="agent-grid agent-grid-unavailable">
+      {agents.map((a) => {
+        const installUrl = sanitizeHttpsUrl(a.installUrl);
+        const docsUrl = sanitizeHttpsUrl(a.docsUrl);
+        const description = AGENT_SHORT_DESCRIPTIONS[a.id];
+        const agentName = displayAgentName(a);
+        const cardLabel = `${agentName} · ${t('common.notInstalled')}`;
+        return (
+          <div
+            key={a.id}
+            className="agent-card disabled agent-card-unavailable"
+            role="group"
+            aria-label={cardLabel}
+          >
+            <div className="agent-card-unavailable-row">
+              <AgentIcon id={a.id} size={30} />
+              <div className="agent-card-body">
+                <div className="agent-card-name">{agentName}</div>
+                {description ? (
+                  <div className="agent-card-description">{description}</div>
+                ) : null}
+              </div>
+            </div>
+            {/* Why is it unavailable? not-on-path vs a broken shim vs a bad
+                *_BIN override each get a distinct, actionable line, full-width
+                below the logo/name. Rendered message-only: the fix actions are
+                hoisted into the shared footer bar so every control lives on one
+                row. */}
+            {(a.diagnostics ?? []).map((diagnostic, i) => (
+              <AgentDiagnosticRow
+                key={`${diagnostic.reason}-${i}`}
+                diagnostic={diagnostic}
+              />
+            ))}
+            {/* Every action for the card collapses into one horizontal bar at
+                the foot, fenced from the content above by a hair divider: Docs
+                + Rescan as quiet icon buttons, Install as the primary labelled
+                CTA holding the right edge. */}
+            <div className="agent-card-footer">
+              {docsUrl ? (
+                <a
+                  href={docsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="agent-card-link agent-card-link--muted agent-card-link--icon"
+                  onClick={(event) => {
+                    onInstallIntent();
+                    if (onOpenFixUrl) {
+                      event.preventDefault();
+                      onOpenFixUrl(docsUrl, a, 'docs');
+                    }
+                  }}
+                  title={t('settings.agentInstall.docs')}
+                  aria-label={t('settings.agentInstall.docs')}
+                >
+                  <Icon name="file" size={15} />
+                </a>
+              ) : null}
+              <button
+                type="button"
+                className="agent-card-link agent-card-link--muted agent-card-link--icon"
+                onClick={() => onRescan()}
+                title={t('settings.rescan')}
+                aria-label={t('settings.rescan')}
+              >
+                <Icon name="reload" size={15} />
+              </button>
+              {installUrl ? (
+                <a
+                  href={installUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="agent-card-link agent-card-link--ghost"
+                  onClick={(event) => {
+                    onInstallIntent();
+                    const target =
+                      a.id === 'amr' && attributeAmrInstallUrl
+                        ? attributeAmrInstallUrl(installUrl)
+                        : installUrl;
+                    if (onOpenFixUrl) {
+                      event.preventDefault();
+                      onOpenFixUrl(target, a, 'install');
+                    } else if (target !== installUrl) {
+                      event.currentTarget.href = target;
+                    }
+                  }}
+                >
+                  {t('settings.agentInstall.install')}
+                </a>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/tests/components/EntryShell.onboarding-unavailable-agents.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding-unavailable-agents.test.tsx
@@ -1,0 +1,337 @@
+// @vitest-environment jsdom
+//
+// Regression test for issue #4662: when the onboarding "Local CLI" step
+// detects zero usable local coding agents, it must surface the same
+// unavailable-agent install cards (Install/Docs links + diagnostics) that
+// Settings shows — not just the bare `settings.noAgentsDetected` sentence.
+
+import { useState } from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryShell } from '../../src/components/EntryShell';
+import { I18nProvider } from '../../src/i18n';
+import type { AgentInfo, AppConfig } from '../../src/types';
+
+const analyticsMocks = vi.hoisted(() => ({
+  track: vi.fn(),
+}));
+
+// Onboarding wires the grid's diagnostic fix-buttons to openExternalUrl (it has
+// no AMR attribution to apply). Spy on it so we can assert the Install fix-button
+// actually fires instead of resolving to a dead no-op (#4662 review follow-up).
+const registryMocks = vi.hoisted(() => ({
+  openExternalUrl: vi.fn(async () => true),
+}));
+
+vi.mock('../../src/providers/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/providers/registry')>();
+  return {
+    ...actual,
+    openExternalUrl: registryMocks.openExternalUrl,
+  };
+});
+
+vi.mock('../../src/analytics/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
+  return {
+    ...actual,
+    useAnalytics: () => ({
+      newRequestId: vi.fn(() => 'request-1'),
+      setConfigureGlobals: vi.fn(),
+      setConsent: vi.fn(),
+      setIdentity: vi.fn(),
+      track: analyticsMocks.track,
+    }),
+    useAppVersion: () => null,
+  };
+});
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// An unavailable CLI agent carrying install/docs URLs plus a typed diagnostic
+// with a rescan fix action — exactly the shape Settings renders as an install
+// card with a fix-button row.
+function unavailableCliAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    id: 'gemini',
+    name: 'Gemini CLI',
+    bin: 'gemini',
+    available: false,
+    installUrl: 'https://example.com/install-gemini',
+    docsUrl: 'https://example.com/docs-gemini',
+    diagnostics: [
+      {
+        reason: 'not-on-path',
+        severity: 'error',
+        message: 'Gemini CLI was not found on your PATH.',
+        fixActions: [{ kind: 'rescan' }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    mode: 'daemon',
+    agentId: null,
+    agentModels: {},
+    apiProtocol: 'anthropic',
+    apiProtocolConfigs: {},
+    apiKey: '',
+    baseUrl: '',
+    model: '',
+    ...overrides,
+  } as AppConfig;
+}
+
+function onboardingProps(
+  overrides: Partial<React.ComponentProps<typeof EntryShell>> = {},
+): React.ComponentProps<typeof EntryShell> {
+  return {
+    skills: [],
+    designTemplates: [],
+    designSystems: [],
+    projects: [],
+    templates: [],
+    promptTemplates: [],
+    defaultDesignSystemId: null,
+    connectors: [],
+    connectorsLoading: false,
+    config: baseConfig(),
+    agents: [unavailableCliAgent()],
+    daemonLive: true,
+    onModeChange: vi.fn(),
+    onAgentChange: vi.fn(),
+    onAgentModelChange: vi.fn(),
+    onApiProtocolChange: vi.fn(),
+    onApiModelChange: vi.fn(),
+    onConfigPersist: vi.fn(),
+    onRefreshAgents: vi.fn(() => [unavailableCliAgent()]),
+    onCreateProject: vi.fn(),
+    onCreatePluginShareProject: vi.fn(),
+    onImportClaudeDesign: vi.fn(),
+    onOpenProject: vi.fn(),
+    onOpenLiveArtifact: vi.fn(),
+    onDeleteProject: vi.fn(),
+    onRenameProject: vi.fn(),
+    onChangeDefaultDesignSystem: vi.fn(),
+    onPersistComposioKey: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onCompleteOnboarding: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderOnboarding(
+  overrides: Partial<React.ComponentProps<typeof EntryShell>> = {},
+) {
+  window.history.replaceState(null, '', '/onboarding');
+  const props = onboardingProps(overrides);
+
+  function Harness() {
+    const [config, setConfig] = useState(props.config);
+    return (
+      <I18nProvider initial="en">
+        <EntryShell
+          {...props}
+          config={config}
+          onConfigPersist={(next) => {
+            props.onConfigPersist(next);
+            setConfig(next as AppConfig);
+          }}
+        />
+      </I18nProvider>
+    );
+  }
+
+  render(<Harness />);
+  return props;
+}
+
+// Onboarding is two screens since #6475: a cloud identity step, then a
+// model-source radio group gated behind Continue. Both have to be walked
+// before the Local CLI setup panel this suite asserts on ever mounts.
+async function openLocalCliPanel(): Promise<void> {
+  const cloudContinue = await screen.findByRole('button', {
+    name: 'Continue (signed in)',
+  });
+  fireEvent.click(cloudContinue);
+  fireEvent.click(await screen.findByRole('radio', { name: /Local Agent/i }));
+  fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+}
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  vi.useRealTimers();
+  analyticsMocks.track.mockReset();
+  registryMocks.openExternalUrl.mockClear();
+  window.sessionStorage.clear();
+});
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+  analyticsMocks.track.mockReset();
+  registryMocks.openExternalUrl.mockClear();
+});
+
+describe('EntryShell onboarding Local CLI empty state', () => {
+  it('renders unavailable-agent install cards (Docs/Install links + diagnostic) when no usable agent is detected', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: true, profile: 'prod', user: null, configPath: '/x' }),
+    ) as typeof fetch;
+
+    renderOnboarding();
+
+    await openLocalCliPanel();
+
+    const localPanel = await waitFor(() => {
+      const panel = screen
+        .getByText('Local CLI')
+        .closest('.onboarding-view__setup-panel');
+      if (!(panel instanceof HTMLElement)) throw new Error('local panel not found');
+      // Wait until the scan has finished and the empty-state surfaced.
+      if (!panel.querySelector('.onboarding-view__empty-slice')) {
+        throw new Error('empty slice not rendered yet');
+      }
+      return panel;
+    });
+
+    // The intro sentence is still there...
+    expect(localPanel.textContent).toContain('No agents detected yet.');
+
+    // ...but the regression fix adds the unavailable-agent install grid:
+    // the card, its Install + Docs links, and the diagnostic message must render.
+    const grid = localPanel.querySelector('.agent-grid-unavailable');
+    expect(grid).toBeTruthy();
+
+    const installLink = localPanel.querySelector(
+      'a[href="https://example.com/install-gemini"]',
+    );
+    expect(installLink).toBeTruthy();
+    expect(installLink?.textContent).toContain('Install');
+
+    const docsLink = localPanel.querySelector(
+      'a[href="https://example.com/docs-gemini"]',
+    );
+    expect(docsLink).toBeTruthy();
+
+    // The per-diagnostic actionable row is present.
+    expect(localPanel.textContent).toContain(
+      'Gemini CLI was not found on your PATH.',
+    );
+    expect(
+      localPanel.querySelector('[data-reason="not-on-path"]'),
+    ).toBeTruthy();
+  });
+
+  it('excludes the AMR agent from the onboarding install grid', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: true, profile: 'prod', user: null, configPath: '/x' }),
+    ) as typeof fetch;
+
+    const amr = unavailableCliAgent({
+      id: 'amr',
+      name: 'Open Design AMR',
+      installUrl: 'https://example.com/install-amr',
+      docsUrl: 'https://example.com/docs-amr',
+    });
+    const gemini = unavailableCliAgent();
+    renderOnboarding({ agents: [amr, gemini], onRefreshAgents: vi.fn(() => [amr, gemini]) });
+
+    await openLocalCliPanel();
+    const localPanel = await waitFor(() => {
+      const panel = screen.getByText('Local CLI').closest('.onboarding-view__setup-panel');
+      if (!(panel instanceof HTMLElement)) throw new Error('local panel not found');
+      if (!panel.querySelector('.agent-grid-unavailable')) {
+        throw new Error('grid not rendered yet');
+      }
+      return panel;
+    });
+
+    // A normal unavailable agent renders its install card...
+    expect(
+      localPanel.querySelector('a[href="https://example.com/install-gemini"]'),
+    ).toBeTruthy();
+    // ...but AMR is filtered out — onboarding has its own AMR connect flow.
+    expect(
+      localPanel.querySelector('a[href="https://example.com/install-amr"]'),
+    ).toBeNull();
+    expect(localPanel.textContent).not.toContain('Open Design AMR');
+  });
+
+  it('shows only the empty-state sentence (no grid) when there are no unavailable agents', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: true, profile: 'prod', user: null, configPath: '/x' }),
+    ) as typeof fetch;
+
+    renderOnboarding({ agents: [], onRefreshAgents: vi.fn(() => []) });
+
+    await openLocalCliPanel();
+    const localPanel = await waitFor(() => {
+      const panel = screen.getByText('Local CLI').closest('.onboarding-view__setup-panel');
+      if (!(panel instanceof HTMLElement)) throw new Error('local panel not found');
+      if (!panel.querySelector('.onboarding-view__empty-slice')) {
+        throw new Error('empty slice not rendered yet');
+      }
+      return panel;
+    });
+
+    expect(localPanel.textContent).toContain('No agents detected yet.');
+    expect(localPanel.querySelector('.agent-grid-unavailable')).toBeNull();
+  });
+
+  it('routes the card-footer Install link through openExternalUrl', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: true, profile: 'prod', user: null, configPath: '/x' }),
+    ) as typeof fetch;
+
+    // Onboarding runs inside the packaged app, where letting the anchor
+    // navigate would replace the app's own window. The card footer's Install
+    // link must hand off to openExternalUrl instead — the affordance this
+    // whole empty state exists to provide.
+    const gemini = unavailableCliAgent({
+      diagnostics: [
+        {
+          reason: 'not-on-path',
+          severity: 'error',
+          message: 'Gemini CLI was not found on your PATH.',
+          fixActions: [{ kind: 'openInstall' }],
+        },
+      ],
+    });
+    renderOnboarding({ agents: [gemini], onRefreshAgents: vi.fn(() => [gemini]) });
+
+    await openLocalCliPanel();
+    const localPanel = await waitFor(() => {
+      const panel = screen.getByText('Local CLI').closest('.onboarding-view__setup-panel');
+      if (!(panel instanceof HTMLElement)) throw new Error('local panel not found');
+      if (!panel.querySelector('.agent-card-footer .agent-card-link--ghost')) {
+        throw new Error('install link not rendered yet');
+      }
+      return panel;
+    });
+
+    // The diagnostic itself is message-only in this layout; every action lives
+    // in the footer bar.
+    expect(localPanel.querySelector('[data-reason="not-on-path"] button')).toBeNull();
+
+    const installLink = localPanel.querySelector(
+      '.agent-card-footer .agent-card-link--ghost',
+    );
+    expect(installLink).toBeTruthy();
+    fireEvent.click(installLink as HTMLElement);
+    expect(registryMocks.openExternalUrl).toHaveBeenCalledWith(
+      'https://example.com/install-gemini',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #4662

## Why

Onboarding → Local coding agent is one of the first screens a new user hits. When no usable local CLI agent is detected, the empty state showed only a flat "No agents detected yet…" sentence + a Rescan button — a dead end at the exact moment the user most needs install guidance. Settings → Local CLI already renders rich per-agent install cards (Install/Docs links + diagnostics), so onboarding was strictly worse than Settings for the same situation. This surfaces the same cards in onboarding so the empty state becomes actionable.

(Filed by QA during #4632; the maintainer confirmed it's current behavior — not a fixture artifact — and suggested the shared-component approach.)

## What users will see

In onboarding → Local coding agent, when no usable agent is detected, the empty state now shows the same unavailable-agent install cards as Settings: each supported CLI's icon + name + short description, Install / Docs links, and per-agent diagnostics (e.g. "… was not found on your PATH" with a fix action). The "No agents detected yet" sentence stays as the intro. **Settings is unchanged.**

## Surface area

- [x] **UI** — onboarding Local CLI empty state now renders the unavailable-agent install-card grid

(No new deps, API/contract, or i18n keys — reuses the existing Settings card markup + translation keys.)

## Screenshots

**Before** — bare empty state (reporter's capture in the issue):

![before](https://github.com/user-attachments/assets/fecf137a-596d-4ae1-b96b-c2b124798e42)

**After** — onboarding empty state now surfaces the install cards:

<img width="1280" height="800" alt="pr4662-after" src="https://github.com/user-attachments/assets/35f612e6-cefc-496e-b18d-0bd81e8e7ffb" />

## Bug fix verification

- **Test path:** `apps/web/tests/components/EntryShell.onboarding-unavailable-agents.test.tsx`
- **Red on base / green on branch: yes.** The primary test fails at `expect(grid).toBeTruthy()` (the `.agent-grid-unavailable` grid is absent) against the pre-fix bare empty state, and passes with the fix. A second test — `wires the diagnostic Install fix-button to openExternalUrl` — was also confirmed red without the onboarding `onOpenFixUrl` wiring, then green with it.
- Also covered: AMR is excluded from the onboarding grid; the no-unavailable-agents case renders only the sentence (no grid).

## Validation

- Implementation: extracted the unavailable-agent install-card grid (previously inline in `SettingsDialog.tsx`) into a shared `UnavailableAgentGrid` component, reused in both Settings and onboarding (the maintainer-preferred "option 2"). Settings behavior is preserved byte-for-byte — the AMR-attribution / external-open handlers are passed in as props; onboarding excludes AMR (it has its own connect flow) and wires the diagnostic fix-buttons to `openExternalUrl`.
- `pnpm typecheck` (all packages): **clean (exit 0)**
- `pnpm --filter @open-design/web test`: **344 files / 3436 passed, 1 skipped, 0 failed**