### PR TITLE
fix(landing-page): make Product/Resources nav items pure dropdown toggles

### DIFF
--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -154,16 +154,20 @@
       });
     }
 
-    // Dropdown disclosure toggles. Product and Resources are category labels
-    // (not pages), rendered as <button data-nav-dropdown-toggle> that open
-    // their own dropdown instead of navigating (Product used to bounce to the
-    // homepage, Resources to /blog/). On pointer devices CSS :hover still
-    // opens them; this handles click and — crucially — TAP on touch devices
-    // with no hover (touch laptops / tablets at desktop width), where the
-    // dropdown was otherwise unreachable. On the flattened mobile menu the
-    // dropdown is always shown, so toggling is a harmless no-op.
+    // Product and Resources are category labels (not pages), rendered as
+    // <button data-nav-dropdown-toggle> disclosures that open their own
+    // dropdown instead of navigating (Product used to bounce to the homepage,
+    // Resources to /blog/). They are driven SOLELY by the JS-toggled .is-open
+    // class — `.has-dropdown-click` opts them out of the CSS :hover /
+    // :focus-within reveal so an explicit click / Escape close always wins.
+    //
+    // At <=1080px the hamburger menu flattens every dropdown to always-visible,
+    // so there these buttons are plain section headers, not disclosures: drop
+    // the disclosure ARIA (it must never announce "collapsed" over already
+    // visible links) and make the click a no-op.
     const dropdownToggles = document.querySelectorAll('[data-nav-dropdown-toggle]');
     if (dropdownToggles.length > 0) {
+      const navFlattened = window.matchMedia('(max-width: 1080px)');
       const closeDropdown = (li) => {
         li.classList.remove('is-open');
         const btn = li.querySelector('[data-nav-dropdown-toggle]');
@@ -174,20 +178,39 @@
           if (li !== except) closeDropdown(li);
         });
       };
+      // Toggle between desktop disclosure mode and flattened-mobile header mode
+      // whenever the breakpoint is crossed, so the ARIA state matches reality.
+      const syncDisclosureMode = () => {
+        const flattened = navFlattened.matches;
+        dropdownToggles.forEach((btn) => {
+          const li = btn.closest('li.has-dropdown');
+          if (flattened) {
+            btn.removeAttribute('aria-expanded');
+            btn.removeAttribute('aria-haspopup');
+            if (li) li.classList.remove('is-open');
+          } else {
+            btn.setAttribute('aria-haspopup', 'true');
+            if (!btn.hasAttribute('aria-expanded')) btn.setAttribute('aria-expanded', 'false');
+          }
+        });
+      };
+      syncDisclosureMode();
+      navFlattened.addEventListener('change', syncDisclosureMode);
       dropdownToggles.forEach((btn) => {
         const li = btn.closest('li.has-dropdown');
         if (!li) return;
         btn.addEventListener('click', (ev) => {
           ev.stopPropagation();
+          if (navFlattened.matches) return; // flattened mobile menu — not a disclosure
           const open = !li.classList.contains('is-open');
           closeAllDropdowns(li);
           li.classList.toggle('is-open', open);
           btn.setAttribute('aria-expanded', open ? 'true' : 'false');
         });
       });
-      // The rest of the header still opens on pure CSS :hover / :focus-within.
-      // When any other header item becomes active, close a click-pinned
-      // dropdown so a pinned panel and a hovered panel can't show at once.
+      // The four hub menus still open on pure CSS :hover / :focus-within. When
+      // any other header item becomes active, close a click-pinned disclosure
+      // so a pinned panel and a hovered panel can't show at once.
       document.querySelectorAll('li.has-dropdown').forEach((li) => {
         const closeOthers = () => closeAllDropdowns(li);
         li.addEventListener('mouseenter', closeOthers);

--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -185,6 +185,14 @@
           btn.setAttribute('aria-expanded', open ? 'true' : 'false');
         });
       });
