### PR TITLE
fix: normalize Vela Kimi K2.7 model ids

### DIFF
--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -50,6 +50,7 @@ export function normalizeVelaModelId(rawId: string): string | null {
   if (/^deepseek_v3_2$/i.test(withoutPrefix)) return 'deepseek-v3.2';
   if (/^deepseek-v3-2$/i.test(withoutPrefix)) return 'deepseek-v3.2';
   if (/^kimi_k2_6$/i.test(withoutPrefix)) return 'kimi-k2.6';
+  if (/^kimi_k2_7_code$/i.test(withoutPrefix)) return 'kimi-k2.7-code';
   if (/^glm_5_1$/i.test(withoutPrefix)) return 'glm-5.1';
   if (/^glm_5$/i.test(withoutPrefix)) return 'glm-5';
   const versioned = normalizeKnownVelaVersionId(withoutPrefix);

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -126,6 +126,7 @@ describe('AMR runtime def', () => {
   it('normalizes Vela public model ids to link-canonical ACP model ids', () => {
     expect(normalizeVelaModelId('public_model_deepseek_v3_2')).toBe('deepseek-v3.2');
     expect(normalizeVelaModelId('public_model_kimi_k2_6')).toBe('kimi-k2.6');
+    expect(normalizeVelaModelId('public_model_kimi_k2_7_code')).toBe('kimi-k2.7-code');
     expect(normalizeVelaModelId('public_model_gemini_2_5_flash')).toBe('gemini-2.5-flash');
     expect(normalizeVelaModelId('public_model_gemini_3_1_flash_lite_preview')).toBe(
       'gemini-3.1-flash-lite-preview',
@@ -146,6 +147,7 @@ describe('AMR runtime def', () => {
     expect(normalizeVelaModelId('vela/deepseek-v3.2')).toBe('deepseek-v3.2');
     expect(normalizeVelaModelId('deepseek-v3-2')).toBe('deepseek-v3.2');
     expect(normalizeVelaModelId('vela/deepseek-v3-2')).toBe('deepseek-v3.2');
+    expect(normalizeVelaModelId('vela/public_model_kimi_k2_7_code')).toBe('kimi-k2.7-code');
   });
 
   it('parses `vela models` output with fast chat defaults and plain canonical labels', () => {


### PR DESCRIPTION
## Summary
- normalize Vela `public_model_kimi_k2_7_code` to the canonical `kimi-k2.7-code` model id
- cover both bare `public_model_...` and `vela/public_model_...` inputs in the AMR normalization test

Closes #4410.

## Testing
- pnpm typecheck
- pnpm --filter @open-design/daemon test -- -t "normalizes Vela public model ids to link-canonical ACP model ids" amr-acp-integration.test.ts

## Notes
- `pnpm guard` currently fails due to existing stale design-system manifest artifacts unrelated to this change
- assigning the upstream issue was not permitted for this account (`ReplaceActorsForAssignable`)
