### PR TITLE
Fix New Project folder picker silent failures

### DIFF
--- a/apps/daemon/src/native-folder-dialog.ts
+++ b/apps/daemon/src/native-folder-dialog.ts
@@ -3,6 +3,25 @@ export interface NativeFolderDialogCommand {
   args: string[];
 }
 
+function errorCode(error: unknown): unknown {
+  return error && typeof error === 'object' && 'code' in error
+    ? (error as { code?: unknown }).code
+    : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  return String(error);
+}
+
+function hardLinuxFolderDialogFailure(error: unknown, stderrText: string): string | null {
+  const code = errorCode(error);
+  if (code === 'ENOENT') return 'zenity is not installed';
+  if (/cannot open display/i.test(stderrText)) return stderrText;
+  if (/no such file or directory/i.test(stderrText) && /zenity/i.test(stderrText)) return stderrText;
+  return null;
+}
+
 const WINDOWS_FOLDER_DIALOG_SCRIPT = [
   'Add-Type -AssemblyName System.Windows.Forms;',
   '$owner = New-Object System.Windows.Forms.Form;',
@@ -32,6 +51,22 @@ export function buildWindowsFolderDialogCommand(): NativeFolderDialogCommand {
 export function parseFolderDialogStdout(error: unknown, stdout: string): string | null {
   if (error) {
     return null;
+  }
+
+  const selectedPath = stdout.trim();
+  return selectedPath.length > 0 ? selectedPath : null;
+}
+
+export function parseLinuxFolderDialogResult(error: unknown, stdout: string, stderr: string): string | null {
+  if (error) {
+    const stderrText = stderr.trim();
+    const code = errorCode(error);
+    const hardFailure = hardLinuxFolderDialogFailure(error, stderrText);
+    if (hardFailure) {
+      throw new Error(`Could not open folder picker: ${hardFailure}`);
+    }
+    if (code === 1) return null;
+    throw new Error(`Could not open folder picker: ${stderrText || errorMessage(error)}`);
   }
 
   const selectedPath = stdout.trim();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2879,7 +2879,7 @@ function requestRunOverride(runId, tokenRunId) {
 }
 
 function openNativeFolderDialog() {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const platform = process.platform;
     if (platform === 'darwin') {
       // `choose folder` is handled specially by the system: it presents a fully
@@ -2903,8 +2903,18 @@ function openNativeFolderDialog() {
         'zenity',
         ['--file-selection', '--directory', '--title=Select a code folder to link'],
         { timeout: 120_000 },
-        (err, stdout) => {
-          if (err) return resolve(null);
+        (err, stdout, stderr) => {
+          if (err) {
+            const code = err && typeof err === 'object' && 'code' in err
+              ? (err as { code?: unknown }).code
+              : undefined;
+            const stderrText = typeof stderr === 'string' ? stderr.trim() : '';
+            if (code === 1 && !stderrText) return resolve(null);
+            const message = stderrText || (typeof code === 'string' && code === 'ENOENT'
+              ? 'zenity is not installed'
+              : String(err && err.message ? err.message : err));
+            return reject(new Error(`Could not open folder picker: ${message}`));
+          }
           const p = stdout.trim();
           resolve(p || null);
         },

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -190,7 +190,11 @@ import {
 } from './skills.js';
 import { validateLinkedDirs } from './linked-dirs.js';
 import { installFromTarget, uninstallById, sanitizeRepoName } from './library-install.js';
-import { buildWindowsFolderDialogCommand, parseFolderDialogStdout } from './native-folder-dialog.js';
+import {
+  buildWindowsFolderDialogCommand,
+  parseFolderDialogStdout,
+  parseLinuxFolderDialogResult,
+} from './native-folder-dialog.js';
 import {
   AssetCacheError,
   assetCacheRewriteUrl,
@@ -2904,19 +2908,11 @@ function openNativeFolderDialog() {
         ['--file-selection', '--directory', '--title=Select a code folder to link'],
         { timeout: 120_000 },
         (err, stdout, stderr) => {
-          if (err) {
-            const code = err && typeof err === 'object' && 'code' in err
-              ? (err as { code?: unknown }).code
-              : undefined;
-            const stderrText = typeof stderr === 'string' ? stderr.trim() : '';
-            if (code === 1 && !stderrText) return resolve(null);
-            const message = stderrText || (typeof code === 'string' && code === 'ENOENT'
-              ? 'zenity is not installed'
-              : String(err && err.message ? err.message : err));
-            return reject(new Error(`Could not open folder picker: ${message}`));
+          try {
+            resolve(parseLinuxFolderDialogResult(err, stdout, stderr));
+          } catch (folderDialogError) {
+            reject(folderDialogError);
           }
-          const p = stdout.trim();
-          resolve(p || null);
         },
       );
     } else if (platform === 'win32') {

--- a/apps/daemon/tests/native-folder-dialog.test.ts
+++ b/apps/daemon/tests/native-folder-dialog.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildWindowsFolderDialogCommand,
+  parseLinuxFolderDialogResult,
   parseFolderDialogStdout,
 } from '../src/native-folder-dialog.js';
+
+function dialogError(message: string, code: string | number): Error & { code: string | number } {
+  const err = new Error(message) as Error & { code: string | number };
+  err.code = code;
+  return err;
+}
 
 describe('native folder dialog helpers', () => {
   it('builds the Windows folder picker command with STA mode', () => {
@@ -42,5 +49,31 @@ describe('native folder dialog helpers', () => {
 
   it('returns null when the native dialog command fails', () => {
     expect(parseFolderDialogStdout(new Error('cancelled'), 'C:\\Users\\Ada\\Project\r\n')).toBeNull();
+  });
+
+  it('parses a selected Linux folder path from stdout', () => {
+    expect(parseLinuxFolderDialogResult(null, '/home/ada/project\n', '')).toBe('/home/ada/project');
+  });
+
+  it('keeps Linux cancel quiet even when zenity emits GTK warnings on stderr', () => {
+    const err = dialogError('Command failed: zenity', 1);
+
+    expect(parseLinuxFolderDialogResult(err, '', '(zenity:123): Gtk-WARNING **: Theme parsing error\n')).toBeNull();
+  });
+
+  it('throws for Linux folder picker display failures', () => {
+    const err = dialogError('Command failed: zenity', 1);
+
+    expect(() => parseLinuxFolderDialogResult(err, '', 'Gtk-WARNING **: cannot open display: :99')).toThrow(
+      'Could not open folder picker: Gtk-WARNING **: cannot open display: :99',
+    );
+  });
+
+  it('throws a stable message when zenity is missing', () => {
+    const err = dialogError('spawn zenity ENOENT', 'ENOENT');
+
+    expect(() => parseLinuxFolderDialogResult(err, '', '')).toThrow(
+      'Could not open folder picker: zenity is not installed',
+    );
   });
 });

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -744,10 +744,16 @@ export function NewProjectPanel({
         });
         return;
       }
-      const picked = await openFolderDialog();
-      if (picked) {
-        setWorkingDir(picked);
-        setWorkingDirToken(null);
+      try {
+        const picked = await openFolderDialog({ throwOnError: true });
+        if (picked) {
+          setWorkingDir(picked);
+          setWorkingDirToken(null);
+        }
+      } catch (err) {
+        setWorkingDirError({
+          message: err instanceof Error ? err.message : t('workingDirPicker.unavailable'),
+        });
       }
     } finally {
       setWorkingDirPicking(false);

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -75,6 +75,14 @@ type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => 
 
 type NewProjectPlatform = Exclude<ProjectPlatform, 'auto'>;
 
+function folderPickerErrorDetails(err: unknown): string | undefined {
+  if (!(err instanceof Error)) return undefined;
+  const message = err.message.trim();
+  if (!message) return undefined;
+  const detail = message.replace(/^Could not open folder picker:\s*/i, '').trim();
+  return detail || message;
+}
+
 const DESIGN_PLATFORMS: Array<{
   value: NewProjectPlatform;
   labelKey: keyof Dict;
@@ -752,7 +760,8 @@ export function NewProjectPanel({
         }
       } catch (err) {
         setWorkingDirError({
-          message: err instanceof Error ? err.message : t('workingDirPicker.unavailable'),
+          message: t('chat.linkedFolderPickError'),
+          details: folderPickerErrorDetails(err),
         });
       }
     } finally {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1595,11 +1595,11 @@ export async function deleteLiveArtifact(projectId: string, artifactId: string):
 
 async function readApiErrorBody(resp: Response): Promise<{ message: string; code?: string }> {
   try {
-    const json = (await resp.json()) as { error?: { code?: string; message?: string }; message?: string };
-    const message = json.error?.message ?? json.message;
+    const json = (await resp.json()) as { error?: { code?: string; message?: string } | string; message?: string };
+    const message = typeof json.error === 'string' ? json.error : json.error?.message ?? json.message;
     return {
       message: typeof message === 'string' && message.length > 0 ? message : `Request failed (${resp.status}).`,
-      ...(typeof json.error?.code === 'string' ? { code: json.error.code } : {}),
+      ...(typeof json.error === 'object' && typeof json.error?.code === 'string' ? { code: json.error.code } : {}),
     };
   } catch {
     return { message: `Request failed (${resp.status}).` };
@@ -2044,13 +2044,22 @@ export async function renameProjectFile(
   return (await resp.json()) as RenameProjectFileResponse;
 }
 
-export async function openFolderDialog(): Promise<string | null> {
+export async function openFolderDialog(options: { throwOnError?: boolean } = {}): Promise<string | null> {
   try {
     const resp = await fetch('/api/dialog/open-folder', { method: 'POST' });
-    if (!resp.ok) return null;
+    if (!resp.ok) {
+      if (options.throwOnError) {
+        const errorBody = await readApiErrorBody(resp);
+        throw new Error(errorBody.message);
+      }
+      return null;
+    }
     const data = await resp.json();
     return typeof data.path === 'string' && data.path.length > 0 ? data.path : null;
-  } catch {
+  } catch (err) {
+    if (options.throwOnError) {
+      throw err instanceof Error ? err : new Error('Could not open folder picker');
+    }
     return null;
   }
 }

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -795,6 +795,28 @@ describe('NewProjectPanel working directory picker', () => {
     expect(await screen.findByText(/Couldn't open the folder picker/i)).toBeTruthy();
     expect(mockedOpenFolderDialog).not.toHaveBeenCalled();
   });
+
+  it('surfaces browser picker daemon failures instead of silently treating them as cancel', async () => {
+    mockedIsHostAvailable.mockReturnValue(false);
+    mockedOpenFolderDialog.mockRejectedValue(new Error('Could not open folder picker: zenity is not installed'));
+
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={templates}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Local storage' }));
+
+    expect(await screen.findByText('Could not open folder picker: zenity is not installed')).toBeTruthy();
+    expect(mockedOpenFolderDialog).toHaveBeenCalledWith({ throwOnError: true });
+  });
 });
 
 describe('NewProjectPanel folder import feedback', () => {

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -796,7 +796,7 @@ describe('NewProjectPanel working directory picker', () => {
     expect(mockedOpenFolderDialog).not.toHaveBeenCalled();
   });
 
-  it('surfaces browser picker daemon failures instead of silently treating them as cancel', async () => {
+  it('surfaces browser picker daemon failures with localized copy and native details', async () => {
     mockedIsHostAvailable.mockReturnValue(false);
     mockedOpenFolderDialog.mockRejectedValue(new Error('Could not open folder picker: zenity is not installed'));
 
@@ -814,7 +814,9 @@ describe('NewProjectPanel working directory picker', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Local storage' }));
 
-    expect(await screen.findByText('Could not open folder picker: zenity is not installed')).toBeTruthy();
+    expect(await screen.findByText('Could not open folder picker')).toBeTruthy();
+    expect(await screen.findByText('zenity is not installed')).toBeTruthy();
+    expect(screen.queryByText('Could not open folder picker: zenity is not installed')).toBeNull();
     expect(mockedOpenFolderDialog).toHaveBeenCalledWith({ throwOnError: true });
   });
 });

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -19,6 +19,7 @@ import {
   fetchProjectFileText,
   fetchSkillExample,
   isDeployProviderId,
+  openFolderDialog,
   updateDeployConfig,
   uploadProjectFiles,
   writeProjectTextFileDetailed,
@@ -150,6 +151,38 @@ describe('writeProjectTextFileDetailed', () => {
       code: 'ARTIFACT_REGRESSION',
       message: 'new artifact is smaller than the prior version',
     });
+  });
+});
+
+describe('openFolderDialog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the legacy fail-soft behavior unless throwOnError is requested', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify({ error: 'Could not open folder picker: zenity is not installed' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } },
+      )),
+    );
+
+    await expect(openFolderDialog()).resolves.toBeNull();
+  });
+
+  it('throws daemon picker messages when throwOnError is requested', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify({ error: 'Could not open folder picker: zenity is not installed' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } },
+      )),
+    );
+
+    await expect(openFolderDialog({ throwOnError: true }))
+      .rejects.toThrow('Could not open folder picker: zenity is not installed');
   });
 });
 


### PR DESCRIPTION
Fixes #4758

## Why

The New Project local-storage folder picker could fail before returning a path, especially on Linux/headless setups where `zenity` is missing or cannot open a display. The daemon treated those failures like a quiet user cancel, so clicking the button appeared to do nothing.

## What users will see

In the New Project local-storage flow, canceling the native folder picker still stays quiet. Real picker failures now show the existing localized folder-picker error toast, with the daemon/native root-cause detail shown beneath it so users can tell when their environment cannot open the folder picker.

## Surface area

- [x] **UI** - New Project local-storage folder-picker failure now shows a localized error toast in `apps/web` instead of silently doing nothing; native detail is shown as secondary details.
- [ ] **Keyboard shortcut** - no change
- [ ] **CLI / env var** - no change
- [x] **API / contract** - `/api/dialog/open-folder` now reports real native picker failures as daemon errors; user cancel still returns `path: null`.
- [ ] **Extension point** - no change
- [ ] **i18n keys** - no new keys
- [ ] **New top-level dependency** - no new dependency
- [x] **Default behavior change** - existing browser/local-storage users now see an error for real picker failures; cancel behavior remains unchanged.
- [ ] **None** - user-visible bug fix

## Screenshots

Not included. This is an error-toast path for native picker failures such as missing `zenity` or no display; the visual-regression bot reported `visual-new-project-modal` unchanged.

## Bug fix verification

- `apps/daemon/tests/native-folder-dialog.test.ts` covers Linux `zenity` cancel with warning stderr, selected path parsing, missing `zenity`, and `cannot open display` hard failures.
- `apps/web/tests/components/NewProjectPanel.test.tsx` covers the New Project local-storage failure path and verifies the top-level toast copy stays client-owned while native detail is shown separately.
- `apps/web/tests/providers/registry.test.ts` covers the folder-picker helper's legacy fail-soft behavior and the new `throwOnError` path used by New Project.

## Validation

- `apps/daemon/node_modules/.bin/vitest.cmd run -c vitest.config.ts tests/native-folder-dialog.test.ts` - passed
- `apps/web/node_modules/.bin/vitest.cmd run -c vitest.config.ts tests/components/NewProjectPanel.test.tsx tests/providers/registry.test.ts --maxWorkers=1` - passed
- `corepack pnpm --filter @open-design/daemon typecheck` - passed
- `corepack pnpm --filter @open-design/web typecheck` - passed
- `corepack pnpm typecheck` - passed
- `git diff --check` - passed

## Notes

- `corepack pnpm guard` still fails on catalog-wide stale generated design-system artifacts (`design-tokens.json` and `tailwind-v4.css`) across existing design-systems manifests. This diff does not touch those files.
