### PR TITLE
[codex] Bump bundled Vela CLI to 0.0.19

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-ucVnjvGC3BbcZRFakkky9gzoBPieEGRe79vx9uAggnM=";
-  webHash = "sha256-b7bG0AW2m2oDIil4cnnr7xns0X1qxtSeOXS77Ks8m8s=";
+  daemonHash = "sha256-pezjJJDcKFr91DD/nxvtQ4VP4IcbYZJBnR4GhGhfzUk=";
+  webHash = "sha256-JgPpbRJ6SEcGGoorhrCNvTQkhZ3tDZB1sS0oRX/RDx8=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,8 +783,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.18
-        version: 0.0.18
+        specifier: 0.0.19
+        version: 0.0.19
 
   tools/release:
     dependencies:
@@ -1950,33 +1950,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.18':
-    resolution: {integrity: sha512-HN6vCzaqiSVGQX4ZYjpiJb5WEYsrfAXHTk6+KT8ttO78KRCl2URILunML9h88zkvRDkYy0pdw7Pm6BxIs7yQ1Q==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.19':
+    resolution: {integrity: sha512-18sQlsfLiMDHxOfYjV05alWabbCQ20xtXRhACoIWVPdcqcQp5+SJHE9nwyAuoQV5xkTJiPSc3niuzH3RicpCDg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.18':
-    resolution: {integrity: sha512-p0kBx8x+WRmlfbN5cKx8KN//R9gUTZ5JP2VaiOkYktzFXSo+/8MB5biEHBj+NTQTECzlM7CYA8DZETfMZ9egFA==}
+  '@powerformer/vela-cli-darwin-x64@0.0.19':
+    resolution: {integrity: sha512-ttOzkUwYuBgBCfQqxpxUjh4trfCGwg2cs1+n+AK5UUAzZxzukyexRgSkWFoONcnYZ9f1Yg4ItwJ4eeFr/vF5yQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.18':
-    resolution: {integrity: sha512-ykeePUT9F+kr6YGelWuErS2NnWdkctDTooOcEr5LFa83dxN0j6/v3HLhMdEChW5LohNgJIVNEufpAmV+A/hnnQ==}
+  '@powerformer/vela-cli-linux-arm64@0.0.19':
+    resolution: {integrity: sha512-qWzTTMOpEo54jnlhgMrt8p8NrOpx9ou9SQyWc4nDqcNCm47evonvVrXY9SCZzGUdBJnDJCMtjRshzkp5H1OM+g==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.18':
-    resolution: {integrity: sha512-9T1jJ+0CaPbycu7rAO+kGLvhETcZYixHy/fWugsA2xRZZTGHjVL2iAfqrz6luo2/j1C3yR/b0Ddjykmh/XxrMg==}
+  '@powerformer/vela-cli-linux-x64@0.0.19':
+    resolution: {integrity: sha512-J2JUnvfOgi6uHqE1sripaFFGI4LArJlfo7WKmfadB1s4fk5rVkSP3koRmqtTLOBPayVgGfqksBifCkrSsOP7Pg==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.18':
-    resolution: {integrity: sha512-NEZL4EtxlBtzch2elugHRiV5ApBAsjlfakcQfAUMMxoatTkQs3fPWLKip9LnkW7c9j3bhZJFPXL9fXf5gIwZRg==}
+  '@powerformer/vela-cli-win32-x64@0.0.19':
+    resolution: {integrity: sha512-0HKqydALitrcUM3ntk+iGR10DoMqI/7lx4WdhgLYBz5nFlX/Flpbe2Vn1GYrexWqm+x5q8m5pEp4YeIjpGKfmw==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.18':
-    resolution: {integrity: sha512-0UxAaTyF6xm6nh65dQfPlTuu4913JOjftAk6PxAWuilyJav3GFuF4OMFa31PlVstNOCnEqxW4QgUj2HSbVD/EA==}
+  '@powerformer/vela-cli@0.0.19':
+    resolution: {integrity: sha512-gjE+DfF67c6V9asJfOSPpNSBGryiQD2OicsilLsX1p8cXNOpnTkQecDeTDntdHRWTi0ZQ31MQEuKilTH6WdXUg==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -6741,28 +6741,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.18':
+  '@powerformer/vela-cli-darwin-arm64@0.0.19':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.18':
+  '@powerformer/vela-cli-darwin-x64@0.0.19':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.18':
+  '@powerformer/vela-cli-linux-arm64@0.0.19':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.18':
+  '@powerformer/vela-cli-linux-x64@0.0.19':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.18':
+  '@powerformer/vela-cli-win32-x64@0.0.19':
     optional: true
 
-  '@powerformer/vela-cli@0.0.18':
+  '@powerformer/vela-cli@0.0.19':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.18
-      '@powerformer/vela-cli-darwin-x64': 0.0.18
-      '@powerformer/vela-cli-linux-arm64': 0.0.18
-      '@powerformer/vela-cli-linux-x64': 0.0.18
-      '@powerformer/vela-cli-win32-x64': 0.0.18
+      '@powerformer/vela-cli-darwin-arm64': 0.0.19
+      '@powerformer/vela-cli-darwin-x64': 0.0.19
+      '@powerformer/vela-cli-linux-arm64': 0.0.19
+      '@powerformer/vela-cli-linux-x64': 0.0.19
+      '@powerformer/vela-cli-win32-x64': 0.0.19
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -25,7 +25,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.18"
+    "@powerformer/vela-cli": "0.0.19"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

I am opening this after publishing Vela CLI 0.0.19 from powerformer/vela#434. Open Design's packaged build consumes the Vela CLI through tools/pack, so this bumps the packaged optional dependency to the release that includes OpenCode session reuse across turns for AMR.

This unblocks packaged Open Design from shipping the approved Vela AMR session reuse work without relying on a locally installed Vela binary.

## What users will see

Packaged Open Design builds will bundle Vela CLI 0.0.19 instead of 0.0.18. Users using the bundled AMR/OpenCode path get the upstream session reuse fix from Vela CLI 0.0.19.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not UI-facing.

## Bug fix verification

This PR consumes the upstream Vela release rather than changing Open Design source behavior directly.

- Upstream Vela PR: https://github.com/powerformer/vela/pull/434
- Vela release workflow: https://github.com/powerformer/vela/actions/runs/28358447690
- Vela release: https://github.com/powerformer/vela/releases/tag/vela-cli/v0.0.19
- npm latest confirmed: `@powerformer/vela-cli@0.0.19` with gitHead `1f9ccef51b87e64d5d0c284745b9c5b187dab172`

## Validation

- `pnpm install`
- `git diff --check`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack test`
- `pnpm guard`
- `pnpm typecheck`

Nix note: this machine does not have `nix`, so I could not run `pnpm nix:update-hash` or `nix flake check --print-build-logs --keep-going` locally. The lockfile diff only updates the `tools/pack` optional Vela CLI package entries.