### PR TITLE
fix(ci): merge-queue needs-validation gate skips non-PR refs, not eject clean PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1005,9 +1005,22 @@ jobs:
               exit 1
             fi
             for pr in $prs; do
-              # Plain assignment (not in an `if`) so a failed lookup trips set -e / pipefail and
-              # blocks rather than being read as "no label" and waving the merge through.
-              labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name')"
+              # Source 2 (commit-subject `(#N)`) can capture a number that is NOT a queued PR:
+              # a PR whose title ends in `(#N)` referencing the ISSUE it fixes — e.g. #4833,
+              # "fix(plugins): ... (#4828)", where 4828 is the fixed issue, not a PR. Looking up
+              # such a number with `gh pr view` fails with "Could not resolve to a PullRequest",
+              # which (as a plain assignment under set -e) used to eject a clean, label-free PR
+              # from the queue forever. Distinguish that DEFINITIVE "not a PR" (skip — it was a
+              # spurious reference) from a TRANSIENT API failure (still fail closed → block).
+              if ! labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name' 2>/tmp/pr_view_err)"; then
+                if grep -q 'Could not resolve to a PullRequest' /tmp/pr_view_err; then
+                  echo "PR #$pr: not a pull request (spurious (#N) reference, e.g. a fixed issue) — skipping."
+                  continue
+                fi
+                echo "::error::label lookup for #$pr failed — blocking merge (fail closed):"
+                cat /tmp/pr_view_err
+                exit 1
+              fi
               if printf '%s\n' "$labels" | grep -qx 'needs-validation'; then
                 echo "::error::PR #$pr still has 'needs-validation' — blocking merge."
                 exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -969,10 +969,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
-          # Resolving the queued PR via commits/<sha>/pulls is unreliable: the merge queue squashes,
-          # so the queued commits are NEW synthetic SHAs GitHub does not associate back to the PR —
-          # that found nothing and waved a needs-validation PR through (#4736). Enumerate the group's
-          # PRs from three sources and take the union (see below).
+          # Resolving the queued PR via commits/<sha>/pulls alone is unreliable: the merge queue
+          # squashes, so the queued commits are NEW synthetic SHAs GitHub does not associate back
+          # to the PR — that found nothing and waved a needs-validation PR through (#4736). So we
+          # resolve each merge-group commit to a PR from several signals, per commit (see below).
           MERGE_GROUP_REF: ${{ github.event.merge_group.head_ref }}
           BASE_SHA: ${{ github.event.merge_group.base_sha }}
           HEAD_SHA: ${{ github.event.merge_group.head_sha }}
@@ -981,53 +981,62 @@ jobs:
           if [ "$EVENT_NAME" != "merge_group" ]; then
             echo "needs-validation is gated at merge time in the merge_group context; nothing to enforce on $EVENT_NAME (PR check stays green)."
           else
-            # Enumerate EVERY PR in the group from the union of three independent sources, so a
-            # batched group (more than one PR) cannot hide an unchecked PR behind the ref tip:
-            #   1. ref `.../pr-<N>-<sha>` — names the (tip) entry; squash-safe.
-            #   2. each commit subject's trailing `(#N)` — the queue's per-entry squash commit
-            #      carries its own PR number, so this recovers the NON-tip PRs of a batched group.
+            # Resolve EVERY merge-group commit to at least one real PR and check its labels.
+            # Each queued entry can be recovered from up to three signals:
+            #   1. ref `.../pr-<N>-<sha>` — names the (tip) entry only; squash-safe.
+            #   2. the commit subject's trailing `(#N)` — the queue appends each entry's own PR
+            #      number, so this recovers the NON-tip PRs of a batched group.
             #   3. commits/<sha>/pulls — covers a non-squash queue where commits map back directly.
