### PR TITLE
chore: improve CSS (spacing, focus-ring, mobile fixes, safe-area, red…

### DIFF
--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -1,6 +1,13 @@
 * { box-sizing: border-box; }
 
-html, body, #root { height: 100%; margin: 0; }
+html {
+  height: 100%;
+  margin: 0;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body, #root { height: 100%; margin: 0; }
 
 body {
   font-family: var(--sans);
@@ -10,6 +17,19 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 .od-loading-shell {

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -14,7 +14,7 @@
   height: 38px;
   position: sticky;
   top: 0;
-  z-index: 4;
+  z-index: var(--z-sticky);
 }
 .chat-project-back {
   width: 28px;
@@ -1053,12 +1053,13 @@
 
 .composer {
   padding: 10px 16px;
+  padding-bottom: calc(10px + env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
   gap: 8px;
   background: transparent;
   position: relative;
-  z-index: 1;
+  z-index: var(--z-base);
 }
 .split:has(.session-mode-toggle__popover),
 .split-chat-slot:has(.session-mode-toggle__popover),
@@ -1074,7 +1075,7 @@
 .composer:has(.composer-tools-menu),
 .composer:has(.composer-design-toolbox-menu),
 .composer:has(.composer-import-menu) {
-  z-index: 80;
+  z-index: var(--z-popover);
 }
 .chat-composer-slot {
   flex: 0 0 auto;
@@ -1512,7 +1513,7 @@
   position: absolute;
   bottom: calc(100% + 6px);
   left: 0;
-  z-index: 1502;
+  z-index: var(--z-compose);
   display: flex;
   width: max-content;
   max-width: calc(100vw - 32px);
@@ -2220,7 +2221,7 @@
 .staged-preview-modal {
   position: fixed;
   inset: 0;
-  z-index: 1200;
+  z-index: var(--z-modal);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2420,4 +2421,22 @@
   white-space: nowrap;
   max-width: 106px;
   line-height: 12px;
+}
+
+/* Mobile: reduz padding horizontal do log e do composer em viewports estreitos.
+   padding-inline não toca padding-top/bottom nem o safe-area do composer. */
+@media (max-width: 599px) {
+  .chat-log  { padding-inline: 12px; }
+  .composer  { padding-inline: 10px; }
+}
+
+/* Reduced-motion: animações de loop infinito (.chat-loading-dot,
+   .chat-loading-sheen) não são cobertas de forma adequada pelo guard global
+   de animation-duration; interromper com animation:none é o tratamento correto
+   para vestibular disorder. Segue padrão já presente para .msg e .run-error. */
+@media (prefers-reduced-motion: reduce) {
+  .chat-loading-state,
+  .chat-loading-mark span,
+  .chat-loading-lines span,
+  .composer-toolbox-standalone-popup { animation: none; }
 }

--- a/apps/web/src/styles/primitives.css
+++ b/apps/web/src/styles/primitives.css
@@ -10,7 +10,7 @@ button {
   transition: background var(--dur-quick) var(--ease-out), border-color var(--dur-quick) var(--ease-out), color var(--dur-quick) var(--ease-out), box-shadow var(--dur-quick) var(--ease-out);
 }
 button:hover:not(:disabled) { background: var(--bg-subtle); border-color: var(--border-strong); }
-button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+button:focus-visible { outline: 2px solid var(--focus-ring-color-cta); outline-offset: var(--focus-ring-offset); }
 
 button.primary {
   display: inline-flex;
@@ -108,7 +108,7 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 4000;
+  z-index: var(--z-tooltip);
   max-width: min(260px, calc(100vw - 16px));
   padding: 5px 8px;
   border: 1px solid var(--border-strong);
@@ -242,7 +242,7 @@ textarea { resize: vertical; font-family: inherit; }
   white-space: nowrap;
 }
 .od-select-menu {
-  z-index: 9000;
+  z-index: var(--z-select);
   padding: 4px;
   overflow-y: auto;
   overflow-x: hidden;
@@ -326,4 +326,18 @@ code {
   border-radius: var(--radius-xs);
   font-size: 0.92em;
   color: var(--text);
+}
+
+/* iOS: prevent font-size zoom on input focus (requires >= 16px). Only on touch
+   devices; desktop is unaffected. */
+@media (hover: none) and (pointer: coarse) {
+  input, textarea, select, .od-select-trigger { font-size: 16px; }
+}
+
+/* Touch targets: WCAG 2.5.5 recommends 44×44px minimum. Current elements sit
+   around 32–36px. min-height only — no padding change, desktop unaffected. */
+@media (hover: none) and (pointer: coarse) {
+  button, input, select, .od-select-trigger { min-height: 44px; }
+  button.icon-btn { min-height: 44px; min-width: 44px; }
+  .od-select-option { min-height: 44px; }
 }

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -9,6 +9,8 @@
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto 1fr;
   height: 100vh;
+  height: 100dvh;
+  padding-bottom: env(safe-area-inset-bottom);
   background: var(--bg-app);
   overflow: hidden;
 }
@@ -21,6 +23,8 @@
   width: 100vw;
   max-width: 100vw;
   height: 100vh;
+  height: 100dvh;
+  padding-bottom: env(safe-area-inset-bottom);
   min-width: 0;
   min-height: 0;
   display: grid;
@@ -62,7 +66,7 @@
   -webkit-app-region: drag;
   overflow: hidden;
   position: relative;
-  z-index: 120;
+  z-index: var(--z-chrome);
 }
 .workspace-tabs-chrome.app-chrome-header::after {
   content: '';
@@ -142,7 +146,7 @@
   gap: 0;
   padding-left: 0;
   position: relative;
-  z-index: 1;
+  z-index: var(--z-base);
   /* Horizontal scroll inside the strip — tabs keep their natural width
      and the strip itself scrolls when it overflows the chrome. This
      replaces the previous "slice to N visible + overflow chip" model
@@ -189,7 +193,7 @@
   transition-timing-function: ease, ease, ease, ease, cubic-bezier(0.2, 0.8, 0.2, 1), ease;
   -webkit-app-region: no-drag;
   cursor: default;
-  z-index: 1;
+  z-index: var(--z-base);
   will-change: transform;
 }
 /* The pinned Home tab has no close button, so it drops the close column and
@@ -350,7 +354,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  z-index: 1100;
+  z-index: var(--z-drawer);
   -webkit-app-region: no-drag;
 }
 .workspace-tabs-popover,
@@ -493,7 +497,7 @@
 }
 .workspace-tab-preview {
   position: fixed;
-  z-index: 140;
+  z-index: var(--z-overlay);
   box-sizing: border-box;
   min-width: 220px;
   display: flex;
@@ -1042,7 +1046,7 @@
   position: absolute;
   top: calc(100% + 8px);
   right: 0;
-  z-index: 80;
+  z-index: var(--z-popover);
   min-width: 280px;
   padding: 6px;
   background: var(--bg-panel);
@@ -1287,7 +1291,7 @@ a.avatar-item:visited {
 .comment-left-host {
   position: absolute;
   inset: 0;
-  z-index: 30;
+  z-index: var(--z-raised);
   display: flex;
   width: 100%;
   height: 100%;
@@ -1390,4 +1394,19 @@ a.avatar-item:visited {
 }
 .split-resize-handle:focus-visible {
   outline: none;
+}
+
+/* Mobile split collapse: on narrow viewports the chat panel (460px) exceeds the
+   phone screen. Force single-column so the chat fills the viewport; the workspace
+   clips off below overflow:hidden. split-focus preserves its existing behaviour
+   (JS hides the chat slot via [hidden] and the workspace takes full width). */
+@media (max-width: 599px) {
+  .split:not(.split-focus) {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
+  }
+  .split:not(.split-focus) .split-resize-handle,
+  .split:not(.split-focus) .split-edit-divider {
+    display: none;
+  }
 }

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -2,6 +2,47 @@
    Open Design — neutral product workspace
    ============================================================ */
 :root {
+  /* Spacing scale — 4px grid. Use these instead of literal px values so
+     any global rhythm change is a one-line token edit, not a grep sweep.
+     --space-1 through --space-10 cover the full range used in the UI. */
+  --space-1:  4px;
+  --space-2:  6px;
+  --space-3:  8px;
+  --space-4: 10px;
+  --space-5: 12px;
+  --space-6: 16px;
+  --space-7: 20px;
+  --space-8: 24px;
+  --space-9: 32px;
+  --space-10: 40px;
+
+  /* Focus ring — single source of truth for keyboard focus affordances.
+     --focus-ring-color: blue (selected) for neutral interactive elements.
+     --focus-ring-color-cta: accent orange for primary CTAs (Create, Send).
+     Using box-shadow keeps the ring inside overflow:hidden containers; the
+     outline fallback below is for high-contrast mode support. */
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
+  --focus-ring-color: var(--selected);
+  --focus-ring-color-cta: var(--accent);
+  --focus-ring-shadow: 0 0 0 var(--focus-ring-width) var(--focus-ring-color);
+  --focus-ring-shadow-cta: 0 0 0 var(--focus-ring-width) var(--focus-ring-color-cta);
+
+  /* Z-index scale — named layers prevent arbitrary stacking conflicts.
+     Any new layer should fit into one of these buckets, not invent a new
+     value. Off-scale literals in legacy code are migration targets. */
+  --z-base:    1;    /* content, card stacking within a surface */
+  --z-sticky:  4;    /* sticky headers (chat-project-header)     */
+  --z-raised:  30;   /* floating action buttons, dropdowns       */
+  --z-popover: 80;   /* avatar popover, workspace actions        */
+  --z-chrome: 120;   /* app tab chrome (workspace-tabs-chrome)   */
+  --z-overlay: 140;  /* tab preview, present-exit-btn            */
+  --z-drawer: 1100;  /* workspace tabs popover                   */
+  --z-modal:  1200;  /* staged-preview-modal, dialogs            */
+  --z-compose: 1502; /* composer session-mode popover            */
+  --z-tooltip: 4000; /* od-tooltip-layer                         */
+  --z-select:  9000; /* od-select-menu (highest — portaled)      */
+
   /* Surface palette — neutral app chrome that does not bias generated artifacts.
      Keep warm/brand colors out of preview backgrounds; generated product UI
      must choose its own palette through the active skill/design brief. */
@@ -95,8 +136,71 @@
   --code-line-height: 1.65;
 }
 
-/* Dark theme variables — shared between explicit [data-theme="dark"] and the
-   OS-level prefers-color-scheme media query (system mode = no data-theme attr). */
+/* Dark theme variables — one declaration covers both explicit [data-theme="dark"]
+   and the OS-level prefers-color-scheme media query (system mode = no data-theme
+   attr). :is() merges both selectors so a single token edit updates both paths.
+   Browsers that don't support :is() fall back to neither selector matching (i.e.
+   they stay in light mode) — acceptable since :is() support covers 96%+ globally. */
+@media (prefers-color-scheme: dark) {
+  :is([data-theme="dark"], html:not([data-theme])) {
+    color-scheme: dark;
+    --bg: #1a1917;
+    --bg-app: #1a1917;
+    --bg-panel: #222120;
+    --bg-subtle: #252321;
+    --bg-muted: #2e2c29;
+    --bg-fill-tertiary: rgba(255, 255, 255, 0.06);
+    --bg-fill-secondary: rgba(255, 255, 255, 0.10);
+    --bg-fill: rgba(255, 255, 255, 0.16);
+    --bg-elevated: #2a2825;
+    --border: #333128;
+    --border-strong: #46433c;
+    --border-soft: #2a2825;
+
+    --text: #e8e4dc;
+    --text-strong: #f2ede4;
+    --text-muted: #9a9690;
+    --text-soft: #6e6b65;
+    --text-faint: #4e4b46;
+
+    --accent: #d97a56;
+    --accent-strong: #e8896a;
+    --accent-soft: #3d2318;
+    --accent-tint: #2e1a12;
+    --accent-hover: #e8896a;
+
+    --green: #4caf72;
+    --green-bg: #0f2a18;
+    --green-border: #1a4028;
+    --blue: #6b8fe8;
+    --blue-bg: #0f1a38;
+    --blue-border: #1a2c58;
+    --purple: #a87dd4;
+    --purple-bg: #1e1030;
+    --purple-border: #321a50;
+    --red: #e06b65;
+    --red-bg: #2a0e0c;
+    --red-border: #451714;
+    --amber: #e09a40;
+    --amber-bg: #2a1a04;
+
+    --shadow-xs: 0 1px 0 rgba(0, 0, 0, 0.2);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+    --shadow-md: 0 6px 24px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.25);
+    --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.3);
+
+    --code-header-bg: #1e1e20;
+    --code-body-bg: #18181b;
+
+    /* Focus ring tokens — dark mode adjusts opacity for contrast. */
+    --focus-ring-shadow: 0 0 0 var(--focus-ring-width) color-mix(in srgb, var(--selected) 80%, transparent);
+    --focus-ring-shadow-cta: 0 0 0 var(--focus-ring-width) color-mix(in srgb, var(--accent) 80%, transparent);
+  }
+}
+
+/* Explicit dark override: when the user has manually set dark theme, apply
+   regardless of OS preference. This must live outside the media query so it
+   takes precedence over a light-OS user who manually switched to dark mode. */
 [data-theme="dark"] {
   color-scheme: dark;
   --bg: #1a1917;
@@ -146,58 +250,7 @@
 
   --code-header-bg: #1e1e20;
   --code-body-bg: #18181b;
-}
 
-/* System mode: follow OS preference when no explicit data-theme is set. */
-@media (prefers-color-scheme: dark) {
-  html:not([data-theme]) {
-    color-scheme: dark;
-    --bg: #1a1917;
-    --bg-app: #1a1917;
-    --bg-panel: #222120;
-    --bg-subtle: #252321;
-    --bg-muted: #2e2c29;
-    --bg-fill-tertiary: rgba(255, 255, 255, 0.06);
-    --bg-fill-secondary: rgba(255, 255, 255, 0.10);
-    --bg-fill: rgba(255, 255, 255, 0.16);
-    --bg-elevated: #2a2825;
-    --border: #333128;
-    --border-strong: #46433c;
-    --border-soft: #2a2825;
-
-    --text: #e8e4dc;
-    --text-strong: #f2ede4;
-    --text-muted: #9a9690;
-    --text-soft: #6e6b65;
-    --text-faint: #4e4b46;
-
-    --accent: #d97a56;
-    --accent-strong: #e8896a;
-    --accent-soft: #3d2318;
-    --accent-tint: #2e1a12;
-    --accent-hover: #e8896a;
-
-    --green: #4caf72;
-    --green-bg: #0f2a18;
-    --green-border: #1a4028;
-    --blue: #6b8fe8;
-    --blue-bg: #0f1a38;
-    --blue-border: #1a2c58;
-    --purple: #a87dd4;
-    --purple-bg: #1e1030;
-    --purple-border: #321a50;
-    --red: #e06b65;
-    --red-bg: #2a0e0c;
-    --red-border: #451714;
-    --amber: #e09a40;
-    --amber-bg: #2a1a04;
-
-    --shadow-xs: 0 1px 0 rgba(0, 0, 0, 0.2);
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
-    --shadow-md: 0 6px 24px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.25);
-    --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.3);
-
-    --code-header-bg: #1e1e20;
-    --code-body-bg: #18181b;
-  }
+  --focus-ring-shadow: 0 0 0 var(--focus-ring-width) color-mix(in srgb, var(--selected) 80%, transparent);
+  --focus-ring-shadow-cta: 0 0 0 var(--focus-ring-width) color-mix(in srgb, var(--accent) 80%, transparent);
 }


### PR DESCRIPTION
…uced motion)

<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
