### PR TITLE
feat(landing): first-touch attribution cookie for source→payment

### DIFF
--- a/apps/landing-page/app/_components/attribution-cookie.astro
+++ b/apps/landing-page/app/_components/attribution-cookie.astro
@@ -1,0 +1,60 @@
+---
+/*
+ * First-touch acquisition cookie for cross-app payment attribution.
+ *
+ * The marketing site (open-design.ai) and the vela checkout/wallet page
+ * (served same-origin at open-design.ai/cloud/*) share the open-design.ai
+ * domain. This captures utm_* + the external referrer on landing and stores a
+ * FIRST-TOUCH cookie (`od_attr`) so the checkout page can read it back and
+ * attribute the payment to the originating traffic source — closing the
+ * "external source -> payment" gap (per-channel/per-campaign revenue).
+ *
+ * - Forward-only: only affects traffic after this ships.
+ * - First-touch wins: never overwritten, so the original source survives
+ *   later internal navigation.
+ * - Falls back to the referrer host when no utm is present, so organic
+ *   search (google/bing) is attributed too, not just tagged links.
+ * - Sets nothing for true direct traffic (no utm, no external referrer).
+ *
+ * Injected alongside PostHog on every page. No PostHog dependency.
+ */
+---
+<script is:inline>
+(function () {
+  try {
+    var COOKIE = 'od_attr';
+    // First-touch: if we already captured a source, keep it.
+    if (document.cookie.indexOf(COOKIE + '=') !== -1) return;
+
+    var qs = new URLSearchParams(window.location.search);
+    var get = function (k) { var v = qs.get(k); return v ? String(v).slice(0, 120) : ''; };
+    var utmSource = get('utm_source');
+
+    var ref = '';
+    try {
+      if (document.referrer) {
+        var rh = new URL(document.referrer).hostname;
+        if (rh && rh.indexOf('open-design') === -1) ref = rh.slice(0, 120);
+      }
+    } catch (e) {}
+
+    // Nothing to attribute (direct, no utm, no external referrer) -> skip.
+    if (!utmSource && !ref) return;
+
+    var data = {
+      s: utmSource, m: get('utm_medium'), c: get('utm_campaign'),
+      ct: get('utm_content'), tm: get('utm_term'),
+      ref: ref, lp: (location.pathname || '/').slice(0, 80), t: Date.now()
+    };
+
+    // 30-day first-touch window. Use the apex domain in production so the
+    // same-origin checkout page (open-design.ai/cloud/*) can read it; on
+    // preview/dev hosts fall back to a host-only cookie so it still works.
+    var host = location.hostname || '';
+    var domainAttr = /(^|\.)open-design\.ai$/.test(host) ? ';domain=.open-design.ai' : '';
+    var secure = location.protocol === 'https:' ? ';Secure' : '';
+    document.cookie = COOKIE + '=' + encodeURIComponent(JSON.stringify(data)) +
+      ';path=/;max-age=' + (60 * 60 * 24 * 30) + domainAttr + ';SameSite=Lax' + secure;
+  } catch (e) {}
+})();
+</script>

--- a/apps/landing-page/app/_components/site-analytics.astro
+++ b/apps/landing-page/app/_components/site-analytics.astro
@@ -1,0 +1,22 @@
+---
+/*
+ * Unified head analytics for every landing-page template.
+ *
+ * Bundles the three head-level trackers — Google Analytics, PostHog product
+ * analytics, and the first-touch attribution cookie — behind a single mount
+ * point. Templates include `<SiteAnalytics />` instead of wiring each tracker
+ * by hand, so a marketing entry point can no longer silently miss one. (Before
+ * this, every bespoke `<head>` wired GoogleAnalytics individually and several
+ * pages — blog / tutorials / stories — were missing PostHog and the attribution
+ * cookie entirely; arriving there with `?utm_source=` was attributed as direct.)
+ *
+ * Each child self-derives its context (PostHog reads the route for page_name;
+ * the attribution cookie reads utm/referrer from the URL), so no props needed.
+ */
+import GoogleAnalytics from './google-analytics.astro';
+import PostHogAnalytics from './posthog-analytics.astro';
+import AttributionCookie from './attribution-cookie.astro';
+---
+<GoogleAnalytics />
+<PostHogAnalytics />
+<AttributionCookie />

--- a/apps/landing-page/app/_components/sub-page-layout.astro
+++ b/apps/landing-page/app/_components/sub-page-layout.astro
@@ -21,6 +21,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from './favicon-links.astro';
 import GoogleAnalytics from './google-analytics.astro';
 import PostHogAnalytics from './posthog-analytics.astro';
