### PR TITLE
[codex] fix packaged runtime dependency drift

### DIFF
--- a/tools/pack/src/mac-prebundle.ts
+++ b/tools/pack/src/mac-prebundle.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 
 import type { ToolPackConfig } from "./config.js";
+import { PREBUNDLE_RUNTIME_DEPENDENCIES, PREBUNDLE_RUNTIME_DEPENDENCY_NAMES } from "./prebundle-runtime-dependencies.js";
 
 export const MAC_PREBUNDLED_APP_DIR_NAME = "prebundled";
 export const MAC_PREBUNDLE_META_DIR_NAME = "prebundle-meta";
@@ -13,10 +14,7 @@ export const MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER =
   'import { createRequire as __odCreateRequire } from "node:module"; const require = __odCreateRequire(import.meta.url);';
 export const MAC_PREBUNDLE_ENTRYPOINTS_DIR_NAME = "prebundle-entrypoints";
 
-export const MAC_PREBUNDLE_RUNTIME_DEPENDENCIES = {
-  "better-sqlite3": "12.9.0",
-  "blake3-wasm": "2.1.5",
-} as const;
+export const MAC_PREBUNDLE_RUNTIME_DEPENDENCIES = PREBUNDLE_RUNTIME_DEPENDENCIES;
 
 export const MAC_STANDALONE_PREBUNDLE_EXCLUDED_INTERNAL_PACKAGES = [
   "@open-design/daemon",
@@ -42,7 +40,7 @@ export const MAC_PREBUNDLE_POLICIES = {
     label: "packaged main",
   },
   daemonCli: {
-    externals: ["better-sqlite3", "blake3-wasm"],
+    externals: PREBUNDLE_RUNTIME_DEPENDENCY_NAMES,
     forbiddenInputs: [
       "/node_modules/@open-design/daemon/",
       "/node_modules/better-sqlite3/",
@@ -56,7 +54,7 @@ export const MAC_PREBUNDLE_POLICIES = {
     label: "daemon cli",
   },
   daemonSidecar: {
-    externals: ["better-sqlite3", "blake3-wasm"],
+    externals: PREBUNDLE_RUNTIME_DEPENDENCY_NAMES,
     forbiddenInputs: [
       "/node_modules/@open-design/daemon/",
       "/node_modules/better-sqlite3/",

--- a/tools/pack/src/prebundle-runtime-dependencies.ts
+++ b/tools/pack/src/prebundle-runtime-dependencies.ts
@@ -1,0 +1,8 @@
+export const PREBUNDLE_RUNTIME_DEPENDENCIES = {
+  "better-sqlite3": "12.10.0",
+  "blake3-wasm": "2.1.5",
+} as const;
+
+export const PREBUNDLE_RUNTIME_DEPENDENCY_NAMES = Object.keys(
+  PREBUNDLE_RUNTIME_DEPENDENCIES,
+) as (keyof typeof PREBUNDLE_RUNTIME_DEPENDENCIES)[];

--- a/tools/pack/src/win-prebundle.ts
+++ b/tools/pack/src/win-prebundle.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 
 import type { ToolPackConfig } from "./config.js";
+import { PREBUNDLE_RUNTIME_DEPENDENCIES, PREBUNDLE_RUNTIME_DEPENDENCY_NAMES } from "./prebundle-runtime-dependencies.js";
 
 export const WIN_PREBUNDLED_APP_DIR_NAME = "prebundled";
 export const WIN_PREBUNDLE_META_DIR_NAME = "prebundle-meta";
@@ -13,10 +14,7 @@ export const WIN_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER =
   'import { createRequire as __odCreateRequire } from "node:module"; const require = __odCreateRequire(import.meta.url);';
 export const WIN_PREBUNDLE_ENTRYPOINTS_DIR_NAME = "prebundle-entrypoints";
 
-export const WIN_PREBUNDLE_RUNTIME_DEPENDENCIES = {
-  "better-sqlite3": "12.9.0",
-  "blake3-wasm": "2.1.5",
-} as const;
+export const WIN_PREBUNDLE_RUNTIME_DEPENDENCIES = PREBUNDLE_RUNTIME_DEPENDENCIES;
 
 export const WIN_STANDALONE_PREBUNDLE_EXCLUDED_INTERNAL_PACKAGES = [
   "@open-design/daemon",
@@ -42,7 +40,7 @@ export const WIN_PREBUNDLE_POLICIES = {
     label: "packaged main",
   },
   daemonCli: {
-    externals: ["better-sqlite3", "blake3-wasm"],
+    externals: PREBUNDLE_RUNTIME_DEPENDENCY_NAMES,
     forbiddenInputs: [
       "/node_modules/@open-design/daemon/",
       "/node_modules/better-sqlite3/",
@@ -56,7 +54,7 @@ export const WIN_PREBUNDLE_POLICIES = {
     label: "daemon cli",
   },
   daemonSidecar: {
-    externals: ["better-sqlite3", "blake3-wasm"],
+    externals: PREBUNDLE_RUNTIME_DEPENDENCY_NAMES,
     forbiddenInputs: [
       "/node_modules/@open-design/daemon/",
       "/node_modules/better-sqlite3/",

--- a/tools/pack/tests/mac-prebundle.test.ts
+++ b/tools/pack/tests/mac-prebundle.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -78,12 +78,24 @@ describe("mac standalone prebundle policy", () => {
     expect(MAC_PREBUNDLE_POLICIES.webSidecar.externals).toEqual([]);
     expect(MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER).toContain("createRequire");
     expect(MAC_PREBUNDLE_RUNTIME_DEPENDENCIES).toEqual({
-      "better-sqlite3": "12.9.0",
+      "better-sqlite3": "12.10.0",
       "blake3-wasm": "2.1.5",
     });
     expect(MAC_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-cli.mjs");
     expect(MAC_PREBUNDLED_DAEMON_SIDECAR_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-sidecar.mjs");
     expect(MAC_PREBUNDLED_WEB_SIDECAR_RELATIVE_PATH).toBe("app/prebundled/web-sidecar.mjs");
+  });
+
+  it("keeps external daemon runtime dependency versions aligned with daemon package.json", async () => {
+    const daemonPackageJson = JSON.parse(
+      await readFile(join(process.cwd(), "..", "..", "apps", "daemon", "package.json"), "utf8"),
+    ) as { dependencies?: Record<string, string> };
+
+    for (const dependency of MAC_PREBUNDLE_POLICIES.daemonSidecar.externals) {
+      expect(MAC_PREBUNDLE_RUNTIME_DEPENDENCIES[dependency]).toBe(
+        daemonPackageJson.dependencies?.[dependency],
+      );
+    }
   });
 });
 

--- a/tools/pack/tests/win-prebundle.test.ts
+++ b/tools/pack/tests/win-prebundle.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -78,12 +78,24 @@ describe("win standalone prebundle policy", () => {
     expect(WIN_PREBUNDLE_POLICIES.webSidecar.externals).toEqual([]);
     expect(WIN_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER).toContain("createRequire");
     expect(WIN_PREBUNDLE_RUNTIME_DEPENDENCIES).toEqual({
-      "better-sqlite3": "12.9.0",
+      "better-sqlite3": "12.10.0",
       "blake3-wasm": "2.1.5",
     });
     expect(WIN_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-cli.mjs");
     expect(WIN_PREBUNDLED_DAEMON_SIDECAR_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-sidecar.mjs");
     expect(WIN_PREBUNDLED_WEB_SIDECAR_RELATIVE_PATH).toBe("app/prebundled/web-sidecar.mjs");
+  });
+
+  it("keeps external daemon runtime dependency versions aligned with daemon package.json", async () => {
+    const daemonPackageJson = JSON.parse(
+      await readFile(join(process.cwd(), "..", "..", "apps", "daemon", "package.json"), "utf8"),
+    ) as { dependencies?: Record<string, string> };
+
+    for (const dependency of WIN_PREBUNDLE_POLICIES.daemonSidecar.externals) {
+      expect(WIN_PREBUNDLE_RUNTIME_DEPENDENCIES[dependency]).toBe(
+        daemonPackageJson.dependencies?.[dependency],
+      );
+    }
   });
 });
 


### PR DESCRIPTION
Refs #4638

## Why

Issue #4638 exposed a packaged daemon startup failure where required runtime dependencies under `Resources/app/node_modules` could disappear and the daemon then died with `ERR_MODULE_NOT_FOUND`.

While tracing that path, I found a concrete packaging drift: the standalone prebundle runtime dependency list still installed `better-sqlite3@12.9.0`, but `apps/daemon/package.json` now declares `better-sqlite3@12.10.0`. The daemon prebundle externalizes `better-sqlite3` and `blake3-wasm`, so these versions need to stay aligned with the daemon package declaration.

## What users will see

No direct UI change. Future packaged builds will install the daemon runtime dependency version declared by the daemon package instead of a stale hard-coded version.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A.

## Bug fix verification

- Test path that reproduces the bug: `tools/pack/tests/mac-prebundle.test.ts` and `tools/pack/tests/win-prebundle.test.ts`
- Did the test go red on `main` and green on this branch? Not run as a separate main checkout. The existing focused suite was green before the fix; this PR adds an alignment assertion that would fail against the previous `better-sqlite3@12.9.0` runtime constant and now passes.

## Validation

- `pnpm --filter @open-design/tools-pack test -- tests/mac-prebundle.test.ts tests/win-prebundle.test.ts`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack build`
- `git diff --check`

Note: validation was run on this machine with Node `v22.22.0`, so pnpm emitted the repository engine warning for Node `~24`; the commands completed successfully.
