### PR TITLE
Fix BYOK model discovery error after successful connection test

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3366,6 +3366,8 @@ export function SettingsDialog({
     providerModelsState.cacheKey === providerModelsKey
       ? providerModelsState.result
       : null;
+  const providerConnectionTestSucceeded =
+    providerTestState.status === 'done' && providerTestState.result.ok;
   const loadedAccountModelCount =
     currentProviderModelsResult?.ok && currentProviderModelsResult.models?.length
       ? currentProviderModelsResult.models.length
@@ -3373,8 +3375,14 @@ export function SettingsDialog({
   const apiKeyAuthFailed =
     currentProviderModelsResult?.ok === false &&
     currentProviderModelsResult.kind === 'auth_failed';
+  const staleBaseUrlDiscoveryFailure =
+    providerConnectionTestSucceeded &&
+    currentProviderModelsResult?.ok === false &&
+    currentProviderModelsResult.kind === 'invalid_base_url';
   const providerModelsFailureMessage =
-    currentProviderModelsResult?.ok === false && !apiKeyAuthFailed
+    currentProviderModelsResult?.ok === false &&
+    !apiKeyAuthFailed &&
+    !staleBaseUrlDiscoveryFailure
       ? t('settings.fetchModelsFailed', {
           detail:
             currentProviderModelsResult.detail ||

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1783,6 +1783,143 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(await screen.findByText('Could not fetch models: provider unavailable')).toBeTruthy();
   });
 
+  it('clears provider model discovery errors after a successful BYOK connection test', async () => {
+    const connectionResponse = deferred<Response>();
+    const testConnectionRequests: Array<RequestInit | undefined> = [];
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: false,
+      kind: 'invalid_base_url',
+      latencyMs: 12,
+      detail: 'Base URL invalid or unreachable',
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      expect(url).toBe('/api/test/connection');
+      testConnectionRequests.push(init);
+      return connectionResponse.promise;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: '',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-openai' },
+    });
+    fireEvent.blur(screen.getByLabelText('API key'));
+
+    const discoveryError = await screen.findByText(
+      'Could not fetch models: Base URL invalid or unreachable',
+    );
+    expect(discoveryError).toBeTruthy();
+    await waitFor(() => {
+      expect(testConnectionRequests).toHaveLength(1);
+    });
+    expect(JSON.parse(String(testConnectionRequests[0]?.body))).toMatchObject({
+      mode: 'provider',
+      protocol: 'openai',
+      apiKey: 'sk-openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+    });
+
+    connectionResponse.resolve(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          kind: 'ok',
+          latencyMs: 31,
+          model: 'gpt-4o',
+          sample: 'pong',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connected\. Replied in 31 ms/)).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Could not fetch models: Base URL invalid or unreachable'),
+      ).toBeNull();
+    });
+  });
+
+  it('keeps real provider model discovery errors after a successful BYOK connection test', async () => {
+    const connectionResponse = deferred<Response>();
+    const testConnectionRequests: Array<RequestInit | undefined> = [];
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: false,
+      kind: 'upstream_unavailable',
+      latencyMs: 12,
+      status: 503,
+      detail: 'provider unavailable',
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      expect(url).toBe('/api/test/connection');
+      testConnectionRequests.push(init);
+      return connectionResponse.promise;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: '',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-openai' },
+    });
+    fireEvent.blur(screen.getByLabelText('API key'));
+
+    expect(await screen.findByText('Could not fetch models: provider unavailable')).toBeTruthy();
+    await waitFor(() => {
+      expect(testConnectionRequests).toHaveLength(1);
+    });
+
+    connectionResponse.resolve(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          kind: 'ok',
+          latencyMs: 31,
+          model: 'gpt-4o',
+          sample: 'pong',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connected\. Replied in 31 ms/)).toBeTruthy();
+    });
+    expect(screen.getByText('Could not fetch models: provider unavailable')).toBeTruthy();
+  });
+
   it('supports custom model entry in BYOK mode', async () => {
     const { onPersist } = renderSettingsDialog({ apiProtocol: 'openai', baseUrl: 'https://api.openai.com/v1', model: 'gpt-4o', apiProviderBaseUrl: 'https://api.openai.com/v1' });
 


### PR DESCRIPTION
Fixes #4877

## Why

I picked this P1 BYOK bug because an Anthropic-compatible endpoint can pass the connection test while the automatic model discovery status still shows a red `Base URL invalid or unreachable` error. That leaves users with contradictory feedback during setup and makes a working custom endpoint look broken.

## What users will see

In Settings / onboarding BYOK setup, once the configured provider connection test succeeds, the stale automatic model discovery error under the model picker no longer remains as a red error for the same configuration. Model discovery failures still show normally before a successful connection test.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: the affected UI is a transient mocked provider status. The regression test covers the exact before/after state by rendering the error, completing a successful connection test, and asserting the error disappears.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.execution.test.tsx`
- Did the test go red on `main` and green on this branch? yes. The new focused test failed before the source change because the `field-error` remained after a successful BYOK connection test, then passed after the fix.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx -t "clears provider model discovery errors after a successful BYOK connection test"`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx`
- `pnpm typecheck`
- `pnpm guard`
