### PR TITLE
Fix plugins flyout closing while typing in its search box

### DIFF
--- a/apps/web/src/components/ComposerPlusMenu.tsx
+++ b/apps/web/src/components/ComposerPlusMenu.tsx
@@ -243,8 +243,19 @@ export function ComposerPlusMenu({
   function scheduleCloseSubmenu() {
     cancelSubmenuClose();
     submenuCloseTimer.current = setTimeout(() => {
-      setSubmenu(null);
       submenuCloseTimer.current = null;
+      // Typing into a flyout's search box narrows its list, which reflows rows
+      // out from under a stationary cursor — the browser then synthesizes a
+      // `mouseleave` on the flyout even though the pointer never moved. Honoring
+      // that close would yank the search box (and its preview column) away
+      // mid-search, making the plugin impossible to pick. Keep the submenu open
+      // while its own search input still owns focus; the outside-click / Escape
+      // handlers remain the deliberate ways to dismiss it.
+      const active = document.activeElement;
+      if (active && popupRef.current?.contains(active) && active.tagName === 'INPUT') {
+        return;
+      }
+      setSubmenu(null);
     }, 200);
   }
 

--- a/apps/web/tests/components/ComposerPlusMenu.test.tsx
+++ b/apps/web/tests/components/ComposerPlusMenu.test.tsx
@@ -7,7 +7,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ComponentProps } from 'react';
 import { ComposerPlusMenu } from '../../src/components/ComposerPlusMenu';
@@ -84,6 +84,42 @@ describe('ComposerPlusMenu pick-row caret protection', () => {
 
     fireEvent.click(screen.getByRole('menuitem', { name: /^MCP/i }));
     expectPickRowPreventsMousedown(/Linear/i);
+  });
+
+  it('keeps the plugin flyout open when filtering reflows fire a mouseleave mid-search', () => {
+    vi.useFakeTimers();
+    try {
+      renderMenu({
+        plugins: [
+          PLUGIN,
+          { id: 'p2', title: 'Slide Builder', manifest: {} } as never,
+        ],
+      });
+      fireEvent.click(screen.getByTestId('plus-trigger'));
+      fireEvent.click(screen.getByRole('menuitem', { name: /Plugins/i }));
+
+      // The user clicks into the search box (focus enters the flyout) and types,
+      // pruning the list. In a real browser the shrinking list reflows rows out
+      // from under the stationary cursor, so Chromium synthesizes a `mouseleave`
+      // on the flyout even though the pointer never moved.
+      const search = screen.getByPlaceholderText('Plugins') as HTMLInputElement;
+      search.focus();
+      fireEvent.change(search, { target: { value: 'deck' } });
+      const flyout = document.querySelector('.plus-menu__flyout') as HTMLElement;
+      fireEvent.mouseLeave(flyout);
+
+      // The hover-close grace period elapses; the panel must survive because the
+      // search box still owns focus — yanking it away would make the plugin
+      // impossible to pick.
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(screen.queryByPlaceholderText('Plugins')).not.toBeNull();
+      expect(screen.getByRole('menuitem', { name: /Deck Maker/i })).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('resets the shared search query when switching submenus', () => {


### PR DESCRIPTION
Fixes #4856

## Why

I hit this myself while building on top of OD: in the composer `+` menu → **Plugins** flyout, typing a plugin name into the search box very easily makes the whole flyout vanish, so you can't pick the plugin you were searching for. It's a frustrating, easy-to-trigger interaction bug on a primary surface (choosing a plugin from the composer).

The pain: the Plugins submenu is hover-controlled — the flyout's `onMouseLeave` starts a 200ms close timer. Typing narrows the list, which reflows rows out from under a *stationary* cursor, so the browser synthesizes a `mouseleave` on the flyout even though the pointer never moved. That fires the close timer mid-search and unmounts both flyout columns (the search/list column and the live-preview column) at once.

## What users will see

In the composer `+` menu, the **Plugins** flyout now stays open while you type in its search box. You can narrow the list and click the filtered plugin instead of the panel disappearing out from under you. Dismissing still works the usual ways — click outside or press Escape.

## Surface area

- [x] **UI** — fixes interaction behavior of the composer `+` menu Plugins flyout in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**

## Screenshots

Behavior change (no visual redesign): before, typing in the Plugins search box closed the flyout mid-search; after, the flyout stays open while the search input has focus. Reproduced and confirmed fixed locally via `pnpm tools-dev run web`.

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow", the bug is encoded as a falsifiable red spec first:

- Test path that reproduces the bug: `apps/web/tests/components/ComposerPlusMenu.test.tsx` → `"keeps the plugin flyout open when filtering reflows fire a mouseleave mid-search"`
- Did the test go red on `main` and green on this branch? **yes** — the new spec fails against the unpatched `scheduleCloseSubmenu` and passes with the fix.
- The spec focuses the search box, types to narrow the list, dispatches the reflow-style `mouseleave`, advances the 200ms close timer, and asserts the flyout (search box + filtered row) is still mounted.

Validation run locally:
- `pnpm --filter @open-design/web exec vitest run tests/components/ComposerPlusMenu.test.tsx` — 10/10 pass
- `pnpm --filter @open-design/web exec vitest run tests/components/ComposerPlusMenu.caret.test.tsx tests/components/PluginsView.test.tsx` — 20/20 pass
- `pnpm --filter @open-design/web typecheck` — clean
