### PR TITLE
fix(memory): validate cached rule-proposal decisions on mount + harden prompt (#4690)

### DIFF
--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -697,7 +697,7 @@ export function composeSystemPrompt({
     }
 
     parts.push(
-      `\n\n## Propose new verified rules from corrections\n\nWhen the user corrects your output in a way that implies a reusable, checkable rule, PROPOSE it — never save it silently. Emit a proposal card the user can Keep, Edit, or Discard:\n\n<od-card type="rule-proposal">\n{ "name": "<short name>", "description": "<one line>", "assertion": "<what must hold>", "check": "<how to verify it>", "rationale": "<why you inferred it>" }\n</od-card>\n\nPropose at most one rule per turn, and only when confident it generalizes beyond the current artifact.`,
+      `\n\n## Propose new verified rules from corrections\n\nWhen the user corrects your output in a way that implies a reusable, checkable rule, PROPOSE it — never save it silently. Emit a proposal card the user can Keep, Edit, or Discard:\n\n<od-card type="rule-proposal">\n{ "name": "<short name>", "description": "<one line>", "assertion": "<what must hold>", "check": "<how to verify it>", "rationale": "<why you inferred it>" }\n</od-card>\n\nPropose at most one rule per turn, and only when confident it generalizes beyond the current artifact. Do not claim in prose that a rule was recorded, saved, noted, added to memory, or will be remembered unless this same response includes the rule-proposal card for that rule; the rule becomes saved only after the user clicks Keep.`,
     );
   }
 

--- a/apps/web/src/components/OdCard.tsx
+++ b/apps/web/src/components/OdCard.tsx
@@ -123,11 +123,13 @@ async function validateCachedRuleProposalDecision(
   if (decision.status === 'idle') return decision;
 
   const resp = await fetch('/api/memory');
-  if (!resp.ok) return { status: 'idle' };
+  if (!resp.ok) return null;
   if (decision.status === 'discarded') return decision;
 
-  const body = await resp.json() as { entries?: unknown };
-  const entries = Array.isArray(body.entries) ? body.entries as MemoryEntrySummaryLike[] : [];
+  const body = await resp.json().catch(() => null) as { entries?: unknown } | null;
+  if (!Array.isArray(body?.entries)) return null;
+
+  const entries = body.entries as MemoryEntrySummaryLike[];
   return entries.some((entry) => isMatchingRuleEntry(decision, entry)) ? decision : { status: 'idle' };
 }
 
@@ -346,8 +348,7 @@ function RuleProposalCard({
         }
       })
       .catch(() => {
-        // Keep the cached state on transient validation failures. Non-OK daemon
-        // responses above are treated as an authoritative cache invalidation.
+        // Keep the cached state on transient validation failures.
       });
     return () => {
       cancelled = true;

--- a/apps/web/src/components/OdCard.tsx
+++ b/apps/web/src/components/OdCard.tsx
@@ -11,7 +11,7 @@
 //
 // The parser + payload types live in '@open-design/contracts' (od-card.ts) so
 // web and daemon share one source of truth. This file only renders.
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type {
   OdCard,
   OdCardTaskBrief,
@@ -31,8 +31,14 @@ const RULE_PROPOSAL_DECISION_PREFIX = 'od:rule-proposal-decision:';
 
 type RuleProposalDecision =
   | { status: 'idle' }
-  | { status: 'saved'; name: string }
+  | { status: 'saved'; name: string; id?: string }
   | { status: 'discarded' };
+
+type MemoryEntrySummaryLike = {
+  id?: unknown;
+  name?: unknown;
+  type?: unknown;
+};
 
 function hashRuleProposalKey(input: string): string {
   let hash = 5381;
@@ -66,12 +72,22 @@ function readRuleProposalDecision(key: string): RuleProposalDecision {
       return {
         status: 'saved',
         name: typeof parsed.name === 'string' && parsed.name.trim() ? parsed.name : '',
+        ...(typeof parsed.id === 'string' && parsed.id.trim() ? { id: parsed.id } : {}),
       };
     }
   } catch {
     // Storage can be unavailable in hardened contexts; fall back to per-mount state.
   }
   return { status: 'idle' };
+}
+
+function clearRuleProposalDecision(key: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Best effort only: storage can be unavailable in hardened contexts.
+  }
 }
 
 function writeRuleProposalDecision(key: string, decision: Exclude<RuleProposalDecision, { status: 'idle' }>) {
@@ -94,6 +110,26 @@ export interface BrandBrowserAssistResult {
 export type BrandBrowserAssistConfirm = (
   card: OdCardBrandBrowserAssist,
 ) => Promise<BrandBrowserAssistResult | void> | BrandBrowserAssistResult | void;
+
+function isMatchingRuleEntry(decision: Extract<RuleProposalDecision, { status: 'saved' }>, entry: MemoryEntrySummaryLike) {
+  if (entry.type !== 'rule') return false;
+  if (decision.id && entry.id === decision.id) return true;
+  return typeof entry.name === 'string' && entry.name === decision.name;
+}
+
+async function validateCachedRuleProposalDecision(
+  decision: RuleProposalDecision,
+): Promise<RuleProposalDecision | null> {
+  if (decision.status === 'idle') return decision;
+
+  const resp = await fetch('/api/memory');
+  if (!resp.ok) return { status: 'idle' };
+  if (decision.status === 'discarded') return decision;
+
+  const body = await resp.json() as { entries?: unknown };
+  const entries = Array.isArray(body.entries) ? body.entries as MemoryEntrySummaryLike[] : [];
+  return entries.some((entry) => isMatchingRuleEntry(decision, entry)) ? decision : { status: 'idle' };
+}
 
 export function OdCardView({
   card,
@@ -296,6 +332,28 @@ function RuleProposalCard({
   const [editing, setEditing] = useState(false);
   const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle');
 
+  useEffect(() => {
+    const cachedDecision = readRuleProposalDecision(storageKey);
+    if (cachedDecision.status === 'idle') return;
+
+    let cancelled = false;
+    void validateCachedRuleProposalDecision(cachedDecision)
+      .then((validated) => {
+        if (cancelled || !validated) return;
+        if (validated.status === 'idle') {
+          clearRuleProposalDecision(storageKey);
+          setDecision({ status: 'idle' });
+        }
+      })
+      .catch(() => {
+        // Keep the cached state on transient validation failures. Non-OK daemon
+        // responses above are treated as an authoritative cache invalidation.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [storageKey]);
+
   if (decision.status === 'discarded') return null;
 
   if (decision.status === 'saved') {
@@ -341,7 +399,12 @@ function RuleProposalCard({
         setStatus('error');
         return;
       }
-      const savedDecision = { status: 'saved', name: name.trim() } as const;
+      const body = await resp.json().catch(() => null) as { entry?: { id?: unknown } } | null;
+      const savedDecision = {
+        status: 'saved',
+        name: name.trim(),
+        ...(typeof body?.entry?.id === 'string' ? { id: body.entry.id } : {}),
+      } as const;
       writeRuleProposalDecision(storageKey, savedDecision);
       setDecision(savedDecision);
       setStatus('idle');

--- a/apps/web/tests/components/OdCard.test.tsx
+++ b/apps/web/tests/components/OdCard.test.tsx
@@ -42,6 +42,29 @@ function renderRuleCard(card: OdCardRuleProposal = RULE_CARD, instanceScope = 's
   );
 }
 
+function memoryListResponse(entries: Array<{ id: string; name: string; type: string }> = []) {
+  return new Response(JSON.stringify({ entries }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function savedRuleResponse(id = 'rule_palette_only') {
+  return new Response(JSON.stringify({
+    entry: {
+      id,
+      name: 'Palette only',
+      description: 'Only use the brand palette.',
+      type: 'rule',
+      body: 'Assertion: Every CSS color must match a brand token.',
+      updatedAt: 1,
+    },
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 beforeEach(() => {
   window.localStorage.clear();
   vi.restoreAllMocks();
@@ -83,10 +106,15 @@ describe('OdCard brand browser assist', () => {
 
 describe('OdCard rule proposal decisions', () => {
   it('keeps the saved state after the card remounts', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
-    );
+    vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/memory' && init?.method === 'POST') return Promise.resolve(savedRuleResponse());
+      if (url === '/api/memory') {
+        return Promise.resolve(memoryListResponse([
+          { id: 'rule_palette_only', name: 'Palette only', type: 'rule' },
+        ]));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    }));
 
     const first = renderRuleCard();
     fireEvent.click(screen.getByRole('button', { name: 'Keep' }));
@@ -102,7 +130,37 @@ describe('OdCard rule proposal decisions', () => {
     expect(screen.queryByRole('button', { name: 'Keep' })).toBeNull();
   });
 
+  it('reverts stale saved decisions when memory is unavailable', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/memory' && init?.method === 'POST') return Promise.resolve(savedRuleResponse());
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = renderRuleCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Keep' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved “Palette only” as a rule')).toBeTruthy();
+    });
+    first.unmount();
+
+    renderRuleCard();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Keep' })).toBeTruthy();
+    });
+    expect(screen.getByText('Palette only')).toBeTruthy();
+    expect(screen.queryByText('Saved “Palette only” as a rule')).toBeNull();
+    expect(window.localStorage.length).toBe(0);
+  });
+
   it('keeps the discarded state after the card remounts', () => {
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (url === '/api/memory') return Promise.resolve(memoryListResponse([]));
+      return Promise.resolve(new Response(null, { status: 404 }));
+    }));
+
     const first = renderRuleCard();
     fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
 
@@ -113,6 +171,24 @@ describe('OdCard rule proposal decisions', () => {
 
     expect(screen.queryByText('Palette only')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Keep' })).toBeNull();
+  });
+
+  it('reverts stale discarded decisions when memory is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+
+    const first = renderRuleCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+
+    expect(screen.queryByText('Palette only')).toBeNull();
+    first.unmount();
+
+    renderRuleCard();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Keep' })).toBeTruthy();
+    });
+    expect(screen.getByText('Palette only')).toBeTruthy();
+    expect(window.localStorage.length).toBe(0);
   });
 
   it('does not reuse discarded decisions across scoped card instances', () => {

--- a/apps/web/tests/components/OdCard.test.tsx
+++ b/apps/web/tests/components/OdCard.test.tsx
@@ -65,6 +65,13 @@ function savedRuleResponse(id = 'rule_palette_only') {
   });
 }
 
+function memoryFailureResponse() {
+  return new Response(JSON.stringify({ error: 'memory list failed' }), {
+    status: 500,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 beforeEach(() => {
   window.localStorage.clear();
   vi.restoreAllMocks();
@@ -130,9 +137,10 @@ describe('OdCard rule proposal decisions', () => {
     expect(screen.queryByRole('button', { name: 'Keep' })).toBeNull();
   });
 
-  it('reverts stale saved decisions when memory is unavailable', async () => {
+  it('reverts stale saved decisions when the memory entry is absent', async () => {
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {
       if (url === '/api/memory' && init?.method === 'POST') return Promise.resolve(savedRuleResponse());
+      if (url === '/api/memory') return Promise.resolve(memoryListResponse([]));
       return Promise.resolve(new Response(null, { status: 404 }));
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -155,6 +163,32 @@ describe('OdCard rule proposal decisions', () => {
     expect(window.localStorage.length).toBe(0);
   });
 
+  it('keeps saved decisions when memory validation fails', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/memory' && init?.method === 'POST') return Promise.resolve(savedRuleResponse());
+      if (url === '/api/memory') return Promise.resolve(memoryFailureResponse());
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = renderRuleCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Keep' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved “Palette only” as a rule')).toBeTruthy();
+    });
+    first.unmount();
+
+    renderRuleCard();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/memory');
+    });
+    expect(screen.getByText('Saved “Palette only” as a rule')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Keep' })).toBeNull();
+    expect(window.localStorage.length).toBe(1);
+  });
+
   it('keeps the discarded state after the card remounts', () => {
     vi.stubGlobal('fetch', vi.fn((url: string) => {
       if (url === '/api/memory') return Promise.resolve(memoryListResponse([]));
@@ -173,8 +207,9 @@ describe('OdCard rule proposal decisions', () => {
     expect(screen.queryByRole('button', { name: 'Keep' })).toBeNull();
   });
 
-  it('reverts stale discarded decisions when memory is unavailable', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+  it('keeps discarded decisions when memory validation fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(memoryFailureResponse());
+    vi.stubGlobal('fetch', fetchMock);
 
     const first = renderRuleCard();
     fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
@@ -185,10 +220,11 @@ describe('OdCard rule proposal decisions', () => {
     renderRuleCard();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Keep' })).toBeTruthy();
+      expect(fetchMock).toHaveBeenCalledWith('/api/memory');
     });
-    expect(screen.getByText('Palette only')).toBeTruthy();
-    expect(window.localStorage.length).toBe(0);
+    expect(screen.queryByText('Palette only')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Keep' })).toBeNull();
+    expect(window.localStorage.length).toBe(1);
   });
 
   it('does not reuse discarded decisions across scoped card instances', () => {

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -362,7 +362,7 @@ export function composeSystemPrompt({
     }
 
     parts.push(
-      `\n\n## Propose new verified rules from corrections\n\nWhen the user corrects your output in a way that implies a reusable, checkable rule, PROPOSE it — never save it silently. Emit a proposal card the user can Keep, Edit, or Discard:\n\n<od-card type="rule-proposal">\n{ "name": "<short name>", "description": "<one line>", "assertion": "<what must hold>", "check": "<how to verify it>", "rationale": "<why you inferred it>" }\n</od-card>\n\nPropose at most one rule per turn, and only when confident it generalizes beyond the current artifact.`,
+      `\n\n## Propose new verified rules from corrections\n\nWhen the user corrects your output in a way that implies a reusable, checkable rule, PROPOSE it — never save it silently. Emit a proposal card the user can Keep, Edit, or Discard:\n\n<od-card type="rule-proposal">\n{ "name": "<short name>", "description": "<one line>", "assertion": "<what must hold>", "check": "<how to verify it>", "rationale": "<why you inferred it>" }\n</od-card>\n\nPropose at most one rule per turn, and only when confident it generalizes beyond the current artifact. Do not claim in prose that a rule was recorded, saved, noted, added to memory, or will be remembered unless this same response includes the rule-proposal card for that rule; the rule becomes saved only after the user clicks Keep.`,
     );
   }
 


### PR DESCRIPTION
Fixes #4690

> **Carry-forward of #4711.** The original fix by @sjh9714 was reviewed and **approved by @nettee**, but the PR was auto-closed for author inactivity before it could merge. This re-opens the same approach (its three commits are cherry-picked here, authored by @sjh9714 — full credit to them) rebased onto current `main`. The only manual work was resolving one merge conflict in `OdCard.tsx` where `main` had since added the `BrandBrowserAssist*` types around the same insertion point — both additions are kept side by side, no behavior change.

## Why

Picking up a clean, already-approved bug fix that fell off the queue. The bug: the daemon sometimes claims in prose that a memory rule was "saved/recorded" **without** emitting a `rule-proposal` card, and separately, stale `localStorage` `saved`/`discarded` decisions can survive a namespace/worktree reset — so a rule card renders as a "Saved" chip even though no backing rule exists.

## What users will see

A rule-proposal card no longer gets stuck showing a stale **"Saved"** chip after the underlying memory entry is gone (e.g. after a worktree/namespace reset) — on mount it re-validates against `/api/memory` and falls back to the Keep/Discard prompt when the rule is absent. The daemon prompt is also hardened so the assistant won't claim a rule was saved unless the same response actually emits the card. No new UI entry point.

## Surface area

- [x] **Default behavior change** — the daemon/contracts prompt wording is tightened (no schema/shape change) and stale cached decisions are now invalidated on mount; existing users see the corrected behavior without opting in.

## Screenshots

N/A — no new UI surface; the visible effect (a stale "Saved" chip reverting to the Keep/Discard prompt) is a race/reset-state correction covered by the new unit tests.

## Bug fix verification

- Test path: `apps/web/tests/components/OdCard.test.tsx` — three new specs:
  - `reverts stale saved decisions when the memory entry is absent`
  - `keeps saved decisions when memory validation fails`
  - `keeps discarded decisions when memory validation fails`
- Red/green: **yes.** Short-circuiting `validateCachedRuleProposalDecision` to return the decision unchanged (simulating pre-fix behavior) turns exactly those 3 specs **red**; with the fix in place all **8/8 pass**.

## Validation

- `pnpm typecheck` → exit 0 (all packages, incl. `@open-design/web`, daemon, contracts)
- `pnpm --filter @open-design/web exec vitest run tests/components/OdCard.test.tsx` → **8 passed (8)**
- Node 24.18 / pnpm 10.33.2, fresh `pnpm install` in an isolated worktree
