### PR TITLE
[codex] reduce noisy visual report matches

### DIFF
--- a/e2e/scripts/visual-report.ts
+++ b/e2e/scripts/visual-report.ts
@@ -61,7 +61,12 @@ type CompareCaseOps = {
   putFile?: (r2: R2Config, key: string, filePath: string) => Promise<void>;
   findBaseline?: (r2: R2Config, caseName: string, candidateShas: string[]) => Promise<BaselineLookup | null>;
   downloadObject?: (r2: R2Config, key: string, outputPath: string) => Promise<void>;
-  writeDiffPng?: (mainPath: string, prPath: string, diffPath: string) => Promise<number>;
+  writeDiffPng?: (mainPath: string, prPath: string, diffPath: string) => Promise<DiffPngResult>;
+};
+
+type DiffPngResult = {
+  diffPixels: number;
+  totalPixels: number;
 };
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -207,9 +212,9 @@ export async function compareCase(input: {
   const diffPath = path.join(outputDir, 'diff', `${visualCase.name}.png`);
   await downloadObjectOp(r2, baseline.key, mainPath);
 
-  let diffPixels: number;
+  let diffResult: DiffPngResult;
   try {
-    diffPixels = await writeDiffPngOp(mainPath, visualCase.path, diffPath);
+    diffResult = await writeDiffPngOp(mainPath, visualCase.path, diffPath);
   } catch (error) {
     return {
       name: visualCase.name,
@@ -231,11 +236,11 @@ export async function compareCase(input: {
   await putFileOp(r2, mainKey, mainPath);
   await putFileOp(r2, diffKey, diffPath);
 
-  const diffPixelRatio = diffPixels / pngPixelCount(visualBuffer, visualCase.path);
+  const diffPixelRatio = diffResult.diffPixels / diffResult.totalPixels;
   return {
     name: visualCase.name,
-    status: isChangedVisualDiff(diffPixels, diffPixelRatio) ? 'changed' : 'unchanged',
-    diffPixels,
+    status: isChangedVisualDiff(diffResult.diffPixels, diffPixelRatio) ? 'changed' : 'unchanged',
+    diffPixels: diffResult.diffPixels,
     diffPixelRatio,
     baselineSha: baseline.sha,
     baselineBehindBy: baseline.behindBy,
@@ -249,7 +254,7 @@ export function isChangedVisualDiff(diffPixels: number, diffPixelRatio: number):
   return diffPixels >= changedPixelFloor && diffPixelRatio >= changedPixelRatioFloor;
 }
 
-async function writeDiffPng(mainPath: string, prPath: string, diffPath: string): Promise<number> {
+async function writeDiffPng(mainPath: string, prPath: string, diffPath: string): Promise<DiffPngResult> {
   const main = PNG.sync.read(await readFile(mainPath));
   const pr = PNG.sync.read(await readFile(prPath));
   assertPngSize(main, mainPath);
@@ -273,7 +278,7 @@ async function writeDiffPng(mainPath: string, prPath: string, diffPath: string):
 
   await mkdir(path.dirname(diffPath), { recursive: true });
   await writeFile(diffPath, PNG.sync.write(diff));
-  return diffPixels;
+  return { diffPixels, totalPixels: width * height };
 }
 
 export type DiffBox = {
@@ -485,16 +490,6 @@ function assertPngHeaderSize(buffer: Buffer, filePath: string): void {
     throw new Error(`Visual case ${filePath} is not a valid PNG file`);
   }
   assertPngPixels(buffer.readUInt32BE(16), buffer.readUInt32BE(20), filePath);
-}
-
-function pngPixelCount(buffer: Buffer, filePath: string): number {
-  if (buffer.length < 24) {
-    throw new Error(`Visual case ${filePath} is not a valid PNG file`);
-  }
-  const width = buffer.readUInt32BE(16);
-  const height = buffer.readUInt32BE(20);
-  assertPngPixels(width, height, filePath);
-  return width * height;
 }
 
 function assertPngSize(png: PNG, filePath: string): void {

--- a/e2e/scripts/visual-report.ts
+++ b/e2e/scripts/visual-report.ts
@@ -13,6 +13,8 @@ const marker = '<!-- visual-regression-bot -->';
 const visualPrefix = 'visual-regression';
 const inlineCaseLimit = 20;
 const pixelThreshold = 0.1;
+const changedPixelFloor = 500;
+const changedPixelRatioFloor = 0.02;
 const diffBoxPadding = 6;
 const diffBoxMergeDistance = 12;
 const diffBoxStrokeWidth = 3;
@@ -46,6 +48,7 @@ type ComparedCase = {
   name: string;
   status: 'changed' | 'unchanged' | 'missing-baseline' | 'failed';
   diffPixels?: number;
+  diffPixelRatio?: number;
   baselineSha?: string;
   baselineBehindBy?: number;
   mainUrl?: string;
@@ -228,16 +231,22 @@ export async function compareCase(input: {
   await putFileOp(r2, mainKey, mainPath);
   await putFileOp(r2, diffKey, diffPath);
 
+  const diffPixelRatio = diffPixels / pngPixelCount(visualBuffer, visualCase.path);
   return {
     name: visualCase.name,
-    status: diffPixels > 0 ? 'changed' : 'unchanged',
+    status: isChangedVisualDiff(diffPixels, diffPixelRatio) ? 'changed' : 'unchanged',
     diffPixels,
+    diffPixelRatio,
     baselineSha: baseline.sha,
     baselineBehindBy: baseline.behindBy,
     mainUrl: publicUrl(r2, mainKey),
     prUrl: publicUrl(r2, prKey),
     diffUrl: publicUrl(r2, diffKey),
   };
+}
+
+export function isChangedVisualDiff(diffPixels: number, diffPixelRatio: number): boolean {
+  return diffPixels >= changedPixelFloor && diffPixelRatio >= changedPixelRatioFloor;
 }
 
 async function writeDiffPng(mainPath: string, prPath: string, diffPath: string): Promise<number> {
@@ -478,6 +487,16 @@ function assertPngHeaderSize(buffer: Buffer, filePath: string): void {
   assertPngPixels(buffer.readUInt32BE(16), buffer.readUInt32BE(20), filePath);
 }
 
+function pngPixelCount(buffer: Buffer, filePath: string): number {
+  if (buffer.length < 24) {
+    throw new Error(`Visual case ${filePath} is not a valid PNG file`);
+  }
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  assertPngPixels(width, height, filePath);
+  return width * height;
+}
+
 function assertPngSize(png: PNG, filePath: string): void {
   assertPngPixels(png.width, png.height, filePath);
 }
@@ -588,7 +607,7 @@ function renderComment(input: { compared: ComparedCase[]; headSha: string; baseS
   lines.push('', summaryLine({ changed, unchanged, missing, failed }), '');
 
   if (changed.length > 0) {
-    lines.push('### Changed cases', '', ...renderCaseTable(changed.slice(0, inlineCaseLimit)), '');
+    lines.push('### Changed cases', '', ...renderCaseList(changed.slice(0, inlineCaseLimit)), '');
     if (changed.length > inlineCaseLimit) {
       lines.push(`_${changed.length - inlineCaseLimit} additional changed case(s) omitted from this comment._`, '');
     }
@@ -603,11 +622,11 @@ function renderComment(input: { compared: ComparedCase[]; headSha: string; baseS
   }
 
   if (missing.length > 0) {
-    lines.push('<details><summary>PR screenshots without baselines</summary>', '', ...renderCaseTable(missing.slice(0, inlineCaseLimit), false), '</details>', '');
+    lines.push('<details><summary>PR screenshots without baselines</summary>', '', ...renderCaseList(missing.slice(0, inlineCaseLimit), false), '</details>', '');
   }
 
   if (unchanged.length > 0) {
-    lines.push('<details><summary>Unchanged cases</summary>', '', ...renderCaseTable(unchanged.slice(0, inlineCaseLimit)), '</details>', '');
+    lines.push('<details><summary>Unchanged cases</summary>', '', ...renderCaseList(unchanged.slice(0, inlineCaseLimit)), '</details>', '');
   }
 
   lines.push('_Visual diff is advisory only and does not block merging._', '');
@@ -623,21 +642,32 @@ function summaryLine(groups: { changed: ComparedCase[]; unchanged: ComparedCase[
   ].join(' · ');
 }
 
-function renderCaseTable(cases: ComparedCase[], includeDiff = true): string[] {
-  const lines = includeDiff
-    ? ['| Case | Main | PR | Diff |', '| --- | --- | --- | --- |']
-    : ['| Case | PR |', '| --- | --- |'];
-
+function renderCaseList(cases: ComparedCase[], includeDiff = true): string[] {
+  const lines: string[] = [];
   for (const visualCase of cases) {
     const baselineNote = visualCase.baselineBehindBy != null && visualCase.baselineBehindBy > 0
-      ? `<br><sub>baseline ${visualCase.baselineBehindBy} commit(s) behind</sub>`
+      ? ` · baseline ${visualCase.baselineBehindBy} commit(s) behind`
       : '';
+    const diffNote = visualCase.diffPixels == null
+      ? ''
+      : ` · ${visualCase.diffPixels.toLocaleString('en-US')} px${visualCase.diffPixelRatio == null ? '' : ` (${formatPercent(visualCase.diffPixelRatio)})`}`;
+    lines.push(`#### ${escapeMarkdown(visualCase.name)}`);
+    const notes = `${diffNote}${baselineNote}`.replace(/^ · /u, '');
+    if (notes.length > 0) {
+      lines.push(`<sub>${escapeHtml(notes)}</sub>`);
+    }
     if (includeDiff) {
       lines.push(
-        `| ${escapeMarkdown(visualCase.name)}${baselineNote} | ${imageCell(visualCase.mainUrl, 'main')} | ${imageCell(visualCase.prUrl, 'pr')} | ${imageCell(visualCase.diffUrl, 'diff')} |`,
+        '',
+        `<strong>Main</strong><br>${imageCell(visualCase.mainUrl, 'main')}`,
+        '',
+        `<strong>PR</strong><br>${imageCell(visualCase.prUrl, 'pr')}`,
+        '',
+        `<strong>Diff</strong><br>${imageCell(visualCase.diffUrl, 'diff')}`,
+        '',
       );
     } else {
-      lines.push(`| ${escapeMarkdown(visualCase.name)} | ${imageCell(visualCase.prUrl, 'pr')} |`);
+      lines.push('', `<strong>PR</strong><br>${imageCell(visualCase.prUrl, 'pr')}`, '');
     }
   }
 
@@ -645,7 +675,11 @@ function renderCaseTable(cases: ComparedCase[], includeDiff = true): string[] {
 }
 
 function imageCell(url: string | undefined, alt: string): string {
-  return url == null ? 'n/a' : `<img src="${escapeHtml(url)}" alt="${escapeHtml(alt)}" width="280">`;
+  return url == null ? 'n/a' : `<img src="${escapeHtml(url)}" alt="${escapeHtml(alt)}" width="640">`;
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(2)}%`;
 }
 
 async function objectExists(r2: R2Config, key: string): Promise<boolean> {

--- a/e2e/tests/visual-report.test.ts
+++ b/e2e/tests/visual-report.test.ts
@@ -51,7 +51,7 @@ describe('visual report PNG sizing', () => {
         writeDiffPng: async (_mainPath: string, prPath: string, diffPath: string) => {
           await mkdir(path.dirname(diffPath), { recursive: true });
           await writeFile(diffPath, await readFile(prPath));
-          return 0;
+          return { diffPixels: 0, totalPixels: 4 };
         },
       };
 
@@ -122,7 +122,7 @@ describe('visual report PNG sizing', () => {
           downloadObject: async () => {
             throw new Error('download failed');
           },
-          writeDiffPng: async () => 0,
+          writeDiffPng: async () => ({ diffPixels: 0, totalPixels: 4 }),
         },
       )).rejects.toThrow('download failed');
     } finally {
@@ -250,7 +250,7 @@ describe('visual report PNG sizing', () => {
           writeDiffPng: async (_mainPath: string, prPath: string, diffPath: string) => {
             await mkdir(path.dirname(diffPath), { recursive: true });
             await writeFile(diffPath, await readFile(prPath));
-            return 32;
+            return { diffPixels: 32, totalPixels: 1_600 };
           },
         },
       );
@@ -259,7 +259,7 @@ describe('visual report PNG sizing', () => {
         name: 'visual-good',
         status: 'unchanged',
         diffPixels: 32,
-        diffPixelRatio: 8,
+        diffPixelRatio: 0.02,
       });
     } finally {
       await rm(workDir, { recursive: true, force: true });

--- a/e2e/tests/visual-report.test.ts
+++ b/e2e/tests/visual-report.test.ts
@@ -11,6 +11,7 @@ import {
   compareCase,
   diffBoxesFromMask,
   drawBox,
+  isChangedVisualDiff,
   mergeDiffBoxes,
   padBox,
   type DiffBox,
@@ -213,6 +214,62 @@ describe('visual report PNG sizing', () => {
     } finally {
       await rm(workDir, { recursive: true, force: true });
     }
+  });
+
+  test('treats tiny pixel diffs as unchanged visual noise', async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), 'visual-report-'));
+    try {
+      const outputDir = path.join(workDir, 'output');
+      const goodPath = path.join(workDir, 'visual-good.png');
+      const pngBuffer = PNG.sync.write(createFilledPng(2, 2));
+      await writeFile(goodPath, pngBuffer);
+
+      const r2 = {
+        bucket: 'visual-bucket',
+        publicOrigin: 'https://example.invalid',
+        client: {} as never,
+      };
+
+      const result = await compareCase(
+        {
+          r2,
+          prNumber: '12',
+          runId: '34',
+          headSha: 'b'.repeat(40),
+          visualCase: { name: 'visual-good', path: goodPath },
+          candidateShas: ['c'.repeat(40)],
+          outputDir,
+        },
+        {
+          putFile: async () => {},
+          findBaseline: async () => ({ sha: 'a'.repeat(40), key: 'baseline/visual-good.png', behindBy: 0 }),
+          downloadObject: async (_r2: unknown, _key: string, outputPath: string) => {
+            await mkdir(path.dirname(outputPath), { recursive: true });
+            await writeFile(outputPath, pngBuffer);
+          },
+          writeDiffPng: async (_mainPath: string, prPath: string, diffPath: string) => {
+            await mkdir(path.dirname(diffPath), { recursive: true });
+            await writeFile(diffPath, await readFile(prPath));
+            return 32;
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        name: 'visual-good',
+        status: 'unchanged',
+        diffPixels: 32,
+        diffPixelRatio: 8,
+      });
+    } finally {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test('requires both absolute and relative visual diff thresholds', async () => {
+    expect(isChangedVisualDiff(499, 0.5)).toBe(false);
+    expect(isChangedVisualDiff(25_000, 0.019)).toBe(false);
+    expect(isChangedVisualDiff(25_000, 0.02)).toBe(true);
   });
 
   test('huge-dimension PNG headers fail before decode and upload', async () => {


### PR DESCRIPTION
## Summary

- Treat visual diffs as changed only when they pass both an absolute pixel floor and a relative area floor.
- Include diff pixel count and percentage in the generated visual report.
- Render changed/missing/unchanged cases as vertical sections with larger images so Main/PR/Diff are easier to inspect.

## Why

The visual report currently marks any non-zero pixel diff as changed, so cases with 1 px or a few dozen px differences are surfaced as changed. This creates noisy reports and obscures meaningful visual regressions.

## Validation

- `pnpm --filter @open-design/e2e typecheck`
- `pnpm --filter @open-design/e2e exec vitest run -c vitest.config.ts tests/visual-report.test.ts`
