### PR TITLE
Add reusable-workflow-author plugin

### DIFF
--- a/plugins/community/reusable-workflow-author/SKILL.md
+++ b/plugins/community/reusable-workflow-author/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: reusable-workflow-author
+description: Turn a one-line workflow brief into a local Open Design plugin folder (SKILL.md + open-design.json + example) ready to install into My plugins.
+---
+
+# reusable-workflow-author
+
+Use this skill when the user describes a **reusable workflow** in one or two sentences and wants it shipped as an Open Design plugin they can install locally.
+
+## Required outcome
+
+Produce a folder named `generated-plugin/` in the active project workspace containing at minimum:
+
+- `SKILL.md` — agent behavior, with frontmatter (`name`, `description`) and clear instructions.
+- `open-design.json` — valid plugin manifest: `specVersion`, `name`, `version`, `description`, `od.kind`, `od.mode`, `od.taskKind`, `od.pipeline`, `od.inputs`, `od.capabilities`.
+
+Add `examples/` or `assets/` only when they materially help the plugin be reviewed or run. Do not create empty directories.
+
+## Authoring rules
+
+- Follow `docs/plugins-spec.md` and the schema at `docs/schemas/open-design.plugin.v1.json`.
+- `SKILL.md` is the canonical behavior description; `open-design.json` describes how OD installs, applies, and presents it.
+- Keep the plugin local-user friendly — no marketplace publishing, enterprise trust, or private team catalog setup required to install it.
+- Plugin id is lowercase letters, numbers, dashes, underscores, or dots. Derive it from the user's workflow verb (e.g. `brief-to-landing`, `sales-deck-from-csv`, `sponsor-pack-builder`).
+- Keep `capabilities` minimal. Default to `["prompt:inject"]`; add `fs:read` only if the plugin stages assets into the project cwd, `fs:write` only for plugin-owned post-run writes.
+- Do not invent `plugin.repo` owners. If `gh auth status` does not expose a real GitHub login, omit `plugin.repo` and report the auth problem with the recovery commands (`gh auth refresh`, `gh auth login`, or `od plugin publish-repo …`).
+
+## Workflow
+
+1. **Read the brief.** Extract the workflow goal in one sentence. If the brief is ambiguous, surface the smallest possible `<question-form>` to lock audience + output shape before writing files.
+2. **Choose the task kind.** Pick one of `new-generation` (most common), `code-migration`, `figma-migration`, or `tune-collab`. Map the workflow to `od.mode` (e.g. `deck`, `landing`, `prototype`, `scenario`).
+3. **Plan the pipeline.** Compose 2–4 stages from OD's first-party atoms:
+   - `discovery` — `discovery-question-form`
+   - `plan` — `direction-picker`, `todo-write`
+   - `generate` — `file-write`, `live-artifact` (or `media-image` for asset-heavy workflows)
+   - `critique` — `critique-theater` with `repeat: true`, `until: "critique.score>=4 || iterations>=3"`
+4. **Declare inputs.** Surface the 1–3 fields the user must fill on the detail page (`name`, `type`, `required`, `placeholder`, default where obvious). Bind them to `od.useCase.query` via `{{var}}`.
+5. **Write `SKILL.md`.** Frontmatter + a short prose body covering: when to fire, required outputs, the workflow steps, and any gotchas specific to this workflow.
+6. **Write `open-design.json`.** Schema-valid, minimal `capabilities`, `od.pipeline.stages[]`, `od.useCase.query`, `od.inputs[]`. Set `specVersion: "1.0.0"`.
+7. **Self-check.** Run `od plugin validate <folder>`; fix every error before reporting done.
+8. **Finish with a readiness summary.** Name the files, state validate status, and point the user at one of three buttons in the plugin-folder card: **Add to My plugins**, **Publish repo**, or **Open Design PR**. Do not recreate those flows as freeform shell suggestions.
+
+## Anti-patterns to avoid
+
+- ❌ Aggressive `capabilities` (declaring `bash` / `network` / coarse `connector` when scoped `connector:<id>` would do).
+- ❌ `connectors.required[]` without the matching `connector:<id>` capability.
+- ❌ Pipeline stages without `atoms`, or stages that reference atoms not in the v1 surface set.
+- ❌ Inventing `plugin.repo` owners such as `open-design-user`, `<vendor>`, `your-org`, or `your-username`.
+- ❌ Stating `homepage` / `repo` URLs that the user has not actually published yet.
+- ❌ Empty `examples/` or `assets/` directories created just to match a folder sketch.
+- ❌ A pipeline longer than 4 stages — split the workflow instead.
+
+## Validation
+
+After writing the folder:
+
+```bash
+od plugin validate generated-plugin
+od plugin pack    generated-plugin --out /tmp/reusable-workflow-author.tgz
+od plugin install --source "$(pwd)/generated-plugin"
+```
+
+All three must succeed before reporting done. Validation errors must be fixed in place, not hand-waved.

