### PR TITLE
fix(ci): harden backport automerge provenance

### DIFF
--- a/.github/workflows/backport-automerge.yml
+++ b/.github/workflows/backport-automerge.yml
@@ -32,6 +32,13 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
+      - name: Checkout trusted repository history
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
       - name: Resolve the backport PR for this run
         id: pr
         env:
@@ -53,30 +60,58 @@ jobs:
             exit 0
           fi
           row="$(gh pr view "$num" --repo "$REPO" \
-                  --json number,baseRefName,isDraft,title,author,isCrossRepository,headRefOid)"
-          # "Pristine" = every commit on the branch was committed by github-actions[bot] — the
-          # untouched korthout cherry-pick of code already reviewed on main. If a human pushed any
-          # commit (resolving a conflict, fixing a failing test), that commit's committer is NOT
-          # github-actions[bot], so pristine=false and the auto-approve/merge below are skipped:
-          # those commits were never reviewed, so the PR must go through human review instead.
-          # Paginate across ALL commits (--paginate) — a >100-commit PR must not pass on the
-          # strength of its first page; one non-bot committer anywhere fails it. Count the lines
-          # that do NOT equal the literal bot login (-F/-x; the [..] is not a regex class) with
-          # grep -c, whose count semantics are portable (unlike `grep -qv`, whose early-exit status
-          # is unreliable across BSD/GNU).
-          # Fail closed on a partial/failed lookup: --paginate may emit several pages and THEN fail
-          # on a later one; `|| true` would keep that partial output and could read all-bot. Capture
-          # gh's exit status via `if !` and blank the list on any failure, so pristine needs a
-          # complete, successful enumeration of every commit.
-          if ! logins="$(gh api "repos/$REPO/pulls/$num/commits?per_page=100" --paginate \
-                          --jq '.[].committer.login // "none"' 2>/dev/null)"; then
-            logins=""
+                  --json number,baseRefName,baseRefOid,isDraft,title,body,author,isCrossRepository,headRefOid)"
+          # "Pristine" = the backport's cumulative diff is patch-equivalent to the source PR's
+          # reviewed merge commit on main. Do NOT trust commit author/committer identity here:
+          # those are plain git headers, and a collaborator can forge github-actions[bot]'s
+          # committer email on an otherwise human-pushed commit. GitHub API-created commits are
+          # unsigned in this path, and korthout's legitimate cherry-picks are unsigned too, so
+          # signature fields cannot prove bot provenance either. Bound what auto-merge can land
+          # instead: if a human pushes a conflict resolution, CI fix, or malicious extra change,
+          # the cumulative patch-id differs from the source PR's already-reviewed main diff and
+          # pristine=false; the PR then falls back to human review.
+          body="$(printf '%s' "$row" | jq -r '.body // ""')"
+          source_num="$(printf '%s\n' "$body" | sed -nE 's/.*Backport of #([0-9]+) .*/\1/p' | head -n 1)"
+          source_merge=""
+          source_base=""
+          source_state=""
+          source_merged_at=""
+          backport_base=""
+          if [ -n "$source_num" ]; then
+            source="$(gh pr view "$source_num" --repo "$REPO" \
+                        --json state,mergedAt,mergeCommit,baseRefName 2>/dev/null || true)"
+            if [ -n "$source" ]; then
+              source_state="$(printf '%s' "$source" | jq -r '.state // ""')"
+              source_merged_at="$(printf '%s' "$source" | jq -r '.mergedAt // ""')"
+              source_base="$(printf '%s' "$source" | jq -r '.baseRefName // ""')"
+              source_merge="$(printf '%s' "$source" | jq -r '.mergeCommit.oid // ""')"
+            fi
           fi
