### PR TITLE
fix(web): lift dark-mode picker secondary text to an AA-legible token (#4468)

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -746,7 +746,7 @@
 .home-hero__plugin-hover-kicker {
   display: block;
   margin-bottom: 2px;
-  color: var(--text-faint);
+  color: var(--text-muted);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0;
@@ -757,7 +757,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 4px 8px;
-  color: var(--text-faint);
+  color: var(--text-muted);
   font-size: 11px;
 }
 .home-hero__plugin-hover-meta span {

--- a/apps/web/src/styles/home/plugins-view.css
+++ b/apps/web/src/styles/home/plugins-view.css
@@ -136,7 +136,7 @@
 .plugins-view__tab-hint {
   overflow: hidden;
   max-width: 100%;
-  color: var(--text-faint);
+  color: var(--text-muted);
   font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -183,7 +183,7 @@
 
 .plugins-view__section-count {
   flex: 0 0 auto;
-  color: var(--text-faint);
+  color: var(--text-muted);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
 }
@@ -356,7 +356,7 @@
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 8px;
-  color: var(--text-faint);
+  color: var(--text-muted);
   font-size: 11.5px;
 }
 

--- a/apps/web/tests/styles/picker-dark-mode-contrast.test.ts
+++ b/apps/web/tests/styles/picker-dark-mode-contrast.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Regression for #4468: in dark mode the home context/plugin picker drew its
+// secondary text (tab hints, per-section counts, option meta, and the
+// hover-card kicker/meta) in `--text-faint`, which resolves to ~1.85:1 against
+// the picker surface — well below the WCAG AA 4.5:1 floor for normal text.
+// These selectors must use a token that clears AA on the dark picker surface.
+
+const pluginsViewCss = readFileSync(
+  new URL('../../src/styles/home/plugins-view.css', import.meta.url),
+  'utf8',
+);
+const homeHeroCss = readFileSync(
+  new URL('../../src/styles/home/home-hero.css', import.meta.url),
+  'utf8',
+);
+const tokensCss = readFileSync(
+  new URL('../../src/styles/tokens.css', import.meta.url),
+  'utf8',
+);
+
+function stripComments(css: string): string {
+  return css.replace(/\/\*[^]*?\*\//g, '');
+}
+
+function cssBlock(rawCss: string, selector: string): string {
+  const css = stripComments(rawCss);
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(css)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) return match[2] ?? '';
+  }
+  throw new Error(`Missing CSS block for ${selector}`);
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [
+    ...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g')),
+  ];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+// Resolve a design token from the explicit dark theme scope in tokens.css.
+function darkToken(name: string): string {
+  const scope = cssBlock(tokensCss, '[data-theme="dark"]');
+  return ruleValue(scope, name);
+}
+
+// Resolve a `var(--token)` reference (or a literal hex) to a hex string.
+function resolveColor(value: string): string {
+  const varMatch = value.match(/^var\(\s*(--[\w-]+)\s*\)$/);
+  return varMatch ? darkToken(varMatch[1]!) : value;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const normalized = hex.trim().replace(/^#/, '');
+  if (!/^(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(normalized)) {
+    throw new Error(`Expected #rgb or #rrggbb, got ${hex}`);
+  }
+  const expanded =
+    normalized.length === 3
+      ? [...normalized].map((char) => `${char}${char}`).join('')
+      : normalized;
+  return [
+    Number.parseInt(expanded.slice(0, 2), 16),
+    Number.parseInt(expanded.slice(2, 4), 16),
+    Number.parseInt(expanded.slice(4, 6), 16),
+  ];
+}
+
+function luminance([r, g, b]: [number, number, number]): number {
+  const channel = (value: number) => {
+    const normalized = value / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const first = luminance(hexToRgb(resolveColor(foreground)));
+  const second = luminance(hexToRgb(resolveColor(background)));
+  const lighter = Math.max(first, second);
+  const darker = Math.min(first, second);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// Picker panel is --bg-panel; the hover card is a color-mix dominated by
+// --bg-subtle, which is the lighter component (so the more conservative base
+// for light-on-dark contrast).
+const PICKER_SECONDARY_TEXT = [
+  { css: pluginsViewCss, selector: '.plugins-view__tab-hint', surface: 'var(--bg-panel)' },
+  { css: pluginsViewCss, selector: '.plugins-view__section-count', surface: 'var(--bg-panel)' },
+  { css: pluginsViewCss, selector: '.plugins-view__meta', surface: 'var(--bg-panel)' },
+  { css: homeHeroCss, selector: '.home-hero__plugin-hover-kicker', surface: 'var(--bg-subtle)' },
+  { css: homeHeroCss, selector: '.home-hero__plugin-hover-meta', surface: 'var(--bg-subtle)' },
+] as const;
+
+describe('home picker dark-mode contrast (#4468)', () => {
+  it('keeps picker secondary text at WCAG AA on the dark surface', () => {
+    for (const { css, selector, surface } of PICKER_SECONDARY_TEXT) {
+      const color = ruleValue(cssBlock(css, selector), 'color');
+      expect(
+        contrastRatio(color, surface),
+        `${selector} color ${color} on ${surface}`,
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it('locks the regression: --text-faint would fail AA here', () => {
+    // Guards the fix's intent — if a selector regresses back to --text-faint,
+    // the AA assertion above fails, because faint is sub-AA on this surface.
+    expect(contrastRatio('var(--text-faint)', 'var(--bg-panel)')).toBeLessThan(3);
+  });
+});


### PR DESCRIPTION
Fixes #4468

## Why

Picked this up after the linked PR went inactive and the issue was reopened for community contribution. I run Open Design in dark mode and the context/plugin picker above the prompt was genuinely hard to scan: the per-tab hints and counts, the option meta pills, and the marketplace hover card's kicker/meta were almost invisible.

The pain is an accessibility one. Those secondary-text selectors use `--text-faint`, which in the dark theme is `#4e4b46`. Against the picker surface (`--bg-panel` `#222120`) that is ~**1.85:1**, well under the WCAG AA 4.5:1 floor for normal text, so the metadata reads as barely-there smudges.

## What users will see

In dark mode, the secondary text in the home context/plugin picker becomes clearly legible instead of nearly invisible: the per-tab hints (e.g. "12 installed"), the section counts (e.g. "6 items"), the option meta pills, and the marketplace hover card's kicker + meta line. Primary text and light mode are unchanged. The search icon and the search input placeholder are intentionally left as-is, since the report is about text legibility and placeholders are conventionally dimmer.

## Surface area

- [x] **UI** — dark-mode text contrast in the home context/plugin picker (`apps/web`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Before/after of the picker secondary text in dark mode (same tokens/surfaces as production), counts/hints/meta/hover-card kicker go from ~1.85:1 (faint) to ~5.46:1 (muted):

<!-- screenshot: picker-contrast-before-after.png attached below -->

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/picker-dark-mode-contrast.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — on `main` it fails with `.plugins-view__tab-hint color var(--text-faint) on var(--bg-panel): expected 1.851485923993882 to be greater than or equal to 4.5`; on this branch both specs pass.
- The spec resolves the real dark-theme tokens from `tokens.css` and the picker surfaces, then asserts WCAG AA (>= 4.5:1) for all five secondary-text selectors, plus a guard that `--text-faint` is sub-AA on this surface so a regression back to it re-reds the suite.

## Validation

- `pnpm guard` — pass (55/55)
- `pnpm typecheck` — pass (`@open-design/web` `tsc -b --noEmit` clean)
- `pnpm --filter @open-design/web exec vitest run tests/styles/picker-dark-mode-contrast.test.ts` — 2 passed
