### PR TITLE
fix(chat): give prompt_too_large card a New conversation CTA

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -3010,6 +3010,20 @@ export function ChatPane({
                             >
                               {t('chat.amrBalanceGate.plansCta')}
                             </button>
+                          ) : runFailureUi.primaryAction === 'reduce-context' ? (
+                            // prompt_too_large: steer the user to start a fresh
+                            // conversation rather than retrying the same oversized
+                            // context (which would deterministically fail again).
+                            // Opens a new conversation tab via onNewConversation.
+                            // Retry stays secondary below via secondaryRetry.
+                            <button
+                              type="button"
+                              className="chat-error-action"
+                              disabled={newConversationDisabled}
+                              onClick={() => onNewConversation?.()}
+                            >
+                              {t('chat.runError.reduceContextCta')}
+                            </button>
                           ) : null}
                           {canResumeFailedRun ? (
                             // Resumable failure: continue the agent's existing

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -119,6 +119,7 @@ export const ar: Dict = {
   'chat.runError.title.artifactMissing': 'لم يتم إنشاء أي مخرجات',
   'chat.runError.signInMessage.amr': 'لم يتم تسجيل دخول وكيل OpenDesign Cloud بعد — سجّل الدخول لبدء استخدامه.',
   'chat.runError.signInMessage.other': '{agent} لم يسجّل الدخول. تحقق من حالة تسجيل الدخول محليًا. نوصي بوكيل OpenDesign Cloud — أكثر ثباتًا وأفضل قيمة.',
+  'chat.runError.reduceContextCta': 'محادثة جديدة',
   'chat.runError.agentFallback': 'الوكيل',
   'chat.runError.sourceLabel': 'تفاصيل الخطأ',
   'chat.runError.sourceExpandAria': 'توسيع مصدر الخطأ',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -119,6 +119,7 @@ export const de: Dict = {
   'chat.runError.title.artifactMissing': 'Kein Ergebnis erzeugt',
   'chat.runError.signInMessage.amr': 'Der OpenDesign Cloud-Agent ist noch nicht angemeldet – melde dich an, um ihn zu nutzen.',
   'chat.runError.signInMessage.other': '{agent} ist nicht angemeldet. Prüfe den Anmeldestatus lokal. Wir empfehlen den OpenDesign Cloud-Agenten – stabiler und günstiger.',
+  'chat.runError.reduceContextCta': 'Neue Unterhaltung',
   'chat.runError.agentFallback': 'der Agent',
   'chat.runError.sourceLabel': 'Fehlerdetails',
   'chat.runError.sourceExpandAria': 'Fehlerquelle einblenden',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -119,6 +119,7 @@ export const en: Dict = {
   'chat.runError.title.artifactMissing': 'No deliverable produced',
   'chat.runError.signInMessage.amr': 'The OpenDesign Cloud agent isn\'t signed in yet — sign in to start using it.',
   'chat.runError.signInMessage.other': '{agent} isn\'t signed in. Check its sign-in status locally. We recommend the OpenDesign Cloud agent — steadier and better value.',
+  'chat.runError.reduceContextCta': 'New conversation',
   'chat.runError.agentFallback': 'the agent',
   'chat.runError.sourceLabel': 'Error details',
   'chat.runError.sourceExpandAria': 'Expand error source',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -119,6 +119,7 @@ export const esES: Dict = {
   'chat.runError.title.artifactMissing': 'No se generó ningún entregable',
   'chat.runError.signInMessage.amr': 'El agente de OpenDesign Cloud aún no ha iniciado sesión; inicia sesión para empezar a usarlo.',
   'chat.runError.signInMessage.other': '{agent} no ha iniciado sesión. Comprueba su estado de inicio de sesión en local. Recomendamos el agente de OpenDesign Cloud: más estable y rentable.',
+  'chat.runError.reduceContextCta': 'Nueva conversación',
   'chat.runError.agentFallback': 'el agente',
   'chat.runError.sourceLabel': 'Detalles del error',
   'chat.runError.sourceExpandAria': 'Mostrar el origen del error',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -119,6 +119,7 @@ export const fa: Dict = {
   'chat.runError.title.artifactMissing': 'خروجی قابل تحویلی ایجاد نشد',
   'chat.runError.signInMessage.amr': 'عامل OpenDesign Cloud هنوز وارد نشده است — برای استفاده وارد شوید.',
   'chat.runError.signInMessage.other': '{agent} وارد نشده است. وضعیت ورود را به‌صورت محلی بررسی کنید. عامل OpenDesign Cloud را توصیه می‌کنیم — پایدارتر و مقرون‌به‌صرفه‌تر.',
+  'chat.runError.reduceContextCta': 'گفتگوی جدید',
   'chat.runError.agentFallback': 'عامل',
   'chat.runError.sourceLabel': 'جزئیات خطا',
   'chat.runError.sourceExpandAria': 'گسترش منبع خطا',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -119,6 +119,7 @@ export const fr: Dict = {
   'chat.runError.title.artifactMissing': 'Aucun livrable généré',
   'chat.runError.signInMessage.amr': 'L\'agent OpenDesign Cloud n\'est pas encore connecté — connectez-vous pour l\'utiliser.',
   'chat.runError.signInMessage.other': '{agent} n\'est pas connecté. Vérifiez son état de connexion en local. Nous recommandons l\'agent OpenDesign Cloud — plus stable et plus économique.',
+  'chat.runError.reduceContextCta': 'Nouvelle conversation',
   'chat.runError.agentFallback': 'l\'agent',
   'chat.runError.sourceLabel': 'Détails de l’erreur',
   'chat.runError.sourceExpandAria': 'Afficher la source de l’erreur',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -119,6 +119,7 @@ export const hu: Dict = {
   'chat.runError.title.artifactMissing': 'Nem készült átadható fájl',
   'chat.runError.signInMessage.amr': 'Az OpenDesign Cloud ügynök még nincs bejelentkezve – jelentkezz be a használatához.',
   'chat.runError.signInMessage.other': '{agent} nincs bejelentkezve. Ellenőrizd a bejelentkezési állapotát helyben. Az OpenDesign Cloud ügynököt ajánljuk – stabilabb és gazdaságosabb.',
+  'chat.runError.reduceContextCta': 'Új beszélgetés',
   'chat.runError.agentFallback': 'az ügynök',
   'chat.runError.sourceLabel': 'Hiba részletei',
   'chat.runError.sourceExpandAria': 'Hibaforrás kibontása',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -119,6 +119,7 @@ export const id: Dict = {
   'chat.runError.title.artifactMissing': 'Tidak ada hasil yang dibuat',
   'chat.runError.signInMessage.amr': 'Agen OpenDesign Cloud belum masuk — masuk untuk mulai menggunakannya.',
   'chat.runError.signInMessage.other': '{agent} belum masuk. Periksa status masuknya secara lokal. Kami menyarankan agen OpenDesign Cloud — lebih stabil dan hemat.',
+  'chat.runError.reduceContextCta': 'Percakapan baru',
   'chat.runError.agentFallback': 'agen',
   'chat.runError.sourceLabel': 'Detail kesalahan',
   'chat.runError.sourceExpandAria': 'Perluas sumber kesalahan',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -119,6 +119,7 @@ export const it: Dict = {
   'chat.runError.title.artifactMissing': 'Nessun risultato prodotto',
   'chat.runError.signInMessage.amr': 'L\'agente OpenDesign Cloud non ha ancora effettuato l\'accesso — accedi per iniziare a usarlo.',
   'chat.runError.signInMessage.other': '{agent} non ha effettuato l\'accesso. Controlla lo stato di accesso in locale. Consigliamo l\'agente OpenDesign Cloud — più stabile e conveniente.',
+  'chat.runError.reduceContextCta': 'Nuova conversazione',
   'chat.runError.agentFallback': 'l\'agente',
   'chat.runError.sourceLabel': "Dettagli dell'errore",
   'chat.runError.sourceExpandAria': "Espandi l'origine dell'errore",

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -119,6 +119,7 @@ export const ja: Dict = {
   'chat.runError.title.artifactMissing': '成果物が生成されませんでした',
   'chat.runError.signInMessage.amr': 'OpenDesign Cloud エージェントはまだサインインしていません。サインインして使い始めてください。',
   'chat.runError.signInMessage.other': '{agent} がサインインしていません。ローカルでサインイン状態を確認してください。より安定してお得な OpenDesign Cloud エージェントがおすすめです。',
+  'chat.runError.reduceContextCta': '新しい会話',
   'chat.runError.agentFallback': 'エージェント',
   'chat.runError.sourceLabel': 'エラーの詳細',
   'chat.runError.sourceExpandAria': 'エラーのソースを展開',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -119,6 +119,7 @@ export const ko: Dict = {
   'chat.runError.title.artifactMissing': '결과물이 생성되지 않음',
   'chat.runError.signInMessage.amr': 'OpenDesign Cloud 에이전트가 아직 로그인되지 않았습니다. 로그인하여 사용을 시작하세요.',
   'chat.runError.signInMessage.other': '{agent}이(가) 로그인되지 않았습니다. 로컬에서 로그인 상태를 확인하세요. 더 안정적이고 경제적인 OpenDesign Cloud 에이전트를 추천합니다.',
+  'chat.runError.reduceContextCta': '새 대화',
   'chat.runError.agentFallback': '에이전트',
   'chat.runError.sourceLabel': '오류 세부 정보',
   'chat.runError.sourceExpandAria': '오류 소스 펼치기',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -119,6 +119,7 @@ export const pl: Dict = {
   'chat.runError.title.artifactMissing': 'Nie utworzono rezultatu',
   'chat.runError.signInMessage.amr': 'Agent OpenDesign Cloud nie jest jeszcze zalogowany — zaloguj się, aby zacząć go używać.',
   'chat.runError.signInMessage.other': '{agent} nie jest zalogowany. Sprawdź jego stan logowania lokalnie. Polecamy agenta OpenDesign Cloud — stabilniejszego i korzystniejszego.',
+  'chat.runError.reduceContextCta': 'Nowa rozmowa',
   'chat.runError.agentFallback': 'agent',
   'chat.runError.sourceLabel': 'Szczegóły błędu',
   'chat.runError.sourceExpandAria': 'Rozwiń źródło błędu',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -119,6 +119,7 @@ export const ptBR: Dict = {
   'chat.runError.title.artifactMissing': 'Nenhum entregável gerado',
   'chat.runError.signInMessage.amr': 'O agente OpenDesign Cloud ainda não fez login — faça login para começar a usá-lo.',
   'chat.runError.signInMessage.other': '{agent} não fez login. Verifique o status de login localmente. Recomendamos o agente OpenDesign Cloud — mais estável e econômico.',
+  'chat.runError.reduceContextCta': 'Nova conversa',
   'chat.runError.agentFallback': 'o agente',
   'chat.runError.sourceLabel': 'Detalhes do erro',
   'chat.runError.sourceExpandAria': 'Expandir origem do erro',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -119,6 +119,7 @@ export const ru: Dict = {
   'chat.runError.title.artifactMissing': 'Результат не создан',
   'chat.runError.signInMessage.amr': 'Агент OpenDesign Cloud ещё не вошёл в систему — войдите, чтобы начать им пользоваться.',
   'chat.runError.signInMessage.other': '{agent} не выполнил вход. Проверьте статус входа локально. Рекомендуем агента OpenDesign Cloud — стабильнее и выгоднее.',
+  'chat.runError.reduceContextCta': 'Новый диалог',
   'chat.runError.agentFallback': 'агент',
   'chat.runError.sourceLabel': 'Сведения об ошибке',
   'chat.runError.sourceExpandAria': 'Развернуть источник ошибки',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -119,6 +119,7 @@ export const th: Dict = {
   'chat.runError.title.artifactMissing': 'ไม่มีไฟล์ผลงานที่สร้างขึ้น',
   'chat.runError.signInMessage.amr': 'เอเจนต์ OpenDesign Cloud ยังไม่ได้ลงชื่อเข้าใช้ — ลงชื่อเข้าใช้เพื่อเริ่มใช้งาน',
   'chat.runError.signInMessage.other': '{agent} ยังไม่ได้ลงชื่อเข้าใช้ โปรดตรวจสอบสถานะการลงชื่อเข้าใช้ในเครื่อง เราแนะนำเอเจนต์ OpenDesign Cloud ที่เสถียรและคุ้มค่ากว่า',
+  'chat.runError.reduceContextCta': 'การสนทนาใหม่',
   'chat.runError.agentFallback': 'เอเจนต์',
   'chat.runError.sourceLabel': 'รายละเอียดข้อผิดพลาด',
   'chat.runError.sourceExpandAria': 'ขยายแหล่งที่มาของข้อผิดพลาด',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -119,6 +119,7 @@ export const tr: Dict = {
   'chat.runError.title.artifactMissing': 'Teslim edilebilir çıktı oluşturulmadı',
   'chat.runError.signInMessage.amr': 'OpenDesign Cloud aracısı henüz oturum açmadı — kullanmaya başlamak için oturum açın.',
   'chat.runError.signInMessage.other': '{agent} oturum açmadı. Oturum durumunu yerel olarak kontrol edin. Daha kararlı ve hesaplı OpenDesign Cloud aracısını öneririz.',
+  'chat.runError.reduceContextCta': 'Yeni sohbet',
   'chat.runError.agentFallback': 'aracı',
   'chat.runError.sourceLabel': 'Hata ayrıntıları',
   'chat.runError.sourceExpandAria': 'Hata kaynağını genişlet',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -119,6 +119,7 @@ export const uk: Dict = {
   'chat.runError.title.artifactMissing': 'Результат не створено',
   'chat.runError.signInMessage.amr': 'Агент OpenDesign Cloud ще не ввійшов — увійдіть, щоб почати користуватися ним.',
   'chat.runError.signInMessage.other': '{agent} не ввійшов. Перевірте стан входу локально. Рекомендуємо агента OpenDesign Cloud — стабільніший і вигідніший.',
+  'chat.runError.reduceContextCta': 'Нова розмова',
   'chat.runError.agentFallback': 'агент',
   'chat.runError.sourceLabel': 'Деталі помилки',
   'chat.runError.sourceExpandAria': 'Розгорнути джерело помилки',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -125,6 +125,7 @@ export const zhCN: Dict = {
     "OpenDesign Cloud 智能体尚未登录，前往登录即可正常使用",
   "chat.runError.signInMessage.other":
     "{agent}尚未登录，请本地检查登录状态。推荐使用 OpenDesign Cloud 智能体，更稳定划算",
+  "chat.runError.reduceContextCta": "新开对话",
   "chat.runError.agentFallback": "智能体",
   "chat.runError.sourceLabel": "查看错误详情",
   "chat.runError.sourceExpandAria": "展开报错源码",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -125,6 +125,7 @@ export const zhTW: Dict = {
     "OpenDesign Cloud 智慧體尚未登入，前往登入即可正常使用",
   "chat.runError.signInMessage.other":
     "{agent}尚未登入，請在本機檢查登入狀態。推薦使用 OpenDesign Cloud 智慧體，更穩定划算",
+  "chat.runError.reduceContextCta": "另開對話",
   "chat.runError.agentFallback": "智慧體",
   "chat.runError.sourceLabel": "查看錯誤詳情",
   "chat.runError.sourceExpandAria": "展開錯誤原始碼",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2870,6 +2870,7 @@ export interface Dict {
   'chat.runError.title.artifactMissing': string;
   'chat.runError.signInMessage.amr': string;
   'chat.runError.signInMessage.other': string;
+  'chat.runError.reduceContextCta': string;
   'chat.runError.cliMissingMessage': string;
   'chat.runError.promptTooLargeMessage': string;
   'chat.runError.modelUnavailableMessage': string;

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -168,6 +168,7 @@ export type RunFailurePrimaryAction =
   | 'upgrade'
   | 'launch-terminal-auth'
   | 'launch-terminal-switch-model'
+  | 'reduce-context'
   // No self-contained recovery button. Used when retrying is futile (e.g. a
   // hard quota / exhausted credits) and the only forward path is the AMR switch
   // card rendered below, so the card shows guidance copy without a dead Retry.
@@ -349,10 +350,20 @@ const AGENT_AGNOSTIC_FAILURE_UI: Record<string, RunFailureUi> = {
     'chat.runError.cliMissingMessage',
   ),
   // Input exceeded the model context window (user_action: reduce_context).
-  AGENT_PROMPT_TOO_LARGE: retryWithGuidance(
-    'chat.runError.title.promptTooLarge',
-    'chat.runError.promptTooLargeMessage',
-  ),
+  AGENT_PROMPT_TOO_LARGE: {
+    primaryAction: 'reduce-context',
+    titleKey: 'chat.runError.title.promptTooLarge',
+    messageKey: 'chat.runError.promptTooLargeMessage',
+    secondaryRetry: true,
+    showSwitchCard: false,
+  },
+  PROMPT_TOO_LARGE: {
+    primaryAction: 'reduce-context',
+    titleKey: 'chat.runError.title.promptTooLarge',
+    messageKey: 'chat.runError.promptTooLargeMessage',
+    secondaryRetry: true,
+    showSwitchCard: false,
+  },
   // Selected model is missing/disabled (user_action: switch_model).
   AMR_MODEL_UNAVAILABLE: retryWithGuidance(
     'chat.runError.title.modelUnavailable',

--- a/apps/web/tests/components/ChatPane.reduce-context-cta.test.tsx
+++ b/apps/web/tests/components/ChatPane.reduce-context-cta.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+/**
+ * The in-chat reduce-context CTA (issue #4782). When a run fails with a daemon
+ * `user_action: 'reduce_context'` classification (prompt_too_large), the error
+ * card must render a concrete "New conversation" button — retrying re-sends the
+ * same oversized context and fails identically, so the recovery path is to
+ * start fresh. Retry is demoted to the secondary action.
+ *
+ * Before the fix the card fell through to a bare Retry, offering no affordance
+ * toward the actual fix. Resolver behaviour itself is covered by
+ * amr-guidance.test.ts; here we only assert ChatPane's render wiring.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import type { AppConfig, ChatMessage } from '../../src/types';
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => (key: string) => key,
+  useI18n: () => ({ t: (key: string, vars?: Record<string, unknown>) => key, locale: 'en' }),
+}));
+
+vi.mock('../../src/components/AssistantMessage', () => ({
+  AssistantMessage: ({ message }: { message: ChatMessage }) => (
+    <div data-testid={`assistant-${message.id}`}>{message.content}</div>
+  ),
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function reduceContextFailedMessage(agentId: string): ChatMessage {
+  return {
+    id: 'msg-reduce-context',
+    role: 'assistant',
+    content: 'The prompt was too large.',
+    createdAt: 1,
+    runId: 'run-reduce-context',
+    runStatus: 'failed',
+    agentId,
+    events: [
+      {
+        kind: 'status',
+        label: 'error',
+        detail: 'Prompt too large.',
+        code: 'PROMPT_TOO_LARGE',
+        user_action: 'reduce_context',
+      },
+    ],
+  } as unknown as ChatMessage;
+}
+
+function renderChat(
+  agentId: string,
+  handlers: {
+    onRetry?: (m: ChatMessage) => void;
+    onNewConversation?: () => void;
+    newConversationDisabled?: boolean;
+  } = {},
+) {
+  return render(
+    <ChatPane
+      messages={[reduceContextFailedMessage(agentId)]}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      onRetry={handlers.onRetry ?? vi.fn()}
+      onNewConversation={handlers.onNewConversation ?? vi.fn()}
+      newConversationDisabled={handlers.newConversationDisabled ?? false}
+      conversations={[
+        { projectId: 'project-1', id: 'conv-1', title: 'Current', createdAt: 1, updatedAt: 1 },
+      ]}
+      activeConversationId="conv-1"
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      config={{
+        agentId,
+        agentCliEnv: {},
+        installationId: 'install-123',
+        telemetry: { metrics: true },
+      } as unknown as AppConfig}
+    />,
+  );
+}
+
+describe('ChatPane reduce-context CTA', () => {
+  it('renders a New conversation button that starts a fresh conversation', () => {
+    const onNewConversation = vi.fn();
+    renderChat('amr', { onNewConversation });
+
+    const cta = screen.getByText('chat.runError.reduceContextCta');
+    expect(cta).toBeTruthy();
+
+    fireEvent.click(cta);
+    expect(onNewConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps Retry available as the secondary recovery action', () => {
+    const onRetry = vi.fn();
+    renderChat('amr', { onRetry });
+
+    expect(screen.getByText('chat.runError.reduceContextCta')).toBeTruthy();
+    const retry = screen.getByText('promptTemplates.retry');
+    expect(retry).toBeTruthy();
+
+    fireEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]![0]).toMatchObject({ id: 'msg-reduce-context' });
+  });
+
+  it('disables the New conversation CTA when new conversations are disabled', () => {
+    const onNewConversation = vi.fn();
+    renderChat('codex', { onNewConversation, newConversationDisabled: true });
+
+    const cta = screen.getByText('chat.runError.reduceContextCta') as HTMLButtonElement;
+    expect(cta.disabled).toBe(true);
+
+    fireEvent.click(cta);
+    expect(onNewConversation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/runtime/amr-guidance.test.ts
+++ b/apps/web/tests/runtime/amr-guidance.test.ts
@@ -301,7 +301,6 @@ describe('resolveRunFailureUi', () => {
     const cases: Array<[string, string, string | null]> = [
       ['ARTIFACT_NOT_FOUND', 'chat.runError.title.artifactMissing', null],
       ['AGENT_UNAVAILABLE', 'chat.runError.title.cliMissing', 'chat.runError.cliMissingMessage'],
-      ['AGENT_PROMPT_TOO_LARGE', 'chat.runError.title.promptTooLarge', 'chat.runError.promptTooLargeMessage'],
       ['AMR_MODEL_UNAVAILABLE', 'chat.runError.title.modelUnavailable', 'chat.runError.modelUnavailableMessage'],
       ['TOOL_LOOP_DETECTED', 'chat.runError.title.toolLoop', 'chat.runError.toolLoopMessage'],
       ['ROLE_MARKER_HALLUCINATION', 'chat.runError.title.outputInvalid', 'chat.runError.outputInvalidMessage'],
@@ -315,6 +314,21 @@ describe('resolveRunFailureUi', () => {
           titleKey,
           messageKey,
           secondaryRetry: false,
+          showSwitchCard: false,
+        });
+      }
+    }
+  });
+
+  it('maps prompt-too-large root cause to reduce-context action (#4782)', () => {
+    for (const code of ['AGENT_PROMPT_TOO_LARGE', 'PROMPT_TOO_LARGE']) {
+      for (const agent of ['claude', 'codex', 'amr', 'antigravity', null]) {
+        const ui = resolveRunFailureUi(code, null, agent);
+        expect(ui).toMatchObject({
+          primaryAction: 'reduce-context',
+          titleKey: 'chat.runError.title.promptTooLarge',
+          messageKey: 'chat.runError.promptTooLargeMessage',
+          secondaryRetry: true,
           showSwitchCard: false,
         });
       }


### PR DESCRIPTION
Closes #4782

## Why

Follow-up to #4738 (drive the chat error-card CTA from the daemon `user_action`, reliability epic #3408 §5). The design review on #4738 approved the CTA set but flagged one non-blocking gap: the `prompt_too_large` / `reduce_context` failure card surfaced only a bare **Retry** button. Retry re-sends the *same* oversized context, so it fails again the same way — the card names the cause but offers no affordance toward the actual fix. Every other actionable state already gives a real next step (`switch_model` → switch model, `recharge` → top up, `login` → sign in), so `reduce_context` was the odd one out.

I picked this up off the issue (`/claim`); maintainer confirmed the direction and option (1) — a single "New conversation" CTA.

## What users will see

When a run fails because the prompt is too large, the gray error card now shows a primary **新建对话 / New conversation** button that starts a fresh conversation (the recovery path), with **Retry** demoted to the secondary slot it already occupied. Before, the same card showed only Retry.

## Surface area

- [x] **UI** — error card in `apps/web` gains a dedicated `reduce-context` primary CTA
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** — added `chat.runError.reduceContextCta` across all locales
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

Implementation notes: `amr-guidance.ts` already resolves `reduce_context` to `primaryAction: 'reduce-context'`, so no resolver logic changed — `ChatPane.tsx` just gains the matching render branch, wired to the existing `onNewConversation` prop. Retry stays available via the existing `secondaryRetry` path. New i18n key added to `types.ts` first, then all 18 locale files.

## Screenshots

Before / after of the `prompt_too_large` card (faithful recreation using the real `.run-error` card structure + tokens — see note below):

<!-- 拖拽 reduce-context-card-screenshot.png 到这里 -->
<img width="1120" height="1352" alt="reduce-context-card-screenshot" src="https://github.com/user-attachments/assets/f08d1a8e-8cf5-40cc-afe1-8540aeafc7ab" />


> Note on the screenshot: this is a faithful re-render of the actual card (same `.run-error` markup, classes, and token values from `apps/web/src/styles/chat.css`), not a mocked-up redesign. A live capture from a running instance wasn't practical — the BYOK provider I had on hand silently truncates over-long input instead of returning a context-length error, so the daemon never classifies `reduce_context`, and OD's 4 MB request-body cap blocks forcing it from the composer. The render wiring itself is covered by the red→green spec below.

## Validation

Run from the repo root unless noted:

- `pnpm --filter @open-design/web typecheck` — green (covers the new i18n key across all locales + the threaded `onOpenSettings` prop).
- Focused web suites (from `apps/web`, `npx vitest run -c vitest.config.ts <files>`):
  - `tests/components/ChatPane.reduce-context-cta.test.tsx` — 3 pass (new "New conversation" CTA wiring; red→green verified by stashing the `ChatPane.tsx` change).
  - `tests/components/ChatPane.switch-model-cta.test.tsx` — pass.
  - `tests/components/workspace/SideChatTab.test.tsx` — pass (regression: `onOpenSettings` + `onNewConversation` reach `ChatPane` on the side-chat mount).
  - `tests/runtime/amr-guidance.test.ts` — 20 pass (incl. the new Antigravity `RATE_LIMITED` + classified-`retry` regression case).
- Note: `pnpm guard` and the broader UI P0 e2e have pre-existing, unrelated failures on this Windows box / CI (stale `design-systems` token fixtures; an `amr-run-failure-recovery` e2e flaking on the privacy-consent banner intercepting pointer events) — confirmed present on `main`, not introduced here.

## Bug fix verification

- Test path: `apps/web/tests/components/ChatPane.reduce-context-cta.test.tsx`
- Red on `main`, green on this branch? **yes** (verified by stashing the `ChatPane.tsx` change — the spec fails without it, passes with it).
- The spec asserts the card renders the **New conversation** CTA wired to `onNewConversation`, keeps Retry as the secondary action, and disables the CTA when `newConversationDisabled` is set.

