### PR TITLE
ci: consolidate runner selection contract

### DIFF
--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 
 GITHUB_HOSTED = ["ubuntu-24.04"]
+WINDOWS_HOSTED = ["windows-latest"]
 CONTABO_CONTROL = ["self-hosted", "Linux", "X64", "od-persistent-ci", "od-ci-hot-poc"]
 BLACKSMITH_4V = ["blacksmith-4vcpu-ubuntu-2404"]
 
@@ -21,26 +22,34 @@ def normalize_mode(raw_mode):
     return "default"
 
 
-def resolve_profiles(mode):
-    hosted_or_blacksmith = BLACKSMITH_4V if mode == "performance" else GITHUB_HOSTED
-    blacksmith_default = GITHUB_HOSTED if mode == "economic" else BLACKSMITH_4V
-    contabo_control = CONTABO_CONTROL if mode == "default" else GITHUB_HOSTED
+def resolve_contract(mode):
+    general_medium = BLACKSMITH_4V if mode == "performance" else GITHUB_HOSTED
+    hot_path = GITHUB_HOSTED if mode == "economic" else BLACKSMITH_4V
+    control = CONTABO_CONTROL if mode == "default" else GITHUB_HOSTED
 
     return {
-        "mode": mode,
-        "github_hosted": GITHUB_HOSTED,
-        "contabo_control": contabo_control,
-        "hosted_or_blacksmith": hosted_or_blacksmith,
-        "blacksmith_default": blacksmith_default,
+        "runs_on": {
+            "control": control,
+            "general_medium": general_medium,
+            "workspace_unit": GITHUB_HOSTED,
+            "windows_tools": WINDOWS_HOSTED,
+            "js_hot": hot_path,
+            "ui_hot": hot_path,
+            "visual_hot": hot_path,
+        },
+        "decision": {
+            "schema_version": 1,
+            "mode": mode,
+        },
     }
 
 
 def main():
-    profiles = resolve_profiles(normalize_mode(os.environ.get("OD_CI_RUNNER_MODE")))
+    contract = resolve_contract(normalize_mode(os.environ.get("OD_CI_RUNNER_MODE")))
     output_path = os.environ.get("GITHUB_OUTPUT")
     lines = [
         f"{key}={value if isinstance(value, str) else compact_json(value)}"
-        for key, value in profiles.items()
+        for key, value in contract.items()
     ]
 
     if output_path:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  runners:
+    name: Resolve runner profiles
+    runs-on: ubuntu-24.04
+    outputs:
+      runs_on: ${{ steps.runners.outputs.runs_on }}
+      decision: ${{ steps.runners.outputs.decision }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Resolve runner profiles
+        id: runners
+        env:
+          OD_CI_RUNNER_MODE: ${{ vars.OD_CI_RUNNER_MODE }}
+        run: python3 .github/scripts/runners.py
+
   scopes:
     name: Detect validation scopes
-    runs-on: ${{ fromJSON((vars.OD_CI_RUNNER_MODE == 'performance' || vars.OD_CI_RUNNER_MODE == 'economic') && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","od-persistent-ci","od-ci-hot-poc"]') }}
+    needs: [runners]
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).control }}
     outputs:
       ci_mode: ${{ steps.detect.outputs.ci_mode }}
       daemon_tests_required: ${{ steps.detect.outputs.daemon_tests_required }}
@@ -115,30 +133,10 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  runners:
-    name: Resolve runner profiles
-    runs-on: ubuntu-24.04
-    outputs:
-      mode: ${{ steps.runners.outputs.mode }}
-      github_hosted: ${{ steps.runners.outputs.github_hosted }}
-      contabo_control: ${{ steps.runners.outputs.contabo_control }}
-      hosted_or_blacksmith: ${{ steps.runners.outputs.hosted_or_blacksmith }}
-      blacksmith_default: ${{ steps.runners.outputs.blacksmith_default }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Resolve runner profiles
-        id: runners
-        env:
-          OD_CI_RUNNER_MODE: ${{ vars.OD_CI_RUNNER_MODE }}
-        run: python3 .github/scripts/runners.py
-
   static_gate:
     name: Static gate
     needs: [runners]
-    runs-on: ${{ fromJSON(needs.runners.outputs.contabo_control) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).control }}
     timeout-minutes: 10
     env:
       ACTIONLINT_VERSION: 1.7.12
@@ -220,7 +218,7 @@ jobs:
     name: Validate Nix flake
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_nix_validation == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.hosted_or_blacksmith) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).general_medium }}
     timeout-minutes: 45
     permissions:
       contents: read
