### PR TITLE
fix(daemon): surface Antigravity silent / no_text exits as AGENT_EXECUTION_FAILED

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2276,6 +2276,36 @@ async function testAgentConnectionInternal(
         );
       const exitedCleanly =
         (winner.code === 0 && !winner.signal) || acpForcedShutdown || claudeCompletedTurn;
+      const stderrTail = sink.getStderrTail().trim();
+      const rawStdoutTail = sink.getRawStdoutTail().trim();
+      // Antigravity `no_text` handoff-drop guard: must run BEFORE the
+      // visible-text success path, because the connection probe's
+      // visible-text path would otherwise treat the bare `no_text`
+      // token as successful assistant output. Exact trim match — not
+      // a regex — so legitimate stdout mentioning the token does not
+      // false-fire. (issue #3536; mirrors the chat-route guard in
+      // apps/daemon/src/server.ts:8367+.)
+      const noTextHandoff =
+        rawStdoutTail === 'no_text' || stderrTail === 'no_text';
+      if (input.agentId === 'antigravity' && exitedCleanly && noTextHandoff) {
+        console.warn(
+          `[test:agent] ${def.name} → antigravity_no_text_handoff: stdout=${redactSecrets(rawStdoutTail)} stderr=${redactSecrets(stderrTail)}`,
+        );
+        return {
+          ok: false,
+          kind: 'agent_spawn_failed',
+          latencyMs,
+          model,
+          agentName: def.name,
+          detail:
+            'Antigravity CLI exited with a `no_text` handoff signal — the upstream result was dropped. Retry the test, switch models in agy\'s TUI, or update agy to the latest version.',
+          diagnostics: buildDiagnostics({
+            phase: 'connection_smoke_test',
+            exitCode: winner.code,
+            signal: winner.signal,
+          }),
+        };
+      }
       if (visibleText) {
         const rawSample = truncateSample(visibleText);
         const exitInfo = { code: winner.code, signal: winner.signal };
@@ -2284,8 +2314,6 @@ async function testAgentConnectionInternal(
         }
         if (exitedCleanly) return resultFromAgentText(visibleText, exitInfo);
       }
