### PR TITLE
fix(daemon): detect codex installed via the standalone Codex.app bundle

### DIFF
--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -43,14 +43,23 @@ let cachedToolchainHome: string | null = null;
 let cachedToolchainDirs: string[] | null = null;
 let cachedToolchainDirsAt = 0;
 
-function userToolchainDirs() {
+// Resolve the home directory detection should search, honoring the sandbox /
+// `OD_AGENT_HOME` override. `hasOverride` lets callers scope strictly to the
+// override home (skipping real-machine system locations) so sandboxed
+// detection runs and tests stay deterministic instead of reaching the host.
+function resolveDetectionHome(): { home: string; hasOverride: boolean } {
   const sandboxRuntime = resolveSandboxRuntimeConfigFromEnv(
     process.env,
     RUNTIME_PROJECT_ROOT,
   );
   const homeOverride =
     sandboxRuntime?.roots.agentHomeDir ?? process.env.OD_AGENT_HOME;
-  const home = homeOverride || homedir();
+  return { home: homeOverride || homedir(), hasOverride: Boolean(homeOverride) };
+}
+
+function userToolchainDirs() {
+  const { home, hasOverride } = resolveDetectionHome();
+  const homeOverride = hasOverride ? home : undefined;
   const now = Date.now();
   if (
     cachedToolchainHome === home &&
@@ -258,6 +267,42 @@ function packagedBuiltInExecutable(
   }
 }
 
+// The official OpenAI Codex desktop app (bundle id `com.openai.codex`) ships
+// the `codex` CLI *inside* its macOS application bundle at
+// `Codex.app/Contents/Resources/codex` and does NOT add it to PATH unless the
+// user explicitly runs the app's "Install command line tool" action. Users who
+// installed Codex only through the app therefore see a "not installed" agent
+// card even though a healthy native `codex` binary exists on disk, because
+// neither PATH nor the user-toolchain search dirs cover the app bundle. Probe
+// the well-known bundle locations so app-only installs are detected. This is a
+// last-resort fallback that ranks below PATH, so an explicit `npm i -g` /
+// Homebrew / version-manager install always wins.
+function codexAppBundleExecutable(def: RuntimeAgentDef): string | null {
+  if (def?.id !== 'codex') return null;
+  for (const candidate of codexAppBundleCandidates()) {
+    const resolved = executableFilePath(candidate);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+function codexAppBundleCandidates(): string[] {
+  // The Codex app bundle is a macOS-only concept; other platforms have no
+  // analogous standalone install of the `codex` CLI to probe for here.
+  if (process.platform !== 'darwin') return [];
+  const { home, hasOverride } = resolveDetectionHome();
+  const bundleSuffix = ['Codex.app', 'Contents', 'Resources', 'codex'];
+  // User-scoped install (~/Applications). Honors the override home so
+  // sandboxed detection runs and tests stay deterministic.
+  const candidates = [path.join(home, 'Applications', ...bundleSuffix)];
+  // System-wide /Applications install. Skip it under an override home for the
+  // same isolation reason `userToolchainDirs` skips Homebrew/system bins.
+  if (!hasOverride) {
+    candidates.unshift(path.join('/Applications', ...bundleSuffix));
+  }
+  return candidates;
+}
+
 export function resolveAgentExecutable(
   def: RuntimeAgentDef,
   configuredEnv: Record<string, string> = {},
@@ -294,9 +339,11 @@ export function inspectAgentExecutableResolution(
     }
   }
   const builtInPath = packagedBuiltInExecutable(def, configuredEnv);
+  const appBundlePath = codexAppBundleExecutable(def);
   return {
     configuredOverridePath,
     pathResolvedPath,
-    selectedPath: configuredOverridePath || builtInPath || pathResolvedPath,
+    selectedPath:
+      configuredOverridePath || builtInPath || pathResolvedPath || appBundlePath,
   };
 }

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -286,7 +286,12 @@ function codexAppBundleExecutable(def: RuntimeAgentDef): string | null {
   return null;
 }
 
-function codexAppBundleCandidates(): string[] {
+// Exported for tests: the no-override `/Applications` branch can't be exercised
+// through `resolveAgentExecutable` deterministically (it would depend on the
+// host actually having `/Applications/Codex.app`), so tests assert the built
+// candidate list directly to catch a path typo or ordering regression in the
+// common real-world install case.
+export function codexAppBundleCandidates(): string[] {
   // The Codex app bundle is a macOS-only concept; other platforms have no
   // analogous standalone install of the `codex` CLI to probe for here.
   if (process.platform !== 'darwin') return [];

--- a/apps/daemon/src/runtimes/launch.ts
+++ b/apps/daemon/src/runtimes/launch.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { accessSync, closeSync, constants, openSync, readdirSync, readSync, realpathSync, statSync } from 'node:fs';
 import path, { delimiter } from 'node:path';
 import { inspectAgentExecutableResolution, userToolchainBinDirs } from './executables.js';
 import type { RuntimeAgentDef } from './types.js';
@@ -164,11 +164,26 @@ function codexNativeTargetTriple(): string {
 }
 
 function looksLikeCodexNodeWrapper(filePath: string): boolean {
+  // Read only the first 64KB rather than slurping the whole file: the selected
+  // codex path can now be the native Codex.app binary (~190MB), and
+  // `readFileSync` would otherwise load all of it into a string just to sniff a
+  // shebang. A node wrapper is a tiny script, so the header is enough.
+  let fd: number | null = null;
   try {
-    const body = readFileSync(filePath, { encoding: 'utf8' }).slice(0, 64_000);
-    return /node|@openai\/codex|codex-/i.test(body);
+    fd = openSync(filePath, 'r');
+    const buffer = Buffer.alloc(64_000);
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    return /node|@openai\/codex|codex-/i.test(buffer.toString('utf8', 0, bytesRead));
   } catch {
     return false;
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Best-effort close; nothing actionable if it fails.
+      }
+    }
   }
 }
 

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import { relative, resolve } from 'node:path';
 import {
-  assert, chmodSync, claude, deepseek, gemini, join, minimalAgentDef, mkdirSync, mkdtempSync, resolveAgentExecutable, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
+  assert, chmodSync, claude, codex, deepseek, gemini, join, minimalAgentDef, mkdirSync, mkdtempSync, resolveAgentExecutable, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 
 const fsTest = process.platform === 'win32' ? test.skip : test;
@@ -505,6 +505,151 @@ fsTest(
     } finally {
       rmSync(sandbox, { recursive: true, force: true });
       rmSync(realVpHome, { recursive: true, force: true });
+    }
+  },
+);
+
+// The official OpenAI Codex desktop app (bundle id `com.openai.codex`) ships
+// the `codex` CLI inside `Codex.app/Contents/Resources/codex` and does NOT add
+// it to PATH unless the user runs the app's "Install command line tool"
+// action. App-only installs must still be detected so the agent picker doesn't
+// show Codex as "not installed" while a healthy native binary sits in the
+// bundle. `~/Applications` honors OD_AGENT_HOME so the case stays deterministic.
+fsTest(
+  'resolveAgentExecutable finds codex inside ~/Applications/Codex.app when PATH is empty',
+  () => {
+    const home = mkdtempSync(join(tmpdir(), 'od-codex-app-bundle-'));
+    try {
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () =>
+        withPlatform('darwin', () => {
+          const bundleDir = join(
+            home,
+            'Applications',
+            'Codex.app',
+            'Contents',
+            'Resources',
+          );
+          const codexBin = join(bundleDir, 'codex');
+          mkdirSync(bundleDir, { recursive: true });
+          writeFileSync(codexBin, '');
+          chmodSync(codexBin, 0o755);
+          process.env.OD_AGENT_HOME = home;
+          process.env.PATH = '/usr/bin:/bin';
+
+          const resolved = resolveAgentExecutable(codex);
+          assert.equal(resolved, codexBin);
+        }),
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+);
+
+// A real PATH/npm/Homebrew install is a deliberate CLI install and must
+// outrank the app-bundle fallback.
+fsTest(
+  'resolveAgentExecutable prefers a PATH codex over the Codex.app bundle',
+  () => {
+    const home = mkdtempSync(join(tmpdir(), 'od-codex-app-bundle-precedence-'));
+    try {
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () =>
+        withPlatform('darwin', () => {
+          const bundleDir = join(
+            home,
+            'Applications',
+            'Codex.app',
+            'Contents',
+            'Resources',
+          );
+          mkdirSync(bundleDir, { recursive: true });
+          const bundleCodex = join(bundleDir, 'codex');
+          writeFileSync(bundleCodex, '');
+          chmodSync(bundleCodex, 0o755);
+
+          const pathBin = join(home, 'path-bin');
+          mkdirSync(pathBin, { recursive: true });
+          const pathCodex = join(pathBin, 'codex');
+          writeFileSync(pathCodex, '');
+          chmodSync(pathCodex, 0o755);
+
+          process.env.OD_AGENT_HOME = home;
+          process.env.PATH = pathBin;
+
+          const resolved = resolveAgentExecutable(codex);
+          assert.equal(resolved, pathCodex);
+        }),
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+);
+
+// The Codex.app fallback is macOS-only; on other platforms an identically
+// laid-out directory must not be treated as an install.
+fsTest(
+  'resolveAgentExecutable ignores Codex.app bundle on non-darwin platforms',
+  () => {
+    const home = mkdtempSync(join(tmpdir(), 'od-codex-app-bundle-linux-'));
+    try {
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () =>
+        withPlatform('linux', () => {
+          const bundleDir = join(
+            home,
+            'Applications',
+            'Codex.app',
+            'Contents',
+            'Resources',
+          );
+          const codexBin = join(bundleDir, 'codex');
+          mkdirSync(bundleDir, { recursive: true });
+          writeFileSync(codexBin, '');
+          chmodSync(codexBin, 0o755);
+          process.env.OD_AGENT_HOME = home;
+          process.env.PATH = '/usr/bin:/bin';
+
+          const resolved = resolveAgentExecutable(codex);
+          assert.equal(resolved, null);
+        }),
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+);
+
+// The app-bundle fallback is codex-specific. A different agent that happens to
+// ship a `codex`-named binary must not be resolved out of the Codex.app bundle.
+fsTest(
+  'resolveAgentExecutable does not apply the Codex.app fallback to non-codex agents',
+  () => {
+    const home = mkdtempSync(join(tmpdir(), 'od-codex-app-bundle-id-'));
+    try {
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () =>
+        withPlatform('darwin', () => {
+          const bundleDir = join(
+            home,
+            'Applications',
+            'Codex.app',
+            'Contents',
+            'Resources',
+          );
+          const codexBin = join(bundleDir, 'codex');
+          mkdirSync(bundleDir, { recursive: true });
+          writeFileSync(codexBin, '');
+          chmodSync(codexBin, 0o755);
+          process.env.OD_AGENT_HOME = home;
+          process.env.PATH = '/usr/bin:/bin';
+
+          const resolved = resolveAgentExecutable(
+            minimalAgentDef({ id: 'gemini', bin: 'codex' }),
+          );
+          assert.equal(resolved, null);
+        }),
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
     }
   },
 );

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -521,7 +521,7 @@ fsTest(
   () => {
     const home = mkdtempSync(join(tmpdir(), 'od-codex-app-bundle-'));
     try {
-      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () =>
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'OD_SANDBOX_MODE', 'OD_DATA_DIR'], () =>
         withPlatform('darwin', () => {
           const bundleDir = join(
             home,
@@ -534,6 +534,11 @@ fsTest(
           mkdirSync(bundleDir, { recursive: true });
           writeFileSync(codexBin, '');
           chmodSync(codexBin, 0o755);
+          // resolveDetectionHome() consults OD_SANDBOX_MODE / OD_DATA_DIR
+          // before OD_AGENT_HOME, so clear them or an ambient sandbox env
+          // (dev/CI) would override `home` or throw on OD_DATA_DIR.
+          delete process.env.OD_SANDBOX_MODE;
+          delete process.env.OD_DATA_DIR;
           process.env.OD_AGENT_HOME = home;
           process.env.PATH = '/usr/bin:/bin';
 
@@ -554,7 +559,7 @@ fsTest(
   () => {
     const home = mkdtempSync(join(tmpdir(), 'od-codex-app-bundle-precedence-'));
     try {
-      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () =>
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'OD_SANDBOX_MODE', 'OD_DATA_DIR'], () =>
         withPlatform('darwin', () => {
           const bundleDir = join(
             home,
@@ -574,6 +579,10 @@ fsTest(
           writeFileSync(pathCodex, '');
           chmodSync(pathCodex, 0o755);
 
+          // See note above: clear sandbox env so resolveDetectionHome()
+          // honors this fixture's OD_AGENT_HOME deterministically.
+          delete process.env.OD_SANDBOX_MODE;
+          delete process.env.OD_DATA_DIR;
           process.env.OD_AGENT_HOME = home;
           process.env.PATH = pathBin;
 
@@ -594,7 +603,7 @@ fsTest(
   () => {
     const home = mkdtempSync(join(tmpdir(), 'od-codex-app-bundle-linux-'));
     try {
-      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () =>
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'OD_SANDBOX_MODE', 'OD_DATA_DIR'], () =>
         withPlatform('linux', () => {
           const bundleDir = join(
             home,
@@ -607,6 +616,11 @@ fsTest(
           mkdirSync(bundleDir, { recursive: true });
           writeFileSync(codexBin, '');
           chmodSync(codexBin, 0o755);
+          // resolveDetectionHome() consults OD_SANDBOX_MODE / OD_DATA_DIR
+          // before OD_AGENT_HOME, so clear them or an ambient sandbox env
+          // (dev/CI) would override `home` or throw on OD_DATA_DIR.
+          delete process.env.OD_SANDBOX_MODE;
+          delete process.env.OD_DATA_DIR;
           process.env.OD_AGENT_HOME = home;
           process.env.PATH = '/usr/bin:/bin';
 
@@ -627,7 +641,7 @@ fsTest(
   () => {
     const home = mkdtempSync(join(tmpdir(), 'od-codex-app-bundle-id-'));
     try {
-      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () =>
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'OD_SANDBOX_MODE', 'OD_DATA_DIR'], () =>
         withPlatform('darwin', () => {
           const bundleDir = join(
             home,
@@ -640,6 +654,11 @@ fsTest(
           mkdirSync(bundleDir, { recursive: true });
           writeFileSync(codexBin, '');
           chmodSync(codexBin, 0o755);
+          // resolveDetectionHome() consults OD_SANDBOX_MODE / OD_DATA_DIR
+          // before OD_AGENT_HOME, so clear them or an ambient sandbox env
+          // (dev/CI) would override `home` or throw on OD_DATA_DIR.
+          delete process.env.OD_SANDBOX_MODE;
+          delete process.env.OD_DATA_DIR;
           process.env.OD_AGENT_HOME = home;
           process.env.PATH = '/usr/bin:/bin';
 

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -3,6 +3,7 @@ import { relative, resolve } from 'node:path';
 import {
   assert, chmodSync, claude, codex, deepseek, gemini, join, minimalAgentDef, mkdirSync, mkdtempSync, resolveAgentExecutable, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
+import { codexAppBundleCandidates } from '../../src/runtimes/executables.js';
 
 const fsTest = process.platform === 'win32' ? test.skip : test;
 
@@ -653,3 +654,57 @@ fsTest(
     }
   },
 );
+
+// The fixtures above all set OD_AGENT_HOME, which scopes the probe to the
+// override home and skips the system `/Applications` path. The PR's main
+// real-world case is the no-override `/Applications/Codex.app` install, so
+// assert the candidate list directly: `/Applications/...` must be present and
+// ranked first (a path typo or ordering regression here would silently miss
+// the common case while every OD_AGENT_HOME-scoped test still passes).
+fsTest(
+  'codexAppBundleCandidates probes /Applications first when no home override is set',
+  () => {
+    return withEnvSnapshot(
+      ['OD_AGENT_HOME', 'OD_SANDBOX_MODE', 'OD_DATA_DIR'],
+      () =>
+        withPlatform('darwin', () => {
+          delete process.env.OD_AGENT_HOME;
+          delete process.env.OD_SANDBOX_MODE;
+          delete process.env.OD_DATA_DIR;
+
+          const candidates = codexAppBundleCandidates();
+          const bundleSuffix = join(
+            'Applications',
+            'Codex.app',
+            'Contents',
+            'Resources',
+            'codex',
+          );
+          const [system, userScoped] = candidates;
+
+          assert.equal(candidates.length, 2);
+          assert.equal(
+            system,
+            join('/', bundleSuffix),
+            `expected the system /Applications bundle first; got ${JSON.stringify(candidates)}`,
+          );
+          // The user-scoped (~/Applications) candidate must also be present, be
+          // a distinct absolute path, and not be the system one.
+          assert.ok(
+            userScoped !== undefined &&
+              userScoped !== system &&
+              userScoped.endsWith(`/${bundleSuffix}`),
+            `expected a distinct ~/Applications candidate; got ${JSON.stringify(candidates)}`,
+          );
+        }),
+    );
+  },
+);
+
+// On non-darwin platforms there is no app bundle to probe, so the candidate
+// list must be empty regardless of home override.
+fsTest('codexAppBundleCandidates is empty on non-darwin platforms', () => {
+  return withPlatform('linux', () => {
+    assert.deepEqual(codexAppBundleCandidates(), []);
+  });
+});


### PR DESCRIPTION
## Why

**Use case:** I installed Codex on macOS via the official OpenAI Codex desktop app (`Codex.app`, bundle id `com.openai.codex`) and never ran the app's "Install command line tool" action. Open Design kept showing Codex as "not installed" in the agent picker even though a healthy native `codex` binary was sitting on disk the whole time.

**Pain:** Agent detection (`apps/daemon/src/runtimes/executables.ts`) only resolves `codex` through `PATH` plus the user-toolchain dirs (`npm`/`nvm`/`fnm`/`mise`/Homebrew/`~/.local/bin`/…). The standalone Codex app ships the CLI inside `Codex.app/Contents/Resources/codex` and does **not** add it to `PATH` unless the user explicitly installs the CLI shim. So a very common install path — "download the app, never touch the terminal" — surfaces as a ghost "not installed" entry, and the only escape is to hand-set `CODEX_BIN` or manually symlink the binary onto `PATH`.

Verified on my machine with the exact GUI/launchd `PATH` the daemon inherits: old resolution → `NOT FOUND`; new resolution → `/Applications/Codex.app/Contents/Resources/codex`. The binary itself is healthy (`codex --version` → `codex-cli 0.133.0-alpha.1`); the gap is purely that nothing looked inside the app bundle.

## What users will see

macOS users who installed Codex through the official desktop app (to `/Applications` or `~/Applications`) now get Codex auto-detected in the agent picker with no configuration — no need to run "Install command line tool", set `CODEX_BIN`, or symlink anything by hand. Users who already had Codex on `PATH` (via `npm i -g`, Homebrew, or the CLI shim) see no change.

## Surface area

- [x] **None** — internal daemon resolution change + tests. (Adds no new UI/CLI/API/env/i18n surface; reuses the existing agent picker. The new fallback is gated to `darwin` and ranks below `PATH`.)

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/executables.test.ts` → `resolveAgentExecutable finds codex inside ~/Applications/Codex.app when PATH is empty`
- Red on `main`, green on this branch: **yes** (confirmed by stashing the source change — the spec fails with "expected null to equal …/codex", passes with the fix restored).
- Also added: precedence (`PATH` codex wins over the bundle), platform gate (ignored on non-darwin), and id scoping (the fallback only applies to the `codex` agent, never a non-codex agent that happens to ship a `codex`-named binary).

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/executables.test.ts` → 23 passed (4 new)
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/launch.test.ts tests/runtimes/detection-diagnostics.test.ts tests/runtimes/env-and-detection.test.ts` → 73 passed / 1 skipped
- `pnpm --filter @open-design/daemon typecheck` → clean
- `pnpm guard` → 55/55

## Implementation notes

- The probe targets the **exact** path `Codex.app/Contents/Resources/codex` (the real CLI — verified `--help` prints "Codex CLI"), not a recursive search. It deliberately avoids `Contents/MacOS/Codex` (the GUI entry point) and the nested `Resources/plugins/.../app-server-runtime/codex` helper, so there is no false-positive risk.
- The fallback honors the `OD_AGENT_HOME` / sandbox override exactly like `userToolchainDirs`: under an override home only `<home>/Applications/...` is probed and the system `/Applications` path is skipped, so sandboxed detection runs and tests stay deterministic.
- `launch.ts`'s `looksLikeCodexNodeWrapper` now reads only the first 64KB via a bounded `fd` read. The selected codex path can now be the ~190MB native `Codex.app` binary, which `readFileSync` would otherwise load whole into a string just to sniff a shebang.

## Adjacent issues / follow-up

- **Windows/Linux standalone-app installs are not covered.** The fallback is `darwin`-gated because `.app` bundles are a macOS concept. If OpenAI ships a desktop Codex on those platforms that bundles the CLI, detecting it is a follow-up — I didn't want to invent unverified install paths. Cross-platform escape hatches (`CODEX_BIN`, the app's CLI-install action) still work today.
- **Non-standard app locations** (e.g. the app dragged to `~/Desktop`) are not probed; only `/Applications` and `~/Applications`. Those users can still set `CODEX_BIN`.
