### PR TITLE
feat(skills): add instagram-carousel skill for OD daemon

### DIFF
--- a/skills/instagram-carousel/SKILL.md
+++ b/skills/instagram-carousel/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: instagram-carousel
+description: |
+  Generate a 7-slide Instagram carousel as self-contained HTML.
+  Each slide is 1080x1350px. Output is a single HTML file with
+  inline CSS, Google Fonts, and all slides in sequence.
+triggers:
+  - "instagram carousel"
+  - "social carousel"
+  - "carousel slides"
+od:
+  mode: prototype
+  preview:
+    type: html
+    entry: index.html
+  design_system:
+    requires: true
+    sections: [color, typography, layout, components]
+  craft:
+    requires: [typography, anti-ai-slop]
+  outputs:
+    primary: index.html
+---
+
+# Instagram Carousel Builder
+
+You are building a 7-slide Instagram carousel as a single self-contained HTML file. Every slide is exactly 1080px wide by 1350px tall. The output must work as a local file opened in a browser — all CSS inline, fonts loaded from Google Fonts CDN, no external dependencies besides fonts.
+
+## CRITICAL: Headless Mode
+
+Do NOT use AskUserQuestion or any interactive tool. All content is provided in the user prompt. Do NOT run a discovery phase. Do NOT ask clarifying questions. Read the prompt, build the carousel, output the artifact immediately.
+
+## Slide Structure
+
+The carousel has exactly 7 slides in this order:
+
+1. **Cover** — Hook headline + subcopy + "Swipe →" indicator + social handle
+2. **Content 1** — Ghost number (01) + step label + headline + body + handle
+3. **Content 2** — Ghost number (02) + step label + headline + body + handle
+4. **Content 3** — Ghost number (03) + step label + headline + body + handle
+5. **Content 4** — Ghost number (04) + step label + headline + body + handle
+6. **Content 5** — Ghost number (05) + step label + headline + body + handle
+7. **CTA** — Eyebrow + headline + "Link in Bio" button + subcopy + handle
+
+## HTML Architecture
+
+```html
+<div class="gallery" id="gallery">
+  <!-- Repeat for each slide: -->
+  <div class="frame-wrap">
+    <div class="slide-frame" id="carousel-1-slide-N">
+      <div class="slide">
+        <!-- slide content -->
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+**Required classes** (screenshot tooling depends on these):
+- `.slide-frame` — the 1080x1350 container. Must have `width: 1080px; height: 1350px`.
+- `.slide` — the content area inside the frame. Same dimensions.
+- `.frame-wrap` — outer wrapper for each slide.
+- `.gallery` with `id="gallery"` — the parent container.
+
+## CSS Rules
+
+Read the active DESIGN.md. Apply its color palette, typography, and spacing rules. Specifically:
+
+- Use the display font for headlines (ALL CAPS, letter-spacing: 0.06em minimum)
+- Use the body font for body text
+- Use the brand accent color for: divider lines, one accent element per slide max
+- Background colors must alternate per the brand's section rhythm
+- `border-radius: 0` unless the brand's DESIGN.md explicitly allows rounded corners
+- All font sizes use `px` units (not rem/em/cqw — this is a fixed-dimension canvas)
+- Social handle appears on every slide, bottom-right or bottom-center, muted color
+
+## Typography Scale (1080px canvas)
+
+- Cover headline: 48-64px display font, ALL CAPS
+- Content headline: 36-44px display font, ALL CAPS
+- Content body: 22-26px body font, regular weight
+- Step label: 14-16px body font, uppercase, tracked
+- Ghost number: 180-220px display font, opacity 0.06-0.08
+- CTA headline: 44-56px display font, ALL CAPS
+- Social handle: 14-16px body font, muted
+
+## Slide Composition Rules
+
+- Cover: headline at bottom-third of slide, subcopy below, generous top space
+- Content slides: ghost number top-left (absolute positioned), content vertically centered
+- Each content slide has an orange/accent divider line between step-label and headline
+- CTA: content bottom-third, "Link in Bio" as a styled button element
+- "Swipe →" indicator on cover slide only, bottom area
+
+## Output Contract
+
+- Write a single `index.html` file wrapped in `<artifact type="html" title="Instagram Carousel">` tags
+- ALL CSS must be in a `<style>` tag in `<head>` — no external stylesheets
+- Google Fonts loaded via `<link>` in `<head>` (the only allowed external resource)
+- No JavaScript required (static slides, no navigation needed)
+- Slides render vertically stacked — screenshot tooling captures each `.slide-frame` individually
+
+## Quality Checks Before Output
+
+1. Exactly 7 `.slide-frame` elements
+2. Every slide is 1080x1350px
+3. Brand colors from DESIGN.md used — no hardcoded colors outside of `:root`
+4. Display font from DESIGN.md on all headlines
+5. Social handle on every slide
+6. No emoji icons
+7. No placeholder text or lorem ipsum
+8. ALL CAPS on headlines with letter-spacing ≥ 0.06em

--- a/skills/instagram-carousel/assets/reference.html
+++ b/skills/instagram-carousel/assets/reference.html
@@ -1,0 +1,207 @@
+<!--
+  Reference: target HTML structure for instagram-carousel skill.
+  Agent should produce this DOM shape. Content and styling come from
+  the user prompt and active DESIGN.md.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=1080">
+  <title>Carousel Reference</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    .gallery {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+      padding: 24px;
+      background: #1a1a1a;
+    }
+
+    .frame-wrap {
+      flex-shrink: 0;
+    }
+
+    .slide-frame {
+      width: 1080px;
+      height: 1350px;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .slide {
+      width: 1080px;
+      height: 1350px;
+      position: relative;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* --- Cover slide --- */
+    .slide[data-screen-label="01 Cover"] {
+      justify-content: flex-end;
+      padding: 0 80px 120px;
+    }
+
+    .slide[data-screen-label="01 Cover"] .head {
+      font-size: 56px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      line-height: 1.1;
+    }
+
+    .slide[data-screen-label="01 Cover"] .subcopy {
+      font-size: 18px;
+      margin-top: 20px;
+      opacity: 0.7;
+    }
+
+    .swipe {
+      font-size: 16px;
+      text-transform: uppercase;
+      letter-spacing: 0.15em;
+      position: absolute;
+      bottom: 60px;
+      left: 80px;
+      opacity: 0.5;
+    }
+
+    /* --- Content slides --- */
+    .ghost-num {
+      position: absolute;
+      top: 40px;
+      left: 60px;
+      font-size: 200px;
+      opacity: 0.07;
+      line-height: 1;
+      font-weight: 400;
+    }
+
+    .content-mid {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+      height: 100%;
+      padding: 0 80px;
+    }
+
+    .step-label {
+      font-size: 15px;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-weight: 500;
+    }
+
+    .divider {
+      width: 48px;
+      height: 3px;
+      margin: 16px 0;
+      /* accent color from DESIGN.md */
+    }
+
+    .head-content {
+      font-size: 40px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      line-height: 1.15;
+    }
+
+    .body {
+      font-size: 24px;
+      line-height: 1.5;
+      margin-top: 20px;
+      max-width: 880px;
+    }
+
+    /* --- CTA slide --- */
+    .eyebrow {
+      font-size: 15px;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .cta-btn {
+      display: inline-block;
+      padding: 16px 48px;
+      font-size: 18px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 600;
+      margin-top: 24px;
+      border: 2px solid currentColor;
+    }
+
+    .cta-sub {
+      font-size: 16px;
+      margin-top: 16px;
+      opacity: 0.6;
+    }
+
+    /* --- Handle (all slides) --- */
+    .handle {
+      position: absolute;
+      bottom: 30px;
+      right: 40px;
+      font-size: 15px;
+      opacity: 0.4;
+    }
+  </style>
+</head>
+<body>
+  <div class="gallery" id="gallery">
+
+    <!-- Slide 1: Cover -->
+    <div class="frame-wrap">
+      <div class="slide-frame" id="carousel-1-slide-1">
+        <div class="slide" data-screen-label="01 Cover">
+          <div class="content content-bottom">
+            <h2 class="head">COVER HEADLINE GOES HERE</h2>
+            <p class="subcopy">keyword one · keyword two · keyword three</p>
+          </div>
+          <div class="swipe">Swipe <span class="arr">&rarr;</span></div>
+          <div class="handle">@handle</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Slide 2: Content -->
+    <div class="frame-wrap">
+      <div class="slide-frame" id="carousel-1-slide-2">
+        <div class="slide" data-screen-label="02">
+          <div class="ghost-num">01</div>
+          <div class="content content-mid">
+            <div class="step-label">Step Label</div>
+            <div class="divider"></div>
+            <h2 class="head-content">CONTENT HEADLINE</h2>
+            <p class="body">Body text goes here. Keep it educational and direct.</p>
+          </div>
+          <div class="handle">@handle</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Slides 3-6: same structure as slide 2, ghost-num 02-05 -->
+
+    <!-- Slide 7: CTA -->
+    <div class="frame-wrap">
+      <div class="slide-frame" id="carousel-1-slide-7">
+        <div class="slide" data-screen-label="07 CTA">
+          <div class="content content-bottom">
+            <div class="eyebrow">CTA Eyebrow</div>
+            <h2 class="head">CTA HEADLINE HERE</h2>
+            <div class="cta-btn">Link in Bio</div>
+            <div class="cta-sub">Book a consultation · brand.com</div>
+          </div>
+          <div class="handle">@handle</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `skills/instagram-carousel` skill that generates 7-slide 1080x1350 HTML carousels from structured JSON specs
- Includes `SKILL.md` (skill definition with system prompt, slide schema, and rendering rules) and `assets/reference.html` (reference implementation)
- Designed for headless invocation by the OD daemon when social-engine routes carousel rendering through the bridge API

## Context
Companion PR in social-engine adds the bridge module that calls this skill via the OD daemon REST API. This PR can be reviewed and merged independently.

## Test plan
- [ ] Review SKILL.md for completeness of slide schema and rendering instructions
- [ ] Open `assets/reference.html` in a browser and verify it renders a valid 1080x1350 carousel
- [ ] Confirm the skill loads correctly when the OD daemon indexes the skills directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)