### PR TITLE
[codex] Polish design-system preview UI for release

### DIFF
--- a/apps/web/src/components/BrandPreviewCard.module.css
+++ b/apps/web/src/components/BrandPreviewCard.module.css
@@ -99,7 +99,7 @@
 .previewHeadSticky {
   position: sticky;
   top: 0;
-  z-index: 20;
+  z-index: 4;
   align-items: center;
   flex-wrap: nowrap;
   width: 100%;

--- a/apps/web/src/components/DesignSystemPreviewModal.tsx
+++ b/apps/web/src/components/DesignSystemPreviewModal.tsx
@@ -12,13 +12,19 @@ import {
   fetchDesignSystemPreview,
   fetchDesignSystemShowcase,
 } from '../providers/registry';
-import type { DesignSystemSummary } from '../types';
+import { useDesignKit } from '../runtime/design-kit';
+import type { DesignSystemDetail, DesignSystemSummary } from '../types';
 import { DesignSpecView } from './DesignSpecView';
+import { DesignKitView } from './DesignKitView';
 import { PreviewModal } from './PreviewModal';
 
 interface Props {
   system: DesignSystemSummary;
   onClose: () => void;
+}
+
+function isDesignSystemDetail(system: DesignSystemSummary): system is DesignSystemDetail {
+  return typeof (system as { body?: unknown }).body === 'string';
 }
 
 // Two-tab DS preview: a complete Showcase webpage rendered from the system's
@@ -43,6 +49,38 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
   const [showcaseHtml, setShowcaseHtml] = useState<string | null | undefined>(undefined);
   const [tokensHtml, setTokensHtml] = useState<string | null | undefined>(undefined);
   const [specBody, setSpecBody] = useState<string | null | undefined>(undefined);
+  const [detail, setDetail] = useState<DesignSystemDetail | null | undefined>(
+    () => (isDesignSystemDetail(system) ? system : undefined),
+  );
+  const [reloadKey, setReloadKey] = useState(0);
+  const projectId = detail?.projectId ?? system.projectId;
+  const detailBody = detail?.body ?? (isDesignSystemDetail(system) ? system.body : undefined);
+  const richProjectPreview = Boolean(projectId);
+  const { kit, loading: kitLoading } = useDesignKit({
+    designSystemId: system.id,
+    title: detail?.title ?? system.title,
+    projectId,
+    body: detailBody,
+    packageInfo: detail?.packageInfo,
+    swatches: detail?.swatches ?? system.swatches,
+    showcaseHtml: null,
+    editable: Boolean(detail?.isEditable ?? system.isEditable),
+    reloadKey,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setDetail(isDesignSystemDetail(system) ? system : undefined);
+    setReloadKey((key) => key + 1);
+    void fetchDesignSystem(system.id).then((next) => {
+      if (cancelled) return;
+      if (next) setDetail(next);
+      setReloadKey((key) => key + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [system]);
 
   // Lazy-load each view on first reveal. Both endpoints are cheap, but this
   // keeps the network panel quiet when the user only opens one tab.
@@ -68,7 +106,7 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
           });
         }
       }
-      if (viewId === 'showcase' && showcaseHtml === undefined) {
+      if (viewId === 'showcase' && !richProjectPreview && showcaseHtml === undefined) {
         setShowcaseHtml(null);
         void fetchDesignSystemShowcase(system.id).then((html) => setShowcaseHtml(html));
       }
@@ -77,7 +115,7 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
         void fetchDesignSystemPreview(system.id).then((html) => setTokensHtml(html));
       }
     },
-    [analytics.track, system.id, system.source, showcaseHtml, tokensHtml],
+    [analytics.track, richProjectPreview, system.id, system.source, showcaseHtml, tokensHtml],
   );
 
   // Fetch DESIGN.md the first time the side panel opens. Once we have it we
@@ -85,12 +123,16 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
   const handleSidebarToggle = useCallback(
     (open: boolean) => {
       if (!open || specBody !== undefined) return;
+      if (detailBody !== undefined) {
+        setSpecBody(detailBody);
+        return;
+      }
       setSpecBody(null);
       void fetchDesignSystem(system.id).then((detail) =>
         setSpecBody(detail?.body ?? null),
       );
     },
-    [system.id, specBody],
+    [detailBody, system.id, specBody],
   );
 
   // If the system swaps under us (rare but possible), wipe all caches.
@@ -100,12 +142,30 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
     setSpecBody(undefined);
   }, [system.id]);
 
