### PR TITLE
[codex] Fix deck keyboard double-step navigation

### DIFF
--- a/apps/daemon/src/prompts/deck-framework.ts
+++ b/apps/daemon/src/prompts/deck-framework.ts
@@ -287,12 +287,13 @@ export const DECK_SKELETON_HTML = `<!doctype html>
         try { localStorage.setItem(STORE, String(idx)); } catch (_) {}
       }
       function onKey(e) {
+        if (e.__odDeckKeyHandled) return;
         var t = e.target;
         if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
-        if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') { e.preventDefault(); go(idx + 1); }
-        else if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.preventDefault(); go(idx - 1); }
-        else if (e.key === 'Home') { e.preventDefault(); go(0); }
-        else if (e.key === 'End') { e.preventDefault(); go(slides.length - 1); }
+        if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') { e.__odDeckKeyHandled = true; e.preventDefault(); go(idx + 1); }
+        else if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.__odDeckKeyHandled = true; e.preventDefault(); go(idx - 1); }
+        else if (e.key === 'Home') { e.__odDeckKeyHandled = true; e.preventDefault(); go(0); }
+        else if (e.key === 'End') { e.__odDeckKeyHandled = true; e.preventDefault(); go(slides.length - 1); }
       }
       // Capture phase + listen on both targets — inside the OD iframe,
       // focus may be on window OR document; a single non-capture listener

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6917,6 +6917,7 @@ function HtmlViewer({
   useEffect(() => {
     if (!effectiveDeck || mode !== 'preview') return;
     function onKey(e: KeyboardEvent) {
+      if (document.activeElement === iframeRef.current) return;
       const target = e.target as HTMLElement | null;
       if (target) {
         const tag = target.tagName;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2407,7 +2407,8 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       var source = '';
       if (typeof listener === 'function') source = String(listener);
       else if (listener && typeof listener.handleEvent === 'function') source = String(listener.handleEvent);
-      return /\\bod:slide\\b/.test(source);
+      if (/\\bod:slide\\b/.test(source)) return true;
+      return /slide/i.test(source) && /message/i.test(source);
     } catch (_) {
       return false;
     }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2026,7 +2026,6 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   const safeInitialSlideIndex = Number.isFinite(initialSlideIndex)
     ? Math.max(0, Math.floor(initialSlideIndex))
     : 0;
-  const hasNativeSlideMessageHandler = /\bod:slide\b/.test(doc);
   const isFrameworkDeck = /\bid\s*=\s*["']deck-stage["']/i.test(doc);
   const styleFix = isFrameworkDeck
     ? ''
@@ -2035,7 +2034,6 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
 </style>`;
   const script = `<script data-od-deck-bridge>(function(){
   var initialSlideIndex = ${safeInitialSlideIndex};
-  var nativeSlideMessageHandler = ${JSON.stringify(hasNativeSlideMessageHandler)};
   var didRestoreInitialSlide = initialSlideIndex <= 0;
   function slides(){
     // Structured selectors first so decorative .slide markup in non-deck
@@ -2413,10 +2411,6 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     var before = odSlideMessageBeforeIndex;
     odSlideMessageBeforeIndex = -1;
     var current = activeIndex(slides());
-    if (nativeSlideMessageHandler && data.action !== 'go') {
-      setTimeout(report, 0);
-      return;
-    }
     if (data.action === 'go' && typeof data.index === 'number') {
       if (current === data.index) {
         report();

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2401,11 +2401,27 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   var odSlideMessageBeforeIndex = -1;
   var odDeckBridgeInstallingMessageListener = false;
-  var odHasExternalMessageListener = false;
+  var odHasExternalSlideMessageListener = false;
+  function odMaybeHandlesSlideMessages(listener) {
+    try {
+      var source = '';
+      if (typeof listener === 'function') source = String(listener);
+      else if (listener && typeof listener.handleEvent === 'function') source = String(listener.handleEvent);
+      return /\\bod:slide\\b/.test(source);
+    } catch (_) {
+      return false;
+    }
+  }
   try {
     var odOriginalAddEventListener = window.addEventListener;
     window.addEventListener = function(type, listener, options) {
-      if (type === 'message' && !odDeckBridgeInstallingMessageListener) odHasExternalMessageListener = true;
+      if (
+        type === 'message' &&
+        !odDeckBridgeInstallingMessageListener &&
+        odMaybeHandlesSlideMessages(listener)
+      ) {
+        odHasExternalSlideMessageListener = true;
+      }
       return odOriginalAddEventListener.call(this, type, listener, options);
     };
   } catch (_) {}
@@ -2448,7 +2464,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       report();
       return;
     }
-    if (odHasExternalMessageListener) {
+    if (odHasExternalSlideMessageListener) {
       setTimeout(applyBridgeFallback, 0);
       return;
     }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2037,6 +2037,23 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   const script = `<script data-od-deck-bridge>(function(){
   var initialSlideIndex = ${safeInitialSlideIndex};
   var didRestoreInitialSlide = initialSlideIndex <= 0;
+  if (${JSON.stringify(isFrameworkDeck)}) {
+    window.addEventListener('keydown', function(ev){
+      var key = ev && ev.key;
+      if (
+        key !== 'ArrowRight' &&
+        key !== 'PageDown' &&
+        key !== ' ' &&
+        key !== 'ArrowLeft' &&
+        key !== 'PageUp' &&
+        key !== 'Home' &&
+        key !== 'End'
+      ) return;
+      var t = ev.target;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      ev.stopPropagation();
+    }, true);
+  }
   function slides(){
     // Structured selectors first so decorative .slide markup in non-deck
     // pages (icons, badges, code samples) is not counted as deck slides;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2400,17 +2400,31 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     gotoIndex(initialSlideIndex);
   }
   var odSlideMessageBeforeIndex = -1;
-  window.addEventListener('message', function(ev){
+  var odDeckBridgeInstallingMessageListener = false;
+  var odHasExternalMessageListener = false;
+  try {
+    var odOriginalAddEventListener = window.addEventListener;
+    window.addEventListener = function(type, listener, options) {
+      if (type === 'message' && !odDeckBridgeInstallingMessageListener) odHasExternalMessageListener = true;
+      return odOriginalAddEventListener.call(this, type, listener, options);
+    };
+  } catch (_) {}
+  function addOdSlideMessageListener(listener, options) {
+    odDeckBridgeInstallingMessageListener = true;
+    try { window.addEventListener('message', listener, options); }
+    finally { odDeckBridgeInstallingMessageListener = false; }
+  }
+  addOdSlideMessageListener(function(ev){
     var data = ev && ev.data;
     if (!data || data.type !== 'od:slide') return;
     odSlideMessageBeforeIndex = activeIndex(slides());
   }, true);
-  window.addEventListener('message', function(ev){
+  addOdSlideMessageListener(function(ev){
     var data = ev && ev.data;
     if (!data || data.type !== 'od:slide') return;
     var before = odSlideMessageBeforeIndex;
     odSlideMessageBeforeIndex = -1;
-    setTimeout(function(){
+    function applyBridgeFallback() {
       var current = activeIndex(slides());
       if (data.action === 'go' && typeof data.index === 'number') {
         if (current === data.index) {
@@ -2429,7 +2443,16 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
         return;
       }
       go(data.action);
-    }, 0);
+    }
+    if (before >= 0 && activeIndex(slides()) !== before) {
+      report();
+      return;
+    }
+    if (odHasExternalMessageListener) {
+      setTimeout(applyBridgeFallback, 0);
+      return;
+    }
+    applyBridgeFallback();
   });
   function ownDeckButton(id, action){
     var btn = document.getElementById(id);

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2026,6 +2026,8 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   const safeInitialSlideIndex = Number.isFinite(initialSlideIndex)
     ? Math.max(0, Math.floor(initialSlideIndex))
     : 0;
+  const hasInlineSlideMessageListener =
+    /addEventListener\s*\(\s*['"]message['"]/i.test(doc) && /\bod:slide\b/.test(doc);
   const isFrameworkDeck = /\bid\s*=\s*["']deck-stage["']/i.test(doc);
   const styleFix = isFrameworkDeck
     ? ''
@@ -2365,6 +2367,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       var i = activeIndex(list);
       var count = list.length;
       var progressWidth = count ? ((i + 1) / count * 100) + '%' : '0';
+      updateDeckChrome(i, count);
       window.parent.postMessage({
         type: 'od:slide-state',
         active: i,
@@ -2401,7 +2404,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   var odSlideMessageBeforeIndex = -1;
   var odDeckBridgeInstallingMessageListener = false;
-  var odHasExternalSlideMessageListener = false;
+  var odHasExternalSlideMessageListener = ${JSON.stringify(hasInlineSlideMessageListener)};
   function odMaybeHandlesSlideMessages(listener) {
     try {
       var source = '';
@@ -2434,7 +2437,11 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   addOdSlideMessageListener(function(ev){
     var data = ev && ev.data;
     if (!data || data.type !== 'od:slide') return;
-    odSlideMessageBeforeIndex = activeIndex(slides());
+    var before = activeIndex(slides());
+    odSlideMessageBeforeIndex = before;
+    setTimeout(function(){
+      if (activeIndex(slides()) !== before) report();
+    }, 0);
   }, true);
   addOdSlideMessageListener(function(ev){
     var data = ev && ev.data;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2410,24 +2410,26 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (!data || data.type !== 'od:slide') return;
     var before = odSlideMessageBeforeIndex;
     odSlideMessageBeforeIndex = -1;
-    var current = activeIndex(slides());
-    if (data.action === 'go' && typeof data.index === 'number') {
-      if (current === data.index) {
+    setTimeout(function(){
+      var current = activeIndex(slides());
+      if (data.action === 'go' && typeof data.index === 'number') {
+        if (current === data.index) {
+          report();
+          return;
+        }
+        gotoIndex(data.index);
+        return;
+      }
+      // Some generated decks ship their own od:slide listener. Let every
+      // listener for this message event settle first; then, if the artifact
+      // already moved from the captured index, report instead of applying the
+      // same command again.
+      if (before >= 0 && current !== before) {
         report();
         return;
       }
-      gotoIndex(data.index);
-      return;
-    }
-    // Some generated decks ship their own od:slide listener. Because their
-    // listener is registered before this bridge, it may already have consumed
-    // the same host command by the time we run. In that case report the new
-    // state instead of applying the command again.
-    if (before >= 0 && current !== before) {
-      report();
-      return;
-    }
-    go(data.action);
+      go(data.action);
+    }, 0);
   });
   function ownDeckButton(id, action){
     var btn = document.getElementById(id);

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2026,6 +2026,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   const safeInitialSlideIndex = Number.isFinite(initialSlideIndex)
     ? Math.max(0, Math.floor(initialSlideIndex))
     : 0;
+  const hasNativeSlideMessageHandler = /\bod:slide\b/.test(doc);
   const isFrameworkDeck = /\bid\s*=\s*["']deck-stage["']/i.test(doc);
   const styleFix = isFrameworkDeck
     ? ''
@@ -2034,6 +2035,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
 </style>`;
   const script = `<script data-od-deck-bridge>(function(){
   var initialSlideIndex = ${safeInitialSlideIndex};
+  var nativeSlideMessageHandler = ${JSON.stringify(hasNativeSlideMessageHandler)};
   var didRestoreInitialSlide = initialSlideIndex <= 0;
   function slides(){
     // Structured selectors first so decorative .slide markup in non-deck
@@ -2399,11 +2401,39 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     didRestoreInitialSlide = true;
     gotoIndex(initialSlideIndex);
   }
+  var odSlideMessageBeforeIndex = -1;
   window.addEventListener('message', function(ev){
     var data = ev && ev.data;
     if (!data || data.type !== 'od:slide') return;
-    if (data.action === 'go' && typeof data.index === 'number') gotoIndex(data.index);
-    else go(data.action);
+    odSlideMessageBeforeIndex = activeIndex(slides());
+  }, true);
+  window.addEventListener('message', function(ev){
+    var data = ev && ev.data;
+    if (!data || data.type !== 'od:slide') return;
+    var before = odSlideMessageBeforeIndex;
+    odSlideMessageBeforeIndex = -1;
+    var current = activeIndex(slides());
+    if (nativeSlideMessageHandler && data.action !== 'go') {
+      setTimeout(report, 0);
+      return;
+    }
+    if (data.action === 'go' && typeof data.index === 'number') {
+      if (current === data.index) {
+        report();
+        return;
+      }
+      gotoIndex(data.index);
+      return;
+    }
+    // Some generated decks ship their own od:slide listener. Because their
+    // listener is registered before this bridge, it may already have consumed
+    // the same host command by the time we run. In that case report the new
+    // state instead of applying the command again.
+    if (before >= 0 && current !== before) {
+      report();
+      return;
+    }
+    go(data.action);
   });
   function ownDeckButton(id, action){
     var btn = document.getElementById(id);

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
@@ -164,6 +164,59 @@ describe('deck bridge — nested slide markup (#1530)', () => {
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 4 });
   });
 
+  it('prevents framework decks from handling one keyboard event on both window and document', async () => {
+    const bodyHtml = `
+      <div class="deck-stage" id="deck-stage">
+        <section class="slide">One</section>
+        <section class="slide">Two</section>
+        <section class="slide">Three</section>
+      </div>
+    `;
+    const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      deck: true,
+    });
+    const script = extractDeckBridgeScript(srcdoc);
+    const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const win = dom.window;
+    Object.defineProperty(win, 'parent', {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+
+    const slides = Array.from(win.document.querySelectorAll('.slide'));
+    let active = 0;
+    function paint() {
+      slides.forEach((slide, index) => {
+        slide.toggleAttribute('hidden', index !== active);
+      });
+    }
+    function go(index: number) {
+      active = Math.max(0, Math.min(slides.length - 1, index));
+      paint();
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key !== 'ArrowRight') return;
+      event.preventDefault();
+      go(active + 1);
+    }
+    win.addEventListener('keydown', onKey, true);
+    win.document.addEventListener('keydown', onKey, true);
+    paint();
+
+    const evaluate = new win.Function(script);
+    evaluate.call(win);
+    win.document.body.dispatchEvent(new win.KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'ArrowRight',
+    }));
+
+    expect(active).toBe(1);
+  });
+
   it('scrolls documentElement when body looks horizontally scrollable in a sandboxed Simple Deck', async () => {
     const { win, parentPostMessage } = setupDeckBridge(`
       <style>

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { buildSrcdoc } from '../../src/runtime/srcdoc';
+
+function extractDeckBridgeScript(srcdoc: string): string {
+  const match = srcdoc.match(/<script data-od-deck-bridge>([\s\S]*?)<\/script>/);
+  if (!match || !match[1]) {
+    throw new Error('deck bridge script not found in srcdoc');
+  }
+  return match[1];
+}
+
+function setupDeckThatMentionsSlideMessages() {
+  const bodyHtml = `
+    <section class="slide" style="display:block">Slide One</section>
+    <section class="slide" style="display:none">Slide Two</section>
+    <p>Protocol token: od:slide</p>
+  `;
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: vi.fn() },
+  });
+  Object.defineProperty(win, 'setTimeout', {
+    configurable: true,
+    value: vi.fn(() => 0),
+  });
+  Object.defineProperty(win, 'clearTimeout', {
+    configurable: true,
+    value: vi.fn(),
+  });
+
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+  const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+  return { win, slides };
+}
+
+describe('deck bridge - slide message text', () => {
+  it('keeps host navigation active when content mentions the od:slide protocol without handling it', () => {
+    const { win, slides } = setupDeckThatMentionsSlideMessages();
+    const [first, second] = slides;
+    if (!first || !second) throw new Error('expected two slides');
+
+    win.dispatchEvent(
+      new win.MessageEvent('message', { data: { type: 'od:slide', action: 'next' } }),
+    );
+
+    expect(first.style.display).toBe('none');
+    expect(second.style.display).toBe('');
+    win.close();
+  });
+});

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
@@ -103,6 +103,54 @@ function setupDeckWithNativeSlideMessageHandler() {
   return { flushTimers, win, slides };
 }
 
+function setupDeckWithConstantNativeSlideMessageHandler() {
+  const bodyHtml = `
+    <section class="slide" style="display:block">Slide One</section>
+    <section class="slide" style="display:none">Slide Two</section>
+    <section class="slide" style="display:none">Slide Three</section>
+  `;
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: vi.fn() },
+  });
+  const flushTimers = installQueuedTimers(win);
+
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+  flushTimers();
+
+  const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+  const SLIDE_MESSAGE = 'od:slide';
+  function isSlideMessage(data: { type?: string } | null | undefined) {
+    return data?.type === SLIDE_MESSAGE;
+  }
+  function activeIndex() {
+    return Math.max(0, slides.findIndex((slide) => slide.style.display !== 'none'));
+  }
+  function render(active: number) {
+    slides.forEach((slide, index) => {
+      slide.style.display = index === active ? '' : 'none';
+    });
+  }
+  function onSlideMessage(event: MessageEvent) {
+    if (!isSlideMessage(event.data)) return;
+    if (event.data.action === 'next') render(Math.min(slides.length - 1, activeIndex() + 1));
+    if (event.data.action === 'prev') render(Math.max(0, activeIndex() - 1));
+  }
+  win.addEventListener('message', onSlideMessage);
+
+  return { flushTimers, win, slides };
+}
+
 describe('deck bridge - slide message text', () => {
   it('keeps host navigation active when content mentions the od:slide protocol without handling it', () => {
     const { flushTimers, win, slides } = setupDeckThatMentionsSlideMessages();
@@ -151,6 +199,22 @@ describe('deck bridge - slide message text', () => {
     expect(first.hidden).toBe(true);
     expect(second.hidden).toBe(false);
     expect(third.hidden).toBe(true);
+    win.close();
+  });
+
+  it('detects constant-based post-bridge slide handlers before applying fallback', () => {
+    const { flushTimers, win, slides } = setupDeckWithConstantNativeSlideMessageHandler();
+    const [first, second, third] = slides;
+    if (!first || !second || !third) throw new Error('expected three slides');
+
+    win.dispatchEvent(
+      new win.MessageEvent('message', { data: { type: 'od:slide', action: 'next' } }),
+    );
+    flushTimers();
+
+    expect(first.style.display).toBe('none');
+    expect(second.style.display).toBe('');
+    expect(third.style.display).toBe('none');
     win.close();
   });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
@@ -119,6 +119,25 @@ describe('deck bridge - slide message text', () => {
     win.close();
   });
 
+  it('keeps bridge-owned fallback synchronous when unrelated message listeners exist', () => {
+    const { win, slides } = setupDeckThatMentionsSlideMessages();
+    const [first, second] = slides;
+    if (!first || !second) throw new Error('expected two slides');
+
+    win.addEventListener('message', (event) => {
+      if (!event.data || event.data.type !== 'od:theme') return;
+      win.document.documentElement.dataset.theme = String(event.data.theme || '');
+    });
+
+    win.dispatchEvent(
+      new win.MessageEvent('message', { data: { type: 'od:slide', action: 'next' } }),
+    );
+
+    expect(first.style.display).toBe('none');
+    expect(second.style.display).toBe('');
+    win.close();
+  });
+
   it('does not apply a second step when a native slide message handler runs later in the same event', () => {
     const { flushTimers, win, slides } = setupDeckWithNativeSlideMessageHandler();
     const [first, second, third] = slides;

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
@@ -12,6 +12,26 @@ function extractDeckBridgeScript(srcdoc: string): string {
   return match[1];
 }
 
+function installQueuedTimers(win: object) {
+  const callbacks: Array<() => void> = [];
+  Object.defineProperty(win, 'setTimeout', {
+    configurable: true,
+    value: vi.fn((callback: () => void) => {
+      if (typeof callback === 'function') callbacks.push(callback);
+      return callbacks.length;
+    }),
+  });
+  Object.defineProperty(win, 'clearTimeout', {
+    configurable: true,
+    value: vi.fn(),
+  });
+  return function flushTimers() {
+    for (let i = 0; i < 100 && callbacks.length; i += 1) {
+      callbacks.shift()?.();
+    }
+  };
+}
+
 function setupDeckThatMentionsSlideMessages() {
   const bodyHtml = `
     <section class="slide" style="display:block">Slide One</section>
@@ -31,33 +51,87 @@ function setupDeckThatMentionsSlideMessages() {
     configurable: true,
     value: { postMessage: vi.fn() },
   });
-  Object.defineProperty(win, 'setTimeout', {
-    configurable: true,
-    value: vi.fn(() => 0),
-  });
-  Object.defineProperty(win, 'clearTimeout', {
-    configurable: true,
-    value: vi.fn(),
-  });
+  const flushTimers = installQueuedTimers(win);
 
   const evaluate = new win.Function(script);
   evaluate.call(win);
+  flushTimers();
   const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
-  return { win, slides };
+  return { flushTimers, win, slides };
+}
+
+function setupDeckWithNativeSlideMessageHandler() {
+  const bodyHtml = `
+    <section class="slide" hidden>Slide One</section>
+    <section class="slide" hidden>Slide Two</section>
+    <section class="slide" hidden>Slide Three</section>
+  `;
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: vi.fn() },
+  });
+  const flushTimers = installQueuedTimers(win);
+
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+  flushTimers();
+
+  let active = 0;
+  const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+  function render() {
+    slides.forEach((slide, index) => {
+      slide.hidden = index !== active;
+    });
+  }
+  win.addEventListener('message', (event) => {
+    if (!event.data || event.data.type !== 'od:slide') return;
+    if (event.data.action === 'next') active = Math.min(slides.length - 1, active + 1);
+    if (event.data.action === 'prev') active = Math.max(0, active - 1);
+    render();
+  });
+  render();
+
+  return { flushTimers, win, slides };
 }
 
 describe('deck bridge - slide message text', () => {
   it('keeps host navigation active when content mentions the od:slide protocol without handling it', () => {
-    const { win, slides } = setupDeckThatMentionsSlideMessages();
+    const { flushTimers, win, slides } = setupDeckThatMentionsSlideMessages();
     const [first, second] = slides;
     if (!first || !second) throw new Error('expected two slides');
 
     win.dispatchEvent(
       new win.MessageEvent('message', { data: { type: 'od:slide', action: 'next' } }),
     );
+    flushTimers();
 
     expect(first.style.display).toBe('none');
     expect(second.style.display).toBe('');
+    win.close();
+  });
+
+  it('does not apply a second step when a native slide message handler runs later in the same event', () => {
+    const { flushTimers, win, slides } = setupDeckWithNativeSlideMessageHandler();
+    const [first, second, third] = slides;
+    if (!first || !second || !third) throw new Error('expected three slides');
+
+    win.dispatchEvent(
+      new win.MessageEvent('message', { data: { type: 'od:slide', action: 'next' } }),
+    );
+    flushTimers();
+
+    expect(first.hidden).toBe(true);
+    expect(second.hidden).toBe(false);
+    expect(third.hidden).toBe(true);
     win.close();
   });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-slide-message-text.test.ts
@@ -151,6 +151,46 @@ function setupDeckWithConstantNativeSlideMessageHandler() {
   return { flushTimers, win, slides };
 }
 
+function setupDeckWithStoppingNativeSlideMessageHandler() {
+  const bodyHtml = `
+    <section class="slide" style="display:block">Slide One</section>
+    <section class="slide" style="display:none">Slide Two</section>
+    <nav><span id="deck-cur">01</span>/<span id="deck-total">02</span></nav>
+  `;
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  const postMessage = vi.fn();
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage },
+  });
+  const flushTimers = installQueuedTimers(win);
+
+  const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+  win.addEventListener('message', (event) => {
+    if (!event.data || event.data.type !== 'od:slide') return;
+    event.stopImmediatePropagation();
+    if (event.data.action === 'next') {
+      slides[0]!.style.display = 'none';
+      slides[1]!.style.display = '';
+      win.document.getElementById('deck-cur')!.textContent = '02';
+    }
+  });
+
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+  flushTimers();
+
+  return { flushTimers, postMessage, win, slides };
+}
+
 describe('deck bridge - slide message text', () => {
   it('keeps host navigation active when content mentions the od:slide protocol without handling it', () => {
     const { flushTimers, win, slides } = setupDeckThatMentionsSlideMessages();
@@ -215,6 +255,26 @@ describe('deck bridge - slide message text', () => {
     expect(first.style.display).toBe('none');
     expect(second.style.display).toBe('');
     expect(third.style.display).toBe('none');
+    win.close();
+  });
+
+  it('reports native slide state when an earlier handler stops propagation', () => {
+    const { flushTimers, postMessage, win, slides } = setupDeckWithStoppingNativeSlideMessageHandler();
+    const [first, second] = slides;
+    if (!first || !second) throw new Error('expected two slides');
+
+    win.dispatchEvent(
+      new win.MessageEvent('message', { data: { type: 'od:slide', action: 'next' } }),
+    );
+    flushTimers();
+
+    expect(first.style.display).toBe('none');
+    expect(second.style.display).toBe('');
+    expect(win.document.getElementById('deck-cur')?.textContent).toBe('02');
+    expect(postMessage).toHaveBeenLastCalledWith(
+      { type: 'od:slide-state', active: 1, count: 2 },
+      '*',
+    );
     win.close();
   });
 });

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -414,6 +414,28 @@ test('[P0] deck host navigation advances one slide when the deck also handles sl
   await expect(frame.getByText('Slide Three')).toBeHidden();
 });
 
+test('[P0] deck host navigation works when deck content only mentions slide messages', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Deck protocol text');
+  await seedDeckArtifact(
+    page,
+    projectId,
+    'protocol-text-deck.html',
+    'Protocol Text Deck',
+    ['Slide One', 'Slide Two'],
+    { mentionsSlideMessageProtocol: true },
+  );
+  await page.goto(`/projects/${projectId}/files/protocol-text-deck.html`);
+  await openDesignFile(page, 'protocol-text-deck.html');
+
+  const frame = artifactPreviewFrame(page);
+  await expect(frame.getByText('Slide One')).toBeVisible();
+  await expect(frame.getByText('Protocol token: od:slide')).toBeVisible();
+  await page.getByLabel('Next slide').click();
+  await expect(frame.getByText('Slide Two')).toBeVisible();
+  await expect(frame.getByText('Slide One')).toBeHidden();
+});
+
 
 test('[P0] simple deck keeps the active slide stable across preview mode switches', async ({ page }) => {
   await routeMockAgents(page);
@@ -669,7 +691,7 @@ async function seedDeckArtifact(
   fileName: string,
   title: string,
   slides: string[],
-  options: { selfHandlesSlideMessages?: boolean } = {},
+  options: { selfHandlesSlideMessages?: boolean; mentionsSlideMessageProtocol?: boolean } = {},
 ) {
   const slideHtml = slides
     .map((slide, index) => `<section class="slide" data-od-id="slide-${index + 1}"${index === 0 ? '' : ' hidden'}><h1>${slide}</h1></section>`)
@@ -697,12 +719,15 @@ async function seedDeckArtifact(
     })();
     </script>`
     : '';
+  const protocolText = options.mentionsSlideMessageProtocol
+    ? '<p>Protocol token: od:slide</p>'
+    : '';
   const resp = await page.request.post(
     `/api/projects/${projectId}/files`,
     {
       data: {
         name: fileName,
-        content: `<!doctype html><html><body>${slideHtml}${slideScript}</body></html>`,
+        content: `<!doctype html><html><body>${slideHtml}${protocolText}${slideScript}</body></html>`,
         artifactManifest: {
           version: 1,
           kind: 'deck',

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -414,6 +414,28 @@ test('[P0] deck host navigation advances one slide when the deck also handles sl
   await expect(frame.getByText('Slide Three')).toBeHidden();
 });
 
+test('[P0] focused deck keyboard navigation advances one slide when the deck handles keys', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Deck iframe keyboard single step');
+  await seedDeckArtifact(
+    page,
+    projectId,
+    'iframe-keyboard-deck.html',
+    'Iframe Keyboard Deck',
+    ['Slide One', 'Slide Two', 'Slide Three'],
+    { frameworkDeck: true, handlesKeyboard: true, stopsSlideMessagePropagation: true },
+  );
+  await page.goto(`/projects/${projectId}/files/iframe-keyboard-deck.html`);
+  await openDesignFile(page, 'iframe-keyboard-deck.html');
+
+  const frame = artifactPreviewFrame(page);
+  await expect(frame.getByText('Slide One')).toBeVisible();
+  await frame.locator('body').click();
+  await page.keyboard.press('ArrowRight');
+  await expect(frame.getByText('Slide Two')).toBeVisible();
+  await expect(frame.getByText('Slide Three')).toBeHidden();
+});
+
 test('[P0] deck host navigation works when deck content only mentions slide messages', async ({ page }) => {
   await routeMockAgents(page);
   const projectId = await createEmptyProject(page, 'Deck protocol text');
@@ -726,15 +748,21 @@ async function seedDeckArtifact(
     selfHandlesSlideMessages?: boolean;
     mentionsSlideMessageProtocol?: boolean;
     stopsSlideMessagePropagation?: boolean;
+    handlesKeyboard?: boolean;
+    frameworkDeck?: boolean;
   } = {},
 ) {
   const slideHtml = slides
     .map((slide, index) => `<section class="slide" data-od-id="slide-${index + 1}"${index === 0 ? '' : ' hidden'}><h1>${slide}</h1></section>`)
     .join('\n');
+  const deckHtml = options.frameworkDeck
+    ? `<div class="deck-stage" id="deck-stage">${slideHtml}</div>`
+    : slideHtml;
   const deckChrome = options.stopsSlideMessagePropagation
     ? '<nav><span id="deck-cur">01</span> / <span id="deck-total">03</span></nav>'
     : '';
-  const slideScript = options.selfHandlesSlideMessages || options.stopsSlideMessagePropagation
+  const slideScript =
+    options.selfHandlesSlideMessages || options.stopsSlideMessagePropagation || options.handlesKeyboard
     ? `<script>
     (() => {
       let active = 0;
@@ -762,6 +790,20 @@ async function seedDeckArtifact(
         render();
         ${options.stopsSlideMessagePropagation ? '' : "window.parent.postMessage({ type: 'od:slide-state', active, count: slides.length }, '*');"}
       });
+      ${
+        options.handlesKeyboard
+          ? `function onKey(event) {
+        if (event.key !== 'ArrowRight') return;
+        event.preventDefault();
+        active = Math.min(slides.length - 1, active + 1);
+        render();
+      }
+      window.addEventListener('keydown', onKey, true);
+      document.addEventListener('keydown', onKey, true);
+      document.body.setAttribute('tabindex', '-1');
+      document.body.focus();`
+          : ''
+      }
       render();
       ${options.stopsSlideMessagePropagation ? '' : "window.parent.postMessage({ type: 'od:slide-state', active, count: slides.length }, '*');"}
     })();
@@ -775,7 +817,7 @@ async function seedDeckArtifact(
     {
       data: {
         name: fileName,
-        content: `<!doctype html><html><body>${deckChrome}${slideHtml}${protocolText}${slideScript}</body></html>`,
+        content: `<!doctype html><html><body>${deckChrome}${deckHtml}${protocolText}${slideScript}</body></html>`,
         artifactManifest: {
           version: 1,
           kind: 'deck',

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -393,6 +393,27 @@ test('[P0] manual edit mode keeps deck navigation available for deck-shaped HTML
   await expect(frame.getByText('Slide Two')).toBeVisible();
 });
 
+test('[P0] deck host navigation advances one slide when the deck also handles slide messages', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Deck keyboard single step');
+  await seedDeckArtifact(
+    page,
+    projectId,
+    'keyboard-deck.html',
+    'Keyboard Deck',
+    ['Slide One', 'Slide Two', 'Slide Three'],
+    { selfHandlesSlideMessages: true },
+  );
+  await page.goto(`/projects/${projectId}/files/keyboard-deck.html`);
+  await openDesignFile(page, 'keyboard-deck.html');
+
+  const frame = artifactPreviewFrame(page);
+  await expect(frame.getByText('Slide One')).toBeVisible();
+  await page.getByLabel('Next slide').click();
+  await expect(frame.getByText('Slide Two')).toBeVisible();
+  await expect(frame.getByText('Slide Three')).toBeHidden();
+});
+
 
 test('[P0] simple deck keeps the active slide stable across preview mode switches', async ({ page }) => {
   await routeMockAgents(page);
@@ -648,16 +669,40 @@ async function seedDeckArtifact(
   fileName: string,
   title: string,
   slides: string[],
+  options: { selfHandlesSlideMessages?: boolean } = {},
 ) {
   const slideHtml = slides
     .map((slide, index) => `<section class="slide" data-od-id="slide-${index + 1}"${index === 0 ? '' : ' hidden'}><h1>${slide}</h1></section>`)
     .join('\n');
+  const slideScript = options.selfHandlesSlideMessages
+    ? `<script>
+    (() => {
+      let active = 0;
+      const slides = Array.from(document.querySelectorAll('.slide'));
+      function render() { slides.forEach((slide, index) => { slide.hidden = index !== active; }); }
+      window.addEventListener('message', (event) => {
+        if (!event.data || event.data.type !== 'od:slide') return;
+        if (event.data.action === 'next') active = Math.min(slides.length - 1, active + 1);
+        if (event.data.action === 'prev') active = Math.max(0, active - 1);
+        if (event.data.action === 'first') active = 0;
+        if (event.data.action === 'last') active = slides.length - 1;
+        if (event.data.action === 'go' && typeof event.data.index === 'number') {
+          active = Math.max(0, Math.min(slides.length - 1, event.data.index));
+        }
+        render();
+        window.parent.postMessage({ type: 'od:slide-state', active, count: slides.length }, '*');
+      });
+      render();
+      window.parent.postMessage({ type: 'od:slide-state', active, count: slides.length }, '*');
+    })();
+    </script>`
+    : '';
   const resp = await page.request.post(
     `/api/projects/${projectId}/files`,
     {
       data: {
         name: fileName,
-        content: `<!doctype html><html><body>${slideHtml}</body></html>`,
+        content: `<!doctype html><html><body>${slideHtml}${slideScript}</body></html>`,
         artifactManifest: {
           version: 1,
           kind: 'deck',

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -402,7 +402,7 @@ test('[P0] deck host navigation advances one slide when the deck also handles sl
     'keyboard-deck.html',
     'Keyboard Deck',
     ['Slide One', 'Slide Two', 'Slide Three'],
-    { selfHandlesSlideMessages: true },
+    { stopsSlideMessagePropagation: true },
   );
   await page.goto(`/projects/${projectId}/files/keyboard-deck.html`);
   await openDesignFile(page, 'keyboard-deck.html');
@@ -434,6 +434,37 @@ test('[P0] deck host navigation works when deck content only mentions slide mess
   await page.getByLabel('Next slide').click();
   await expect(frame.getByText('Slide Two')).toBeVisible();
   await expect(frame.getByText('Slide One')).toBeHidden();
+});
+
+test('[P0] deck host counter stays synced when a self-handling deck stops slide messages', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Deck stopped message sync');
+  await seedDeckArtifact(
+    page,
+    projectId,
+    'stopped-message-deck.html',
+    'Stopped Message Deck',
+    ['Slide One', 'Slide Two', 'Slide Three'],
+    { stopsSlideMessagePropagation: true },
+  );
+  await page.goto(`/projects/${projectId}/files/stopped-message-deck.html`);
+  await openDesignFile(page, 'stopped-message-deck.html');
+
+  const frame = artifactPreviewFrame(page);
+  const hostCounter = page.locator('.deck-nav-counter');
+  await expect(frame.getByText('Slide One')).toBeVisible();
+  await expect(hostCounter).toHaveText('1 / 3');
+  await expect(frame.locator('#deck-cur')).toHaveText('01');
+
+  await page.getByLabel('Next slide').click();
+  await expect(frame.getByText('Slide Two')).toBeVisible();
+  await expect(hostCounter).toHaveText('2 / 3');
+  await expect(frame.locator('#deck-cur')).toHaveText('02');
+
+  await page.getByLabel('Previous slide').click();
+  await expect(frame.getByText('Slide One')).toBeVisible();
+  await expect(hostCounter).toHaveText('1 / 3');
+  await expect(frame.locator('#deck-cur')).toHaveText('01');
 });
 
 
@@ -691,19 +722,36 @@ async function seedDeckArtifact(
   fileName: string,
   title: string,
   slides: string[],
-  options: { selfHandlesSlideMessages?: boolean; mentionsSlideMessageProtocol?: boolean } = {},
+  options: {
+    selfHandlesSlideMessages?: boolean;
+    mentionsSlideMessageProtocol?: boolean;
+    stopsSlideMessagePropagation?: boolean;
+  } = {},
 ) {
   const slideHtml = slides
     .map((slide, index) => `<section class="slide" data-od-id="slide-${index + 1}"${index === 0 ? '' : ' hidden'}><h1>${slide}</h1></section>`)
     .join('\n');
-  const slideScript = options.selfHandlesSlideMessages
+  const deckChrome = options.stopsSlideMessagePropagation
+    ? '<nav><span id="deck-cur">01</span> / <span id="deck-total">03</span></nav>'
+    : '';
+  const slideScript = options.selfHandlesSlideMessages || options.stopsSlideMessagePropagation
     ? `<script>
     (() => {
       let active = 0;
       const slides = Array.from(document.querySelectorAll('.slide'));
-      function render() { slides.forEach((slide, index) => { slide.style.display = index === active ? '' : 'none'; }); }
+      function render() {
+        slides.forEach((slide, index) => {
+          slide.style.display = index === active ? '' : 'none';
+          slide.toggleAttribute('hidden', index !== active);
+        });
+        const cur = document.getElementById('deck-cur');
+        const total = document.getElementById('deck-total');
+        if (cur) cur.textContent = String(active + 1).padStart(2, '0');
+        if (total) total.textContent = String(slides.length).padStart(2, '0');
+      }
       window.addEventListener('message', (event) => {
         if (!event.data || event.data.type !== 'od:slide') return;
+        ${options.stopsSlideMessagePropagation ? 'event.stopImmediatePropagation();' : ''}
         if (event.data.action === 'next') active = Math.min(slides.length - 1, active + 1);
         if (event.data.action === 'prev') active = Math.max(0, active - 1);
         if (event.data.action === 'first') active = 0;
@@ -712,10 +760,10 @@ async function seedDeckArtifact(
           active = Math.max(0, Math.min(slides.length - 1, event.data.index));
         }
         render();
-        window.parent.postMessage({ type: 'od:slide-state', active, count: slides.length }, '*');
+        ${options.stopsSlideMessagePropagation ? '' : "window.parent.postMessage({ type: 'od:slide-state', active, count: slides.length }, '*');"}
       });
       render();
-      window.parent.postMessage({ type: 'od:slide-state', active, count: slides.length }, '*');
+      ${options.stopsSlideMessagePropagation ? '' : "window.parent.postMessage({ type: 'od:slide-state', active, count: slides.length }, '*');"}
     })();
     </script>`
     : '';
@@ -727,7 +775,7 @@ async function seedDeckArtifact(
     {
       data: {
         name: fileName,
-        content: `<!doctype html><html><body>${slideHtml}${protocolText}${slideScript}</body></html>`,
+        content: `<!doctype html><html><body>${deckChrome}${slideHtml}${protocolText}${slideScript}</body></html>`,
         artifactManifest: {
           version: 1,
           kind: 'deck',

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -701,7 +701,7 @@ async function seedDeckArtifact(
     (() => {
       let active = 0;
       const slides = Array.from(document.querySelectorAll('.slide'));
-      function render() { slides.forEach((slide, index) => { slide.hidden = index !== active; }); }
+      function render() { slides.forEach((slide, index) => { slide.style.display = index === active ? '' : 'none'; }); }
       window.addEventListener('message', (event) => {
         if (!event.data || event.data.type !== 'od:slide') return;
         if (event.data.action === 'next') active = Math.min(slides.length - 1, active + 1);

--- a/packages/contracts/src/prompts/deck-framework.ts
+++ b/packages/contracts/src/prompts/deck-framework.ts
@@ -287,12 +287,13 @@ export const DECK_SKELETON_HTML = `<!doctype html>
         try { localStorage.setItem(STORE, String(idx)); } catch (_) {}
       }
       function onKey(e) {
+        if (e.__odDeckKeyHandled) return;
         var t = e.target;
         if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
-        if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') { e.preventDefault(); go(idx + 1); }
-        else if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.preventDefault(); go(idx - 1); }
-        else if (e.key === 'Home') { e.preventDefault(); go(0); }
-        else if (e.key === 'End') { e.preventDefault(); go(slides.length - 1); }
+        if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') { e.__odDeckKeyHandled = true; e.preventDefault(); go(idx + 1); }
+        else if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.__odDeckKeyHandled = true; e.preventDefault(); go(idx - 1); }
+        else if (e.key === 'Home') { e.__odDeckKeyHandled = true; e.preventDefault(); go(0); }
+        else if (e.key === 'End') { e.__odDeckKeyHandled = true; e.preventDefault(); go(slides.length - 1); }
       }
       // Capture phase + listen on both targets — inside the OD iframe,
       // focus may be on window OR document; a single non-capture listener

--- a/templates/deck-framework.html
+++ b/templates/deck-framework.html
@@ -224,12 +224,13 @@
         try { localStorage.setItem(STORE, String(idx)); } catch (_) {}
       }
       function onKey(e) {
+        if (e.__odDeckKeyHandled) return;
         var t = e.target;
         if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
-        if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') { e.preventDefault(); go(idx + 1); }
-        else if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.preventDefault(); go(idx - 1); }
-        else if (e.key === 'Home') { e.preventDefault(); go(0); }
-        else if (e.key === 'End') { e.preventDefault(); go(slides.length - 1); }
+        if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') { e.__odDeckKeyHandled = true; e.preventDefault(); go(idx + 1); }
+        else if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.__odDeckKeyHandled = true; e.preventDefault(); go(idx - 1); }
+        else if (e.key === 'Home') { e.__odDeckKeyHandled = true; e.preventDefault(); go(0); }
+        else if (e.key === 'End') { e.__odDeckKeyHandled = true; e.preventDefault(); go(slides.length - 1); }
       }
       // Capture phase + listen on both targets — inside the OD iframe,
       // focus may be on window OR document; a single non-capture listener


### PR DESCRIPTION
## Summary
- Prevent host deck navigation from applying a second step when the artifact already handles `od:slide` messages.
- Keep explicit `go` navigation idempotent when the target slide is already active.
- Add E2E coverage for decks with their own slide message handler.

## Validation
- Not run locally; branch was inspected for a clean merge against `main` before opening the PR.
