### PR TITLE
fix(amr): extend ACP stage timeout

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -22,7 +22,7 @@ const MAX_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // mirroring the outer chat watchdog's escape-hatch semantics — without this,
 // `OD_ACP_STAGE_TIMEOUT_MS=0` would call `setTimeout(..., 0)` and fail every
 // ACP session on the next tick instead of disabling the watchdog.
-const DEFAULT_STAGE_TIMEOUT_MS = 600_000;
+const DEFAULT_STAGE_TIMEOUT_MS = 30 * 60 * 1000;
 const ACP_ARTIFACT_OPEN_PATTERN = String.raw`<\s*(?:\|?\s*DSML[\s,]+artifact\b|artifact\b)`;
 const ACP_GENERATED_FILE_PREFIX_PATTERN =
   String.raw`(?:here\s+is|here'?s)\s+the\s+generated\s+file\s*:?\s*(?:\r?\n|\s)*`;

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -22,7 +22,7 @@ const MAX_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // mirroring the outer chat watchdog's escape-hatch semantics — without this,
 // `OD_ACP_STAGE_TIMEOUT_MS=0` would call `setTimeout(..., 0)` and fail every
 // ACP session on the next tick instead of disabling the watchdog.
-const DEFAULT_STAGE_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_STAGE_TIMEOUT_MS = 10 * 60 * 1000;
 const ACP_ARTIFACT_OPEN_PATTERN = String.raw`<\s*(?:\|?\s*DSML[\s,]+artifact\b|artifact\b)`;
 const ACP_GENERATED_FILE_PREFIX_PATTERN =
   String.raw`(?:here\s+is|here'?s)\s+the\s+generated\s+file\s*:?\s*(?:\r?\n|\s)*`;

--- a/apps/daemon/src/runtimes/chat-run-lifecycle.ts
+++ b/apps/daemon/src/runtimes/chat-run-lifecycle.ts
@@ -114,10 +114,16 @@ export function resolveChatRunShutdownGraceMs() {
   return Math.max(0, Math.floor(raw));
 }
 
