### PR TITLE
Add MotoChefe Design System plugin

### DIFF
--- a/plugins/community/motochefe-design-system-mquaxx0c/SKILL.md
+++ b/plugins/community/motochefe-design-system-mquaxx0c/SKILL.md
@@ -1,0 +1,140 @@
+# MotoChefe Design System
+
+> A reusable Claude Design-style package for the MotoChefe electric mobility brand.
+> Source: https://motochefebrasil.com.br/
+
+## Product Overview
+
+**MotoChefe** is Brazil's leading electric mobility brand — a national manufacturer of electric scooters, cyclomotors, tricycles, and e-bikes founded in 2019. Headquartered in the Zona Franca de Manaus, MotoChefe operates 70+ owned stores and 310+ dealer points across 20+ Brazilian states. The brand is the official sponsor of Clube de Regatas Vasco da Gama and has celebrity endorsements from Diego Ribas and Ronaldinho Gaúcho.
+
+**Primary UI surfaces:** Marketing website (product showcase, franchise pitch, store locator), e-commerce product pages, dealer portal, customer support/Club MotoChefe app.
+
+**Core capabilities:** Electric vehicle manufacturing, national franchise network, exclusive battery insurance program, 35+ vehicle models across 4 categories (Autopropelidos, Ciclomotor, Triciclos, E-Bikes).
+
+## Source and Context References
+
+| Source | Method | Notes |
+|---|---|---|
+| https://motochefebrasil.com.br/ | Live website fetch | Homepage, /modelos/, /sobre/ — primary evidence |
+| Elementor Kit CSS | Inline `<style>` extraction | Color tokens, typography, layout variables |
+| SVG logo files | Direct asset download | Ativo_blck_1.svg, Ativo_wht_1.svg |
+| OG image | Direct asset download | icone_motochefe.png (528×528) |
+| `context/github/motochefebrasil/files/` | Extracted snapshots | CSS tokens, font inventory, component patterns |
+
+All color hex values extracted from Elementor kit CSS (`--e-global-color-*` variables) and inline `<style>` blocks. Typography extracted from Elementor kit global typography settings. No GitHub repository was available — all evidence sourced from the live production website.
+
+## Package Contents
+
+```
+ds-motochefebrasil-design-system/
+├── DESIGN.md                  # Canonical design rules (9 sections)
+├── README.md                  # This file — package guide
+├── SKILL.md                   # Agent-usable skill entry with YAML frontmatter
+├── colors_and_type.css        # Reusable CSS tokens + typography (100+ properties)
+├── context/
+│   ├── source-context.md      # Source evidence and intake notes
+│   └── github/
+│       ├── github-repository.md
+│       └── motochefebrasil/files/
+│           ├── css-tokens.md
+│           ├── font-inventory.md
+│           └── component-patterns.md
+├── assets/
+│   ├── logo-black.svg         # Wordmark — black variant (for light bg)
+│   ├── logo-white.svg         # Wordmark — white variant (for dark bg)
+│   └── icon-motochefe.png     # App/OG icon (528×528, MC motorcycle)
+├── build/
+│   ├── logo.svg               # Runtime logo (copy of logo-black.svg)
+│   └── icon.png               # Runtime icon (copy of icon-motochefe.png)
+├── preview/
+│   ├── colors-primary.html    # Full brand color swatches
+│   ├── colors-theme-light.html # Light & dark theme comparison
+│   ├── typography-specimens.html # Font families + type scale
+│   ├── spacing-tokens.html    # Spacing, radius, shadow tokens
+│   ├── brand-assets.html      # Logo/icon/gradient asset gallery
+│   └── components-buttons.html # Buttons, cards, nav, footer, stats
+├── source_examples/
+│   └── (extracted component snapshots from live site)
+└── ui_kits/
+    └── app/
+        ├── index.html         # Runnable app shell demo (React + Babel)
+        ├── README.md          # Kit structure + usage guide
+        └── components/
+            └── App.jsx        # Full marketing page: Header → Hero → Stats → Products → Reasons → Footer
+```
+
+## Preview Manifest
+
+| Preview Card | Path | What to Inspect |
+|---|---|---|
+| Brand Colors | `preview/colors-primary.html` | Gold palette (`#DBB42C`), neutrals (`#090909`, `#1F1F1F`, `#2E2E2E`), functional colors (`#3D9CD2`, `#D63939`, `#FFBC7D`), dark mode overlays |
+| Theme Comparison | `preview/colors-theme-light.html` | Light vs dark mode side-by-side with real MotoChefe content — shows how tokens adapt across themes |
+| Typography | `preview/typography-specimens.html` | 5 font families (Bebas Neue, Be Vietnam Pro, Outfit, Playfair Display, Roboto Slab), full type scale h1–small, weight/size/line-height |
+| Spacing & Radius | `preview/spacing-tokens.html` | 8-step spacing scale (4px–100px), 5 radius values (8px–9999px), 4 shadow levels (sm–glass) |
+| Brand Assets | `preview/brand-assets.html` | Logo SVGs (black/white variants loaded via `<img>`), app icon PNG, gold gradient, stat badge |
+| Components | `preview/components-buttons.html` | Buttons (primary/secondary/ghost), badges, product cards, stat cards, nav bar, footer — all using `--mc-*` tokens |
+
+## Preserved Assets
+
+- `assets/logo-black.svg` — MotoChefe wordmark, black variant for light backgrounds (downloaded from WordPress media uploads)
+- `assets/logo-white.svg` — MotoChefe wordmark, white variant for dark backgrounds
+- `assets/icon-motochefe.png` — App/OG icon, 528×528px, motorcycle illustration
+- `build/logo.svg` — Runtime copy of logo-black.svg for downstream projects
+- `build/icon.png` — Runtime copy of icon-motochefe.png for downstream projects
+
+## UI Kit
+
+The `ui_kits/app/` directory contains a runnable marketing page demo built with React + Babel:
+
+- **Entry**: `ui_kits/app/index.html` — loads React 18.3.1, ReactDOM, Babel standalone, `../../colors_and_type.css`, and all component scripts
+- **Components**: `ui_kits/app/components/App.jsx` — 6 components (Header, Hero, Stats, ProductCategories, SixReasons, Footer) exposed as `window.*` globals
+- **Design notes**: All components use `--mc-*` CSS custom properties, gold pill buttons, 24px radius cards, Bebas Neue display stats, alternating light/dark sections
+- **Source basis**: Components modeled directly after the live production site at motochefebrasil.com.br
+
+## Reuse Workflow
+
+1. **Read `DESIGN.md`** for the full visual system rules, anti-patterns, and voice guidelines — this is the canonical source of truth
+2. **Import `colors_and_type.css`** into any HTML/React project — it provides all CSS custom properties (`--mc-*`), Google Fonts imports, base resets, heading styles, dark mode overrides, and utility classes
+3. **Check `preview/`** cards for visual reference on how tokens render in practice
+4. **Use `assets/`** for logo SVGs (`logo-black.svg`, `logo-white.svg`) and app icon (`icon-motochefe.png`)
+5. **Use `build/`** for runtime copies when downstream projects expect a `build/` directory
+6. **Refer to `source_examples/`** for real component implementation patterns extracted from the live site
+7. **Refer to `ui_kits/app/`** for an applied marketing page example using the token system
+8. **Consult `context/`** for source evidence notes, CSS token extraction details, and component pattern documentation
+
+## Quick Start
+
+```html
+<link rel="stylesheet" href="colors_and_type.css">
+
+<style>
+  .my-component {
+    background: var(--mc-gold);
+    color: var(--mc-black);
+    border-radius: var(--mc-radius-pill);
+    font-family: var(--mc-font-heading);
+    padding: var(--mc-space-md) var(--mc-space-xl);
+  }
+</style>
+```
+
+## Design System Highlights
+
+- **Gold + Black palette**: `#DBB42C` (gold accent) + `#090909` (near-black) + `#FFFFFF` — premium automotive feel
+- **5 font families**: Bebas Neue (display), Be Vietnam Pro (headings/body), Outfit (UI), Playfair Display (accent italic), Roboto Slab (serif)
+- **24px radius cards**, 9999px pill buttons, glassmorphism on dark surfaces only
+- **1280px max container**, Bootstrap grid, 576/768/1024px breakpoints
+- **Alternating light/dark sections** for visual rhythm
+- **Motion**: 150ms micro / 300ms standard / 600ms dramatic, all respecting `prefers-reduced-motion`
+
+## Provenance Notes
+
+- All color hex values extracted from Elementor kit CSS (`--e-global-color-*` variables) and inline `<style>` blocks on the live site.
+- Typography extracted from Elementor kit global typography settings and heading declarations.
+- Spacing, radius, and shadow values observed from component CSS across homepage, models, and about pages.
+- Logo SVGs downloaded directly from WordPress media uploads (wp-content/uploads/2025/10/).
+- No GitHub repository was available — all evidence sourced from the live production website.
+
+## Provenance
+
+Formalized by Open Design from candidate 8ab24c93-ac30-497c-8375-de59dfc68176.