-            # Sources 2/3 depend on the compare API. Capture it in a REQUIRED assignment (no
-            # `|| true`) so an API failure trips set -e and blocks — otherwise an empty result would
-            # silently fall back to the ref tip and merge a batched needs-validation PR unchecked.
-            # Only grep no-match (an empty set within a SUCCESSFUL response) is tolerated.
+            # A `(#N)` can also be a spurious reference — e.g. #4833, titled "... (#4828)", where
+            # 4828 is the fixed ISSUE, not a PR; `gh pr view 4828` then fails with "Could not
+            # resolve to a PullRequest". We must NOT fail closed on that (it ejected a clean,
+            # label-free PR from the queue forever) — but we must also NOT blindly skip it, or a
+            # batched non-tip PR whose only recovered number is such a reference would go unchecked
+            # and a needs-validation entry could slip through (#4736). So we resolve PER COMMIT:
+            # ignore a non-PR candidate only when its commit is still covered by another candidate
+            # that DOES resolve to a real PR; a commit that resolves to no PR fails closed.
             compare_json="$(gh api "repos/$REPO/compare/$BASE_SHA...$HEAD_SHA")"
             ref_prs="$(printf '%s\n' "$MERGE_GROUP_REF" | grep -oE 'pr-[0-9]+' | grep -oE '[0-9]+' || true)"
-            msg_prs="$(printf '%s' "$compare_json" | jq -r '.commits[].commit.message | split("\n")[0]' | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' || true)"
-            assoc_prs=""
-            for s in $(printf '%s' "$compare_json" | jq -r '.commits[].sha'); do
-              pulls="$(gh api "repos/$REPO/commits/$s/pulls" --jq '.[].number')"   # required; failure blocks
-              assoc_prs="$(printf '%s\n%s\n' "$assoc_prs" "$pulls")"
-            done
-            prs="$(printf '%s\n%s\n%s\n' "$ref_prs" "$msg_prs" "$assoc_prs" | grep -E '^[0-9]+$' | sort -u || true)"
-            if [ -z "$prs" ]; then
-              echo "::error::could not resolve any PR from merge_group ref '$MERGE_GROUP_REF' / commits — blocking merge (fail closed)."
+            commit_shas="$(printf '%s' "$compare_json" | jq -r '.commits[].sha')"
+            if [ -z "$commit_shas" ]; then
+              echo "::error::merge_group compare $BASE_SHA...$HEAD_SHA returned no commits — cannot resolve queued PRs; blocking merge (fail closed)."
               exit 1
             fi
-            for pr in $prs; do
-              # Source 2 (commit-subject `(#N)`) can capture a number that is NOT a queued PR:
-              # a PR whose title ends in `(#N)` referencing the ISSUE it fixes — e.g. #4833,
-              # "fix(plugins): ... (#4828)", where 4828 is the fixed issue, not a PR. Looking up
-              # such a number with `gh pr view` fails with "Could not resolve to a PullRequest",
-              # which (as a plain assignment under set -e) used to eject a clean, label-free PR
-              # from the queue forever. Distinguish that DEFINITIVE "not a PR" (skip — it was a
-              # spurious reference) from a TRANSIENT API failure (still fail closed → block).
-              if ! labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name' 2>/tmp/pr_view_err)"; then
-                if grep -q 'Could not resolve to a PullRequest' /tmp/pr_view_err; then
-                  echo "PR #$pr: not a pull request (spurious (#N) reference, e.g. a fixed issue) — skipping."
-                  continue
+            checked=""
+            for sha in $commit_shas; do
+              subject="$(printf '%s' "$compare_json" | jq -r --arg s "$sha" '.commits[] | select(.sha==$s) | .commit.message | split("\n")[0]')"
+              subj_prs="$(printf '%s' "$subject" | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' || true)"
+              # Required assignment (no `|| true`): a transient API failure must block, not
+              # silently shrink this commit's candidate set.
+              assoc_prs="$(gh api "repos/$REPO/commits/$sha/pulls" --jq '.[].number')"
+              ref_for_commit=""
+              [ "$sha" = "$HEAD_SHA" ] && ref_for_commit="$ref_prs"
+              candidates="$(printf '%s\n%s\n%s\n' "$subj_prs" "$assoc_prs" "$ref_for_commit" | grep -E '^[0-9]+$' | sort -u || true)"
+              covered=0
+              for pr in $candidates; do
+                if ! labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name' 2>/tmp/pr_view_err)"; then
+                  if grep -q 'Could not resolve to a PullRequest' /tmp/pr_view_err; then
+                    echo "commit $sha: candidate #$pr is not a pull request (e.g. an issue reference) — ignoring this candidate."
+                    continue
+                  fi
+                  echo "::error::label lookup for #$pr (commit $sha) failed — blocking merge (fail closed):"
+                  cat /tmp/pr_view_err
+                  exit 1
                 fi
