### PR TITLE
feat(daemon): resume cursor-agent CLI session across chat turns

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -6,6 +6,12 @@ type ParserKind = string;
 type ParserState = {
   cursorTextSoFar: string;
   cursorTurnStart: number;
+  // Last `session_id` seen on a cursor-agent event. cursor-agent mints its
+  // own chat id (it has no `--session-id` flag, only `--resume <chatId>`),
+  // so the daemon must capture the emitted id to resume the same chat on
+  // follow-up turns. Emitted once per distinct id as an `agent_session`
+  // control event the server stores under (conversationId, agentId).
+  cursorSessionId?: string;
   openCodeToolUses: Set<string>;
   codexToolUses: Set<string>;
   codexErrorEmitted: boolean;
@@ -590,6 +596,18 @@ function reconcileCursorTurnReplay(text: string, onEvent: StreamEventHandler, st
 
 function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: ParserState): boolean {
   if (!isRecord(obj)) return false;
+
+  // cursor-agent stamps every event with its own `session_id`. Surface the
+  // first/changed value as a control event so the server can persist it for
+  // `--resume` on the next turn. Additive: does not consume the event.
+  if (
+    typeof obj.session_id === 'string' &&
+    obj.session_id.length > 0 &&
+    state.cursorSessionId !== obj.session_id
+  ) {
+    state.cursorSessionId = obj.session_id;
+    onEvent({ type: 'agent_session', sessionId: obj.session_id });
+  }
 
   if (obj.type === 'system' && obj.subtype === 'init') {
     onEvent({

--- a/apps/daemon/src/runtimes/defs/cursor-agent.ts
+++ b/apps/daemon/src/runtimes/defs/cursor-agent.ts
@@ -77,11 +77,26 @@ export const cursorAgentDef = {
       if (options.model && options.model !== 'default') {
         args.push('--model', options.model);
       }
+      // Resume the CLI's own chat across turns so it keeps working memory and
+      // the daemon can skip resending the full transcript (resumesSessionViaCli
+      // gate in server.ts). cursor-agent has no `--session-id`: it mints its
+      // own id on the create turn (captured from the event stream and stored by
+      // the daemon), so we only pass `--resume <chatId>` when a stored id
+      // exists — never the daemon-minted `newSessionId`, which the CLI would
+      // silently treat as a fresh chat.
+      if (typeof runtimeContext.resumeSessionId === 'string' && runtimeContext.resumeSessionId) {
+        args.push('--resume', runtimeContext.resumeSessionId);
+      }
       return args;
     },
     promptViaStdin: true,
     streamFormat: 'json-event-stream',
     eventParser: 'cursor-agent',
+    // cursor-agent's CLI carries multi-turn memory via `--resume <chatId>`.
+    // The daemon captures the emitted `session_id` (see json-event-stream.ts /
+    // server.ts capturedAgentCliSessionId) and replays it next turn, which
+    // lets composeChatUserRequestForAgent skip the transcript on follow-ups.
+    resumesSessionViaCli: true,
     // `cursor-agent status` is a cheap, side-effect-free auth check. Declaring
     // it here is what makes detection surface an "auth required" badge for
     // Cursor Agent (the generalized probe only runs for adapters that opt in).

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9465,6 +9465,19 @@ export async function startServer({
       persistDeliveredAgentSessionState = () => {
         if (persisted) return;
         persisted = true;
+        // cursor-agent has no `--session-id` flag: it mints its own chat id
+        // and we cannot force the daemon's `newSessionId`. Persisting that
+        // unusable id here would make the next turn `--resume <unknown>`,
+        // which cursor-agent silently treats as a fresh chat (no error) while
+        // skipTranscript drops the history — silent context loss. So skip the
+        // create-branch for cursor-agent; its real emitted id is stored via
+        // persistCapturedAgentSession in the success path below.
+        if (def.id === 'cursor-agent') {
+          if (agentResumeCtx.isResuming && includeStableInstructions) {
+            updateAgentSessionStableHash(db, run.conversationId, def.id, currentStableHash);
+          }
+          return;
+        }
         if (!agentResumeCtx.isResuming && agentResumeCtx.newSessionId) {
           upsertAgentSession(db, {
             conversationId: run.conversationId,
@@ -9501,6 +9514,12 @@ export async function startServer({
     let artifactRegistered = false;
     // Set when sendAgentEvent sees substantive user-visible output.
     let agentProducedOutput = false;
+    // Last CLI session id captured from the agent's own event stream
+    // (cursor-agent emits `session_id`; surfaced as an `agent_session`
+    // control event by the json-event-stream parser). cursor-agent has no
+    // `--session-id` flag, so the daemon cannot mint the id ahead of time —
+    // it must persist the emitted id to resume the same chat next turn.
+    let capturedAgentCliSessionId: string | null = null;
     // Only daemon-initiated quiet-period termination should be treated
     // as `succeeded` in the close handler. A later unrelated SIGTERM /
     // SIGKILL (external `kill`, OOM, container shutdown) must keep its
@@ -10307,6 +10326,13 @@ export async function startServer({
     }
 
     const sendAgentEvent = (ev) => {
+      // Control event from the cursor-agent parser carrying the CLI's own
+      // chat session id. Capture it for resume persistence; never forward
+      // it to the client (it is not user-visible content).
+      if (ev?.type === 'agent_session' && typeof ev.sessionId === 'string' && ev.sessionId) {
+        capturedAgentCliSessionId = ev.sessionId;
+        return;
+      }
       if (ev?.type === 'error') {
         if (agentStreamError) return;
         flushVisibleAgentStderr();
@@ -11013,6 +11039,25 @@ export async function startServer({
       }
       if (status === 'succeeded') {
         persistDeliveredAgentSessionState();
+      }
+      // cursor-agent resume: store the CLI's own emitted chat id so the next
+      // turn can `--resume <chatId>` and skip resending the transcript. On a
+      // successful run with no captured id, persistCapturedAgentSession CLEARS
+      // the row, so the next turn safely starts fresh with the full transcript
+      // instead of silently resuming nothing.
+      if (
+        def.id === 'cursor-agent' &&
+        def.resumesSessionViaCli === true &&
+        run.conversationId
+      ) {
+        if (status === 'succeeded') {
+          persistCapturedAgentSession(db, {
+            conversationId: run.conversationId,
+            agentId: def.id,
+            sessionId: capturedAgentCliSessionId,
+            stablePromptHash: currentStableHash,
+          });
+        }
       }
       finishWithRetryDecision(status, code, signal);
       } finally {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9499,6 +9499,8 @@ export async function startServer({
     // "agent finished the deliverable and went idle" rather than
     // "agent stalled with nothing to show" (issue #1451).
     let artifactRegistered = false;
+    // Set when sendAgentEvent sees substantive user-visible output.
+    let agentProducedOutput = false;
     // Only daemon-initiated quiet-period termination should be treated
     // as `succeeded` in the close handler. A later unrelated SIGTERM /
     // SIGKILL (external `kill`, OOM, container shutdown) must keep its
@@ -9580,6 +9582,17 @@ export async function startServer({
         // daemon-initiated so an unrelated later signal (external
         // kill, OOM) is NOT silently reclassified to `succeeded` —
         // only signals from this watchdog branch should be.
+        artifactQuietShutdownRequested = true;
+        if (acpSession?.abort) {
+          acpSession.abort();
+        }
+        if (child && !child.killed) design.runs.signalChild(run, 'SIGTERM');
+        scheduleForcedChildShutdown();
+        return;
+      }
+      // cursor-agent / prompt-via-stdin: turn finished (usage) but child
+      // may idle on open stdin until the watchdog fires (#3372 family).
+      if (run.turnCompletedCleanly && agentProducedOutput) {
         artifactQuietShutdownRequested = true;
         if (acpSession?.abort) {
           acpSession.abort();
@@ -10165,7 +10178,6 @@ export async function startServer({
     // contribute to this flag; ACP sessions and plain stdout streams are
     // covered by their own success/failure paths and the empty-output
     // guard below skips them via `trackingSubstantiveOutput`.
-    let agentProducedOutput = false;
     let trackingSubstantiveOutput = false;
     const looksLikeGeminiJsonEventStream = (text: string) => (
       isGeminiJsonEventStream(parseGeminiJsonEventStreamEvents(text))
@@ -10352,6 +10364,13 @@ export async function startServer({
         agentProducedOutput = true;
       }
       send('agent', ev);
+      // json-event-stream adapters (cursor-agent) keep stdin open; close on
+      // terminal usage so the child exits instead of idle-stalling (#3372).
+      if (def.promptViaStdin || def.id === 'cursor-agent') {
+        try {
+          applyClaudeStreamJsonRunBookkeeping(run, ev);
+        } catch {}
+      }
     };
     const parseBufferedAntigravityGeminiJsonEventStream = () => {
       if (

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -571,6 +571,28 @@ describe('applyClaudeStreamJsonRunBookkeeping', () => {
     expect(run.child.stdin.end).not.toHaveBeenCalled();
   });
 
+  it('closes stdin on cursor-agent terminal usage (single-shot stream-json, #3372)', () => {
+    const run = {
+      stdinOpen: true,
+      turnCompletedCleanly: false,
+      child: {
+        stdin: {
+          destroyed: false,
+          end: vi.fn(),
+        },
+      },
+    };
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'usage',
+      usage: { input_tokens: 1200, output_tokens: 400 },
+    });
+
+    expect(run.turnCompletedCleanly).toBe(true);
+    expect(run.stdinOpen).toBe(false);
+    expect(run.child.stdin.end).toHaveBeenCalled();
+  });
+
   it('closes stdin and records clean completion after an AskUserQuestion tool_use followed by end_turn (#4273)', () => {
     // Regression test: the dead AskUserQuestion detection branch used to add
     // the tool_use id to pendingHostAnswers and return early, preventing stdin


### PR DESCRIPTION
## Summary

Teach the daemon to resume the **cursor-agent** CLI session across chat turns, so follow-up turns stop re-sending the full rendered transcript (and the ~121k-token stable instruction block). This eliminates the multi-turn input-token blowups (~1.4M peaks) and the per-turn ingestion cost for cursor-agent, mirroring the existing `claude`/`codebuddy` `resumesSessionViaCli` path.

Key difference from `claude`: **cursor-agent has no `--session-id` flag.** It mints its own chat id (emitted as `session_id` on every stream event) and resumes via `--resume <chatId>`. Passing the daemon-minted `newSessionId` to `--resume` does *not* error — cursor-agent silently starts a fresh chat — which would cause silent context loss if the claude path were reused as-is. So this PR captures and persists the CLI's **own emitted** id instead.

## Changes

- **`json-event-stream.ts`** — surface the cursor-agent `session_id` as an additive `agent_session` control event (emitted once per distinct id; does not consume the event).
- **`server.ts`** — capture that id per run; on success persist it via `persistCapturedAgentSession` (which **clears** the row when no id was captured, so the next turn safely falls back to a full-transcript create instead of resuming nothing). Skip the daemon-minted-id create-branch for cursor-agent so the unusable id is never stored. The #3372 quiet-shutdown bookkeeping in `sendAgentEvent` is preserved.
- **`cursor-agent.ts`** — `resumesSessionViaCli: true`; append `--resume <chatId>` only when a stored id exists.

## Safety / no-regression

- **First turn** and **capture-miss turns** are byte-identical to today (full transcript create). There is no path that resumes with a wrong id.
- The existing `skipTranscript` / `computeIncludeStable` gates already key off `agentResumeCtx.isResuming`; this PR only wires cursor-agent into them.

## Validation

- Headless CLI spike (`--print --output-format stream-json --resume <id>`): input tokens **106,250 → 50**, cache-read **215,008** on the resume turn (full 25-server MCP set enabled). Confirms `--resume` continues the chat and the daemon-side transcript skip is correct.
- Daemon `tsc` build + prebundle gate pass (stall-fix `applyClaudeStreamJsonRunBookkeeping` refs intact).
- **Pending:** in-app multi-turn latency numbers (new conversation + follow-up) via the desktop UI — marking this **draft** until those are attached.

## Notes

- Stacks on the #4555 / #3372 cursor-agent post-usage stall-fix family.