--- a/plugins/community/motochefe-design-system-mquaxx0c/open-design.json
+++ b/plugins/community/motochefe-design-system-mquaxx0c/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "motochefe-design-system-mquaxx0c",
+  "title": "MotoChefe Design System",
+  "version": "0.1.0",
+  "description": "> A reusable Claude Design-style package for the MotoChefe electric mobility brand. > Source: https://motochefebrasil.com.br/",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/motochefe-design-system-mquaxx0c/references/provenance.json
+++ b/plugins/community/motochefe-design-system-mquaxx0c/references/provenance.json
@@ -1,0 +1,40 @@
+{
+  "candidateId": "8ab24c93-ac30-497c-8375-de59dfc68176",
+  "projectId": "ds-motochefebrasil-design-system",
+  "runId": "634f2eef-8862-455a-a1f9-277fd1e8b862",
+  "conversationId": "04fc874e-1536-431b-8028-11aa01a9b102",
+  "provenance": {
+    "summary": "Detected from README.md, SKILL.md, ui_kits/app/README.md, context/source-context.md after a successful run.",
+    "detectedAt": 1782440210296
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 8525,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 7053,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "ui_kits/app/README.md",
+      "label": "ui_kits/app/README.md",
+      "size": 6026,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 10614,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/motochefe-design-system-mquaxx0c/references/source-1-README.md
+++ b/plugins/community/motochefe-design-system-mquaxx0c/references/source-1-README.md
@@ -1,0 +1,136 @@
+# MotoChefe Design System
+
+> A reusable Claude Design-style package for the MotoChefe electric mobility brand.
+> Source: https://motochefebrasil.com.br/
+
+## Product Overview
+
+**MotoChefe** is Brazil's leading electric mobility brand — a national manufacturer of electric scooters, cyclomotors, tricycles, and e-bikes founded in 2019. Headquartered in the Zona Franca de Manaus, MotoChefe operates 70+ owned stores and 310+ dealer points across 20+ Brazilian states. The brand is the official sponsor of Clube de Regatas Vasco da Gama and has celebrity endorsements from Diego Ribas and Ronaldinho Gaúcho.
+
+**Primary UI surfaces:** Marketing website (product showcase, franchise pitch, store locator), e-commerce product pages, dealer portal, customer support/Club MotoChefe app.
+
+**Core capabilities:** Electric vehicle manufacturing, national franchise network, exclusive battery insurance program, 35+ vehicle models across 4 categories (Autopropelidos, Ciclomotor, Triciclos, E-Bikes).
+
+## Source and Context References
+
+| Source | Method | Notes |
+|---|---|---|
+| https://motochefebrasil.com.br/ | Live website fetch | Homepage, /modelos/, /sobre/ — primary evidence |
+| Elementor Kit CSS | Inline `<style>` extraction | Color tokens, typography, layout variables |
+| SVG logo files | Direct asset download | Ativo_blck_1.svg, Ativo_wht_1.svg |
+| OG image | Direct asset download | icone_motochefe.png (528×528) |
+| `context/github/motochefebrasil/files/` | Extracted snapshots | CSS tokens, font inventory, component patterns |
+
+All color hex values extracted from Elementor kit CSS (`--e-global-color-*` variables) and inline `<style>` blocks. Typography extracted from Elementor kit global typography settings. No GitHub repository was available — all evidence sourced from the live production website.
+
+## Package Contents
+
+```
+ds-motochefebrasil-design-system/
+├── DESIGN.md                  # Canonical design rules (9 sections)
+├── README.md                  # This file — package guide
+├── SKILL.md                   # Agent-usable skill entry with YAML frontmatter
+├── colors_and_type.css        # Reusable CSS tokens + typography (100+ properties)
+├── context/
+│   ├── source-context.md      # Source evidence and intake notes
+│   └── github/
+│       ├── github-repository.md
+│       └── motochefebrasil/files/
+│           ├── css-tokens.md
+│           ├── font-inventory.md
+│           └── component-patterns.md
+├── assets/
+│   ├── logo-black.svg         # Wordmark — black variant (for light bg)
+│   ├── logo-white.svg         # Wordmark — white variant (for dark bg)
+│   └── icon-motochefe.png     # App/OG icon (528×528, MC motorcycle)
+├── build/
+│   ├── logo.svg               # Runtime logo (copy of logo-black.svg)
+│   └── icon.png               # Runtime icon (copy of icon-motochefe.png)
+├── preview/
+│   ├── colors-primary.html    # Full brand color swatches
+│   ├── colors-theme-light.html # Light & dark theme comparison
+│   ├── typography-specimens.html # Font families + type scale
+│   ├── spacing-tokens.html    # Spacing, radius, shadow tokens
+│   ├── brand-assets.html      # Logo/icon/gradient asset gallery
+│   └── components-buttons.html # Buttons, cards, nav, footer, stats
+├── source_examples/
+│   └── (extracted component snapshots from live site)
+└── ui_kits/
+    └── app/
+        ├── index.html         # Runnable app shell demo (React + Babel)
+        ├── README.md          # Kit structure + usage guide
+        └── components/
+            └── App.jsx        # Full marketing page: Header → Hero → Stats → Products → Reasons → Footer
+```
+
+## Preview Manifest
+
+| Preview Card | Path | What to Inspect |
+|---|---|---|
+| Brand Colors | `preview/colors-primary.html` | Gold palette (`#DBB42C`), neutrals (`#090909`, `#1F1F1F`, `#2E2E2E`), functional colors (`#3D9CD2`, `#D63939`, `#FFBC7D`), dark mode overlays |
+| Theme Comparison | `preview/colors-theme-light.html` | Light vs dark mode side-by-side with real MotoChefe content — shows how tokens adapt across themes |
+| Typography | `preview/typography-specimens.html` | 5 font families (Bebas Neue, Be Vietnam Pro, Outfit, Playfair Display, Roboto Slab), full type scale h1–small, weight/size/line-height |
+| Spacing & Radius | `preview/spacing-tokens.html` | 8-step spacing scale (4px–100px), 5 radius values (8px–9999px), 4 shadow levels (sm–glass) |
+| Brand Assets | `preview/brand-assets.html` | Logo SVGs (black/white variants loaded via `<img>`), app icon PNG, gold gradient, stat badge |
+| Components | `preview/components-buttons.html` | Buttons (primary/secondary/ghost), badges, product cards, stat cards, nav bar, footer — all using `--mc-*` tokens |
+
+## Preserved Assets
+
+- `assets/logo-black.svg` — MotoChefe wordmark, black variant for light backgrounds (downloaded from WordPress media uploads)
+- `assets/logo-white.svg` — MotoChefe wordmark, white variant for dark backgrounds
+- `assets/icon-motochefe.png` — App/OG icon, 528×528px, motorcycle illustration
+- `build/logo.svg` — Runtime copy of logo-black.svg for downstream projects
+- `build/icon.png` — Runtime copy of icon-motochefe.png for downstream projects
+
+## UI Kit
+
+The `ui_kits/app/` directory contains a runnable marketing page demo built with React + Babel:
+
+- **Entry**: `ui_kits/app/index.html` — loads React 18.3.1, ReactDOM, Babel standalone, `../../colors_and_type.css`, and all component scripts
+- **Components**: `ui_kits/app/components/App.jsx` — 6 components (Header, Hero, Stats, ProductCategories, SixReasons, Footer) exposed as `window.*` globals
+- **Design notes**: All components use `--mc-*` CSS custom properties, gold pill buttons, 24px radius cards, Bebas Neue display stats, alternating light/dark sections
+- **Source basis**: Components modeled directly after the live production site at motochefebrasil.com.br
+
+## Reuse Workflow
+
+1. **Read `DESIGN.md`** for the full visual system rules, anti-patterns, and voice guidelines — this is the canonical source of truth
+2. **Import `colors_and_type.css`** into any HTML/React project — it provides all CSS custom properties (`--mc-*`), Google Fonts imports, base resets, heading styles, dark mode overrides, and utility classes
+3. **Check `preview/`** cards for visual reference on how tokens render in practice
+4. **Use `assets/`** for logo SVGs (`logo-black.svg`, `logo-white.svg`) and app icon (`icon-motochefe.png`)
+5. **Use `build/`** for runtime copies when downstream projects expect a `build/` directory
+6. **Refer to `source_examples/`** for real component implementation patterns extracted from the live site
+7. **Refer to `ui_kits/app/`** for an applied marketing page example using the token system
+8. **Consult `context/`** for source evidence notes, CSS token extraction details, and component pattern documentation
+
+## Quick Start
+
+```html
+<link rel="stylesheet" href="colors_and_type.css">
+
+<style>
+  .my-component {
+    background: var(--mc-gold);
+    color: var(--mc-black);
+    border-radius: var(--mc-radius-pill);
+    font-family: var(--mc-font-heading);
+    padding: var(--mc-space-md) var(--mc-space-xl);
+  }
+</style>
+```
+
+## Design System Highlights
+
+- **Gold + Black palette**: `#DBB42C` (gold accent) + `#090909` (near-black) + `#FFFFFF` — premium automotive feel
+- **5 font families**: Bebas Neue (display), Be Vietnam Pro (headings/body), Outfit (UI), Playfair Display (accent italic), Roboto Slab (serif)
+- **24px radius cards**, 9999px pill buttons, glassmorphism on dark surfaces only
+- **1280px max container**, Bootstrap grid, 576/768/1024px breakpoints
+- **Alternating light/dark sections** for visual rhythm
+- **Motion**: 150ms micro / 300ms standard / 600ms dramatic, all respecting `prefers-reduced-motion`
+
+## Provenance Notes
+
+- All color hex values extracted from Elementor kit CSS (`--e-global-color-*` variables) and inline `<style>` blocks on the live site.
+- Typography extracted from Elementor kit global typography settings and heading declarations.
+- Spacing, radius, and shadow values observed from component CSS across homepage, models, and about pages.
+- Logo SVGs downloaded directly from WordPress media uploads (wp-content/uploads/2025/10/).
+- No GitHub repository was available — all evidence sourced from the live production website.

--- a/plugins/community/motochefe-design-system-mquaxx0c/references/source-2-SKILL.md
+++ b/plugins/community/motochefe-design-system-mquaxx0c/references/source-2-SKILL.md
@@ -1,0 +1,132 @@
+---
+name: MotoChefe Design System
+description: Reusable design tokens, typography, colors, components, and brand assets for the MotoChefe electric mobility brand (motochefebrasil.com.br). Gold + black palette, Be Vietnam Pro + Bebas Neue typography, 24px radius cards, 1280px container.
+user-invocable: true
+---
+
+# MotoChefe Design System Skill
+
+## What is inside
+
+This package provides a complete, reusable design system for building MotoChefe-branded UI artifacts. Everything is grounded in evidence extracted from the live production site at motochefebrasil.com.br.
+
+| File | Purpose |
+|---|---|
+| `DESIGN.md` | Canonical design rules — visual theme, color, typography, spacing, layout, components, motion, voice, anti-patterns |
+| `colors_and_type.css` | 100+ CSS custom properties (`--mc-*`), Google Fonts imports, base resets, heading styles, dark mode, utility classes |
+| `README.md` | Package guide — product overview, source references, preview manifest, reuse workflow |
+| `SKILL.md` | This file — agent-usable skill entry for future design work |
+| `preview/` | 6 focused HTML review cards (colors, themes, typography, spacing, assets, components) |
+| `assets/` | Logo SVGs (black/white), app icon PNG — downloaded from live site |
+| `build/` | Runtime copies of logo + icon for downstream projects |
+| `context/` | Source evidence — intake notes, CSS token extraction, font inventory, component patterns |
+| `source_examples/` | Real CSS snapshots from the live site: header, footer, stats-bar, product-card |
+| `ui_kits/app/` | Runnable marketing page kit — React components + token system + own README |
+
+## Source context
+
+- **Product**: MotoChefe — Brazil's leading electric mobility manufacturer (scooters, cyclomotors, tricycles, e-bikes)
+- **Founded**: 2019, Zona Franca de Manaus, Brazil
+- **Scale**: 200K+ products sold, 70+ owned stores, 310+ dealer points across 20+ states
+- **Website**: https://motochefebrasil.com.br/ — WordPress + ArchHub theme + Elementor page builder + MotionPage animations
+- **No GitHub repo** — all design evidence extracted directly from the live production website
+- **Extraction method**: Direct website fetch, CSS/asset extraction from live HTML, SVG/PNG download from WordPress media uploads
+- **Key pages analyzed**: Homepage (hero, stats, models, reasons, testimonials, footer), Models (product categories), About (company story, factory, timeline)
+- **Evidence snapshots**: `context/github/motochefebrasil/files/` — CSS token extraction, font inventory, component patterns
+- **Source component CSS**: `source_examples/` — header.css, footer.css, stats-bar.css, product-card.css
+
+## When to use this skill
+
+Use this skill when:
+
+- Building pages, prototypes, or decks for **MotoChefe** or **motochefebrasil.com.br**
+- Matching the MotoChefe visual style: **gold + black, automotive premium feel**
+- Using MotoChefe brand tokens: `#DBB42C` (gold), `#090909` (near-black), Bebas Neue display font, Be Vietnam Pro headings/body
+- Creating marketing materials, landing pages, product pages, or franchise pitch decks for electric mobility in Brazil
+- Designing dealer portals, store locators, or customer-facing surfaces for the MotoChefe franchise network
+
+## How to use
+
+### Step-by-step workflow
+
+1. **Read `DESIGN.md`** — the canonical source of truth for color, typography, spacing, layout, components, motion, voice, and anti-patterns
+2. **Import `colors_and_type.css`** — provides all `--mc-*` CSS custom properties, Google Fonts imports, base resets, heading styles, dark mode overrides, and utility classes
+3. **Check `preview/`** — 6 focused cards showing how tokens render in practice
+4. **Use `assets/`** — logo SVGs (`logo-black.svg`, `logo-white.svg`) and app icon (`icon-motochefe.png`)
+5. **Use `build/`** — runtime copies when downstream projects expect a `build/` directory
+6. **Refer to `source_examples/`** — real CSS patterns extracted from the live site
+7. **Refer to `ui_kits/app/`** — full applied marketing page example with React components
+
+### Quick start
+
+```html
+<link rel="stylesheet" href="colors_and_type.css">
+
+<style>
+  .my-component {
+    background: var(--mc-gold);
+    color: var(--mc-black);
+    border-radius: var(--mc-radius-pill);
+    font-family: var(--mc-font-heading);
+    padding: var(--mc-space-md) var(--mc-space-xl);
+  }
+</style>
+```
+
+## Design system highlights
+
+### Color palette
+
+| Token | Hex | Role |
+|---|---|---|
+| `--mc-gold` | `#DBB42C` | Primary accent — CTAs, highlights, gradients, focus rings |
+| `--mc-gold-dark` | `#B18D11` | Hover states on gold, gradient stop |
+| `--mc-gold-bar` | `#B7A45F` | Header top accent bar |
+| `--mc-black` | `#000000` | Heading text (light mode) |
+| `--mc-near-black` | `#090909` | Dark backgrounds, hero sections |
+| `--mc-charcoal` | `#1F1F1F` | Footer background, dark cards |
+| `--mc-white` | `#FFFFFF` | Light surfaces, text on dark |
+
+### Typography
+
+| Role | Font | Usage |
+|---|---|---|
+| Display / Hero | Bebas Neue | Hero headlines, large stats, all-caps impact text |
+| Headings / Body | Be Vietnam Pro | h1–h6, body copy, primary workhorse font |
+| Secondary / UI | Outfit | Captions, labels, secondary UI elements |
+| Accent / Decorative | Playfair Display (italic) | Decorative quotes, editorial moments |
+| Serif Accent | Roboto Slab | Occasional serif contrast |
+
+### Spacing and layout
+
+- **8-step spacing scale**: 4px (xs) → 8px (sm) → 16px (md) → 24px (lg) → 40px (xl) → 60px (2xl) → 80px (3xl) → 100px (4xl)
+- **Border radius**: 8px (sm) → 16px (md) → 24px (lg) → 9999px (pill) → 50% (full circle)
+- **Max container**: 1280px boxed layout, Bootstrap-derived responsive grid
+- **Breakpoints**: 576px (sm), 768px (md), 1024px (lg)
+
+### Key component patterns
+
+- **Buttons**: Gold `#DBB42C` background, black text, pill radius (9999px), padding 12px 32px; hover darken to `#B18D11`
+- **Cards**: 24px radius, full-bleed image with gradient overlay (bottom), text overlay with category + model name
+- **Stats**: Bebas Neue display font, large numbers with "+" prefix, small uppercase labels, on dark backgrounds
+- **Navigation**: Fixed white header, gold accent bar on top, shrinks on scroll; mobile fullscreen dark overlay
+- **Product cards**: 24px radius, image overlay at 65% opacity, hover scale 1.02 + shadow intensify
+
+### Motion
+
+- **Default easing**: cubic-bezier(0.25, 0.46, 0.45, 0.94)
+- **Micro**: 150ms — hover states, focus rings
+- **Standard**: 300ms — card hovers, nav transitions
+- **Dramatic**: 600ms — page transitions, scroll reveals
+- All animations respect `prefers-reduced-motion: reduce`
+
+### Anti-patterns (avoid)
+
+- Purple/violet gradients — the palette is gold + black + white
+- Inter/Roboto/Arial as display fonts
+- Gradient text (`background-clip: text`)
+- Warm beige/cream/pink backgrounds
+- Emoji as feature icons
+- Lorem ipsum — always use real Portuguese copy
+- Glassmorphism on light surfaces (reserved for dark surfaces only)
+- Generic stock photography of "business people in meetings"

--- a/plugins/community/motochefe-design-system-mquaxx0c/references/source-3-README.md
+++ b/plugins/community/motochefe-design-system-mquaxx0c/references/source-3-README.md
@@ -1,0 +1,91 @@
+# MotoChefe UI Kit — App
+
+A runnable marketing page interface kit demonstrating the MotoChefe design system in a real product surface. This kit provides a complete, functional marketing page with Header, Hero, Stats, Product Categories, 6 Reasons, and Footer components — all built with the MotoChefe token system.
+
+## Kit structure
+
+```
+ui_kits/app/
+├── index.html              # Entry point — loads React + Babel + tokens + renders App
+├── README.md               # This file — kit documentation
+└── components/
+    └── App.jsx             # Complete marketing page shell (Header → Hero → Stats → Products → Reasons → Footer)
+```
+
+| File | Purpose |
+|---|---|
+| `index.html` | Runnable HTML entry point. Loads `../../colors_and_type.css` for design tokens, React 18.3.1 + ReactDOM 18.3.1 + Babel 7.29.0 via unpkg CDN for JSX rendering. Includes CSS skeleton fallback. |
+| `components/App.jsx` | Single-file React component containing all 6 section components. Each exposed as `window.*` global for independent reuse. |
+| `README.md` | This documentation file — kit structure, components, usage, design notes, source basis. |
+
+## Component files
+
+| Component | Role | Source Evidence |
+|---|---|---|
+| `Header` | Sticky nav bar with logo, nav links (Sobre, Modelos, Franqueado, Contato), gold accent bar, CTA button (Suporte) | Live site header: fixed white, logo left, nav center, gold top bar at `#B7A45F` |
+| `Hero` | Full-viewport dark hero with overline ("Desde 2019"), display headline ("Líder em mobilidade elétrica sobre duas rodas no Brasil"), body text, and gold CTA button | Homepage hero: dark gradient bg, Be Vietnam Pro 50px heading, gold pill CTA |
+| `Stats` | Three-column stat numbers on dark background: +200K, +310, +70 | Homepage stats bar: Bebas Neue display numbers, gold color, uppercase labels |
+| `ProductCategories` | 2×2 grid of product category cards with gradient overlays: Autopropelidos, Ciclomotor, Triciclos, E-Bikes | Homepage models section: 24px radius cards, gradient bottom overlay, category + description |
+| `SixReasons` | 3×2 grid of numbered reason cards on dark background with gold numbers | Homepage "6 Razões" section: charcoal `#1F1F1F` cards, 24px radius, Bebas Neue numbers |
+| `Footer` | Three-column dark footer with logo, product links, company links, copyright bar | Site footer: `#1F1F1F`, multi-column nav, white logo, copyright text at 30% opacity |
+
+## Usage workflow
+
+### Quick start
+
+1. **Open `ui_kits/app/index.html`** in a browser — it renders a complete MotoChefe marketing page
+2. **All components use the shared token system** from `../../colors_and_type.css` (`--mc-*` CSS custom properties)
+3. **Components are exposed as `window.*` globals**: `window.App`, `window.Header`, `window.Hero`, `window.Stats`, `window.ProductCategories`, `window.SixReasons`, `window.Footer`
+
+### Detailed workflow
+
+1. **To run**: open `index.html` in a browser — React loads from CDN, Babel transpiles JSX, and the composed App renders
+2. **To modify**: edit `components/App.jsx` — all components are in a single file for simplicity
+3. **To extend**: add new component functions in `App.jsx`, expose them on `window`, and compose them into the `App` render tree
+4. **To extract a single component**: access any `window.*` global (e.g., `window.Header`) and render it standalone in a new HTML file that loads the same token CSS
+5. **To split into separate files**: move each component into its own `.jsx` file, expose each as a `window.*` global, and load them via `<script type="text/babel">` tags in index.html
+
+### Token usage example
+
+```jsx
+// All components use --mc-* CSS custom properties from colors_and_type.css
+const buttonStyle = {
+  background: 'var(--mc-gold)',
+  color: 'var(--mc-black)',
+  borderRadius: 'var(--mc-radius-pill)',
+  fontFamily: 'var(--mc-font-heading)',
+  padding: 'var(--mc-space-md) var(--mc-space-xl)',
+};
+```
+
+## Design notes
+
+- All typography uses `var(--mc-font-heading)`, `var(--mc-font-display)`, `var(--mc-font-body)` tokens from `colors_and_type.css`
+- Colors reference the brand palette: `#DBB42C` (gold), `#090909` (near-black), `#1F1F1F` (charcoal), `#FFFFFF` (white)
+- Buttons use pill radius (9999px), gold background, black text — matching the live site exactly
+- Product category cards use 24px border-radius — consistent with the design system's card pattern
+- Stats section uses Bebas Neue display font at 56px with gold color — matching the live stats bar
+- Footer uses 3-column grid layout with 60px gap, matching the production site's footer structure
+- This is a marketing/brand surface, not a chat/workspace app — components match the actual MotoChefe product
+- The CSS skeleton fallback ensures the page renders instantly before React loads, providing good perceived performance
+- Sections alternate between light (`#FFFFFF`) and dark (`#090909`) backgrounds for visual rhythm
+
+## Source basis
+
+All components are modeled directly after the live production site at https://motochefebrasil.com.br/. The layout structure, color usage, typography choices, and component patterns directly match the Elementor-built WordPress site.
+
+| Component | Evidence Source | Key Pattern |
+|---|---|---|
+| Header | Homepage `<style>` blocks | Sticky positioning, gold accent bar (`#B7A45F`), logo + nav + CTA layout |
+| Hero | Homepage hero section | Full-viewport dark gradient, 50px heading, overline with letter-spacing |
+| Stats | Homepage stats bar | Bebas Neue numbers, 3-column grid, dark background |
+| Product categories | `/modelos/` page | 2×2 grid, 24px radius, gradient overlays |
+| 6 Reasons | Homepage reasons section | Charcoal cards, numbered layout, 3-column grid |
+| Footer | Site footer | `#1F1F1F` background, 3-column nav, copyright bar |
+
+## Dependencies
+
+- React 18.3.1 (loaded via unpkg CDN)
+- ReactDOM 18.3.1 (loaded via unpkg CDN)
+- Babel standalone 7.29.0 (for JSX transpilation in browser)
+- `../../colors_and_type.css` (MotoChefe design tokens)

--- a/plugins/community/motochefe-design-system-mquaxx0c/references/source-4-source-context.md
+++ b/plugins/community/motochefe-design-system-mquaxx0c/references/source-4-source-context.md
@@ -1,0 +1,96 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Motochefebrasil Design System
+
+https://motochefebrasil.com.br/
+
+## GitHub Repositories
+
+- https://motochefebrasil.com.br
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+### GitHub Connector Intake Runbook
+
+GitHub repository intake is required before drafting the design system:
+1. For each linked repository, run the bounded intake command before writing design-system files. The command tries this-device access first (`git clone`, then authenticated GitHub CLI via `gh auth login --web`) and uses the Composio GitHub connector only as a connector-platform fallback.
+   - `"$OD_NODE_BIN" "$OD_BIN" tools connectors github-design-context --repo 'https://motochefebrasil.com.br' --output context/github/github-repository.md`
+2. Do not call GitHub connector tree/content/raw tools directly from the agent. Large repositories can trigger `CONNECTOR_OUTPUT_TOO_LARGE`; the bounded intake command is the only allowed GitHub repository intake path for this workflow.
+3. The intake command selects design-system-relevant source files plus available logos/icons/fonts and writes a reviewable evidence note plus file snapshots under `context/github/`; keep those files as the source evidence for this design-system project.
+4. If you already hit `CONNECTOR_OUTPUT_TOO_LARGE` or `CONNECTOR_RATE_LIMITED` from a direct connector call, do not stop and do not retry the same direct tool. Run the bounded intake command above, then inspect the written snapshots.
+5. Treat `Read method: git-clone` as the preferred this-device path. Treat `Read method: connector` as valid connector-platform fallback evidence when local git/GitHub CLI could not read the repository.
+6. The command is strict: if the bounded intake command cannot write snapshot files, stop and explain the permission, GitHub CLI login, connection, rate-limit, or clone problem. Do not use ad-hoc public GitHub browsing, memory, or URL-only inference for design-system files.
+7. Inspect the generated evidence note plus snapshots for README, package manifests, Tailwind/theme/token files, global CSS, font declarations, component source for buttons/forms/navigation/cards/tables, layout shells, icons/logos/assets, and representative app entry files.
+8. Use that evidence to create or update `DESIGN.md`, `colors_and_type.css`, `README.md`, `SKILL.md`, `preview/`, `ui_kits/app/`, `assets/`, and `fonts/` so the Design System tab can review the output as a reusable package.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`: none.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Locally parsed Figma summaries under `context/figma/`: none.
+Fonts, logos, and assets selected: none.
+
+Uploaded brand asset files under `assets/`: none.
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.


### PR DESCRIPTION
Add MotoChefe Design System (motochefe-design-system-mquaxx0c) plugin.
Version: 0.1.0
Description: > A reusable Claude Design-style package for the MotoChefe electric mobility brand. > Source: https://motochefebrasil.com.br/