+import AttributionCookie from './attribution-cookie.astro';
 import ResourceHints from './resource-hints.astro';
 import HeaderEnhancer from './header-enhancer.astro';
 import { Header, type HeaderProps } from './header';
@@ -141,6 +142,7 @@ const ldArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
 
     <GoogleAnalytics />
     <PostHogAnalytics />
+    <AttributionCookie />
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Open Design" />

--- a/apps/landing-page/app/_components/sub-page-layout.astro
+++ b/apps/landing-page/app/_components/sub-page-layout.astro
@@ -19,9 +19,7 @@ import '../sub-pages.css';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from './favicon-links.astro';
-import GoogleAnalytics from './google-analytics.astro';
-import PostHogAnalytics from './posthog-analytics.astro';
-import AttributionCookie from './attribution-cookie.astro';
+import SiteAnalytics from './site-analytics.astro';
 import ResourceHints from './resource-hints.astro';
 import HeaderEnhancer from './header-enhancer.astro';
 import { Header, type HeaderProps } from './header';
@@ -140,9 +138,7 @@ const ldArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
     <FaviconLinks />
     <ResourceHints />
 
-    <GoogleAnalytics />
-    <PostHogAnalytics />
-    <AttributionCookie />
+    <SiteAnalytics />
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Open Design" />

--- a/apps/landing-page/app/pages/blog/[slug].astro
+++ b/apps/landing-page/app/pages/blog/[slug].astro
@@ -10,6 +10,7 @@ import { getCollection, render } from 'astro:content';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import GoogleAnalytics from '../../_components/google-analytics.astro';
+import AttributionCookie from '../../_components/attribution-cookie.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -208,6 +209,7 @@ const author = getBlogAuthor((post.data as { author?: string }).author);
     />
     <script is:inline type='application/ld+json' set:html={JSON.stringify(breadcrumbJsonLd)} />
     <GoogleAnalytics />
+    <AttributionCookie />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/blog/[slug].astro
+++ b/apps/landing-page/app/pages/blog/[slug].astro
@@ -9,8 +9,7 @@
 import { getCollection, render } from 'astro:content';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import GoogleAnalytics from '../../_components/google-analytics.astro';
-import AttributionCookie from '../../_components/attribution-cookie.astro';
+import SiteAnalytics from '../../_components/site-analytics.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -208,8 +207,7 @@ const author = getBlogAuthor((post.data as { author?: string }).author);
       category={post.data.category}
     />
     <script is:inline type='application/ld+json' set:html={JSON.stringify(breadcrumbJsonLd)} />
-    <GoogleAnalytics />
-    <AttributionCookie />
+    <SiteAnalytics />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/blog/index.astro
+++ b/apps/landing-page/app/pages/blog/index.astro
@@ -13,8 +13,7 @@
 import { getCollection } from 'astro:content';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import GoogleAnalytics from '../../_components/google-analytics.astro';
