### PR TITLE
fix(web): hide empty tool_call/tool_call_update status rows in assistant process

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -2794,13 +2794,18 @@ function buildBlocks(events: AgentEvent[]): Block[] {
       continue;
     }
     if (ev.kind === "status") {
+      // Keep in sync with providers/daemon.ts TRANSIENT_ACP_STATUS_LABELS.
+      // The live SSE path normalizes these to "running", but the
+      // persisted-events path does not — so bare labels survive here.
       if (
         ev.label === "streaming" ||
         ev.label === "starting" ||
         ev.label === "running" ||
         ev.label === "requesting" ||
         ev.label === "thinking" ||
-        ev.label === "empty_response"
+        ev.label === "empty_response" ||
+        ev.label === "tool_call" ||
+        ev.label === "tool_call_update"
       )
         continue;
       const last = out[out.length - 1];


### PR DESCRIPTION
## Why

When the daemon persists agent events (instead of streaming them live), the `TRANSIENT_ACP_STATUS_LABELS` normalization in `providers/daemon.ts` is not applied. This causes bare `tool_call` and `tool_call_update` status labels to reach `buildBlocks()`, which renders them as expandable "tool ran but produced no output" rows. These labels carry no tool name, input, output, or detail — they're purely internal status markers.

## What users will see

Empty `tool_call` / `tool_call_update` status pills no longer appear in the assistant process panel. Real tool calls with visible metadata continue to render normally.

## Changes

`apps/web/src/components/AssistantMessage.tsx` — added `tool_call` and `tool_call_update` to the existing status label skip-list in `buildBlocks()`, with a comment referencing `TRANSIENT_ACP_STATUS_LABELS` in `providers/daemon.ts` as the canonical source.

## Surface area

- [x] Web UI (`apps/web`)
- [ ] Daemon (`apps/daemon`)
- [ ] CLI (`od`)
- [ ] Desktop shell
- [ ] Packaged app
- [ ] Contracts or `.github`
- [ ] Design systems / skills / craft / design templates
- [ ] Docs / i18n
- [ ] New dependency

## Verification

- `pnpm typecheck`: clean (all apps)
- `pnpm --filter @open-design/web test`: 355/357 pass (2 pre-existing FileViewer timeouts, unrelated)
- CI: all gates green (workspace unit tests, web workspace tests, E2E Vitest, UI P0 smoke, visual regression)

Closes #4618

---

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)