-          nonbot="$(printf '%s\n' "$logins" | grep -Fvxc 'github-actions[bot]' || true)"
-          if [ -n "$logins" ] && [ "${nonbot:-1}" = "0" ]; then
+
+          base_oid="$(printf '%s' "$row" | jq -r '.baseRefOid')"
+          head_oid="$(printf '%s' "$row" | jq -r '.headRefOid')"
+          source_patch_id=""
+          backport_patch_id=""
+          if [ -n "$source_merge" ] \
+            && [ "$source_state" = "MERGED" ] \
+            && [ -n "$source_merged_at" ] \
+            && [ "$source_base" = "main" ] \
+            && [ -n "$base_oid" ] \
+            && [ -n "$head_oid" ]; then
+            git fetch --no-tags origin \
+              "+refs/heads/$(printf '%s' "$row" | jq -r '.baseRefName'):refs/remotes/origin/$(printf '%s' "$row" | jq -r '.baseRefName')" \
+              "+refs/pull/$num/head:refs/remotes/pull/$num/head"
+            backport_base="$(git merge-base "$base_oid" "$head_oid" 2>/dev/null || true)"
+            if [ -n "$backport_base" ]; then
+              source_patch_id="$(git diff --binary "$source_merge^" "$source_merge" | git patch-id --verbatim | awk '{print $1}')"
+              backport_patch_id="$(git diff --binary "$backport_base" "$head_oid" | git patch-id --verbatim | awk '{print $1}')"
+            fi
+          fi
+          if [ -n "$source_patch_id" ] && [ "$source_patch_id" = "$backport_patch_id" ]; then
             pristine=true
           else
             pristine=false
+            echo "Backport PR #$num is not patch-equivalent to source PR #${source_num:-unknown}; skipping auto-merge"
           fi
           {
             echo "found=true"
@@ -86,7 +121,7 @@ jobs:
             echo "title=$(printf '%s' "$row" | jq -r .title)"
             echo "author=$(printf '%s' "$row" | jq -r '.author.login')"
             echo "cross=$(printf '%s' "$row" | jq -r '.isCrossRepository')"
-            echo "head_oid=$(printf '%s' "$row" | jq -r '.headRefOid')"
+            echo "head_oid=$head_oid"
             echo "pristine=$pristine"
           } >> "$GITHUB_OUTPUT"
 
@@ -96,9 +131,10 @@ jobs:
         # Approve as github-actions[bot] — a DIFFERENT identity than the App that authored the PR
         # (an author can't approve its own PR) — under the SAME bot-identity + SHA + CI gates as
         # the merge below, so only the release bot's own verified backports are auto-approved.