@@ -428,7 +426,7 @@ jobs:
     name: Preflight
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_preflight == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.hosted_or_blacksmith) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).general_medium }}
     timeout-minutes: 45
 
     steps:
@@ -441,7 +439,7 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ needs.runners.outputs.hosted_or_blacksmith }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).general_medium) }}
 
       # `scripts/postinstall.mjs` only prebuilds package/tool entrypoints that
       # are needed immediately after install for linked bins and shared
@@ -477,9 +475,9 @@ jobs:
 
   workspace_unit_tests:
     name: Workspace unit tests
-    needs: [scopes]
+    needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_workspace_unit_tests == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).workspace_unit }}
     timeout-minutes: 20
 
     steps:
@@ -491,6 +489,8 @@ jobs:
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
+        with:
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).workspace_unit) }}
 
       - name: Workspace unit tests
         run: |
@@ -528,9 +528,9 @@ jobs:
 
   windows_tools_pack_payload_tests:
     name: Windows tools-pack payload tests
-    needs: [scopes]
+    needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_windows_tools_pack_payload_tests == 'true' }}
-    runs-on: windows-latest
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).windows_tools }}
     timeout-minutes: 20
 
     steps:
@@ -539,6 +539,8 @@ jobs:
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
+        with:
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).windows_tools) }}
 
       - name: Windows launcher payload archive tests
         run: pnpm --filter @open-design/tools-pack exec vitest run tests/launcher-payload.test.ts
@@ -547,7 +549,7 @@ jobs:
     name: Web workspace tests
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_web_workspace_tests == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.blacksmith_default) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).js_hot }}
     timeout-minutes: 20
 
     steps:
@@ -560,7 +562,7 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).js_hot) }}
 
       - name: Prebuild web sidecar declarations
         run: pnpm --filter @open-design/web build:sidecar
@@ -572,7 +574,7 @@ jobs:
     name: E2E Vitest
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_e2e_vitest == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.blacksmith_default) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).js_hot }}
     timeout-minutes: 20
 
     steps:
@@ -585,14 +587,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).js_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).js_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |
@@ -607,7 +609,7 @@ jobs:
     name: Playwright critical (${{ matrix.group }})
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_playwright_critical == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.blacksmith_default) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -628,14 +630,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |
@@ -655,7 +657,7 @@ jobs:
     name: UI P0 smoke
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.blacksmith_default) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
     timeout-minutes: 30
 
     steps:
@@ -668,14 +670,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |
@@ -706,7 +708,7 @@ jobs:
     name: UI P0 (${{ matrix.name }})
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.blacksmith_default) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -723,14 +725,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |
@@ -761,7 +763,7 @@ jobs:
     name: Playwright visual (${{ matrix.name }})
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_playwright_visual == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.blacksmith_default) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).visual_hot }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -778,14 +780,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).visual_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ needs.runners.outputs.blacksmith_default }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).visual_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |
@@ -850,7 +852,7 @@ jobs:
     name: Docker image build
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_docker_build == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.hosted_or_blacksmith) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).general_medium }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -905,7 +907,7 @@ jobs:
       - playwright_visual
       - docker_pr
     if: ${{ always() }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.contabo_control) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).control }}
     timeout-minutes: 5
 
     steps:
@@ -1021,7 +1023,7 @@ jobs:
       - runners
       - validate
     if: ${{ always() }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.contabo_control) }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).control }}
     timeout-minutes: 5
     continue-on-error: true
 

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -182,8 +182,12 @@ function runnerOutput(profiles: Record<string, string>, key: string): string {
   return value;
 }
 
