### PR TITLE
fix(landing-page): stop :loc fold from shadowing /plugins hub pages

### DIFF
--- a/apps/landing-page/public/_redirects
+++ b/apps/landing-page/public/_redirects
@@ -192,7 +192,17 @@
 # paths still fold to English via the `/<retired>/* -> /:splat` rules above.
 # The /skills /systems /templates legacy listings below are NOT static (their
 # generators were removed), so folding them is safe.
+#
+# The same `plugins` collision bites the per-section folds, not just the
+# `/:loc/plugins/*` shape warned against above: `:loc` matches the literal
+# segment `plugins`, so `/plugins/{skills,systems,templates}/` binds
+# `:loc=plugins` and 301s to `/plugins/plugins/{...}/` (404). Guard the real
+# English hub pages with a 200 rewrite FIRST so the folds never see them
+# (first match wins). `/plugins/craft/` has no fold below, so it needs none.
 # ---------------------------------------------------------------------------
+/plugins/skills/*     /plugins/skills/:splat     200
+/plugins/systems/*    /plugins/systems/:splat    200
+/plugins/templates/*  /plugins/templates/:splat  200
 /:loc/skills/*     /:loc/plugins/skills/     301
 /:loc/systems/*    /:loc/plugins/systems/    301
 /:loc/templates/*  /:loc/plugins/templates/  301


### PR DESCRIPTION
## Why

Three live catalog pages are returning 404 in production:
`https://open-design.ai/plugins/templates/`, `/plugins/skills/`, and
`/plugins/systems/`. They 301 to `/plugins/plugins/{...}/` (a doubled,
non-existent path) and then 404. `/plugins/craft/` is unaffected.

Root cause: PR #4709 consolidated the kept-locale legacy catalog folds
into `:loc` placeholder rules
(`/:loc/{skills,systems,templates}/* -> /:loc/plugins/...`). The `:loc`
placeholder matches *any* single path segment — including the literal
segment `plugins`. So the canonical English hub pages
`/plugins/templates/` bind `:loc=plugins` and 301 to
`/plugins/plugins/templates/`. `craft` survives only because it has no
fold. The same block already warns against a generic `/:loc/plugins/*`
fold for exactly this 200-must-stay reason, but the per-section folds hit
the identical collision.

## What users will see

Visiting the Templates / Skills / Systems sections from the `/plugins/`
hub (or directly) loads the catalog page again instead of a 404. No
visible change to localized URLs or any other route.

## Surface area

- [x] **None** — config-only fix to `apps/landing-page/public/_redirects` (Cloudflare Pages redirect rules).

## Bug fix verification

A cheap red spec wasn't available: this is a Cloudflare Pages
`_redirects` matching behavior with no existing test harness in-repo
(the rules are only evaluated by Cloudflare's edge / `wrangler pages
dev`, not by `astro check`). Verified end-to-end with `wrangler pages
dev` against a fixture tree instead:

- **Before (current `main` `_redirects`):** `/plugins/templates/`,
  `/plugins/skills/`, `/plugins/systems/` → `301 -> /plugins/plugins/.../`
  (reproduces the production 404); `/plugins/craft/` → 200.
- **After (this branch):** all four hub pages → 200; the faceted
  `/plugins/templates/<kind>/` children → 200; every locale fold
  unchanged (`/zh/templates/* -> /zh/plugins/templates/`, `/ja/systems/*`,
  `/tr/templates/*`; retired `/vi/templates/* -> /templates/*`,
  `/fa/skills/* -> /skills/*`).

The fix adds three `200` rewrites before the `:loc` folds so
first-match-wins serves the real static hub pages; it keeps the `:loc`
consolidation intact (does not reintroduce the per-locale rule-count
blowup #4709 fixed).

## Validation

- `wrangler pages dev` reproduce-then-fix (above); `wrangler` parses the
  updated file as 111 valid redirect rules, 0 errors.
- Config-only change to a static asset; no TypeScript / build surface
  touched, so `pnpm guard` / `pnpm typecheck` are unaffected.