--- a/plugins/community/reusable-workflow-author/examples/sample-workflow/open-design.json
+++ b/plugins/community/reusable-workflow-author/examples/sample-workflow/open-design.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "brief-to-landing",
+  "title": "Brief to landing",
+  "version": "0.1.0",
+  "description": "Turn a one-paragraph product brief into a 3-section marketing landing page.",
+  "license": "MIT",
+  "tags": ["landing", "marketing", "example"],
+  "compat": {
+    "agentSkills": [{ "path": "../SKILL.md" }]
+  },
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "mode": "landing",
+    "scenario": "marketing",
+    "useCase": {
+      "query": "Make a 3-section marketing landing page for {{product}} targeting {{audience}}."
+    },
+    "pipeline": {
+      "stages": [
+        { "id": "discovery", "atoms": ["discovery-question-form"] },
+        { "id": "plan", "atoms": ["todo-write"] },
+        { "id": "generate", "atoms": ["file-write"] },
+        { "id": "critique", "atoms": ["critique-theater"], "repeat": true, "until": "critique.score>=4 || iterations>=3" }
+      ]
+    },
+    "inputs": [
+      { "name": "product", "type": "string", "required": true, "label": "Product", "placeholder": "an AI browser extension for design teams" },
+      { "name": "audience", "type": "string", "required": true, "label": "Audience", "placeholder": "indie product designers, 25–40" }
+    ],
+    "capabilities": ["prompt:inject"]
+  }
+}

--- a/plugins/community/reusable-workflow-author/open-design.json
+++ b/plugins/community/reusable-workflow-author/open-design.json
@@ -32,17 +32,12 @@
     ]
   },
   "od": {
-    "kind": "scenario",
+    "kind": "skill",
     "taskKind": "new-generation",
     "scenario": "plugin-authoring",
     "mode": "scenario",
     "engineRequirements": {
       "od": ">=0.4.0"
-    },
-    "preview": {
-      "type": "html",
-      "entry": "./examples/sample-workflow/index.html",
-      "motion": "static"
     },
     "useCase": {
       "query": {
@@ -95,9 +90,7 @@
       ]
     },
     "capabilities": [
-      "prompt:inject",
-      "fs:read",
-      "fs:write"
+      "prompt:inject"
     ],
     "inputs": [
       {

--- a/plugins/community/reusable-workflow-author/open-design.json
+++ b/plugins/community/reusable-workflow-author/open-design.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "reusable-workflow-author",
+  "title": "Reusable workflow author",
+  "title_i18n": {
+    "en": "Reusable workflow author",
+    "zh-CN": "可复用工作流编写器"
+  },
+  "version": "0.1.0",
+  "description": "Turn a one-line workflow brief into a local Open Design plugin folder (SKILL.md + open-design.json + example) ready to install into My plugins.",
+  "description_i18n": {
+    "en": "Turn a one-line workflow brief into a local Open Design plugin folder (SKILL.md + open-design.json + example) ready to install into My plugins.",
+    "zh-CN": "把一句工作流描述变成可安装的 Open Design 插件文件夹（SKILL.md + open-design.json + 示例），直接加入「我的插件」。"
+  },
+  "author": {
+    "name": "Open Design",
+    "url": "https://github.com/VaqueroGroup"
+  },
+  "license": "MIT",
+  "tags": [
+    "scenario",
+    "plugin-authoring",
+    "workflow",
+    "my-plugins"
+  ],
+  "compat": {
+    "agentSkills": [
+      {
+        "path": "./SKILL.md"
+      }
+    ]
+  },
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "scenario": "plugin-authoring",
+    "mode": "scenario",
+    "engineRequirements": {
+      "od": ">=0.4.0"
+    },
+    "preview": {
+      "type": "html",
+      "entry": "./examples/sample-workflow/index.html",
+      "motion": "static"
+    },
+    "useCase": {
+      "query": {
+        "en": "Author a reusable Open Design plugin for: {{pluginGoal}}. Produce a folder named generated-plugin with SKILL.md, open-design.json, and any useful examples or assets. Follow docs/plugins-spec.md and finish with a readiness summary plus next actions: Add to My plugins, Publish repo, or Open Design PR.",
+        "zh-CN": "编写一个用于「{{pluginGoal}}」的可复用 Open Design 插件，生成名为 generated-plugin 的文件夹，包含 SKILL.md、open-design.json，以及有用的 examples 或 assets。遵循 docs/plugins-spec.md，并在最后总结它是否可以添加到 My plugins，同时给出下一步操作：添加到 My plugins、发布仓库或创建 Open Design PR。"
+      },
+      "exampleOutputs": [
+        {
+          "path": "./examples/sample-workflow/open-design.json",
+          "title": "Sample workflow manifest"
+        }
+      ]
+    },
+    "context": {
+      "atoms": [
+        "discovery-question-form",
+        "todo-write",
+        "file-write",
+        "critique-theater"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "discovery",
+          "atoms": [
+            "discovery-question-form"
+          ]
+        },
+        {
+          "id": "plan",
+          "atoms": [
+            "todo-write"
+          ]
+        },
+        {
+          "id": "generate-plugin",
+          "atoms": [
+            "file-write"
+          ]
+        },
+        {
+          "id": "review-plugin",
+          "atoms": [
+            "critique-theater"
+          ],
+          "repeat": true,
+          "until": "critique.score>=4 || iterations>=3"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:read",
+      "fs:write"
+    ],
+    "inputs": [
+      {
+        "name": "pluginGoal",
+        "type": "text",
+        "required": false,
+        "default": "a reusable workflow described by the user's prompt",
+        "label": "Plugin goal",
+        "placeholder": "turn a brand brief into a launch landing page workflow"
+      }
+    ]
+  },
+  "plugin": {
+    "repo": "https://github.com/VaqueroGroup/reusable-workflow-author"
+  },
+  "homepage": "https://github.com/VaqueroGroup/reusable-workflow-author"
+}


### PR DESCRIPTION
Add reusable-workflow-author (reusable-workflow-author) plugin.

Version: 0.1.0
Description: Turn a one-line workflow brief into a local Open Design plugin folder — SKILL.md, open-design.json, and a minimal example.