### PR TITLE
fix(daemon): normalize additive cache usage so cache-hit ratio never exceeds 1

### DIFF
--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -325,6 +325,66 @@ function extractUsageCacheFields(usage: Record<string, unknown>): UsageCacheFiel
   };
 }
 
+interface EffectiveInputTokens {
+  // The cache-inclusive prompt size, the denominator a cache-hit ratio divides
+  // into. `undefined` when there is no input figure to anchor on.
+  effectiveInput: number | undefined;
+  // The portion that was NOT served from cache. `undefined` when the provider
+  // gave no cache split to compute it from.
+  uncachedInput: number | undefined;
+}
+
+// `input_tokens` is reported in two incompatible conventions across the
+// provider/runtime matrix, and the SAME field name (`cached_input_tokens` etc.)
+// appears under both:
+//   - INCLUSIVE (OpenAI chat-completions, codex's rollout `last_token_usage`):
+//     input_tokens already contains the cache-read subset → effective = input,
+//     uncached = input - read.
+//   - ADDITIVE (Anthropic, and the Responses-API / ACP usage that the AMR/vela
+//     and pi STREAM emits): input_tokens is the UNCACHED remainder and the
+//     cache-read/creation tokens are reported separately on top → effective =
+//     input + read + creation, uncached = input.
+// Picking the wrong convention is not cosmetic: treating an additive payload as
+// inclusive makes the denominator far too small, so `cache_hit_ratio` /
+// `first_call_cache_hit_ratio` blow past 1.0 (observed ~78% of AMR and ~57% of
+// pi follow-up runs) and `uncached_input_tokens` collapses to 0.
+//
+// The discriminator is a hard arithmetic invariant, not a heuristic guess: a
+// cache-read subset can never exceed the total it is a subset of, so
+// `cacheRead > input` is impossible under inclusive accounting and proves the
+// payload is additive. Anthropic is additive by field shape regardless. Every
+// `cacheRead <= input` payload therefore stays byte-identical to the prior
+// behavior; only the previously-corrupt additive case is repaired.
+function resolveEffectiveInputTokens(
+  inputTokens: number | undefined,
+  cacheReadInputTokens: number | undefined,
+  cacheCreationInputTokens: number | undefined,
+  cacheTokenSource: 'anthropic' | 'openai' | 'unavailable' | undefined,
+): EffectiveInputTokens {
+  if (inputTokens === undefined) {
+    return { effectiveInput: undefined, uncachedInput: undefined };
+  }
+  const read = cacheReadInputTokens ?? 0;
+  const additive =
+    cacheTokenSource === 'anthropic' ||
+    (cacheTokenSource === 'openai' &&
+      cacheReadInputTokens !== undefined &&
+      read > inputTokens);
+  if (additive) {
+    return {
+      effectiveInput: inputTokens + read + (cacheCreationInputTokens ?? 0),
+      uncachedInput: inputTokens,
+    };
+  }
+  return {
+    effectiveInput: inputTokens,
+    uncachedInput:
+      cacheTokenSource === 'openai' && cacheReadInputTokens !== undefined
+        ? Math.max(0, inputTokens - cacheReadInputTokens)
+        : undefined,
+  };
+}
+
 export function scanRunEventsForUsageAnalytics(
   events: RunEventForAnalyticsObservability[],
   reqBodyModel: unknown,
@@ -420,19 +480,16 @@ export function scanRunEventsForUsageAnalytics(
     firstCallCacheTokenSource = fields.cacheTokenSource;
     break;
   }
-  // Anthropic reports input_tokens as the UNCACHED portion (cache_read and
-  // cache_creation are separate), so the effective input is their sum; OpenAI
-  // folds cached into input_tokens. Mirrors the last-call effective computation
-  // below exactly, including cache_creation, so the first-call and last-call
-  // ratios share one denominator definition.
-  const firstCallInputEffective =
-    firstCallInputTokens !== undefined
-      ? firstCallCacheTokenSource === 'anthropic'
-        ? firstCallInputTokens +
-          (firstCallCacheReadInputTokens ?? 0) +
-          (firstCallCacheCreationInputTokens ?? 0)
-        : firstCallInputTokens
-      : undefined;
+  // Effective-input / uncached resolution is shared with the last-call scan
+  // below (one denominator definition for `first_call_cache_hit_ratio` and
+  // `cache_hit_ratio`), and now normalizes additive-vs-inclusive usage so the
+  // ratio can never exceed 1. See resolveEffectiveInputTokens.
+  const { effectiveInput: firstCallInputEffective } = resolveEffectiveInputTokens(
+    firstCallInputTokens,
+    firstCallCacheReadInputTokens,
+    firstCallCacheCreationInputTokens,
+    firstCallCacheTokenSource,
+  );
   const firstCallCacheHitRatio =
     firstCallInputEffective !== undefined &&
     firstCallInputEffective > 0 &&
@@ -440,25 +497,18 @@ export function scanRunEventsForUsageAnalytics(
       ? firstCallCacheReadInputTokens / firstCallInputEffective
       : undefined;
 
-  const inputTokensEffective =
-    inputTokens !== undefined
-      ? cacheTokenSource === 'anthropic'
-        ? inputTokens + (cacheReadInputTokens ?? 0) + (cacheCreationInputTokens ?? 0)
-        : inputTokens
-      : undefined;
+  const { effectiveInput: inputTokensEffective, uncachedInput: uncachedInputTokens } =
+    resolveEffectiveInputTokens(
+      inputTokens,
+      cacheReadInputTokens,
+      cacheCreationInputTokens,
+      cacheTokenSource,
+    );
   const totalTokens =
     providerTotalTokens ??
     (inputTokensEffective !== undefined && outputTokens !== undefined
       ? inputTokensEffective + outputTokens
       : undefined);
-  const uncachedInputTokens =
-    inputTokens !== undefined && cacheTokenSource === 'anthropic'
-      ? inputTokens
-      : inputTokens !== undefined &&
-          cacheTokenSource === 'openai' &&
-          cacheReadInputTokens !== undefined
-        ? Math.max(0, inputTokens - cacheReadInputTokens)
-        : undefined;
   const estimatedContextTokens =
     inputTokensEffective !== undefined && userQueryTokens > 0
       ? Math.max(0, inputTokensEffective - userQueryTokens)

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -170,6 +170,81 @@ describe('scanRunEventsForUsageAnalytics', () => {
     expect(result.cache_hit_ratio).toBeCloseTo(2_560 / 31_711);
   });
 
+  it('normalizes additive Responses-API / ACP usage where cache_read exceeds input_tokens', () => {
+    // Real AMR/vela follow-up shape: the stream reports input_tokens as the
+    // UNCACHED remainder with cached_input_tokens reported separately ON TOP, so
+    // cache_read > input. Treating it as inclusive (cache_read ⊆ input) made the
+    // denominator far too small and produced cache_hit_ratio ≫ 1 (the corrupt
+    // ~78% of AMR follow-up runs). It must resolve to a sane <=1 ratio with the
+    // cache-read folded into the effective input.
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 140_187,
+              output_tokens: 64,
+              cached_input_tokens: 659_456,
+            },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    expect(result).toMatchObject({
+      input_tokens_provider: 140_187,
+      input_tokens_effective: 799_643,
+      cache_read_input_tokens: 659_456,
+      uncached_input_tokens: 140_187,
+      cache_token_source: 'openai',
+    });
+    expect(result.cache_hit_ratio).toBeCloseTo(659_456 / 799_643);
+    expect(result.cache_hit_ratio).toBeLessThanOrEqual(1);
+    // The first model call of the turn shares the same denominator definition,
+    // so first_call_cache_hit_ratio must be repaired in lockstep.
+    expect(result.first_call_input_tokens).toBe(140_187);
+    expect(result.first_call_cache_read_input_tokens).toBe(659_456);
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(659_456 / 799_643);
+    expect(result.first_call_cache_hit_ratio).toBeLessThanOrEqual(1);
+  });
+
+  it('keeps inclusive OpenAI usage (cache_read <= input) byte-identical after the additive fix', () => {
+    // Guards the discriminator: an inclusive payload (cached ⊆ input) must stay
+    // on the input-as-total path — effective = input, uncached = input - read —
+    // exactly as before, so the additive repair cannot regress codex/openai.
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 1_000,
+              output_tokens: 20,
+              cached_input_tokens: 250,
+            },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    expect(result).toMatchObject({
+      input_tokens_provider: 1_000,
+      input_tokens_effective: 1_000,
+      cache_read_input_tokens: 250,
+      uncached_input_tokens: 750,
+      cache_token_source: 'openai',
+    });
+    expect(result.cache_hit_ratio).toBeCloseTo(250 / 1_000);
+    expect(result.first_call_cache_hit_ratio).toBeCloseTo(250 / 1_000);
+  });
+
   it.each([
     {
       name: 'claude anthropic usage',


### PR DESCRIPTION
## Why

**Author's use case.** While standing up the session-reuse verification dashboard (the v0.13.0 native-resume optimization, PR #4629/#4888), I sliced `run_finished` by `agent_provider_id × is_followup_turn` to read `first_call_cache_hit_ratio` — the signal that tells us whether resume warmed the cache. The numbers for AMR and pi were impossible: a *ratio* coming back as `4.7`, `40`, even `139`.

**The pain.** `first_call_cache_hit_ratio` (and `cache_hit_ratio`) must be in `[0,1]`. In production they are corrupt for two engines:

| agent | follow-up `run_finished` with ratio > 1 |
|---|---|
| `amr` | **~78%** |
| `pi` | **~57%** |
| `opencode` | ~15% |
| `codex_cli` / `claude_code` | ~0% (clean) |

Root cause: the effective-input computation assumes every `openai` cache source folds the cache-read subset into `input_tokens` (`cached ⊆ input`). That holds for OpenAI chat-completions and codex's rollout `last_token_usage`, but the **Responses-API / ACP usage that the AMR/vela and pi streams emit** reports `input_tokens` as the **UNCACHED remainder** with cache-read tokens reported **separately, on top** — so `cache_read > input`. Dividing `cache_read` by that too-small denominator blows the ratio past `1.0`, and the sibling `uncached_input_tokens` collapses to `0`.

Net effect: **the AMR session-reuse win cannot be measured** with the current metric, and any dashboard/alert reading these fields for AMR/pi is reading garbage.

## What changed

One shared helper `resolveEffectiveInputTokens` now resolves effective-input + uncached for both the first-call and last-call scans, so their denominators can never drift. It detects the additive shape from a **hard arithmetic invariant** rather than a per-agent guess: a cache-read subset can never exceed the total it is a subset of, so `cache_read > input` is impossible under inclusive accounting and *proves* the payload is additive (Anthropic is additive by field shape regardless). Additive payloads fold cache-read/creation into the denominator (== existing anthropic semantics) and report `uncached = input`.

Every `cache_read <= input` payload stays **byte-identical** to prior behavior — codex/openai/inclusive-ACP are untouched; only the previously-corrupt additive case is repaired.

Verified on the real production data shapes: AMR `4.70 → 0.825`, `108 → 0.991`; pi `40 → 0.976`; inclusive/anthropic unchanged (`0.25 → 0.25`, `0.08 → 0.08`, `0.16 → 0.16`).

## What users will see

Nothing in the product UI — this is internal telemetry correctness. Downstream, the reliability/session-reuse dashboards stop showing impossible >1 cache-hit ratios and zeroed uncached input for AMR/pi, so the v0.13.0 resume optimization becomes measurable for those engines.

## Bug follow-up (red spec)

`tests/run-analytics-observability.test.ts`:
- **red → green**: an AMR-shaped additive event (`input_tokens: 140187`, `cached_input_tokens: 659456`) — on `main` yields `input_tokens_effective: 140187` / `uncached: 0` (and ratio ≈ 4.7); on this branch yields `input_tokens_effective: 799643` / `uncached: 140187` / `ratio ≈ 0.825 ≤ 1`.
- **regression guard**: an inclusive OpenAI event (`cache_read ≤ input`) stays on the input-as-total path (`effective = input`, `uncached = input − read`), so codex/openai cannot regress.

## Surface area

- [x] Daemon (analytics/observability) — `apps/daemon/src/run-analytics-observability.ts`
- [x] Tests — `apps/daemon/tests/run-analytics-observability.test.ts`
- No UI, CLI, contracts, schema, env, or i18n surface (internal telemetry computation only).

## Validation

- `pnpm --filter @open-design/daemon exec tsc --noEmit` → 0 errors
- `vitest run tests/run-analytics-observability.test.ts` → 33 passed (incl. 2 new)
- adjacent suites green: `langfuse-bridge`, `codex-rollout-usage`, `run-analytics-observability` → 70 passed
- red spec confirmed red on pre-fix source, green on branch