### PR TITLE
fix(daemon): fail OpenCode tool-only empty responses

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7561,23 +7561,21 @@ export async function startServer({
     // be recorded for that failure mode. See PR #3412.
     let firstBufferedStdoutAt: number | null = null;
     // Tracks whether any stream the run is using actually emitted user-
-    // visible content. Only the streams routed through `sendAgentEvent`
-    // contribute to this flag; ACP sessions and plain stdout streams are
-    // covered by their own success/failure paths and the empty-output
-    // guard below skips them via `trackingSubstantiveOutput`.
+    // visible content or a deliverable. Only the streams routed through
+    // `sendAgentEvent` contribute to this flag; ACP sessions and plain stdout
+    // streams are covered by their own success/failure paths and the
+    // empty-output guard below skips them via `trackingSubstantiveOutput`.
     let agentProducedOutput = false;
     let trackingSubstantiveOutput = false;
-    // Event types that count as "the agent actually produced something the
-    // user can see." Lifecycle markers (`status`) and meter readings
-    // (`usage`) deliberately do NOT count — a model can emit token-usage
-    // numbers for an empty completion (issue #691), and a `status:running`
-    // banner without any follow-up is exactly the silent-failure shape we
-    // want to surface as failed instead of succeeded.
+    // Event types that count as "the agent actually produced a response or a
+    // deliverable." Lifecycle markers (`status`), meter readings (`usage`),
+    // and tool activity deliberately do NOT count: a run can successfully read
+    // files or call tools and still terminate before returning text/artifacts
+    // to the user. Treat that as empty output instead of a silent success
+    // (issues #691, #4814).
     const SUBSTANTIVE_AGENT_EVENT_TYPES = new Set([
       'text_delta',
       'thinking_delta',
-      'tool_use',
-      'tool_result',
       'artifact',
     ]);
     // First-token timing must reflect when the user actually starts seeing

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7569,13 +7569,12 @@ export async function startServer({
     let trackingSubstantiveOutput = false;
     // Event types that count as "the agent actually produced a response or a
     // deliverable." Lifecycle markers (`status`), meter readings (`usage`),
-    // and tool activity deliberately do NOT count: a run can successfully read
-    // files or call tools and still terminate before returning text/artifacts
+    // reasoning deltas, and tool activity deliberately do NOT count: a run can
+    // think/read/call tools and still terminate before returning text/artifacts
     // to the user. Treat that as empty output instead of a silent success
     // (issues #691, #4814).
     const SUBSTANTIVE_AGENT_EVENT_TYPES = new Set([
       'text_delta',
-      'thinking_delta',
       'artifact',
     ]);
     // First-token timing must reflect when the user actually starts seeing

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -243,6 +243,66 @@ process.exit(0);
     );
   });
 
+  it('marks OpenCode tool-only runs failed when no assistant output is produced', async () => {
+    const conversationId = `conv-${randomUUID()}`;
+
+    await withFakeAgent(
+      'opencode',
+      `
+console.log(JSON.stringify({ type: 'step_start', sessionID: 'opencode-tool-only-session' }));
+console.log(JSON.stringify({
+  type: 'tool_use',
+  sessionID: 'opencode-tool-only-session',
+  part: {
+    tool: 'Read',
+    callID: 'call-read-1',
+    state: {
+      status: 'completed',
+      input: JSON.stringify({ file: 'src/app.ts' }),
+      output: 'file contents',
+    },
+  },
+}));
+console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 0 } } }));
+process.exit(0);
+`,
+      async () => {
+        const response = await fetch(`${baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            conversationId,
+            message: 'read the file and summarize it',
+          }),
+        });
+        const body = await response.text();
+
+        expect(response.ok).toBe(true);
+        expect(body).toContain('"type":"tool_use"');
+        expect(body).toContain('"type":"tool_result"');
+        expect(body).toContain('AGENT_EXECUTION_FAILED');
+        expect(body).toContain('Agent completed without producing any output');
+        expect(body).toContain('"status":"failed"');
+        expect(body).not.toContain('"status":"succeeded"');
+
+        const runsResponse = await fetch(
+          `${baseUrl}/api/runs?conversationId=${encodeURIComponent(conversationId)}`,
+        );
+        const runsBody = (await runsResponse.json()) as {
+          runs: Array<{ conversationId: string | null; status: string; exitCode: number | null }>;
+        };
+
+        expect(runsBody.runs).toHaveLength(1);
+        expect(runsBody.runs[0]).toMatchObject({
+          conversationId,
+          status: 'failed',
+          exitCode: 0,
+        });
+      },
+    );
+  });
+
   it('passes OPENCODE_CONFIG_CONTENT external_directory rules for the managed project cwd', async () => {
     if (!process.env.OD_DATA_DIR) {
       throw new Error('OD_DATA_DIR is required for OpenCode cwd permission tests');

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2261,6 +2261,63 @@ process.exit(0);
     );
   });
 
+  it('marks reasoning-only stream runs failed when no assistant output is produced', async () => {
+    const reasoningLine = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'I should inspect the project before answering.',
+          },
+        ],
+      },
+    });
+    const resultLine = JSON.stringify({
+      type: 'result',
+      is_error: false,
+      usage: { input_tokens: 1, output_tokens: 0 },
+    });
+
+    await withFakeAgent(
+      'qodercli',
+      `
+console.log(${JSON.stringify(reasoningLine)});
+console.log(${JSON.stringify(resultLine)});
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'qoder',
+            message: 'think but do not answer',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(
+          eventsResponse,
+          'Agent completed without producing any output',
+        );
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('"type":"thinking_delta"');
+        expect(eventsBody).toContain('AGENT_EXECUTION_FAILED');
+        expect(eventsBody).toContain('Agent completed without producing any output');
+        expect(eventsBody).not.toContain('"status":"succeeded"');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
   it('fails Qoder runs when the result reports is_error with exit code 0', async () => {
     const qoderResultLine = JSON.stringify({
       type: 'result',


### PR DESCRIPTION
Fixes #4814

## Why

OpenCode can complete tool activity and exit successfully without returning assistant text or an artifact. I hit this while investigating the report in #4814: the daemon was treating completed `tool_use` / `tool_result` events as substantive output, so the existing empty-output guard never ran and the chat could look like it stopped silently.

The same class of bug also applies to reasoning-only streams: `thinking_delta` is visible activity and useful for first-token timing, but it is not a final answer or deliverable. This PR makes the empty-output success check match what users actually need from the run: assistant text or an artifact.

## What users will see

Agent runs that only perform tools or stream reasoning and then exit now fail with the existing “Agent completed without producing any output” error instead of looking like a successful empty response.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — daemon lifecycle fix only.

## Bug fix verification

- Test path that reproduces the tool-only bug: `apps/daemon/tests/chat-route.test.ts`
- Test path that reproduces the reasoning-only follow-up: `apps/daemon/tests/chat-route.test.ts`
- Did the tests go red on `main` and green on this branch? yes — the fake OpenCode regression covers completed tool activity + exit `0` without assistant text, and the fake Qoder regression covers `thinking_delta` + successful usage + exit `0` without assistant text.
- Parser coverage in `apps/daemon/tests/runtimes/json-event-stream.test.ts` and `apps/daemon/tests/runtimes/qoder-stream.test.ts` still verifies the underlying stream events are normalized and streamed.

## Validation

- `apps/daemon/node_modules/.bin/vitest.CMD run -c vitest.config.ts tests/chat-route.test.ts -t "marks reasoning-only stream runs failed" --hookTimeout=90000 --testTimeout=90000`
- `apps/daemon/node_modules/.bin/vitest.CMD run -c vitest.config.ts tests/chat-route.test.ts -t "marks OpenCode tool-only runs failed" --hookTimeout=90000 --testTimeout=90000`
- `apps/daemon/node_modules/.bin/vitest.CMD run -c vitest.config.ts tests/runtimes/qoder-stream.test.ts tests/runtimes/json-event-stream.test.ts`
- `corepack pnpm@10.33.2 --filter @open-design/contracts build`
- `corepack pnpm@10.33.2 --filter @open-design/registry-protocol build`
- `node_modules/.bin/tsc.CMD -p apps/daemon/tsconfig.json --noEmit`
- `node_modules/.bin/tsc.CMD -p apps/daemon/tsconfig.tests.json --noEmit`
- `node_modules/.bin/tsc.CMD -p scripts/tsconfig.json --noEmit`
- `git diff --check`

Notes:

- `pnpm guard` currently fails on unrelated stale generated design-system manifests across `design-systems/*/manifest.json`.
- The full recursive `pnpm typecheck` is blocked in this checkout because nested package scripts resolve the global `pnpm 11.7.0`, while the repo requires `pnpm >=10.33.2 <11`; the daemon/package checks above were run with the repo-pinned `pnpm 10.33.2` path or direct `tsc` commands.