-import AttributionCookie from '../../_components/attribution-cookie.astro';
+import SiteAnalytics from '../../_components/site-analytics.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LazyImg from '../../_components/lazy-img.astro';
@@ -183,8 +182,7 @@ const localizedPostField = (
       description={seoDescription}
       pathname={Astro.url.pathname}
     />
-    <GoogleAnalytics />
-    <AttributionCookie />
+    <SiteAnalytics />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/blog/index.astro
+++ b/apps/landing-page/app/pages/blog/index.astro
@@ -14,6 +14,7 @@ import { getCollection } from 'astro:content';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import GoogleAnalytics from '../../_components/google-analytics.astro';
+import AttributionCookie from '../../_components/attribution-cookie.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LazyImg from '../../_components/lazy-img.astro';
@@ -183,6 +184,7 @@ const localizedPostField = (
       pathname={Astro.url.pathname}
     />
     <GoogleAnalytics />
+    <AttributionCookie />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -8,6 +8,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from '../_components/favicon-links.astro';
 import GoogleAnalytics from '../_components/google-analytics.astro';
 import PostHogAnalytics from '../_components/posthog-analytics.astro';
+import AttributionCookie from '../_components/attribution-cookie.astro';
 import ResourceHints from '../_components/resource-hints.astro';
 import LocaleSwitcherScript from '../_components/locale-switcher-script.astro';
 import PreciseLazyload from '../_components/precise-lazyload.astro';
@@ -166,6 +167,7 @@ const matterRuntime = readFileSync(
 
     <GoogleAnalytics />
     <PostHogAnalytics />
+    <AttributionCookie />
 
     {/*
      * Hero LCP preload. Cloudflare Pages turns this <link rel="preload"> into

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -6,9 +6,7 @@ import { createRequire } from 'node:module';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from '../_components/favicon-links.astro';
-import GoogleAnalytics from '../_components/google-analytics.astro';
-import PostHogAnalytics from '../_components/posthog-analytics.astro';
-import AttributionCookie from '../_components/attribution-cookie.astro';
+import SiteAnalytics from '../_components/site-analytics.astro';
 import ResourceHints from '../_components/resource-hints.astro';
 import LocaleSwitcherScript from '../_components/locale-switcher-script.astro';
 import PreciseLazyload from '../_components/precise-lazyload.astro';
@@ -165,9 +163,7 @@ const matterRuntime = readFileSync(
     <FaviconLinks />
     <ResourceHints />
 
-    <GoogleAnalytics />
-    <PostHogAnalytics />
-    <AttributionCookie />
+    <SiteAnalytics />
 
     {/*
      * Hero LCP preload. Cloudflare Pages turns this <link rel="preload"> into

--- a/apps/landing-page/app/pages/stories/ikigai-one.astro
+++ b/apps/landing-page/app/pages/stories/ikigai-one.astro
@@ -17,8 +17,7 @@
  */
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import GoogleAnalytics from '../../_components/google-analytics.astro';
-import AttributionCookie from '../../_components/attribution-cookie.astro';
+import SiteAnalytics from '../../_components/site-analytics.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -96,8 +95,7 @@ const headerHtml = renderToStaticMarkup(
       image={ogImage}
     />
     <script is:inline type='application/ld+json' set:html={JSON.stringify(breadcrumbJsonLd)} />
-    <GoogleAnalytics />
-    <AttributionCookie />
+    <SiteAnalytics />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/stories/ikigai-one.astro
+++ b/apps/landing-page/app/pages/stories/ikigai-one.astro
@@ -18,6 +18,7 @@
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import GoogleAnalytics from '../../_components/google-analytics.astro';
+import AttributionCookie from '../../_components/attribution-cookie.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -96,6 +97,7 @@ const headerHtml = renderToStaticMarkup(
     />
     <script is:inline type='application/ld+json' set:html={JSON.stringify(breadcrumbJsonLd)} />
     <GoogleAnalytics />
+    <AttributionCookie />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/stories/index.astro
+++ b/apps/landing-page/app/pages/stories/index.astro
@@ -12,8 +12,7 @@
  */
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import GoogleAnalytics from '../../_components/google-analytics.astro';
-import AttributionCookie from '../../_components/attribution-cookie.astro';
+import SiteAnalytics from '../../_components/site-analytics.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -99,8 +98,7 @@ const headerHtml = renderToStaticMarkup(
       image={ogImage}
     />
     <script is:inline type='application/ld+json' set:html={JSON.stringify(collectionJsonLd)} />
-    <GoogleAnalytics />
-    <AttributionCookie />
+    <SiteAnalytics />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/stories/index.astro
+++ b/apps/landing-page/app/pages/stories/index.astro
@@ -13,6 +13,7 @@
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import GoogleAnalytics from '../../_components/google-analytics.astro';
+import AttributionCookie from '../../_components/attribution-cookie.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -99,6 +100,7 @@ const headerHtml = renderToStaticMarkup(
     />
     <script is:inline type='application/ld+json' set:html={JSON.stringify(collectionJsonLd)} />
     <GoogleAnalytics />
+    <AttributionCookie />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/tutorials/[slug].astro
+++ b/apps/landing-page/app/pages/tutorials/[slug].astro
@@ -11,8 +11,7 @@
 import { getCollection, render } from 'astro:content';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import GoogleAnalytics from '../../_components/google-analytics.astro';
-import AttributionCookie from '../../_components/attribution-cookie.astro';
+import SiteAnalytics from '../../_components/site-analytics.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -142,8 +141,7 @@ const tutorialCopy =
       datePublished={entry.data.date}
       category={tutorialCopy.category}
     />
-    <GoogleAnalytics />
-    <AttributionCookie />
+    <SiteAnalytics />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/tutorials/[slug].astro
+++ b/apps/landing-page/app/pages/tutorials/[slug].astro
@@ -12,6 +12,7 @@ import { getCollection, render } from 'astro:content';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import GoogleAnalytics from '../../_components/google-analytics.astro';
+import AttributionCookie from '../../_components/attribution-cookie.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -142,6 +143,7 @@ const tutorialCopy =
       category={tutorialCopy.category}
     />
     <GoogleAnalytics />
+    <AttributionCookie />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/tutorials/index.astro
+++ b/apps/landing-page/app/pages/tutorials/index.astro
@@ -14,6 +14,7 @@ import { getCollection } from 'astro:content';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import GoogleAnalytics from '../../_components/google-analytics.astro';
+import AttributionCookie from '../../_components/attribution-cookie.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -128,6 +129,7 @@ const featuredCopy = featuredTutorial ? localizedTutorial(featuredTutorial) : un
       pathname={Astro.url.pathname}
     />
     <GoogleAnalytics />
+    <AttributionCookie />
   </head>
   <body>
     <div class='shell'>

--- a/apps/landing-page/app/pages/tutorials/index.astro
+++ b/apps/landing-page/app/pages/tutorials/index.astro
@@ -13,8 +13,7 @@
 import { getCollection } from 'astro:content';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import GoogleAnalytics from '../../_components/google-analytics.astro';
-import AttributionCookie from '../../_components/attribution-cookie.astro';
+import SiteAnalytics from '../../_components/site-analytics.astro';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
 import { Header, type HeaderProps } from '../../_components/header';
 import LocaleSwitcherScript from '../../_components/locale-switcher-script.astro';
@@ -128,8 +127,7 @@ const featuredCopy = featuredTutorial ? localizedTutorial(featuredTutorial) : un
       description={seoDescription}
       pathname={Astro.url.pathname}
     />
-    <GoogleAnalytics />
-    <AttributionCookie />
+    <SiteAnalytics />
   </head>
   <body>
     <div class='shell'>


### PR DESCRIPTION
## Why

I'm on the growth/commercialization side, building a paying-user funnel
dashboard. To allocate growth budget I need to answer "which channel /
campaign brings the best paying users" — but today I can't: Open Design is a
desktop app and UTM isn't wired through to payment, so ~95% of payers'
external source resolves to `$direct`. The acquisition source of our paying
users is effectively a black box.

This is step 1 of connecting external source → payment. The marketing site
(open-design.ai) and the vela checkout/wallet page are served on the **same
origin** (`open-design.ai/cloud/*`), so a first-touch cookie set here can be
read at checkout. This PR captures `utm_*` + the external referrer on landing
into a first-touch `od_attr` cookie. A companion vela PR reads it at checkout
and carries it into `billing_payment_result`, closing the loop.

Forward-only and self-contained on this side — it only writes a cookie. With
no reader on the vela side yet, it's a harmless no-op, so it can land
independently and start accruing first-touch data.

## What users will see

Nothing visible — no UI, no behavior change. It's an internal first-touch
attribution cookie, consistent with the PostHog/GA analytics already on the
marketing site. It only writes for visitors arriving with a utm tag or an
external referrer; true direct traffic sets nothing.

## What changed (head analytics consolidation)

A reviewer flagged that several bespoke marketing heads (blog/{index,[slug]},
tutorials/{index,[slug]}, stories/{index,ikigai-one}) don't use
`sub-page-layout` and wired `GoogleAnalytics` by hand — so they'd never get
the cookie, and a visitor arriving at `/blog/...?utm_source=...` would still
resolve to direct at checkout. Rather than hand-add the cookie to each (same
fragility), I bundled all three head trackers into a single
`<SiteAnalytics />` component (Google Analytics + PostHog + AttributionCookie)
that every landing template now mounts. A marketing entry point can no longer
silently miss a tracker.

**Intentional coverage change worth naming:** those bespoke pages previously
had ONLY GoogleAnalytics — they were also missing PostHog. Consolidating gives
them PostHog too. That's a small analytics-coverage gain (real marketing pages
that should be tracked), not a user-facing behavior change; PostHog autocapture
stays off, so it's the same curated event set as the rest of the site.

## Surface area

- [x] **None** — head-level analytics only (attribution cookie + the
  GA/PostHog/cookie consolidation); no UI / CLI / API / contract / i18n /
  dependency changes.

## Screenshots

N/A — no UI surface.

## Validation

- `astro check` on `apps/landing-page` → 0 errors.
- Verified every landing template now mounts `<SiteAnalytics />`; no page
  imports a tracker component directly anymore (only `site-analytics.astro`
  does).
- Cookie first-touch behavior: skips on direct traffic, not overwritten on
  later navigation; apex `.open-design.ai` in prod with a host-only fallback
  on preview hosts so it's testable on the Cloudflare preview.