+      // The rest of the header still opens on pure CSS :hover / :focus-within.
+      // When any other header item becomes active, close a click-pinned
+      // dropdown so a pinned panel and a hovered panel can't show at once.
+      document.querySelectorAll('li.has-dropdown').forEach((li) => {
+        const closeOthers = () => closeAllDropdowns(li);
+        li.addEventListener('mouseenter', closeOthers);
+        li.addEventListener('focusin', closeOthers);
+      });
       // Outside-click and Escape close any open disclosure dropdown.
       document.addEventListener('click', (ev) => {
         document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {

--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -139,9 +139,10 @@
         ev.stopPropagation();
         setOpen(!navEl.classList.contains('is-open'));
       });
-      // Close when clicking any actual nav link (but not the Product
-      // parent trigger — its href='/' is a real page link, so we let it
-      // navigate which closes the menu naturally).
+      // Close when clicking any actual nav link. The Product and Resources
+      // parent triggers are <button>s (category labels that only open their
+      // dropdown), not <a>s, so they are naturally excluded here and never
+      // close the mobile menu on tap.
       primaryNav.querySelectorAll('a').forEach((link) => {
         link.addEventListener('click', () => setOpen(false));
       });
@@ -150,6 +151,48 @@
       });
       document.addEventListener('keydown', (ev) => {
         if (ev.key === 'Escape') setOpen(false);
+      });
+    }
+
+    // Dropdown disclosure toggles. Product and Resources are category labels
+    // (not pages), rendered as <button data-nav-dropdown-toggle> that open
+    // their own dropdown instead of navigating (Product used to bounce to the
+    // homepage, Resources to /blog/). On pointer devices CSS :hover still
+    // opens them; this handles click and — crucially — TAP on touch devices
+    // with no hover (touch laptops / tablets at desktop width), where the
+    // dropdown was otherwise unreachable. On the flattened mobile menu the
+    // dropdown is always shown, so toggling is a harmless no-op.
+    const dropdownToggles = document.querySelectorAll('[data-nav-dropdown-toggle]');
+    if (dropdownToggles.length > 0) {
+      const closeDropdown = (li) => {
+        li.classList.remove('is-open');
+        const btn = li.querySelector('[data-nav-dropdown-toggle]');
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+      };
+      const closeAllDropdowns = (except) => {
+        document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
+          if (li !== except) closeDropdown(li);
+        });
+      };
+      dropdownToggles.forEach((btn) => {
+        const li = btn.closest('li.has-dropdown');
+        if (!li) return;
+        btn.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          const open = !li.classList.contains('is-open');
+          closeAllDropdowns(li);
+          li.classList.toggle('is-open', open);
+          btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        });
+      });
+      // Outside-click and Escape close any open disclosure dropdown.
+      document.addEventListener('click', (ev) => {
+        document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
+          if (!li.contains(ev.target)) closeDropdown(li);
+        });
+      });
+      document.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Escape') closeAllDropdowns(null);
       });
     }
 

--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -154,57 +154,13 @@
       });
     }
 
-    // Product and Resources are category labels (not pages), rendered as
-    // <button data-nav-dropdown-toggle> disclosures that open their own
-    // dropdown instead of navigating (Product used to bounce to the homepage,
-    // Resources to /blog/). They are real disclosures at EVERY breakpoint,
-    // driven solely by the JS-toggled .is-open class — `.has-dropdown-click`
-    // opts them out of the CSS :hover / :focus-within reveal AND collapses
-    // them on the flattened mobile menu, so the SSR aria-expanded="false" is
-    // truthful even before/without JS (the panel is CSS-collapsed by default
-    // at every width: desktop flyout, mobile accordion). On desktop this also
-    // handles tap on touch laptops/tablets that have no hover.
-    const dropdownToggles = document.querySelectorAll('[data-nav-dropdown-toggle]');
-    if (dropdownToggles.length > 0) {
-      const closeDropdown = (li) => {
-        li.classList.remove('is-open');
-        const btn = li.querySelector('[data-nav-dropdown-toggle]');
-        if (btn) btn.setAttribute('aria-expanded', 'false');
-      };
-      const closeAllDropdowns = (except) => {
-        document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
-          if (li !== except) closeDropdown(li);
-        });
-      };
-      dropdownToggles.forEach((btn) => {
-        const li = btn.closest('li.has-dropdown');
-        if (!li) return;
-        btn.addEventListener('click', (ev) => {
-          ev.stopPropagation();
-          const open = !li.classList.contains('is-open');
-          closeAllDropdowns(li);
-          li.classList.toggle('is-open', open);
-          btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-        });
-      });
-      // The four hub menus still open on pure CSS :hover / :focus-within. When
-      // any other header item becomes active, close a click-pinned disclosure
-      // so a pinned panel and a hovered panel can't show at once.
-      document.querySelectorAll('li.has-dropdown').forEach((li) => {
-        const closeOthers = () => closeAllDropdowns(li);
-        li.addEventListener('mouseenter', closeOthers);
-        li.addEventListener('focusin', closeOthers);
-      });
-      // Outside-click and Escape close any open disclosure dropdown.
-      document.addEventListener('click', (ev) => {
-        document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
-          if (!li.contains(ev.target)) closeDropdown(li);
-        });
-      });
-      document.addEventListener('keydown', (ev) => {
-        if (ev.key === 'Escape') closeAllDropdowns(null);
-      });
-    }
+    // Product and Resources are category labels (not pages): they render as
+    // <button class="nav-trigger"> so they never navigate (Product used to
+    // bounce to the homepage, Resources to /blog/), and their dropdown is
+    // revealed by the SAME pure-CSS :hover / :focus-within rule as the hub
+    // menus — no JS, so it works on first paint / with JS disabled, and on
+    // touch (tapping the button focuses it → :focus-within reveals the menu).
+    // No JS enhancement is needed here.
 
     const starSlots = document.querySelectorAll('[data-github-stars]');
     if (starSlots.length > 0) {

--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -157,17 +157,15 @@
     // Product and Resources are category labels (not pages), rendered as
     // <button data-nav-dropdown-toggle> disclosures that open their own
     // dropdown instead of navigating (Product used to bounce to the homepage,
-    // Resources to /blog/). They are driven SOLELY by the JS-toggled .is-open
-    // class — `.has-dropdown-click` opts them out of the CSS :hover /
-    // :focus-within reveal so an explicit click / Escape close always wins.
-    //
-    // At <=1080px the hamburger menu flattens every dropdown to always-visible,
-    // so there these buttons are plain section headers, not disclosures: drop
-    // the disclosure ARIA (it must never announce "collapsed" over already
-    // visible links) and make the click a no-op.
+    // Resources to /blog/). They are real disclosures at EVERY breakpoint,
+    // driven solely by the JS-toggled .is-open class — `.has-dropdown-click`
+    // opts them out of the CSS :hover / :focus-within reveal AND collapses
+    // them on the flattened mobile menu, so the SSR aria-expanded="false" is
+    // truthful even before/without JS (the panel is CSS-collapsed by default
+    // at every width: desktop flyout, mobile accordion). On desktop this also
+    // handles tap on touch laptops/tablets that have no hover.
     const dropdownToggles = document.querySelectorAll('[data-nav-dropdown-toggle]');
     if (dropdownToggles.length > 0) {
-      const navFlattened = window.matchMedia('(max-width: 1080px)');
       const closeDropdown = (li) => {
         li.classList.remove('is-open');
         const btn = li.querySelector('[data-nav-dropdown-toggle]');
@@ -178,30 +176,11 @@
           if (li !== except) closeDropdown(li);
         });
       };
