### PR TITLE
Fix Home submit handoff state

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -645,7 +645,7 @@ export function EntryShell({
         examplePromptBrief: payload.examplePromptContext.brief,
       } : {}),
     };
-    onCreateProject({
+    return onCreateProject({
       name,
       skillId: payload.skillId ?? null,
       designSystemId: payload.designSystemId ?? null,

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -8,6 +8,7 @@ import { EntryShell } from '../../src/components/EntryShell';
 import { AMR_LOGIN_TIMEOUT_MS } from '../../src/components/amrLoginPolling';
 import { I18nProvider } from '../../src/i18n';
 import type { AgentInfo, AppConfig } from '../../src/types';
+import { setHomeHeroPrompt } from '../helpers/home-hero-lexical';
 
 const analyticsMocks = vi.hoisted(() => ({
   track: vi.fn(),
@@ -386,6 +387,36 @@ describe('EntryShell new project rail', () => {
         ([input, init]) => input === '/api/projects' && init?.method === 'POST',
       ),
     ).toBeUndefined();
+  });
+});
+
+describe('EntryShell Home submit handoff', () => {
+  it('keeps the Home run button in sending state until project creation resolves', async () => {
+    globalThis.fetch = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+      if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+      if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+      if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+      return jsonResponse({});
+    }) as typeof fetch;
+    let resolveCreate: (accepted: boolean) => void = () => undefined;
+    const onCreateProject = vi.fn(
+      () => new Promise<boolean>((resolve) => { resolveCreate = resolve; }),
+    );
+    renderHome({ onCreateProject });
+
+    await screen.findByTestId('home-hero-input');
+    setHomeHeroPrompt('Build a landing page');
+    const submit = await screen.findByTestId('home-hero-submit') as HTMLButtonElement;
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
+    expect(submit.disabled).toBe(true);
+    expect(submit.textContent).toContain('Sending…');
+
+    resolveCreate(true);
+    await waitFor(() => expect(submit.disabled).toBe(false));
   });
 });
 


### PR DESCRIPTION
Fixes #4879

## Why

Home submissions create a project asynchronously before routing into the project detail view. `HomeView.submit()` already awaits its `onSubmit` callback so the Home composer can stay in its in-flight state, but `EntryShell` was calling `onCreateProject(...)` without returning its promise.

That meant the Home submit handler could clear `sending` before project creation/navigation finished, briefly re-enabling the Home run button during the handoff.

## What users will see

After sending a prompt from Home, the Home run button stays in its `Sending…`/disabled state until project creation resolves, so it no longer appears as a stale idle control during the transition into the project detail page.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this is a transient submit-handoff state fix rather than a new visual surface. The regression test asserts the visible button state (`Sending…` and disabled) during the async project-creation window.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.onboarding.test.tsx`
- Did the test go red on `main` and green on this branch? yes — with the source change reverted, the new test fails because the submit button is already enabled while `onCreateProject` is still pending (`expected false to be true`); with this branch it passes.

## Validation

- `pnpm --filter '@open-design/web^...' --if-present run build`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding.test.tsx -t "keeps the Home run button" --maxWorkers=2`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding.test.tsx --maxWorkers=2`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/HomeView.composer-sending-state.test.tsx --maxWorkers=2`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test` — one pre-existing baseline failure remains in `FileWorkspace.design-system.test.tsx` (`refreshes before downloading the current project archive` expected 4 events but got 5); confirmed the same focused failure after reverting this PR's diff.

Note: local environment prints engine warnings because this runner has Node `v22.22.3` while the repo targets Node `~24`; the focused tests and typecheck above still passed.
