### PR TITLE
[codex] add landing QA Feishu summary

### DIFF
--- a/.github/scripts/landing-page-daily-feishu.ts
+++ b/.github/scripts/landing-page-daily-feishu.ts
@@ -1,0 +1,587 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHmac } from "node:crypto";
+
+type PullFile = {
+  filename: string;
+};
+
+type PullRequest = {
+  draft: boolean;
+  html_url: string;
+  merge_commit_sha: string | null;
+  merged_at: string | null;
+  number: number;
+  state: "open" | "closed";
+  title: string;
+  updated_at: string;
+  user?: { login?: string };
+};
+
+type SearchIssue = {
+  number: number;
+};
+
+type SearchResponse = {
+  items: SearchIssue[];
+  total_count: number;
+};
+
+type WorkflowRun = {
+  conclusion: string | null;
+  created_at: string;
+  event: string;
+  head_sha: string;
+  html_url: string;
+  id: number;
+  name: string | null;
+  run_attempt?: number;
+  run_number: number;
+  run_started_at?: string | null;
+  status: string;
+  updated_at: string;
+};
+
+type WorkflowRunsResponse = {
+  workflow_runs: WorkflowRun[];
+};
+
+type LandingPull = {
+  files: PullFile[];
+  pull: PullRequest;
+};
+
+type StagingSnapshot = {
+  current: WorkflowRun | null;
+  inFlight: WorkflowRun | null;
+  failed: WorkflowRun | null;
+};
+
+type DeploymentState =
+  | { kind: "deployed"; label: string; run: WorkflowRun }
+  | { kind: "deploying"; label: string; run: WorkflowRun }
+  | { kind: "failed"; label: string; run: WorkflowRun }
+  | { kind: "not-merged"; label: string }
+  | { kind: "pending"; label: string };
+
+const LANDING_EXACT_PATHS = new Set([
+  ".github/workflows/blog-indexing-on-deploy.yml",
+  ".github/workflows/landing-page-ci.yml",
+  ".github/workflows/landing-page-production.yml",
+  ".github/workflows/landing-page-staging.yml",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+]);
+
+const LANDING_PREFIXES = [
+  "apps/landing-page/",
+  "craft/",
+  "design-systems/",
+  "design-templates/open-design-landing/",
+  "plugins/",
+  "skills/",
+  "templates/",
+];
+
+const MAX_CARD_PULLS = 30;
+const PR_FETCH_CONCURRENCY = 8;
+const STAGING_URL = "https://staging.open-design.ai";
+const STAGING_WORKFLOW = "landing-page-staging.yml";
+const PRODUCTION_WORKFLOW = "landing-page-production.yml";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (value == null || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function optionalEnv(name: string, fallback = ""): string {
+  const value = process.env[name];
+  return value == null || value.length === 0 ? fallback : value;
+}
+
+function githubApiBase(): string {
+  return optionalEnv("GITHUB_API_URL", "https://api.github.com").replace(/\/+$/, "");
+}
+
+async function githubJson<T>(path: string): Promise<T> {
+  const token = requiredEnv("GH_TOKEN");
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    let response;
+    try {
+      response = await fetch(`${githubApiBase()}${path}`, {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${token}`,
+          "x-github-api-version": "2022-11-28",
+        },
+      });
+    } catch (error) {
+      if (attempt === 5) throw error;
+      await retryDelay(attempt);
+      continue;
+    }
+    if (response.ok) {
+      return (await response.json()) as T;
+    }
+    const body = await response.text();
+    const retryable = response.status === 429 || response.status >= 500;
+    if (!retryable || attempt === 5) {
+      throw new Error(`GitHub API ${path} failed: HTTP ${response.status} ${body.slice(0, 500)}`);
+    }
+    console.warn(`[landing-feishu] GitHub API ${path} attempt ${attempt}/5 failed: HTTP ${response.status}`);
+    await retryDelay(attempt);
+  }
+  throw new Error(`GitHub API ${path} failed`);
+}
+
+function retryDelay(attempt: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.min(1000 * 2 ** (attempt - 1), 15000)));
+}
+
+function encodeQuery(params: Record<string, string | number>): string {
+  return new URLSearchParams(Object.entries(params).map(([key, value]) => [key, String(value)])).toString();
+}
+
+async function searchPullNumbers(repo: string, since: Date): Promise<number[]> {
+  const query = `repo:${repo} is:pr is:merged base:main merged:>=${since.toISOString()}`;
+  const numbers: number[] = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const response = await githubJson<SearchResponse>(
+      `/search/issues?${encodeQuery({ q: query, sort: "updated", order: "desc", per_page: 100, page })}`,
+    );
+    numbers.push(...response.items.map((item) => item.number));
+    if (numbers.length >= response.total_count || response.items.length < 100) break;
+  }
+  return [...new Set(numbers)];
+}
+
+async function pullRequest(repo: string, number: number): Promise<PullRequest> {
+  return githubJson<PullRequest>(`/repos/${repo}/pulls/${number}`);
+}
+
+async function pullFiles(repo: string, number: number): Promise<PullFile[]> {
+  const files: PullFile[] = [];
+  for (let page = 1; page <= 4; page += 1) {
+    const pageFiles = await githubJson<PullFile[]>(`/repos/${repo}/pulls/${number}/files?${encodeQuery({ per_page: 100, page })}`);
+    files.push(...pageFiles);
+    if (pageFiles.length < 100) break;
+  }
+  return files;
+}
+
+async function workflowRuns(repo: string, workflow: string): Promise<WorkflowRun[]> {
+  const response = await githubJson<WorkflowRunsResponse>(
+    `/repos/${repo}/actions/workflows/${workflow}/runs?${encodeQuery({ branch: "main", per_page: 100 })}`,
+  );
+  return response.workflow_runs;
+}
+
+function latestSuccessfulRun(runs: WorkflowRun[]): WorkflowRun | null {
+  return sortRunsNewestFirst(runs).find((run) => run.status === "completed" && run.conclusion === "success") ?? null;
+}
+
+function sortRunsNewestFirst(runs: WorkflowRun[]): WorkflowRun[] {
+  return [...runs].sort((a, b) => {
+    const timeDiff = runOperationalTime(b) - runOperationalTime(a);
+    if (timeDiff !== 0) return timeDiff;
+    return (b.run_attempt ?? 1) - (a.run_attempt ?? 1);
+  });
+}
+
+function runOperationalTime(run: WorkflowRun | null): number {
+  if (run == null) return 0;
+  return new Date(run.run_started_at ?? run.updated_at ?? run.created_at).getTime();
+}
+
+function createStagingSnapshot(stagingRuns: WorkflowRun[]): StagingSnapshot {
+  const runs = sortRunsNewestFirst(stagingRuns);
+  const current = latestSuccessfulRun(runs);
+  const currentTime = runOperationalTime(current);
+  const newerThanCurrent = (run: WorkflowRun) => runOperationalTime(run) > currentTime;
+  return {
+    current,
+    inFlight:
+      runs.find((run) => newerThanCurrent(run) && ["queued", "in_progress", "waiting", "pending", "requested"].includes(run.status)) ?? null,
+    failed: runs.find((run) => newerThanCurrent(run) && run.status === "completed" && run.conclusion !== "success") ?? null,
+  };
+}
+
+function isLandingPath(path: string): boolean {
+  return LANDING_EXACT_PATHS.has(path) || LANDING_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+function landingBuckets(files: PullFile[]): string {
+  const labels = new Set<string>();
+  for (const { filename } of files) {
+    if (filename.startsWith("apps/landing-page/")) labels.add("landing app");
+    else if (filename.startsWith("design-templates/open-design-landing/")) labels.add("homepage template");
+    else if (filename.startsWith("skills/")) labels.add("skills catalog");
+    else if (filename.startsWith("design-systems/")) labels.add("systems catalog");
+    else if (filename.startsWith("craft/")) labels.add("craft catalog");
+    else if (filename.startsWith("templates/")) labels.add("templates catalog");
+    else if (filename.startsWith("plugins/")) labels.add("plugins catalog");
+    else if (filename.startsWith(".github/workflows/landing-page")) labels.add("landing CI");
+    else if (filename.startsWith(".github/workflows/blog-indexing")) labels.add("blog indexing");
+    else if (LANDING_EXACT_PATHS.has(filename)) labels.add("workspace plumbing");
+  }
+  return [...labels].join(", ") || "landing-related files";
+}
+
+function isAncestor(ancestor: string | null, descendant: string | null): boolean {
+  if (ancestor == null || descendant == null) return false;
+  if (ancestor === descendant) return true;
+  if (!/^[0-9a-f]{40}$/.test(ancestor) || !/^[0-9a-f]{40}$/.test(descendant)) return false;
+  try {
+    execFileSync("git", ["merge-base", "--is-ancestor", ancestor, descendant], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveDeploymentState(pull: PullRequest, staging: StagingSnapshot): DeploymentState {
+  if (pull.merged_at == null || pull.merge_commit_sha == null) {
+    return { kind: "not-merged", label: pull.state === "open" ? "PR 未合并, staging 暂无" : "PR 已关闭未合并" };
+  }
+
+  if (staging.current != null && isAncestor(pull.merge_commit_sha, staging.current.head_sha)) {
+    return { kind: "deployed", label: "已自动部署到当前 staging.open-design.ai", run: staging.current };
+  }
+
+  if (staging.inFlight != null && isAncestor(pull.merge_commit_sha, staging.inFlight.head_sha)) {
+    return { kind: "deploying", label: "正在部署到 staging.open-design.ai", run: staging.inFlight };
+  }
+
+  if (staging.failed != null && isAncestor(pull.merge_commit_sha, staging.failed.head_sha)) {
+    return { kind: "failed", label: `staging 部署 ${staging.failed.conclusion ?? "未成功"}`, run: staging.failed };
+  }
+
+  return { kind: "pending", label: "已合并, 当前 staging.open-design.ai 尚未包含" };
+}
+
+function shortSha(sha: string | null): string {
+  return sha == null ? "" : sha.slice(0, 7);
+}
+
+function shanghaiDateTime(value: string | Date): string {
+  const date = typeof value === "string" ? new Date(value) : value;
+  return new Intl.DateTimeFormat("zh-CN", {
+    dateStyle: "short",
+    timeStyle: "short",
+    timeZone: "Asia/Shanghai",
+  }).format(date);
+}
+
+function sanitizeMarkdown(value: string): string {
+  return value.replace(/\s+/g, " ").replaceAll("[", "［").replaceAll("]", "］").replaceAll("`", "'");
+}
+
+function truncate(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, Math.max(0, limit - 1))}…`;
+}
+
+function stateLine(state: DeploymentState): string {
+  if ("run" in state) {
+    return `${state.label}: [run #${state.run.run_number}](${state.run.html_url})`;
+  }
+  return state.label;
+}
+
+function buildPullLine(item: LandingPull, index: number, state: DeploymentState): string {
+  const { pull, files } = item;
+  const title = truncate(sanitizeMarkdown(pull.title), 90);
+  const actor = pull.user?.login != null ? ` by ${pull.user.login}` : "";
+  const when =
+    pull.merged_at != null
+      ? `merged ${shanghaiDateTime(pull.merged_at)}`
+      : pull.state === "open"
+        ? `updated ${shanghaiDateTime(pull.updated_at)}`
+        : `closed ${shanghaiDateTime(pull.updated_at)}`;
+  const merge = pull.merge_commit_sha != null ? `, ${shortSha(pull.merge_commit_sha)}` : "";
+  return [
+    `${index + 1}. [#${pull.number} ${title}](${pull.html_url})`,
+    `   - ${when}${actor}${merge}`,
+    `   - 改动: ${landingBuckets(files)}`,
+    `   - staging: ${stateLine(state)}`,
+  ].join("\n");
+}
+
+function buildCard(params: {
+  activeRuns: WorkflowRun[];
+  deployedCount: number;
+  landingPulls: LandingPull[];
+  now: Date;
+  productionRun: WorkflowRun;
+  repo: string;
+  runUrl: string;
+  staging: StagingSnapshot;
+  states: Map<number, DeploymentState>;
+}): Record<string, unknown> {
+  const { activeRuns, deployedCount, landingPulls, now, productionRun, repo, runUrl, staging, states } = params;
+  const latestSuccess = staging.current;
+  const deployingCount = [...states.values()].filter((state) => state.kind === "deploying").length;
+  const headerTemplate = deployingCount > 0 ? "orange" : "blue";
+  const shown = landingPulls.slice(0, MAX_CARD_PULLS);
+  const omitted = Math.max(0, landingPulls.length - shown.length);
+  const summaryLines = [
+    `**仓库**: ${repo}`,
+    `**验收范围**: 最近一次正式发布之后新增的 landing 相关 PR`,
+    `**正式环境基线**: [production run #${productionRun.run_number}](${productionRun.html_url}) @ ${shortSha(productionRun.head_sha)}, ${shanghaiDateTime(productionRun.updated_at)}`,
+    `**生成时间**: ${shanghaiDateTime(now)}`,
+    `**staging**: [staging.open-design.ai](${STAGING_URL})`,
+    latestSuccess != null
+      ? `**最新成功 staging 部署**: [run #${latestSuccess.run_number}](${latestSuccess.html_url}) @ ${shortSha(latestSuccess.head_sha)}`
+      : "**最新成功 staging 部署**: 未找到",
+    activeRuns.length > 0 ? `**当前 staging 部署中**: ${activeRuns.map((run) => `[run #${run.run_number}](${run.html_url})`).join(", ")}` : "",
+    runUrl.length > 0 ? `**本次汇总 CI**: [run](${runUrl})` : "",
+  ].filter(Boolean);
+
+  const pullLines =
+    shown.length === 0
+      ? "最近一次正式发布之后没有发现新增 landing 相关 PR。"
+      : shown.map((item, index) => buildPullLine(item, index, states.get(item.pull.number) ?? { kind: "pending", label: "状态未知" })).join("\n");
+
+  const footer = omitted > 0 ? `\n\n还有 ${omitted} 个 landing PR 未展示, 请打开本次汇总 CI 查看完整日志。` : "";
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      template: headerTemplate,
+      title: { tag: "plain_text", content: "Landing QA 验收摘要" },
+    },
+    elements: [
+      {
+        tag: "div",
+        text: {
+          tag: "lark_md",
+          content: `${summaryLines.join("\n")}\n\n**待 QA 验收**: ${landingPulls.length} 个 landing PR, ${deployedCount} 个已进入 staging, ${deployingCount} 个正在部署。`,
+        },
+      },
+      { tag: "hr" },
+      {
+        tag: "div",
+        text: { tag: "lark_md", content: `${pullLines}${footer}` },
+      },
+    ],
+  };
+}
+
+function signedEnvelope(card: Record<string, unknown>): Record<string, unknown> {
+  const body = { msg_type: "interactive", card };
+  const signSecret = optionalEnv("FEISHU_SIGN_SECRET");
+  if (signSecret.length === 0) return body;
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const sign = createHmac("sha256", `${timestamp}\n${signSecret}`).update("").digest("base64");
+  return { timestamp, sign, ...body };
+}
+
+async function postFeishu(card: Record<string, unknown>): Promise<void> {
+  const webhook = requiredEnv("FEISHU_WEBHOOK");
+  const body = signedEnvelope(card);
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const response = await fetch(webhook, {
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const text = await response.text();
+    let code: unknown = null;
+    try {
+      const parsed = JSON.parse(text) as { code?: unknown; StatusCode?: unknown };
+      code = parsed.code ?? parsed.StatusCode ?? null;
+    } catch {
+      // Feishu normally returns JSON, but preserve the HTTP status fallback.
+    }
+    if (response.ok && (code === 0 || code == null)) {
+      console.log(`[landing-feishu] delivered (HTTP ${response.status}, code ${code ?? "n/a"})`);
+      return;
+    }
+    const retryable = response.status === 429 || response.status >= 500 || code === 9499;
+    console.warn(`[landing-feishu] attempt ${attempt}/5 failed: HTTP ${response.status} code ${String(code)} ${text.slice(0, 500)}`);
+    if (!retryable || attempt === 5) {
+      throw new Error(`Feishu webhook failed: HTTP ${response.status} code ${String(code)}`);
+    }
+    await retryDelay(attempt);
+  }
+}
+
+async function collectLandingPullsSinceProduction(repo: string, productionRun: WorkflowRun): Promise<LandingPull[]> {
+  const productionTime = new Date(productionRun.created_at);
+  const numbers = await searchPullNumbers(repo, productionTime);
+  const pulls = await mapLimit(numbers, PR_FETCH_CONCURRENCY, async (number) => {
+    const [pull, files] = await Promise.all([pullRequest(repo, number), pullFiles(repo, number)]);
+    if (pull.merged_at == null || pull.merge_commit_sha == null) {
+      return null;
+    }
+    if (isAncestor(pull.merge_commit_sha, productionRun.head_sha)) {
+      return null;
+    }
+    const landingFiles = files.filter((file) => isLandingPath(file.filename));
+    if (landingFiles.length > 0) {
+      return { pull, files: landingFiles };
+    }
+    return null;
+  });
+  return pulls.filter((item): item is LandingPull => item != null).sort((a, b) => {
+    const aTime = new Date(a.pull.merged_at ?? a.pull.updated_at).getTime();
+    const bTime = new Date(b.pull.merged_at ?? b.pull.updated_at).getTime();
+    return bTime - aTime;
+  });
+}
+
+async function mapLimit<T, R>(items: T[], limit: number, mapper: (item: T) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index] as T);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+async function run(): Promise<void> {
+  const repo = requiredEnv("GITHUB_REPOSITORY");
+  const now = new Date();
+  const [productionRuns, stagingRuns] = await Promise.all([workflowRuns(repo, PRODUCTION_WORKFLOW), workflowRuns(repo, STAGING_WORKFLOW)]);
+  const productionRun = latestSuccessfulRun(productionRuns);
+  if (productionRun == null) {
+    throw new Error(`No successful ${PRODUCTION_WORKFLOW} run found on main; cannot compute the QA delta from production.`);
+  }
+  const landingPulls = await collectLandingPullsSinceProduction(repo, productionRun);
+  const staging = createStagingSnapshot(stagingRuns);
+  const states = new Map<number, DeploymentState>();
+  let deployedCount = 0;
+  for (const item of landingPulls) {
+    const state = resolveDeploymentState(item.pull, staging);
+    states.set(item.pull.number, state);
+    if (state.kind === "deployed") deployedCount += 1;
+  }
+  const activeRuns = staging.inFlight == null ? [] : [staging.inFlight];
+  const runUrl = optionalEnv("RUN_URL");
+  const card = buildCard({ activeRuns, deployedCount, landingPulls, now, productionRun, repo, runUrl, staging, states });
+
+  console.log(
+    JSON.stringify(
+      {
+        activeStagingRuns: activeRuns.map((run) => ({ head_sha: run.head_sha, run_number: run.run_number, status: run.status, url: run.html_url })),
+        currentStaging: staging.current == null ? null : { head_sha: staging.current.head_sha, run_number: staging.current.run_number, url: staging.current.html_url },
+        productionBaseline: { head_sha: productionRun.head_sha, run_number: productionRun.run_number, url: productionRun.html_url },
+        landingPrs: landingPulls.map((item) => ({ number: item.pull.number, state: states.get(item.pull.number)?.kind })),
+      },
+      null,
+      2,
+    ),
+  );
+  await postFeishu(card);
+}
+
+function selfCheck(): void {
+  const now = new Date();
+  const run: WorkflowRun = {
+    conclusion: "success",
+    created_at: now.toISOString(),
+    event: "push",
+    head_sha: "b".repeat(40),
+    html_url: "https://github.com/nexu-io/open-design/actions/runs/1",
+    id: 1,
+    name: "landing-page-staging",
+    run_attempt: 1,
+    run_number: 12,
+    run_started_at: now.toISOString(),
+    status: "completed",
+    updated_at: now.toISOString(),
+  };
+  const pull: LandingPull = {
+    files: [{ filename: "apps/landing-page/app/page.tsx" }],
+    pull: {
+      draft: false,
+      html_url: "https://github.com/nexu-io/open-design/pull/123",
+      merge_commit_sha: "a".repeat(40),
+      merged_at: now.toISOString(),
+      number: 123,
+      state: "closed",
+      title: "Update landing hero",
+      updated_at: now.toISOString(),
+      user: { login: "designer" },
+    },
+  };
+  const card = buildCard({
+    activeRuns: [],
+    deployedCount: 1,
+    landingPulls: [pull],
+    now,
+    productionRun: { ...run, html_url: "https://github.com/nexu-io/open-design/actions/runs/3", name: "landing-page-production", run_number: 11 },
+    repo: "nexu-io/open-design",
+    runUrl: "https://github.com/nexu-io/open-design/actions/runs/2",
+    staging: createStagingSnapshot([run]),
+    states: new Map([[123, { kind: "deployed", label: "已自动部署到 staging.open-design.ai", run }]]),
+  });
+  const json = JSON.stringify(card);
+  if (STAGING_WORKFLOW !== "landing-page-staging.yml") {
+    throw new Error("self-check expected staging workflow to stay landing-page-staging.yml");
+  }
+  if (PRODUCTION_WORKFLOW !== "landing-page-production.yml") {
+    throw new Error("self-check expected production workflow to stay landing-page-production.yml");
+  }
+  if (!json.includes("正式环境基线") || !json.includes("待 QA 验收")) {
+    throw new Error("self-check expected QA production-baseline copy");
+  }
+  if (!json.includes(STAGING_URL)) {
+    throw new Error(`self-check expected card to include ${STAGING_URL}`);
+  }
+  const older = new Date(now.getTime() - 120000).toISOString();
+  const newer = new Date(now.getTime() - 60000).toISOString();
+  const latest = now.toISOString();
+  const historicalStaging = { ...run, created_at: older, head_sha: "a".repeat(40), run_number: 10, run_started_at: older, updated_at: older };
+  const currentStaging = { ...run, created_at: newer, head_sha: "b".repeat(40), run_number: 12, run_started_at: newer, updated_at: newer };
+  const historicalOnlyState = resolveDeploymentState(pull.pull, createStagingSnapshot([currentStaging, historicalStaging]));
+  if (historicalOnlyState.kind === "deployed") {
+    throw new Error("self-check expected historical staging success not to count as current staging deployment");
+  }
+  const rerunHistoricalStaging = { ...historicalStaging, run_attempt: 2, run_started_at: latest, updated_at: latest };
+  const rerunState = resolveDeploymentState(pull.pull, createStagingSnapshot([currentStaging, rerunHistoricalStaging]));
+  if (rerunState.kind !== "deployed") {
+    throw new Error("self-check expected rerun historical staging success to become current staging deployment");
+  }
+  const rerunCard = buildCard({
+    activeRuns: [],
+    deployedCount: 1,
+    landingPulls: [pull],
+    now,
+    productionRun: { ...run, html_url: "https://github.com/nexu-io/open-design/actions/runs/3", name: "landing-page-production", run_number: 11 },
+    repo: "nexu-io/open-design",
+    runUrl: "https://github.com/nexu-io/open-design/actions/runs/2",
+    staging: createStagingSnapshot([currentStaging, rerunHistoricalStaging]),
+    states: new Map([[123, { kind: "deployed", label: "已自动部署到 staging.open-design.ai", run: rerunHistoricalStaging }]]),
+  });
+  const rerunJson = JSON.stringify(rerunCard);
+  if (!rerunJson.includes("**最新成功 staging 部署**: [run #10]")) {
+    throw new Error("self-check expected rerun staging header to use the rerun historical deployment");
+  }
+  if (!String(resolveDeploymentState).includes("正在部署")) {
+    throw new Error("self-check expected deploying status copy");
+  }
+  if (!LANDING_PREFIXES.includes("apps/landing-page/")) {
+    throw new Error("self-check expected apps/landing-page/ path prefix");
+  }
+  console.log("[landing-feishu] self-check passed");
+}
+
+const command = process.argv[2] ?? "run";
+if (command === "self-check") {
+  selfCheck();
+} else if (command === "run") {
+  await run();
+} else {
+  throw new Error(`Unknown command: ${command}`);
+}

--- a/.github/workflows/landing-page-daily-feishu.yml
+++ b/.github/workflows/landing-page-daily-feishu.yml
@@ -1,0 +1,53 @@
+name: landing-page-daily-feishu
+
+# Every morning at 09:00 Asia/Shanghai, summarize landing-related PR activity
+# added after the latest successful landing-page-production deployment and post
+# it to Feishu for QA. The card marks merged PRs that are already included in
+# staging.open-design.ai by comparing their merge commit against successful
+# landing-page-staging runs. If a staging deploy is still running, the card
+# links the in-flight CI run.
+
+on:
+  schedule:
+    # 01:00 UTC = 09:00 Asia/Shanghai
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: landing-page-daily-feishu
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Notify Feishu with landing PR summary
+    if: github.repository == 'nexu-io/open-design' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout main history
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Check landing Feishu summary script
+        run: node --experimental-strip-types .github/scripts/landing-page-daily-feishu.ts self-check
+
+      - name: Post landing PR summary to Feishu
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_LANDING_WEBHOOK || secrets.FEISHU_RELEASE_WEBHOOK }}
+          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_LANDING_SIGN_SECRET || secrets.FEISHU_RELEASE_SIGN_SECRET }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node --experimental-strip-types .github/scripts/landing-page-daily-feishu.ts