-  const detail = (
+  const richPreview = (
+    <div className="ds-modal-rich-kit">
+      {kit ? (
+        <DesignKitView
+          kit={kit}
+          variant="panel"
+          dataTestId="design-system-modal-kit"
+        />
+      ) : (
+        <div className="viewer-empty">
+          {kitLoading ? t('ds.workspaceLoadingLabel') : t('ds.workspacePreparing')}
+        </div>
+      )}
+    </div>
+  );
+
+  const modal = (
     <PreviewModal
       title={system.title}
       subtitle={system.summary || system.category}
       views={[
-        { id: 'showcase', label: t('ds.showcase'), html: showcaseHtml },
+        richProjectPreview
+          ? { id: 'showcase', label: t('ds.showcase'), custom: richPreview }
+          : { id: 'showcase', label: t('ds.showcase'), html: showcaseHtml },
         { id: 'tokens', label: t('ds.tokens'), html: tokensHtml },
       ]}
       initialViewId="showcase"
@@ -148,7 +208,7 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
           templates_type: system.source ?? 'library',
         })
       }
-      sidebar={{
+      sidebar={richProjectPreview ? undefined : {
         label: t('ds.specToggle'),
         defaultOpen: true,
         onToggle: handleSidebarToggle,
@@ -165,6 +225,6 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
     />
   );
 
-  if (typeof document === 'undefined') return detail;
-  return createPortal(detail, document.body);
+  if (typeof document === 'undefined') return modal;
+  return createPortal(modal, document.body);
 }

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1932,12 +1932,10 @@ export function FileWorkspace({
               const browserTitle = browserUrl
                 ? browserTab.title?.trim() || labelFromUrl(browserUrl)
                 : browserTab.label;
-              const browserMeta = browserUrl ? formatBrowserTabUrl(browserUrl) : undefined;
               return (
                 <Tab
                   key={browserTab.id}
                   label={browserTitle}
-                  meta={browserMeta}
                   title={browserUrl ? `${browserTitle}\n${browserUrl}` : browserTitle}
                   active={activeTab === browserTab.id}
                   onActivate={() => setPersistedActive(browserTab.id)}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -127,10 +127,6 @@ interface Props {
   prompt: string;
   onPromptChange: (value: string) => void;
   onSubmit: HomeHeroSubmitHandler;
-  // Send pressed on an EMPTY composer while the placeholder carousel is
-  // showing: the host seeds the prompt with `scenario.text`, binds the
-  // scenario's template, and creates the project — one-click "just start".
-  onSubmitScenario?: (scenario: PlaceholderScenario) => void;
   sessionMode?: ChatSessionMode;
   onSessionModeChange?: (mode: ChatSessionMode) => void;
   activePluginTitle: string | null;
@@ -256,6 +252,7 @@ const EMPTY_STAGED_FILES: File[] = [];
 const EMPTY_SKILLS: SkillSummary[] = [];
 const EMPTY_MCP_OPTIONS: McpServerConfig[] = [];
 const EMPTY_CONNECTOR_OPTIONS: ConnectorDetail[] = [];
+const ignorePlaceholderScenario = () => undefined;
 
 export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
   {
@@ -263,7 +260,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     prompt,
     onPromptChange,
     onSubmit,
-    onSubmitScenario = () => undefined,
     firstRunGuide,
     sessionMode = 'design',
     onSessionModeChange,
@@ -365,9 +361,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
   // getContextMention regex) + the caret box the popover anchors to.
   const [mentionTrigger, setMentionTrigger] = useState<{ query: string } | null>(null);
   const [caretRect, setCaretRect] = useState<CaretRect | null>(null);
-  // The scenario the placeholder carousel is currently showing. A Send on an
-  // empty composer submits THIS scenario's text + template (see handleSend).
-  const [carouselScenario, setCarouselScenario] = useState<PlaceholderScenario | null>(null);
   const editorRef = useRef<LexicalComposerInputHandle | null>(null);
   const promptEditorRef = useRef<HTMLDivElement | null>(null);
   const mentionPickerRef = useRef<HTMLDivElement | null>(null);
@@ -385,12 +378,11 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     : t('homeHero.placeholder');
   const mentionActive = Boolean(mentionTrigger);
   const mentionQuery = mentionTrigger?.query ?? '';
-  // Scenarios the carousel cycles, with copy resolved through `t()` so the
-  // typed placeholder AND the submitted query follow the locale. With a
-  // create-template chip selected we narrow to that template's scenarios (so
-  // the suggestions match the picked output and a submit keeps that template);
-  // with nothing bound we cycle the full set. Memoised by chip + locale so the
-  // reference only changes on a real switch, which restarts the carousel.
+  // Scenarios the carousel cycles, with copy resolved through `t()`. With a
+  // create-template chip selected we narrow to that template's scenarios so
+  // the suggestions match the picked output; with nothing bound we cycle the
+  // full set. Memoised by chip + locale so the reference only changes on a
+  // real switch, which restarts the carousel.
   const carouselScenarios = useMemo<PlaceholderScenario[]>(() => {
     const resolved = PLACEHOLDER_SCENARIO_DEFS.map((def) => ({
       id: def.id,
@@ -417,22 +409,10 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     !activePluginIsExplicit &&
     !mentionActive &&
     carouselScenarios.length > 0;
-  // Empty composer, but the carousel is offering a runnable scenario from the
-  // CURRENT pool: Send stays highlighted and submits that scenario instead of
-  // sitting disabled. The membership check guards the brief window after a
-  // template switch before the carousel reports the new pool's first scenario.
-  const carouselSubmittable =
-    carouselActive &&
-    carouselScenario !== null &&
-    carouselScenarios.some((scenario) => scenario.id === carouselScenario.id);
-  const sendEnabled = canSubmit || carouselSubmittable;
+  const sendEnabled = canSubmit;
   function handleSend() {
-    if (submitting || submitDisabled) return;
-    if (canSubmit) {
-      onSubmit();
-      return;
-    }
-    if (carouselSubmittable && carouselScenario) onSubmitScenario(carouselScenario);
+    if (!canSubmit) return;
+    onSubmit();
   }
   const fileMatches = useMemo(
     () =>
@@ -1353,7 +1333,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
             <PlaceholderCarousel
               active={carouselActive}
               scenarios={carouselScenarios}
-              onScenarioChange={setCarouselScenario}
+              onScenarioChange={ignorePlaceholderScenario}
             />
           </div>
         </div>

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -71,7 +71,6 @@ import { missingRequiredInputs, pluginInputsAreValid } from '../utils/pluginRequ
 import { HomeHero, type ExamplePromptInfo, type HomeHeroHandle } from './HomeHero';
 import { findChip, HOME_HERO_CHIPS, type HomeHeroChip } from './home-hero/chips';
 import { homeHeroChipLabel } from './home-hero/chip-labels';
-import type { PlaceholderScenario } from './home-hero/placeholderScenarios';
 import { consumePendingHomeChip, HOME_CHIP_INTENT_EVENT } from '../runtime/home-intent';
 import { navigate } from '../router';
 import {
@@ -276,13 +275,6 @@ export function HomeView({
   const [fallbackProjectMetadata, setFallbackProjectMetadata] =
     useState<ProjectMetadata | null>(null);
   const [active, setActive] = useState<ActivePlugin | null>(null);
-  // A placeholder-carousel scenario the user submitted on an empty composer.
-  // We seed the prompt + bind the template synchronously, then let an effect
-  // fire submit() once both have committed (submit() reads state, not args).
-  const [pendingCarouselSubmit, setPendingCarouselSubmit] = useState<{
-    text: string;
-    chipId: string | null;
-  } | null>(null);
   const [sessionMode, setSessionMode] = useState<ChatSessionMode>('design');
   const [activeSkill, setActiveSkill] = useState<SkillSummary | null>(null);
   const [selectedPluginContexts, setSelectedPluginContexts] = useState<SelectedPluginContext[]>([]);
@@ -1540,52 +1532,6 @@ export function HomeView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [plugins, chipIntentTick]);
 
-  // Send pressed on an empty composer while the placeholder carousel showed a
-  // scenario. Bind that scenario's template exactly as a rail pick would and
-  // seed its text, then defer the create to submit() (which resolves the
-  // snapshot and builds the same payload the manual flow does).
-  function submitScenario(scenario: PlaceholderScenario) {
-    if (sending) return;
-    setError(null);
-    const chip = scenario.chipId ? findChip(scenario.chipId) : null;
-    const action = chip?.action ?? null;
-    const record =
-      action?.kind === 'apply-scenario'
-        ? plugins.find((plugin) => plugin.id === action.pluginId) ?? null
-        : null;
-    // When the user already picked this template (the carousel-over-a-selected-
-    // template case), its binding is live — reuse it instead of re-applying,
-    // which would reset the resolved snapshot and re-fire chip analytics.
-    const alreadyBound = Boolean(chip && active?.chipId === chip.id && !active.explicitPick);
-    if (chip && record && !alreadyBound) {
-      pickChip(chip);
-    } else if (!chip || !record) {
-      // Template unavailable (bundle missing / catalog still loading) — fall
-      // back to a free-form create from the line alone rather than dead-ending.
-      setActive(null);
-    }
-    setPrompt(scenario.text);
-    setPromptEditedByUser(true);
-    setPendingCarouselSubmit({
-      text: scenario.text,
-      chipId: chip && (record || alreadyBound) ? scenario.chipId : null,
-    });
-  }
-
-  // Fire the deferred carousel submit once the seeded prompt AND the bound
-  // chip have landed in state, so submit()'s closure reads the real values.
-  useEffect(() => {
-    const pending = pendingCarouselSubmit;
-    if (!pending || sending) return;
-    if (prompt.trim() !== pending.text.trim()) return;
-    if (pending.chipId !== null && active?.chipId !== pending.chipId) return;
-    setPendingCarouselSubmit(null);
-    void submit();
-    // submit() is a stable in-component declaration; depending on it would add
-    // churn without changing behavior (mirrors the chip-intent effect above).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingCarouselSubmit, prompt, active, sending]);
-
   async function submit() {
     // The send button disables itself while sending, but the Enter-to-send
     // path lands here directly — swallow re-entry during the in-flight window.
@@ -1767,7 +1713,6 @@ export function HomeView({
         prompt={prompt}
         onPromptChange={handlePromptChange}
         onSubmit={submit}
-        onSubmitScenario={submitScenario}
         submitting={sending}
         activePluginTitle={activeBadgeTitle}
         activePluginIsExplicit={activePluginIsExplicit}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -190,6 +190,7 @@ import { DesignSystemPicker } from './DesignSystemPicker';
 import { PluginDetailsModal } from './PluginDetailsModal';
 import { DesignSystemPreviewModal } from './DesignSystemPreviewModal';
 import { ChatPane } from './ChatPane';
+import { SessionModeToggle } from './SessionModeToggle';
 import type { QuestionFormOpenRequest } from './AssistantMessage';
 import type { ChatSendMeta } from './ChatComposer';
 import {
@@ -6271,6 +6272,10 @@ export function ProjectView({
     const record = plugins.find((plugin) => plugin.id === normalizedId);
     if (record) setContextPluginDetails(record);
   }, []);
+  const handleOpenContextDesignSystemDetails = useCallback(async (system: DesignSystemSummary) => {
+    const detail = await fetchDesignSystem(system.id);
+    setContextDesignSystemDetails(detail ?? system);
+  }, []);
   const chatDesignSystemSummary = useMemo(() => {
     if (activeDesignSystemSummary) return activeDesignSystemSummary;
     const designSystemName = activePluginSnapshot?.inputs?.designSystem;
@@ -6394,54 +6399,61 @@ export function ProjectView({
   // CLI / agent selector lives below the chat conversation (composer footer),
   // not in the top-right header.
   const executionControls = (
-    <AvatarMenu
-      config={config}
-      agents={agents}
-      daemonLive={daemonLive}
-      onModeChange={onModeChange}
-      onOpen={() => {
-        trackComposerBarClick(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          element: 'agent_selector_open',
-          ...(project?.id ? { project_id: project.id } : {}),
-        });
-      }}
-      onAgentChange={(id) => {
-        trackComposerBarClick(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          element: 'agent_select',
-          agent_id: id,
-          ...(project?.id ? { project_id: project.id } : {}),
-        });
-        onAgentChange(id);
-      }}
-      onAgentModelChange={(agentId, choice) => {
-        trackComposerBarClick(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          element: 'agent_model_select',
-          agent_id: agentId,
-          ...(choice?.model ? { model_id: choice.model } : {}),
-          ...(project?.id ? { project_id: project.id } : {}),
-        });
-        onAgentModelChange(agentId, choice);
-      }}
-      onApiModelChange={(model) => {
-        trackComposerBarClick(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          element: 'agent_model_select',
-          model_id: model,
-          ...(project?.id ? { project_id: project.id } : {}),
-        });
-        onApiModelChange?.(model);
-      }}
-      onOpenSettings={onOpenSettings}
-      onRefreshAgents={onRefreshAgents}
-      placement="up"
-    />
+    <>
+      <SessionModeToggle
+        mode={activeSessionMode}
+        onChange={handleActiveConversationSessionModeChange}
+        disabled={currentConversationControlStreaming}
+      />
+      <AvatarMenu
+        config={config}
+        agents={agents}
+        daemonLive={daemonLive}
+        onModeChange={onModeChange}
+        onOpen={() => {
+          trackComposerBarClick(analytics.track, {
+            page_name: 'chat_panel',
+            area: 'chat_composer',
+            element: 'agent_selector_open',
+            ...(project?.id ? { project_id: project.id } : {}),
+          });
+        }}
+        onAgentChange={(id) => {
+          trackComposerBarClick(analytics.track, {
+            page_name: 'chat_panel',
+            area: 'chat_composer',
+            element: 'agent_select',
+            agent_id: id,
+            ...(project?.id ? { project_id: project.id } : {}),
+          });
+          onAgentChange(id);
+        }}
+        onAgentModelChange={(agentId, choice) => {
+          trackComposerBarClick(analytics.track, {
+            page_name: 'chat_panel',
+            area: 'chat_composer',
+            element: 'agent_model_select',
+            agent_id: agentId,
+            ...(choice?.model ? { model_id: choice.model } : {}),
+            ...(project?.id ? { project_id: project.id } : {}),
+          });
+          onAgentModelChange(agentId, choice);
+        }}
+        onApiModelChange={(model) => {
+          trackComposerBarClick(analytics.track, {
+            page_name: 'chat_panel',
+            area: 'chat_composer',
+            element: 'agent_model_select',
+            model_id: model,
+            ...(project?.id ? { project_id: project.id } : {}),
+          });
+          onApiModelChange?.(model);
+        }}
+        onOpenSettings={onOpenSettings}
+        onRefreshAgents={onRefreshAgents}
+        placement="up"
+      />
+    </>
   );
 
   return (
@@ -6507,7 +6519,7 @@ export function ProjectView({
               onSendQueuedNow={sendQueuedChatSendNow}
               onRequestOpenFile={requestOpenFile}
               onRequestPluginDetails={handleOpenContextPluginDetails}
-              onRequestDesignSystemDetails={setContextDesignSystemDetails}
+              onRequestDesignSystemDetails={handleOpenContextDesignSystemDetails}
               onRequestPluginFolderAgentAction={handlePluginFolderAgentAction}
               activePluginActionPaths={activePluginActionPaths}
               hiddenPluginActionPaths={hiddenAssistantPluginActionPaths}

--- a/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
+++ b/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
@@ -35,8 +35,7 @@ interface Props {
   // own static placeholder instead). The parent gates this on "empty composer,
   // nothing else bound".
   active: boolean;
-  // Fired whenever the displayed scenario changes (including on first show), so
-  // the parent always knows which scenario a Send would submit.
+  // Fired whenever the displayed scenario changes (including on first show).
   onScenarioChange: (scenario: PlaceholderScenario) => void;
 }
 

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -751,6 +751,9 @@
   background: var(--bg);
   isolation: isolate;
 }
+.entry-main__topbar:has(.entry-settings-menu__popover) {
+  z-index: 1900;
+}
 .entry-main__topbar::before {
   content: '';
   position: absolute;

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -1568,6 +1568,16 @@
   overflow: auto;
   min-height: 0;
 }
+.ds-modal-rich-kit {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  background: var(--bg);
+}
+.ds-modal-rich-kit .design-kit {
+  max-width: none;
+}
 .plugin-media-stage__empty {
   color: var(--text-muted);
   font-size: 13px;

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -1396,6 +1396,9 @@
   top: 0;
   z-index: 4;
 }
+.ws-tabs-shell:has(.entry-settings-menu__popover) {
+  z-index: 1900;
+}
 .ws-tabs-bar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Why

Polish the design-system preview UI on the `release/v0.12.0` branch before release.

## What users will see

Design-system preview surfaces have cleaner modal, workspace, home, and project-view presentation on the release line.

## Surface area

- Design-system preview modal UI.
- Home and project view presentation.
- Workspace drawer and viewer styling.
- Related release UI cleanup in web components and CSS.

## Screenshots

Not included.

## Bug fix verification

Not run locally.

## Validation

Not run locally; branch was inspected against `release/v0.12.0` before opening the PR.
