### PR TITLE
fix(web): use daemon MCP install info in agent guide

### DIFF
--- a/apps/web/src/components/UseEverywhereModal.tsx
+++ b/apps/web/src/components/UseEverywhereModal.tsx
@@ -17,7 +17,10 @@ import { useT } from '../i18n';
 import { modalOverlay, modalContent } from '../motion';
 import type { Dict } from '../i18n/types';
 import {
+  agentGuideSnippetUsesMcpInstallInfo,
   buildAgentGuideMarkdown,
+  renderAgentGuideSnippetBody,
+  type AgentGuideMcpInstallInfo,
   type AgentGuideOptions,
 } from './use-everywhere/agent-guide';
 import {
@@ -147,14 +150,43 @@ export function UseEverywhereGuidePanel({
   const [activeId, setActiveId] = useState<GuideSection['id']>('overview');
   const [guideCopy, setGuideCopy] = useState<CopyState>('idle');
   const [snippetCopy, setSnippetCopy] = useState<{ key: string; state: CopyState } | null>(null);
+  const [mcpInstallInfo, setMcpInstallInfo] = useState<AgentGuideMcpInstallInfo | null>(null);
+  const mcpInstallInfoRequestRef = useRef<Promise<AgentGuideMcpInstallInfo | null> | null>(null);
   const guideSections = useMemo(() => localizeGuideSections(t), [t]);
+
+  function loadMcpInstallInfo(): Promise<AgentGuideMcpInstallInfo | null> {
+    if (!mcpInstallInfoRequestRef.current) {
+      mcpInstallInfoRequestRef.current = fetch('/api/mcp/install-info')
+        .then(async (res) => {
+          if (!res.ok) throw new Error(`daemon ${res.status}`);
+          const data = (await res.json()) as unknown;
+          if (isAgentGuideMcpInstallInfo(data)) return data;
+          return null;
+        })
+        .catch(() => null);
+    }
+    return mcpInstallInfoRequestRef.current;
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    loadMcpInstallInfo()
+      .then((data) => {
+        if (cancelled) return;
+        setMcpInstallInfo(data);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const guideOptions: AgentGuideOptions = useMemo(() => {
     const opts: AgentGuideOptions = {};
     if (daemonUrl) opts.daemonUrl = daemonUrl;
     if (versionHint) opts.versionHint = versionHint;
+    if (mcpInstallInfo) opts.mcpInstallInfo = mcpInstallInfo;
     return opts;
-  }, [daemonUrl, versionHint]);
+  }, [daemonUrl, mcpInstallInfo, versionHint]);
 
   const fullGuide = useMemo(
     () => buildAgentGuideMarkdown(guideOptions),
@@ -177,7 +209,14 @@ export function UseEverywhereGuidePanel({
   }, [activeId, guideSections]);
 
   async function onCopyGuide() {
-    const state = await copyText(fullGuide);
+    const installInfo = mcpInstallInfo ?? await loadMcpInstallInfo();
+    if (installInfo && installInfo !== mcpInstallInfo) {
+      setMcpInstallInfo(installInfo);
+    }
+    const guide = installInfo
+      ? buildAgentGuideMarkdown({ ...guideOptions, mcpInstallInfo: installInfo })
+      : fullGuide;
+    const state = await copyText(guide);
     setGuideCopy(state);
     if (state !== 'idle') {
       window.setTimeout(() => setGuideCopy('idle'), COPY_RESET_MS);
@@ -190,7 +229,17 @@ export function UseEverywhereGuidePanel({
       area: 'use_everywhere_tab',
       element: 'copy',
     });
-    const text = applyDaemonUrl(snippet.body, daemonUrl);
+    let installInfo = mcpInstallInfo;
+    if (agentGuideSnippetUsesMcpInstallInfo(snippet) && !installInfo) {
+      installInfo = await loadMcpInstallInfo();
+      if (installInfo && installInfo !== mcpInstallInfo) {
+        setMcpInstallInfo(installInfo);
+      }
+    }
+    const text = renderAgentGuideSnippetBody(snippet, {
+      daemonUrl,
+      mcpInstallInfo: installInfo,
+    });
     const state = await copyText(text);
     setSnippetCopy({ key, state });
     if (state !== 'idle') {
@@ -230,6 +279,7 @@ export function UseEverywhereGuidePanel({
         <SectionView
           section={activeSection}
           daemonUrl={daemonUrl}
+          mcpInstallInfo={mcpInstallInfo}
           snippetCopy={snippetCopy}
           onCopySnippet={onCopySnippet}
         />
@@ -283,6 +333,16 @@ export function UseEverywhereGuidePanel({
   );
 }
 
+function isAgentGuideMcpInstallInfo(data: unknown): data is AgentGuideMcpInstallInfo {
+  if (!data || typeof data !== 'object') return false;
+  const candidate = data as Partial<AgentGuideMcpInstallInfo>;
+  return (
+    typeof candidate.command === 'string' &&
+    Array.isArray(candidate.args) &&
+    candidate.args.every((arg) => typeof arg === 'string')
+  );
+}
+
 async function copyText(text: string): Promise<CopyState> {
   if (typeof navigator === 'undefined' || !navigator.clipboard) {
     return 'failed';
@@ -298,6 +358,7 @@ async function copyText(text: string): Promise<CopyState> {
 interface SectionViewProps {
   section: GuideSection;
   daemonUrl: string | undefined;
+  mcpInstallInfo: AgentGuideMcpInstallInfo | null;
   snippetCopy: { key: string; state: CopyState } | null;
   onCopySnippet: (key: string, snippet: CodeSnippet) => void;
 }
@@ -305,6 +366,7 @@ interface SectionViewProps {
 function SectionView({
   section,
   daemonUrl,
+  mcpInstallInfo,
   snippetCopy,
   onCopySnippet,
 }: SectionViewProps) {
@@ -356,7 +418,12 @@ function SectionView({
                 className="use-everywhere-snippet__pre"
                 data-language={snippet.language}
               >
-                <code>{applyDaemonUrl(snippet.body, daemonUrl)}</code>
+                <code>
+                  {renderAgentGuideSnippetBody(snippet, {
+                    daemonUrl,
+                    mcpInstallInfo,
+                  })}
+                </code>
               </pre>
             </div>
           );

--- a/apps/web/src/components/use-everywhere/agent-guide.ts
+++ b/apps/web/src/components/use-everywhere/agent-guide.ts
@@ -15,6 +15,12 @@ export interface AgentGuideOptions {
   /** Live daemon URL detected at modal-open time. Defaults to the documented port. */
   daemonUrl?: string;
   /**
+   * Launch spec returned by `/api/mcp/install-info`. When present, MCP
+   * snippets use this absolute command/args/env tuple instead of assuming
+   * an `od` binary exists on PATH.
+   */
+  mcpInstallInfo?: AgentGuideMcpInstallInfo | null;
+  /**
    * Optional `od` binary path / hint. When provided we mention it in the
    * setup checklist so the agent knows whether to run `od …` directly or
    * spawn the packaged binary.
@@ -24,10 +30,22 @@ export interface AgentGuideOptions {
   versionHint?: string;
 }
 
+export interface AgentGuideMcpInstallInfo {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export interface AgentGuideSnippetRenderOptions {
+  daemonUrl: string | undefined;
+  mcpInstallInfo: AgentGuideMcpInstallInfo | null;
+}
+
 const DEFAULT_DAEMON_URL = 'http://127.0.0.1:7456';
 
 export function buildAgentGuideMarkdown(options: AgentGuideOptions = {}): string {
   const daemonUrl = (options.daemonUrl ?? DEFAULT_DAEMON_URL).replace(/\/$/, '');
+  const installInfo = normalizeMcpInstallInfo(options.mcpInstallInfo);
   const lines: string[] = [];
 
   lines.push('# Open Design — agent setup guide');
@@ -56,12 +74,23 @@ export function buildAgentGuideMarkdown(options: AgentGuideOptions = {}): string
   lines.push('');
   lines.push('   If it 404s or times out, ask the user to run `pnpm tools-dev` (dev) or open the Open Design app (packaged).');
   lines.push('');
-  lines.push('2. Detect available agent CLIs and confirm `od` is on PATH:');
+  if (installInfo) {
+    lines.push('2. Use this daemon-reported MCP server config. Do not replace it with a bare `od` command:');
+    lines.push('');
+    lines.push('   ```json');
+    lines.push(indent(buildMcpServerConfigSnippet(installInfo), '   '));
+    lines.push('   ```');
+    lines.push('');
+    lines.push(`   This config came from \`${daemonUrl}/api/mcp/install-info\` and preserves the absolute command, args, and env needed by packaged installs.`);
+  } else {
+    lines.push('2. Detect available agent CLIs and confirm `od` is on PATH:');
+    lines.push('');
+    lines.push('   ```bash');
+    lines.push('   od doctor');
+    lines.push('   od status --json');
+    lines.push('   ```');
+  }
   lines.push('');
-  lines.push('   ```bash');
-  lines.push('   od doctor');
-  lines.push('   od status --json');
-  lines.push('   ```');
   if (options.cliHint) {
     lines.push('');
     lines.push(`   The user reported \`od\` at: \`${options.cliHint}\``);
@@ -88,7 +117,7 @@ export function buildAgentGuideMarkdown(options: AgentGuideOptions = {}): string
   lines.push('');
 
   for (const section of GUIDE_SECTIONS) {
-    lines.push(...renderSection(section, daemonUrl));
+    lines.push(...renderSection(section, daemonUrl, installInfo));
   }
 
   lines.push('## Reference URLs');
@@ -109,7 +138,31 @@ export function buildAgentGuideMarkdown(options: AgentGuideOptions = {}): string
   return lines.join('\n');
 }
 
-function renderSection(section: GuideSection, daemonUrl: string): string[] {
+export function renderAgentGuideSnippetBody(
+  snippet: CodeSnippet,
+  options: AgentGuideSnippetRenderOptions,
+): string {
+  const daemonUrl = (options.daemonUrl ?? DEFAULT_DAEMON_URL).replace(/\/$/, '');
+  return renderSnippetBody(
+    snippet,
+    daemonUrl,
+    normalizeMcpInstallInfo(options.mcpInstallInfo),
+  );
+}
+
+export function agentGuideSnippetUsesMcpInstallInfo(snippet: CodeSnippet): boolean {
+  return (
+    snippet.language === 'json' &&
+    snippet.body.includes('"mcpServers"') &&
+    snippet.body.includes('"command": "od"')
+  );
+}
+
+function renderSection(
+  section: GuideSection,
+  daemonUrl: string,
+  installInfo: AgentGuideMcpInstallInfo | null,
+): string[] {
   const lines: string[] = [];
   lines.push(`## ${substituteDaemonUrl(section.heading, daemonUrl)}`);
   lines.push('');
@@ -122,7 +175,7 @@ function renderSection(section: GuideSection, daemonUrl: string): string[] {
     lines.push('');
   }
   for (const snippet of section.snippets) {
-    lines.push(...renderSnippet(snippet, daemonUrl));
+    lines.push(...renderSnippet(snippet, daemonUrl, installInfo));
   }
   if (section.footer) {
     lines.push(`> ${substituteDaemonUrl(section.footer, daemonUrl)}`);
@@ -131,17 +184,69 @@ function renderSection(section: GuideSection, daemonUrl: string): string[] {
   return lines;
 }
 
-function renderSnippet(snippet: CodeSnippet, daemonUrl: string): string[] {
+function renderSnippet(
+  snippet: CodeSnippet,
+  daemonUrl: string,
+  installInfo: AgentGuideMcpInstallInfo | null,
+): string[] {
   const lines: string[] = [];
   lines.push(`### ${substituteDaemonUrl(snippet.label, daemonUrl)}`);
   lines.push('');
   lines.push('```' + snippet.language);
-  lines.push(substituteDaemonUrl(snippet.body, daemonUrl));
+  lines.push(renderSnippetBody(snippet, daemonUrl, installInfo));
   lines.push('```');
   lines.push('');
   return lines;
 }
 
+function renderSnippetBody(
+  snippet: CodeSnippet,
+  daemonUrl: string,
+  installInfo: AgentGuideMcpInstallInfo | null,
+): string {
+  if (installInfo && agentGuideSnippetUsesMcpInstallInfo(snippet)) {
+    return buildMcpServerConfigSnippet(installInfo);
+  }
+  return substituteDaemonUrl(snippet.body, daemonUrl);
+}
+
 function substituteDaemonUrl(body: string, daemonUrl: string): string {
   return body.replace(/http:\/\/127\.0\.0\.1:7456/g, daemonUrl);
+}
+
+function buildMcpServerConfigSnippet(info: AgentGuideMcpInstallInfo): string {
+  const env = info.env && Object.keys(info.env).length > 0 ? info.env : undefined;
+  return JSON.stringify(
+    {
+      mcpServers: {
+        'open-design': {
+          command: info.command,
+          args: info.args,
+          ...(env ? { env } : {}),
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function normalizeMcpInstallInfo(
+  info: AgentGuideMcpInstallInfo | null | undefined,
+): AgentGuideMcpInstallInfo | null {
+  if (!info || typeof info.command !== 'string' || info.command.length === 0) return null;
+  if (!Array.isArray(info.args) || !info.args.every((arg) => typeof arg === 'string')) return null;
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(info.env ?? {})) {
+    if (typeof value === 'string') env[key] = value;
+  }
+  return {
+    command: info.command,
+    args: info.args,
+    ...(Object.keys(env).length > 0 ? { env } : {}),
+  };
+}
+
+function indent(body: string, prefix: string): string {
+  return body.split('\n').map((line) => `${prefix}${line}`).join('\n');
 }

--- a/apps/web/tests/components/use-everywhere-agent-guide.test.ts
+++ b/apps/web/tests/components/use-everywhere-agent-guide.test.ts
@@ -74,4 +74,51 @@ describe('buildAgentGuideMarkdown', () => {
     expect(md).toContain('- Daemon: `http://example.test:5555`');
     expect(md).toContain('- MCP install info: `http://example.test:5555/api/mcp/install-info`');
   });
+
+  it('uses daemon install-info for the MCP config instead of assuming od is on PATH', () => {
+    const md = buildAgentGuideMarkdown({
+      daemonUrl: 'http://127.0.0.1:7456',
+      mcpInstallInfo: {
+        command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+        args: [
+          'C:\\Program Files\\Open Design\\resources\\app\\apps\\daemon\\dist\\cli.js',
+          'mcp',
+        ],
+        env: {
+          ELECTRON_RUN_AS_NODE: '1',
+          OD_DATA_DIR: 'C:\\Users\\Ada\\AppData\\Roaming\\Open Design',
+        },
+      },
+    });
+
+    expect(md).toContain('"command": "C:\\\\Program Files\\\\Open Design\\\\Open Design.exe"');
+    expect(md).toContain(
+      '"C:\\\\Program Files\\\\Open Design\\\\resources\\\\app\\\\apps\\\\daemon\\\\dist\\\\cli.js"',
+    );
+    expect(md).toContain('"ELECTRON_RUN_AS_NODE": "1"');
+    expect(md).toContain('"OD_DATA_DIR": "C:\\\\Users\\\\Ada\\\\AppData\\\\Roaming\\\\Open Design"');
+    expect(md).not.toContain('"command": "od"');
+  });
+
+  it('does not rewrite CLI snippets with POSIX env prefixes for Windows packaged installs', () => {
+    const md = buildAgentGuideMarkdown({
+      daemonUrl: 'http://127.0.0.1:7456',
+      mcpInstallInfo: {
+        command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+        args: [
+          'C:\\Program Files\\Open Design\\resources\\app\\apps\\daemon\\dist\\cli.js',
+          'mcp',
+        ],
+        env: {
+          ELECTRON_RUN_AS_NODE: '1',
+          OD_DATA_DIR: 'C:\\Users\\Ada\\AppData\\Roaming\\Open Design',
+        },
+      },
+    });
+
+    expect(md).toContain('"command": "C:\\\\Program Files\\\\Open Design\\\\Open Design.exe"');
+    expect(md).toContain('"ELECTRON_RUN_AS_NODE": "1"');
+    expect(md).toContain('od skills list --json');
+    expect(md).not.toMatch(/^\s*ELECTRON_RUN_AS_NODE=1\s+OD_DATA_DIR=/m);
+  });
 });

--- a/apps/web/tests/components/use-everywhere-copy-guide.test.tsx
+++ b/apps/web/tests/components/use-everywhere-copy-guide.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { UseEverywhereGuidePanel } from '../../src/components/UseEverywhereModal';
+
+const originalFetch = globalThis.fetch;
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+
+describe('UseEverywhereGuidePanel copy guide', () => {
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('copies the daemon install-info launch spec into the agent guide', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+        args: [
+          'C:\\Program Files\\Open Design\\resources\\app\\apps\\daemon\\dist\\cli.js',
+          'mcp',
+        ],
+        env: {
+          ELECTRON_RUN_AS_NODE: '1',
+          OD_DATA_DIR: 'C:\\Users\\Ada\\AppData\\Roaming\\Open Design',
+        },
+        daemonUrl: 'http://127.0.0.1:7456',
+        platform: 'win32',
+        cliExists: true,
+        nodeExists: true,
+        buildHint: null,
+      }),
+    } satisfies Partial<Response>) as typeof fetch;
+
+    render(<UseEverywhereGuidePanel daemonUrl="http://127.0.0.1:7456" />);
+
+    await waitFor(() =>
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/mcp/install-info'),
+    );
+    fireEvent.click(screen.getByTestId('use-everywhere-copy-guide'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0]?.[0] as string;
+    expect(copied).toContain('"command": "C:\\\\Program Files\\\\Open Design\\\\Open Design.exe"');
+    expect(copied).toContain(
+      '"C:\\\\Program Files\\\\Open Design\\\\resources\\\\app\\\\apps\\\\daemon\\\\dist\\\\cli.js"',
+    );
+    expect(copied).toContain('"ELECTRON_RUN_AS_NODE": "1"');
+    expect(copied).not.toContain('"command": "od"');
+  });
+
+  it('waits for daemon install-info before copying the guide', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    let resolveFetch: (response: Partial<Response>) => void = () => {};
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    ) as typeof fetch;
+
+    render(<UseEverywhereGuidePanel daemonUrl="http://127.0.0.1:7456" />);
+
+    await waitFor(() =>
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/mcp/install-info'),
+    );
+    fireEvent.click(screen.getByTestId('use-everywhere-copy-guide'));
+    await Promise.resolve();
+
+    expect(writeText).not.toHaveBeenCalled();
+
+    resolveFetch({
+      ok: true,
+      json: async () => ({
+        command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+        args: [
+          'C:\\Program Files\\Open Design\\resources\\app\\apps\\daemon\\dist\\cli.js',
+          'mcp',
+        ],
+        env: {
+          ELECTRON_RUN_AS_NODE: '1',
+          OD_DATA_DIR: 'C:\\Users\\Ada\\AppData\\Roaming\\Open Design',
+        },
+      }),
+    } satisfies Partial<Response>);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0]?.[0] as string;
+    expect(copied).toContain('"command": "C:\\\\Program Files\\\\Open Design\\\\Open Design.exe"');
+    expect(copied).not.toContain('"command": "od"');
+  });
+
+  it('waits for daemon install-info before copying the MCP tab snippet', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    let resolveFetch: (response: Partial<Response>) => void = () => {};
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    ) as typeof fetch;
+
+    render(<UseEverywhereGuidePanel daemonUrl="http://127.0.0.1:7456" />);
+
+    await waitFor(() =>
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/mcp/install-info'),
+    );
+    fireEvent.click(screen.getByTestId('use-everywhere-tab-mcp'));
+    fireEvent.click(screen.getByRole('button', {
+      name: /copy snippet: generic mcp client config/i,
+    }));
+    await Promise.resolve();
+
+    expect(writeText).not.toHaveBeenCalled();
+
+    resolveFetch({
+      ok: true,
+      json: async () => ({
+        command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+        args: [
+          'C:\\Program Files\\Open Design\\resources\\app\\apps\\daemon\\dist\\cli.js',
+          'mcp',
+        ],
+        env: {
+          ELECTRON_RUN_AS_NODE: '1',
+          OD_DATA_DIR: 'C:\\Users\\Ada\\AppData\\Roaming\\Open Design',
+        },
+      }),
+    } satisfies Partial<Response>);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0]?.[0] as string;
+    expect(copied).toContain('"command": "C:\\\\Program Files\\\\Open Design\\\\Open Design.exe"');
+    expect(copied).toContain(
+      '"C:\\\\Program Files\\\\Open Design\\\\resources\\\\app\\\\apps\\\\daemon\\\\dist\\\\cli.js"',
+    );
+    expect(copied).toContain('"ELECTRON_RUN_AS_NODE": "1"');
+    expect(copied).not.toContain('"command": "od"');
+
+    await waitFor(() => {
+      const mcpSection = screen.getByTestId('use-everywhere-section-mcp');
+      expect(mcpSection.textContent).toContain(
+        '"command": "C:\\\\Program Files\\\\Open Design\\\\Open Design.exe"',
+      );
+      expect(mcpSection.textContent).not.toContain('"command": "od"');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #4852

## Why

I hit this while reviewing the Windows packaged-app MCP setup path. The Use Everywhere copied guide still included a generic `"command": "od"` MCP config, but Windows packaged installs may not expose an `od` binary on PATH.

The daemon already exposes the working launch tuple through `/api/mcp/install-info`. The handoff guide should use that same source so pasted MCP config can start the server in packaged installs.

## What users will see

Opening Use Everywhere and copying the agent guide now includes the daemon-reported MCP command, args, and env. On Windows packaged installs, the copied JSON points at the absolute Open Design executable/CLI script and preserves env such as `ELECTRON_RUN_AS_NODE` and `OD_DATA_DIR`, instead of telling agents to spawn bare `od`.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshot attached. This changes copied markdown generated from the existing Use Everywhere panel, not the visual layout. The clipboard path is covered by `apps/web/tests/components/use-everywhere-copy-guide.test.tsx`.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/use-everywhere-agent-guide.test.ts`, `apps/web/tests/components/use-everywhere-copy-guide.test.tsx`
- Did the test go red on `main` and green on this branch? yes — the regression covered the copied guide still emitting `"command": "od"` instead of the daemon install-info launch spec.

## Validation

- `PATH=/Users/liguanchen/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/use-everywhere-agent-guide.test.ts tests/components/use-everywhere-copy-guide.test.tsx` — 2 files / 11 tests passed
- `PATH=/Users/liguanchen/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --filter @open-design/web typecheck`
- `PATH=/Users/liguanchen/.nvm/versions/node/v24.15.0/bin:$PATH pnpm guard`
- `PATH=/Users/liguanchen/.nvm/versions/node/v24.15.0/bin:$PATH pnpm typecheck`
