### PR TITLE
fix: enforce deck slide count handoff

### DIFF
--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -1300,9 +1300,18 @@ function renderMetadataBlock(
     );
   }
   if (metadata.kind === 'deck') {
+    const slideCount =
+      typeof metadata.slideCount === 'string' && metadata.slideCount.trim().length > 0
+        ? metadata.slideCount.trim()
+        : null;
     lines.push(
-      `- **slideCount**: ${metadata.slideCount ?? '(unknown — ask only if the Active plugin / Plugin inputs block does not already include slideCount)'}`,
+      `- **slideCount**: ${slideCount ?? '(unknown — ask only if the Active plugin / Plugin inputs block does not already include slideCount)'}`,
     );
+    if (slideCount) {
+      lines.push(
+        `- **required slide count**: ${slideCount}. This overrides any conflicting slide-count or page-count text in the user's prompt.`,
+      );
+    }
     lines.push(
       `- **speakerNotes**: ${typeof metadata.speakerNotes === 'boolean' ? metadata.speakerNotes : '(unknown — ask: include speaker notes?)'}`,
     );

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -291,6 +291,21 @@ describe('composeSystemPrompt', () => {
     expect(prompt).not.toContain('**platformTargets**');
   });
 
+  it('makes deck slide count authoritative over conflicting prompt text', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'deck',
+        speakerNotes: true,
+        slideCount: '25-30 pages',
+      } as any,
+    });
+
+    expect(prompt).toContain('- **slideCount**: 25-30 pages');
+    expect(prompt).toContain(
+      "- **required slide count**: 25-30 pages. This overrides any conflicting slide-count or page-count text in the user's prompt.",
+    );
+  });
+
   it('tells artifact generation to summarize instead of dumping raw HTML source into chat', () => {
     const prompt = composeSystemPrompt({
       metadata: { kind: 'prototype', fidelity: 'production' } as any,

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -244,7 +244,7 @@ function defaultPluginIdForMetadata(metadata: ProjectMetadata): string | null {
   return defaultScenarioPluginIdForProjectMetadata(metadata);
 }
 
-function defaultPluginInputsForCreate(
+export function defaultPluginInputsForCreate(
   input: CreateInput,
   pluginId: string | null,
 ): Record<string, unknown> | null {
@@ -264,11 +264,15 @@ function defaultPluginInputsForCreate(
   }
 
   if (pluginId === 'example-simple-deck') {
+    const slideCount =
+      typeof input.metadata.slideCount === 'string' && input.metadata.slideCount.trim().length > 0
+        ? input.metadata.slideCount.trim()
+        : '10-15 pages';
     return {
       deckType: 'pitch deck',
       topic: projectName || 'the user brief',
       audience: 'decision makers',
-      slideCount: '10-15 pages',
+      slideCount,
       speakerNotes: input.metadata.speakerNotes
         ? 'include speaker notes'
         : 'no speaker notes',

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1829,18 +1829,18 @@ export function HomeView({
       // stripped from this set just below to form the run-facing inputs.
       const submittedApplyInputs = submittedActive ? submittedActive.inputs : defaultInputs;
       // Inputs forwarded to the run AND used to build the run-facing snapshot:
-      // drop every now-hidden footer/media setting so the first-turn
-      // question-form flow collects them instead of inheriting a baked-in
-      // default (`ratio: 16:9`, `duration: 5`, `audioType: speech`, …). The
+      // drop now-hidden footer/media defaults so the first-turn question-form
+      // flow collects them instead of inheriting a baked-in default (`ratio:
+      // 16:9`, `duration: 5`, `audioType: speech`, …). `slideCount` has one
+      // narrow exception: a non-default value may come from the user's visible
+      // deck-query edit and must remain authoritative.
       // snapshot is resolved from these stripped inputs too — the daemon renders
       // `## Plugin inputs` from `snapshot.inputs` and tells the agent not to
       // re-ask about anything listed there, so leaving the deferred defaults in
-      // the snapshot would suppress the discovery flow even though
-      // `onSubmit.pluginInputs` was stripped. Stripping only removes non-required
-      // fields (`subject`/`style`/`aspect`/`mediaKind` stay), so the
-      // od-media-generation apply still validates.
+      // the snapshot would suppress the discovery flow even though the user did
+      // not explicitly choose them.
       const submittedPluginInputs = submittedActive
-        ? stripArtifactFooterInputs(submittedApplyInputs)
+        ? stripArtifactFooterInputs(submittedApplyInputs, submittedActive.inputFields)
         : defaultInputs;
       const activeInputsChangedForSubmit = submittedActive
         ? !inputsEqual(submittedActive.result?.appliedPlugin?.inputs ?? submittedActive.inputs, submittedPluginInputs)
@@ -2372,22 +2372,44 @@ const ARTIFACT_FOOTER_FIELD_NAMES = new Set([
   'voice',
 ]);
 
+const AUTHORITATIVE_HIDDEN_INPUT_NAMES = new Set(['slideCount']);
+
 // The prototype/deck footer no longer exposes these settings, so any plugin
 // default for them must NOT be seeded into the Home composer's inputs — that
 // would forward a prefilled value (e.g. `fidelity: high-fidelity`) to the run
 // instead of leaving it "unknown" for the first-turn discovery flow to ask.
 function stripArtifactFooterInputs(
   inputs: Record<string, unknown>,
+  fields: InputFieldSpec[] = [],
 ): Record<string, unknown> {
   if (!Object.keys(inputs).some((key) => ARTIFACT_FOOTER_FIELD_NAMES.has(key))) {
     return inputs;
   }
+  const fieldsByName = new Map(fields.map((field) => [field.name, field]));
   const next: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(inputs)) {
-    if (ARTIFACT_FOOTER_FIELD_NAMES.has(key)) continue;
+    if (ARTIFACT_FOOTER_FIELD_NAMES.has(key)) {
+      const field = fieldsByName.get(key);
+      if (
+        AUTHORITATIVE_HIDDEN_INPUT_NAMES.has(key) &&
+        field &&
+        !inputValueMatchesDefault(value, field.default)
+      ) {
+        next[key] = value;
+      }
+      continue;
+    }
     next[key] = value;
   }
   return next;
+}
+
+function inputValueMatchesDefault(value: unknown, defaultValue: unknown): boolean {
+  if (defaultValue === undefined) return false;
+  if (typeof value === 'string' || typeof defaultValue === 'string') {
+    return String(value ?? '').trim() === String(defaultValue ?? '').trim();
+  }
+  return Object.is(value, defaultValue);
 }
 
 function footerInputNamesForChip(_chipId: string | null): string[] {

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { EntryShell } from '../../src/components/EntryShell';
+import { EntryShell, defaultPluginInputsForCreate } from '../../src/components/EntryShell';
 import { AMR_LOGIN_TIMEOUT_MS } from '../../src/components/amrLoginPolling';
 import { I18nProvider } from '../../src/i18n';
 import type { AgentInfo, AppConfig } from '../../src/types';
@@ -351,6 +351,27 @@ describe('EntryShell design systems view', () => {
     renderHome({ onDesignSystemsRefresh }, '/design-systems');
 
     await waitFor(() => expect(onDesignSystemsRefresh).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe('EntryShell project defaults', () => {
+  it('uses deck metadata slide count when preparing default plugin inputs', () => {
+    const inputs = defaultPluginInputsForCreate({
+      name: 'Architecture blueprint',
+      skillId: null,
+      designSystemId: null,
+      metadata: {
+        kind: 'deck',
+        slideCount: '25-30 pages',
+        speakerNotes: true,
+      },
+    } as any, 'example-simple-deck');
+
+    expect(inputs).toMatchObject({
+      topic: 'Architecture blueprint',
+      slideCount: '25-30 pages',
+      speakerNotes: 'include speaker notes',
+    });
   });
 });
 

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -1631,6 +1631,70 @@ describe('HomeView prompt handoff', () => {
     })));
   });
 
+  it('keeps user-edited deck slide count inputs when submitting a rendered deck query', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (url, init) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [SIMPLE_DECK_PLUGIN] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (typeof url === 'string' && url.includes('/api/plugins/example-simple-deck/apply')) {
+        const body = typeof init?.body === 'string' ? JSON.parse(init.body) : {};
+        return new Response(JSON.stringify({
+          ...SIMPLE_DECK_APPLY_RESULT,
+          appliedPlugin: {
+            ...SIMPLE_DECK_APPLY_RESULT.appliedPlugin,
+            inputs: body.inputs ?? SIMPLE_DECK_APPLY_RESULT.appliedPlugin.inputs,
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    stubAnimationFrame();
+    const onSubmit = vi.fn();
+
+    const { rerender } = render(
+      <HomeView
+        projects={[]}
+        onSubmit={onSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+
+    await screen.findByTestId('home-hero-input');
+    rerender(
+      <HomeView
+        projects={[]}
+        onSubmit={onSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        promptHandoff={createPluginUseHandoff(4, 'example-simple-deck', {
+          action: 'use-with-query',
+        })}
+      />,
+    );
+
+    const seed =
+      'Create a pitch deck for decision makers about the user brief with 10-15 pages. Speaker notes: include speaker notes. Use the active project design system.';
+    await waitFor(() => expect(homeHeroPromptText()).toBe(seed));
+
+    await setPromptAndSettle(seed.replace('10-15 pages', '25-30 pages'));
+    fireEvent.click(screen.getByTestId('home-hero-submit'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      pluginId: 'example-simple-deck',
+      pluginInputs: expect.objectContaining({
+        slideCount: '25-30 pages',
+      }),
+    })));
+  });
+
   it('extracts a placeholder edit even after the use-with-query draft prefix is also edited', async () => {
     // The "tweak a preset before running" case: with an existing draft,
     // use-with-query appends the rendered query; the user then edits BOTH the

--- a/packages/contracts/src/prompts/plugin-block.ts
+++ b/packages/contracts/src/prompts/plugin-block.ts
@@ -38,6 +38,12 @@ export function renderPluginBlock(snapshot: AppliedPluginSnapshot): string {
     for (const key of inputKeys) {
       lines.push(`- **${key}**: ${formatInput(inputs[key])}`);
     }
+    const slideCount = authoritativeSlideCountInput(inputs);
+    if (slideCount) {
+      lines.push(
+        `- **required slide count**: ${slideCount}. This overrides any conflicting slide-count or page-count text in the user's prompt.`,
+      );
+    }
   }
 
   const atomIds = snapshot.resolvedContext?.atoms ?? [];
@@ -53,6 +59,18 @@ export function renderPluginBlock(snapshot: AppliedPluginSnapshot): string {
   }
 
   return lines.join('\n');
+}
+
+function authoritativeSlideCountInput(
+  inputs: AppliedPluginSnapshot['inputs'],
+): string | null {
+  for (const key of ['slideCount', 'slides', 'pageCount']) {
+    const value = inputs[key];
+    if (value === undefined || value === null || typeof value === 'boolean') continue;
+    const text = String(value).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
 }
 
 function formatInput(value: string | number | boolean | undefined): string {

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -692,9 +692,18 @@ function kindDetailLines(
     );
   }
   if (metadata.kind === 'deck') {
+    const slideCount =
+      typeof metadata.slideCount === 'string' && metadata.slideCount.trim().length > 0
+        ? metadata.slideCount.trim()
+        : null;
     out.push(
-      `- **slideCount**: ${metadata.slideCount ?? '(unknown — ask only if the Active plugin / Plugin inputs block does not already include slideCount)'}`,
+      `- **slideCount**: ${slideCount ?? '(unknown — ask only if the Active plugin / Plugin inputs block does not already include slideCount)'}`,
     );
+    if (slideCount) {
+      out.push(
+        `- **required slide count**: ${slideCount}. This overrides any conflicting slide-count or page-count text in the user's prompt.`,
+      );
+    }
     out.push(
       `- **speakerNotes**: ${typeof metadata.speakerNotes === 'boolean' ? metadata.speakerNotes : '(unknown — ask: include speaker notes?)'}`,
     );

--- a/packages/contracts/tests/__snapshots__/system-prompt-metadata-block.test.ts.snap
+++ b/packages/contracts/tests/__snapshots__/system-prompt-metadata-block.test.ts.snap
@@ -36,6 +36,7 @@ These are the structured choices the user made (or skipped) when creating this p
 
 - **kind**: deck
 - **slideCount**: 12
+- **required slide count**: 12. This overrides any conflicting slide-count or page-count text in the user's prompt.
 - **speakerNotes**: true"
 `;
 

--- a/packages/contracts/tests/plugin-block.test.ts
+++ b/packages/contracts/tests/plugin-block.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { renderPluginBlock } from '../src/prompts/plugin-block.js';
+
 import type { AppliedPluginSnapshot } from '../src/plugins/apply.js';
+import { renderPluginBlock } from '../src/prompts/plugin-block.js';
 
 function makeSnapshot(overrides: Partial<AppliedPluginSnapshot> = {}): AppliedPluginSnapshot {
   return {
@@ -87,5 +88,19 @@ describe('renderPluginBlock', () => {
     expect(out).toContain('Walks a designer through a pitch deck.');
     expect(out).not.toContain('  Walks');
     expect(out).toContain('_write me a deck about fluorine_');
+  });
+
+  it('makes slideCount plugin inputs authoritative over conflicting prompt text', () => {
+    const block = renderPluginBlock(makeSnapshot({
+      inputs: {
+        slideCount: '25-30 pages',
+        topic: 'architecture blueprint',
+      },
+    }));
+
+    expect(block).toContain('- **slideCount**: 25-30 pages');
+    expect(block).toContain(
+      "- **required slide count**: 25-30 pages. This overrides any conflicting slide-count or page-count text in the user's prompt.",
+    );
   });
 });

--- a/packages/contracts/tests/system-prompt.test.ts
+++ b/packages/contracts/tests/system-prompt.test.ts
@@ -156,6 +156,21 @@ describe('composeSystemPrompt', () => {
     expect(prompt).not.toContain('`实时作品`');
   });
 
+  it('makes deck slide count authoritative over conflicting prompt text', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'deck',
+        speakerNotes: true,
+        slideCount: '25-30 pages',
+      } as any,
+    });
+
+    expect(prompt).toContain('- **slideCount**: 25-30 pages');
+    expect(prompt).toContain(
+      "- **required slide count**: 25-30 pages. This overrides any conflicting slide-count or page-count text in the user's prompt.",
+    );
+  });
+
   it('treats an active design system as the visual direction', () => {
     const prompt = composeSystemPrompt({
       designSystemTitle: 'ComfyUI',


### PR DESCRIPTION
Fixes #3565

## Why

I hit issue #3565 while looking for high-value papercuts in the deck creation flow. The Home deck page-count selector and the Simple Deck plugin both collected a `slideCount`, but that value could be treated as ordinary context instead of a hard generation constraint.

The pain is user-facing: if the user chose or edited a range such as `25-30 pages`, conflicting free-form prompt text could still lead the agent to generate a different deck size.

## What users will see

Deck page-count selections and edited Simple Deck page-count queries are honored as an explicit required slide/page count during generation, even when the prompt text contains a conflicting range.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshots: this is a prompt-handoff/default behavior fix with no new visual UI surface.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/prompts/system.test.ts`
  - `packages/contracts/tests/system-prompt.test.ts`
  - `packages/contracts/tests/plugin-block.test.ts`
  - `apps/web/tests/components/EntryShell.onboarding.test.tsx`
  - `apps/web/tests/components/HomeView.prefill.test.tsx`
- Did the test go red on `main` and green on this branch? yes — the regression specs were added first on the branch from `upstream/main` and failed before the source changes, then passed after the fix.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/prompts/system.test.ts tests/plugins-canon.test.ts`
- `pnpm --filter @open-design/contracts exec vitest run tests/system-prompt.test.ts tests/plugin-block.test.ts`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding.test.tsx tests/components/HomeView.prefill.test.tsx`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/HomeView.media-options.test.tsx`
- `git diff --check`
