### PR TITLE
feat(media): add Pollinations as a free, no-key image provider

### DIFF
--- a/apps/daemon/src/media/config.ts
+++ b/apps/daemon/src/media/config.ts
@@ -108,6 +108,9 @@ const ENV_KEYS: Record<string, string[]> = {
   aihubmix: ['OD_AIHUBMIX_API_KEY', 'AIHUBMIX_API_KEY'],
   tavily: ['OD_TAVILY_API_KEY', 'TAVILY_API_KEY'],
   leonardo: ['OD_LEONARDO_API_KEY', 'LEONARDO_API_KEY'],
+  // Pollinations works anonymously with no key; a publishable pk_ key
+  // (POLLINATIONS_API_KEY) only raises rate limits.
+  pollinations: ['OD_POLLINATIONS_API_KEY', 'POLLINATIONS_API_KEY'],
 };
 
 // Resolve an `OD_*_DIR` env override using the same semantics as

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -629,6 +629,11 @@ export async function generateMedia(args: {
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'pollinations' && surface === 'image') {
+      const result = await renderPollinationsImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
     } else if (def.provider === 'imagerouter' && surface === 'image') {
       const result = await renderImageRouterImage(ctx, credentials);
       bytes = result.bytes;
@@ -827,6 +832,61 @@ function defaultAspectFor(surface: MediaSurface): string | undefined {
   if (surface === 'image') return '1:1';
   if (surface === 'video') return '16:9';
   return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Provider: Pollinations (free, no API key)
+//
+// Pollinations serves an image from a plain GET URL:
+//   https://image.pollinations.ai/prompt/<encoded prompt>?width=&height=&model=&nologo=true
+// The anonymous tier needs no key. When a publishable key is configured it is
+// sent as a Bearer token to raise rate limits. This is the one no-key image
+// provider in the catalog, so it gives every user a free image path.
+// ---------------------------------------------------------------------------
+const POLLINATIONS_SIZES: Record<string, { width: number; height: number }> = {
+  '1:1': { width: 1024, height: 1024 },
+  '4:5': { width: 1024, height: 1280 },
+  '3:4': { width: 1024, height: 1365 },
+  '9:16': { width: 1024, height: 1820 },
+  '16:9': { width: 1280, height: 720 },
+  '1.91:1': { width: 1280, height: 670 },
+};
+
+async function renderPollinationsImage(
+  ctx: MediaContext,
+  credentials: ProviderConfig,
+): Promise<RenderResult> {
+  const size =
+    (ctx.aspect ? POLLINATIONS_SIZES[ctx.aspect] : undefined) || { width: 1024, height: 1024 };
+  // Map the catalog id (e.g. `pollinations-flux`) to the Pollinations model name.
+  const wire = ctx.wireModel || ctx.model || 'pollinations-flux';
+  const model = wire.replace(/^pollinations-/, '') || 'flux';
+  const prompt = ctx.prompt || 'A clean, high-quality image.';
+  const base = (credentials.baseUrl || 'https://image.pollinations.ai').replace(/\/+$/, '');
+  const params = new URLSearchParams({
+    width: String(size.width),
+    height: String(size.height),
+    model,
+    nologo: 'true',
+    referrer: 'open-design',
+  });
+  const url = `${base}/prompt/${encodeURIComponent(prompt)}?${params.toString()}`;
+  const headers: Record<string, string> = {};
+  if (credentials.apiKey) headers.Authorization = `Bearer ${credentials.apiKey}`;
+  const res = await fetch(url, withMediaRequestInit(ctx, { headers }));
+  if (!res.ok) {
+    const detail = (await res.text().catch(() => '')).slice(0, 200);
+    throw new Error(`pollinations ${res.status}: ${detail}`);
+  }
+  const bytes = Buffer.from(await res.arrayBuffer());
+  const contentType = res.headers.get('content-type') || '';
+  const suggestedExt = contentType.includes('png') ? '.png' : '.jpg';
+  const kb = Math.round(bytes.length / 1024);
+  return {
+    bytes,
+    providerNote: `pollinations/${model} · ${size.width}x${size.height} · ${kb} KB`,
+    suggestedExt,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -873,13 +873,28 @@ async function renderPollinationsImage(
   const url = `${base}/prompt/${encodeURIComponent(prompt)}?${params.toString()}`;
   const headers: Record<string, string> = {};
   if (credentials.apiKey) headers.Authorization = `Bearer ${credentials.apiKey}`;
-  const res = await fetch(url, withMediaRequestInit(ctx, { headers }));
-  if (!res.ok) {
-    const detail = (await res.text().catch(() => '')).slice(0, 200);
-    throw new Error(`pollinations ${res.status}: ${detail}`);
+  // Pollinations occasionally answers 200 with an empty body for an otherwise
+  // valid request (we have seen this on the landscape aspects). Returning those
+  // bytes would persist a zero-byte file while reporting success, so retry once
+  // and reject the response if it still comes back empty.
+  let bytes = Buffer.alloc(0);
+  let contentType = '';
+  let lastStatus = 0;
+  for (let attempt = 0; attempt < 2 && bytes.length === 0; attempt++) {
+    const res = await fetch(url, withMediaRequestInit(ctx, { headers }));
+    lastStatus = res.status;
+    if (!res.ok) {
+      const detail = (await res.text().catch(() => '')).slice(0, 200);
+      throw new Error(`pollinations ${res.status}: ${detail}`);
+    }
+    bytes = Buffer.from(await res.arrayBuffer());
+    contentType = res.headers.get('content-type') || '';
   }
-  const bytes = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get('content-type') || '';
+  if (bytes.length === 0) {
+    throw new Error(
+      `pollinations ${lastStatus}: empty image response for ${size.width}x${size.height}`,
+    );
+  }
   const suggestedExt = contentType.includes('png') ? '.png' : '.jpg';
   const kb = Math.round(bytes.length / 1024);
   return {

--- a/apps/daemon/src/media/models.ts
+++ b/apps/daemon/src/media/models.ts
@@ -19,6 +19,7 @@ export type MediaProvider = {
   settingsVisible?: boolean;
   supportsCustomModel?: boolean;
   customModelPlaceholder?: string;
+  optionalApiKey?: boolean;
 };
 
 export type MediaModel = {
@@ -37,6 +38,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   { id: 'grok', label: 'xAI Grok Imagine', hint: 'grok-imagine — image + video with native audio', integrated: true, defaultBaseUrl: 'https://api.x.ai/v1' },
   { id: 'hyperframes', label: 'HyperFrames', hint: 'Local HTML -> MP4 renderer', integrated: true, credentialsRequired: false, settingsVisible: false },
   { id: 'nanobanana', label: 'Nano Banana', hint: 'Google official by default; custom gateway configurable', integrated: true, defaultBaseUrl: 'https://generativelanguage.googleapis.com', supportsCustomModel: true },
+  { id: 'pollinations', label: 'Pollinations', hint: 'Free, no key (Flux); optional pk_ key raises limits', integrated: true, credentialsRequired: false, optionalApiKey: true, settingsVisible: true, defaultBaseUrl: 'https://image.pollinations.ai', docsUrl: 'https://pollinations.ai' },
   { id: 'imagerouter', label: 'ImageRouter', hint: 'OpenAI-compatible image + video routing', integrated: true, defaultBaseUrl: 'https://api.imagerouter.io/v1/openai', docsUrl: 'https://docs.imagerouter.io/api-reference/image-generation/', supportsCustomModel: true, customModelPlaceholder: 'openai/gpt-image-2 or xAI/grok-imagine-video' },
   { id: 'openrouter', label: 'OpenRouter', hint: 'Unified gateway for image + video models', integrated: true, credentialsRequired: true, settingsVisible: true, defaultBaseUrl: 'https://openrouter.ai/api/v1', docsUrl: 'https://openrouter.ai/settings/keys' },
   { id: 'custom-image', label: 'Custom Image API', hint: 'OpenAI-compatible images/generations + images/edits (local or cloud)', integrated: true, docsUrl: 'https://platform.openai.com/docs/api-reference/images', supportsCustomModel: true, customModelPlaceholder: 'my-image-model' },
@@ -91,6 +93,7 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'gpt-image-1-mini', label: 'gpt-image-1-mini', hint: 'OpenAI · low-cost variant', provider: 'openai', caps: ['t2i', 'i2i'] },
   { id: 'dall-e-3', label: 'dall-e-3', hint: 'OpenAI · classic', provider: 'openai', caps: ['t2i'] },
   { id: 'dall-e-2', label: 'dall-e-2', hint: 'OpenAI · legacy', provider: 'openai', caps: ['t2i'] },
+  { id: 'pollinations-flux', label: 'Pollinations Flux', hint: 'Free · no API key · Flux', provider: 'pollinations', caps: ['t2i'] },
   { id: 'codex-gpt-image-2', label: 'gpt-image-2 (Codex)', hint: 'Codex Subscription · local CLI imagegen', provider: 'codex', caps: ['t2i', 'i2i'] },
 
   { id: 'doubao-seedream-3-0-t2i-250415', label: 'seedream-3.0', hint: 'ByteDance · Doubao image', provider: 'volcengine', caps: ['t2i'] },

--- a/apps/daemon/tests/media/pollinations.test.ts
+++ b/apps/daemon/tests/media/pollinations.test.ts
@@ -1,0 +1,135 @@
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateMedia } from '../../src/media/index.js';
+
+// 1x1 transparent PNG.
+const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+
+describe('pollinations media generation', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const realFetch = globalThis.fetch;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+  const originalDataDir = process.env.OD_DATA_DIR;
+  const originalKey = process.env.OD_POLLINATIONS_API_KEY;
+  const originalKeyAlt = process.env.POLLINATIONS_API_KEY;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-pollinations-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(projectsRoot, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
+    delete process.env.OD_POLLINATIONS_API_KEY;
+    delete process.env.POLLINATIONS_API_KEY;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    const restore = (name: string, value: string | undefined) => {
+      if (value == null) delete process.env[name];
+      else process.env[name] = value;
+    };
+    restore('OD_MEDIA_CONFIG_DIR', originalMediaConfigDir);
+    restore('OD_DATA_DIR', originalDataDir);
+    restore('OD_POLLINATIONS_API_KEY', originalKey);
+    restore('POLLINATIONS_API_KEY', originalKeyAlt);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('renders an image with no key on the 16:9 aspect', async () => {
+    let calledUrl = '';
+    let sentAuth: unknown;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      calledUrl = String(input);
+      sentAuth = (init?.headers as Record<string, string> | undefined)?.Authorization;
+      return new Response(Buffer.from(PNG_BASE64, 'base64'), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'pollinations-flux',
+      prompt: 'A calm landscape, minimal photography',
+      aspect: '16:9',
+      output: 'poll.png',
+    });
+
+    expect(calledUrl.startsWith('https://image.pollinations.ai/prompt/')).toBe(true);
+    expect(calledUrl).toContain('width=1280');
+    expect(calledUrl).toContain('height=720');
+    expect(calledUrl).toContain('model=flux');
+    // Free anonymous tier: no Authorization header when no key is configured.
+    expect(sentAuth).toBeUndefined();
+
+    expect(result.providerId).toBe('pollinations');
+    expect(result.providerNote).toContain('pollinations/flux');
+    expect(result.providerNote).toContain('1280x720');
+
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'poll.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a zero-byte 200 response instead of writing an empty file', async () => {
+    const fetchMock = vi.fn(async () => new Response(new Uint8Array(0), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'pollinations-flux',
+      prompt: 'A calm landscape, minimal photography',
+      aspect: '16:9',
+      output: 'empty.jpg',
+    })).rejects.toThrow(/pollinations .*empty image response/i);
+
+    // It should have retried once before giving up (two attempts total).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // No zero-byte artifact should have been persisted.
+    await expect(readFile(path.join(projectsRoot, 'project-1', 'empty.jpg')))
+      .rejects.toThrow();
+  });
+
+  it('sends an Authorization Bearer header when an optional key is configured', async () => {
+    process.env.OD_POLLINATIONS_API_KEY = 'pk-test-key';
+    let sentAuth: unknown;
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      sentAuth = (init?.headers as Record<string, string> | undefined)?.Authorization;
+      return new Response(Buffer.from(PNG_BASE64, 'base64'), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'pollinations-flux',
+      prompt: 'A calm landscape, minimal photography',
+      aspect: '1:1',
+      output: 'keyed.png',
+    });
+
+    expect(sentAuth).toBe('Bearer pk-test-key');
+  });
+});

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -6497,6 +6497,10 @@ function MediaProvidersSection({
           const disabled = false;
           const supportsCustomModel = provider.supportsCustomModel === true;
           const requiresCredentials = provider.credentialsRequired !== false;
+          // Some providers work with no key (free tier) but accept an optional
+          // key for higher limits. Show the key field for those too, without
+          // marking them as requiring credentials (so they stay picker-ready).
+          const showApiKeyFields = requiresCredentials || provider.optionalApiKey === true;
           const clearable = isStoredMediaProviderEntryPresent(entry);
           const apiKeyVisible = visibleApiKeys.has(provider.id);
           return (
@@ -6538,7 +6542,7 @@ function MediaProvidersSection({
                 */}
               </div>
               {provider.id === 'grok' ? <XaiOAuthControl /> : null}
-              {requiresCredentials ? (
+              {showApiKeyFields ? (
                 <div className="media-provider-body">
                   <div className="media-provider-secret-field">
                     <input

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -34,6 +34,7 @@ export type MediaProviderId =
   | 'grok'
   | 'hyperframes'
   | 'nanobanana'
+  | 'pollinations'
   | 'imagerouter'
   | 'openrouter'
   | 'custom-image'
@@ -75,6 +76,8 @@ export interface MediaProvider {
   supportsCustomModel?: boolean;
   /** Placeholder text for custom model override fields in Settings. */
   customModelPlaceholder?: string;
+  /** Show a key field in Settings even though a key is not required (free tier works without one). */
+  optionalApiKey?: boolean;
 }
 
 /**
@@ -133,6 +136,17 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     defaultBaseUrl: 'https://generativelanguage.googleapis.com',
     docsUrl: 'https://ai.google.dev/gemini-api/docs/api-key',
     supportsCustomModel: true,
+  },
+  {
+    id: 'pollinations',
+    label: 'Pollinations',
+    hint: 'Free, no key (Flux); optional pk_ key raises limits',
+    integrated: true,
+    credentialsRequired: false,
+    optionalApiKey: true,
+    settingsVisible: true,
+    defaultBaseUrl: 'https://image.pollinations.ai',
+    docsUrl: 'https://pollinations.ai',
   },
   {
     id: 'imagerouter',
@@ -368,6 +382,13 @@ export const IMAGE_MODELS: MediaModel[] = [
     label: 'dall-e-2',
     hint: 'OpenAI · legacy',
     provider: 'openai',
+    caps: ['t2i'],
+  },
+  {
+    id: 'pollinations-flux',
+    label: 'Pollinations Flux',
+    hint: 'Free · no API key · Flux',
+    provider: 'pollinations',
     caps: ['t2i'],
   },
   {


### PR DESCRIPTION
<div align="center">

# Pollinations: a free, no-key image provider

**Generate images out of the box, with zero setup and no API key.**

<sub>

`media` · `byok` · `image` · `daemon` + `web`

</sub>

</div>

---

## Why

I was building image-heavy content in OD and kept hitting the same wall: every image provider in the gallery needs a key before it produces a single pixel. Pollinations already ships in the repo as an MCP server and its public Flux endpoint works anonymously, but it was never wired up as a media provider, so the one source that needs no account at all could not be picked from the gallery. This makes it a first-class provider so a brand-new user can generate an image immediately, and anyone who wants higher limits can paste an optional publishable `pk_` key.

## What users will see

- **Settings -> Media providers** gains a **Pollinations** row. It is usable straight away with **no API key** (free Flux tier), and it has an optional **Paste API key** field for people who want higher rate limits with a `pk_` key. Leave it blank for the free anonymous tier.
- The image **model picker** gains a **Pollinations Flux** option that generates with zero setup.
- No existing provider or default changes; this is purely additive.

## Surface area

- [x] **UI** — new setting in `apps/web` (Pollinations row + optional key field in Media providers)
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — new `OD_POLLINATIONS_API_KEY` / `POLLINATIONS_API_KEY` env var (optional key)
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — reuses existing `settings.mediaProvider*` keys, none added
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## How it works

```mermaid
flowchart LR
    A[od media generate<br/>--model pollinations-flux] --> B[dispatcher<br/>media/index.ts]
    B --> C[renderPollinationsImage]
    C --> D[GET image.pollinations.ai/prompt/...<br/>width · height · model · nologo]
    D --> E[image bytes -> artifact]
    K[optional pk_ key<br/>Settings or POLLINATIONS_API_KEY] -. Bearer .-> C
```

- New provider + model in both media registries (daemon and web), kept in sync.
- Renderer maps the requested aspect ratio to Pollinations dimensions and sends the optional key as a `Bearer` token only when one is present.
- Provider is `credentialsRequired: false` so it is selectable with no setup, plus a new `optionalApiKey` flag so the row still shows a key field for the optional `pk_` key.

## Screenshots
<img width="686" height="858" alt="pollinations-generated" src="https://github.com/user-attachments/assets/acc45ca7-ce80-4577-8024-5f89a50bc86a" />
<img width="1920" height="937" alt="pollinations-key-field" src="https://github.com/user-attachments/assets/2efcd5c8-d6e8-4f9e-b859-721987aae0f9" />

## Bug fix verification

A reviewer flagged that Pollinations can answer HTTP 200 with an empty body, which the first cut of the renderer would have persisted as a zero-byte file while reporting success.

- Test path: `apps/daemon/tests/media/pollinations.test.ts`
- The renderer is new in this PR, so there is no `main` baseline. The zero-byte test fails against the pre-fix renderer (which only checked `res.ok`) and passes after the guard. The empty-body behavior itself was confirmed against the live `image.pollinations.ai` endpoint.
- Fix: retry once, then throw `pollinations <status>: empty image response ...` instead of returning empty bytes.

## Validation

| Check | Result |
|---|---|
| `verify-media-models.mjs` (TS + JS registries match) | ✅ OK |
| web `tsc -b --noEmit` | ✅ clean |
| daemon `typecheck` | ✅ clean |
| daemon tests `tests/media/pollinations.test.ts` | ✅ 3 passing (16:9 no-key, zero-byte rejection + retry, optional key header) |
| Live generate, no key, 4:5 | ✅ real `1024x1280` JPEG, `usedStubFallback: false` |
| Live Settings UI | ✅ Pollinations selectable, optional key field renders |