-      const stderrTail = sink.getStderrTail().trim();
-      const rawStdoutTail = sink.getRawStdoutTail().trim();
       if ((input.agentId === 'opencode' || input.agentId === 'mimo') && exitedCleanly && rawStdoutTail) {
         const recoveredText = extractOpenCodeTextFromRawStdout(rawStdoutTail).trim();
         if (recoveredText) {
@@ -2366,6 +2394,47 @@ async function testAgentConnectionInternal(
           detail: claudeDiagnostic.detail,
           diagnostics: buildDiagnostics({
             phase: 'spawn',
+            exitCode: winner.code,
+            signal: winner.signal,
+          }),
+        };
+      }
+      // Antigravity silent-exit guard: real agy 1.0.13+ exits cleanly
+      // with no stdout / no stderr for many reasons (missing brain
+      // folder, upstream timeout, model-not-selected). Without a
+      // typed classification the smoke probe falls through to
+      // `kind: 'unknown'` with a bare "exit 0" detail — the Settings
+      // UI renders that as "Test failed: exit 0" (English) or
+      // "Échec du test : exit 0" (French), the exact text from the
+      // issue screenshot. Surface an antigravity-specific actionable
+      // detail instead. The `no_text` handoff-drop shape is handled
+      // earlier in this function (BEFORE the visible-text success
+      // path); the auth path is still reachable when stdout or the
+      // log file carries the actual auth signal (handled above by
+      // classifyAgentAuthFailure). (issue #3536; mirrors the
+      // chat-route guard in apps/daemon/src/server.ts:8367+.)
+      if (
+        input.agentId === 'antigravity' &&
+        exitedCleanly &&
+        !visibleText &&
+        !auth &&
+        !claudeDiagnostic &&
+        !rawStdoutTail &&
+        !stderrTail
+      ) {
+        console.warn(
+          `[test:agent] ${def.name} → antigravity_silent_exit: ${redactSecrets(rawDetail)}`,
+        );
+        return {
+          ok: false,
+          kind: 'agent_spawn_failed',
+          latencyMs,
+          model,
+          agentName: def.name,
+          detail:
+            'Antigravity CLI exited without producing output. Open agy in a terminal to inspect state, switch models, or update agy, then retry the test. The agy --log-file may contain more detail.',
+          diagnostics: buildDiagnostics({
+            phase: 'connection_smoke_test',
             exitCode: winner.code,
             signal: winner.signal,
           }),

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2432,7 +2432,7 @@ async function testAgentConnectionInternal(
           model,
           agentName: def.name,
           detail:
-            'Antigravity CLI exited without producing output. Open agy in a terminal to inspect state, switch models, or update agy, then retry the test. The agy --log-file may contain more detail.',
+            'Antigravity CLI exited without producing output. The daemon piped agy\'s `--log-file` to a temporary path with the upstream reason. Check the daemon-run log for details, or run `agy` alone in a terminal to verify the CLI is functional, then retry the test.',
           diagnostics: buildDiagnostics({
             phase: 'connection_smoke_test',
             exitCode: winner.code,

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1913,6 +1913,7 @@ async function testAgentConnectionInternal(
   let childExit: Promise<AgentChildExit> | null = null;
   let childClosed = false;
   let promptFile: PreparedPromptFile | null = null;
+  let connectionTestAgentLogPath: string | undefined;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let abortHandler: (() => void) | null = null;
   const sink = createAgentSink();
@@ -2066,6 +2067,16 @@ async function testAgentConnectionInternal(
     let args: string[];
     try {
       promptFile = await preparePromptFileForAgent(def, SMOKE_PROMPT, 'connection-test');
+      // Antigravity: allocate a per-run --log-file path so the silent-
+      // exit guard below can read the actual upstream error (e.g.
+      // Windows path issue, missing brain directory) and surface it in
+      // the test result detail. Mirrors the chat-route pattern at
+      // apps/daemon/src/server.ts:6693.
+      const agentLogFilePath =
+        def.id === 'antigravity'
+          ? path.join(os.tmpdir(), `od-agy-conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.log`)
+          : undefined;
+      if (agentLogFilePath) connectionTestAgentLogPath = agentLogFilePath;
       args = def.buildArgs(
         SMOKE_PROMPT,
         [],
@@ -2074,6 +2085,7 @@ async function testAgentConnectionInternal(
         {
           cwd: tempDir,
           ...(promptFile ? { promptFilePath: promptFile.path } : {}),
+          ...(agentLogFilePath ? { agentLogFilePath } : {}),
         },
       );
       // Connection tests should validate the adapter's core CLI path, not
@@ -2422,6 +2434,25 @@ async function testAgentConnectionInternal(
         !rawStdoutTail &&
         !stderrTail
       ) {
+        // Read the agy --log-file to extract the actual upstream error
+        // (e.g. Windows path issue, missing brain directory) and
+        // surface it in the test result detail. Strip the agy Go log
+        // prefix (timestamp / pid / source-file) so the user sees just
+        // the actionable message.
+        let agyLogError = '';
+        if (connectionTestAgentLogPath) {
+          try {
+            const logContent = await fsp.readFile(connectionTestAgentLogPath, 'utf8');
+            const lines = logContent.split('\n');
+            const lastError = lines.filter((l) => /^E\d{4}\s/.test(l)).pop();
+            if (lastError) {
+              agyLogError = lastError.replace(
+                /^E\d{4}\s+[\d:.]+?\s+\d+\s+[\w._-]+:\d+\]\s*/,
+                '',
+              );
+            }
+          } catch { /* log file missing or unreadable — fall through */ }
+        }
         console.warn(
           `[test:agent] ${def.name} → antigravity_silent_exit: ${redactSecrets(rawDetail)}`,
         );
@@ -2431,8 +2462,9 @@ async function testAgentConnectionInternal(
           latencyMs,
           model,
           agentName: def.name,
-          detail:
-            'Antigravity CLI exited without producing output. The daemon piped agy\'s `--log-file` to a temporary path with the upstream reason. Check the daemon-run log for details, or run `agy` alone in a terminal to verify the CLI is functional, then retry the test.',
+          detail: agyLogError
+            ? `Antigravity CLI exited without producing output.\n\nagy: ${agyLogError}`
+            : 'Antigravity CLI exited without producing output. Run `agy` alone in a terminal to verify the CLI is functional, then retry the test.',
           diagnostics: buildDiagnostics({
             phase: 'connection_smoke_test',
             exitCode: winner.code,
@@ -2576,6 +2608,11 @@ async function testAgentConnectionInternal(
     await promptFile?.cleanup().catch(() => {
       // Best-effort cleanup; the OS reaps /tmp eventually.
     });
+    if (connectionTestAgentLogPath) {
+      await fsp.unlink(connectionTestAgentLogPath).catch(() => {
+        // Best-effort cleanup.
+      });
+    }
   }
 }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8437,20 +8437,25 @@ export async function startServer({
         // OAuth prompt (handled by Guard 3 above). (issue #3536;
         // see adjacent: apps/daemon/src/connectionTest.ts:2384 has
         // the same blind spot in the smoke probe.)
-        const isAntigravitySilentExit =
-          !authFailure && !serviceFailure && def.id === 'antigravity';
         const errorCode = authFailure
           ? 'AGENT_AUTH_REQUIRED'
           : isAntigravityQuota
             ? 'RATE_LIMITED'
             : 'AGENT_EXECUTION_FAILED';
+        // Antigravity-aware message: when agy exits 0 with no stdout
+        // (any reason — auth, quota, upstream drop, brain-folder
+        // missing, prompt-not-delivered), surface actionable guidance
+        // keyed on the classified reason. The blanket "expired session"
+        // message was empirically wrong — many users reporting #3536
+        // confirmed agy works in a terminal but not from OD. Without
+        // reading agy's log file or stderr stdout we cannot distinguish
+        // the root cause, so the message tells the user to inspect the
+        // daemon-run log file directly.
         const msg = authFailure
-          ? authFailure.message ?? `${def.name} authentication expired. Please re-authenticate and retry.`
+          ? authFailure.message ?? antigravityAuthGuidance()
           : isAntigravityQuota
             ? antigravityQuotaGuidance()
-            : isAntigravitySilentExit
-              ? `Antigravity CLI exited without producing output. Open agy in a terminal to inspect state, switch models, or update agy, then retry this chat. The agy --log-file may contain more detail.`
-              : `${def.name} returned an empty response. This may indicate an expired session — try re-authenticating the agent.`;
+            : `Antigravity CLI exited without producing output. The daemon piped agy's \`--log-file\` to a temporary path that should contain the upstream reason. Check the daemon-run log file for details — its path is available in the daemon log output for this run — or run \`agy\` alone in a terminal to verify the CLI is functional, then retry this chat.`;
         send('error', createSseErrorPayload(
           errorCode,
           msg,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8364,6 +8364,28 @@ export async function startServer({
           ));
           return finishWithRetryDecision('failed', 0, signal);
         }
+        // Antigravity handoff-drop guard: agy print-mode runs that
+        // exit cleanly with a bare `no_text` token on stdout/stderr
+        // (1.0.4+ handoff dropped the upstream result) must not fall
+        // through to `succeeded` — the chat would show no reply and
+        // the user has no actionable signal. Surface as a retryable
+        // AGENT_EXECUTION_FAILED. Exact trim match is intentional:
+        // a substring/regex match would false-fire on legitimate
+        // assistant text that happens to mention the token (e.g.
+        // "processed no_text signal and recovered"). (issue #3536;
+        // PR #3840 reviewer feedback.)
+        if (
+          def.id === 'antigravity' &&
+          (agentStdoutTail.trim() === 'no_text' ||
+            agentStderrTail.trim() === 'no_text')
+        ) {
+          send('error', createSseErrorPayload(
+            'AGENT_EXECUTION_FAILED',
+            'Antigravity CLI exited with a `no_text` handoff signal — the upstream result was dropped. Retry the run, switch models in agy\'s TUI, or update agy to the latest version.',
+            { retryable: true },
+          ));
+          return finishWithRetryDecision('failed', 0, signal);
+        }
       }
       // Plain-stream empty-output guard: plain agents send raw stdout
       // chunks without structured event tracking. Detect auth failures
@@ -8400,25 +8422,34 @@ export async function startServer({
           : null;
         const isAntigravityQuota =
           def.id === 'antigravity' && serviceFailure === 'RATE_LIMITED';
-        // Antigravity-only fallback: if neither classifier matched but
-        // the run was silent, lean on the empirical observation that
-        // an empty agy print-mode exit almost always means
-        // missing-OAuth (the only other silent path is quota, which
-        // the log-file check above already caught).
-        const useAntigravityAuthFallback =
+        // Antigravity-only fallback: when an agy print-mode run exits 0
+        // with no stdout AND neither auth nor quota/upstream signal
+        // appears in the log file, surface a retryable
+        // AGENT_EXECUTION_FAILED rather than the blanket
+        // AGENT_AUTH_REQUIRED the previous version returned. Real
+        // agy 1.0.13+ exits silently for many reasons (missing brain
+        // folder, upstream timeout, model-not-selected), not just
+        // missing OAuth — telling the user to re-login when their
+        // login is valid is a dead end. The auth path is still
+        // reachable when the log file carries the
+        // "You are not logged into Antigravity" line (handled above
+        // by classifyAgentAuthFailure) or when stdout carries the
+        // OAuth prompt (handled by Guard 3 above). (issue #3536;
+        // see adjacent: apps/daemon/src/connectionTest.ts:2384 has
+        // the same blind spot in the smoke probe.)
+        const isAntigravitySilentExit =
           !authFailure && !serviceFailure && def.id === 'antigravity';
-        const errorCode =
-          authFailure || useAntigravityAuthFallback
-            ? 'AGENT_AUTH_REQUIRED'
-            : isAntigravityQuota
-              ? 'RATE_LIMITED'
-              : 'AGENT_EXECUTION_FAILED';
+        const errorCode = authFailure
+          ? 'AGENT_AUTH_REQUIRED'
+          : isAntigravityQuota
+            ? 'RATE_LIMITED'
+            : 'AGENT_EXECUTION_FAILED';
         const msg = authFailure
           ? authFailure.message ?? `${def.name} authentication expired. Please re-authenticate and retry.`
           : isAntigravityQuota
             ? antigravityQuotaGuidance()
-            : useAntigravityAuthFallback
-              ? antigravityAuthGuidance()
+            : isAntigravitySilentExit
+              ? `Antigravity CLI exited without producing output. Open agy in a terminal to inspect state, switch models, or update agy, then retry this chat. The agy --log-file may contain more detail.`
               : `${def.name} returned an empty response. This may indicate an expired session — try re-authenticating the agent.`;
         send('error', createSseErrorPayload(
           errorCode,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8455,7 +8455,15 @@ export async function startServer({
           try {
             const lines = combinedDetail.split('\n');
             const lastError = lines.filter((l) => /^E\d{4}\s/.test(l)).pop();
-            return lastError ? `\n\nagy reported: ${lastError.trim()}` : '';
+            if (!lastError) return '';
+            // Strip timestamp / pid / source-file prefix (agy Go log
+            // format: "EMMDD hh:mm:ss.sss pid file.go:line] message")
+            // so the surfaced text is just the actionable message.
+            const msg = lastError.replace(
+              /^E\d{4}\s+[\d:.]+?\s+\d+\s+[\w._-]+:\d+\]\s*/,
+              '',
+            );
+            return `\n\nagy: ${msg}`;
           } catch { return ''; }
         })();
         const msg = authFailure

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8442,20 +8442,27 @@ export async function startServer({
           : isAntigravityQuota
             ? 'RATE_LIMITED'
             : 'AGENT_EXECUTION_FAILED';
-        // Antigravity-aware message: when agy exits 0 with no stdout
-        // (any reason — auth, quota, upstream drop, brain-folder
-        // missing, prompt-not-delivered), surface actionable guidance
-        // keyed on the classified reason. The blanket "expired session"
-        // message was empirically wrong — many users reporting #3536
-        // confirmed agy works in a terminal but not from OD. Without
-        // reading agy's log file or stderr stdout we cannot distinguish
-        // the root cause, so the message tells the user to inspect the
-        // daemon-run log file directly.
+        // Antigravity-aware message: when agy exits 0 with no
+        // stdout, surface whether auth / quota matched, and
+        // otherwise extract the last error line from the agy log
+        // file so the user sees the actual upstream reason (e.g.
+        // Windows path issue, missing brain directory, upstream
+        // timeout) instead of a generic "exited without output."
+        // The previous version always emitted the auth guidance,
+        // which was empirically wrong for many #3536 reporters.
+        const antigravityLogTail = (() => {
+          if (def.id !== 'antigravity' || !agentLogFilePath) return '';
+          try {
+            const lines = combinedDetail.split('\n');
+            const lastError = lines.filter((l) => /^E\d{4}\s/.test(l)).pop();
+            return lastError ? `\n\nagy reported: ${lastError.trim()}` : '';
+          } catch { return ''; }
+        })();
         const msg = authFailure
-          ? authFailure.message ?? antigravityAuthGuidance()
+          ? (authFailure.message ?? antigravityAuthGuidance()) + antigravityLogTail
           : isAntigravityQuota
-            ? antigravityQuotaGuidance()
-            : `Antigravity CLI exited without producing output. The daemon piped agy's \`--log-file\` to a temporary path that should contain the upstream reason. Check the daemon-run log file for details — its path is available in the daemon log output for this run — or run \`agy\` alone in a terminal to verify the CLI is functional, then retry this chat.`;
+            ? antigravityQuotaGuidance() + antigravityLogTail
+            : `Antigravity CLI exited without producing output.${antigravityLogTail}${antigravityLogTail ? '' : ' Check the agy --log-file for details — its path is in the daemon-run log output for this run.'}`;
         send('error', createSseErrorPayload(
           errorCode,
           msg,

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2116,6 +2116,152 @@ process.exit(0);
     );
   });
 
+  it('reports a silent Antigravity exit as AGENT_EXECUTION_FAILED instead of AGENT_AUTH_REQUIRED (issue #3536)', async () => {
+    // Real agy 1.0.13+ exits cleanly with no stdout, no stderr, and a
+    // log file that does not contain a recoverable auth / quota /
+    // upstream signal when the brain folder is missing, the selected
+    // model is unreachable, or the upstream times out. The previous
+    // blanket fallback surfaced this as AGENT_AUTH_REQUIRED, which
+    // told the user to re-login even when their login was valid. After
+    // the fix the run is reported as a retryable AGENT_EXECUTION_FAILED
+    // so the chat surfaces an actionable message instead of an auth
+    // path the user cannot act on. (issue #3536; reviewer feedback on
+    // PR #3840.)
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+// No stdout, no stderr, exit 0 — matches the real agy -p - "hello"
+// shape on machines where the brain folder or upstream is unreachable.
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'event: error');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        // Must NOT surface auth guidance when there is no auth signal.
+        expect(eventsBody).not.toContain('AGENT_AUTH_REQUIRED');
+        expect(eventsBody).not.toContain('open a terminal and run `agy` once');
+        expect(eventsBody).toContain('event: error');
+        expect(eventsBody).toContain('AGENT_EXECUTION_FAILED');
+        expect(eventsBody).toContain('Antigravity CLI exited without producing output');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
+  it('surfaces an Antigravity bare `no_text` handoff drop as AGENT_EXECUTION_FAILED (issue #3536)', async () => {
+    // Antigravity CLI versions can emit a bare `no_text` token on
+    // stdout when the upstream handoff drops the result. Without a
+    // typed classification the run falls through as succeeded and the
+    // chat shows no reply. The guard uses exact trim match (not a
+    // regex) so legitimate assistant text mentioning the token does
+    // not false-fire. (PR #3840 reviewer feedback.)
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write('no_text\\n');
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'AGENT_EXECUTION_FAILED');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: error');
+        expect(eventsBody).toContain('AGENT_EXECUTION_FAILED');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
+  it('does not classify Antigravity stdout mentioning "no_text" as a failure (issue #3536)', async () => {
+    // Exact-trim-match guard: legitimate assistant text containing the
+    // token (e.g. an assistant reporting "processed no_text signal
+    // and recovered") must NOT be misclassified as
+    // AGENT_EXECUTION_FAILED. The buffered Gemini parser sees init +
+    // message + result, so the run goes through the normal success
+    // path. (PR #3840 reviewer feedback.)
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({ type: 'init', session_id: 'agy-1', model: 'gemini-3.5-flash' }) + '\\n');
+process.stdout.write(JSON.stringify({ type: 'message', role: 'assistant', content: 'processed no_text signal and recovered', delta: true }) + '\\n');
+process.stdout.write(JSON.stringify({ type: 'result', status: 'success', stats: { input_tokens: 4, output_tokens: 8 } }) + '\\n');
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'event: final');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).not.toContain('AGENT_EXECUTION_FAILED');
+        expect(eventsBody).not.toContain('AGENT_AUTH_REQUIRED');
+        expect(statusBody.status).toBe('succeeded');
+      },
+    );
+  });
+
   it('preserves the first buffered stdout timestamp for Antigravity Gemini assistant text', () => {
     const timestamp = bufferedAntigravityGeminiFirstTokenAt(
       [{

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -3392,6 +3392,117 @@ process.exit(0);
     );
   });
 
+  it('reports Antigravity silent exits with an actionable detail instead of a bare "exit 0" (issue #3536)', async () => {
+    // Real agy 1.0.13+ exits cleanly with no stdout, no stderr, and a
+    // log file with no recoverable auth / quota / upstream signal
+    // when the brain folder is missing, the selected model is
+    // unreachable, or the upstream times out. The previous fallback
+    // surfaced this as a bare "exit 0" detail, which the Settings UI
+    // renders as "Test failed: exit 0" (English) / "Échec du test :
+    // exit 0" (French) — the exact text from the issue screenshot.
+    // After the fix the smoke probe returns an actionable detail
+    // telling the user to inspect agy / switch models / update agy,
+    // and the auth-required guidance is reserved for actual auth
+    // signals. (issue #3536.)
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+// No stdout, no stderr, exit 0 — matches the real agy -p - "hello"
+// shape on machines where the brain folder or upstream is
+// unreachable.
+process.exit(0);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'antigravity' });
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Antigravity',
+        });
+        expect(result.detail).toContain(
+          'Antigravity CLI exited without producing output',
+        );
+        // Must NOT surface the auth guidance when there is no auth
+        // signal in stdout/stderr/log.
+        expect(result.detail).not.toContain('open a terminal and run `agy` once');
+      },
+    );
+  });
+
+  it('reports Antigravity bare `no_text` handoff drops with an actionable detail (issue #3536)', async () => {
+    // Antigravity CLI versions can emit a bare `no_text` token on
+    // stdout when the upstream handoff drops the result. Without a
+    // typed classification the smoke probe returns a bare "exit 0 ·
+    // stdout: no_text" detail. After the fix the probe reports the
+    // same handoff-drop message the chat close path uses. Exact trim
+    // match — not a regex — so legitimate stdout mentioning the
+    // token does not false-fire. (PR #3840 reviewer feedback.)
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write('no_text\\n');
+process.exit(0);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'antigravity' });
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Antigravity',
+        });
+        expect(result.detail).toContain('handoff signal');
+        expect(result.detail).toContain('no_text');
+      },
+    );
+  });
+
+  it('does not classify Antigravity stdout auth prompts through the silent-exit branch (issue #3536)', async () => {
+    // Negative test: when agy prints visible stdout (e.g. an auth
+    // prompt), the connection probe's existing visible-text path
+    // runs first and returns success — the new antigravity
+    // silent-exit branch must NOT fire and must NOT add the
+    // "Antigravity CLI exited without producing output" detail.
+    // (The connection probe's auth-prompt handling differs from
+    // the chat route's: the probe treats any visible stdout as
+    // success because the agent did run; auth-prompt suppression
+    // is the chat route's job. That's pre-existing behavior, not
+    // in scope here.)
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write('Authentication required. Please visit the URL to log in: https://accounts.google.com/o/oauth2/auth?client_id=12345\\n');
+process.stdout.write('Waiting for authentication (timeout 30s)...\\n');
+process.stdout.write('Error: authentication timed out.\\n');
+process.exit(0);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'antigravity' });
+        // Visible-text path: agent ran, probe returns success.
+        expect(result.ok).toBe(true);
+        // The new silent-exit detail must NOT be attached.
+        expect(result.detail ?? '').not.toContain(
+          'Antigravity CLI exited without producing output',
+        );
+        expect(result.detail ?? '').not.toContain('handoff signal');
+      },
+    );
+  });
+
   it('keeps non-auth Cursor Agent runtime failures on the generic spawn path', async () => {
     await withFakeCursorAgent(
       `


### PR DESCRIPTION
Fixes #3536

## What this PR actually does

**Important: This PR improves error reporting for Antigravity failures, but cannot fix the underlying "agy doesn't produce output on Windows" bug. The root cause is in the agy binary itself — see "Unfixable from Open Design" below.**

This PR fixes three things on the chat route + connection probe side:

1. **Wrong classification**: agy silent / `no_text` exits were falling through to `AGENT_AUTH_REQUIRED` with misleading "open a terminal and run `agy` once" guidance (when the user's auth was valid). Now classified as `AGENT_EXECUTION_FAILED` with actionable detail.

2. **No regression test for the prior PR #3840 case**: PR #3764 and #3840 were closed (one for bundling an unrelated FileViewer change, one for using a regex substring match that false-positives on legitimate text mentioning `no_text`). This PR uses the reviewer-requested **exact trim match** (not a regex) and includes the negative false-positive test.

3. **No log-file context in error messages**: when Guard 4 surfaces `AGENT_EXECUTION_FAILED` for antigravity, the user can't see *why* agy failed — only "exit 0". Now the daemon surfaces the actual last error line from agy's `--log-file`, stripped of timestamp/pid noise, so the user can see the upstream cause.

## Unfixable from Open Design

The user reports "#3536 is the goal is to have Anti-Gravity working in OpenDesign as an execution mode." Local reproduction on this machine (agy 1.0.13 at `C:\Users\etien\AppData\Local\agy\bin\agy.exe`, the latest version per `agy update`) confirms the underlying issue is in agy itself:

- agy's Go keyring library cannot read the `LegacyGeneric:target=gemini:antigravity` Windows credential (verified via `cmdkey /list`). Print mode runs hit `error getting token source: You are not logged into Antigravity.` before the fallback to `~/.gemini/oauth_creds.json` can complete.
- Even when auth eventually succeeds (visible via `Auth done received` in the agy CLI log) and the API call to `daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent` returns a `ResponseID`, the response is not written to stdout. The transcript.jsonl path uses a Unix-style `/Users/etien/...` literal on Windows — the file gets created at the correct Windows path but stays 0 bytes; agy's log reports it can't open the very file it just created. This is an agy Go string-formatting bug, not solvable from outside.
- Both `agy -p - "say hello"` (print mode, stdin-piped prompt) and `agy -p "say hello"` (print mode, positional prompt) exhibit the same symptom on this machine: exit 0, empty stdout, no useful output.

Neither of these is fixable in Open Design. The fixes belong upstream in agy. Recommended upstream fixes:

1. agy's keyring library needs to handle `LegacyGeneric` Windows credentials, or agy needs to default to file-based auth on Windows when keyring fails.
2. agy's transcript.jsonl path computation should use `filepath.Join` on the OS-appropriate home, not a hardcoded `/Users/<name>/...` template.

Workaround for the user, until agy ships a fix: report the issue to Antigravity, or use a different agent (codex, gemini-cli, claude) which work in Open Design on this same machine.

## What users will see now

**Chat route** (`POST /api/runs` with `agentId: "antigravity"`):
- Silent agy exit → `AGENT_EXECUTION_FAILED` (was `AGENT_AUTH_REQUIRED`)
- Bare `no_text\n` on stdout → `AGENT_EXECUTION_FAILED` (was succeeded with raw token forwarded)
- Error message includes the actual agy log error, e.g.:
  > `Antigravity CLI exited without producing output.\n\nagy: open /Users/etien/.gemini/antigravity-cli/brain/.../transcript.jsonl: The system cannot find the path specified.`
- Existing auth-prompt path is unchanged: agy prints OAuth URL → still classified as `AGENT_AUTH_REQUIRED` with the `ANTIGRAVITY_AUTH_GUIDANCE` text.

**Connection probe** (`POST /api/test/connection` agent mode):
- Silent agy exit → `kind: 'agent_spawn_failed'` (was `kind: 'unknown'`) with the actual agy log error in `detail`. Before, the detail was just `"exit 0"`.
- `no_text\n` on stdout → same fix.

## Why the surface area here is daemon-only

- **Chat: no UI change**. The error message appears in the existing SSE error channel; web UI just renders it via existing error rendering.
- **CLI**: no `od` command changes needed; the existing `od agent run` / `od test:agent` surfaces use the same daemon HTTP API.
- **i18n**: the chat error is rendered as-is. The connection probe label "Échec du test" (French) / "Test failed" (English) is pre-existing `settings.testSpawnAgent` text, unchanged. Changing the misleading "Impossible de démarrer Antigravity" prefix when `kind === 'agent_spawn_failed'` is reachable but adds a new `ConnectionTestKind` + 18 locale files — deferred to a separate PR.

## Files touched (4)

| File | Lines |
|------|-------|
| `apps/daemon/src/server.ts` | Exact-trim `no_text` guard in chat Guard 3 + always-use-agency-aware Guard 4 message + surface last agy log E-line |
| `apps/daemon/src/connectionTest.ts` | Allocate `--log-file` path for antigravity in smoke probe + read it after silent exit + surface last E-line; bare `no_text` exact-trim guard before visible-text path |
| `apps/daemon/tests/chat-route.test.ts` | +3 regression tests |
| `apps/daemon/tests/connection-test.test.ts` | +3 regression tests |

## Bug fix verification (per AGENTS.md `Bug follow-up workflow`)

Each red spec was confirmed red on `main` (pre-fix) and green on this branch:

| Test | Pre-fix | Branch |
|------|---------|--------|
| silent Antigravity chat exit → `AGENT_EXECUTION_FAILED` | returns `AGENT_AUTH_REQUIRED` | `AGENT_EXECUTION_FAILED` with new message |
| bare `no_text\n` stdout → `AGENT_EXECUTION_FAILED` | falls through to `succeeded` | `AGENT_EXECUTION_FAILED` |
| JSONL stream mentioning `no_text` → succeeds (PR #3840 false-positive guard) | already green | still green |
| silent Antigravity connection probe exit → `agent_spawn_failed` with log error | returns `unknown` with `"exit 0"` | `agent_spawn_failed` with agy log error |
| bare `no_text\n` connection probe → `agent_spawn_failed` with handoff message | returns `success` | `agent_spawn_failed` |
| Antigravity stdout auth prompt connection probe | passes existing visible-text path | still passes (negative test) |

## Validation

- `pnpm --filter @open-design/daemon typecheck` — clean.
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t "Antigravity"` — 10/10.
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts -t "Antigravity"` — 3/3.
- `pnpm guard` — all individual checks pass; the trailing `ELIFECYCLE` exit-1 is a pre-existing issue on `main` (reproducible on the upstream commit, unrelated to this PR).

## Why this PR avoids the close reasons for #3764 and #3840

- **#3764 close reason: "PR includes an unrelated FileViewer export behavior change"**. This PR touches **only** `apps/daemon/src/...` and `apps/daemon/tests/...`; zero changes to `apps/web/**`.
- **#3764 close reason: "missing regression test at the chat-route seam"**. Six regression tests added (3 chat, 3 connection probe).
- **#3840 close reason: "regex substring match causes false-positive"**. This PR uses `text.trim() === 'no_text'` — exact trim, no regex. The third chat-route test guards against this exact failure mode.
- **#3840 close reason: "PR closed by bot after 5 days no author response"**. I'll respond to review feedback within 24h.

## Reproduction (local on this machine)

```powershell
& "$env:LOCALAPPDATA\agy\bin\agy.exe" --version          # 1.0.13
& "$env:LOCALAPPDATA\agy\bin\agy.exe" --log-file $env:TEMP\agy-repro.log -p - "hello"
# exit: 0, stdout: empty, stderr: empty
Get-Content $env:TEMP\agy-repro.log | Select-String "streamGenerate|error"
# Shows the API call IS made; the response just isn't delivered to stdout.
```

After this PR, the same input via Open Design:
- Chat run: error SSE event with `AGENT_EXECUTION_FAILED` + actual agy log error
- Connection probe: `kind: 'agent_spawn_failed'` with actual agy log error in detail
