### PR TITLE
fix(web): keep buttons in one row

### DIFF
--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -345,7 +345,7 @@
 }
 
 .library-install-form .library-import-source-control {
-  grid-template-columns: repeat(2, auto);
+  grid-template-columns: repeat(3, auto);
 }
 
 .library-install-form .library-import-mode-control {

--- a/apps/web/tests/components/DesignSystemsSection.test.tsx
+++ b/apps/web/tests/components/DesignSystemsSection.test.tsx
@@ -1,12 +1,36 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import postcss, { type Rule } from 'postcss';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { DesignSystemSummary } from '@open-design/contracts';
 
 import { DesignSystemsSection } from '../../src/components/DesignSystemsSection';
 import { fetchDesignSystems, updateDesignSystemDraft } from '../../src/providers/registry';
 import type { AppConfig } from '../../src/types';
+
+const memoryCss = readFileSync(resolve(process.cwd(), 'src/styles/viewer/memory.css'), 'utf8');
+const memoryCssRoot = postcss.parse(memoryCss, { from: 'src/styles/viewer/memory.css' });
+
+function topLevelRuleWithProperty(selector: string, property: string): Rule {
+  const match = memoryCssRoot.nodes.find((node): node is Rule => {
+    if (node.type !== 'rule') return false;
+    if (!node.selectors.includes(selector)) return false;
+    return node.nodes.some((child) => child.type === 'decl' && child.prop === property);
+  });
+  if (!match) throw new Error(`Missing CSS block for ${selector}`);
+  return match;
+}
+
+function ruleValue(rule: Rule, property: string): string {
+  const decl = rule.nodes.find(
+    (node) => node.type === 'decl' && node.prop === property,
+  );
+  if (!decl || decl.type !== 'decl') throw new Error(`Missing CSS property ${property}`);
+  return decl.value.trim();
+}
 
 const editable: DesignSystemSummary = {
   id: 'user:acme',
@@ -147,5 +171,31 @@ describe('DesignSystemsSection rename (issue #2811)', () => {
     render(<DesignSystemsSection cfg={cfg} setCfg={() => {}} />);
     await screen.findByText('Linear');
     expect(screen.queryByRole('button', { name: /Rename Linear/i })).toBeNull();
+  });
+
+  it('keeps segmented control columns in sync with rendered buttons', async () => {
+    render(<DesignSystemsSection cfg={cfg} setCfg={() => {}} />);
+
+    await screen.findByText('Linear');
+
+    for (const selector of [
+      '.library-install-form .library-import-source-control',
+      '.library-install-form .library-import-mode-control',
+    ]) {
+      const control = document.querySelector(selector);
+      expect(control).toBeTruthy();
+
+      const buttonCount = control!.querySelectorAll('button').length;
+      expect(buttonCount).toBeGreaterThan(0);
+
+      const gridTemplateColumns = ruleValue(
+        topLevelRuleWithProperty(selector, 'grid-template-columns'),
+        'grid-template-columns',
+      );
+      const repeatMatch = /^repeat\((\d+),\s*auto\)$/.exec(gridTemplateColumns);
+
+      expect(repeatMatch).toBeTruthy();
+      expect(Number(repeatMatch![1])).toBe(buttonCount);
+    }
   });
 });


### PR DESCRIPTION
Fixes #4770 

## Why

I picked up this issue to fix a layout bug in the design system install form.

Previously, an extra button was added to the segmented controls, but the CSS grid column count was still set to `repeat(2, auto)`, which caused the controls to wrap. This PR updates the column count and adds a regression test to ensure the rendered button count stays aligned with the configured grid columns.

## What users will see

In Settings → Design Systems → Add design system, the import source  segmented controls now stay on a single row instead of wrapping because of a stale column count.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots
before：
<img width="2158" height="1554" alt="image" src="https://github.com/user-attachments/assets/065ca834-77bc-4499-b839-8e000d6f9a16" />
after：
<img width="2160" height="1604" alt="image" src="https://github.com/user-attachments/assets/08e83722-1b5f-492f-9b0a-4a120f4d0963" />


## Bug fix verification

- Test path that reproduces the bug:
  `apps/web/tests/components/DesignSystemsSection.test.tsx`
- Did the test go red on `main` and green on this branch?:
  Yes
- The new regression test failed against the pre-fix state that matched `main`, then passed after updating the segmented control grid column counts from `2` to `3`.

## Validation

- `cd apps/web && pnpm exec vitest run -c vitest.config.ts tests/components/DesignSystemsSection.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`