-function runnerLabels(profiles: Record<string, string>, key: string): string[] {
-  return JSON.parse(runnerOutput(profiles, key)) as string[];
+function runnerDecision(profiles: Record<string, string>): { schema_version: number; mode: string } {
+  return JSON.parse(runnerOutput(profiles, "decision")) as { schema_version: number; mode: string };
+}
+
+function runnerRunsOn(profiles: Record<string, string>): Record<string, string[]> {
+  return JSON.parse(runnerOutput(profiles, "runs_on")) as Record<string, string[]>;
 }
 
 async function writeFakeGhBin(binDir: string, releases: unknown[]): Promise<void> {
@@ -225,7 +229,8 @@ describe("packaged smoke workflow", () => {
     const job = sectionBetween(workflow, "  windows_tools_pack_payload_tests:", "  web_workspace_tests:");
     const validate = sectionBetween(workflow, "  validate:", "          if [ -n \"$failures\" ]; then");
 
-    expect(job).toContain("runs-on: windows-latest");
+    expect(job).toContain("fromJSON(needs.runners.outputs.runs_on).windows_tools");
+    expect(job).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).windows_tools)");
     expect(job).toContain("needs.scopes.outputs.run_windows_tools_pack_payload_tests == 'true'");
     expect(job).toContain("pnpm --filter @open-design/tools-pack exec vitest run tests/launcher-payload.test.ts");
     expect(validate).toContain("windows_tools_pack_payload_tests");
@@ -497,7 +502,7 @@ describe("packaged smoke workflow", () => {
 
   it("[P2] keeps PR and merge queue CI separated by hot/full validation mode", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");
-    const scopes = sectionBetween(workflow, "  scopes:", "  runners:");
+    const scopes = sectionBetween(workflow, "  scopes:", "  static_gate:");
     const validate = sectionBetween(workflow, "  validate:", "  runtime_summary:");
 
     expect(workflow).toContain("ci_mode:");
@@ -530,8 +535,8 @@ describe("packaged smoke workflow", () => {
 
   it("[P2] routes default CI through cost-sensitive runner tiers", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");
-    const scopes = sectionBetween(workflow, "  scopes:", "  runners:");
-    const runners = sectionBetween(workflow, "  runners:", "  static_gate:");
+    const runners = sectionBetween(workflow, "  runners:", "  scopes:");
+    const scopes = sectionBetween(workflow, "  scopes:", "  static_gate:");
     const staticGate = sectionBetween(workflow, "  static_gate:", "  nix_validation:");
     const workspaceUnitTests = sectionBetween(workflow, "  workspace_unit_tests:", "  windows_tools_pack_payload_tests:");
     const webWorkspaceTests = sectionBetween(workflow, "  web_workspace_tests:", "  e2e_vitest:");
@@ -542,20 +547,28 @@ describe("packaged smoke workflow", () => {
     const uiP0 = sectionBetween(workflow, "  ui_p0:", "  playwright_visual:");
     const visual = sectionBetween(workflow, "  playwright_visual:", "  docker_pr:");
 
-    expect(scopes).toContain('["self-hosted","Linux","X64","od-persistent-ci","od-ci-hot-poc"]');
     expect(runners).toContain("runs-on: ubuntu-24.04");
+    expect(runners).toContain("runs_on: ${{ steps.runners.outputs.runs_on }}");
+    expect(runners).toContain("decision: ${{ steps.runners.outputs.decision }}");
     expect(runners).toContain("python3 .github/scripts/runners.py");
+    expect(scopes).toContain("needs: [runners]");
+    expect(scopes).toContain("fromJSON(needs.runners.outputs.runs_on).control");
     expect(staticGate).toContain("needs: [runners]");
-    expect(staticGate).toContain("needs.runners.outputs.contabo_control");
-    expect(workspaceUnitTests).toContain("runs-on: ubuntu-24.04");
-    expect(webWorkspaceTests).toContain("needs.runners.outputs.blacksmith_default");
+    expect(staticGate).toContain("fromJSON(needs.runners.outputs.runs_on).control");
+    expect(workspaceUnitTests).toContain("fromJSON(needs.runners.outputs.runs_on).workspace_unit");
+    expect(workspaceUnitTests).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).workspace_unit)");
+    expect(webWorkspaceTests).toContain("fromJSON(needs.runners.outputs.runs_on).js_hot");
+    expect(webWorkspaceTests).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).js_hot)");
     expect(webWorkspaceTests).not.toContain('"od-persistent-ci"');
-    expect(e2eVitest).toContain("needs.runners.outputs.blacksmith_default");
+    expect(e2eVitest).toContain("fromJSON(needs.runners.outputs.runs_on).js_hot");
+    expect(e2eVitest).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).js_hot)");
     expect(e2eVitest).not.toContain('"od-persistent-ci"');
-    expect(nixValidation).toContain("needs.runners.outputs.hosted_or_blacksmith");
-    expect(preflight).toContain("needs.runners.outputs.hosted_or_blacksmith");
-    expect(dockerPr).toContain("needs.runners.outputs.hosted_or_blacksmith");
-    expect(uiP0).toContain("needs.runners.outputs.blacksmith_default");
+    expect(nixValidation).toContain("fromJSON(needs.runners.outputs.runs_on).general_medium");
+    expect(preflight).toContain("fromJSON(needs.runners.outputs.runs_on).general_medium");
+    expect(preflight).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).general_medium)");
+    expect(dockerPr).toContain("fromJSON(needs.runners.outputs.runs_on).general_medium");
+    expect(uiP0).toContain("fromJSON(needs.runners.outputs.runs_on).ui_hot");
+    expect(uiP0).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot)");
     expect(uiP0).toContain("include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}");
     expect(uiP0CiMatrix.map((entry) => entry.name)).toEqual([
       "entry-settings",
@@ -570,33 +583,64 @@ describe("packaged smoke workflow", () => {
       "ui/project-management-flows.test.ts",
       "ui/workspace-keyboard-flows.test.ts",
     ]);
-    expect(visual).toContain("needs.runners.outputs.blacksmith_default");
+    expect(visual).toContain("fromJSON(needs.runners.outputs.runs_on).visual_hot");
+    expect(visual).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).visual_hot)");
+    expect(workflow).not.toContain("needs.runners.outputs.contabo_control");
+    expect(workflow).not.toContain("needs.runners.outputs.hosted_or_blacksmith");
+    expect(workflow).not.toContain("needs.runners.outputs.blacksmith_default");
   });
 
   it("[P2] resolves CI runner profiles by mode", async () => {
     const defaultProfiles = await runRunners();
-    expect(runnerOutput(defaultProfiles, "mode")).toBe("default");
-    expect(runnerLabels(defaultProfiles, "contabo_control")).toEqual([
+    const defaultRunsOn = runnerRunsOn(defaultProfiles);
+    expect(runnerDecision(defaultProfiles)).toEqual({ schema_version: 1, mode: "default" });
+    expect(Object.keys(defaultRunsOn).sort()).toEqual([
+      "control",
+      "general_medium",
+      "js_hot",
+      "ui_hot",
+      "visual_hot",
+      "windows_tools",
+      "workspace_unit",
+    ]);
+    expect(defaultRunsOn.control).toEqual([
       "self-hosted",
       "Linux",
       "X64",
       "od-persistent-ci",
       "od-ci-hot-poc",
     ]);
-    expect(runnerLabels(defaultProfiles, "hosted_or_blacksmith")).toEqual(["ubuntu-24.04"]);
-    expect(runnerLabels(defaultProfiles, "blacksmith_default")).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(defaultRunsOn.general_medium).toEqual(["ubuntu-24.04"]);
+    expect(defaultRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
+    expect(defaultRunsOn.windows_tools).toEqual(["windows-latest"]);
+    expect(defaultRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(defaultRunsOn.ui_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(defaultRunsOn.visual_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(defaultProfiles).not.toHaveProperty("contabo_control");
+    expect(defaultProfiles).not.toHaveProperty("hosted_or_blacksmith");
+    expect(defaultProfiles).not.toHaveProperty("blacksmith_default");
 
     const performanceProfiles = await runRunners("performance");
-    expect(runnerOutput(performanceProfiles, "mode")).toBe("performance");
-    expect(runnerLabels(performanceProfiles, "contabo_control")).toEqual(["ubuntu-24.04"]);
-    expect(runnerLabels(performanceProfiles, "hosted_or_blacksmith")).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
-    expect(runnerLabels(performanceProfiles, "blacksmith_default")).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    const performanceRunsOn = runnerRunsOn(performanceProfiles);
+    expect(runnerDecision(performanceProfiles)).toEqual({ schema_version: 1, mode: "performance" });
+    expect(performanceRunsOn.control).toEqual(["ubuntu-24.04"]);
+    expect(performanceRunsOn.general_medium).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(performanceRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
+    expect(performanceRunsOn.windows_tools).toEqual(["windows-latest"]);
+    expect(performanceRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(performanceRunsOn.ui_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(performanceRunsOn.visual_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
 
     const economicProfiles = await runRunners("economic");
-    expect(runnerOutput(economicProfiles, "mode")).toBe("economic");
-    expect(runnerLabels(economicProfiles, "contabo_control")).toEqual(["ubuntu-24.04"]);
-    expect(runnerLabels(economicProfiles, "hosted_or_blacksmith")).toEqual(["ubuntu-24.04"]);
-    expect(runnerLabels(economicProfiles, "blacksmith_default")).toEqual(["ubuntu-24.04"]);
+    const economicRunsOn = runnerRunsOn(economicProfiles);
+    expect(runnerDecision(economicProfiles)).toEqual({ schema_version: 1, mode: "economic" });
+    expect(economicRunsOn.control).toEqual(["ubuntu-24.04"]);
+    expect(economicRunsOn.general_medium).toEqual(["ubuntu-24.04"]);
+    expect(economicRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
+    expect(economicRunsOn.windows_tools).toEqual(["windows-latest"]);
+    expect(economicRunsOn.js_hot).toEqual(["ubuntu-24.04"]);
+    expect(economicRunsOn.ui_hot).toEqual(["ubuntu-24.04"]);
+    expect(economicRunsOn.visual_hot).toEqual(["ubuntu-24.04"]);
   });
 
   it("[P2] routes CI follow-ons through generic handoff workflows", async () => {

--- a/e2e/ui/settings-connectors-auth-happy-path.test.ts
+++ b/e2e/ui/settings-connectors-auth-happy-path.test.ts
@@ -46,6 +46,8 @@ function baseConfig(): Record<string, unknown> {
     skillId: null,
     designSystemId: null,
     onboardingCompleted: true,
+    privacyDecisionAt: 1,
+    telemetry: { metrics: true, content: true },
     composio: {
       apiKey: '',
       apiKeyConfigured: true,
@@ -68,9 +70,9 @@ async function waitForLoadingToClear(page: Page) {
 async function gotoEntryHome(page: Page) {
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
-  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
-  if (await privacyDialog.isVisible()) {
-    await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
+  const privacyRegion = page.getByRole('region', { name: /Help us improve Open Design/i });
+  if (await privacyRegion.isVisible().catch(() => false)) {
+    await privacyRegion.getByRole('button', { name: /I get it|not now|got it/i }).click();
   }
   await expect(page.getByTestId('home-hero')).toBeVisible();
 }

--- a/e2e/ui/settings-connectors-auth-recovery.test.ts
+++ b/e2e/ui/settings-connectors-auth-recovery.test.ts
@@ -59,6 +59,8 @@ function baseConfig(): Record<string, unknown> {
     skillId: null,
     designSystemId: null,
     onboardingCompleted: true,
+    privacyDecisionAt: 1,
+    telemetry: { metrics: true, content: true },
     composio: {
       apiKey: '',
       apiKeyConfigured: true,
@@ -89,9 +91,9 @@ async function waitForLoadingToClear(page: Page) {
 async function gotoEntryHome(page: Page) {
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
-  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
-  if (await privacyDialog.isVisible()) {
-    await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
+  const privacyRegion = page.getByRole('region', { name: /Help us improve Open Design/i });
+  if (await privacyRegion.isVisible().catch(() => false)) {
+    await privacyRegion.getByRole('button', { name: /I get it|not now|got it/i }).click();
   }
   await expect(page.getByTestId('home-hero')).toBeVisible();
 }


### PR DESCRIPTION
## Why

This PR turns the CI runner resolver into the single source of truth for
`runs-on` selection before adding any external resolver or Cloudflare wrapper.

The current workflow exposed several provider-shaped job outputs such as
`contabo_control`, `hosted_or_blacksmith`, and `blacksmith_default`. That made
call sites know too much about the current provider mix and made later fallback
or sampling logic harder to add without touching many jobs.

## What users will see

No product UI change. CI should keep the same effective runner choices for each
mode, but workflow jobs now consume ecological runner keys from one JSON
contract.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

Not applicable.

## Validation

- `python3 .github/scripts/runners.py`
- `OD_CI_RUNNER_MODE=performance python3 .github/scripts/runners.py`
- `OD_CI_RUNNER_MODE=economic python3 .github/scripts/runners.py`
- `actionlint -color`
- `python3 .github/scripts/handoff.py self-check`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts`
- `pnpm guard`
- `pnpm typecheck`