-      // Toggle between desktop disclosure mode and flattened-mobile header mode
-      // whenever the breakpoint is crossed, so the ARIA state matches reality.
-      const syncDisclosureMode = () => {
-        const flattened = navFlattened.matches;
-        dropdownToggles.forEach((btn) => {
-          const li = btn.closest('li.has-dropdown');
-          if (flattened) {
-            btn.removeAttribute('aria-expanded');
-            btn.removeAttribute('aria-haspopup');
-            if (li) li.classList.remove('is-open');
-          } else {
-            btn.setAttribute('aria-haspopup', 'true');
-            if (!btn.hasAttribute('aria-expanded')) btn.setAttribute('aria-expanded', 'false');
-          }
-        });
-      };
-      syncDisclosureMode();
-      navFlattened.addEventListener('change', syncDisclosureMode);
       dropdownToggles.forEach((btn) => {
         const li = btn.closest('li.has-dropdown');
         if (!li) return;
         btn.addEventListener('click', (ev) => {
           ev.stopPropagation();
-          if (navFlattened.matches) return; // flattened mobile menu — not a disclosure
           const open = !li.classList.contains('is-open');
           closeAllDropdowns(li);
           li.classList.toggle('is-open', open);

--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -180,20 +180,24 @@ export function Header({
                 for its own family; every other section maps to its own
                 trigger below, so a sub-page never marks Product by accident. */}
             <li className='has-dropdown'>
-              <a
-                href={href('/')}
+              <button
+                type='button'
+                data-nav-dropdown-toggle
+                aria-haspopup='true'
+                aria-expanded='false'
                 className={
-                  active === 'product' ||
+                  'nav-trigger' +
+                  (active === 'product' ||
                   active === 'home' ||
                   active === 'html-anything' ||
                   active === 'html-video'
-                    ? 'is-active'
-                    : undefined
+                    ? ' is-active'
+                    : '')
                 }
               >
                 {productMenuCopy.product}
                 <span className='dropdown-caret' aria-hidden='true'>▾</span>
-              </a>
+              </button>
               <ul className='nav-dropdown' aria-label={productMenuCopy.product}>
                 <li>
                   <a href={href('/')}>
@@ -338,20 +342,24 @@ export function Header({
             {/* Resources — the top-level link mirrors the live site, which
                 points it at the blog index. */}
             <li className='has-dropdown'>
-              <a
-                href={href('/blog/')}
+              <button
+                type='button'
+                data-nav-dropdown-toggle
+                aria-haspopup='true'
+                aria-expanded='false'
                 className={
-                  active === 'resources' ||
+                  'nav-trigger' +
+                  (active === 'resources' ||
                   active === 'blog' ||
                   active === 'tutorials' ||
                   active === 'download'
-                    ? 'is-active'
-                    : undefined
+                    ? ' is-active'
+                    : '')
                 }
               >
                 {productMenuCopy.resources}
                 <span className='dropdown-caret' aria-hidden='true'>▾</span>
-              </a>
+              </button>
               <ul className='nav-dropdown' aria-label={productMenuCopy.resources}>
                 <li>
                   <a href={href('/blog/')}>

--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -179,17 +179,14 @@ export function Header({
             {/* Product — the Open Design products. The trigger lights up only
                 for its own family; every other section maps to its own
                 trigger below, so a sub-page never marks Product by accident.
-                `has-dropdown-click` opts this menu out of the CSS :hover /
-                :focus-within reveal so it is driven solely by the JS .is-open
-                toggle (disclosure-button semantics) — otherwise a retained
-                hover/focus would re-open the panel right after an explicit
-                click/Escape close. */}
-            <li className='has-dropdown has-dropdown-click'>
+                It is a <button> (not a link) so it never navigates — Product
+                used to bounce to the homepage — but its dropdown is revealed
+                by the SAME pure-CSS :hover / :focus-within rule as the hub
+                menus, so it works with no JS (first paint / script failure)
+                and on touch (tapping focuses the button → :focus-within). */}
+            <li className='has-dropdown'>
               <button
                 type='button'
-                data-nav-dropdown-toggle
-                aria-haspopup='true'
-                aria-expanded='false'
                 className={
                   'nav-trigger' +
                   (active === 'product' ||
@@ -345,15 +342,12 @@ export function Header({
             </li>
 
             {/* Resources — a category label (Blog / Tutorials / Compare), not
-                a page. `has-dropdown-click` opts it out of the CSS hover /
-                focus-within reveal so the JS .is-open toggle is the single
-                source of truth for open/close (see Product above). */}
-            <li className='has-dropdown has-dropdown-click'>
+                a page; a <button> so it never navigates (it used to bounce to
+                /blog/), with its dropdown revealed by the same pure-CSS
+                :hover / :focus-within rule as the hub menus (see Product). */}
+            <li className='has-dropdown'>
               <button
                 type='button'
-                data-nav-dropdown-toggle
-                aria-haspopup='true'
-                aria-expanded='false'
                 className={
                   'nav-trigger' +
                   (active === 'resources' ||

--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -178,8 +178,13 @@ export function Header({
           <ul className='nav-links'>
             {/* Product — the Open Design products. The trigger lights up only
                 for its own family; every other section maps to its own
-                trigger below, so a sub-page never marks Product by accident. */}
-            <li className='has-dropdown'>
+                trigger below, so a sub-page never marks Product by accident.
+                `has-dropdown-click` opts this menu out of the CSS :hover /
+                :focus-within reveal so it is driven solely by the JS .is-open
+                toggle (disclosure-button semantics) — otherwise a retained
+                hover/focus would re-open the panel right after an explicit
+                click/Escape close. */}
+            <li className='has-dropdown has-dropdown-click'>
               <button
                 type='button'
                 data-nav-dropdown-toggle
@@ -339,9 +344,11 @@ export function Header({
               </ul>
             </li>
 
-            {/* Resources — the top-level link mirrors the live site, which
-                points it at the blog index. */}
-            <li className='has-dropdown'>
+            {/* Resources — a category label (Blog / Tutorials / Compare), not
+                a page. `has-dropdown-click` opts it out of the CSS hover /
+                focus-within reveal so the JS .is-open toggle is the single
+                source of truth for open/close (see Product above). */}
+            <li className='has-dropdown has-dropdown-click'>
               <button
                 type='button'
                 data-nav-dropdown-toggle

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -680,6 +680,30 @@ body::before {
   letter-spacing: 0.04em;
 }
 
+/* Product / Resources are category labels, not pages — they render as
+   disclosure buttons that toggle their own dropdown instead of navigating
+   (Product used to bounce to the homepage, Resources to /blog/). Style the
+   button to read identically to the sibling <a> nav links, then reset the
+   native button chrome. */
+.nav-links .nav-trigger {
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.18s ease;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.nav-links .nav-trigger:hover { color: var(--coral); }
+
 /* AMR partner logo at the tail of the nav links (700×272 lockup scaled to
    the bar). */
 .nav-links .nav-amr {
@@ -729,7 +753,8 @@ body::before {
   transition: transform 0.18s ease, color 0.18s ease;
 }
 .nav-links li.has-dropdown:hover .dropdown-caret,
-.nav-links li.has-dropdown:focus-within .dropdown-caret {
+.nav-links li.has-dropdown:focus-within .dropdown-caret,
+.nav-links li.has-dropdown.is-open .dropdown-caret {
   /* keep the -1px optical baseline; nudge down 1px more as the open affordance */
   transform: translateY(0);
   color: var(--coral);
@@ -753,7 +778,8 @@ body::before {
   z-index: 50;
 }
 .nav-links li.has-dropdown:hover .nav-dropdown,
-.nav-links li.has-dropdown:focus-within .nav-dropdown {
+.nav-links li.has-dropdown:focus-within .nav-dropdown,
+.nav-links li.has-dropdown.is-open .nav-dropdown {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
@@ -792,6 +818,7 @@ body::before {
   }
   .site-chrome:has(.nav-links li.has-dropdown:hover)::after,
   .site-chrome:has(.nav-links li.has-dropdown:focus-within)::after,
+  .site-chrome:has(.nav-links li.has-dropdown.is-open)::after,
   .site-chrome:has(.locale-switch[open])::after {
     opacity: 1;
     transition-delay: 0ms;
@@ -5219,8 +5246,11 @@ footer .container {
     border-bottom: 1px solid rgba(26, 26, 26, 0.06);
   }
   .nav-links li:last-child { border-bottom: none; }
-  .nav-links a {
+  .nav-links a,
+  .nav-links .nav-trigger {
     display: block;
+    width: 100%;
+    text-align: left;
     padding: 14px 0;
     font-size: 16px;
   }

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -752,9 +752,8 @@ body::before {
   color: var(--ink-faint);
   transition: transform 0.18s ease, color 0.18s ease;
 }
-.nav-links li.has-dropdown:not(.has-dropdown-click):hover .dropdown-caret,
-.nav-links li.has-dropdown:not(.has-dropdown-click):focus-within .dropdown-caret,
-.nav-links li.has-dropdown.is-open .dropdown-caret {
+.nav-links li.has-dropdown:hover .dropdown-caret,
+.nav-links li.has-dropdown:focus-within .dropdown-caret {
   /* keep the -1px optical baseline; nudge down 1px more as the open affordance */
   transform: translateY(0);
   color: var(--coral);
@@ -777,9 +776,8 @@ body::before {
   transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s;
   z-index: 50;
 }
-.nav-links li.has-dropdown:not(.has-dropdown-click):hover .nav-dropdown,
-.nav-links li.has-dropdown:not(.has-dropdown-click):focus-within .nav-dropdown,
-.nav-links li.has-dropdown.is-open .nav-dropdown {
+.nav-links li.has-dropdown:hover .nav-dropdown,
+.nav-links li.has-dropdown:focus-within .nav-dropdown {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
@@ -816,9 +814,8 @@ body::before {
        the blur; opening stays instant via the override below. */
     transition: opacity 220ms cubic-bezier(0.23, 1, 0.32, 1) 120ms;
   }
-  .site-chrome:has(.nav-links li.has-dropdown:not(.has-dropdown-click):hover)::after,
-  .site-chrome:has(.nav-links li.has-dropdown:not(.has-dropdown-click):focus-within)::after,
-  .site-chrome:has(.nav-links li.has-dropdown.is-open)::after,
+  .site-chrome:has(.nav-links li.has-dropdown:hover)::after,
+  .site-chrome:has(.nav-links li.has-dropdown:focus-within)::after,
   .site-chrome:has(.locale-switch[open])::after {
     opacity: 1;
     transition-delay: 0ms;
@@ -5291,15 +5288,6 @@ footer .container {
   /* Let the Solution panel flow naturally inside the flattened nav panel
      instead of scrolling within a capped box. */
   .nav-dropdown-solution { max-height: none; overflow: visible; }
-  /* Product / Resources stay real disclosures here too: unlike the hub menus
-     (always flattened-visible), their panel is collapsed until the JS .is-open
-     toggle, so the button's aria-expanded matches what's visible even in SSR /
-     no-JS, and tapping the control actually shows/hides its links (an
-     accordion). Re-show the caret, hidden by default on mobile, as the
-     expand affordance. */
-  .nav-links li.has-dropdown-click .nav-dropdown { display: none; }
-  .nav-links li.has-dropdown-click.is-open .nav-dropdown { display: grid; }
-  .nav-links li.has-dropdown-click .dropdown-caret { display: inline-flex; }
 }
 @media (max-width: 1080px) {
   .container { padding: 0 32px; }

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -752,8 +752,8 @@ body::before {
   color: var(--ink-faint);
   transition: transform 0.18s ease, color 0.18s ease;
 }
-.nav-links li.has-dropdown:hover .dropdown-caret,
-.nav-links li.has-dropdown:focus-within .dropdown-caret,
+.nav-links li.has-dropdown:not(.has-dropdown-click):hover .dropdown-caret,
+.nav-links li.has-dropdown:not(.has-dropdown-click):focus-within .dropdown-caret,
 .nav-links li.has-dropdown.is-open .dropdown-caret {
   /* keep the -1px optical baseline; nudge down 1px more as the open affordance */
   transform: translateY(0);
@@ -777,8 +777,8 @@ body::before {
   transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s;
   z-index: 50;
 }
-.nav-links li.has-dropdown:hover .nav-dropdown,
-.nav-links li.has-dropdown:focus-within .nav-dropdown,
+.nav-links li.has-dropdown:not(.has-dropdown-click):hover .nav-dropdown,
+.nav-links li.has-dropdown:not(.has-dropdown-click):focus-within .nav-dropdown,
 .nav-links li.has-dropdown.is-open .nav-dropdown {
   opacity: 1;
   visibility: visible;
@@ -816,8 +816,8 @@ body::before {
        the blur; opening stays instant via the override below. */
     transition: opacity 220ms cubic-bezier(0.23, 1, 0.32, 1) 120ms;
   }
-  .site-chrome:has(.nav-links li.has-dropdown:hover)::after,
-  .site-chrome:has(.nav-links li.has-dropdown:focus-within)::after,
+  .site-chrome:has(.nav-links li.has-dropdown:not(.has-dropdown-click):hover)::after,
+  .site-chrome:has(.nav-links li.has-dropdown:not(.has-dropdown-click):focus-within)::after,
   .site-chrome:has(.nav-links li.has-dropdown.is-open)::after,
   .site-chrome:has(.locale-switch[open])::after {
     opacity: 1;

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -5291,6 +5291,15 @@ footer .container {
   /* Let the Solution panel flow naturally inside the flattened nav panel
      instead of scrolling within a capped box. */
   .nav-dropdown-solution { max-height: none; overflow: visible; }
+  /* Product / Resources stay real disclosures here too: unlike the hub menus
+     (always flattened-visible), their panel is collapsed until the JS .is-open
+     toggle, so the button's aria-expanded matches what's visible even in SSR /
+     no-JS, and tapping the control actually shows/hides its links (an
+     accordion). Re-show the caret, hidden by default on mobile, as the
+     expand affordance. */
+  .nav-links li.has-dropdown-click .nav-dropdown { display: none; }
+  .nav-links li.has-dropdown-click.is-open .nav-dropdown { display: grid; }
+  .nav-links li.has-dropdown-click .dropdown-caret { display: inline-flex; }
 }
 @media (max-width: 1080px) {
   .container { padding: 0 32px; }

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -1430,15 +1430,17 @@ const matterRuntime = readFileSync(
             if (ev.key === 'Escape') setNavOpen(false);
           });
         })();
-        // Dropdown disclosure toggles. Product and Resources are category
-        // labels rendered as <button data-nav-dropdown-toggle> that open their
-        // own dropdown instead of navigating. CSS :hover still opens them on
-        // pointer devices; this handles click and TAP on touch devices with no
-        // hover (touch laptops / tablets at desktop width). Mirrors the same
-        // wiring in `header-enhancer.astro` (used by every sub-page).
+        // Product and Resources are category labels rendered as
+        // <button data-nav-dropdown-toggle> disclosures driven solely by the
+        // JS-toggled .is-open class (`.has-dropdown-click` opts them out of the
+        // CSS :hover / :focus-within reveal, so an explicit click/Escape close
+        // always wins). At <=1080px the hamburger menu flattens every dropdown
+        // to always-visible, so there they are plain section headers: drop the
+        // disclosure ARIA and no-op the click. Mirrors `header-enhancer.astro`.
         (function enhanceNavDropdownToggles() {
           const toggles = document.querySelectorAll('[data-nav-dropdown-toggle]');
           if (toggles.length === 0) return;
+          const navFlattened = window.matchMedia('(max-width: 1080px)');
           const closeDropdown = (li) => {
             li.classList.remove('is-open');
             const btn = li.querySelector('[data-nav-dropdown-toggle]');
@@ -1449,20 +1451,37 @@ const matterRuntime = readFileSync(
               if (li !== except) closeDropdown(li);
             });
           };
+          const syncDisclosureMode = () => {
+            const flattened = navFlattened.matches;
+            toggles.forEach((btn) => {
+              const li = btn.closest('li.has-dropdown');
+              if (flattened) {
+                btn.removeAttribute('aria-expanded');
+                btn.removeAttribute('aria-haspopup');
+                if (li) li.classList.remove('is-open');
+              } else {
+                btn.setAttribute('aria-haspopup', 'true');
+                if (!btn.hasAttribute('aria-expanded')) btn.setAttribute('aria-expanded', 'false');
+              }
+            });
+          };
+          syncDisclosureMode();
+          navFlattened.addEventListener('change', syncDisclosureMode);
           toggles.forEach((btn) => {
             const li = btn.closest('li.has-dropdown');
             if (!li) return;
             btn.addEventListener('click', (ev) => {
               ev.stopPropagation();
+              if (navFlattened.matches) return; // flattened mobile menu — not a disclosure
               const open = !li.classList.contains('is-open');
               closeAllDropdowns(li);
               li.classList.toggle('is-open', open);
               btn.setAttribute('aria-expanded', open ? 'true' : 'false');
             });
           });
-          // The rest of the header still opens on pure CSS :hover / :focus-within.
+          // The four hub menus still open on pure CSS :hover / :focus-within.
           // When any other header item becomes active, close a click-pinned
-          // dropdown so a pinned panel and a hovered panel can't show at once.
+          // disclosure so a pinned panel and a hovered panel can't show at once.
           document.querySelectorAll('li.has-dropdown').forEach((li) => {
             const closeOthers = () => closeAllDropdowns(li);
             li.addEventListener('mouseenter', closeOthers);

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -1460,6 +1460,14 @@ const matterRuntime = readFileSync(
               btn.setAttribute('aria-expanded', open ? 'true' : 'false');
             });
           });
+          // The rest of the header still opens on pure CSS :hover / :focus-within.
+          // When any other header item becomes active, close a click-pinned
+          // dropdown so a pinned panel and a hovered panel can't show at once.
+          document.querySelectorAll('li.has-dropdown').forEach((li) => {
+            const closeOthers = () => closeAllDropdowns(li);
+            li.addEventListener('mouseenter', closeOthers);
+            li.addEventListener('focusin', closeOthers);
+          });
           document.addEventListener('click', (ev) => {
             document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
               if (!li.contains(ev.target)) closeDropdown(li);

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -1430,54 +1430,11 @@ const matterRuntime = readFileSync(
             if (ev.key === 'Escape') setNavOpen(false);
           });
         })();
-        // Product and Resources are category labels rendered as
-        // <button data-nav-dropdown-toggle> disclosures driven solely by the
-        // JS-toggled .is-open class (`.has-dropdown-click` opts them out of the
-        // CSS :hover / :focus-within reveal AND collapses them on the flattened
-        // mobile menu, so the SSR aria-expanded="false" is truthful even
-        // before/without JS — collapsed by default at every width: desktop
-        // flyout, mobile accordion). Mirrors `header-enhancer.astro`.
-        (function enhanceNavDropdownToggles() {
-          const toggles = document.querySelectorAll('[data-nav-dropdown-toggle]');
-          if (toggles.length === 0) return;
-          const closeDropdown = (li) => {
-            li.classList.remove('is-open');
-            const btn = li.querySelector('[data-nav-dropdown-toggle]');
-            if (btn) btn.setAttribute('aria-expanded', 'false');
-          };
-          const closeAllDropdowns = (except) => {
-            document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
-              if (li !== except) closeDropdown(li);
-            });
-          };
-          toggles.forEach((btn) => {
-            const li = btn.closest('li.has-dropdown');
-            if (!li) return;
-            btn.addEventListener('click', (ev) => {
-              ev.stopPropagation();
-              const open = !li.classList.contains('is-open');
-              closeAllDropdowns(li);
-              li.classList.toggle('is-open', open);
-              btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-            });
-          });
-          // The four hub menus still open on pure CSS :hover / :focus-within.
-          // When any other header item becomes active, close a click-pinned
-          // disclosure so a pinned panel and a hovered panel can't show at once.
-          document.querySelectorAll('li.has-dropdown').forEach((li) => {
-            const closeOthers = () => closeAllDropdowns(li);
-            li.addEventListener('mouseenter', closeOthers);
-            li.addEventListener('focusin', closeOthers);
-          });
-          document.addEventListener('click', (ev) => {
-            document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
-              if (!li.contains(ev.target)) closeDropdown(li);
-            });
-          });
-          document.addEventListener('keydown', (ev) => {
-            if (ev.key === 'Escape') closeAllDropdowns(null);
-          });
-        })();
+        // Product and Resources are category-label <button class="nav-trigger">
+        // triggers (not links, so they never navigate) whose dropdown is
+        // revealed by the same pure-CSS :hover / :focus-within rule as the hub
+        // menus — no JS needed (works on first paint / JS-disabled, and on
+        // touch via focus). See header-enhancer.astro.
         enhanceDragIcon();
         enhanceWire();
         enhanceStatementReveal();

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -1430,6 +1430,45 @@ const matterRuntime = readFileSync(
             if (ev.key === 'Escape') setNavOpen(false);
           });
         })();
+        // Dropdown disclosure toggles. Product and Resources are category
+        // labels rendered as <button data-nav-dropdown-toggle> that open their
+        // own dropdown instead of navigating. CSS :hover still opens them on
+        // pointer devices; this handles click and TAP on touch devices with no
+        // hover (touch laptops / tablets at desktop width). Mirrors the same
+        // wiring in `header-enhancer.astro` (used by every sub-page).
+        (function enhanceNavDropdownToggles() {
+          const toggles = document.querySelectorAll('[data-nav-dropdown-toggle]');
+          if (toggles.length === 0) return;
+          const closeDropdown = (li) => {
+            li.classList.remove('is-open');
+            const btn = li.querySelector('[data-nav-dropdown-toggle]');
+            if (btn) btn.setAttribute('aria-expanded', 'false');
+          };
+          const closeAllDropdowns = (except) => {
+            document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
+              if (li !== except) closeDropdown(li);
+            });
+          };
+          toggles.forEach((btn) => {
+            const li = btn.closest('li.has-dropdown');
+            if (!li) return;
+            btn.addEventListener('click', (ev) => {
+              ev.stopPropagation();
+              const open = !li.classList.contains('is-open');
+              closeAllDropdowns(li);
+              li.classList.toggle('is-open', open);
+              btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+            });
+          });
+          document.addEventListener('click', (ev) => {
+            document.querySelectorAll('li.has-dropdown.is-open').forEach((li) => {
+              if (!li.contains(ev.target)) closeDropdown(li);
+            });
+          });
+          document.addEventListener('keydown', (ev) => {
+            if (ev.key === 'Escape') closeAllDropdowns(null);
+          });
+        })();
         enhanceDragIcon();
         enhanceWire();
         enhanceStatementReveal();

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -1433,14 +1433,13 @@ const matterRuntime = readFileSync(
         // Product and Resources are category labels rendered as
         // <button data-nav-dropdown-toggle> disclosures driven solely by the
         // JS-toggled .is-open class (`.has-dropdown-click` opts them out of the
-        // CSS :hover / :focus-within reveal, so an explicit click/Escape close
-        // always wins). At <=1080px the hamburger menu flattens every dropdown
-        // to always-visible, so there they are plain section headers: drop the
-        // disclosure ARIA and no-op the click. Mirrors `header-enhancer.astro`.
+        // CSS :hover / :focus-within reveal AND collapses them on the flattened
+        // mobile menu, so the SSR aria-expanded="false" is truthful even
+        // before/without JS — collapsed by default at every width: desktop
+        // flyout, mobile accordion). Mirrors `header-enhancer.astro`.
         (function enhanceNavDropdownToggles() {
           const toggles = document.querySelectorAll('[data-nav-dropdown-toggle]');
           if (toggles.length === 0) return;
-          const navFlattened = window.matchMedia('(max-width: 1080px)');
           const closeDropdown = (li) => {
             li.classList.remove('is-open');
             const btn = li.querySelector('[data-nav-dropdown-toggle]');
@@ -1451,28 +1450,11 @@ const matterRuntime = readFileSync(
               if (li !== except) closeDropdown(li);
             });
           };
-          const syncDisclosureMode = () => {
-            const flattened = navFlattened.matches;
-            toggles.forEach((btn) => {
-              const li = btn.closest('li.has-dropdown');
-              if (flattened) {
-                btn.removeAttribute('aria-expanded');
-                btn.removeAttribute('aria-haspopup');
-                if (li) li.classList.remove('is-open');
-              } else {
-                btn.setAttribute('aria-haspopup', 'true');
-                if (!btn.hasAttribute('aria-expanded')) btn.setAttribute('aria-expanded', 'false');
-              }
-            });
-          };
-          syncDisclosureMode();
-          navFlattened.addEventListener('change', syncDisclosureMode);
           toggles.forEach((btn) => {
             const li = btn.closest('li.has-dropdown');
             if (!li) return;
             btn.addEventListener('click', (ev) => {
               ev.stopPropagation();
-              if (navFlattened.matches) return; // flattened mobile menu — not a disclosure
               const open = !li.classList.contains('is-open');
               closeAllDropdowns(li);
               li.classList.toggle('is-open', open);


### PR DESCRIPTION
<!-- No linked issue: nav UX/IA fix surfaced during a navigation review. -->

## Why

The Product and Resources top-level nav items were `<a>` links pointing at the
homepage (`/`) and the blog (`/blog/`) respectively. Two problems:

1. **Confusing IA.** They are category labels, not pages — clicking "Product"
   just reloaded the homepage and "Resources" jumped to the blog, inconsistent
   with Solution/Agent/Plugins/Community which open their own hubs.
2. **Touch reachability.** Their dropdowns open on `:hover`. On touch devices
   with no hover that sit at desktop width (touch laptops, tablets in
   landscape ≥1081px), tapping the item navigated away before the dropdown
   could open, so the dropdown children were effectively unreachable. (Phones
   ≤1080px were already fine — the hamburger menu flattens every dropdown
   inline.)

## What users will see

Clicking **Product** or **Resources** now opens its dropdown in place instead
of navigating away — they behave as the category toggles they look like. Hover
still opens them on desktop. The other four items (Solution, Agent, Plugins,
Community) are unchanged and still link to their hub pages. Every destination
that used to be reachable still is: the homepage from the logo + the Product
dropdown's "Open Design" entry, and the blog from the Resources dropdown's
"Blog" entry.

## Surface area

- [x] **UI** — Product/Resources nav triggers change from links to disclosure buttons (dropdown opens on click/tap instead of navigating).

## Screenshots

Behavioural change (no new layout). Verified on a local dev build:
- Product/Resources render as `<button data-nav-dropdown-toggle>` (no `href`); the four hub items remain `<a href>`.
- Clicking a trigger toggles `.is-open` → CSS reveals the dropdown; hover still works; outside-click / Escape close it.
- Cloudflare preview attached to this PR can be exercised on a real phone.

## Bug fix verification

Not a logic-path bug with a cheap red spec (it's a hover/touch + IA behaviour).
Verified against a local dev server (`astro dev`): served HTML confirms the two
triggers are buttons without `href`, the four hubs keep their `href`, the
`.is-open` reveal CSS is present, and the toggle JS is wired in both the
homepage's inline enhancer (`index.astro`) and the shared `header-enhancer.astro`
used by sub-pages. `astro check` passes (0 errors).

## Validation

- `pnpm --filter @open-design/landing-page typecheck` (astro check) → 0 errors, 0 warnings.
- Local `astro dev` served-HTML checks for markup/CSS/JS presence on `/` (homepage) and the shared enhancer.
- `pnpm guard` + full build run via the `Validate landing page` CI gate.
