### PR TITLE
chore(release): bump main to 0.12.1 ahead of stable 0.12.0

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "description": "Open Design renderer host bridge protocol.",

--- a/packages/launcher-proto/package.json
+++ b/packages/launcher-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/launcher-proto",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/release",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "description": "Open Design release domain primitives.",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-release",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

**Author's use case:** I went to reproduce tomorrow's 09:00 (Asia/Shanghai) auto beta build before it fires, so the nightly Feishu card doesn't fail again.

**Pain being addressed:** The scheduled daily beta (`notify-daily-feishu.yml`, cron `0 1 * * *` → reuses `release-beta.yml` from `main`) has failed **every morning since 2026-06-27**. Root cause: stable shipped **0.12.0** (tag `open-design-v0.12.0`, 2026-06-26) but `main`'s packaged base version stayed at **0.11.1**. `release-beta`'s metadata guard (`tools/release/src/metadata/prepare-beta.ts`) requires the packaged base version to be **strictly greater** than the latest stable, so the `metadata` job dies before any platform builds with:

```
[release-beta] packaged base version 0.11.1 must be strictly greater than latest stable 0.12.0
```

The beta feed has been stuck at `0.11.1-beta.16` since then. This is the same trap documented for the 0.10.1→0.10.2 lockstep bump (#4387): once a stable release lands, `main` must continue to lead it.

## What I changed

Bumped all **18 workspace `package.json` versions** in lockstep from `0.11.1` → `0.12.1` (root, `apps/*`, `packages/*`, `tools/*`, `e2e`). No lockfile change — all internal deps use the `workspace:` protocol (matches the #39cad2b8a 0.11.0 bump precedent, which also left `pnpm-lock.yaml` untouched). No source/test changes — `packaged-smoke-workflow.test.ts` uses synthetic stable fixtures and reads the packaged version dynamically, so it is version-agnostic.

## What users will see

Nothing user-facing changes. The next daily beta will build and publish `0.12.1-beta.1` and the Feishu card will post again instead of failing silently.

## Verification

Ran the **real** `prepare-beta` guard against the live stable/beta feeds:

- Before (0.11.1): `packaged base version 0.11.1 must be strictly greater than latest stable 0.12.0` → exit 1 (this is what fails at 09:00).
- After (0.12.1): resolves `base version: 0.12.1`, `beta version: 0.12.1-beta.1`, `latest stable: 0.12.0` → exit 0.

## Surface area

- [x] Release/version metadata (18 workspace `package.json` version fields)

> No CLI/UI/contract/i18n/dependency surface touched — this is a pure lockstep version bump to satisfy the release-beta guard.

## Note on red spec

The failure is environmental (depends on live git tags + R2 feed state), not reproducible by a hermetic unit test — the existing `prepare-beta` guard tests use synthetic stable fixtures (`stableVersion: 0.0.1`) and so always pass regardless of the real version skew. Encoding "main must lead the real latest stable" as a test would couple CI to live release state; flagging here rather than adding a brittle spec.

⚠️ Time-sensitive: needs to merge before **2026-06-30 01:00 UTC** to unblock the next scheduled beta.