### PR TITLE
Fix chat resize handle hitbox

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1355,10 +1355,9 @@ a.avatar-item:visited {
 .split-resize-handle::before {
   content: "";
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: -10px;
-  right: -10px;
+  inset-block: 0;
+  inset-inline-start: 0;
+  inset-inline-end: -10px;
   cursor: col-resize;
 }
 .split-resize-handle::after {

--- a/apps/web/tests/styles/split-resize-handle.test.ts
+++ b/apps/web/tests/styles/split-resize-handle.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const shellCss = readFileSync(new URL('../../src/styles/shell.css', import.meta.url), 'utf8');
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = shellCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('split resize handle styles', () => {
+  it('keeps the expanded hitbox out of the chat scrollbar side', () => {
+    const handleHitbox = cssDeclarations('.split-resize-handle::before');
+
+    expect(ruleValue(handleHitbox, 'inset-block')).toBe('0');
+    expect(ruleValue(handleHitbox, 'inset-inline-start')).toBe('0');
+    expect(ruleValue(handleHitbox, 'inset-inline-end')).toBe('-10px');
+    expect(handleHitbox).not.toContain('left: -10px');
+    expect(handleHitbox).not.toContain('right: -10px');
+  });
+});


### PR DESCRIPTION
Fixes #4797

## Why

Dragging the chat scrollbar on Windows could start chat/workspace resizing because the split resize handle expanded its invisible hitbox 10px into both neighboring panes. That put the resize target over the chat scrollbar zone, matching the reporter's screenshots showing an offset pointer area.

## What users will see

Users can drag the chat scrollbar without accidentally resizing the chat/workspace split. The visible divider and keyboard resizing behavior stay the same.

## Surface area

- [x] UI
- [ ] Keyboard shortcut
- [ ] CLI/env var
- [ ] API/contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

N/A - this is a hitbox-only CSS behavior fix with no intended visual change.

## Bug fix verification

Added a stylesheet regression test that asserts the split resize handle's expanded hitbox starts at the divider on the chat side and expands only toward `inline-end`, preventing the old physical `left: -10px; right: -10px` overlap from coming back.

## Validation

- [x] `corepack pnpm exec vitest run tests/styles/split-resize-handle.test.ts -c vitest.config.ts --maxWorkers=2 --reporter=verbose`
- [x] `corepack pnpm --filter @open-design/web typecheck`
- [x] Equivalent root typecheck segments with pinned `pnpm@10.33.2`:
  - `corepack pnpm -r --workspace-concurrency=4 --if-present run typecheck` progressed through web and most packages, then stopped when `apps/daemon` invoked bare global `pnpm@11.7.0` inside its script.
  - Follow-up checks passed: contracts build, registry-protocol build, daemon `tsc` configs, desktop typecheck, tools-pack typecheck, and `scripts/tsconfig.json`.
- [x] `git diff --check`
- [x] Guard follow-up policy tests: `node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/web-import-isolation.test.ts scripts/check-cross-app-imports.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/lint-craft-references.test.ts`
- [ ] `corepack pnpm guard` currently fails on pre-existing stale generated design-system manifest artifacts (`design-tokens.json` / `tailwind-v4.css` across bundled design systems), unrelated to this two-file web CSS fix.