### PR TITLE
fix(web): stop the split resize handle from hijacking chat scrollbar drags (#4797)

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1506,7 +1506,13 @@ a.avatar-item:visited {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -2px;
+  /* Do not overhang the chat pane. The chat log's scrollbar sits flush against
+     this divider's left edge, so a negative `left` lets the resize grab area
+     (z-index: 45) cover the scrollbar and hijack scrollbar drags into a panel
+     resize (#4797). -2px still clips the scrollbar's outer edge, so pull the
+     chat-side edge fully to 0. Keep the wider grab area on the workspace side,
+     which has no edge scrollbar here. */
+  left: 0;
   right: -10px;
   cursor: col-resize;
 }

--- a/apps/web/tests/styles/split-resize-handle-hitbox.test.ts
+++ b/apps/web/tests/styles/split-resize-handle-hitbox.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const shellCss = readFileSync(new URL('../../src/styles/shell.css', import.meta.url), 'utf8');
+
+function cssDeclarations(css: string, selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [
+    ...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g')),
+  ];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+function pxValue(value: string): number {
+  const trimmed = value.trim();
+  if (trimmed === '0') return 0; // CSS lengths may drop the unit on zero.
+  const match = /^(-?\d+(?:\.\d+)?)px$/.exec(trimmed);
+  if (!match) throw new Error(`Expected a px length, got "${value}"`);
+  return Number(match[1]);
+}
+
+describe('split resize handle hit area', () => {
+  // Regression for #4797: dragging the chat pane's scrollbar resized the
+  // chat <> workspace split instead of scrolling. The chat log's scrollbar is
+  // flush against the resize divider's left (chat-side) edge, so the handle's
+  // pointer-capturing ::before (z-index: 45) must not overhang into the chat
+  // pane — a negative `left` parks the grab area on top of the scrollbar.
+  it('does not overhang the chat pane where the scrollbar sits', () => {
+    const hitArea = cssDeclarations(shellCss, '.split-resize-handle::before');
+    expect(pxValue(ruleValue(hitArea, 'left'))).toBeGreaterThanOrEqual(0);
+  });
+
+  // The grab area may still extend toward the workspace side, which has no
+  // edge scrollbar at this boundary, so resizing stays comfortable to start.
+  it('keeps a generous grab area on the workspace side', () => {
+    const hitArea = cssDeclarations(shellCss, '.split-resize-handle::before');
+    expect(pxValue(ruleValue(hitArea, 'right'))).toBeLessThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
Fixes #4797

## Why

I resize the chat ↔ workspace split a lot, and in a busy conversation I kept catching the chat on its own scrollbar: trying to drag the scrollbar thumb to scroll the log would instead resize the whole panel. It happens right at the divider — exactly where the scrollbar sits — so scrolling a long chat by grabbing the bar is unreliable.

The resize handle paints a pointer-capturing `::before` (`z-index: 45`) that overhung 10px into the chat pane (`left: -10px`). The chat log's edge scrollbar sits flush against that divider, so the grab area sat directly on top of the scrollbar and swallowed the drag as a resize.

## What users will see

Dragging the chat pane's scrollbar now scrolls the chat as expected instead of resizing the split. The resize divider still grabs normally — it keeps its wider hit area on the workspace side (which has no edge scrollbar there), so starting a resize from the divider is unchanged.

## Surface area

- [x] **UI** — the chat ↔ workspace resize divider hit area (`.split-resize-handle::before` in `apps/web/src/styles/shell.css`)

No CLI / contract / i18n surface: this is a CSS hit-area fix on an existing divider.

## Screenshots

This is a pointer hit-area change with no visual difference — the divider looks identical; only the grab area on the chat-scrollbar side changed. (Happy to attach a screen recording of the before/after drag if useful.)

## Bug fix verification

- Test path: `apps/web/tests/styles/split-resize-handle-hitbox.test.ts`
- Red on `main`, green on this branch: yes. The guard parses `shell.css` and asserts the handle's `::before` does not overhang into the chat pane (`left >= 0`). On `main` it is `-10px` (fails); after the fix it is `0` (passes). A second assertion keeps the workspace-side grab area (`right <= 0`) so the divider stays comfortable to grab. This mirrors the existing CSS-invariant guards under `tests/styles/`.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/styles/` — 20 files / 48 tests pass (incl. the new spec)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm guard` — pass
