### PR TITLE
fix(plugins): add bundled Perplexity AI design-system manifest (#4828)

### DIFF
--- a/plugins/_official/design-systems/perplexity/DESIGN.md
+++ b/plugins/_official/design-systems/perplexity/DESIGN.md
@@ -1,0 +1,286 @@
+# Design System Inspired by Perplexity AI
+
+> Category: AI & LLM
+> Conversational AI search engine. Deep-dark canvas, sharp typography, single violet accent, dense information hierarchy.
+
+## 1. Visual Theme & Atmosphere
+
+Perplexity reads like a research terminal: unhurried, precise, and confident. The dark surface is not decorative — it reduces visual noise so citations, sources, and answers can breathe. There is no gradient hero, no animated blob, no hero illustration. The chrome disappears and the content leads. Light mode exists but the dark variant is the brand-defining surface.
+
+Core atmosphere words: **grounded, sharp, credible, quiet**. Every layout decision serves legibility over aesthetics.
+
+## 2. Color
+
+All values are sampled from Perplexity's production interface and marketing site (May 2025).
+
+### Dark surface (default)
+
+| Token | Hex | OKLch | Role |
+|---|---|---|---|
+| `--bg-base` | `#0f0f10` | `oklch(8% 0.004 280)` | Page background |
+| `--bg-surface` | `#19191a` | `oklch(12% 0.004 280)` | Card / sidebar surface |
+| `--bg-elevated` | `#232325` | `oklch(16% 0.005 280)` | Tooltip, popover, hover state |
+| `--border` | `#2e2e30` | `oklch(21% 0.005 280)` | Divider, input border |
+| `--text-primary` | `#f0f0f0` | `oklch(95% 0 0)` | Body copy, headings |
+| `--text-secondary` | `#9b9b9b` | `oklch(64% 0 0)` | Meta, captions, labels |
+| `--text-tertiary` | `#5c5c5e` | `oklch(42% 0 0)` | Placeholder, disabled |
+| `--accent` | `#a855f7` | `oklch(62% 0.22 307)` | Primary CTA, focus ring, active tab |
+| `--accent-hover` | `#c084fc` | `oklch(72% 0.20 307)` | Hover state on accent |
+| `--accent-subtle` | `#3b1f5e` | `oklch(22% 0.14 307)` | Accent tint background |
+| `--success` | `#22c55e` | `oklch(72% 0.19 145)` | Verified source badge |
+| `--warning` | `#f59e0b` | `oklch(74% 0.17 72)` | Caution |
+| `--error` | `#ef4444` | `oklch(63% 0.21 27)` | Error state |
+
+### Light surface
+
+| Token | Hex | Role |
+|---|---|---|
+| `--bg-base` | `#ffffff` | Page background |
+| `--bg-surface` | `#f8f8f8` | Card surface |
+| `--bg-elevated` | `#f0f0f0` | Hover / elevated |
+| `--border` | `#e0e0e0` | Divider |
+| `--text-primary` | `#0f0f10` | Body copy |
+| `--text-secondary` | `#5c5c5e` | Meta |
+| `--accent` | `#7c3aed` |  Primary CTA, focus ring, active tab |
+
+### Usage rules
+
+- Accent (`#a855f7`) is reserved for a single interactive element per view — the primary action. Do not use it decoratively.
+- Never use white text on the accent color in body copy; reserve that combination for buttons and badges only.
+- Backgrounds stack in exactly three levels: base → surface → elevated. Do not invent a fourth.
+
+## 3. Typography
+
+Perplexity uses a system-default sans-serif stack for UI elements and a clean geometric monospace for code blocks. No custom display face is licensed for third-party use.
+
+### Families
+
+| Role | Family | Fallback |
+|---|---|---|
+| UI / body | `"Inter"` | `ui-sans-serif, system-ui, -apple-system, sans-serif` |
+| Code / citations | `"JetBrains Mono"` | `ui-monospace, "Cascadia Code", monospace` |
+| Numeric data | `"Inter"` with tabular nums | feature: `tnum`, `ss01` |
+
+### Scale
+
+| Label | Size | Line height | Weight | Usage |
+|---|---|---|---|---|
+| `display` | 2rem / 32px | 1.2 | 600 | Page title, hero answer headline |
+| `heading-l` | 1.375rem / 22px | 1.3 | 600 | Section heading |
+| `heading-m` | 1.125rem / 18px | 1.4 | 600 | Sub-section heading |
+| `body` | 0.9375rem / 15px | 1.65 | 400 | Primary reading copy |
+| `body-sm` | 0.8125rem / 13px | 1.55 | 400 | Secondary, meta |
+| `caption` | 0.6875rem / 11px | 1.4 | 400 | Source labels, timestamps |
+| `code` | 0.875rem / 14px | 1.6 | 400 | Inline code, citations |
+
+### Rules
+
+- Line length: 55–70 characters for body copy. Wider than 80 chars in dense reading layouts breaks comprehension.
+- Inter is loaded from Google Fonts or self-hosted; do not use Helvetica or Arial as a substitute — the weight rendering differs.
+- Bold (700) is used for answer headings only, never for emphasis within body paragraphs; use color change or size for inline emphasis.
+
+## 4. Spacing & Grid
+
+Perplexity uses an **8px base unit** throughout.
+
+| Token | Value | Usage |
+|---|---|---|
+| `--space-1` | 4px | Icon gap, tight label padding |
+| `--space-2` | 8px | Inline padding, small element gap |
+| `--space-3` | 12px | Component internal padding |
+| `--space-4` | 16px | Card padding, section gap |
+| `--space-5` | 24px | Between-component spacing |
+| `--space-6` | 32px | Section divider gap |
+| `--space-7` | 48px | Page-level vertical rhythm |
+| `--space-8` | 64px | Hero / above-fold padding |
+
+### Layout grid
+
+- **Max content width:** 720px for the answer column (reading context); 1100px for the full-page shell.
+- **Sidebar:** 280px fixed; collapses under 900px viewport.
+- **Columns:** 12-column, 16px gutter.
+- Mobile: single column, 16px side margin.
+
+### Border radius
+
+| Token | Value | Usage |
+|---|---|---|
+| `--radius-sm` | 4px | Inline badge, tag |
+| `--radius-md` | 8px | Input field, card |
+| `--radius-lg` | 12px | Modal, popover |
+| `--radius-xl` | 16px | Bottom sheet, floating panel |
+| `--radius-full` | 9999px | Pill button, avatar |
+
+## 5. Layout & Composition
+
+### The answer-first pattern
+
+The primary layout is a centered single-column answer, flanked by a source sidebar on the right. Nothing competes for attention above the fold. The question appears as a `heading-l` immediately followed by the answer body — no hero image, no decorative element.
+
+### Source cards
+
+Sources appear as compact horizontal chips (favicon + domain + excerpt) stacked below the answer or in a right rail. Each chip has:
+- `--bg-surface` background
+- `--border` 1px stroke
+- `--radius-md` corners
+- Favicon 16×16, clipped to circle
+- Domain text in `body-sm`, secondary color
+- Hover: `--bg-elevated`, no transition (instant)
+
+### Search bar
+
+- Full-width, `--bg-surface` fill, `--border` 1px stroke, `--radius-xl`
+- Inner padding: 14px horizontal, 12px vertical
+- Placeholder in `--text-tertiary`
+- Focus: `--accent` 2px outline, no box-shadow
+- Submit icon: right-aligned, accent color on focus
+
+### Iconography
+
+16×16 and 20×20 only. Stroke-based, 1.5px stroke weight, square caps, miter joins. Never fill-based icons in the UI chrome. Heroicons (MIT) is the closest open-source match.
+
+## 6. Components
+
+### Primary button
+
+```css
+background: var(--accent);
+color: #fff;
+border-radius: var(--radius-md);
+padding: 10px 20px;
+font-size: 0.9375rem;
+font-weight: 500;
+border: none;
+cursor: pointer;
+transition: background 120ms ease;
+
+&:hover { background: var(--accent-hover); }
+&:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+&:disabled { opacity: 0.4; cursor: not-allowed; }
+```
+
+### Ghost button
+
+```css
+background: transparent;
+color: var(--text-primary);
+border: 1px solid var(--border);
+border-radius: var(--radius-md);
+padding: 9px 20px;
+
+&:hover { background: var(--bg-elevated); }
+```
+
+### Source badge
+
+```css
+display: inline-flex;
+align-items: center;
+gap: 6px;
+background: var(--bg-surface);
+border: 1px solid var(--border);
+border-radius: var(--radius-sm);
+padding: 3px 8px;
+font-size: 0.6875rem;
+color: var(--text-secondary);
+```
+
+### Answer card
+
+```css
+background: var(--bg-surface);
+border: 1px solid var(--border);
+border-radius: var(--radius-lg);
+padding: var(--space-5);
+```
+
+No drop shadow. Elevation is communicated through border contrast, not shadow.
+
+### Input / search field
+
+```css
+background: var(--bg-surface);
+border: 1px solid var(--border);
+border-radius: var(--radius-xl);
+padding: 12px 16px;
+font-size: 0.9375rem;
+color: var(--text-primary);
+outline: none;
+
+&:focus { border-color: var(--accent); }
+```
+
+### Tab bar
+
+Tabs use `--text-secondary` by default. Active tab: `--text-primary` + 2px bottom border in `--accent`. No background highlight on the active tab.
+
+### Skeleton loader
+
+```css
+background: linear-gradient(
+  90deg,
+  var(--bg-elevated) 25%,
+  var(--bg-surface)  50%,
+  var(--bg-elevated) 75%
+);
+background-size: 400% 100%;
+animation: skeleton-shimmer 1.4s ease infinite;
+border-radius: var(--radius-sm);
+```
+
+## 7. Motion & Interaction
+
+Perplexity's interactions are nearly imperceptible — the brand is anti-animation. Every transition exists to prevent jarring state jumps, not to delight.
+
+| Action | Duration | Easing |
+|---|---|---|
+| Hover state change | 120ms | `ease` |
+| Panel / sidebar open | 160ms | `ease-out` |
+| Modal appear | 200ms | `ease-out` |
+| Skeleton shimmer | 1400ms | `ease` infinite |
+| Accordion expand | 180ms | `ease-in-out` |
+
+Rules:
+- No spring physics, no bounce, no overshoot.
+- `prefers-reduced-motion: reduce` → all transitions collapse to 0ms instant.
+- No entrance animations for content — the answer appears immediately, not with a fade-in sequence.
+- The streaming answer text appears character-by-character via the model stream, not via CSS animation.
+
+## 8. Voice & Brand
+
+### Tone
+
+- **Precise:** Say the thing directly. No throat-clearing ("Great question!"), no filler phrases.
+- **Cited:** Every factual claim is attributed. Hedging language ("according to", "reportedly") is preferred over assertions.
+- **Neutral:** No personality performance. Perplexity is a tool, not a friend. The interface does not compliment the user.
+- **Dense:** Short paragraphs, numbered lists for steps, bullet lists for options. Wall-of-text answers are a bug.
+
+### UI copy patterns
+
+| Context | Pattern |
+|---|---|
+| Empty state | `Ask anything.` — no emoji, no exclamation mark |
+| Loading | `Searching…` — ellipsis, no spinner label |
+| Error | `Something went wrong. Try again.` — direct, no apology |
+| Success | No toast — the result is the confirmation |
+| CTA | `Search`, `Ask`, `Summarize` — verb-only, no "Click to …" |
+
+### What Perplexity is not
+
+- Not playful (no winking emoji, no casual slang in UI copy)
+- Not enterprise-formal (no "leverage", no "synergy")
+- Not a news outlet (no editorial headlines, no opinionated framing)
+
+## 9. Anti-patterns
+
+These patterns are inconsistent with the Perplexity visual language and should be avoided in any artifact using this design system.
+
+- **Gradient backgrounds.** `--bg-base` is a flat near-black. No hero gradients, no mesh gradients, no color blobs.
+- **Drop shadows.** Elevation is expressed through background color steps (`base → surface → elevated`), never box-shadow.
+- **Colorful icons.** All UI icons are monochrome at `--text-secondary`. No multi-color icon sets.
+- **Rounded pill cards.** Cards use `--radius-lg` (12px), not full-pill radii. Pill shapes are reserved for tags and avatars only.
+- **Decorative illustration.** No isometric 3D, no blob characters, no abstract art in the UI chrome. If an image is shown, it is a source thumbnail or user-uploaded content.
+- **Accent overuse.** Purple (`--accent`) appears once per view: the primary button or the active focus state. Using it for headings, dividers, or backgrounds breaks the hierarchy.
+- **Modal overload.** Perplexity resolves choices inline (inline pickers, inline follow-ups) rather than spawning a blocking modal dialog.
+- **Capitalized section labels.** Section labels are sentence case, not ALL CAPS or Title Case.
+- **Inter at display size as a display face.** Inter at 2rem+ looks thin. Use weight 600, not 700, for display headings, and never stretch or condense it.

--- a/plugins/_official/design-systems/perplexity/open-design.json
+++ b/plugins/_official/design-systems/perplexity/open-design.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-perplexity",
+  "title": "Perplexity AI",
+  "title_i18n": {
+    "zh-CN": "Perplexity AI",
+    "zh-TW": "Perplexity AI",
+    "ja": "Perplexity AI",
+    "ko": "Perplexity AI",
+    "de": "Perplexity AI",
+    "fr": "Perplexity AI",
+    "ru": "Perplexity AI",
+    "es": "Perplexity AI",
+    "pt-BR": "Perplexity AI",
+    "it": "Perplexity AI",
+    "vi": "Perplexity AI",
+    "pl": "Perplexity AI",
+    "id": "Perplexity AI",
+    "nl": "Perplexity AI",
+    "ar": "Perplexity AI",
+    "tr": "Perplexity AI",
+    "uk": "Perplexity AI",
+    "en": "Perplexity AI"
+  },
+  "version": "0.1.0",
+  "description": "Conversational AI search engine. Deep-dark canvas, sharp typography, single violet accent, dense information hierarchy.",
+  "description_i18n": {
+    "zh-CN": "对话式 AI 搜索引擎。深邃暗色画布、锐利字体、单一紫罗兰强调色、高密度信息层级。",
+    "zh-TW": "對話式 AI 搜尋引擎。深邃暗色畫布、銳利字體、單一紫羅蘭強調色、高密度資訊層級。",
+    "ja": "対話型AI検索エンジン。深いダークキャンバス、シャープなタイポグラフィ、単一のバイオレットアクセント、高密度な情報階層。",
+    "ko": "대화형 AI 검색 엔진. 깊은 다크 캔버스, 선명한 타이포그래피, 단일 바이올렛 강조색, 고밀도 정보 계층.",
+    "de": "Dialogorientierte KI-Suchmaschine. Tiefdunkle Leinwand, scharfe Typografie, einzelner violetter Akzent, dichte Informationshierarchie.",
+    "fr": "Moteur de recherche IA conversationnel. Toile très sombre, typographie nette, unique accent violet, hiérarchie d'information dense.",
+    "ru": "Разговорная ИИ-поисковая система. Глубокий тёмный холст, чёткая типографика, единственный фиолетовый акцент, плотная информационная иерархия.",
+    "es": "Motor de búsqueda de IA conversacional. Lienzo muy oscuro, tipografía nítida, único acento violeta, jerarquía de información densa.",
+    "pt-BR": "Mecanismo de busca de IA conversacional. Tela profundamente escura, tipografia nítida, único acento violeta, hierarquia de informação densa.",
+    "it": "Motore di ricerca AI conversazionale. Tela molto scura, tipografia nitida, singolo accento viola, gerarchia delle informazioni densa.",
+    "vi": "Công cụ tìm kiếm AI hội thoại. Nền tối sâu, kiểu chữ sắc nét, một điểm nhấn tím, phân cấp thông tin dày đặc.",
+    "pl": "Konwersacyjna wyszukiwarka AI. Głęboko ciemne tło, ostra typografia, pojedynczy fioletowy akcent, gęsta hierarchia informacji.",
+    "id": "Mesin pencari AI percakapan. Kanvas gelap pekat, tipografi tajam, satu aksen ungu, hierarki informasi padat.",
+    "nl": "Conversationele AI-zoekmachine. Diepdonker canvas, scherpe typografie, enkele violette accentkleur, dichte informatiehiërarchie.",
+    "ar": "محرك بحث ذكاء اصطناعي حواري. لوحة داكنة عميقة، طباعة حادة، لمسة بنفسجية واحدة، تسلسل هرمي كثيف للمعلومات.",
+    "tr": "Sohbet temelli yapay zekâ arama motoru. Derin koyu tuval, keskin tipografi, tek mor vurgu, yoğun bilgi hiyerarşisi.",
+    "uk": "Розмовна пошукова система зі ШІ. Глибоке темне полотно, чітка типографіка, єдиний фіолетовий акцент, щільна інформаційна ієрархія.",
+    "en": "Conversational AI search engine. Deep-dark canvas, sharp typography, single violet accent, dense information hierarchy."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "ai-llm"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the Perplexity AI design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the Perplexity AI design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "perplexity",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 413
+    "bundledPreinstallCount": 414
   },
   "plugins": [
     {
@@ -2315,6 +2315,30 @@
         "first-party",
         "design",
         "retro-nostalgic"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-perplexity",
+      "title": "Perplexity AI",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/perplexity",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Conversational AI search engine. Deep-dark canvas, sharp typography, single violet accent, dense information hierarchy.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "ai-llm"
       ],
       "license": "MIT",
       "mode": "design-system",


### PR DESCRIPTION
Fixes #4828

## Why

Scratching the itch on a triaged user-facing bug: on `/plugins/systems/`, the **Perplexity AI** card is a dead end — clicking it falls back to the systems index instead of opening a detail page.

**Root cause:** the Perplexity system ships a card from `design-systems/perplexity/` (which has `DESIGN.md`), but there is **no matching bundled-plugin manifest** under `plugins/_official/design-systems/perplexity/`. `detailHrefForSystemSlug()` therefore finds no plugin and the card href degrades to the `/plugins/systems/` index. (The same gap affects a handful of other newer systems; this PR is scoped to Perplexity per the issue.)

## What users will see

On **Plugins → Design Systems**, clicking the **Perplexity AI** card now opens its own detail page (`/plugins/design-system-perplexity/`), the same as OpenAI, Claude, and the other bundled systems — instead of bouncing back to the systems index. No other surfaces change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

<!-- Extension-point note: this adds the bundled plugin entry for `perplexity`
     under `plugins/_official/design-systems/`. The manifest carries embedded
     18-locale `title_i18n`/`description_i18n` for parity with sibling
     manifests, but those are plugin-data values, not new keys in the
     `TRANSLATIONS.md` locale workflow — so the i18n box is intentionally left
     unchecked. -->

## Screenshots

N/A — not a UI surface (no `apps/web` / `apps/desktop` change). The user-visible effect is the card's link target, covered under **Bug fix verification** below (`/plugins/systems/` fallback → `/plugins/design-system-perplexity/`).

## Bug fix verification

This is purely additive plugin **data** — there is no source/logic change. `detailHrefForSystemSlug()` was already correct; the bug was the missing manifest, so a dedicated red *unit* spec isn't the natural form. The falsifiable check is the static build output, run on both states:

- **Reproduces (red, before fix):** `build:static` emits the systems-index card for Perplexity with `href="/plugins/systems/"` (fallback) and produces **no** `/plugins/design-system-perplexity/` page.
- **Fixed (green, this branch):** the same build produces a real **`/plugins/design-system-perplexity/`** detail page, and the systems-index card now links to it (`href="/plugins/design-system-perplexity/"`) — matching how `openai` et al. behave.

So: red on the pre-fix tree, green on this branch — yes, at the build/integration level rather than a unit test, for the reason above.

## Validation

- `pnpm --filter @open-design/landing-page typecheck` → 0 errors
- `pnpm --filter @open-design/landing-page build:static` → builds the `/plugins/design-system-perplexity/` detail page; systems-index card resolves to it instead of the fallback.
- Manifest structure diffed identical to `openai` (`jq paths`; only values differ); `DESIGN.md` diffed byte-identical to `design-systems/perplexity/DESIGN.md`; marketplace seed entry (`open-design-marketplace.json`, sorted insert + `bundledPreinstallCount` 413→414) matches sibling design-system entries exactly.
- Rebased onto latest `main`; re-verified the surface (manifest still absent upstream) and re-ran the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
