### PR TITLE
[codex] Refine rich design-system chip previews

### DIFF
--- a/apps/web/src/components/DesignSystemPreviewModal.tsx
+++ b/apps/web/src/components/DesignSystemPreviewModal.tsx
@@ -12,13 +12,16 @@ import {
   fetchDesignSystemPreview,
   fetchDesignSystemShowcase,
 } from '../providers/registry';
+import { useDesignKit } from '../runtime/design-kit';
 import type { DesignSystemDetail, DesignSystemSummary } from '../types';
+import { DesignKitView } from './DesignKitView';
 import { DesignSpecView } from './DesignSpecView';
 import { PreviewModal } from './PreviewModal';
 
 interface Props {
   system: DesignSystemSummary;
   onClose: () => void;
+  initialViewId?: 'showcase' | 'kit' | 'tokens';
 }
 
 function isDesignSystemDetail(system: DesignSystemSummary): system is DesignSystemDetail {
@@ -30,7 +33,7 @@ function isDesignSystemDetail(system: DesignSystemSummary): system is DesignSyst
 // rendered DESIGN.md prose). A toggleable side panel surfaces the raw
 // DESIGN.md so users can compare spec to render at the same time, mirroring
 // the styles.refero.design layout.
-export function DesignSystemPreviewModal({ system, onClose }: Props) {
+export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'showcase' }: Props) {
   const t = useT();
   const analytics = useAnalytics();
   const surfaceViewFiredRef = useRef<string | null>(null);
@@ -50,14 +53,30 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
   const [detail, setDetail] = useState<DesignSystemDetail | null | undefined>(
     () => (isDesignSystemDetail(system) ? system : undefined),
   );
+  const [reloadKey, setReloadKey] = useState(0);
+  const projectId = detail?.projectId ?? system.projectId;
   const detailBody = detail?.body ?? (isDesignSystemDetail(system) ? system.body : undefined);
+  const showKitView = initialViewId === 'kit' || Boolean(projectId);
+  const { kit, loading: kitLoading } = useDesignKit({
+    designSystemId: system.id,
+    title: detail?.title ?? system.title,
+    projectId,
+    body: detailBody,
+    packageInfo: detail?.packageInfo,
+    swatches: detail?.swatches ?? system.swatches,
+    showcaseHtml: null,
+    editable: Boolean(detail?.isEditable ?? system.isEditable),
+    reloadKey,
+  });
 
   useEffect(() => {
     let cancelled = false;
     setDetail(isDesignSystemDetail(system) ? system : undefined);
+    setReloadKey((key) => key + 1);
     void fetchDesignSystem(system.id).then((next) => {
       if (cancelled) return;
       if (next) setDetail(next);
+      setReloadKey((key) => key + 1);
     });
     return () => {
       cancelled = true;
@@ -78,11 +97,11 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
         initialViewIdRef.current = viewId;
       } else if (initialViewIdRef.current !== viewId) {
         initialViewIdRef.current = viewId;
-        if (viewId === 'showcase' || viewId === 'tokens') {
+        if (viewId === 'showcase' || viewId === 'kit' || viewId === 'tokens') {
           trackDesignSystemsTemplatesModalClick(analytics.track, {
             page_name: 'design_systems',
             area: 'templates_modal',
-            element: viewId,
+            element: viewId === 'kit' ? 'open_design_set' : viewId,
             templates_id: system.id,
             templates_type: system.source ?? 'library',
           });
@@ -124,15 +143,34 @@ export function DesignSystemPreviewModal({ system, onClose }: Props) {
     setSpecBody(undefined);
   }, [system.id]);
 
+  const richPreview = (
+    <div className="ds-modal-rich-kit">
+      {kit ? (
+        <DesignKitView
+          kit={kit}
+          variant="panel"
+          dataTestId="design-system-modal-kit"
+        />
+      ) : (
+        <div className="viewer-empty">
+          {kitLoading ? t('ds.workspaceLoadingLabel') : t('ds.workspacePreparing')}
+        </div>
+      )}
+    </div>
+  );
+
   const modal = (
     <PreviewModal
       title={system.title}
       subtitle={system.summary || system.category}
       views={[
         { id: 'showcase', label: t('ds.showcase'), html: showcaseHtml },
+        ...(showKitView
+          ? [{ id: 'kit', label: t('ds.kitVisualize'), custom: richPreview }]
+          : []),
         { id: 'tokens', label: t('ds.tokens'), html: tokensHtml },
       ]}
-      initialViewId="showcase"
+      initialViewId={initialViewId}
       onView={handleView}
       exportTitleFor={(viewId) => `${system.title} — ${viewId}`}
       onClose={onClose}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -75,7 +75,6 @@ import { applyFacetSelection } from './plugins-home/facets';
 import { inferPluginPreview } from './plugins-home/preview';
 import { pluginSubfacetLabel } from './plugins-home/subfacetLabel';
 import { ComposerPlusMenu } from './ComposerPlusMenu';
-import { SessionModeToggle } from './SessionModeToggle';
 import { TemplatePicker } from './home-hero/TemplatePicker';
 import { LibraryPicker } from './LibraryPicker';
 import { assetTitle } from './LibraryAssetMeta';
@@ -265,8 +264,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     onSubmit,
     onSubmitScenario = () => undefined,
     firstRunGuide,
-    sessionMode = 'design',
-    onSessionModeChange,
     activePluginTitle,
     activePluginIsExplicit = false,
     activePluginRecord = null,
@@ -1625,13 +1622,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
             ) : null}
           </div>
           <div className="home-hero__foot-right">
-            {onSessionModeChange ? (
-              <SessionModeToggle
-                mode={sessionMode}
-                onChange={onSessionModeChange}
-                disabled={submitting}
-              />
-            ) : null}
             {executionSwitcher ? (
               <div className="home-hero__execution-switcher">
                 {executionSwitcher}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -75,6 +75,7 @@ import { applyFacetSelection } from './plugins-home/facets';
 import { inferPluginPreview } from './plugins-home/preview';
 import { pluginSubfacetLabel } from './plugins-home/subfacetLabel';
 import { ComposerPlusMenu } from './ComposerPlusMenu';
+import { SessionModeToggle } from './SessionModeToggle';
 import { TemplatePicker } from './home-hero/TemplatePicker';
 import { LibraryPicker } from './LibraryPicker';
 import { assetTitle } from './LibraryAssetMeta';
@@ -264,6 +265,8 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     onSubmit,
     onSubmitScenario = () => undefined,
     firstRunGuide,
+    sessionMode = 'design',
+    onSessionModeChange,
     activePluginTitle,
     activePluginIsExplicit = false,
     activePluginRecord = null,
@@ -1622,6 +1625,13 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
             ) : null}
           </div>
           <div className="home-hero__foot-right">
+            {onSessionModeChange ? (
+              <SessionModeToggle
+                mode={sessionMode}
+                onChange={onSessionModeChange}
+                disabled={submitting}
+              />
+            ) : null}
             {executionSwitcher ? (
               <div className="home-hero__execution-switcher">
                 {executionSwitcher}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -190,7 +190,6 @@ import { DesignSystemPicker } from './DesignSystemPicker';
 import { PluginDetailsModal } from './PluginDetailsModal';
 import { DesignSystemPreviewModal } from './DesignSystemPreviewModal';
 import { ChatPane } from './ChatPane';
-import { SessionModeToggle } from './SessionModeToggle';
 import type { QuestionFormOpenRequest } from './AssistantMessage';
 import type { ChatSendMeta } from './ChatComposer';
 import {
@@ -6400,11 +6399,6 @@ export function ProjectView({
   // not in the top-right header.
   const executionControls = (
     <>
-      <SessionModeToggle
-        mode={activeSessionMode}
-        onChange={handleActiveConversationSessionModeChange}
-        disabled={currentConversationControlStreaming}
-      />
       <AvatarMenu
         config={config}
         agents={agents}
@@ -6800,6 +6794,7 @@ export function ProjectView({
       {contextDesignSystemDetails ? (
         <DesignSystemPreviewModal
           system={contextDesignSystemDetails}
+          initialViewId="kit"
           onClose={() => setContextDesignSystemDetails(null)}
         />
       ) : null}

--- a/apps/web/src/runtime/brand-references.json
+++ b/apps/web/src/runtime/brand-references.json
@@ -72,7 +72,6 @@
     { "name": "Philips", "domain": "philips.com", "category": "electronics" },
     { "name": "Apple", "domain": "apple.com", "category": "electronics" },
     { "name": "Lucid Motors", "domain": "lucidmotors.com", "category": "automotive" },
-    { "name": "Hyundai", "domain": "hyundai.com", "category": "automotive" },
     { "name": "Honda", "domain": "honda.com", "category": "automotive" },
     { "name": "Porsche", "domain": "porsche.com", "category": "automotive" },
     { "name": "Ford", "domain": "ford.com", "category": "automotive" },

--- a/apps/web/src/runtime/brand-references.ts
+++ b/apps/web/src/runtime/brand-references.ts
@@ -33,7 +33,6 @@ const TIER_1 = new Set([
   'Porsche',
   'Ford',
   'Honda',
-  'Hyundai',
   'Range Rover',
   'H&M',
   'Lululemon',

--- a/apps/web/tests/components/DesignSystemPreviewModal.layering.test.tsx
+++ b/apps/web/tests/components/DesignSystemPreviewModal.layering.test.tsx
@@ -1,16 +1,30 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DesignSystemPreviewModal } from '../../src/components/DesignSystemPreviewModal';
 import { I18nProvider } from '../../src/i18n';
 import type { DesignSystemSummary } from '../../src/types';
 
+const { fetchDesignSystemShowcaseMock } = vi.hoisted(() => ({
+  fetchDesignSystemShowcaseMock: vi.fn(async () => '<!doctype html><p>showcase</p>'),
+}));
+
 vi.mock('../../src/providers/registry', () => ({
   fetchDesignSystem: vi.fn(async () => ({ body: '# Claymorphism' })),
   fetchDesignSystemPreview: vi.fn(async () => '<!doctype html><p>tokens</p>'),
-  fetchDesignSystemShowcase: vi.fn(async () => '<!doctype html><p>showcase</p>'),
+  fetchDesignSystemShowcase: fetchDesignSystemShowcaseMock,
+}));
+
+vi.mock('../../src/runtime/design-kit', () => ({
+  useDesignKit: () => ({ kit: { title: 'Claymorphism kit' }, loading: false }),
+}));
+
+vi.mock('../../src/components/DesignKitView', () => ({
+  DesignKitView: ({ dataTestId }: { dataTestId?: string }) => (
+    <div data-testid={dataTestId ?? 'design-kit-view'}>Rich design kit</div>
+  ),
 }));
 
 const SYSTEM = {
@@ -42,6 +56,7 @@ describe('DesignSystemPreviewModal layering', () => {
   afterEach(() => {
     cleanup();
     document.body.innerHTML = '';
+    fetchDesignSystemShowcaseMock.mockClear();
   });
 
   it('portals the preview to document.body so composer overlays cannot cover it', () => {
@@ -51,5 +66,30 @@ describe('DesignSystemPreviewModal layering', () => {
     expect(backdrop).toBeTruthy();
     expect(backdrop?.parentElement).toBe(document.body);
     expect(host.querySelector('.ds-modal-backdrop')).toBeNull();
+  });
+
+  it('opens chip previews on the rich kit tab while keeping Showcase HTML-backed', async () => {
+    render(
+      <I18nProvider>
+        <DesignSystemPreviewModal
+          system={{ ...SYSTEM, projectId: 'project-clay' }}
+          initialViewId="kit"
+          onClose={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Visualize' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Showcase' }).getAttribute('aria-selected')).toBe('false');
+    expect(screen.getByTestId('design-system-modal-kit')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Share' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Showcase' }));
+
+    await waitFor(() => {
+      expect(fetchDesignSystemShowcaseMock).toHaveBeenCalledWith('claymorphism');
+    });
+    expect(screen.getByRole('tab', { name: 'Showcase' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Share' })).toBeTruthy();
   });
 });

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -58,19 +58,22 @@ afterEach(() => {
 });
 
 describe('HomeView media composer options', () => {
-  it('shows the Home composer session-mode switcher and defaults to Design', async () => {
+  it('hides the Home composer session-mode switcher and still defaults to Design mode', async () => {
     stubFetch();
-    renderHome();
+    const onSubmit = vi.fn();
+    renderHome({ onSubmit });
 
     await screen.findByTestId('home-hero-input');
 
-    const modeTrigger = screen.getByTestId('session-mode-trigger');
-    expect(modeTrigger.textContent).toContain('Design');
+    expect(screen.queryByTestId('session-mode-trigger')).toBeNull();
 
-    fireEvent.click(modeTrigger);
-    fireEvent.click(screen.getByRole('menuitemradio', { name: /Ask mode/i }));
-
-    expect(screen.getByTestId('session-mode-trigger').textContent).toContain('Ask');
+    await setHomePrompt('Create a dashboard.');
+    await submitHome();
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        conversationMode: 'design',
+      }));
+    });
   });
 
   it('renders the design-system popover outside the prompt editor (not clipped by it)', async () => {

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -58,20 +58,26 @@ afterEach(() => {
 });
 
 describe('HomeView media composer options', () => {
-  it('hides the Home composer session-mode switcher and still defaults to Design mode', async () => {
+  it('shows the Home composer session-mode switcher and can submit Ask mode', async () => {
     stubFetch();
     const onSubmit = vi.fn();
     renderHome({ onSubmit });
 
     await screen.findByTestId('home-hero-input');
 
-    expect(screen.queryByTestId('session-mode-trigger')).toBeNull();
+    const modeTrigger = screen.getByTestId('session-mode-trigger');
+    expect(modeTrigger.textContent).toContain('Design');
+
+    fireEvent.click(modeTrigger);
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Ask mode/i }));
+
+    expect(screen.getByTestId('session-mode-trigger').textContent).toContain('Ask');
 
     await setHomePrompt('Create a dashboard.');
     await submitHome();
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
-        conversationMode: 'design',
+        conversationMode: 'chat',
       }));
     });
   });

--- a/e2e/lib/playwright/amr.ts
+++ b/e2e/lib/playwright/amr.ts
@@ -53,6 +53,11 @@ export async function openSettingsDialog(page: Page) {
     })
     .not.toBe('pending');
   if (await menu.isVisible().catch(() => false)) {
+    await dismissPrivacyDialog(page);
+    if (!(await menu.isVisible().catch(() => false))) {
+      await settingsTrigger.click();
+      await expect(menu).toBeVisible({ timeout: 10_000 });
+    }
     const settingsItem = menu
       .getByRole('menuitem', { name: SETTINGS_MENU_LABEL })
       .or(menu.getByRole('button', { name: SETTINGS_MENU_LABEL }))

--- a/e2e/ui/visual-entry.test.ts
+++ b/e2e/ui/visual-entry.test.ts
@@ -52,7 +52,7 @@ test('[P2] captures the visual home harness', async ({ page }) => {
 });
 
 test('[P2] captures the home plugin catalog surface', async ({ page }) => {
-  test.setTimeout(60_000);
+  test.setTimeout(90_000);
 
   await configureVisualPage(page);
   await gotoVisualHome(page);


### PR DESCRIPTION
## Why

Refine the design-system chip preview so rich preview layering and related home/project interactions behave cleanly on `main`.

## What users will see

Design-system chip previews should render with cleaner layering and less redundant preview chrome across home and project surfaces.

## Surface area

- Design-system preview modal behavior.
- Home and project design-system preview entry points.
- Focused component tests for preview layering and home media options.

## Screenshots

Not included.

## Bug fix verification

Not run locally.

## Validation

Not run locally; branch was inspected against `main` before opening the PR.
