### PR TITLE
[codex] Add BYOK provider presets

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -803,6 +803,14 @@ function inspectProviderCompletion(
     };
   }
 
+  if (protocol === 'bedrock') {
+    return {
+      valid: false,
+      kind: 'unknown',
+      detail: 'AWS Bedrock BYOK connection tests need AWS credential signing, which is not supported by the current API-key smoke test.',
+    };
+  }
+
   return { valid: false };
 }
 
@@ -1204,6 +1212,10 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         },
       };
     }
+    case 'bedrock':
+      throw new Error(
+        'AWS Bedrock BYOK requires AWS credential signing; the current provider smoke test only supports API-key based providers.',
+      );
     default:
       throw new Error(`Unknown protocol: ${(input as { protocol?: string }).protocol}`);
   }

--- a/apps/daemon/src/integrations/provider-models.ts
+++ b/apps/daemon/src/integrations/provider-models.ts
@@ -247,15 +247,6 @@ export async function listProviderModels(
   input: ProviderModelsInput,
 ): Promise<ProviderModelsResponse> {
   const start = Date.now();
-  if (input.protocol === 'bedrock') {
-    return {
-      ok: true,
-      kind: 'success',
-      latencyMs: Date.now() - start,
-      models: BEDROCK_MODEL_OPTIONS,
-      detail: 'AWS Bedrock uses a static seed until AWS credential-backed discovery is available.',
-    };
-  }
   if (input.protocol === 'azure') {
     return {
       ok: false,
@@ -272,6 +263,15 @@ export async function listProviderModels(
       kind: validated.forbidden ? 'forbidden' : 'invalid_base_url',
       latencyMs: Date.now() - start,
       detail: validated.error ?? '',
+    };
+  }
+  if (input.protocol === 'bedrock') {
+    return {
+      ok: true,
+      kind: 'success',
+      latencyMs: Date.now() - start,
+      models: BEDROCK_MODEL_OPTIONS,
+      detail: 'AWS Bedrock uses a static seed until AWS credential-backed discovery is available.',
     };
   }
 

--- a/apps/daemon/src/integrations/provider-models.ts
+++ b/apps/daemon/src/integrations/provider-models.ts
@@ -18,6 +18,14 @@ type ProviderModelsInput = ProviderModelsRequest & {
 };
 
 const PROVIDER_MODELS_TIMEOUT_MS = 12_000;
+const BEDROCK_MODEL_OPTIONS: ProviderModelOption[] = [
+  { id: 'anthropic.claude-3-5-sonnet-20241022-v2:0', label: 'Claude 3.5 Sonnet v2' },
+  { id: 'anthropic.claude-3-5-haiku-20241022-v1:0', label: 'Claude 3.5 Haiku' },
+  { id: 'anthropic.claude-3-haiku-20240307-v1:0', label: 'Claude 3 Haiku' },
+  { id: 'amazon.nova-pro-v1:0', label: 'Amazon Nova Pro' },
+  { id: 'amazon.nova-lite-v1:0', label: 'Amazon Nova Lite' },
+  { id: 'amazon.nova-micro-v1:0', label: 'Amazon Nova Micro' },
+];
 
 function appendVersionedApiPath(baseUrl: string, suffix: string): string {
   const url = new URL(baseUrl);
@@ -212,6 +220,15 @@ export async function listProviderModels(
   input: ProviderModelsInput,
 ): Promise<ProviderModelsResponse> {
   const start = Date.now();
+  if (input.protocol === 'bedrock') {
+    return {
+      ok: true,
+      kind: 'success',
+      latencyMs: Date.now() - start,
+      models: BEDROCK_MODEL_OPTIONS,
+      detail: 'AWS Bedrock uses a static seed until AWS credential-backed discovery is available.',
+    };
+  }
   if (input.protocol === 'azure') {
     return {
       ok: false,

--- a/apps/daemon/src/integrations/provider-models.ts
+++ b/apps/daemon/src/integrations/provider-models.ts
@@ -92,6 +92,32 @@ function uniqueModels(models: ProviderModelOption[]): ProviderModelOption[] {
   return out.sort((a, b) => a.id.localeCompare(b.id));
 }
 
+function isOpenAiChatModelId(id: string): boolean {
+  const normalized = id.trim().toLowerCase();
+  if (!normalized) return false;
+  if (
+    normalized.includes('embedding') ||
+    normalized.includes('moderation') ||
+    normalized.includes('rerank') ||
+    normalized.includes('whisper') ||
+    normalized.includes('tts') ||
+    normalized.includes('transcribe') ||
+    normalized.includes('speech') ||
+    normalized.includes('image') ||
+    normalized.includes('video') ||
+    normalized.includes('dall-e') ||
+    normalized.includes('stable-diffusion') ||
+    normalized.includes('flux') ||
+    (
+      normalized.includes('wan') &&
+      /(?:^|[-_.:])(?:t2v|i2v|v2v)(?:[-_.:]|$)/u.test(normalized)
+    )
+  ) {
+    return false;
+  }
+  return !/(?:^|[-_.:])(?:t2i|i2i|t2v|i2v|v2v|tts|asr|ocr)(?:[-_.:]|$)/u.test(normalized);
+}
+
 function extractOpenAiModels(data: unknown): ProviderModelOption[] {
   const items = (data as { data?: unknown }).data;
   if (!Array.isArray(items)) return [];
@@ -99,6 +125,7 @@ function extractOpenAiModels(data: unknown): ProviderModelOption[] {
     items
       .map((item) => (item as { id?: unknown })?.id)
       .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      .filter(isOpenAiChatModelId)
       .map((id) => ({ id, label: id })),
   );
 }

--- a/apps/daemon/src/routes/chat.ts
+++ b/apps/daemon/src/routes/chat.ts
@@ -180,19 +180,19 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     const protocol = body.protocol;
     if (
       typeof protocol !== 'string' ||
-      !['anthropic', 'openai', 'azure', 'google', 'ollama', 'senseaudio', 'aihubmix'].includes(protocol)
+      !['anthropic', 'openai', 'azure', 'google', 'ollama', 'senseaudio', 'aihubmix', 'bedrock'].includes(protocol)
     ) {
       return sendApiError(
         res,
         400,
         'BAD_REQUEST',
-        'protocol must be one of anthropic|openai|azure|google|ollama|senseaudio|aihubmix',
+        'protocol must be one of anthropic|openai|azure|google|ollama|senseaudio|aihubmix|bedrock',
       );
     }
     // AIHubMix's catalogue (GET /api/v1/models?type=llm) is public, so its
     // model list loads without a key. Every other protocol needs the key to
     // hit its /v1/models endpoint.
-    const apiKeyRequired = protocol !== 'aihubmix';
+    const apiKeyRequired = protocol !== 'aihubmix' && protocol !== 'bedrock';
     if (
       typeof body.baseUrl !== 'string' ||
       typeof body.apiKey !== 'string' ||
@@ -258,28 +258,31 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         const protocol = body.protocol;
         if (
           typeof protocol !== 'string' ||
-          !['anthropic', 'openai', 'azure', 'google', 'ollama', 'senseaudio', 'aihubmix'].includes(protocol)
+          !['anthropic', 'openai', 'azure', 'google', 'ollama', 'senseaudio', 'aihubmix', 'bedrock'].includes(protocol)
         ) {
           return sendApiError(
             res,
             400,
             'BAD_REQUEST',
-            'protocol must be one of anthropic|openai|azure|google|ollama|senseaudio|aihubmix',
+            'protocol must be one of anthropic|openai|azure|google|ollama|senseaudio|aihubmix|bedrock',
           );
         }
+        const apiKeyRequired = protocol !== 'bedrock';
         if (
           typeof body.baseUrl !== 'string' ||
           typeof body.apiKey !== 'string' ||
           typeof body.model !== 'string' ||
           !body.baseUrl.trim() ||
-          !body.apiKey.trim() ||
+          (apiKeyRequired && !body.apiKey.trim()) ||
           !body.model.trim()
         ) {
           return sendApiError(
             res,
             400,
             'BAD_REQUEST',
-            'baseUrl, apiKey, and model are required',
+            apiKeyRequired
+              ? 'baseUrl, apiKey, and model are required'
+              : 'baseUrl and model are required',
           );
         }
         const reasoningDenial = authorizeReasoningEgress({

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -715,6 +715,58 @@ describe('POST /api/test/connection provider mode', () => {
     ).toBe(false);
   });
 
+  it('rejects malformed AWS Bedrock model-list URLs before static seeds', async () => {
+    const fetchMock = passThroughOrUpstream(() => jsonResponse({ error: 'unexpected upstream call' }, { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/provider/models`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        protocol: 'bedrock',
+        baseUrl: 'not-a-url',
+        apiKey: '',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: false,
+      kind: 'invalid_base_url',
+    });
+    expect(
+      fetchMock.mock.calls.some(
+        ([input]) => !String(input).startsWith(baseUrl),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects forbidden AWS Bedrock model-list URLs before static seeds', async () => {
+    const fetchMock = passThroughOrUpstream(() => jsonResponse({ error: 'unexpected upstream call' }, { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/provider/models`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        protocol: 'bedrock',
+        baseUrl: 'http://10.0.0.8:8080',
+        apiKey: '',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: false,
+      kind: 'forbidden',
+    });
+    expect(
+      fetchMock.mock.calls.some(
+        ([input]) => !String(input).startsWith(baseUrl),
+      ),
+    ).toBe(false);
+  });
+
   it('checks SenseAudio non-chat model availability without probing chat completions', async () => {
     const fetchMock = passThroughOrUpstream((url) => {
       if (url === 'https://api.senseaudio.cn/v1/models') {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -679,6 +679,39 @@ describe('POST /api/test/connection provider mode', () => {
     );
   });
 
+  it('returns static AWS Bedrock model seeds without calling upstream fetch', async () => {
+    const fetchMock = passThroughOrUpstream(() => jsonResponse({ error: 'unexpected upstream call' }, { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/provider/models`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        protocol: 'bedrock',
+        baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        apiKey: '',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      kind: 'success',
+    });
+    expect(body.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        }),
+      ]),
+    );
+    expect(
+      fetchMock.mock.calls.some(
+        ([input]) => !String(input).startsWith(baseUrl),
+      ),
+    ).toBe(false);
+  });
+
   it('checks SenseAudio non-chat model availability without probing chat completions', async () => {
     const fetchMock = passThroughOrUpstream((url) => {
       if (url === 'https://api.senseaudio.cn/v1/models') {
@@ -774,6 +807,36 @@ describe('POST /api/test/connection provider mode', () => {
       'https://api.senseaudio.cn/v1/chat/completions',
       expect.objectContaining({ method: 'POST' }),
     );
+  });
+
+  it('reports AWS Bedrock connection tests as unsupported without calling upstream fetch', async () => {
+    const fetchMock = passThroughOrUpstream(() => jsonResponse({ error: 'unexpected upstream call' }, { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'bedrock',
+        baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        apiKey: '',
+        model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: false,
+      kind: 'unknown',
+      model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    });
+    expect(String(body.detail)).toContain('AWS Bedrock BYOK requires AWS credential signing');
+    expect(
+      fetchMock.mock.calls.some(
+        ([input]) => !String(input).startsWith(baseUrl),
+      ),
+    ).toBe(false);
   });
 
   it('maps a 404 to not_found_model', async () => {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -204,6 +204,9 @@ describe('POST /api/provider/models', () => {
           { id: 'gpt-4o-mini', object: 'model' },
           { id: 'gpt-4o', object: 'model' },
           { id: 'gpt-4o', object: 'model' },
+          { id: 'wan2-1-14b-t2v-250225', object: 'model' },
+          { id: 'text-embedding-3-large', object: 'model' },
+          { id: 'dall-e-3', object: 'model' },
         ],
       });
     });

--- a/apps/web/src/analytics/byok-run.ts
+++ b/apps/web/src/analytics/byok-run.ts
@@ -42,6 +42,8 @@ export function byokAgentProviderId(
       return 'ollama_cloud';
     case 'senseaudio':
       return 'senseaudio';
+    case 'bedrock':
+      return 'other';
     default:
       return 'other';
   }

--- a/apps/web/src/components/MemoryModelInline.tsx
+++ b/apps/web/src/components/MemoryModelInline.tsx
@@ -129,6 +129,12 @@ function chatProtocolFromAgent(
   return null;
 }
 
+function memoryProviderFromApiProtocol(
+  protocol: ApiProtocol,
+): MemoryExtractionProvider | null {
+  return protocol === 'bedrock' ? null : protocol;
+}
+
 function cliAgentLabel(agentId: string | null | undefined): string | null {
   if (!agentId) return null;
   const id = agentId.trim().toLowerCase();
@@ -225,8 +231,9 @@ export function MemoryModelInline({
   // derived from the agent id (claude → anthropic, codex → openai,
   // …), while the "Same as chat" default can still run the selected
   // local CLI directly on daemon-supported adapters.
+  const apiMemoryProvider = memoryProviderFromApiProtocol(apiProtocol);
   const effectiveChatProtocol: MemoryExtractionProvider | null =
-    mode === 'api' ? apiProtocol : chatProtocolFromAgent(cliAgentId);
+    mode === 'api' ? apiMemoryProvider : chatProtocolFromAgent(cliAgentId);
   const sameAsChatCliLabel =
     mode === 'daemon' ? cliAgentLabel(cliAgentId) : null;
 
@@ -273,8 +280,12 @@ export function MemoryModelInline({
     (modelId: string): MemoryExtractionConfigShape => {
       const trimmedModel = modelId.trim();
       if (mode === 'api') {
+        const provider = memoryProviderFromApiProtocol(apiProtocol);
+        if (!provider) {
+          throw new Error('Memory extraction is not available for AWS Bedrock BYOK yet.');
+        }
         return {
-          provider: apiProtocol,
+          provider,
           model: trimmedModel,
           baseUrl: chatBaseUrl.trim(),
           apiKey: chatApiKey,
@@ -342,6 +353,7 @@ export function MemoryModelInline({
   // so we don't spam PATCH /api/memory/config on every character.
   useEffect(() => {
     if (mode !== 'api') return;
+    if (!apiMemoryProvider) return;
     if (busy) return;
     if (customEditing) return;
     if (!config || !config.model) return;
@@ -349,7 +361,7 @@ export function MemoryModelInline({
     const newTail = (chatApiKey || '').slice(-4);
     const azureVersion = apiProtocol === 'azure' ? chatApiVersion.trim() : '';
     const drift =
-      config.provider !== apiProtocol
+      config.provider !== apiMemoryProvider
       || config.baseUrl !== trimmedBaseUrl
       || config.apiVersion !== azureVersion
       || config.apiKeyTail !== newTail;
@@ -361,6 +373,7 @@ export function MemoryModelInline({
   }, [
     mode,
     apiProtocol,
+    apiMemoryProvider,
     chatApiKey,
     chatBaseUrl,
     chatApiVersion,
@@ -388,18 +401,20 @@ export function MemoryModelInline({
         setCustomDraft(savedModel || '');
         return;
       }
+      if (mode === 'api' && !apiMemoryProvider) return;
       setCustomEditing(false);
       await persist(buildOverride(value));
     },
-    [persist, buildOverride, savedModel],
+    [mode, apiMemoryProvider, persist, buildOverride, savedModel],
   );
 
   const onSaveCustom = useCallback(async () => {
     const trimmed = customDraft.trim();
     if (!trimmed) return;
+    if (mode === 'api' && !apiMemoryProvider) return;
     await persist(buildOverride(trimmed));
     setCustomEditing(false);
-  }, [customDraft, persist, buildOverride]);
+  }, [customDraft, mode, apiMemoryProvider, persist, buildOverride]);
 
   // Stable unique id for the labelling span so multiple instances of
   // this picker (or instances rendered alongside other Memory pickers)
@@ -469,7 +484,7 @@ export function MemoryModelInline({
         popoverClassName="settings-byok-select-popover"
         models={selectOptions}
         value={selectValue}
-        disabled={busy}
+        disabled={busy || (mode === 'api' && !apiMemoryProvider)}
         onChange={(value) => void onSelectChange(value)}
       />
       {customActive ? (

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -796,6 +796,23 @@ function currentApiProtocolConfig(config: AppConfig): ApiProtocolConfig {
   };
 }
 
+function persistByokProviderConfigDraft(
+  config: AppConfig,
+  draftKey: string,
+  apiConfig: ApiProtocolConfig,
+): AppConfig {
+  return {
+    ...config,
+    byokProviderConfigDrafts: {
+      ...(config.byokProviderConfigDrafts ?? {}),
+      [draftKey]: {
+        apiConfig,
+        maxTokens: config.maxTokens,
+      },
+    },
+  };
+}
+
 function byokProviderDraftKey(
   protocol: ApiProtocol,
   apiProviderBaseUrl: string | null | undefined,
@@ -1116,6 +1133,7 @@ export function sanitizeSettingsSavePayload(
     apiProtocol: initial.apiProtocol,
     apiVersion: initial.apiVersion,
     apiProtocolConfigs: initial.apiProtocolConfigs,
+    byokProviderConfigDrafts: initial.byokProviderConfigDrafts,
     apiProviderBaseUrl: initial.apiProviderBaseUrl,
     baseUrl: initial.baseUrl,
     model: initial.model,
@@ -1707,12 +1725,13 @@ export function SettingsDialog({
   };
   const setByokProvider = (provider: ByokProviderPreset) => {
     const currentDraftKey = byokProviderKeyForConfig(cfg);
+    const currentApiConfig = currentApiProtocolConfig(cfg);
     if ((cfg.apiProviderBaseUrl ?? null) === null) {
       lastCustomByokProviderDraftKeysRef.current[cfg.apiProtocol ?? 'anthropic'] =
         currentDraftKey;
     }
     byokProviderFormDraftsRef.current[currentDraftKey] = {
-      apiConfig: currentApiProtocolConfig(cfg),
+      apiConfig: currentApiConfig,
       maxTokens: cfg.maxTokens,
       maxTokensInput,
       providerModelsCommittedKey,
@@ -1748,6 +1767,9 @@ export function SettingsDialog({
       const savedDraft = nextProviderDraftKey
         ? byokProviderFormDraftsRef.current[nextProviderDraftKey]
         : undefined;
+      const persistedDraft = nextProviderDraftKey
+        ? current.byokProviderConfigDrafts?.[nextProviderDraftKey]
+        : undefined;
       const applyDraftUiState = (draft: ByokProviderFormDraft | undefined) => {
         setShowApiKey(draft?.showApiKey ?? false);
         setApiModelCustomEditing(draft?.apiModelCustomEditing ?? false);
@@ -1763,22 +1785,47 @@ export function SettingsDialog({
       if (savedDraft) {
         applyDraftUiState(savedDraft);
         return applyApiProtocolConfig(
-          {
-            ...switched,
-            maxTokens: savedDraft.maxTokens,
-          },
+          persistByokProviderConfigDraft(
+            {
+              ...switched,
+              maxTokens: savedDraft.maxTokens,
+            },
+            currentDraftKey,
+            currentApiProtocolConfig(current),
+          ),
           provider.protocol,
           savedDraft.apiConfig,
         );
       }
-      applyDraftUiState(undefined);
+      if (persistedDraft) {
+        applyDraftUiState(undefined);
+        return applyApiProtocolConfig(
+          persistByokProviderConfigDraft(
+            {
+              ...switched,
+              maxTokens: persistedDraft.maxTokens,
+            },
+            currentDraftKey,
+            currentApiProtocolConfig(current),
+          ),
+          provider.protocol,
+          persistedDraft.apiConfig,
+        );
+      }
+      const switchedWithCurrentDraft = persistByokProviderConfigDraft(
+        switched,
+        currentDraftKey,
+        currentApiProtocolConfig(current),
+      );
       if (provider.custom) {
-        return updateCurrentApiProtocolConfig(switched, {
+        applyDraftUiState(undefined);
+        return updateCurrentApiProtocolConfig(switchedWithCurrentDraft, {
           apiProviderBaseUrl: null,
           ...(providerChanged ? { model: '' } : {}),
         });
       }
-      return updateCurrentApiProtocolConfig(switched, {
+      applyDraftUiState(undefined);
+      return updateCurrentApiProtocolConfig(switchedWithCurrentDraft, {
         ...(providerChanged ? { apiKey: '' } : {}),
         baseUrl: provider.baseUrl,
         model: provider.model,

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -72,6 +72,8 @@ import {
 import type { KnownProvider } from '../state/config';
 import { navigate as navigateRoute, useRoute } from '../router';
 import {
+  API_PROTOCOL_TABS,
+  DEFAULT_BASE_URL_BY_PROTOCOL,
   API_PROTOCOL_LABELS,
   isFixedOriginGateway,
   resolveFixedOriginBaseUrl,
@@ -2490,11 +2492,37 @@ export function SettingsDialog({
       custom: true,
     },
   ];
-  const customByokProvider = byokProviderPresets[byokProviderPresets.length - 1];
+  const customByokProvider = byokProviderPresets.find((provider) => provider.custom) ?? {
+    id: 'custom',
+    title: t('settings.customProvider'),
+    protocol: apiProtocol,
+    baseUrl: cfg.baseUrl,
+    model: cfg.model,
+    custom: true,
+  };
+  const byokPresetProtocols = new Set(
+    byokProviderPresets
+      .filter((provider) => !provider.custom)
+      .map((provider) => provider.protocol),
+  );
+  const byokProviderOptions: ReadonlyArray<ByokProviderPreset> = [
+    ...byokProviderPresets.filter((provider) => !provider.custom),
+    ...API_PROTOCOL_TABS.filter((tab) => !byokPresetProtocols.has(tab.id)).map((tab) => {
+      const fallback = defaultApiProtocolConfig(tab.id);
+      return {
+        id: `protocol-${tab.id}`,
+        title: tab.title,
+        protocol: tab.id,
+        baseUrl: fallback.baseUrl || DEFAULT_BASE_URL_BY_PROTOCOL[tab.id],
+        model: fallback.model || SUGGESTED_MODELS_BY_PROTOCOL[tab.id][0] || '',
+      };
+    }),
+    customByokProvider,
+  ];
   const selectedByokProvider =
     cfg.apiProviderBaseUrl === null
       ? customByokProvider
-      : byokProviderPresets.find(
+      : byokProviderOptions.find(
         (provider) =>
           !provider.custom &&
           provider.protocol === apiProtocol &&
@@ -3750,7 +3778,7 @@ export function SettingsDialog({
                 >
                   <div className="protocol-chip-group protocol-chip-group--providers">
                     <div className="protocol-chip-group-options">
-                      {byokProviderPresets.map((provider) => {
+                      {byokProviderOptions.map((provider) => {
                         const active = selectedByokProvider?.id === provider.id;
                         const configured = byokProviderConfigured(provider);
                         const statusLabel = configured

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3746,7 +3746,7 @@ export function SettingsDialog({
                 <div
                   className="protocol-chips protocol-chips--providers"
                   role="tablist"
-                  aria-label={t('settings.quickFillProvider')}
+                  aria-label={t('settings.protocolAria')}
                 >
                   <div className="protocol-chip-group protocol-chip-group--providers">
                     <div className="protocol-chip-group-options">
@@ -3762,6 +3762,7 @@ export function SettingsDialog({
                             type="button"
                             role="tab"
                             aria-selected={active}
+                            aria-label={provider.title}
                             className={'protocol-chip protocol-chip--provider' + (active ? ' active' : '')}
                             title={`${provider.title} - ${statusLabel}`}
                             onClick={() => {
@@ -3786,7 +3787,6 @@ export function SettingsDialog({
                               aria-hidden
                             />
                             <span>{provider.title}</span>
-                            <VisuallyHidden>{statusLabel}</VisuallyHidden>
                           </button>
                         );
                       })}

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -785,6 +785,14 @@ function currentApiProtocolConfig(config: AppConfig): ApiProtocolConfig {
   };
 }
 
+function byokProviderDraftKey(
+  protocol: ApiProtocol,
+  apiProviderBaseUrl: string | null | undefined,
+  baseUrl: string,
+): string {
+  return `${protocol}:${apiProviderBaseUrl ?? `custom:${baseUrl}`}`;
+}
+
 function applyApiProtocolConfig(
   config: AppConfig,
   protocol: ApiProtocol,
@@ -846,7 +854,9 @@ export function updateCurrentApiProtocolConfig(
   const nextApiConfig: ApiProtocolConfig = {
     ...currentApiProtocolConfig(config),
     ...patch,
-    ...(clearedApiKey && defaultModel ? { model: defaultModel } : {}),
+    ...(clearedApiKey && defaultModel && patch.model === undefined
+      ? { model: defaultModel }
+      : {}),
   };
   return applyApiProtocolConfig(
     {
@@ -1224,6 +1234,7 @@ export function SettingsDialog({
     };
   }, []);
   const [showApiKey, setShowApiKey] = useState(false);
+  const byokProviderApiKeyDraftsRef = useRef<Record<string, string>>({});
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
   const [settingsSidebarCollapsed, setSettingsSidebarCollapsed] = useState(false);
   const [settingsFullscreen, setSettingsFullscreen] = useState(false);
@@ -1666,16 +1677,44 @@ export function SettingsDialog({
   };
   const setByokProvider = (provider: ByokProviderPreset) => {
     setApiModelCustomEditing(false);
+    setShowApiKey(false);
     apiModelUserSelectedRef.current = false;
     focusByokRequiredFieldAfterProtocolSwitchRef.current = !provider.custom;
     setCfg((current) => {
+      const currentApiConfig = currentApiProtocolConfig(current);
+      const currentProtocol = current.apiProtocol ?? 'anthropic';
+      const currentProviderDraftKey = byokProviderDraftKey(
+        currentProtocol,
+        currentApiConfig.apiProviderBaseUrl,
+        currentApiConfig.baseUrl,
+      );
+      byokProviderApiKeyDraftsRef.current[currentProviderDraftKey] =
+        currentApiConfig.apiKey;
+      const nextProviderBaseUrl = provider.custom ? null : provider.baseUrl;
+      const providerChanged = provider.custom
+        ? currentApiConfig.apiProviderBaseUrl !== null
+        : currentProtocol !== provider.protocol ||
+          currentApiConfig.apiProviderBaseUrl !== nextProviderBaseUrl;
       const switched = switchApiProtocolConfig(current, provider.protocol);
+      const switchedApiConfig = currentApiProtocolConfig(switched);
+      const nextProviderDraftKey = byokProviderDraftKey(
+        provider.protocol,
+        nextProviderBaseUrl,
+        provider.custom ? switchedApiConfig.baseUrl : provider.baseUrl,
+      );
+      const scopedApiKey =
+        byokProviderApiKeyDraftsRef.current[nextProviderDraftKey] ??
+        (switchedApiConfig.apiProviderBaseUrl === nextProviderBaseUrl
+          ? switchedApiConfig.apiKey
+          : '');
       if (provider.custom) {
         return updateCurrentApiProtocolConfig(switched, {
+          ...(providerChanged ? { apiKey: scopedApiKey } : {}),
           apiProviderBaseUrl: null,
         });
       }
       return updateCurrentApiProtocolConfig(switched, {
+        ...(providerChanged ? { apiKey: scopedApiKey } : {}),
         baseUrl: provider.baseUrl,
         model: provider.model,
         apiProviderBaseUrl: provider.baseUrl,

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2336,17 +2336,24 @@ export function SettingsDialog({
     },
     {
       id: 'google-ai-studio',
-      title: 'Google AI Studio',
+      title: 'Google Gemini',
       protocol: 'google',
       baseUrl: 'https://generativelanguage.googleapis.com',
       model: 'gemini-3.5-flash',
     },
     {
       id: 'ollama',
-      title: 'Ollama',
+      title: 'Ollama Cloud',
       protocol: 'ollama',
-      baseUrl: 'http://localhost:11434',
-      model: 'gemma3:4b',
+      baseUrl: 'https://ollama.com',
+      model: 'gpt-oss:120b',
+    },
+    {
+      id: 'azure',
+      title: 'Azure OpenAI',
+      protocol: 'azure',
+      baseUrl: '',
+      model: '',
     },
     {
       id: 'siliconflow',

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -377,6 +377,17 @@ type ProviderModelsState =
   | { status: 'running'; cacheKey: string }
   | { status: 'done'; cacheKey: string; result: ProviderModelsResponse };
 
+interface ByokProviderFormDraft {
+  apiConfig: ApiProtocolConfig;
+  maxTokensInput: string;
+  maxTokens: AppConfig['maxTokens'];
+  providerModelsCommittedKey: string | null;
+  providerModelsState: ProviderModelsState;
+  showApiKey: boolean;
+  apiModelCustomEditing: boolean;
+  apiModelUserSelected: boolean;
+}
+
 type ByokRequiredField = ByokDraftField;
 type ByokPreconditionAction = 'test';
 type ByokFieldMissing = 'api_key' | 'base_url' | 'model' | 'multiple' | 'none';
@@ -791,6 +802,15 @@ function byokProviderDraftKey(
   baseUrl: string,
 ): string {
   return `${protocol}:${apiProviderBaseUrl ?? `custom:${baseUrl}`}`;
+}
+
+function byokProviderKeyForConfig(config: AppConfig): string {
+  const apiConfig = currentApiProtocolConfig(config);
+  return byokProviderDraftKey(
+    config.apiProtocol ?? 'anthropic',
+    apiConfig.apiProviderBaseUrl,
+    apiConfig.baseUrl,
+  );
 }
 
 function applyApiProtocolConfig(
@@ -1234,7 +1254,12 @@ export function SettingsDialog({
     };
   }, []);
   const [showApiKey, setShowApiKey] = useState(false);
-  const byokProviderApiKeyDraftsRef = useRef<Record<string, string>>({});
+  const byokProviderFormDraftsRef = useRef<Record<string, ByokProviderFormDraft>>({});
+  const lastCustomByokProviderDraftKeysRef = useRef<Partial<Record<ApiProtocol, string>>>(
+    (initial.apiProviderBaseUrl ?? null) === null
+      ? { [initial.apiProtocol ?? 'anthropic']: byokProviderKeyForConfig(initial) }
+      : {},
+  );
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
   const [settingsSidebarCollapsed, setSettingsSidebarCollapsed] = useState(false);
   const [settingsFullscreen, setSettingsFullscreen] = useState(false);
@@ -1467,6 +1492,7 @@ export function SettingsDialog({
   const providerModelsRevisionRef = useRef(0);
   const providerTestFirstResetRef = useRef(true);
   const providerModelsFirstResetRef = useRef(true);
+  const providerModelsSkipNextResetRef = useRef(false);
   const deferAfterKeyCleanRef = useRef(false);
   const providerAutoTestKeyRef = useRef<string | null>(null);
   const byokLastUnsuccessfulTestKeyRef = useRef<string | null>(null);
@@ -1631,6 +1657,10 @@ export function SettingsDialog({
       providerModelsFirstResetRef.current = false;
       return;
     }
+    if (providerModelsSkipNextResetRef.current) {
+      providerModelsSkipNextResetRef.current = false;
+      return;
+    }
     providerModelsRevisionRef.current += 1;
     providerModelsAbortRef.current?.abort();
     providerModelsAbortRef.current = null;
@@ -1676,45 +1706,80 @@ export function SettingsDialog({
     });
   };
   const setByokProvider = (provider: ByokProviderPreset) => {
-    setApiModelCustomEditing(false);
-    setShowApiKey(false);
-    apiModelUserSelectedRef.current = false;
+    const currentDraftKey = byokProviderKeyForConfig(cfg);
+    if ((cfg.apiProviderBaseUrl ?? null) === null) {
+      lastCustomByokProviderDraftKeysRef.current[cfg.apiProtocol ?? 'anthropic'] =
+        currentDraftKey;
+    }
+    byokProviderFormDraftsRef.current[currentDraftKey] = {
+      apiConfig: currentApiProtocolConfig(cfg),
+      maxTokens: cfg.maxTokens,
+      maxTokensInput,
+      providerModelsCommittedKey,
+      providerModelsState,
+      showApiKey,
+      apiModelCustomEditing,
+      apiModelUserSelected: apiModelUserSelectedRef.current,
+    };
+    const nextProviderBaseUrlForCurrent = provider.custom ? null : provider.baseUrl;
+    const providerChangedBeforeSwitch = provider.custom
+      ? (cfg.apiProviderBaseUrl ?? null) !== null
+      : (cfg.apiProtocol ?? 'anthropic') !== provider.protocol ||
+        (cfg.apiProviderBaseUrl ?? null) !== nextProviderBaseUrlForCurrent;
     focusByokRequiredFieldAfterProtocolSwitchRef.current = !provider.custom;
+    providerModelsSkipNextResetRef.current = providerChangedBeforeSwitch;
     setCfg((current) => {
-      const currentApiConfig = currentApiProtocolConfig(current);
       const currentProtocol = current.apiProtocol ?? 'anthropic';
-      const currentProviderDraftKey = byokProviderDraftKey(
-        currentProtocol,
-        currentApiConfig.apiProviderBaseUrl,
-        currentApiConfig.baseUrl,
-      );
-      byokProviderApiKeyDraftsRef.current[currentProviderDraftKey] =
-        currentApiConfig.apiKey;
       const nextProviderBaseUrl = provider.custom ? null : provider.baseUrl;
       const providerChanged = provider.custom
-        ? currentApiConfig.apiProviderBaseUrl !== null
+        ? (current.apiProviderBaseUrl ?? null) !== null
         : currentProtocol !== provider.protocol ||
-          currentApiConfig.apiProviderBaseUrl !== nextProviderBaseUrl;
+          (current.apiProviderBaseUrl ?? null) !== nextProviderBaseUrl;
       const switched = switchApiProtocolConfig(current, provider.protocol);
-      const switchedApiConfig = currentApiProtocolConfig(switched);
-      const nextProviderDraftKey = byokProviderDraftKey(
+      const fallbackApiConfig = currentApiProtocolConfig(switched);
+      const customDraftKey = provider.custom
+        ? lastCustomByokProviderDraftKeysRef.current[provider.protocol]
+        : null;
+      const nextProviderDraftKey = customDraftKey ?? byokProviderDraftKey(
         provider.protocol,
         nextProviderBaseUrl,
-        provider.custom ? switchedApiConfig.baseUrl : provider.baseUrl,
+        provider.custom ? fallbackApiConfig.baseUrl : provider.baseUrl,
       );
-      const scopedApiKey =
-        byokProviderApiKeyDraftsRef.current[nextProviderDraftKey] ??
-        (switchedApiConfig.apiProviderBaseUrl === nextProviderBaseUrl
-          ? switchedApiConfig.apiKey
-          : '');
+      const savedDraft = nextProviderDraftKey
+        ? byokProviderFormDraftsRef.current[nextProviderDraftKey]
+        : undefined;
+      const applyDraftUiState = (draft: ByokProviderFormDraft | undefined) => {
+        setShowApiKey(draft?.showApiKey ?? false);
+        setApiModelCustomEditing(draft?.apiModelCustomEditing ?? false);
+        apiModelUserSelectedRef.current = draft?.apiModelUserSelected ?? false;
+        setMaxTokensInput(
+          draft
+            ? draft.maxTokensInput
+            : switched.maxTokens == null ? '' : String(switched.maxTokens),
+        );
+        setProviderModelsCommittedKey(draft?.providerModelsCommittedKey ?? null);
+        setProviderModelsState(draft?.providerModelsState ?? { status: 'idle' });
+      };
+      if (savedDraft) {
+        applyDraftUiState(savedDraft);
+        return applyApiProtocolConfig(
+          {
+            ...switched,
+            maxTokens: savedDraft.maxTokens,
+          },
+          provider.protocol,
+          savedDraft.apiConfig,
+        );
+      }
+      applyDraftUiState(undefined);
       if (provider.custom) {
         return updateCurrentApiProtocolConfig(switched, {
-          ...(providerChanged ? { apiKey: scopedApiKey } : {}),
           apiProviderBaseUrl: null,
+          ...(providerChanged ? { model: '' } : {}),
         });
       }
       return updateCurrentApiProtocolConfig(switched, {
-        ...(providerChanged ? { apiKey: scopedApiKey } : {}),
+        ...(providerChanged ? { apiKey: '' } : {}),
         baseUrl: provider.baseUrl,
         model: provider.model,
         apiProviderBaseUrl: provider.baseUrl,
@@ -3135,6 +3200,8 @@ export function SettingsDialog({
     ),
     [fetchedApiModelOptions, suggestedApiModelIds],
   );
+  const loadedModelDropdownCount =
+    loadedAccountModelCount > 0 ? apiModelOptions.length : 0;
   // Shared hook: live AIHubMix catalogue for aihubmix, static registry for
   // other providers (same list the chat composer's image picker uses).
   const byokImageModelOptions = useByokImageModelOptions(apiProtocol);
@@ -4849,10 +4916,16 @@ export function SettingsDialog({
                 modelsLoadedFromAccountMessage={
                   loadedAccountModelCount > 0
                     ? t(
-                        hidesAccountModelSourceLabel(apiProtocol)
+                        hidesAccountModelSourceLabel(apiProtocol) ||
+                          loadedModelDropdownCount > loadedAccountModelCount
                           ? 'settings.modelsLoadedCount'
                           : 'settings.modelsLoadedFromAccount',
-                        { count: loadedAccountModelCount },
+                        {
+                          count:
+                            loadedModelDropdownCount > loadedAccountModelCount
+                              ? loadedModelDropdownCount
+                              : loadedAccountModelCount,
+                        },
                       )
                     : null
                 }

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -445,12 +445,26 @@ export function canFetchProviderModels(
   protocol: ApiProtocol,
 ): boolean {
   return (
+    !isProviderModelDiscoveryUnsupported(protocol, config.baseUrl) &&
     protocol !== 'azure' &&
     protocol !== 'ollama' &&
     (protocol === 'bedrock' || Boolean(config.apiKey.trim())) &&
     Boolean(config.baseUrl.trim()) &&
     isValidApiBaseUrl(config.baseUrl)
   );
+}
+
+export function isProviderModelDiscoveryUnsupported(
+  protocol: ApiProtocol,
+  baseUrl: string,
+): boolean {
+  if (protocol === 'azure' || protocol === 'ollama') return true;
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === 'token-plan-cn.xiaomimimo.com';
+  } catch {
+    return false;
+  }
 }
 
 function missingByokConnectionFields(
@@ -2112,6 +2126,21 @@ export function SettingsDialog({
       }
       return;
     }
+    if (isProviderModelDiscoveryUnsupported(apiProtocol, cfg.baseUrl)) {
+      trackModelsFetchResult({
+        result: 'failed',
+        error_code: 'unsupported_provider_models',
+        error_kind: 'unsupported_provider_models',
+        duration_ms: 0,
+      });
+      if (!options.silent) {
+        setByokPreconditionNotice({
+          action: 'test',
+          message: t('settings.fetchModelsUnsupported'),
+        });
+      }
+      return;
+    }
     const modelFetchBlockingIssues = blockingByokDraftIssues(
       byokModelFetchDraftValidation,
     );
@@ -2987,7 +3016,7 @@ export function SettingsDialog({
   useEffect(() => {
     if (cfg.mode !== 'api') return;
     if (visualStabilityMode) return;
-    if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;
+    if (isProviderModelDiscoveryUnsupported(apiProtocol, cfg.baseUrl)) return;
     if (byokFirstPartyBaseUrl?.hostTypo) return;
     if (blockingByokDraftIssues(byokModelFetchDraftValidation).length > 0) return;
     // AIHubMix needs no key and prefills its base URL, so there's nothing to
@@ -4790,7 +4819,10 @@ export function SettingsDialog({
                 }
                 providerModelsFailureMessage={providerModelsFailureMessage}
                 showAzureModelFetchHint={apiProtocol === 'azure'}
-                showFetchModelsUnsupportedHint={apiProtocol === 'ollama'}
+                showFetchModelsUnsupportedHint={
+                  apiProtocol !== 'azure' &&
+                  isProviderModelDiscoveryUnsupported(apiProtocol, cfg.baseUrl)
+                }
                 showSuggestedModelsHint={apiProtocol !== 'azure' && !selectedProvider}
                 azureModelFetchHint={t('settings.azureModelFetchHint')}
                 onCustomModelChange={(value) => updateApiConfig({ model: value })}

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -73,7 +73,6 @@ import type { KnownProvider } from '../state/config';
 import { navigate as navigateRoute, useRoute } from '../router';
 import {
   API_PROTOCOL_LABELS,
-  API_PROTOCOL_TABS,
   isFixedOriginGateway,
   resolveFixedOriginBaseUrl,
   SUGGESTED_MODELS_BY_PROTOCOL,
@@ -195,6 +194,15 @@ export type SettingsSection =
   // navigate() call so openSettings only owns dialog-bound sections.
   | 'library'
   | 'about';
+
+interface ByokProviderPreset {
+  id: string;
+  title: string;
+  protocol: ApiProtocol;
+  baseUrl: string;
+  model: string;
+  custom?: boolean;
+}
 
 // One-shot focus hint when opening the dialog. `'amr'` scrolls the AMR agent
 // card into view on the execution section and plays a highlight (plus a
@@ -344,12 +352,6 @@ type TestState =
   | { status: 'running' }
   | { status: 'done'; result: ConnectionTestResponse };
 
-const GATEWAY_API_PROTOCOLS = new Set<ApiProtocol>([
-  'ollama',
-  'senseaudio',
-  'aihubmix',
-]);
-
 // Providers whose live model fetch IS their full account catalogue, so the
 // per-option "from your account" badge and the "Loaded N from your account"
 // hint are noise — every option carries the same badge and distinguishes
@@ -357,6 +359,7 @@ const GATEWAY_API_PROTOCOLS = new Set<ApiProtocol>([
 // Add a protocol here when the same applies to another provider.
 const ACCOUNT_MODEL_SOURCE_LABEL_HIDDEN = new Set<ApiProtocol>([
   'aihubmix',
+  'bedrock',
 ]);
 
 function hidesAccountModelSourceLabel(protocol: ApiProtocol): boolean {
@@ -442,7 +445,7 @@ export function canFetchProviderModels(
   return (
     protocol !== 'azure' &&
     protocol !== 'ollama' &&
-    Boolean(config.apiKey.trim()) &&
+    (protocol === 'bedrock' || Boolean(config.apiKey.trim())) &&
     Boolean(config.baseUrl.trim()) &&
     isValidApiBaseUrl(config.baseUrl)
   );
@@ -467,8 +470,9 @@ function missingByokModelFetchFields(
   const missing: ByokRequiredField[] = [];
   // AIHubMix publishes its catalogue on a public endpoint, so its model list
   // loads without a key (the user shouldn't need to paste a key just to browse
-  // models). Every other protocol fetches /v1/models behind the key.
-  if (protocol !== 'aihubmix' && !config.apiKey.trim()) missing.push('api_key');
+  // models). Bedrock uses a static model seed until AWS auth lands in BYOK.
+  // Every other protocol fetches /v1/models behind the key.
+  if (protocol !== 'aihubmix' && protocol !== 'bedrock' && !config.apiKey.trim()) missing.push('api_key');
   if (!config.baseUrl.trim()) missing.push('base_url');
   return missing;
 }
@@ -583,6 +587,10 @@ const API_KEY_CONSOLE_LINKS: Record<ApiProtocol, { host: string; url: string }> 
   aihubmix: {
     host: 'aihubmix.com',
     url: 'https://aihubmix.com/?aff=JA1e',
+  },
+  bedrock: {
+    host: 'aws.amazon.com',
+    url: 'https://aws.amazon.com/bedrock/',
   },
 };
 
@@ -1640,11 +1648,23 @@ export function SettingsDialog({
       return { ...c, mode };
     });
   };
-  const setApiProtocol = (protocol: ApiProtocol) => {
+  const setByokProvider = (provider: ByokProviderPreset) => {
     setApiModelCustomEditing(false);
     apiModelUserSelectedRef.current = false;
-    focusByokRequiredFieldAfterProtocolSwitchRef.current = true;
-    setCfg((c) => switchApiProtocolConfig(c, protocol));
+    focusByokRequiredFieldAfterProtocolSwitchRef.current = !provider.custom;
+    setCfg((current) => {
+      const switched = switchApiProtocolConfig(current, provider.protocol);
+      if (provider.custom) {
+        return updateCurrentApiProtocolConfig(switched, {
+          apiProviderBaseUrl: null,
+        });
+      }
+      return updateCurrentApiProtocolConfig(switched, {
+        baseUrl: provider.baseUrl,
+        model: provider.model,
+        apiProviderBaseUrl: provider.baseUrl,
+      });
+    });
   };
   const updateApiConfig = (patch: Partial<ApiProtocolConfig>) =>
     setCfg((c) => updateCurrentApiProtocolConfig(c, patch));
@@ -2299,18 +2319,187 @@ export function SettingsDialog({
 
   const apiProtocol = cfg.apiProtocol ?? 'anthropic';
   const apiKeyConsoleLink = API_KEY_CONSOLE_LINKS[apiProtocol];
-  const apiProtocolTabGroups = [
+  const byokProviderPresets: ReadonlyArray<ByokProviderPreset> = [
     {
-      id: 'protocols',
-      label: t('settings.protocolGroupProtocols'),
-      tabs: API_PROTOCOL_TABS.filter((tab) => !GATEWAY_API_PROTOCOLS.has(tab.id)),
+      id: 'anthropic',
+      title: 'Anthropic',
+      protocol: 'anthropic',
+      baseUrl: 'https://api.anthropic.com',
+      model: 'claude-sonnet-4-5',
     },
     {
-      id: 'gateways',
-      label: t('settings.protocolGroupGateways'),
-      tabs: API_PROTOCOL_TABS.filter((tab) => GATEWAY_API_PROTOCOLS.has(tab.id)),
+      id: 'openai',
+      title: 'OpenAI',
+      protocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+    },
+    {
+      id: 'google-ai-studio',
+      title: 'Google AI Studio',
+      protocol: 'google',
+      baseUrl: 'https://generativelanguage.googleapis.com',
+      model: 'gemini-3.5-flash',
+    },
+    {
+      id: 'ollama',
+      title: 'Ollama',
+      protocol: 'ollama',
+      baseUrl: 'http://localhost:11434',
+      model: 'gemma3:4b',
+    },
+    {
+      id: 'siliconflow',
+      title: '硅基流动',
+      protocol: 'openai',
+      baseUrl: 'https://api.siliconflow.cn/v1',
+      model: 'deepseek-ai/DeepSeek-V3.1',
+    },
+    {
+      id: 'ppio',
+      title: 'PPIO',
+      protocol: 'openai',
+      baseUrl: 'https://api.ppinfra.com/v3/openai',
+      model: 'deepseek/deepseek-v3.1',
+    },
+    {
+      id: 'nvidia',
+      title: 'NVIDIA',
+      protocol: 'openai',
+      baseUrl: 'https://integrate.api.nvidia.com/v1',
+      model: 'openai/gpt-oss-120b',
+    },
+    {
+      id: 'stepfun',
+      title: 'StepFun',
+      protocol: 'openai',
+      baseUrl: 'https://api.stepfun.ai/v1',
+      model: 'step-2-mini',
+    },
+    {
+      id: 'bedrock',
+      title: 'AWS Bedrock',
+      protocol: 'bedrock',
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    },
+    {
+      id: 'deepseek',
+      title: 'DeepSeek',
+      protocol: 'openai',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-chat',
+    },
+    {
+      id: 'openrouter',
+      title: 'OpenRouter',
+      protocol: 'openai',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'anthropic/claude-3.7-sonnet',
+    },
+    {
+      id: 'mistral',
+      title: 'Mistral AI',
+      protocol: 'openai',
+      baseUrl: 'https://api.mistral.ai/v1',
+      model: 'mistral-large-latest',
+    },
+    {
+      id: 'xai',
+      title: 'xAI',
+      protocol: 'openai',
+      baseUrl: 'https://api.x.ai/v1',
+      model: 'grok-4',
+    },
+    {
+      id: 'together',
+      title: 'Together AI',
+      protocol: 'openai',
+      baseUrl: 'https://api.together.xyz/v1',
+      model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+    },
+    {
+      id: 'huggingface',
+      title: 'Hugging Face',
+      protocol: 'openai',
+      baseUrl: 'https://router.huggingface.co/v1',
+      model: 'openai/gpt-oss-120b',
+    },
+    {
+      id: 'qwen',
+      title: '千问',
+      protocol: 'openai',
+      baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      model: 'qwen-plus',
+    },
+    {
+      id: 'volcengine',
+      title: '火山引擎',
+      protocol: 'openai',
+      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+      model: 'doubao-seed-1-6',
+    },
+    {
+      id: 'qianfan',
+      title: '百度千帆',
+      protocol: 'openai',
+      baseUrl: 'https://qianfan.baidubce.com/v2',
+      model: 'ernie-4.5-turbo-128k',
+    },
+    {
+      id: 'vllm',
+      title: 'vLLM',
+      protocol: 'openai',
+      baseUrl: 'http://127.0.0.1:8000/v1',
+      model: 'model',
+    },
+    {
+      id: 'mimo',
+      title: '小米 MiMo',
+      protocol: 'openai',
+      baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+      model: 'mimo-v2.5-pro',
+    },
+    {
+      id: 'minimax',
+      title: 'MiniMax',
+      protocol: 'anthropic',
+      baseUrl: 'https://api.minimaxi.com/anthropic',
+      model: 'MiniMax-M2.7-highspeed',
+    },
+    {
+      id: 'moonshot',
+      title: 'Moonshot',
+      protocol: 'openai',
+      baseUrl: 'https://api.moonshot.cn/v1',
+      model: 'kimi-k2-0711-preview',
+    },
+    {
+      id: 'zhipu',
+      title: '智谱',
+      protocol: 'openai',
+      baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+      model: 'glm-4.6',
+    },
+    {
+      id: 'custom',
+      title: t('settings.customProvider'),
+      protocol: apiProtocol,
+      baseUrl: cfg.baseUrl,
+      model: cfg.model,
+      custom: true,
     },
   ];
+  const customByokProvider = byokProviderPresets[byokProviderPresets.length - 1];
+  const selectedByokProvider =
+    cfg.apiProviderBaseUrl === null
+      ? customByokProvider
+      : byokProviderPresets.find(
+        (provider) =>
+          !provider.custom &&
+          provider.protocol === apiProtocol &&
+          provider.baseUrl === cfg.apiProviderBaseUrl,
+      ) ?? customByokProvider;
   const baseUrlValid = isValidApiBaseUrl(cfg.baseUrl);
   const baseUrlInvalid = Boolean(cfg.baseUrl.trim() && !baseUrlValid);
   const byokRequiredLabel = (field: ByokRequiredField): string => {
@@ -2598,6 +2787,25 @@ export function SettingsDialog({
     selectedProvider,
     cfg.baseUrl,
   );
+  const byokProviderConfigured = (provider: ByokProviderPreset): boolean => {
+    if (provider.custom) {
+      return canRunProviderConnectionTest(currentApiProtocolConfig(cfg), {
+        requiresApiKey: byokRequiresApiKey,
+      }) && isValidApiBaseUrl(cfg.baseUrl);
+    }
+    const entry = provider.protocol === apiProtocol
+      ? currentApiProtocolConfig(cfg)
+      : cfg.apiProtocolConfigs?.[provider.protocol];
+    if (!entry || entry.baseUrl !== provider.baseUrl) return false;
+    const knownProvider = KNOWN_PROVIDERS.find((item) => item.baseUrl === provider.baseUrl);
+    return canRunProviderConnectionTest(entry, {
+      requiresApiKey: byokProviderRequiresApiKey(
+        provider.protocol,
+        knownProvider,
+        entry.baseUrl,
+      ),
+    }) && isValidApiBaseUrl(entry.baseUrl);
+  };
   const byokFirstPartyBaseUrl = useMemo(
     () => byokFirstPartyBaseUrlHint(
       apiProtocol,
@@ -3536,25 +3744,28 @@ export function SettingsDialog({
               </div>
               {cfg.mode === 'api' ? (
                 <div
-                  className="protocol-chips"
+                  className="protocol-chips protocol-chips--providers"
                   role="tablist"
-                  aria-label={t('settings.protocolAria')}
+                  aria-label={t('settings.quickFillProvider')}
                 >
-                  {apiProtocolTabGroups.map((group) => (
-                    <div className="protocol-chip-group" key={group.id}>
-                      <span className="protocol-chip-group-label">
-                        {group.label}
-                      </span>
-                      <div className="protocol-chip-group-options">
-                        {group.tabs.map((tab) => (
+                  <div className="protocol-chip-group protocol-chip-group--providers">
+                    <div className="protocol-chip-group-options">
+                      {byokProviderPresets.map((provider) => {
+                        const active = selectedByokProvider?.id === provider.id;
+                        const configured = byokProviderConfigured(provider);
+                        const statusLabel = configured
+                          ? t('settings.mediaProviderConfigured')
+                          : t('settings.mediaProviderUnset');
+                        return (
                           <button
-                            key={tab.id}
+                            key={provider.id}
                             type="button"
                             role="tab"
-                            aria-selected={apiProtocol === tab.id}
-                            className={'protocol-chip' + (apiProtocol === tab.id ? ' active' : '')}
+                            aria-selected={active}
+                            className={'protocol-chip protocol-chip--provider' + (active ? ' active' : '')}
+                            title={`${provider.title} - ${statusLabel}`}
                             onClick={() => {
-                              const byokProviderId = byokProtocolToTracking(tab.id);
+                              const byokProviderId = byokProtocolToTracking(provider.protocol);
                               if (byokProviderId) {
                                 trackSettingsByokProviderOptionClick(analytics.track, {
                                   page_name: 'settings',
@@ -3562,18 +3773,25 @@ export function SettingsDialog({
                                   element: 'byok_provider_option',
                                   action: 'select_byok_provider',
                                   provider_id: byokProviderId,
-                                  is_selected: apiProtocol === tab.id,
+                                  is_selected: active,
                                 });
                               }
-                              setApiProtocol(tab.id);
+                              if (!active) {
+                                setByokProvider(provider);
+                              }
                             }}
                           >
-                            {tab.title}
+                            <span
+                              className={`protocol-chip-status${configured ? ' is-configured' : ' is-unset'}`}
+                              aria-hidden
+                            />
+                            <span>{provider.title}</span>
+                            <VisuallyHidden>{statusLabel}</VisuallyHidden>
                           </button>
-                        ))}
-                      </div>
+                        );
+                      })}
                     </div>
-                  ))}
+                  </div>
                 </div>
               ) : null}
           {cfg.mode === 'daemon' ? (

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3247,8 +3247,6 @@ export function SettingsDialog({
     ),
     [fetchedApiModelOptions, suggestedApiModelIds],
   );
-  const loadedModelDropdownCount =
-    loadedAccountModelCount > 0 ? apiModelOptions.length : 0;
   // Shared hook: live AIHubMix catalogue for aihubmix, static registry for
   // other providers (same list the chat composer's image picker uses).
   const byokImageModelOptions = useByokImageModelOptions(apiProtocol);
@@ -4963,15 +4961,11 @@ export function SettingsDialog({
                 modelsLoadedFromAccountMessage={
                   loadedAccountModelCount > 0
                     ? t(
-                        hidesAccountModelSourceLabel(apiProtocol) ||
-                          loadedModelDropdownCount > loadedAccountModelCount
+                        hidesAccountModelSourceLabel(apiProtocol)
                           ? 'settings.modelsLoadedCount'
                           : 'settings.modelsLoadedFromAccount',
                         {
-                          count:
-                            loadedModelDropdownCount > loadedAccountModelCount
-                              ? loadedModelDropdownCount
-                              : loadedAccountModelCount,
+                          count: loadedAccountModelCount,
                         },
                       )
                     : null

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3001,9 +3001,17 @@ export function SettingsDialog({
         requiresApiKey: byokRequiresApiKey,
       }) && isValidApiBaseUrl(cfg.baseUrl);
     }
-    const entry = provider.protocol === apiProtocol
+    const providerDraft = cfg.byokProviderConfigDrafts?.[
+      byokProviderDraftKey(provider.protocol, provider.baseUrl, provider.baseUrl)
+    ]?.apiConfig;
+    const activeProvider = selectedByokProvider?.id === provider.id;
+    const entry = activeProvider
       ? currentApiProtocolConfig(cfg)
-      : cfg.apiProtocolConfigs?.[provider.protocol];
+      : providerDraft ?? (
+        provider.protocol === apiProtocol
+          ? undefined
+          : cfg.apiProtocolConfigs?.[provider.protocol]
+      );
     if (!entry || entry.baseUrl !== provider.baseUrl) return false;
     const knownProvider = KNOWN_PROVIDERS.find((item) => item.baseUrl === provider.baseUrl);
     return canRunProviderConnectionTest(entry, {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2377,13 +2377,6 @@ export function SettingsDialog({
       model: 'step-2-mini',
     },
     {
-      id: 'bedrock',
-      title: 'AWS Bedrock',
-      protocol: 'bedrock',
-      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
-      model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    },
-    {
       id: 'deepseek',
       title: 'DeepSeek',
       protocol: 'openai',

--- a/apps/web/src/providers/anthropic.ts
+++ b/apps/web/src/providers/anthropic.ts
@@ -67,6 +67,12 @@ export async function streamMessage(
   if (cfg.apiProtocol === 'aihubmix') {
     return streamMessageAIHubMix(cfg, system, history, signal, handlers, context);
   }
+  if (cfg.apiProtocol === 'bedrock') {
+    handlers.onError(
+      new Error('AWS Bedrock BYOK chat requires AWS credential signing and is not supported by the current API-key proxy.'),
+    );
+    return;
+  }
   if (cfg.apiProtocol === 'openai' || (!cfg.apiProtocol && isOpenAICompatible(cfg.model, cfg.baseUrl))) {
     return streamMessageOpenAI(cfg, system, history, signal, handlers);
   }

--- a/apps/web/src/state/apiProtocols.ts
+++ b/apps/web/src/state/apiProtocols.ts
@@ -184,7 +184,6 @@ export const API_PROTOCOL_TABS: ReadonlyArray<{
   { id: 'ollama', title: 'Ollama Cloud' },
   { id: 'senseaudio', title: 'SenseAudio' },
   { id: 'aihubmix', title: 'AIHubMix' },
-  { id: 'bedrock', title: 'AWS Bedrock' },
 ];
 
 export const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {

--- a/apps/web/src/state/apiProtocols.ts
+++ b/apps/web/src/state/apiProtocols.ts
@@ -102,6 +102,14 @@ export const SUGGESTED_MODELS_BY_PROTOCOL: Record<ApiProtocol, readonly string[]
     'deepseek-chat',
     'deepseek-reasoner',
   ],
+  bedrock: [
+    'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    'anthropic.claude-3-5-haiku-20241022-v1:0',
+    'anthropic.claude-3-haiku-20240307-v1:0',
+    'amazon.nova-pro-v1:0',
+    'amazon.nova-lite-v1:0',
+    'amazon.nova-micro-v1:0',
+  ],
   ollama: [
     'cogito-2.1:671b',
     'deepseek-v3.1:671b',
@@ -162,6 +170,7 @@ export const FAST_MODEL_BY_PROTOCOL: Record<ApiProtocol, string> = {
   ollama: 'gemma3:4b',
   senseaudio: 'senseaudio-s2-flash',
   aihubmix: 'gpt-4o-mini',
+  bedrock: 'amazon.nova-lite-v1:0',
 };
 
 export const API_PROTOCOL_TABS: ReadonlyArray<{
@@ -175,6 +184,7 @@ export const API_PROTOCOL_TABS: ReadonlyArray<{
   { id: 'ollama', title: 'Ollama Cloud' },
   { id: 'senseaudio', title: 'SenseAudio' },
   { id: 'aihubmix', title: 'AIHubMix' },
+  { id: 'bedrock', title: 'AWS Bedrock' },
 ];
 
 export const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {
@@ -185,6 +195,7 @@ export const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {
   ollama: 'Ollama Cloud API',
   senseaudio: 'SenseAudio API',
   aihubmix: 'AIHubMix API',
+  bedrock: 'AWS Bedrock',
 };
 
 export const API_KEY_PLACEHOLDERS: Record<ApiProtocol, string> = {
@@ -195,6 +206,7 @@ export const API_KEY_PLACEHOLDERS: Record<ApiProtocol, string> = {
   ollama: 'Ollama API key',
   senseaudio: 'SenseAudio API key',
   aihubmix: 'sk-...',
+  bedrock: 'AWS credentials',
 };
 
 // Default base URL the daemon assumes when the user leaves the field
@@ -208,6 +220,7 @@ export const DEFAULT_BASE_URL_BY_PROTOCOL: Record<ApiProtocol, string> = {
   ollama: 'https://ollama.com',
   senseaudio: 'https://api.senseaudio.cn',
   aihubmix: 'https://aihubmix.com/v1',
+  bedrock: 'https://bedrock-runtime.us-east-1.amazonaws.com',
 };
 
 // Fixed-origin gateways: managed single-endpoint providers where the user only

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -493,6 +493,8 @@ function downgradeUnsupportedChatProtocol(config: AppConfig): void {
   }
 
   config.apiProtocol = DEFAULT_CONFIG.apiProtocol;
+  config.apiKey = DEFAULT_CONFIG.apiKey;
+  config.apiVersion = DEFAULT_CONFIG.apiVersion;
   config.baseUrl = DEFAULT_CONFIG.baseUrl;
   config.model = DEFAULT_CONFIG.model;
   config.apiProviderBaseUrl = DEFAULT_CONFIG.apiProviderBaseUrl;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -480,6 +480,24 @@ function isValidOrbitTime(time: string): boolean {
   return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
 }
 
+function isBedrockRuntimeBaseUrl(baseUrl: string): boolean {
+  return (baseUrl || '').toLowerCase().includes('bedrock-runtime');
+}
+
+function downgradeUnsupportedChatProtocol(config: AppConfig): void {
+  if (
+    config.apiProtocol !== 'bedrock'
+    && !isBedrockRuntimeBaseUrl(config.baseUrl)
+  ) {
+    return;
+  }
+
+  config.apiProtocol = DEFAULT_CONFIG.apiProtocol;
+  config.baseUrl = DEFAULT_CONFIG.baseUrl;
+  config.model = DEFAULT_CONFIG.model;
+  config.apiProviderBaseUrl = DEFAULT_CONFIG.apiProviderBaseUrl;
+}
+
 function inferApiProtocol(model: string, baseUrl: string): ApiProtocol {
   try {
     const normalized = (baseUrl || '').toLowerCase();
@@ -495,7 +513,6 @@ function inferApiProtocol(model: string, baseUrl: string): ApiProtocol {
     // APP-Code attribution header even though the wire shape is
     // OpenAI-compatible.
     if (normalized.includes('aihubmix.com')) return 'aihubmix';
-    if (normalized.includes('bedrock-runtime')) return 'bedrock';
     return isOpenAICompatible(model, baseUrl) ? 'openai' : 'anthropic';
   } catch {
     // Preserve the rest of the user's settings even if an old saved base URL is
@@ -569,6 +586,8 @@ export function loadConfig(): AppConfig {
       }
       merged.configMigrationVersion = CONFIG_MIGRATION_VERSION;
     }
+
+    downgradeUnsupportedChatProtocol(merged);
 
     // Fixed-origin gateways (e.g. AIHubMix) hide the Base URL field, so a config
     // persisted before the origin was auto-resolved can carry an empty baseUrl.

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -203,6 +203,57 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     ],
   },
   {
+    label: 'SiliconFlow',
+    protocol: 'openai',
+    baseUrl: 'https://api.siliconflow.cn/v1',
+    model: 'deepseek-ai/DeepSeek-V3.1',
+    models: [
+      'deepseek-ai/DeepSeek-V3.1',
+      'deepseek-ai/DeepSeek-R1',
+      'Qwen/Qwen3-Coder-480B-A35B-Instruct',
+    ],
+  },
+  {
+    label: 'PPIO',
+    protocol: 'openai',
+    baseUrl: 'https://api.ppinfra.com/v3/openai',
+    model: 'deepseek/deepseek-v3.1',
+    models: ['deepseek/deepseek-v3.1', 'deepseek/deepseek-r1'],
+  },
+  {
+    label: 'NVIDIA',
+    protocol: 'openai',
+    baseUrl: 'https://integrate.api.nvidia.com/v1',
+    model: 'openai/gpt-oss-120b',
+    models: [
+      'openai/gpt-oss-120b',
+      'meta/llama-3.1-405b-instruct',
+      'nvidia/llama-3.1-nemotron-70b-instruct',
+    ],
+  },
+  {
+    label: 'StepFun',
+    protocol: 'openai',
+    baseUrl: 'https://api.stepfun.ai/v1',
+    model: 'step-2-mini',
+    models: ['step-2-mini', 'step-1-8k', 'step-1-32k'],
+  },
+  {
+    label: 'AWS Bedrock',
+    protocol: 'bedrock',
+    baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+    model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    models: [
+      'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      'anthropic.claude-3-5-haiku-20241022-v1:0',
+      'anthropic.claude-3-haiku-20240307-v1:0',
+      'amazon.nova-pro-v1:0',
+      'amazon.nova-lite-v1:0',
+      'amazon.nova-micro-v1:0',
+    ],
+    requiresApiKey: false,
+  },
+  {
     label: 'DeepSeek — OpenAI',
     protocol: 'openai',
     baseUrl: 'https://api.deepseek.com',
@@ -213,6 +264,71 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
       'deepseek-v4-flash',
       'deepseek-v4-pro',
     ],
+  },
+  {
+    label: 'Mistral AI',
+    protocol: 'openai',
+    baseUrl: 'https://api.mistral.ai/v1',
+    model: 'mistral-large-latest',
+    models: ['mistral-large-latest', 'ministral-8b-latest', 'ministral-3b-latest'],
+  },
+  {
+    label: 'xAI',
+    protocol: 'openai',
+    baseUrl: 'https://api.x.ai/v1',
+    model: 'grok-4',
+    models: ['grok-4', 'grok-3', 'grok-3-mini'],
+  },
+  {
+    label: 'Together AI',
+    protocol: 'openai',
+    baseUrl: 'https://api.together.xyz/v1',
+    model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+    models: [
+      'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+      'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
+      'Qwen/Qwen2.5-Coder-32B-Instruct',
+    ],
+  },
+  {
+    label: 'Hugging Face',
+    protocol: 'openai',
+    baseUrl: 'https://router.huggingface.co/v1',
+    model: 'openai/gpt-oss-120b',
+    models: [
+      'openai/gpt-oss-120b',
+      'Qwen/Qwen3-Coder-480B-A35B-Instruct',
+      'meta-llama/Llama-3.1-8B-Instruct',
+    ],
+  },
+  {
+    label: 'Qwen',
+    protocol: 'openai',
+    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    model: 'qwen-plus',
+    models: ['qwen-plus', 'qwen-turbo', 'qwen-max', 'qwen3-coder-plus'],
+  },
+  {
+    label: 'Volcengine Ark',
+    protocol: 'openai',
+    baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+    model: 'doubao-seed-1-6',
+    models: ['doubao-seed-1-6', 'doubao-seed-1-6-thinking', 'deepseek-v3'],
+  },
+  {
+    label: 'Baidu Qianfan',
+    protocol: 'openai',
+    baseUrl: 'https://qianfan.baidubce.com/v2',
+    model: 'ernie-4.5-turbo-128k',
+    models: ['ernie-4.5-turbo-128k', 'ernie-4.5-8k-preview'],
+  },
+  {
+    label: 'vLLM',
+    protocol: 'openai',
+    baseUrl: 'http://127.0.0.1:8000/v1',
+    model: 'model',
+    models: ['model', 'llama3', 'qwen3'],
+    requiresApiKey: false,
   },
   {
     label: 'MiniMax — OpenAI',
@@ -235,6 +351,20 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
     model: 'mimo-v2.5-pro',
     models: ['mimo-v2.5-pro'],
+  },
+  {
+    label: 'Moonshot',
+    protocol: 'openai',
+    baseUrl: 'https://api.moonshot.cn/v1',
+    model: 'kimi-k2-0711-preview',
+    models: ['kimi-k2-0711-preview', 'moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k'],
+  },
+  {
+    label: 'Zhipu',
+    protocol: 'openai',
+    baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    model: 'glm-4.6',
+    models: ['glm-4.6', 'glm-4-plus', 'glm-4-air'],
   },
   {
     label: 'Ollama Cloud (managed)',
@@ -380,6 +510,7 @@ function inferApiProtocol(model: string, baseUrl: string): ApiProtocol {
     // APP-Code attribution header even though the wire shape is
     // OpenAI-compatible.
     if (normalized.includes('aihubmix.com')) return 'aihubmix';
+    if (normalized.includes('bedrock-runtime')) return 'bedrock';
     return isOpenAICompatible(model, baseUrl) ? 'openai' : 'anthropic';
   } catch {
     // Preserve the rest of the user's settings even if an old saved base URL is

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -481,7 +481,15 @@ function isValidOrbitTime(time: string): boolean {
 }
 
 function isBedrockRuntimeBaseUrl(baseUrl: string): boolean {
-  return (baseUrl || '').toLowerCase().includes('bedrock-runtime');
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return (
+      /^bedrock-runtime(?:-fips)?[.-].*\.amazonaws\.com(?:\.cn)?$/.test(hostname)
+      || /^bedrock-runtime(?:-fips)?[.-].*\.api\.aws$/.test(hostname)
+    );
+  } catch {
+    return false;
+  }
 }
 
 function downgradeUnsupportedChatProtocol(config: AppConfig): boolean {

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -484,12 +484,12 @@ function isBedrockRuntimeBaseUrl(baseUrl: string): boolean {
   return (baseUrl || '').toLowerCase().includes('bedrock-runtime');
 }
 
-function downgradeUnsupportedChatProtocol(config: AppConfig): void {
+function downgradeUnsupportedChatProtocol(config: AppConfig): boolean {
   if (
     config.apiProtocol !== 'bedrock'
     && !isBedrockRuntimeBaseUrl(config.baseUrl)
   ) {
-    return;
+    return false;
   }
 
   config.apiProtocol = DEFAULT_CONFIG.apiProtocol;
@@ -499,6 +499,7 @@ function downgradeUnsupportedChatProtocol(config: AppConfig): void {
   config.model = DEFAULT_CONFIG.model;
   config.apiProviderBaseUrl = DEFAULT_CONFIG.apiProviderBaseUrl;
   delete config.apiProtocolConfigs?.bedrock;
+  return true;
 }
 
 function inferApiProtocol(model: string, baseUrl: string): ApiProtocol {
@@ -590,7 +591,8 @@ export function loadConfig(): AppConfig {
       merged.configMigrationVersion = CONFIG_MIGRATION_VERSION;
     }
 
-    downgradeUnsupportedChatProtocol(merged);
+    const downgradedUnsupportedChatProtocol =
+      downgradeUnsupportedChatProtocol(merged);
 
     // Fixed-origin gateways (e.g. AIHubMix) hide the Base URL field, so a config
     // persisted before the origin was auto-resolved can carry an empty baseUrl.
@@ -599,6 +601,10 @@ export function loadConfig(): AppConfig {
     // model-list fetch and leaves only the static suggestion list.
     if (merged.apiProtocol) {
       merged.baseUrl = resolveFixedOriginBaseUrl(merged.apiProtocol, merged.baseUrl);
+    }
+
+    if (downgradedUnsupportedChatProtocol) {
+      saveConfig(merged);
     }
 
     return merged;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -498,6 +498,7 @@ function downgradeUnsupportedChatProtocol(config: AppConfig): void {
   config.baseUrl = DEFAULT_CONFIG.baseUrl;
   config.model = DEFAULT_CONFIG.model;
   config.apiProviderBaseUrl = DEFAULT_CONFIG.apiProviderBaseUrl;
+  delete config.apiProtocolConfigs?.bedrock;
 }
 
 function inferApiProtocol(model: string, baseUrl: string): ApiProtocol {

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -239,21 +239,6 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     models: ['step-2-mini', 'step-1-8k', 'step-1-32k'],
   },
   {
-    label: 'AWS Bedrock',
-    protocol: 'bedrock',
-    baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
-    model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    models: [
-      'anthropic.claude-3-5-sonnet-20241022-v2:0',
-      'anthropic.claude-3-5-haiku-20241022-v1:0',
-      'anthropic.claude-3-haiku-20240307-v1:0',
-      'amazon.nova-pro-v1:0',
-      'amazon.nova-lite-v1:0',
-      'amazon.nova-micro-v1:0',
-    ],
-    requiresApiKey: false,
-  },
-  {
     label: 'DeepSeek — OpenAI',
     protocol: 'openai',
     baseUrl: 'https://api.deepseek.com',

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -1356,6 +1356,30 @@
   text-overflow: ellipsis;
   transition: background 120ms var(--ease-out), color 120ms var(--ease-out), border-color 120ms var(--ease-out), box-shadow 120ms var(--ease-out);
 }
+.protocol-chip--provider {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.protocol-chip-status {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+  background: var(--text-disabled, #94a3b8);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-disabled, #94a3b8) 16%, transparent);
+}
+.protocol-chip-status.is-configured {
+  background: var(--success, #22c55e);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--success, #22c55e) 18%, transparent);
+}
+.protocol-chip-status.is-unset {
+  background: var(--text-disabled, #94a3b8);
+}
+.protocol-chip.active .protocol-chip-status {
+  background: currentColor;
+  box-shadow: 0 0 0 2px color-mix(in srgb, currentColor 22%, transparent);
+}
 .protocol-chip:hover:not(.active) {
   background: var(--bg-subtle);
   color: var(--text);

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -264,6 +264,11 @@ export interface ApiProtocolConfig {
   byokSpeechVoice?: string;
 }
 
+export interface ByokProviderConfigDraft {
+  apiConfig: ApiProtocolConfig;
+  maxTokens?: number;
+}
+
 // Per-CLI model + reasoning the user picked in the model menu. Each agent
 // keeps its own slot so flipping between Codex and Gemini doesn't reset the
 // other one's choice. Missing entries fall back to the agent's first
@@ -389,6 +394,8 @@ export interface AppConfig {
   byokSpeechModel?: string;
   byokSpeechVoice?: string;
   apiProtocolConfigs?: Partial<Record<ApiProtocol, ApiProtocolConfig>>;
+  /** BYOK provider drafts keyed by protocol + selected provider base URL. */
+  byokProviderConfigDrafts?: Record<string, ByokProviderConfigDraft>;
   /** Internal config schema/migration version for localStorage upgrades. */
   configMigrationVersion?: number;
   /** Base URL of the selected known provider; cleared once the user customizes provider fields. */

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -105,7 +105,15 @@ export type {
 } from '@open-design/contracts';
 
 export type ExecMode = 'daemon' | 'api';
-export type ApiProtocol = 'anthropic' | 'openai' | 'azure' | 'google' | 'ollama' | 'senseaudio' | 'aihubmix';
+export type ApiProtocol =
+  | 'anthropic'
+  | 'openai'
+  | 'azure'
+  | 'google'
+  | 'ollama'
+  | 'senseaudio'
+  | 'aihubmix'
+  | 'bedrock';
 
 export type LiveArtifactTabId = `live:${string}`;
 // Tab ids are arbitrary strings; the template-literal members below are

--- a/apps/web/src/utils/apiProtocol.ts
+++ b/apps/web/src/utils/apiProtocol.ts
@@ -9,6 +9,7 @@ const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {
   ollama: 'Ollama Cloud API',
   senseaudio: 'SenseAudio API',
   aihubmix: 'AIHubMix API',
+  bedrock: 'AWS Bedrock',
 };
 
 const API_PROTOCOL_AGENT_IDS: Record<ApiProtocol, string> = {
@@ -19,6 +20,7 @@ const API_PROTOCOL_AGENT_IDS: Record<ApiProtocol, string> = {
   ollama: 'ollama-cloud-api',
   senseaudio: 'senseaudio-api',
   aihubmix: 'aihubmix-api',
+  bedrock: 'bedrock-api',
 };
 
 export function apiProtocolLabel(protocol: ApiProtocol | undefined): string {
@@ -45,6 +47,7 @@ export function usesAnthropicProxy(cfg: AppConfig): boolean {
     cfg.apiProtocol === 'google' ||
     cfg.apiProtocol === 'senseaudio' ||
     cfg.apiProtocol === 'aihubmix' ||
+    cfg.apiProtocol === 'bedrock' ||
     cfg.apiProtocol === 'openai'
   ) {
     return false;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -502,6 +502,55 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(apiKeyInput.type).toBe('password');
   });
 
+  it('persists provider-scoped BYOK drafts across Settings reopen', async () => {
+    const first = renderSettingsDialog({
+      apiProtocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    const apiKeyInput = screen.getByLabelText('API key') as HTMLInputElement;
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-openai-provider' } });
+    fireEvent.click(screen.getByRole('tab', { name: 'DeepSeek' }));
+
+    await waitForPersist(
+      first.onPersist,
+      expect.objectContaining({
+        apiProviderBaseUrl: 'https://api.deepseek.com',
+        baseUrl: 'https://api.deepseek.com',
+        byokProviderConfigDrafts: expect.objectContaining({
+          'openai:https://api.openai.com/v1': expect.objectContaining({
+            apiConfig: expect.objectContaining({
+              apiKey: 'sk-openai-provider',
+              baseUrl: 'https://api.openai.com/v1',
+              model: 'gpt-4o',
+            }),
+          }),
+        }),
+      }),
+      {},
+    );
+
+    const persistedConfig = first.onPersist.mock.calls.at(-1)?.[0] as AppConfig;
+    first.unmount();
+
+    renderSettingsDialog(persistedConfig);
+    expect((screen.getByLabelText('Base URL') as HTMLInputElement).value).toBe(
+      'https://api.deepseek.com',
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+
+    expect((screen.getByLabelText('API key') as HTMLInputElement).value).toBe(
+      'sk-openai-provider',
+    );
+    expect((screen.getByLabelText('Base URL') as HTMLInputElement).value).toBe(
+      'https://api.openai.com/v1',
+    );
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain('gpt-4o');
+  });
+
   it('keeps BYOK file-editing limits discoverable from the provider heading (issue #1106)', () => {
     // Regression cover: switching from Local CLI to BYOK previously gave no
     // signal that file-editing tools (`Read`/`Write`/`Edit`) are absent on the

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -425,6 +425,10 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(screen.getByRole('tab', { name: 'OpenAI' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Azure OpenAI' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Google Gemini' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Ollama Cloud' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'SenseAudio' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'AIHubMix' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'AWS Bedrock' })).toBeTruthy();
     expect(screen.getByLabelText('Gateway preset')).toBeTruthy();
     expect(screen.getByLabelText('Model')).toBeTruthy();
     const baseUrlInput = screen.getByLabelText('Base URL') as HTMLInputElement;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -417,15 +417,14 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(dialog.classList.contains('settings-fullscreen')).toBe(false);
   });
 
-  it('renders BYOK protocol tabs and toggles API key visibility', () => {
+  it('renders BYOK provider preset tabs and toggles API key visibility', () => {
     renderSettingsDialog();
 
+    expect(screen.getByRole('tablist', { name: en['settings.protocolAria'] })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Anthropic' }).getAttribute('aria-selected')).toBe('true');
     expect(screen.getByRole('tab', { name: 'OpenAI' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Azure OpenAI' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Google Gemini' })).toBeTruthy();
-    expect(screen.getByText('Protocols')).toBeTruthy();
-    expect(screen.getByText('Gateways')).toBeTruthy();
     expect(screen.getByLabelText('Gateway preset')).toBeTruthy();
     expect(screen.getByLabelText('Model')).toBeTruthy();
     const baseUrlInput = screen.getByLabelText('Base URL') as HTMLInputElement;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -468,6 +468,29 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     ).toBe('https://platform.openai.com/api-keys');
   });
 
+  it('resets API key draft and visibility when switching BYOK provider presets', () => {
+    renderSettingsDialog({
+      apiProtocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    const apiKeyInput = screen.getByLabelText('API key') as HTMLInputElement;
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-openai-provider' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+    expect(apiKeyInput.value).toBe('sk-openai-provider');
+    expect(apiKeyInput.type).toBe('text');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'DeepSeek' }));
+
+    expect(apiKeyInput.value).toBe('');
+    expect(apiKeyInput.type).toBe('password');
+    expect((screen.getByLabelText('Base URL') as HTMLInputElement).value).toBe(
+      'https://api.deepseek.com',
+    );
+  });
+
   it('keeps BYOK file-editing limits discoverable from the provider heading (issue #1106)', () => {
     // Regression cover: switching from Local CLI to BYOK previously gave no
     // signal that file-editing tools (`Read`/`Write`/`Edit`) are absent on the

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -468,7 +468,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     ).toBe('https://platform.openai.com/api-keys');
   });
 
-  it('resets API key draft and visibility when switching BYOK provider presets', () => {
+  it('isolates API key draft and visibility by BYOK provider preset', () => {
     renderSettingsDialog({
       apiProtocol: 'openai',
       baseUrl: 'https://api.openai.com/v1',
@@ -489,6 +489,17 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect((screen.getByLabelText('Base URL') as HTMLInputElement).value).toBe(
       'https://api.deepseek.com',
     );
+
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-deepseek-provider' } });
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+
+    expect(apiKeyInput.value).toBe('sk-openai-provider');
+    expect(apiKeyInput.type).toBe('text');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'DeepSeek' }));
+
+    expect(apiKeyInput.value).toBe('sk-deepseek-provider');
+    expect(apiKeyInput.type).toBe('password');
   });
 
   it('keeps BYOK file-editing limits discoverable from the provider heading (issue #1106)', () => {
@@ -902,7 +913,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
     fireEvent.blur(screen.getByLabelText('API key'));
 
-    expect(await screen.findByText('✓ Loaded 1 models from your account.')).toBeTruthy();
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
     expect(fetchProviderModelsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         protocol: 'openai',
@@ -979,7 +990,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     // If onByokKeyCommit committed the dirty-key cache key, the auto-fetch
     // effect would bail on providerModelsCommittedKey !== providerModelsKey
     // and this text would never appear.
-    expect(await screen.findByText('✓ Loaded 1 models from your account.')).toBeTruthy();
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
     expect(fetchProviderModelsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         protocol: 'openai',
@@ -1007,7 +1018,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
 
-    expect(await screen.findByText('✓ Loaded 1 models from your account.')).toBeTruthy();
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
     expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain(
       'Account Ready (account-ready-model) · From your account',
     );
@@ -1019,6 +1030,74 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       }),
       {},
     );
+  });
+
+  it('does not carry a generic preset model into a fresh custom provider before discovery', async () => {
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      models: [{ id: 'endpoint-model', label: 'Endpoint Model' }],
+    });
+    const { onPersist } = renderSettingsDialog({
+      apiProtocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Custom provider' }));
+
+    expect((screen.getByLabelText('Custom model id') as HTMLInputElement).value).toBe('');
+
+    fireEvent.change(screen.getByLabelText('Base URL'), {
+      target: { value: 'https://custom.example.com/v1' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-custom' },
+    });
+    fireEvent.blur(screen.getByLabelText('API key'));
+
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain(
+      'Endpoint Model (endpoint-model) · From your account',
+    );
+    await waitForPersist(
+      onPersist,
+      expect.objectContaining({
+        apiProviderBaseUrl: null,
+        baseUrl: 'https://custom.example.com/v1',
+        model: 'endpoint-model',
+      }),
+      {},
+    );
+  });
+
+  it('restores fetched model discovery state when switching back to a provider', async () => {
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      models: [{ id: 'account-ready-model', label: 'Account Ready' }],
+    });
+    renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: 'sk-openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'DeepSeek' }));
+    expect(screen.queryByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeNull();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+    expect(screen.getByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
+    expect(fetchProviderModelsMock).toHaveBeenCalledTimes(1);
   });
 
   it('keeps a suggested model the user explicitly re-picked after discovery resolves', async () => {
@@ -1050,7 +1129,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
     fireEvent.blur(screen.getByLabelText('API key'));
 
-    expect(await screen.findByText('✓ Loaded 1 models from your account.')).toBeTruthy();
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
 
     // The explicit pick must survive discovery — no silent rewrite to the
     // first fetched account model.
@@ -1176,7 +1255,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
 
     fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
-    expect(await screen.findByText('✓ Loaded 8 models from your account.')).toBeTruthy();
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
 
     const modelPicker = screen.getByRole('combobox', { name: 'Model' });
     fireEvent.click(modelPicker);
@@ -1192,6 +1271,39 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       'gpt-5.5 · From your account',
       'Custom (type below)…',
     ]);
+  });
+
+  it('reports the merged dropdown count when account models are combined with provider suggestions', async () => {
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      models: [
+        { id: 'glm-4.6', label: 'glm-4.6' },
+        { id: 'account-glm-1', label: 'Account GLM 1' },
+        { id: 'account-glm-2', label: 'Account GLM 2' },
+        { id: 'account-glm-3', label: 'Account GLM 3' },
+        { id: 'account-glm-4', label: 'Account GLM 4' },
+        { id: 'account-glm-5', label: 'Account GLM 5' },
+        { id: 'account-glm-6', label: 'Account GLM 6' },
+        { id: 'account-glm-7', label: 'Account GLM 7' },
+      ],
+    });
+    renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: 'sk-zhipu',
+      baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+      model: 'glm-4.6',
+      apiProviderBaseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: '智谱' }));
+
+    expect(await screen.findByText('✓ Loaded 10 models.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('combobox', { name: 'Model' }));
+    const modelPopover = screen.getByTestId('settings-byok-model-popover');
+    expect(within(modelPopover).getByRole('option', { name: 'glm-4-plus · Suggested' })).toBeTruthy();
+    expect(within(modelPopover).getByRole('option', { name: 'glm-4-air · Suggested' })).toBeTruthy();
   });
 
   it('fetches provider models, merges them into the picker, and preserves a custom current model', async () => {
@@ -1215,7 +1327,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
     expect((screen.getByLabelText('Custom model id') as HTMLInputElement).value).toBe('custom-still-here');
 
-    expect(await screen.findByText('✓ Loaded 2 models from your account.')).toBeTruthy();
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
     expect(fetchProviderModelsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         protocol: 'openai',
@@ -1253,14 +1365,14 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
 
     fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
-    expect(await screen.findByText('✓ Loaded 1 models from your account.')).toBeTruthy();
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
 
     fireEvent.change(screen.getByLabelText('Base URL'), {
       target: { value: 'https://proxy.example.com/v1' },
     });
 
     await waitFor(() => {
-      expect(screen.queryByText('✓ Loaded 1 models from your account.')).toBeNull();
+      expect(screen.queryByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeNull();
     });
   });
 

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -919,6 +919,15 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Ollama Cloud' }));
     expect(screen.queryByRole('button', { name: 'Fetch models' })).toBeNull();
     expect(screen.getByText('Model discovery is not available for this protocol.')).toBeTruthy();
+
+    fetchProviderModelsMock.mockClear();
+    fireEvent.click(screen.getByRole('tab', { name: '小米 MiMo' }));
+    await new Promise((resolve) => window.setTimeout(resolve, 350));
+
+    expect(fetchProviderModelsMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Fetch models' })).toBeNull();
+    expect(screen.getByText('Model discovery is not available for this protocol.')).toBeTruthy();
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain('mimo-v2.5-pro');
   });
 
   it('auto-loads provider models after a pasted dirty key is cleaned on blur', async () => {

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -428,7 +428,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(screen.getByRole('tab', { name: 'Ollama Cloud' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'SenseAudio' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'AIHubMix' })).toBeTruthy();
-    expect(screen.getByRole('tab', { name: 'AWS Bedrock' })).toBeTruthy();
+    expect(screen.queryByRole('tab', { name: 'AWS Bedrock' })).toBeNull();
     expect(screen.getByLabelText('Gateway preset')).toBeTruthy();
     expect(screen.getByLabelText('Model')).toBeTruthy();
     const baseUrlInput = screen.getByLabelText('Base URL') as HTMLInputElement;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -502,6 +502,27 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(apiKeyInput.type).toBe('password');
   });
 
+  it('shows configured status from provider-scoped drafts for same-protocol presets', () => {
+    renderSettingsDialog({
+      apiProtocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    const apiKeyInput = screen.getByLabelText('API key') as HTMLInputElement;
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-openai-provider' } });
+    fireEvent.click(screen.getByRole('tab', { name: 'DeepSeek' }));
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-deepseek-provider' } });
+
+    expect(screen.getByRole('tab', { name: 'OpenAI' }).getAttribute('title')).toBe(
+      'OpenAI - Configured',
+    );
+    expect(screen.getByRole('tab', { name: 'DeepSeek' }).getAttribute('title')).toBe(
+      'DeepSeek - Configured',
+    );
+  });
+
   it('persists provider-scoped BYOK drafts across Settings reopen', async () => {
     const first = renderSettingsDialog({
       apiProtocol: 'openai',
@@ -1322,7 +1343,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     ]);
   });
 
-  it('reports the merged dropdown count when account models are combined with provider suggestions', async () => {
+  it('reports the account model count when account models are combined with provider suggestions', async () => {
     fetchProviderModelsMock.mockResolvedValueOnce({
       ok: true,
       kind: 'success',
@@ -1348,7 +1369,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: '智谱' }));
 
-    expect(await screen.findByText('✓ Loaded 10 models.')).toBeTruthy();
+    expect(await screen.findByText('✓ Loaded 8 models from your account.')).toBeTruthy();
     fireEvent.click(screen.getByRole('combobox', { name: 'Model' }));
     const modelPopover = screen.getByTestId('settings-byok-model-popover');
     expect(within(modelPopover).getByRole('option', { name: 'glm-4-plus · Suggested' })).toBeTruthy();

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -7,6 +7,7 @@ import {
   deriveComposioCredentialState,
   configForManualOrbitRun,
   isOrbitRunDisabled,
+  isProviderModelDiscoveryUnsupported,
   isValidApiBaseUrl,
   mergeProviderModelOptions,
   providerModelsCacheKey,
@@ -254,6 +255,27 @@ describe('SettingsDialog provider model fetch helpers', () => {
         'ollama',
       ),
     ).toBe(false);
+    expect(
+      canFetchProviderModels(
+        {
+          apiKey: 'sk-mimo',
+          baseUrl: 'https://token-plan-cn.xiaomimimo.com/anthropic',
+        },
+        'anthropic',
+      ),
+    ).toBe(false);
+    expect(
+      isProviderModelDiscoveryUnsupported(
+        'openai',
+        'https://token-plan-cn.xiaomimimo.com/v1',
+      ),
+    ).toBe(true);
+    expect(
+      isProviderModelDiscoveryUnsupported(
+        'anthropic',
+        'https://token-plan-cn.xiaomimimo.com/anthropic',
+      ),
+    ).toBe(true);
   });
 
   it('merges fetched provider models before static suggestions without duplicates', () => {

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -916,7 +916,8 @@ describe('loadConfig', () => {
   it('downgrades legacy Bedrock Runtime configs to the default chat protocol', () => {
     const legacyConfig: Partial<AppConfig> = {
       mode: 'api',
-      apiKey: '',
+      apiKey: 'bedrock-secret',
+      apiVersion: 'bedrock-2023-05-31',
       baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
       model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
       agentId: null,
@@ -928,6 +929,8 @@ describe('loadConfig', () => {
     const config = loadConfig();
 
     expect(config.apiProtocol).toBe('anthropic');
+    expect(config.apiKey).toBe('');
+    expect(config.apiVersion).toBe('');
     expect(config.baseUrl).toBe(DEFAULT_CONFIG.baseUrl);
     expect(config.model).toBe(DEFAULT_CONFIG.model);
     expect(config.apiProviderBaseUrl).toBe(DEFAULT_CONFIG.apiProviderBaseUrl);
@@ -937,7 +940,8 @@ describe('loadConfig', () => {
     const savedConfig: Partial<AppConfig> = {
       mode: 'api',
       apiProtocol: 'bedrock',
-      apiKey: '',
+      apiKey: 'bedrock-secret',
+      apiVersion: 'bedrock-2023-05-31',
       baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
       model: 'amazon.nova-lite-v1:0',
       configMigrationVersion: 1,
@@ -950,6 +954,8 @@ describe('loadConfig', () => {
     const config = loadConfig();
 
     expect(config.apiProtocol).toBe('anthropic');
+    expect(config.apiKey).toBe('');
+    expect(config.apiVersion).toBe('');
     expect(config.baseUrl).toBe(DEFAULT_CONFIG.baseUrl);
     expect(config.model).toBe(DEFAULT_CONFIG.model);
     expect(config.apiProviderBaseUrl).toBe(DEFAULT_CONFIG.apiProviderBaseUrl);

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -913,6 +913,48 @@ describe('loadConfig', () => {
     expect(config.apiProtocol).toBe('anthropic');
   });
 
+  it('downgrades legacy Bedrock Runtime configs to the default chat protocol', () => {
+    const legacyConfig: Partial<AppConfig> = {
+      mode: 'api',
+      apiKey: '',
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(legacyConfig));
+
+    const config = loadConfig();
+
+    expect(config.apiProtocol).toBe('anthropic');
+    expect(config.baseUrl).toBe(DEFAULT_CONFIG.baseUrl);
+    expect(config.model).toBe(DEFAULT_CONFIG.model);
+    expect(config.apiProviderBaseUrl).toBe(DEFAULT_CONFIG.apiProviderBaseUrl);
+  });
+
+  it('downgrades explicitly persisted Bedrock configs to the default chat protocol', () => {
+    const savedConfig: Partial<AppConfig> = {
+      mode: 'api',
+      apiProtocol: 'bedrock',
+      apiKey: '',
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      model: 'amazon.nova-lite-v1:0',
+      configMigrationVersion: 1,
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(savedConfig));
+
+    const config = loadConfig();
+
+    expect(config.apiProtocol).toBe('anthropic');
+    expect(config.baseUrl).toBe(DEFAULT_CONFIG.baseUrl);
+    expect(config.model).toBe(DEFAULT_CONFIG.model);
+    expect(config.apiProviderBaseUrl).toBe(DEFAULT_CONFIG.apiProviderBaseUrl);
+  });
+
   it('infers protocol for legacy daemon-mode API fields without changing mode', () => {
     const daemonConfig: Partial<AppConfig> = {
       mode: 'daemon',

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -896,6 +896,31 @@ describe('loadConfig', () => {
     expect(loadConfig().baseUrl).toBe('https://api.example.com/v1');
   });
 
+  it('keeps custom proxy paths containing bedrock-runtime on their selected protocol', () => {
+    const persisted: Partial<AppConfig> = {
+      mode: 'api',
+      apiProtocol: 'openai',
+      apiKey: 'sk-proxy',
+      apiVersion: '2024-01-01',
+      baseUrl: 'https://proxy.example.com/bedrock-runtime/v1',
+      model: 'gpt-4o',
+      configMigrationVersion: 1,
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(persisted));
+
+    const config = loadConfig();
+
+    expect(config.apiProtocol).toBe('openai');
+    expect(config.apiKey).toBe('sk-proxy');
+    expect(config.apiVersion).toBe('2024-01-01');
+    expect(config.baseUrl).toBe('https://proxy.example.com/bedrock-runtime/v1');
+    expect(config.model).toBe('gpt-4o');
+    expect(store.get('open-design:config')).toBe(JSON.stringify(persisted));
+  });
+
   it('migrates legacy Anthropic API configs to an explicit apiProtocol', () => {
     const legacyConfig: Partial<AppConfig> = {
       mode: 'api',

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -945,6 +945,19 @@ describe('loadConfig', () => {
       baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
       model: 'amazon.nova-lite-v1:0',
       configMigrationVersion: 1,
+      apiProtocolConfigs: {
+        bedrock: {
+          apiKey: 'nested-bedrock-secret',
+          apiVersion: 'bedrock-2023-05-31',
+          baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+          model: 'amazon.nova-lite-v1:0',
+        },
+        openai: {
+          apiKey: 'sk-openai',
+          baseUrl: 'https://api.openai.com/v1',
+          model: 'gpt-4o',
+        },
+      },
       agentId: null,
       skillId: null,
       designSystemId: null,
@@ -959,6 +972,12 @@ describe('loadConfig', () => {
     expect(config.baseUrl).toBe(DEFAULT_CONFIG.baseUrl);
     expect(config.model).toBe(DEFAULT_CONFIG.model);
     expect(config.apiProviderBaseUrl).toBe(DEFAULT_CONFIG.apiProviderBaseUrl);
+    expect(config.apiProtocolConfigs?.bedrock).toBeUndefined();
+    expect(config.apiProtocolConfigs?.openai).toEqual({
+      apiKey: 'sk-openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+    });
   });
 
   it('infers protocol for legacy daemon-mode API fields without changing mode', () => {

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -978,6 +978,20 @@ describe('loadConfig', () => {
       baseUrl: 'https://api.openai.com/v1',
       model: 'gpt-4o',
     });
+
+    const persisted = JSON.parse(
+      store.get('open-design:config') ?? '{}',
+    ) as Partial<AppConfig>;
+    expect(persisted.apiProtocol).toBe('anthropic');
+    expect(persisted.apiKey).toBe('');
+    expect(persisted.apiVersion).toBe('');
+    expect(persisted.baseUrl).toBe(DEFAULT_CONFIG.baseUrl);
+    expect(persisted.apiProtocolConfigs?.bedrock).toBeUndefined();
+    expect(persisted.apiProtocolConfigs?.openai).toEqual({
+      apiKey: 'sk-openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+    });
   });
 
   it('infers protocol for legacy daemon-mode API fields without changing mode', () => {

--- a/e2e/ui/settings-api-protocol.test.ts
+++ b/e2e/ui/settings-api-protocol.test.ts
@@ -237,7 +237,7 @@ test('[P0] @critical BYOK quick fill provider updates fields and saved settings 
 
   await openSettingsDialogFromEntry(page);
   const reopenedDialog = page.getByRole('dialog');
-  await expect(reopenedDialog.getByRole('tab', { name: 'OpenAI', exact: true })).toHaveAttribute('aria-selected', 'true');
+  await expect(reopenedDialog.getByRole('tab', { name: 'DeepSeek', exact: true })).toHaveAttribute('aria-selected', 'true');
   await expect(providerPresetCombobox(reopenedDialog)).toContainText(/DeepSeek — OpenAI/i);
   await expectModelComboboxText(reopenedDialog, /deepseek-chat/i);
   await expect(reopenedDialog.getByLabel('Base URL')).toHaveValue('https://api.deepseek.com');

--- a/e2e/ui/settings-api-protocol.test.ts
+++ b/e2e/ui/settings-api-protocol.test.ts
@@ -29,6 +29,24 @@ async function openSettingsDialogFromEntry(page: Page) {
   return openSettingsDialog(page);
 }
 
+async function closeSettingsDialogIfOpen(page: Page) {
+  const dialog = page.getByRole('dialog');
+  if ((await dialog.count()) === 0) return;
+  await page.keyboard.press('Escape');
+  try {
+    await expect(dialog).toHaveCount(0, { timeout: T.short });
+    return;
+  } catch {
+    // Fall back to the chrome button if focus is inside a nested popover or
+    // another transient surface swallowed Escape.
+  }
+  const closeButton = dialog.getByRole('button', { name: 'Close', exact: true });
+  if ((await closeButton.count()) > 0) {
+    await closeButton.click({ force: true, timeout: T.short });
+  }
+  await expect(dialog).toHaveCount(0);
+}
+
 async function openExecutionSettings(
   page: Page,
   config: Record<string, unknown>,
@@ -342,13 +360,7 @@ test('[P0] BYOK auto-loads provider models and reuses cached results for the sam
   await expect(modelPopover.getByRole('option', { name: 'ZZ Prerelease Model (zz-prerelease-model)' })).toHaveCount(1);
   await page.keyboard.press('Escape');
 
-  if ((await page.getByRole('dialog').count()) > 0) {
-    const closeButton = page.getByRole('dialog').getByRole('button', { name: 'Close', exact: true });
-    if ((await closeButton.count()) > 0) {
-      await closeButton.click({ force: true });
-    }
-    await expect(page.getByRole('dialog')).toHaveCount(0);
-  }
+  await closeSettingsDialogIfOpen(page);
 
   await openSettingsDialogFromEntry(page);
   const reopenedDialog = page.getByRole('dialog');

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -3625,6 +3625,8 @@ export function byokProtocolToTracking(
       return 'ollama_cloud';
     case 'senseaudio':
       return 'senseaudio';
+    case 'bedrock':
+      return null;
     default:
       return null;
   }

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -179,7 +179,15 @@ export interface ConnectionTestDiagnostics {
   stderrTail?: string;
 }
 
-export type ConnectionTestProtocol = 'anthropic' | 'openai' | 'azure' | 'google' | 'ollama' | 'senseaudio' | 'aihubmix';
+export type ConnectionTestProtocol =
+  | 'anthropic'
+  | 'openai'
+  | 'azure'
+  | 'google'
+  | 'ollama'
+  | 'senseaudio'
+  | 'aihubmix'
+  | 'bedrock';
 
 export interface ProviderTestRequest extends ReasoningExecutionRequestFields {
   protocol: ConnectionTestProtocol;

--- a/packages/contracts/src/api/finalize.ts
+++ b/packages/contracts/src/api/finalize.ts
@@ -1,4 +1,3 @@
-import type { ConnectionTestProtocol } from './connectionTest';
 import type { ReasoningExecutionRequestFields } from './reasoningExecution';
 
 // Shared DTOs for the `/api/projects/:id/finalize/<provider>` family of
@@ -16,9 +15,16 @@ export const FINALIZE_SCHEMA_VERSION = 1;
 
 /**
  * Provider ids supported by the finalized-design synthesis path.
- * Matches the BYOK protocols exposed by Settings and connection tests.
+ * Matches the daemon/web finalize allowlists. This is intentionally narrower
+ * than connection-test/provider-model protocols because some transports can be
+ * tested or listed before finalized-design synthesis supports them.
  */
-export type FinalizeProviderProtocol = ConnectionTestProtocol;
+export type FinalizeProviderProtocol =
+  | 'anthropic'
+  | 'openai'
+  | 'azure'
+  | 'google'
+  | 'ollama';
 
 /**
  * Request body for `POST /api/projects/:id/finalize/<provider>`.


### PR DESCRIPTION
## Summary
- Add BYOK provider presets and model metadata for supported provider flows.
- Wire provider preset fields through connection testing, chat routing, settings state, and UI selection surfaces.
- Extend analytics and contracts so preset-backed provider selections are represented consistently.

## Validation
- Not run locally; branch was inspected for a clean merge against latest `main` before opening the PR.
