### PR TITLE
[codex] Fix stale Claude session resume retry

### DIFF
--- a/apps/daemon/src/agent-resume-failure.ts
+++ b/apps/daemon/src/agent-resume-failure.ts
@@ -1,0 +1,15 @@
+// Signatures Claude Code prints to stderr when a `--resume <id>` target no
+// longer exists on disk (session pruned, repo moved machines, ~/.claude
+// cleared). Keep this helper pure so runtime recovery and analytics
+// classification can both use the same matcher without pulling in DB state.
+const CLAUDE_RESUME_FAILURE_PATTERNS: RegExp[] = [
+  /no conversation found with session id/i,
+  /no session found/i,
+  /session .* not found/i,
+];
+
+/** True when CLI output indicates a resume target session is missing. */
+export function isClaudeResumeFailure(text: string): boolean {
+  if (!text) return false;
+  return CLAUDE_RESUME_FAILURE_PATTERNS.some((re) => re.test(text));
+}

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -7,6 +7,7 @@ import {
   getAgentSessionRecord,
   upsertAgentSession,
 } from './db.js';
+export { isClaudeResumeFailure } from './agent-resume-failure.js';
 
 type SqliteDb = Database.Database;
 
@@ -74,17 +75,6 @@ export function persistCapturedAgentSession(
   return 'cleared';
 }
 
-// Signatures Claude Code prints to stderr when a `--resume <id>` target no
-// longer exists on disk (session pruned, repo moved machines, ~/.claude
-// cleared). VERIFY against the installed CLI during implementation and add
-// the exact observed string to a mocks/ fixture — these patterns are the
-// planning-time best guess, intentionally permissive.
-const CLAUDE_RESUME_FAILURE_PATTERNS: RegExp[] = [
-  /no conversation found with session id/i,
-  /no session found/i,
-  /session .* not found/i,
-];
-
 /** sha256 hex digest of the composed stable instruction block. */
 export function hashStableInstructions(stable: string): string {
   return createHash('sha256').update(stable, 'utf8').digest('hex');
@@ -104,10 +94,4 @@ export function computeIncludeStable(
   currentStableHash: string,
 ): boolean {
   return !isResuming || storedStableHash !== currentStableHash;
-}
-
-/** True when CLI output indicates a resume target session is missing. */
-export function isClaudeResumeFailure(text: string): boolean {
-  if (!text) return false;
-  return CLAUDE_RESUME_FAILURE_PATTERNS.some((re) => re.test(text));
 }

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -5,6 +5,7 @@ import type {
   TrackingRunFailureUserAction,
 } from '@open-design/contracts/analytics';
 
+import { isClaudeResumeFailure } from './agent-resume-failure.js';
 import { classifyAmrAccountFailure } from './integrations/vela-errors.js';
 import { classifyAgentServiceFailure } from './runtimes/auth.js';
 import type { RunResult, RunStatusForAnalytics } from './run-result.js';
@@ -303,6 +304,7 @@ function processExitDetail(
   if (/\bstdin: write EOF\b/i.test(text)) return 'stdin_write_eof';
   if (isAgentConfigInvalidText(text)) return 'agent_config_invalid';
   if (isFabricatedRoleMarkerText(text)) return 'fabricated_role_marker';
+  if (isClaudeResumeFailure(text)) return 'session_resume_missing';
   if (/\bjson-rpc id \d+: Internal error\b/i.test(text)) {
     return 'agent_protocol_error';
   }
@@ -529,6 +531,16 @@ export function classifyRunFailure(
       'child_close',
       retryable,
       retryable ? 'retry' : 'none',
+    );
+  }
+
+  if (isClaudeResumeFailure(text)) {
+    return classification(
+      'process_exit',
+      'session_resume_missing',
+      'session_init',
+      retryableHint ?? true,
+      'retry',
     );
   }
 

--- a/apps/daemon/src/run-retry-policy.ts
+++ b/apps/daemon/src/run-retry-policy.ts
@@ -73,6 +73,9 @@ function isTransientRetryCategory(
   if (category === 'upstream_unavailable') return true;
   if (category === 'empty_output') return stage === undefined || stage === 'first_token_wait';
   if (category === 'timeout') return stage === 'first_token_wait';
+  if (category === 'process_exit' && detail === 'session_resume_missing') {
+    return stage === undefined || stage === 'session_init';
+  }
   return false;
 }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12344,15 +12344,15 @@ export async function startServer({
       ) {
         // The stored session id no longer resolves (pruned / machine moved
         // / ~/.claude cleared). Drop it so the next turn starts a fresh
-        // session seeded with the full transcript, and surface a retryable
-        // error rather than a confusing hard failure.
+        // session seeded with the full transcript. Route through the shared
+        // retry finalizer so the same run can recover once automatically.
         clearAgentSession(db, run.conversationId, def.id);
         send('error', createSseErrorPayload(
           'AGENT_EXECUTION_FAILED',
-          'The previous Claude session could not be resumed (it may have expired). Resend your message to continue with a fresh session.',
+          'The previous Claude session could not be resumed (it may have expired). Retrying with a fresh session.',
           { retryable: true },
         ));
-        return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+        return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
       }
       // Empty-output guard: a clean `code === 0` exit with no visible
       // output means the run silently finished without producing anything.

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -571,6 +571,21 @@ describe('classifyRunFailure', () => {
     });
   });
 
