### PR TITLE
docs: remove API token requirement for local docker setups

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -62,19 +62,11 @@ From the repository root:
    cp .env.example .env
    ```
 
-2. Generate a secure token:
+2. Start the service:
 
    ```bash
-   openssl rand -hex 32
+   docker compose up -d
    ```
-
-3. Open `.env` in your editor, find `OD_API_TOKEN=`, and paste the generated token there.
-
-Then start the service:
-
-```bash
-docker compose up -d
-```
 
 Open the app in your browser:
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -12,7 +12,9 @@ OPEN_DESIGN_ALLOWED_ORIGINS=
 
 # Recommended unless OPEN_DESIGN_DISABLE_API_AUTH=1 is set behind a trusted,
 # already-authenticated reverse proxy.
-# Generate a secure 32-byte hex token by running `openssl rand -hex 32` and paste it below.
+# NOTE: For local Docker development (where OPEN_DESIGN_PORT is bound to 127.0.0.1),
+# LEAVE THIS BLANK. Setting it will break the local web UI due to Docker's network NAT.
+# Only generate a token (`openssl rand -hex 32`) if you are hosting remotely.
 OD_API_TOKEN=
 
 # Optional escape hatch for deployments whose reverse proxy already authenticates


### PR DESCRIPTION


Fixes #4831

## Why

This PR resolves a significant onboarding friction point for users following the Docker Quickstart guide.

Currently, the `QUICKSTART.md` instructs users to generate and set an `OD_API_TOKEN`. However, when users run `docker compose up -d` locally, Docker's bridge networking NAT changes incoming requests (e.g., from `127.0.0.1` to the Docker bridge gateway like `172.17.0.1`). The daemon's API token middleware sees a non-loopback IP, treats the local web UI's requests as external, and blocks them with a 401 Unauthorized since the browser doesn't send the bearer token. This traps the user on the BYOK screen.

Since the `deploy/docker-compose.yml` strictly binds the container's port to `127.0.0.1:7456:7456`, the container is completely inaccessible from external networks via the host OS natively. The token check provides no additional security for local execution; it only breaks the UI. 

This PR removes the aggressive token generation instructions from the Quickstart and updates the `.env.example` comments to explicitly instruct local Docker users to leave it blank.

## What users will see

*(Skipping, documentation update only)*

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

*(Skipping, documentation update only)*

## Bug fix verification

- **Test path that reproduces the bug:** N/A (Documentation/configuration issue)
- **Did the test go red on `main` and green on this branch?** N/A
- **If a red spec wasn't cheap to write, explain why and what verification you did instead:** This is a documentation fix for a networking NAT environment issue, verified by reviewing the daemon's auth middleware (`api-token-auth.ts`).

## Validation

- Manually verified that removing `OD_API_TOKEN` bypasses the `isApiTokenMiddlewareEnabled()` guard for loopback requests masked by Docker NAT.