--- a/.github/workflows/landing-page-production.yml
+++ b/.github/workflows/landing-page-production.yml
@@ -46,11 +46,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
-          # Production always ships `main`. workflow_dispatch can be launched
-          # from any ref via the Actions "Use workflow from" dropdown, so pin
-          # the checkout to main — the deployed artifact must equal reviewed
-          # main, never whatever branch/tag the operator happened to select.
-          ref: main
+          # The job-level gate above ensures this dispatch came from main.
+          # Pin checkout to the dispatch SHA, not floating main, so the
+          # workflow_run.head_sha used by follow-up QA/reporting jobs is exactly
+          # the commit that production shipped.
+          ref: ${{ github.sha }}
+
+      - name: Verify production checkout commit
+        run: |
+          set -euo pipefail
+          deployed_sha="$(git rev-parse HEAD)"
+          if [ "$deployed_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::production checkout resolved $deployed_sha but workflow dispatch SHA is $GITHUB_SHA"
+            exit 1
+          fi
+          main_sha="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+          if [ "$GITHUB_SHA" != "$main_sha" ]; then
+            echo "::error::refusing production deploy for stale workflow SHA $GITHUB_SHA; current origin/main is $main_sha"
+            echo "::error::dispatch a fresh production workflow from current main, or add an explicit rollback path instead of rerunning an old deploy."
+            exit 1
+          fi
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -41,6 +41,9 @@ const releaseBetaScriptPath = join(workspaceRoot, "tools", "release", "src", "me
 const packagedPackageJsonPath = join(workspaceRoot, "apps", "packaged", "package.json");
 const scopesScriptPath = join(workspaceRoot, "scripts", "scopes.ts");
 const notifyDailyFeishuWorkflowPath = join(workspaceRoot, ".github", "workflows", "notify-daily-feishu.yml");
+const landingPageDailyFeishuWorkflowPath = join(workspaceRoot, ".github", "workflows", "landing-page-daily-feishu.yml");
+const landingPageProductionWorkflowPath = join(workspaceRoot, ".github", "workflows", "landing-page-production.yml");
+const landingPageDailyFeishuScriptPath = join(workspaceRoot, ".github", "scripts", "landing-page-daily-feishu.ts");
 const releasePublishMetadataScriptPath = join(
   workspaceRoot,
   "tools",
@@ -758,6 +761,58 @@ describe("packaged smoke workflow", () => {
     // Default path: an empty input builds main, never a release branch.
     expect(resolveJob).toContain('echo "ref=main" >> "$GITHUB_OUTPUT"');
     expect(resolveJob).not.toContain("refs/heads/release/v*");
+  });
+
+  it("[P2] sends the daily landing PR summary to Feishu with staging deployment status", async () => {
+    const [workflow, productionWorkflow, script] = await Promise.all([
+      readFile(landingPageDailyFeishuWorkflowPath, "utf8"),
+      readFile(landingPageProductionWorkflowPath, "utf8"),
+      readFile(landingPageDailyFeishuScriptPath, "utf8"),
+    ]);
+    const trigger = sectionBetween(workflow, "on:", "\npermissions:");
+    const productionCheckout = sectionBetween(productionWorkflow, "- name: Checkout", "- name: Setup pnpm");
+
+    expect(trigger).toContain('cron: "0 1 * * *"');
+    expect(trigger).not.toContain("lookback_hours:");
+    expect(workflow).toContain("actions: read");
+    expect(workflow).toContain("contents: read");
+    expect(workflow).toContain("pull-requests: read");
+    expect(workflow).toContain("github.ref == 'refs/heads/main'");
+    expect(workflow).toContain("FEISHU_WEBHOOK: ${{ secrets.FEISHU_LANDING_WEBHOOK || secrets.FEISHU_RELEASE_WEBHOOK }}");
+    expect(workflow).toContain("FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_LANDING_SIGN_SECRET || secrets.FEISHU_RELEASE_SIGN_SECRET }}");
+    expect(workflow).toContain("node --experimental-strip-types .github/scripts/landing-page-daily-feishu.ts self-check");
+    expect(workflow).toContain("node --experimental-strip-types .github/scripts/landing-page-daily-feishu.ts");
+    expect(workflow).toContain("ref: main");
+    expect(workflow).toContain("fetch-depth: 0");
+    expect(productionCheckout).toContain("ref: ${{ github.sha }}");
+    expect(productionCheckout).not.toContain("ref: main");
+    expect(productionCheckout).toContain("Verify production checkout commit");
+    expect(productionCheckout).toContain('deployed_sha="$(git rev-parse HEAD)"');
+    expect(productionCheckout).toContain('$deployed_sha" != "$GITHUB_SHA');
+    expect(productionCheckout).toContain('main_sha="$(git ls-remote origin refs/heads/main');
+    expect(productionCheckout).toContain('$GITHUB_SHA" != "$main_sha');
+    expect(productionCheckout).toContain("refusing production deploy for stale workflow SHA");
+
+    expect(script).toContain('const STAGING_URL = "https://staging.open-design.ai"');
+    expect(script).toContain('const STAGING_WORKFLOW = "landing-page-staging.yml"');
+    expect(script).toContain('const PRODUCTION_WORKFLOW = "landing-page-production.yml"');
+    expect(script).toContain("type StagingSnapshot");
+    expect(script).toContain("createStagingSnapshot");
+    expect(script).toContain("run_started_at");
+    expect(script).toContain("run_attempt");
+    expect(script).toContain("runOperationalTime");
+    expect(script).toContain("staging: StagingSnapshot");
+    expect(script).toContain("historical staging success not to count as current staging deployment");
+    expect(script).toContain("rerun historical staging success to become current staging deployment");
+    expect(script).toContain("rerun staging header to use the rerun historical deployment");
+    expect(script).toContain("No successful ${PRODUCTION_WORKFLOW} run found on main");
+    expect(script).toContain("正式环境基线");
+    expect(script).toContain("待 QA 验收");
+    expect(script).toContain("git\", [\"merge-base\", \"--is-ancestor\"");
+    expect(script).toContain("已自动部署到当前 staging.open-design.ai");
+    expect(script).toContain("正在部署到 staging.open-design.ai");
+    expect(script).toContain("apps/landing-page/");
+    expect(script).toContain(".github/workflows/landing-page-staging.yml");
   });
 
   it("[P2] supports stable dry-run metadata and prepublish boundaries", async () => {


### PR DESCRIPTION
## Why

We need a daily QA handoff for landing-page changes that have not yet shipped to production. The previous 24-hour summary window was too noisy for QA because it mixed open activity with the actual acceptance scope.

This PR adds a scheduled Feishu summary that uses the latest successful `landing-page-production` run as the production baseline, then reports landing-related PRs merged after that baseline and whether each has reached `staging.open-design.ai`.

## What users will see

Every morning at 09:00 Asia/Shanghai, the configured Feishu group receives a "Landing QA 验收摘要" card. The card lists the production baseline, the latest staging deploy, each landing PR awaiting QA, and links any staging deploy that is still running.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — a new scheduled GitHub Actions notification posts a landing QA summary to Feishu
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface. A dry run was sent to the provided Feishu webhook and delivered successfully.

## Bug fix verification

-

## Validation

- `node --experimental-strip-types .github/scripts/landing-page-daily-feishu.ts self-check`
- Dry run to the provided Feishu webhook: delivered with `HTTP 200, code 0`
- `git diff --check`
- `git diff --cached --check`
- `pnpm --filter @open-design/e2e exec vitest run -c vitest.config.ts tests/packaged-smoke-workflow.test.ts -t "daily landing PR summary"`
- `pnpm --filter @open-design/e2e typecheck`

Notes:
- Local commands were run under Node v22.22.0, so pnpm emitted the repo's Node `~24` engine warning.
- `actionlint` was not available locally.
- `pnpm guard` is blocked in the original mixed worktree by pre-existing untracked/generated files and `tools/pr/` layout violations outside this PR scope.