+  it('maps missing Claude resume sessions to a retryable session-init detail', () => {
+    expect(
+      classify(
+        'AGENT_EXECUTION_FAILED',
+        'Error: No conversation found with session ID: 98c0bf52-be6d-4c7f-b91d-570436ab09f1',
+      ),
+    ).toMatchObject({
+      failure_category: 'process_exit',
+      failure_detail: 'session_resume_missing',
+      failure_stage: 'session_init',
+      retryable: true,
+      user_action: 'retry',
+    });
+  });
+
   it('adds process-exit details for spawn and protocol failures', () => {
     expect(classify('AGENT_EXECUTION_FAILED', 'spawn failed: spawn ENOEXEC')).toMatchObject({
       failure_category: 'process_exit',

--- a/apps/daemon/tests/run-retry-policy.test.ts
+++ b/apps/daemon/tests/run-retry-policy.test.ts
@@ -188,6 +188,23 @@ describe('decideSafeRunRetry', () => {
     });
   });
 
+  it('allows a stale resume session to retry once before any side effects', () => {
+    expect(
+      decide({
+        failure: {
+          failure_category: 'process_exit',
+          failure_detail: 'session_resume_missing',
+          failure_stage: 'session_init',
+          retryable: true,
+        },
+      }),
+    ).toMatchObject({
+      shouldRetry: true,
+      retryAttemptIndex: 1,
+      retryReason: 'transient_failure',
+    });
+  });
+
   it('never auto-retries process kills, crashes, or interruptions', () => {
     for (const failure_detail of [
       'signal_killed',

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -279,6 +279,7 @@ export type TrackingRunFailureDetail =
   | 'fabricated_role_marker'
   | 'permission_request_not_found'
   | 'qoder_stop_sequence'
+  | 'session_resume_missing'
   | 'signal_killed'
   | 'process_crashed'
   | 'interrupted'


### PR DESCRIPTION
## Why

Claude resume failures can be reported as missing-session failures, but the retry path did not classify that stale resume condition clearly enough to trigger the intended retry behavior.

## What users will see

Runs that hit a stale Claude resume session can be classified and retried more accurately instead of surfacing as an unrecoverable generic execution failure.

## Surface area

- Adds a shared Claude resume failure helper.
- Updates run failure classification and retry policy handling.
- Wires the server path to use the helper.
- Extends daemon tests for classification and retry policy coverage.

## Screenshots

Not applicable.

## Bug fix verification

Not run locally.

## Validation

Not run locally; branch was inspected against `main` before opening the PR.
