### PR TITLE
fix(brands): wire brand routes and fix auto-send race that broke extraction

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -526,6 +526,7 @@ import { registerMediaRoutes } from './routes/media.js';
 import { registerProjectRoutes, registerProjectArtifactRoutes, registerProjectFileRoutes, registerProjectUploadRoutes } from './routes/project/index.js';
 import { registerVelaRoutes } from './routes/vela.js';
 import { registerFinalizeRoutes, registerImportRoutes, registerProjectExportRoutes } from './import-export-routes.js';
+import { registerBrandRoutes } from './brand-routes.js';
 import { registerHandoffRoutes } from './routes/handoff.js';
 import { EmptyTranscriptError, synthesizeHandoffPrompt } from './handoff-design.js';
 import { TranscriptExportLockedError } from './transcript-export.js';
@@ -4008,6 +4009,19 @@ export async function startServer({
     conversations: conversationDeps,
     projectFiles: projectFileDeps,
     validation: validationDeps,
+  });
+
+  // Brands: list / extract / finalize / detail / delete / logo.
+  registerBrandRoutes(app, {
+    brandsRoot: path.join(RUNTIME_DATA_DIR, 'brands'),
+    userDesignSystemsRoot: USER_DESIGN_SYSTEMS_DIR,
+    projectsRoot: PROJECTS_DIR,
+    skillsRoot: SKILLS_DIR,
+    dataDir: RUNTIME_DATA_DIR,
+    db,
+    // In-memory run registry so brand status can reconcile with active or
+    // just-finished extraction runs before they flush to the DB.
+    runs: design.runs,
   });
 
   // Resource catalog

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5819,6 +5819,16 @@ export function ProjectView({
     const pendingPrompt = project.pendingPrompt;
     if (!pendingPrompt) return;
     if (autoSendFirstMessageRef.current) {
+      // Rescue the auto-send seed before clearing pendingPrompt server-side.
+      // INVARIANT: every caller that sets the `od:auto-send-first` flag also
+      // guarantees a non-empty pendingPrompt or attachments (App.tsx,
+      // BrandsTab, EntryShell, DesignSystemFlow). The once-only render-time
+      // capture above can freeze autoSendSeedRef to '' when we navigate
+      // straight into a freshly-created project whose pendingPrompt loads on a
+      // later render (e.g. brand extraction); without this rescue the dispatch
+      // effect below sees an empty seed and silently drops the first message,
+      // leaving the agent run unstarted.
+      if (!autoSendSeedRef.current) autoSendSeedRef.current = pendingPrompt;
       onClearPendingPrompt();
       return;
     }
@@ -6019,8 +6029,11 @@ export function ProjectView({
     ).trim();
     const attachments = autoSendAttachmentsRef.current ?? [];
     if (!seed && attachments.length === 0) {
-      autoSentRef.current = true;
-      clearAutoSendSession(project.id);
+      // Flag is set (auto-send expected) but the seed has not resolved yet.
+      // The project's pendingPrompt can still be loading right after navigating
+      // into a freshly-created project. Do NOT consume the flag here; return and
+      // let this effect retry once pendingPrompt / autoSendSeedRef populates
+      // (project.pendingPrompt is in the dep array, so the retry is automatic).
       return;
     }
     autoSentRef.current = true;

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -709,6 +709,98 @@ describe('ProjectView daemon cleanup', () => {
     }
   });
 
+  // Regression (red on the buggy version): when the UI navigates straight into
+  // a freshly-created project (e.g. brand extraction), project.pendingPrompt is
+  // absent on the first render and arrives on a later prop update. The once-only
+  // render-time seed capture froze autoSendSeedRef to '' and the dispatch effect
+  // dropped the first message, so the agent never started. The seed-rescue in
+  // the clear-effect plus not consuming the auto-send flag on an empty seed must
+  // keep the auto-send alive across the late pendingPrompt.
+  it('auto-sends when pendingPrompt arrives after the first render', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockResolvedValue(undefined);
+
+    chatPaneSpy.mockClear();
+    streamViaDaemon.mockClear();
+    window.sessionStorage.setItem('od:auto-send-first:race-project', '1');
+
+    const prompt = 'extract the brand for example.com';
+
+    try {
+      // First render WITHOUT pendingPrompt (the placeholder phase before the
+      // project record loads). Lets the dispatch effect run once with no seed.
+      const view = render(
+        <ProjectView
+          project={{ id: 'race-project', name: 'Project', skillId: null, designSystemId: null } as never}
+          routeFileName={null}
+          config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+          agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          daemonLive
+          onModeChange={() => {}}
+          onAgentChange={() => {}}
+          onAgentModelChange={() => {}}
+          onRefreshAgents={() => {}}
+          onOpenSettings={() => {}}
+          onBack={() => {}}
+          onClearPendingPrompt={() => {}}
+          onTouchProject={() => {}}
+          onProjectChange={() => {}}
+          onProjectsRefresh={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(chatPaneSpy).toHaveBeenCalled());
+      expect(streamViaDaemon).not.toHaveBeenCalled();
+
+      // pendingPrompt arrives on a later prop update (same project id, no remount).
+      view.rerender(
+        <ProjectView
+          project={{ id: 'race-project', name: 'Project', skillId: null, designSystemId: null, pendingPrompt: prompt } as never}
+          routeFileName={null}
+          config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+          agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          daemonLive
+          onModeChange={() => {}}
+          onAgentChange={() => {}}
+          onAgentModelChange={() => {}}
+          onRefreshAgents={() => {}}
+          onOpenSettings={() => {}}
+          onBack={() => {}}
+          onClearPendingPrompt={() => {}}
+          onTouchProject={() => {}}
+          onProjectChange={() => {}}
+          onProjectsRefresh={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+      const sent = streamViaDaemon.mock.calls[0]?.[0] as {
+        history?: Array<{ role: string; content: string }>;
+      };
+      expect(sent.history?.[sent.history.length - 1]).toMatchObject({
+        role: 'user',
+        content: prompt,
+      });
+    } finally {
+      window.sessionStorage.removeItem('od:auto-send-first:race-project');
+    }
+  });
+
   it('auto-sends Home-staged design files as first-turn daemon attachments', async () => {
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([]);


### PR DESCRIPTION
## Why

I hit this running Open Design locally: "Extract a brand" was dead end to end. `POST /api/brands` returned 404, so the New Brand flow hung forever at "Extracting..." and `od brand create <url>` failed too. Scratching my own itch, but it affects anyone trying brand extraction on `main`.

Two root causes: (1) `registerBrandRoutes` is defined and unit-tested but was never mounted in `server.ts`, so every `/api/brands` call 404'd. (2) After mounting them, extraction still hung: `ProjectView` captured the auto-send seed from `project.pendingPrompt` on first render, which is empty when navigating straight into a freshly-created brand project; the clear-effect then wiped `pendingPrompt` and the dispatch effect bailed on the empty seed, silently dropping the first agent message.

## What users will see

"Extract a brand" / "New Design System" now works: paste a URL and the agent runs the extraction live, instead of a permanent "Extracting..." spinner. The same fix unblocks `od brand create <url>` headlessly (it hits the same routes).

## Surface area

- [x] **API / contract**: mounts the existing `/api/brands` routes (`registerBrandRoutes`) that were never registered on the server.

No new UI or CLI surface is added. The web New Brand flow and the `od brand` CLI both existed but were dead because they hit these unmounted routes; this repairs both surfaces at once.

## Bug fix verification

- Test path: `apps/web/tests/components/ProjectView.run-cleanup.test.tsx` ("auto-sends when pendingPrompt arrives after the first render")
- Did the test go red on `main` and green on this branch? **yes**. On `main` the dispatch effect consumes the auto-send flag on the empty seed and never retries (`streamViaDaemon` is never called, the test times out); on this branch the clear-effect rescues the seed so the auto-send fires exactly once.

## Validation

- `pnpm guard` (60/60) and `pnpm typecheck` (root, all packages): green
- `pnpm --filter @open-design/web test` including the new spec, and daemon `brand-routes.test.ts` (9/9): green
