### PR TITLE
[codex] add agenti v praxi design system

### DIFF
--- a/design-systems/agenti-v-praxi/DESIGN.md
+++ b/design-systems/agenti-v-praxi/DESIGN.md
@@ -1,0 +1,158 @@
+---
+name: Agenti v praxi
+slug: agenti-v-praxi
+version: 0.1.0
+category: Brands
+surface: web
+description: Prakticky cesky design system pro edukaci, produkty a workflow kolem AI agentu v realne praci.
+colors:
+  ink: "#111315"
+  graphite: "#252A2F"
+  muted: "#6B7280"
+  line: "#D8DEE6"
+  paper: "#F7F4EF"
+  surface: "#FFFFFF"
+  agent_green: "#22C55E"
+  signal_blue: "#2563EB"
+  warm_accent: "#F59E0B"
+  alert_red: "#DC2626"
+typography:
+  display:
+    fontFamily: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif
+    weight: 720
+  body:
+    fontFamily: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif
+    weight: 450
+  mono:
+    fontFamily: JetBrains Mono, SFMono-Regular, Consolas, monospace
+---
+
+# Agenti v praxi
+
+> Category: Brands
+> Practical Czech AI-agent education and workflow operating language.
+
+## Brand Essence
+
+Agenti v praxi is a practical Czech operating system for understanding and using AI agents in everyday work. The brand should feel useful, awake, technically literate and human. It is not a futuristic spectacle; it is a calm cockpit for people who want to ship better workflows.
+
+Core promise: turn abstract AI potential into concrete repeatable practice.
+
+## Personality
+
+- Practical before poetic.
+- Curious, direct, quietly ambitious.
+- Czech-first language with natural operator vocabulary.
+- Clear enough for beginners, precise enough for builders.
+- Avoid hype words unless they are immediately grounded in a real workflow.
+
+## Visual Direction
+
+Use a bright utilitarian workspace aesthetic: warm off-white backgrounds, crisp graphite text, thin rules, compact panels, and strong color only where it signals action or state. The interface should look like a working desk for agentic operations, not a generic SaaS landing page.
+
+## Color Roles
+
+- Paper (`#F7F4EF`): page background, editorial sections, calm empty states.
+- Surface (`#FFFFFF`): cards, tables, dialogs, input fields.
+- Ink (`#111315`): primary text and strong UI anchors.
+- Graphite (`#252A2F`): nav, dense panels, secondary headlines.
+- Muted (`#6B7280`): captions, metadata, supporting text.
+- Line (`#D8DEE6`): borders, separators, grid lines.
+- Agent Green (`#22C55E`): successful automation, active agents, progress, positive state.
+- Signal Blue (`#2563EB`): primary actions, links, selected controls.
+- Warm Accent (`#F59E0B`): notes, highlights, callouts, Czech editorial warmth.
+- Alert Red (`#DC2626`): destructive actions, failures, risk warnings.
+
+## Typography
+
+Use Inter or a close system sans-serif. Headlines are confident but not oversized. Use JetBrains Mono or SF Mono for prompts, commands, logs, token names, agent names and workflow IDs.
+
+Suggested scale:
+
+- H1: 40/46, weight 720, tight but not theatrical.
+- H2: 28/34, weight 700.
+- H3: 20/28, weight 650.
+- Body: 16/25, weight 450.
+- Small: 13/19, weight 500.
+- Mono labels: 12/18, uppercase optional, letter spacing 0.
+
+## Layout Principles
+
+- Prefer dense, scan-friendly layouts over decorative hero pages.
+- Use full-width sections and restrained cards for repeated items only.
+- Keep dashboards, workflow builders and lesson pages highly structured.
+- Use 8px radius for cards and panels, 6px for controls, 999px only for small status pills.
+- Use generous whitespace around main learning content, tighter spacing inside operational tools.
+- Avoid purple-blue gradients, floating blobs, fake 3D gloss and generic AI neon.
+
+## Components
+
+### Buttons
+
+Primary buttons use Signal Blue background, white text and compact height. Secondary buttons are white with Line border and Ink text. Destructive buttons use Alert Red. Icon buttons should use familiar icons and tooltips.
+
+### Cards
+
+Cards are for lessons, workflow templates, agents, examples and repeated resources. Use white surface, 1px Line border, 8px radius, subtle shadow only if needed. Cards should have clear metadata: use case, difficulty, time, required tools.
+
+### Callouts
+
+Use Warm Accent for practical notes and Agent Green for successful patterns. Risk callouts use Alert Red but stay calm in tone: explain consequence and remedy.
+
+### Tables
+
+Tables should be compact and operational: status, owner, tool, trigger, output, next action. Use mono for IDs and tool names.
+
+### Workflow Diagrams
+
+Represent agents as nodes, tools as connectors and human checkpoints as explicit gates. Use Graphite lines, Agent Green active states and Warm Accent for review checkpoints.
+
+### Code and Prompt Blocks
+
+Use Graphite or Ink backgrounds with light text for longer prompt/code blocks. Use mono typography. Include small labels such as `PROMPT`, `OUTPUT`, `CHECKLIST`, `AGENT ROLE`.
+
+## Content Patterns
+
+Use Czech headlines that say the practical outcome:
+
+- Jak z jednoho promptu udelat opakovatelny workflow
+- Agent neni chatbot. Je to proces s pameti, nastroji a kontrolou.
+- Nejdriv kontrola rizik, potom automatizace.
+
+Preferred microcopy:
+
+- Spustit workflow
+- Pridat agenta
+- Zkontrolovat vystup
+- Ulozit jako sablonu
+- Otevrit audit
+- Vyzkouset na prikladu
+
+Avoid:
+
+- Magie AI
+- Revoluce jednim klikem
+- Autonomni vsechno
+- Bez prace a bez kontroly
+
+## Page Archetypes
+
+### Learning Article
+
+Warm Paper background, clear editorial rhythm, diagrams and concrete examples. One practical takeaway per section.
+
+### Workflow Template
+
+Compact operational page: goal, inputs, agent role, tools, checkpoints, output, failure modes.
+
+### Dashboard
+
+Dense but calm: active workflows, runs, costs, quality signals, open reviews. State colors must be semantic.
+
+### Landing / Offer Page
+
+Lead with the literal offer or name: Agenti v praxi. Show real examples, not abstract AI decoration. The first viewport should immediately signal practical AI-agent education and workflows.
+
+## Accessibility
+
+Maintain strong contrast. Do not rely on color alone for status. Keep Czech diacritics supported when available, but generated artifacts may remain ASCII-safe when necessary.

