### PR TITLE
[codex] Backport design-system tracking to release/v0.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ e2e/ui/reports
 e2e/ui/test-results
 apps/web/playwright/
 
+# Playwright MCP capture output (YAML page snapshots + PNG screenshots).
+# Written ad-hoc during local visual checks; never commit — these hold local
+# UI/session state and are not a maintained test fixture.
+.playwright-mcp/
+
 # Legacy folder name from before the rename; keep ignored so existing
 # clones don't accidentally stage stale runtime data.
 .ocd

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -17,6 +17,8 @@ import {
   deriveConfigureGlobals,
   modelIdForTracking,
   sessionModeToTracking,
+  type TrackingDesignSystemSource,
+  type TrackingDesignSystemKind,
 } from '@open-design/contracts/analytics';
 import type { OdNativeEvent } from '@open-design/agui-adapter';
 import { newInsertId, readAnalyticsContext } from '../analytics.js';
@@ -798,6 +800,33 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           ),
         ),
       ];
+      // Map the internal DS selection source -> the wire `design_system_source`
+      // enum (previously hard-wired to unknown/not_applicable). And derive
+      // official-vs-custom from the id shape (`user:<id>` => custom). See the
+      // design-system tracking spec §3.5 (U3/U4).
+      const dsSelectedId = analyticsDesignSystemSelection.id;
+      const designSystemSourceForRun: TrackingDesignSystemSource = (() => {
+        switch (analyticsDesignSystemSelection.source) {
+          case 'request':
+            return 'user_selected';
+          case 'plugin':
+            return 'template_inherited';
+          case 'project':
+            return 'project_saved';
+          case 'app-default':
+            return 'default';
+          case 'none':
+          default:
+            return dsSelectedId ? 'unknown' : 'not_applicable';
+        }
+      })();
+      const designSystemKindForRun: TrackingDesignSystemKind | undefined = dsSelectedId
+        ? dsSelectedId.startsWith('user:')
+          ? 'custom'
+          : 'official'
+        : undefined;
+      const designSystemSlugForRun =
+        dsSelectedId && !dsSelectedId.startsWith('user:') ? dsSelectedId : undefined;
       const baseProps: Record<string, unknown> = {
         page_name: isDesignSystemRun ? 'design_system_project' : 'chat_panel',
         area: isDesignSystemRun ? 'design_system_generation' : 'chat_composer',
@@ -814,12 +843,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         project_kind: runProjectKind,
         ...(hintEntryFrom ? { entry_from: hintEntryFrom } : {}),
         ...sessionDimensionProps,
-        design_system_id: analyticsDesignSystemSelection.id ?? undefined,
+        design_system_id: dsSelectedId ?? undefined,
         design_system_selection_source: analyticsDesignSystemSelection.source,
-        design_system_source:
-          analyticsDesignSystemSelection.id
-            ? 'unknown'
-            : 'not_applicable',
+        design_system_source: designSystemSourceForRun,
+        ...(designSystemKindForRun ? { design_system_kind: designSystemKindForRun } : {}),
+        ...(designSystemSlugForRun ? { design_system_slug: designSystemSlugForRun } : {}),
         ...(isDesignSystemRun ? {
           ds_source_origin: typeof dsRunContext.origin === 'string'
             ? dsRunContext.origin

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -31,7 +31,7 @@ import {
   readCodexRolloutFirstCall,
 } from '../codex-rollout-usage.js';
 import type { ConnectorService } from '../connectors/service.js';
-import { getProject, listConversations, upsertMessage } from '../db.js';
+import { getProject, listConversations, updateProject, upsertMessage } from '../db.js';
 import { readVelaLoginStatus } from '../integrations/vela.js';
 import {
   deriveLangfuseDeliveryState,
@@ -743,6 +743,9 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       const hintIsFirstRun = typeof analyticsHints.isFirstRun === 'boolean'
         ? analyticsHints.isFirstRun
         : undefined;
+      // Marks the AI-optimize (deep enrichment) run so completion can emit
+      // design_system_enrich_result + flag the DS ai_refined (C14/C15).
+      const hintDsEnrichment = analyticsHints.dsEnrichment === true;
       const hintHasExistingArtifact = typeof analyticsHints.hasExistingArtifact === 'boolean'
         ? analyticsHints.hasExistingArtifact
         : undefined;
@@ -930,6 +933,43 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         );
         const result = runResultFromStatus(status.status);
         const errorCode = deriveRunErrorCode(status);
+        // C14/C15: AI-optimize (enrichment) run settled. Emit the dedicated
+        // result event and, on success, flag the DS ai_refined so the
+        // programmatic-vs-refined cohorts are comparable (tracking spec §6).
+        if (hintDsEnrichment) {
+          design.analytics.capture({
+            eventName: 'design_system_enrich_result',
+            context: analyticsContext,
+            appVersion: design.getAppVersion(),
+            properties: {
+              page_name: 'design_system_project',
+              area: 'design_system_enrich',
+              result,
+              design_system_id: dsSelectedId ?? undefined,
+              project_id: requestProjectId,
+              run_id: run.id,
+              ...(errorCode ? { error_code: errorCode } : {}),
+              duration_ms: Math.max(0, Date.now() - run.createdAt),
+            },
+            insertId: newInsertId(),
+          });
+          if (result === 'success' && requestProjectId) {
+            try {
+              const enrichedProject = getProject(db, requestProjectId);
+              if (enrichedProject) {
+                updateProject(db, requestProjectId, {
+                  metadata: {
+                    ...(enrichedProject.metadata ?? {}),
+                    enrichmentStatus: 'ai_refined',
+                    enrichmentCompletedAt: Date.now(),
+                  },
+                });
+              }
+            } catch {
+              // Best-effort flag; the enrich_result event already recorded the outcome.
+            }
+          }
+        }
         const failure = classifyRunFailure({
           result,
           status,

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -19,6 +19,7 @@ import {
   sessionModeToTracking,
   type TrackingDesignSystemSource,
   type TrackingDesignSystemKind,
+  type TrackingDesignSystemEditSurface,
 } from '@open-design/contracts/analytics';
 import type { OdNativeEvent } from '@open-design/agui-adapter';
 import { newInsertId, readAnalyticsContext } from '../analytics.js';
@@ -827,6 +828,18 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         : undefined;
       const designSystemSlugForRun =
         dsSelectedId && !dsSelectedId.startsWith('user:') ? dsSelectedId : undefined;
+      // E1 (tracking spec §3.4): a DS-project run that edits an EXISTING design
+      // system carries which surface drove it. comment/mark ride their own
+      // entry_from; everything else editing an existing DS is the chat surface.
+      // First-generation runs (no existing artifact) get no edit_surface.
+      const editSurfaceForRun: TrackingDesignSystemEditSurface | undefined =
+        runProjectKind === 'design_system' && hintHasExistingArtifact === true
+          ? hintEntryFrom === 'comment'
+            ? 'comment'
+            : hintEntryFrom === 'mark'
+              ? 'mark'
+              : 'chat'
+          : undefined;
       const baseProps: Record<string, unknown> = {
         page_name: isDesignSystemRun ? 'design_system_project' : 'chat_panel',
         area: isDesignSystemRun ? 'design_system_generation' : 'chat_composer',
@@ -848,6 +861,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         design_system_source: designSystemSourceForRun,
         ...(designSystemKindForRun ? { design_system_kind: designSystemKindForRun } : {}),
         ...(designSystemSlugForRun ? { design_system_slug: designSystemSlugForRun } : {}),
+        ...(editSurfaceForRun ? { edit_surface: editSurfaceForRun } : {}),
         ...(isDesignSystemRun ? {
           ds_source_origin: typeof dsRunContext.origin === 'string'
             ? dsRunContext.origin

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -680,6 +680,36 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     }
     design.runs.start(run, () => startChatRun(meta, run));
 
+    const reqBody = requestBody;
+    const analyticsHints =
+      (reqBody as { analyticsHints?: Record<string, unknown> | null }).analyticsHints
+        && typeof (reqBody as { analyticsHints?: unknown }).analyticsHints === 'object'
+        ? ((reqBody as { analyticsHints?: Record<string, unknown> }).analyticsHints ?? {})
+        : {};
+    // Marks the AI-optimize (deep enrichment) run so completion can flag the DS
+    // ai_refined even when analytics is unavailable or disabled.
+    const hintDsEnrichment = analyticsHints.dsEnrichment === true;
+    const requestProjectId = typeof reqBody.projectId === 'string' ? reqBody.projectId : null;
+    if (hintDsEnrichment && requestProjectId) {
+      design.runs.wait(run).then((status: TerminalRunStatus) => {
+        if (runResultFromStatus(status.status) !== 'success') return;
+        try {
+          const enrichedProject = getProject(db, requestProjectId);
+          if (enrichedProject) {
+            updateProject(db, requestProjectId, {
+              metadata: {
+                ...(enrichedProject.metadata ?? {}),
+                enrichmentStatus: 'ai_refined',
+                enrichmentCompletedAt: Date.now(),
+              },
+            });
+          }
+        } catch {
+          // Best-effort flag; do not fail run completion if metadata refresh fails.
+        }
+      }).catch(() => {});
+    }
+
     const analyticsContext = readAnalyticsContext(req);
     if (analyticsContext) {
       run.analyticsContext = analyticsContext;
@@ -692,7 +722,6 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       });
     }).catch(() => {});
     if (analyticsContext) {
-      const reqBody = requestBody;
       const runInsertId = newInsertId();
       const appCfgForAnalytics = await readAppConfig(RUNTIME_DATA_DIR).catch(
         () => ({} as Record<string, unknown>),
@@ -726,11 +755,6 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       const userQueryTokens = promptText.length > 0
         ? Math.ceil(promptText.length / 4)
         : 0;
-      const analyticsHints =
-        (reqBody as { analyticsHints?: Record<string, unknown> | null }).analyticsHints
-          && typeof (reqBody as { analyticsHints?: unknown }).analyticsHints === 'object'
-          ? ((reqBody as { analyticsHints?: Record<string, unknown> }).analyticsHints ?? {})
-          : {};
       const hintEntryFrom = typeof analyticsHints.entryFrom === 'string'
         ? analyticsHints.entryFrom
         : undefined;
@@ -743,9 +767,6 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       const hintIsFirstRun = typeof analyticsHints.isFirstRun === 'boolean'
         ? analyticsHints.isFirstRun
         : undefined;
-      // Marks the AI-optimize (deep enrichment) run so completion can emit
-      // design_system_enrich_result + flag the DS ai_refined (C14/C15).
-      const hintDsEnrichment = analyticsHints.dsEnrichment === true;
       const hintHasExistingArtifact = typeof analyticsHints.hasExistingArtifact === 'boolean'
         ? analyticsHints.hasExistingArtifact
         : undefined;
@@ -756,7 +777,6 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           ? { has_existing_artifact: hintHasExistingArtifact }
           : {}),
       };
-      const requestProjectId = typeof reqBody.projectId === 'string' ? reqBody.projectId : null;
       const runProjectForAnalytics = requestProjectId
         ? toProjectRecord(getProject(db, requestProjectId))
         : null;
@@ -934,9 +954,8 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         const result = runResultFromStatus(status.status);
         const errorCode = deriveRunErrorCode(status);
         // C14/C15: AI-optimize (enrichment) run settled. Emit the dedicated
-        // result event and, on success, flag the DS ai_refined so the
-        // programmatic-vs-refined cohorts are comparable (tracking spec §6).
-        if (hintDsEnrichment) {
+        // result event; the success metadata flag runs outside this analytics gate.
+        if (hintDsEnrichment && analyticsContext) {
           design.analytics.capture({
             eventName: 'design_system_enrich_result',
             context: analyticsContext,
@@ -953,22 +972,6 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             },
             insertId: newInsertId(),
           });
-          if (result === 'success' && requestProjectId) {
-            try {
-              const enrichedProject = getProject(db, requestProjectId);
-              if (enrichedProject) {
-                updateProject(db, requestProjectId, {
-                  metadata: {
-                    ...(enrichedProject.metadata ?? {}),
-                    enrichmentStatus: 'ai_refined',
-                    enrichmentCompletedAt: Date.now(),
-                  },
-                });
-              }
-            } catch {
-              // Best-effort flag; the enrich_result event already recorded the outcome.
-            }
-          }
         }
         const failure = classifyRunFailure({
           result,

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -333,6 +333,14 @@ function toProjectRecord(value: unknown): ProjectRecord | null {
     : null;
 }
 
+function isProjectEnrichableDesignSystem(project: ProjectRecord): boolean {
+  if (typeof project.designSystemId === 'string' && project.designSystemId.length > 0) {
+    return true;
+  }
+  const metadata = project.metadata;
+  return metadata?.importedFrom === 'brand-extraction' || metadata?.importedFrom === 'design-system';
+}
+
 function toConversationRecords(value: unknown): ConversationRecord[] {
   return Array.isArray(value)
     ? value.filter((item): item is ConversationRecord =>
@@ -694,8 +702,8 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       design.runs.wait(run).then((status: TerminalRunStatus) => {
         if (runResultFromStatus(status.status) !== 'success') return;
         try {
-          const enrichedProject = getProject(db, requestProjectId);
-          if (enrichedProject) {
+          const enrichedProject = toProjectRecord(getProject(db, requestProjectId));
+          if (enrichedProject && isProjectEnrichableDesignSystem(enrichedProject)) {
             updateProject(db, requestProjectId, {
               metadata: {
                 ...(enrichedProject.metadata ?? {}),

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1473,6 +1473,11 @@ function resolveRunProjectKindForAnalytics({
 }) {
   if (typeof hintProjectKind === 'string') return hintProjectKind;
   if (projectMetadata?.importedFrom === 'design-system') return 'design_system';
+  // Brand-extraction backing projects (kind:'brand', importedFrom:
+  // 'brand-extraction') ARE design systems — a brand is one source for a DS,
+  // not a separate object. Report them as design_system so DS-project runs
+  // (creation + later edits) drill down cleanly. See design-system tracking spec §1.
+  if (projectMetadata?.importedFrom === 'brand-extraction') return 'design_system';
   // Pass videoModel so a HyperFrames project (kind=video + videoModel=
   // hyperframes-html) is reported as project_kind=hyperframes, not generic
   // video. The web-supplied `hintProjectKind` already encodes this when set.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import {
   trackProjectCreateResult,
 } from './analytics/events';
 import { deriveUploadCohort } from './analytics/upload-tracking';
+import { setPendingDesignSystemCreateEntry } from './analytics/ds-create-entry';
 import { detectClientType } from './analytics/identity';
 import {
   deriveConfigureGlobals,
@@ -2248,7 +2249,10 @@ function AppInner() {
         onRenameProject={handleRenameProject}
         onProjectsRefresh={refreshProjectsStrict}
         onChangeDefaultDesignSystem={handleChangeDefaultDesignSystem}
-        onCreateDesignSystem={() => navigate({ kind: 'design-system-create' })}
+        onCreateDesignSystem={() => {
+          setPendingDesignSystemCreateEntry('design_systems_page');
+          navigate({ kind: 'design-system-create' });
+        }}
         onOpenDesignSystem={(id: string) => navigate({ kind: 'design-system-detail', designSystemId: id })}
         onDesignSystemsRefresh={refreshDesignSystems}
         onPersistComposioKey={handleConfigPersistComposioKey}

--- a/apps/web/src/analytics/ds-create-entry.ts
+++ b/apps/web/src/analytics/ds-create-entry.ts
@@ -1,0 +1,29 @@
+// Pending entry-source hint for the /design-systems/create flow.
+//
+// The route `{ kind: 'design-system-create' }` carries no params, so the
+// create page can't otherwise tell *where the user came from*. Each
+// `navigate({ kind: 'design-system-create' })` call site sets the source
+// here right before navigating; the create page consumes it once for its
+// `page_view` and `create_result` `entry_from`. Kept as a transient
+// module-level value (not storage): it's set-then-consumed within the same
+// SPA navigation. A reload before consumption simply falls back to the
+// onboarding/`unknown` heuristic — acceptable for an analytics hint.
+
+import type { TrackingDesignSystemCreateEntryFrom } from '@open-design/contracts/analytics';
+
+let pendingEntry: TrackingDesignSystemCreateEntryFrom | null = null;
+
+export function setPendingDesignSystemCreateEntry(
+  from: TrackingDesignSystemCreateEntryFrom,
+): void {
+  pendingEntry = from;
+}
+
+// Returns the pending entry source and clears it, so a later visit that
+// arrives without a set() (e.g. a direct URL load) doesn't inherit a stale
+// source.
+export function consumeDesignSystemCreateEntry(): TrackingDesignSystemCreateEntryFrom | null {
+  const value = pendingEntry;
+  pendingEntry = null;
+  return value;
+}

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -53,6 +53,8 @@ import type {
   DesignSystemsCreateClickProps,
   DesignSystemsPresetBrandPickerClickProps,
   DesignSystemsPresetBrandPickerSurfaceViewProps,
+  DesignSystemEnrichClickProps,
+  DesignSystemEnrichResultProps,
   IntegrationsTabClickProps,
   IntegrationsMcpTabClickProps,
   IntegrationsConnectorsTabClickProps,
@@ -508,6 +510,20 @@ export function trackDesignSystemsPresetBrandPickerSurfaceView(
   props: DesignSystemsPresetBrandPickerSurfaceViewProps,
 ): void {
   send(track, 'surface_view', props);
+}
+
+export function trackDesignSystemEnrichClick(
+  track: Track,
+  props: DesignSystemEnrichClickProps,
+): void {
+  send(track, 'ui_click', props);
+}
+
+export function trackDesignSystemEnrichResult(
+  track: Track,
+  props: DesignSystemEnrichResultProps,
+): void {
+  send(track, 'design_system_enrich_result', props);
 }
 
 export function trackIntegrationsTabClick(

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -51,6 +51,8 @@ import type {
   DesignSystemsTemplatesModalClickProps,
   DesignSystemsTemplatesModalSharePopoverClickProps,
   DesignSystemsCreateClickProps,
+  DesignSystemsPresetBrandPickerClickProps,
+  DesignSystemsPresetBrandPickerSurfaceViewProps,
   IntegrationsTabClickProps,
   IntegrationsMcpTabClickProps,
   IntegrationsConnectorsTabClickProps,
@@ -492,6 +494,20 @@ export function trackDesignSystemsCreateClick(
   props: DesignSystemsCreateClickProps,
 ): void {
   send(track, 'ui_click', props);
+}
+
+export function trackDesignSystemsPresetBrandPickerClick(
+  track: Track,
+  props: DesignSystemsPresetBrandPickerClickProps,
+): void {
+  send(track, 'ui_click', props);
+}
+
+export function trackDesignSystemsPresetBrandPickerSurfaceView(
+  track: Track,
+  props: DesignSystemsPresetBrandPickerSurfaceViewProps,
+): void {
+  send(track, 'surface_view', props);
 }
 
 export function trackIntegrationsTabClick(

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -55,6 +55,7 @@ import type {
   DesignSystemsPresetBrandPickerSurfaceViewProps,
   DesignSystemEnrichClickProps,
   DesignSystemEnrichResultProps,
+  DesignSystemEditClickProps,
   IntegrationsTabClickProps,
   IntegrationsMcpTabClickProps,
   IntegrationsConnectorsTabClickProps,
@@ -524,6 +525,13 @@ export function trackDesignSystemEnrichResult(
   props: DesignSystemEnrichResultProps,
 ): void {
   send(track, 'design_system_enrich_result', props);
+}
+
+export function trackDesignSystemEditClick(
+  track: Track,
+  props: DesignSystemEditClickProps,
+): void {
+  send(track, 'ui_click', props);
 }
 
 export function trackIntegrationsTabClick(

--- a/apps/web/src/components/BrandPreviewCard.tsx
+++ b/apps/web/src/components/BrandPreviewCard.tsx
@@ -14,6 +14,8 @@ import { Button } from '@open-design/components';
 import type { BrandSummary } from '@open-design/contracts';
 import { useT } from '../i18n';
 import { navigate } from '../router';
+import { useAnalytics } from '../analytics/provider';
+import { trackDesignSystemEditClick } from '../analytics/events';
 import { requestHomeChip } from '../runtime/home-intent';
 import { brandSummaryToKit } from '../runtime/design-kit';
 import { DesignKitView } from './DesignKitView';
@@ -43,6 +45,7 @@ export function BrandPreviewCard({
   onOpenProject,
 }: BrandPreviewCardProps) {
   const t = useT();
+  const analytics = useAnalytics();
   const compact = variant === 'compact';
   const { meta, brand } = summary;
   const name = brand?.name?.trim() || (meta.sourceUrl ? new URL(meta.sourceUrl).hostname.replace(/^www\./, '') : 'Brand');
@@ -61,6 +64,16 @@ export function BrandPreviewCard({
   const useInChat = useCallback(async () => {
     const designSystemId = meta.designSystemId;
     if (!designSystemId || busy) return;
+    trackDesignSystemEditClick(analytics.track, {
+      page_name: 'design_systems',
+      area: 'design_system_edit',
+      element: 'brand_card_use_in_chat',
+      module: 'brand_card',
+      edit_surface: 'direct_module',
+      artifact_kind: 'design_system',
+      design_system_id: designSystemId,
+      project_id: projectId ?? undefined,
+    });
     setBusy(true);
     try {
       if (onApplyDesignSystem) {
@@ -77,22 +90,42 @@ export function BrandPreviewCard({
     } finally {
       setBusy(false);
     }
-  }, [meta.designSystemId, busy, onApplyDesignSystem]);
+  }, [meta.designSystemId, busy, onApplyDesignSystem, analytics.track, projectId]);
 
   const openProject = useCallback(async () => {
     if (!projectId) return;
+    trackDesignSystemEditClick(analytics.track, {
+      page_name: 'design_systems',
+      area: 'design_system_edit',
+      element: 'brand_card_open_project',
+      module: 'brand_card',
+      edit_surface: 'direct_module',
+      artifact_kind: 'design_system',
+      design_system_id: meta.designSystemId ?? undefined,
+      project_id: projectId,
+    });
     if (onOpenProject) {
       const opened = await onOpenProject(projectId);
       if (opened === false) setBackingProjectMissing(true);
       return;
     }
     navigate({ kind: 'project', projectId, fileName: null, conversationId: null });
-  }, [onOpenProject, projectId]);
+  }, [onOpenProject, projectId, analytics.track, meta.designSystemId]);
 
   const deleteBrand = useCallback(async () => {
     if (busy) return;
     const ok = window.confirm(t('brandDetail.deleteConfirm').replace('{name}', name));
     if (!ok) return;
+    trackDesignSystemEditClick(analytics.track, {
+      page_name: 'design_systems',
+      area: 'design_system_edit',
+      element: 'brand_card_delete',
+      module: 'brand_card',
+      edit_surface: 'direct_module',
+      artifact_kind: 'design_system',
+      design_system_id: meta.designSystemId ?? undefined,
+      project_id: projectId ?? undefined,
+    });
     setBusy(true);
     try {
       await fetch(`/api/brands/${encodeURIComponent(meta.id)}`, { method: 'DELETE' });
@@ -101,7 +134,7 @@ export function BrandPreviewCard({
     } catch {
       setBusy(false);
     }
-  }, [busy, meta.id, name, onChanged, t]);
+  }, [busy, meta.id, meta.designSystemId, name, onChanged, t, analytics.track, projectId]);
 
   const badgeSlot = extracting ? (
     <span className={`${styles.badge} ${styles.badgeBusy}`} role="status">

--- a/apps/web/src/components/BrandPreviewCard.tsx
+++ b/apps/web/src/components/BrandPreviewCard.tsx
@@ -94,16 +94,19 @@ export function BrandPreviewCard({
 
   const openProject = useCallback(async () => {
     if (!projectId) return;
-    trackDesignSystemEditClick(analytics.track, {
-      page_name: 'design_systems',
-      area: 'design_system_edit',
-      element: 'brand_card_open_project',
-      module: 'brand_card',
-      edit_surface: 'direct_module',
-      artifact_kind: 'design_system',
-      design_system_id: meta.designSystemId ?? undefined,
-      project_id: projectId,
-    });
+    const designSystemId = meta.designSystemId;
+    if (designSystemId) {
+      trackDesignSystemEditClick(analytics.track, {
+        page_name: 'design_systems',
+        area: 'design_system_edit',
+        element: 'brand_card_open_project',
+        module: 'brand_card',
+        edit_surface: 'direct_module',
+        artifact_kind: 'design_system',
+        design_system_id: designSystemId,
+        project_id: projectId,
+      });
+    }
     if (onOpenProject) {
       const opened = await onOpenProject(projectId);
       if (opened === false) setBackingProjectMissing(true);
@@ -116,16 +119,19 @@ export function BrandPreviewCard({
     if (busy) return;
     const ok = window.confirm(t('brandDetail.deleteConfirm').replace('{name}', name));
     if (!ok) return;
-    trackDesignSystemEditClick(analytics.track, {
-      page_name: 'design_systems',
-      area: 'design_system_edit',
-      element: 'brand_card_delete',
-      module: 'brand_card',
-      edit_surface: 'direct_module',
-      artifact_kind: 'design_system',
-      design_system_id: meta.designSystemId ?? undefined,
-      project_id: projectId ?? undefined,
-    });
+    const designSystemId = meta.designSystemId;
+    if (designSystemId) {
+      trackDesignSystemEditClick(analytics.track, {
+        page_name: 'design_systems',
+        area: 'design_system_edit',
+        element: 'brand_card_delete',
+        module: 'brand_card',
+        edit_surface: 'direct_module',
+        artifact_kind: 'design_system',
+        design_system_id: designSystemId,
+        project_id: projectId ?? undefined,
+      });
+    }
     setBusy(true);
     try {
       await fetch(`/api/brands/${encodeURIComponent(meta.id)}`, { method: 'DELETE' });

--- a/apps/web/src/components/DesignKitView.tsx
+++ b/apps/web/src/components/DesignKitView.tsx
@@ -27,6 +27,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { Button, Textarea } from '@open-design/components';
+import type { DesignSystemEditClickProps } from '@open-design/contracts/analytics';
 import { useT } from '../i18n';
 import { openExternalUrl, projectRawUrl } from '../providers/registry';
 import { buildSrcdoc } from '../runtime/srcdoc';
@@ -278,6 +279,10 @@ export interface DesignKitViewProps {
   onDownload?: () => void;
   onImport?: () => void;
   onReset?: () => void;
+  onEditClick?: (
+    element: DesignSystemEditClickProps['element'],
+    module: DesignSystemEditClickProps['module'],
+  ) => void;
   uploading?: KitUploadModule | null;
   actionBusy?: string | null;
   onActionFeedback?: (tone: DesignKitActionFeedbackTone, message: string) => void;
@@ -306,6 +311,7 @@ function DesignKitViewInner({
   onDownload,
   onImport,
   onReset,
+  onEditClick,
   uploading,
   actionBusy,
   onActionFeedback,
@@ -542,6 +548,22 @@ function DesignKitViewInner({
     [t],
   );
 
+  function uploadElementForModule(module: KitUploadModule): DesignSystemEditClickProps['element'] {
+    return module === 'logo' ? 'logo_upload' : module === 'font' ? 'font_upload' : 'image_upload';
+  }
+
+  function uploadTrackingModule(module: KitUploadModule): DesignSystemEditClickProps['module'] {
+    return module === 'logo' ? 'logo' : module === 'font' ? 'typography' : 'images';
+  }
+
+  function designMdTrackingModule(module: DesignMdModuleSpec): DesignSystemEditClickProps['module'] {
+    if (module.id === 'typography') return 'typography';
+    if (module.id === 'palette') return 'palette';
+    if (module.id === 'imageryLayout') return 'images';
+    if (module.id === 'designSystem') return 'kit';
+    return 'design_md';
+  }
+
   function handleFile(module: KitUploadModule, event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     event.target.value = '';
@@ -574,7 +596,10 @@ function DesignKitViewInner({
         ? /\.(otf|ttf|woff2?)$/i.test(f.name)
         : f.type.startsWith('image/') || /\.svg$/i.test(f.name),
     );
-    if (file) onUploadModule(module, file);
+    if (file) {
+      onEditClick?.(uploadElementForModule(module), uploadTrackingModule(module));
+      onUploadModule(module, file);
+    }
   }
 
   async function pasteImage(module: Exclude<KitUploadModule, 'font'>) {
@@ -586,6 +611,7 @@ function DesignKitViewInner({
         if (!imageType) continue;
         const blob = await item.getType(imageType);
         const ext = imageType.split('/')[1]?.replace('jpeg', 'jpg') || 'png';
+        onEditClick?.(uploadElementForModule(module), uploadTrackingModule(module));
         onActionFeedback?.('loading', t('ds.uploading'));
         onUploadModule(module, new File([blob], `clipboard-${module}-${Date.now()}.${ext}`, { type: imageType }));
         return;
@@ -597,6 +623,7 @@ function DesignKitViewInner({
 
   function openDesignMdEditor() {
     if (!designMd) return;
+    onEditClick?.('design_md_edit', 'design_md');
     setDesignMdTarget({ kind: 'all' });
     setDesignMdDraft(designMd.body);
     setDesignMdOpen(true);
@@ -604,6 +631,7 @@ function DesignKitViewInner({
 
   function openDesignMdModuleEditor(module: DesignMdModuleSpec) {
     if (!designMd) return;
+    onEditClick?.('design_md_edit', designMdTrackingModule(module));
     const slice = designMdModuleSlice(designMd.body, module);
     setDesignMdTarget({ kind: 'module', module });
     setDesignMdDraft(slice.text);
@@ -626,12 +654,14 @@ function DesignKitViewInner({
 
   async function copyDesignMd() {
     if (!designMd?.body) return;
+    onEditClick?.('design_md_copy', 'design_md');
     await copyDesignMdText(designMd.body);
   }
 
   async function copyDesignMdModule(module: DesignMdModuleSpec) {
     if (!designMd?.body) return;
     const slice = designMdModuleSlice(designMd.body, module);
+    onEditClick?.('design_md_copy', designMdTrackingModule(module));
     await copyDesignMdText(slice.text);
   }
 
@@ -654,9 +684,11 @@ function DesignKitViewInner({
       void copyDesignMd();
     } else if (key === 'u' && canUpload) {
       event.preventDefault();
+      onEditClick?.('logo_upload', 'logo');
       logoInputRef.current?.click();
     } else if (key === 'r' && onRefresh) {
       event.preventDefault();
+      onEditClick?.('kit_refresh', 'kit');
       onRefresh();
     } else if (
       (event.key === 'Delete' || event.key === 'Backspace') &&
@@ -665,6 +697,7 @@ function DesignKitViewInner({
       target.closest('[data-kit-logo-stage]')
     ) {
       event.preventDefault();
+      onEditClick?.('logo_delete', 'logo');
       void onDeleteLogo(activeLogo);
     }
   }
@@ -681,6 +714,7 @@ function DesignKitViewInner({
   function openColorEditor(index: number) {
     const color = colors[index];
     if (!color) return;
+    onEditClick?.('color_edit', 'palette');
     setColorEditor({
       index,
       label: color.name || color.role || `Color ${index + 1}`,
@@ -736,6 +770,7 @@ function DesignKitViewInner({
     const file = event.target.files?.[0];
     event.target.value = '';
     if (!file) return;
+    onEditClick?.('design_md_upload', 'design_md');
     const text = await file.text();
     setDesignMdTarget({ kind: 'all' });
     setDesignMdDraft(text);
@@ -816,7 +851,10 @@ function DesignKitViewInner({
     return moduleActionButton(
       label,
       'upload',
-      () => (module === 'logo' ? logoInputRef : module === 'font' ? fontInputRef : imageInputRef).current?.click(),
+      () => {
+        onEditClick?.(uploadElementForModule(module), uploadTrackingModule(module));
+        (module === 'logo' ? logoInputRef : module === 'font' ? fontInputRef : imageInputRef).current?.click();
+      },
       Boolean(uploading || anyActionBusy),
       busy,
     );
@@ -832,7 +870,10 @@ function DesignKitViewInner({
             className={styles.uploadBtn}
             disabled={uploading === module || anyActionBusy}
             aria-busy={(uploading === module || actionBusy === `upload:${module}`) || undefined}
-            onClick={() => (module === 'logo' ? logoInputRef : module === 'font' ? fontInputRef : imageInputRef).current?.click()}
+            onClick={() => {
+              onEditClick?.(uploadElementForModule(module), uploadTrackingModule(module));
+              (module === 'logo' ? logoInputRef : module === 'font' ? fontInputRef : imageInputRef).current?.click();
+            }}
           >
             {uploading === module || actionBusy === `upload:${module}`
               ? t('ds.uploading')
@@ -1087,7 +1128,10 @@ function DesignKitViewInner({
                       ? moduleActionButton(
                           t('ds.deleteLogo'),
                           'trash',
-                          () => void onDeleteLogo(activeLogo),
+                          () => {
+                            onEditClick?.('logo_delete', 'logo');
+                            void onDeleteLogo(activeLogo);
+                          },
                           Boolean(uploading || anyActionBusy),
                           actionBusy === `delete-logo:${activeLogo}`,
                         )
@@ -1370,7 +1414,10 @@ function DesignKitViewInner({
                             className={`${styles.shotDelete} ${
                               actionBusy === `delete-image:${sampleIndex}` ? styles.shotDeleteLoading : ''
                             }`}
-                            onClick={() => void onDeleteImage(sampleIndex)}
+                            onClick={() => {
+                              onEditClick?.('image_delete', 'images');
+                              void onDeleteImage(sampleIndex);
+                            }}
                             disabled={Boolean(uploading || anyActionBusy)}
                             aria-busy={(actionBusy === `delete-image:${sampleIndex}`) || undefined}
                             aria-label={t('ds.deleteImage', { caption: cap })}
@@ -1402,10 +1449,30 @@ function DesignKitViewInner({
                 {moduleActions(
                   <>
                     {designMdModuleActionButtons(designMdModules.designSystem)}
-                    {!stickyHeader && onRefresh ? moduleActionButton(t('ds.refresh'), 'refresh', onRefresh, anyActionBusy, actionBusy === 'refresh') : null}
-                    {!stickyHeader && onDownload ? moduleActionButton(t('ds.download'), 'download', onDownload, anyActionBusy, actionBusy === 'download') : null}
-                    {!stickyHeader && onImport ? moduleActionButton(t('ds.importFolder'), 'import', onImport, anyActionBusy, actionBusy === 'import') : null}
-                    {!stickyHeader && onReset ? moduleActionButton(t('ds.reset'), 'reload', onReset, anyActionBusy, actionBusy === 'reset') : null}
+                    {!stickyHeader && onRefresh
+                      ? moduleActionButton(t('ds.refresh'), 'refresh', () => {
+                          onEditClick?.('kit_refresh', 'kit');
+                          onRefresh();
+                        }, anyActionBusy, actionBusy === 'refresh')
+                      : null}
+                    {!stickyHeader && onDownload
+                      ? moduleActionButton(t('ds.download'), 'download', () => {
+                          onEditClick?.('kit_download', 'kit');
+                          onDownload();
+                        }, anyActionBusy, actionBusy === 'download')
+                      : null}
+                    {!stickyHeader && onImport
+                      ? moduleActionButton(t('ds.importFolder'), 'import', () => {
+                          onEditClick?.('kit_import', 'kit');
+                          onImport();
+                        }, anyActionBusy, actionBusy === 'import')
+                      : null}
+                    {!stickyHeader && onReset
+                      ? moduleActionButton(t('ds.reset'), 'reload', () => {
+                          onEditClick?.('kit_reset', 'kit');
+                          onReset();
+                        }, anyActionBusy, actionBusy === 'reset')
+                      : null}
                   </>,
                 )}
               </div>

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -91,6 +91,8 @@ import {
   trackDesignSystemCreateResult,
   trackDesignSystemReviewResult,
   trackDesignSystemsCreateClick,
+  trackDesignSystemsPresetBrandPickerClick,
+  trackDesignSystemsPresetBrandPickerSurfaceView,
   trackDesignSystemSourceIngestResult,
   trackDesignSystemStatusResult,
   trackFileUploadResult,
@@ -100,6 +102,7 @@ import {
   clearOnboardingSessionId,
   peekOnboardingSessionId,
 } from '../analytics/onboarding-session';
+import { consumeDesignSystemCreateEntry } from '../analytics/ds-create-entry';
 import { deriveUploadCohort } from '../analytics/upload-tracking';
 import {
   designSystemFolderCountBucket,
@@ -383,18 +386,39 @@ export function DesignSystemCreationFlow({
   // OnboardingView, which owns the `area=design_system` step page_view.
   const analytics = useAnalytics();
   const creationPageViewFiredRef = useRef(false);
+  // Resolved create entry source. Consumed once from the pending hint set by
+  // the navigate() call site (§3.1); falls back to the onboarding-session /
+  // design_systems_page heuristic for direct URL loads. Reused by
+  // create_result so the funnel "entry → success" lines up.
+  const createEntryFromRef = useRef<TrackingDesignSystemCreateEntryFrom | null>(null);
   useEffect(() => {
     if (embedded) return;
     if (creationPageViewFiredRef.current) return;
     creationPageViewFiredRef.current = true;
     const onboardingSessionId = peekOnboardingSessionId();
+    const resolvedEntry: TrackingDesignSystemCreateEntryFrom =
+      consumeDesignSystemCreateEntry() ??
+      (onboardingSessionId ? 'onboarding' : 'design_systems_page');
+    createEntryFromRef.current = resolvedEntry;
     trackPageView(analytics.track, {
       page_name: 'design_systems',
       area: 'design_system_create',
       view_type: 'page',
-      entry_from: onboardingSessionId ? 'onboarding' : 'design_systems_page',
+      entry_from: resolvedEntry,
     });
   }, [analytics.track, embedded]);
+
+  // Preset-brand picker impression — fires each time the modal opens from the
+  // standalone create form. Gated on `embedded` to mirror the create page_view
+  // / clicks (onboarding owns its own area).
+  useEffect(() => {
+    if (embedded) return;
+    if (!brandPickerOpen) return;
+    trackDesignSystemsPresetBrandPickerSurfaceView(analytics.track, {
+      page_name: 'design_systems',
+      area: 'preset_brand_picker',
+    });
+  }, [brandPickerOpen, embedded, analytics.track]);
 
   // `emitDsFileUpload` reports the user-side dropzone batch. `picked`
   // is the raw FileList; `staged` is what survived the size/count
@@ -835,9 +859,8 @@ export function DesignSystemCreationFlow({
     const onboardingSessionId = peekOnboardingSessionId();
     const createEntryFrom: TrackingDesignSystemCreateEntryFrom = embedded
       ? 'onboarding'
-      : onboardingSessionId
-        ? 'onboarding'
-        : 'design_systems_page';
+      : (createEntryFromRef.current ??
+        (onboardingSessionId ? 'onboarding' : 'design_systems_page'));
     const ingestEntryFrom: TrackingDesignSystemSourceIngestEntryFrom = embedded
       ? 'onboarding'
       : onboardingSessionId
@@ -1058,7 +1081,10 @@ export function DesignSystemCreationFlow({
                   className="ghost ds-brand-start-btn"
                   aria-haspopup="dialog"
                   aria-expanded={brandPickerOpen}
-                  onClick={() => setBrandPickerOpen(true)}
+                  onClick={() => {
+                    emitCreateFormClick('start_from_brand');
+                    setBrandPickerOpen(true);
+                  }}
                 >
                   <Icon name="sparkles" />
                   {t('dsCreate.startFromBrand')}
@@ -1067,7 +1093,17 @@ export function DesignSystemCreationFlow({
               <BrandPickerModal
                 open={brandPickerOpen}
                 onClose={() => setBrandPickerOpen(false)}
-                onPick={(brand) => handlePickBrandReference(brand.domain)}
+                onPick={(brand) => {
+                  if (!embedded) {
+                    trackDesignSystemsPresetBrandPickerClick(analytics.track, {
+                      page_name: 'design_systems',
+                      area: 'preset_brand_picker',
+                      element: 'brand_pick',
+                      preset_brand_category: brand.category,
+                    });
+                  }
+                  handlePickBrandReference(brand.domain);
+                }}
                 title={t('dsCreate.startFromBrand')}
                 subtitle={t('dsCreate.brandPickerSubtitle')}
                 actionLabel={t('dsCreate.add')}

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -867,6 +867,7 @@ export function DesignSystemCreationFlow({
         ? 'onboarding'
         : 'design_systems_page';
     const designSystemOrigin = deriveDesignSystemOrigin(snapshot);
+    const designSystemOrigins = deriveDesignSystemOrigins(snapshot);
     function emitCreateResult(
       result: 'success' | 'failed' | 'cancelled',
       designSystemId: string | undefined,
@@ -881,6 +882,7 @@ export function DesignSystemCreationFlow({
         design_system_id: designSystemId,
         project_id: projectId,
         design_system_source: designSystemOrigin,
+        ...(designSystemOrigins ? { ds_source_origins: designSystemOrigins } : {}),
         source_count: snapshot.sourceCount,
         created_as_project: result === 'success',
         has_brand_description: snapshot.hasBrandDescription,
@@ -4210,6 +4212,32 @@ function deriveDesignSystemOrigin(snapshot: {
   if (snapshot.hasDesignMd) return 'manual_create';
   if (snapshot.hasBrandDescription) return 'manual_create';
   return 'unknown';
+}
+
+// Multi-value companion to deriveDesignSystemOrigin: lists EVERY source used
+// instead of flattening to a single `mixed`, so analytics can read which
+// sources combine (tracking spec comment ②). Returns a comma-joined string
+// (target_platforms/connectors convention) or undefined when nothing is set.
+function deriveDesignSystemOrigins(snapshot: {
+  hasBrandDescription: boolean;
+  hasDesignMd?: boolean;
+  sourceUrlCount: number;
+  githubRepoCount: number;
+  localFolderCount: number;
+  figFileCount: number;
+  assetFileCount: number;
+}): string | undefined {
+  const nonGithubSourceUrlCount = Math.max(0, snapshot.sourceUrlCount - snapshot.githubRepoCount);
+  const origins: TrackingDesignSystemOrigin[] = [];
+  if (snapshot.githubRepoCount > 0) origins.push('github_repo');
+  if (nonGithubSourceUrlCount > 0) origins.push('source_url');
+  if (snapshot.localFolderCount > 0) origins.push('local_code');
+  if (snapshot.figFileCount > 0) origins.push('fig');
+  if (snapshot.assetFileCount > 0) origins.push('assets');
+  if (snapshot.hasDesignMd === true) origins.push('manual_create');
+  // Brand description alone (no concrete source) still reads as manual_create.
+  if (origins.length === 0 && snapshot.hasBrandDescription) origins.push('manual_create');
+  return origins.length > 0 ? origins.join(',') : undefined;
 }
 
 // Mirrors the DesignSystemsTab helper but lives here too so the

--- a/apps/web/src/components/DesignSystemPicker.tsx
+++ b/apps/web/src/components/DesignSystemPicker.tsx
@@ -20,6 +20,7 @@ import {
 } from '../i18n/content';
 import { fetchDesignSystemPreview } from '../providers/registry';
 import { navigate } from '../router';
+import { setPendingDesignSystemCreateEntry } from '../analytics/ds-create-entry';
 import { useBrandsByDesignSystemId } from '../runtime/brands';
 import { BrandPreviewCard } from './BrandPreviewCard';
 import { DesignSystemPreviewModal } from './DesignSystemPreviewModal';
@@ -285,6 +286,7 @@ export function DesignSystemPicker({
   };
   const createDesignSystem = () => {
     setOpen(false);
+    setPendingDesignSystemCreateEntry('composer_picker');
     navigate({ kind: 'design-system-create' });
   };
 

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -1275,6 +1275,7 @@ function DesignSystemDetail({
           badgeSlot={badgeSlot}
           actionsSlot={actionsSlot}
           showCover={false}
+          onEditClick={emitEditClick}
           noticeSlot={
             downloadFailed ? (
               <div className={styles.missingProjectNotice}>{t('dsManager.downloadFailed')}</div>

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -5,8 +5,10 @@ import {
   trackDesignSystemsTemplateCardClick,
   trackDesignSystemsTopClick,
   trackDesignSystemStatusResult,
+  trackDesignSystemEditClick,
   trackPageView,
 } from '../analytics/events';
+import type { DesignSystemEditClickProps } from '@open-design/contracts/analytics';
 import type {
   TrackingDesignSystemStatusAction,
   TrackingDesignSystemStatusValue,
@@ -1079,6 +1081,7 @@ function DesignSystemDetail({
   onSystemsRefresh,
   onActionFeedback,
 }: DetailProps) {
+  const analytics = useAnalytics();
   const isUser = isUserSystem(system);
   const status = system.status ?? 'draft';
   const published = status === 'published';
@@ -1129,6 +1132,23 @@ function DesignSystemDetail({
   const host = designSystemLogoHost(system) || undefined;
   const projectId = detail?.projectId ?? system.projectId;
 
+  // Direct in-panel DS edits (E3 / §3.6). All carry edit_surface=direct_module
+  // + artifact_kind=design_system + the DS id so "edit depth" drills down.
+  function emitEditClick(
+    element: DesignSystemEditClickProps['element'],
+    module: DesignSystemEditClickProps['module'],
+  ) {
+    trackDesignSystemEditClick(analytics.track, {
+      page_name: 'design_systems',
+      area: 'design_system_edit',
+      element,
+      module,
+      edit_surface: 'direct_module',
+      artifact_kind: 'design_system',
+      design_system_id: system.id,
+      project_id: projectId ?? undefined,
+    });
+  }
   const { kit } = useDesignKit({
     designSystemId: system.id,
     title: system.title,
@@ -1147,6 +1167,7 @@ function DesignSystemDetail({
 
   async function handleDownload() {
     if (downloading) return;
+    emitEditClick('download', 'general');
     setDownloading(true);
     setDownloadFailed(false);
     onActionFeedback('loading', t('dsManager.downloadTitle'));
@@ -1214,7 +1235,10 @@ function DesignSystemDetail({
         <Button
           variant="primary"
           className={styles.actionButton}
-          onClick={() => onEdit(system)}
+          onClick={() => {
+            emitEditClick('edit_with_agent', 'general');
+            onEdit(system);
+          }}
           disabled={busy}
           aria-busy={actionBusy === 'edit' || undefined}
           title={t('dsManager.openSystemAria', { title: system.title })}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -68,6 +68,7 @@ import type {
 import { agentIdToTracking } from '@open-design/contracts/analytics';
 import { useT } from '../i18n';
 import { navigate, useRoute } from '../router';
+import { setPendingDesignSystemCreateEntry } from '../analytics/ds-create-entry';
 import type {
   AgentInfo,
   ApiProtocol,
@@ -709,6 +710,7 @@ export function EntryShell({
             onThemeChange={onThemeChange}
             onGoBuild={() => {
               onCompleteOnboarding();
+              setPendingDesignSystemCreateEntry('onboarding');
               navigate({ kind: 'design-system-create' });
             }}
           />

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1712,7 +1712,7 @@ function OnboardingView({
       return;
     }
     if (isLastStep) {
-      await runOnboardingCompletion();
+      await runOnboardingCompletion('completed_without_design_system');
       onFinish();
       return;
     }
@@ -1757,7 +1757,13 @@ function OnboardingView({
   // final picks even on a fast click before React commits the latest state.
   // Callers pick the destination: home (`onFinish`) or the design-system
   // create flow (`onGoBuild`).
-  async function runOnboardingCompletion(): Promise<void> {
+  // `completionType` distinguishes the final-step fork (C2, tracking spec §3.1):
+  // 'completed_with_design_system' when the user chose "Build a design system",
+  // 'completed_without_design_system' when they went straight Home. Lets the
+  // funnel measure how many users skip DS creation at onboarding.
+  async function runOnboardingCompletion(
+    completionType: TrackingOnboardingCompletionType,
+  ): Promise<void> {
     emitAboutYouSubmit();
     void persistOnboardingProfileToMemory();
     const newsletterEmail = profileRef.current.email;
@@ -1768,19 +1774,19 @@ function OnboardingView({
       await submitNewsletterEmail(newsletterEmail);
     }
     emitOnboardingClick('continue', 'continue');
-    emitOnboardingComplete('completed', 'completed_without_design_system');
+    emitOnboardingComplete('completed', completionType);
     clearOnboardingSessionId();
   }
 
   async function handleFinishToHome(): Promise<void> {
     if (newsletterSubmitting) return;
-    await runOnboardingCompletion();
+    await runOnboardingCompletion('completed_without_design_system');
     onFinish();
   }
 
   async function handleFinishToBuild(): Promise<void> {
     if (newsletterSubmitting) return;
-    await runOnboardingCompletion();
+    await runOnboardingCompletion('completed_with_design_system');
     onGoBuild();
   }
 

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -8,10 +8,11 @@ import {
   type ReactNode,
 } from 'react';
 import { Button } from '@open-design/components';
-import type { TrackingProjectKind } from '@open-design/contracts/analytics';
+import type { DesignSystemEditClickProps, TrackingProjectKind } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
 import {
   trackFileManagerClick,
+  trackDesignSystemEditClick,
   trackFileUploadResult,
   trackPageView,
   trackTabLauncherClick,
@@ -2490,6 +2491,7 @@ function DesignSystemProjectPanel({
   githubConnected?: boolean;
 }) {
   const t = useT();
+  const analytics = useAnalytics();
   const [reviewDecisions, setReviewDecisions] = useState<Record<string, DesignSystemReviewDecision>>({});
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
   const [feedbackSection, setFeedbackSection] = useState<string | null>(null);
@@ -2530,6 +2532,21 @@ function DesignSystemProjectPanel({
   const initialDesignMdRef = useRef<string | null>(null);
   const initialBrandJsonRef = useRef<string | null>(null);
   const initialBrandJsonLoadedRef = useRef(false);
+  function emitDesignSystemProjectEditClick(
+    element: DesignSystemEditClickProps['element'],
+    module: DesignSystemEditClickProps['module'],
+  ) {
+    trackDesignSystemEditClick(analytics.track, {
+      page_name: 'design_system_project',
+      area: 'design_system_edit',
+      element,
+      module,
+      edit_surface: 'direct_module',
+      artifact_kind: 'design_system',
+      design_system_id: system.id,
+      project_id: projectId,
+    });
+  }
 
   const refreshKitDependencies = useCallback(async (options?: { finalizeBrand?: boolean }) => {
     if (options?.finalizeBrand && brandId) {
@@ -3174,7 +3191,10 @@ function DesignSystemProjectPanel({
       id: 'refresh',
       label: t('ds.refresh'),
       icon: 'refresh',
-      onClick: () => void refreshKit(),
+      onClick: () => {
+        emitDesignSystemProjectEditClick('kit_refresh', 'kit');
+        void refreshKit();
+      },
       disabled: Boolean(kitActionBusy) || statusBusy || defaultBusy,
       loading: kitActionBusy === 'refresh',
     },
@@ -3182,7 +3202,10 @@ function DesignSystemProjectPanel({
       id: 'download',
       label: t('dsManager.downloadTitle'),
       icon: 'download',
-      onClick: () => void downloadKit(),
+      onClick: () => {
+        emitDesignSystemProjectEditClick('kit_download', 'kit');
+        void downloadKit();
+      },
       disabled: Boolean(kitActionBusy) || statusBusy || defaultBusy,
       loading: kitActionBusy === 'download',
     },
@@ -3341,6 +3364,7 @@ function DesignSystemProjectPanel({
           onDeleteImage={(index) => void removeKitImage(index)}
           onRefresh={() => void refreshKit()}
           onDownload={() => void downloadKit()}
+          onEditClick={emitDesignSystemProjectEditClick}
           uploading={kitUploading}
           actionBusy={kitActionBusy}
           onActionFeedback={notifyKit}

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -86,6 +86,7 @@ import {
 import type { ChatSessionMode, WorkspaceContextItem } from '@open-design/contracts';
 import { createTerminal, killTerminal } from '../state/projects';
 import { navigate } from '../router';
+import { setPendingDesignSystemCreateEntry } from '../analytics/ds-create-entry';
 import type { QuestionForm } from '../artifacts/question-form';
 import { DesignFilesPanel, type DesignFilesNavState } from './DesignFilesPanel';
 import { DesignBrowserPanel, labelFromUrl, type BrowserPageInfo } from './DesignBrowserPanel';
@@ -2243,6 +2244,7 @@ export function FileWorkspace({
                 area: 'file_manager',
                 element: 'create_design_system',
               });
+              setPendingDesignSystemCreateEntry('project_canvas');
               navigate({ kind: 'design-system-create' });
             }}
             onSelectFromLibrary={() => {

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -74,6 +74,7 @@ import { homeHeroChipLabel } from './home-hero/chip-labels';
 import type { PlaceholderScenario } from './home-hero/placeholderScenarios';
 import { consumePendingHomeChip, HOME_CHIP_INTENT_EVENT } from '../runtime/home-intent';
 import { navigate } from '../router';
+import { setPendingDesignSystemCreateEntry } from '../analytics/ds-create-entry';
 import {
   buildHomeMediaComposer,
   homeMediaSurfaceForChipId,
@@ -1490,6 +1491,7 @@ export function HomeView({
         // Brands merged into Design systems: brand extraction now starts from
         // the unified design-system create wizard (which carries the
         // "start from a brand" picker), rather than a separate Brand Kit tab.
+        setPendingDesignSystemCreateEntry('home_card');
         navigate({ kind: 'design-system-create' });
         return;
       }

--- a/apps/web/src/components/LibrarySection.tsx
+++ b/apps/web/src/components/LibrarySection.tsx
@@ -33,6 +33,7 @@ import {
 } from '../providers/registry';
 import { useInView } from './plugins-home/useInView';
 import { navigate } from '../router';
+import { setPendingDesignSystemCreateEntry } from '../analytics/ds-create-entry';
 import { setComposerSeed, setDesignSystemAssetSeed, setHomeComposerAssetSeed } from '../state/libraryHandoff';
 import { Button, Dialog, DialogDescription, DialogFooter, DialogTitle } from '@open-design/components';
 import { Icon } from './Icon';
@@ -767,6 +768,7 @@ export function LibrarySection({ active, onOpenProject }: Props) {
       setDesignSystemAssetSeed({ files });
       setDsMenuOpen(false);
       setSelectedIds(new Set());
+      setPendingDesignSystemCreateEntry('library');
       navigate({ kind: 'design-system-create' });
     } finally {
       setDsBusy(false);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -244,6 +244,10 @@ type ProjectChatSendMeta = ChatSendMeta & {
    *  this send (e.g. 'resume_continue' from the resumable-failure Continue
    *  action). Behavior never depends on it; it only shapes PostHog props. */
   entryFrom?: ChatAnalyticsEntryFrom;
+  /** Marks this send as the AI-optimize (deep enrichment) run so the daemon
+   *  can emit design_system_enrich_result + flag the DS as ai_refined on
+   *  success (tracking spec C14/C15). Analytics-only. */
+  dsEnrichment?: boolean;
 };
 
 export function mergeSavedPreviewComment(current: PreviewComment[], saved: PreviewComment): PreviewComment[] {
@@ -4359,6 +4363,7 @@ export function ProjectView({
           ...(sessionTurn
             ? { turnIndex: sessionTurn.turnIndex, isFirstRun: sessionTurn.isFirstRun }
             : {}),
+          ...(meta?.dsEnrichment ? { dsEnrichment: true } : {}),
           hasExistingArtifact,
           // This branch only runs in daemon (local-execution) mode, so the
           // runtime is the bundled AMR cloud agent or a local coding CLI —
@@ -6141,7 +6146,7 @@ export function ProjectView({
       }),
       [],
       [],
-      skillIds.length > 0 ? { skillIds } : undefined,
+      { ...(skillIds.length > 0 ? { skillIds } : {}), dsEnrichment: true },
     ).finally(() => setBrandEnrichmentStarting(false));
   }, [
     activeDesignSystemSummary,

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -77,6 +77,7 @@ import {
   trackArtifactHeaderClick,
   trackComposerBarClick,
   trackDesignSystemApplyResult,
+  trackDesignSystemEnrichClick,
   trackPageView,
   trackRunCreated,
   trackRunFinished,
@@ -6123,6 +6124,13 @@ export function ProjectView({
     if (brandEnrichmentStarting) return;
     const system = designSystemProject ?? activeDesignSystemSummary;
     const skillIds = installedBrandEnrichmentSkillIds(skills);
+    trackDesignSystemEnrichClick(analytics.track, {
+      page_name: 'design_system_project',
+      area: 'design_system_enrich',
+      element: 'ai_optimize',
+      design_system_id: projectDesignSystemId ?? undefined,
+      project_kind: 'design_system',
+    });
     setBrandEnrichmentStarting(true);
     void handleSend(
       buildBrandEnrichmentPrompt(brandEnrichmentPromptSeed || brandEnrichmentPromptSeedCache, {
@@ -6137,12 +6145,14 @@ export function ProjectView({
     ).finally(() => setBrandEnrichmentStarting(false));
   }, [
     activeDesignSystemSummary,
+    analytics,
     brandEnrichmentPromptSeed,
     brandEnrichmentPromptSeedCache,
     brandEnrichmentStarting,
     designSystemProject,
     handleSend,
     currentProject.metadata,
+    projectDesignSystemId,
     projectFiles,
     skills,
   ]);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -246,7 +246,7 @@ type ProjectChatSendMeta = ChatSendMeta & {
   entryFrom?: ChatAnalyticsEntryFrom;
   /** Marks this send as the AI-optimize (deep enrichment) run so the daemon
    *  can emit design_system_enrich_result + flag the DS as ai_refined on
-   *  success (tracking spec C14/C15). Analytics-only. */
+   *  success (tracking spec C14/C15). Daemon mode only. */
   dsEnrichment?: boolean;
 };
 
@@ -6078,7 +6078,9 @@ export function ProjectView({
     autoSendAttachmentsRef.current = isAutoSend ? readAutoSendAttachments(project.id) : [];
   }
   const brandEnrichmentEligibleForProject =
-    projectIsProgrammaticBrandExtraction && !autoSendFirstMessageRef.current;
+    config.mode === 'daemon' &&
+    projectIsProgrammaticBrandExtraction &&
+    !autoSendFirstMessageRef.current;
   const [initialDraft, setInitialDraft] = useState<
     { projectId: string; value: string } | undefined
   >(
@@ -6126,7 +6128,7 @@ export function ProjectView({
   // skill bundle, refining the SAME registered design system in place. Shared by
   // the chat "Continue" affordance and the ready-toast "AI Optimize" nudge.
   const handleBrandEnrichment = useCallback(() => {
-    if (brandEnrichmentStarting) return;
+    if (brandEnrichmentStarting || config.mode !== 'daemon') return;
     const system = designSystemProject ?? activeDesignSystemSummary;
     const skillIds = installedBrandEnrichmentSkillIds(skills);
     trackDesignSystemEnrichClick(analytics.track, {
@@ -6154,6 +6156,7 @@ export function ProjectView({
     brandEnrichmentPromptSeed,
     brandEnrichmentPromptSeedCache,
     brandEnrichmentStarting,
+    config.mode,
     designSystemProject,
     handleSend,
     currentProject.metadata,

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -810,7 +810,9 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
       area: 'onboarding',
       result: 'completed',
       exit_step_name: 'design_system',
-      completion_type: 'completed_without_design_system',
+      // This flow clicks "Build a design system" at the final step, so the
+      // completion records the with-DS fork (C2 — tracking spec §3.1).
+      completion_type: 'completed_with_design_system',
       runtime_type: 'amr_cloud',
       has_about_you: true,
       has_design_system_request: false,

--- a/docs/design-system-tracking-spec.md
+++ b/docs/design-system-tracking-spec.md
@@ -1,0 +1,263 @@
+# Design System 埋点方案（Tracking Spec）
+
+> 状态：方案稿（仅设计，未实现代码）
+> 关联 PR：#4691 `feat(brands): turn any brand into a reusable design system`，分支 `iodized-nephew`
+> 目标读者：埋点实现 / 数据分析
+> 维护：本文件是“代码现状 + 目标口径”的对照表，落地后逐条勾掉。
+
+## 术语：只有一个对象 = Design System（先读这段，避免被 brand 绕晕）
+
+整个功能里**只有一个用户层对象：Design System（设计系统）**。代码里之所以到处出现 “brand”，是因为它活在**不同层次**，不是第二个对象：
+
+| 层 | 名字 | 是不是用户看到的对象 | 说明 |
+|---|---|---|---|
+| **对象层（唯一）** | **Design System** | ✅ 是 | 用户只看到/管理“设计系统”。左侧导航只有一个 design-systems 入口；`/brands` 旧链接已 redirect 到 `/design-systems`（router.ts:102）；`BrandsTab` 是遗留死代码，导航无按钮可达。 |
+| **来源层（怎么造出来的）** | brand 只是一种**输入源** | ❌ 否 | 和 website / 文件 / Figma / DESIGN.md 并列。“Start from a brand” = 选一个**预设品牌当素材**，是输入方式，不是独立对象。 |
+| **内部管道层** | brand（实现命名） | ❌ 否 | daemon 抽取引擎叫 brand（`brand.json`、backing project `kind:'brand'`、`brand-extract` skill），产物 register 成 `user:<id>` 的 design system。PR 已合并应用链路：**no parallel brandId path**，一切走 `designSystemId`（apps/daemon/src/brands/index.ts:1-17）。 |
+
+**本文档口径**：凡“对象”一律 `design_system_*`；“brand” 只出现在两处——①来源维度的取值之一；②预设品牌选择器（它确实是在选 brand 当素材）。AI 优化事件统一叫 `design_system_enrich`（不是 brand_enrichment）。
+
+---
+
+## 0. 业务目标（埋点要回答的问题）
+
+1. **创建漏斗**：从入口到成功创建一个 DS，每一步的转化与流失在哪。
+2. **输入源偏好**：用户更爱用 Website / 文件 / 文本 / Figma / **预设品牌** 哪种来源；多网站用得多不多（决定是否保留“Add”）。
+3. **AI 转化**：程序化抽取后，有多少人真正点了 **AI 优化（深度抽取）**。
+4. **编辑/迭代**：DS 生成后，有多少人回去 **编辑** 它（Draft/Edit/Chat），怎么编、编多频。
+5. **使用**：DS 被用来做东西的频次；选的是 **官方** 还是 **自建**，具体哪个。
+6. **效果对比**：仅程序化 vs 经 AI 优化 的 DS，使用频次/留存差异。
+7. **北极星关联**：用户创建/使用 DS 的量 ↔ **留存** 与 **复购转化**。
+
+要支撑 6/7，必须先把 **“DS 本身是一种 project”** 这件事在数据里标清楚（见 §1）。
+
+---
+
+## 1. 地基：DS-project 类型标记（已定口径）
+
+**决策：用户层只有一种 project 类型 `project_kind='design_system'`。**（不存在 “brand 项目 vs design-system 项目” 的二分——见顶部术语段。）
+
+现状（探查结论）：
+- 数据层：DS 的载体 project 现在底层 tag 为 `kind:'brand'` + `metadata.brandId` / `metadata.brandDesignSystemId`。
+  - `apps/daemon/src/brands/index.ts:229`
+  - 识别函数 `isProgrammaticBrandExtractionProject()` @ `apps/web/src/runtime/brand-enrichment.ts:41`
+- 埋点层：`TrackingProjectKind` **已含 `'design_system'` 但从未真正写入**。
+  - `packages/contracts/src/analytics/events.ts:99`
+- 业务 ProjectKind（`packages/contracts/src/api/projects.ts:9`）目前 **没有** `'design_system'`，仅 `prototype/deck/template/other/brand/image/video/audio`。
+
+**要做的接通**：
+1. 埋点映射层把这个底层 `kind:'brand'` 的载体 project **统一上报为 `project_kind='design_system'`**（不要求改业务 ProjectKind 枚举）。
+2. 所有**碰到 DS-project 的事件**（run_created / run_finished / project page_view / 编辑事件）都带上这个维度。
+3. 下钻基线口径：
+   - `project_kind='design_system'` → 用户在 **编辑/打磨 DS 本身**
+   - `project_kind≠'design_system'` 且 `design_system_id` 有值 → 用户在 **用 DS 做别的产物**
+
+> 这一条是 §6/§7 一切分析的前提，优先级最高。
+
+---
+
+## 2. 维度字典（新增 / 收紧的字段）
+
+### 2.1 两个最容易混的字段，先讲清区别（回应评论①）
+
+它俩名字像，但问的是**两件不同的事**：
+
+- **`design_system_source`** ＝ 一次 run **用** DS 时，这个 DS 是**怎么被选中的**（使用时刻的“选择来源”）。
+- **`ds_source_origins`** ＝ 这个 DS 当初**是用什么素材造出来的**（创建时刻的“输入素材”）。
+
+**`design_system_source` 取值含义**（run_created 用）：
+
+| 值 | 含义（大白话） |
+|---|---|
+| `user_selected` | 用户这次**主动**在选择器里选了某个 DS |
+| `default` | 没主动选，用的是用户/工作区设的**默认** DS |
+| `project_saved` | 用的是**这个项目里已存**的 DS（继承自项目） |
+| `template_inherited` | DS 是从**模板**带过来的 |
+| `not_applicable` | 这次 run 跟 DS **无关**（没用任何 DS） |
+| `unknown` | **没采集到**——当前的 bug：daemon 把它硬写成 unknown/not_applicable（runs.ts:814-817），需修 |
+
+### 2.2 字段总表
+
+| 字段 | 取值 | 用途 | 现状 |
+|---|---|---|---|
+| `project_kind` | `... / 'design_system'` | 区分 DS-project vs 普通 project | 枚举有，未写入 |
+| `design_system_kind` | `official / custom` | 官方预设 vs 用户自建 | **缺** |
+| `design_system_slug` | string（仅 official） | 官方具体是哪一个 | **缺**（自建只用 id/hash） |
+| `design_system_id` | string | DS 标识；自建形如 `user:<id>` | 有 |
+| `design_system_source` | 见 §2.1 表 | run 用的 DS 怎么选中的 | 有枚举，但 daemon 硬写成 unknown，**未真上报** |
+| `ds_source_origins` | **string[]（多值）** 例 `["website","local_code"]` | DS 用哪些素材造的（见评论②） | ⚠️ 现为单值会塌缩成 `mixed`，需改多值 |
+| `enrichment_status` | `programmatic / ai_refined` | 仅程序化 vs 经 AI 优化 | **缺**（无字段可区分） |
+| `edit_surface` | `chat / edit / draw / comment / mark / direct_module` | 编辑 DS 的入口工具（见 §3.4，评论⑤已修正：无 draft） | **缺** |
+| `source_count` | number | 一次创建加了几个来源（含多网站） | 有（create_result） |
+| `preset_brand_category` | string（枚举类目，**非域名**） | **预设品牌**素材选了哪类（来源层，见评论④） | **缺** |
+| `is_quick_pick` | bool | 是否从快捷预设品牌选 | **缺** |
+
+> **关于评论②（多来源不要塌缩成 mixed）**：`ds_source_origins` 改为**数组/多值**，把每个实际用到的来源都列出来（如既选了 website 又选了 local code，就上报 `["website","local_code"]`），**不再**只报一个 `mixed`。落地建议：作为逗号拼接字符串上报（对齐现有 `target_platforms`/`connectors` 的多值写法），如 `"website,local_code"`；分析侧可直接拆开统计每种来源的占比，也能算“多来源”的组合。`mixed` 仅在需要“是否多来源”的布尔判断时由列表长度派生，不再作为唯一取值。
+>
+> **关于评论④（brand 很怪）**：这里的 `preset_brand_category` 属于**来源层**——它是“用户拿哪一类**预设品牌**当创建素材”，brand 是 DS 的一种输入，不是另一个对象（见顶部术语段）。字段已从 `brand_category` 重命名为 `preset_brand_category` 以消歧。
+
+**隐私红线（必须遵守，contracts events.ts:622 已声明）**：
+- ❌ 禁止上报：brand 文本、网站 URL 原文、文件名、DESIGN.md 原文。
+- 预设品牌选择器只报 `preset_brand_category` + `is_quick_pick`，**不报域名**。
+- 官方 DS 可报 `design_system_slug`；自建只报 `design_system_id`（已是 `user:<id>` 形式）。
+- 公共参数（event_id/session_id/device_*/app_version/configure_* 等）由 AnalyticsProvider 自动带，**不要手动塞**。
+
+---
+
+## 3. 事件清单（按生命周期）
+
+> 图例：✅ 已实现 ｜ ⚠️ 部分/有坑 ｜ ❌ 缺口（本方案新增）
+> 三元组 = `page_name` · `area` · `element`
+
+### 3.1 创建入口（来源区分）
+
+| # | 事件 | 类型 | 三元组 | 关键维度 | 状态 | 位置 |
+|---|---|---|---|---|---|---|
+| C1 | DS create 页曝光 | `page_view` | design_systems · design_system_create · — | **`entry_from`（见下表）** | ⚠️ | DesignSystemFlow.tsx:391 |
+| C2 | **Onboarding：创建 vs Go Home** | `ui_click` | design_systems(或 home) · onboarding_ds_step · `build_design_system / go_home` | entry_from | ❌ | Onboarding 第4步两个按钮 |
+
+> C2 回答“多少人选择不创建直接进首页”，是创建漏斗的第一个流失点。
+
+#### 创建入口来源（entry_from）必须分清——你要的三类
+
+枚举 `TrackingDesignSystemsEntryFrom` 已有 6 个值，足够区分；**但当前 C1 的 page_view 写死成二选一（`onboarding ? 'onboarding' : 'design_systems_page'`，DesignSystemFlow.tsx:391），把所有非 onboarding 入口都塌成了 `design_systems_page`**。要做的是：每个 `navigate({kind:'design-system-create'})` 调用处把真实来源透传进去，page_view 如实上报。
+
+| 你说的来源 | `entry_from` 取值 | 实际入口（navigate 调用处） |
+|---|---|---|
+| **1. Onboarding 链路** | `onboarding` | onboarding 第4步 → router.ts:92 |
+| **2. 左侧 Design System Tab** | `design_systems_page` | DesignSystemsTab 的「创建」(App.tsx:2246 onCreateDesignSystem) · EntryShell.tsx:722 |
+| **3. 产品里其他 DS 入口** | 按入口细分（见下） | 见下列各处 |
+
+第 3 类“其他入口”再拆细，别全归一类：
+
+| 入口 | 建议 `entry_from` | 位置 | 现状 |
+|---|---|---|---|
+| Home 页卡片/空态 | `home_card` | HomeView.tsx:1492 | 枚举有，未透传 |
+| Composer 的 DS 选择器“新建” | `composer_picker` | DesignSystemPicker.tsx:234 | 枚举有，未透传 |
+| 项目设置内创建 | `project_settings` | — | 枚举有，未透传 |
+| 项目内画布/文件区创建 | **`project_canvas`（建议新增）** | FileWorkspace.tsx:2215 | **枚举缺** |
+| Library 内创建 | **`library`（建议新增）** | LibrarySection.tsx:770 | **枚举缺** |
+| 兜底 | `unknown` | — | 有 |
+
+> 落地要点：① 给 `TrackingDesignSystemsEntryFrom` 补 `project_canvas` / `library` 两个值；② 把 `DesignSystemFlow.tsx:391` 的二元判断改成从“发起导航的入口”透传真实 `entry_from`（在每个 `navigate({kind:'design-system-create'})` 调用处带上来源标记，落进 create 页读取）；③ create_result（C11）也带同一个 `entry_from`，这样“入口 → 成功率”能直接下钻。
+
+### 3.2 创建输入源
+
+| # | 事件 | 类型 | 三元组 | 关键维度 | 状态 | 位置 |
+|---|---|---|---|---|---|---|
+| C3 | 加 Website 链接 | `ui_click` | design_systems · design_system_create · `source_url_add` | `source_url_count`（见 C10） | ✅ | DesignSystemFlow.tsx:597/663 |
+| C4 | Figma URL | `ui_click` | …· `figma_url_add` | — | ✅ | :678 |
+| C5 | 展开 Advanced / 浏览文件夹 / 上传.fig / 加素材 | `ui_click` | …· `show_access_methods/browse_folder/upload_fig/add_assets` | methods_expanded | ✅ | :716/766/1141/1254 |
+| C6 | 文件上传结果 | `file_upload_result` | design_systems · design_system_source · — | source_type, cohort, result | ✅ | DesignSystemFlow.tsx:416 |
+| C7 | **预设品牌：打开选择器** | `ui_click` | design_systems · design_system_create · `start_from_brand` | — | ❌ | DesignSystemFlow.tsx:1079 |
+| C8 | **预设品牌选择器曝光** | `surface_view` | design_systems · preset_brand_picker · — | — | ❌ | BrandPickerModal 打开 |
+| C9 | **选中某预设品牌 / quick-pick** | `ui_click` | design_systems · preset_brand_picker · `brand_pick/quick_pick/close` | `preset_brand_category`, `is_quick_pick` | ❌ | BrandPickerModal onPick |
+| C10 | **多网站**：每次 add 带当前数量 | （C3 上加维度） | …· `source_url_add` | `source_url_count` | ⚠️ | 现仅 create_result 带 source_count |
+
+> C7–C9 是“预设品牌当来源”的盲区，必补。C10 决定“是否保留 Add 按钮”。
+
+### 3.3 创建结果与 AI 优化
+
+| # | 事件 | 类型 | 三元组 | 关键维度 | 状态 | 位置 |
+|---|---|---|---|---|---|---|
+| C11 | 创建 kickoff 结果 | `design_system_create_result` | design_systems · design_system_create · — | result, design_system_id, **ds_source_origins**, source_count, has_brand_description, duration_ms | ✅(字段需补多值) | DesignSystemFlow.tsx:853 |
+| C12 | 实时抽取 ready/failed | `design_system_status_result` | design_systems · design_system_status · — | result, action | ✅ | DesignSystemsTab.tsx:452 |
+| C13 | **AI 优化（深度抽取）触发** | `ui_click` | design_system_project · design_system_enrich · `ai_optimize` | design_system_id, project_kind | ❌ | ProjectView.tsx:6234（BrandEnrichmentBanner） |
+| C14 | **AI 优化结果** | `design_system_enrich_result` | design_system_project · design_system_enrich · — | result, duration_ms, design_system_id | ❌ | enrichment run 完成 |
+| C15 | **enrichment 状态落库** | （非事件，数据字段） | — | `ProjectMetadata.enrichmentStatus: programmatic/ai_refined` + `enrichmentCompletedAt` | ❌ | apps/daemon brands/metadata |
+
+> C13/C14 = 你要的“AI 转化率”。C15 是 §6 效果对比的前提：没有这个字段，事后无法区分两类 DS。事件名统一用 `design_system_enrich`（不叫 brand_enrichment）。
+
+### 3.4 生成后编辑 / 迭代（按评论⑤修正：没有 draft，编辑走右侧工具且本质都经 Chat）
+
+**修正口径（评论⑤）**：DS 生成出来是一组**原始 HTML 产物**。编辑它**没有单独的 draft 态**，而是用项目**右侧的工具：Draw / Edit / Comment / Mark**，外加直接 **Chat**。关键认知：**Draw/Edit/Comment/Mark 本质和 Chat 一样——它们最终都把意图喂给 agent，由一次 run 真正去改 HTML**（例如你 Comment 一下，其实是转成 chat 让 agent 改）。所以这些编辑动作在数据上几乎都落成 `run_created`，用 `edit_surface` 维度区分是从哪个工具发起的。
+
+`edit_surface` 取值：
+
+| `edit_surface` | 从哪发起 | 本质 |
+|---|---|---|
+| `chat` | 直接在对话框发消息 | agent run |
+| `edit` | 右侧 **Edit** 工具 | 经 agent run（ArtifactToolbarClick element=`edit`，events.ts:1932） |
+| `draw` | 右侧 **Draw** 工具 | 经 agent run（DrawToolbarClick，events.ts:1966） |
+| `comment` | 右侧 **Comment** 工具 | 经 agent run（CommentPopoverClick：save_comment/send_to_chat，events.ts:1993） |
+| `mark` | 右侧 **Mark** 工具 | 经 agent run |
+| `direct_module` | DS 面板上的就地模块按钮（§3.6） | 部分直接改、部分经 agent |
+
+| # | 事件 | 类型 | 三元组 | 关键维度 | 状态 | 说明 |
+|---|---|---|---|---|---|---|
+| E1 | **编辑 DS（chat/draw/edit/comment/mark）** | `run_created` | design_system_project · design_system_generation · — | `project_kind='design_system'`, `edit_surface`, `has_existing_artifact=true`, `is_first_run=false`, design_system_id | ⚠️ | run 基础设施有，要确保带 `project_kind` + `edit_surface`，并用 `has_existing_artifact` 把“后续编辑”与“首次生成”分开 |
+| E2 | **右侧工具点击**（Draw/Edit/Comment/Mark） | `ui_click` | design_system_project · artifact_toolbar · `edit/draw/comment/mark/...` | `artifact_kind='design_system'`, design_system_id | ⚠️ | 工具点击事件已存在（ArtifactToolbar/Draw/Comment），需确保在 DS 项目里带上 `artifact_kind='design_system'` 维度以便筛 DS 编辑 |
+| E3 | **模块按钮点击**（见 §3.6） | `ui_click` | design_system_project · design_system_edit · `<module_action>` | `edit_surface='direct_module'`, `module`, `artifact_kind='design_system'`, design_system_id | ❌ | 20 个未埋按钮 |
+
+**两层标记机制**：
+- 项目层：`project_kind='design_system'` → DS-project 内的任何 run/点击都能被识别为“在编辑 DS”。
+- 动作层：编辑事件统一带 `artifact_kind='design_system'` + `edit_surface`，无论从 Chat 还是右侧 Draw/Edit/Comment/Mark 发起，都能筛出“针对 DS 的编辑”，并区分入口工具。
+
+### 3.5 使用 DS（run 创建，含官方/自建）
+
+| # | 事件 | 类型 | 三元组 | 关键维度 | 状态 | 位置 |
+|---|---|---|---|---|---|---|
+| U1 | Home 选 DS → 发送 run | `run_created` | chat_panel · chat_composer · — | design_system_id, **design_system_kind**, **design_system_slug**, design_system_source, project_kind | ⚠️ | HomeHero.tsx:1662 → App.tsx:1337 → daemon runs.ts |
+| U2 | CTC “用 Agent 编辑” → 新项目 | `ui_click` + 随后 run | design_systems · design_system_list · `edit_with_agent` | design_system_id, design_system_kind | ❌(按钮) | DesignSystemsTab.tsx:1075 onEdit |
+| U3 | **修复 daemon 来源上报** | （改 U1 字段） | — | 真正上报 `design_system_source`（request/plugin/project/app-default→映射到 §2.1 枚举） | ⚠️ | runs.ts:814-817 现被硬覆盖为 unknown |
+| U4 | **官方 vs 自建维度** | （改 U1 字段） | — | `design_system_kind`, `design_system_slug` | ❌ | 由 id 前缀/注册表派生 |
+
+> U3/U4 = 你要的“是否主动选了 DS / 官方还是自建 / 具体哪个”。现在全是 unknown，必修。
+
+### 3.6 编辑/预览面板按钮清单（23 个，13% 已埋）
+
+统一口径：`page_name=design_system_project`，`area=design_system_edit`，带 `edit_surface='direct_module'` + `artifact_kind='design_system'` + `design_system_id` + `module`。`element` 命名建议如下。
+
+**通用操作（DS 层级）** — DesignSystemsTab.tsx
+| 按钮 | element | 状态 | 行 |
+|---|---|---|---|
+| 用 Agent 编辑 | `edit_with_agent` | ❌ | 1075 |
+| 刷新 | `refresh` | ❌ | 1087 |
+| 下载 | `download` | ❌ | 1099 |
+| 设为默认 | `set_default` | ✅ (status_result) | 1126 |
+| 发布/取消发布 | `publish`/`unpublish` | ✅ | 1138 |
+| 删除 | `delete` | ✅ | 1150 |
+
+**模块操作** — DesignKitView.tsx（统一 `area=design_system_edit`，`module` 维度区分）
+| 模块 | 按钮 | element | module | 状态 | 行 |
+|---|---|---|---|---|---|
+| Logo | 上传 / 复制图 / 删除 | `logo_upload`/`logo_copy`/`logo_delete` | logo | ❌ | 649-653 |
+| Brand/DesignMD | 复制 / 编辑 / 上传 MD | `design_md_copy`/`design_md_edit`/`design_md_upload` | design_md | ❌ | 452/454/459 |
+| Typography | 上传字体 | `font_upload` | typography | ❌ | 701 |
+| Palette | 改颜色 | `color_edit` | palette | ❌ | 766 |
+| Images | 上传 / 复制 / 删除 | `image_upload`/`image_copy`/`image_delete` | images | ❌ | 883/884/914 |
+| Kit | 刷新/下载/导入/重置/打开 | `kit_refresh`/`kit_download`/`kit_import`/`kit_reset`/`kit_open` | kit | ❌ | 948-963 |
+
+**Brand 卡（BrandPreviewCard.tsx）**（注：这是预设品牌素材的预览卡，属来源层）
+| 按钮 | element | 状态 | 行 |
+|---|---|---|---|
+| 用到新对话 | `use_in_chat` | ❌ | 118 |
+| 打开项目 | `open_project` | ❌ | 127 |
+| 删除 | `delete` | ❌ | 136 |
+
+---
+
+## 4. 现状盘点（一句话）
+
+- **创建侧**：主干已埋（page_view / 各输入点击 / 文件上传 / create_result / status_result）；缺 **预设品牌选择器(C7-C9)**、**Onboarding 创建-vs-跳过(C2)**、**AI 优化(C13-C15)**；`ds_source_origins` 需改多值(评论②)；**`entry_from` 入口来源被写死成二元、需透传真实来源(§3.1)**。
+- **使用侧**：run 基础设施在，但 **官方/自建 + 来源口径全是 unknown(U3/U4)**，CTC 入口按钮未埋(U2)。
+- **编辑侧**：几乎空白——23 个面板按钮埋了 3 个；缺整条编辑/迭代生命周期(E1-E3)。
+- **地基**：`project_kind='design_system'` 枚举有、未接通(§1)；`enrichment_status` 字段完全缺(C15)。
+
+## 5. 分期落地建议（实现时用）
+
+- **第一期（地基 + 两个盲区）**：§1 接通 `project_kind` → U3/U4 修 daemon 来源&官方/自建 → C7-C9 预设品牌选择器 → C13-C15 AI 优化事件+状态字段 → `ds_source_origins` 改多值 → **§3.1 `entry_from` 三类入口透传（补 `project_canvas`/`library` 枚举值 + 改掉二元写死）**。直接支撑留存/复购/AI 转化分析。
+- **第二期（编辑生命周期）**：E1-E3 + §3.6 全部面板/模块按钮。
+- **第三期（补全）**：C2 Onboarding 分叉、C10 多网站计数、其余次级动作。
+- 每期：契约（contracts）改完先 `pnpm --filter @open-design/contracts build` 再 web typecheck；新 interface 记得加进 events.ts 末尾总 union；落地后同步飞书「埋点文档2.0」表 `MUu2Au`（对外写，动手前确认）。
+
+## 6. 分析口径（落地后怎么用）
+
+- **DS 创建量/人**：`design_system_create_result{result=success}` 按 person 计数。
+- **AI 转化率**：`design_system_enrich_result` 触发数 ÷ 程序化创建数。
+- **程序化 vs AI优化 留存**：按 `enrichment_status` 分群，看各自 DS 的后续 `run_created{design_system_id=...}` 频次与 WAU 留存。
+- **编辑深度**：`project_kind='design_system'` 的 run（E1）+ 右侧工具点击（E2）+ 模块按钮（E3）频次，可再按 `edit_surface` 拆 chat/edit/draw/comment/mark/direct_module。
+- **创建入口转化**：`design_system_create_result` 按 `entry_from`（onboarding / design_systems_page / home_card / composer_picker / project_canvas / library …）下钻，看各入口的成功率与占比（见 §3.1）。
+- **来源偏好**：`ds_source_origins` 多值拆开，统计每种来源占比与“多来源”组合（评论②）。
+- **使用偏好**：`run_created` 按 `design_system_kind(official/custom)` 与 `design_system_slug` 下钻。
+- **留存/复购关联**：以“是否创建过 DS / 创建数量分桶 / 是否用过 AI 优化”为用户属性，关联留存曲线与复购转化（注意 OD 留存须限已认证用户，见团队留存口径备忘）。

--- a/docs/design-system-tracking-spec.md
+++ b/docs/design-system-tracking-spec.md
@@ -32,7 +32,7 @@
 | C2 Onboarding 创建 vs Go Home（用 completion_type with/without_design_system 区分） | ✅ 已实现 |
 | E1 DS 编辑 run 带 `edit_surface`(chat/comment/mark，daemon 从 entry_from 派生） | ✅ 已实现 |
 | E3 §3.6 编辑按钮：edit_with_agent/refresh/download/reset/color/logo·image delete/上传×3(含 paste)/design_md_edit + Brand 卡三键 | ✅ 已实现 |
-| C14 `design_system_enrich_result`、C15 `ProjectMetadata.enrichmentStatus` | ⏳ follow-up（需关联 enrichment run 完成） |
+| C14 `design_system_enrich_result` + C15 `ProjectMetadata.enrichmentStatus`/`enrichmentCompletedAt`（daemon 在 enrichment run 完成时发事件 + 成功则标 ai_refined） | ✅ 已实现 |
 | C10 多网站计数；少量按钮 `kit_import`(无实现)/`kit_open`(无状态外链)/`design_md_copy·upload`(无独立 handler) | ⏳ 未实现/枚举预留 |
 
 ## 0. 业务目标（埋点要回答的问题）

--- a/docs/design-system-tracking-spec.md
+++ b/docs/design-system-tracking-spec.md
@@ -30,8 +30,10 @@
 | C13 AI 优化点击 `design_system_enrich`/`ai_optimize` | ✅ 已实现 |
 | `ds_source_origins` 多值（评论②，create_result 列全部来源不再塌缩成 mixed） | ✅ 已实现 |
 | C2 Onboarding 创建 vs Go Home（用 completion_type with/without_design_system 区分） | ✅ 已实现 |
+| E1 DS 编辑 run 带 `edit_surface`(chat/comment/mark，daemon 从 entry_from 派生） | ✅ 已实现 |
+| E3 §3.6 编辑按钮：edit_with_agent/refresh/download/reset/color/logo·image delete/上传×3(含 paste)/design_md_edit + Brand 卡三键 | ✅ 已实现 |
 | C14 `design_system_enrich_result`、C15 `ProjectMetadata.enrichmentStatus` | ⏳ follow-up（需关联 enrichment run 完成） |
-| C10 多网站计数、E1-E3 + §3.6 全部编辑按钮 | ⏳ 未实现 |
+| C10 多网站计数；少量按钮 `kit_import`(无实现)/`kit_open`(无状态外链)/`design_md_copy·upload`(无独立 handler) | ⏳ 未实现/枚举预留 |
 
 ## 0. 业务目标（埋点要回答的问题）
 

--- a/docs/design-system-tracking-spec.md
+++ b/docs/design-system-tracking-spec.md
@@ -19,6 +19,18 @@
 
 ---
 
+## 实现进度（分支 `ds-tracking-impl`）
+
+| 片 | 状态 |
+|---|---|
+| §1 `project_kind='design_system'`（brand-extraction project 映射） | ✅ 已实现 |
+| §3.5 U3/U4：`design_system_source` 真实映射 + `design_system_kind`(official/custom)/`slug` | ✅ 已实现 |
+| §3.1 创建入口来源透传（6 入口 + `project_canvas`/`library`/`composer_picker`） | ✅ 已实现 |
+| C7-C9 预设品牌选择器（`start_from_brand` / surface_view / `brand_pick`） | ✅ 已实现（`is_quick_pick` 待办） |
+| C13 AI 优化点击 `design_system_enrich`/`ai_optimize` | ✅ 已实现 |
+| C14 `design_system_enrich_result`、C15 `ProjectMetadata.enrichmentStatus` | ⏳ follow-up（需关联 enrichment run 完成） |
+| `ds_source_origins` 多值（评论②）、C2 Onboarding 分叉、C10、E1-E3 + §3.6 全部按钮 | ⏳ 未实现 |
+
 ## 0. 业务目标（埋点要回答的问题）
 
 1. **创建漏斗**：从入口到成功创建一个 DS，每一步的转化与流失在哪。

--- a/docs/design-system-tracking-spec.md
+++ b/docs/design-system-tracking-spec.md
@@ -28,8 +28,9 @@
 | §3.1 创建入口来源透传（6 入口 + `project_canvas`/`library`/`composer_picker`） | ✅ 已实现 |
 | C7-C9 预设品牌选择器（`start_from_brand` / surface_view / `brand_pick`） | ✅ 已实现（`is_quick_pick` 待办） |
 | C13 AI 优化点击 `design_system_enrich`/`ai_optimize` | ✅ 已实现 |
+| `ds_source_origins` 多值（评论②，create_result 列全部来源不再塌缩成 mixed） | ✅ 已实现 |
 | C14 `design_system_enrich_result`、C15 `ProjectMetadata.enrichmentStatus` | ⏳ follow-up（需关联 enrichment run 完成） |
-| `ds_source_origins` 多值（评论②）、C2 Onboarding 分叉、C10、E1-E3 + §3.6 全部按钮 | ⏳ 未实现 |
+| C2 Onboarding 分叉、C10 多网站计数、E1-E3 + §3.6 全部编辑按钮 | ⏳ 未实现 |
 
 ## 0. 业务目标（埋点要回答的问题）
 

--- a/docs/design-system-tracking-spec.md
+++ b/docs/design-system-tracking-spec.md
@@ -29,8 +29,9 @@
 | C7-C9 预设品牌选择器（`start_from_brand` / surface_view / `brand_pick`） | ✅ 已实现（`is_quick_pick` 待办） |
 | C13 AI 优化点击 `design_system_enrich`/`ai_optimize` | ✅ 已实现 |
 | `ds_source_origins` 多值（评论②，create_result 列全部来源不再塌缩成 mixed） | ✅ 已实现 |
+| C2 Onboarding 创建 vs Go Home（用 completion_type with/without_design_system 区分） | ✅ 已实现 |
 | C14 `design_system_enrich_result`、C15 `ProjectMetadata.enrichmentStatus` | ⏳ follow-up（需关联 enrichment run 完成） |
-| C2 Onboarding 分叉、C10 多网站计数、E1-E3 + §3.6 全部编辑按钮 | ⏳ 未实现 |
+| C10 多网站计数、E1-E3 + §3.6 全部编辑按钮 | ⏳ 未实现 |
 
 ## 0. 业务目标（埋点要回答的问题）
 

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -581,6 +581,13 @@ async function setupAmrWorkspace(
     assistantText?: string;
   },
 ) {
+  await page.route('**/api/skills', async (route) => {
+    await route.fulfill({ json: { skills: [] } });
+  });
+  await page.route('**/api/design-templates', async (route) => {
+    await route.fulfill({ json: { designTemplates: [] } });
+  });
+
   const root = join(tmpdir(), `open-design-amr-ui-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const homeDir = join(root, 'home');
   const velaBin = await writeFakeVelaBin(join(root, 'bin'), {

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -5,13 +5,14 @@ import { routeAgents } from '../lib/playwright/mock-factory.js';
 
 // The `/projects` view in `EntryShell` renders a `CenteredLoader` until
 // `projectsLoading || skillsLoading || designSystemsLoading` all clear
-// (`apps/web/src/components/EntryShell.tsx`), and `designSystemsLoading` only
-// clears once `GET /api/design-systems` resolves (`App.tsx` `dsLoading`). A test
-// that lands on `/projects` but leaves `/api/design-systems` unmocked therefore
-// gates its first assertion on the real daemon's response time — fast locally,
-// but a flaky >10s loader under CI load (this dequeued PR #4548 from the merge
-// queue). Stub the endpoint so the projects view renders deterministically.
-async function stubDesignSystemsEmpty(page: Page): Promise<void> {
+// (`apps/web/src/components/EntryShell.tsx`). Tests that land on `/projects`
+// should stub the catalog endpoints that are unrelated to the project-list
+// behavior under test; otherwise a large registry response can keep the first
+// assertion gated on daemon/catalog timing instead of the UI contract.
+async function stubCatalogsEmpty(page: Page): Promise<void> {
+  await page.route('**/api/design-templates', async (route) => {
+    await route.fulfill({ json: { designTemplates: [] } });
+  });
   await page.route('**/api/design-systems', async (route) => {
     await route.fulfill({ json: { designSystems: [] } });
   });
@@ -232,7 +233,7 @@ test('[P0] projects empty state create action opens the new project flow', async
     await route.continue();
   });
 
-  await stubDesignSystemsEmpty(page);
+  await stubCatalogsEmpty(page);
   await page.goto('/projects');
   await expect(page.locator('.designs-empty-state')).toBeVisible();
   await page.locator('.designs-empty-cta').click();
@@ -1261,7 +1262,7 @@ test('[P2] projects sub tabs switch between Recent and Your designs ordering', a
     await route.fulfill({ json: { liveArtifacts: [] } });
   });
 
-  await stubDesignSystemsEmpty(page);
+  await stubCatalogsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
 
@@ -1417,7 +1418,7 @@ test('[P2] projects page shows the empty state when there are no projects', asyn
     await route.continue();
   });
 
-  await stubDesignSystemsEmpty(page);
+  await stubCatalogsEmpty(page);
   await page.goto('/projects');
   await expect(page).toHaveURL(/\/projects$/);
   await expect(page.locator('.tab-empty')).toBeVisible();
@@ -1447,7 +1448,7 @@ test('[P2] projects page shows the no-results state and recovers when search is 
     await route.fulfill({ json: { liveArtifacts: [] } });
   });
 
-  await stubDesignSystemsEmpty(page);
+  await stubCatalogsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
   await expect(homeDesignCard(page, 'Searchable Prototype')).toBeVisible();
@@ -1483,7 +1484,7 @@ test('[P2] projects grid overflow menu closes on outside click and Escape', asyn
     await route.fulfill({ json: { liveArtifacts: [] } });
   });
 
-  await stubDesignSystemsEmpty(page);
+  await stubCatalogsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
 
@@ -1554,7 +1555,7 @@ test('[P2] projects kanban view groups cards into status columns', async ({ page
     await route.fulfill({ json: { liveArtifacts: [] } });
   });
 
-  await stubDesignSystemsEmpty(page);
+  await stubCatalogsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
   await page.getByTestId('designs-view-kanban').click();
@@ -1645,7 +1646,7 @@ test('[P1] projects page shows live artifact cards, supports search, and opens t
     });
   });
 
-  await stubDesignSystemsEmpty(page);
+  await stubCatalogsEmpty(page);
   await page.goto('/projects');
   await expectDesignsView(page);
 

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -64,7 +64,9 @@ export type AnalyticsEventName =
   | 'design_system_create_result'
   | 'design_system_review_result'
   | 'design_system_status_result'
-  | 'design_system_apply_result';
+  | 'design_system_apply_result'
+  // AI optimize (deep enrichment) of a programmatically-extracted DS.
+  | 'design_system_enrich_result';
 
 // ---- Pages ---------------------------------------------------------------
 
@@ -706,6 +708,8 @@ export type TrackingDesignSystemsArea =
   // Preset-brand picker opened from the create form ("Start from a brand").
   // A brand here is one *source* for a design system, not a separate object.
   | 'preset_brand_picker'
+  // AI-optimize (deep enrichment) banner on a DS-as-project.
+  | 'design_system_enrich'
   | 'composer';
 
 export type TrackingDesignSystemsViewType =
@@ -1049,6 +1053,30 @@ export interface DesignSystemApplyResultProps {
   run_id?: string;
   error_code?: string;
   duration_ms: number;
+}
+
+// AI optimize (deep enrichment) of a programmatically-extracted design system.
+// `design_system_enrich` click = the user pressed "AI Optimize" on the banner;
+// `design_system_enrich_result` = the enrichment run settled. Together they
+// give the AI-conversion rate (clicked ÷ programmatic creates) and, with
+// ProjectMetadata.enrichmentStatus, the programmatic-vs-ai_refined comparison.
+export interface DesignSystemEnrichClickProps {
+  page_name: 'design_system_project';
+  area: 'design_system_enrich';
+  element: 'ai_optimize';
+  design_system_id?: string;
+  project_kind?: TrackingProjectKind | null;
+}
+
+export interface DesignSystemEnrichResultProps {
+  page_name: 'design_system_project';
+  area: 'design_system_enrich';
+  result: 'success' | 'failed' | 'cancelled';
+  design_system_id?: string;
+  project_id?: string;
+  run_id?: string;
+  error_code?: string;
+  duration_ms?: number;
 }
 
 // --- Generic page_view (existing surfaces) ---
@@ -2408,6 +2436,7 @@ export type UiClickProps =
   | DesignSystemsTemplatesModalSharePopoverClickProps
   | DesignSystemsCreateClickProps
   | DesignSystemsPresetBrandPickerClickProps
+  | DesignSystemEnrichClickProps
   | IntegrationsTabClickProps
   | IntegrationsMcpTabClickProps
   | IntegrationsConnectorsTabClickProps
@@ -3198,7 +3227,8 @@ export type AnalyticsEventPayload =
   | { event: 'design_system_create_result'; props: DesignSystemCreateResultProps }
   | { event: 'design_system_review_result'; props: DesignSystemReviewResultProps }
   | { event: 'design_system_status_result'; props: DesignSystemStatusResultProps }
-  | { event: 'design_system_apply_result'; props: DesignSystemApplyResultProps };
+  | { event: 'design_system_apply_result'; props: DesignSystemApplyResultProps }
+  | { event: 'design_system_enrich_result'; props: DesignSystemEnrichResultProps };
 
 // ---- Enum mapping helpers (code ↔ CSV wire format) -----------------------
 

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -990,6 +990,11 @@ export interface DesignSystemCreateResultProps {
   project_id?: string;
   design_system_id?: string;
   design_system_source: TrackingDesignSystemOrigin;
+  // Every source actually used, comma-joined (e.g. `source_url,local_code`),
+  // so multi-source creates aren't flattened to the single `mixed` value of
+  // `design_system_source`. Mirrors the multi-value convention of
+  // target_platforms/connectors. See tracking spec dimension dict + comment ②.
+  ds_source_origins?: string;
   source_count: number;
   created_as_project: boolean;
   has_brand_description: boolean;

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -703,6 +703,9 @@ export type TrackingDesignSystemsArea =
   | 'design_system_generation'
   | 'design_system_preview'
   | 'design_system_picker'
+  // Preset-brand picker opened from the create form ("Start from a brand").
+  // A brand here is one *source* for a design system, not a separate object.
+  | 'preset_brand_picker'
   | 'composer';
 
 export type TrackingDesignSystemsViewType =
@@ -718,6 +721,10 @@ export type TrackingDesignSystemsEntryFrom =
   | 'home_card'
   | 'composer_picker'
   | 'project_settings'
+  // Created from inside a project's canvas / file workspace.
+  | 'project_canvas'
+  // Created from the Library surface.
+  | 'library'
   | 'unknown';
 
 // Origin of the design system itself. NOT the same field as
@@ -747,6 +754,22 @@ export type TrackingDesignSystemStatus =
   | 'failed'
   | 'archived'
   | 'unknown';
+
+// Whether a design system is an official/preset one or user-built. Derived
+// from the design_system_id shape: `user:<id>` => custom, everything else
+// (registry-backed presets) => official. `unknown` when no DS is in play.
+export type TrackingDesignSystemKind = 'official' | 'custom' | 'unknown';
+
+// Which surface initiated an edit of an existing design system. All of the
+// non-`direct_module` surfaces ultimately route through the agent (a run);
+// `direct_module` is an in-panel module button (some direct, some agent-routed).
+export type TrackingDesignSystemEditSurface =
+  | 'chat'
+  | 'edit'
+  | 'draw'
+  | 'comment'
+  | 'mark'
+  | 'direct_module';
 
 export interface DesignSystemsPageViewProps {
   page_name: 'design_systems' | 'design_system_project' | 'home' | 'studio';
@@ -837,7 +860,12 @@ export type TrackingDesignSystemCreateEntryFrom =
   | 'onboarding'
   | 'design_systems_page'
   | 'home_card'
+  | 'composer_picker'
   | 'project_settings'
+  // Created from inside a project's canvas / file workspace.
+  | 'project_canvas'
+  // Created from the Library surface.
+  | 'library'
   | 'unknown';
 
 export type TrackingDesignSystemSourceIngestEntryFrom =
@@ -1563,10 +1591,32 @@ export interface DesignSystemsCreateClickProps {
     | 'browse_folder'
     | 'upload_fig'
     | 'add_assets'
+    // Opens the preset-brand picker ("Start from a brand").
+    | 'start_from_brand'
     | 'continue_to_generation'
     | 'back';
   // State *after* the toggle; only sent with element=show_access_methods.
   methods_expanded?: boolean;
+}
+
+// Preset-brand picker ("Start from a brand") on the /design-systems/create
+// form. Picking a brand adds its site as a *source* for the design system —
+// brand is an input here, not a separate object. Privacy: never send the raw
+// brand domain/URL; only the curated category + quick-pick flag.
+export interface DesignSystemsPresetBrandPickerClickProps {
+  page_name: 'design_systems';
+  area: 'preset_brand_picker';
+  element: 'brand_pick' | 'quick_pick' | 'close';
+  // Curated category bucket of the picked brand (e.g. `software`, `finance`).
+  // Only on brand_pick / quick_pick. Never the domain.
+  preset_brand_category?: string;
+  // True when picked from the quick "popular brands" row rather than search.
+  is_quick_pick?: boolean;
+}
+
+export interface DesignSystemsPresetBrandPickerSurfaceViewProps {
+  page_name: 'design_systems';
+  area: 'preset_brand_picker';
 }
 
 // INTEGRATIONS
@@ -2357,6 +2407,7 @@ export type UiClickProps =
   | DesignSystemsTemplatesModalClickProps
   | DesignSystemsTemplatesModalSharePopoverClickProps
   | DesignSystemsCreateClickProps
+  | DesignSystemsPresetBrandPickerClickProps
   | IntegrationsTabClickProps
   | IntegrationsMcpTabClickProps
   | IntegrationsConnectorsTabClickProps
@@ -2525,6 +2576,7 @@ export type SurfaceViewProps =
   | PluginDetailModalSurfaceViewProps
   | PluginImportModalSurfaceViewProps
   | DesignSystemsTemplatesModalSurfaceViewProps
+  | DesignSystemsPresetBrandPickerSurfaceViewProps
   | AssistantFeedbackReasonPanelSurfaceViewProps
   | QuestionsFormSurfaceViewProps
   | UpdateIndicatorSurfaceViewProps
@@ -2630,7 +2682,14 @@ export interface RunCreatedProps {
   project_kind: TrackingProjectKind | null;
   design_system_id?: string;
   design_system_source: TrackingDesignSystemSource;
+  // Official preset vs user-built; `design_system_slug` carries the concrete
+  // preset id when official (never set for custom — only the id is sent there).
+  design_system_kind?: TrackingDesignSystemKind;
+  design_system_slug?: string;
   design_system_version?: string;
+  // Which surface drove this run when it's editing an existing DS
+  // (chat / edit / draw / comment / mark). Only on design_system_project runs.
+  edit_surface?: TrackingDesignSystemEditSurface;
   // DS-variant context. `ds_source_origin` mirrors the
   // `TrackingDesignSystemOrigin` set used on DS page_views (where
   // the DS came from), separate from the runtime-selection

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -1652,6 +1652,51 @@ export interface DesignSystemsPresetBrandPickerSurfaceViewProps {
   area: 'preset_brand_picker';
 }
 
+// Direct in-panel edits of an existing design system (tracking spec §3.6,
+// E3). Covers the DS list general ops (edit-with-agent / refresh / download),
+// the DesignKitView module buttons (logo / typography / palette / images /
+// kit), and the brand preview card. `edit_surface` is always `direct_module`
+// here; agent-routed edits (chat / draw / edit / comment / mark) ride on
+// run_created.edit_surface instead. Never carries artifact content/URLs.
+export interface DesignSystemEditClickProps {
+  page_name: 'design_systems' | 'design_system_project';
+  area: 'design_system_edit';
+  element:
+    | 'edit_with_agent'
+    | 'refresh'
+    | 'download'
+    | 'logo_upload'
+    | 'logo_delete'
+    | 'design_md_copy'
+    | 'design_md_edit'
+    | 'design_md_upload'
+    | 'font_upload'
+    | 'color_edit'
+    | 'image_upload'
+    | 'image_delete'
+    | 'kit_refresh'
+    | 'kit_download'
+    | 'kit_import'
+    | 'kit_reset'
+    | 'kit_open'
+    | 'brand_card_use_in_chat'
+    | 'brand_card_open_project'
+    | 'brand_card_delete';
+  module?:
+    | 'logo'
+    | 'design_md'
+    | 'typography'
+    | 'palette'
+    | 'images'
+    | 'kit'
+    | 'brand_card'
+    | 'general';
+  edit_surface?: TrackingDesignSystemEditSurface;
+  artifact_kind?: 'design_system';
+  design_system_id?: string;
+  project_id?: string;
+}
+
 // INTEGRATIONS
 export interface IntegrationsTabClickProps {
   page_name: 'integrations';
@@ -2442,6 +2487,7 @@ export type UiClickProps =
   | DesignSystemsCreateClickProps
   | DesignSystemsPresetBrandPickerClickProps
   | DesignSystemEnrichClickProps
+  | DesignSystemEditClickProps
   | IntegrationsTabClickProps
   | IntegrationsMcpTabClickProps
   | IntegrationsConnectorsTabClickProps

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -162,6 +162,12 @@ export interface ChatAnalyticsHints {
   // onto run_created / run_finished, overriding its own BYOK-blind
   // derivation. Omitted means "let the daemon keep its derived value".
   runtimeType?: TrackingRuntimeType;
+  // Analytics-only marker that THIS run is the AI-optimize ("enrich") pass on a
+  // programmatically-extracted design system. The web AI-optimize path sets it;
+  // the daemon uses it to emit `design_system_enrich_result` and to stamp the
+  // `ai_refined` enrichment metadata on success. It carries no execution
+  // semantics — omitting it just means the run is not an enrichment pass.
+  dsEnrichment?: boolean;
 }
 
 export interface RunScopedMcpServerConfig extends Omit<McpServerConfig, 'enabled'> {

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -180,6 +180,12 @@ export interface ProjectMetadata {
   brandId?: string;
   brandSourceUrl?: string;
   brandDesignSystemId?: string;
+  // AI-optimize (deep enrichment) state for a programmatically-extracted DS.
+  // `programmatic` (or unset) = fast pass only; `ai_refined` = a user-triggered
+  // enrichment run completed successfully. Lets analytics compare the two
+  // cohorts' retention/usage (tracking spec C15 / §6).
+  enrichmentStatus?: 'programmatic' | 'ai_refined';
+  enrichmentCompletedAt?: number;
 }
 
 export interface Project {

--- a/packages/contracts/tests/analytics-design-system-helpers.test.ts
+++ b/packages/contracts/tests/analytics-design-system-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { ChatAnalyticsHints } from '../src/api/chat.js';
 import {
   designSystemFolderCountBucket,
   designSystemLengthBucket,
@@ -123,6 +124,28 @@ describe('designSystemModuleType', () => {
     expect(designSystemModuleType('motion')).toBe('other');
     expect(designSystemModuleType('')).toBe('other');
     expect(designSystemModuleType(null)).toBe('other');
+  });
+});
+
+describe('ChatAnalyticsHints.dsEnrichment (AI-optimize request shape)', () => {
+  it('declares the analytics-only enrichment marker the daemon gates on', () => {
+    // The web AI-optimize path stamps `dsEnrichment: true`; the daemon reads it
+    // with a strict `=== true` gate (routes/runs.ts) to emit
+    // design_system_enrich_result and stamp the `ai_refined` DS metadata. The
+    // shared contract MUST declare the field so typed ChatRequest callers can
+    // discover/type-check it — this test compile-fails if the field is dropped,
+    // guarding against the web/daemon-ahead-of-contract drift.
+    const enrichHint: ChatAnalyticsHints = { dsEnrichment: true };
+    expect(enrichHint.dsEnrichment === true).toBe(true);
+
+    // A run with no enrichment marker reads as a normal (non-enrich) run.
+    const plainHint: ChatAnalyticsHints = {};
+    expect(plainHint.dsEnrichment === true).toBe(false);
+
+    // The field is optional and analytics-only: an explicit false is still
+    // "not an enrichment pass" under the daemon's strict gate.
+    const falseHint: ChatAnalyticsHints = { dsEnrichment: false };
+    expect(falseHint.dsEnrichment === true).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why

Backport design-system tracking work to the `release/v0.12.0` branch so release builds emit the design-system creation, onboarding, and enrichment analytics added for PR #4740.

## What users will see

No direct UI change is expected beyond the existing design-system flows continuing to report richer analytics and lifecycle metadata on the release line.

## Surface area

- Design-system analytics event contracts and tests.
- Web instrumentation for onboarding, brand picker, design-system creation, edit lifecycle, and enrichment actions.
- Daemon run route metadata and chat analytics hints.
- Design-system tracking documentation.
- `.playwright-mcp` capture output ignored in git.

## Screenshots

Not applicable.

## Bug fix verification

Not run locally.

## Validation

Not run locally; branch was inspected against `release/v0.12.0` before opening the PR.
