### PR TITLE
fix(landing-page): drop redirecting legacy routes from sitemap

### DIFF
--- a/apps/landing-page/astro.config.ts
+++ b/apps/landing-page/astro.config.ts
@@ -294,7 +294,17 @@ export default defineConfig({
         ) {
           item.priority = 0.9;
           item.changefreq = changefreq.weekly;
-        } else if (path === '/craft/' || path === '/plugins/') {
+        } else if (
+          path === '/craft/' ||
+          path === '/plugins/' ||
+          // Canonical section hubs that the legacy /skills, /systems, and
+          // /templates roots now 301 to — keep them on the elevated catalog
+          // crawl hint (0.7 / weekly) rather than letting them fall through
+          // to the generic 0.5 / monthly default.
+          path === '/plugins/skills/' ||
+          path === '/plugins/systems/' ||
+          path === '/plugins/templates/'
+        ) {
           item.priority = 0.7;
           item.changefreq = changefreq.weekly;
         } else {

--- a/apps/landing-page/astro.config.ts
+++ b/apps/landing-page/astro.config.ts
@@ -250,6 +250,15 @@ export default defineConfig({
       filter: (page) => {
         if (page.includes('/og/')) return false;
         const path = new URL(page).pathname;
+        // Legacy catalog routes (/skills, /systems, /templates) now live
+        // under /plugins/* and are 301-redirected by `public/_redirects`,
+        // and legacy region-cased locale codes (zh-CN, zh-TW, es-ES, pt-BR)
+        // 301 to their canonical lowercase locale (/zh/, /es/). Their old
+        // page routes still build, so without this guard `@astrojs/sitemap`
+        // lists ~460 redirecting URLs. A sitemap must carry only final 200
+        // canonical URLs — never redirects — so drop these legacy prefixes.
+        if (/^\/(skills|systems|templates)\//.test(path)) return false;
+        if (/^\/(zh-CN|zh-TW|es-ES|pt-BR)\//.test(path)) return false;
         const localeMatch = path.match(/^\/([a-z]{2}(?:-[a-z]{2})?)\//);
         if (localeMatch) {
           const code = localeMatch[1];
@@ -285,13 +294,7 @@ export default defineConfig({
         ) {
           item.priority = 0.9;
           item.changefreq = changefreq.weekly;
-        } else if (
-          path === '/skills/' ||
-          path === '/systems/' ||
-          path === '/templates/' ||
-          path === '/craft/' ||
-          path === '/plugins/'
-        ) {
+        } else if (path === '/craft/' || path === '/plugins/') {
           item.priority = 0.7;
           item.changefreq = changefreq.weekly;
         } else {


### PR DESCRIPTION
<!-- No linked issue: this is a standalone SEO hygiene fix surfaced by a GSC audit. -->

## Why

While auditing why a large share of `open-design.ai` pages show as "not indexed"
in Google Search Console, I crawled the full published sitemap (`sitemap-0.xml`,
1,217 URLs) and found that **468 of them (38%) return a 301 redirect** rather
than a final 200.

They fall into two groups:
- The legacy catalog routes `/skills/*`, `/systems/*`, `/templates/*` (176 + 173
  + 111 URLs). These now live under `/plugins/*` and are 301-redirected by
  `public/_redirects`, but their old page routes still build, so
  `@astrojs/sitemap` keeps emitting them.
- Legacy region-cased locale codes `/zh-CN/`, `/zh-TW/`, `/es-ES/`, `/pt-BR/`
  (8 URLs) that 301 to their canonical lowercase locale (`/zh/`, `/es/`).

A sitemap should advertise only final, canonical 200 URLs. Listing redirects
wastes crawl budget and is the primary feeder of GSC's **"Page with redirect"**
exclusion bucket. This is the cheapest, highest-leverage fix from the audit.

## What users will see

No user-visible change. The redirects themselves are untouched — every old
`/skills/…`, `/systems/…`, `/templates/…`, and old-locale URL keeps 301-ing to
its canonical home via `public/_redirects`, so existing links and bookmarks
still resolve. The only change is that `sitemap-0.xml` shrinks from 1,217 to 749
entries (it drops the 468 redirecting URLs), so Google crawls only canonical
pages.

## Surface area

- [x] **None** — internal config change (sitemap generation filter); no UI, API, CLI, or behavior change for end users.

## Screenshots

N/A — no UI surface.

## Bug fix verification

Not a code-path bug, so no red-spec test. Verified empirically instead: crawled
every URL in the live `sitemap-0.xml` (1,217) and recorded HTTP status — 749×200,
468×301. Re-applied the new filter rules to that exact dataset:
- All 468 redirecting URLs are now excluded (0 redirects remain).
- All 749 canonical 200 URLs are retained (0 good pages dropped).

## Validation

- Crawled the production sitemap (1,217 URLs) and bucketed by HTTP status to
  confirm the 468 redirect entries and validate the filter against real data
  (749 kept / 468 dropped, no 200 removed).
- `pnpm guard` + `pnpm typecheck` run via the `Validate workspace` CI gate
  (local full-monorepo install hits an unrelated native-build issue on this
  machine; the change is a pure filter/regex edit in `astro.config.ts`).
