### PR TITLE
hide empty tool_call/tool_call_update status rows in buildBlocks

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -2800,7 +2800,13 @@ function buildBlocks(events: AgentEvent[]): Block[] {
         ev.label === "running" ||
         ev.label === "requesting" ||
         ev.label === "thinking" ||
-        ev.label === "empty_response"
+        ev.label === "empty_response" ||
+        // Persisted events path: daemon normalizes tool_call / tool_call_update
+        // to 'running' via TRANSIENT_ACP_STATUS_LABELS in providers/daemon.ts,
+        // but the persisted-events path bypasses that normalization, so bare
+        // labels survive here with no detail to show.
+        ev.label === "tool_call" ||
+        ev.label === "tool_call_update"
       )
         continue;
       const last = out[out.length - 1];


### PR DESCRIPTION
The persisted-events path skips the daemon's TRANSIENT_ACP_STATUS_LABELS normalization, so bare tool_call/tool_call_update labels render as empty expandable rows in the assistant process panel. Adding both to the skip list in buildBlocks() to match the live SSE path.