--- a/design-systems/agenti-v-praxi/USAGE.md
+++ b/design-systems/agenti-v-praxi/USAGE.md
@@ -1,0 +1,31 @@
+# Agenti v praxi Usage
+
+Design System package guide for Open Design agents and reviewers.
+
+## Read Order
+
+1. Read this file first to understand the package contract.
+2. Read `DESIGN.md` for brand intent, tone, layout posture, and component rules.
+3. Paste `tokens.css` into the first artifact `<style>` block before writing component CSS.
+4. Use raw hex values only inside the token block. Component CSS should use `var(--token-name)`.
+
+## Design Highlights
+
+- Bright, utilitarian Czech operator workspace for practical AI-agent education.
+- Warm paper background, white operational surfaces, crisp graphite text, and thin rules.
+- Signal Blue for primary actions, Agent Green for successful automation, Warm Accent for notes and callouts.
+- Dense but calm layouts for workflows, dashboards, templates, lessons, and audits.
+
+## Do
+
+- Keep the language practical and Czech-first when writing user-facing copy.
+- Show real workflow structure: inputs, agent role, tools, checkpoints, outputs, and failure modes.
+- Use mono type for prompts, commands, logs, agent IDs, tool names, and workflow labels.
+- Make status colors semantic and pair them with labels or icons.
+
+## Avoid
+
+- Avoid generic AI neon, purple gradients, floating blobs, and decorative futurism.
+- Avoid oversized marketing composition for tools, dashboards, or lesson surfaces.
+- Avoid claiming that agents remove human review. Human checkpoints are part of the brand.
+- Avoid raw hex values outside `tokens.css` unless the artifact is explicitly documenting the palette.

--- a/design-systems/agenti-v-praxi/manifest.json
+++ b/design-systems/agenti-v-praxi/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "od-design-system-project/v1",
+  "id": "agenti-v-praxi",
+  "name": "Agenti v praxi",
+  "category": "Brands",
+  "description": "Practical Czech AI-agent education and workflow operating language.",
+  "source": {
+    "type": "bundled",
+    "origin": "hand-authored from local Open Design seed"
+  },
+  "files": {
+    "design": "DESIGN.md",
+    "tokens": "tokens.css"
+  },
+  "usage": "USAGE.md",
+  "importMode": "normalized",
+  "craft": {
+    "applies": [],
+    "suggested": [
+      "color",
+      "accessibility-baseline"
+    ],
+    "exemptions": []
+  }
+}

--- a/design-systems/agenti-v-praxi/tokens.css
+++ b/design-systems/agenti-v-praxi/tokens.css
@@ -1,0 +1,58 @@
+/* Agenti v praxi design tokens.
+ * Copy this :root block into generated artifacts before component CSS,
+ * then reference values through var(--token-name).
+ */
+
+:root {
+  --bg: #f7f4ef;
+  --surface: #ffffff;
+  --surface-warm: #fffaf0;
+  --fg: #111315;
+  --fg-2: #252a2f;
+  --meta: #6b7280;
+  --border: #d8dee6;
+  --border-soft: #e8edf3;
+
+  --accent: #2563eb;
+  --accent-hover: #1d4ed8;
+  --accent-active: #1e40af;
+  --accent-contrast: #ffffff;
+
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #dc2626;
+  --focus-ring: rgba(37, 99, 235, 0.35);
+
+  --font-display: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-body: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", SFMono-Regular, Consolas, monospace;
+
+  --font-size-xs: 12px;
+  --font-size-sm: 13px;
+  --font-size-md: 16px;
+  --font-size-lg: 20px;
+  --font-size-xl: 28px;
+  --font-size-2xl: 40px;
+
+  --line-height-tight: 1.15;
+  --line-height-body: 1.56;
+  --tracking-display: 0;
+
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+
+  --shadow-subtle: 0 1px 2px rgba(17, 19, 21, 0.06), 0 12px 28px rgba(17, 19, 21, 0.06);
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --motion-base: 180ms;
+}


### PR DESCRIPTION
## Summary

Adds a bundled Agenti v praxi design system package with canonical DESIGN.md, token CSS, usage guidance, and a v1 manifest.

## Validation

- pnpm exec tsx scripts/check-design-system-manifests.ts

## Notes

This preserves the local Open Design seed as a versioned design-system source that can be reused from GitHub instead of only living in local .od project state.