-export function resolveAcpStageTimeoutMs(): number | undefined {
+export function resolveAcpStageTimeoutMs(agentDefault?: number): number | undefined {
+  assertValidRuntimeDefInactivityTimeoutMs(agentDefault);
   const raw = Number(process.env.OD_ACP_STAGE_TIMEOUT_MS);
-  if (!Number.isFinite(raw)) return undefined;
-  return Math.min(MAX_CHAT_RUN_INACTIVITY_TIMEOUT_MS, Math.max(0, Math.floor(raw)));
+  if (Number.isFinite(raw)) {
+    return Math.min(MAX_CHAT_RUN_INACTIVITY_TIMEOUT_MS, Math.max(0, Math.floor(raw)));
+  }
+  if (agentDefault !== undefined) {
+    return Math.min(MAX_CHAT_RUN_INACTIVITY_TIMEOUT_MS, agentDefault);
+  }
+  return undefined;
 }
 
 type GeminiJsonEventStreamEvent = Record<string, unknown>;

--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -281,4 +281,8 @@ export const amrAgentDef = {
   // selection comes from the live `vela models` catalog and is preflighted
   // before spawn.
   defaultModelEnvVar: 'VELA_DEFAULT_MODEL',
+  // Vela/OpenCode can spend extended stretches silent while the upstream
+  // provider is still working. Keep the outer chat watchdog aligned with the
+  // 30-minute ACP stage timeout so the daemon does not fail the run first.
+  inactivityTimeoutMs: 30 * 60 * 1000,
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -116,6 +116,7 @@ export {
   bufferedAntigravityGeminiFirstTokenAt,
   classifyChatRunCloseStatus,
   looksLikeGeminiJsonEventStream,
+  resolveAcpStageTimeoutMs,
   resolveActiveInactivityTimeoutMs,
   resolveChatRunArtifactQuietPeriodMs,
   resolveChatRunInactivityTimeoutMs,
@@ -7764,7 +7765,7 @@ export async function startServer({
         uploadRoot: UPLOAD_DIR,
       });
     } else if (def.streamFormat === 'acp-json-rpc') {
-      const acpStageTimeoutMs = resolveAcpStageTimeoutMs();
+      const acpStageTimeoutMs = resolveAcpStageTimeoutMs(def.inactivityTimeoutMs);
       acpSession = attachAcpSession({
         child,
         prompt: composed,

--- a/apps/daemon/tests/runtimes/chat-run-inactivity-timeout.test.ts
+++ b/apps/daemon/tests/runtimes/chat-run-inactivity-timeout.test.ts
@@ -20,6 +20,7 @@ import {
   assertValidRuntimeDefInactivityTimeoutMs,
   resolveChatRunInactivityTimeoutMs,
 } from '../../src/server.js';
+import { amrAgentDef } from '../../src/runtimes/defs/amr.js';
 import { copilotAgentDef } from '../../src/runtimes/defs/copilot.js';
 
 const ENV_KEY = 'OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS';
@@ -141,6 +142,12 @@ describe('resolveChatRunInactivityTimeoutMs', () => {
 describe('copilotAgentDef.inactivityTimeoutMs', () => {
   it('ships a 30-minute inactivity hint so Copilot silent-thinking phases do not trip the default watchdog (#2467)', () => {
     expect(copilotAgentDef.inactivityTimeoutMs).toBe(THIRTY_MINUTES_MS);
+  });
+});
+
+describe('amrAgentDef.inactivityTimeoutMs', () => {
+  it('ships a 30-minute inactivity hint so the outer chat watchdog matches ACP stage timeouts for slow upstream providers', () => {
+    expect(amrAgentDef.inactivityTimeoutMs).toBe(THIRTY_MINUTES_MS);
   });
 });
 

--- a/apps/daemon/tests/runtimes/chat-run-inactivity-timeout.test.ts
+++ b/apps/daemon/tests/runtimes/chat-run-inactivity-timeout.test.ts
@@ -18,6 +18,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   assertValidRuntimeDefInactivityTimeoutMs,
+  resolveAcpStageTimeoutMs,
   resolveChatRunInactivityTimeoutMs,
 } from '../../src/server.js';
 import { amrAgentDef } from '../../src/runtimes/defs/amr.js';
@@ -136,6 +137,40 @@ describe('resolveChatRunInactivityTimeoutMs', () => {
     // wins when both are valid.
     process.env[ENV_KEY] = '15000';
     expect(resolveChatRunInactivityTimeoutMs(THIRTY_MINUTES_MS)).toBe(15_000);
+  });
+});
+
+describe('resolveAcpStageTimeoutMs', () => {
+  const originalEnv = process.env.OD_ACP_STAGE_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OD_ACP_STAGE_TIMEOUT_MS;
+    } else {
+      process.env.OD_ACP_STAGE_TIMEOUT_MS = originalEnv;
+    }
+  });
+
+  it('leaves the ACP session default untouched when no env override or def hint is set', () => {
+    delete process.env.OD_ACP_STAGE_TIMEOUT_MS;
+    expect(resolveAcpStageTimeoutMs()).toBeUndefined();
+  });
+
+  it('uses the runtime inactivity hint when the ACP env override is unset', () => {
+    delete process.env.OD_ACP_STAGE_TIMEOUT_MS;
+    expect(resolveAcpStageTimeoutMs(THIRTY_MINUTES_MS)).toBe(THIRTY_MINUTES_MS);
+  });
+
+  it('lets the ACP env override take precedence over the runtime inactivity hint', () => {
+    process.env.OD_ACP_STAGE_TIMEOUT_MS = '900000';
+    expect(resolveAcpStageTimeoutMs(THIRTY_MINUTES_MS)).toBe(900_000);
+  });
+
+  it('throws on an invalid runtime inactivity hint so ACP and chat watchdog config cannot drift silently', () => {
+    delete process.env.OD_ACP_STAGE_TIMEOUT_MS;
+    expect(() => resolveAcpStageTimeoutMs(Number.NaN)).toThrow(
+      /RuntimeAgentDef\.inactivityTimeoutMs/,
+    );
   });
 });
 


### PR DESCRIPTION
## Why

AMR runs can legitimately spend more than 10 minutes waiting on a slow upstream model/provider without emitting ACP stdout. The previous default ACP stage watchdog ended those runs with `ACP response timed out after 600000ms` before Vela/OpenCode's own 30-minute prompt timeout could apply.

## What users will see

AMR runs now tolerate up to 30 minutes of ACP-stage silence by default before timing out, reducing premature failures for slow model responses.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: no new red spec; this is a default threshold adjustment based on a production AMR timeout diagnostic. Existing timeout env coverage verifies the ACP timeout override path.
- Did the test go red on `main` and green on this branch? no

## Validation

- `git diff --check`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp-timeout-env.test.ts`