-        # pristine == 'true' is critical here: it means NO human commit was pushed, so the diff is
-        # exactly what was already reviewed on main. If a human resolved a conflict or fixed CI,
-        # pristine is false and this skips — that unreviewed code must get a real human review.
+        # pristine == 'true' is critical here: it means the release-branch diff is patch-equivalent
+        # to the reviewed source PR merge commit on main. If a human resolved a conflict or fixed
+        # CI with a different diff, pristine is false and this skips — that code must get a real
+        # human review.
         if: >-
           ${{ steps.pr.outputs.found == 'true'
               && steps.pr.outputs.draft == 'false'
@@ -123,9 +159,9 @@ jobs:
         #  - PR head == the exact SHA CI passed on (head_oid == workflow_run.head_sha), and
         #    --match-head-commit re-checks at merge time — so a commit pushed after CI went
         #    green is never merged untested.
-        #  - pristine == 'true' — every commit was committed by github-actions[bot], i.e. nobody
-        #    pushed human commits on top of the cherry-pick. Once a human touches the branch the
-        #    diff is no longer the reviewed-on-main code, so we fall back to human review.
+        #  - pristine == 'true' — the backport cumulative diff is patch-equivalent to the source
+        #    PR merge commit that was reviewed on main. Once the branch's net diff differs from the
+        #    reviewed-on-main code, we fall back to human review.
         if: >-
           ${{ steps.pr.outputs.found == 'true'
               && steps.pr.outputs.draft == 'false'
@@ -148,7 +184,11 @@ jobs:
       - name: Notify Feishu on failed backport CI
         # Same identity gates as the merge step: only ping for a genuine bot backport from the
         # same repo, so a fork / non-bot PR named backport-* can't spam the release group.
-        if: ${{ steps.pr.outputs.found == 'true' && steps.pr.outputs.author == 'app/open-design-release-bot' && steps.pr.outputs.cross == 'false' && github.event.workflow_run.conclusion == 'failure' }}
+        # The head_oid == workflow_run.head_sha gate matches the approve/merge steps: a stale
+        # failed run can finish after the PR head advanced, and should not page about a SHA that is
+        # no longer the PR head. Page on failure and timed_out, but not cancelled: force-pushes can
+        # cancel superseded PR runs as part of normal backport iteration.
+        if: ${{ steps.pr.outputs.found == 'true' && steps.pr.outputs.author == 'app/open-design-release-bot' && steps.pr.outputs.cross == 'false' && steps.pr.outputs.head_oid == github.event.workflow_run.head_sha && (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out') }}
         env:
           FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
           FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
@@ -156,6 +196,7 @@ jobs:
           BASE: ${{ steps.pr.outputs.base }}
           TITLE: ${{ steps.pr.outputs.title }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           python3 - <<'PY'
           import os, time, hmac, hashlib, base64, json, urllib.request
@@ -163,7 +204,7 @@ jobs:
           if not wh:
               raise SystemExit(0)
           secret = os.environ.get("FEISHU_SIGN_SECRET", "")
-          text = (f"⚠️ backport PR #{os.environ['NUM']} CI 失败（目标 {os.environ['BASE']}）\n"
+          text = (f"⚠️ backport PR #{os.environ['NUM']} CI {os.environ.get('CONCLUSION','failed')}（目标 {os.environ['BASE']}）\n"
                   f"{os.environ.get('TITLE','')}\n需要人工跟进：{os.environ.get('RUN_URL','')}")
           body = {"msg_type": "text", "content": {"text": text}}
           if secret:

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -68,6 +68,19 @@ function sectionBetween(content: string, start: string, end: string): string {
   return content.slice(startIndex, endIndex);
 }
 
+async function gitPatchId(mode: "--stable" | "--verbatim", diff: string): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const child = execFile("git", ["patch-id", mode], { cwd: workspaceRoot, encoding: "utf8" }, (error, stdout, stderr) => {
+      if (error) {
+        reject(Object.assign(error, { stdout, stderr }));
+        return;
+      }
+      resolve(stdout.trim().split(/\s+/)[0] ?? "");
+    });
+    child.stdin?.end(diff);
+  });
+}
+
 async function runReleaseStableForFailure(env: Record<string, string>): Promise<string> {
   try {
     await execFileAsync(process.execPath, ["--experimental-strip-types", releaseStableScriptPath], {
@@ -236,13 +249,26 @@ describe("packaged smoke workflow", () => {
     expect(workflow).toContain('startswith("release/v")');
 
     // A human commit pushed on top of the cherry-pick (conflict resolution, CI fix) is never
-    // reviewed, so auto-approve/merge require pristine == 'true': every commit's committer is
-    // github-actions[bot]. The committers are paginated across all commits and any non-bot one
-    // fails the count. Otherwise the PR falls back to human review.
+    // reviewed, so auto-approve/merge require pristine == 'true': the backport cumulative diff
+    // must be patch-equivalent to the source PR's reviewed merge commit on main. Author/committer
+    // identity is a spoofable git header, so the gate must not trust github-actions[bot] metadata.
     expect(workflow).toContain("steps.pr.outputs.pristine == 'true'");
-    expect(workflow).toContain('.[].committer.login // "none"');
-    expect(workflow).toContain("--paginate");
-    expect(workflow).toContain("grep -Fvxc 'github-actions[bot]'");
+    expect(workflow).toContain("Checkout trusted repository history");
+    expect(workflow).toContain("fetch-depth: 0");
+    expect(workflow).toContain("Backport of #([0-9]+)");
+    expect(workflow).toContain("source_patch_id");
+    expect(workflow).toContain("backport_patch_id");
+    expect(workflow).toContain("git patch-id --verbatim");
+    expect(workflow).not.toContain("git patch-id --stable");
+    expect(workflow).toContain("+refs/heads/$(printf '%s' \"$row\" | jq -r '.baseRefName')");
+    expect(workflow).toContain("+refs/pull/$num/head:refs/remotes/pull/$num/head");
+    expect(workflow).toContain('backport_base="$(git merge-base "$base_oid" "$head_oid" 2>/dev/null || true)"');
+    expect(workflow).toContain('if [ -n "$backport_base" ]; then');
+    expect(workflow).toContain("git diff --binary \"$source_merge^\" \"$source_merge\"");
+    expect(workflow).toContain("git diff --binary \"$backport_base\" \"$head_oid\"");
+    expect(workflow).toContain("source_base\" = \"main");
+    expect(workflow).not.toContain('.[].committer.login // "none"');
+    expect(workflow).not.toContain("grep -Fvxc 'github-actions[bot]'");
 
     // The PR is resolved from the run's authoritative workflow_run.pull_requests association
     // (filtered to the release/* base at exactly the run's SHA), not a branch-name guess, and the
@@ -263,12 +289,48 @@ describe("packaged smoke workflow", () => {
     expect(approveStep).toContain("steps.pr.outputs.author == 'app/open-design-release-bot'");
     expect(approveStep).toContain("steps.pr.outputs.pristine == 'true'");
     expect(approveStep).toContain("github.token");
+    expect(approveStep).toContain("github.event.workflow_run.conclusion == 'success'");
 
-    // The Feishu failure path carries the same identity gates, so a fork / non-bot backport-*
-    // PR can't spam the release group.
-    const feishuStep = sectionBetween(workflow, "Notify Feishu on failed backport CI", "FEISHU_WEBHOOK");
+    // The Feishu failure path carries the same identity + SHA gates, so a fork / non-bot
+    // backport-* PR can't spam the release group and stale failed runs do not page after the PR
+    // head advanced. Alert on failure and timed_out, but not routine cancelled runs.
+    const feishuStep = sectionBetween(workflow, "Notify Feishu on failed backport CI", "python3");
     expect(feishuStep).toContain("steps.pr.outputs.author == 'app/open-design-release-bot'");
     expect(feishuStep).toContain("steps.pr.outputs.cross == 'false'");
+    expect(feishuStep).toContain("steps.pr.outputs.head_oid == github.event.workflow_run.head_sha");
+    expect(feishuStep).toContain(
+      "(github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out')",
+    );
+    expect(feishuStep).not.toContain("'cancelled'");
+  });
+
+  it("[P2] keeps the backport patch-equivalence gate whitespace-sensitive", async () => {
+    const compactDiff = [
+      "diff --git a/script.py b/script.py",
+      "--- a/script.py",
+      "+++ b/script.py",
+      "@@ -1 +1 @@",
+      "-print(1)",
+      "+print(2)",
+      "",
+    ].join("\n");
+    const whitespaceDiff = [
+      "diff --git a/script.py b/script.py",
+      "--- a/script.py",
+      "+++ b/script.py",
+      "@@ -1 +1 @@",
+      "-print(1)",
+      "+ print(2)",
+      "",
+    ].join("\n");
+
+    const compactStable = await gitPatchId("--stable", compactDiff);
+    const whitespaceStable = await gitPatchId("--stable", whitespaceDiff);
+    const compactVerbatim = await gitPatchId("--verbatim", compactDiff);
+    const whitespaceVerbatim = await gitPatchId("--verbatim", whitespaceDiff);
+
+    expect(compactStable).toBe(whitespaceStable);
+    expect(compactVerbatim).not.toBe(whitespaceVerbatim);
   });
 
   it("[P2] gates the plugin-preview manifest auto-merge as a trusted workflow_run consumer", async () => {


### PR DESCRIPTION
## Why

This is a security follow-up from the plugin-preview automerge work in #4727. While landing that PR, we found the same provenance bug in the existing backport auto-merge path: it treated `.committer.login == github-actions[bot]` as proof that a backport branch was untouched, but that value is derived from spoofable git commit headers.

The pain is release-branch integrity. `backport-*` branches are writable by repository collaborators and release branches rely on this workflow as the green-CI merge gate, so a write-access account could push an unreviewed commit with a forged bot committer and let the workflow approve and merge it into `release/v*`.

## What users will see

No product UI changes. Clean bot backports still auto-approve and merge after CI passes. Backport PRs whose final diff is not patch-equivalent to the source PR that already merged on `main` now fall back to human review. Feishu alerts for failed backport CI are also bound to the current PR head SHA and include timed-out CI runs, so stale failures from superseded heads should not page the release channel.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A; no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `e2e/tests/packaged-smoke-workflow.test.ts`
- Did the test go red on `main` and green on this branch? The updated assertions were not run on `main`; they assert the new trusted workflow_run gate and the old workflow lacks those patch-equivalence strings. They pass on this branch.
- Additional verification: reproduced the new patch-id gate against real clean backport PR #4735. Source PR #4725 and backport PR #4735 produced the same `git patch-id --verbatim` value: `7f376b4481a0f949fefa35726fbb661b451abefa`.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts`
- `pnpm guard`
- `pnpm typecheck`
- Manual workflow string checks confirmed the old `.committer.login` / `github-actions[bot]` pristine gate is gone and Feishu now requires `head_oid == workflow_run.head_sha` plus `failure || timed_out`.
