### PR TITLE
fix(byok): correct MiniMax LLM API domain from minimaxi.com to minimax.io

### DIFF
--- a/apps/daemon/src/routes/chat.ts
+++ b/apps/daemon/src/routes/chat.ts
@@ -442,7 +442,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     //   bare host                            → /v1/<route>            (api.openai.com, api.anthropic.com)
     //   ends in /vN                          → no inject              (api.openai.com/v1, /v1)
     //   /vN sub-path                         → no inject              (api.deepinfra.com/v1/openai, openrouter.ai/api/v1)
-    //   non-versioned compat sub-path        → /v1/<route>            (api.deepseek.com/anthropic, api.minimaxi.com/anthropic)
+    //   non-versioned compat sub-path        → /v1/<route>            (api.deepseek.com/anthropic, api.minimax.io/anthropic)
     // Previously the check was end-of-path only, which broke the
     // /v1/openai sub-path case. A naive "non-empty path → respect"
     // would break the /anthropic sub-path case. Matching `/vN` as a

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -387,8 +387,8 @@ describe('API proxy routes', () => {
       'https://api.deepseek.com/anthropic/v1/messages',
     ],
     [
-      'https://api.minimaxi.com/anthropic',
-      'https://api.minimaxi.com/anthropic/v1/messages',
+      'https://api.minimax.io/anthropic',
+      'https://api.minimax.io/anthropic/v1/messages',
     ],
     [
       'https://token-plan-cn.xiaomimimo.com/anthropic',

--- a/apps/web/src/providers/openai-compatible.ts
+++ b/apps/web/src/providers/openai-compatible.ts
@@ -40,7 +40,7 @@ export function isOpenAICompatible(model: string, baseUrl: string): boolean {
   // Explicit OpenAI-compatible providers/models should win even when a host or
   // unrelated path segment happens to contain the word "anthropic".
   if (u.includes('xiaomimimo.com/v1')) return true;
-  if (u.includes('api.minimaxi.com/v1')) return true;
+  if (u.includes('api.minimax.io/v1')) return true;
   if (u.includes('api.deepseek')) return true;
   if (u.includes('api.groq')) return true;
   if (u.includes('api.together')) return true;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -145,7 +145,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
   {
     label: 'MiniMax — Anthropic',
     protocol: 'anthropic',
-    baseUrl: 'https://api.minimaxi.com/anthropic',
+    baseUrl: 'https://api.minimax.io/anthropic',
     model: 'MiniMax-M2.7-highspeed',
     models: [
       'MiniMax-M2.7-highspeed',
@@ -217,7 +217,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
   {
     label: 'MiniMax — OpenAI',
     protocol: 'openai',
-    baseUrl: 'https://api.minimaxi.com/v1',
+    baseUrl: 'https://api.minimax.io/v1',
     model: 'MiniMax-M2.7-highspeed',
     models: [
       'MiniMax-M2.7-highspeed',

--- a/apps/web/tests/providers/openai-compatible.test.ts
+++ b/apps/web/tests/providers/openai-compatible.test.ts
@@ -17,8 +17,8 @@ describe('isOpenAICompatible', () => {
   });
 
   it('routes MiniMax Anthropic endpoint paths away from OpenAI-compatible chat completions', () => {
-    expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimaxi.com/v1/anthropic')).toBe(false);
-    expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimaxi.com/anthropic/v1')).toBe(false);
+    expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimax.io/v1/anthropic')).toBe(false);
+    expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimax.io/anthropic/v1')).toBe(false);
   });
 
   it('lets explicit OpenAI models win when only the host name contains anthropic', () => {


### PR DESCRIPTION
## Why

hey! I was using Open Design with MiniMax's Anthropic-compatible endpoint and noticed the BYOK presets were pointing at the wrong domain — `api.minimaxi.com` instead of `api.minimax.io`. MiniMax's own docs are pretty clear: the LLM/chat API lives at `minimax.io`, not `minimaxi.com`. Anyone who tried the pre-filled Settings presets for MiniMax would just get a 404 and have no idea why :')

found it while cross-referencing the platform docs at https://platform.minimax.io/docs/api-reference/text-anthropic-api — both the Anthropic-compatible path (`/anthropic`) and the OpenAI-compatible path (`/v1`) are on `api.minimax.io`.

(note: the TTS media API at `api.minimaxi.chat` is a separate product/domain and is intentionally left alone — that one looks correct)

## What users will see

- The **MiniMax — Anthropic** and **MiniMax — OpenAI** BYOK presets in Settings now point at the correct `api.minimax.io` domain so they actually work out of the box
- The OpenAI-compatible provider detection in `openai-compatible.ts` now matches the real domain so routing logic works correctly when users paste in the right URL

## Surface area

- [x] **UI** — BYOK preset `baseUrl` values in Settings → AI Providers updated for both MiniMax entries
- [ ] **Keyboard shortcut** — no change
- [ ] **CLI / env var** — no new subcommands or `OD_*` vars
- [ ] **API / contract** — no endpoint or contract shape changes
- [ ] **Extension point** — no skills / design-systems / craft changes
- [ ] **i18n keys** — none added
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — users who had the MiniMax presets auto-filled will now get the correct domain on first use (previously the preset pointed at a non-functional domain)
- [ ] **None**

## Screenshots

N/A — the change is to the pre-filled URL value in the existing Settings → AI Providers preset fields, no visual layout change.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/openai-compatible.test.ts` (domain detection) and `apps/daemon/tests/proxy-routes.test.ts` (Anthropic proxy routing with MiniMax base URL)
- The test URLs in both files were pointing at `api.minimaxi.com` (wrong domain) — updating them to `api.minimax.io` alongside the source fix is the verification. A red-spec-then-green sequence isn't meaningful here since the tests were already wrong by mirroring the bug; the fix corrects both together.
- Manual verification: confirmed `https://api.minimax.io/v1` and `https://api.minimax.io/anthropic` are the live endpoints per https://platform.minimax.io/docs/api-reference/text-anthropic-api

## Validation

- `pnpm guard` — 55/55 pass
- `cd apps/daemon && npx vitest run tests/proxy-routes.test.ts` — 75/75 pass
- `cd apps/web && npx vitest run tests/providers/openai-compatible.test.ts` — 5/5 pass
