### PR TITLE
fix(web): show the mark Queue action only while a run is active (#4367)

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -732,6 +732,14 @@ export function PreviewDrawOverlay({
   const activePreview = previewIndex !== null ? imagePreviews[previewIndex] ?? null : null;
   const canAddToInput = canSubmit;
   const canSend = canSubmit && !sendDisabled;
+  // The Queue action only differs from Send while a run is in flight: it stages
+  // the mark for the next turn. When the conversation is idle, queuing
+  // immediately drains and executes, so a standalone Queue control just
+  // duplicates Send and reads as a (non-existent) batch-hold — the confusion in
+  // #4367. Surface it only while sending is disabled, matching the comment
+  // composer (BoardComposerPopover), which gates Queue on the same state. To
+  // stage marks without sending at idle, the "add to input" action remains.
+  const showQueue = sendDisabled;
   const canUndo = (undoCount > 0 || hasBox) && !sending;
   const canRedo = redoCount > 0 && !sending;
   const chromeHidden = capturing || hideChrome;
@@ -1028,7 +1036,7 @@ export function PreviewDrawOverlay({
               }}
               onKeyDown={(e) => {
                 if (isImeComposing(e, composingRef.current)) return;
-                if (e.key === 'Enter') void send('queue');
+                if (e.key === 'Enter') void send(showQueue ? 'queue' : 'send');
               }}
             />
             <button
@@ -1051,26 +1059,28 @@ export function PreviewDrawOverlay({
                 <RemixIcon name="input-field" size={15} />
               )}
             </button>
-            <button
-              type="button"
-              onClick={() => void send('queue')}
-              disabled={sending || !canSubmit}
-              aria-label={pendingAction === 'queue' ? t('chat.annotationQueueing') : t('chat.annotationQueue')}
-              title={pendingAction === 'queue' ? t('chat.annotationQueueing') : t('chat.annotationQueue')}
-              data-tooltip={pendingAction === 'queue' ? t('chat.annotationQueueing') : t('chat.annotationQueue')}
-              className="preview-draw-icon-action"
-              style={{
-                ...drawActionButtonStyle(false),
-                opacity: canSubmit ? 1 : 0.4,
-                cursor: sending ? 'wait' : (canSubmit ? 'pointer' : 'not-allowed'),
-              }}
-            >
-              {pendingAction === 'queue' ? (
-                <Icon name="spinner" size={14} />
-              ) : (
-                <RemixIcon name="list-check-2" size={15} />
-              )}
-            </button>
+            {showQueue ? (
+              <button
+                type="button"
+                onClick={() => void send('queue')}
+                disabled={sending || !canSubmit}
+                aria-label={pendingAction === 'queue' ? t('chat.annotationQueueing') : t('chat.annotationQueue')}
+                title={pendingAction === 'queue' ? t('chat.annotationQueueing') : t('chat.annotationQueue')}
+                data-tooltip={pendingAction === 'queue' ? t('chat.annotationQueueing') : t('chat.annotationQueue')}
+                className="preview-draw-icon-action"
+                style={{
+                  ...drawActionButtonStyle(false),
+                  opacity: canSubmit ? 1 : 0.4,
+                  cursor: sending ? 'wait' : (canSubmit ? 'pointer' : 'not-allowed'),
+                }}
+              >
+                {pendingAction === 'queue' ? (
+                  <Icon name="spinner" size={14} />
+                ) : (
+                  <RemixIcon name="list-check-2" size={15} />
+                )}
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={() => void send('send')}

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -3139,7 +3139,7 @@ describe('FileViewer tweaks toolbar', () => {
     expect((await screen.findByRole('button', { name: 'Preview viewport' })).textContent).toContain('Tablet');
   });
 
-  it('keeps the Draw bar open after queueing an annotation', () => {
+  it('keeps the Draw bar open after submitting an annotation', () => {
     render(
       <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
         liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
@@ -3149,7 +3149,9 @@ describe('FileViewer tweaks toolbar', () => {
     clickAgentTool('draw-overlay-toggle');
     const note = screen.getByPlaceholderText('Add a note for this mark');
     fireEvent.change(note, { target: { value: 'mark this' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Queue' }));
+    // The conversation is idle here, so Send is the submit affordance — Queue
+    // only appears while a run is in flight (#4367).
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
 
     expect(screen.getByPlaceholderText('Add a note for this mark')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Click' })).toBeNull();

--- a/apps/web/tests/components/PreviewDrawOverlay.queue-idle.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.queue-idle.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+// Regression for #4367: the "Queue" action only does something distinct from
+// "Send" while a run is in flight — it stages the mark for the next turn. When
+// the conversation is idle, queuing immediately drains and executes, which is
+// indistinguishable from Send and misled users into expecting a batch-hold.
+// So the overlay must only surface Queue while sending is disabled (busy),
+// mirroring the comment composer (BoardComposerPopover), which only shows Queue
+// when sendDisabled. At idle, Send is the single submit affordance.
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PreviewDrawOverlay } from '../../src/components/PreviewDrawOverlay';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PreviewDrawOverlay queue affordance is busy-only (#4367)', () => {
+  it('hides Queue when the conversation is idle so it cannot be misread as a batch-hold', () => {
+    render(
+      <PreviewDrawOverlay active>
+        <div data-testid="content" />
+      </PreviewDrawOverlay>,
+    );
+
+    const note = document.querySelector('.preview-draw-note-input') as HTMLInputElement;
+    fireEvent.change(note, { target: { value: 'looks good' } });
+
+    // Send is the only submit affordance while idle...
+    const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+    expect(send.disabled).toBe(false);
+    // ...and there is no separate Queue button to confuse with an immediate send.
+    expect(screen.queryByRole('button', { name: 'Queue' })).toBeNull();
+  });
+
+  it('shows Queue only while sending is disabled (a run is in flight)', () => {
+    render(
+      <PreviewDrawOverlay active sendDisabled sendDisabledReason="Task running">
+        <div data-testid="content" />
+      </PreviewDrawOverlay>,
+    );
+
+    const note = document.querySelector('.preview-draw-note-input') as HTMLInputElement;
+    fireEvent.change(note, { target: { value: 'looks good' } });
+
+    const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+    const queue = screen.getByRole('button', { name: 'Queue' }) as HTMLButtonElement;
+    // Send is held (cannot run mid-task) and Queue takes over to stage for the next turn.
+    expect(send.disabled).toBe(true);
+    expect(queue.disabled).toBe(false);
+  });
+
+  it('routes the Enter shortcut to Queue while a run is in flight', async () => {
+    const annotation = vi.fn();
+    window.addEventListener('opendesign:annotation', annotation);
+    try {
+      render(
+        <PreviewDrawOverlay active sendDisabled sendDisabledReason="Task running">
+          <div data-testid="content" />
+        </PreviewDrawOverlay>,
+      );
+
+      const note = document.querySelector('.preview-draw-note-input') as HTMLInputElement;
+      fireEvent.change(note, { target: { value: 'stage this for next turn' } });
+      fireEvent.keyDown(note, { key: 'Enter' });
+
+      // Send is disabled mid-run, so Enter must stage via Queue rather than no-op.
+      await waitFor(() => expect(annotation).toHaveBeenCalledTimes(1));
+      expect(annotation.mock.calls[0]?.[0].detail).toMatchObject({
+        action: 'queue',
+        note: 'stage this for next turn',
+      });
+    } finally {
+      window.removeEventListener('opendesign:annotation', annotation);
+    }
+  });
+});

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -106,7 +106,10 @@ describe('PreviewDrawOverlay', () => {
     expect(input?.style.maxWidth).toBe('100%');
   });
 
-  it('queues a note when Enter submits from the draw input', async () => {
+  it('submits a note via the primary Send action when Enter is pressed while idle', async () => {
+    // Enter maps to the primary submit, which is Send while idle — Queue only
+    // exists while a run is in flight (#4367), so Enter must not route through
+    // the now-hidden queue path at idle.
     const annotation = vi.fn();
     window.addEventListener('opendesign:annotation', annotation);
 
@@ -125,7 +128,7 @@ describe('PreviewDrawOverlay', () => {
 
       await waitFor(() => expect(annotation).toHaveBeenCalledTimes(1));
       expect(annotation.mock.calls[0]?.[0].detail).toMatchObject({
-        action: 'queue',
+        action: 'send',
         note: 'Please inspect this panel.',
       });
     } finally {


### PR DESCRIPTION
Supersedes #4370 — rebased onto the latest main. The original was approved but auto-closed for inactivity; the rebase force-pushed the branch, which makes GitHub refuse to reopen it, so this re-files the same change.

Fixes #4367

## Why

I was looking for a well-scoped bug to fix and picked this fresh, unclaimed report. A first-time reporter expected the Mark overlay's "Queue" / "加入队列" button to collect multiple annotations and send them together, but clicking it while the conversation was idle executed the mark immediately — looking exactly like Send. The maintainer confirmed this is a real UX/semantics problem (the button means "add to the chat queue and auto-run when idle", so an idle queue drains instantly) and suggested either relabeling the button or building a real batch flow.

Rather than relabel (which leaves the idle redundancy in place) or build a new batch feature (out of scope for a bug fix), this aligns the Mark overlay with the pattern already used everywhere else: the comment composer (`BoardComposerPopover`) only surfaces "Queue" when the conversation is busy (`queueOnSend = sendDisabled`). The Mark overlay was the lone exception that showed a standalone Queue button at all times. Queuing only does anything distinct from Send while a run is in flight (it stages the mark for the next turn), so at idle a separate Queue control is pure redundancy and the source of the confusion.

## What users will see

In the artifact preview's Mark (annotation) toolbar, the "Queue" button now appears only while a run is active — i.e. when Send is held because the agent is busy, Queue takes over to stage the mark for the next turn. When the conversation is idle there is no separate Queue button: you Send the mark, or use "Add to input" to stack it into the composer without sending (which is how you collect several marks before sending). Pressing Enter in the note field follows the same rule — it sends while idle and queues while a run is active.

## Surface area

- [x] **UI** — the Mark overlay no longer shows a standalone Queue button at idle
- [x] **Keyboard shortcut** — Enter in the mark-note field now maps to Send while idle / Queue while busy (previously always Queue)
- [x] **Default behavior change** — existing users will notice the Queue button is gone from the idle Mark toolbar

CLI: not applicable — this is interactive web-preview composer behavior; the `od` CLI does not render the Mark overlay, so there is no CLI surface to mirror.

## Screenshots

Idle Mark toolbar — **before** (Queue button present, indistinguishable from Send):

<img width="1280" alt="before — idle Mark toolbar shows the Queue button" src="https://github.com/user-attachments/assets/1ce6f640-6b75-4009-aa16-22b8cbe503d9" />

Idle Mark toolbar — **after** (Queue hidden; only Add-to-input + Send remain):

<img width="1280" alt="after — idle Mark toolbar without the Queue button" src="https://github.com/user-attachments/assets/c48a7a49-f4aa-4ef5-8560-b5d6c108be6f" />

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/PreviewDrawOverlay.queue-idle.test.tsx`
- Did the test go red on `main` and green on this branch? **yes** — the "hides Queue when idle" assertion fails on `main` (Queue is always rendered) and passes after gating it on `sendDisabled`. The busy-state path (Queue present, Send held) stays green, and the existing e2e `app-manual-edit` flow that queues a mark while a run is held open is unaffected.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web exec vitest run tests/components/PreviewDrawOverlay tests/components/FileViewer.test.tsx tests/components/BoardComposerPopover.queue-on-busy.test.tsx` — pass (one unrelated pre-existing slow test, `allows downloads in the in-tab HTML presentation iframe`, times out at the default 5s and passes at `--testTimeout=30000`)

