### PR TITLE
Fix Kimi ACP prompt delivery

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import type { Writable } from 'node:stream';
 import path from 'node:path';
 import type { ExecutionProfile } from '@open-design/contracts';
+import { createCommandInvocation } from '@open-design/platform';
 import {
   createDsmlArtifactTextSuppressor,
   createToolCallTextSuppressor,
@@ -804,10 +805,12 @@ export async function detectAcpModels({
 }: DetectAcpModelsOptions): Promise<ModelOption[]> {
   const effectiveTimeoutMs = resolveAcpTimeoutMs(env, timeoutMs);
   return await new Promise<ModelOption[]>((resolve, reject) => {
-    const child = spawn(bin, args, {
+    const invocation = createCommandInvocation({ command: bin, args, env });
+    const child = spawn(invocation.command, invocation.args, {
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...env },
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
     });
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -14,6 +14,9 @@ export const kimiAgentDef = {
         timeoutMs: 15_000,
         defaultModelOption: DEFAULT_MODEL_OPTION,
       }),
+    // Chat runs now require `kimi acp`; do not advertise an install that only
+    // proves `kimi --version` works.
+    requiresModelProbe: true,
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       { id: 'kimi-k2-turbo-preview', label: 'kimi-k2-turbo-preview' },

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MODEL_OPTION } from './shared.js';
+import { detectAcpModels, DEFAULT_MODEL_OPTION } from './shared.js';
 import type { RuntimeAgentDef } from '../types.js';
 
 export const kimiAgentDef = {
@@ -6,24 +6,21 @@ export const kimiAgentDef = {
     name: 'Kimi CLI',
     bin: 'kimi',
     versionArgs: ['--version'],
+    fetchModels: async (resolvedBin, env) =>
+      detectAcpModels({
+        bin: resolvedBin,
+        args: ['acp'],
+        env,
+        timeoutMs: 15_000,
+        defaultModelOption: DEFAULT_MODEL_OPTION,
+      }),
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       { id: 'kimi-k2-turbo-preview', label: 'kimi-k2-turbo-preview' },
       { id: 'moonshot-v1-8k', label: 'moonshot-v1-8k' },
       { id: 'moonshot-v1-32k', label: 'moonshot-v1-32k' },
     ],
-    buildArgs: (prompt, _imagePaths, _extraAllowedDirs = [], options = {}) => {
-      const args = ['-p', prompt, '--output-format', 'stream-json'];
-      if (options.model && options.model !== 'default') {
-        args.push('--model', options.model);
-      }
-      return args;
-    },
-    // Kimi's prompt mode requires the full composed prompt as `-p <prompt>`.
-    // Keep this under Windows' ~32 KB CreateProcess command-line ceiling so
-    // /api/chat can fail fast with AGENT_PROMPT_TOO_LARGE instead of letting
-    // spawn surface ENAMETOOLONG / E2BIG.
-    maxPromptArgBytes: 30_000,
-    streamFormat: 'json-event-stream',
-    eventParser: 'kimi',
+    buildArgs: () => ['acp'],
+    streamFormat: 'acp-json-rpc',
+    externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -7,7 +7,11 @@ import {
 } from './models.js';
 import { applyAgentLaunchEnv, resolveAgentLaunch } from './launch.js';
 import { spawnEnvForAgent } from './env.js';
-import { probeAgentAuthStatus } from './auth.js';
+import {
+  classifyAgentServiceFailure,
+  probeAgentAuthStatus,
+  type AgentAuthProbeResult,
+} from './auth.js';
 import { agentCapabilities } from './capabilities.js';
 import { installMetaForAgent } from './metadata.js';
 import { resolveAmrProfile } from '../integrations/vela.js';
@@ -30,18 +34,46 @@ type FetchedRuntimeModels = {
   models: RuntimeModelOption[];
   source: RuntimeModelSource;
   requiredProbeFailed?: boolean;
+  auth?: AgentAuthProbeResult;
 };
 
-function fallbackModels(def: RuntimeAgentDef): FetchedRuntimeModels {
+function fallbackModels(
+  def: RuntimeAgentDef,
+  options: { requiredProbeFailed?: boolean; auth?: AgentAuthProbeResult } = {},
+): FetchedRuntimeModels {
+  const requiredProbeFailed =
+    options.requiredProbeFailed ?? Boolean(def.requiresModelProbe);
   return {
     models: def.fallbackModels,
     source: 'fallback',
-    ...(def.requiresModelProbe ? { requiredProbeFailed: true } : {}),
+    ...(requiredProbeFailed ? { requiredProbeFailed: true } : {}),
+    ...(options.auth ? { auth: options.auth } : {}),
   };
 }
 
 function amrModelScopeFromEnv(env: NodeJS.ProcessEnv): string {
   return resolveAmrProfile(env);
+}
+
+function errorText(error: unknown): string {
+  const err = error as { message?: unknown; stdout?: unknown; stderr?: unknown };
+  return [err.message, err.stdout, err.stderr]
+    .filter((part): part is string => typeof part === 'string' && part.trim().length > 0)
+    .join('\n') || String(error || '');
+}
+
+function modelProbeAuthFailure(
+  def: RuntimeAgentDef,
+  error: unknown,
+): AgentAuthProbeResult | null {
+  const text = errorText(error);
+  if (classifyAgentServiceFailure(text) !== 'AGENT_AUTH_REQUIRED') {
+    return null;
+  }
+  return {
+    status: 'missing',
+    message: `${def.name} appears to be installed but is not authenticated. Sign in with the CLI in a terminal, then rescan.`,
+  };
 }
 
 function withRememberedAmrModels(
@@ -52,7 +84,7 @@ function withRememberedAmrModels(
   if (def.id !== 'amr' || modelResult.models.length > 0) return modelResult;
   const rememberedModels = getRememberedLiveModels(def.id, amrModelScopeFromEnv(env));
   if (rememberedModels.length === 0) return modelResult;
-  return { models: rememberedModels, source: 'live' };
+  return { ...modelResult, models: rememberedModels, source: 'live' };
 }
 
 async function fetchModels(
@@ -67,7 +99,13 @@ async function fetchModels(
         return fallbackModels(def);
       }
       return { models: parsed, source: 'live' };
-    } catch {
+    } catch (error) {
+      const auth = def.requiresModelProbe
+        ? modelProbeAuthFailure(def, error)
+        : null;
+      if (auth) {
+        return fallbackModels(def, { requiredProbeFailed: false, auth });
+      }
       return fallbackModels(def);
     }
   }
@@ -249,7 +287,8 @@ async function probe(
   if (caps) {
     agentCapabilities.set(def.id, caps);
   }
-  const authDiagnostic = auth ? buildAuthDiagnostic(def, auth) : null;
+  const surfacedAuth = surfacedModelResult.auth ?? auth;
+  const authDiagnostic = surfacedAuth ? buildAuthDiagnostic(def, surfacedAuth) : null;
   return {
     ...stripFns(def),
     models: surfacedModelResult.models,
@@ -257,10 +296,10 @@ async function probe(
     available: true,
     path: launch.selectedPath,
     version: outcome.version,
-    ...(auth
+    ...(surfacedAuth
       ? {
-          authStatus: auth.status,
-          ...(auth.message ? { authMessage: auth.message } : {}),
+          authStatus: surfacedAuth.status,
+          ...(surfacedAuth.message ? { authMessage: surfacedAuth.message } : {}),
         }
       : {}),
     ...(authDiagnostic ? { diagnostics: [authDiagnostic] } : {}),

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -29,7 +29,16 @@ import type {
 type FetchedRuntimeModels = {
   models: RuntimeModelOption[];
   source: RuntimeModelSource;
+  requiredProbeFailed?: boolean;
 };
+
+function fallbackModels(def: RuntimeAgentDef): FetchedRuntimeModels {
+  return {
+    models: def.fallbackModels,
+    source: 'fallback',
+    ...(def.requiresModelProbe ? { requiredProbeFailed: true } : {}),
+  };
+}
 
 function amrModelScopeFromEnv(env: NodeJS.ProcessEnv): string {
   return resolveAmrProfile(env);
@@ -55,15 +64,15 @@ async function fetchModels(
     try {
       const parsed = await def.fetchModels(resolvedBin, env);
       if (!parsed || parsed.length === 0) {
-        return { models: def.fallbackModels, source: 'fallback' };
+        return fallbackModels(def);
       }
       return { models: parsed, source: 'live' };
     } catch {
-      return { models: def.fallbackModels, source: 'fallback' };
+      return fallbackModels(def);
     }
   }
   if (!def.listModels) {
-    return { models: def.fallbackModels, source: 'fallback' };
+    return fallbackModels(def);
   }
   try {
     const { stdout } = await execAgentFile(resolvedBin, def.listModels.args, {
@@ -79,11 +88,11 @@ async function fetchModels(
     // usable list (e.g. cursor-agent's "No models available"); fall back
     // to the static hint so the picker isn't stuck on Default-only.
     if (!parsed || parsed.length === 0) {
-      return { models: def.fallbackModels, source: 'fallback' };
+      return fallbackModels(def);
     }
     return { models: parsed, source: 'live' };
   } catch {
-    return { models: def.fallbackModels, source: 'fallback' };
+    return fallbackModels(def);
   }
 }
 
@@ -234,6 +243,9 @@ async function probe(
     probeAgentAuthStatus(def, launch.launchPath, probeEnv),
   ]);
   const surfacedModelResult = withRememberedAmrModels(def, probeEnv, modelResult);
+  if (surfacedModelResult.requiredProbeFailed) {
+    return unavailableAgent(def);
+  }
   if (caps) {
     agentCapabilities.set(def.id, caps);
   }
@@ -272,6 +284,7 @@ function stripFns(
     buildArgs,
     listModels,
     fetchModels,
+    requiresModelProbe,
     fallbackModels,
     helpArgs,
     capabilityFlags,

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -128,6 +128,11 @@ export type RuntimeAgentDef = {
     resolvedBin: string,
     env: RuntimeEnv,
   ) => Promise<RuntimeModelOption[] | null>;
+  // When true, agent detection treats a failed/empty model probe as an
+  // unavailable runtime instead of advertising static fallback models. Use this
+  // when the model probe also verifies the transport that chat runs require
+  // (for example an ACP-only adapter whose run path is `<bin> acp`).
+  requiresModelProbe?: boolean;
   reasoningOptions?: RuntimeReasoningOption[];
   supportsImagePaths?: boolean;
   maxPromptArgBytes?: number;
@@ -222,6 +227,7 @@ export type DetectedAgent = Omit<
   | 'buildArgs'
   | 'listModels'
   | 'fetchModels'
+  | 'requiresModelProbe'
   | 'fallbackModels'
   | 'helpArgs'
   | 'capabilityFlags'

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -758,6 +758,7 @@ test('kimi args use ACP and never embed the prompt in argv', () => {
   assert.equal(kimi.eventParser, undefined);
   assert.equal(kimi.mcpDiscovery, undefined);
   assert.equal(kimi.externalMcpInjection, 'acp-merge');
+  assert.equal(kimi.requiresModelProbe, true);
 });
 
 test('kimi args route explicit model selections through ACP session setup', () => {

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -745,30 +745,25 @@ test('kilo args use acp subcommand for json-rpc streaming', () => {
   assert.equal(kilo.streamFormat, 'acp-json-rpc');
 });
 
-test('kimi args use prompt-mode JSONL instead of ACP', () => {
+test('kimi args use ACP and never embed the prompt in argv', () => {
   const prompt = 'design a page';
   const args = kimi.buildArgs(prompt, [], [], {});
 
-  assert.deepEqual(args, ['-p', prompt, '--output-format', 'stream-json']);
-  assert.equal(args.includes('acp'), false);
+  assert.deepEqual(args, ['acp']);
+  assert.equal(args.includes(prompt), false);
+  assert.equal(args.includes('-p'), false);
+  assert.equal(args.includes('--prompt'), false);
   assert.equal(args.includes('--yolo'), false);
-  assert.equal(kimi.streamFormat, 'json-event-stream');
-  assert.equal(kimi.eventParser, 'kimi');
+  assert.equal(kimi.streamFormat, 'acp-json-rpc');
+  assert.equal(kimi.eventParser, undefined);
   assert.equal(kimi.mcpDiscovery, undefined);
-  assert.equal(kimi.externalMcpInjection, undefined);
+  assert.equal(kimi.externalMcpInjection, 'acp-merge');
 });
 
-test('kimi args pass explicit model selections through prompt mode', () => {
+test('kimi args route explicit model selections through ACP session setup', () => {
   const args = kimi.buildArgs('hello', [], [], { model: 'moonshot-v1-32k' });
 
-  assert.deepEqual(args, [
-    '-p',
-    'hello',
-    '--output-format',
-    'stream-json',
-    '--model',
-    'moonshot-v1-32k',
-  ]);
+  assert.deepEqual(args, ['acp']);
 });
 
 test('kilo fetchModels falls back to fallbackModels when detection fails', async () => {

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -505,7 +505,7 @@ test('detectAgents includes sanitized install and docs metadata from split runti
   }
 });
 
-fsTest('detectAgents keeps Kimi available when the installed CLI rejects the legacy acp positional arg', async () => {
+fsTest('detectAgents marks Kimi unavailable when the installed CLI rejects the required acp mode', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-detect-kimi-modern-'));
   try {
     return await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
@@ -537,8 +537,7 @@ fsTest('detectAgents keeps Kimi available when the installed CLI rejects the leg
       const kimi = agents.find((agent) => agent.id === 'kimi');
 
       assert.ok(kimi);
-      assert.equal(kimi.available, true);
-      assert.equal(kimi.version, 'kimi 0.6.0');
+      assert.equal(kimi.available, false);
       assert.equal(kimi.models[0]?.id, 'default');
       assert.equal(kimi.models[1]?.id, 'kimi-k2-turbo-preview');
       assert.equal(kimi.models[2]?.id, 'moonshot-v1-8k');

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -469,6 +469,36 @@ test('resolveAgentExecutable prefers opencode-cli before desktop opencode fallba
   }
 });
 
+function writeKimiTestCli(dir: string, script: string): string {
+  const scriptPath = join(dir, 'kimi-impl.mjs');
+  writeFileSync(scriptPath, script);
+  if (process.platform === 'win32') {
+    const bin = join(dir, 'kimi.cmd');
+    writeFileSync(
+      bin,
+      [
+        '@echo off',
+        `"${process.execPath}" "%~dp0kimi-impl.mjs" %*`,
+        'exit /b %ERRORLEVEL%',
+        '',
+      ].join('\r\n'),
+    );
+    return bin;
+  }
+  const bin = join(dir, 'kimi');
+  writeFileSync(
+    bin,
+    [
+      '#!/bin/sh',
+      'DIR="$(cd "$(dirname "$0")" && pwd)"',
+      `exec "${process.execPath}" "$DIR/kimi-impl.mjs" "$@"`,
+      '',
+    ].join('\n'),
+  );
+  chmodSync(bin, 0o755);
+  return bin;
+}
+
 test('detectAgents includes sanitized install and docs metadata from split runtime metadata', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-agent-install-meta-'));
   try {
@@ -505,15 +535,13 @@ test('detectAgents includes sanitized install and docs metadata from split runti
   }
 });
 
-fsTest('detectAgents marks Kimi unavailable when the installed CLI rejects the required acp mode', async () => {
+test('detectAgents marks Kimi unavailable when the installed CLI rejects the required acp mode', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-detect-kimi-modern-'));
   try {
     return await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
-      const kimiBin = join(dir, 'kimi');
-      writeFileSync(
-        kimiBin,
+      writeKimiTestCli(
+        dir,
         [
-          '#!/usr/bin/env node',
           'const args = process.argv.slice(2);',
           "if (args.includes('acp')) {",
           "  console.error('error: too many arguments. Expected 0 arguments but got 1.');",
@@ -528,7 +556,6 @@ fsTest('detectAgents marks Kimi unavailable when the installed CLI rejects the r
           '',
         ].join('\n'),
       );
-      chmodSync(kimiBin, 0o755);
 
       process.env.PATH = dir;
       process.env.OD_AGENT_HOME = dir;
@@ -542,6 +569,54 @@ fsTest('detectAgents marks Kimi unavailable when the installed CLI rejects the r
       assert.equal(kimi.models[1]?.id, 'kimi-k2-turbo-preview');
       assert.equal(kimi.models[2]?.id, 'moonshot-v1-8k');
       assert.equal(kimi.models[3]?.id, 'moonshot-v1-32k');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detectAgents keeps Kimi available when ACP starts but requires auth', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-detect-kimi-acp-auth-'));
+  try {
+    return await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      writeKimiTestCli(
+        dir,
+        [
+          'const args = process.argv.slice(2);',
+          "if (args.length === 1 && args[0] === '--version') {",
+          "  console.log('kimi 0.20.0');",
+          '  process.exit(0);',
+          '}',
+          "if (args.length === 1 && args[0] === 'acp') {",
+          "  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: 401, message: 'Authentication required. Run kimi login first.' } }) + '\\n');",
+          '  setTimeout(() => process.exit(1), 1000);',
+          '} else {',
+          "  console.error('unexpected args: ' + JSON.stringify(args));",
+          '  process.exit(1);',
+          '}',
+          '',
+        ].join('\n'),
+      );
+
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+
+      const agents = await detectAgents();
+      const kimi = agents.find((agent) => agent.id === 'kimi');
+
+      assert.ok(kimi);
+      assert.equal(kimi.available, true);
+      assert.equal(kimi.authStatus, 'missing');
+      assert.match(kimi.authMessage ?? '', /Kimi CLI.*not authenticated/);
+      assert.equal(kimi.modelsSource, 'fallback');
+      assert.deepEqual(
+        kimi.models.map((model) => model.id),
+        ['default', 'kimi-k2-turbo-preview', 'moonshot-v1-8k', 'moonshot-v1-32k'],
+      );
+      assert.equal(
+        kimi.diagnostics?.some((diagnostic) => diagnostic.reason === 'auth-missing'),
+        true,
+      );
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/daemon/tests/runtimes/prompt-budget.test.ts
+++ b/apps/daemon/tests/runtimes/prompt-budget.test.ts
@@ -146,18 +146,12 @@ test('checkPromptArgvBudget gives DeepSeek-specific guidance for large contexts'
   assert.match(flagged.message, /stdin-capable adapter/);
 });
 
-test('Kimi prompt mode declares and enforces an argv-byte budget', () => {
-  assert.equal(kimi.maxPromptArgBytes, 30_000);
+test('Kimi ACP mode does not declare an argv-byte budget', () => {
+  assert.equal(kimi.maxPromptArgBytes, undefined);
 
-  const oversized = 'x'.repeat(kimi.maxPromptArgBytes + 1);
+  const oversized = 'x'.repeat(100_000);
   const flagged = checkPromptArgvBudget(kimi, oversized, 'win32');
-  assert.ok(flagged, 'oversized Kimi prompts must trip the argv-byte guard');
-  assert.equal(flagged.code, 'AGENT_PROMPT_TOO_LARGE');
-  assert.equal(flagged.limit, kimi.maxPromptArgBytes);
-  assert.equal(flagged.bytes, kimi.maxPromptArgBytes + 1);
-  assert.match(flagged.message, /Kimi CLI/);
-  assert.match(flagged.message, /command-line argument/);
-  assert.match(flagged.message, /stdin support/);
+  assert.equal(flagged, null);
 
   assert.equal(checkPromptArgvBudget(kimi, 'hello'), null);
 });

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -99,6 +99,7 @@ If both signals agree, detection is confident. If only one signal fires, we mark
 | **kilo** | `kilo` | — | ❌ | ✅ | ✅ (`acp-json-rpc`) | P2 |
 | **vibe** | `vibe-acp` | `~/.vibe/` | ❌ | ✅ | ✅ (`acp-json-rpc`) | P2 |
 | **trae-cli** | `traecli` | Trae CLI config | Trae CLI managed | ❌ (prompt-injected) | ✅ | ✅ (`acp-json-rpc`) | P2 |
+| **kimi** | `kimi` | Kimi Code config | Kimi Code managed | ❌ (prompt-injected) | ✅ | ✅ (`acp-json-rpc`) | P2 |
 | **deepseek** | `deepseek` | `~/.deepseek/` | `~/.deepseek/skills/` | ❌ (prompt-injected) | ✅ | ✅ (plain text) | P2 |
 | **qoder** | `qodercli` | Qoder CLI config | Qoder CLI managed | ❌ (prompt-injected) | ✅ | ✅ (`stream-json`) | P2 |
 | **pi** | `pi` | `~/.pi/agent/` | `~/.pi/agent/skills/` | ❌ (prompt-injected) | ✅ | ✅ (`pi-rpc` JSON-RPC) | P2 |
@@ -233,7 +234,15 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 - Extension UI: auto-resolved. pi's RPC protocol can request user dialogs (`select`, `confirm`, `input`, `editor`) and fire-and-forget notifications (`setStatus`, `setWidget`, `notify`, `setTitle`, `set_editor_text`). Dialog methods are auto-approved (confirm → true, select → first option) and fire-and-forget methods are silently consumed because the web UI has no surface for them.
 - **Gotcha:** pi's RPC `prompt` response is asynchronous — `success: true` only means the prompt was accepted, not that the agent finished. Agent failures after acceptance surface through the normal event stream (`extension_error`, `auto_retry_end` with `success: false`) and the empty-output guard.
 
-### 5.12 DeepSeek TUI
+### 5.12 Kimi CLI
+
+- Invocation: `kimi acp`, using the daemon's shared ACP JSON-RPC transport. Kimi Code 0.20.x exposes prompt mode through `-p/--prompt <prompt>` only; it does not accept `--print`, `--input-format`, or `--output-format` outside prompt mode. The adapter therefore avoids prompt mode entirely so large composed prompts are sent through ACP instead of Windows argv.
+- Streaming: `acp-json-rpc`; the daemon uses the same ACP event path as Devin, Kiro, Kilo, Vibe, and Trae CLI.
+- Models: dynamic through the ACP handshake when available. If detection cannot start `kimi acp` (for example, an older CLI rejects the subcommand), the picker falls back to Kimi's static model hints.
+- Skills: prompt injection only in v1. External MCP servers are forwarded through the ACP launch descriptor with the existing `acp-merge` path.
+- **Gotcha:** Detection still treats older `kimi --version`-only installs as available with fallback models. Those installs may need to upgrade to a Kimi Code build with `kimi acp` before chat runs can use the ACP adapter.
+
+### 5.13 DeepSeek TUI
 
 - Invocation: `deepseek exec --auto [--model <id>] "<prompt>"`. The `deepseek` dispatcher owns the `exec` / `--auto` subcommands and delegates to a sibling `deepseek-tui` runtime binary at exec time; upstream documents both binaries as required (the npm and cargo paths install them together). We only probe the dispatcher — `deepseek-tui` on its own doesn't accept this argv shape, so advertising it as a fallback would surface the agent as available but fail on the first chat run. A future revision could teach resolution + buildArgs which binary was selected and emit a verified `deepseek-tui` invocation, with a regression test exercising that path.
 - Streaming: plain text deltas to stdout in non-`--json` mode (tool-call notifications go to stderr). Skipping `--json` is intentional — `deepseek exec --json` batches the entire run into one trailing summary object instead of streaming, which would freeze the chat UI until end-of-turn.

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -238,9 +238,9 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 
 - Invocation: `kimi acp`, using the daemon's shared ACP JSON-RPC transport. Kimi Code 0.20.x exposes prompt mode through `-p/--prompt <prompt>` only; it does not accept `--print`, `--input-format`, or `--output-format` outside prompt mode. The adapter therefore avoids prompt mode entirely so large composed prompts are sent through ACP instead of Windows argv.
 - Streaming: `acp-json-rpc`; the daemon uses the same ACP event path as Devin, Kiro, Kilo, Vibe, and Trae CLI.
-- Models: dynamic through the ACP handshake when available. If detection cannot start `kimi acp` (for example, an older CLI rejects the subcommand), the picker falls back to Kimi's static model hints.
+- Models: dynamic through the ACP handshake when available. If detection cannot start `kimi acp` (for example, an older CLI rejects the subcommand), Kimi is marked unavailable instead of advertising a version-only install that cannot chat. If ACP starts but reports missing authentication, Kimi stays visible with fallback model hints and an auth remediation.
 - Skills: prompt injection only in v1. External MCP servers are forwarded through the ACP launch descriptor with the existing `acp-merge` path.
-- **Gotcha:** Detection still treats older `kimi --version`-only installs as available with fallback models. Those installs may need to upgrade to a Kimi Code build with `kimi acp` before chat runs can use the ACP adapter.
+- **Gotcha:** Kimi now requires ACP support for chat runs. Older `kimi --version`-only installs should upgrade to a Kimi Code build with `kimi acp`; auth-required ACP installs should sign in through the Kimi CLI and rescan.
 
 ### 5.13 DeepSeek TUI
 


### PR DESCRIPTION
Fixes #4796

## Why

I hit the Kimi Windows prompt-size failure from #4796 while validating Kimi Code 0.20.0. The current adapter sends the whole composed prompt as `-p <prompt>`, which keeps Windows users under the CreateProcess command-line ceiling and can produce `AGENT_PROMPT_TOO_LARGE` before Kimi ever starts.

During validation, Kimi Code 0.20.x did not accept the proposed stdin print shape (`--print`, `--input-format`, or `--output-format` without `-p`). It does expose `kimi acp`, so this switches Open Design to Kimi's ACP stdio transport instead of argv prompt mode.

## What users will see

Kimi runs now start through `kimi acp`. Large Open Design prompts are no longer placed in the command line, so Windows users should not hit the Kimi-specific argv prompt budget for normal chat runs. Model selection is routed through the ACP session setup instead of a `--model` argv flag.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** - changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

N/A - daemon runtime adapter change only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/agent-args.test.ts` (`kimi args use ACP and never embed the prompt in argv`) and `apps/daemon/tests/runtimes/prompt-budget.test.ts` (`Kimi ACP mode does not declare an argv-byte budget`).
- Did the test go red on `main` and green on this branch? yes. The new Kimi assertions failed against the prompt-mode adapter (`-p <prompt> --output-format stream-json`, `maxPromptArgBytes: 30000`) and passed after switching to `kimi acp`.
- Local Kimi CLI evidence: `kimi --version` is 0.20.0; `--print` and `--input-format` are rejected; `--output-format` without `-p` is rejected; `kimi acp --help` succeeds. A direct ACP helper probe reached the Kimi ACP handshake and stopped at `Authentication required`, confirming the endpoint is live in this install.

## Validation

- [x] `pnpm exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts tests/runtimes/prompt-budget.test.ts` from `apps/daemon` - red before source change, green after (`68 passed`).
- [x] `pnpm --filter @open-design/daemon typecheck` - passed with pnpm 10.33.2 first on PATH.
- [x] `pnpm typecheck` - passed with pnpm 10.33.2 first on PATH.
- [x] `git diff --check` - passed.
- [ ] `pnpm guard` - attempted; blocked by repo-wide pre-existing design-system manifest freshness failures (`design-systems/*/manifest.json` stale `design-tokens.json` / `tailwind-v4.css`), unrelated to this Kimi runtime diff.