-                echo "::error::label lookup for #$pr failed — blocking merge (fail closed):"
-                cat /tmp/pr_view_err
+                covered=1
+                case " $checked " in *" $pr "*) ;; *) checked="$checked $pr";; esac
+                if printf '%s\n' "$labels" | grep -qx 'needs-validation'; then
+                  echo "::error::PR #$pr still has 'needs-validation' — blocking merge."
+                  exit 1
+                fi
+                echo "PR #$pr: no needs-validation label."
+              done
+              if [ "$covered" -eq 0 ]; then
+                echo "::error::merge-group commit $sha resolved to no pull request (candidates: ${candidates:-none}) — cannot verify needs-validation; blocking merge (fail closed)."
                 exit 1
               fi
-              if printf '%s\n' "$labels" | grep -qx 'needs-validation'; then
-                echo "::error::PR #$pr still has 'needs-validation' — blocking merge."
-                exit 1
-              fi
-              echo "PR #$pr: no needs-validation label."
             done
-            echo "No 'needs-validation' label in the queued group ($prs) — clear to merge."
+            echo "No 'needs-validation' label in the queued group ($checked ) — clear to merge."
           fi
 
   runtime_summary:


### PR DESCRIPTION
## Why

PR #4833 (titled \`fix(plugins): ... (#4828)\`, fixing issue #4828) has **no \`needs-validation\` label**, is **APPROVED** and **CLEAN**, yet keeps getting **ejected from the merge queue**.

Root cause: the merge_group \`needs-validation\` gate (Validate workspace → "Block merge while the needs-validation label is present") enumerates the queued PRs from three sources. **Source 2** scrapes a trailing \`(#N)\` from each commit subject to recover non-tip PRs of a batched group. But that \`(#N)\` was the **issue reference** in the author's title — \`#4828\` is an **issue**, not a PR. The gate then ran \`gh pr view 4828\` as a plain assignment under \`set -e\`, which fails with \`Could not resolve to a PullRequest\` → step exits 1 → the clean PR is kicked out of the queue and can **never land** while its title carries that reference.

Failing run: https://github.com/nexu-io/open-design/actions/runs/28372983724/job/84056764556

## What users will see

No user-facing change. This only affects the merge-queue admission gate: PRs whose title references a fixed issue as \`(#N)\` will no longer be falsely ejected from the queue. Contributors stop seeing clean, approved PRs mysteriously dropped from the merge queue.

## Surface area

**None** — workflow-only change (\`.github/workflows/ci.yml\`); no runtime/product code, no new user-visible surface.

## Fix

In the per-PR loop, distinguish a **definitive "not a PR"** (\`Could not resolve to a PullRequest\` → skip; it was a spurious \`(#N)\` reference such as a fixed issue) from a **transient API failure** (still fail closed → block). Real \`needs-validation\` PRs are still enforced; issue references no longer eject clean merges.

## Validation

- \`ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"\` → OK
- \`bash -n\` on the step script → OK
- Mocked \`gh\` functional test of the loop:
  - #4828 (issue, "Could not resolve") + #4833 (clean) → skips 4828, **clears to merge** ✅
  - clean PR + a PR with \`needs-validation\` → **blocks** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)