### PR TITLE
[codex] Restore preview Edit annotation and capture flow

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -179,6 +179,8 @@ interface Props {
   onEnsureProject: () => Promise<string | null>;
   commentAttachments?: ChatCommentAttachment[];
   onRemoveCommentAttachment?: (id: string) => void;
+  incomingAttachments?: ChatAttachment[];
+  onIncomingAttachmentsAccepted?: (paths: string[]) => void;
   // Available skills the user can compose into a turn via @<skill>. The
   // chat layer already filters out disabled skills before passing them in
   // here, so the picker can render the list as-is. Keep this optional so
@@ -347,6 +349,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       onEnsureProject,
       commentAttachments = [],
       onRemoveCommentAttachment,
+      incomingAttachments = [],
+      onIncomingAttachmentsAccepted,
       skills = [],
       onSend,
       onStop,
@@ -1110,6 +1114,29 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         return next;
       });
     }
+
+    useEffect(() => {
+      if (incomingAttachments.length === 0) return;
+      const acceptedPaths = Array.from(new Set(incomingAttachments.map((attachment) => attachment.path)));
+      setStaged((current) => {
+        const knownPaths = new Set(current.map((attachment) => attachment.path));
+        let order = Math.max(nextAttachmentOrderRef.current, nextChatAttachmentOrder(current));
+        const additions: ChatAttachment[] = [];
+        for (const attachment of incomingAttachments) {
+          if (knownPaths.has(attachment.path)) continue;
+          knownPaths.add(attachment.path);
+          additions.push({
+            ...attachment,
+            order: attachment.order ?? order++,
+          });
+        }
+        if (additions.length === 0) return current;
+        const next = sortChatAttachmentsByOrder([...current, ...additions]);
+        nextAttachmentOrderRef.current = Math.max(order, nextChatAttachmentOrder(next));
+        return next;
+      });
+      onIncomingAttachmentsAccepted?.(acceptedPaths);
+    }, [incomingAttachments, onIncomingAttachmentsAccepted]);
 
     function appendContextAttachment(filePath: string) {
       setStaged((current) => {

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -466,6 +466,8 @@ interface Props {
   onAttachComment?: (comment: PreviewComment) => void;
   onDetachComment?: (commentId: string) => void;
   onDeleteComment?: (commentId: string) => void;
+  composerAttachmentInbox?: ChatAttachment[];
+  onComposerAttachmentsAccepted?: (paths: string[]) => void;
   onSend: (
     prompt: string,
     attachments: ChatAttachment[],
@@ -695,6 +697,8 @@ export function ChatPane({
   onAttachComment,
   onDetachComment,
   onDeleteComment,
+  composerAttachmentInbox = [],
+  onComposerAttachmentsAccepted,
   onSend,
   onRetry,
   onResumeRun,
@@ -952,6 +956,11 @@ export function ChatPane({
   } | null>(null);
   const [composerSlotHeight, setComposerSlotHeight] = useState(0);
   const [editingQueuedSendId, setEditingQueuedSendId] = useState<string | null>(null);
+  useEffect(() => {
+    if (composerAttachmentInbox.length > 0 && tab !== 'chat') {
+      setTab('chat');
+    }
+  }, [composerAttachmentInbox.length, tab]);
   // Reverse scan (no array copy) + memo so this and the maps below don't
   // recompute on every non-`messages` render (scroll, hover, toggles).
   const lastAssistantId = useMemo(() => {
@@ -1816,6 +1825,8 @@ export function ChatPane({
       onEnsureProject={onEnsureProject}
       commentAttachments={commentsToAttachments(attachedComments)}
       onRemoveCommentAttachment={onDetachComment}
+      incomingAttachments={tab === 'chat' ? composerAttachmentInbox : []}
+      onIncomingAttachmentsAccepted={onComposerAttachmentsAccepted}
       onSend={(prompt, attachments, commentAttachments, meta) => {
         pinnedToBottomRef.current = true;
         scrolledToFormRef.current = new Set();

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,31 +1,21 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
-import { createPortal, flushSync } from 'react-dom';
-import { Button, Input, Select } from '@open-design/components';
-import { APP_CHROME_FILE_ACTIONS_ID, APP_CHROME_FILE_ACTIONS_SELECTOR } from './AppChromeHeader';
-import {
-  buildSocialSharePayload,
-  OPEN_DESIGN_GITHUB_REPO_URL,
-  type SocialShareRequest,
-  type SocialShareResponse,
-} from '@open-design/contracts';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { APP_CHROME_FILE_ACTIONS_ID } from './AppChromeHeader';
 import {
   anonymizeArtifactId,
   artifactKindToTracking,
   type TrackingProjectKind,
-  type TrackingDeployProvider,
 } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
 import { trackIframeLoad } from '../observability/iframe-error';
 import {
   trackArtifactExportResult,
-  trackArtifactDeployResult,
   trackArtifactHeaderClick,
   trackArtifactToolbarClick,
-  trackCommentPopoverClick,
-  trackDrawToolbarClick,
   trackPageView,
   trackPresentPopoverClick,
   trackShareOptionPopoverClick,
+  trackTweaksPopoverClick,
 } from '../analytics/events';
 import { MarkdownRenderer, artifactRendererRegistry } from '../artifacts/renderer-registry';
 import { renderMarkdownToSafeHtml } from '../artifacts/markdown';
@@ -37,7 +27,6 @@ import {
   fetchLiveArtifactRefreshes,
   checkDeploymentLink,
   CLOUDFLARE_PAGES_PROVIDER_ID,
-  createSocialSharePayload,
   DEFAULT_DEPLOY_PROVIDER_ID,
   deployProjectFile,
   fetchCloudflarePagesZones,
@@ -60,40 +49,34 @@ import {
   type WebDeployProviderId,
   type WebUpdateDeployConfigRequest,
   writeProjectTextFile,
-  writeProjectTextFileDetailed,
 } from '../providers/registry';
 import type { ProjectFilePreview } from '../providers/registry';
 import {
-  downloadImageDataUrl,
+  exportAsHtml,
+  dataUrlToBlob,
+  exportAsImage,
   exportAsJsx,
   exportAsMd,
   exportAsPdf,
-  exportProjectAsHtml,
   exportProjectAsPdf,
   exportProjectAsZip,
-  copyImageDataUrlToClipboard,
   exportReactComponentAsHtml,
   exportReactComponentAsZip,
-  captureHostIframeSnapshot,
-  imageDataUrlToBlob,
   openSandboxedPreviewInNewTab,
-  prepareImageExportTarget,
   requestPreviewSnapshot,
-  type ExportProgress,
-  type ImageExportFormat,
+  type PreviewSnapshot,
+  type PreviewSnapshotViewport,
 } from '../runtime/exports';
-import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
-import { shouldConsumeSlideNav } from '../runtime/slide-nav';
 import { findHtmlEntriesReferencing } from '../runtime/jsx-module-refs';
 import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } from '../runtime/srcdoc';
+import { DEFAULT_IMAGE_MODEL } from '../media/models';
 import {
+  hasTweaksTemplate,
   hasUrlModeBridge,
-  htmlNeedsFocusGuard,
   htmlNeedsSandboxShim,
   parseForceInline,
   shouldUrlLoadHtmlPreview,
-  type UrlLoadDecision,
 } from './file-viewer-render-mode';
 import { saveTemplate } from '../state/projects';
 import type {
@@ -105,18 +88,13 @@ import type {
   ProjectFile,
 } from '../types';
 import { Icon } from './Icon';
-import { RemixIcon } from './RemixIcon';
-import { SocialShareGrid } from './SocialShareGrid';
 import { Toast } from './Toast';
-import { PreviewDrawOverlay, type DrawToolbarElement } from './PreviewDrawOverlay';
+import { PaletteTweaks, type PaletteId } from './PaletteTweaks';
+import { PreviewDrawOverlay, type PreviewDrawMode } from './PreviewDrawOverlay';
 import {
   buildBoardCommentAttachments,
-  commentSnapshotEqual,
-  commentTargetDisplayName,
-  commentVisibleOnDeckSlide,
+  buildVisualAnnotationAttachment,
   commentsToAttachments,
-  isValidCommentOverlayPosition,
-  liveCommentTargetMapsEqual,
   liveSnapshotForComment,
   overlayBoundsFromSnapshot,
   selectionKindLabel,
@@ -124,16 +102,11 @@ import {
   type PreviewCommentSnapshot,
 } from '../comments';
 import { applyPodMemberRemoval } from '../lib/pod-members';
-import { AnnotationHoverPopover, BoardComposerPopover } from './BoardComposerPopover';
-import {
-  OD_PREVIEW_KEEP_ALIVE,
-  PooledIframe,
-  previewIframeKeepAliveKey,
-} from './IframeKeepAlivePool';
+import { BoardComposerPopover } from './BoardComposerPopover';
 import type {
+  ChatAttachment,
   ChatCommentAttachment,
   PreviewComment,
-  PreviewCommentAttachment,
   PreviewCommentMember,
   PreviewCommentTarget,
 } from '../types';
@@ -149,11 +122,6 @@ import {
 import { MANUAL_EDIT_STYLE_PROPS, type ManualEditBridgeMessage, type ManualEditHistoryEntry, type ManualEditPatch, type ManualEditStyles, type ManualEditTarget } from '../edit-mode/types';
 import { isRenderableSketchJson, SketchPreview } from './SketchPreview';
 
-function resolveChromeActionsHost(): HTMLElement | null {
-  return document.querySelector<HTMLElement>(APP_CHROME_FILE_ACTIONS_SELECTOR)
-    ?? document.getElementById(APP_CHROME_FILE_ACTIONS_ID);
-}
-
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 type SlideState = { active: number; count: number };
 type BoardTool = 'inspect' | 'pod';
@@ -164,8 +132,80 @@ export type ManualEditPendingStyleSave = {
   label: string;
   version: number;
 };
+type AnnotateStyleChangeMessage = {
+  type: 'od:annotate-style-change';
+  id: string;
+  property: string;
+  value: string;
+  label?: string;
+};
+type AnnotateTextChangeMessage = {
+  type: 'od:annotate-text-change';
+  id: string;
+  value: string;
+  label?: string;
+};
+type AnnotateImageChangeMessage = {
+  type: 'od:annotate-image-change';
+  id: string;
+  file: File;
+  alt?: string;
+  label?: string;
+};
+type AnnotateImageSrcChangeMessage = {
+  type: 'od:annotate-image-src-change';
+  id: string;
+  src: string;
+  alt?: string;
+  label?: string;
+};
+type AnnotateImagePromptMessage = {
+  type: 'od:annotate-image-prompt';
+  id: string;
+  prompt: string;
+  src?: string;
+  alt?: string;
+  targetKind?: 'src' | 'background' | 'href';
+  label?: string;
+};
+type AnnotateCaptureMessage = {
+  type: 'od:annotate-capture';
+  captureId?: string;
+  overlay?: AnnotateCaptureOverlay;
+};
+type AnnotateCaptureOverlay = {
+  html?: string;
+  css?: string;
+  scrollX?: number;
+  scrollY?: number;
+};
+type AnnotateChangeMessage =
+  | AnnotateStyleChangeMessage
+  | AnnotateTextChangeMessage
+  | AnnotateImageChangeMessage
+  | AnnotateImageSrcChangeMessage
+  | AnnotateImagePromptMessage
+  | AnnotateCaptureMessage;
+type AnnotatePendingStyleSave = {
+  styles: Record<string, string>;
+  label: string;
+};
+type AnnotatePendingTextSave = {
+  value: string;
+  label: string;
+};
+type AnnotateCaptureStage = 'requested' | 'snapshotting' | 'uploading' | 'staged' | 'failed';
+type AnnotateCaptureJob = {
+  id: string;
+  stage: AnnotateCaptureStage;
+  error?: string;
+};
+type AnnotateCaptureOverlayRequest = {
+  reject: () => void;
+  resolve: (overlay: AnnotateCaptureOverlay | null) => void;
+};
 type PreviewViewportId = 'desktop' | 'tablet' | 'mobile';
-type PreviewCanvasSize = { width: number; height: number; scrollLeft?: number; scrollTop?: number };
+type PreviewCanvasSize = { width: number; height: number };
 type CommentPreviewCanvasOptions = {
   boardMode: boolean;
   sidePanelCollapsed: boolean;
@@ -181,15 +221,6 @@ type PreviewViewportPreset = {
   labelKey: keyof Dict;
   titleKey: keyof Dict;
 };
-const IMAGE_EXPORT_FORMAT_OPTIONS: Array<{
-  value: ImageExportFormat;
-  label: string;
-  extension: string;
-}> = [
-  { value: 'png', label: 'PNG', extension: '.png' },
-  { value: 'jpeg', label: 'JPEG', extension: '.jpg' },
-  { value: 'webp', label: 'WebP', extension: '.webp' },
-];
 type DeployProviderOption = {
   id: WebDeployProviderId;
   labelKey: 'fileViewer.vercelProvider' | 'fileViewer.cloudflarePagesProvider';
@@ -200,6 +231,7 @@ type DeployProviderOption = {
     | 'fileViewer.cloudflareApiTokenPlaceholder';
   tokenReuseHintKey: 'fileViewer.vercelTokenReuseHint' | 'fileViewer.cloudflareApiTokenReuseHint';
   tokenRequiredKey: 'fileViewer.vercelTokenRequired' | 'fileViewer.cloudflareApiTokenRequired';
+  previewHintKey: 'fileViewer.vercelPreviewOnly' | 'fileViewer.cloudflarePagesPreviewHint';
   tokenLabelKey:
     | 'fileViewer.vercelToken'
     | 'fileViewer.cloudflareApiToken';
@@ -243,13 +275,6 @@ const PREVIEW_VIEWPORT_PRESETS: PreviewViewportPreset[] = [
     titleKey: 'fileViewer.viewportMobileTitle',
   },
 ];
-
-function previewViewportIcon(viewport: PreviewViewportId): string {
-  if (viewport === 'tablet') return 'tablet-line';
-  if (viewport === 'mobile') return 'smartphone-line';
-  return 'computer-line';
-}
-
 const EXPORT_READY_NUDGE_STORAGE_PREFIX = 'open-design:export-ready-nudge:';
 const COMMENT_SIDE_DOCK_WIDTH = 320;
 const COMMENT_SIDE_DOCK_RAIL_WIDTH = 42;
@@ -299,13 +324,6 @@ type InspectTarget = {
 
 const MAX_CACHED_SLIDE_STATES = 64;
 const htmlPreviewSlideState = new Map<string, SlideState>();
-const MAX_CACHED_PREVIEW_VIEWPORTS = 128;
-// Grace window before the inspect hover card is torn down. Long enough to absorb
-// the async iframe mouseout (od:comment-leave) that fires when the pointer slides
-// onto the card or hops back onto the element under it, short enough to read as
-// an immediate dismiss when the pointer really leaves.
-const HOVER_CARD_DISMISS_DELAY_MS = 80;
-const htmlPreviewViewportState = new Map<string, PreviewViewportId>();
 const MARKDOWN_CODE_BLOCK_ATTR = 'data-markdown-code-block';
 const MARKDOWN_COPY_BLOCK_ATTR = 'data-copy-code-block';
 const MARKDOWN_COPY_BUTTON_CLASS = 'markdown-code-copy';
@@ -320,6 +338,7 @@ const DEPLOY_PROVIDER_OPTIONS: DeployProviderOption[] = [
     tokenPlaceholderKey: 'fileViewer.vercelTokenPlaceholder',
     tokenReuseHintKey: 'fileViewer.vercelTokenReuseHint',
     tokenRequiredKey: 'fileViewer.vercelTokenRequired',
+    previewHintKey: 'fileViewer.vercelPreviewOnly',
     tokenLabelKey: 'fileViewer.vercelToken',
   },
   {
@@ -330,6 +349,7 @@ const DEPLOY_PROVIDER_OPTIONS: DeployProviderOption[] = [
     tokenPlaceholderKey: 'fileViewer.cloudflareApiTokenPlaceholder',
     tokenReuseHintKey: 'fileViewer.cloudflareApiTokenReuseHint',
     tokenRequiredKey: 'fileViewer.cloudflareApiTokenRequired',
+    previewHintKey: 'fileViewer.cloudflarePagesPreviewHint',
     tokenLabelKey: 'fileViewer.cloudflareApiToken',
     accountIdLabelKey: 'fileViewer.cloudflareAccountId',
     accountIdHintKey: 'fileViewer.cloudflareAccountIdHint',
@@ -405,22 +425,6 @@ function deployResultState(status?: string): 'ready' | 'delayed' | 'protected' |
   if (status === 'failed' || status === 'conflict') return 'failed';
   if (status === 'link-delayed' || status === 'pending') return 'delayed';
   return 'ready';
-}
-
-function publicShareUrlForDeployment(deployment?: WebDeploymentInfo | null): string {
-  if (!deployment) return '';
-  const cloudflare = deployment.cloudflarePages;
-  const customDomainUrl = cloudflare?.customDomain?.status === 'ready'
-    ? cloudflare.customDomain.url?.trim()
-    : '';
-  if (customDomainUrl) return customDomainUrl;
-  const pagesDevUrl = cloudflare?.pagesDev?.status === 'ready'
-    ? cloudflare.pagesDev.url?.trim()
-    : '';
-  if (pagesDevUrl) return pagesDevUrl;
-  return deployResultState(deployment.status) === 'ready'
-    ? deployment.url?.trim() || ''
-    : '';
 }
 
 async function copyTextToClipboard(text: string): Promise<boolean> {
@@ -524,24 +528,17 @@ function PreviewViewportControls({
     <div className="viewer-viewport-switcher" ref={menuRef}>
       <button
         type="button"
-        className={`viewer-action viewer-viewport-trigger${open ? '' : ' od-tooltip'}`}
+        className="viewer-action viewer-viewport-trigger"
         aria-label={t('fileViewer.viewportAria')}
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
         title={t(activePreset.titleKey)}
-        data-tooltip={open ? undefined : t(activePreset.titleKey)}
-        data-tooltip-placement="bottom"
         tabIndex={tabIndex}
         onClick={() => setOpen((value) => !value)}
       >
-        <RemixIcon
-          name={previewViewportIcon(activePreset.id)}
-          size={14}
-          className="viewer-viewport-icon"
-        />
         <span>{t(activePreset.labelKey)}</span>
-        <RemixIcon name="arrow-down-s-line" size={14} />
+        <Icon name="chevron-down" size={11} />
       </button>
       {open ? (
         <div className="viewer-viewport-menu" id={listboxId} role="listbox" aria-label={t('fileViewer.viewportAria')}>
@@ -560,10 +557,7 @@ function PreviewViewportControls({
                   setOpen(false);
                 }}
               >
-                <span className="viewer-viewport-menu-label">
-                  <RemixIcon name={previewViewportIcon(preset.id)} size={14} />
-                  <span>{t(preset.labelKey)}</span>
-                </span>
+                <span>{t(preset.labelKey)}</span>
                 {selected ? <Icon name="check" size={13} /> : null}
               </button>
             );
@@ -578,17 +572,32 @@ function previewViewportStyle(
   viewport: PreviewViewportId,
   previewScale = 1,
   canvasSize?: PreviewCanvasSize,
-  options?: PreviewScaleOptions,
 ): CSSProperties & Record<string, string | number> {
   const preset = PREVIEW_VIEWPORT_PRESETS.find((item) => item.id === viewport) ?? PREVIEW_VIEWPORT_PRESETS[0]!;
   if (!preset.width) return {};
-  const effectiveScale = effectivePreviewScale(viewport, previewScale, canvasSize, options);
+  const effectiveScale = effectivePreviewScale(viewport, previewScale, canvasSize);
   return {
     '--preview-viewport-width': `${preset.width}px`,
     '--preview-viewport-height': `${preset.height}px`,
     '--preview-scale': effectiveScale,
     '--preview-user-scale': previewScale,
   };
+}
+
+export function effectivePreviewScale(
+  viewport: PreviewViewportId,
+  previewScale: number,
+  canvasSize?: PreviewCanvasSize,
+  options?: PreviewScaleOptions,
+) {
+  if (viewport === 'desktop') return previewScale;
+  const preset = PREVIEW_VIEWPORT_PRESETS.find((item) => item.id === viewport);
+  if (!preset?.width || !preset.height || !canvasSize?.width || !canvasSize.height) return previewScale;
+  const canvasPadding = options?.canvasPadding ?? 48;
+  const availableWidth = Math.max(1, canvasSize.width - canvasPadding);
+  const availableHeight = Math.max(1, canvasSize.height - canvasPadding);
+  const fitScale = Math.min(1, availableWidth / preset.width, availableHeight / preset.height);
+  return Math.min(previewScale, fitScale);
 }
 
 export function commentPreviewCanvasSize(
@@ -627,22 +636,6 @@ function usesStackedCommentSideDock(
   const sideDockWidth = options.sidePanelCollapsed ? COMMENT_SIDE_DOCK_RAIL_WIDTH : COMMENT_SIDE_DOCK_WIDTH;
   const dockedWidth = canvasSize.width - (dockPadding * 2) - COMMENT_SIDE_DOCK_GAP - sideDockWidth;
   return dockedWidth < COMMENT_SIDE_DOCK_MIN_CANVAS_WIDTH;
-}
-
-export function effectivePreviewScale(
-  viewport: PreviewViewportId,
-  previewScale: number,
-  canvasSize?: PreviewCanvasSize,
-  options?: PreviewScaleOptions,
-) {
-  if (viewport === 'desktop') return previewScale;
-  const preset = PREVIEW_VIEWPORT_PRESETS.find((item) => item.id === viewport);
-  if (!preset?.width || !preset.height || !canvasSize?.width || !canvasSize.height) return previewScale;
-  const canvasPadding = options?.canvasPadding ?? 48;
-  const availableWidth = Math.max(1, canvasSize.width - canvasPadding);
-  const availableHeight = Math.max(1, canvasSize.height - canvasPadding);
-  const fitScale = Math.min(1, availableWidth / preset.width, availableHeight / preset.height);
-  return Math.min(previewScale, fitScale);
 }
 
 type PreviewOverlayTransform = { scale: number; offsetX: number; offsetY: number };
@@ -702,111 +695,6 @@ function manualEditPreviewShellStyle(
   return previewScaleShellStyle(viewport, previewScale);
 }
 
-function deploymentTimestamp(deployment: WebDeploymentInfo): number {
-  const maybeDeployedAt = (deployment as WebDeploymentInfo & { deployedAt?: number | string }).deployedAt;
-  const candidates = [maybeDeployedAt, deployment.updatedAt, deployment.createdAt];
-  for (const candidate of candidates) {
-    if (typeof candidate === 'number' && Number.isFinite(candidate)) return candidate;
-    if (typeof candidate === 'string') {
-      const parsed = Date.parse(candidate);
-      if (Number.isFinite(parsed)) return parsed;
-    }
-  }
-  return 0;
-}
-
-function compareDeploymentsByNewest(a: WebDeploymentInfo, b: WebDeploymentInfo): number {
-  return deploymentTimestamp(b) - deploymentTimestamp(a);
-}
-
-function shareUrlForDeployment(deployment: WebDeploymentInfo): string {
-  const customDomain = deployment.providerId === CLOUDFLARE_PAGES_PROVIDER_ID
-    ? deployment.cloudflarePages?.customDomain
-    : undefined;
-  if (customDomain?.status === 'ready' && customDomain.url?.trim()) {
-    return customDomain.url.trim();
-  }
-  return deployment.url?.trim() || '';
-}
-
-function resolveShareUrl(rawUrl: string): string {
-  const trimmed = rawUrl.trim();
-  if (!trimmed) return '';
-  if (/^https?:\/\//i.test(trimmed)) return trimmed;
-  if (typeof window === 'undefined') return trimmed;
-  return new URL(trimmed, window.location.origin).toString();
-}
-
-function pickLatestShareDeployment(
-  deploymentsByProvider: Partial<Record<WebDeployProviderId, WebDeploymentInfo>>,
-): WebDeploymentInfo | null {
-  return Object.values(deploymentsByProvider)
-    .filter((deployment): deployment is WebDeploymentInfo =>
-      Boolean(deployment && shareUrlForDeployment(deployment) && deployResultState(deployment.status) !== 'failed'))
-    .sort(compareDeploymentsByNewest)[0] ?? null;
-}
-
-function manualEditFloatingPanelStyle(
-  target: ManualEditTarget,
-  previewScale: number,
-  canvasSize: PreviewCanvasSize | undefined,
-): CSSProperties {
-  const scale = Number.isFinite(previewScale) && previewScale > 0 ? previewScale : 1;
-  const panelWidth = 320;
-  const preferredPanelHeight = 380;
-  const pad = 12;
-  const canvasWidth = canvasSize?.width ?? 1200;
-  const canvasHeight = canvasSize?.height ?? 800;
-  const panelHeight = Math.min(preferredPanelHeight, Math.max(260, canvasHeight - pad * 2));
-  const targetLeft = target.rect.x * scale;
-  const targetTop = target.rect.y * scale;
-  const targetRight = (target.rect.x + target.rect.width) * scale;
-  let left = targetRight + pad;
-  if (left + panelWidth > canvasWidth - pad) {
-    left = Math.max(pad, targetLeft - panelWidth - pad);
-  }
-  const top = Math.max(
-    pad,
-    Math.min(targetTop, Math.max(pad, canvasHeight - panelHeight - pad)),
-  );
-  // Height is left to the content (auto): a short inspector (e.g. typography
-  // only) should be a compact card, not a tall half-empty panel. The cap only
-  // engages for long inspectors, at which point the scroll body takes over.
-  return {
-    left,
-    top,
-    width: panelWidth,
-    maxHeight: panelHeight,
-  };
-}
-
-// Anchors the hover "edit params" affordance to the top-right corner of the
-// hovered element, just inside its bounds so moving the cursor from the
-// element onto the icon does not drop the hover. Uses the same iframe→canvas
-// coordinate basis as the floating inspector panel.
-function manualEditHoverIconStyle(
-  target: ManualEditTarget,
-  previewScale: number,
-  canvasSize: PreviewCanvasSize | undefined,
-): CSSProperties {
-  const scale = Number.isFinite(previewScale) && previewScale > 0 ? previewScale : 1;
-  const iconSize = 26;
-  const inset = 4;
-  const canvasWidth = canvasSize?.width ?? 1200;
-  const canvasHeight = canvasSize?.height ?? 800;
-  const targetTop = target.rect.y * scale;
-  const targetRight = (target.rect.x + target.rect.width) * scale;
-  const left = Math.max(
-    inset,
-    Math.min(targetRight - iconSize - inset, canvasWidth - iconSize - inset),
-  );
-  const top = Math.max(
-    inset,
-    Math.min(targetTop + inset, canvasHeight - iconSize - inset),
-  );
-  return { left, top, width: iconSize, height: iconSize };
-}
-
 export function cancelManualEditPendingStyleSnapshot(
   pending: ManualEditPendingStyleSave | null,
   id: string,
@@ -828,26 +716,16 @@ function usePreviewCanvasSize<T extends HTMLElement>() {
     if (!el) return;
     const measure = () => {
       const rect = el.getBoundingClientRect();
-      setSize({
-        width: rect.width,
-        height: rect.height,
-        scrollLeft: el.scrollLeft,
-        scrollTop: el.scrollTop,
-      });
+      setSize({ width: rect.width, height: rect.height });
     };
     measure();
-    let observer: ResizeObserver | null = null;
     if (typeof ResizeObserver !== 'undefined') {
-      observer = new ResizeObserver(measure);
+      const observer = new ResizeObserver(measure);
       observer.observe(el);
+      return () => observer.disconnect();
     }
-    el.addEventListener('scroll', measure, { passive: true });
     window.addEventListener('resize', measure);
-    return () => {
-      observer?.disconnect();
-      el.removeEventListener('scroll', measure);
-      window.removeEventListener('resize', measure);
-    };
+    return () => window.removeEventListener('resize', measure);
   }, []);
 
   return [ref, size] as const;
@@ -876,67 +754,6 @@ function setSlideStateCached(key: string, state: SlideState) {
   }
 }
 
-function waitForIframeLoadOrTimeout(iframe: HTMLIFrameElement, timeout = 750): Promise<void> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      iframe.removeEventListener('load', finish);
-      window.clearTimeout(timer);
-      resolve();
-    };
-    const timer = window.setTimeout(finish, timeout);
-    iframe.addEventListener('load', finish, { once: true });
-  });
-}
-
-function waitForAnimationFrame(): Promise<void> {
-  return new Promise((resolve) => {
-    if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(() => resolve());
-      return;
-    }
-    window.setTimeout(resolve, 0);
-  });
-}
-
-function temporarilyExposeIframeForSnapshot(iframe: HTMLIFrameElement): () => void {
-  const previousVisibility = iframe.style.visibility;
-  const previousOpacity = iframe.style.opacity;
-  const previousPointerEvents = iframe.style.pointerEvents;
-  iframe.style.visibility = 'visible';
-  iframe.style.opacity = '0.001';
-  iframe.style.pointerEvents = 'none';
-  return () => {
-    iframe.style.visibility = previousVisibility;
-    iframe.style.opacity = previousOpacity;
-    iframe.style.pointerEvents = previousPointerEvents;
-  };
-}
-
-async function requestPreviewSnapshotWithRetry(iframe: HTMLIFrameElement): Promise<Awaited<ReturnType<typeof requestPreviewSnapshot>>> {
-  const timeouts = [1500, 3000, 6000];
-  for (const timeout of timeouts) {
-    const snapshot = await requestPreviewSnapshot(iframe, timeout);
-    if (snapshot) return snapshot;
-    await waitForAnimationFrame();
-  }
-  return null;
-}
-
-function previewViewportStateKey(projectId: string, file: Pick<ProjectFile, 'name' | 'path'>): string {
-  return `${projectId}:${file.path || file.name}`;
-}
-
-function setPreviewViewportCached(key: string, viewport: PreviewViewportId) {
-  htmlPreviewViewportState.set(key, viewport);
-  if (htmlPreviewViewportState.size > MAX_CACHED_PREVIEW_VIEWPORTS) {
-    const oldest = htmlPreviewViewportState.keys().next().value;
-    if (oldest != null) htmlPreviewViewportState.delete(oldest);
-  }
-}
-
 interface Props {
   projectId: string;
   projectKind: TrackingProjectKind;
@@ -944,6 +761,7 @@ interface Props {
   liveHtml?: string;
   filesRefreshKey?: number;
   isDeck?: boolean;
+  onExportAsPptx?: ((fileName: string) => void) | undefined;
   streaming?: boolean;
   commentQueueOnSend?: boolean;
   commentSendDisabled?: boolean;
@@ -951,22 +769,17 @@ interface Props {
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean, images?: File[]) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
   onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[], images?: File[]) => Promise<boolean | void> | boolean | void;
+  onStageBoardCapture?: (att: ChatAttachment) => void;
   onFileSaved?: () => Promise<void> | void;
+  commentPortalId?: string;
+  onCommentModeChange?: (active: boolean) => void;
+  shareRequest?: { nonce: number } | null;
+  downloadRequest?: { nonce: number } | null;
+  slideNavRequest?: { slideIndex: number; nonce: number } | null;
   // Open `openName` as a tab (focusing it) and close `closeName` in one
   // atomic tab-state update. The React module pointer uses this to jump to the
   // HTML entry that renders a module and drop the dead-end module tab.
   onOpenFileReplacing?: (openName: string, closeName: string) => void;
-  commentPortalId?: string;
-  onCommentModeChange?: (active: boolean) => void;
-  // Bumped nonce asking this viewer to open its Share/Export menu (chat-side
-  // "Share" next-step action). Only HTML artifacts expose a Share menu.
-  shareRequest?: { nonce: number } | null;
-  // Bumped nonce asking this viewer to open its Download/Export menu (chat-side
-  // "Download" next-step action).
-  downloadRequest?: { nonce: number } | null;
-  // Bumped nonce asking a deck preview to flip to `slideIndex` (a queued chat
-  // send for this file just started processing).
-  slideNavRequest?: { slideIndex: number; nonce: number } | null;
 }
 
 export function FileViewer({
@@ -976,20 +789,15 @@ export function FileViewer({
   liveHtml,
   filesRefreshKey = 0,
   isDeck,
+  onExportAsPptx,
   streaming,
-  commentQueueOnSend = false,
-  commentSendDisabled = false,
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
+  onStageBoardCapture,
   onFileSaved,
   onOpenFileReplacing,
-  commentPortalId,
-  onCommentModeChange,
-  shareRequest,
-  downloadRequest,
-  slideNavRequest,
 }: Props) {
   const rendererMatch = artifactRendererRegistry.resolve({
     file,
@@ -1020,19 +828,14 @@ export function FileViewer({
         liveHtml={liveHtml}
         filesRefreshKey={filesRefreshKey}
         isDeck={rendererMatch.renderer.id === 'deck-html'}
+        onExportAsPptx={onExportAsPptx}
         streaming={Boolean(streaming)}
-        commentQueueOnSend={commentQueueOnSend}
-        commentSendDisabled={commentSendDisabled}
         previewComments={previewComments}
         onSavePreviewComment={onSavePreviewComment}
         onRemovePreviewComment={onRemovePreviewComment}
         onSendBoardCommentAttachments={onSendBoardCommentAttachments}
+        onStageBoardCapture={onStageBoardCapture}
         onFileSaved={onFileSaved}
-        commentPortalId={commentPortalId}
-        onCommentModeChange={onCommentModeChange}
-        shareRequest={shareRequest}
-        downloadRequest={downloadRequest}
-        slideNavRequest={slideNavRequest}
       />
     );
   }
@@ -1098,14 +901,7 @@ export function LiveArtifactViewer({
   const [loading, setLoading] = useState(true);
   const [reloadKey, setReloadKey] = useState(0);
   const [zoom, setZoom] = useState(100);
-  const liveArtifactViewportKey = `${projectId}:live-artifact:${liveArtifact.artifactId}`;
-  const [previewViewport, setPreviewViewportState] = useState<PreviewViewportId>(
-    () => htmlPreviewViewportState.get(liveArtifactViewportKey) ?? 'desktop',
-  );
-  const setPreviewViewport = useCallback((viewport: PreviewViewportId) => {
-    setPreviewViewportCached(liveArtifactViewportKey, viewport);
-    setPreviewViewportState(viewport);
-  }, [liveArtifactViewportKey]);
+  const [previewViewport, setPreviewViewport] = useState<PreviewViewportId>('desktop');
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -1114,14 +910,12 @@ export function LiveArtifactViewer({
   const [refreshEvents, setRefreshEvents] = useState<LiveArtifactRefreshEvent[]>([]);
   const [refreshHistory, setRefreshHistory] = useState<LiveArtifactRefreshLogEntry[]>([]);
   const [presentMenuOpen, setPresentMenuOpen] = useState(false);
-  const [zoomMenuOpen, setZoomMenuOpen] = useState(false);
-  const zoomMenuRef = useRef<HTMLDivElement | null>(null);
   const [inTabPresent, setInTabPresent] = useState(false);
   const presentWrapRef = useRef<HTMLDivElement | null>(null);
   const [chromeActionsHost, setChromeActionsHost] = useState<HTMLElement | null>(null);
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    setChromeActionsHost(resolveChromeActionsHost());
+    setChromeActionsHost(document.getElementById(APP_CHROME_FILE_ACTIONS_ID));
   }, []);
   useEffect(() => {
     if (!presentMenuOpen) return;
@@ -1147,10 +941,6 @@ export function LiveArtifactViewer({
     setRefreshSuccess(null);
     setRefreshEvents([]);
   }, [projectId, liveArtifact.artifactId]);
-
-  useEffect(() => {
-    setPreviewViewportState(htmlPreviewViewportState.get(liveArtifactViewportKey) ?? 'desktop');
-  }, [liveArtifactViewportKey]);
 
   useEffect(() => {
     if (!refreshSuccess) return;
@@ -1260,6 +1050,7 @@ export function LiveArtifactViewer({
     [projectId, liveArtifact.artifactId, reloadKey],
   );
   const previewScale = zoom / 100;
+  const previewActive = mode === 'preview';
 
   // Instrument the live-artifact iframe so failed loads — usually a
   // missing artifact file or a stuck `od://` resolver — surface in
@@ -1276,6 +1067,10 @@ export function LiveArtifactViewer({
       projectId,
     });
   }, [mode, previewUrl, liveArtifact.artifactId, projectId]);
+
+  function bumpZoom(delta: number) {
+    setZoom((z) => Math.max(25, Math.min(200, z + delta)));
+  }
 
   async function handleRefresh() {
     if (refreshing) return;
@@ -1340,23 +1135,6 @@ export function LiveArtifactViewer({
     return () => document.removeEventListener('keydown', onKey);
   }, [inTabPresent]);
 
-  useEffect(() => {
-    if (!zoomMenuOpen) return;
-    const onDocClick = (e: MouseEvent) => {
-      if (!zoomMenuRef.current) return;
-      if (!zoomMenuRef.current.contains(e.target as Node)) setZoomMenuOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setZoomMenuOpen(false);
-    };
-    document.addEventListener('mousedown', onDocClick);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onDocClick);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [zoomMenuOpen]);
-
   return (
     <div className={`viewer html-viewer live-artifact-viewer${inTabPresent ? ' is-tab-present' : ''}`}>
       {((node: ReactNode) => (
@@ -1364,29 +1142,27 @@ export function LiveArtifactViewer({
       ))(
         <div className="present-wrap chrome-present-wrap" ref={presentWrapRef}>
           <button
-            className="chrome-action chrome-action-secondary chrome-action-icon present-trigger od-tooltip"
+            className="chrome-action chrome-action-secondary present-trigger"
             aria-haspopup="menu"
             aria-expanded={presentMenuOpen}
-            aria-label={t('fileViewer.present')}
-            data-tooltip={t('fileViewer.present')}
-            data-tooltip-placement="bottom"
-            title={t('fileViewer.present')}
             onClick={() => setPresentMenuOpen((v) => !v)}
           >
-            <RemixIcon name="slideshow-3-line" size={15} />
+            <Icon name="present" size={13} />
+            <span>{t('fileViewer.present')}</span>
+            <Icon name="chevron-down" size={11} />
           </button>
           {presentMenuOpen ? (
             <div className="present-menu" role="menu">
               <button role="menuitem" onClick={presentInThisTab}>
-                <span className="present-icon"><RemixIcon name="eye-line" size={14} /></span>{' '}
+                <span className="present-icon"><Icon name="eye" size={13} /></span>{' '}
                 {t('fileViewer.presentInTab')}
               </button>
               <button role="menuitem" onClick={presentFullscreen}>
-                <span className="present-icon"><RemixIcon name="play-line" size={14} /></span>{' '}
+                <span className="present-icon"><Icon name="play" size={13} /></span>{' '}
                 {t('fileViewer.presentFullscreen')}
               </button>
               <button role="menuitem" onClick={presentNewTab}>
-                <span className="present-icon"><RemixIcon name="share-forward-line" size={14} /></span>{' '}
+                <span className="present-icon"><Icon name="share" size={13} /></span>{' '}
                 {t('fileViewer.presentNewTab')}
               </button>
             </div>
@@ -1406,15 +1182,13 @@ export function LiveArtifactViewer({
       ) : null}
       <div className="viewer-toolbar">
         <div className="viewer-toolbar-left">
-            <button
-              type="button"
-              className="icon-only od-tooltip"
-              onClick={() => setReloadKey((n) => n + 1)}
-              title={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-              data-tooltip={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-              data-tooltip-placement="bottom"
-              aria-label={`${t('fileViewer.reloadAria')} ${t('fileViewer.preview')}`}
-            >
+          <button
+            type="button"
+            className="icon-only"
+            onClick={() => setReloadKey((n) => n + 1)}
+            title={t('fileViewer.reload')}
+            aria-label={t('fileViewer.reloadAria')}
+          >
             <Icon name="reload" size={14} />
           </button>
         </div>
@@ -1433,60 +1207,53 @@ export function LiveArtifactViewer({
           </div>
           <div
             className="viewer-preview-controls"
-            data-active={mode === 'preview' ? 'true' : 'false'}
-            aria-hidden={mode === 'preview' ? undefined : true}
+            data-active={previewActive ? 'true' : 'false'}
+            aria-hidden={previewActive ? undefined : true}
           >
             <span className="viewer-divider" aria-hidden />
             <PreviewViewportControls
               viewport={previewViewport}
               onViewport={setPreviewViewport}
               t={t}
-              tabIndex={mode === 'preview' ? 0 : -1}
+              tabIndex={previewActive ? 0 : -1}
             />
             <span className="viewer-divider" aria-hidden />
-            <div className="zoom-menu viewer-toolbar-zoom" ref={zoomMenuRef}>
-              <button
-                type="button"
-                className="viewer-action zoom-trigger od-tooltip"
-                aria-haspopup="menu"
-                aria-expanded={zoomMenuOpen}
-                title={t('fileViewer.resetZoom')}
-                data-tooltip={t('fileViewer.resetZoom')}
-                data-tooltip-placement="bottom"
-                tabIndex={mode === 'preview' ? 0 : -1}
-                onClick={() => setZoomMenuOpen((v) => !v)}
-              >
-                <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
-              </button>
-              {zoomMenuOpen && mode === 'preview' ? (
-                <div className="zoom-menu-popover" role="menu">
-                  {[50, 75, 100, 125, 150, 200].map((level) => (
-                    <button
-                      key={level}
-                      type="button"
-                      className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
-                      role="menuitem"
-                      onClick={() => {
-                        setZoom(level);
-                        setZoomMenuOpen(false);
-                      }}
-                    >
-                      <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
-                      {zoom === level ? (
-                        <Icon name="check" size={13} />
-                      ) : null}
-                    </button>
-                  ))}
-                </div>
-              ) : null}
-            </div>
+            <button
+              type="button"
+              className="icon-only"
+              onClick={() => bumpZoom(-25)}
+              title={t('fileViewer.zoomOut')}
+              aria-label={t('fileViewer.zoomOut')}
+              tabIndex={previewActive ? 0 : -1}
+            >
+              <Icon name="minus" size={14} />
+            </button>
+            <button
+              type="button"
+              className="viewer-action viewer-zoom-level"
+              onClick={() => setZoom(100)}
+              title={t('fileViewer.resetZoom')}
+              tabIndex={previewActive ? 0 : -1}
+            >
+              <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
+            </button>
+            <button
+              type="button"
+              className="icon-only"
+              onClick={() => bumpZoom(25)}
+              title={t('fileViewer.zoomIn')}
+              aria-label={t('fileViewer.zoomIn')}
+              tabIndex={previewActive ? 0 : -1}
+            >
+              <Icon name="plus" size={14} />
+            </button>
             <span className="viewer-divider" aria-hidden />
             <a
               className="ghost-link"
               href={liveArtifactPreviewUrl(projectId, liveArtifact.artifactId)}
               target="_blank"
               rel="noreferrer noopener"
-              tabIndex={mode === 'preview' ? 0 : -1}
+              tabIndex={previewActive ? 0 : -1}
             >
               {t('fileViewer.open')}
             </a>
@@ -1541,8 +1308,8 @@ export function LiveArtifactViewer({
         ) : null}
         <div
           className={`live-artifact-preview-layer preview-viewport preview-viewport-${previewViewport}`}
-          data-active={mode === 'preview' ? 'true' : 'false'}
-          aria-hidden={mode === 'preview' ? undefined : true}
+          data-active={previewActive ? 'true' : 'false'}
+          aria-hidden={previewActive ? undefined : true}
           style={previewViewportStyle(previewViewport, previewScale, previewBodySize)}
         >
           <div className="preview-frame-clip">
@@ -1559,7 +1326,7 @@ export function LiveArtifactViewer({
             </div>
           </div>
         </div>
-        {mode !== 'preview' && loading ? (
+        {previewActive ? null : loading ? (
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
         ) : mode === 'code' ? (
           <LiveArtifactCodePanel
@@ -2298,439 +2065,14 @@ function formatCommentTime(ts: number, t: TranslateFn): string {
   return new Date(ts).toLocaleDateString();
 }
 
-function commentActivityAt(comment: PreviewComment): number {
-  return Math.max(
-    Number.isFinite(comment.updatedAt) ? comment.updatedAt : 0,
-    Number.isFinite(comment.createdAt) ? comment.createdAt : 0,
-  );
-}
-
-function commentCreatedAt(comment: PreviewComment): number {
-  return Number.isFinite(comment.createdAt) ? comment.createdAt : commentActivityAt(comment);
-}
-
-function commentTargetIntersectsPreview(
-  target: PreviewCommentSnapshot | null,
-  scale: number,
-  offset: { x: number; y: number },
-  bounds?: PreviewCanvasSize,
-): boolean {
-  if (!target || !bounds?.width || !bounds.height) return true;
-  const rect = overlayBoundsFromSnapshot(target, scale, offset);
-  const margin = 8;
-  return (
-    rect.left + rect.width > margin &&
-    rect.top + rect.height > margin &&
-    rect.left < bounds.width - margin &&
-    rect.top < bounds.height - margin
-  );
-}
-
 function commentDisplayLabel(comment: PreviewComment, t: TranslateFn): string {
   if (comment.elementId.startsWith('pin-')) return t('chat.comments.pin');
-  const label = String(comment.label || '').trim().toLowerCase();
-  const htmlHint = String(comment.htmlHint || '').trim().toLowerCase();
-  const elementId = String(comment.elementId || '').trim().toLowerCase();
-  const source = `${label} ${htmlHint} ${elementId}`;
-  if (/\b(?:img|picture|video|canvas|svg)\b/.test(source)) return t('chat.comments.targetImage');
-  if (/\b(?:button|input|textarea|select|label)\b/.test(source)) return t('chat.comments.targetControl');
-  if (/^<a\b/.test(htmlHint)) return t('chat.comments.targetLink');
-  if (/\b(?:h1|h2|h3|h4|h5|h6|p|span|strong|em|small|li|dt|dd)\b/.test(source)) return t('chat.comments.targetText');
-  if (/\b(?:section|main|header|footer|nav|article|aside)\b/.test(source)) return t('chat.comments.targetSection');
-  if (label.endsWith('.html') || elementId.startsWith('file-comment-')) return t('chat.comments.targetPage');
-  if (comment.text.trim()) return t('chat.comments.targetText');
-  return t('chat.comments.targetArea');
+  return comment.label || comment.elementId;
 }
 
-export function CommentSidePanel({
-  comments,
-  projectId,
-  selectedIds,
-  activeCommentId,
-  collapsed,
-  onCollapsedChange,
-  onToggleSelect,
-  onSelectAll,
-  onClearSelection,
-  onReorder,
-  onReply,
-  onSendSelected,
-  onCreateComment,
-  sending,
-  queueOnSend = false,
-  sendDisabled = false,
-  renderCreateForm = true,
-  t,
-  composer,
-}: {
-  comments: PreviewComment[];
-  projectId?: string;
-  selectedIds: Set<string>;
-  activeCommentId: string | null;
-  collapsed: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
-  onToggleSelect: (commentId: string) => void;
-  onSelectAll: () => void;
-  onClearSelection: () => void;
-  onReorder?: (orderedIds: string[]) => void;
-  onReply: (comment: PreviewComment) => void;
-  onSendSelected: () => void | Promise<void>;
-  onCreateComment?: (note: string) => boolean | Promise<boolean>;
-  sending: boolean;
-  queueOnSend?: boolean;
-  sendDisabled?: boolean;
-  renderCreateForm?: boolean;
-  t: TranslateFn;
-  composer?: ReactNode;
-}) {
-  const [newCommentDraft, setNewCommentDraft] = useState('');
-  const [dragState, setDragState] = useState<CommentSideDragState | null>(null);
-  const sorted = comments;
-  const visibleSelectedIds = new Set(comments.filter((comment) => selectedIds.has(comment.id)).map((comment) => comment.id));
-  const selectedCount = visibleSelectedIds.size;
-  const allSelected = comments.length > 0 && selectedCount === comments.length;
-  const commentsLabel = t('chat.tabComments');
-  const canCreateComment = Boolean(onCreateComment) && newCommentDraft.trim().length > 0 && !sending && !sendDisabled;
-  const canReorder = Boolean(onReorder && sorted.length > 1);
-  const collapsedRailRef = useRef<HTMLButtonElement | null>(null);
-  const expandedToggleRef = useRef<HTMLButtonElement | null>(null);
-  const pendingToggleFocusRef = useRef<'collapsed' | 'expanded' | null>(null);
-  const panelId = useId();
-  const handleDragStart = (event: ReactDragEvent<HTMLButtonElement>, comment: PreviewComment) => {
-    if (!canReorder) return;
-    event.dataTransfer.effectAllowed = 'move';
-    event.dataTransfer.setData(COMMENT_SIDE_DRAG_MIME, comment.id);
-    event.dataTransfer.setData('text/plain', comment.id);
-    setDragState({ draggingId: comment.id, overId: comment.id, edge: null });
-  };
-  const handleDragOver = (event: ReactDragEvent<HTMLDivElement>, targetId: string) => {
-    if (!canReorder) return;
-    const draggingId = dragState?.draggingId || event.dataTransfer.getData(COMMENT_SIDE_DRAG_MIME);
-    if (!draggingId) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-    if (draggingId === targetId) {
-      if (dragState?.overId !== targetId || dragState.edge !== null) {
-        setDragState({ draggingId, overId: targetId, edge: null });
-      }
-      return;
-    }
-    const edge = commentSideDropEdgeForEvent(event);
-    if (
-      dragState?.draggingId !== draggingId ||
-      dragState.overId !== targetId ||
-      dragState.edge !== edge
-    ) {
-      setDragState({ draggingId, overId: targetId, edge });
-    }
-  };
-  const handleDrop = (event: ReactDragEvent<HTMLDivElement>, targetId: string) => {
-    if (!canReorder) return;
-    event.preventDefault();
-    const draggingId =
-      dragState?.draggingId ||
-      event.dataTransfer.getData(COMMENT_SIDE_DRAG_MIME) ||
-      event.dataTransfer.getData('text/plain');
-    if (!draggingId || draggingId === targetId) {
-      setDragState(null);
-      return;
-    }
-    const edge = dragState?.overId === targetId && dragState.edge
-      ? dragState.edge
-      : commentSideDropEdgeForEvent(event);
-    const nextIds = reorderPreviewCommentIds(sorted, draggingId, targetId, edge);
-    if (nextIds.join('\0') !== sorted.map((comment) => comment.id).join('\0')) {
-      onReorder?.(nextIds);
-    }
-    setDragState(null);
-  };
-  const submitNewComment = async () => {
-    if (!onCreateComment || !newCommentDraft.trim()) return;
-    const saved = await onCreateComment(newCommentDraft.trim());
-    if (saved) setNewCommentDraft('');
-  };
-
-  useEffect(() => {
-    const target =
-      pendingToggleFocusRef.current === 'collapsed'
-        ? collapsedRailRef.current
-        : pendingToggleFocusRef.current === 'expanded'
-          ? expandedToggleRef.current
-          : null;
-    if (!target) return;
-    pendingToggleFocusRef.current = null;
-    target.focus();
-  }, [collapsed]);
-
-  const handleCollapsedChange = (
-    nextCollapsed: boolean,
-    nextFocusTarget: 'collapsed' | 'expanded',
-  ) => {
-    pendingToggleFocusRef.current = nextFocusTarget;
-    onCollapsedChange(nextCollapsed);
-  };
-
-  if (collapsed) {
-    return (
-      <button
-        ref={collapsedRailRef}
-        type="button"
-        className="comment-side-rail"
-        data-testid="comment-side-collapsed-rail"
-        aria-label={t('preview.showSidebar', { label: commentsLabel })}
-        aria-expanded={false}
-        title={t('preview.showSidebar', { label: commentsLabel })}
-        onClick={() => handleCollapsedChange(false, 'expanded')}
-      >
-        <RemixIcon name="message-3-line" size={15} />
-        <span>{commentsLabel}</span>
-        {comments.length > 0 ? <strong>{comments.length}</strong> : null}
-      </button>
-    );
-  }
-
-  return (
-    <aside id={panelId} className="comment-side-panel" data-testid="comment-side-panel" aria-label={commentsLabel}>
-      <div className="comment-side-header">
-        <div className="comment-side-title">
-          <RemixIcon name="message-3-line" size={15} />
-          <span>{commentsLabel}</span>
-        </div>
-        <div className="comment-side-header-actions">
-          {comments.length > 0 ? (
-            <button
-              type="button"
-              className="comment-side-select-all"
-              disabled={allSelected}
-              onClick={onSelectAll}
-            >
-              {t('chat.comments.selectAll')}
-            </button>
-          ) : null}
-          <button
-            ref={expandedToggleRef}
-            type="button"
-            className="comment-side-collapse"
-            aria-label={t('preview.hideSidebar', { label: commentsLabel })}
-            aria-controls={panelId}
-            aria-expanded={true}
-            title={t('preview.hideSidebar', { label: commentsLabel })}
-            onClick={() => handleCollapsedChange(true, 'collapsed')}
-          >
-            <Icon name="chevron-right" size={14} />
-          </button>
-        </div>
-      </div>
-      <div
-        className="comment-side-list"
-        onDragLeave={(event) => {
-          const related = event.relatedTarget;
-          if (related instanceof Node && event.currentTarget.contains(related)) return;
-          setDragState(null);
-        }}
-      >
-        {sorted.length === 0 ? (
-          <div className="comment-side-empty">
-            {t('chat.comments.emptySaved')}
-          </div>
-        ) : sorted.map((comment, index) => {
-          const selected = visibleSelectedIds.has(comment.id);
-          const active = comment.id === activeCommentId;
-          const isDragging = dragState?.draggingId === comment.id;
-          const dropClass = dragState?.overId === comment.id &&
-            dragState.draggingId !== comment.id &&
-            dragState.edge
-            ? ` comment-side-item-drop-${dragState.edge}`
-            : '';
-          return (
-            <div
-              key={comment.id}
-              className={`comment-side-item${selected ? ' selected' : ''}${active ? ' active' : ''}${isDragging ? ' dragging' : ''}${dropClass}`}
-              data-testid="comment-side-item"
-              data-comment-id={comment.id}
-              aria-current={active ? 'true' : undefined}
-              role="button"
-              tabIndex={0}
-              onDragOver={(event) => handleDragOver(event, comment.id)}
-              onDrop={(event) => handleDrop(event, comment.id)}
-              onClick={() => onReply(comment)}
-              onKeyDown={(event) => {
-                if (event.key !== 'Enter' && event.key !== ' ') return;
-                event.preventDefault();
-                onReply(comment);
-              }}
-            >
-              <div className="comment-side-item-head">
-                <button
-                  type="button"
-                  className="comment-side-drag-handle"
-                  title={t('chat.queuedReorder')}
-                  aria-label={t('chat.queuedReorder')}
-                  draggable={canReorder}
-                  disabled={!canReorder}
-                  onClick={(event) => event.stopPropagation()}
-                  onDragStart={(event) => handleDragStart(event, comment)}
-                  onDragEnd={() => setDragState(null)}
-                >
-                  <Icon name="grip-vertical" size={13} />
-                </button>
-                <span className="comment-side-author">
-                  <strong>{`${index + 1}. ${commentDisplayLabel(comment, t)}`}</strong>
-                </span>
-                <span className="comment-side-time">{formatCommentTime(commentActivityAt(comment), t)}</span>
-                <button
-                  type="button"
-                  className={`comment-side-check${selected ? ' checked' : ''}`}
-                  aria-label={selected ? t('chat.comments.deselect') : t('chat.comments.select')}
-                  aria-pressed={selected}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onToggleSelect(comment.id);
-                  }}
-                >
-                  {selected ? <Icon name="check" size={11} /> : null}
-                </button>
-              </div>
-              <div className="comment-side-body">{comment.note}</div>
-              {projectId && comment.attachments && comment.attachments.length > 0 ? (
-                <div className="comment-side-attachments">
-                  {comment.attachments.map((attachment) => {
-                    const url = projectRawUrl(projectId, attachment.path);
-                    return (
-                      <a
-                        key={attachment.path}
-                        className="comment-side-attachment"
-                        data-testid="comment-side-attachment"
-                        href={url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={attachment.name}
-                        title={attachment.name}
-                        onClick={(event) => event.stopPropagation()}
-                      >
-                        <img src={url} alt={attachment.name} />
-                      </a>
-                    );
-                  })}
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
-      </div>
-      {selectedCount > 0 ? (
-        <div className="comment-side-selectbar" data-testid="comment-side-selectbar">
-          <span className="comment-side-selectcount">{t('chat.comments.nSelected', { n: selectedCount })}</span>
-          <Button variant="ghost" onClick={onClearSelection}>
-            {t('chat.comments.clear')}
-          </Button>
-          <Button
-            variant="primary"
-            data-testid="comment-side-send-claude"
-            disabled={sending || sendDisabled}
-            onClick={() => void onSendSelected()}
-          >
-            {sending
-              ? t('chat.comments.sending')
-              : queueOnSend
-                ? t('chat.annotationQueue')
-                : t('chat.comments.sendToChat')}
-          </Button>
-        </div>
-      ) : null}
-      {composer ? <div className="comment-side-composer">{composer}</div> : null}
-      {renderCreateForm && onCreateComment ? (
-        <form
-          className="comment-side-new-comment composer"
-          onSubmit={(event) => {
-            event.preventDefault();
-            void submitNewComment();
-          }}
-        >
-          <div className="composer-shell comment-side-new-comment-shell">
-            <div className="composer-input-wrap">
-              <div className="composer-textarea-layer">
-                <textarea
-                  value={newCommentDraft}
-                  placeholder={t('chat.comments.placeholder')}
-                  aria-label={t('chat.comments.placeholder')}
-                  onChange={(event) => setNewCommentDraft(event.target.value)}
-                  onKeyDown={(event) => {
-                    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-                      event.preventDefault();
-                      void submitNewComment();
-                    }
-                  }}
-                />
-              </div>
-            </div>
-            <div className="composer-row comment-side-new-comment-actions">
-              <button
-                type="button"
-                className="icon-btn"
-                title={t('chat.cliSettingsTitle')}
-                aria-label={t('chat.cliSettingsAria')}
-                disabled
-              >
-                <span className="composer-tools-at" aria-hidden>
-                  @
-                </span>
-              </button>
-              <button
-                type="button"
-                className="icon-btn"
-                title={t('chat.attachTitle')}
-                aria-label={t('chat.attachAria')}
-                disabled
-              >
-                <Icon name="attach" size={15} />
-              </button>
-              <span className="composer-spacer" />
-              <button
-                type="submit"
-                className={`composer-send${sending ? ' is-sending' : ''}`}
-                disabled={!canCreateComment}
-              >
-                <Icon name="send" size={13} />
-                <span>{sending ? t('chat.comments.sending') : t('chat.send')}</span>
-              </button>
-            </div>
-          </div>
-        </form>
-      ) : null}
-    </aside>
-  );
-}
-
-const COMMENT_SIDE_DRAG_MIME = 'application/x-open-design-preview-comment';
-
-type CommentSideDropEdge = 'before' | 'after';
-
-interface CommentSideDragState {
-  draggingId: string;
-  overId: string | null;
-  edge: CommentSideDropEdge | null;
-}
-
-function commentSideDropEdgeForEvent(event: ReactDragEvent<HTMLElement>): CommentSideDropEdge {
-  const rect = event.currentTarget.getBoundingClientRect();
-  return event.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
-}
-
-function reorderPreviewCommentIds(
-  comments: PreviewComment[],
-  draggingId: string,
-  targetId: string,
-  edge: CommentSideDropEdge,
-): string[] {
-  const ids = comments.map((comment) => comment.id);
-  const from = ids.indexOf(draggingId);
-  if (from < 0) return ids;
-  const [draggedId] = ids.splice(from, 1);
-  const targetIndex = ids.indexOf(targetId);
-  if (targetIndex < 0 || !draggedId) return comments.map((comment) => comment.id);
-  ids.splice(edge === 'after' ? targetIndex + 1 : targetIndex, 0, draggedId);
-  return ids;
+function commentAvatarInitial(comment: PreviewComment): string {
+  const seed = comment.label || comment.elementId || '?';
+  return seed.charAt(0).toUpperCase();
 }
 
 export function appendSavedPreviewCommentOrder(
@@ -2751,74 +2093,137 @@ export function appendSavedPreviewCommentOrder(
   return next.join('\0') === currentOrderIds.join('\0') ? currentOrderIds : next;
 }
 
-function CommentSideDock({
+export function CommentSidePanel({
   comments,
-  projectId,
   selectedIds,
-  activeCommentId,
+  activeCommentId: _activeCommentId,
   collapsed,
   onCollapsedChange,
+  onClose,
   onToggleSelect,
-  onSelectAll,
+  onSelectAll: _onSelectAll,
   onClearSelection,
-  onReorder,
+  onReorder: _onReorder,
   onReply,
   onSendSelected,
-  onCreateComment,
   sending,
-  queueOnSend = false,
-  sendDisabled = false,
-  renderCreateForm = true,
   t,
-  composer,
 }: {
   comments: PreviewComment[];
-  projectId?: string;
   selectedIds: Set<string>;
-  activeCommentId: string | null;
+  activeCommentId?: string | null;
   collapsed: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
+  onClose?: () => void;
   onToggleSelect: (commentId: string) => void;
-  onSelectAll: () => void;
+  onSelectAll?: () => void;
   onClearSelection: () => void;
-  onReorder?: (orderedIds: string[]) => void;
+  onReorder?: (ids: string[]) => void;
   onReply: (comment: PreviewComment) => void;
   onSendSelected: () => void | Promise<void>;
-  onCreateComment?: (note: string) => boolean | Promise<boolean>;
   sending: boolean;
-  queueOnSend?: boolean;
-  sendDisabled?: boolean;
-  renderCreateForm?: boolean;
   t: TranslateFn;
-  composer?: ReactNode;
 }) {
+  const sorted = [...comments].sort((a, b) => b.createdAt - a.createdAt);
+  const visibleSelectedIds = new Set(comments.filter((comment) => selectedIds.has(comment.id)).map((comment) => comment.id));
+  const selectedCount = visibleSelectedIds.size;
+  const commentsLabel = t('chat.tabComments');
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        className="comment-side-rail"
+        data-testid="comment-side-collapsed-rail"
+        aria-label={t('preview.showSidebar', { label: commentsLabel })}
+        title={t('preview.showSidebar', { label: commentsLabel })}
+        onClick={() => onCollapsedChange(false)}
+      >
+        <Icon name="comment" size={14} />
+        <span>{commentsLabel}</span>
+        {comments.length > 0 ? <strong>{comments.length}</strong> : null}
+      </button>
+    );
+  }
+
   return (
-    <div
-      className={`comment-side-dock${collapsed ? ' collapsed' : ''}`}
-      data-testid="comment-side-dock"
-    >
-      <CommentSidePanel
-        comments={comments}
-        projectId={projectId}
-        selectedIds={selectedIds}
-        activeCommentId={activeCommentId}
-        collapsed={collapsed}
-        onCollapsedChange={onCollapsedChange}
-        onToggleSelect={onToggleSelect}
-        onSelectAll={onSelectAll}
-        onClearSelection={onClearSelection}
-        onReorder={onReorder}
-        onReply={onReply}
-        onSendSelected={onSendSelected}
-        onCreateComment={onCreateComment}
-        sending={sending}
-        queueOnSend={queueOnSend}
-        sendDisabled={sendDisabled}
-        renderCreateForm={renderCreateForm}
-        t={t}
-        composer={composer}
-      />
-    </div>
+    <aside className="comment-side-panel" data-testid="comment-side-panel" aria-label={commentsLabel}>
+      <div className="comment-side-header">
+        <div className="comment-side-title">
+          <Icon name="comment" size={14} />
+          <span>{commentsLabel}</span>
+        </div>
+        <button
+          type="button"
+          className="comment-side-close"
+          aria-label={t('common.close')}
+          title={t('common.close')}
+          onClick={onClose}
+        >
+          <Icon name="close" size={12} />
+        </button>
+      </div>
+      <div className="comment-side-list">
+        {sorted.length === 0 ? (
+          <div className="comment-side-empty">
+            {t('chat.comments.emptySaved')}
+          </div>
+        ) : sorted.map((comment) => {
+          const selected = visibleSelectedIds.has(comment.id);
+          return (
+            <div
+              key={comment.id}
+              className={`comment-side-item${selected ? ' selected' : ''}`}
+              data-testid="comment-side-item"
+            >
+              <div className="comment-side-item-head">
+                <span className="comment-side-author">
+                  <span className="comment-side-avatar" aria-hidden>
+                    {commentAvatarInitial(comment)}
+                  </span>
+                  <strong>{commentDisplayLabel(comment, t)}</strong>
+                </span>
+                <span className="comment-side-time">{formatCommentTime(comment.createdAt, t)}</span>
+                <button
+                  type="button"
+                  className={`comment-side-check${selected ? ' checked' : ''}`}
+                  aria-label={selected ? t('chat.comments.deselect') : t('chat.comments.select')}
+                  aria-pressed={selected}
+                  onClick={() => onToggleSelect(comment.id)}
+                >
+                  {selected ? <Icon name="check" size={11} /> : null}
+                </button>
+              </div>
+              <div className="comment-side-body">{comment.note}</div>
+              <button
+                type="button"
+                className="comment-side-reply"
+                data-testid="comment-side-edit"
+                onClick={() => onReply(comment)}
+              >
+                {t('chat.comments.edit')}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {selectedCount > 0 ? (
+        <div className="comment-side-selectbar" data-testid="comment-side-selectbar">
+          <span className="comment-side-selectcount">{t('chat.comments.nSelected', { n: selectedCount })}</span>
+          <button type="button" className="ghost" onClick={onClearSelection}>
+            {t('chat.comments.clear')}
+          </button>
+          <button
+            type="button"
+            className="primary"
+            data-testid="comment-side-send-claude"
+            disabled={sending}
+            onClick={() => void onSendSelected()}
+          >
+            {sending ? t('chat.comments.sending') : t('chat.comments.sendToChat')}
+          </button>
+        </div>
+      ) : null}
+    </aside>
   );
 }
 
@@ -2942,9 +2347,9 @@ function InspectPanel({
           <strong title={target.label || target.elementId}>{target.label || target.elementId}</strong>
           <code title={target.selector}>{target.elementId}</code>
         </div>
-        <Button variant="ghost" onClick={onClose} aria-label="Close inspect">
+        <button type="button" className="ghost" onClick={onClose} aria-label="Close inspect">
           ×
-        </Button>
+        </button>
       </header>
 
       {target.clickedDescendant ? (
@@ -2967,14 +2372,14 @@ function InspectPanel({
         <div className="inspect-section-label">Colors</div>
         <div className="inspect-row">
           <label htmlFor="ip-color">Text</label>
-          <Input
+          <input
             id="ip-color"
             data-testid="inspect-color"
             type="color"
             value={colorHex}
             onChange={(e) => setVal('color', e.target.value)}
           />
-          <Input
+          <input
             type="text"
             value={colorHex}
             onChange={(e) => setVal('color', e.target.value)}
@@ -2983,14 +2388,14 @@ function InspectPanel({
         </div>
         <div className="inspect-row">
           <label htmlFor="ip-bg">Background</label>
-          <Input
+          <input
             id="ip-bg"
             data-testid="inspect-bg"
             type="color"
             value={bgHex}
             onChange={(e) => setVal('background-color', e.target.value)}
           />
-          <Input
+          <input
             type="text"
             value={bgHex}
             onChange={(e) => setVal('background-color', e.target.value)}
@@ -3017,7 +2422,7 @@ function InspectPanel({
         </div>
         <div className="inspect-row">
           <label htmlFor="ip-fw">Weight</label>
-          <Select
+          <select
             id="ip-fw"
             value={fontWeight}
             onChange={(e) => setVal('font-weight', e.target.value)}
@@ -3025,11 +2430,11 @@ function InspectPanel({
             {['100', '300', '400', '500', '600', '700', '800', '900'].map((w) => (
               <option key={w} value={w}>{w}</option>
             ))}
-          </Select>
+          </select>
         </div>
         <div className="inspect-row">
           <label htmlFor="ip-ta">Align</label>
-          <Select
+          <select
             id="ip-ta"
             value={textAlign}
             onChange={(e) => setVal('text-align', e.target.value)}
@@ -3037,7 +2442,7 @@ function InspectPanel({
             {['left', 'center', 'right', 'justify'].map((a) => (
               <option key={a} value={a}>{a}</option>
             ))}
-          </Select>
+          </select>
         </div>
       </section>
 
@@ -3074,23 +2479,25 @@ function InspectPanel({
       </section>
 
       <footer className="inspect-panel-footer">
-        <Button
-          variant="ghost"
+        <button
+          type="button"
+          className="ghost"
           onClick={() => {
             setDraft({});
             onResetElement(target.elementId);
           }}
         >
           Reset element
-        </Button>
-        <Button
-          variant="primary"
+        </button>
+        <button
+          type="button"
+          className="primary"
           data-testid="inspect-save"
           disabled={saving}
           onClick={onSaveToSource}
         >
           {saving ? 'Saving…' : justSaved ? 'Saved ✓' : 'Save to source'}
-        </Button>
+        </button>
       </footer>
       {error ? <div className="inspect-panel-error">{error}</div> : null}
     </aside>
@@ -3530,14 +2937,9 @@ function CommentPreviewOverlays({
   hoveredTarget,
   hoveredPodMemberId,
   activeTarget,
-  activeExistingCommentId = null,
   boardTool,
-  showActivePin = false,
   scale,
-  offsetX,
-  offsetY,
   strokePoints,
-  activeSlideIndex = null,
   onOpenComment,
 }: {
   comments: PreviewComment[];
@@ -3545,47 +2947,25 @@ function CommentPreviewOverlays({
   hoveredTarget: PreviewCommentSnapshot | null;
   hoveredPodMemberId: string | null;
   activeTarget: PreviewCommentSnapshot | null;
-  activeExistingCommentId?: string | null;
   boardTool: BoardTool;
-  showActivePin?: boolean;
   scale: number;
-  offsetX: number;
-  offsetY: number;
   strokePoints: StrokePoint[];
-  activeSlideIndex?: number | null;
   onOpenComment: (comment: PreviewComment, snapshot: PreviewCommentSnapshot) => void;
 }) {
-  const overlayOffset = useMemo(() => ({ x: offsetX, y: offsetY }), [offsetX, offsetY]);
-  const visibleComments = useMemo(
-    () =>
-      comments
-        .map((comment, globalIndex) => ({
-          comment,
-          markerNumber: globalIndex + 1,
-          snapshot: liveSnapshotForComment(comment, liveTargets),
-        }))
-        .filter((item): item is { comment: PreviewComment; markerNumber: number; snapshot: PreviewCommentSnapshot } =>
-          Boolean(item.snapshot),
-        )
-        .filter(({ comment }) => commentVisibleOnDeckSlide(comment, activeSlideIndex)),
-    [comments, liveTargets, activeSlideIndex],
-  );
-  // `onOpenComment` is an inline arrow from the parent (new identity every
-  // render), so read it through a ref to keep the saved-marker memo below from
-  // busting. The closure only calls stable state setters, so a current ref read
-  // is always correct.
-  const onOpenCommentRef = useRef(onOpenComment);
-  onOpenCommentRef.current = onOpenComment;
-  // Memoize the saved-marker subtree. While the user draws a pod lasso,
-  // `strokePoints` updates on every pointermove and re-renders this overlay;
-  // without this, every saved marker (bounds + JSX) was rebuilt each frame.
-  // Keyed only on the marker inputs (NOT strokePoints), so a steady set of
-  // comments reuses the whole subtree and React skips reconciling it.
-  const savedMarkers = useMemo(
-    () =>
-      visibleComments.map(({ comment, markerNumber, snapshot }) => {
-        const bounds = overlayBoundsFromSnapshot(snapshot, scale, overlayOffset);
-        const label = commentTargetDisplayName(comment);
+  const visibleComments = comments
+    .map((comment, index) => ({
+      comment,
+      index,
+      snapshot: liveSnapshotForComment(comment, liveTargets),
+    }))
+    .filter((item): item is { comment: PreviewComment; index: number; snapshot: PreviewCommentSnapshot } =>
+      Boolean(item.snapshot),
+    );
+  const targetOverlay = activeTarget ?? hoveredTarget;
+  return (
+    <div className="comment-overlay-layer" aria-hidden={false}>
+      {visibleComments.map(({ comment, index, snapshot }) => {
+        const bounds = overlayBoundsFromSnapshot(snapshot, scale);
         return (
           <div
             key={comment.id}
@@ -3597,59 +2977,32 @@ function CommentPreviewOverlays({
               height: bounds.height,
             }}
             data-testid={`comment-saved-marker-${comment.elementId}`}
-            onClick={() => onOpenCommentRef.current(comment, snapshot)}
           >
             <div className="comment-saved-outline" />
             <button
               type="button"
               className="comment-saved-pin"
-              onClick={(event) => {
-                event.stopPropagation();
-                onOpenCommentRef.current(comment, snapshot);
-              }}
-              title={`${markerNumber}. ${label}: ${comment.note}`}
-              aria-label={`Open comment for ${label}`}
+              onClick={() => onOpenComment(comment, snapshot)}
+              title={`${comment.elementId}: ${comment.note}`}
+              aria-label={`Open comment for ${comment.elementId}`}
             >
-              {markerNumber}
+              {index + 1}
             </button>
           </div>
         );
-      }),
-    [visibleComments, scale, overlayOffset],
-  );
-  const activeSavedIndex = activeExistingCommentId
-    ? comments.findIndex((comment) => comment.id === activeExistingCommentId)
-    : -1;
-  const activePinNumber = activeSavedIndex >= 0
-    ? activeSavedIndex + 1
-    : comments.length + 1;
-  const targetOverlay = activeTarget ?? hoveredTarget;
-  return (
-    <div className="comment-overlay-layer" aria-hidden={false}>
-      {savedMarkers}
+      })}
       {targetOverlay ? (
         <CommentTargetOverlay
           snapshot={targetOverlay}
           scale={scale}
-          offset={overlayOffset}
           selected={Boolean(activeTarget)}
           hoveredMemberId={hoveredPodMemberId}
         />
       ) : null}
-      {showActivePin && activeTarget ? (
-        <div
-          className="comment-active-pin"
-          style={activeCommentPinStyle(activeTarget, scale, overlayOffset)}
-          data-testid="comment-active-pin"
-          aria-hidden="true"
-        >
-          {activePinNumber}
-        </div>
-      ) : null}
       {boardTool === 'pod' && strokePoints.length > 1 ? (
         <svg className="board-pod-stroke">
           <polyline
-            points={strokePoints.map((point) => `${offsetX + point.x * scale},${offsetY + point.y * scale}`).join(' ')}
+            points={strokePoints.map((point) => `${point.x * scale},${point.y * scale}`).join(' ')}
           />
         </svg>
       ) : null}
@@ -3657,43 +3010,24 @@ function CommentPreviewOverlays({
   );
 }
 
-function activeCommentPinStyle(
-  target: PreviewCommentSnapshot,
-  scale: number,
-  offset: { x: number; y: number } = { x: 0, y: 0 },
-): CSSProperties {
-  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
-  const anchor = target.hoverPoint ?? {
-    x: target.position.x,
-    y: target.position.y,
-  };
-  return {
-    left: Math.round(offset.x + anchor.x * safeScale),
-    top: Math.round(offset.y + anchor.y * safeScale),
-  };
-}
-
 export function CommentTargetOverlay({
   snapshot,
   scale,
-  offset,
   selected,
   hoveredMemberId,
 }: {
   snapshot: PreviewCommentSnapshot;
   scale: number;
-  offset?: { x: number; y: number };
   selected: boolean;
   hoveredMemberId?: string | null;
 }) {
-  const overlayOffset = offset ?? { x: 0, y: 0 };
   const displayMembers = podDisplayMembers(snapshot);
   if (displayMembers.length > 0) {
     const overlayWeights = podOverlayWeights(displayMembers);
     return (
       <>
         {displayMembers.map((member, index) => {
-          const bounds = overlayBoundsFromSnapshot(member, scale, overlayOffset);
+          const bounds = overlayBoundsFromSnapshot(member, scale);
           const width = Math.round(member.position.width);
           const height = Math.round(member.position.height);
           const overlayWeight = overlayWeights[index] ?? {
@@ -3728,7 +3062,7 @@ export function CommentTargetOverlay({
   // Non-member fallback: single-element snapshots have no per-member chips,
   // so the hover-focus channel never reaches this branch — no is-hover-focused
   // class needed here.
-  const bounds = overlayBoundsFromSnapshot(snapshot, scale, overlayOffset);
+  const bounds = overlayBoundsFromSnapshot(snapshot, scale);
   return (
     <div
       className={`comment-target-overlay${selected ? ' selected' : ''}`}
@@ -3826,7 +3160,6 @@ function buildPodSnapshot(input: {
     text: snapshot.text,
     position: snapshot.position,
     htmlHint: snapshot.htmlHint,
-    style: snapshot.style,
   }));
   const summary = selected
     .slice(0, 3)
@@ -4009,34 +3342,6 @@ function finiteBridgeInteger(value: unknown): number | undefined {
   return clampBridgeCoordinate(value);
 }
 
-function normalizeAnnotationStyle(input: unknown): PreviewCommentSnapshot['style'] {
-  if (!input || typeof input !== 'object') return undefined;
-  const raw = input as Record<string, unknown>;
-  const style: NonNullable<PreviewCommentSnapshot['style']> = {};
-  for (const key of ANNOTATION_STYLE_KEYS) {
-    const value = raw[key];
-    if (typeof value !== 'string') continue;
-    const trimmed = value.replace(/\s+/g, ' ').trim();
-    if (trimmed) style[key] = trimmed.slice(0, 120);
-  }
-  return Object.keys(style).length > 0 ? style : undefined;
-}
-
-const ANNOTATION_STYLE_KEYS = [
-  'color',
-  'backgroundColor',
-  'fontSize',
-  'fontWeight',
-  'lineHeight',
-  'textAlign',
-  'fontFamily',
-  'paddingTop',
-  'paddingRight',
-  'paddingBottom',
-  'paddingLeft',
-  'borderRadius',
-] as const;
-
 function clampBridgeCoordinate(value: unknown): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return 0;
@@ -4198,12 +3503,10 @@ function ReactComponentViewer({
         <div className="viewer-toolbar-left">
           <button
             type="button"
-            className="icon-only od-tooltip"
+            className="icon-only"
             onClick={() => setReloadKey((n) => n + 1)}
-            title={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-            data-tooltip={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-            data-tooltip-placement="bottom"
-            aria-label={`${t('fileViewer.reloadAria')} ${t('fileViewer.preview')}`}
+            title={t('fileViewer.reload')}
+            aria-label={t('fileViewer.reloadAria')}
           >
             <Icon name="reload" size={14} />
           </button>
@@ -4234,23 +3537,17 @@ function ReactComponentViewer({
               <div className="share-menu" ref={shareRef}>
                 <button
                   type="button"
-                  className="viewer-action primary viewer-action-export od-tooltip"
+                  className="viewer-action primary viewer-action-export"
                   aria-haspopup="menu"
                   aria-expanded={shareMenuOpen}
-                  title={t('fileViewer.shareLabel')}
-                  data-tooltip={t('fileViewer.shareLabel')}
-                  data-tooltip-placement="bottom"
                   onClick={() => setShareMenuOpen((v) => !v)}
                 >
-                  <span className="export-action-spacer" aria-hidden />
+                  <Icon name="download" size={13} />
                   <span>{t('fileViewer.shareLabel')}</span>
-                  <RemixIcon name="arrow-down-s-line" size={14} />
+                  <Icon name="chevron-down" size={11} />
                 </button>
                 {shareMenuOpen ? (
                   <div className="share-menu-popover" role="menu">
-                    <div className="share-menu-section-label" role="presentation">
-                      {t('common.share')}
-                    </div>
                     <button
                       type="button"
                       className="share-menu-item"
@@ -4260,7 +3557,7 @@ function ReactComponentViewer({
                         exportAsJsx(source, exportTitle, sourceExtension);
                       }}
                     >
-                      <span className="share-menu-icon"><RemixIcon name="file-code-line" size={15} /></span>
+                      <span className="share-menu-icon"><Icon name="file-code" size={14} /></span>
                       <span>{t('fileViewer.exportJsx')}</span>
                     </button>
                     <button
@@ -4272,7 +3569,7 @@ function ReactComponentViewer({
                         exportReactComponentAsHtml(source, exportTitle);
                       }}
                     >
-                      <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
+                      <span className="share-menu-icon"><Icon name="file" size={14} /></span>
                       <span>{t('fileViewer.exportReactHtml')}</span>
                     </button>
                     <div className="share-menu-divider" />
@@ -4285,7 +3582,7 @@ function ReactComponentViewer({
                         exportReactComponentAsZip(source, exportTitle, sourceExtension);
                       }}
                     >
-                      <span className="share-menu-icon"><RemixIcon name="file-zip-line" size={15} /></span>
+                      <span className="share-menu-icon"><Icon name="download" size={14} /></span>
                       <span>{t('fileViewer.exportZip')}</span>
                     </button>
                   </div>
@@ -4417,19 +3714,14 @@ function HtmlViewer({
   liveHtml,
   filesRefreshKey = 0,
   isDeck,
+  onExportAsPptx,
   streaming,
-  commentQueueOnSend = false,
-  commentSendDisabled = false,
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
+  onStageBoardCapture,
   onFileSaved,
-  commentPortalId,
-  onCommentModeChange,
-  shareRequest,
-  downloadRequest,
-  slideNavRequest,
 }: {
   projectId: string;
   projectKind: TrackingProjectKind;
@@ -4437,25 +3729,25 @@ function HtmlViewer({
   liveHtml?: string;
   filesRefreshKey?: number;
   isDeck: boolean;
+  onExportAsPptx?: ((fileName: string) => void) | undefined;
   streaming: boolean;
-  commentQueueOnSend?: boolean;
-  commentSendDisabled?: boolean;
   previewComments?: PreviewComment[];
-  onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean, images?: File[]) => Promise<PreviewComment | null>;
+  onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
   onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[], images?: File[]) => Promise<boolean | void> | boolean | void;
+  onStageBoardCapture?: (att: ChatAttachment) => void;
   onFileSaved?: () => Promise<void> | void;
-  commentPortalId?: string;
-  onCommentModeChange?: (active: boolean) => void;
-  shareRequest?: { nonce: number } | null;
-  downloadRequest?: { nonce: number } | null;
-  slideNavRequest?: { slideIndex: number; nonce: number } | null;
 }) {
-  const { locale, t } = useI18n();
+  const t = useT();
   const analytics = useAnalytics();
-  // Latest per-slide capture progress for the programmatic exporters, read by
-  // the loading-toast ticker in fireShareExport to render elapsed time + ETA.
-  const exportProgressRef = useRef<{ done: number; total: number } | null>(null);
+  const annotateT = t as unknown as (key: string, vars?: Record<string, string | number>) => string;
+  const annotateStrings = {
+    uploadImage: annotateT('annotate.uploadImage') || '上传图片',
+    imageRef: annotateT('annotate.imageRef') || '图片参考',
+    textRef: annotateT('annotate.textRef') || '文本参考',
+    colorRef: annotateT('annotate.colorRef') || '颜色参考',
+    refOptions: annotateT('annotate.refOptions') || '参考选项',
+  };
   // Shared helper for the share menu: emit studio_click share_option on
   // entry and artifact_export_result on resolution. Sync exports report
   // success immediately after the call returns; async exports get .then
@@ -4464,19 +3756,24 @@ function HtmlViewer({
   const fireShareExport = (
     format:
       | 'pdf'
+      | 'pptx'
       | 'zip'
       | 'html'
-      | 'image'
       | 'markdown'
       | 'template'
-      | 'share_link'
-      | 'share_page',
+      | 'vercel'
+      | 'cloudflare_pages',
     fn: () => Promise<unknown> | unknown,
   ) => {
     const requestId = analytics.newRequestId();
     const artifactId = anonymizeArtifactId({ projectId, fileName: file.name });
     const artifactKind = artifactKindToTracking({ fileKind: file.kind ?? null });
-    const trackingFormat = format;
+    const trackingFormat =
+      format === 'vercel' || format === 'cloudflare_pages'
+        ? 'share_page'
+        : format === 'pptx'
+          ? 'template'
+          : format;
     trackShareOptionPopoverClick(
       analytics.track,
       {
@@ -4509,87 +3806,19 @@ function HtmlViewer({
         { requestId },
       );
     };
-    const toastFormats = new Set(['pdf', 'zip', 'html', 'image', 'markdown']);
-    // Programmatic exports compute in-browser and can take a while (one render
-    // per deck slide), so the loading toast ticks every second with elapsed time
-    // and — once at least one slide is captured — a live ETA derived from the
-    // average time per completed slide. onExportProgress (passed into the export
-    // call by the menu item) feeds slide progress into exportProgressRef.
-    exportProgressRef.current = null;
-    const startedAt = performance.now();
-    let ticker: ReturnType<typeof setInterval> | null = null;
-    const renderLoadingToast = () => {
-      if (!toastFormats.has(format)) return;
-      const elapsedS = Math.max(0, Math.round((performance.now() - startedAt) / 1000));
-      const p = exportProgressRef.current;
-      let message: string;
-      if (p && p.total > 1 && p.done > 0) {
-        const remainingS = Math.max(
-          1,
-          Math.round(((performance.now() - startedAt) / p.done) * (p.total - p.done) / 1000),
-        );
-        message = t('fileViewer.exportSlideEta', { current: p.done, total: p.total, seconds: remainingS });
-      } else if (p && p.total > 1) {
-        message = t('fileViewer.exportSlideProgress', { current: p.done, total: p.total });
-      } else {
-        message = elapsedS > 0
-          ? t('fileViewer.exportingElapsed', { seconds: elapsedS })
-          : t('fileViewer.exportingProgress');
-      }
-      setExportToast({ message, tone: 'loading' });
-    };
-    const stopTicker = () => {
-      if (ticker != null) {
-        clearInterval(ticker);
-        ticker = null;
-      }
-    };
-    if (toastFormats.has(format)) {
-      renderLoadingToast();
-      ticker = setInterval(renderLoadingToast, 1000);
-    }
-    const failToast = () => {
-      stopTicker();
-      if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportFailed'), tone: 'error' });
-    };
     try {
       const out = fn();
       if (out && typeof (out as Promise<unknown>).then === 'function') {
         (out as Promise<unknown>).then(
-          (result) => {
-            stopTicker();
-            if (result === 'cancelled') {
-              finish('cancelled');
-              if (toastFormats.has(format)) setExportToast(null);
-              return;
-            }
-            finish('success');
-            if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
-          },
-          (err) => {
-            finish('failed', err instanceof Error ? err.name : 'UNKNOWN');
-            failToast();
-          },
+          () => finish('success'),
+          (err) => finish('failed', err instanceof Error ? err.name : 'UNKNOWN'),
         );
       } else {
-        stopTicker();
-        if (out === 'cancelled') {
-          finish('cancelled');
-          if (toastFormats.has(format)) setExportToast(null);
-          return;
-        }
         finish('success');
-        if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
       }
     } catch (err) {
       finish('failed', err instanceof Error ? err.name : 'UNKNOWN');
-      failToast();
     }
-  };
-  // Feeds per-slide capture progress into the ref the loading-toast ticker reads
-  // (apps/web/src/runtime/exports.ts drives this for the PDF exporter).
-  const onExportProgress: ExportProgress = (done, total) => {
-    exportProgressRef.current = { done, total };
   };
   // P0 helpers — keep the artifact_id + artifact_kind derivation in one place
   // so each per-button onClick stays a one-liner. We compute lazily inside the
@@ -4600,9 +3829,8 @@ function HtmlViewer({
       | 'reload'
       | 'preview'
       | 'source'
-      | 'screenshot'
       | 'tweaks'
-      | 'mark'
+      | 'draw'
       | 'comment'
       | 'pods'
       | 'inspect'
@@ -4614,32 +3842,13 @@ function HtmlViewer({
     trackArtifactToolbarClick(analytics.track, {
       page_name: 'artifact',
       area: 'artifact_toolbar',
-      element,
-      artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-      artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-    });
-  };
-  const fireDrawToolbarClick = (
-    element: DrawToolbarElement,
-    submitAction?: 'draft' | 'queue' | 'send',
-  ) => {
-    trackDrawToolbarClick(analytics.track, {
-      page_name: 'artifact',
-      area: 'draw_toolbar',
-      element,
-      ...(submitAction ? { submit_action: submitAction } : {}),
+      element: element === 'draw' ? 'mark' : element,
       artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
       artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
     });
   };
   const fireArtifactHeaderClick = (
-    element:
-      | 'back'
-      | 'edit'
-      | 'present_dropdown'
-      | 'download_dropdown'
-      | 'share_dropdown'
-      | 'settings',
+    element: 'back' | 'edit' | 'present_dropdown' | 'share_dropdown' | 'settings',
   ) => {
     trackArtifactHeaderClick(analytics.track, {
       page_name: 'artifact',
@@ -4660,34 +3869,17 @@ function HtmlViewer({
       artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
     });
   };
-  const fireCommentPopoverClick = (
-    element: 'save_comment' | 'send_to_chat' | 'add_note',
-  ) => {
-    trackCommentPopoverClick(analytics.track, {
-      page_name: 'artifact',
-      area: 'comment_popover',
-      element,
-      artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-      artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-    });
-  };
   const [mode, setMode] = useState<'preview' | 'source'>('preview');
   const [source, setSource] = useState<string | null>(liveHtml ?? null);
   const [inlinedSource, setInlinedSource] = useState<string | null>(null);
   const [zoom, setZoom] = useState(100);
-  const fileViewportKey = previewViewportStateKey(projectId, file);
-  const [previewViewport, setPreviewViewportState] = useState<PreviewViewportId>(
-    () => htmlPreviewViewportState.get(fileViewportKey) ?? 'desktop',
-  );
-  const setPreviewViewport = useCallback((viewport: PreviewViewportId) => {
-    setPreviewViewportCached(fileViewportKey, viewport);
-    setPreviewViewportState(viewport);
-  }, [fileViewportKey]);
+  const [previewViewport, setPreviewViewport] = useState<PreviewViewportId>('desktop');
+  const [modeMenuOpen, setModeMenuOpen] = useState(false);
+  const modeMenuRef = useRef<HTMLDivElement | null>(null);
   const [zoomMenuOpen, setZoomMenuOpen] = useState(false);
   const zoomMenuRef = useRef<HTMLDivElement | null>(null);
   const [presentMenuOpen, setPresentMenuOpen] = useState(false);
-  const [deployMenuOpen, setDeployMenuOpen] = useState(false);
-  const [downloadMenuOpen, setDownloadMenuOpen] = useState(false);
+  const [shareMenuOpen, setShareMenuOpen] = useState(false);
   const [exportReadyNudge, setExportReadyNudge] = useState(false);
   const exportReadyNudgeSeenRef = useRef<Set<string>>(new Set());
   // Template save UX. We surface a transient "Saved" pill in the share
@@ -4696,20 +3888,11 @@ function HtmlViewer({
   const [templateNote, setTemplateNote] = useState<string | null>(null);
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [templateName, setTemplateName] = useState('');
-
-  useEffect(() => {
-    setPreviewViewportState(htmlPreviewViewportState.get(fileViewportKey) ?? 'desktop');
-  }, [fileViewportKey]);
   const [templateDescription, setTemplateDescription] = useState('');
   const [templateSaveError, setTemplateSaveError] = useState<string | null>(null);
   const [deployment, setDeployment] = useState<WebDeploymentInfo | null>(null);
   const [deploymentsByProvider, setDeploymentsByProvider] = useState<Partial<Record<WebDeployProviderId, WebDeploymentInfo>>>({});
   const [deployModalOpen, setDeployModalOpen] = useState(false);
-  const [deployModalIntent, setDeployModalIntent] = useState<'deploy' | 'social-share'>('deploy');
-  const closeDeployModal = useCallback(() => {
-    setDeployModalOpen(false);
-    setDeployModalIntent('deploy');
-  }, []);
   const [deployConfig, setDeployConfig] = useState<WebDeployConfigResponse | null>(null);
   const [deploying, setDeploying] = useState(false);
   const [deployPhase, setDeployPhase] = useState<'idle' | 'deploying' | 'preparing-link'>('idle');
@@ -4718,7 +3901,6 @@ function HtmlViewer({
   const [deployResult, setDeployResult] = useState<WebDeployProjectFileResponse | null>(null);
   const [copiedDeployLink, setCopiedDeployLink] = useState<string | null>(null);
   const [deployProviderId, setDeployProviderId] = useState<WebDeployProviderId>(DEFAULT_DEPLOY_PROVIDER_ID);
-  const [projectSocialShare, setProjectSocialShare] = useState<SocialShareResponse | null>(null);
   const [deployToken, setDeployToken] = useState('');
   const [teamId, setTeamId] = useState('');
   const [teamSlug, setTeamSlug] = useState('');
@@ -4729,58 +3911,28 @@ function HtmlViewer({
   const [cloudflareZoneId, setCloudflareZoneId] = useState('');
   const [cloudflareDomainPrefix, setCloudflareDomainPrefix] = useState('');
   const deployProviderLoadSeqRef = useRef(0);
-  const deployTokenInputRef = useRef<HTMLInputElement | null>(null);
-  useEffect(() => {
-    if (!deployModalOpen) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      event.preventDefault();
-      closeDeployModal();
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [closeDeployModal, deployModalOpen]);
   const [inTabPresent, setInTabPresent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const [boardMode, setBoardMode] = useState(false);
-  const [commentPanelOpen, setCommentPanelOpen] = useState(false);
-  const [commentCreateMode, setCommentCreateMode] = useState(false);
   const [boardTool, setBoardTool] = useState<BoardTool>('inspect');
   const [inspectMode, setInspectMode] = useState(false);
-  const [agentToolsOpen, setAgentToolsOpen] = useState(false);
+  const [annotateMode, setAnnotateMode] = useState(false);
+  const [annotateFrozenSource, setAnnotateFrozenSource] = useState<string | null>(null);
+  const [palettePopoverOpen, setPalettePopoverOpen] = useState(false);
+  const [selectedPalette, setSelectedPalette] = useState<PaletteId | null>(null);
+  const [previewPalette, setPreviewPalette] = useState<PaletteId | null>(null);
   const [drawOverlayOpen, setDrawOverlayOpen] = useState(false);
+  const [drawOverlayMode, setDrawOverlayMode] = useState<PreviewDrawMode>('click');
   // for hint managing hint box state
   const [openHintBox, setOpenHintBox] = useState(true);
   const [manualEditMode, setManualEditModeRaw] = useState(false);
-  const [manualEditSrcDocActive, setManualEditSrcDocActive] = useState(false);
   const [manualEditFrozenSource, setManualEditFrozenSource] = useState<string | null>(null);
-  // Source snapshot frozen while a non-edit annotation pass (Mark/Draw,
-  // Comment, Inspect) is open. The file-watcher live-reload (chokidar →
-  // filesRefresh → preview refresh) would otherwise re-render the iframe
-  // mid-annotation whenever the agent rewrites the file — wiping in-progress
-  // strokes, the picked element, scroll, and focus. We hold the snapshot
-  // captured at mode entry and release it on exit, so the latest content
-  // flushes in exactly once when the user is done. Manual Edit keeps its own
-  // freeze (manualEditFrozenSource) because it also streams live style
-  // patches over postMessage. NOTE: this intentionally pauses the
-  // comment-mode agent-edit live refresh added with the §5162 cache-bust —
-  // the user reported that mid-comment refresh as disruptive; eventual
-  // consistency is preserved by the flush on close.
-  const [annotationFrozenSource, setAnnotationFrozenSource] = useState<string | null>(null);
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
-  const [commentPortalHost, setCommentPortalHost] = useState<HTMLElement | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const activatedSrcDocTransportHtmlRef = useRef<string | null>(null);
-  // Tracks the iframe DOM node whose dedupe ref was last reset by the
-  // srcDoc onLoad handler. We reset the dedupe exactly once per freshly
-  // mounted iframe (the first load is the shell HTML), and skip every
-  // subsequent load on the same node (those are our own
-  // document.open/write/close inside the shell). See onLoad below for
-  // the infinite-loop story (issue #2361).
-  const srcDocFrameDedupeResetForRef = useRef<HTMLIFrameElement | null>(null);
   const isActivePreviewIframeSource = useCallback((source: MessageEventSource | null) => {
     return !!source && source === iframeRef.current?.contentWindow;
   }, []);
@@ -4791,6 +3943,11 @@ function HtmlViewer({
       source === urlPreviewIframeRef.current?.contentWindow ||
       source === srcDocPreviewIframeRef.current?.contentWindow
     );
+  }, []);
+  const previewIframeForSource = useCallback((source: MessageEventSource | null): HTMLIFrameElement | null => {
+    if (!source) return null;
+    const candidates = [iframeRef.current, urlPreviewIframeRef.current, srcDocPreviewIframeRef.current];
+    return candidates.find((frame): frame is HTMLIFrameElement => !!frame && frame.contentWindow === source) ?? null;
   }, []);
   const previewScrollRestoreRef = useRef<{
     hostLeft: number;
@@ -4818,41 +3975,12 @@ function HtmlViewer({
     setManualEditModeRaw((prev) => {
       const value = typeof next === 'function' ? (next as (p: boolean) => boolean)(prev) : next;
       if (value !== prev && !value) {
+        setManualEditFrozenSource(null);
         setManualEditViewportWidth(null);
       }
       return value;
     });
   }, []);
-  useEffect(() => {
-    setManualEditSrcDocActive(false);
-    setManualEditFrozenSource(null);
-  }, [projectId, file.name]);
-  useEffect(() => {
-    onCommentModeChange?.(commentPanelOpen);
-  }, [commentPanelOpen, onCommentModeChange]);
-  useEffect(() => () => {
-    onCommentModeChange?.(false);
-  }, [onCommentModeChange]);
-  useEffect(() => {
-    if (!commentPanelOpen || !commentPortalId) {
-      setCommentPortalHost(null);
-      return;
-    }
-    let cancelled = false;
-    let raf = 0;
-    const findHost = () => {
-      if (cancelled) return;
-      const host = document.getElementById(commentPortalId);
-      setCommentPortalHost(host);
-      if (!host) raf = window.requestAnimationFrame(findHost);
-    };
-    findHost();
-    return () => {
-      cancelled = true;
-      if (raf) window.cancelAnimationFrame(raf);
-      setCommentPortalHost(null);
-    };
-  }, [commentPanelOpen, commentPortalId]);
   const capturePreviewScrollPosition = useCallback(() => {
     const host = previewBodyRef.current;
     let frameLeft = 0;
@@ -4922,19 +4050,7 @@ function HtmlViewer({
   }, []);
   const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([]);
   const [selectedManualEditTarget, setSelectedManualEditTarget] = useState<ManualEditTarget | null>(null);
-  const [manualEditHoverTarget, setManualEditHoverTarget] = useState<ManualEditTarget | null>(null);
-  const [manualEditPageStylesOpen, setManualEditPageStylesOpen] = useState(false);
-  const [manualEditPanelPosition, setManualEditPanelPosition] = useState<{ left: number; top: number } | null>(null);
-  const [manualEditDraftDirty, setManualEditDraftDirty] = useState(false);
   const selectedManualEditTargetIdRef = useRef<string | null>(null);
-  const manualEditSelectionDraftRef = useRef<{ id: string; draft: ManualEditDraft } | null>(null);
-  // Tracks the iframe's in-flight inline text edit. `finishManualEditTextSession`
-  // posts the explicit finish and resolves only after the iframe acks AND the
-  // resulting commit has been applied, so exit/dismiss/cancel never tear down
-  // mid-round-trip and drop the final edit (the #3647 exit-path regression).
-  const manualEditTextSessionIdRef = useRef<string | null>(null);
-  const manualEditTextFinishRef = useRef<(() => void) | null>(null);
-  const manualEditTextCommitInFlightRef = useRef<Promise<unknown> | null>(null);
   const [manualEditDraft, setManualEditDraft] = useState<ManualEditDraft>(() => emptyManualEditDraft());
   const [manualEditHistory, setManualEditHistory] = useState<ManualEditHistoryEntry[]>([]);
   const [manualEditUndone, setManualEditUndone] = useState<ManualEditHistoryEntry[]>([]);
@@ -4943,12 +4059,17 @@ function HtmlViewer({
   const manualEditSavingRef = useRef(false);
   const manualEditPendingStyleRef = useRef<ManualEditPendingStyleSave | null>(null);
   const manualEditStyleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const annotatePendingStyleRef = useRef<Map<string, AnnotatePendingStyleSave>>(new Map());
+  const annotatePendingTextRef = useRef<Map<string, AnnotatePendingTextSave>>(new Map());
+  const annotateStyleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const annotateCaptureJobsRef = useRef<Map<string, AnnotateCaptureJob>>(new Map());
+  const annotateCaptureOverlayRef = useRef<AnnotateCaptureOverlay | null>(null);
+  const annotateCaptureOverlayRequestsRef = useRef<Map<string, AnnotateCaptureOverlayRequest>>(new Map());
   const manualEditPreviewVersionRef = useRef(0);
   const sourceRef = useRef<string | null>(source);
   const sourceFileKeyRef = useRef<string | null>(null);
   const templateNameId = useId();
   const templateDescriptionId = useId();
-  const imageExportTitleId = useId();
   // Opt back into the legacy inline-asset srcDoc path via `?forceInline=1`
   // on the host page. Lets users escape-hatch around the URL-load default
   // for non-deck HTML that depends on the in-iframe localStorage shim.
@@ -4958,49 +4079,10 @@ function HtmlViewer({
   );
   const [activeCommentTarget, setActiveCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [hoveredCommentTarget, setHoveredCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
-  // True while the pointer is physically over the floating hover card. The card
-  // sits on top of the preview iframe, so reaching it makes the iframe fire a
-  // mouseout -> od:comment-leave. We ignore that leave while pinned so the card
-  // (and its selectable values) stays put instead of unmounting and flickering.
-  // The pointer cannot be over the iframe and the host card at once, so a fresh
-  // od:comment-hover never races this; only the card's own leave clears it.
-  const hoverCardPinnedRef = useRef(false);
-  // Tearing the card down is always deferred by a beat rather than done
-  // synchronously. The iframe's mouseout (od:comment-leave) arrives async via
-  // postMessage; the card's own mouseenter and the next od:comment-hover are the
-  // signals that the pointer actually landed on the card or back on the element
-  // it overlaps. Deferring lets those cancel the dismiss before it lands.
-  // Synchronous teardown raced ahead of them: the card flickered on the way in
-  // and vanished the moment you moved off it back onto the element it described.
-  const hoverCardDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cancelHoverCardDismiss = useCallback(() => {
-    if (hoverCardDismissTimerRef.current !== null) {
-      clearTimeout(hoverCardDismissTimerRef.current);
-      hoverCardDismissTimerRef.current = null;
-    }
-  }, []);
-  const scheduleHoverCardDismiss = useCallback(() => {
-    if (hoverCardDismissTimerRef.current !== null) clearTimeout(hoverCardDismissTimerRef.current);
-    hoverCardDismissTimerRef.current = setTimeout(() => {
-      hoverCardDismissTimerRef.current = null;
-      // hoverCardPinnedRef tracks "pointer is physically over the card". If it
-      // got (re-)pinned while we waited, this now-stale dismiss must not fire.
-      if (!hoverCardPinnedRef.current) setHoveredCommentTarget(null);
-    }, HOVER_CARD_DISMISS_DELAY_MS);
-  }, []);
   const [hoveredPodMemberId, setHoveredPodMemberId] = useState<string | null>(null);
-  // If the card unmounts for any other reason while the pointer is still over
-  // it (its onMouseLeave never fires), drop the pin so later leaves dismiss
-  // normally instead of being swallowed forever.
-  useEffect(() => {
-    if (!hoveredCommentTarget) hoverCardPinnedRef.current = false;
-  }, [hoveredCommentTarget]);
-  // Don't let a pending dismiss outlive the component.
-  useEffect(() => cancelHoverCardDismiss, [cancelHoverCardDismiss]);
   const [activePreviewCommentId, setActivePreviewCommentId] = useState<string | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
   const liveCommentTargetsRef = useRef(liveCommentTargets);
-  const [commentOrderIds, setCommentOrderIds] = useState<string[]>([]);
   const [commentDraft, setCommentDraft] = useState('');
   // Inspect mode shares the iframe selection bridge with comment mode but
   // routes the picked element to a side panel that mutates per-element CSS
@@ -5024,81 +4106,33 @@ function HtmlViewer({
   const [inspectSavedAt, setInspectSavedAt] = useState<number | null>(null);
   const [inspectError, setInspectError] = useState<string | null>(null);
   const [queuedBoardNotes, setQueuedBoardNotes] = useState<string[]>([]);
-  // Images attached to an element comment ("评论此元素"). Kept as raw Files
-  // (uploaded on send) with object-URL thumbnails for preview/remove, mirroring
-  // the markup overlay's image tray.
-  const [boardImages, setBoardImages] = useState<File[]>([]);
-  const [activeCommentExistingAttachments, setActiveCommentExistingAttachments] =
-    useState<PreviewCommentAttachment[]>([]);
-  const [boardImagePreviews, setBoardImagePreviews] = useState<{ file: File; url: string }[]>([]);
-  const [boardPreviewIndex, setBoardPreviewIndex] = useState<number | null>(null);
   const [sendingBoardBatch, setSendingBoardBatch] = useState(false);
-  useEffect(() => {
-    const next = boardImages.map((file) => ({ file, url: URL.createObjectURL(file) }));
-    setBoardImagePreviews(next);
-    return () => {
-      next.forEach((item) => URL.revokeObjectURL(item.url));
-    };
-  }, [boardImages]);
   const [commentSavedToast, setCommentSavedToast] = useState<string | null>(null);
   const [templateSavedToast, setTemplateSavedToast] = useState<string | null>(null);
-  const [deploySavedToast, setDeploySavedToast] = useState<{ message: string; details: string } | null>(null);
-  const [deployActionToast, setDeployActionToast] = useState<string | null>(null);
-  const [imageExportModalOpen, setImageExportModalOpen] = useState(false);
-  const [imageExportFormat, setImageExportFormat] = useState<ImageExportFormat>('png');
-  const [imageExportBusy, setImageExportBusy] = useState(false);
-  const [imageExportPreparing, setImageExportPreparing] = useState(false);
-  const [imageExportError, setImageExportError] = useState<string | null>(null);
-  const [imageExportSavedToast, setImageExportSavedToast] = useState<{ message: string; details: string } | null>(null);
-  const [imageExportPreparedBlob, setImageExportPreparedBlob] = useState<{ format: ImageExportFormat; blob: Blob } | null>(null);
-  const imageExportSnapshotDataUrlRef = useRef<string | null>(null);
-  const imageExportPrepareIdRef = useRef(0);
-  // Threads the share-popover click → artifact_export_result(image) pair, the
-  // same correlation other export formats get via fireShareExport. The image
-  // export is a separate modal flow, so it owns its own request id / start.
-  const imageExportRequestIdRef = useRef<string | null>(null);
-  const imageExportStartedRef = useRef(0);
-  // Guards against double-emitting the image export result: each modal
-  // session (reset in openImageExportModal) resolves to exactly one
-  // success / failed / cancelled, no matter which exit path runs.
-  const imageExportResolvedRef = useRef(false);
-  // Same click→result correlation for Save as template, which now reports the
-  // export result only after the template is actually saved (not on open).
-  const templateExportRequestIdRef = useRef<string | null>(null);
-  const templateExportStartedRef = useRef(0);
-  // Same one-terminal-result guard as image export: a template session
-  // (reset in openSaveAsTemplateModal) emits exactly one success/failed/
-  // cancelled, whether it ends in a save or a modal dismiss.
-  const templateExportResolvedRef = useRef(false);
-  const screenshotInFlightRef = useRef(false);
-  const [exportToast, setExportToast] = useState<
-    { message: string; tone: 'default' | 'success' | 'error' | 'loading' } | null
-  >(null);
-  const [shareLinkFeedback, setShareLinkFeedback] = useState<'copied' | 'failed' | null>(null);
-  const [shareGuideToast, setShareGuideToast] = useState<string | null>(null);
+  const [annotateCaptureToast, setAnnotateCaptureToast] = useState<string | null>(null);
   const [selectedSideCommentIds, setSelectedSideCommentIds] = useState<Set<string>>(() => new Set());
   const [commentSidePanelCollapsed, setCommentSidePanelCollapsed] = useState(false);
   const [strokePoints, setStrokePoints] = useState<StrokePoint[]>([]);
+  const [tweaksMode, setTweaksMode] = useState(false);
+  const [tweaksAvailable, setTweaksAvailable] = useState(false);
+  // Tracks the `file.name` for which we've already mirrored the artifact's
+  // initial `__edit_mode_available` announcement into `tweaksMode`. Agent-
+  // generated `.twk-panel` artifacts mount their panel visible by default,
+  // so the toolbar toggle should also start ON — otherwise the user has to
+  // click toggle-on → toggle-off to actually hide the panel they're seeing.
+  // We only mirror ONCE per file: subsequent re-emissions (iframe remount
+  // when the user flips render mode by opening Themes, etc.) would otherwise
+  // re-toggle the user's choice.
+  const firstEditModeAvailableSeenForFileRef = useRef<string | null>(null);
   const previewStateKey = `${projectId}:${file.name}`;
   const previewScale = zoom / 100;
-  const localCommentSideDockActive = commentPanelOpen && !commentPortalHost;
-  const boardPreviewCanvasSize = commentPreviewCanvasSize(previewBodySize, {
-    boardMode: localCommentSideDockActive,
-    sidePanelCollapsed: commentSidePanelCollapsed,
-    viewport: previewViewport,
-  });
-  const boardSideDockStacked = usesStackedCommentSideDock(previewBodySize, {
-    boardMode: localCommentSideDockActive,
-    sidePanelCollapsed: commentSidePanelCollapsed,
-    viewport: previewViewport,
-  });
 
   function deploymentMapForCurrentFile(items: WebDeploymentInfo[]) {
     const next: Partial<Record<WebDeployProviderId, WebDeploymentInfo>> = {};
     for (const option of DEPLOY_PROVIDER_OPTIONS) {
-      const deploymentForProvider = items
-        .filter((item) => item.fileName === file.name && item.providerId === option.id && item.url?.trim())
-        .sort(compareDeploymentsByNewest)[0];
+      const deploymentForProvider = items.find(
+        (item) => item.fileName === file.name && item.providerId === option.id && item.url?.trim(),
+      );
       if (deploymentForProvider) next[option.id] = deploymentForProvider;
     }
     return next;
@@ -5215,23 +4249,12 @@ function HtmlViewer({
   const [slideState, setSlideState] = useState<SlideState | null>(
     () => htmlPreviewSlideState.get(previewStateKey) ?? null,
   );
-  const boardPreviewScaleOptions = localCommentSideDockActive ? { canvasPadding: 0 } : undefined;
-  const overlayPreviewScale = effectivePreviewScale(
-    previewViewport,
-    previewScale,
-    boardPreviewCanvasSize,
-    boardPreviewScaleOptions,
-  );
-  const overlayPreviewTransform: PreviewOverlayTransform = {
-    scale: overlayPreviewScale,
-    offsetX: 0,
-    offsetY: 0,
-  };
+  const overlayPreviewScale = effectivePreviewScale(previewViewport, previewScale, previewBodySize);
   const shareRef = useRef<HTMLDivElement | null>(null);
   const [chromeActionsHost, setChromeActionsHost] = useState<HTMLElement | null>(null);
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    setChromeActionsHost(resolveChromeActionsHost());
+    setChromeActionsHost(document.getElementById(APP_CHROME_FILE_ACTIONS_ID));
   }, []);
 
   useEffect(() => {
@@ -5253,23 +4276,11 @@ function HtmlViewer({
       sourceRef.current = null;
     }
     let cancelled = false;
-    // Cache-bust the fetch on every mtime / reload / files-refresh bump.
-    // Without this, an agent edit during Comment mode (srcDoc path) gets
-    // stale HTML from the browser HTTP cache — the source state ends up
-    // identical to the previous value, srcDoc is byte-equal to the last
-    // activated HTML, canActivateSrcDocTransport bails on the dedupe
-    // check, and the preview only refreshes when Comment closes and the
-    // url-load iframe takes over with its own ?v=mtime cache-bust.
-    void fetchProjectFileText(projectId, file.name, {
-      cacheBustKey: `${file.mtime}-${reloadKey}-${filesRefreshKey}`,
-    }).then((text) => {
-      if (cancelled) return;
-      // Chokidar emits agent rewrites as unlink+add+change bursts; a
-      // transient null mid-burst would blank source → srcDoc empty →
-      // shell stays on prior frame. Keep the last good text instead.
-      if (text == null) return;
-      setSource(text);
-      sourceRef.current = text;
+    void fetchProjectFileText(projectId, file.name).then((text) => {
+      if (!cancelled) {
+        setSource(text);
+        sourceRef.current = text;
+      }
     });
     return () => {
       cancelled = true;
@@ -5301,16 +4312,10 @@ function HtmlViewer({
   // never surface and the deck becomes a static, unnavigable preview.
   const looksLikeDeck = useMemo(() => {
     if (!source) return false;
-    return /class\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])/i.test(source);
+    return /class\s*=\s*['"][^'"]*\bslide\b/i.test(source);
   }, [source]);
   const effectiveDeck = isDeck || looksLikeDeck;
-  const showDeckNavigation = effectiveDeck && (slideState === null || slideState.count > 0);
   const livePreviewSource = inlinedSource ?? source;
-  // Annotation modes that should hold the preview still while open. Manual
-  // Edit is handled by its own freeze just below; these are the non-edit
-  // passes (Mark/Draw, Comment, Inspect) that also must not be yanked out
-  // from under the user by a background file change.
-  const annotationFreezeActive = drawOverlayOpen || boardMode || inspectMode;
   // Freeze the iframe input on the snapshot taken at Edit-mode entry. Any
   // source rewrite during edit (1.5s debounced set-style patches) stays
   // invisible to the iframe — live updates flow through od-edit-preview-style
@@ -5320,30 +4325,30 @@ function HtmlViewer({
       setManualEditFrozenSource(livePreviewSource);
     }
   }, [manualEditMode, manualEditFrozenSource, livePreviewSource]);
-  // Capture / release the annotation snapshot at mode entry / exit. Captured
-  // once (the `=== null` guard), so a mid-pass file change can't slip a fresh
-  // snapshot in; cleared on exit so `previewSource` falls back to the latest
-  // live source and the deferred update lands in one clean render.
   useEffect(() => {
-    if (annotationFreezeActive) {
-      if (annotationFrozenSource === null && livePreviewSource != null) {
-        setAnnotationFrozenSource(livePreviewSource);
-      }
-    } else if (annotationFrozenSource !== null) {
-      setAnnotationFrozenSource(null);
+    if (!annotateMode) {
+      setAnnotateFrozenSource(null);
+      return;
     }
-  }, [annotationFreezeActive, annotationFrozenSource, livePreviewSource]);
+    if (annotateFrozenSource === null && livePreviewSource != null) {
+      setAnnotateFrozenSource(livePreviewSource);
+    }
+  }, [annotateMode, annotateFrozenSource, livePreviewSource]);
   const previewSource = (manualEditMode && manualEditFrozenSource !== null)
     ? manualEditFrozenSource
-    : (annotationFreezeActive && annotationFrozenSource !== null)
-      ? annotationFrozenSource
+    : (annotateMode && annotateFrozenSource !== null)
+      ? annotateFrozenSource
       : livePreviewSource;
   const manualEditPageStylesEnabled = typeof source === 'string' && isManualEditFullHtmlDocument(source);
+  const drawClickSelectionMode = drawOverlayOpen && drawOverlayMode === 'click' && !manualEditMode;
   const urlModeBridge = hasUrlModeBridge(source);
-  const manualEditRequiresSrcDoc = manualEditMode || manualEditSrcDocActive;
   // When we URL-load the iframe directly, skip every in-host inlining /
   // srcDoc-rebuilding step. The browser does the asset resolution itself,
   // which is the whole point of the URL-load path.
+  // Detect the class based tweaks template so we keep the srcDoc path on
+  // first load: the bridge that emits `od:tweaks-available` is only injected
+  // by buildSrcdoc, never on the URL load iframe.
+  const tweaksBridgeRequired = hasTweaksTemplate(source);
   // Auto-fall back to the srcDoc path when the artifact will crash under
   // the URL-load iframe's bare `sandbox="allow-scripts"` — Babel-standalone
   // React prototypes and any HTML that reads Web Storage at mount throw
@@ -5355,93 +4360,60 @@ function HtmlViewer({
     () => source != null && htmlNeedsSandboxShim(source),
     [source],
   );
-  const needsFocusGuard = useMemo(
-    () => source != null && htmlNeedsFocusGuard(source),
-    [source],
-  );
-  const [urlSelectionBridgeReady, setUrlSelectionBridgeReady] = useState(false);
-  const urlLoadDecision: UrlLoadDecision = {
+  const useUrlLoadPreview = shouldUrlLoadHtmlPreview({
     mode,
     isDeck: effectiveDeck,
-    commentMode: boardMode,
-    urlCommentBridge: urlSelectionBridgeReady,
+    commentMode: boardMode || drawClickSelectionMode,
     editMode: manualEditMode,
     urlModeBridge,
     inspectMode,
+    annotateMode,
+    paletteActive: palettePopoverOpen || selectedPalette !== null,
     drawMode: drawOverlayOpen,
+    screenshotCapture: true,
+    tweaksBridge: tweaksBridgeRequired,
     forceInline: forceInline || needsSandboxShim,
-    needsFocusGuard,
-  };
-  const useUrlLoadPreview = shouldUrlLoadHtmlPreview(urlLoadDecision) && !manualEditRequiresSrcDoc;
+  });
+  const activeSrcDocPreviewIframe = useCallback((): HTMLIFrameElement | null => {
+    return srcDocPreviewIframeRef.current ?? (!useUrlLoadPreview ? iframeRef.current : null);
+  }, [useUrlLoadPreview]);
   const basePreviewSrcUrl = useMemo(
-    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`,
+    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
     [projectId, file.name, file.mtime, reloadKey],
   );
   const [previewSrcUrl, setPreviewSrcUrl] = useState(basePreviewSrcUrl);
-  // Hold the iframe URL still (it carries file.mtime) while the user is mid
-  // annotation/edit, mirroring the source freeze above. Otherwise a
-  // background file change bumps mtime → basePreviewSrcUrl → a URL-load
-  // reload right under an active mark/comment/edit/inspect. Captured once at
-  // mode entry via a ref and released on exit, so the deferred reload lands
-  // exactly once when the user is done.
-  const interactivePreviewModeActive = annotationFreezeActive || manualEditMode;
-  const frozenPreviewSrcUrlRef = useRef<string | null>(null);
-  if (interactivePreviewModeActive) {
-    if (frozenPreviewSrcUrlRef.current === null) {
-      frozenPreviewSrcUrlRef.current = basePreviewSrcUrl;
-    }
-  } else {
-    frozenPreviewSrcUrlRef.current = null;
-  }
-  const effectiveBasePreviewSrcUrl = frozenPreviewSrcUrlRef.current ?? basePreviewSrcUrl;
-  // Switching to a different file/project while an annotation tool is still
-  // open must NOT keep the viewer pinned to the previous artifact. The
-  // per-file annotation data is already reset on file.name change, but the
-  // freeze snapshots and the mode flags would otherwise survive — leaving the
-  // frozen source/URL stuck on the old file until the user manually closes the
-  // tool (and clearing the freeze alone would just re-freeze the old source
-  // before the new file's fetch lands). Close the per-file tools and drop both
-  // freezes on a file/project switch so the new artifact renders live, the way
-  // manualEditFrozenSource is reset just above.
-  useEffect(() => {
-    frozenPreviewSrcUrlRef.current = null;
-    setAnnotationFrozenSource(null);
-    setDrawOverlayOpen(false);
-    setBoardMode(false);
-    setInspectMode(false);
-    setSrcDocMaterialized(false);
-    // Closing boardMode alone is not enough: the comment dock renders off
-    // `commentPanelOpen` and a panel save reuses `activeCommentTarget` /
-    // `activePreviewCommentId`, both file-scoped. Left open across a file swap
-    // the dock stays visible and the next save would post back to the previous
-    // file/element. Fully tear the comment tool down here. (The composer data —
-    // activeCommentTarget, drafts, queued notes — is cleared by the file.name
-    // reset effect below; these are the UI-open flags it doesn't touch.)
-    setCommentPanelOpen(false);
-    setCommentCreateMode(false);
-    setActivePreviewCommentId(null);
-  }, [projectId, file.name]);
   const activePreviewSrcUrl = (
-    previewSrcUrl === effectiveBasePreviewSrcUrl ||
-    previewSrcUrl.startsWith(`${effectiveBasePreviewSrcUrl}&`)
+    previewSrcUrl === basePreviewSrcUrl ||
+    previewSrcUrl.startsWith(`${basePreviewSrcUrl}&`)
   )
     ? previewSrcUrl
-    : effectiveBasePreviewSrcUrl;
+    : basePreviewSrcUrl;
   useEffect(() => {
-    setPreviewSrcUrl(effectiveBasePreviewSrcUrl);
-    setUrlSelectionBridgeReady(false);
-  }, [effectiveBasePreviewSrcUrl]);
+    setPreviewSrcUrl(basePreviewSrcUrl);
+  }, [basePreviewSrcUrl]);
+  // Keep `iframeRef.current` aligned with whichever iframe is currently
+  // visible so the existing postMessage send sites do not need to know that
+  // there are two iframes mounted. Plain `useEffect` (rather than layout)
+  // because all reads of `iframeRef.current` are in async user handlers or
+  // postMessage callbacks, never synchronous during render, and `useEffect`
+  // does not warn under `renderToStaticMarkup`.
   useEffect(() => {
     iframeRef.current = useUrlLoadPreview ? urlPreviewIframeRef.current : srcDocPreviewIframeRef.current;
+  }, [useUrlLoadPreview]);
+  // When the render mode flips, the now-active iframe has already loaded
+  // (its `onLoad` fired when it first mounted, often long before the user
+  // toggled), so we manually re-push the current bridge state instead of
+  // relying on the iframe's load event. `syncBridgeModes` is a closure over
+  // the latest state, so reading it through a ref keeps this effect's deps
+  // honest while still firing the up-to-date sync function.
+  const syncBridgeModesRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    syncBridgeModesRef.current();
   }, [useUrlLoadPreview]);
 
   useEffect(() => {
     if (filesRefreshKey === 0) return;
-    // Defer the file-watcher live-reload while annotating; the effect re-runs
-    // when the mode closes (interactivePreviewModeActive flips) and applies
-    // the now-current URL in one pass.
-    if (interactivePreviewModeActive) return;
-    const nextSrc = `${effectiveBasePreviewSrcUrl}&fr=${filesRefreshKey}`;
+    const nextSrc = `${basePreviewSrcUrl}&fr=${filesRefreshKey}`;
     const timeout = window.setTimeout(() => {
       if (useUrlLoadPreview && urlPreviewIframeRef.current?.contentWindow) {
         urlPreviewIframeRef.current.contentWindow.location.replace(nextSrc);
@@ -5450,7 +4422,7 @@ function HtmlViewer({
       }
     }, 180);
     return () => window.clearTimeout(timeout);
-  }, [effectiveBasePreviewSrcUrl, filesRefreshKey, useUrlLoadPreview, interactivePreviewModeActive]);
+  }, [basePreviewSrcUrl, filesRefreshKey, useUrlLoadPreview]);
 
   useEffect(() => {
     setInlinedSource(null);
@@ -5463,7 +4435,7 @@ function HtmlViewer({
     return () => {
       cancelled = true;
     };
-  }, [source, effectiveDeck, projectId, file.name, reloadKey, useUrlLoadPreview]);
+  }, [source, effectiveDeck, projectId, file.name, useUrlLoadPreview]);
 
   const srcDoc = useMemo(
     () => (previewSource ? buildSrcdoc(previewSource, {
@@ -5471,35 +4443,21 @@ function HtmlViewer({
       baseHref: projectRawUrl(projectId, baseDirFor(file.name)),
       initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
       selectionBridge: true,
-      // Always inject the manual-edit bridge into the PREVIEW srcDoc (not the
-      // export path), so the document is byte-identical across preview /
-      // comment / draw / edit. The bridge boots dormant (`enabled=false`) and
-      // only acts on the host's `od-edit-mode {enabled:true}` postMessage
-      // (sent by syncBridgeModes), with all its handlers gated on `enabled`
-      // and its styles scoped to `html[data-od-edit-mode]`. Gating injection on
-      // edit mode instead changed the srcdoc string on entering Edit, which
-      // re-parses the whole document — the "reload from scratch on switch" the
-      // user hit. Mirrors the always-on tweaks bridge rationale above.
-      editBridge: true,
-      paletteBridge: false,
-      previewFocusGuard: true,
+      editBridge: manualEditMode,
+      paletteBridge: true,
+      initialPalette: selectedPalette,
+      annotateBridge: annotateMode,
     }) : ''),
-    [previewSource, effectiveDeck, projectId, file.name, previewStateKey],
+    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, manualEditMode, selectedPalette, annotateMode],
   );
   const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
+  const [hasLazySrcDocTransport, setHasLazySrcDocTransport] = useState(useUrlLoadPreview);
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
   const [srcDocShellReady, setSrcDocShellReady] = useState(false);
-  // Sticky once the srcDoc iframe has materialized the real artifact for the
-  // first time (i.e. the first entry into Mark/Edit/Comment/Inspect). Until
-  // then the srcDoc iframe stays on the lazy shell — so passive preview never
-  // runs a hidden second copy of the artifact (no double mount, and no white:
-  // we only materialize while the iframe is VISIBLE, where scroll/reveal
-  // animations fire correctly). Once materialized it stays real even back in
-  // URL-load mode (hidden), so every later mode toggle is an instant
-  // visibility swap with no re-load. Reset on file/project change.
-  const [srcDocMaterialized, setSrcDocMaterialized] = useState(false);
   const wasUrlLoadPreviewRef = useRef(useUrlLoadPreview);
-  const urlPreviewKeepAliveKey = previewIframeKeepAliveKey(projectId, file.name);
+  useEffect(() => {
+    if (useUrlLoadPreview) setHasLazySrcDocTransport(true);
+  }, [useUrlLoadPreview]);
   // Reset the shell-ready latch whenever the srcDoc iframe re-mounts. The
   // next shell will post `od:srcdoc-transport-ready` (or fire onLoad) and
   // flip this back to true. See #2253.
@@ -5521,137 +4479,44 @@ function HtmlViewer({
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
   }, []);
-  useEffect(() => {
-    function onMessage(ev: MessageEvent) {
-      const frame = urlPreviewIframeRef.current;
-      if (ev.source !== frame?.contentWindow) return;
-      if (frame.getAttribute('src') === 'about:blank') return;
-      const data = ev.data as { type?: string } | null;
-      if (data?.type !== 'od:url-selection-bridge-ready') return;
-      setUrlSelectionBridgeReady(true);
-    }
-    window.addEventListener('message', onMessage);
-    return () => window.removeEventListener('message', onMessage);
-  }, []);
-  // Lazy transport preloads an empty shell only while URL-load is the active
-  // transport. Once srcdoc becomes active (sandbox shim, Draw, Screenshot,
-  // Tweaks, etc.), mount the real artifact HTML directly so we do not depend on
-  // a postMessage activation that can race (#2253) and strand the iframe blank
-  // (#2361, #2791).
-  const captureModeActive = drawOverlayOpen;
-  // Once `srcDocMaterialized` is set (after the first mode entry), keep the
-  // srcDoc iframe on the real artifact even when hidden behind URL-load, so
-  // re-entering a mode is an instant visibility swap rather than a re-mount +
-  // re-load. Direct-mount path (no #2361/#2791 postMessage race).
-  const useLazySrcDocTransport =
-    !manualEditRequiresSrcDoc && !captureModeActive && useUrlLoadPreview && !srcDocMaterialized;
+  const useLazySrcDocTransport = (useUrlLoadPreview || hasLazySrcDocTransport) && !annotateMode;
   const srcDocTransportContent = useLazySrcDocTransport ? lazySrcDocTransport : srcDoc;
-  // Materialize the srcDoc iframe the first time it actually becomes the active
-  // (visible) transport — i.e. the first Mark/Edit/Comment/Inspect entry. We do
-  // NOT pre-render it while hidden/idle: that ran a second live copy during
-  // passive preview (double mount) and rendered scroll/reveal-animated content
-  // while invisible, which left it stuck blank (the white-on-enter bug). Doing
-  // it on first visible entry means the one materialization paints correctly,
-  // and the sticky flag keeps it warm for every subsequent toggle.
-  useEffect(() => {
-    if (!useUrlLoadPreview && !srcDocMaterialized) setSrcDocMaterialized(true);
-  }, [useUrlLoadPreview, srcDocMaterialized]);
-  // When the srcDoc switch is driven ONLY by Draw/annotation mode — an
-  // artifact that would otherwise URL-load — keep the URL-load iframe warm
-  // instead of parking it at about:blank. Draw is a quick "mark → screenshot →
-  // close" round-trip; parking forces a full artifact re-fetch the moment the
-  // overlay closes, which users see as a jarring black → loading → reload right
-  // after every screenshot. Sticky srcDoc modes (inspect / edit / palette /
-  // tweaks / comment / deck / focus-guard / sandbox-shim) keep parking, so two
-  // live copies never linger beyond the brief annotation pass.
-  const srcDocForcedOnlyByDraw =
-    drawOverlayOpen &&
-    !manualEditRequiresSrcDoc &&
-    shouldUrlLoadHtmlPreview({ ...urlLoadDecision, drawMode: false });
-  const urlTransportSrc =
-    useUrlLoadPreview || srcDocForcedOnlyByDraw ? activePreviewSrcUrl : 'about:blank';
-  const activateSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
-    if (!canActivateSrcDocTransport({
+  const urlTransportSrc = useUrlLoadPreview ? activePreviewSrcUrl : 'about:blank';
+  const activateSrcDocTransport = useCallback((
+    target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current,
+    options?: { force?: boolean },
+  ) => {
+    const canActivate = options?.force
+      ? Boolean(srcDoc && useLazySrcDocTransport && srcDocShellReady && activatedSrcDocTransportHtmlRef.current !== srcDoc)
+      : canActivateSrcDocTransport({
       srcDoc,
       useUrlLoadPreview,
       useLazySrcDocTransport,
       shellReady: srcDocShellReady,
       activatedHtml: activatedSrcDocTransportHtmlRef.current,
-    })) return false;
-    // A SECOND activation while Comment mode is on would document.open +
-    // write over the iframe's existing document. The window-level message
-    // listener survives, but iframe.onLoad does NOT refire for
-    // document.write, so host-side re-init (slide nav sync, scroll
-    // restore, bridge replay) is silently skipped — the visible page can
-    // drift out of sync with the host's tracked state (e.g. the page
-    // indicator shows 3 while the iframe rendered page 4 of the freshly
-    // edited deck). Force a fresh shell mount under Comment so onLoad
-    // fires and the full re-init pipeline runs against the new HTML.
-    //
-    // Skip the remount path in Manual Edit, where the postMessage
-    // activate carries the patched HTML and host-side scroll/slide
-    // state intentionally stays put across the patch.
-    if (boardMode && activatedSrcDocTransportHtmlRef.current !== null) {
-      activatedSrcDocTransportHtmlRef.current = null;
-      setSrcDocTransportResetKey((key) => key + 1);
-      return true;
-    }
+    });
+    if (!canActivate) return false;
     const win = target?.contentWindow;
     if (!win) return false;
     win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
     activatedSrcDocTransportHtmlRef.current = srcDoc;
     return true;
-  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview, srcDocShellReady, boardMode]);
-  const activateLoadedSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
-    if (!canActivateSrcDocTransport({
-      srcDoc,
-      useUrlLoadPreview,
-      useLazySrcDocTransport,
-      shellReady: true,
-      activatedHtml: activatedSrcDocTransportHtmlRef.current,
-    })) return false;
-    const win = target?.contentWindow;
-    if (!win) return false;
-    win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
-    activatedSrcDocTransportHtmlRef.current = srcDoc;
-    return true;
-  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview]);
-  const activateSrcDocSnapshotTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
-    if (!srcDoc) return false;
-    const win = target?.contentWindow;
-    if (!win) return false;
-    win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
-    return true;
-  }, [srcDoc]);
+  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview, srcDocShellReady]);
   useEffect(() => {
     if (useUrlLoadPreview) {
       activatedSrcDocTransportHtmlRef.current = null;
-      // Remounting the srcDoc iframe on a render-mode flip resets it to a fresh
-      // lazy shell — needed ONLY for the lazy postMessage-activation path
-      // (#2253 shell-ready handshake). When the srcDoc iframe is direct-mounted
-      // (prewarmed, or an annotation mode), its content lives in the srcdoc
-      // attribute, so a remount would just throw away the warm render and force
-      // a reload. That is exactly the thrash users saw toggling Comment
-      // (URL-load) ↔ Mark (srcDoc): each flip remounted and reloaded. Keep the
-      // iframe alive in the direct-mount case so the toggle is a pure
-      // visibility swap.
-      if (!wasUrlLoadPreviewRef.current && useLazySrcDocTransport) {
+      if (!wasUrlLoadPreviewRef.current) {
         setSrcDocTransportResetKey((key) => key + 1);
       }
       wasUrlLoadPreviewRef.current = true;
       return;
     }
-    if (wasUrlLoadPreviewRef.current && useLazySrcDocTransport) {
-      setSrcDocTransportResetKey((key) => key + 1);
-      activatedSrcDocTransportHtmlRef.current = null;
-    }
     wasUrlLoadPreviewRef.current = false;
     activateSrcDocTransport();
-  }, [activateSrcDocTransport, useUrlLoadPreview, useLazySrcDocTransport]);
-  
+  }, [activateSrcDocTransport, useUrlLoadPreview]);
   useEffect(() => {
     restorePreviewScrollPosition();
-  }, [boardMode, drawOverlayOpen, manualEditMode, srcDoc, restorePreviewScrollPosition]);
+  }, [annotateMode, boardMode, manualEditMode, srcDoc, restorePreviewScrollPosition]);
 
   useEffect(() => {
     function onMessage(ev: MessageEvent) {
@@ -5770,17 +4635,17 @@ function HtmlViewer({
     if (!win) return;
     win.postMessage({
       type: 'od:comment-mode',
-      enabled: boardMode,
-      mode: boardTool,
+      enabled: boardMode || drawClickSelectionMode,
+      mode: drawClickSelectionMode ? 'picker' : boardTool,
     }, '*');
-  }, [boardMode, boardTool, srcDoc, useUrlLoadPreview]);
+  }, [boardMode, boardTool, drawClickSelectionMode, srcDoc]);
 
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
     win.postMessage({ type: 'od-edit-mode', enabled: manualEditMode }, '*');
     postSelectedManualEditTargetToIframe(manualEditMode ? selectedManualEditTarget?.id ?? null : null);
-  }, [manualEditMode, selectedManualEditTarget?.id, srcDoc, useUrlLoadPreview]);
+  }, [manualEditMode, selectedManualEditTarget?.id, srcDoc]);
 
   const previewStyleToIframe = useCallback((id: string, styles: Partial<ManualEditStyles>, version: number) => {
     const win = iframeRef.current?.contentWindow;
@@ -5800,19 +4665,575 @@ function HtmlViewer({
     if (!win) return;
     win.postMessage({
       type: 'od:comment-mode',
-      enabled: boardMode,
-      mode: boardTool,
+      enabled: boardMode || drawClickSelectionMode,
+      mode: drawClickSelectionMode ? 'picker' : boardTool,
     }, '*');
     win.postMessage({ type: 'od-edit-mode', enabled: manualEditMode }, '*');
     postSelectedManualEditTargetToIframe(manualEditMode ? selectedManualEditTarget?.id ?? null : null, target);
+    // Push the toolbar's current `tweaksMode` to both dialects so the artifact
+    // aligns to host state on every load (including render-mode swaps that
+    // expose a different iframe. e.g. opening the Themes popover). Without
+    // this, an artifact that defaults to `open=true` would re-open on every
+    // swap and visually contradict a toolbar that is currently off.
+    win.postMessage({ type: 'od:tweaks-panel-visible', visible: tweaksMode }, '*');
+    win.postMessage({ type: tweaksMode ? '__activate_edit_mode' : '__deactivate_edit_mode' }, '*');
     win.postMessage({ type: 'od:inspect-mode', enabled: inspectMode }, '*');
+    win.postMessage({ type: 'od:annotate-mode', enabled: annotateMode }, '*');
+    win.postMessage({ type: 'od:annotate-locale', strings: annotateStrings }, '*');
+    const palette = previewPalette ?? selectedPalette;
+    win.postMessage({ type: 'od:palette', palette }, '*');
   }
+
+  function syncBridgeModesAfterTransport(target: HTMLIFrameElement | null = iframeRef.current) {
+    syncBridgeModes(target);
+    window.setTimeout(() => syncBridgeModes(target), 0);
+    window.setTimeout(() => syncBridgeModes(target), 160);
+  }
+  // Keep the ref pointing at the latest `syncBridgeModes` closure so the
+  // render-mode-swap effect above (which can fire before this declaration in
+  // execution order) always calls the up-to-date function.
+  syncBridgeModesRef.current = syncBridgeModes;
 
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
     win.postMessage({ type: 'od:inspect-mode', enabled: inspectMode }, '*');
-  }, [inspectMode, srcDoc, useUrlLoadPreview]);
+  }, [inspectMode, srcDoc]);
+
+  useEffect(() => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    win.postMessage({ type: 'od:annotate-mode', enabled: annotateMode }, '*');
+    win.postMessage({ type: 'od:annotate-locale', strings: annotateStrings }, '*');
+  }, [annotateMode, srcDoc, annotateStrings.uploadImage]);
+
+  const annotateCaptureFailureMessage = '截图失败，请重试';
+  const annotateCaptureProgressMessage = '正在截图...';
+  const annotateCaptureSuccessMessage = '截图已加入 Chat';
+
+  const updateAnnotateCaptureJob = useCallback((
+    jobId: string,
+    stage: AnnotateCaptureStage,
+    error?: string,
+  ) => {
+    annotateCaptureJobsRef.current.set(jobId, { id: jobId, stage, error });
+    if (stage === 'failed') {
+      if (error) console.warn('[annotate] capture job failed:', jobId, error);
+      setAnnotateCaptureToast(annotateCaptureFailureMessage);
+    }
+  }, []);
+
+  const stageSnapshotForChat = useCallback(async (jobId: string, snap: PreviewSnapshot): Promise<boolean> => {
+    updateAnnotateCaptureJob(jobId, 'uploading');
+    if (!onStageBoardCapture || !projectId) {
+      updateAnnotateCaptureJob(jobId, 'failed', 'missing onStageBoardCapture or projectId');
+      return false;
+    }
+    try {
+      const mime = snap.mime ?? snap.blob?.type ?? snap.dataUrl?.match(/^data:([^;,]+)/)?.[1] ?? 'image/png';
+      const ext = mime.includes('svg') ? 'svg' : 'png';
+      const blob = snap.blob ?? (snap.dataUrl ? dataUrlToBlob(snap.dataUrl) : null);
+      if (!blob) {
+        updateAnnotateCaptureJob(jobId, 'failed', 'snapshot has no image payload');
+        return false;
+      }
+      const file = new File([blob], `screenshot-${Date.now()}.${ext}`, { type: mime });
+      const result = await uploadProjectFiles(projectId, [file]);
+      const uploaded = result.uploaded[0];
+      if (!uploaded?.path) {
+        updateAnnotateCaptureJob(jobId, 'failed', 'upload returned no file path');
+        return false;
+      }
+      onStageBoardCapture({ path: uploaded.path, name: uploaded.name, kind: 'image', size: uploaded.size });
+      updateAnnotateCaptureJob(jobId, 'staged');
+      return true;
+    } catch (err) {
+      console.warn('[annotate] screenshot stage failed:', err);
+      updateAnnotateCaptureJob(jobId, 'failed', err instanceof Error ? err.message : String(err));
+      return false;
+    }
+  }, [onStageBoardCapture, projectId, updateAnnotateCaptureJob]);
+
+  const fallbackPreviewSnapshot = useCallback((
+    iframe: HTMLIFrameElement,
+    overlay: AnnotateCaptureOverlay | null,
+    sourceHtml?: string | null,
+    viewport?: PreviewSnapshotViewport | null,
+  ): PreviewSnapshot | null => {
+    const overlaySelector = '#oi-sel,#oi-hov,#oi-svg,#oi-card,.oi-badge,.oi-shot,.oi-shot-fly,#oi-cpk';
+    const rect = iframe.getBoundingClientRect();
+    const cropX = Math.max(0, Math.round(viewport?.x ?? 0));
+    const cropY = Math.max(0, Math.round(viewport?.y ?? 0));
+    const w = Math.max(1, Math.round((viewport?.w ?? rect.width) || 1024));
+    const h = Math.max(1, Math.round((viewport?.h ?? rect.height) || 768));
+    let frameScrollX = 0;
+    let frameScrollY = 0;
+    try {
+      frameScrollX = Number(iframe.contentWindow?.scrollX ?? 0);
+      frameScrollY = Number(iframe.contentWindow?.scrollY ?? 0);
+    } catch {
+      frameScrollX = 0;
+      frameScrollY = 0;
+    }
+    const sx = Math.max(0, Number(overlay?.scrollX ?? frameScrollX) + cropX);
+    const sy = Math.max(0, Number(overlay?.scrollY ?? frameScrollY) + cropY);
+    let docW = w;
+    let docH = h;
+    try {
+      const doc = iframe.contentDocument;
+      docW = Math.max(
+        w,
+        Math.ceil(doc?.documentElement?.scrollWidth ?? 0),
+        Math.ceil(doc?.body?.scrollWidth ?? 0),
+        Math.ceil(sx + w),
+      );
+      docH = Math.max(
+        h,
+        Math.ceil(doc?.documentElement?.scrollHeight ?? 0),
+        Math.ceil(doc?.body?.scrollHeight ?? 0),
+        Math.ceil(sy + h),
+      );
+    } catch {
+      docW = Math.max(w, Math.ceil(sx + w));
+      docH = Math.max(h, Math.ceil(sy + h));
+    }
+    const appendOverlayLayer = (root: Element, ownerDoc: Document) => {
+      if (!overlay?.html) return;
+      const head = root.querySelector('head') ?? root;
+      const body = root.querySelector('body') ?? root;
+      const overlayStyle = ownerDoc.createElement('style');
+      overlayStyle.textContent = `${overlay.css ?? ''}#od-snapshot-overlay-layer{position:absolute!important;left:0!important;top:0!important;width:${w + cropX}px!important;height:${h + cropY}px!important;overflow:hidden!important;pointer-events:none!important;background:transparent!important;z-index:2147483647!important;transform:translate(${sx - cropX}px,${sy - cropY}px)!important;transform-origin:0 0!important;}#od-snapshot-overlay-layer #oi-sel,#od-snapshot-overlay-layer #oi-hov,#od-snapshot-overlay-layer #oi-svg,#od-snapshot-overlay-layer #oi-card,#od-snapshot-overlay-layer .oi-badge,#od-snapshot-overlay-layer .oi-shot,#od-snapshot-overlay-layer .oi-shot-fly,#od-snapshot-overlay-layer #oi-cpk{display:block;}`;
+      head.appendChild(overlayStyle);
+      const layer = ownerDoc.createElement('div');
+      layer.id = 'od-snapshot-overlay-layer';
+      layer.innerHTML = overlay.html;
+      body.appendChild(layer);
+    };
+    let pageHtml = '';
+    try {
+      const liveRoot = iframe.contentDocument?.documentElement?.cloneNode(true);
+      if (
+        liveRoot &&
+        'querySelectorAll' in liveRoot &&
+        'setAttribute' in liveRoot
+      ) {
+        const liveElement = liveRoot as Element;
+        liveElement.querySelectorAll('script').forEach((node) => node.remove());
+        liveElement.querySelectorAll('base').forEach((node) => node.remove());
+        liveElement.querySelectorAll(overlaySelector).forEach((node) => node.remove());
+        const head = liveElement.querySelector('head') ?? liveElement;
+        const style = document.createElement('style');
+        style.textContent = `html{margin:0!important;width:${docW}px!important;min-height:${docH}px!important;overflow:hidden!important;}body{margin:0!important;width:${docW}px!important;min-height:${docH}px!important;transform:translate(${-sx}px,${-sy}px)!important;transform-origin:0 0!important;}*{content-visibility:visible!important;}`;
+        head.appendChild(style);
+        appendOverlayLayer(liveElement, document);
+        liveElement.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+        pageHtml = new XMLSerializer().serializeToString(liveElement);
+      }
+    } catch {
+      pageHtml = '';
+    }
+    if (!pageHtml) {
+      const html = sourceHtml || iframe.getAttribute('srcdoc');
+      if (!html) return null;
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      doc.querySelectorAll('script').forEach((node) => node.remove());
+      doc.querySelectorAll('base').forEach((node) => node.remove());
+      doc.querySelectorAll(overlaySelector).forEach((node) => node.remove());
+      const style = doc.createElement('style');
+      style.textContent = `html{margin:0!important;width:${docW}px!important;min-height:${docH}px!important;overflow:hidden!important;}body{margin:0!important;width:${docW}px!important;min-height:${docH}px!important;transform:translate(${-sx}px,${-sy}px)!important;transform-origin:0 0!important;}*{content-visibility:visible!important;}`;
+      (doc.head || doc.documentElement).appendChild(style);
+      appendOverlayLayer(doc.documentElement, doc);
+      doc.documentElement.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+      pageHtml = new XMLSerializer().serializeToString(doc.documentElement);
+    }
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}"><foreignObject x="0" y="0" width="${w}" height="${h}">${pageHtml}</foreignObject></svg>`;
+    return { dataUrl: '', blob: new Blob([svg], { type: 'image/svg+xml' }), mime: 'image/svg+xml', w, h };
+  }, []);
+
+  function sizeFromSvgText(svg: string, fallback: { w: number; h: number }): { w: number; h: number } {
+    const root = svg.match(/<svg\b[^>]*>/i)?.[0] ?? '';
+    const width = Number.parseFloat(root.match(/\bwidth=["']?([\d.]+)/i)?.[1] ?? '');
+    const height = Number.parseFloat(root.match(/\bheight=["']?([\d.]+)/i)?.[1] ?? '');
+    if (Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0) {
+      return { w: width, h: height };
+    }
+    const viewBox = root.match(/\bviewBox=["']\s*[-\d.]+\s+[-\d.]+\s+([\d.]+)\s+([\d.]+)/i);
+    const vbWidth = Number.parseFloat(viewBox?.[1] ?? '');
+    const vbHeight = Number.parseFloat(viewBox?.[2] ?? '');
+    if (Number.isFinite(vbWidth) && vbWidth > 0 && Number.isFinite(vbHeight) && vbHeight > 0) {
+      return { w: vbWidth, h: vbHeight };
+    }
+    return fallback;
+  }
+
+  // Best-effort SVG → PNG via canvas. Try both data URLs and object URLs:
+  // browsers differ on which source can decode a foreignObject SVG reliably.
+  const tryConvertToPng = useCallback(async (snap: PreviewSnapshot): Promise<PreviewSnapshot> => {
+    const mime = snap.mime
+      ?? snap.blob?.type
+      ?? snap.dataUrl?.match(/^data:([^;,]+)/)?.[1];
+    if (!mime?.includes('svg')) return snap;
+    const blob = snap.blob ?? (snap.dataUrl ? dataUrlToBlob(snap.dataUrl) : null);
+    if (!blob) return snap;
+    const svgBlob = blob;
+    let svgText = '';
+    try {
+      svgText = await blob.text();
+    } catch {
+      svgText = '';
+    }
+    const intrinsic = sizeFromSvgText(svgText, { w: snap.w, h: snap.h });
+    const dpr = window.devicePixelRatio || 1;
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(intrinsic.w * dpr));
+    canvas.height = Math.max(1, Math.round(intrinsic.h * dpr));
+    const context = canvas.getContext('2d');
+    if (!context) return snap;
+    const ctx = context;
+    ctx.scale(dpr, dpr);
+
+    async function canvasToPng(): Promise<PreviewSnapshot | null> {
+      const pngBlob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'));
+      return pngBlob ? { dataUrl: '', blob: pngBlob, mime: 'image/png', w: canvas.width, h: canvas.height } : null;
+    }
+
+    async function drawImageElement(source: string): Promise<PreviewSnapshot | null> {
+      const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+        const el = new Image();
+        const timer = window.setTimeout(() => reject(new Error('img load timed out')), 5000);
+        el.onload = () => {
+          window.clearTimeout(timer);
+          resolve(el);
+        };
+        el.onerror = () => {
+          window.clearTimeout(timer);
+          reject(new Error('img load failed'));
+        };
+        el.src = source;
+      });
+      ctx.clearRect(0, 0, intrinsic.w, intrinsic.h);
+      ctx.drawImage(img, 0, 0, intrinsic.w, intrinsic.h);
+      return canvasToPng();
+    }
+
+    async function drawImageBitmapFallback(): Promise<PreviewSnapshot | null> {
+      if (typeof createImageBitmap !== 'function') return null;
+      const bitmap = await createImageBitmap(svgBlob);
+      try {
+        ctx.clearRect(0, 0, intrinsic.w, intrinsic.h);
+        ctx.drawImage(bitmap, 0, 0, intrinsic.w, intrinsic.h);
+        return await canvasToPng();
+      } finally {
+        bitmap.close();
+      }
+    }
+
+    const sources: string[] = [];
+    if (snap.dataUrl?.startsWith('data:image/svg')) sources.push(snap.dataUrl);
+    if (svgText) {
+      sources.push(`data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgText)}`);
+    }
+    const objectUrl = URL.createObjectURL(svgBlob);
+    sources.push(objectUrl);
+    try {
+      for (const source of Array.from(new Set(sources))) {
+        try {
+          const png = await drawImageElement(source);
+          if (png) return png;
+        } catch {
+          // Try the next SVG transport.
+        }
+      }
+      try {
+        const png = await drawImageBitmapFallback();
+        if (png) return png;
+      } catch {
+        // Keep the original SVG fallback if browser rasterization is blocked.
+      }
+      return snap;
+    } finally {
+      URL.revokeObjectURL(objectUrl);
+    }
+  }, []);
+
+  function previewCaptureIframe(sourceWindow?: MessageEventSource | null): HTMLIFrameElement | null {
+    const sourceFrame = sourceWindow ? previewIframeForSource(sourceWindow) : null;
+    if (sourceFrame) return sourceFrame;
+    const preferredFrame = annotateMode
+      ? srcDocPreviewIframeRef.current
+      : (useUrlLoadPreview ? urlPreviewIframeRef.current : srcDocPreviewIframeRef.current);
+    if (preferredFrame?.contentWindow) return preferredFrame;
+    if (iframeRef.current?.contentWindow && iframeRef.current.dataset.odActive === 'true') {
+      return iframeRef.current;
+    }
+    const visibleFrame = [srcDocPreviewIframeRef.current, urlPreviewIframeRef.current].find((frame) => {
+      if (!frame?.contentWindow) return false;
+      const rect = frame.getBoundingClientRect();
+      const style = window.getComputedStyle(frame);
+      return rect.width > 1 &&
+        rect.height > 1 &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        style.opacity !== '0';
+    }) ?? null;
+    return visibleFrame
+      ?? preferredFrame
+      ?? srcDocPreviewIframeRef.current
+      ?? urlPreviewIframeRef.current;
+  }
+
+  function snapshotViewportForIframe(iframe: HTMLIFrameElement): PreviewSnapshotViewport | null {
+    const frameRect = iframe.getBoundingClientRect();
+    const frameClientWidth = iframe.clientWidth || frameRect.width;
+    const frameClientHeight = iframe.clientHeight || frameRect.height;
+    if (!frameRect.width || !frameRect.height || !frameClientWidth || !frameClientHeight) {
+      return null;
+    }
+    const hostRect = previewBodyRef.current?.getBoundingClientRect();
+    const windowRect = {
+      bottom: window.innerHeight || frameRect.bottom,
+      left: 0,
+      right: window.innerWidth || frameRect.right,
+      top: 0,
+    };
+    const clipLeft = Math.max(frameRect.left, hostRect?.left ?? frameRect.left, windowRect.left);
+    const clipTop = Math.max(frameRect.top, hostRect?.top ?? frameRect.top, windowRect.top);
+    const clipRight = Math.min(frameRect.right, hostRect?.right ?? frameRect.right, windowRect.right);
+    const clipBottom = Math.min(frameRect.bottom, hostRect?.bottom ?? frameRect.bottom, windowRect.bottom);
+    const visibleWidth = clipRight - clipLeft;
+    const visibleHeight = clipBottom - clipTop;
+    if (visibleWidth <= 1 || visibleHeight <= 1) {
+      return {
+        h: Math.max(1, Math.round(frameClientHeight)),
+        w: Math.max(1, Math.round(frameClientWidth)),
+        x: 0,
+        y: 0,
+      };
+    }
+    const scaleX = frameRect.width / frameClientWidth || 1;
+    const scaleY = frameRect.height / frameClientHeight || 1;
+    return {
+      h: Math.max(1, Math.round(visibleHeight / scaleY)),
+      w: Math.max(1, Math.round(visibleWidth / scaleX)),
+      x: Math.max(0, Math.round((clipLeft - frameRect.left) / scaleX)),
+      y: Math.max(0, Math.round((clipTop - frameRect.top) / scaleY)),
+    };
+  }
+
+  function postPreviewStateToCaptureFrame(target: HTMLIFrameElement | null) {
+    const win = target?.contentWindow;
+    if (!win) return;
+    const snapshot = previewScrollRestoreRef.current;
+    const scroll = snapshot ?? {
+      frameLeft: previewScrollPositionRef.current.frameLeft,
+      frameTop: previewScrollPositionRef.current.frameTop,
+      canvasLeft: previewScrollPositionRef.current.canvasLeft,
+      canvasTop: previewScrollPositionRef.current.canvasTop,
+    };
+    win.postMessage({
+      type: 'od:preview-scroll-restore',
+      frameLeft: scroll.frameLeft,
+      frameTop: scroll.frameTop,
+      canvasLeft: scroll.canvasLeft,
+      canvasTop: scroll.canvasTop,
+    }, '*');
+    win.postMessage({
+      type: '__dc_set_viewport',
+      ...dcViewportRef.current,
+    }, '*');
+    syncBridgeModesAfterTransport(target);
+  }
+
+  async function prepareCaptureIframe(
+    target: HTMLIFrameElement | null,
+    options?: { activateTransport?: boolean; syncViewport?: boolean },
+  ): Promise<boolean> {
+    const win = target?.contentWindow;
+    if (!target || !win) return false;
+    const activated = options?.activateTransport === false
+      ? false
+      : activateSrcDocTransport(target, { force: true });
+    if (activated) {
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          target.removeEventListener('load', finish);
+          resolve();
+        };
+        target.addEventListener('load', finish, { once: true });
+        window.setTimeout(finish, 600);
+      });
+    }
+    if (options?.syncViewport !== false) {
+      postPreviewStateToCaptureFrame(target);
+    }
+    await new Promise((resolve) => window.requestAnimationFrame(() => resolve(null)));
+    return true;
+  }
+
+  const captureToChat = useCallback(async (
+    sourceWindow?: MessageEventSource | null,
+    options?: { overlay?: AnnotateCaptureOverlay | null; playAnimation?: boolean; cleanCapture?: boolean },
+  ) => {
+    const jobId = `annotate-capture-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    setAnnotateCaptureToast(annotateCaptureProgressMessage);
+    updateAnnotateCaptureJob(jobId, 'requested');
+    const iframe = previewCaptureIframe(sourceWindow);
+    if (!iframe) {
+      updateAnnotateCaptureJob(jobId, 'failed', 'no preview iframe available');
+      return;
+    }
+
+    const win = iframe.contentWindow;
+    if (!win) {
+      updateAnnotateCaptureJob(jobId, 'failed', 'preview iframe has no contentWindow');
+      return;
+    }
+    updateAnnotateCaptureJob(jobId, 'snapshotting');
+    const isCapturingVisibleFrame = isActivePreviewIframeSource(win);
+    await prepareCaptureIframe(iframe, {
+      activateTransport: !isCapturingVisibleFrame,
+      syncViewport: !isCapturingVisibleFrame,
+    });
+    // cleanCapture=true (Screenshot button): capture the page content with no
+    // inspect/annotate UI chrome. Use the bridge with skipOverlay so the OI
+    // elements injected into the iframe DOM are excluded from the snapshot.
+    // The bridge runs inside the iframe (same-origin to itself) so it can
+    // always reach the content regardless of the daemon/web port difference.
+    // Ask the iframe bridge for a PNG. It still uses the same viewport snapshot
+    // structure internally, but rasterizes before sending the result back.
+    const cleanCapture = options?.cleanCapture ?? false;
+    const requestedOverlay = cleanCapture ? null : (options?.overlay ?? null);
+    const viewport = snapshotViewportForIframe(iframe);
+    const canUseSnapshotBridge = iframe.getAttribute('data-od-render-mode') !== 'url-load';
+    const snapshotPromise = canUseSnapshotBridge
+      ? Promise.race([
+        requestPreviewSnapshot(iframe, 5200, cleanCapture
+          ? { skipOverlay: true, viewport }
+          : { overlay: requestedOverlay, viewport }),
+        new Promise<null>((resolve) => window.setTimeout(() => resolve(null), 5400)),
+      ])
+      : Promise.resolve(null);
+    if (options?.playAnimation !== false) {
+      win.postMessage({ type: 'od:annotate-trigger-animation' }, '*');
+    }
+    const overlayForFallback = cleanCapture
+      ? null
+      : (requestedOverlay ?? (annotateMode ? annotateCaptureOverlayRef.current : null));
+    const rawSnap = await snapshotPromise ?? fallbackPreviewSnapshot(iframe, overlayForFallback, srcDoc, viewport);
+    // If the bridge had to fall back to SVG, try one more rasterization pass in
+    // the host. If it still is not PNG, fail instead of staging a misleading SVG.
+    const snap = rawSnap ? await tryConvertToPng(rawSnap) : rawSnap;
+    win.postMessage({ type: 'od:annotate-capture-result', dataUrl: snap?.dataUrl ?? null }, '*');
+    if (!snap) {
+      updateAnnotateCaptureJob(jobId, 'failed', 'snapshot returned null');
+      return;
+    }
+    const staged = await stageSnapshotForChat(jobId, snap);
+    if (staged) setAnnotateCaptureToast(annotateCaptureSuccessMessage);
+  }, [activateSrcDocTransport, annotateMode, fallbackPreviewSnapshot, previewIframeForSource, srcDoc, stageSnapshotForChat, tryConvertToPng, updateAnnotateCaptureJob, useUrlLoadPreview]);
+
+  // Screenshot button captures the currently visible preview. Outside
+  // annotate mode this is clean page content; inside annotate mode it keeps
+  // the annotation UI the user can see.
+  const handleAnnotateCaptureClick = useCallback(() => {
+    if (annotateMode) {
+      const target = activeSrcDocPreviewIframe() ?? iframeRef.current;
+      void captureToChat(target?.contentWindow ?? null, {
+        cleanCapture: false,
+        playAnimation: false,
+      });
+      return;
+    }
+    void captureToChat(null, { playAnimation: false, cleanCapture: true });
+  }, [activeSrcDocPreviewIframe, annotateMode, captureToChat]);
+
+  useEffect(() => {
+    function onMessage(ev: MessageEvent) {
+      if (!annotateMode) return;
+      const data = ev.data as AnnotateChangeMessage | null;
+      if (data?.type === 'od:annotate-capture') {
+        if (data.captureId) {
+          const pending = annotateCaptureOverlayRequestsRef.current.get(data.captureId);
+          if (pending) {
+            pending.resolve(data.overlay ?? null);
+            return;
+          }
+        }
+        annotateCaptureOverlayRef.current = data.overlay ?? null;
+        void captureToChat(ev.source, { playAnimation: false });
+        return;
+      }
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (data?.type === 'od:annotate-style-change') {
+        queueAnnotateStyleSave(data);
+        return;
+      }
+      if (data?.type === 'od:annotate-text-change') {
+        queueAnnotateTextSave(data);
+        return;
+      }
+      if (data?.type === 'od:annotate-image-change') {
+        void saveAnnotateImageChange(data);
+        return;
+      }
+      if (data?.type === 'od:annotate-image-src-change') {
+        void saveAnnotateImageSrcChange(data);
+        return;
+      }
+      if (data?.type === 'od:annotate-image-prompt') {
+        void saveAnnotateImagePrompt(data, ev.source);
+      }
+    }
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [annotateMode, captureToChat, isOurPreviewIframeSource]);
+
+  useEffect(() => {
+    if (annotateMode) return;
+    void flushAnnotateStyleSave();
+  }, [annotateMode]);
+
+  useEffect(() => {
+    function onKeyDown(ev: KeyboardEvent) {
+      const activeIframe = annotateMode
+        ? (activeSrcDocPreviewIframe() ?? iframeRef.current)
+        : (iframeRef.current ?? (useUrlLoadPreview ? urlPreviewIframeRef.current : srcDocPreviewIframeRef.current));
+      const win = activeIframe?.contentWindow;
+      if ((ev.metaKey || ev.ctrlKey) && ev.key.toLowerCase() === 'z') {
+        if (!annotateMode || !win) return;
+        ev.preventDefault();
+        win.postMessage({ type: 'od:annotate-undo' }, '*');
+        return;
+      }
+      if ((ev.metaKey || ev.ctrlKey) && ev.key.toLowerCase() === 'm') {
+        ev.preventDefault();
+        if (annotateMode && win) {
+          win.postMessage({ type: 'od:annotate-trigger-capture' }, '*');
+          return;
+        }
+        void captureToChat(null, { playAnimation: false, cleanCapture: true });
+      }
+    }
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [activeSrcDocPreviewIframe, annotateMode, captureToChat, useUrlLoadPreview]);
+
+  useEffect(() => () => {
+    if (annotateStyleTimerRef.current) clearTimeout(annotateStyleTimerRef.current);
+    annotateStyleTimerRef.current = null;
+    annotateCaptureOverlayRequestsRef.current.forEach((request) => request.reject());
+    annotateCaptureOverlayRequestsRef.current.clear();
+  }, []);
+
+  useEffect(() => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    const palette = previewPalette ?? selectedPalette;
+    win.postMessage({ type: 'od:palette', palette }, '*');
+  }, [previewPalette, selectedPalette, srcDoc]);
 
   // Mirror the bridge's `od:comment-targets` broadcast into
   // `liveCommentTargets` whenever EITHER Inspect or Comments mode is
@@ -5826,7 +5247,7 @@ function HtmlViewer({
   // artifacts) because the comment-mode listener short-circuits on
   // `!boardMode`. Issue #890.
   useEffect(() => {
-    if (!inspectMode && !boardMode) {
+    if (!inspectMode && !boardMode && !drawClickSelectionMode) {
       setLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
       return;
     }
@@ -5843,41 +5264,108 @@ function HtmlViewer({
       data.targets.forEach((item) => {
         const elementId = String(item?.elementId || '');
         if (!elementId) return;
-        const position = {
-          x: clampBridgeCoordinate(item?.position?.x),
-          y: clampBridgeCoordinate(item?.position?.y),
-          width: clampBridgeCoordinate(item?.position?.width),
-          height: clampBridgeCoordinate(item?.position?.height),
-        };
-        if (!isValidCommentOverlayPosition(position)) return;
         next.set(elementId, {
           filePath: file.name,
           elementId,
           selector: String(item?.selector || ''),
           label: String(item?.label || ''),
           text: String(item?.text || ''),
-          position,
+          position: {
+            x: clampBridgeCoordinate(item?.position?.x),
+            y: clampBridgeCoordinate(item?.position?.y),
+            width: clampBridgeCoordinate(item?.position?.width),
+            height: clampBridgeCoordinate(item?.position?.height),
+          },
           htmlHint: String(item?.htmlHint || ''),
-          style: normalizeAnnotationStyle(item?.style),
           selectionKind: 'element',
           memberCount: undefined,
-          ...(typeof item?.slideIndex === 'number' ? { slideIndex: item.slideIndex } : {}),
         });
       });
-      setLiveCommentTargets((current) => (
-        liveCommentTargetMapsEqual(current, next) ? current : next
-      ));
+      setLiveCommentTargets(next);
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [inspectMode, boardMode, file.name, isOurPreviewIframeSource]);
+  }, [inspectMode, boardMode, drawClickSelectionMode, file.name, isOurPreviewIframeSource]);
+
+  useEffect(() => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    // Send all known dialects so the artifact can pick up whichever it speaks:
+    //  - `od:tweaks-panel-visible` is the bridge protocol used by class-based
+    //    panels emitted from the tweaks skill template (`.tw-panel`).
+    //  - `__activate_edit_mode` / `__deactivate_edit_mode` is the protocol
+    //    agent-generated artifacts use for their own React-mounted `.twk-panel`.
+    // Deps intentionally exclude `srcDoc`: on iframe remount, sync happens via
+    // `syncBridgeModes` (bridge) and the artifact's own
+    // `__edit_mode_available` announcement (postMessage panels).
+    win.postMessage({ type: 'od:tweaks-panel-visible', visible: tweaksMode }, '*');
+    win.postMessage({ type: tweaksMode ? '__activate_edit_mode' : '__deactivate_edit_mode' }, '*');
+  }, [tweaksMode]);
+
+  // Receive tweaks-side state from the iframe. Supports both bridge messages
+  // (`od:tweaks-*` for skill-template artifacts) and the artifact-native
+  // edit-mode protocol (`__edit_mode_*` for agent-generated artifacts). Either
+  // surface controls toolbar availability and mirrors local close into the
+  // toolbar toggle state.
+  useEffect(() => {
+    function onMessage(ev: MessageEvent) {
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      const data = ev.data as { type?: string; available?: boolean; visible?: boolean } | null;
+      if (!data?.type) return;
+      if (data.type === 'od:tweaks-available') {
+        // Scope this to the active iframe only. The hidden srcDoc iframe's
+        // tweaks bridge always evaluates `document.querySelector('.tw-panel')`
+        // and posts `available: false` for agent-protocol (`.twk-panel`)
+        // artifacts that ship no class based panel. Without this guard that
+        // `false` would land after `__edit_mode_available` had already set
+        // `tweaksAvailable = true` and silently disable the toolbar button.
+        // `__edit_mode_*` below stays accepted from either iframe — those
+        // signals carry real artifact intent and must survive render mode
+        // flips.
+        if (ev.source !== iframeRef.current?.contentWindow) return;
+        setTweaksAvailable(!!data.available);
+      } else if (data.type === 'od:tweaks-panel-state') {
+        setTweaksMode(!!data.visible);
+      } else if (data.type === '__edit_mode_available') {
+        setTweaksAvailable(true);
+        // Mirror the artifact's reported default visibility into `tweaksMode`
+        // exactly once per file. Per design-templates/tweaks/SKILL.md the
+        // artifact MAY emit `{ visible: boolean }` on the availability
+        // payload to declare a default-closed panel; if absent we treat it
+        // as default-open because the SDK pattern is `useState(true)` and
+        // omitting `visible` is the backward-compatible signal that the
+        // panel is already on screen. Without this mirror, the toolbar reads
+        // OFF while the panel is clearly visible and the user has to click
+        // toggle-on then toggle-off to actually hide it. Guarded by
+        // `firstEditModeAvailableSeenForFileRef` so a later iframe remount
+        // (Themes popover flipping render mode, etc.) doesn't snap a
+        // user-driven OFF back to ON. `syncBridgeModes` remains the source
+        // of truth on every subsequent load: it pushes the current
+        // `tweaksMode` into the artifact via `__activate_edit_mode` /
+        // `__deactivate_edit_mode` so the artifact tracks the toolbar.
+        if (firstEditModeAvailableSeenForFileRef.current !== file.name) {
+          firstEditModeAvailableSeenForFileRef.current = file.name;
+          setTweaksMode(data.visible !== false);
+        }
+      } else if (data.type === '__edit_mode_dismissed') {
+        setTweaksMode(false);
+      }
+    }
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+    // `file.name` is in the dep list so the handler's `firstEditMode-
+    // AvailableSeenForFileRef.current !== file.name` guard compares against
+    // the currently-displayed file. Without this, the listener would close
+    // over the first-render `file.name`; switching to another `.twk-panel`
+    // artifact would never re-mirror the new artifact's default-open state
+    // because the stale closure's comparison kept matching. PR #1643 review.
+  }, [file.name]);
 
   useEffect(() => {
     setActiveCommentTarget(null);
     setHoveredCommentTarget(null);
     setLiveCommentTargets(new Map());
     setCommentDraft('');
-    setActiveCommentExistingAttachments([]);
     setActiveInspectTarget(null);
     setInspectOverrides({});
     setInspectSavedAt(null);
@@ -5888,24 +5376,26 @@ function HtmlViewer({
     setManualEditViewportWidth(null);
     setManualEditTargets([]);
     setSelectedManualEditTarget(null);
-    setManualEditPanelPosition(null);
     selectedManualEditTargetIdRef.current = null;
     setManualEditDraft(emptyManualEditDraft());
-    setManualEditDraftDirty(false);
     setManualEditHistory([]);
     setManualEditUndone([]);
     setManualEditError(null);
     manualEditPendingStyleRef.current = null;
     clearManualEditStyleTimer();
+    // Stale tweaks state can carry across files (especially toolbar "on" with
+    // no panel underneath). Reset both and let the iframe bridge re-announce.
+    setTweaksMode(false);
+    setTweaksAvailable(false);
   }, [file.name]);
 
-  // Selecting a new file or turning inspect/comment-inspect off resets the panel target.
+  // Selecting a new file or turning inspect off resets the panel target.
   useEffect(() => {
-    if (!inspectMode && !(boardMode && boardTool === 'inspect')) {
+    if (!inspectMode) {
       setActiveInspectTarget(null);
       setInspectError(null);
     }
-  }, [inspectMode, boardMode, boardTool]);
+  }, [inspectMode]);
 
   // Hydrate the host-authoritative override map from the artifact source
   // synchronously, *before* React commits a render that carries a new
@@ -5942,8 +5432,8 @@ function HtmlViewer({
   }, [selectedManualEditTarget?.id]);
 
   useEffect(() => {
-    if (!boardMode) {
-      setCommentCreateMode(false);
+    const selectionMode = boardMode || drawClickSelectionMode;
+    if (!selectionMode) {
       setActiveCommentTarget((current) => (current ? null : current));
       setHoveredCommentTarget((current) => (current ? null : current));
       setActivePreviewCommentId((current) => (current ? null : current));
@@ -5964,18 +5454,10 @@ function HtmlViewer({
         width: clampBridgeCoordinate(data.position?.width),
         height: clampBridgeCoordinate(data.position?.height),
       },
-      hoverPoint: data.hoverPoint
-        ? {
-            x: clampBridgeCoordinate(data.hoverPoint.x),
-            y: clampBridgeCoordinate(data.hoverPoint.y),
-          }
-        : undefined,
       htmlHint: String(data.htmlHint || ''),
-      style: normalizeAnnotationStyle(data.style),
       selectionKind: data.selectionKind === 'pod' ? 'pod' : 'element',
       memberCount: finiteBridgeInteger(data.memberCount),
       podMembers: Array.isArray(data.podMembers) ? data.podMembers : undefined,
-      ...(typeof data.slideIndex === 'number' ? { slideIndex: data.slideIndex } : {}),
     });
     function onMessage(ev: MessageEvent) {
       if (!isOurPreviewIframeSource(ev.source)) return;
@@ -5989,99 +5471,51 @@ function HtmlViewer({
         const next = new Map<string, PreviewCommentSnapshot>();
         data.targets.forEach((item) => {
           const snapshot = snapshotFromData(item);
-          if (!snapshot.elementId || !isValidCommentOverlayPosition(snapshot.position)) return;
-          next.set(snapshot.elementId, snapshot);
+          if (snapshot.elementId) next.set(snapshot.elementId, snapshot);
         });
-        setLiveCommentTargets((current) => (
-          liveCommentTargetMapsEqual(current, next) ? current : next
+        setLiveCommentTargets(next);
+        setActiveCommentTarget((current) => (
+          current
+            ? current.selectionKind === 'pod'
+              ? current
+              : next.get(current.elementId) ?? null
+            : null
         ));
-        setActiveCommentTarget((current) => {
-          if (!current) return null;
-          if (current.selectionKind === 'pod') return current;
-          const updated = next.get(current.elementId);
-          if (!updated || !isValidCommentOverlayPosition(updated.position)) return null;
-          return commentSnapshotEqual(current, updated) ? current : updated;
-        });
-        setHoveredCommentTarget((current) => {
-          if (!current) return null;
-          if (current.selectionKind === 'pod') return current;
-          const updated = next.get(current.elementId);
-          if (!updated || !isValidCommentOverlayPosition(updated.position)) return null;
-          return commentSnapshotEqual(current, updated) ? current : updated;
-        });
-        return;
-      }
-      if (data.type === 'od:comment-active-target-update') {
-        const snapshot = snapshotFromData(data);
-        if (!snapshot.elementId || !isValidCommentOverlayPosition(snapshot.position)) return;
-        // Fires on every pointermove while a target is active — skip the Map
-        // clone and the active/hovered state writes when nothing changed, so a
-        // steady hover doesn't re-render the whole overlay each frame.
-        setLiveCommentTargets((current) => {
-          const existing = current.get(snapshot.elementId);
-          if (existing && commentSnapshotEqual(existing, snapshot)) return current;
-          return new Map(current).set(snapshot.elementId, snapshot);
-        });
-        setActiveCommentTarget((current) =>
-          current && current.elementId === snapshot.elementId && !commentSnapshotEqual(current, snapshot)
-            ? snapshot
-            : current,
-        );
-        setHoveredCommentTarget((current) =>
-          current && current.elementId === snapshot.elementId && !commentSnapshotEqual(current, snapshot)
-            ? snapshot
-            : current,
-        );
+        setHoveredCommentTarget((current) => (
+          current
+            ? current.selectionKind === 'pod'
+              ? current
+              : next.get(current.elementId) ?? null
+            : null
+        ));
         return;
       }
       if (data.type === 'od:comment-leave') {
-        // Already firmly on the card — nothing to dismiss.
-        if (hoverCardPinnedRef.current) return;
-        // The pointer left the element. It may be sliding onto the floating card
-        // (which overlaps the iframe) or hopping toward an adjacent element —
-        // both should keep the card up. Defer the dismiss so the card's
-        // mouseenter or the next comment-hover can cancel it; only a leave with
-        // nothing following actually tears the card down.
-        scheduleHoverCardDismiss();
+        setHoveredCommentTarget(null);
         return;
       }
       if (data.type === 'od:comment-hover') {
         const snapshot = snapshotFromData(data);
-        if (!snapshot.elementId || !isValidCommentOverlayPosition(snapshot.position)) return;
-        // Pointer landed on an element — cancel any deferred dismiss so moving
-        // from the card back onto the element it describes keeps the card.
-        cancelHoverCardDismiss();
-        // Hover repeats the same snapshot per pointermove frame — keep the
-        // existing state object (and skip the Map clone) when it is unchanged.
-        setHoveredCommentTarget((current) =>
-          current && current.elementId === snapshot.elementId && commentSnapshotEqual(current, snapshot)
-            ? current
-            : snapshot,
-        );
-        setLiveCommentTargets((current) => {
-          const existing = current.get(snapshot.elementId);
-          if (existing && commentSnapshotEqual(existing, snapshot)) return current;
-          return new Map(current).set(snapshot.elementId, snapshot);
-        });
+        if (!snapshot.elementId) return;
+        setHoveredCommentTarget(snapshot);
+        setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
         return;
       }
       if (data.type === 'od:comment-target') {
         const snapshot = snapshotFromData(data);
-        if (!snapshot.elementId || !isValidCommentOverlayPosition(snapshot.position)) return;
-        const shouldOpenComposer = boardMode || commentCreateMode;
-        cancelHoverCardDismiss();
-        setActiveCommentTarget((current) => (shouldOpenComposer ? snapshot : current));
+        if (!snapshot.elementId) return;
+        const existing = previewComments.find((comment) =>
+          comment.filePath === file.name &&
+          comment.status === 'open' &&
+          comment.elementId === snapshot.elementId,
+        );
+        setActiveCommentTarget(snapshot);
         setHoveredCommentTarget(snapshot);
-        setLiveCommentTargets((current) => {
-          const existing = current.get(snapshot.elementId);
-          if (existing && commentSnapshotEqual(existing, snapshot)) return current;
-          return new Map(current).set(snapshot.elementId, snapshot);
-        });
-        if (shouldOpenComposer) {
-          setActivePreviewCommentId(null);
-          setCommentDraft('');
+        setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
+        if (boardMode) {
+          setActivePreviewCommentId(existing?.id ?? null);
+          setCommentDraft(existing?.note ?? '');
           setQueuedBoardNotes([]);
-          setActiveCommentExistingAttachments([]);
         }
         return;
       }
@@ -6118,36 +5552,17 @@ function HtmlViewer({
         setActivePreviewCommentId(null);
         setQueuedBoardNotes([]);
         setCommentDraft('');
-        setActiveCommentExistingAttachments([]);
         setStrokePoints([]);
       }
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [activeCommentTarget, boardMode, boardTool, cancelHoverCardDismiss, commentPortalHost, file.name, isOurPreviewIframeSource, previewComments, scheduleHoverCardDismiss]);
-
-  useEffect(() => {
-    if (!boardMode || !activeCommentTarget || activeCommentTarget.selectionKind === 'pod') return;
-    iframeRef.current?.contentWindow?.postMessage({
-      type: 'od:comment-active-target',
-      elementId: activeCommentTarget.elementId,
-      selector: activeCommentTarget.selector,
-    }, '*');
-  }, [activeCommentTarget?.elementId, activeCommentTarget?.selector, activeCommentTarget?.selectionKind, boardMode]);
+  }, [boardMode, drawClickSelectionMode, file.name, isOurPreviewIframeSource, previewComments]);
 
   useEffect(() => {
     if (!manualEditMode) {
       setManualEditTargets([]);
       setSelectedManualEditTarget(null);
-      setManualEditHoverTarget(null);
-      setManualEditPageStylesOpen(false);
-      setManualEditPanelPosition(null);
-      setManualEditDraftDirty(false);
-      selectedManualEditTargetIdRef.current = null;
-      manualEditSelectionDraftRef.current = null;
-      manualEditTextSessionIdRef.current = null;
-      manualEditTextFinishRef.current = null;
-      manualEditTextCommitInFlightRef.current = null;
       setManualEditError(null);
       manualEditPendingStyleRef.current = null;
       if (manualEditStyleTimerRef.current) {
@@ -6173,71 +5588,7 @@ function HtmlViewer({
         return;
       }
       if (data.type === 'od-edit-select') {
-        setManualEditHoverTarget(null);
         void selectManualEditTarget(data.target);
-        return;
-      }
-      if (data.type === 'od-edit-hover') {
-        // While an inline text edit is live, hovering must not surface or switch
-        // any affordance — that instability is the other half of #3646.
-        if (manualEditTextSessionIdRef.current) return;
-        // Hover only surfaces a lightweight "edit params" affordance; it must
-        // NOT switch the pinned inspector. The panel changes only when the
-        // user clicks that affordance (or a container/image body), so moving
-        // the cursor across the canvas never yanks the panel away mid-edit.
-        setManualEditHoverTarget(
-          data.target.id === selectedManualEditTargetIdRef.current ? null : data.target,
-        );
-        return;
-      }
-      if (data.type === 'od-edit-background') {
-        // Clicking empty canvas deselects and opens the compact page-styles
-        // card — only meaningful for full HTML documents.
-        setManualEditHoverTarget(null);
-        if (typeof source === 'string' && isManualEditFullHtmlDocument(source)) {
-          void clearManualEditTargetSelection();
-          setManualEditPageStylesOpen(true);
-        }
-        return;
-      }
-      if (data.type === 'od-edit-text-commit') {
-        // Keep the apply promise reachable so any teardown (host- or
-        // iframe-initiated) can await it and honor a failed save before tearing
-        // down. It self-clears once resolved, keyed to identity so a newer
-        // commit is never clobbered.
-        const commit = applyManualEdit({
-          id: String(data.id),
-          kind: 'set-text',
-          value: String(data.value),
-        }, 'Edit text');
-        manualEditTextCommitInFlightRef.current = commit;
-        void (async () => {
-          try { await commit; } catch { /* failure honored by teardown / surfaced by applyManualEdit */ }
-          if (manualEditTextCommitInFlightRef.current === commit) {
-            manualEditTextCommitInFlightRef.current = null;
-          }
-        })();
-        return;
-      }
-      if (data.type === 'od-edit-text-session') {
-        const sessionId = String(data.id || '');
-        if (data.active) {
-          manualEditTextSessionIdRef.current = sessionId;
-          return;
-        }
-        if (manualEditTextSessionIdRef.current === sessionId) {
-          manualEditTextSessionIdRef.current = null;
-        }
-        const pending = manualEditTextFinishRef.current;
-        if (pending) {
-          // settle() awaits the in-flight commit before resolving the caller's
-          // teardown, so the final edit is never dropped.
-          pending();
-        }
-        // Iframe-driven finishes (Enter / clicking another target) leave the
-        // commit promise in place; it self-clears on resolution, and any later
-        // teardown still awaits it via settlePendingManualEditCommit so a failed
-        // save is never silently torn down.
         return;
       }
     }
@@ -6288,6 +5639,14 @@ function HtmlViewer({
     setManualEditError('Saved styles differed from the active preview. Reconciled the selected target from source.');
   }
 
+  function scheduleManualEditStyleSave() {
+    if (manualEditStyleTimerRef.current) clearTimeout(manualEditStyleTimerRef.current);
+    manualEditStyleTimerRef.current = setTimeout(() => {
+      manualEditStyleTimerRef.current = null;
+      void flushManualEditStyleSave();
+    }, 1000);
+  }
+
   function clearManualEditStyleTimer() {
     if (!manualEditStyleTimerRef.current) return;
     clearTimeout(manualEditStyleTimerRef.current);
@@ -6314,151 +5673,33 @@ function HtmlViewer({
     manualEditPendingStyleRef.current = pending;
     setManualEditError(null);
     previewStyleToIframe(id, styles, version);
+    scheduleManualEditStyleSave();
   }
 
   async function flushManualEditStyleSave(): Promise<boolean> {
     const pending = manualEditPendingStyleRef.current;
     if (!pending) return true;
-    if (manualEditSavingRef.current) return false;
+    if (manualEditSavingRef.current) {
+      scheduleManualEditStyleSave();
+      return false;
+    }
     manualEditPendingStyleRef.current = null;
     return applyManualEdit({ id: pending.id, kind: 'set-style', styles: pending.styles }, pending.label);
   }
 
-  function cancelManualEditStyleDraft() {
-    const pending = manualEditPendingStyleRef.current;
-    if (!pending) return;
-    clearManualEditStyleTimer();
-    manualEditPendingStyleRef.current = null;
-    const base = sourceRef.current ?? '';
-    const target = pending.id === '__body__'
-      ? null
-      : selectedManualEditTarget?.id === pending.id
-        ? selectedManualEditTarget
-        : manualEditTargets.find((item) => item.id === pending.id) ?? null;
-    const sourceStyles = target
-      ? inspectorManualEditStyles(target, base)
-      : readManualEditStyles(base, pending.id);
-    const resetStyles = MANUAL_EDIT_STYLE_PROPS.reduce<Partial<ManualEditStyles>>((acc, key) => {
-      acc[key] = sourceStyles[key] ?? '';
-      return acc;
-    }, {});
-    previewStyleToIframe(pending.id, resetStyles, nextManualEditPreviewVersion());
-    if (!target || target.id === selectedManualEditTarget?.id) {
-      setManualEditDraft((current) => ({
-        ...current,
-        styles: target ? sourceStyles : current.styles,
-        fullSource: base,
-      }));
-    }
-    setManualEditError(null);
-  }
-
-  // Ends the iframe's inline text edit and resolves only once it acks (and any
-  // resulting commit has been applied). Callers that tear down edit state must
-  // await this so the final edit is never dropped — the #3647 exit-path bug.
-  // A timeout backstops a detached iframe so teardown can never hang.
-  // Resolves to whether the session ended cleanly: true when there was nothing
-  // to commit or the commit succeeded, false when the pending text commit
-  // failed (applyManualEdit returned false / threw). Callers that tear down
-  // edit state must honor a false result — keep edit mode open and preserve the
-  // error so a failed save never looks like a successful one (#4291 review).
-  function finishManualEditTextSession(commit: boolean): Promise<boolean> {
-    const win = iframeRef.current?.contentWindow;
-    if (!win || !manualEditTextSessionIdRef.current) return Promise.resolve(true);
-    return new Promise<boolean>((resolve) => {
-      let settled = false;
-      let timer: ReturnType<typeof setTimeout> | null = null;
-      const settle = () => {
-        if (settled) return;
-        settled = true;
-        if (timer) { clearTimeout(timer); timer = null; }
-        // Mark the session ended even on the timeout path, so a follow-up
-        // clearManualEditTargetSelection (e.g. from cancel) does not see a live
-        // session and re-finish it with commit:true — turning cancel into save.
-        manualEditTextSessionIdRef.current = null;
-        if (manualEditTextFinishRef.current === settle) manualEditTextFinishRef.current = null;
-        // Wait out the in-flight commit before resolving, so the final edit is
-        // persisted before teardown even if the timeout backstop won the race
-        // against the iframe's ack. The commit clears its own ref on resolution.
-        const commitInFlight = manualEditTextCommitInFlightRef.current;
-        void (async () => {
-          let committed = true;
-          try {
-            // applyManualEdit resolves false when the save fails (or the source
-            // changed externally); surface that so callers can abort teardown.
-            if ((await commitInFlight) === false) committed = false;
-          } catch {
-            committed = false;
-          }
-          resolve(committed);
-        })();
-      };
-      manualEditTextFinishRef.current = settle;
-      win.postMessage({ type: 'od-edit-text-finish', commit }, '*');
-      // Backstop a detached iframe so teardown can never hang; the ack path
-      // clears this timer when it wins.
-      timer = setTimeout(settle, 1500);
-    });
-  }
-
-  // Settles whatever inline text edit is still pending before teardown and
-  // reports whether it committed cleanly: the live session if one is active,
-  // otherwise an in-flight commit left by an iframe-driven finish (Enter /
-  // click-another-target). Returns false on a failed commit so callers keep
-  // edit mode open with the error rather than tearing down through it (#4291).
-  async function settlePendingManualEditCommit(): Promise<boolean> {
-    if (manualEditTextSessionIdRef.current) {
-      return finishManualEditTextSession(true);
-    }
-    const commitInFlight = manualEditTextCommitInFlightRef.current;
-    if (!commitInFlight) return true;
-    try {
-      return (await commitInFlight) !== false;
-    } catch {
-      return false;
-    }
-  }
-
   async function exitManualEditModeAfterFlush(): Promise<boolean> {
-    // A failed text commit must keep edit mode open with its error visible,
-    // rather than tearing down (which would clear the error) and looking saved.
-    if (!(await settlePendingManualEditCommit())) {
-      return false;
-    }
     const ok = await flushManualEditStyleSave();
     if (!ok) return false;
-    setManualEditPanelPosition(null);
     setManualEditMode(false);
     return true;
   }
 
-  // Clears the hover affordance and re-arms the iframe's per-element hover
-  // dedupe so re-entering the same element re-announces it. Called from the
-  // workspace's own mouseleave (host-side), NOT the iframe's mouseleave — the
-  // affordance overlays the iframe, so reacting to the iframe leaving would
-  // yank it out from under the cursor and strobe on/off.
-  function clearManualEditHover() {
-    setManualEditHoverTarget(null);
-    const win = iframeRef.current?.contentWindow;
-    if (win) win.postMessage({ type: 'od-edit-hover-reset' }, '*');
-  }
-
   async function selectManualEditTarget(target: ManualEditTarget) {
-    setManualEditPageStylesOpen(false);
-    if (manualEditPendingStyleRef.current?.id !== target.id) cancelManualEditStyleDraft();
+    if (!(await flushManualEditStyleSave())) return;
     const base = sourceRef.current ?? '';
-    const nextDraft = manualEditDraftForTarget(target, base);
-    selectedManualEditTargetIdRef.current = target.id;
-    manualEditSelectionDraftRef.current = { id: target.id, draft: nextDraft };
-    setSelectedManualEditTarget(target);
-    setManualEditDraft(nextDraft);
-    setManualEditDraftDirty(false);
-    setManualEditError(null);
-  }
-
-  function manualEditDraftForTarget(target: ManualEditTarget, base: string): ManualEditDraft {
     const fields = readManualEditFields(base, target.id);
-    return {
+    setSelectedManualEditTarget(target);
+    setManualEditDraft({
       text: fields.text ?? target.fields.text ?? target.text,
       href: fields.href ?? target.fields.href ?? '',
       src: fields.src ?? target.fields.src ?? '',
@@ -6467,132 +5708,15 @@ function HtmlViewer({
       attributesText: JSON.stringify(readManualEditAttributes(base, target.id), null, 2),
       outerHtml: readManualEditOuterHtml(base, target.id) || target.outerHtml,
       fullSource: base,
-    };
+    });
+    setManualEditError(null);
   }
 
   async function clearManualEditTargetSelection() {
-    // If an inline edit is still live (e.g. clearing the selection from the
-    // panel mid-edit), commit it first so it is not lost. Keep the selection
-    // and the error if that commit fails.
-    if (!(await settlePendingManualEditCommit())) {
-      return;
-    }
-    cancelManualEditStyleDraft();
-    selectedManualEditTargetIdRef.current = null;
-    manualEditSelectionDraftRef.current = null;
-    manualEditTextSessionIdRef.current = null;
+    if (!(await flushManualEditStyleSave())) return;
     setSelectedManualEditTarget(null);
-    setManualEditPanelPosition(null);
     setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
-    setManualEditDraftDirty(false);
     setManualEditError(null);
-  }
-
-  // The inspector is scoped to one element (or the page). Closing it should
-  // only collapse the panel and keep the user in edit mode — exiting edit is
-  // the toolbar toggle's job. Dismiss flushes any in-flight tweak first so
-  // nothing is lost; cancel reverts the in-flight unsaved tweak instead.
-  async function dismissManualEditPanel() {
-    // Closing the panel must not swallow a failed text commit: keep it open
-    // with the error if the pending edit could not be saved.
-    if (!(await settlePendingManualEditCommit())) {
-      return;
-    }
-    const ok = await flushManualEditStyleSave();
-    if (!ok) return;
-    if (selectedManualEditTarget) void clearManualEditTargetSelection();
-    else setManualEditPageStylesOpen(false);
-  }
-
-  function manualEditContentPatchForDraft(
-    target: ManualEditTarget,
-    draft: ManualEditDraft,
-    base: string,
-  ): { patch: ManualEditPatch; label: string } | null {
-    const fields = readManualEditFields(base, target.id);
-    if (target.kind === 'text' || target.kind === 'token') {
-      const currentText = fields.text ?? target.fields.text ?? target.text;
-      if (draft.text !== currentText) {
-        return { patch: { id: target.id, kind: 'set-text', value: draft.text }, label: t('manualEdit.applyContent') };
-      }
-      return null;
-    }
-    if (target.kind === 'link') {
-      const currentText = fields.text ?? target.fields.text ?? target.text;
-      const currentHref = fields.href ?? target.fields.href ?? '';
-      if (draft.text !== currentText || draft.href !== currentHref) {
-        return { patch: { id: target.id, kind: 'set-link', text: draft.text, href: draft.href }, label: t('manualEdit.applyContent') };
-      }
-      return null;
-    }
-    if (target.kind === 'image') {
-      const currentSrc = fields.src ?? target.fields.src ?? '';
-      const currentAlt = fields.alt ?? target.fields.alt ?? '';
-      if (draft.src !== currentSrc || draft.alt !== currentAlt) {
-        return { patch: { id: target.id, kind: 'set-image', src: draft.src, alt: draft.alt }, label: t('manualEdit.applyContent') };
-      }
-      return null;
-    }
-    const currentOuterHtml = readManualEditOuterHtml(base, target.id) || target.outerHtml;
-    if (draft.outerHtml !== currentOuterHtml) {
-      return { patch: { id: target.id, kind: 'set-outer-html', html: draft.outerHtml }, label: t('manualEdit.applyHtml') };
-    }
-    return null;
-  }
-
-  async function saveManualEditPanelDraft() {
-    const hadTextSession = Boolean(manualEditTextSessionIdRef.current || manualEditTextCommitInFlightRef.current);
-    if (!(await settlePendingManualEditCommit())) return;
-    if (selectedManualEditTarget && !hadTextSession) {
-      const base = sourceRef.current ?? '';
-      const contentPatch = manualEditContentPatchForDraft(selectedManualEditTarget, manualEditDraft, base);
-      if (contentPatch && !(await applyManualEdit(contentPatch.patch, contentPatch.label))) return;
-    }
-    const ok = await flushManualEditStyleSave();
-    if (!ok) return;
-    if (selectedManualEditTarget) void clearManualEditTargetSelection();
-    else setManualEditPageStylesOpen(false);
-  }
-
-  async function resetManualEditPanelDraft() {
-    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(false);
-    cancelManualEditStyleDraft();
-    if (!selectedManualEditTarget) {
-      setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
-      setManualEditError(null);
-      return;
-    }
-    const snapshot = manualEditSelectionDraftRef.current?.id === selectedManualEditTarget.id
-      ? manualEditSelectionDraftRef.current.draft
-      : manualEditDraftForTarget(selectedManualEditTarget, sourceRef.current ?? '');
-    const base = sourceRef.current ?? '';
-    const currentOuterHtml = readManualEditOuterHtml(base, selectedManualEditTarget.id);
-    if (snapshot.outerHtml && currentOuterHtml && snapshot.outerHtml !== currentOuterHtml) {
-      const ok = await applyManualEdit(
-        { id: selectedManualEditTarget.id, kind: 'set-outer-html', html: snapshot.outerHtml },
-        'Reset element',
-      );
-      if (!ok) return;
-    }
-    const refreshedBase = sourceRef.current ?? base;
-    setManualEditDraft({
-      ...snapshot,
-      fullSource: refreshedBase,
-      styles: inspectorManualEditStyles(selectedManualEditTarget, refreshedBase),
-    });
-    setManualEditDraftDirty(false);
-    setManualEditError(null);
-    postSelectedManualEditTargetToIframe(selectedManualEditTarget.id);
-  }
-
-  async function cancelManualEditPanel() {
-    if (manualEditTextSessionIdRef.current) await finishManualEditTextSession(false);
-    if (selectedManualEditTarget) {
-      void clearManualEditTargetSelection();
-    } else {
-      cancelManualEditStyleDraft();
-      setManualEditPageStylesOpen(false);
-    }
   }
 
   async function applyManualEdit(patch: ManualEditPatch, label: string): Promise<boolean> {
@@ -6612,16 +5736,11 @@ function HtmlViewer({
         baseSource,
         'The file changed outside manual edit mode. Refreshing before applying manual edits.',
       ))) return false;
-      const saved = await writeProjectTextFileDetailed(projectId, file.name, result.source, {
+      const saved = await writeProjectTextFile(projectId, file.name, result.source, {
         artifactManifest: file.artifactManifest,
       });
-      if (!saved.ok) {
-        const status = 'status' in saved ? saved.status : undefined;
-        const code = 'code' in saved ? saved.code : undefined;
-        const message = 'message' in saved ? saved.message : 'Unknown save error';
-        setManualEditError(
-          `Could not save the edited file${status ? ` (${status}${code ? ` ${code}` : ''})` : ''}: ${message}`,
-        );
+      if (!saved) {
+        setManualEditError('Could not save the edited file.');
         return false;
       }
       const entry: ManualEditHistoryEntry = {
@@ -6641,54 +5760,251 @@ function HtmlViewer({
       setManualEditHistory((current) => [entry, ...current]);
       setManualEditUndone([]);
       setManualEditDraft((current) => ({ ...current, fullSource: result.source }));
-      if (patch.kind === 'set-text') {
-        setSelectedManualEditTarget((current) => current?.id === patch.id
-          ? { ...current, text: patch.value, fields: { ...current.fields, text: patch.value } }
-          : current);
-        setManualEditDraft((current) => ({ ...current, text: patch.value, fullSource: result.source }));
-      } else if (patch.kind === 'set-link') {
-        setSelectedManualEditTarget((current) => current?.id === patch.id
-          ? { ...current, text: patch.text, fields: { ...current.fields, text: patch.text, href: patch.href } }
-          : current);
-        setManualEditDraft((current) => ({ ...current, text: patch.text, href: patch.href, fullSource: result.source }));
-      } else if (patch.kind === 'set-image') {
-        setSelectedManualEditTarget((current) => current?.id === patch.id
-          ? { ...current, fields: { ...current.fields, src: patch.src, alt: patch.alt } }
-          : current);
-        setManualEditDraft((current) => ({ ...current, src: patch.src, alt: patch.alt, fullSource: result.source }));
-      } else if (patch.kind === 'remove-element') {
-        if (manualEditPendingStyleRef.current?.id === patch.id) {
-          manualEditPendingStyleRef.current = null;
-          clearManualEditStyleTimer();
-        }
-        selectedManualEditTargetIdRef.current = null;
-        manualEditSelectionDraftRef.current = null;
-        setSelectedManualEditTarget(null);
-        setManualEditTargets((current) => current.filter((target) => target.id !== patch.id));
-        setManualEditDraft(emptyManualEditDraft(result.source));
-        setManualEditDraftDirty(false);
-        postSelectedManualEditTargetToIframe(null);
-      } else {
-        setManualEditDraft((current) => ({ ...current, fullSource: result.source }));
-      }
-      if (
-        patch.kind !== 'remove-element' &&
-        patch.kind !== 'set-token' &&
-        patch.kind !== 'set-full-source' &&
-        selectedManualEditTargetIdRef.current === patch.id
-      ) {
-        setManualEditDraftDirty(true);
-      }
       if (patch.kind === 'set-style') {
         reconcileManualEditStyleSave(patch.id, patch.styles, result.source);
       }
-      setManualEditError(null);
       await onFileSaved?.();
       return true;
     } finally {
       manualEditSavingRef.current = false;
       setManualEditSaving(false);
+      if (manualEditPendingStyleRef.current) scheduleManualEditStyleSave();
     }
+  }
+
+  function queueAnnotateStyleSave(change: AnnotateStyleChangeMessage) {
+    const id = change.id.trim();
+    const property = change.property.trim();
+    const value = change.value.trim();
+    if (!id || !property) return;
+    const current = annotatePendingStyleRef.current.get(id);
+    annotatePendingStyleRef.current.set(id, {
+      label: change.label?.trim() || '注释样式',
+      styles: { ...(current?.styles ?? {}), [property]: value },
+    });
+    scheduleAnnotateStyleSave();
+  }
+
+  function queueAnnotateTextSave(change: AnnotateTextChangeMessage) {
+    const id = change.id.trim();
+    if (!id) return;
+    annotatePendingTextRef.current.set(id, {
+      label: change.label?.trim() || '注释文本',
+      value: change.value,
+    });
+    scheduleAnnotateStyleSave();
+  }
+
+  async function saveAnnotateImageChange(change: AnnotateImageChangeMessage): Promise<boolean> {
+    const id = change.id.trim();
+    if (!id || !(change.file instanceof File)) return false;
+    if (manualEditSavingRef.current) {
+      window.setTimeout(() => void saveAnnotateImageChange(change), 250);
+      return false;
+    }
+    try {
+      const result = await uploadProjectFiles(projectId, [change.file]);
+      const uploaded = result.uploaded[0];
+      if (!uploaded?.path) {
+        console.error('[annotate] image upload failed:', result.error);
+        return false;
+      }
+      const src = toOwnerRelativePath(file.name, uploaded.path);
+      return applyManualEdit(
+        { id, kind: 'set-image', src, alt: change.alt ?? '' },
+        change.label?.trim() || '注释图片',
+      );
+    } catch (err) {
+      console.error('[annotate] image upload failed:', err);
+      return false;
+    }
+  }
+
+  async function saveAnnotateImageSrcChange(change: AnnotateImageSrcChangeMessage): Promise<boolean> {
+    const id = change.id.trim();
+    const src = change.src.trim();
+    if (!id) return false;
+    if (manualEditSavingRef.current) {
+      window.setTimeout(() => void saveAnnotateImageSrcChange(change), 250);
+      return false;
+    }
+    return applyManualEdit(
+      { id, kind: 'set-image', src, alt: change.alt ?? '' },
+      change.label?.trim() || '注释图片',
+    );
+  }
+
+  function postAnnotateImagePromptResult(
+    source: MessageEventSource | null,
+    payload: { ok: boolean; src?: string; alt?: string; error?: string },
+  ) {
+    const message = { type: 'od:annotate-image-prompt-result', ...payload };
+    const targets = new Set<Window>();
+    if (iframeRef.current?.contentWindow) targets.add(iframeRef.current.contentWindow);
+    if (srcDocPreviewIframeRef.current?.contentWindow) targets.add(srcDocPreviewIframeRef.current.contentWindow);
+    if (urlPreviewIframeRef.current?.contentWindow) targets.add(urlPreviewIframeRef.current.contentWindow);
+    if (source && typeof (source as Window).postMessage === 'function') {
+      try {
+        (source as Window).postMessage(message, '*');
+      } catch {
+        // Some MessageEvent sources (for example MessagePort) do not accept
+        // a Window-style targetOrigin. The preview iframe targets below are
+        // the reliable delivery path.
+      }
+    }
+    for (const target of targets) {
+      try {
+        target.postMessage(message, '*');
+      } catch {
+        // Best-effort UI status delivery; generation/save failures are logged
+        // by the caller and surfaced through any target that accepts the post.
+      }
+    }
+  }
+
+  function extractResponseError(data: unknown): string | null {
+    if (!data || typeof data !== 'object') return null;
+    const error = (data as { error?: unknown }).error;
+    if (typeof error === 'string') return error;
+    if (error && typeof error === 'object') {
+      const message = (error as { message?: unknown }).message;
+      if (typeof message === 'string') return message;
+    }
+    return null;
+  }
+
+  async function waitForAnnotateMediaTask(taskId: string): Promise<ProjectFile> {
+    let since = 0;
+    const deadline = Date.now() + 180_000;
+    while (Date.now() < deadline) {
+      const resp = await fetch(`/api/media/tasks/${encodeURIComponent(taskId)}/wait`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ since, timeoutMs: 25_000 }),
+      });
+      const data = (await resp.json().catch(() => null)) as
+        | {
+            status?: string;
+            nextSince?: number;
+            file?: ProjectFile;
+            error?: { message?: string } | string;
+          }
+        | null;
+      if (!resp.ok) {
+        throw new Error(extractResponseError(data) || `media task wait failed (${resp.status})`);
+      }
+      since = typeof data?.nextSince === 'number' ? data.nextSince : since;
+      if (data?.status === 'done' && data.file?.name) return data.file;
+      if (data?.status === 'failed' || data?.status === 'interrupted') {
+        const err = data.error;
+        throw new Error(typeof err === 'string' ? err : err?.message || 'image generation failed');
+      }
+    }
+    throw new Error('image generation timed out');
+  }
+
+  async function waitForManualEditIdle(timeoutMs = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (manualEditSavingRef.current && Date.now() < deadline) {
+      await new Promise((resolve) => window.setTimeout(resolve, 120));
+    }
+  }
+
+  async function saveAnnotateImagePrompt(
+    change: AnnotateImagePromptMessage,
+    source: MessageEventSource | null,
+  ): Promise<boolean> {
+    const id = change.id.trim();
+    const prompt = change.prompt.trim();
+    if (!id || !prompt) {
+      postAnnotateImagePromptResult(source, { ok: false, error: '请输入图片 prompt' });
+      return false;
+    }
+    try {
+      const output = `annotate-image-${Date.now()}.png`;
+      const resp = await fetch(`/api/projects/${encodeURIComponent(projectId)}/media/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          surface: 'image',
+          model: DEFAULT_IMAGE_MODEL,
+          prompt,
+          output,
+          aspect: '1:1',
+        }),
+      });
+      const data = (await resp.json().catch(() => null)) as
+        | { taskId?: string; error?: string | { message?: string } }
+        | null;
+      if (!resp.ok || !data?.taskId) {
+        throw new Error(extractResponseError(data) || `image generation failed (${resp.status})`);
+      }
+      const generated = await waitForAnnotateMediaTask(data.taskId);
+      const generatedPath = generated.path || generated.name;
+      const src = toOwnerRelativePath(file.name, generatedPath);
+      const alt = change.alt?.trim() || prompt;
+      await waitForManualEditIdle();
+      const targetKind = change.targetKind ?? 'src';
+      const patch: ManualEditPatch =
+        targetKind === 'background'
+          ? { id, kind: 'set-style', styles: { backgroundImage: `url("${src.replace(/"/g, '\\"')}")` } }
+          : targetKind === 'href'
+            ? { id, kind: 'set-attributes', attributes: { href: src, 'xlink:href': src } }
+            : { id, kind: 'set-image', src, alt };
+      const ok = await applyManualEdit(patch, change.label?.trim() || '注释图片生成');
+      if (!ok) throw new Error('image save failed');
+      postAnnotateImagePromptResult(source, { ok: true, src, alt });
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[annotate] image prompt generation failed:', err);
+      postAnnotateImagePromptResult(source, {
+        ok: false,
+        error: message || '生成失败，请重试',
+      });
+      return false;
+    }
+  }
+
+  function scheduleAnnotateStyleSave() {
+    if (annotateStyleTimerRef.current) clearTimeout(annotateStyleTimerRef.current);
+    annotateStyleTimerRef.current = setTimeout(() => {
+      annotateStyleTimerRef.current = null;
+      void flushAnnotateStyleSave();
+    }, 700);
+  }
+
+  async function flushAnnotateStyleSave(): Promise<boolean> {
+    if (annotatePendingStyleRef.current.size === 0 && annotatePendingTextRef.current.size === 0) return true;
+    if (manualEditSavingRef.current) {
+      scheduleAnnotateStyleSave();
+      return false;
+    }
+    const styleEntries = Array.from(annotatePendingStyleRef.current.entries());
+    const textEntries = Array.from(annotatePendingTextRef.current.entries());
+    annotatePendingStyleRef.current.clear();
+    annotatePendingTextRef.current.clear();
+    for (const [id, pending] of styleEntries) {
+      const ok = await applyManualEdit(
+        { id, kind: 'set-style', styles: pending.styles as Partial<ManualEditStyles> },
+        pending.label,
+      );
+      if (!ok) {
+        console.error('[annotate] autosave failed for style edit:', id, pending.styles);
+        return false;
+      }
+    }
+    for (const [id, pending] of textEntries) {
+      const ok = await applyManualEdit(
+        { id, kind: 'set-text', value: pending.value },
+        pending.label,
+      );
+      if (!ok) {
+        console.error('[annotate] autosave failed for text edit:', id);
+        return false;
+      }
+    }
+    return true;
   }
 
   async function confirmManualEditHistorySource(expectedSource: string, message: string): Promise<boolean> {
@@ -6818,13 +6134,6 @@ function HtmlViewer({
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
     win.postMessage({ type: 'od:slide', action }, '*');
-  }
-
-  function syncCachedSlideStateToIframe(target: HTMLIFrameElement | null = iframeRef.current) {
-    const active = htmlPreviewSlideState.get(previewStateKey)?.active;
-    const win = target?.contentWindow;
-    if (!win || typeof active !== 'number') return;
-    win.postMessage({ type: 'od:slide', action: 'go', index: active }, '*');
   }
 
   function postInspectSet(elementId: string, selector: string, prop: string, value: string) {
@@ -6960,6 +6269,23 @@ function HtmlViewer({
   }, [presentMenuOpen]);
 
   useEffect(() => {
+    if (!modeMenuOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!modeMenuRef.current) return;
+      if (!modeMenuRef.current.contains(e.target as Node)) setModeMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setModeMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [modeMenuOpen]);
+
+  useEffect(() => {
     if (!zoomMenuOpen) return;
     const onDocClick = (e: MouseEvent) => {
       if (!zoomMenuRef.current) return;
@@ -6977,35 +6303,13 @@ function HtmlViewer({
   }, [zoomMenuOpen]);
 
   useEffect(() => {
-    if (!agentToolsOpen) return;
-    const onDocClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (target?.closest('.artifact-tool-menu-anchor')) return;
-      closeArtifactToolMenus();
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeArtifactToolMenus();
-    };
-    document.addEventListener('mousedown', onDocClick);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onDocClick);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [agentToolsOpen]);
-
-  useEffect(() => {
-    if (!deployMenuOpen && !downloadMenuOpen) return;
+    if (!shareMenuOpen) return;
     const onDocClick = (e: MouseEvent) => {
       if (!shareRef.current) return;
-      if (shareRef.current.contains(e.target as Node)) return;
-      setDeployMenuOpen(false);
-      setDownloadMenuOpen(false);
+      if (!shareRef.current.contains(e.target as Node)) setShareMenuOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return;
-      setDeployMenuOpen(false);
-      setDownloadMenuOpen(false);
+      if (e.key === 'Escape') setShareMenuOpen(false);
     };
     document.addEventListener('mousedown', onDocClick);
     document.addEventListener('keydown', onKey);
@@ -7013,40 +6317,15 @@ function HtmlViewer({
       document.removeEventListener('mousedown', onDocClick);
       document.removeEventListener('keydown', onKey);
     };
-  }, [deployMenuOpen, downloadMenuOpen]);
+  }, [shareMenuOpen]);
 
   useEffect(() => {
     if (!inTabPresent) return;
-    const bodyStyle = document.body.style;
-    const previousChromeHeight = bodyStyle.getPropertyValue('--workspace-tabs-chrome-height');
-    const updateChromeHeight = () => {
-      const chrome = document.querySelector<HTMLElement>('.workspace-tabs-chrome.app-chrome-header');
-      const height = chrome?.getBoundingClientRect().height ?? 0;
-      if (height > 0) {
-        bodyStyle.setProperty('--workspace-tabs-chrome-height', `${Math.round(height)}px`);
-      } else {
-        bodyStyle.removeProperty('--workspace-tabs-chrome-height');
-      }
-    };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setInTabPresent(false);
     };
-    updateChromeHeight();
     document.addEventListener('keydown', onKey);
-    window.addEventListener('resize', updateChromeHeight);
-    const chrome = document.querySelector<HTMLElement>('.workspace-tabs-chrome.app-chrome-header');
-    const observer = chrome && typeof ResizeObserver !== 'undefined' ? new ResizeObserver(updateChromeHeight) : null;
-    if (observer && chrome) observer.observe(chrome);
-    return () => {
-      document.removeEventListener('keydown', onKey);
-      window.removeEventListener('resize', updateChromeHeight);
-      observer?.disconnect();
-      if (previousChromeHeight) {
-        bodyStyle.setProperty('--workspace-tabs-chrome-height', previousChromeHeight);
-      } else {
-        bodyStyle.removeProperty('--workspace-tabs-chrome-height');
-      }
-    };
+    return () => document.removeEventListener('keydown', onKey);
   }, [inTabPresent]);
 
   function openInNewTab() {
@@ -7061,29 +6340,10 @@ function HtmlViewer({
   // Snapshot this project as a reusable template. The daemon snapshots
   // EVERY html/text/code file in the project (not just the file open in
   // the viewer), so the template captures the whole design, not a single
-  // page. Surfaced here in the Download menu because templates are saved
-  // from the same artifact output surface as files.
+  // page. Surfaced here in the Share menu because that's where the user's
+  // share / export mental model already lives.
   function openSaveAsTemplateModal() {
-    setDownloadMenuOpen(false);
-    // Start the template click→result correlation; the result fires later from
-    // handleSaveAsTemplate once the save actually resolves.
-    const requestId = analytics.newRequestId();
-    templateExportRequestIdRef.current = requestId;
-    templateExportStartedRef.current = performance.now();
-    templateExportResolvedRef.current = false;
-    trackShareOptionPopoverClick(
-      analytics.track,
-      {
-        page_name: 'artifact',
-        area: 'share_option_popover',
-        artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-        artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-        element: 'template',
-        project_id: projectId,
-        project_kind: projectKind,
-      },
-      { requestId },
-    );
+    setShareMenuOpen(false);
     const defaultName =
       file.name.replace(/\.html?$/i, '') || t('fileViewer.templateNameDefault');
     setTemplateName(defaultName);
@@ -7092,34 +6352,6 @@ function HtmlViewer({
     setTemplateModalOpen(true);
   }
 
-  // Component-scoped so both the save flow and the modal Cancel button emit
-  // the one terminal result for a template export session.
-  const fireTemplateExportResult = (
-    result: 'success' | 'failed' | 'cancelled',
-    errorCode?: string,
-  ) => {
-    if (templateExportResolvedRef.current) return;
-    templateExportResolvedRef.current = true;
-    const requestId = templateExportRequestIdRef.current ?? analytics.newRequestId();
-    const started = templateExportStartedRef.current || performance.now();
-    trackArtifactExportResult(
-      analytics.track,
-      {
-        page_name: 'artifact',
-        area: 'share_option_popover',
-        artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-        artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-        export_format: 'template',
-        result,
-        ...(errorCode ? { error_code: errorCode } : {}),
-        export_duration_ms: Math.round(performance.now() - started),
-        project_id: projectId,
-        project_kind: projectKind,
-      },
-      { requestId },
-    );
-  };
-
   async function handleSaveAsTemplate() {
     const name = templateName.trim();
     if (!name) return;
@@ -7127,11 +6359,6 @@ function HtmlViewer({
     setTemplateNote(null);
     setTemplateSaveError(null);
     let savedName: string | null = null;
-    // Default to failed; flips to success only when the save resolves. The
-    // finally block reports exactly one artifact_export_result(template),
-    // covering the !tpl branch and any thrown error too.
-    let templateOutcome: 'success' | 'failed' = 'failed';
-    let templateErrorCode: string | undefined = 'UNKNOWN';
     try {
       const tpl = await saveTemplate({
         name,
@@ -7140,7 +6367,6 @@ function HtmlViewer({
       });
       if (!tpl) {
         setTemplateSaveError(t('fileViewer.savedTemplateFail'));
-        templateErrorCode = 'SAVE_FAILED';
         return;
       }
       savedName = tpl.name;
@@ -7150,11 +6376,8 @@ function HtmlViewer({
       setTemplateNote(t('fileViewer.savedTemplate', { name: tpl.name }));
       // Show success toast
       setTemplateSavedToast(t('fileViewer.savedTemplate', { name: tpl.name }));
-      templateOutcome = 'success';
-      templateErrorCode = undefined;
     } finally {
       setSavingTemplate(false);
-      fireTemplateExportResult(templateOutcome, templateErrorCode);
       if (savedName) {
         // Auto-clear the note so the menu doesn't keep stale state next open.
         setTimeout(() => setTemplateNote(null), 4000);
@@ -7162,25 +6385,13 @@ function HtmlViewer({
     }
   }
 
-  async function openDeployModal(
-    nextProviderId: WebDeployProviderId = deployProviderId,
-    intent: 'deploy' | 'social-share' = 'deploy',
-  ) {
-    setDeployMenuOpen(false);
+  async function openDeployModal(nextProviderId: WebDeployProviderId = deployProviderId) {
+    setShareMenuOpen(false);
     setDeployModalOpen(true);
-    setDeployModalIntent(intent);
     setDeployError(null);
-    setDeployActionToast(null);
     setCopiedDeployLink(null);
     setDeployPhase('idle');
     await loadDeployProvider(nextProviderId, { fallbackToExisting: true });
-  }
-
-  async function openSocialShareFlow() {
-    const providerWithDeployment = DEPLOY_PROVIDER_OPTIONS.find(
-      (option) => deploymentsByProvider[option.id]?.url?.trim(),
-    )?.id;
-    await openDeployModal(providerWithDeployment ?? deployProviderId, 'social-share');
   }
 
   async function changeDeployProvider(nextProviderId: WebDeployProviderId) {
@@ -7193,13 +6404,10 @@ function HtmlViewer({
   async function saveDeployConfig() {
     setSavingDeployConfig(true);
     setDeployError(null);
-    setDeployActionToast(null);
     try {
       if (deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID) {
         if (!deployToken.trim()) {
-          setDeployActionToast(t('fileViewer.cloudflareApiTokenRequired'));
-          deployTokenInputRef.current?.focus();
-          return null;
+          throw new Error(t('fileViewer.cloudflareApiTokenRequired'));
         }
         if (!cloudflareAccountId.trim()) {
           throw new Error(t('fileViewer.cloudflareAccountIdRequired'));
@@ -7244,40 +6452,11 @@ function HtmlViewer({
     setDeploying(true);
     setDeployPhase('deploying');
     setDeployError(null);
-    setDeployActionToast(null);
     setCopiedDeployLink(null);
-    // Real-deploy analytics: report success only after the provider actually
-    // accepts the publish, failed on any hard error / missing config. This is
-    // distinct from the share-popover "opened" signal (artifact_export_result).
-    const deployStarted = performance.now();
-    const providerForTracking: TrackingDeployProvider =
-      deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? 'cloudflare_pages' : 'vercel';
-    const firstConfigure = !deployConfig?.configured;
-    let savedNewToken = false;
-    const fireDeployResult = (
-      result: 'success' | 'failed' | 'cancelled',
-      errorCode?: string,
-    ) => {
-      trackArtifactDeployResult(analytics.track, {
-        page_name: 'artifact',
-        area: 'deploy_modal',
-        artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-        artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-        provider: providerForTracking,
-        result,
-        saved_new_token: savedNewToken,
-        first_configure: firstConfigure,
-        ...(errorCode ? { error_code: errorCode } : {}),
-        deploy_duration_ms: Math.round(performance.now() - deployStarted),
-        project_id: projectId,
-        project_kind: projectKind,
-      });
-    };
     try {
       const cloudflarePagesSelection = buildCloudflarePagesDeploySelection();
       const typedToken = deployToken.trim();
       const hasNewToken = typedToken && typedToken !== deployConfig?.tokenMask;
-      savedNewToken = Boolean(hasNewToken);
       const cloudflareHints = cloudflareConfigHintsFromForm();
       const cloudflareHintsChanged = deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID && Boolean(
         cloudflareHints?.lastZoneId !== deployConfig?.cloudflarePages?.lastZoneId ||
@@ -7293,12 +6472,7 @@ function HtmlViewer({
         !deployConfig?.configured;
       if (needsConfigSave) {
         const nextConfig = await saveDeployConfig();
-        if (!nextConfig) {
-          // saveDeployConfig bailed (missing/invalid token, e.g. user clicked
-          // Deploy without entering a key) — count as a failed deploy attempt.
-          fireDeployResult('failed', 'CONFIG_REQUIRED');
-          return;
-        }
+        if (!nextConfig) return;
         if (!nextConfig?.configured) {
           const option = getDeployProviderOption(deployProviderId);
           throw new Error(t(option.tokenRequiredKey, { provider: t(option.labelKey) }));
@@ -7312,34 +6486,10 @@ function HtmlViewer({
       }));
       setDeployment(next);
       setDeployResult(next);
-      if (deployResultState(next.status) !== 'failed') {
-        fireDeployResult('success');
-        setDeploySavedToast({
-          message: t('fileViewer.deploySuccessToast'),
-          details: t('fileViewer.deploySuccessToastDetails', {
-            provider: deployProviderLabel,
-            url: next.url,
-          }),
-        });
-      } else {
-        fireDeployResult('failed', `STATUS_${next.status ?? 'UNKNOWN'}`);
-      }
     } catch (err) {
       const option = getDeployProviderOption(deployProviderId);
-      const message = err instanceof Error
-        ? err.message
-        : t('fileViewer.deployProviderFailed', { provider: t(option.labelKey) });
-      const tokenRequired =
-        message === t(option.tokenRequiredKey, { provider: t(option.labelKey) });
-      if (tokenRequired) {
-        setDeployActionToast(message);
-        deployTokenInputRef.current?.focus();
-      } else {
-        setDeployError(message);
-      }
-      fireDeployResult(
-        'failed',
-        tokenRequired ? 'CONFIG_REQUIRED' : err instanceof Error ? err.name : 'UNKNOWN',
+      setDeployError(
+        err instanceof Error ? err.message : t('fileViewer.deployProviderFailed', { provider: t(option.labelKey) }),
       );
     } finally {
       setDeploying(false);
@@ -7389,26 +6539,8 @@ function HtmlViewer({
     }, 1800);
   }
 
-  async function copyShareLink(url: string) {
-    const safeUrl = url.trim();
-    if (!safeUrl) {
-      setShareLinkFeedback('failed');
-      setExportToast({ message: t('useEverywhere.copyFailed'), tone: 'error' });
-      return false;
-    }
-    const ok = await copyToClipboard(safeUrl);
-    const feedback = ok ? 'copied' : 'failed';
-    setShareLinkFeedback(feedback);
-    if (!ok) setExportToast({ message: t('useEverywhere.copyFailed'), tone: 'error' });
-    window.setTimeout(() => {
-      setShareLinkFeedback((current) => (current === feedback ? null : current));
-    }, 1800);
-    return ok;
-  }
-
   function presentInThisTab() {
     setPresentMenuOpen(false);
-    setMode('preview');
     setInTabPresent(true);
   }
 
@@ -7427,37 +6559,16 @@ function HtmlViewer({
     openInNewTab();
   }
 
-  function reloadHtmlPreview() {
-    fireArtifactToolbarClick('reload');
-    capturePreviewScrollPosition();
-    imageExportSnapshotDataUrlRef.current = null;
-    setInlinedSource(null);
-    setReloadKey((key) => key + 1);
-    if (!useUrlLoadPreview) {
-      activatedSrcDocTransportHtmlRef.current = null;
-      setSrcDocShellReady(false);
-      setSrcDocTransportResetKey((key) => key + 1);
-    }
-  }
-
   function selectMode(nextMode: 'preview' | 'source') {
     if (nextMode === 'source') setDrawOverlayOpen(false);
     setMode(nextMode);
+    setModeMenuOpen(false);
   }
 
   function activateBoard(nextTool?: BoardTool) {
     setMode('preview');
     setBoardMode(true);
     if (nextTool) setBoardTool(nextTool);
-  }
-
-  function activateBoardPicker(nextTool: BoardTool) {
-    clearBoardComposer();
-    fireArtifactToolbarClick(nextTool === 'pod' ? 'pods' : 'comment');
-    setCommentPanelOpen(false);
-    setCommentCreateMode(false);
-    activateBoard(nextTool);
-    setAgentToolsOpen(false);
   }
 
   function clearBoardComposer() {
@@ -7467,133 +6578,7 @@ function HtmlViewer({
     setActivePreviewCommentId(null);
     setCommentDraft('');
     setQueuedBoardNotes([]);
-    setBoardImages([]);
-    setActiveCommentExistingAttachments([]);
-    setBoardPreviewIndex(null);
     setStrokePoints([]);
-  }
-
-  function addBoardImages(files: File[]) {
-    const imgs = files.filter((file) => file.type.startsWith('image/'));
-    if (imgs.length > 0) setBoardImages((current) => [...current, ...imgs]);
-  }
-
-  function removeBoardImage(index: number) {
-    setBoardImages((current) => current.filter((_, i) => i !== index));
-    setBoardPreviewIndex(null);
-  }
-
-  function closeArtifactToolMenus() {
-    setAgentToolsOpen(false);
-  }
-
-  function activateDrawTool() {
-    fireArtifactToolbarClick('mark');
-    const next = !drawOverlayOpen;
-    if (!next) {
-      setDrawOverlayOpen(false);
-      setAgentToolsOpen(false);
-      return;
-    }
-    capturePreviewScrollPosition();
-    const activateDraw = () => {
-      setCommentPanelOpen(false);
-      setCommentCreateMode(false);
-      setBoardMode(false);
-      clearBoardComposer();
-      setInspectMode(false);
-      setMode('preview');
-      setDrawOverlayOpen(true);
-      closeArtifactToolMenus();
-    };
-    if (manualEditMode) {
-      void exitManualEditModeAfterFlush().then((ok) => {
-        if (ok) activateDraw();
-      });
-      return;
-    }
-    activateDraw();
-  }
-
-  function activateCommentTool() {
-    fireArtifactToolbarClick('comment');
-    capturePreviewScrollPosition();
-    if (boardMode && !commentCreateMode && boardTool === 'inspect') {
-      setBoardMode(false);
-      setCommentCreateMode(false);
-      clearBoardComposer();
-      setAgentToolsOpen(false);
-      return;
-    }
-    const activateComment = () => {
-      setCommentPanelOpen(false);
-      setCommentCreateMode(false);
-      clearBoardComposer();
-      setInspectMode(false);
-      setDrawOverlayOpen(false);
-      setMode('preview');
-      activateBoard('inspect');
-      closeArtifactToolMenus();
-    };
-    if (manualEditMode) {
-      void exitManualEditModeAfterFlush().then((ok) => {
-        if (ok) activateComment();
-      });
-      return;
-    }
-    activateComment();
-  }
-
-  function activateCommentCreateTool() {
-    fireArtifactToolbarClick('comment');
-    capturePreviewScrollPosition();
-    if (boardMode && commentCreateMode) {
-      setBoardMode(false);
-      setCommentCreateMode(false);
-      setCommentPanelOpen(false);
-      clearBoardComposer();
-      closeArtifactToolMenus();
-      return;
-    }
-    const activateCommentCreate = () => {
-      setCommentPanelOpen(true);
-      setCommentSidePanelCollapsed(false);
-      setCommentCreateMode(true);
-      if (!activeCommentTarget) clearBoardComposer();
-      setInspectMode(false);
-      setDrawOverlayOpen(false);
-      setMode('preview');
-      activateBoard('inspect');
-      closeArtifactToolMenus();
-    };
-    if (manualEditMode) {
-      void exitManualEditModeAfterFlush().then((ok) => {
-        if (ok) activateCommentCreate();
-      });
-      return;
-    }
-    activateCommentCreate();
-  }
-
-  function activateManualEditTool() {
-    fireArtifactToolbarClick('edit');
-    capturePreviewScrollPosition();
-    if (!manualEditMode) {
-      setCommentPanelOpen(false);
-      setCommentCreateMode(false);
-      setBoardMode(false);
-      clearBoardComposer();
-      setInspectMode(false);
-      setDrawOverlayOpen(false);
-      setMode('preview');
-      setManualEditViewportWidth(previewBodyRef.current?.clientWidth ?? null);
-      setManualEditSrcDocActive(true);
-      setManualEditMode(true);
-      closeArtifactToolMenus();
-      return;
-    }
-    closeArtifactToolMenus();
-    void exitManualEditModeAfterFlush();
   }
 
   function queueCurrentDraft() {
@@ -7603,60 +6588,19 @@ function HtmlViewer({
     setCommentDraft('');
   }
 
-  function currentActiveComposerComment(): PreviewComment | null {
-    if (!activePreviewCommentId) return null;
-    return previewComments.find((comment) => (
-      comment.id === activePreviewCommentId &&
-      comment.filePath === file.name &&
-      comment.status === 'open'
-    )) ?? null;
-  }
-
-  function currentActiveComposerAttachments(): PreviewCommentAttachment[] {
-    return currentActiveComposerComment()?.attachments ?? activeCommentExistingAttachments;
-  }
-
-  function withDeckSlideIndex(target: PreviewCommentTarget): PreviewCommentTarget {
-    if (!effectiveDeck || typeof slideState?.active !== 'number') return target;
-    if (typeof target.slideIndex === 'number') return target;
-    return { ...target, slideIndex: slideState.active };
-  }
-
   async function sendBoardBatch() {
     if (!activeCommentTarget || !onSendBoardCommentAttachments) return;
     const nextNotes = [...queuedBoardNotes];
     if (commentDraft.trim()) nextNotes.push(commentDraft.trim());
-    if (nextNotes.length === 0 && boardImages.length === 0) {
-      const existingComment = currentActiveComposerComment();
-      if (existingComment) {
-        setSendingBoardBatch(true);
-        try {
-          await onSendBoardCommentAttachments(commentsToAttachments([existingComment]));
-          clearBoardComposer();
-        } finally {
-          setSendingBoardBatch(false);
-        }
-      }
-      return;
-    }
+    if (nextNotes.length === 0) return;
     setSendingBoardBatch(true);
     try {
-      const existingAttachments = currentActiveComposerAttachments();
-      const attachments = buildBoardCommentAttachments({
-        target: withDeckSlideIndex(targetFromSnapshot(activeCommentTarget)),
-        notes: nextNotes,
-        includeImageOnly: boardImages.length > 0,
-        imageAttachmentCount: boardImages.length,
-      }).map((attachment) => (
-        existingAttachments.length > 0
-          ? { ...attachment, imageAttachments: existingAttachments }
-          : attachment
-      ));
-      const accepted = await onSendBoardCommentAttachments(
-        attachments,
-        boardImages,
+      await onSendBoardCommentAttachments(
+        buildBoardCommentAttachments({
+          target: targetFromSnapshot(activeCommentTarget),
+          notes: nextNotes,
+        }),
       );
-      if (accepted === false) return;
       clearBoardComposer();
     } finally {
       setSendingBoardBatch(false);
@@ -7664,85 +6608,23 @@ function HtmlViewer({
   }
 
   async function savePersistentComment() {
-    if (!activeCommentTarget || !onSavePreviewComment) return;
-    // Allow saving when there is text OR an attached image (image-only notes).
-    if (!commentDraft.trim() && boardImages.length === 0 && currentActiveComposerAttachments().length === 0) return;
+    if (!activeCommentTarget || !commentDraft.trim() || !onSavePreviewComment) return;
     const isFreePin = activeCommentTarget.elementId.startsWith('pin-');
-    setSendingBoardBatch(true);
-    try {
-      const target = withDeckSlideIndex(targetFromSnapshot(activeCommentTarget));
-      const saved = await onSavePreviewComment(
-        target,
-        commentDraft.trim(),
-        false,
-        boardImages,
-      );
-      if (saved) {
-        rememberSavedPreviewCommentOrder(saved.id);
-        clearBoardComposer();
-        setActiveCommentExistingAttachments(saved.attachments ?? []);
-        setBoardMode(true);
-        setCommentCreateMode(true);
-        setCommentPanelOpen(true);
-        setCommentSidePanelCollapsed(false);
-        setActivePreviewCommentId(saved.id);
-        setCommentSavedToast(isFreePin ? t('chat.comments.pinSavedToast') : t('chat.comments.savedToast'));
-      }
-    } finally {
-      setSendingBoardBatch(false);
-    }
-  }
-
-  async function savePanelComment(note: string) {
-    if (!onSavePreviewComment) return false;
-    const cleanNote = note.trim();
-    if (!cleanNote) return false;
-    const idSeed = Date.now().toString(36);
-    const target: PreviewCommentTarget = activeCommentTarget
-      ? targetFromSnapshot(activeCommentTarget)
-      : {
-          filePath: file.name,
-          elementId: `file-comment-${idSeed}-${Math.floor(Math.random() * 1e6).toString(36)}`,
-          selector: 'html',
-          label: file.name,
-          text: '',
-          position: { x: 0, y: 0, width: 0, height: 0 },
-          htmlHint: '',
-          selectionKind: 'element',
-        };
-    setSendingBoardBatch(true);
-    try {
-      const saved = await onSavePreviewComment(target, cleanNote, false);
-      if (saved) {
-        rememberSavedPreviewCommentOrder(saved.id);
-        setCommentSavedToast(t('chat.comments.savedToast'));
-        if (activeCommentTarget) clearBoardComposer();
-      }
-      return Boolean(saved);
-    } finally {
-      setSendingBoardBatch(false);
+    const saved = await onSavePreviewComment(
+      targetFromSnapshot(activeCommentTarget),
+      commentDraft.trim(),
+      false,
+    );
+    if (saved) {
+      clearBoardComposer();
+      setCommentSavedToast(isFreePin ? t('chat.comments.pinSavedToast') : t('chat.comments.savedToast'));
     }
   }
 
   const showPresent = source !== null;
+  const canShare = source !== null;
   const exportTitle = file.name.replace(/\.html?$/i, '') || file.name;
-  const artifactKind = file.artifactManifest?.kind ?? file.artifactKind ?? null;
-  const rendererId = file.artifactManifest?.renderer ?? null;
-  const isDeckArtifact = isDeck || artifactKind === 'deck' || rendererId === 'deck-html' || file.kind === 'presentation';
-  const isMarkdownArtifact =
-    artifactKind === 'markdown-document' ||
-    rendererId === 'markdown' ||
-    file.kind === 'text' && /\.mdx?$/i.test(file.name);
-  const isShareableArtifact =
-    file.kind === 'html' ||
-    isDeckArtifact ||
-    artifactKind === 'html' ||
-    rendererId === 'html';
-  const canShare = source !== null && isShareableArtifact;
-  const canDownload = source !== null && (isShareableArtifact || isMarkdownArtifact);
-  const showMarkdownExport = source !== null && isMarkdownArtifact;
-  const showImageExport = canShare;
-
+  const canPptx = canShare && Boolean(onExportAsPptx) && !streaming;
   useEffect(() => {
     const nudgeKey = `${projectId}\n${file.name}`;
     if (!canShare || exportReadyNudgeSeenRef.current.has(nudgeKey)) return;
@@ -7754,360 +6636,23 @@ function HtmlViewer({
     return () => window.clearTimeout(timeout);
   }, [canShare, file.name, projectId]);
 
-  // Chat-side "Share" next-step action: when a new share request arrives, open
-  // the share menu (the toolbar's "Share" button → deploy menu, which holds the
-  // share-link items AND the "publish online" providers). This is the right
-  // surface for "share" — publishing is the prerequisite for a shareable link,
-  // and that publish step lives here; the download menu is export-to-disk, a
-  // different intent. The artifact source may still be loading when the request
-  // lands (the file was just auto-opened), so we defer until `canShare` flips
-  // true and only consume each nonce once.
-  const consumedShareNonceRef = useRef<number | null>(null);
-  useEffect(() => {
-    const nonce = shareRequest?.nonce;
-    if (nonce == null) return;
-    if (consumedShareNonceRef.current === nonce) return;
-    if (!canShare) return;
-    consumedShareNonceRef.current = nonce;
-    setExportReadyNudge(false);
-    markExportReadyNudgeSeen(projectId, file.name);
-    setDownloadMenuOpen(false);
-    setDeployMenuOpen(true);
-  }, [shareRequest?.nonce, canShare, projectId, file.name]);
-
-  // Parallel to shareRequest, but opens the Download / Export menu instead — the
-  // assistant "next step" card's Download row routes here so it surfaces the same
-  // PDF / image / zip / standalone-HTML / template options the toolbar exposes.
-  const consumedDownloadNonceRef = useRef<number | null>(null);
-  useEffect(() => {
-    const nonce = downloadRequest?.nonce;
-    if (nonce == null) return;
-    if (consumedDownloadNonceRef.current === nonce) return;
-    if (!canShare) return;
-    consumedDownloadNonceRef.current = nonce;
-    setExportReadyNudge(false);
-    markExportReadyNudgeSeen(projectId, file.name);
-    setDeployMenuOpen(false);
-    setDownloadMenuOpen(true);
-  }, [downloadRequest?.nonce, canShare, projectId, file.name]);
-
-  // A queued chat send for this deck just started: flip the preview to the
-  // slide its marked element lives on. We write the cached slide state first so
-  // a freshly-mounted iframe (the tab may have just been activated) restores to
-  // the target on load via syncCachedSlideStateToIframe(), then post directly
-  // to cover the already-loaded iframe. The consume-once guard lives in
-  // `shouldConsumeSlideNav` (keyed by file outside this component) so it holds
-  // across remounts — switching away from and back to the deck must not replay
-  // the stale request and yank the preview off wherever the user navigated.
-  useEffect(() => {
-    const nonce = slideNavRequest?.nonce;
-    if (nonce == null) return;
-    if (!effectiveDeck) return;
-    const requested = slideNavRequest?.slideIndex;
-    if (typeof requested !== 'number' || !Number.isFinite(requested) || requested < 0) return;
-    if (!shouldConsumeSlideNav(previewStateKey, nonce)) return;
-    const target = Math.floor(requested);
-    const cachedCount = htmlPreviewSlideState.get(previewStateKey)?.count;
-    const count = slideState?.count ?? cachedCount ?? target + 1;
-    setSlideStateCached(previewStateKey, { active: target, count });
-    setSlideState({ active: target, count });
-    syncCachedSlideStateToIframe();
-  }, [slideNavRequest?.nonce, slideNavRequest?.slideIndex, effectiveDeck, previewStateKey, slideState?.count]);
-
-  const openDownloadMenu = () => {
-    fireArtifactHeaderClick('download_dropdown');
-    setExportReadyNudge(false);
-    markExportReadyNudgeSeen(projectId, file.name);
-    setDeployMenuOpen(false);
-    setDownloadMenuOpen((v) => !v);
-  };
-  const openDeployMenu = () => {
+  const openExportMenu = () => {
     fireArtifactHeaderClick('share_dropdown');
     setExportReadyNudge(false);
     markExportReadyNudgeSeen(projectId, file.name);
-    setDownloadMenuOpen(false);
-    setDeployMenuOpen((v) => !v);
+    setShareMenuOpen((v) => !v);
   };
-  const captureExportImageSnapshot = useCallback(async () => {
-    // The host compositor grabs on-screen pixels, so any transient hover chrome
-    // over the preview leaks into the capture. The screenshot control's own
-    // tooltip is already dismissed by TooltipLayer's pointerdown/click listener,
-    // but that setState(null) has not repainted yet when capture starts. Wait
-    // two frames so the dismissal commits first — mirrors the double-rAF guard
-    // in the browser screenshot flow (DesignBrowserPanel).
-    await waitForAnimationFrame();
-    await waitForAnimationFrame();
-    // Prefer the desktop compositor screenshot of the visible preview region:
-    // it returns the real rendered pixels (fonts, external CSS, gradients,
-    // images) and is never tainted, so it cannot produce the black/blank frames
-    // the in-iframe SVG-foreignObject bridge does. Works for both srcDoc and
-    // URL-load previews. Falls through to the bridge on pure web (no host).
-    const visibleIframe = iframeRef.current ?? srcDocPreviewIframeRef.current;
-    const hostSnapshot = await captureHostIframeSnapshot(visibleIframe);
-    if (hostSnapshot) return hostSnapshot;
-
-    if (!useUrlLoadPreview) {
-      const activeIframe = srcDocPreviewIframeRef.current ?? iframeRef.current;
-      if (!activeIframe) return null;
-      await waitForIframeLoadOrTimeout(activeIframe, 250);
-      await waitForAnimationFrame();
-      return requestPreviewSnapshotWithRetry(activeIframe);
-    }
-
-    const urlIframe = iframeRef.current ?? urlPreviewIframeRef.current;
-    if (urlIframe) {
-      await waitForIframeLoadOrTimeout(urlIframe, 250);
-      await waitForAnimationFrame();
-      const urlSnapshot = await requestPreviewSnapshotWithRetry(urlIframe);
-      if (urlSnapshot) return urlSnapshot;
-    }
-
-    const srcDocIframe = srcDocPreviewIframeRef.current;
-    if (!srcDocIframe) {
-      const activeIframe = iframeRef.current;
-      if (!activeIframe) return null;
-      return requestPreviewSnapshotWithRetry(activeIframe);
-    }
-
-    if (useLazySrcDocTransport && !srcDocShellReady) {
-      await waitForIframeLoadOrTimeout(srcDocIframe, 500);
-    }
-    if (useLazySrcDocTransport && activateSrcDocSnapshotTransport(srcDocIframe)) {
-      await waitForIframeLoadOrTimeout(srcDocIframe);
-    }
-    const restoreVisibility = temporarilyExposeIframeForSnapshot(srcDocIframe);
-    try {
-      await waitForAnimationFrame();
-      return requestPreviewSnapshotWithRetry(srcDocIframe);
-    } finally {
-      restoreVisibility();
-    }
-  }, [
-    activateSrcDocSnapshotTransport,
-    srcDocShellReady,
-    useLazySrcDocTransport,
-    useUrlLoadPreview,
-  ]);
-
-  const handleCopyScreenshot = useCallback(async () => {
-    fireArtifactToolbarClick('screenshot');
-    if (screenshotInFlightRef.current) return;
-    screenshotInFlightRef.current = true;
-    setExportToast({ message: t('fileViewer.screenshotCopying'), tone: 'loading' });
-    try {
-      const snap = await captureExportImageSnapshot();
-      if (!snap) {
-        setExportToast({ message: t('fileViewer.screenshotPreviewLoading'), tone: 'error' });
-        return;
-      }
-      const result = await copyImageDataUrlToClipboard(snap.dataUrl);
-      setExportToast(
-        result === 'copied'
-          ? { message: t('fileViewer.screenshotCopied'), tone: 'success' }
-          : {
-              message: t(
-                result === 'denied'
-                  ? 'fileViewer.screenshotClipboardDenied'
-                  : 'fileViewer.screenshotCaptureFailed',
-              ),
-              tone: 'error',
-            },
-      );
-    } catch (err) {
-      console.warn('[handleCopyScreenshot] failed:', err);
-      setExportToast({ message: t('fileViewer.screenshotCaptureFailed'), tone: 'error' });
-    } finally {
-      screenshotInFlightRef.current = false;
-    }
-  }, [captureExportImageSnapshot, t]);
-
-  const prepareImageExportBlob = useCallback(async (format: ImageExportFormat) => {
-    const prepareId = imageExportPrepareIdRef.current + 1;
-    imageExportPrepareIdRef.current = prepareId;
-    setImageExportPreparing(true);
-    setImageExportError(null);
-    setImageExportPreparedBlob(null);
-    try {
-      let dataUrl = imageExportSnapshotDataUrlRef.current;
-      if (!dataUrl) {
-        const snap = await captureExportImageSnapshot();
-        if (!snap) throw new Error('Snapshot capture returned null');
-        dataUrl = snap.dataUrl;
-        imageExportSnapshotDataUrlRef.current = dataUrl;
-      }
-      const blob = await imageDataUrlToBlob(dataUrl, format);
-      if (blob.size <= 0) throw new Error('Snapshot capture produced an empty image');
-      if (imageExportPrepareIdRef.current === prepareId) {
-        setImageExportPreparedBlob({ format, blob });
-      }
-    } catch (err) {
-      console.warn('[exportAsImage] failed to prepare snapshot:', err);
-      if (imageExportPrepareIdRef.current === prepareId) {
-        setImageExportError(t('fileViewer.exportImageFailed'));
-      }
-    } finally {
-      if (imageExportPrepareIdRef.current === prepareId) {
-        setImageExportPreparing(false);
-      }
-    }
-  }, [captureExportImageSnapshot, t]);
-
-  const openImageExportModal = async () => {
-    flushSync(() => {
-      setDownloadMenuOpen(false);
-    });
-    // Start the image export's own click→result correlation (separate modal
-    // flow, so it can't ride fireShareExport).
-    const requestId = analytics.newRequestId();
-    imageExportRequestIdRef.current = requestId;
-    imageExportStartedRef.current = performance.now();
-    imageExportResolvedRef.current = false;
-    trackShareOptionPopoverClick(
-      analytics.track,
-      {
-        page_name: 'artifact',
-        area: 'share_option_popover',
-        artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-        artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-        element: 'image',
-        project_id: projectId,
-        project_kind: projectKind,
-      },
-      { requestId },
-    );
-    setImageExportError(null);
-    setImageExportPreparedBlob(null);
-    imageExportSnapshotDataUrlRef.current = null;
-    await waitForAnimationFrame();
-    await waitForAnimationFrame();
-    setImageExportModalOpen(true);
-    void prepareImageExportBlob(imageExportFormat);
-  };
-
-  const changeImageExportFormat = (format: ImageExportFormat) => {
-    setImageExportFormat(format);
-    void prepareImageExportBlob(format);
-  };
-
-  // Component-scoped so both the save flow and the modal Cancel button can
-  // emit the one terminal result for an image export session.
-  const fireImageExportResult = (
-    result: 'success' | 'failed' | 'cancelled',
-    errorCode?: string,
-  ) => {
-    if (imageExportResolvedRef.current) return;
-    imageExportResolvedRef.current = true;
-    const requestId = imageExportRequestIdRef.current ?? analytics.newRequestId();
-    const started = imageExportStartedRef.current || performance.now();
-    trackArtifactExportResult(
-      analytics.track,
-      {
-        page_name: 'artifact',
-        area: 'share_option_popover',
-        artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-        artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-        export_format: 'image',
-        result,
-        ...(errorCode ? { error_code: errorCode } : {}),
-        export_duration_ms: Math.round(performance.now() - started),
-        project_id: projectId,
-        project_kind: projectKind,
-      },
-      { requestId },
-    );
-  };
-
-  async function handleImageExportSave() {
-    const prepared = imageExportPreparedBlob;
-    if (!prepared || prepared.format !== imageExportFormat) {
-      setImageExportError(t('fileViewer.exportImageFailed'));
-      fireImageExportResult('failed', 'BLOB_NOT_READY');
-      return;
-    }
-    setImageExportBusy(true);
-    setImageExportError(null);
-    try {
-      const target = await prepareImageExportTarget(exportTitle, imageExportFormat, { useNativePicker: false });
-      if (!target) {
-        // Not a terminal state: the modal stays open so the user can retry or
-        // Cancel. The cancelled result is emitted by the Cancel button.
-        return;
-      }
-      const preparedDataUrl = imageExportSnapshotDataUrlRef.current;
-      if (target.method === 'download' && imageExportFormat === 'png' && preparedDataUrl) {
-        downloadImageDataUrl(preparedDataUrl, target.filename);
-      } else {
-        await target.save(prepared.blob);
-      }
-      setImageExportModalOpen(false);
-      fireImageExportResult('success');
-      setImageExportSavedToast({
-        message: target.method === 'picker'
-          ? t('fileViewer.exportImageSaved')
-          : t('fileViewer.exportImageDownloadStarted'),
-        details: target.method === 'picker'
-          ? target.filename
-          : t('fileViewer.exportImageDownloadDetails', { filename: target.filename }),
-      });
-    } catch (err) {
-      console.warn('[exportAsImage] failed to save snapshot:', err);
-      setImageExportError(t('fileViewer.exportImageFailed'));
-      fireImageExportResult('failed', err instanceof Error ? err.name : 'UNKNOWN');
-    } finally {
-      setImageExportBusy(false);
-    }
-  }
-  const creationSortedSideComments = useMemo(
+  const visibleSideComments = useMemo(
     () => previewComments
       .filter((comment) => comment.filePath === file.name && comment.status === 'open')
-      .sort((a, b) => commentCreatedAt(a) - commentCreatedAt(b)),
+      .sort((a, b) => b.createdAt - a.createdAt),
     [file.name, previewComments],
-  );
-  useEffect(() => {
-    const creationIds = creationSortedSideComments.map((comment) => comment.id);
-    setCommentOrderIds((current) => {
-      const visible = new Set(creationIds);
-      const kept = current.filter((id) => visible.has(id));
-      const added = creationIds.filter((id) => !kept.includes(id));
-      const next = [...kept, ...added];
-      return next.join('\0') === current.join('\0') ? current : next;
-    });
-  }, [creationSortedSideComments]);
-  const visibleSideComments = useMemo(() => {
-    if (commentOrderIds.length === 0) return creationSortedSideComments;
-    const byId = new Map(creationSortedSideComments.map((comment) => [comment.id, comment]));
-    const ordered = commentOrderIds
-      .map((id) => byId.get(id))
-      .filter((comment): comment is PreviewComment => Boolean(comment));
-    const orderedIds = new Set(ordered.map((comment) => comment.id));
-    const missing = creationSortedSideComments.filter((comment) => !orderedIds.has(comment.id));
-    return [...ordered, ...missing];
-  }, [creationSortedSideComments, commentOrderIds]);
-  function rememberSavedPreviewCommentOrder(savedId: string) {
-    setCommentOrderIds((current) =>
-      appendSavedPreviewCommentOrder(current, visibleSideComments, savedId),
-    );
-  }
-  const activeSideCommentId = activePreviewCommentId;
-  const activeCommentTargetVisible = commentTargetIntersectsPreview(
-    activeCommentTarget,
-    overlayPreviewScale,
-    { x: overlayPreviewTransform.offsetX, y: overlayPreviewTransform.offsetY },
-    previewBodySize,
   );
   useEffect(() => {
     if (!boardMode || !activePreviewCommentId) return;
     const stillOpen = visibleSideComments.some((comment) => comment.id === activePreviewCommentId);
     if (!stillOpen) clearBoardComposer();
   }, [activePreviewCommentId, boardMode, visibleSideComments]);
-  useEffect(() => {
-    if (!effectiveDeck || slideState == null || !boardMode) return;
-    if (!activePreviewCommentId) return;
-    const activeComment = visibleSideComments.find((comment) => comment.id === activePreviewCommentId);
-    if (activeComment && !commentVisibleOnDeckSlide(activeComment, slideState.active)) {
-      clearBoardComposer();
-    }
-  }, [activePreviewCommentId, boardMode, effectiveDeck, slideState?.active, visibleSideComments]);
   const activeDeployment = deployResult || deployment;
   const activeDeployedUrl = activeDeployment?.url?.trim() || '';
   const activeDeploymentDelayed = activeDeployment?.status === 'link-delayed';
@@ -8175,149 +6720,25 @@ function HtmlViewer({
       ? t('fileViewer.redeployToProvider', { provider: label })
       : t('fileViewer.deployToProvider', { provider: label });
   };
-  const deployedEntries = DEPLOY_PROVIDER_OPTIONS
-    .map((option) => deploymentsByProvider[option.id])
-    .filter((item): item is WebDeploymentInfo => Boolean(item?.url?.trim()));
-  const shareableDeploymentUrl =
-    DEPLOY_PROVIDER_OPTIONS.map((option) => deploymentsByProvider[option.id])
-      .map((item) => publicShareUrlForDeployment(item))
-      .find(Boolean) ?? '';
-  const socialShareBlockedDeployment =
-    shareableDeploymentUrl
-      ? null
-      : deployedEntries.find((item) => deployResultState(item.status) === 'protected' && !publicShareUrlForDeployment(item)) ??
-        deployedEntries.find((item) => !publicShareUrlForDeployment(item)) ??
-        null;
-  const socialShareBlockedState = socialShareBlockedDeployment
-    ? deployResultState(socialShareBlockedDeployment.status)
-    : null;
-  const socialShareDisplayUrl =
-    shareableDeploymentUrl || socialShareBlockedDeployment?.url?.trim() || activeDeployedUrl;
-  const socialShareUnavailableMessage =
-    socialShareBlockedState === 'protected'
-      ? t('fileViewer.deployLinkProtected')
-      : socialShareBlockedState === 'delayed'
-        ? t('fileViewer.deployLinkDelayed')
-        : t('socialShare.deployFirst');
-  const projectSocialShareRequest = useMemo<SocialShareRequest | null>(() => {
-    if (!socialShareDisplayUrl) return null;
-    const title = t('socialShare.projectTitle', { title: exportTitle });
-    const text = t('socialShare.projectText', {
-      title: exportTitle,
-      repo: OPEN_DESIGN_GITHUB_REPO_URL,
-    });
-    return {
-      kind: 'project-html',
-      locale,
-      url: socialShareDisplayUrl,
-      title,
-      text,
-      copyText: t('socialShare.projectCopyText', {
-        title: exportTitle,
-        url: socialShareDisplayUrl,
-        repo: OPEN_DESIGN_GITHUB_REPO_URL,
-      }),
-    };
-  }, [exportTitle, locale, socialShareDisplayUrl, t]);
-  const projectSocialShareFallback = useMemo(
-    () => (projectSocialShareRequest ? buildSocialSharePayload(projectSocialShareRequest) : null),
-    [projectSocialShareRequest],
-  );
-  // Gate the async payload load on a stable *content* key, not the memo's
-  // object identity. The request object can take a fresh identity on renders
-  // where its inputs are value-equal (e.g. while deployment polling re-sets
-  // state with a new map reference), and keying the effect on that identity
-  // made `setProjectSocialShare` re-fire every render — an infinite render
-  // loop once a deployment URL is available (#regression: ready-deploy share).
-  const projectSocialShareKey = projectSocialShareRequest
-    ? JSON.stringify(projectSocialShareRequest)
-    : '';
-  useEffect(() => {
-    setProjectSocialShare(null);
-    if (!projectSocialShareRequest) return;
-    let cancelled = false;
-    void createSocialSharePayload(projectSocialShareRequest)
-      .then((payload) => {
-        if (!cancelled) setProjectSocialShare(payload);
-      })
-      .catch(() => {
-        if (!cancelled) setProjectSocialShare(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectSocialShareKey]);
-  const activeProjectSocialShare = projectSocialShare ?? projectSocialShareFallback;
-  const socialShareMenuLabel =
-    activeProjectSocialShare
-      ? t('socialShare.projectSection')
-      : socialShareBlockedState === 'protected'
-        ? t('fileViewer.deployLinkProtectedLabel')
-        : socialShareBlockedState === 'delayed'
-        ? t('fileViewer.deployLinkPreparingLabel')
-          : t('socialShare.deployFirst');
-  const deployActionIconFor = (providerId: WebDeployProviderId) => {
-    if (providerId === 'cloudflare-pages') return 'pages-line';
-    return 'upload-cloud-line';
-  };
-  const latestShareDeployment = useMemo(
-    () => pickLatestShareDeployment(deploymentsByProvider),
-    [deploymentsByProvider],
-  );
-  const latestDeployedShareUrl = latestShareDeployment
-    ? shareUrlForDeployment(latestShareDeployment)
-    : '';
-  const latestShareState = latestShareDeployment
-    ? deployResultState(latestShareDeployment.status)
-    : null;
-  const sharePageUrl = useMemo(
-    () => resolveShareUrl(latestDeployedShareUrl),
-    [latestDeployedShareUrl],
-  );
-  const canCopyShareLink = !streaming && Boolean(sharePageUrl);
-  const canOpenSharePage = !streaming && Boolean(sharePageUrl) && latestShareState !== 'delayed';
-  const shareLinkStatusHint =
-    streaming
-      ? t('fileViewer.shareAfterGenerationComplete')
-      : latestShareState === 'delayed'
-      ? t('fileViewer.deployLinkDelayed')
-      : latestShareState === 'protected'
-        ? t('fileViewer.deployLinkProtected')
-        : '';
-  const shareUnavailableHint = streaming
-    ? t('fileViewer.shareAfterGenerationComplete')
-    : t('fileViewer.shareLinkRequiresDeploy');
-  const copyShareLinkLabel =
-    shareLinkFeedback === 'copied'
-      ? t('fileViewer.copied')
-      : shareLinkFeedback === 'failed'
-        ? t('useEverywhere.copyFailed')
-        : t('fileViewer.copyShareLink');
-  const shareMenuLabel = t('fileViewer.shareLabel');
-  const deployMenuLabel = t('fileViewer.deployModalTitle') || 'Deploy';
-  const isSocialShareDeployModal = deployModalIntent === 'social-share';
-  const deployModalKicker = isSocialShareDeployModal
-    ? t('socialShare.projectSection')
-    : deployProviderLabel;
-  const deployModalTitle = isSocialShareDeployModal
-    ? t('socialShare.publishPageTitle')
-    : t('fileViewer.deployToProvider', { provider: deployProviderLabel });
-  const deployModalSubtitle = isSocialShareDeployModal
-    ? t('socialShare.publishPageSubtitle')
-    : t('fileViewer.deployModalSubtitle');
+  const deployCopyLinks = DEPLOY_PROVIDER_OPTIONS.map((option) => ({
+    providerId: option.id,
+    providerLabel: t(option.labelKey),
+    url: deploymentsByProvider[option.id]?.url?.trim() || '',
+  })).filter((item) => item.url);
   const deployButtonLabel =
     deployPhase === 'deploying'
       ? t('fileViewer.deployingToProvider', { provider: deployProviderLabel })
       : deployPhase === 'preparing-link'
         ? t('fileViewer.preparingPublicLink')
-        : isSocialShareDeployModal
-          ? t('socialShare.publishPageTitle')
-          : deployMenuLabel;
+        : t('fileViewer.deployToProvider', { provider: deployProviderLabel });
   const copyDeployLabel = (url: string) =>
     copiedDeployLink === url.trim()
       ? t('fileViewer.copied')
       : t('fileViewer.copyDeployLink');
+  const copyDeployMenuLabel = (providerLabel: string, url: string) =>
+    copiedDeployLink === url.trim()
+      ? t('fileViewer.copied')
+      : `${t('fileViewer.copyDeployLink')} · ${providerLabel}`;
   const statusLabelFor = (state: ReturnType<typeof deployResultState>) => {
     if (state === 'ready') return t('fileViewer.deployLinkReady');
     if (state === 'protected') return t('fileViewer.deployLinkProtectedLabel');
@@ -8326,323 +6747,63 @@ function HtmlViewer({
   };
   const boardAvailable = mode === 'preview' && source !== null;
   const showPreviewToolbarControls = mode === 'preview';
-  const commentPreviewLayoutClass = [
-    'comment-preview-layer',
-    localCommentSideDockActive ? 'comment-preview-layer-with-side-dock' : '',
-    localCommentSideDockActive && commentSidePanelCollapsed ? 'comment-preview-layer-dock-collapsed' : '',
-    boardSideDockStacked ? 'comment-preview-layer-side-dock-stacked' : '',
-  ].filter(Boolean).join(' ');
-  // Edit mode opens clean: the inspector only appears once the user pins an
-  // element (click its hover affordance / a container) or opens page styles by
-  // clicking the empty canvas. No more full-height panel popping on toggle.
-  const manualEditPageCardActive =
-    manualEditMode && !selectedManualEditTarget && manualEditPageStylesOpen;
-  const manualEditPanelActive =
-    manualEditMode && (!!selectedManualEditTarget || manualEditPageCardActive);
-  const manualEditResetAvailable = selectedManualEditTarget ? manualEditDraftDirty : false;
-  const manualEditPanel = manualEditPanelActive ? (
-    <ManualEditPanel
-      targets={manualEditTargets}
-      selectedTarget={selectedManualEditTarget}
-      draft={manualEditDraft}
-      history={manualEditHistory}
-      error={manualEditError}
-      canUndo={manualEditHistory.length > 0}
-      canRedo={manualEditUndone.length > 0}
-      busy={manualEditSaving}
-      resetAvailable={manualEditResetAvailable}
-      pageStylesEnabled={manualEditPageStylesEnabled}
-      onSelectTarget={(target) => {
-        void selectManualEditTarget(target);
-      }}
-      onDraftChange={(draft) => {
-        setManualEditDraft(draft);
-        setManualEditDraftDirty(Boolean(selectedManualEditTarget));
-      }}
-      onStyleChange={(id, styles, label) => {
-        void handleManualEditStyleChange(id, styles, label);
-      }}
-      onInvalidStyle={cancelManualEditPendingStyles}
-      onApplyPatch={(patch, label) => {
-        void applyManualEdit(patch, label);
-      }}
-      onError={setManualEditError}
-      onClearSelection={() => {
-        void clearManualEditTargetSelection();
-      }}
-      onExit={() => {
-        void dismissManualEditPanel();
-      }}
-      onCancelDraft={() => {
-        void cancelManualEditPanel();
-      }}
-      onSaveDraft={() => {
-        void saveManualEditPanelDraft();
-      }}
-      onResetDraft={() => {
-        void resetManualEditPanelDraft();
-      }}
-      onUndo={() => {
-        void undoManualEdit();
-      }}
-      onRedo={() => {
-        void redoManualEdit();
-      }}
-      floatingClassName={manualEditPageCardActive ? 'manual-edit-page-card' : undefined}
-      floatingStyle={selectedManualEditTarget
-        ? {
-            ...manualEditFloatingPanelStyle(
-              selectedManualEditTarget,
-              overlayPreviewScale,
-              previewBodySize,
-            ),
-            ...(manualEditPanelPosition ?? {}),
-          }
-        : { top: 12, right: 12, width: 320 }}
-      onFloatingPositionChange={selectedManualEditTarget ? setManualEditPanelPosition : undefined}
-      onPickImage={async (pickedFile) => {
-        const result = await uploadProjectFiles(projectId, [pickedFile]);
-        const uploaded = result.uploaded[0];
-        if (!uploaded?.path) {
-          setManualEditError(result.error ?? t('manualEdit.uploadImageFailed'));
-          return null;
-        }
-        setManualEditError(null);
-        return toOwnerRelativePath(file.name, uploaded.path);
-      }}
-    />
-  ) : null;
-  const manualEditHoverAffordance =
-    manualEditMode &&
-    manualEditHoverTarget &&
-    manualEditHoverTarget.id !== selectedManualEditTarget?.id ? (
-      <button
-        type="button"
-        className="manual-edit-hover-action"
-        data-testid="manual-edit-hover-open"
-        aria-label={t('manualEdit.editParams')}
-        title={t('manualEdit.editParams')}
-        style={manualEditHoverIconStyle(
-          manualEditHoverTarget,
-          overlayPreviewScale,
-          previewBodySize,
-        )}
-        onClick={() => {
-          const target = manualEditHoverTarget;
-          setManualEditHoverTarget(null);
-          void selectManualEditTarget(target);
-        }}
-      >
-        <Icon name="sliders" size={15} />
-      </button>
-    ) : null;
-  const activeComposerComment = activePreviewCommentId
-    ? visibleSideComments.find((comment) => comment.id === activePreviewCommentId) ?? null
-    : null;
-  const activeComposerAttachments =
-    activeComposerComment?.attachments ?? activeCommentExistingAttachments;
-  const commentComposer = boardMode && activeCommentTarget && activeCommentTargetVisible ? (
-    <BoardComposerPopover
-      target={activeCommentTarget}
-      existing={activeComposerComment}
-      draft={commentDraft}
-      notes={queuedBoardNotes}
-      onDraft={setCommentDraft}
-      onAddDraft={queueCurrentDraft}
-      onRemoveQueuedNote={(index) =>
-        setQueuedBoardNotes((current) => current.filter((_, currentIndex) => currentIndex !== index))
-      }
-      onClose={clearBoardComposer}
-      onSaveComment={() => { fireCommentPopoverClick('save_comment'); return savePersistentComment(); }}
-      onSendBatch={() => { fireCommentPopoverClick('send_to_chat'); return sendBoardBatch(); }}
-      images={boardImagePreviews}
-      existingImages={
-        activeComposerAttachments.map((attachment) => ({
-          url: projectRawUrl(projectId, attachment.path),
-          name: attachment.name,
-        }))
-      }
-      onAttachImages={addBoardImages}
-      onRemoveImage={removeBoardImage}
-      onPreviewImage={setBoardPreviewIndex}
-      onRemoveMember={(elementId) => {
-        setActiveCommentTarget((current) => {
-          const { next, shouldClose } = applyPodMemberRemoval(current, elementId);
-          if (shouldClose) clearBoardComposer();
-          return next;
-        });
-        setHoveredPodMemberId((current) => (current === elementId ? null : current));
-      }}
-      onHoverMember={setHoveredPodMemberId}
-      onDeleteComment={onRemovePreviewComment ? async (commentId) => {
-        await onRemovePreviewComment(commentId);
-        clearBoardComposer();
-        setSelectedSideCommentIds((current) => {
-          if (!current.has(commentId)) return current;
-          const next = new Set(current);
-          next.delete(commentId);
-          return next;
-        });
-        setActivePreviewCommentId((current) => (current === commentId ? null : current));
-      } : undefined}
-      sending={sendingBoardBatch}
-      queueOnSend={commentQueueOnSend}
-      sendDisabled={commentSendDisabled}
-      t={t}
-      scale={overlayPreviewScale}
-      offset={{ x: overlayPreviewTransform.offsetX, y: overlayPreviewTransform.offsetY }}
-      bounds={previewBodySize}
-      docked={false}
-      commenting
-    />
-  ) : null;
-  const boardPreviewImage =
-    boardPreviewIndex !== null ? boardImagePreviews[boardPreviewIndex] ?? null : null;
-  const boardImagePreviewModal = boardPreviewImage
-    ? createPortal(
-        <div
-          className="staged-preview-modal"
-          role="dialog"
-          aria-modal="true"
-          aria-label={boardPreviewImage.file.name}
-          onMouseDown={(e) => {
-            if (e.target === e.currentTarget) setBoardPreviewIndex(null);
-          }}
-        >
-          <div className="staged-preview-card">
-            <div className="staged-preview-head">
-              <span title={boardPreviewImage.file.name}>{boardPreviewImage.file.name}</span>
-              <button
-                type="button"
-                className="icon-only od-tooltip"
-                onClick={() => setBoardPreviewIndex(null)}
-                aria-label={t('common.close')}
-                title={t('common.close')}
-                data-tooltip={t('common.close')}
-              >
-                <Icon name="close" size={14} />
-              </button>
-            </div>
-            <img src={boardPreviewImage.url} alt={boardPreviewImage.file.name} />
-          </div>
-        </div>,
-        document.body,
-      )
-    : null;
-  const commentSidePanel = commentPanelOpen ? (
-    <CommentSideDock
-      comments={visibleSideComments}
-      projectId={projectId}
-      selectedIds={selectedSideCommentIds}
-      activeCommentId={activeSideCommentId}
-      collapsed={commentPortalHost ? false : commentSidePanelCollapsed}
-      onCollapsedChange={setCommentSidePanelCollapsed}
-      onToggleSelect={(commentId) => {
-        setSelectedSideCommentIds((current) => {
-          const next = new Set(current);
-          if (next.has(commentId)) next.delete(commentId);
-          else next.add(commentId);
-          return next;
-        });
-      }}
-      onSelectAll={() => setSelectedSideCommentIds(new Set(visibleSideComments.map((comment) => comment.id)))}
-      onClearSelection={() => setSelectedSideCommentIds(new Set())}
-      onReorder={(orderedIds) => setCommentOrderIds(orderedIds)}
-      onReply={(comment) => {
-        // Reply == edit on a flat-thread model: prefill the
-        // popover with the existing note so the user sees and
-        // mutates the current text. Save runs through the
-        // same upsert path; matching project/conv/file/element
-        // updates note in place rather than creating a new row.
-        const snapshot = liveSnapshotForComment(comment, liveCommentTargets) ?? {
-          filePath: comment.filePath,
-          elementId: comment.elementId,
-          selector: comment.selector,
-          label: comment.label,
-          text: comment.text,
-          position: comment.position,
-          htmlHint: comment.htmlHint,
-          style: comment.style,
-          selectionKind: comment.selectionKind ?? 'element',
-          memberCount: comment.memberCount,
-          podMembers: comment.podMembers,
-          ...(typeof comment.slideIndex === 'number' ? { slideIndex: comment.slideIndex } : {}),
-        };
-        setActiveCommentTarget(snapshot);
-        setHoveredCommentTarget(snapshot);
-        setActivePreviewCommentId(comment.id);
-        setCommentDraft(comment.note);
-        setQueuedBoardNotes([]);
-        setActiveCommentExistingAttachments(comment.attachments ?? []);
-        setBoardMode(true);
-        setCommentCreateMode(true);
-        setCommentPanelOpen(true);
-        setCommentSidePanelCollapsed(false);
-      }}
-      onSendSelected={async () => {
-        if (!onSendBoardCommentAttachments) return;
-        const selected = visibleSideComments.filter(
-          (comment) => selectedSideCommentIds.has(comment.id),
-        );
-        if (selected.length === 0) return;
-        fireCommentPopoverClick('send_to_chat');
-        const sentIds = new Set(selected.map((comment) => comment.id));
-        setSendingBoardBatch(true);
-        try {
-          const accepted = await onSendBoardCommentAttachments(commentsToAttachments(selected));
-          if (accepted !== false) {
-            setSelectedSideCommentIds(new Set());
-            setCommentOrderIds((current) => current.filter((id) => !sentIds.has(id)));
-            setActivePreviewCommentId((current) => current && sentIds.has(current) ? null : current);
-          }
-        } finally {
-          setSendingBoardBatch(false);
-        }
-      }}
-      onCreateComment={savePanelComment}
-      sending={sendingBoardBatch}
-      queueOnSend={commentQueueOnSend}
-      sendDisabled={commentSendDisabled}
-      renderCreateForm={!commentPortalHost}
-      t={t}
-      composer={null}
-    />
-  ) : null;
+
+  async function reloadHtmlPreview() {
+    fireArtifactToolbarClick('reload');
+    await flushAnnotateStyleSave();
+    setAnnotateFrozenSource(null);
+    if (annotateMode) setAnnotateMode(false);
+    setReloadKey((n) => n + 1);
+  }
 
   return (
-    <div className={`viewer html-viewer${inTabPresent ? ' is-tab-present' : ''}`}>
+    <div className="viewer html-viewer">
       <div className="viewer-toolbar">
         <div className="viewer-toolbar-left">
           <button
             type="button"
-            className="icon-only od-tooltip"
-            onClick={reloadHtmlPreview}
-            title={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-            data-tooltip={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-            data-tooltip-placement="bottom"
-            aria-label={`${t('fileViewer.reloadAria')} ${t('fileViewer.preview')}`}
+            className="icon-only"
+            onClick={() => {
+              void reloadHtmlPreview();
+            }}
+            title={t('fileViewer.reload')}
+            aria-label={t('fileViewer.reloadAria')}
           >
             <Icon name="reload" size={14} />
           </button>
-          <div className="viewer-tabs" role="tablist" aria-label="View mode">
-            {([
-              ['preview', t('fileViewer.preview')],
-              ['source', t('fileViewer.source')],
-            ] as const).map(([id, label]) => (
-              <button
-                key={id}
-                type="button"
-                role="tab"
-                className={`viewer-tab ${mode === id ? 'active' : ''}`}
-                aria-selected={mode === id}
-                onClick={() => {
-                  fireArtifactToolbarClick(id);
-                  selectMode(id);
-                }}
-              >
-                {label}
-              </button>
-            ))}
+          <div className="viewer-mode-menu" ref={modeMenuRef}>
+            <button
+              type="button"
+              className="viewer-action viewer-mode-trigger"
+              aria-haspopup="menu"
+              aria-expanded={modeMenuOpen}
+              onClick={() => setModeMenuOpen((v) => !v)}
+            >
+              <span>{mode === 'preview' ? t('fileViewer.preview') : t('fileViewer.source')}</span>
+              <Icon name="chevron-down" size={11} />
+            </button>
+            {modeMenuOpen ? (
+              <div className="viewer-mode-popover" role="menu">
+                {([
+                  ['preview', t('fileViewer.preview')],
+                  ['source', t('fileViewer.source')],
+                ] as const).map(([id, label]) => (
+                  <button
+                    key={id}
+                    type="button"
+                    className={`viewer-mode-menu-item${mode === id ? ' active' : ''}`}
+                    role="menuitem"
+                    onClick={() => {
+                      fireArtifactToolbarClick(id);
+                      selectMode(id);
+                    }}
+                  >
+                    <span>{label}</span>
+                    {mode === id ? <Icon name="check" size={13} /> : null}
+                  </button>
+                ))}
+              </div>
+            ) : null}
           </div>
           {showPreviewToolbarControls ? (
             <>
@@ -8652,9 +6813,47 @@ function HtmlViewer({
                 onViewport={setPreviewViewport}
                 t={t}
               />
+              <span className="viewer-divider" aria-hidden />
+              <div className="zoom-menu" ref={zoomMenuRef}>
+                <button
+                  type="button"
+                  className="viewer-action zoom-trigger"
+                  aria-haspopup="menu"
+                  aria-expanded={zoomMenuOpen}
+                  onClick={() => {
+                    fireArtifactToolbarClick('zoom_level_dropdown');
+                    setZoomMenuOpen((v) => !v);
+                  }}
+                  style={{ minWidth: 64 }}
+                >
+                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
+                  <Icon name="chevron-down" size={11} />
+                </button>
+                {zoomMenuOpen ? (
+                  <div className="zoom-menu-popover" role="menu">
+                    {[50, 75, 100, 125, 150, 200].map((level) => (
+                      <button
+                        key={level}
+                        type="button"
+                        className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
+                        role="menuitem"
+                        onClick={() => {
+                          setZoom(level);
+                          setZoomMenuOpen(false);
+                        }}
+                      >
+                        <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
+                        {zoom === level ? (
+                          <Icon name="check" size={13} />
+                        ) : null}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
             </>
           ) : null}
-          {showPreviewToolbarControls && showDeckNavigation ? (
+          {showPreviewToolbarControls && effectiveDeck ? (
             <span
               className="deck-nav"
               role="group"
@@ -8662,11 +6861,9 @@ function HtmlViewer({
             >
               <button
                 type="button"
-                className="icon-only od-tooltip"
+                className="icon-only"
                 onClick={() => postSlide('prev')}
                 title={t('fileViewer.previousSlide')}
-                data-tooltip={t('fileViewer.previousSlide')}
-                data-tooltip-placement="bottom"
                 aria-label={t('fileViewer.previousSlide')}
                 disabled={slideState !== null && slideState.active <= 0}
               >
@@ -8679,11 +6876,9 @@ function HtmlViewer({
               </span>
               <button
                 type="button"
-                className="icon-only od-tooltip"
+                className="icon-only"
                 onClick={() => postSlide('next')}
                 title={t('fileViewer.nextSlide')}
-                data-tooltip={t('fileViewer.nextSlide')}
-                data-tooltip-placement="bottom"
                 aria-label={t('fileViewer.nextSlide')}
                 disabled={
                   slideState !== null &&
@@ -8694,123 +6889,154 @@ function HtmlViewer({
               </button>
             </span>
           ) : null}
+          <button
+            type="button"
+            className={`viewer-toggle${tweaksMode ? ' on' : ''}`}
+            title={tweaksAvailable ? t('fileViewer.tweaks') : t('fileViewer.tweaksUnavailable')}
+            aria-pressed={tweaksMode}
+            disabled={!tweaksAvailable}
+            data-coming-soon={!tweaksAvailable ? 'true' : undefined}
+            onClick={() => setTweaksMode((v) => !v)}
+          >
+            <Icon name="tweaks" size={13} />
+            <span>{t('fileViewer.tweaks')}</span>
+            <span className="switch" aria-hidden />
+          </button>
         </div>
         <div className="viewer-toolbar-actions">
           {showPreviewToolbarControls ? (
             <>
-              {mode === 'preview' ? (
+              <div className="palette-tweaks-anchor">
                 <button
                   type="button"
-                  className="viewer-action viewer-action-icon od-tooltip"
-                  data-testid="screenshot-copy-button"
-                  data-tooltip={t('fileViewer.screenshot')}
-                  data-tooltip-placement="bottom"
-                  title={t('fileViewer.screenshot')}
-                  aria-label={t('fileViewer.screenshot')}
-                  onClick={handleCopyScreenshot}
+                  className={`viewer-action${selectedPalette || palettePopoverOpen ? ' active' : ''}`}
+                  data-testid="palette-tweaks-toggle"
+                  title="Themes"
+                  aria-haspopup="dialog"
+                  aria-expanded={palettePopoverOpen}
+                  onClick={() => {
+                    fireArtifactToolbarClick('tweaks');
+                    setPalettePopoverOpen((v) => !v);
+                  }}
                 >
-                  <RemixIcon name="screenshot-2-line" size={15} />
+                  <Icon name="paint-bucket" size={13} />
+                  <span>Themes</span>
+                  {selectedPalette ? (
+                    <span
+                      className="palette-tweaks-badge"
+                      aria-hidden
+                      style={{
+                        backgroundColor:
+                          selectedPalette === 'coral' ? '#ff5a3c' :
+                          selectedPalette === 'electric' ? '#7c3aed' :
+                          selectedPalette === 'acid-forest' ? '#16a34a' :
+                          selectedPalette === 'risograph' ? '#e11d48' :
+                          '#0a0a0a',
+                      }}
+                    />
+                  ) : null}
                 </button>
-              ) : null}
-              <div className="artifact-tool-menu-anchor">
-                <button
-                  type="button"
-                  className={`viewer-action viewer-action-icon viewer-comment-toggle od-tooltip${boardMode && !commentCreateMode && boardTool === 'inspect' ? ' active' : ''}`}
-                  data-testid="board-mode-toggle"
-                  data-tooltip={t('fileViewer.comment')}
-                  data-tooltip-placement="bottom"
-                  title={t('fileViewer.comment')}
-                  aria-label={t('fileViewer.comment')}
-                  aria-pressed={boardMode && !commentCreateMode && boardTool === 'inspect'}
-                  onClick={activateCommentTool}
-                >
-                  <RemixIcon name="chat-new-line" size={15} />
-                </button>
+                <PaletteTweaks
+                  open={palettePopoverOpen}
+                  selected={selectedPalette}
+                  onChange={(nextPalette) => {
+                    // P0 ui_click area=tweaks_popover. status_before/after
+                    // reflect whether THIS variant was selected. Picking
+                    // "Original" (nextPalette === null) reads as turning
+                    // off the previously selected variant — record that
+                    // by passing the prior selection as variant_name.
+                    const targetVariant = nextPalette ?? selectedPalette;
+                    if (targetVariant) {
+                      const wasSelected = selectedPalette === targetVariant;
+                      const willBeSelected = nextPalette === targetVariant;
+                      trackTweaksPopoverClick(analytics.track, {
+                        page_name: 'artifact',
+                        area: 'tweaks_popover',
+                        element: 'variant_option',
+                        variant_name: targetVariant,
+                        artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
+                        artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
+                        status_before: wasSelected ? 'on' : 'off',
+                        status_after: willBeSelected ? 'on' : 'off',
+                      });
+                    }
+                    setSelectedPalette(nextPalette);
+                  }}
+                  onPreview={setPreviewPalette}
+                  onClose={() => setPalettePopoverOpen(false)}
+                />
               </div>
               <button
-                className={`viewer-action viewer-action-icon od-tooltip${drawOverlayOpen ? ' active' : ''}`}
+                className={`viewer-action${drawOverlayOpen ? ' active' : ''}`}
                 type="button"
                 data-testid="draw-overlay-toggle"
-                data-tooltip={t('fileViewer.mark')}
-                data-tooltip-placement="bottom"
-                title={t('fileViewer.mark')}
-                aria-label={t('fileViewer.mark')}
+                title={t('fileViewer.draw')}
                 aria-pressed={drawOverlayOpen}
-                onClick={activateDrawTool}
+                onClick={() => {
+                  fireArtifactToolbarClick('draw');
+                  const next = !drawOverlayOpen;
+                  if (!next) {
+                    setDrawOverlayOpen(false);
+                    return;
+                  }
+                  const activateDraw = () => {
+                    setAnnotateMode(false);
+                    setBoardMode(false);
+                    clearBoardComposer();
+                    setInspectMode(false);
+                    setDrawOverlayMode('draw');
+                    setMode('preview');
+                    setDrawOverlayOpen(true);
+                  };
+                  if (manualEditMode) {
+                    void exitManualEditModeAfterFlush().then((ok) => {
+                      if (ok) activateDraw();
+                    });
+                    return;
+                  }
+                  activateDraw();
+                }}
               >
-                <RemixIcon name="mark-pen-line" size={15} />
+                <Icon name="draw" size={13} />
+                <span>{t('fileViewer.draw')}</span>
               </button>
-              <span className="viewer-toolbar-tool-divider" aria-hidden />
-              <button
-                className={`viewer-action viewer-action-icon od-tooltip${manualEditMode ? ' active' : ''}`}
-                type="button"
-                data-testid="manual-edit-mode-toggle"
-                data-tooltip={t('fileViewer.edit')}
-                data-tooltip-placement="bottom"
-                title={t('fileViewer.edit')}
-                aria-label={t('fileViewer.edit')}
-                aria-pressed={manualEditMode}
-                onClick={activateManualEditTool}
-              >
-                <RemixIcon name="edit-line" size={15} />
-              </button>
-              <span className="viewer-toolbar-tool-divider" aria-hidden />
-              <button
-                type="button"
-                className={`viewer-action viewer-comment-count-trigger viewer-comment-toggle od-tooltip${boardMode && commentCreateMode ? ' active' : ''}`}
-                data-testid="comment-panel-toggle"
-                data-tooltip={t('chat.tabComments')}
-                data-tooltip-placement="bottom"
-                title={t('chat.tabComments')}
-                aria-label={`${t('chat.tabComments')} (${visibleSideComments.length})`}
-                aria-pressed={boardMode && commentCreateMode}
-                onClick={activateCommentCreateTool}
-              >
-                <RemixIcon name="message-3-line" size={15} />
-                <span className="viewer-comment-count" aria-hidden>{visibleSideComments.length}</span>
-              </button>
-              {source !== null && mode === 'preview' ? (
-                <div className="zoom-menu viewer-toolbar-zoom" ref={zoomMenuRef}>
-                  <button
-                    type="button"
-                    className="viewer-action zoom-trigger od-tooltip"
-                    aria-haspopup="menu"
-                    aria-expanded={zoomMenuOpen}
-                    title={t('fileViewer.resetZoom')}
-                    data-tooltip={t('fileViewer.resetZoom')}
-                    data-tooltip-placement="bottom"
-                    onClick={() => {
-                      fireArtifactToolbarClick('zoom_level_dropdown');
-                      setZoomMenuOpen((v) => !v);
-                    }}
-                  >
-                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
-                  </button>
-                  {zoomMenuOpen ? (
-                    <div className="zoom-menu-popover" role="menu">
-                      {[50, 75, 100, 125, 150, 200].map((level) => (
-                        <button
-                          key={level}
-                          type="button"
-                          className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
-                          role="menuitem"
-                          onClick={() => {
-                            setZoom(level);
-                            setZoomMenuOpen(false);
-                          }}
-                        >
-                          <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
-                          {zoom === level ? (
-                            <Icon name="check" size={13} />
-                          ) : null}
-                        </button>
-                      ))}
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
             </>
           ) : null}
+          <button
+            className={`viewer-action${annotateMode ? ' active' : ''}`}
+            type="button"
+            data-testid="annotate-mode-toggle"
+            title="Edit"
+            aria-pressed={annotateMode}
+            onClick={() => {
+              capturePreviewScrollPosition();
+              setAnnotateMode((v) => {
+                const next = !v;
+                if (next) {
+                  setBoardMode(false);
+                  clearBoardComposer();
+                  setInspectMode(false);
+                  setDrawOverlayOpen(false);
+                  setManualEditMode(false);
+                  setMode('preview');
+                }
+                return next;
+              });
+            }}
+          >
+            <Icon name="eye" size={13} />
+            <span>Edit</span>
+          </button>
+          <button
+            className="viewer-action annotate-capture-pill"
+            type="button"
+            data-testid="annotate-capture-button"
+            title="截屏到 Chat"
+            onClick={handleAnnotateCaptureClick}
+          >
+            <Icon name="image" size={13} />
+            <span>截屏</span>
+          </button>
         </div>
       </div>
       {((filePrimaryActions: ReactNode) => (
@@ -8819,242 +7045,104 @@ function HtmlViewer({
           {showPresent ? (
             <div className="present-wrap chrome-present-wrap">
               <button
-                className="chrome-action chrome-action-secondary chrome-action-icon present-trigger od-tooltip"
+                className="chrome-action chrome-action-secondary present-trigger"
                 aria-haspopup="menu"
                 aria-expanded={presentMenuOpen}
-                aria-label={t('fileViewer.present')}
-                data-tooltip={t('fileViewer.present')}
-                data-tooltip-placement="bottom"
-                title={t('fileViewer.present')}
                 onClick={() => {
                   fireArtifactHeaderClick('present_dropdown');
                   setPresentMenuOpen((v) => !v);
                 }}
               >
-                <RemixIcon name="slideshow-3-line" size={15} />
+                <Icon name="present" size={13} />
+                <span>{t('fileViewer.present')}</span>
+                <Icon name="chevron-down" size={11} />
               </button>
               {presentMenuOpen ? (
                 <div className="present-menu" role="menu">
                   <button role="menuitem" onClick={() => { firePresentPopoverClick('in_this_tab'); presentInThisTab(); }}>
-                    <span className="present-icon"><RemixIcon name="eye-line" size={14} /></span>{' '}
+                    <span className="present-icon"><Icon name="eye" size={13} /></span>{' '}
                     {t('fileViewer.presentInTab')}
                   </button>
                   <button role="menuitem" onClick={() => { firePresentPopoverClick('fullscreen'); presentFullscreen(); }}>
-                    <span className="present-icon"><RemixIcon name="play-line" size={14} /></span>{' '}
+                    <span className="present-icon"><Icon name="play" size={13} /></span>{' '}
                     {t('fileViewer.presentFullscreen')}
                   </button>
                   <button role="menuitem" onClick={() => { firePresentPopoverClick('new_tab'); presentNewTab(); }}>
-                    <span className="present-icon"><RemixIcon name="share-forward-line" size={14} /></span>{' '}
+                    <span className="present-icon"><Icon name="share" size={13} /></span>{' '}
                     {t('fileViewer.presentNewTab')}
                   </button>
                 </div>
               ) : null}
             </div>
           ) : null}
-          {canShare || canDownload ? (
-            <div className="chrome-file-action-menus" ref={shareRef}>
-              {canShare ? (
-                <div className="share-menu chrome-share-menu">
-                  <button
-                    type="button"
-                    className="chrome-action chrome-action-secondary chrome-action-with-label chrome-action-text-only"
-                    aria-haspopup="menu"
-                    aria-expanded={deployMenuOpen}
-                    aria-label={shareMenuLabel}
-                    onClick={openDeployMenu}
-                  >
-                    <span>{shareMenuLabel}</span>
-                  </button>
-                  {deployMenuOpen ? (
-                    <div className="share-menu-popover" role="menu">
-                      <div className="share-menu-section-label" role="presentation">
-                        {t('fileViewer.shareMenuShareLink')}
-                      </div>
-                      {sharePageUrl ? (
-                        <>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            disabled={!canCopyShareLink}
-                            title={!canCopyShareLink ? shareUnavailableHint : shareLinkStatusHint || undefined}
-                            onClick={() => {
-                              if (!canCopyShareLink || !sharePageUrl) return;
-                              fireShareExport('share_link', async () => {
-                                const ok = await copyShareLink(sharePageUrl);
-                                if (!ok) throw new Error('copy_share_link_failed');
-                              });
-                            }}
-                          >
-                            <span className="share-menu-icon"><RemixIcon name="file-copy-line" size={15} /></span>
-                            <span className="share-menu-text">
-                              <span>{copyShareLinkLabel}</span>
-                              {shareLinkStatusHint ? (
-                                <small>{shareLinkStatusHint}</small>
-                              ) : null}
-                            </span>
-                          </button>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            disabled={!canOpenSharePage}
-                            title={!canOpenSharePage ? shareLinkStatusHint || shareUnavailableHint : shareLinkStatusHint || undefined}
-                            onClick={() => {
-                              if (!canOpenSharePage || !sharePageUrl) return;
-                              setDeployMenuOpen(false);
-                              fireShareExport('share_page', () => {
-                                window.open(sharePageUrl, '_blank', 'noopener');
-                              });
-                            }}
-                          >
-                            <span className="share-menu-icon"><RemixIcon name="external-link-line" size={15} /></span>
-                            <span className="share-menu-text">
-                              <span>{t('fileViewer.openSharePage')}</span>
-                              {shareLinkStatusHint ? (
-                                <small>{shareLinkStatusHint}</small>
-                              ) : null}
-                            </span>
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          type="button"
-                          className="share-menu-item share-menu-guide"
-                          role="menuitem"
-                          title={shareUnavailableHint}
-                          onClick={() => {
-                            // Share-intent-but-blocked signal: user wants a
-                            // share link but nothing is deployed yet.
-                            trackShareOptionPopoverClick(
-                              analytics.track,
-                              {
-                                page_name: 'artifact',
-                                area: 'share_option_popover',
-                                artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-                                artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-                                element: 'publish_required_guide',
-                                project_id: projectId,
-                                project_kind: projectKind,
-                              },
-                              { requestId: analytics.newRequestId() },
-                            );
-                            setShareGuideToast(shareUnavailableHint);
-                          }}
-                        >
-                          <span className="share-menu-icon"><RemixIcon name="link" size={15} /></span>
-                          <span className="share-menu-text">
-                            <span>
-                              {streaming
-                                ? t('fileViewer.shareAfterGenerationComplete')
-                                : t('fileViewer.shareLinkPublishGuide')}
-                            </span>
-                          </span>
-                        </button>
-                      )}
-                      <div className="share-menu-divider" />
-                      <div className="share-menu-section-label" role="presentation">
-                        {t('fileViewer.shareMenuPublishOnline')}
-                      </div>
-                      {DEPLOY_PROVIDER_OPTIONS.map((option) => (
-                        <button
-                          key={option.id}
-                          type="button"
-                          className="share-menu-item"
-                          role="menuitem"
-                          onClick={() => {
-                            // Just open the deploy modal. The real publish is
-                            // tracked by artifact_deploy_result from
-                            // deployToSelectedProvider — no "popover opened"
-                            // export event here.
-                            void openDeployModal(option.id);
-                          }}
-                        >
-                          <span className="share-menu-icon">
-                            <RemixIcon name={deployActionIconFor(option.id)} size={15} />
-                          </span>
-                          <span>{deployActionLabelFor(option.id)}</span>
-                        </button>
-                      ))}
-                      <div className="share-menu-divider" />
-                      <div className="share-menu-section-label" role="presentation">
-                        {t('socialShare.projectSection')}
-                      </div>
-                      <button
-                        type="button"
-                        className="share-menu-item"
-                        role="menuitem"
-                        onClick={() => {
-                          setDeployMenuOpen(false);
-                          // Deploy-then-share also routes through the deploy
-                          // modal; the real publish is tracked by
-                          // artifact_deploy_result, not an export event.
-                          void openSocialShareFlow();
-                        }}
-                      >
-                        <span className="share-menu-icon">
-                          <RemixIcon
-                            name={activeProjectSocialShare ? 'share-forward-line' : 'upload-cloud-line'}
-                            size={15}
-                          />
-                        </span>
-                        <span>{socialShareMenuLabel}</span>
-                      </button>
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
-              {canDownload ? (
-                <div className="share-menu chrome-share-menu">
-                  <button
-                    type="button"
-                    className={
-                      'chrome-action chrome-action-primary chrome-action-export' +
-                      (exportReadyNudge ? ' export-ready-nudge' : '')
-                    }
-                    aria-haspopup="menu"
-                    aria-expanded={downloadMenuOpen}
-                    onClick={openDownloadMenu}
-                  >
-                    <span>{t('fileViewer.download')}</span>
-                  </button>
-                  {downloadMenuOpen ? (
-                    <div className="share-menu-popover" role="menu">
+          {canShare ? (
+            <div className="share-menu chrome-share-menu" ref={shareRef}>
+              <button
+                className={
+                  'chrome-action chrome-action-primary chrome-action-export' +
+                  (exportReadyNudge ? ' export-ready-nudge' : '')
+                }
+                aria-haspopup="menu"
+                aria-expanded={shareMenuOpen}
+                onClick={openExportMenu}
+              >
+                <Icon name="download" size={13} />
+                <span>{t('fileViewer.shareLabel')}</span>
+                <Icon name="chevron-down" size={11} />
+              </button>
+              {shareMenuOpen ? (
+                <div className="share-menu-popover" role="menu">
                   <button
                     type="button"
                     className="share-menu-item"
                     role="menuitem"
                     onClick={() => {
-                      setDownloadMenuOpen(false);
+                      setShareMenuOpen(false);
                       fireShareExport('pdf', () => exportProjectAsPdf({
                         deck: effectiveDeck,
-                        fallbackPdf: () => exportAsPdf(source ?? '', exportTitle, { deck: effectiveDeck, onProgress: onExportProgress }),
+                        fallbackPdf: () => exportAsPdf(source ?? '', exportTitle, { deck: effectiveDeck }),
                         filePath: file.name,
                         projectId,
                         title: exportTitle,
                       }));
                     }}
                   >
-                    <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
-                    <span>{t('fileViewer.exportPdf')}</span>
+                    <span className="share-menu-icon"><Icon name="file" size={14} /></span>
+                    <span>
+                      {effectiveDeck
+                        ? t('fileViewer.exportPdfAllSlides')
+                        : t('fileViewer.exportPdf')}
+                    </span>
                   </button>
-                  {showImageExport ? (
-                    <button
-                      type="button"
-                      className="share-menu-item"
-                      role="menuitem"
-                      onClick={openImageExportModal}
-                    >
-                      <span className="share-menu-icon"><RemixIcon name="image-line" size={15} /></span>
-                      <span>{t('fileViewer.exportImage')}</span>
-                    </button>
-                  ) : null}
+                  <button
+                    type="button"
+                    className="share-menu-item"
+                    role="menuitem"
+                    disabled={!canPptx}
+                    title={
+                      onExportAsPptx
+                        ? streaming
+                          ? t('fileViewer.exportPptxBusy')
+                          : t('fileViewer.exportPptxHint')
+                        : t('fileViewer.exportPptxNa')
+                    }
+                    onClick={() => {
+                      setShareMenuOpen(false);
+                      fireShareExport('pptx', () => {
+                        if (onExportAsPptx) onExportAsPptx(file.name);
+                      });
+                    }}
+                  >
+                    <span className="share-menu-icon"><Icon name="present" size={14} /></span>
+                    <span>{t('fileViewer.exportPptx') + '…'}</span>
+                  </button>
+                  <div className="share-menu-divider" />
                   <button
                     type="button"
                     className="share-menu-item"
                     role="menuitem"
                     onClick={() => {
-                      setDownloadMenuOpen(false);
+                      setShareMenuOpen(false);
                       fireShareExport('zip', () => exportProjectAsZip({
                         projectId,
                         filePath: file.name,
@@ -9063,7 +7151,7 @@ function HtmlViewer({
                       }));
                     }}
                   >
-                    <span className="share-menu-icon"><RemixIcon name="file-zip-line" size={15} /></span>
+                    <span className="share-menu-icon"><Icon name="download" size={14} /></span>
                     <span>{t('fileViewer.exportZip')}</span>
                   </button>
                   <button
@@ -9071,46 +7159,71 @@ function HtmlViewer({
                     className="share-menu-item"
                     role="menuitem"
                     onClick={() => {
-                      setDownloadMenuOpen(false);
-                      fireShareExport('html', () => exportProjectAsHtml({
-                        projectId,
-                        filePath: file.name,
-                        fallbackHtml: source ?? '',
-                        fallbackTitle: exportTitle,
-                      }));
+                      setShareMenuOpen(false);
+                      fireShareExport('html', () => exportAsHtml(source ?? '', exportTitle));
                     }}
                   >
-                    <span className="share-menu-icon"><RemixIcon name="file-code-line" size={15} /></span>
+                    <span className="share-menu-icon"><Icon name="file-code" size={14} /></span>
                     <span>{t('fileViewer.exportHtml')}</span>
                   </button>
-                  {showMarkdownExport ? (
+                  {/* Export as Markdown — pass-through download of the
+                      artifact source with a `.md` extension. No conversion
+                      runs; the file body is identical to the Source view.
+                      Useful for piping the artifact into markdown-aware
+                      tooling (LLM context windows, vault apps). See
+                      issue #279. */}
+                  <button
+                    type="button"
+                    className="share-menu-item"
+                    role="menuitem"
+                    onClick={() => {
+                      setShareMenuOpen(false);
+                      fireShareExport('markdown', () => exportAsMd(source ?? '', exportTitle));
+                    }}
+                  >
+                    <span className="share-menu-icon"><Icon name="file" size={14} /></span>
+                    <span>{t('fileViewer.exportMd')}</span>
+                  </button>
+                  {!useUrlLoadPreview ? (
                     <button
                       type="button"
                       className="share-menu-item"
                       role="menuitem"
-                      onClick={() => {
-                        setDownloadMenuOpen(false);
-                        fireShareExport('markdown', () => exportAsMd(source ?? '', exportTitle));
+                      onClick={async () => {
+                        setShareMenuOpen(false);
+                        const iframe = iframeRef.current;
+                        if (!iframe) return;
+                        const snap = await requestPreviewSnapshot(iframe);
+                        try {
+                          if (snap?.dataUrl) {
+                            exportAsImage(snap.dataUrl, exportTitle);
+                          } else {
+                            console.warn('[exportAsImage] snapshot capture returned null');
+                            alert(t('fileViewer.exportImageFailed'));
+                          }
+                        } catch (err) {
+                          console.warn('[exportAsImage] failed to convert snapshot:', err);
+                          alert(t('fileViewer.exportImageFailed'));
+                        }
                       }}
                     >
-                      <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
-                      <span>{t('fileViewer.exportMd')}</span>
+                      <span className="share-menu-icon"><Icon name="image" size={14} /></span>
+                      <span>{t('fileViewer.exportImage')}</span>
                     </button>
                   ) : null}
                   <div className="share-menu-divider" />
-                  <div className="share-menu-section-label" role="presentation">
-                    {t('fileViewer.shareMenuSave')}
-                  </div>
                   <button
                     type="button"
                     className="share-menu-item"
                     role="menuitem"
                     disabled={savingTemplate}
                     onClick={() => {
-                      openSaveAsTemplateModal();
+                      fireShareExport('template', () => {
+                        openSaveAsTemplateModal();
+                      });
                     }}
                   >
-                    <span className="share-menu-icon"><RemixIcon name="file-copy-line" size={15} /></span>
+                    <span className="share-menu-icon"><Icon name="copy" size={14} /></span>
                     <span>
                       {savingTemplate
                         ? t('fileViewer.savingTemplate')
@@ -9119,9 +7232,46 @@ function HtmlViewer({
                           : t('fileViewer.saveAsTemplate')}
                     </span>
                   </button>
+                  <div className="share-menu-divider" />
+                  {DEPLOY_PROVIDER_OPTIONS.map((option) => (
+                    <button
+                      key={option.id}
+                      type="button"
+                      className="share-menu-item"
+                      role="menuitem"
+                      onClick={() => {
+                        const format =
+                          option.id === 'cloudflare-pages'
+                            ? 'cloudflare_pages'
+                            : option.id === 'vercel-self'
+                              ? 'vercel'
+                              : 'vercel';
+                        fireShareExport(format, () => openDeployModal(option.id));
+                      }}
+                    >
+                      <span className="share-menu-icon"><Icon name="upload" size={14} /></span>
+                      <span>{deployActionLabelFor(option.id)}</span>
+                    </button>
+                  ))}
+                  {deployCopyLinks.length > 0 ? (
+                    <div className="share-menu-divider" />
+                  ) : null}
+                  {deployCopyLinks.map((item) => (
+                    <button
+                      key={`copy-${item.providerId}`}
+                      type="button"
+                      className="share-menu-item"
+                      role="menuitem"
+                      onClick={() => {
+                        setShareMenuOpen(false);
+                        void copyDeployLink(item.url);
+                      }}
+                    >
+                      <span className="share-menu-icon"><Icon name="copy" size={14} /></span>
+                      <span>{copyDeployMenuLabel(item.providerLabel, item.url)}</span>
+                    </button>
+                  ))}
                 </div>
-                ) : null}
-              </div>
               ) : null}
             </div>
           ) : null}
@@ -9131,294 +7281,283 @@ function HtmlViewer({
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
         ) : mode === 'preview' ? (
           <div
-            className={`${manualEditMode ? 'manual-edit-workspace' : commentPreviewLayoutClass} preview-viewport preview-viewport-${previewViewport}${drawOverlayOpen ? ' preview-draw-active' : ''}`}
-            data-testid={manualEditMode ? undefined : 'comment-preview-layout'}
-            style={previewViewportStyle(previewViewport, previewScale, boardPreviewCanvasSize, boardPreviewScaleOptions)}
-            onMouseLeave={manualEditMode ? clearManualEditHover : undefined}
+            className={`${manualEditMode ? 'manual-edit-workspace' : 'comment-preview-layer'} preview-viewport preview-viewport-${previewViewport}`}
+            style={previewViewportStyle(previewViewport, previewScale, previewBodySize)}
           >
-            {manualEditPanel}
-            {manualEditHoverAffordance}
-            <div
-              className={manualEditMode ? 'manual-edit-canvas' : 'comment-preview-canvas'}
-              data-testid={manualEditMode ? undefined : 'comment-preview-canvas'}
-            >
-              <div className={manualEditMode ? undefined : 'comment-frame-clip'} style={manualEditMode ? { height: '100%' } : undefined}>
-                <div
-                  style={
-                    manualEditMode
-                      ? manualEditPreviewShellStyle(previewViewport, previewScale, manualEditViewportWidth)
-                      : previewScaleShellStyle(previewViewport, previewScale)
+            {manualEditMode ? (
+              <ManualEditPanel
+                targets={manualEditTargets}
+                selectedTarget={selectedManualEditTarget}
+                draft={manualEditDraft}
+                history={manualEditHistory}
+                error={manualEditError}
+                canUndo={manualEditHistory.length > 0}
+                canRedo={manualEditUndone.length > 0}
+                busy={manualEditSaving}
+                pageStylesEnabled={manualEditPageStylesEnabled}
+                onSelectTarget={selectManualEditTarget}
+                onDraftChange={setManualEditDraft}
+                onStyleChange={(id, styles, label) => {
+                  void handleManualEditStyleChange(id, styles, label);
+                }}
+                onInvalidStyle={cancelManualEditPendingStyles}
+                onApplyPatch={(patch, label) => {
+                  void applyManualEdit(patch, label);
+                }}
+                onError={setManualEditError}
+                onClearSelection={() => {
+                  void clearManualEditTargetSelection();
+                }}
+                onCancelDraft={() => {
+                  if (selectedManualEditTarget) selectManualEditTarget(selectedManualEditTarget);
+                }}
+                onResetDraft={() => {
+                  if (selectedManualEditTarget) void selectManualEditTarget(selectedManualEditTarget);
+                  else setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
+                }}
+                onSaveDraft={() => {
+                  void flushManualEditStyleSave();
+                }}
+                onUndo={() => {
+                  void undoManualEdit();
+                }}
+                onRedo={() => {
+                  void redoManualEdit();
+                }}
+                onPickImage={async (pickedFile) => {
+                  const result = await uploadProjectFiles(projectId, [pickedFile]);
+                  const uploaded = result.uploaded[0];
+                  if (!uploaded?.path) {
+                    setManualEditError(result.error ?? t('manualEdit.uploadImageFailed'));
+                    return null;
                   }
+                  setManualEditError(null);
+                  return toOwnerRelativePath(file.name, uploaded.path);
+                }}
+              />
+            ) : null}
+            <div className={manualEditMode ? 'manual-edit-canvas' : 'comment-frame-clip'}>
+              <div
+                style={
+                  manualEditMode
+                    ? manualEditPreviewShellStyle(previewViewport, previewScale, manualEditViewportWidth)
+                    : previewScaleShellStyle(previewViewport, previewScale)
+                }
+              >
+                <PreviewDrawOverlay
+                  active={drawOverlayOpen}
+                  onActiveChange={setDrawOverlayOpen}
+                  onModeChange={setDrawOverlayMode}
+                  captureTarget={drawClickSelectionMode ? activeCommentTarget : null}
+                  filePath={file.name}
+                  sendDisabled={streaming}
+                  sendDisabledReason="当前正有任务在执行"
                 >
-                  <PreviewDrawOverlay
-                    active={drawOverlayOpen}
-                    onActiveChange={setDrawOverlayOpen}
-                    captureViewport
-                    captureSnapshot={captureExportImageSnapshot}
-                    captureTarget={null}
-                    filePath={file.name}
-                    sendDisabled={streaming}
-                    sendDisabledReason={t('chat.annotationSendDisabledReason')}
-                    onToolbarClick={fireDrawToolbarClick}
-                  >
-                    <div className="artifact-preview-transport-stack">
-                      {OD_PREVIEW_KEEP_ALIVE ? (
-                        <PooledIframe
-                          ref={urlPreviewIframeRef}
-                          cacheKey={urlPreviewKeepAliveKey}
-                          data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
-                          data-od-render-mode="url-load"
-                          data-od-active={useUrlLoadPreview ? 'true' : 'false'}
-                          aria-hidden={useUrlLoadPreview ? undefined : true}
-                          tabIndex={useUrlLoadPreview ? 0 : -1}
-                          title={file.name}
-                          sandbox="allow-scripts allow-downloads"
-                          src={urlTransportSrc}
-                          onLoad={() => {
-                            const frame = urlPreviewIframeRef.current;
-                            if (useUrlLoadPreview) iframeRef.current = frame;
-                            setUrlSelectionBridgeReady(false);
-                            dcViewportRestoreAtRef.current = Date.now();
-                            frame?.contentWindow?.postMessage({
-                              type: '__dc_set_viewport',
-                              ...dcViewportRef.current,
-                            }, '*');
-                            frame?.contentWindow?.postMessage({ type: 'od:url-selection-bridge-probe' }, '*');
-                            syncBridgeModes(frame);
-                            if (useUrlLoadPreview) restorePreviewScrollPosition();
-                          }}
-                        />
-                      ) : (
-                        <iframe
-                          ref={urlPreviewIframeRef}
-                          data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
-                          data-od-render-mode="url-load"
-                          data-od-active={useUrlLoadPreview ? 'true' : 'false'}
-                          aria-hidden={useUrlLoadPreview ? undefined : true}
-                          tabIndex={useUrlLoadPreview ? 0 : -1}
-                          title={file.name}
-                          sandbox="allow-scripts allow-downloads"
-                          src={urlTransportSrc}
-                          onLoad={() => {
-                            const frame = urlPreviewIframeRef.current;
-                            if (useUrlLoadPreview) iframeRef.current = frame;
-                            setUrlSelectionBridgeReady(false);
-                            dcViewportRestoreAtRef.current = Date.now();
-                            frame?.contentWindow?.postMessage({
-                              type: '__dc_set_viewport',
-                              ...dcViewportRef.current,
-                            }, '*');
-                            frame?.contentWindow?.postMessage({ type: 'od:url-selection-bridge-probe' }, '*');
-                            syncBridgeModes(frame);
-                            if (useUrlLoadPreview) restorePreviewScrollPosition();
-                          }}
-                        />
-                      )}
-                      <iframe
-                        key={srcDocTransportResetKey}
-                        ref={srcDocPreviewIframeRef}
-                        data-testid={useUrlLoadPreview ? 'artifact-preview-frame-srcdoc' : 'artifact-preview-frame'}
-                        data-od-render-mode="srcdoc"
-                        data-od-active={useUrlLoadPreview ? 'false' : 'true'}
-                        aria-hidden={useUrlLoadPreview ? true : undefined}
-                        tabIndex={useUrlLoadPreview ? -1 : 0}
-                        title={file.name}
-                        sandbox="allow-scripts allow-downloads"
-                        srcDoc={srcDocTransportContent}
-                        onLoad={() => {
-                          const frame = srcDocPreviewIframeRef.current;
-                          if (!useUrlLoadPreview) iframeRef.current = frame;
-                          // Reset the activation dedupe exactly ONCE per
-                          // freshly mounted iframe DOM node, never on the
-                          // subsequent load events that the same node
-                          // emits during normal srcDoc rendering.
-                          //
-                          // The iframe's load event fires twice for one
-                          // successful activation: once when the lazy
-                          // transport shell HTML loads, and again when
-                          // our own document.open/write/close inside the
-                          // shell finishes. PR #2699 reset the dedupe on
-                          // every load so that switching
-                          // preview -> source -> preview (which remounts
-                          // this iframe as a fresh DOM node) would
-                          // re-activate the new shell. But resetting on
-                          // every load also re-activated on the SECOND
-                          // load of a non-remounted frame, which
-                          // re-triggered document.open/write/close, which
-                          // re-fired the load event, ad infinitum. The
-                          // dedupe ref oscillated between null and the
-                          // current srcDoc thousands of times per render
-                          // and each iteration restarted every CSS
-                          // animation from its `from` keyframe. Designs
-                          // using `animation-fill-mode: both` with
-                          // `from { opacity: 0 }` stayed at opacity 0
-                          // forever and the preview read as blank.
-                          // That is issue #2361.
-                          //
-                          // Tracking the last frame we reset for lets us
-                          // keep PR #2699's "remount after Source toggle"
-                          // fix while breaking the loop on plain renders.
-                          if (frame && srcDocFrameDedupeResetForRef.current !== frame) {
-                            srcDocFrameDedupeResetForRef.current = frame;
-                            activatedSrcDocTransportHtmlRef.current = null;
-                          }
-                          if (useLazySrcDocTransport) setSrcDocShellReady(true);
-                          activateLoadedSrcDocTransport(frame);
-                          dcViewportRestoreAtRef.current = Date.now();
-                          frame?.contentWindow?.postMessage({
-                            type: '__dc_set_viewport',
-                            ...dcViewportRef.current,
-                          }, '*');
-                          replayInspectOverridesToIframe(frame);
-                          syncBridgeModes(frame);
-                          syncCachedSlideStateToIframe(frame);
-                          if (!useUrlLoadPreview) restorePreviewScrollPosition();
-                        }}
-                      />
-                    </div>
-                  </PreviewDrawOverlay>
-                </div>
+                  <div className="artifact-preview-transport-stack">
+                    <iframe
+                      ref={urlPreviewIframeRef}
+                      data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
+                      data-od-render-mode="url-load"
+                      data-od-active={useUrlLoadPreview ? 'true' : 'false'}
+                      aria-hidden={useUrlLoadPreview ? undefined : true}
+                      tabIndex={useUrlLoadPreview ? 0 : -1}
+                      title={file.name}
+                      sandbox="allow-scripts allow-downloads"
+                      allow="display-capture"
+                      src={urlTransportSrc}
+                      onLoad={() => {
+                        const frame = urlPreviewIframeRef.current;
+                        if (useUrlLoadPreview) iframeRef.current = frame;
+                        dcViewportRestoreAtRef.current = Date.now();
+                        frame?.contentWindow?.postMessage({
+                          type: '__dc_set_viewport',
+                          ...dcViewportRef.current,
+                        }, '*');
+                        syncBridgeModesAfterTransport(frame);
+                        if (useUrlLoadPreview) restorePreviewScrollPosition();
+                      }}
+                    />
+                    <iframe
+                      key={srcDocTransportResetKey}
+                      ref={srcDocPreviewIframeRef}
+                      data-testid={useUrlLoadPreview ? 'artifact-preview-frame-srcdoc' : 'artifact-preview-frame'}
+                      data-od-render-mode="srcdoc"
+                      data-od-active={useUrlLoadPreview ? 'false' : 'true'}
+                      aria-hidden={useUrlLoadPreview ? true : undefined}
+                      tabIndex={useUrlLoadPreview ? -1 : 0}
+                      title={file.name}
+                      sandbox="allow-scripts allow-downloads"
+                      allow="display-capture"
+                      srcDoc={srcDocTransportContent}
+                      onLoad={() => {
+                        const frame = srcDocPreviewIframeRef.current;
+                        if (!useUrlLoadPreview) iframeRef.current = frame;
+                        // Any srcDoc iframe load means we are talking to a
+                        // fresh document shell. Clear the activation dedupe so
+                        // switching preview -> source -> preview cannot strand
+                        // the new shell on the blank transport page.
+                        activatedSrcDocTransportHtmlRef.current = null;
+                        // Belt-and-suspenders for the ready handshake: if the
+                        // postMessage racing the parent's listener registration
+                        // ever loses, the load event still tells us the shell
+                        // script ran to completion.
+                        if (useLazySrcDocTransport) setSrcDocShellReady(true);
+                        activateSrcDocTransport(frame);
+                        dcViewportRestoreAtRef.current = Date.now();
+                        frame?.contentWindow?.postMessage({
+                          type: '__dc_set_viewport',
+                          ...dcViewportRef.current,
+                        }, '*');
+                        replayInspectOverridesToIframe(frame);
+                        syncBridgeModesAfterTransport(frame);
+                        if (!useUrlLoadPreview) restorePreviewScrollPosition();
+                      }}
+                    />
+                  </div>
+                </PreviewDrawOverlay>
               </div>
-              {boardMode ? (
-                <CommentPreviewOverlays
-                  comments={commentCreateMode ? visibleSideComments : []}
-                  liveTargets={liveCommentTargets}
-                  hoveredTarget={hoveredCommentTarget}
-                  hoveredPodMemberId={hoveredPodMemberId}
-                  activeTarget={activeCommentTarget}
-                  activeExistingCommentId={activeComposerComment?.id ?? null}
-                  boardTool={boardTool}
-                  showActivePin={commentCreateMode}
-                  scale={overlayPreviewScale}
-                  offsetX={overlayPreviewTransform.offsetX}
-                  offsetY={overlayPreviewTransform.offsetY}
-                  strokePoints={strokePoints}
-                  activeSlideIndex={effectiveDeck ? slideState?.active ?? null : null}
-                  onOpenComment={(comment, snapshot) => {
-                    setCommentPanelOpen(true);
-                    setCommentSidePanelCollapsed(false);
-                    setCommentCreateMode(true);
-                    setBoardMode(true);
-                    setActiveCommentTarget(snapshot);
-                    setHoveredCommentTarget(snapshot);
-                    setActivePreviewCommentId(comment.id);
-                    setCommentDraft(comment.note);
-                    setQueuedBoardNotes([]);
-                    setActiveCommentExistingAttachments(comment.attachments ?? []);
-                  }}
-                />
-              ) : null}
-              {/* Portaled to <body> so the screenshot/export toast escapes the
-                  preview pane's transform + overflow:hidden. */}
-              {exportToast
-                ? createPortal(
-                    <Toast
-                      message={exportToast.message}
-                      tone={exportToast.tone}
-                      role={exportToast.tone === 'error' ? 'alert' : 'status'}
-                      ttlMs={exportToast.tone === 'loading' ? 60000 : 2200}
-                      placement="top"
-                      onDismiss={() => setExportToast(null)}
-                    />,
-                    document.body,
-                  )
-                : null}
-              {commentSavedToast ? (
-                <div className="comment-toast-anchor">
-                  <Toast
-                    message={commentSavedToast}
-                    ttlMs={2200}
-                    onDismiss={() => setCommentSavedToast(null)}
-                  />
-                </div>
-              ) : null}
-              {templateSavedToast ? (
-                <div className="comment-toast-anchor">
-                  <Toast
-                    message={templateSavedToast}
-                    ttlMs={2200}
-                    onDismiss={() => setTemplateSavedToast(null)}
-                  />
-                </div>
-              ) : null}
-              {commentComposer}
-              {boardMode && !commentCreateMode && hoveredCommentTarget && (!activeCommentTarget || commentPortalHost) ? (
-                <AnnotationHoverPopover
-                  target={hoveredCommentTarget}
-                  scale={overlayPreviewScale}
-                  onMouseEnter={() => {
-                    hoverCardPinnedRef.current = true;
-                    cancelHoverCardDismiss();
-                  }}
-                  onMouseLeave={() => {
-                    hoverCardPinnedRef.current = false;
-                    scheduleHoverCardDismiss();
-                  }}
-                />
-              ) : null}
-              {/*
-                Hint banner for Inspect / Picker modes. The bridge in
-                `apps/web/src/runtime/srcdoc.ts` posts `od:comment-targets`
-                with every element annotated with `data-od-id` /
-                `data-screen-label`, so `liveCommentTargets.size` is the
-                authoritative annotation count for the current artifact.
-
-                Two states:
-                - "has targets": the existing copy ("Click any element with
-                  `data-od-id` to tune its style.") for users who just don't
-                  see the crosshair cursor.
-                - "no targets" (issue #890): a freeform-generated artifact
-                  (e.g. PRD → HTML through a Claude-Code-compatible CLI
-                  without a skill) ships zero `data-od-id` annotations. The
-                  bridge's click handler walks up to <html>, finds nothing,
-                  and bails — clicks no-op silently. The static copy made
-                  this look broken; the empty-state copy explains what's
-                  missing and how to fix it. Mirrored across Inspect and
-                  element-pick annotation mode because the failure surface is identical.
-              */}
-              {inspectMode
-                && openHintBox
-                && !activeInspectTarget
-                && !activeCommentTarget ? (
-                <div
-                  className="inspect-empty-hint-container"
-                  data-testid="inspect-empty-hint-container"
-                >
-                  {liveCommentTargets.size === 0 ? (
-                    <div
-                      className="inspect-empty-hint"
-                      data-testid="inspect-empty-hint-no-targets"
-                    >
-                      {inspectMode
-                        ? t('chat.inspect.noEditableTargets')
-                        : t('chat.inspect.noCommentTargets')}
-                    </div>
-                  ) : (
-                    <div
-                      className="inspect-empty-hint"
-                      data-testid="inspect-empty-hint"
-                    >
-                      {inspectMode ? t('chat.inspect.editHint') : t('chat.inspect.commentHint')}
-                    </div>
-                  )}
-                  <button
-                    type="button"
-                    title="Close Inspect Hint"
-                    aria-label="Close Inspect Hint"
-                    onClick={() => setOpenHintBox(false)}
-                    className="orbit-artifact-ghost"
-                  >
-                    <Icon className="" name="close" size={12} />
-                  </button>
-                </div>
-              ) : null}
             </div>
-            {boardImagePreviewModal}
-            {commentPortalHost && commentSidePanel
-              ? createPortal(commentSidePanel, commentPortalHost)
-              : commentPortalId
-                ? null
-                : commentSidePanel}
+            {(boardMode || drawClickSelectionMode) ? (
+              <CommentPreviewOverlays
+                comments={boardMode ? visibleSideComments : []}
+                liveTargets={liveCommentTargets}
+                hoveredTarget={hoveredCommentTarget}
+                hoveredPodMemberId={hoveredPodMemberId}
+                activeTarget={activeCommentTarget}
+                boardTool={boardTool}
+                scale={overlayPreviewScale}
+                strokePoints={strokePoints}
+                onOpenComment={(comment, snapshot) => {
+                  setActiveCommentTarget(snapshot);
+                  setHoveredCommentTarget(snapshot);
+                  setActivePreviewCommentId(comment.id);
+                  setCommentDraft(comment.note);
+                  setQueuedBoardNotes([]);
+                }}
+              />
+            ) : null}
+            {commentSavedToast ? (
+              <div className="comment-toast-anchor">
+                <Toast
+                  message={commentSavedToast}
+                  ttlMs={2200}
+                  onDismiss={() => setCommentSavedToast(null)}
+                />
+              </div>
+            ) : null}
+            {templateSavedToast ? (
+              <div className="comment-toast-anchor">
+                <Toast
+                  message={templateSavedToast}
+                  ttlMs={2200}
+                  onDismiss={() => setTemplateSavedToast(null)}
+                />
+              </div>
+            ) : null}
+            {annotateCaptureToast ? (
+              <div className="comment-toast-anchor">
+                <Toast
+                  message={annotateCaptureToast}
+                  ttlMs={2800}
+                  role="alert"
+                  onDismiss={() => setAnnotateCaptureToast(null)}
+                />
+              </div>
+            ) : null}
+            {boardMode && activeCommentTarget ? (
+              <BoardComposerPopover
+                target={activeCommentTarget}
+                existing={visibleSideComments.find((comment) => comment.elementId === activeCommentTarget.elementId) ?? null}
+                draft={commentDraft}
+                notes={queuedBoardNotes}
+                onDraft={setCommentDraft}
+                onAddDraft={queueCurrentDraft}
+                onRemoveQueuedNote={(index) =>
+                  setQueuedBoardNotes((current) => current.filter((_, currentIndex) => currentIndex !== index))
+                }
+                onClose={clearBoardComposer}
+                onSaveComment={savePersistentComment}
+                onSendBatch={sendBoardBatch}
+                onDeleteComment={async (commentId: string) => {
+                  if (!onRemovePreviewComment) return;
+                  await onRemovePreviewComment(commentId);
+                  clearBoardComposer();
+                }}
+                onRemoveMember={(elementId) => {
+                  setActiveCommentTarget((current) => {
+                    const { next, shouldClose } = applyPodMemberRemoval(current, elementId);
+                    if (shouldClose) clearBoardComposer();
+                    return next;
+                  });
+                  setHoveredPodMemberId((current) => (current === elementId ? null : current));
+                }}
+                onHoverMember={setHoveredPodMemberId}
+                sending={sendingBoardBatch || streaming}
+                t={t}
+              />
+            ) : null}
+            {boardMode ? (
+              <CommentSidePanel
+                comments={visibleSideComments}
+                selectedIds={selectedSideCommentIds}
+                collapsed={commentSidePanelCollapsed}
+                onCollapsedChange={setCommentSidePanelCollapsed}
+                onClose={() => {
+                  setBoardMode(false);
+                  setCommentSidePanelCollapsed(false);
+                  clearBoardComposer();
+                }}
+                onToggleSelect={(commentId) => {
+                  setSelectedSideCommentIds((current) => {
+                    const next = new Set(current);
+                    if (next.has(commentId)) next.delete(commentId);
+                    else next.add(commentId);
+                    return next;
+                  });
+                }}
+                onClearSelection={() => setSelectedSideCommentIds(new Set())}
+                onReply={(comment) => {
+                  // Reply == edit on a flat-thread model: prefill the
+                  // popover with the existing note so the user sees and
+                  // mutates the current text. Save runs through the
+                  // same upsert path; matching project/conv/file/element
+                  // updates note in place rather than creating a new row.
+                  const snapshot = liveSnapshotForComment(comment, liveCommentTargets) ?? {
+                    filePath: comment.filePath,
+                    elementId: comment.elementId,
+                    selector: comment.selector,
+                    label: comment.label,
+                    text: comment.text,
+                    position: comment.position,
+                    htmlHint: comment.htmlHint,
+                    selectionKind: comment.selectionKind ?? 'element',
+                    memberCount: comment.memberCount,
+                    podMembers: comment.podMembers,
+                  };
+                  setActiveCommentTarget(snapshot);
+                  setHoveredCommentTarget(snapshot);
+                  setActivePreviewCommentId(comment.id);
+                  setCommentDraft(comment.note);
+                  setQueuedBoardNotes([]);
+                }}
+                onSendSelected={async () => {
+                  if (!onSendBoardCommentAttachments) return;
+                  const selected = visibleSideComments.filter(
+                    (comment) => selectedSideCommentIds.has(comment.id),
+                  );
+                  if (selected.length === 0) return;
+                  setSendingBoardBatch(true);
+                  try {
+                    await onSendBoardCommentAttachments(commentsToAttachments(selected));
+                    setSelectedSideCommentIds(new Set());
+                  } finally {
+                    setSendingBoardBatch(false);
+                  }
+                }}
+                sending={sendingBoardBatch || streaming}
+                t={t}
+              />
+            ) : null}
             {inspectMode && activeInspectTarget ? (
               <InspectPanel
                 target={activeInspectTarget}
@@ -9444,24 +7583,78 @@ function HtmlViewer({
                 onSaveToSource={() => {
                   void saveInspectToSource();
                 }}
-                onClose={() => {
-                  setActiveInspectTarget(null);
-                  if (boardMode && boardTool === 'inspect') {
-                    setActiveCommentTarget(null);
-                    setHoveredCommentTarget(null);
-                  }
-                }}
+                onClose={() => setActiveInspectTarget(null)}
                 saving={savingInspect}
                 savedAt={inspectSavedAt}
                 error={inspectError}
               />
+            ) : null}
+            {/*
+              Hint banner for Inspect / Picker modes. The bridge in
+              `apps/web/src/runtime/srcdoc.ts` posts `od:comment-targets`
+              with every element annotated with `data-od-id` /
+              `data-screen-label`, so `liveCommentTargets.size` is the
+              authoritative annotation count for the current artifact.
+
+              Two states:
+              - "has targets": the existing copy ("Click any element with
+                `data-od-id` to tune its style.") for users who just don't
+                see the crosshair cursor.
+              - "no targets" (issue #890): a freeform-generated artifact
+                (e.g. PRD → HTML through a Claude-Code-compatible CLI
+                without a skill) ships zero `data-od-id` annotations. The
+                bridge's click handler walks up to <html>, finds nothing,
+                and bails — clicks no-op silently. The static copy made
+                this look broken; the empty-state copy explains what's
+                missing and how to fix it. Mirrored across Inspect and
+                Picker because the failure surface is identical.
+            */}
+            {(inspectMode || (boardMode && boardTool === 'inspect'))
+              && openHintBox
+              && !activeInspectTarget
+              && !activeCommentTarget ? (
+              <div
+                className={`inspect-empty-hint-container${
+                  boardMode && !commentSidePanelCollapsed ? ' comment-side-panel-open' : ''
+                }`}
+                data-testid="inspect-empty-hint-container"
+              >
+                {liveCommentTargets.size === 0 ? (
+                  <div
+                    className="inspect-empty-hint"
+                    data-testid="inspect-empty-hint-no-targets"
+                  >
+                    This artifact has no <code>data-od-id</code>{' '}
+                    annotations yet — ask the agent to add them to the
+                    sections you want to{' '}
+                    {inspectMode ? 'inspect' : 'comment on'}.
+                  </div>
+                ) : (
+                  <div
+                    className="inspect-empty-hint"
+                    data-testid="inspect-empty-hint"
+                  >
+                    Click any element with <code>data-od-id</code> to{' '}
+                    {inspectMode ? 'tune its style' : 'leave a comment'}.
+                  </div>
+                )}
+                <button
+                  type="button"
+                  title="Close Inspect Hint"
+                  aria-label="Close Inspect Hint"
+                  onClick={() => setOpenHintBox(false)}
+                  className="orbit-artifact-ghost"
+                >
+                  <Icon className="" name="close" size={12} />
+                </button>
+              </div>
             ) : null}
           </div>
         ) : (
           <pre className="viewer-source">{source}</pre>
         )}
       </div>
-      {inTabPresent && source && typeof document !== 'undefined' ? createPortal(
+      {inTabPresent && source ? (
         <div
           className="present-overlay"
           role="dialog"
@@ -9489,83 +7682,10 @@ function HtmlViewer({
               srcDoc={srcDoc}
             />
           )}
-        </div>,
-        document.body,
+        </div>
       ) : null}
-      {imageExportModalOpen && typeof document !== 'undefined' ? createPortal(
-        <div className="modal-backdrop viewer-modal-backdrop image-export-backdrop" role="presentation">
-          <div
-            className="modal deploy-modal image-export-modal"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby={imageExportTitleId}
-          >
-            <div className="modal-head">
-              <div className="kicker">IMAGE</div>
-              <h2 id={imageExportTitleId}>{t('fileViewer.exportImage')}</h2>
-              <p className="subtitle">{t('fileViewer.exportImageModalSubtitle')}</p>
-            </div>
-            <div className="deploy-form image-export-form">
-              <fieldset className="image-export-format-field" disabled={imageExportBusy}>
-                <legend>{t('fileViewer.exportImageFormatLabel')}</legend>
-                <div className="image-export-format-options">
-                  {IMAGE_EXPORT_FORMAT_OPTIONS.map((option) => (
-                    <label
-                      key={option.value}
-                      className={`image-export-format-option${imageExportFormat === option.value ? ' active' : ''}`}
-                    >
-                      <input
-                        type="radio"
-                        name="image-export-format"
-                        value={option.value}
-                        aria-label={option.label}
-                        checked={imageExportFormat === option.value}
-                        onChange={() => changeImageExportFormat(option.value)}
-                      />
-                      <span className="image-export-format-text">
-                        <strong>{option.label}</strong>
-                        <span aria-hidden="true">{option.extension}</span>
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              </fieldset>
-              {imageExportError ? (
-                <p className="deploy-error" role="alert">{imageExportError}</p>
-              ) : null}
-            </div>
-            <div className="modal-foot">
-              <button
-                type="button"
-                className="ghost-link button-like"
-                disabled={imageExportBusy}
-                onClick={() => {
-                  // User dismissed the image export modal without saving —
-                  // close the ui_click(image)→result funnel as cancelled.
-                  fireImageExportResult('cancelled', 'MODAL_DISMISSED');
-                  setImageExportModalOpen(false);
-                  setImageExportError(null);
-                }}
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                type="button"
-                className="viewer-action primary"
-                disabled={imageExportBusy || imageExportPreparing || !imageExportPreparedBlob}
-                onClick={() => {
-                  void handleImageExportSave();
-                }}
-              >
-                {imageExportBusy ? t('fileViewer.exportImageSaving') : t('common.save')}
-              </button>
-            </div>
-          </div>
-        </div>,
-        document.body,
-      ) : null}
-      {templateModalOpen && typeof document !== 'undefined' ? createPortal(
-        <div className="modal-backdrop viewer-modal-backdrop" role="presentation">
+      {templateModalOpen ? (
+        <div className="modal-backdrop" role="presentation">
           <div className="modal deploy-modal" role="dialog" aria-modal="true">
             <div className="modal-head">
               <div className="kicker">TEMPLATE</div>
@@ -9602,9 +7722,6 @@ function HtmlViewer({
                 className="ghost-link button-like"
                 disabled={savingTemplate}
                 onClick={() => {
-                  // Dismissed without saving — close the ui_click(template)→
-                  // result funnel as cancelled.
-                  fireTemplateExportResult('cancelled', 'MODAL_DISMISSED');
                   setTemplateModalOpen(false);
                   setTemplateSaveError(null);
                 }}
@@ -9623,81 +7740,19 @@ function HtmlViewer({
               </button>
             </div>
           </div>
-        </div>,
-        document.body,
+        </div>
       ) : null}
-      {deployModalOpen && typeof document !== 'undefined' ? createPortal(
-        <div
-          className="modal-backdrop viewer-modal-backdrop deploy-flow-backdrop"
-          role="presentation"
-          onClick={(event) => {
-            if (event.target === event.currentTarget) closeDeployModal();
-          }}
-        >
+      {deployModalOpen ? (
+        <div className="modal-backdrop" role="presentation">
           <div className="modal deploy-modal deploy-flow-modal" role="dialog" aria-modal="true">
-            <div className="deploy-flow-modal__scroll">
-              <div className="modal-head">
-                <div className="kicker">{deployModalKicker}</div>
-                <h2>{deployModalTitle}</h2>
-                <p className="subtitle">{deployModalSubtitle}</p>
-              </div>
-              <div className="deploy-form">
-                <div className={`deploy-social-share${activeProjectSocialShare ? '' : ' is-locked'}${socialShareBlockedState ? ` is-${socialShareBlockedState}` : ''}`}>
-                  <div className="deploy-social-share__head">
-                    <div className="deploy-social-share__label">
-                      {t('socialShare.projectSection')}
-                    </div>
-                    {socialShareDisplayUrl ? (
-                      <a
-                        className="deploy-social-share__url"
-                        href={socialShareDisplayUrl}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                      >
-                        {socialShareDisplayUrl}
-                      </a>
-                    ) : null}
-                  </div>
-                  {!activeProjectSocialShare || socialShareBlockedState ? (
-                    <p className="hint">{socialShareUnavailableMessage}</p>
-                  ) : null}
-                  {activeProjectSocialShare ? (
-                    <SocialShareGrid
-                      share={activeProjectSocialShare}
-                      onAfterShare={closeDeployModal}
-                    />
-                  ) : null}
-                  {socialShareBlockedDeployment?.url ? (
-                    <div className="deploy-social-share__actions">
-                      <button
-                        type="button"
-                        className="viewer-action"
-                        onClick={() => {
-                          void copyDeployLink(socialShareBlockedDeployment.url);
-                        }}
-                      >
-                        <Icon name="copy" size={14} />
-                        <span>{copyDeployLabel(socialShareBlockedDeployment.url)}</span>
-                      </button>
-                      {activeDeployment?.id === socialShareBlockedDeployment.id ? (
-                        <button
-                          type="button"
-                          className="viewer-action"
-                          disabled={deployPhase === 'preparing-link'}
-                          onClick={() => {
-                            void retryDeploymentLink();
-                          }}
-                        >
-                          {deployPhase === 'preparing-link'
-                            ? t('fileViewer.preparingPublicLink')
-                            : t('fileViewer.retryLink')}
-                        </button>
-                      ) : null}
-                    </div>
-                  ) : null}
-                </div>
+            <div className="modal-head">
+              <div className="kicker">{deployProviderLabel}</div>
+              <h2>{t('fileViewer.deployToProvider', { provider: deployProviderLabel })}</h2>
+              <p className="subtitle">{t('fileViewer.deployModalSubtitle')}</p>
+            </div>
+            <div className="deploy-form">
               <label className="deploy-provider-field">
-                <span className="deploy-field-title">{t('fileViewer.deployProviderLabel')}</span>
+                <span>{t('fileViewer.deployProviderLabel')}</span>
                 <select
                   value={deployProviderId}
                   onChange={(e) => {
@@ -9711,25 +7766,32 @@ function HtmlViewer({
                   ))}
                 </select>
               </label>
-              <div className="field-label-row deploy-token-label-row">
-                <label htmlFor="deploy-token" className="deploy-field-title required">{t(deployProvider.tokenLabelKey)}</label>
-                <a
-                  href={deployProvider.tokenLink}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  {t(deployProvider.tokenLinkKey)}
-                </a>
+              <div className="field-label-row">
+                <label htmlFor="deploy-token">{t(deployProvider.tokenLabelKey)}</label>
+                <div className="field-label-note">
+                  {deployConfig?.configured ? (
+                    <p className="hint">{t(deployProvider.tokenReuseHintKey, { provider: deployProviderLabel })}</p>
+                  ) : null}
+                  {deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? (
+                    <p className="hint">{t('fileViewer.cloudflareApiTokenScopeHint')}</p>
+                  ) : null}
+                  <a
+                    href={deployProvider.tokenLink}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    {t(deployProvider.tokenLinkKey)}
+                  </a>
+                </div>
               </div>
-              <div className="deploy-token-input-row">
-                <input
-                  ref={deployTokenInputRef}
-                  id="deploy-token"
-                  type="password"
-                  value={deployToken}
-                  placeholder={t(deployProvider.tokenPlaceholderKey, { provider: deployProviderLabel })}
-                  onChange={(e) => setDeployToken(e.target.value)}
-                />
+              <input
+                id="deploy-token"
+                type="password"
+                value={deployToken}
+                placeholder={t(deployProvider.tokenPlaceholderKey, { provider: deployProviderLabel })}
+                onChange={(e) => setDeployToken(e.target.value)}
+              />
+              <div className="deploy-config-actions">
                 <button
                   type="button"
                   className="ghost-link button-like"
@@ -9741,21 +7803,11 @@ function HtmlViewer({
                   {savingDeployConfig ? t('fileViewer.savingConfig') : t('fileViewer.save')}
                 </button>
               </div>
-              {deployConfig?.configured || deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? (
-                <div className="deploy-token-hints">
-                  {deployConfig?.configured ? (
-                    <p className="hint">{t(deployProvider.tokenReuseHintKey, { provider: deployProviderLabel })}</p>
-                  ) : null}
-                  {deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? (
-                    <p className="hint">{t('fileViewer.cloudflareApiTokenScopeHint')}</p>
-                  ) : null}
-                </div>
-              ) : null}
               {deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? (
                 <>
                   <div className="deploy-field-grid single-field">
                     <label>
-                      <span className="deploy-field-title required">{t('fileViewer.cloudflareAccountId')}</span>
+                      <span>{t('fileViewer.cloudflareAccountId')}</span>
                       <input
                         value={cloudflareAccountId}
                         onChange={(e) => setCloudflareAccountId(e.target.value)}
@@ -9765,32 +7817,16 @@ function HtmlViewer({
                   </div>
                   <div className="deploy-field-grid cloudflare-domain-grid">
                     <label>
-                      <span className="deploy-field-title">{t('fileViewer.cloudflareDomainPrefixLabel')}</span>
+                      <span>{t('fileViewer.cloudflareDomainPrefixLabel')}</span>
                       <input
                         value={cloudflareDomainPrefix}
                         placeholder={t('fileViewer.cloudflareDomainPrefixPlaceholder')}
                         onChange={(e) => setCloudflareDomainPrefix(e.target.value)}
                       />
                     </label>
-                    <div className="deploy-field-control">
-                      <span className="deploy-field-title-row">
-                        <label className="deploy-field-title" htmlFor="cloudflare-zone-select">
-                          {t('fileViewer.cloudflareZoneLabel')}
-                        </label>
-                        <button
-                          type="button"
-                          className="ghost-link deploy-field-inline-action"
-                          disabled={cloudflareZonesLoading || !deployConfig?.configured}
-                          onClick={() => {
-                            void loadCloudflareZones();
-                          }}
-                        >
-                          <RemixIcon name="refresh-line" size={13} />
-                          {cloudflareZonesLoading ? t('fileViewer.cloudflareZonesLoading') : t('fileViewer.cloudflareZonesRefresh')}
-                        </button>
-                      </span>
+                    <label>
+                      <span>{t('fileViewer.cloudflareZoneLabel')}</span>
                       <select
-                        id="cloudflare-zone-select"
                         value={cloudflareZoneId}
                         disabled={cloudflareZonesLoading || (!deployConfig?.configured && !cloudflareZones.length)}
                         onChange={(e) => setCloudflareZoneId(e.target.value)}
@@ -9804,7 +7840,19 @@ function HtmlViewer({
                           </option>
                         ))}
                       </select>
-                    </div>
+                    </label>
+                  </div>
+                  <div className="deploy-config-actions secondary">
+                    <button
+                      type="button"
+                      className="ghost-link button-like"
+                      disabled={cloudflareZonesLoading || !deployConfig?.configured}
+                      onClick={() => {
+                        void loadCloudflareZones();
+                      }}
+                    >
+                      {cloudflareZonesLoading ? t('fileViewer.cloudflareZonesLoading') : t('fileViewer.cloudflareZonesRefresh')}
+                    </button>
                   </div>
                   {cloudflareZonesError ? (
                     <p className="deploy-error">{cloudflareZonesError}</p>
@@ -9812,7 +7860,9 @@ function HtmlViewer({
                     <p className="hint">{t('fileViewer.cloudflareZonesLoading')}</p>
                   ) : deployConfig?.configured && cloudflareZones.length === 0 ? (
                     <p className="hint">{t('fileViewer.cloudflareZonesEmpty')}</p>
-                  ) : null}
+                  ) : (
+                    <p className="hint">{t('fileViewer.cloudflareCustomDomainHint')}</p>
+                  )}
                   {cloudflareDomainPrefix.trim() && !isValidCloudflareDomainPrefixInput(cloudflareDomainPrefix) ? (
                     <p className="deploy-error">{t('fileViewer.cloudflareDomainPrefixInvalid')}</p>
                   ) : cloudflareHostnamePreview ? (
@@ -9824,7 +7874,7 @@ function HtmlViewer({
               ) : (
                 <div className="deploy-field-grid">
                   <label>
-                    <span className="deploy-field-title">{t('fileViewer.vercelTeamId')}</span>
+                    <span>{t('fileViewer.vercelTeamId')}</span>
                     <input
                       value={teamId}
                       placeholder={t('fileViewer.optional')}
@@ -9832,7 +7882,7 @@ function HtmlViewer({
                     />
                   </label>
                   <label>
-                    <span className="deploy-field-title">{t('fileViewer.vercelTeamSlug')}</span>
+                    <span>{t('fileViewer.vercelTeamSlug')}</span>
                     <input
                       value={teamSlug}
                       placeholder={t('fileViewer.optional')}
@@ -9841,15 +7891,8 @@ function HtmlViewer({
                   </label>
                 </div>
               )}
+              <p className="hint">{t(deployProvider.previewHintKey)}</p>
               {deployError ? <p className="deploy-error">{deployError}</p> : null}
-              {!deployError
-                && deployPhase === 'idle'
-                && deployResultCards.length > 0
-                && deployResultState(activeDeployment?.status) === 'ready' ? (
-                <p className="hint" role="status">
-                  {t('fileViewer.deployLinkReady')} · {t('fileViewer.deployResultLabel')}
-                </p>
-              ) : null}
               {deployResultCards.length > 0 ? (
                 <div className={`deploy-result-block ${deployResultState(activeDeployment?.status)}`}>
                   <div className="deploy-result-summary">
@@ -9929,13 +7972,12 @@ function HtmlViewer({
                   </div>
                 </div>
               ) : null}
-              </div>
             </div>
             <div className="modal-foot">
               <button
                 type="button"
                 className="ghost-link button-like"
-                onClick={closeDeployModal}
+                onClick={() => setDeployModalOpen(false)}
               >
                 {t('common.cancel')}
               </button>
@@ -9951,47 +7993,7 @@ function HtmlViewer({
               </button>
             </div>
           </div>
-        </div>,
-        document.body,
-      ) : null}
-      {deploySavedToast ? (
-        <Toast
-          message={deploySavedToast.message}
-          details={deploySavedToast.details}
-          tone="success"
-          placement="top"
-          ttlMs={3600}
-          onDismiss={() => setDeploySavedToast(null)}
-        />
-      ) : null}
-      {deployActionToast && typeof document !== 'undefined' ? createPortal(
-        <Toast
-          message={deployActionToast}
-          placement="top"
-          ttlMs={2400}
-          role="alert"
-          onDismiss={() => setDeployActionToast(null)}
-        />,
-        document.body,
-      ) : null}
-      {imageExportSavedToast ? (
-        <Toast
-          message={imageExportSavedToast.message}
-          details={imageExportSavedToast.details}
-          tone="success"
-          placement="top"
-          ttlMs={3600}
-          onDismiss={() => setImageExportSavedToast(null)}
-        />
-      ) : null}
-      {shareGuideToast && typeof document !== 'undefined' ? createPortal(
-        <Toast
-          message={shareGuideToast}
-          placement="top"
-          ttlMs={2200}
-          onDismiss={() => setShareGuideToast(null)}
-        />,
-        document.body,
+        </div>
       ) : null}
     </div>
   );
@@ -10034,11 +8036,6 @@ function toOwnerRelativePath(ownerFileName: string, targetPath: string): string 
   const down = targetParts.slice(common);
   const rel = [...up, ...down].join('/');
   return rel || '.';
-}
-
-function isBlockedPreviewAssetScheme(assetRef: string): boolean {
-  const clean = assetRef.replace(/[\s\u0000-\u001F\u007F-\u009F]/g, '');
-  return /^(?:javascript|data):/i.test(clean);
 }
 
 function hasRelativeAssetRefs(html: string): boolean {
@@ -10121,15 +8118,11 @@ async function fetchProjectRelativeText(
 }
 
 function resolveProjectRelativePath(ownerFileName: string, assetRef: string): string | null {
-  if (isBlockedPreviewAssetScheme(assetRef)) return null;
   if (/^(?:https?:|data:|blob:|mailto:|tel:|#|\/)/i.test(assetRef)) return null;
   try {
     const url = new URL(assetRef, `https://od.local/${baseDirFor(ownerFileName)}`);
     if (url.origin !== 'https://od.local') return null;
-    const decodedPath = decodeURIComponent(url.pathname.replace(/^\/+/, ''));
-    const parts = decodedPath.split(/[/\\]/);
-    if (parts.some((part) => part === '..' || part.trim() === '..')) return null;
-    return decodedPath;
+    return decodeURIComponent(url.pathname.replace(/^\/+/, ''));
   } catch {
     return null;
   }
@@ -10602,14 +8595,12 @@ function MarkdownViewer({
   const [text, setText] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [copied, setCopied] = useState(false);
-  const [downloadMenuOpen, setDownloadMenuOpen] = useState(false);
   const markdownArticleRef = useRef<HTMLElement | null>(null);
   const copyBlockTimerRef = useRef<number | null>(null);
   const copiedMarkdownBlockRef = useRef<HTMLElement | null>(null);
   const status = file.artifactManifest?.status ?? 'complete';
   const isStreaming = status === 'streaming';
   const isError = status === 'error';
-  const exportTitle = file.name.replace(/\.mdx?$/i, '') || file.name;
 
   useEffect(() => {
     setText(null);
@@ -10714,36 +8705,6 @@ function MarkdownViewer({
             <Icon name={copied ? 'check' : 'copy'} size={13} />
             <span>{copied ? t('fileViewer.copied') : t('fileViewer.copy')}</span>
           </button>
-          {text !== null ? (
-            <div className="share-menu chrome-share-menu">
-              <button
-                type="button"
-                className="viewer-action"
-                aria-haspopup="menu"
-                aria-expanded={downloadMenuOpen}
-                onClick={() => setDownloadMenuOpen((v) => !v)}
-              >
-                <Icon name="download" size={13} />
-                <span>{t('fileViewer.download')}</span>
-              </button>
-              {downloadMenuOpen ? (
-                <div className="share-menu-popover" role="menu">
-                  <button
-                    type="button"
-                    className="share-menu-item"
-                    role="menuitem"
-                    onClick={() => {
-                      setDownloadMenuOpen(false);
-                      exportAsMd(text, exportTitle);
-                    }}
-                  >
-                    <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
-                    <span>{t('fileViewer.exportMd')}</span>
-                  </button>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
         </div>
       </div>
       <div className="viewer-body">

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -160,6 +160,7 @@ interface Props {
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean, images?: File[]) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
   onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[], images?: File[]) => Promise<boolean | void> | boolean | void;
+  onStageBoardCapture?: (att: ChatAttachment) => void;
   onRequestBrowserUsePrompt?: (prompt: string) => void;
   onPluginFolderAgentAction?: (
     relativePath: string,
@@ -421,6 +422,7 @@ export function FileWorkspace({
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
+  onStageBoardCapture,
   onRequestBrowserUsePrompt,
   onPluginFolderAgentAction,
   activePluginActionPaths,
@@ -2329,6 +2331,7 @@ export function FileWorkspace({
             onSavePreviewComment={onSavePreviewComment}
             onRemovePreviewComment={onRemovePreviewComment}
             onSendBoardCommentAttachments={onSendBoardCommentAttachments}
+            onStageBoardCapture={onStageBoardCapture}
             onFileSaved={onRefreshFiles}
             onOpenFileReplacing={openFileReplacing}
             commentPortalId={commentPortalId}

--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -12,6 +12,7 @@ interface Point { x: number; y: number }
 interface Stroke { points: Point[] }
 interface NormalizedRect { x: number; y: number; width: number; height: number }
 type MarkTool = 'box' | 'pen';
+export type PreviewDrawMode = 'click' | 'draw';
 interface CaptureTarget {
   filePath?: string;
   elementId?: string;
@@ -65,6 +66,7 @@ interface Props {
   sendDisabled?: boolean;
   sendDisabledReason?: string;
   onToolbarClick?: (element: DrawToolbarElement, submitAction?: AnnotationAction) => void;
+  onModeChange?: (mode: PreviewDrawMode) => void;
 }
 
 const STROKE_COLOR = '#ff3b30';

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1160,6 +1160,7 @@ export function ProjectView({
   // include a nonce so re-clicking the same name after the user closed the
   // tab still focuses it.
   const [openRequest, setOpenRequest] = useState<{ name: string; nonce: number } | null>(null);
+  const [composerAttachmentInbox, setComposerAttachmentInbox] = useState<ChatAttachment[]>([]);
   // Like `openRequest`, but additionally asks the preview workspace to open the
   // file's Share/Export menu. Drives the "Share" next-step action: it reuses the
   // existing export/deploy surface rather than introducing a new share backend.
@@ -1892,6 +1893,21 @@ export function ProjectView({
   const requestOpenFile = useCallback((name: string) => {
     if (!name) return;
     setOpenRequest({ name, nonce: Date.now() });
+  }, []);
+
+  const handleStageBoardCapture = useCallback((attachment: ChatAttachment) => {
+    setComposerAttachmentInbox((current) => {
+      if (current.some((item) => item.path === attachment.path)) return current;
+      return [...current, attachment];
+    });
+  }, []);
+
+  const handleComposerAttachmentsAccepted = useCallback((paths: string[]) => {
+    if (paths.length === 0) return;
+    const accepted = new Set(paths);
+    setComposerAttachmentInbox((current) =>
+      current.filter((attachment) => !accepted.has(attachment.path)),
+    );
   }, []);
 
   useEffect(() => {
@@ -6570,6 +6586,8 @@ export function ProjectView({
               onAttachComment={attachPreviewComment}
               onDetachComment={detachPreviewComment}
               onDeleteComment={(commentId) => void removePreviewComment(commentId)}
+              composerAttachmentInbox={composerAttachmentInbox}
+              onComposerAttachmentsAccepted={handleComposerAttachmentsAccepted}
               onSend={handleSend}
               onRetry={handleRetry}
               onResumeRun={handleResumeRun}
@@ -6760,6 +6778,7 @@ export function ProjectView({
           onSavePreviewComment={savePreviewComment}
           onRemovePreviewComment={removePreviewComment}
           onSendBoardCommentAttachments={handleSendBoardCommentAttachments}
+          onStageBoardCapture={handleStageBoardCapture}
           onRequestBrowserUsePrompt={handleBrowserUsePrompt}
           onPluginFolderAgentAction={handlePluginFolderAgentAction}
           activePluginActionPaths={activePluginActionPaths}

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -39,6 +39,10 @@ export interface UrlLoadDecision {
   paletteActive?: boolean;
   /** Draw annotations need the srcDoc snapshot bridge for screenshot export. */
   drawMode?: boolean;
+  /** Full annotation/inspect popup mode needs the srcDoc bridge. */
+  annotateMode?: boolean;
+  /** Screenshot capture uses srcDoc snapshot support. */
+  screenshotCapture?: boolean;
   /**
    * Artifact ships the class based tweaks template (`.tw-panel` / `.tw-hidden`)
    * and therefore needs the srcDoc tweaks bridge so the toolbar toggle can
@@ -85,6 +89,8 @@ export function shouldUrlLoadHtmlPreview(d: UrlLoadDecision): boolean {
   // no parent-injected listener to recolor against.
   if (d.paletteActive) return false;
   if (d.drawMode) return false;
+  if (d.annotateMode) return false;
+  if (d.screenshotCapture) return false;
   // The class based tweaks template relies on the srcDoc tweaks bridge
   // emitting `od:tweaks-available` on mount; on the URL load path the bridge
   // is never injected, so the toolbar toggle would stay disabled even though

--- a/apps/web/src/edit-mode/types.ts
+++ b/apps/web/src/edit-mode/types.ts
@@ -30,6 +30,7 @@ export interface ManualEditStyles {
   justifyContent: string;
   alignItems: string;
   backgroundColor: string;
+  backgroundImage: string;
   opacity: string;
   padding: string;
   paddingTop: string;
@@ -141,7 +142,7 @@ export const MANUAL_EDIT_STYLE_PROPS: readonly (keyof ManualEditStyles)[] = [
   'fontFamily', 'fontSize', 'fontWeight', 'color', 'textAlign', 'lineHeight', 'letterSpacing',
   'width', 'height', 'minHeight',
   'gap', 'flexDirection', 'justifyContent', 'alignItems',
-  'backgroundColor', 'opacity',
+  'backgroundColor', 'backgroundImage', 'opacity',
   'padding', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft',
   'margin', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft',
   'border', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth',

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -357,7 +357,21 @@ export function exportAsMd(source: string, title: string): void {
  * injected into a srcdoc preview iframe. Returns null if the bridge is not
  * present (e.g. URL-load mode) or the capture times out.
  */
-export type PreviewSnapshot = { dataUrl: string; w: number; h: number };
+export type PreviewSnapshot = {
+  dataUrl: string;
+  blob?: Blob;
+  mime?: string;
+  w: number;
+  h: number;
+};
+
+export type PreviewSnapshotViewport = { x?: number; y?: number; w?: number; h?: number };
+
+export type PreviewSnapshotOptions = {
+  skipOverlay?: boolean;
+  overlay?: unknown;
+  viewport?: PreviewSnapshotViewport | null;
+};
 
 export type PreviewSnapshotResult =
   | { ok: true; snapshot: PreviewSnapshot }
@@ -366,6 +380,7 @@ export type PreviewSnapshotResult =
 export function requestPreviewSnapshotResult(
   iframe: HTMLIFrameElement,
   timeout = 8000,
+  options?: PreviewSnapshotOptions,
 ): Promise<PreviewSnapshotResult> {
   const win = iframe.contentWindow;
   if (!win) return Promise.resolve({ ok: false, reason: 'loading' });
@@ -391,7 +406,7 @@ export function requestPreviewSnapshotResult(
     }
     window.addEventListener('message', onMsg);
     try {
-      win.postMessage({ type: 'od:snapshot', id }, '*');
+      win.postMessage({ type: 'od:snapshot', id, ...(options ?? {}) }, '*');
     } catch {
       done = true;
       window.removeEventListener('message', onMsg);
@@ -410,8 +425,9 @@ export function requestPreviewSnapshotResult(
 export async function requestPreviewSnapshot(
   iframe: HTMLIFrameElement,
   timeout = 8000,
+  options?: PreviewSnapshotOptions,
 ): Promise<PreviewSnapshot | null> {
-  const result = await requestPreviewSnapshotResult(iframe, timeout);
+  const result = await requestPreviewSnapshotResult(iframe, timeout, options);
   return result.ok ? result.snapshot : null;
 }
 
@@ -470,7 +486,7 @@ export async function captureHostIframeSnapshot(
 }
 
 /** Convert a data-URL to a Blob without re-encoding through canvas. */
-function dataUrlToBlob(dataUrl: string): Blob {
+export function dataUrlToBlob(dataUrl: string): Blob {
   if (!dataUrl.startsWith('data:')) {
     throw new Error('Invalid data URL');
   }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -17,7 +17,6 @@
 import {
   buildManualEditBridge,
   buildManualEditBridgeStyle,
-  buildManualEditKeyboardGuard,
   MANUAL_EDIT_DISCOVERY_SELECTOR,
   MANUAL_EDIT_SOURCE_PATH_ATTR,
 } from '../edit-mode/bridge';
@@ -32,6 +31,7 @@ export type SrcdocOptions = {
   editBridge?: boolean;
   paletteBridge?: boolean;
   initialPalette?: string | null;
+  annotateBridge?: boolean;
   previewFocusGuard?: boolean;
 };
 
@@ -40,45 +40,20 @@ export type SrcdocOptions = {
  * Microsoft Teams. Teams rejects filenames that contain any of:
  *   : # % & * { } \ < > ? / + | "
  * as well as leading/trailing spaces and the prefix sequence "~$".
- *
- * Each disallowed character (or run of disallowed characters) is replaced with
- * a single hyphen. The result is trimmed of leading and trailing whitespace.
- * Titles that are already safe pass through unchanged.
- *
- * Invariant: the returned string contains none of the Teams-disallowed
- * characters and has no leading or trailing spaces, and does not start
- * with the ~$ prefix.
  */
 export function sanitizePreviewTitle(text: string): string {
-  // Trim first so that leading whitespace cannot hide a ~$ prefix from the
-  // anchor-based check below (e.g. "  ~$Invoice" would otherwise survive).
   let result = text.trim();
-  // Remove every leading ~$ prefix. A single replace(/^~\$/, '') is not
-  // enough when the prefix is doubled ("~$~$Doc"). Loop until stable, then
-  // re-trim in case a space followed the prefix ("~$ Invoice" → " Invoice").
   let prev: string;
   do {
     prev = result;
     result = result.replace(/^~\$/, '').trim();
   } while (result !== prev);
-  // Replace each disallowed character (or run of them) with a single hyphen.
-  // Character class: : # % & * { } \ < > ? / + | "
   // eslint-disable-next-line no-useless-escape
   result = result.replace(/[:#%&*{}\\<>?/+|"]+/g, '-');
-  // Final trim to remove any spaces exposed by the substitution.
   return result.trim();
 }
 
-/**
- * A small set of common named non-ASCII entities that appear in real-world
- * titles (e.g. &ccedil; → ç, &eacute; → é). Keeping this narrow avoids
- * shipping a full HTML entity table while still preventing the "orphaned
- * name;" garbage that results when & is stripped before entity detection.
- * Characters produced here that are Teams-disallowed get cleaned up by the
- * subsequent sanitizePreviewTitle pass.
- */
 const NAMED_ENTITY_MAP: Record<string, string> = {
-  // Latin-1 letters most likely to appear in design/business titles
   agrave: 'à', aacute: 'á', acirc: 'â', atilde: 'ã', auml: 'ä', aring: 'å',
   aelig: 'æ', ccedil: 'ç',
   egrave: 'è', eacute: 'é', ecirc: 'ê', euml: 'ë',
@@ -95,143 +70,76 @@ const NAMED_ENTITY_MAP: Record<string, string> = {
   Ograve: 'Ò', Oacute: 'Ó', Ocirc: 'Ô', Otilde: 'Õ', Ouml: 'Ö', Oslash: 'Ø',
   Ugrave: 'Ù', Uacute: 'Ú', Ucirc: 'Û', Uuml: 'Ü',
   Yacute: 'Ý', THORN: 'Þ',
-  // Common punctuation / symbols that can appear in business document titles
   ndash: '–', mdash: '—', lsquo: '‘', rsquo: '’',
   ldquo: '“', rdquo: '”', hellip: '…', trade: '™', reg: '®',
   copy: '©', deg: '°', euro: '€', pound: '£', yen: '¥',
 };
 
-/**
- * Safe wrapper around String.fromCodePoint that returns U+FFFD for
- * out-of-range values instead of throwing RangeError.
- */
 function safeFromCodePoint(cp: number): string {
   if (cp < 0 || cp > 0x10ffff) return '�';
   return String.fromCodePoint(cp);
 }
 
-/**
- * Decode the minimal HTML entities that browsers render in <title> text:
- * &amp; → & , &lt; → < , &gt; → > , &quot; → " , &apos; → ' , &#N; / &#xN;
- * Also decodes a small set of common named non-ASCII entities (e.g. &ccedil;)
- * so they do not leave orphaned "name;" fragments after the & is sanitized.
- * Numeric entities with out-of-range code points fall back to U+FFFD instead
- * of throwing RangeError.
- */
 function decodeHtmlEntitiesForTitle(encoded: string): string {
   return encoded
-    // Named non-ASCII entities first — before the standard 5 named entities
-    // below, so &amp; still converts to & (not left as a lookup miss).
     .replace(/&([A-Za-z]+);/g, (match, name: string) => NAMED_ENTITY_MAP[name] ?? match)
-    // Standard 5 named entities.
     .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&apos;/gi, "'")
-    // Numeric entities — range-checked to avoid RangeError on huge code points.
     .replace(/&#(\d+);/g, (_, n: string) => safeFromCodePoint(Number(n)))
     .replace(/&#x([0-9a-f]+);/gi, (_, h: string) => safeFromCodePoint(parseInt(h, 16)));
 }
 
-/**
- * Find the character offset of the first real `<title>` tag in an HTML string
- * that is not inside an HTML comment (`<!-- … -->`), a `<script>` block, or a
- * `<style>` block. Returns -1 when no real title is found.
- *
- * The scan is O(n) over the head region. It keeps track of whether the current
- * cursor is inside a comment / script / style and skips any `<title>` found
- * within those contexts.
- */
 function findRealTitleOffset(html: string, searchLimit: number): number {
   let i = 0;
   const limit = Math.min(html.length, searchLimit);
   while (i < limit) {
-    // Check for HTML comment start
-    if (html.charCodeAt(i) === 60 /* < */ && html.slice(i, i + 4) === '<!--') {
+    if (html.charCodeAt(i) === 60 && html.slice(i, i + 4) === '<!--') {
       const end = html.indexOf('-->', i + 4);
-      if (end < 0) return -1; // unclosed comment — no title after this
+      if (end < 0) return -1;
       i = end + 3;
       continue;
     }
-    // Check for <script or <style (case-insensitive)
-    if (html.charCodeAt(i) === 60 /* < */) {
+    if (html.charCodeAt(i) === 60) {
       const tagMatch = /^<(script|style)\b/i.exec(html.slice(i, i + 20));
       if (tagMatch) {
         const closingTag = `</${tagMatch[1]}`;
         const end = html.toLowerCase().indexOf(closingTag.toLowerCase(), i + tagMatch[0].length);
-        if (end < 0) return -1; // unclosed script/style — no title after this
+        if (end < 0) return -1;
         const closeEnd = html.indexOf('>', end);
         i = closeEnd >= 0 ? closeEnd + 1 : end + closingTag.length;
         continue;
       }
-    }
-    // Check for <title (case-insensitive)
-    if (html.charCodeAt(i) === 60 /* < */) {
-      if (/^<title[\s>]/i.test(html.slice(i, i + 8))) {
-        return i;
-      }
+      if (/^<title[\s>]/i.test(html.slice(i, i + 8))) return i;
     }
     i++;
   }
   return -1;
 }
 
-/**
- * Rewrite the <title> element in an HTML string so its text content is
- * Teams-filename-safe. Only the real `<title>` in the `<head>` region is
- * changed — `<title>` occurrences inside HTML comments, `<script>` blocks,
- * or `<style>` blocks are left untouched.
- *
- * Strategy:
- *   1. Locate the `<head>`…`</head>` region (or the area before `<body>`).
- *   2. Within that region, scan past comments and script/style blocks to find
- *      the first unambiguous `<title>` start tag.
- *   3. Decode HTML entities in its text, sanitize, and splice back.
- *
- * Pure string operations — no DOMParser — so it works identically in Node
- * test environments and in the browser.
- *
- * @public — exported for daemon-side URL-load title sanitization.
- */
 export function sanitizeTitleInDoc(html: string): string {
   const lower = html.toLowerCase();
-
-  // Find the end of the <head> region. Use the last </head> before <body>
-  // (mirrors injectBeforeHeadEnd logic) so we don't pick up </head> literals
-  // inside <script>/<style>.
   const bodyStart = lower.indexOf('<body');
   const headEnd = lower.lastIndexOf('</head>', bodyStart >= 0 ? bodyStart - 1 : lower.length - 1);
-
-  // The region to search: up to (and including) </head> if found, otherwise
-  // up to <body> if found, otherwise the entire document.
   const searchLimit = headEnd >= 0
-    ? headEnd + 7 // include the </head> tag itself
+    ? headEnd + 7
     : bodyStart >= 0
       ? bodyStart
       : html.length;
-
-  // Find the real <title> start offset, skipping comments and script/style.
   const titleStart = findRealTitleOffset(html, searchLimit);
   if (titleStart < 0) return html;
-
-  // Locate the end of the <title> open tag.
   const openTagEnd = html.indexOf('>', titleStart);
   if (openTagEnd < 0) return html;
-
-  // Locate the matching </title>.
   const closingTagStart = html.toLowerCase().indexOf('</title>', openTagEnd + 1);
   if (closingTagStart < 0) return html;
   const closingTagEnd = html.indexOf('>', closingTagStart);
   if (closingTagEnd < 0) return html;
-
   const openTag = html.slice(titleStart, openTagEnd + 1);
   const rawContent = html.slice(openTagEnd + 1, closingTagStart);
   const closeTag = html.slice(closingTagStart, closingTagEnd + 1);
-
-  const decoded = decodeHtmlEntitiesForTitle(rawContent);
-  const safe = sanitizePreviewTitle(decoded);
-
+  const safe = sanitizePreviewTitle(decodeHtmlEntitiesForTitle(rawContent));
   return html.slice(0, titleStart) + openTag + safe + closeTag + html.slice(closingTagEnd + 1);
 }
 
@@ -251,17 +159,11 @@ export function buildSrcdoc(
   </head>
   <body>${html}</body>
 </html>`;
-  // Sanitize <title> text before any other transformation so that when the
-  // user prints the preview iframe (Cmd+P → Save as PDF), Chromium uses the
-  // sanitized title as the default filename — one that Microsoft Teams will
-  // accept. Only the title text changes; visible page content is untouched.
-  const withSafeTitle = sanitizeTitleInDoc(wrapped);
-  const withOdIds = annotateMissingOdIds(withSafeTitle);
+  const withOdIds = annotateMissingOdIds(wrapped);
   const withSourcePaths = options.editBridge ? annotateManualEditSourcePaths(withOdIds) : withOdIds;
   const withBase = options.baseHref ? injectBaseHref(withSourcePaths, options.baseHref) : withSourcePaths;
   const withShim = injectSandboxShim(withBase);
-  const withFocusGuard = options.previewFocusGuard ? injectPreviewFocusGuard(withShim) : withShim;
-  const withDeck = options.deck ? injectDeckBridge(withFocusGuard, options.initialSlideIndex) : withFocusGuard;
+  const withDeck = options.deck ? injectDeckBridge(withShim, options.initialSlideIndex) : withShim;
   // Comment + Inspect share an element-selection bridge: both pick a
   // [data-od-id] / [data-screen-label] node and route the host's reply
   // to either the comment popover (annotate) or the inspect panel
@@ -285,9 +187,10 @@ export function buildSrcdoc(
   // it to a per-call option would force iframe srcdoc regeneration (and a
   // visible flash) every time the host toggle flips.
   const withTweaks = injectTweaksBridge(withEdit);
-  return injectSrcdocTransportActivationBridge(
-    injectExportCaptureBridge(injectSnapshotBridge(withTweaks)),
-  );
+  const withAnnotate = injectAnnotateBridge(withTweaks, {
+    initialEnabled: !!options.annotateBridge,
+  });
+  return injectSrcdocTransportActivationBridge(injectSnapshotBridge(withAnnotate));
 }
 
 /**
@@ -376,34 +279,95 @@ function injectSrcdocTransportActivationBridge(doc: string): string {
 
 function injectSnapshotBridge(doc: string): string {
   const script = `<script data-od-snapshot-bridge>(function(){
-  var SNAPSHOT_STYLE_PROPS = [
-    'display','position','box-sizing','width','height','min-width','max-width','min-height','max-height',
-    'margin','margin-top','margin-right','margin-bottom','margin-left',
-    'padding','padding-top','padding-right','padding-bottom','padding-left',
-    'border','border-top','border-right','border-bottom','border-left','border-radius',
-    'font','font-family','font-size','font-weight','font-style','line-height','letter-spacing',
-    'color','background-color','opacity','transform','transform-origin','overflow','overflow-x','overflow-y',
-    'white-space','text-align','vertical-align','object-fit','object-position',
-    'flex','flex-direction','flex-wrap','flex-grow','flex-shrink','flex-basis',
-    'grid','grid-template-columns','grid-template-rows','grid-column','grid-row',
-    'gap','row-gap','column-gap','align-items','align-content','align-self',
-    'justify-items','justify-content','justify-self','inset','top','right','bottom','left',
-    'z-index','box-shadow','text-shadow'
-  ];
+  function isCrossOrigin(src){
+    if (!src || src.indexOf('data:') === 0 || src.indexOf('blob:') === 0) return false;
+    // Protocol-relative URLs (//cdn.example.com/...) are always cross-origin.
+    if (src.indexOf('//') === 0) return true;
+    // In a srcdoc iframe window.location.origin === 'null'.  Every absolute http/https URL
+    // is therefore cross-origin regardless of hostname.
+    if (src.indexOf('http://') === 0 || src.indexOf('https://') === 0) {
+      if (window.location.origin === 'null') return true;
+      try { return new URL(src).origin !== window.location.origin; }
+      catch(_){ return true; }
+    }
+    return false;
+  }
+  // Try to load each cross-origin image with CORS and convert to dataURL.
+  // CDNs that support CORS → embedded as data URL (no taint).
+  // CDNs without CORS → map to null → blanked from clone (no taint, image hidden).
+  function prefetchCrossOriginImages(){
+    var imgs = Array.prototype.slice.call(document.querySelectorAll('img'));
+    var map = {};
+    var promises = [];
+    for (var ii = 0; ii < imgs.length; ii++){
+      (function(imgEl){
+        var src = imgEl.currentSrc || imgEl.getAttribute('src') || '';
+        if (!src || !isCrossOrigin(src) || Object.prototype.hasOwnProperty.call(map, src)) return;
+        map[src] = null;
+        promises.push(new Promise(function(resolve){
+          var settled = false;
+          function finish(){ if(settled) return; settled = true; resolve(undefined); }
+          var probe = new Image();
+          probe.crossOrigin = 'anonymous';
+          probe.onload = function(){
+            var c = document.createElement('canvas');
+            c.width = Math.max(1, probe.naturalWidth);
+            c.height = Math.max(1, probe.naturalHeight);
+            var ctx2 = c.getContext('2d');
+            if (ctx2){ try{ ctx2.drawImage(probe,0,0); map[src]=c.toDataURL(); }catch(_){} }
+            finish();
+          };
+          probe.onerror = finish;
+          probe.src = src;
+          setTimeout(finish, 1200);
+        }));
+      })(imgs[ii]);
+    }
+    return Promise.all(promises).then(function(){ return map; });
+  }
+  function stripUrlFromStyle(style){
+    // Remove any CSS declaration whose value contains url(...) to prevent canvas taint.
+    return style.replace(/[^:;]*:[^;]*url\([^)]*\)[^;]*;?/g, '');
+  }
   function copyComputedStyle(source, target){
     if (!source || !target || source.nodeType !== 1 || target.nodeType !== 1) return;
     var computed = window.getComputedStyle(source);
+    var isFixed = computed.getPropertyValue('position') === 'fixed';
+    // Strip any url() from existing inline style first, then append computed non-url values.
     var style = target.getAttribute('style') || '';
-    for (var i = 0; i < SNAPSHOT_STYLE_PROPS.length; i++){
-      var prop = SNAPSHOT_STYLE_PROPS[i];
-      var value = computed.getPropertyValue(prop);
-      if (value) style += prop + ':' + value + ';';
+    if (style.indexOf('url(') !== -1) style = stripUrlFromStyle(style);
+    for (var i = 0; i < computed.length; i++){
+      var prop = computed[i];
+      var val = computed.getPropertyValue(prop);
+      // Override url() with 'none' so inline style beats any <style> rule.
+      if (val.indexOf('url(') !== -1) { style += prop + ':none;'; continue; }
+      // Skip font-family; we inject a system-font !important reset in sanitizeClone instead.
+      // Embedding web-font names here would reach the browser's CORS-less font cache and taint.
+      if (prop === 'font-family' || prop === 'font') continue;
+      style += prop + ':' + val + ';';
+    }
+    if (isFixed) {
+      var rect = source.getBoundingClientRect();
+      var sx = window.scrollX || 0; var sy = window.scrollY || 0;
+      style += 'position:absolute!important;top:' + (rect.top + sy) + 'px!important;left:' + (rect.left + sx) + 'px!important;right:auto!important;bottom:auto!important;width:' + rect.width + 'px!important;height:' + rect.height + 'px!important;';
     }
     target.setAttribute('style', style);
   }
-  function syncElementState(source, target){
+  function syncElementState(source, target, imgDataUrlMap){
     var tag = source.tagName ? source.tagName.toLowerCase() : '';
-    if (tag === 'img' && source.currentSrc) target.setAttribute('src', source.currentSrc);
+    if (tag === 'img') {
+      var src = source.currentSrc || source.getAttribute('src') || '';
+      if (src) {
+        // imgDataUrlMap === null means "keep all sources" (SVG path — no canvas taint concern).
+        if (!isCrossOrigin(src) || imgDataUrlMap === null) {
+          target.setAttribute('src', src);
+        } else {
+          var mapped = imgDataUrlMap && imgDataUrlMap[src];
+          if (mapped) target.setAttribute('src', mapped);
+          else target.removeAttribute('src');
+        }
+      }
+    }
     if (tag === 'input' || tag === 'textarea') target.setAttribute('value', source.value || '');
     if (tag === 'canvas') {
       try {
@@ -414,269 +378,432 @@ function injectSnapshotBridge(doc: string): string {
       } catch (_) {}
     }
   }
-  function inlineSnapshotStyles(originalRoot, cloneRoot){
+  function inlineSnapshotStyles(originalRoot, cloneRoot, imgDataUrlMap){
     copyComputedStyle(originalRoot, cloneRoot);
-    syncElementState(originalRoot, cloneRoot);
-    var originals = originalRoot.querySelectorAll('*');
-    var clones = cloneRoot.querySelectorAll('*');
-    var count = Math.min(originals.length, clones.length, 3500);
-    for (var i = 0; i < count; i++){
-      copyComputedStyle(originals[i], clones[i]);
-      syncElementState(originals[i], clones[i]);
-    }
-    var scripts = cloneRoot.querySelectorAll('script');
-    for (var s = scripts.length - 1; s >= 0; s--) scripts[s].remove();
-    var links = cloneRoot.querySelectorAll('link[rel~="stylesheet"], link[rel~="preload"], link[rel~="preconnect"]');
-    for (var l = links.length - 1; l >= 0; l--) links[l].remove();
-    var styles = cloneRoot.querySelectorAll('style');
-    for (var st = 0; st < styles.length; st++) {
-      styles[st].textContent = (styles[st].textContent || '')
-        .replace(/@import[^;]+;/gi, '')
-        .replace(/@font-face\\s*\\{[^}]*\\}/gi, '');
-    }
-  }
-  function pruneHiddenSnapshotNodes(originalRoot, cloneRoot){
+    syncElementState(originalRoot, cloneRoot, imgDataUrlMap);
     var originals = originalRoot.querySelectorAll('*');
     var clones = cloneRoot.querySelectorAll('*');
     var count = Math.min(originals.length, clones.length);
-    var removals = [];
     for (var i = 0; i < count; i++){
-      var original = originals[i];
-      var clone = clones[i];
-      if (!original || !clone || !clone.parentNode) continue;
-      var computed = window.getComputedStyle(original);
-      if (computed && (computed.display === 'none' || computed.visibility === 'hidden')) {
-        removals.push(clone);
+      copyComputedStyle(originals[i], clones[i]);
+      syncElementState(originals[i], clones[i], imgDataUrlMap);
+    }
+    var scripts = cloneRoot.querySelectorAll('script');
+    for (var s = scripts.length - 1; s >= 0; s--) scripts[s].remove();
+  }
+  function bakeScrollContainers(originalRoot, cloneRoot){
+    var originals = [originalRoot].concat(Array.prototype.slice.call(originalRoot.querySelectorAll ? originalRoot.querySelectorAll('*') : []));
+    var clones = [cloneRoot].concat(Array.prototype.slice.call(cloneRoot.querySelectorAll ? cloneRoot.querySelectorAll('*') : []));
+    var count = Math.min(originals.length, clones.length);
+    for (var i = 0; i < count; i++){
+      var source = originals[i];
+      var target = clones[i];
+      if (!source || !target || source.nodeType !== 1 || target.nodeType !== 1) continue;
+      var tag = source.tagName ? source.tagName.toLowerCase() : '';
+      if (tag === 'html' || tag === 'body') continue;
+      var scrollLeft = Math.round(source.scrollLeft || 0);
+      var scrollTop = Math.round(source.scrollTop || 0);
+      var scrollW = Math.round(source.scrollWidth || 0);
+      var scrollH = Math.round(source.scrollHeight || 0);
+      var clientW = Math.round(source.clientWidth || 0);
+      var clientH = Math.round(source.clientHeight || 0);
+      if ((scrollLeft === 0 && scrollTop === 0) || (scrollW <= clientW && scrollH <= clientH)) continue;
+      var doc = target.ownerDocument || document;
+      var wrapper = doc.createElement('div');
+      wrapper.setAttribute('data-od-scroll-bake', '1');
+      wrapper.setAttribute(
+        'style',
+        'display:block!important;box-sizing:border-box!important;width:' + Math.max(scrollW, clientW, 1) + 'px!important;min-height:' + Math.max(scrollH, clientH, 1) + 'px!important;transform:translate(' + (-scrollLeft) + 'px,' + (-scrollTop) + 'px)!important;transform-origin:0 0!important;'
+      );
+      while (target.firstChild) wrapper.appendChild(target.firstChild);
+      target.appendChild(wrapper);
+      var style = target.getAttribute('style') || '';
+      style += 'overflow:hidden!important;scrollbar-width:none!important;';
+      target.setAttribute('style', style);
+    }
+  }
+  // Final pass: remove every cross-origin resource that could taint the canvas.
+  function sanitizeClone(root, imgDataUrlMap){
+    // <img>: replace cross-origin src with prefetched data URL or blank; strip srcset.
+    var imgs = root.querySelectorAll('img');
+    for (var i = 0; i < imgs.length; i++){
+      var src = imgs[i].getAttribute('src') || '';
+      if (isCrossOrigin(src)){
+        var du = imgDataUrlMap && imgDataUrlMap[src];
+        if (du) imgs[i].setAttribute('src', du);
+        else imgs[i].removeAttribute('src');
+      }
+      imgs[i].removeAttribute('srcset');
+    }
+    // Remove ALL <link> elements — stylesheets are already inlined as computed styles,
+    // and even "same-origin" stylesheets can @font-face cross-origin fonts.
+    var links = root.querySelectorAll('link');
+    for (var j = links.length - 1; j >= 0; j--) links[j].remove();
+    // Remove ALL canvas elements — tainted source canvases leave untransferable clones.
+    var canvases = root.querySelectorAll('canvas');
+    for (var cv = canvases.length - 1; cv >= 0; cv--) canvases[cv].remove();
+    // Remove embedded media elements: cross-origin content inside these taints the canvas.
+    var media = root.querySelectorAll('iframe,video,audio,embed,object');
+    for (var k = 0; k < media.length; k++) media[k].remove();
+    // Remove <source> elements (picture/video fallback).
+    var srcs = root.querySelectorAll('source');
+    for (var s2 = 0; s2 < srcs.length; s2++) srcs[s2].remove();
+    // SVG <use> with external href (e.g. Bootstrap Icons sprite from CDN).
+    var uses = root.querySelectorAll('use');
+    for (var u = 0; u < uses.length; u++){
+      var uhref = uses[u].getAttribute('href') || uses[u].getAttribute('xlink:href') || '';
+      if (isCrossOrigin(uhref.split('#')[0])) uses[u].remove();
+    }
+    // SVG <image> / <feImage> with cross-origin href.
+    var svgImgs = root.querySelectorAll('image,feImage');
+    for (var si = 0; si < svgImgs.length; si++){
+      var ihref = svgImgs[si].getAttribute('href') || svgImgs[si].getAttribute('xlink:href') || svgImgs[si].getAttribute('src') || '';
+      if (isCrossOrigin(ihref)) svgImgs[si].remove();
+    }
+    // <input type="image"> with cross-origin src.
+    var imgInputs = root.querySelectorAll('input[type="image"]');
+    for (var ii2 = 0; ii2 < imgInputs.length; ii2++){
+      if (isCrossOrigin(imgInputs[ii2].getAttribute('src') || '')) imgInputs[ii2].removeAttribute('src');
+    }
+    // Strip url() from any remaining inline style attributes.
+    var styled = root.querySelectorAll('[style]');
+    for (var m = 0; m < styled.length; m++){
+      var st = styled[m].getAttribute('style') || '';
+      if (st.indexOf('url(') !== -1) styled[m].setAttribute('style', stripUrlFromStyle(st));
+    }
+    // Sanitize <style> block content: strip @import, @font-face, and replace url() with none.
+    var styleEls = root.querySelectorAll('style');
+    for (var n = 0; n < styleEls.length; n++){
+      var txt = styleEls[n].textContent || '';
+      if (txt.indexOf('url(') !== -1 || txt.indexOf('@import') !== -1){
+        txt = txt.replace(/@import\s[^;]+;?/g, '');
+        txt = txt.replace(/@font-face\s*\{[^}]*\}/g, '');
+        txt = txt.replace(/url\([^)]*\)/g, 'none');
+        styleEls[n].textContent = txt;
       }
     }
-    for (var r = removals.length - 1; r >= 0; r--){
-      if (removals[r].parentNode) removals[r].parentNode.removeChild(removals[r]);
+    // Debug: log any remaining cross-origin references so we can catch new cases.
+    var leaks = [];
+    var allAttrSrc = root.querySelectorAll('[src]');
+    for (var d1 = 0; d1 < allAttrSrc.length; d1++){
+      var ds = allAttrSrc[d1].getAttribute('src') || '';
+      if (ds && ds.indexOf('data:') !== 0 && isCrossOrigin(ds)) leaks.push(allAttrSrc[d1].tagName+'[src]='+ds.slice(0,60));
     }
+    var allAttrHref = root.querySelectorAll('[href]');
+    for (var d2 = 0; d2 < allAttrHref.length; d2++){
+      var dh = allAttrHref[d2].getAttribute('href') || '';
+      if (dh && isCrossOrigin(dh.split('#')[0])) leaks.push(allAttrHref[d2].tagName+'[href]='+dh.slice(0,60));
+    }
+    var remainStyle = root.querySelectorAll('[style]');
+    for (var d3 = 0; d3 < remainStyle.length; d3++){
+      if ((remainStyle[d3].getAttribute('style')||'').indexOf('url(') !== -1) leaks.push(remainStyle[d3].tagName+'[style]url()');
+    }
+    var remainStyleEl = root.querySelectorAll('style');
+    for (var d4 = 0; d4 < remainStyleEl.length; d4++){
+      if ((remainStyleEl[d4].textContent||'').indexOf('url(') !== -1) leaks.push('<style>url()');
+    }
+    if (leaks.length) console.warn('[snapshot] remaining cross-origin refs after sanitize:', leaks);
+    // Force system fonts on every element.  Web fonts loaded by the original page sit in the
+    // browser's font cache without CORS headers; reusing them in the SVG foreignObject context
+    // taints the canvas.  A !important override prevents the browser from reaching that cache.
+    var fontHead = root.querySelector('head') || root;
+    var fontReset = document.createElement('style');
+    fontReset.setAttribute('data-od-font-reset', '1');
+    fontReset.textContent = '*,*::before,*::after{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif!important;}';
+    fontHead.appendChild(fontReset);
   }
   function waitForImages(){
     var imgs = Array.prototype.slice.call(document.images || []);
     return Promise.all(imgs.map(function(img){
       if (img.complete) return Promise.resolve();
       return new Promise(function(resolve){
-        img.addEventListener('load', resolve, { once: true });
-        img.addEventListener('error', resolve, { once: true });
+        var settled = false;
+        function finish(){ if(settled) return; settled = true; resolve(undefined); }
+        img.addEventListener('load', finish, { once: true });
+        img.addEventListener('error', finish, { once: true });
+        setTimeout(finish, 900);
       });
     }));
   }
-  function scrollOffset(){
-    var doc = document.documentElement;
-    var body = document.body;
-    return {
-      x: Math.max(window.scrollX || 0, doc ? doc.scrollLeft || 0 : 0, body ? body.scrollLeft || 0 : 0),
-      y: Math.max(window.scrollY || 0, doc ? doc.scrollTop || 0 : 0, body ? body.scrollTop || 0 : 0)
-    };
-  }
-  function escapeAttribute(value){
-    return String(value || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
-  }
-  function snapshotBackgroundColor(){
+  function encodeSvgDataUrl(svg){
     try {
-      var probe = window.getComputedStyle(document.body || document.documentElement);
-      var bg = probe && probe.backgroundColor || '';
-      if (!bg || bg === 'transparent' || bg === 'rgba(0, 0, 0, 0)') return '#ffffff';
-      return bg;
-    } catch (_) { return '#ffffff'; }
-  }
-  // After painting, sample the canvas: a uniform (single-color) bitmap means
-  // the foreignObject rasterizer painted nothing — Chromium frequently refuses
-  // to paint <foreignObject> HTML loaded via <img>. Treating that as an honest
-  // 'empty-render' error (instead of shipping the background-only frame) lets
-  // the host fall back / surface a real failure rather than a silent black PNG.
-  function canvasLooksBlank(ctx, cw, ch){
-    try {
-      var data = ctx.getImageData(0, 0, cw, ch).data;
-      var step = Math.max(4, Math.floor((cw * ch) / 4096)) * 4;
-      var first = null, samples = 0;
-      for (var i = 0; i + 3 < data.length; i += step){
-        samples++;
-        if (!first){ first = [data[i], data[i+1], data[i+2], data[i+3]]; continue; }
-        if (Math.abs(data[i]-first[0]) > 6 || Math.abs(data[i+1]-first[1]) > 6 ||
-            Math.abs(data[i+2]-first[2]) > 6 || Math.abs(data[i+3]-first[3]) > 6) return false;
+      if (typeof TextEncoder !== 'undefined') {
+        var bytes = new TextEncoder().encode(svg);
+        var binary = '';
+        var chunk = 32768;
+        for (var i = 0; i < bytes.length; i += chunk) {
+          var slice = bytes.subarray(i, i + chunk);
+          for (var j = 0; j < slice.length; j++) binary += String.fromCharCode(slice[j]);
+        }
+        return 'data:image/svg+xml;base64,' + btoa(binary);
       }
-      return samples > 8;
-    } catch (_) { return false; }
+      return 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svg)));
+    } catch (_) {
+      return '';
+    }
   }
-  // Rasterize the current view (or the whole document, when opts.full) via an
-  // SVG <foreignObject>. Returns a Promise so it can be reused by both the
-  // od:snapshot message handler AND the export-capture bridge (image export /
-  // PDF) — the foreignObject path is fast and never blocks on external
-  // image network loads the way a DOM-cloning rasterizer does.
-  function captureSnapshot(opts){
-    opts = opts || {};
-    return new Promise(function(resolve, reject){
-      var w = Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1);
-      var h = Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1);
-      var dpr = window.devicePixelRatio || 1;
-      var bgColor = snapshotBackgroundColor();
+  function snapshotViewport(raw){
+    var fullW = Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1);
+    var fullH = Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1);
+    var x = 0;
+    var y = 0;
+    var w = fullW;
+    var h = fullH;
+    if (raw && typeof raw === 'object') {
+      x = Math.max(0, Math.floor(Number(raw.x) || 0));
+      y = Math.max(0, Math.floor(Number(raw.y) || 0));
+      w = Math.max(1, Math.floor(Number(raw.w) || fullW));
+      h = Math.max(1, Math.floor(Number(raw.h) || fullH));
+    }
+    return { fullH: fullH, fullW: fullW, h: h, w: w, x: x, y: y };
+  }
+  function appendSnapshotOverlay(clone, overlayHtml, overlayCss, sx, sy, cropX, cropY, w, h){
+    if (!overlayHtml) return;
+    try {
+      var head = clone.querySelector('head') || clone;
+      var body = clone.querySelector('body') || clone;
+      var style = document.createElement('style');
+      style.setAttribute('data-od-snapshot-overlay', '1');
+      style.textContent = (overlayCss || '') + '#od-snapshot-overlay-layer{position:absolute!important;left:0!important;top:0!important;width:' + (w + cropX) + 'px!important;height:' + (h + cropY) + 'px!important;overflow:hidden!important;pointer-events:none!important;background:transparent!important;z-index:2147483647!important;transform:translate(' + (sx - cropX) + 'px,' + (sy - cropY) + 'px)!important;transform-origin:0 0!important;}#od-snapshot-overlay-layer #oi-sel,#od-snapshot-overlay-layer #oi-hov,#od-snapshot-overlay-layer #oi-svg,#od-snapshot-overlay-layer #oi-card,#od-snapshot-overlay-layer .oi-badge,#od-snapshot-overlay-layer .oi-shot,#od-snapshot-overlay-layer .oi-shot-fly,#od-snapshot-overlay-layer #oi-cpk{display:block;}';
+      head.appendChild(style);
+      var layer = document.createElement('div');
+      layer.setAttribute('id', 'od-snapshot-overlay-layer');
+      layer.innerHTML = overlayHtml;
+      body.appendChild(layer);
+    } catch (_) {}
+  }
+  function inlineOverlayComputedStyles(source, target){
+    if (!source || !target) return;
+    copyComputedStyle(source, target);
+    syncElementState(source, target, null);
+    var originals = source.querySelectorAll ? source.querySelectorAll('*') : [];
+    var clones = target.querySelectorAll ? target.querySelectorAll('*') : [];
+    var count = Math.min(originals.length, clones.length);
+    for (var i = 0; i < count; i++) {
+      copyComputedStyle(originals[i], clones[i]);
+      syncElementState(originals[i], clones[i], null);
+    }
+  }
+  function renderLiveSvgSnapshot(id,opts){
+    try {
+      var viewport = snapshotViewport(opts && opts.viewport);
+      var w = viewport.w;
+      var h = viewport.h;
+      var cropX = viewport.x;
+      var cropY = viewport.y;
       var docW = Math.max(w, document.documentElement.scrollWidth || 0, document.body ? document.body.scrollWidth : 0);
       var docH = Math.max(h, document.documentElement.scrollHeight || 0, document.body ? document.body.scrollHeight : 0);
-      var full = !!opts.full;
-      var capW = full ? docW : w;
-      var capH = full ? docH : h;
+      var sx = Math.max(0, (window.scrollX || document.documentElement.scrollLeft || (document.body ? document.body.scrollLeft : 0) || 0) + cropX);
+      var sy = Math.max(0, (window.scrollY || document.documentElement.scrollTop || (document.body ? document.body.scrollTop : 0) || 0) + cropY);
+      docW = Math.max(docW, sx + w);
+      docH = Math.max(docH, sy + h);
       var clone = document.documentElement.cloneNode(true);
       clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
-      inlineSnapshotStyles(document.documentElement, clone);
-      pruneHiddenSnapshotNodes(document.documentElement, clone);
-      var scroll = full ? { x: 0, y: 0 } : scrollOffset();
-      var cloneBody = clone.querySelector('body');
-      var rootStyle = clone.getAttribute('style') || '';
-      var bodyStyle = cloneBody ? cloneBody.getAttribute('style') || '' : '';
-      var bodyContent = cloneBody ? cloneBody.innerHTML : clone.innerHTML;
-      var wrapperStyle = rootStyle + bodyStyle +
-        'margin:0;position:relative;left:' + (-scroll.x) + 'px;top:' + (-scroll.y) + 'px;' +
-        'width:' + docW + 'px;height:' + docH + 'px;overflow:visible;';
-      var html = '<div xmlns="http://www.w3.org/1999/xhtml" style="' + escapeAttribute(wrapperStyle) + '">' + bodyContent + '</div>';
-      var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + capW + '" height="' + capH + '" viewBox="0 0 ' + capW + ' ' + capH + '">' +
-        '<foreignObject x="0" y="0" width="' + docW + '" height="' + docH + '">' +
+      // Pass null so cross-origin image sources are kept (no canvas taint concern for SVG output).
+      inlineSnapshotStyles(document.documentElement, clone, null);
+      bakeScrollContainers(document.documentElement, clone);
+      var scripts = clone.querySelectorAll('script');
+      for (var s = scripts.length - 1; s >= 0; s--) scripts[s].remove();
+      var bases = clone.querySelectorAll('base');
+      for (var b = bases.length - 1; b >= 0; b--) bases[b].remove();
+      var head = clone.querySelector('head') || clone;
+      var viewportStyle = document.createElement('style');
+      viewportStyle.setAttribute('data-od-live-snapshot', '1');
+      viewportStyle.textContent = 'html{margin:0!important;width:' + docW + 'px!important;min-height:' + docH + 'px!important;overflow:hidden!important;}body{margin:0!important;width:' + docW + 'px!important;min-height:' + docH + 'px!important;transform:translate(' + (-sx) + 'px,' + (-sy) + 'px)!important;transform-origin:0 0!important;}*{content-visibility:visible!important;}';
+      head.appendChild(viewportStyle);
+      // Decorative artifacts injected by the OI bridge are always removed
+      // from the page clone. Annotation captures add them back as a second
+      // viewport-space layer so page content and floating UI cannot drift.
+      var overlaySelector = '#oi-sel,#oi-hov,#oi-svg,#oi-card,.oi-badge,.oi-shot,.oi-shot-fly,#oi-cpk';
+      // Do NOT use [data-oi] here — the selection bridge adds data-oi to page content
+      // elements (e.g. the <h3> the user clicked), so querying it removes page content.
+      var removeFromClone = clone.querySelectorAll(overlaySelector);
+      for (var co = removeFromClone.length - 1; co >= 0; co--) removeFromClone[co].remove();
+      var overlayMarkup = '';
+      if (!opts || !opts.skipOverlay) {
+        var overlayNodes = document.querySelectorAll(overlaySelector);
+        for (var oi = 0; oi < overlayNodes.length; oi++) {
+          try {
+            var node = overlayNodes[oi];
+            var overlayClone = node.cloneNode(true);
+            var r = node.getBoundingClientRect && node.getBoundingClientRect();
+            inlineOverlayComputedStyles(node, overlayClone);
+            if (r && overlayClone && overlayClone.style) {
+              overlayClone.style.position = 'absolute';
+              overlayClone.style.left = Math.round(r.left) + 'px';
+              overlayClone.style.top = Math.round(r.top) + 'px';
+              overlayClone.style.width = Math.round(r.width) + 'px';
+              overlayClone.style.height = Math.round(r.height) + 'px';
+              overlayClone.style.margin = '0';
+              overlayClone.style.transform = 'none';
+            }
+            overlayMarkup += overlayClone.outerHTML || '';
+          } catch (_) {
+            overlayMarkup += overlayNodes[oi].outerHTML || '';
+          }
+        }
+      }
+      var overlayHtml = '';
+      var overlayCss = '';
+      if ((!opts || !opts.skipOverlay) && opts && opts.overlay && opts.overlay.html) {
+        overlayHtml = opts.overlay.html || '';
+        overlayCss = opts.overlay.css || '';
+      } else if (overlayMarkup) {
+        var oiStyle = document.querySelector('style[data-oi]');
+        overlayHtml = overlayMarkup;
+        overlayCss = oiStyle ? oiStyle.textContent || '' : '';
+      }
+      appendSnapshotOverlay(clone, overlayHtml, overlayCss, sx, sy, cropX, cropY, w, h);
+      var html = new XMLSerializer().serializeToString(clone);
+      var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + ' ' + h + '">' +
+        '<foreignObject x="0" y="0" width="' + w + '" height="' + h + '">' +
         html +
         '</foreignObject></svg>';
+      var svgBlob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+      window.parent.postMessage({ type: 'od:snapshot:result', id: id, blob: svgBlob, mime: 'image/svg+xml', w: w, h: h, fallback: 'live-svg' }, '*');
+    } catch (err) {
+      window.parent.postMessage({ type: 'od:snapshot:result', id: id, error: String(err && err.message || err) }, '*');
+    }
+  }
+  function renderSnapshot(id, options){
+    options = options || {};
+    if (options.preferSvg) { renderLiveSvgSnapshot(id, options); return; }
+    prefetchCrossOriginImages().then(function(imgDataUrlMap){
+      var viewport = snapshotViewport(options.viewport);
+      var w = viewport.w;
+      var h = viewport.h;
+      var cropX = viewport.x;
+      var cropY = viewport.y;
+      var dpr = window.devicePixelRatio || 1;
+      var docW = Math.max(w, document.documentElement.scrollWidth || 0, document.body ? document.body.scrollWidth : 0);
+      var docH = Math.max(h, document.documentElement.scrollHeight || 0, document.body ? document.body.scrollHeight : 0);
+      var sx = Math.max(0, (window.scrollX || document.documentElement.scrollLeft || (document.body ? document.body.scrollLeft : 0) || 0) + cropX);
+      var sy = Math.max(0, (window.scrollY || document.documentElement.scrollTop || (document.body ? document.body.scrollTop : 0) || 0) + cropY);
+      docW = Math.max(docW, sx + w);
+      docH = Math.max(docH, sy + h);
+      var clone = document.documentElement.cloneNode(true);
+      clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+      inlineSnapshotStyles(document.documentElement, clone, imgDataUrlMap);
+      bakeScrollContainers(document.documentElement, clone);
+      sanitizeClone(clone, imgDataUrlMap);
+      var baseElsC = clone.querySelectorAll('base');
+      for (var bc = baseElsC.length - 1; bc >= 0; bc--) baseElsC[bc].remove();
+      var viewportStyleC = document.createElement('style');
+      viewportStyleC.setAttribute('data-od-live-snapshot', '1');
+      viewportStyleC.textContent = 'html{margin:0!important;width:' + docW + 'px!important;min-height:' + docH + 'px!important;overflow:hidden!important;}body{margin:0!important;width:' + docW + 'px!important;min-height:' + docH + 'px!important;transform:translate(' + (-sx) + 'px,' + (-sy) + 'px)!important;transform-origin:0 0!important;}*{content-visibility:visible!important;}';
+      (clone.querySelector('head') || clone).appendChild(viewportStyleC);
+      var overlaySelC = '#oi-sel,#oi-hov,#oi-svg,#oi-card,.oi-badge,.oi-shot,.oi-shot-fly,#oi-cpk';
+      var overlayEls = clone.querySelectorAll(overlaySelC);
+      for (var oc = overlayEls.length - 1; oc >= 0; oc--) overlayEls[oc].remove();
+      var serializer = new XMLSerializer();
+      var overlayMarkupC = '';
+      if (!options.skipOverlay) {
+        var overlayNodesC = document.querySelectorAll(overlaySelC);
+        for (var oic = 0; oic < overlayNodesC.length; oic++) {
+          try {
+            var overlayNodeC = overlayNodesC[oic];
+            var overlayCloneC = overlayNodeC.cloneNode(true);
+            var rc = overlayNodeC.getBoundingClientRect && overlayNodeC.getBoundingClientRect();
+            inlineOverlayComputedStyles(overlayNodeC, overlayCloneC);
+            if (rc && overlayCloneC && overlayCloneC.style) {
+              overlayCloneC.style.position = 'absolute';
+              overlayCloneC.style.left = Math.round(rc.left) + 'px';
+              overlayCloneC.style.top = Math.round(rc.top) + 'px';
+              overlayCloneC.style.width = Math.round(rc.width) + 'px';
+              overlayCloneC.style.height = Math.round(rc.height) + 'px';
+              overlayCloneC.style.margin = '0';
+              overlayCloneC.style.transform = 'none';
+            }
+            overlayMarkupC += overlayCloneC.outerHTML || '';
+          } catch (_) {
+            overlayMarkupC += overlayNodesC[oic].outerHTML || '';
+          }
+        }
+      }
+      var overlayHtmlC = '';
+      var overlayCssC = '';
+      if (!options.skipOverlay && options.overlay && options.overlay.html) {
+        overlayHtmlC = options.overlay.html || '';
+        overlayCssC = options.overlay.css || '';
+      } else if (overlayMarkupC) {
+        var oiStyleC = document.querySelector('style[data-oi]');
+        overlayHtmlC = overlayMarkupC;
+        overlayCssC = oiStyleC ? oiStyleC.textContent || '' : '';
+      }
+      appendSnapshotOverlay(clone, overlayHtmlC, overlayCssC, sx, sy, cropX, cropY, w, h);
+      var html = serializer.serializeToString(clone);
+      var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + ' ' + h + '">' +
+        '<foreignObject x="0" y="0" width="' + w + '" height="' + h + '">' +
+        html +
+        '</foreignObject></svg>';
+      function svgSnapshotDataUrl(){
+        try {
+          return 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svg)));
+        } catch (_) {
+          return '';
+        }
+      }
+      function postSvgSnapshot(error){
+        var fallbackUrl = svgSnapshotDataUrl();
+        if (fallbackUrl) {
+          window.parent.postMessage({
+            type: 'od:snapshot:result',
+            id: id,
+            dataUrl: fallbackUrl,
+            w: Math.max(1, Math.floor(w * dpr)),
+            h: Math.max(1, Math.floor(h * dpr)),
+            fallback: 'svg',
+            error: error || null
+          }, '*');
+          return;
+        }
+        window.parent.postMessage({ type: 'od:snapshot:result', id: id, error: error || 'snapshot fallback failed' }, '*');
+      }
+      var svgBlob = new Blob([svg], {type:'image/svg+xml;charset=utf-8'});
+      var svgUrl = URL.createObjectURL(svgBlob);
       var img = new Image();
+      var imageSettled = false;
       img.onload = function(){
+        imageSettled = true;
+        URL.revokeObjectURL(svgUrl);
         try {
           var canvas = document.createElement('canvas');
-          canvas.width = Math.max(1, Math.floor(capW * dpr));
-          canvas.height = Math.max(1, Math.floor(capH * dpr));
+          canvas.width = Math.max(1, Math.floor(w * dpr));
+          canvas.height = Math.max(1, Math.floor(h * dpr));
           var ctx = canvas.getContext('2d');
           if (!ctx) throw new Error('no 2d context');
           ctx.scale(dpr, dpr);
-          // Opaque base so a transparent (un-painted) raster never flattens to
-          // pure black in clipboards / PNG viewers.
-          ctx.fillStyle = bgColor;
-          ctx.fillRect(0, 0, capW, capH);
-          ctx.drawImage(img, 0, 0, capW, capH);
-          if (canvasLooksBlank(ctx, canvas.width, canvas.height)) {
-            reject(new Error('empty-render'));
+          ctx.drawImage(img, 0, 0, w, h);
+          var dataUrl;
+          try { dataUrl = canvas.toDataURL('image/png'); } catch(te) {
+            postSvgSnapshot('tainted:' + String(te && te.message || te));
             return;
           }
-          resolve({ dataUrl: canvas.toDataURL('image/png'), w: canvas.width, h: canvas.height });
+          window.parent.postMessage({ type: 'od:snapshot:result', id: id, dataUrl: dataUrl, w: canvas.width, h: canvas.height }, '*');
         } catch (err) {
-          reject(err instanceof Error ? err : new Error(String(err && err.message || err)));
+          postSvgSnapshot(String(err && err.message || err));
         }
       };
-      img.onerror = function(){ reject(new Error('snapshot image failed')); };
-      img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+      img.onerror = function(){
+        imageSettled = true;
+        URL.revokeObjectURL(svgUrl);
+        postSvgSnapshot('snapshot image failed');
+      };
+      img.src = svgUrl;
+      setTimeout(function(){
+        if (imageSettled) return;
+        imageSettled = true;
+        URL.revokeObjectURL(svgUrl);
+        postSvgSnapshot('snapshot image timed out');
+      }, 5000);
     });
   }
-  // Exposed so the export-capture bridge (same document) can reuse this renderer.
-  window.__odCaptureSnapshot = function(opts){
-    return waitForImages().then(function(){ return captureSnapshot(opts || {}); });
-  };
   window.addEventListener('message', function(ev){
     var data = ev && ev.data;
     if (!data || data.type !== 'od:snapshot' || !data.id) return;
-    window.__odCaptureSnapshot({ full: !!data.full }).then(function(res){
-      window.parent.postMessage({ type: 'od:snapshot:result', id: String(data.id), dataUrl: res.dataUrl, w: res.w, h: res.h }, '*');
-    }, function(err){
-      window.parent.postMessage({ type: 'od:snapshot:result', id: String(data.id), error: String(err && err.message || err) }, '*');
-    });
-  });
-})();</script>`;
-  return injectBeforeBodyEnd(doc, script);
-}
-
-// Export-capture bridge: the in-iframe half of the programmatic PDF /
-// image exporters (apps/web/src/runtime/exports.ts). The preview iframe is
-// sandbox="allow-scripts" WITHOUT allow-same-origin, so the host cannot read
-// iframe.contentDocument — capture must run inside the frame, exactly like the
-// snapshot bridge above. The orchestrator (host) creates a hidden, full-
-// resolution export iframe, posts `od:export-capture`, and assembles the
-// returned per-slide images with jsPDF.
-//
-// Protocol:
-//   in:  { type:'od:export-capture', id, mode:'image', deck:boolean,
-//          single?:boolean, delay:number }
-//   out: { type:'od:export-capture:slide', id, index, total,
-//          dataUrl, w, h, notes }   (one per slide)
-//   out: { type:'od:export-capture:done',  id, total }
-//   out: { type:'od:export-capture:error', id, error }
-//
-// Slides are enumerated/navigated through the existing deck bridge
-// (window.__odDeckSlideState + an `od:slide` self-postMessage), so any deck the
-// on-screen preview can drive, the exporter can too. Image capture reuses the
-// shared SVG-foreignObject renderer (window.__odCaptureSnapshot from the
-// snapshot bridge) — fast and free of any external script load or network wait.
-function injectExportCaptureBridge(doc: string): string {
-  const script = `<script data-od-export-capture-bridge>(function(){
-  function raf(){ return new Promise(function(r){ requestAnimationFrame(function(){ r(); }); }); }
-  function settle(){
-    var fonts = (document.fonts && document.fonts.ready) ? document.fonts.ready.catch(function(){}) : Promise.resolve();
-    var imgs = Promise.all(Array.prototype.slice.call(document.images||[]).map(function(img){
-      if (img.complete) return Promise.resolve();
-      return new Promise(function(r){ img.addEventListener('load', r, {once:true}); img.addEventListener('error', r, {once:true}); });
-    }));
-    return Promise.all([fonts, imgs]).then(raf).then(raf);
-  }
-  function deckState(){
-    try { if (typeof window.__odDeckSlideState === 'function') return window.__odDeckSlideState(); } catch(_){}
-    return { active: 0, count: 1 };
-  }
-  function navTo(index, delay){
-    return new Promise(function(resolve){
-      try { window.postMessage({ type:'od:slide', action:'go', index: index }, '*'); } catch(_){}
-      var tries = 0;
-      function check(){
-        tries++;
-        if (deckState().active === index || tries > 14) { resolve(); return; }
-        setTimeout(check, 80);
-      }
-      setTimeout(check, Math.max(60, delay||0));
-    });
-  }
-  function captureImage(deck){
-    // Reuse the shared SVG-foreignObject renderer (injectSnapshotBridge). For a
-    // deck the active slide fills the viewport, so a viewport capture IS the
-    // slide; a non-deck page captures the full document.
-    if (typeof window.__odCaptureSnapshot !== 'function') {
-      return Promise.reject(new Error('snapshot renderer unavailable'));
-    }
-    return window.__odCaptureSnapshot({ full: !deck });
-  }
-  function notes(){
-    var el = document.getElementById('speaker-notes');
-    if (!el) return '';
-    var t = el.textContent || '';
-    try { var j = JSON.parse(t); if (Array.isArray(j)) return j; } catch(_){}
-    return t.replace(/\\s+/g,' ').trim();
-  }
-  function send(msg){ try { window.parent.postMessage(msg, '*'); } catch(_){} }
-  function run(req){
-    var id = req.id;
-    var deck = !!req.deck;
-    var single = !!req.single;
-    var delay = req.delay || 350;
-    Promise.resolve().then(function(){
-      var st = deckState();
-      var total = (!single && deck && st.count > 1) ? st.count : 1;
-      var notesAll = notes();
-      function noteFor(i){ return Array.isArray(notesAll) ? (notesAll[i]||'') : (i===0 ? notesAll : ''); }
-      var idx = 0;
-      function step(){
-        if (idx >= total){ send({ type:'od:export-capture:done', id:id, total: total }); return; }
-        var i = idx;
-        var navP = (!single && deck && total > 1) ? navTo(i, delay) : Promise.resolve();
-        navP.then(settle).then(function(){
-          try {
-            captureImage(deck).then(function(img){
-              send({ type:'od:export-capture:slide', id:id, index:i, total:total, dataUrl: img.dataUrl, w: img.w, h: img.h, notes: noteFor(i) });
-              idx++; setTimeout(step, 0);
-            }).catch(function(err){ send({ type:'od:export-capture:error', id:id, error: String(err && err.message || err) }); });
-          } catch(err){ send({ type:'od:export-capture:error', id:id, error: String(err && err.message || err) }); }
-        });
-      }
-      step();
-    }).catch(function(err){
-      send({ type:'od:export-capture:error', id:id, error: String(err && err.message || err) });
-    });
-  }
-  window.addEventListener('message', function(ev){
-    var data = ev && ev.data;
-    if (!data || data.type !== 'od:export-capture' || !data.id) return;
-    run(data);
+    var opts = { overlay: data.overlay || null, preferSvg: !!data.preferSvg, skipOverlay: !!data.skipOverlay, viewport: data.viewport || null };
+    if (data.preferSvg) { renderSnapshot(String(data.id), opts); return; }
+    waitForImages().then(function(){ renderSnapshot(String(data.id), opts); });
   });
 })();</script>`;
   return injectBeforeBodyEnd(doc, script);
@@ -959,56 +1086,44 @@ function annotateMissingOdIds(doc: string): string {
 }
 
 function injectManualEditBridge(doc: string): string {
-  const withGuard = injectAfterHeadOpen(doc, buildManualEditKeyboardGuard());
-  const withStyle = injectBeforeHeadEnd(withGuard, buildManualEditBridgeStyle());
-  return injectBeforeBodyEnd(withStyle, buildManualEditBridge(false));
-}
-
-function injectAfterHeadOpen(doc: string, payload: string): string {
-  if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (m) => `${m}${payload}`);
-  return payload + doc;
+  const withStyle = injectBeforeHeadEnd(doc, buildManualEditBridgeStyle());
+  return injectBeforeBodyEnd(withStyle, buildManualEditBridge(true));
 }
 
 function injectBeforeHeadEnd(doc: string, payload: string): string {
-  // String-first: a plain splice before the real </head> (or after <head…>) is
-  // correct for well-formed documents and avoids a full DOMParser parse +
-  // re-serialize. Every bridge calls this, so the parse path was the dominant
-  // srcdoc-build cost; DOMParser is now only the fallback for head-less
-  // fragments where we can't locate an insertion point textually. Find the real
-  // </head> (last one before <body>) to skip </head> literals in <script>/<style>.
+  if (typeof DOMParser !== 'undefined') {
+    try {
+      const parsed = new DOMParser().parseFromString(doc, 'text/html');
+      if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', payload);
+      return serializeHtmlDocument(parsed);
+    } catch { /* DOMParser failed; fall through to string path */ }
+  }
+  // String fallback: find the real </head> (last one before <body>)
+  // to skip </head> literals inside <script>/<style> in <head>.
   const lower = doc.toLowerCase();
   const bodyStart = lower.indexOf('<body');
   const limit = bodyStart >= 0 ? bodyStart : lower.length;
   const idx = lower.lastIndexOf('</head>', limit - 1);
   if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
   if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (m) => `${m}${payload}`);
-  // No recognizable <head>: let DOMParser normalize (it synthesizes a head).
-  if (typeof DOMParser !== 'undefined') {
-    try {
-      const parsed = new DOMParser().parseFromString(doc, 'text/html');
-      if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', payload);
-      return serializeHtmlDocument(parsed);
-    } catch { /* fall through to prepend */ }
-  }
   return payload + doc;
 }
 
 function injectBeforeBodyEnd(doc: string, payload: string): string {
-  // String-first (see injectBeforeHeadEnd). Find the real </body> (last one
-  // before </html>) to skip </body> literals inside <script>/<style>.
-  const lower = doc.toLowerCase();
-  const htmlEnd = lower.lastIndexOf('</html>');
-  const limit = htmlEnd >= 0 ? htmlEnd : lower.length;
-  const idx = lower.lastIndexOf('</body>', limit - 1);
-  if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
-  // No recognizable </body>: let DOMParser normalize (it synthesizes a body).
   if (typeof DOMParser !== 'undefined') {
     try {
       const parsed = new DOMParser().parseFromString(doc, 'text/html');
       if (parsed.body) parsed.body.insertAdjacentHTML('beforeend', payload);
       return serializeHtmlDocument(parsed);
-    } catch { /* fall through to append */ }
+    } catch { /* DOMParser failed; fall through to string path */ }
   }
+  // String fallback: find the real </body> (last one before </html>)
+  // to skip </body> literals inside <script>/<style> in <body>.
+  const lower = doc.toLowerCase();
+  const htmlEnd = lower.lastIndexOf('</html>');
+  const limit = htmlEnd >= 0 ? htmlEnd : lower.length;
+  const idx = lower.lastIndexOf('</body>', limit - 1);
+  if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
   return doc + payload;
 }
 
@@ -1110,49 +1225,6 @@ function injectSandboxShim(doc: string): string {
   return shim + doc;
 }
 
-function injectPreviewFocusGuard(doc: string): string {
-  const script = `<script data-od-preview-focus-guard>(function(){
-  var lastTrustedInputAt = 0;
-  function userActivated(){
-    return Date.now() - lastTrustedInputAt < 1000;
-  }
-  function markTrustedInput(event){
-    if (event && event.isTrusted) lastTrustedInputAt = Date.now();
-  }
-  document.addEventListener('pointerdown', function(event){
-    markTrustedInput(event);
-  }, true);
-  document.addEventListener('keydown', function(event){
-    markTrustedInput(event);
-  }, true);
-  try {
-    var nativeWindowFocus = window.focus && window.focus.bind(window);
-    Object.defineProperty(window, 'focus', {
-      configurable: true,
-      writable: true,
-      value: function(){
-        if (userActivated() && nativeWindowFocus) return nativeWindowFocus();
-      }
-    });
-  } catch (_) {}
-  try {
-    var nativeElementFocus = HTMLElement.prototype.focus;
-    Object.defineProperty(HTMLElement.prototype, 'focus', {
-      configurable: true,
-      writable: true,
-      value: function(options){
-        if (userActivated()) return nativeElementFocus.call(this, options);
-      }
-    });
-  } catch (_) {}
-})();</script>`;
-  if (/<head[^>]*>/i.test(doc))
-    return doc.replace(/<head[^>]*>/i, (m) => `${m}${script}`);
-  if (/<body[^>]*>/i.test(doc))
-    return doc.replace(/<body[^>]*>/i, (m) => `${m}${script}`);
-  return script + doc;
-}
-
 // Selection bridge: shared substrate for Comment mode and Inspect mode.
 // Both modes pick a [data-od-id] / [data-screen-label] element on click;
 // the difference is what the host does with the selection — annotate
@@ -1210,7 +1282,6 @@ function injectSelectionBridge(
   var hoveredId = null;
   var drawing = false;
   var stroke = [];
-  var strokeFrame = null;
   var postTargetsTimer = null;
   // overrides[elementId] = { selector: '[data-od-id="x"]', props: { color: '#fff', ... } }
   var overrides = Object.create(null);
@@ -1238,21 +1309,6 @@ function injectSelectionBridge(
   // brackets (close the <style> tag), and newlines (defense in depth).
   var UNSAFE_VALUE = /[;{}<>\\n\\r]/;
   function active(){ return commentEnabled || inspectEnabled; }
-  function deckSlideIndexForPayload(){
-    try {
-      var state = window.__odDeckSlideState && window.__odDeckSlideState();
-      if (state && typeof state.active === 'number' && state.count > 1) return state.active;
-    } catch (_) {}
-    return null;
-  }
-  function elementVisibleForComment(el, rect){
-    if (!el || !rect || rect.width <= 0 || rect.height <= 0) return false;
-    try {
-      var cs = window.getComputedStyle(el);
-      if (cs.display === 'none' || cs.visibility === 'hidden' || Number(cs.opacity) === 0) return false;
-    } catch (_) {}
-    return true;
-  }
   function esc(value){ try { return window.CSS && CSS.escape ? CSS.escape(value) : String(value).replace(/"/g, '\\\\"'); } catch (_) { return String(value); } }
   // Recompute the selector from elementId rather than trusting the one in
   // the inbound message — a forged selector like
@@ -1423,7 +1479,7 @@ function meaningfulDomFallbackTarget(el) {
 
   var tag = el.tagName ? el.tagName.toLowerCase() : '';
 
-  if (/^(a|button|input|textarea|select|label|img|video|canvas|h1|h2|h3|h4|h5|h6|p|li|td|th)$/.test(tag)) {
+  if (/^(a|button|input|textarea|select|label|img|video|canvas|h1|h2|h3|h4|h5|h6|p|li|td|th|section|article|main|aside|nav)$/.test(tag)) {
     return true;
   }
 
@@ -1452,13 +1508,9 @@ function meaningfulDomFallbackTarget(el) {
   var text = (el.textContent || '').replace(/\s+/g, ' ').trim();
   if (!text) return false;
 
-  if (/^(span|strong|em|b|i|small|code|mark)$/.test(tag)) return true;
-
   var meaningfulChildren = 0;
   for (var child = el.firstElementChild;child;child = child.nextElementSibling) {
-    var childTag = child.tagName ? child.tagName.toLowerCase() : '';
-    if (/^(script|style|template|meta|link|title|noscript)$/.test(childTag)) continue;
-    if ((child.textContent || '').replace(/\s+/g, ' ').trim() || /^(img|video|canvas|svg|input|textarea|select)$/.test(childTag)) {
+    if ((child.textContent || '').replace(/\s+/g, ' ').trim()) {
       meaningfulChildren++;
       if (meaningfulChildren > 1) return false;
     }
@@ -1466,12 +1518,8 @@ function meaningfulDomFallbackTarget(el) {
 
   return true;
 }
-  function generatedRootAnnotation(el, id){
-    return id === 'path-0' && el && el.parentElement === document.body && el.id === 'root';
-  }
-  function targetFrom(el, allowDomFallback, clickedEl, clickPoint){
+  function targetFrom(el, allowDomFallback, clickedEl){
     var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
-    if (allowDomFallback && id && generatedRootAnnotation(el, id)) return null;
     var selector = annotatedSelectorFor(el);
     if (!id && allowDomFallback && meaningfulDomFallbackTarget(el)) {
       selector = domSelectorFor(el);
@@ -1483,23 +1531,16 @@ function meaningfulDomFallbackTarget(el) {
     var cls = typeof el.className === 'string' && el.className.trim() ? '.' + el.className.trim().split(/\\s+/).slice(0,2).join('.') : '';
     var html = '';
     try { html = (el.outerHTML || '').replace(/\\s+/g, ' ').match(/^<[^>]+>/)?.[0] || ''; } catch (_) {}
-    var position = { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) };
-    if (!elementVisibleForComment(el, position)) return null;
     var payload = {
       type: 'od:comment-target',
       elementId: id,
       selector: selector,
       label: tag + cls,
       text: (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 160),
-      position: position,
+      position: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) },
       htmlHint: html.slice(0, 180),
       style: styleSnapshot(el)
     };
-    var slideIndex = deckSlideIndexForPayload();
-    if (typeof slideIndex === 'number') payload.slideIndex = slideIndex;
-    if (clickPoint) {
-      payload.hoverPoint = { x: Math.round(clickPoint.x), y: Math.round(clickPoint.y) };
-    }
     if (clickedEl && clickedEl !== el) {
       var clickedTag = clickedEl.tagName ? clickedEl.tagName.toLowerCase() : 'element';
       var clickedCls = typeof clickedEl.className === 'string' && clickedEl.className.trim() ? '.' + clickedEl.className.trim().split(/\\s+/).slice(0,2).join('.') : '';
@@ -1529,34 +1570,8 @@ function meaningfulDomFallbackTarget(el) {
   }
   var postTargetsPending = false;
   var postPreviewScrollPending = false;
-  var postActiveTargetPending = false;
-  var activeCommentElementId = null;
-  var activeCommentSelector = null;
   function previewScrollElement(){
     return document.querySelector('.design-canvas') || document.scrollingElement || document.documentElement;
-  }
-  function previewScrollBy(left, top){
-    var dx = Number(left || 0);
-    var dy = Number(top || 0);
-    if (!Number.isFinite(dx)) dx = 0;
-    if (!Number.isFinite(dy)) dy = 0;
-    if (!dx && !dy) return;
-    var el = previewScrollElement();
-    if (!el) return;
-    try {
-      if (typeof el.scrollBy === 'function') el.scrollBy({ left: dx, top: dy, behavior: 'auto' });
-      else {
-        el.scrollLeft = (el.scrollLeft || 0) + dx;
-        el.scrollTop = (el.scrollTop || 0) + dy;
-      }
-    } catch (_) {
-      try {
-        el.scrollLeft = (el.scrollLeft || 0) + dx;
-        el.scrollTop = (el.scrollTop || 0) + dy;
-      } catch (__) {}
-    }
-    schedulePostTargets();
-    schedulePostPreviewScroll();
   }
   function postPreviewScroll(){
     var el = previewScrollElement();
@@ -1581,34 +1596,6 @@ function meaningfulDomFallbackTarget(el) {
   function requestPreviewScrollRestore(){
     window.parent.postMessage({ type: 'od:preview-scroll-request' }, '*');
   }
-  function findCommentTargetByIdentity(elementId, selector){
-    var el = null;
-    if (selector) {
-      try { el = document.querySelector(String(selector)); } catch (_) { el = null; }
-    }
-    if (!el && elementId) {
-      try {
-        var id = String(elementId).replace(/"/g, '\\"');
-        el = document.querySelector('[data-od-id="' + id + '"], [data-screen-label="' + id + '"]');
-      } catch (_) { el = null; }
-    }
-    return el;
-  }
-  function postActiveCommentTarget(){
-    if (!active() || !activeCommentElementId) return;
-    var el = findCommentTargetByIdentity(activeCommentElementId, activeCommentSelector);
-    if (!el) return;
-    var payload = targetFrom(el, commentEnabled && mode === 'picker' && !inspectEnabled);
-    if (payload) window.parent.postMessage(Object.assign({}, payload, { type: 'od:comment-active-target-update' }), '*');
-  }
-  function schedulePostActiveCommentTarget(){
-    if (!active() || !activeCommentElementId || postActiveTargetPending) return;
-    postActiveTargetPending = true;
-    window.requestAnimationFrame(function(){
-      postActiveTargetPending = false;
-      postActiveCommentTarget();
-    });
-  }
   function postTargets(){
     if (!active()) return;
     window.parent.postMessage({ type: 'od:comment-targets', targets: allTargets() }, '*');
@@ -1631,79 +1618,22 @@ function meaningfulDomFallbackTarget(el) {
   function postStroke(type){
     window.parent.postMessage({ type: type, points: stroke.slice() }, '*');
   }
-  // Coalesce live stroke updates to one post per frame. The stroke array still
-  // grows synchronously on every pointermove, but the host (which re-renders
-  // the comment overlay on each od:pod-stroke) only sees ~60 updates/sec
-  // instead of one per raw pointer event.
-  function schedulePostStroke(){
-    if (strokeFrame !== null) return;
-    strokeFrame = requestAnimationFrame(function(){
-      strokeFrame = null;
-      postStroke('od:pod-stroke');
-    });
-  }
   function canUseDomFallback(){
-    return commentEnabled && !inspectEnabled;
-  }
-  function eventCandidateElements(event){
-    var items = [];
-    function push(node){
-      if (!node || node.nodeType !== 1) return;
-      if (items.indexOf(node) >= 0) return;
-      items.push(node);
-    }
-    try {
-      if (event && typeof event.composedPath === 'function') {
-        var path = event.composedPath();
-        for (var i = 0; i < path.length; i++) push(path[i]);
-      }
-    } catch (_) {}
-    push(event && event.target);
-    try {
-      if (
-        event &&
-        typeof event.clientX === 'number' &&
-        typeof event.clientY === 'number' &&
-        document.elementsFromPoint
-      ) {
-        var stack = document.elementsFromPoint(event.clientX, event.clientY);
-        for (var s = 0; s < stack.length; s++) push(stack[s]);
-      } else if (
-        event &&
-        typeof event.clientX === 'number' &&
-        typeof event.clientY === 'number' &&
-        document.elementFromPoint
-      ) {
-        push(document.elementFromPoint(event.clientX, event.clientY));
-      }
-    } catch (_) {}
-    return items;
+    return commentEnabled && !inspectEnabled && document.querySelectorAll('[data-od-id], [data-screen-label]').length === 0;
   }
   function closestTarget(event){
-    var candidates = eventCandidateElements(event);
+    var clicked = event.target;
+    var el = clicked;
+    var fallback = null;
     var allowDomFallback = mode === 'picker' && canUseDomFallback();
-    var annotatedFallback = null;
-    for (var i = 0; i < candidates.length; i++) {
-      var clicked = candidates[i];
-      var el = clicked;
-      while (el && el !== document.documentElement) {
-        if (allowDomFallback && meaningfulDomFallbackTarget(el)) {
-          return { target: el, clicked: clicked };
-        }
-        if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) {
-          var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
-          if (allowDomFallback && generatedRootAnnotation(el, id)) {
-            el = el.parentElement;
-            continue;
-          }
-          if (allowDomFallback && !annotatedFallback) annotatedFallback = { target: el, clicked: clicked };
-          if (allowDomFallback) break;
-          return { target: el, clicked: clicked };
-        }
-        el = el.parentElement;
+    while (el && el !== document.documentElement) {
+      if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) {
+        return { target: el, clicked: clicked };
       }
+      if (!fallback && allowDomFallback && meaningfulDomFallbackTarget(el)) fallback = el;
+      el = el.parentElement;
     }
-    return annotatedFallback;
+    return fallback ? { target: fallback, clicked: clicked } : null;
   }
   function applyOverride(elementId, selector, prop, value){
     if (!elementId || !prop) return;
@@ -1740,11 +1670,7 @@ function meaningfulDomFallbackTarget(el) {
       document.documentElement.toggleAttribute('data-od-comment-mode', commentEnabled);
       document.documentElement.setAttribute('data-od-comment-mode-kind', mode);
       if (active()) setTimeout(postTargets, 0);
-      else {
-        hoveredId = null;
-        activeCommentElementId = null;
-        activeCommentSelector = null;
-      }
+      else hoveredId = null;
       if (!commentEnabled || mode !== 'pod') {
         drawing = false;
         stroke = [];
@@ -1760,17 +1686,6 @@ function meaningfulDomFallbackTarget(el) {
       setTimeout(postPreviewScroll, 0);
       return;
     }
-    if (data.type === 'od:comment-active-target') {
-      activeCommentElementId = data.elementId ? String(data.elementId) : null;
-      activeCommentSelector = data.selector ? String(data.selector) : null;
-      schedulePostActiveCommentTarget();
-      return;
-    }
-    if (data.type === 'od:preview-scroll-by') {
-      previewScrollBy(data.left, data.top);
-      return;
-    }
-
     if (data.type === 'od:inspect-mode') {
       inspectEnabled = !!data.enabled;
       document.documentElement.toggleAttribute('data-od-inspect-mode', inspectEnabled);
@@ -1854,14 +1769,8 @@ function meaningfulDomFallbackTarget(el) {
     if (result) {
       ev.preventDefault();
       ev.stopPropagation();
-      var commentPickerClick = commentEnabled && mode === 'picker' && !inspectEnabled;
-      var clickPoint = commentPickerClick ? { x: ev.clientX, y: ev.clientY } : null;
-      var payload = targetFrom(result.target, commentPickerClick, result.clicked, clickPoint);
-      if (payload) {
-        activeCommentElementId = payload.elementId || activeCommentElementId;
-        activeCommentSelector = payload.selector || activeCommentSelector;
-        window.parent.postMessage(payload, '*');
-      }
+      var payload = targetFrom(result.target, commentEnabled && mode === 'picker' && !inspectEnabled, result.clicked);
+      if (payload) window.parent.postMessage(payload, '*');
       return;
     }
     // Free-pin fallback (comment mode only). Lets users drop a comment
@@ -1886,23 +1795,19 @@ function meaningfulDomFallbackTarget(el) {
     var pinX = Math.round(ev.clientX);
     var pinY = Math.round(ev.clientY);
     var pinId = 'pin-' + Date.now().toString(36) + '-' + Math.floor(Math.random() * 1e6).toString(36);
-    var pinSlideIndex = deckSlideIndexForPayload();
-    var pinPayload = {
+    window.parent.postMessage({
       type: 'od:comment-target',
+      elementId: pinId,
       // Synthetic selector / label so daemon upsert validation (which
       // requires both to be non-empty) accepts the saved free-pin.
       selector: '[data-od-pin="' + pinId + '"]',
       label: 'pin',
       text: '',
       position: { x: pinX - 12, y: pinY - 12, width: 24, height: 24 },
-      hoverPoint: { x: pinX, y: pinY },
       htmlHint: '',
       style: null,
       freePin: true
-    };
-    pinPayload.elementId = pinId;
-    if (typeof pinSlideIndex === 'number') pinPayload.slideIndex = pinSlideIndex;
-    window.parent.postMessage(pinPayload, '*');
+    }, '*');
   }, true);
   // Pod drawing — only active in comment mode with the 'pod' tool.
   document.addEventListener('pointerdown', function(ev){
@@ -1921,12 +1826,11 @@ function meaningfulDomFallbackTarget(el) {
     stroke.push(point);
     ev.preventDefault();
     ev.stopPropagation();
-    schedulePostStroke();
+    postStroke('od:pod-stroke');
   }, true);
   function finishStroke(ev){
     if (!drawing || mode !== 'pod') return;
     drawing = false;
-    if (strokeFrame !== null) { cancelAnimationFrame(strokeFrame); strokeFrame = null; }
     if (ev) {
       ev.preventDefault();
       ev.stopPropagation();
@@ -1937,24 +1841,11 @@ function meaningfulDomFallbackTarget(el) {
   document.addEventListener('pointercancel', finishStroke, true);
   window.addEventListener('resize', schedulePostTargets);
   document.addEventListener('scroll', function(){
-    schedulePostActiveCommentTarget();
     schedulePostTargets();
     schedulePostPreviewScroll();
   }, true);
   var mo = new MutationObserver(schedulePostTargets);
-  // childList only — NOT attributes/characterData. Re-walking every annotated
-  // target on every attribute/text mutation made an animated artifact (inline
-  // style/text changes per frame) churn schedulePostTargets continuously while
-  // in comment/inspect mode. Structural changes (childList) still re-walk, and
-  // scroll/resize already re-post geometry for layout shifts.
-  mo.observe(document.documentElement, { subtree: true, childList: true });
-  // The active comment marker still has to follow its own element's text and
-  // attribute edits, but schedulePostActiveCommentTarget re-posts exactly ONE
-  // element (the active comment), so it stays cheap even on animated artifacts —
-  // unlike the full allTargets() re-walk above. This is why attributes/
-  // characterData live on this targeted observer instead of the main observer.
-  var textMo = new MutationObserver(schedulePostActiveCommentTarget);
-  textMo.observe(document.documentElement, { subtree: true, characterData: true, attributes: true });
+  mo.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true });
   // Reflect the host-requested initial modes on the documentElement so
   // the cursor/hover styles match what the bridge picks up on click.
   if (commentEnabled) document.documentElement.toggleAttribute('data-od-comment-mode', true);
@@ -1970,7 +1861,6 @@ function meaningfulDomFallbackTarget(el) {
   setTimeout(requestPreviewScrollRestore, 0);
   setTimeout(requestPreviewScrollRestore, 80);
   setTimeout(requestPreviewScrollRestore, 240);
-  window.__odScheduleCommentTargets = schedulePostTargets;
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', postTargets);
   else setTimeout(postTargets, 0);
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', postPreviewScroll);
@@ -2045,80 +1935,13 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (structured.length) return structured;
     return document.querySelectorAll('.slide');
   }
-  function scrollOverflow(el){
-    if (!el) return 0;
-    return Math.max(0, (el.scrollWidth || 0) - (el.clientWidth || 0));
-  }
-  function overflowMode(el){
-    if (!el || !window.getComputedStyle) return '';
-    try {
-      return String(window.getComputedStyle(el).overflowX || '').toLowerCase();
-    } catch (_) {
-      return '';
-    }
-  }
-  function isScrollableOverflowMode(mode){
-    return mode === 'auto' || mode === 'scroll' || mode === 'overlay';
-  }
-  function isClippedOverflowMode(mode){
-    return mode === 'hidden' || mode === 'clip';
-  }
-  function isRootScrollContainer(el){
-    return !!el && (
-      el === document.scrollingElement ||
-      el === document.documentElement ||
-      el === document.body
-    );
-  }
-  function rootScrollerClipped(){
-    return isClippedOverflowMode(overflowMode(document.documentElement)) ||
-      isClippedOverflowMode(overflowMode(document.body));
-  }
-  function scrollLeftOf(el){
-    if (!el) return 0;
-    try {
-      return Number(el.scrollLeft) || 0;
-    } catch (_) {
-      return 0;
-    }
-  }
-  function scrollTargets(){
-    var targets = [];
-    function add(node){
-      if (!node) return;
-      for (var i=0; i<targets.length; i++) if (targets[i] === node) return;
-      targets.push(node);
-    }
-    add(document.scrollingElement);
-    add(document.documentElement);
-    add(document.body);
-    return targets;
-  }
-  function maxScrollLeft(){
-    var targets = scrollTargets();
-    var value = 0;
-    for (var i=0; i<targets.length; i++) {
-      value = Math.max(value, Number(targets[i].scrollLeft || 0));
-    }
-    return value;
-  }
-  function hasHorizontalScroll(){
-    var targets = scrollTargets();
-    for (var i=0; i<targets.length; i++) {
-      if (targets[i].scrollWidth > targets[i].clientWidth + 1) return true;
-    }
-    return false;
+  function scroller(){
+    if (document.body && document.body.scrollWidth > document.body.clientWidth + 1) return document.body;
+    return document.scrollingElement || document.documentElement;
   }
   function isScrollDeck(){
-    var targets = scrollTargets();
-    for (var i=0; i<targets.length; i++) {
-      var candidate = targets[i];
-      if (scrollOverflow(candidate) <= 1) continue;
-      var mode = overflowMode(candidate);
-      if (isScrollableOverflowMode(mode)) return true;
-      if (isRootScrollContainer(candidate) && !isClippedOverflowMode(mode) && !rootScrollerClipped()) return true;
-    }
-    return false;
+    var sc = scroller();
+    return !!(sc && sc.scrollWidth > sc.clientWidth + 1);
   }
   function findActiveByClass(list){
     for (var i=0; i<list.length; i++) {
@@ -2140,10 +1963,8 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (!list || !list.length) return 0;
     if (isScrollDeck()) {
       var w = Math.max(1, window.innerWidth);
-      return Math.max(0, Math.min(list.length - 1, Math.round(maxScrollLeft() / w)));
+      return Math.max(0, Math.min(list.length - 1, Math.round(scroller().scrollLeft / w)));
     }
-    var byTransform = activeIndexFromTransform(list);
-    if (byTransform >= 0) return byTransform;
     var byClass = findActiveByClass(list);
     if (byClass >= 0) return byClass;
     var byVis = findActiveByVisibility(list);
@@ -2151,17 +1972,10 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     return 0;
   }
   function dispatchKey(key){
-    // Try window first: many deck frameworks listen on both window and
-    // document in capture phase for iframe focus resilience. Dispatching a
-    // bubbling event at document hits the document listener and then the
-    // window listener, turning one host "next" request into two slide moves.
+    // Bubbles so any listener on window picks it up too. We dispatch on
+    // document only — dispatching on window/body in addition would cause
+    // bubbling to fire the same document-level listener twice.
     var init = { key: key, code: key, bubbles: true, cancelable: true, composed: true };
-    var before = activeIndex(slides());
-    try {
-      window.dispatchEvent(new KeyboardEvent('keydown', init));
-      window.dispatchEvent(new KeyboardEvent('keyup', init));
-    } catch (_) {}
-    if (activeIndex(slides()) !== before) return;
     try {
       document.dispatchEvent(new KeyboardEvent('keydown', init));
       document.dispatchEvent(new KeyboardEvent('keyup', init));
@@ -2177,80 +1991,14 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     }
     return 'active';
   }
-  function hasComputedHiddenSibling(list, active){
-    if (active < 0) return false;
-    for (var i=0; i<list.length; i++) {
-      if (i === active) continue;
-      try {
-        var cs = window.getComputedStyle(list[i]);
-        if (cs.display === 'none' || cs.visibility === 'hidden' || cs.opacity === '0') return true;
-      } catch (_) {}
-    }
-    return false;
-  }
   function canSetActive(list){
-    // A bare active-class marker is not enough to prove the host can drive the
-    // deck by class mutation alone. Many generated decks keep that marker in
-    // sync for counters / dots but move the visible slide via a translated
-    // stage or track, so flipping classes in the host bridge updates the
-    // reported slide index while leaving the canvas on the old page. Only
-    // treat class-driven decks as directly mutable when inactive siblings are
-    // actually hidden by computed visibility rules.
-    var active = findActiveByClass(list);
-    if (active >= 0 && hasComputedHiddenSibling(list, active)) return true;
+    if (findActiveByClass(list) >= 0) return true;
     for (var i=0; i<list.length; i++) {
       if (list[i].style.display === 'none') return true;
       if (list[i].style.visibility === 'hidden') return true;
       if (list[i].hasAttribute('hidden')) return true;
     }
     return false;
-  }
-  function transformTrack(list){
-    if (!list || !list.length) return null;
-    var first = list[0];
-    var node = first && first.parentElement;
-    while (node && node !== document.body && node !== document.documentElement) {
-      try {
-        var directSlides = 0;
-        for (var i=0; i<node.children.length; i++) {
-          if (node.children[i].classList && node.children[i].classList.contains('slide')) directSlides += 1;
-        }
-        var style = window.getComputedStyle(node);
-        if (
-          directSlides >= list.length &&
-          (
-            node.style.transform ||
-            style.transform !== 'none' ||
-            /\\b(?:flex|grid)\\b/i.test(style.display)
-          )
-        ) {
-          return node;
-        }
-      } catch (_) {}
-      node = node.parentElement;
-    }
-    return null;
-  }
-  function activeIndexFromTransform(list){
-    var track = transformTrack(list);
-    if (!track) return -1;
-    var raw = track.style.transform || '';
-    var match = raw.match(/translateX\\(\\s*(-?[0-9.]+)\\s*(vw|%)\\s*\\)/i);
-    if (!match) return -1;
-    var value = parseFloat(match[1]);
-    if (!Number.isFinite(value)) return -1;
-    return Math.max(0, Math.min(list.length - 1, Math.round(Math.abs(value) / 100)));
-  }
-  function transformGo(i){
-    var list = slides();
-    var track = transformTrack(list);
-    if (!track) return false;
-    var target = Math.max(0, Math.min(list.length - 1, i));
-    var unit = /translateX\\(\\s*-?[0-9.]+\\s*%\\s*\\)/i.test(track.style.transform || '') ? '%' : 'vw';
-    track.style.transform = 'translateX(' + (-target * 100) + unit + ')';
-    updateDeckChrome(target, list.length);
-    report();
-    return true;
   }
   function updateDeckChrome(i, count){
     var cur = document.getElementById('deck-cur');
@@ -2270,25 +2018,15 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     var usesInlineDisplay = false;
     var usesInlineVisibility = false;
     var usesHidden = false;
-    // Many reveal-animation decks (the frontend-slides family) gate their
-    // staggered entrances on a SEPARATE \`.visible\` class — \`.slide.visible
-    // .reveal { opacity: 1 }\` — that the deck's own show() adds alongside
-    // \`.active\`. Driving navigation by flipping only the active class shows
-    // the slide chrome but leaves every .reveal child stuck at opacity:0, so
-    // the body renders blank. Mirror \`.visible\` in lock-step with the active
-    // slide (only for decks that actually use it, so it is a no-op elsewhere).
-    var usesVisibleClass = false;
     for (var j=0; j<list.length; j++) {
       usesInlineDisplay = usesInlineDisplay || list[j].style.display === 'none';
       usesInlineVisibility = usesInlineVisibility || list[j].style.visibility === 'hidden';
       usesHidden = usesHidden || list[j].hasAttribute('hidden');
-      usesVisibleClass = usesVisibleClass || (list[j].classList && list[j].classList.contains('visible'));
     }
     for (var k=0; k<list.length; k++) {
       if (list[k].classList) {
         list[k].classList.remove('active', 'is-active', 'current');
         if (k === target) list[k].classList.add(activeClass);
-        if (usesVisibleClass) list[k].classList.toggle('visible', k === target);
       }
       if (usesHidden) {
         if (k === target) list[k].removeAttribute('hidden');
@@ -2308,15 +2046,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   function scrollGo(i){
     var list = slides();
     var next = Math.max(0, Math.min(list.length - 1, i));
-    var left = next * window.innerWidth;
-    var targets = scrollTargets();
-    for (var t=0; t<targets.length; t++) {
-      try {
-        targets[t].scrollTo({ left: left, behavior: 'smooth' });
-      } catch (_) {
-        try { targets[t].scrollLeft = left; } catch (__) {}
-      }
-    }
+    scroller().scrollTo({ left: next * window.innerWidth, behavior: 'smooth' });
     setTimeout(report, 380);
   }
   function targetFor(action, list){
@@ -2336,7 +2066,6 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       return;
     }
     if (canSetActive(list) && setActive(target)) return;
-    if (transformGo(target)) return;
     if (action === 'next') dispatchKey('ArrowRight');
     else if (action === 'prev') dispatchKey('ArrowLeft');
     else if (action === 'first') dispatchKey('Home');
@@ -2349,7 +2078,6 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     var target = Math.max(0, Math.min(list.length - 1, i));
     if (isScrollDeck()) { scrollGo(target); return; }
     if (canSetActive(list) && setActive(target)) return;
-    if (transformGo(target)) return;
     var current = activeIndex(list);
     var diff = target - current;
     if (!diff) { report(); return; }
@@ -2358,13 +2086,11 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     for (var k = 0; k < n; k++) dispatchKey(key);
     setTimeout(report, 320);
   }
-  var lastCommentTargetSlideIndex = -1;
   function report(){
     try {
       var list = slides();
       var i = activeIndex(list);
       var count = list.length;
-      var progressWidth = count ? ((i + 1) / count * 100) + '%' : '0';
       window.parent.postMessage({
         type: 'od:slide-state',
         active: i,
@@ -2373,25 +2099,11 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       document.querySelectorAll('.slide-number').forEach(function(el){
         el.setAttribute('data-current',i+1); el.setAttribute('data-total',count);
       });
-      document.querySelectorAll('.progress-bar>span,.deck-progress>span,.deck-progress .bar').forEach(function(el){
-        el.style.width=progressWidth;
+      document.querySelectorAll('.progress-bar>span').forEach(function(el){
+        el.style.width=(count?((i+1)/count*100)+'%':'0');
       });
-      document.querySelectorAll('.deck-progress').forEach(function(el){
-        if (el.querySelector('span,.bar')) return;
-        el.style.width=progressWidth;
-      });
-      if (i !== lastCommentTargetSlideIndex) {
-        lastCommentTargetSlideIndex = i;
-        try {
-          if (typeof window.__odScheduleCommentTargets === 'function') window.__odScheduleCommentTargets();
-        } catch (_) {}
-      }
     } catch (e) {}
   }
-  window.__odDeckSlideState = function(){
-    var list = slides();
-    return { active: activeIndex(list), count: list.length };
-  };
   function restoreInitialSlide(){
     if (didRestoreInitialSlide) { report(); return; }
     var list = slides();
@@ -2596,4 +2308,552 @@ function injectTweaksBridge(doc: string): string {
   if (/<\/head>/i.test(withStyle)) return withStyle.replace(/<\/head>/i, script + '</head>');
   if (/<head[^>]*>/i.test(withStyle)) return withStyle.replace(/<head[^>]*>/i, (m) => m + script);
   return script + withStyle;
+}
+
+/**
+ * Inject the annotation (element-inspect) bridge. It can boot active when
+ * srcdoc is rebuilt for annotation mode, and it still listens for host
+ * `od:annotate-mode` messages after load.
+ */
+function injectAnnotateBridge(doc: string, options: { initialEnabled?: boolean } = {}): string {
+  const initialEnabled = options.initialEnabled ? 'true' : 'false';
+  const script = `<script data-od-annotate-bridge>(function(){
+if(document.documentElement.hasAttribute('data-od-annotate-ready'))return;document.documentElement.setAttribute('data-od-annotate-ready','');
+if(window.__oiCleanup){try{window.__oiCleanup();}catch(_){}}
+var INITIAL_ENABLED=${initialEnabled};
+var SHARE_ORANGE='#bc6a4a',PINK=SHARE_ORANGE,PURPLE=SHARE_ORANGE,CW=312,GAP=10;
+var PP=['display','position','align-items','justify-content','flex-direction','flex-wrap','gap','grid-template-columns','padding','padding-top','padding-right','padding-bottom','padding-left','margin','margin-top','margin-right','margin-bottom','margin-left','border-radius','border-top-left-radius','border-top-right-radius','border-bottom-right-radius','border-bottom-left-radius','border-width','border-style','border-color','background-color','color','font-family','font-size','font-weight','line-height','letter-spacing','text-align','opacity','overflow','box-shadow'];
+var SK={position:'static',opacity:'1',overflow:'visible','border-style':'none','border-width':'0px','border-radius':'0px','border-top-left-radius':'0px','border-top-right-radius':'0px','border-bottom-right-radius':'0px','border-bottom-left-radius':'0px','letter-spacing':'normal','font-weight':'400','background-color':'rgba(0, 0, 0, 0)','text-align':'start',margin:'0px'};
+var CP={'color':1,'background-color':1,'border-color':1};
+var BP={'padding':1,'padding-top':1,'padding-right':1,'padding-bottom':1,'padding-left':1,'margin':1,'margin-top':1,'margin-right':1,'margin-bottom':1,'margin-left':1,'border-radius':1,'border-top-left-radius':1,'border-top-right-radius':1,'border-bottom-right-radius':1,'border-bottom-left-radius':1};
+var css=document.createElement('style');
+css.setAttribute('data-oi','');
+css.textContent='#oi-sel,#oi-hov{position:fixed;pointer-events:none;box-sizing:border-box;z-index:99997;display:none}'
+  +'#oi-sel{border:2px solid var(--oi-accent,#e879a0)}'
+  +'#oi-hov{border:1px solid var(--oi-accent,#e879a0);opacity:.5}'
+  +'#oi-hit{position:fixed;inset:0;z-index:99994;display:none;background:transparent;cursor:crosshair;pointer-events:none}'
+  +'#oi-svg{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:99996;overflow:visible;display:none}'
+  +'#oi-card{position:fixed;z-index:99999;display:none;width:312px;max-height:480px;overflow-y:auto;overflow-x:hidden;background:#fff;border:1px solid rgba(0,0,0,.1);border-radius:10px;box-shadow:0 0 0 .5px rgba(0,0,0,.06),0 4px 6px rgba(0,0,0,.04),0 20px 56px rgba(0,0,0,.16);font-family:ui-monospace,"JetBrains Mono",Menlo,monospace;font-size:11.5px;line-height:1.62;color:#0d0d0d;user-select:text}'
+  +'#oi-card::-webkit-scrollbar{width:3px}'
+  +'#oi-card::-webkit-scrollbar-thumb{background:rgba(0,0,0,.12);border-radius:2px}'
+  +'.oi-hdr{padding:10px 12px 8px;position:sticky;top:0;z-index:2;background:#fff;border-bottom:1px solid rgba(0,0,0,.07);border-radius:10px 10px 0 0;display:flex;align-items:center;justify-content:space-between;gap:6px}'
+  +'.oi-hdr-actions{display:flex;align-items:center;gap:6px;flex-shrink:0}'
+  +'.oi-tag{font-size:11px;font-weight:600;color:#0d0d0d;word-break:break-all}'
+  +'.oi-dim{display:none}'
+  +'.oi-body{padding:8px 0 10px;background:#fff}'
+  +'.oi-row{position:relative;display:grid;grid-template-columns:minmax(96px,.88fr) minmax(120px,1.12fr);column-gap:10px;row-gap:4px;padding:5px 14px 5px 26px;align-items:start}'
+  +'.oi-row:hover{background:rgba(var(--oi-accent-rgb,232,121,160),.07)}'
+  +'.oi-row.active{background:rgba(var(--oi-accent-rgb,232,121,160),.08)}'
+  +'.oi-row.active:before{content:"";position:absolute;left:11px;top:50%;width:6px;height:6px;border-radius:50%;background:var(--oi-accent,#e879a0);transform:translateY(-50%)}'
+  +'.oi-pn{color:var(--oi-accent,#e879a0);font-size:11px;white-space:normal;overflow-wrap:anywhere;line-height:1.55}'
+  +'.oi-pv{text-align:right;font-size:11px;color:#111;display:flex;align-items:flex-start;justify-content:flex-end;gap:5px;min-width:0;white-space:normal;overflow:visible;line-height:1.55}'
+  +'.oi-val{min-width:24px;max-width:160px;overflow:visible;white-space:normal;overflow-wrap:anywhere;outline:none;border-radius:4px;padding:0 2px;cursor:text}'
+  +'.oi-val:focus{background:rgba(var(--oi-accent-rgb,232,121,160),.13);box-shadow:0 0 0 1px rgba(var(--oi-accent-rgb,232,121,160),.45)}'
+  +'.oi-sw{width:10px;height:10px;border-radius:50%;border:1px solid rgba(0,0,0,.14);flex-shrink:0;cursor:pointer}'
+  +'.oi-color-row .oi-val{cursor:text}'
+  +'.oi-color-input{position:absolute;width:1px;height:1px;opacity:0;pointer-events:none}'
+  +'.oi-file-input{position:absolute;width:1px;height:1px;opacity:0;pointer-events:none}'
+  +'.oi-ref{border-top:1px solid rgba(0,0,0,.07);padding:10px 14px 12px}'
+  +'.oi-ref-title{font-size:10px;color:#777;margin-bottom:7px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}'
+  +'.oi-ref-grid{display:flex;flex-wrap:wrap;gap:7px}'
+  +'.oi-image-prompt{border-bottom:1px solid rgba(0,0,0,.07);padding:10px 12px 12px;background:rgba(var(--oi-accent-rgb,232,121,160),.05)}'
+  +'.oi-image-prompt textarea{width:100%;min-height:74px;resize:vertical;box-sizing:border-box;border:1px solid rgba(0,0,0,.14);border-radius:8px;background:#fff;color:#111;padding:8px 9px;font:12px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;outline:none}'
+  +'.oi-image-prompt textarea:focus{border-color:rgba(var(--oi-accent-rgb,232,121,160),.65);box-shadow:0 0 0 3px rgba(var(--oi-accent-rgb,232,121,160),.12)}'
+  +'.oi-image-prompt-foot{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-top:8px}'
+  +'.oi-image-prompt-status{min-width:0;flex:1;color:#777;font:11px/1.35 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;overflow-wrap:anywhere}'
+  +'.oi-image-prompt-status.ok{color:#20865b}'
+  +'.oi-image-prompt-status.err{color:#b6422e}'
+  +'.oi-image-prompt-btn{border:1px solid rgba(var(--oi-accent-rgb,232,121,160),.48);background:rgba(var(--oi-accent-rgb,232,121,160),.1);color:var(--oi-accent,#e879a0);border-radius:999px;padding:5px 10px;font:700 11px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;cursor:pointer;white-space:nowrap}'
+  +'.oi-image-prompt-btn:disabled{opacity:.55;cursor:default}'
+  +'.oi-chip{width:17px;height:17px;border-radius:5px;border:1px solid rgba(0,0,0,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.28);cursor:pointer}'
+  +'.oi-chip:hover{transform:translateY(-1px);box-shadow:0 2px 6px rgba(0,0,0,.14),inset 0 0 0 1px rgba(255,255,255,.28)}'
+  +'.oi-opt{border:1px solid rgba(0,0,0,.13);background:#fff;border-radius:6px;padding:4px 8px;font:11px ui-monospace,Menlo,monospace;color:#111;cursor:pointer;max-width:150px;white-space:normal;overflow-wrap:anywhere;text-align:left;line-height:1.35}'
+  +'.oi-opt:hover{border-color:rgba(var(--oi-accent-rgb,232,121,160),.65);background:rgba(var(--oi-accent-rgb,232,121,160),.08)}'
+  +'.oi-badge{position:fixed;pointer-events:none;z-index:99998;background:var(--oi-distance,#6d28d9);color:#fff;font-family:ui-monospace,monospace;font-size:10px;font-weight:700;padding:2px 7px;border-radius:10px;transform:translate(-50%,-50%);white-space:nowrap}'
+  +'body.oi-mode *{cursor:crosshair!important}'
+  +'body.oi-mode #oi-card,body.oi-mode #oi-card *{cursor:default!important;pointer-events:auto}'
+  +'body.oi-mode #oi-card .oi-hdr{cursor:move!important}'
+  +'body.oi-mode #oi-card .oi-hdr button{cursor:default!important}'
+  +'body.oi-mode #oi-card .oi-val{cursor:text!important}'
+  +'.oi-quad{padding:0}'
+  +'.oi-quad-hd{display:flex;align-items:center;justify-content:space-between;padding:5px 14px 5px 26px;user-select:none}'
+  +'.oi-quad-hd:hover{background:rgba(var(--oi-accent-rgb,232,121,160),.07);cursor:default}'
+  +'.oi-quad-right{display:flex;align-items:center;gap:5px}'
+  +'.oi-quad-sum{color:#111;font-size:11px;font-style:normal}'
+  +'.oi-quad-xbtn{background:none;border:none;padding:1px 5px;cursor:pointer;color:#aaa;font-size:10px;line-height:1;border-radius:3px}'
+  +'.oi-quad-xbtn:hover{color:#555;background:rgba(0,0,0,.06)}'
+  +'.oi-qgrid{display:none;grid-template-columns:1fr 1fr;gap:3px;padding:3px 14px 7px 26px}'
+  +'.oi-quad.open .oi-qgrid{display:grid}'
+  +'.oi-qcell{display:flex;align-items:center;gap:4px;background:rgba(var(--oi-accent-rgb,232,121,160),.05);border:1px solid rgba(var(--oi-accent-rgb,232,121,160),.2);border-radius:4px;padding:0 6px;height:24px;min-width:0}'
+  +'.oi-qicon{color:var(--oi-accent,#e879a0);flex-shrink:0;display:flex;align-items:center;opacity:.8;font-style:normal}'
+  +'.oi-qcell .oi-pv{flex:1;min-width:0;display:flex;align-items:center}'
+  +'.oi-qcell .oi-val{flex:1;min-width:0;outline:none;background:transparent;font:inherit;font-size:11px;color:#111;cursor:text;border-radius:2px;padding:0 2px;text-align:right}'
+  +'.oi-qcell .oi-val:focus{background:rgba(var(--oi-accent-rgb,232,121,160),.13)}'
+  +'#oi-cpk{position:fixed;z-index:100001;display:none;background:#fff;border-radius:14px;width:270px;box-shadow:0 12px 40px rgba(0,0,0,.18),0 0 0 1px rgba(0,0,0,.06);overflow:hidden;user-select:none}'
+  +'.oi-cpk-hdr{display:flex;align-items:center;padding:14px 14px 0;gap:14px;cursor:move;user-select:none}'
+  +'.oi-cpk-tab{border:none;background:transparent;font:600 15px/1.2 system-ui,sans-serif;color:#1a1a1a;cursor:pointer;padding:0;letter-spacing:-.01em}'
+  +'.oi-cpk-tab.active{color:#f54e00}'
+  +'.oi-cpk-sep{flex:1}'
+  +'.oi-cpk-close{width:30px;height:30px;border:1.5px solid #ddd;border-radius:8px;background:#fff;font:17px/1 system-ui,sans-serif;color:#666;cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0;flex-shrink:0}'
+  +'.oi-cpk-close:hover{background:#f5f5f5}'
+  +'.oi-cpk-body{padding:12px 14px 0}'
+  +'.oi-cpk-sv{position:relative;width:100%;height:170px;border-radius:8px;overflow:hidden;cursor:crosshair;margin-bottom:12px}'
+  +'.oi-cpk-sv-bg,.oi-cpk-sv-s,.oi-cpk-sv-v{position:absolute;inset:0}'
+  +'.oi-cpk-sv-s{background:linear-gradient(to right,#fff,transparent)}'
+  +'.oi-cpk-sv-v{background:linear-gradient(to bottom,transparent,#000)}'
+  +'.oi-cpk-svdot{position:absolute;width:14px;height:14px;border-radius:50%;border:2px solid #fff;box-shadow:0 0 0 1px rgba(0,0,0,.35),inset 0 0 0 1px rgba(0,0,0,.1);transform:translate(-50%,-50%);pointer-events:none}'
+  +'.oi-cpk-ctls{display:flex;align-items:center;gap:10px;margin-bottom:10px}'
+  +'.oi-cpk-eye{width:28px;height:28px;border:none;background:transparent;cursor:pointer;padding:0;flex-shrink:0;display:flex;align-items:center;justify-content:center;color:#888;border-radius:5px}'
+  +'.oi-cpk-eye:hover{background:#f0f0f0}'
+  +'.oi-cpk-sliders{flex:1;display:flex;flex-direction:column;gap:8px}'
+  +'.oi-cpk-hue{position:relative;height:12px;border-radius:6px;cursor:pointer;background:linear-gradient(to right,#f00,#ff0,#0f0,#0ff,#00f,#f0f,#f00)}'
+  +'.oi-cpk-atrk{position:relative;height:12px;border-radius:6px;cursor:pointer;background:repeating-linear-gradient(45deg,#ccc,#ccc 5px,#f8f8f8 5px,#f8f8f8 10px)}'
+  +'.oi-cpk-abar{position:absolute;inset:0;border-radius:6px}'
+  +'.oi-cpk-sdot{position:absolute;top:50%;width:16px;height:16px;border-radius:50%;border:2.5px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,.35);transform:translate(-50%,-50%);pointer-events:none}'
+  +'.oi-cpk-inp{display:flex;align-items:center;gap:6px;margin-bottom:12px}'
+  +'.oi-cpk-fmt{border:1.5px solid #e0e0e0;border-radius:7px;padding:5px 8px;font:12px system-ui,sans-serif;color:#333;background:#fafafa;cursor:pointer;white-space:nowrap;flex-shrink:0}'
+  +'.oi-cpk-hexin{flex:1;border:1.5px solid #e0e0e0;border-radius:7px;padding:5px 8px;font:13px ui-monospace,Menlo,monospace;color:#111;background:#fafafa;outline:none;min-width:0;text-transform:uppercase}'
+  +'.oi-cpk-hexin:focus{border-color:#bbb;background:#fff}'
+  +'.oi-cpk-opain{width:40px;border:1.5px solid #e0e0e0;border-radius:7px;padding:5px 4px;font:12px system-ui,sans-serif;color:#111;background:#fafafa;outline:none;text-align:center;-moz-appearance:textfield}'
+  +'.oi-cpk-opain:focus{border-color:#bbb;background:#fff}'
+  +'.oi-cpk-pct{font:12px system-ui,sans-serif;color:#888;flex-shrink:0}'
+  +'.oi-cpk-div{height:1px;background:#f0f0f0}'
+  +'.oi-cpk-pal{padding:10px 14px 12px}'
+  +'.oi-cpk-pal-row{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;font:12px system-ui,sans-serif;color:#555;cursor:pointer}'
+  +'.oi-cpk-pg{display:flex;flex-wrap:wrap;gap:5px}'
+  +'.oi-cpk-pc{width:20px;height:20px;border-radius:5px;border:1.5px solid rgba(0,0,0,.12);cursor:pointer;flex-shrink:0;box-sizing:border-box}'
+  +'.oi-cpk-pc:hover{transform:scale(1.15);box-shadow:0 2px 6px rgba(0,0,0,.18)}'
+  +'.oi-cpk-grad{display:none}'
+  +'.oi-cpk-is-grad .oi-cpk-solid{display:none}'
+  +'.oi-cpk-is-grad .oi-cpk-grad{display:block}'
+  +'.oi-cpk-gbar-wrap{padding:4px 14px 4px}'
+  +'.oi-cpk-gbar{position:relative;height:14px;border-radius:7px;background:repeating-linear-gradient(45deg,#ccc,#ccc 4px,#f8f8f8 4px,#f8f8f8 8px);margin-top:20px;cursor:crosshair;overflow:visible}'
+  +'.oi-cpk-gbar-fill{position:absolute;inset:0;border-radius:7px;pointer-events:none}'
+  +'.oi-cpk-ghandle{position:absolute;top:-19px;width:18px;height:18px;transform:translateX(-50%);cursor:pointer;border-radius:4px;border:2.5px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,.3);box-sizing:border-box}'
+  +'.oi-cpk-ghandle.sel{box-shadow:0 0 0 2.5px #2a7fff,0 1px 4px rgba(0,0,0,.2)}'
+  +'.oi-cpk-gstops-hd{display:flex;align-items:center;justify-content:space-between;padding:8px 14px 6px;font:600 12px system-ui,sans-serif;color:#555}'
+  +'.oi-cpk-gadd{border:none;background:transparent;font:20px/1 system-ui;color:#888;cursor:pointer;padding:0}'
+  +'.oi-cpk-glist{padding:0 14px 12px;display:flex;flex-direction:column;gap:5px;max-height:120px;overflow-y:auto}'
+  +'.oi-cpk-gstop-row{display:flex;align-items:center;gap:4px;border-radius:5px;padding:2px 3px;cursor:pointer}'
+  +'.oi-cpk-gstop-row.sel{background:rgba(42,127,255,.08)}'
+  +'.oi-cpk-gstop-swatch{width:14px;height:14px;border-radius:3px;border:1.5px solid rgba(0,0,0,.15);flex-shrink:0;box-sizing:border-box}'
+  +'.oi-cpk-gstop-hex{flex:1;border:1.5px solid #e0e0e0;border-radius:5px;padding:3px 5px;font:11px ui-monospace,Menlo,monospace;color:#111;background:#fafafa;outline:none;min-width:0;text-transform:uppercase}'
+  +'.oi-cpk-gstop-opa{width:34px;border:1.5px solid #e0e0e0;border-radius:5px;padding:3px 2px;text-align:center;font:11px system-ui;color:#111;background:#fafafa;outline:none;box-sizing:border-box}'
+  +'.oi-cpk-gstop-pct{font:10px system-ui;color:#aaa;flex-shrink:0}'
+  +'.oi-cpk-gstop-pos{width:34px;border:1.5px solid #e0e0e0;border-radius:5px;padding:3px 2px;text-align:center;font:11px system-ui;color:#333;background:#fafafa;outline:none;box-sizing:border-box}'
+  +'.oi-cpk-gstop-del{border:none;background:transparent;font:13px/1 system-ui;color:#ccc;cursor:pointer;padding:0 2px;flex-shrink:0}'
+  +'.oi-cpk-gstop-del:hover{color:#999}'
+  +'.oi-hdr-actions{display:flex;gap:4px;align-items:center}'
+  +'.oi-hdr-btn{border:none;background:transparent;padding:2px 6px;border-radius:3px;font:12px ui-monospace,Menlo,monospace;color:rgba(var(--oi-accent-rgb,232,121,160),.96);cursor:pointer;white-space:nowrap;line-height:1.35;font-weight:700}'
+  +'.oi-hdr-key{opacity:.78;font-size:12px;margin-right:5px;font-weight:700}'
+  +'.oi-hdr-btn:hover{background:rgba(var(--oi-accent-rgb,232,121,160),.1)}'
+  +'.oi-shot{position:fixed;z-index:100000;pointer-events:none;border-radius:10px;background:rgba(0,0,0,.82);box-shadow:0 0 0 9999px rgba(0,0,0,.08),0 0 0 1px rgba(255,255,255,.72) inset;animation:oi-shot-flash 280ms cubic-bezier(.23,1,.32,1) both}'
+  +'.oi-shot-fly{position:fixed;z-index:100001;pointer-events:none;overflow:hidden;border-radius:10px;background:#fff;box-shadow:0 18px 46px rgba(0,0,0,.28),0 0 0 1px rgba(255,255,255,.82) inset;transform-origin:center;animation:oi-shot-fly 1200ms cubic-bezier(.23,1,.32,1) both}'
+  +'.oi-shot-fly>*{pointer-events:none!important;margin:0!important;max-width:none!important;max-height:none!important}'
+  +'@keyframes oi-shot-flash{0%{opacity:0;transform:scale(.985)}34%{opacity:.88;transform:scale(1)}100%{opacity:0;transform:scale(1.01)}}'
+  +'@keyframes oi-shot-fly{0%{opacity:0;transform:translate(0,0) scale(1)}12%{opacity:1;transform:translate(0,-8px) scale(.98)}48%{opacity:1;transform:translate(calc(var(--oi-fly-x)*.38),calc(var(--oi-fly-y)*.18 - 26px)) scale(.56);border-radius:18px}100%{opacity:0;transform:translate(var(--oi-fly-x),var(--oi-fly-y)) scale(.12);border-radius:999px}}';
+document.head.appendChild(css);
+function mk(tag,id){var el=document.createElement(tag);if(id)el.id=id;document.body.appendChild(el);return el;}
+var act=false,sel=null,selR=null,bgs=[],pickedEvents=new WeakSet(),imagePromptTarget=null;
+var ready=false,currentProps=[],activeProp='';
+var L={uploadImage:'⌘M 截屏',imageRef:'Image',textRef:'Text references',colorRef:'Design system colors',refOptions:'Options',imagePrompt:'输入 prompt 重新生成这张图片',regenerateImage:'重新生成图片'};
+function boot(){
+  if(ready||!document.body)return;ready=true;
+  document.querySelectorAll('#oi-hit,#oi-sel,#oi-hov,#oi-svg,#oi-card,.oi-badge,.oi-shot,.oi-shot-fly').forEach(function(el){el.remove();});
+  var hit=mk('div','oi-hit'),selB=mk('div','oi-sel'),hovB=mk('div','oi-hov');
+  var svgEl=document.createElementNS('http://www.w3.org/2000/svg','svg');
+  svgEl.id='oi-svg';svgEl.setAttribute('xmlns','http://www.w3.org/2000/svg');document.body.appendChild(svgEl);
+  var card=mk('div','oi-card');
+  var cardDrag=null;
+  function isHost(el){return !!(el&&el.matches&&el.matches('#oi-hit,#oi-sel,#oi-hov,#oi-svg,#oi-card,.oi-badge,[data-oi],[data-od-annotate-bridge]'));}
+  function domPath(el){var parts=[],node=el;while(node&&node!==document.body){var parent=node.parentElement;if(!parent)break;var children=Array.prototype.slice.call(parent.children).filter(function(child){return!isHost(child);});parts.unshift(children.indexOf(node));node=parent;}return parts.length?'path-'+parts.join('-'):'';}
+  function stableId(el){var explicit=el.getAttribute('data-od-id');if(explicit)return explicit;var generated=el.getAttribute('data-od-source-path')||el.getAttribute('data-od-runtime-id')||domPath(el);if(generated)el.setAttribute('data-od-runtime-id',generated);return generated||'';}
+  function postSave(prop,val){if(!sel)return;var id=stableId(sel);if(!id)return;try{window.parent&&window.parent.postMessage({type:'od:annotate-style-change',id:id,property:prop,value:val,label:eSel(sel)},'*');}catch(_){}}
+  function postTextSave(val){if(!sel)return;var id=stableId(sel);if(!id)return;try{window.parent&&window.parent.postMessage({type:'od:annotate-text-change',id:id,value:val,label:eSel(sel)},'*');}catch(_){}}
+  function postImageSave(file){if(!sel||!file)return;var id=stableId(sel);if(!id)return;try{window.parent&&window.parent.postMessage({type:'od:annotate-image-change',id:id,file:file,alt:sel.getAttribute('alt')||'',label:eSel(sel)},'*');}catch(_){}}
+  function postImageSrcSave(src,alt){if(!sel)return;var id=stableId(sel);if(!id)return;try{window.parent&&window.parent.postMessage({type:'od:annotate-image-src-change',id:id,src:src,alt:alt||'',label:eSel(sel)},'*');}catch(_){}}
+  function postImagePrompt(prompt){if(!sel)return;var info=imagePromptTarget||imageInfo(sel),target=info&&info.target?info.target:sel;var id=stableId(target);if(!id)return;try{window.parent&&window.parent.postMessage({type:'od:annotate-image-prompt',id:id,prompt:prompt,src:(info&&info.src)||'',alt:(target&&target.getAttribute&&target.getAttribute('alt'))||'',targetKind:(info&&info.kind)||'src',label:eSel(target)},'*');}catch(_){}}
+  function eSel(el){var tag=el.tagName.toLowerCase(),cls=Array.from(el.classList).slice(0,5).map(function(c){return'.'+c;}).join(''),id=el.id?'#'+el.id:'';return'&lt;'+tag+'&gt;'+(id||cls);}
+  function esc(s){return String(s).replace(/[&<>"']/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
+  function toHex(rgb){var m=rgb.match(/rgba?\\(\\s*(\\d+),\\s*(\\d+),\\s*(\\d+)/);return m?'#'+[m[1],m[2],m[3]].map(function(n){return(+n).toString(16).padStart(2,'0');}).join(''):rgb;}
+  function colorsIn(s){return String(s||'').match(/#[0-9a-fA-F]{3,8}\\b|rgba?\\([^)]*\\)|hsla?\\([^)]*\\)|oklch\\([^)]*\\)|oklab\\([^)]*\\)|color\\([^)]*\\)/g)||[];}
+  function cleanColor(v){var s=String(v||'').trim();if(!s||/transparent/i.test(s)||/rgba\\([^)]*,\\s*0\\s*\\)$/i.test(s))return'';return toHex(s);}
+  function uniq(arr){var out=[],seen={};(arr||[]).forEach(function(v){var s=String(v||'').trim();if(!s||seen[s.toLowerCase()])return;seen[s.toLowerCase()]=1;out.push(s);});return out;}
+  function hsvToRgb(h,s,v){var i=Math.floor(h/60)%6,f=h/60-Math.floor(h/60),p=v*(1-s),q=v*(1-f*s),t=v*(1-(1-f)*s),rgb=[[v,t,p],[q,v,p],[p,v,t],[p,q,v],[t,p,v],[v,p,q]][i];return{r:Math.round(rgb[0]*255),g:Math.round(rgb[1]*255),b:Math.round(rgb[2]*255)};}
+  function rgbToHsv(r,g,b){r/=255;g/=255;b/=255;var max=Math.max(r,g,b),min=Math.min(r,g,b),d=max-min,s=max===0?0:d/max,v=max,h=0;if(d>0){if(max===r)h=((g-b)/d+6)%6;else if(max===g)h=(b-r)/d+2;else h=(r-g)/d+4;h*=60;}return{h:h,s:s,v:v};}
+  function parseColorToHsva(str){var s=String(str||'').trim(),m,hsv;if((m=s.match(/rgba?\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*,\\s*(\\d+)\\s*(?:,\\s*([\\d.]+))?\\s*\\)/))){hsv=rgbToHsv(+m[1],+m[2],+m[3]);return{h:hsv.h,s:hsv.s,v:hsv.v,a:m[4]!=null?parseFloat(m[4]):1};}if((m=s.match(/^#([0-9a-fA-F]{3,8})$/))){var hx=m[1];if(hx.length===3||hx.length===4)hx=hx.split('').map(function(c){return c+c;}).join('');var r=parseInt(hx.slice(0,2),16),g=parseInt(hx.slice(2,4),16),b=parseInt(hx.slice(4,6),16),a=hx.length>=8?parseInt(hx.slice(6,8),16)/255:1;hsv=rgbToHsv(r,g,b);return{h:hsv.h,s:hsv.s,v:hsv.v,a:a};}return null;}
+  function hsvaToColor(h,s,v,a){var c=hsvToRgb(h,s,v);if(a>=0.999)return'#'+[c.r,c.g,c.b].map(function(n){return n.toString(16).padStart(2,'0');}).join('');return'rgba('+c.r+','+c.g+','+c.b+','+Math.round(a*100)/100+')';}
+  var cpk={el:null,pv:null,h:0,s:1,v:1,a:1,drag:null,moveOff:null,hexFocused:false,opaFocused:false,grad:{stops:[],sel:0},gradDragging:null};
+  var EYESVG='<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/></svg>';
+  function cpkBuild(){
+    if(cpk.el)return;
+    var el=document.createElement('div');el.id='oi-cpk';
+    el.innerHTML=
+      '<div class="oi-cpk-hdr"><button class="oi-cpk-tab active" data-tab="solid">纯色</button><button class="oi-cpk-tab" data-tab="gradient">渐变</button><span class="oi-cpk-sep"></span><button class="oi-cpk-close">×</button></div>'+
+      '<div class="oi-cpk-body">'+
+        '<div class="oi-cpk-sv"><div class="oi-cpk-sv-bg"></div><div class="oi-cpk-sv-s"></div><div class="oi-cpk-sv-v"></div><div class="oi-cpk-svdot"></div></div>'+
+        '<div class="oi-cpk-ctls"><button class="oi-cpk-eye">'+EYESVG+'</button><div class="oi-cpk-sliders"><div class="oi-cpk-hue"><div class="oi-cpk-sdot" id="oi-cpk-hd"></div></div><div class="oi-cpk-atrk"><div class="oi-cpk-abar"></div><div class="oi-cpk-sdot" id="oi-cpk-ad"></div></div></div></div>'+
+        '<div class="oi-cpk-inp"><button class="oi-cpk-fmt">Hex ▾</button><input id="oi-cpk-hex" class="oi-cpk-hexin" type="text" maxlength="6" spellcheck="false"><input id="oi-cpk-opa" class="oi-cpk-opain" type="number" min="0" max="100"><span class="oi-cpk-pct">%</span></div>'+
+      '</div>'+
+      '<div class="oi-cpk-solid"><div class="oi-cpk-div"></div><div class="oi-cpk-pal"><div class="oi-cpk-pal-row"><span>在此页面</span><span>▾</span></div><div class="oi-cpk-pg" id="oi-cpk-pg"></div></div></div>'+
+      '<div class="oi-cpk-grad"><div class="oi-cpk-gbar-wrap"><div class="oi-cpk-gbar" id="oi-cpk-gbar"><div class="oi-cpk-gbar-fill"></div></div></div><div class="oi-cpk-gstops-hd"><span>断点</span><button class="oi-cpk-gadd">+</button></div><div class="oi-cpk-glist" id="oi-cpk-glist"></div></div>';
+    document.body.appendChild(el);cpk.el=el;
+    el.querySelector('.oi-cpk-close').addEventListener('click',function(){cpkClose();});
+    el.querySelector('.oi-cpk-hdr').addEventListener('mousedown',function(e){
+      if(e.target.closest('button'))return;
+      e.preventDefault();
+      var r=el.getBoundingClientRect();
+      cpk.moveOff={x:e.clientX-r.left,y:e.clientY-r.top};
+    });
+    el.querySelectorAll('.oi-cpk-tab').forEach(function(btn){
+      btn.addEventListener('click',function(){
+        el.querySelectorAll('.oi-cpk-tab').forEach(function(b){b.classList.remove('active');});
+        btn.classList.add('active');
+        var isGrad=btn.getAttribute('data-tab')==='gradient';
+        el.classList.toggle('oi-cpk-is-grad',isGrad);
+        if(isGrad){
+          if(!cpk.grad.stops.length){cpk.grad.stops=[{pos:0,h:cpk.h,s:cpk.s,v:cpk.v,a:cpk.a},{pos:1,h:cpk.h,s:Math.max(0,cpk.s-0.5),v:Math.min(1,cpk.v+0.3),a:cpk.a}];cpk.grad.sel=0;}
+          gradUI();cpkEmit();
+        }
+      });
+    });
+    var gbarEl=el.querySelector('#oi-cpk-gbar');
+    gbarEl.addEventListener('mousedown',function(e){
+      if(e.target.classList.contains('oi-cpk-ghandle'))return;
+      var r=gbarEl.getBoundingClientRect(),pos=Math.max(0,Math.min(1,(e.clientX-r.left)/r.width));
+      cpk.grad.stops.push({pos:pos,h:cpk.h,s:cpk.s,v:cpk.v,a:cpk.a});
+      cpk.grad.stops.sort(function(a,b){return a.pos-b.pos;});
+      var newSt=cpk.grad.stops.find(function(s){return Math.abs(s.pos-pos)<0.0001;});
+      cpk.grad.sel=newSt?cpk.grad.stops.indexOf(newSt):0;
+      gradUI();cpkEmit();e.preventDefault();
+    });
+    el.querySelector('.oi-cpk-gadd').addEventListener('click',function(){
+      var pos=0.5;
+      if(cpk.grad.stops.length>=2){var best=0;for(var gai=0;gai<cpk.grad.stops.length-1;gai++){var gap=cpk.grad.stops[gai+1].pos-cpk.grad.stops[gai].pos;if(gap>best){best=gap;pos=(cpk.grad.stops[gai].pos+cpk.grad.stops[gai+1].pos)/2;}}}
+      cpk.grad.stops.push({pos:pos,h:cpk.h,s:cpk.s,v:cpk.v,a:cpk.a});
+      cpk.grad.stops.sort(function(a,b){return a.pos-b.pos;});
+      var newSt2=cpk.grad.stops.find(function(s){return Math.abs(s.pos-pos)<0.0001;});
+      cpk.grad.sel=newSt2?cpk.grad.stops.indexOf(newSt2):0;
+      gradUI();cpkEmit();
+    });
+    // Eyedropper (EyeDropper API)
+    el.querySelector('.oi-cpk-eye').addEventListener('click',function(){
+      if(!window.EyeDropper)return;
+      try{new window.EyeDropper().open().then(function(r){var p=parseColorToHsva(r.sRGBHex);if(p&&cpk.pv){cpk.h=p.h;cpk.s=p.s;cpk.v=p.v;cpkUI();cpkEmit();}}).catch(function(){});}catch(_){}
+    });
+    function clamp(x,lo,hi){return Math.max(lo,Math.min(hi,x));}
+    var svEl=el.querySelector('.oi-cpk-sv');
+    function svDrag(e){var r=svEl.getBoundingClientRect();cpk.s=clamp((e.clientX-r.left)/r.width,0,1);cpk.v=clamp(1-(e.clientY-r.top)/r.height,0,1);cpkUI();cpkEmit();}
+    svEl.addEventListener('mousedown',function(e){e.preventDefault();cpk.drag='sv';svDrag(e);});
+    var hueEl=el.querySelector('.oi-cpk-hue');
+    function hueDrag(e){var r=hueEl.getBoundingClientRect();cpk.h=clamp((e.clientX-r.left)/r.width,0,0.9999)*360;cpkUI();cpkEmit();}
+    hueEl.addEventListener('mousedown',function(e){e.preventDefault();cpk.drag='hue';hueDrag(e);});
+    var aEl=el.querySelector('.oi-cpk-atrk');
+    function aDrag(e){var r=aEl.getBoundingClientRect();cpk.a=clamp((e.clientX-r.left)/r.width,0,1);cpkUI();cpkEmit();}
+    aEl.addEventListener('mousedown',function(e){e.preventDefault();cpk.drag='a';aDrag(e);});
+    document.addEventListener('mousemove',function(e){
+      if(cpk.moveOff){var x=e.clientX-cpk.moveOff.x,y=e.clientY-cpk.moveOff.y;el.style.left=Math.max(0,Math.min(window.innerWidth-el.offsetWidth,x))+'px';el.style.top=Math.max(0,Math.min(window.innerHeight-el.offsetHeight,y))+'px';return;}
+      if(cpk.gradDragging){var gb=el.querySelector('#oi-cpk-gbar');if(gb){var gr=gb.getBoundingClientRect();cpk.gradDragging.pos=Math.max(0,Math.min(1,(e.clientX-gr.left)/gr.width));cpk.grad.stops.sort(function(a,b){return a.pos-b.pos;});cpk.grad.sel=cpk.grad.stops.indexOf(cpk.gradDragging);gradUI();cpkEmit();}return;}
+      if(cpk.drag==='sv')svDrag(e);else if(cpk.drag==='hue')hueDrag(e);else if(cpk.drag==='a')aDrag(e);
+    });
+    document.addEventListener('mouseup',function(){cpk.drag=null;cpk.moveOff=null;cpk.gradDragging=null;});
+    var hexIn=el.querySelector('#oi-cpk-hex'),opaIn=el.querySelector('#oi-cpk-opa');
+    hexIn.addEventListener('change',function(){
+      var h2=hexIn.value.replace(/[^0-9a-fA-F]/g,'');if(h2.length<6)return;
+      var p=parseColorToHsva('#'+h2);if(!p)return;cpk.h=p.h;cpk.s=p.s;cpk.v=p.v;cpkUI();cpkEmit();
+    });
+    opaIn.addEventListener('change',function(){
+      var n=parseInt(opaIn.value,10);if(isNaN(n))return;cpk.a=Math.max(0,Math.min(100,n))/100;cpkUI();cpkEmit();
+    });
+    hexIn.addEventListener('focus',function(){cpk.hexFocused=true;});
+    hexIn.addEventListener('blur',function(){cpk.hexFocused=false;});
+    opaIn.addEventListener('focus',function(){cpk.opaFocused=true;});
+    opaIn.addEventListener('blur',function(){cpk.opaFocused=false;});
+  }
+  function cpkUI(){
+    if(!cpk.el)return;
+    var h=cpk.h,s=cpk.s,v=cpk.v,a=cpk.a,rgb=hsvToRgb(h,s,v),pure=hsvToRgb(h,1,1);
+    var bg=cpk.el.querySelector('.oi-cpk-sv-bg');if(bg)bg.style.background='hsl('+Math.round(h)+',100%,50%)';
+    var svd=cpk.el.querySelector('.oi-cpk-svdot');if(svd){svd.style.left=(s*100)+'%';svd.style.top=((1-v)*100)+'%';}
+    var hd=cpk.el.querySelector('#oi-cpk-hd');if(hd)hd.style.left=(h/360*100)+'%';
+    var abar=cpk.el.querySelector('.oi-cpk-abar');if(abar)abar.style.background='linear-gradient(to right,rgba('+pure.r+','+pure.g+','+pure.b+',0),rgb('+pure.r+','+pure.g+','+pure.b+'))';
+    var ad=cpk.el.querySelector('#oi-cpk-ad');if(ad)ad.style.left=(a*100)+'%';
+    var hexIn=cpk.el.querySelector('#oi-cpk-hex'),opaIn=cpk.el.querySelector('#oi-cpk-opa');
+    var hexStr=[rgb.r,rgb.g,rgb.b].map(function(n){return n.toString(16).toUpperCase().padStart(2,'0');}).join('');
+    if(hexIn&&!cpk.hexFocused)hexIn.value=hexStr;
+    if(opaIn&&!cpk.opaFocused)opaIn.value=Math.round(a*100);
+    if(cpk.el.classList.contains('oi-cpk-is-grad'))gradUI();
+  }
+  function cpkPopulatePalette(){
+    var pg=cpk.el&&cpk.el.querySelector('#oi-cpk-pg');if(!pg)return;
+    var colors=paletteColors(currentProps).filter(function(c){return!!parseColorToHsva(c);});
+    pg.innerHTML=colors.map(function(c){return'<button class="oi-cpk-pc" style="background:'+c+'" title="'+c+'" data-color="'+c+'"></button>';}).join('');
+    pg.querySelectorAll('.oi-cpk-pc').forEach(function(btn){btn.addEventListener('click',function(){var p=parseColorToHsva(btn.getAttribute('data-color'));if(!p)return;cpk.h=p.h;cpk.s=p.s;cpk.v=p.v;cpk.a=p.a;cpkUI();cpkEmit();});});
+  }
+  function cpkEmit(){if(!cpk.pv)return;if(cpk.el&&cpk.el.classList.contains('oi-cpk-is-grad')){var gst=cpk.grad.stops[cpk.grad.sel];if(gst){gst.h=cpk.h;gst.s=cpk.s;gst.v=cpk.v;gst.a=cpk.a;}var css=gradToCSS();var gval=cpk.pv.querySelector('.oi-val'),gsw=cpk.pv.querySelector('.oi-sw');if(gval)gval.textContent=css;if(gsw){gsw.style.background=css;gsw.setAttribute('data-color',css);}if(sel){pushUndo(captureUndo('background-image'));sel.style.setProperty('background-image',css);postSave('background-image',css);}refreshAfterEdit();}else{setColorPv(cpk.pv,hsvaToColor(cpk.h,cpk.s,cpk.v,cpk.a));}}
+  function gradToCSS(){
+    if(!cpk.grad.stops.length)return'transparent';
+    var ss=cpk.grad.stops.slice().sort(function(a,b){return a.pos-b.pos;});
+    return'linear-gradient(to right,'+ss.map(function(s){var c=hsvToRgb(s.h,s.s,s.v);var hex='#'+[c.r,c.g,c.b].map(function(n){return n.toString(16).padStart(2,'0');}).join('');return(s.a<0.999?'rgba('+c.r+','+c.g+','+c.b+','+Math.round(s.a*100)/100+')':hex)+' '+Math.round(s.pos*100)+'%';}).join(',')+')';
+  }
+  function gradUI(){
+    if(!cpk.el)return;
+    var gbar=cpk.el.querySelector('#oi-cpk-gbar'),glist=cpk.el.querySelector('#oi-cpk-glist');
+    if(!gbar||!glist)return;
+    var gfill=gbar.querySelector('.oi-cpk-gbar-fill');
+    if(gfill)gfill.style.background=gradToCSS();
+    gbar.querySelectorAll('.oi-cpk-ghandle').forEach(function(h){h.remove();});
+    cpk.grad.stops.forEach(function(st,i){
+      var handle=document.createElement('div');
+      handle.className='oi-cpk-ghandle'+(i===cpk.grad.sel?' sel':'');
+      var rgb=hsvToRgb(st.h,st.s,st.v);
+      handle.style.cssText='background:rgb('+rgb.r+','+rgb.g+','+rgb.b+');left:'+Math.round(st.pos*100)+'%;';
+      handle.addEventListener('mousedown',function(e){
+        e.stopPropagation();e.preventDefault();
+        cpk.grad.sel=i;cpk.h=st.h;cpk.s=st.s;cpk.v=st.v;cpk.a=st.a;
+        cpk.gradDragging=st;
+        gradUI();cpkUI();
+      });
+      gbar.appendChild(handle);
+    });
+    glist.innerHTML='';
+    cpk.grad.stops.forEach(function(st,i){
+      var rgb=hsvToRgb(st.h,st.s,st.v);
+      var hex=[rgb.r,rgb.g,rgb.b].map(function(n){return n.toString(16).toUpperCase().padStart(2,'0');}).join('');
+      var row=document.createElement('div');
+      row.className='oi-cpk-gstop-row'+(i===cpk.grad.sel?' sel':'');
+      row.innerHTML=
+        '<span class="oi-cpk-gstop-swatch" style="background:rgb('+rgb.r+','+rgb.g+','+rgb.b+')"></span>'+
+        '<input class="oi-cpk-gstop-hex" type="text" maxlength="6" value="'+hex+'" spellcheck="false">'+
+        '<input class="oi-cpk-gstop-opa" type="number" min="0" max="100" value="'+Math.round(st.a*100)+'">'+
+        '<span class="oi-cpk-gstop-pct">%</span>'+
+        '<input class="oi-cpk-gstop-pos" type="number" min="0" max="100" value="'+Math.round(st.pos*100)+'">'+
+        '<span class="oi-cpk-gstop-pct">%</span>'+
+        '<button class="oi-cpk-gstop-del">—</button>';
+      row.addEventListener('mousedown',function(e){if(e.target.tagName==='INPUT'||e.target.tagName==='BUTTON')return;cpk.grad.sel=i;cpk.h=st.h;cpk.s=st.s;cpk.v=st.v;cpk.a=st.a;gradUI();cpkUI();});
+      var hIn=row.querySelector('.oi-cpk-gstop-hex');
+      hIn.addEventListener('change',function(){var h2=hIn.value.replace(/[^0-9a-fA-F]/g,'');if(h2.length<6)return;var p=parseColorToHsva('#'+h2);if(!p)return;st.h=p.h;st.s=p.s;st.v=p.v;if(i===cpk.grad.sel){cpk.h=st.h;cpk.s=st.s;cpk.v=st.v;}gradUI();cpkUI();cpkEmit();});
+      var oIn=row.querySelector('.oi-cpk-gstop-opa');
+      oIn.addEventListener('change',function(){var n=parseInt(oIn.value,10);if(isNaN(n))return;st.a=Math.max(0,Math.min(100,n))/100;if(i===cpk.grad.sel)cpk.a=st.a;gradUI();cpkUI();cpkEmit();});
+      var pIn=row.querySelector('.oi-cpk-gstop-pos');
+      pIn.addEventListener('change',function(){var n=parseInt(pIn.value,10);if(isNaN(n))return;st.pos=Math.max(0,Math.min(100,n))/100;cpk.grad.stops.sort(function(a,b){return a.pos-b.pos;});cpk.grad.sel=cpk.grad.stops.indexOf(st);gradUI();cpkEmit();});
+      row.querySelector('.oi-cpk-gstop-del').addEventListener('click',function(e){e.stopPropagation();if(cpk.grad.stops.length<=2)return;var si=cpk.grad.stops.indexOf(st);if(si>=0)cpk.grad.stops.splice(si,1);if(cpk.grad.sel>=cpk.grad.stops.length)cpk.grad.sel=cpk.grad.stops.length-1;var ns=cpk.grad.stops[cpk.grad.sel];if(ns){cpk.h=ns.h;cpk.s=ns.s;cpk.v=ns.v;cpk.a=ns.a;}gradUI();cpkUI();cpkEmit();});
+      glist.appendChild(row);
+    });
+  }
+  function cpkOpen(pv){
+    cpkBuild();cpk.pv=pv;
+    var val=pv.querySelector('.oi-val'),valStr=val?val.textContent:'',parsed=parseColorToHsva(valStr);
+    cpk.el.querySelectorAll('.oi-cpk-tab').forEach(function(b){b.classList.remove('active');});
+    cpk.el.querySelector('[data-tab="solid"]').classList.add('active');
+    cpk.el.classList.remove('oi-cpk-is-grad');
+    cpk.grad.stops=[];cpk.grad.sel=0;cpk.gradDragging=null;
+    if(parsed){cpk.h=parsed.h;cpk.s=parsed.s;cpk.v=parsed.v;cpk.a=parsed.a;}else{cpk.h=0;cpk.s=0;cpk.v=0;cpk.a=1;}
+    var r=card.getBoundingClientRect(),pw=270,ph=460;
+    var x=r.right+8,y=r.top;
+    if(x+pw>window.innerWidth-8)x=r.left-pw-8;if(x<8)x=8;
+    if(y+ph>window.innerHeight-8)y=window.innerHeight-ph-8;if(y<8)y=8;
+    cpk.el.style.cssText='display:block;left:'+x+'px;top:'+y+'px;';
+    cpkUI();cpkPopulatePalette();
+  }
+  function cpkClose(){if(cpk.el)cpk.el.style.display='none';cpk.pv=null;}
+  function paletteColors(props){var out=[],seen={};function add(v){var c=cleanColor(v);if(!c||seen[c.toLowerCase()]||c==='rgba(0, 0, 0, 0)')return;seen[c.toLowerCase()]=1;out.push(c);}
+    props.forEach(function(p){if(CP[p.n])add(p.v);});
+    try{var rs=getComputedStyle(document.documentElement);for(var i=0;i<rs.length;i++){var n=rs[i];if(n.indexOf('--')===0)colorsIn(rs.getPropertyValue(n)).forEach(add);}}catch(_){}
+    try{Array.from(document.styleSheets).forEach(function(ss){try{Array.from(ss.cssRules||[]).forEach(function(r){colorsIn(r.cssText).forEach(add);});}catch(_){}});}catch(_){}
+    try{Array.from(document.querySelectorAll('[style]')).slice(0,400).forEach(function(el){colorsIn(el.getAttribute('style')).forEach(add);});}catch(_){}
+    return out.slice(0,30);
+  }
+  function colorScore(color){
+    var p=parseColorToHsva(color);
+    if(!p)return 0.25;
+    var rgb=hsvToRgb(p.h,p.s,p.v);
+    var lum=(0.2126*rgb.r+0.7152*rgb.g+0.0722*rgb.b)/255;
+    var hue=((p.h%360)+360)%360;
+    if(lum>.82)return 0;
+    if(hue>=168&&hue<=205)return 0;
+    if(hue>=70&&hue<=165&&p.s>.18)return 3+p.s+((lum>.12&&lum<.72)?0.8:0);
+    if(p.s>.12)return 1+p.s+((lum>.18&&lum<.72)?0.4:0);
+    return lum<.28?.35:.12;
+  }
+  function accentRgbString(color){
+    var p=parseColorToHsva(color);
+    if(!p)return '';
+    var rgb=hsvToRgb(p.h,p.s,p.v);
+    return rgb.r+','+rgb.g+','+rgb.b;
+  }
+  function applyProjectAccent(props){
+    var best=SHARE_ORANGE;
+    PINK=best;
+    PURPLE=best;
+    document.documentElement.style.setProperty('--oi-accent',best);
+    document.documentElement.style.setProperty('--oi-distance',best);
+    var rgb=accentRgbString(best);
+    if(rgb)document.documentElement.style.setProperty('--oi-accent-rgb',rgb);
+  }
+  function valuesFor(prop){var out=[],en={display:['block','flex','grid','inline-flex','inline-block','none'],position:['relative','absolute','fixed','sticky','static'],'align-items':['stretch','flex-start','center','flex-end','baseline'],'justify-content':['flex-start','center','flex-end','space-between','space-around','space-evenly'],'flex-direction':['row','column','row-reverse','column-reverse'],'flex-wrap':['nowrap','wrap','wrap-reverse'],'text-align':['left','center','right','justify'],'font-weight':['300','400','500','600','700','800']};if(en[prop])return en[prop];if(BP[prop])out=out.concat(['0px','4px','8px','12px','16px','20px','24px','32px','40px','48px']);try{Array.from(document.querySelectorAll('body *')).slice(0,600).forEach(function(el){var cs=getComputedStyle(el),v=cs.getPropertyValue(prop).trim();if(v&&v!=='normal'&&v!=='none'&&v!=='auto')out.push(prop==='font-family'?v.split(',')[0].trim().replace(/["']/g,''):v);});}catch(_){}try{var rs=getComputedStyle(document.documentElement);for(var i=0;i<rs.length;i++){var n=rs[i],v=rs.getPropertyValue(n).trim();if(n.indexOf('--')===0&&(/font|type|space|gap|size|radius|leading|line|weight/i.test(n)))out.push(v);}}catch(_){}return uniq(out).slice(0,24);}
+  function textSnippets(){var out=[];try{Array.from(document.querySelectorAll('h1,h2,h3,p,a,button,span')).slice(0,300).forEach(function(el){if(el.children.length)return;var t=(el.textContent||'').replace(/\\s+/g,' ').trim();if(t&&t.length<80)out.push(t);});}catch(_){}return uniq(out).slice(0,16);}
+  function refItems(prop){return prop==='__image'?{kind:'value',title:L.imageRef,items:[L.uploadImage],isUpload:true}:prop==='__text'?{kind:'value',title:L.textRef,items:textSnippets()}:CP[prop]?{kind:'color',title:L.colorRef,items:paletteColors(currentProps)}:{kind:'value',title:L.refOptions+' \xb7 '+prop,items:valuesFor(prop)};}
+  function propsOf(el){var cs=window.getComputedStyle(el),rect=el.getBoundingClientRect(),out=[{n:'width',v:Math.round(rect.width)+'px'},{n:'height',v:Math.round(rect.height)+'px'}];for(var i=0;i<PP.length;i++){var p=PP[i],v=cs.getPropertyValue(p).trim();if(!v)continue;if(SK[p]===v&&!BP[p])continue;if((v==='none'||v==='0px'||v==='normal'||v==='auto')&&['display','overflow','gap'].indexOf(p)<0&&!BP[p])continue;if(p==='font-family')v=v.split(',')[0].trim().replace(/["']/g,'');if(p==='box-shadow'&&v==='none')continue;out.push({n:p,v:v});}return out;}
+  function shownValue(p){if(CP[p.n]){var t=p.v.indexOf('0, 0, 0, 0')>=0||p.v==='transparent';return t?'transparent':toHex(p.v);}return p.v;}
+  function canEditText(el){return !!(el&&el.children&&el.children.length===0&&(el.textContent||'').trim());}
+  function imageName(el){var src=el.getAttribute('src')||'';return src.split('/').pop()||src||L.uploadImage;}
+  function imageNameFromSrc(src){src=String(src||'');var clean=src.split('?')[0].split('#')[0];return clean.split('/').pop()||clean||L.uploadImage;}
+  function firstCssUrl(value){var m=String(value||'').match(/url\\((['"]?)(.*?)\\1\\)/);return m?m[2]:'';}
+  function imageInfo(el){
+    if(!el||!el.tagName)return null;
+    var tag=el.tagName.toLowerCase();
+    if(tag==='img')return{kind:'src',target:el,src:el.getAttribute('src')||'',label:imageName(el)};
+    if(tag==='image'){var href=el.getAttribute('href')||el.getAttribute('xlink:href')||'';return{kind:'href',target:el,src:href,label:imageNameFromSrc(href)};}
+    var nested=null;
+    if(tag==='picture')nested=el.querySelector('img');
+    else if(!canEditText(el))nested=el.querySelector&&el.querySelector(':scope > img, :scope picture img, :scope svg image');
+    if(nested){
+      var nt=nested.tagName&&nested.tagName.toLowerCase();
+      if(nt==='image'){var nh=nested.getAttribute('href')||nested.getAttribute('xlink:href')||'';return{kind:'href',target:nested,src:nh,label:imageNameFromSrc(nh)};}
+      return{kind:'src',target:nested,src:nested.getAttribute('src')||'',label:imageName(nested)};
+    }
+    try{var bg=getComputedStyle(el).getPropertyValue('background-image');var u=firstCssUrl(bg);if(u)return{kind:'background',target:el,src:u,label:imageNameFromSrc(u)};}catch(_){}
+    return null;
+  }
+  function openCard(el){
+    var rect=el.getBoundingClientRect(),props=propsOf(el);
+    var imgInfo=imageInfo(el),isImage=!!imgInfo;
+    imagePromptTarget=imgInfo;
+    if(isImage)props.unshift({n:'__image',v:imgInfo.label});
+    if(canEditText(el))props.unshift({n:'__text',v:(el.textContent||'').trim()});
+    currentProps=props;
+    applyProjectAccent(props);
+    var pm={};for(var pi=0;pi<props.length;pi++)pm[props[pi].n]=props[pi];
+    var QGS={'padding':['padding-top','padding-right','padding-bottom','padding-left'],'margin':['margin-top','margin-right','margin-bottom','margin-left'],'border-radius':['border-top-left-radius','border-top-right-radius','border-bottom-right-radius','border-bottom-left-radius']};
+    var QSM={};for(var qk in QGS){var qs=QGS[qk];for(var qj=0;qj<qs.length;qj++)QSM[qs[qj]]=qk;}
+    var SVGT='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="11" height="11"><path d="M21 3C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3H21ZM20 5H4V19H20V5ZM18 7V9H6V7H18Z"/></svg>';
+    var SVGB='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="11" height="11"><path d="M21 3C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3H21ZM20 5H4V19H20V5ZM18 15V17H6V15H18Z"/></svg>';
+    var SVGL='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="11" height="11"><path d="M21 3C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3H21ZM20 5H4V19H20V5ZM8 7V17H6V7H8Z"/></svg>';
+    var SVGR='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="11" height="11"><path d="M21 3C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3H21ZM20 5H4V19H20V5ZM18 7V17H16V7H18Z"/></svg>';
+    var QO_PM=[0,3,2,1],QI_PM=[SVGT,SVGL,SVGB,SVGR];
+    var QO_BR=[0,1,3,2],QI_BR=['◤','◥','◣','◢'];
+    function mkqcell(sideProp,icon){var sp=pm[sideProp],sv=sp?shownValue(sp):'0px';return '<div class="oi-qcell"><em class="oi-qicon">'+icon+'</em><span class="oi-pv" data-p="'+esc(sideProp)+'"><span class="oi-val" contenteditable="true" spellcheck="false">'+esc(sv)+'</span></span></div>';}
+    function mkquad(sh){var sides=QGS[sh],isR=sh==='border-radius',qo=isR?QO_BR:QO_PM,qi=isR?QI_BR:QI_PM,sp=pm[sh],sum=sp?esc(shownValue(sp)):'',qh='<div class="oi-quad" data-q="'+esc(sh)+'"><div class="oi-quad-hd"><span class="oi-pn">'+esc(sh)+'</span><div class="oi-quad-right">'+(sum?'<em class="oi-quad-sum">'+sum+'</em>':'')+'<button class="oi-quad-xbtn" type="button">▸</button></div></div><div class="oi-qgrid">';for(var k=0;k<4;k++)qh+=mkqcell(sides[qo[k]],qi[k]);return qh+'</div></div>';}
+    var emittedQ={};
+    var h='<div class="oi-hdr"><div class="oi-tag">'+eSel(el)+'</div><div class="oi-hdr-actions"><button class="oi-hdr-btn" type="button" data-action="capture"><span class="oi-hdr-key">⌘M</span>截屏</button></div></div>';
+    if(isImage)h+='<div class="oi-image-prompt"><textarea data-oi-image-prompt spellcheck="false" placeholder="'+esc(L.imagePrompt)+'"></textarea><div class="oi-image-prompt-foot"><span class="oi-image-prompt-status" data-oi-image-status></span><button class="oi-image-prompt-btn" type="button" data-action="regenerate-image">'+esc(L.regenerateImage)+'</button></div></div>';
+    h+='<div class="oi-body">';
+    for(var i=0;i<props.length;i++){
+      var p=props[i];
+      if(QSM[p.n]){var gk=QSM[p.n];if(!emittedQ[gk]&&!pm[gk]){var gs=QGS[gk],allG=true;for(var gi=0;gi<gs.length;gi++){if(!pm[gs[gi]]){allG=false;break;}}if(allG){emittedQ[gk]=true;h+=mkquad(gk);}}continue;}
+      if(QGS[p.n]&&!emittedQ[p.n]){var allQ=true,qa=QGS[p.n];for(var qi2=0;qi2<qa.length;qi2++){if(!pm[qa[qi2]]){allQ=false;break;}}if(allQ){emittedQ[p.n]=true;h+=mkquad(p.n);continue;}}
+      var val=(p.n==='__text'||p.n==='__image')?p.v:shownValue(p),sw='',colorClass=CP[p.n]?' oi-color-row':'';
+      if(CP[p.n]&&val!=='transparent')sw='<span class="oi-sw" data-color="'+esc(val)+'" style="background:'+esc(p.v)+'"></span>';
+      h+='<div class="oi-row'+colorClass+'"><span class="oi-pn">'+esc(p.n==='__text'?'text':p.n==='__image'?'image':p.n)+'</span><span class="oi-pv" data-p="'+esc(p.n)+'">'+sw+'<span class="oi-val" contenteditable="'+(p.n==='__image'?'false':'true')+'" spellcheck="false">'+esc(val)+'</span></span></div>';
+    }
+    h+='</div><div class="oi-ref"><div class="oi-ref-title"></div><div class="oi-ref-grid"></div></div><input class="oi-color-input" type="color" value="#000000"><input class="oi-file-input" type="file" accept="image/*">';
+    card.innerHTML=h;card.scrollTop=0;card.style.display='block';
+    setActiveProp((props.find(function(p){return p.n==='__text'||p.n==='__image';})||props.find(function(p){return CP[p.n];})||props[0]||{}).n||'',false);
+    placeCard(rect);
+  }
+  function renderRefs(prop){var data=refItems(prop),title=card.querySelector('.oi-ref-title'),grid=card.querySelector('.oi-ref-grid');if(!title||!grid)return;title.textContent=data.title;grid.innerHTML=(data.items||[]).map(function(v){return data.kind==='color'?'<button class="oi-chip" type="button" data-color="'+esc(v)+'" title="'+esc(v)+'" style="background:'+esc(v)+'"></button>':'<button class="oi-opt" type="button" '+(data.isUpload?'data-od-upload="1" ':'')+'data-value="'+esc(v)+'" title="'+esc(v)+'">'+esc(v)+'</button>';}).join('');}
+  function imagePromptStatus(text,kind){var st=card.querySelector('[data-oi-image-status]');if(!st)return;st.textContent=text||'';st.className='oi-image-prompt-status'+(kind?' '+kind:'');}
+  function submitImagePrompt(){var input=card.querySelector('[data-oi-image-prompt]'),btn=card.querySelector('[data-action="regenerate-image"]');var prompt=input&&input.value?input.value.trim():'';if(!prompt){imagePromptStatus('先输入图片 prompt','err');if(input)input.focus({preventScroll:true});return;}pushUndo(captureUndo('__image'));if(btn)btn.disabled=true;imagePromptStatus('生成中...','');postImagePrompt(prompt);}
+  function setActiveProp(prop,focusValue){if(!prop)return;activeProp=prop;card.querySelectorAll('.oi-row.active').forEach(function(r){r.classList.remove('active');});card.querySelectorAll('.oi-pv[data-active-color]').forEach(function(n){n.removeAttribute('data-active-color');});var pv=card.querySelector('.oi-pv[data-p="'+prop.replace(/"/g,'\\\\"')+'"]');if(pv){var row=pv.closest('.oi-row');if(row)row.classList.add('active');if(CP[prop])pv.setAttribute('data-active-color','1');if(focusValue){var val=pv.querySelector('.oi-val');if(val){val.focus({preventScroll:true});document.execCommand&&document.execCommand('selectAll',false,null);}}}renderRefs(prop);}
+  function refreshAfterEdit(){if(!sel)return;selR=sel.getBoundingClientRect();posBox(selB,selR);placeCard(selR);}
+  var undoStack=[],isUndoing=false;
+  function playCaptureAnimation(){
+    var target=sel||card;
+    if(!target)return;
+    var r=target.getBoundingClientRect();
+    if(!r||r.width<=0||r.height<=0)return;
+    document.querySelectorAll('.oi-shot,.oi-shot-fly').forEach(function(el){el.remove();});
+    var fx=document.createElement('div');
+    fx.className='oi-shot';
+    fx.style.left=r.left+'px';
+    fx.style.top=r.top+'px';
+    fx.style.width=r.width+'px';
+    fx.style.height=r.height+'px';
+    document.body.appendChild(fx);
+    fx.addEventListener('animationend',function(){fx.remove();},{once:true});
+    setTimeout(function(){if(fx&&fx.parentNode)fx.remove();},340);
+    setTimeout(function(){
+      var fly=document.createElement('div');
+      fly.className='oi-shot-fly';
+      fly.style.left=r.left+'px';
+      fly.style.top=r.top+'px';
+      fly.style.width=r.width+'px';
+      fly.style.height=r.height+'px';
+      fly.style.setProperty('--oi-fly-x',(-(r.left+r.width+120))+'px');
+      fly.style.setProperty('--oi-fly-y',(Math.max(28-r.top,-Math.min(220,r.top*.45)))+'px');
+      try{
+        var clone=target.cloneNode(true);
+        clone.removeAttribute&&clone.removeAttribute('id');
+        clone.setAttribute&&clone.setAttribute('aria-hidden','true');
+        clone.style.width=r.width+'px';
+        clone.style.height=r.height+'px';
+        clone.style.boxSizing='border-box';
+        clone.style.transform='none';
+        fly.appendChild(clone);
+      }catch(_){}
+      document.body.appendChild(fly);
+      fly.addEventListener('animationend',function(){fly.remove();},{once:true});
+      setTimeout(function(){if(fly&&fly.parentNode)fly.remove();},1480);
+    },170);
+  }
+  function inlineOverlayStyle(n,c){try{if(!n||!c||!c.style)return;var cs=getComputedStyle(n),st=c.style;for(var i=0;i<cs.length;i++){var p=cs[i],v=cs.getPropertyValue(p);if(!v||v.indexOf('url(')!==-1)continue;st.setProperty(p,v,cs.getPropertyPriority(p));}var ns=n.children||[],csn=c.children||[],len=Math.min(ns.length,csn.length);for(var j=0;j<len;j++)inlineOverlayStyle(ns[j],csn[j]);}catch(_){}}
+  function overlaySnapshot(){var html='';try{document.querySelectorAll('#oi-sel,#oi-hov,#oi-svg,#oi-card,.oi-badge,.oi-shot,.oi-shot-fly,#oi-cpk,.oi-cpk').forEach(function(n){var c=n.cloneNode(true),r=n.getBoundingClientRect&&n.getBoundingClientRect();inlineOverlayStyle(n,c);if(r&&c&&c.style){c.style.position='absolute';c.style.left=Math.round(r.left)+'px';c.style.top=Math.round(r.top)+'px';c.style.width=Math.round(r.width)+'px';c.style.height=Math.round(r.height)+'px';c.style.margin='0';c.style.transform='none';if(c.id==='oi-card'||c.id==='oi-svg'||c.classList.contains('oi-badge')||c.classList.contains('oi-shot')||c.classList.contains('oi-shot-fly'))c.style.display='block';}html+=c.outerHTML||'';});}catch(_){}return{html:html,css:css.textContent||'',scrollX:window.scrollX||0,scrollY:window.scrollY||0};}
+  function captureAnnotatable(captureId){playCaptureAnimation();try{window.parent&&window.parent.postMessage({type:'od:annotate-capture',captureId:captureId||'',overlay:overlaySnapshot()},'*');}catch(_){}}
+  function pushUndo(entry){if(isUndoing||!entry||!entry.id)return;undoStack.push(entry);if(undoStack.length>80)undoStack.shift();}
+  function captureUndo(prop){if(!sel)return null;var info=prop==='__image'?(imagePromptTarget||imageInfo(sel)):null,target=info&&info.target?info.target:sel,id=stableId(target);if(!id)return null;if(prop==='__text')return{kind:'text',id:id,value:sel.textContent||''};if(prop==='__image'){if(info&&info.kind==='background')return{kind:'style',id:id,prop:'background-image',value:target.style.getPropertyValue('background-image')||''};if(info&&info.kind==='href')return{kind:'image',id:id,src:target.getAttribute('href')||target.getAttribute('xlink:href')||'',alt:''};return{kind:'image',id:id,src:target.getAttribute('src')||'',alt:target.getAttribute('alt')||''};}return{kind:'style',id:id,prop:prop,value:sel.style.getPropertyValue(prop)||''};}
+  function updateRow(prop,value){var pv=card.querySelector('.oi-pv[data-p="'+prop.replace(/"/g,'\\\\"')+'"]'),val=pv&&pv.querySelector('.oi-val'),sw=pv&&pv.querySelector('.oi-sw');if(val)val.textContent=value;if(sw)sw.style.background=value;}
+  function undoLast(){var item=undoStack.pop();if(!item)return;var target=sel&&stableId(sel)===item.id?sel:document.querySelector('[data-od-id="'+item.id.replace(/"/g,'\\\\"')+'"],[data-od-runtime-id="'+item.id.replace(/"/g,'\\\\"')+'"],[data-od-source-path="'+item.id.replace(/"/g,'\\\\"')+'"]');if(!target)return;isUndoing=true;sel=target;if(item.kind==='text'){target.textContent=item.value;updateRow('__text',item.value);refreshAfterEdit();postTextSave(item.value);}else if(item.kind==='image'){target.setAttribute('src',item.src);if(item.alt)target.setAttribute('alt',item.alt);else target.removeAttribute('alt');updateRow('__image',imageName(target));refreshAfterEdit();postImageSrcSave(item.src,item.alt);}else if(item.kind==='style'){if(item.value)target.style.setProperty(item.prop,item.value);else target.style.removeProperty(item.prop);updateRow(item.prop,item.value||getComputedStyle(target).getPropertyValue(item.prop).trim());refreshAfterEdit();postSave(item.prop,item.value);}isUndoing=false;}
+  function applyEdit(node){if(!sel||!node)return;var pv=node.closest('.oi-pv');if(!pv)return;var prop=pv.getAttribute('data-p'),val=prop==='__text'?node.textContent:node.textContent.trim();if(!prop)return;if(prop==='__text'){pushUndo(captureUndo(prop));sel.textContent=val;refreshAfterEdit();postTextSave(val);return;}if(!val)return;pushUndo(captureUndo(prop));if(prop==='width'||prop==='height'){sel.style[prop]=val;}else{sel.style.setProperty(prop,val);}var sw=pv.querySelector('.oi-sw');if(sw&&CP[prop])sw.style.background=val;refreshAfterEdit();postSave(prop,val);}
+  function activeColorPv(){return card.querySelector('.oi-pv[data-active-color="1"]')||card.querySelector('.oi-color-row .oi-pv');}
+  function setColorPv(pv,color){if(!pv)return;var val=pv.querySelector('.oi-val'),sw=pv.querySelector('.oi-sw'),prop=pv.getAttribute('data-p');if(val)val.textContent=color;if(sw){sw.style.background=color;sw.setAttribute('data-color',color);}if(sel&&prop){pushUndo(captureUndo(prop));sel.style.setProperty(prop,color);postSave(prop,color);}refreshAfterEdit();}
+  function chooseImage(){var input=card.querySelector('.oi-file-input');if(input)input.click();}
+  function setValueFor(prop,value){if(prop==='__image'){chooseImage();return;}var pv=card.querySelector('.oi-pv[data-p="'+prop.replace(/"/g,'\\\\"')+'"]'),val=pv&&pv.querySelector('.oi-val');if(!pv||!val)return;if(CP[prop]){setColorPv(pv,value);return;}val.textContent=value;applyEdit(val);}
+  function openColorPicker(pv){if(!pv)return;card.querySelectorAll('.oi-pv[data-active-color]').forEach(function(n){n.removeAttribute('data-active-color');});pv.setAttribute('data-active-color','1');cpkOpen(pv);}
+  function placeCard(r){var vw=window.innerWidth,vh=window.innerHeight,ch=Math.min(440,card.scrollHeight||280);var x=r.right+GAP,y=r.bottom+GAP;if(x+CW>vw-8)x=r.left-CW-GAP;if(x<8)x=Math.max(8,r.left);if(y+ch>vh-8)y=r.top-ch-GAP;if(y<8)y=8;card.style.left=x+'px';card.style.top=y+'px';}
+  function posBox(box,r){box.style.display='block';box.style.left=r.left+'px';box.style.top=r.top+'px';box.style.width=r.width+'px';box.style.height=r.height+'px';}
+  function clrM(){while(svgEl.firstChild)svgEl.removeChild(svgEl.firstChild);bgs.forEach(function(b){b.remove();});bgs=[];svgEl.style.display='none';}
+  function ln(x1,y1,x2,y2,d){var l=document.createElementNS('http://www.w3.org/2000/svg','line');l.setAttribute('x1',x1);l.setAttribute('y1',y1);l.setAttribute('x2',x2);l.setAttribute('y2',y2);l.setAttribute('stroke',PINK);l.setAttribute('stroke-width','1');if(d)l.setAttribute('stroke-dasharray','4 3');svgEl.appendChild(l);}
+  function bdg(x,y,t){var b=document.createElement('div');b.className='oi-badge';b.textContent=t;b.style.left=x+'px';b.style.top=y+'px';document.body.appendChild(b);bgs.push(b);}
+  function meas(sR,hR){clrM();svgEl.style.display='block';var vw=window.innerWidth,vh=window.innerHeight;[[0,sR.top,sR.left,sR.top],[sR.right,sR.top,vw,sR.top],[0,sR.bottom,sR.left,sR.bottom],[sR.right,sR.bottom,vw,sR.bottom],[sR.left,0,sR.left,sR.top],[sR.left,sR.bottom,sR.left,vh],[sR.right,0,sR.right,sR.top],[sR.right,sR.bottom,sR.right,vh]].forEach(function(a){ln(a[0],a[1],a[2],a[3],true);});var ovH=sR.left<hR.right&&sR.right>hR.left,ovV=sR.top<hR.bottom&&sR.bottom>hR.top;var midY=ovV?(Math.max(sR.top,hR.top)+Math.min(sR.bottom,hR.bottom))/2:(sR.top+sR.bottom)/2,midX=ovH?(Math.max(sR.left,hR.left)+Math.min(sR.right,hR.right))/2:(sR.left+sR.right)/2;if(hR.left>=sR.right){ln(sR.right,midY,hR.left,midY,false);bdg((sR.right+hR.left)/2,midY,Math.round(hR.left-sR.right)+'px');}if(hR.right<=sR.left){ln(hR.right,midY,sR.left,midY,false);bdg((hR.right+sR.left)/2,midY,Math.round(sR.left-hR.right)+'px');}if(hR.top>=sR.bottom){ln(midX,sR.bottom,midX,hR.top,false);bdg(midX,(sR.bottom+hR.top)/2,Math.round(hR.top-sR.bottom)+'px');}if(hR.bottom<=sR.top){ln(midX,hR.bottom,midX,sR.top,false);bdg(midX,(hR.bottom+sR.top)/2,Math.round(sR.top-hR.bottom)+'px');};}
+  function enter(){act=true;document.body.classList.add('oi-mode');hit.style.display='block';}
+  function exit(){act=false;document.body.classList.remove('oi-mode');hit.style.display='none';desel();}
+  function desel(){sel=selR=null;card.style.display='none';card.innerHTML='';selB.style.display='none';hovB.style.display='none';clrM();cpkClose();}
+  function select(t){if(!t||t===document.documentElement||t===document.body)return;if(sel===t){selR=sel.getBoundingClientRect();hovB.style.display='none';clrM();posBox(selB,selR);placeCard(selR);return;}sel=t;selR=sel.getBoundingClientRect();hovB.style.display='none';clrM();posBox(selB,selR);openCard(sel);}
+  function targetAtEvent(e){var t=e.target;if(t===hit){hit.style.display='none';t=document.elementFromPoint(e.clientX,e.clientY);hit.style.display='block';}return t;}
+  function pick(e){if(!act||pickedEvents.has(e))return;pickedEvents.add(e);if(card.contains(e.target)||(cpk.el&&cpk.el.contains(e.target)))return;var sx=window.scrollX||0,sy=window.scrollY||0;e.preventDefault();e.stopImmediatePropagation();if(Number(e.detail||0)>1)return;var t=targetAtEvent(e);if(!t||t===document.documentElement||t===document.body)return;select(t);requestAnimationFrame(function(){if((window.scrollX||0)!==sx||(window.scrollY||0)!==sy)window.scrollTo(sx,sy);});}
+  function swallowClick(e){if(!act)return;if(card.contains(e.target)||(cpk.el&&cpk.el.contains(e.target)))return;e.preventDefault();e.stopImmediatePropagation();}
+  function doublePick(e){if(!act)return;if(card.contains(e.target)||(cpk.el&&cpk.el.contains(e.target)))return;e.preventDefault();e.stopImmediatePropagation();var t=targetAtEvent(e);if(sel&&t&&(t===sel||sel.contains(t)||t.contains(sel))){desel();return;}if(t&&t!==document.documentElement&&t!==document.body)select(t);}
+  function move(e){if(cardDrag){var x=e.clientX-cardDrag.x,y=e.clientY-cardDrag.y;card.style.left=Math.max(0,Math.min(window.innerWidth-card.offsetWidth,x))+'px';card.style.top=Math.max(0,Math.min(window.innerHeight-card.offsetHeight,y))+'px';return;}if(!act)return;var t=e.target;if(card.contains(t)){hovB.style.display='none';return;}if(t===sel){hovB.style.display='none';clrM();return;}var r=t.getBoundingClientRect();if(r.width+r.height===0)return;posBox(hovB,r);if(sel){selR=sel.getBoundingClientRect();posBox(selB,selR);meas(selR,r);}}
+  function key(e){if((e.metaKey||e.ctrlKey)&&String(e.key).toLowerCase()==='z'){e.preventDefault();e.stopPropagation();undoLast();return;}if((e.metaKey||e.ctrlKey)&&String(e.key).toLowerCase()==='m'){e.preventDefault();e.stopPropagation();captureAnnotatable();return;}if(e.key==='Escape'){if(sel)desel();else exit();}}
+  function scroll(){if(!sel)return;selR=sel.getBoundingClientRect();posBox(selB,selR);placeCard(selR);}
+  function message(e){if(!e||!e.data)return;if(e.data.type==='od:annotate-mode'){if(e.data.enabled)enter();else exit();return;}if(e.data.type==='od:annotate-locale'){var s=e.data.strings;if(s&&typeof s==='object'){if(s.uploadImage)L.uploadImage=s.uploadImage;if(s.imageRef)L.imageRef=s.imageRef;if(s.textRef)L.textRef=s.textRef;if(s.colorRef)L.colorRef=s.colorRef;if(s.refOptions)L.refOptions=s.refOptions;if(s.imagePrompt)L.imagePrompt=s.imagePrompt;if(s.regenerateImage)L.regenerateImage=s.regenerateImage;}return;}if(e.data.type==='od:annotate-image-prompt-result'){var btn=card.querySelector('[data-action="regenerate-image"]');if(btn)btn.disabled=false;if(e.data.ok){if(sel&&e.data.src){var info=imagePromptTarget||imageInfo(sel),target=info&&info.target?info.target:sel;if(info&&info.kind==='background')target.style.setProperty('background-image','url(\"'+String(e.data.src).replace(/"/g,'\\\\\"')+'\")');else if(info&&info.kind==='href'){target.setAttribute('href',e.data.src);target.setAttribute('xlink:href',e.data.src);}else{target.setAttribute('src',e.data.src);if(e.data.alt)target.setAttribute('alt',e.data.alt);}updateRow('__image',imageNameFromSrc(e.data.src));refreshAfterEdit();}imagePromptStatus('已更新图片','ok');}else imagePromptStatus(e.data.error||'生成失败，请重试','err');return;}if(e.data.type==='od:annotate-capture-result'){return;}if(e.data.type==='od:annotate-trigger-animation'){playCaptureAnimation();return;}if(e.data.type==='od:annotate-undo'){undoLast();return;}if(e.data.type==='od:annotate-trigger-capture'){captureAnnotatable(e.data.captureId||'');return;}if(e.data.type==='od:annotate-pick'){if(!act)enter();var t=document.elementFromPoint(Number(e.data.x||0),Number(e.data.y||0));select(t);}}
+  card.addEventListener('pointerdown',function(e){e.stopPropagation();var pv=e.target.closest&&e.target.closest('.oi-pv');if(pv)setActiveProp(pv.getAttribute('data-p'),false);},true);
+  card.addEventListener('click',function(e){var capBtn=e.target.closest&&e.target.closest('[data-action="capture"]');if(capBtn){captureAnnotatable();return;}var regen=e.target.closest&&e.target.closest('[data-action="regenerate-image"]');if(regen){submitImagePrompt();return;}var xbtn=e.target.closest&&e.target.closest('.oi-quad-xbtn');if(xbtn){var qd=xbtn.closest('.oi-quad');if(qd){qd.classList.toggle('open');xbtn.textContent=qd.classList.contains('open')?'▾':'▸';}return;}var imgTarget=e.target.closest&&e.target.closest('[data-od-upload="1"]');if(imgTarget){chooseImage();return;}var opt=e.target.closest&&e.target.closest('.oi-opt');if(opt){setValueFor(activeProp,opt.getAttribute('data-value')||'');return;}var chip=e.target.closest&&e.target.closest('.oi-chip');if(chip){setValueFor(activeProp,chip.getAttribute('data-color')||'');return;}var sw=e.target.closest&&e.target.closest('.oi-color-row .oi-sw');if(sw){openColorPicker(sw.closest('.oi-pv'));}});
+  card.addEventListener('change',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('oi-color-input'))setColorPv(activeColorPv(),e.target.value);});
+  card.addEventListener('change',function(e){if(!(e.target&&e.target.classList&&e.target.classList.contains('oi-file-input')))return;var file=e.target.files&&e.target.files[0];if(!file||!sel)return;pushUndo(captureUndo('__image'));var url=URL.createObjectURL(file);sel.setAttribute('src',url);var pv=card.querySelector('.oi-pv[data-p="__image"]'),val=pv&&pv.querySelector('.oi-val');if(val)val.textContent=file.name;refreshAfterEdit();postImageSave(file);e.target.value='';});
+  card.addEventListener('input',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('oi-color-input'))setColorPv(activeColorPv(),e.target.value);});
+  card.addEventListener('focusin',function(e){var pv=e.target&&e.target.closest&&e.target.closest('.oi-pv');if(pv)setActiveProp(pv.getAttribute('data-p'),false);});
+  card.addEventListener('input',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('oi-val'))applyEdit(e.target);});
+  card.addEventListener('blur',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('oi-val'))applyEdit(e.target);},true);
+  card.addEventListener('keydown',function(e){if(e.target&&e.target.matches&&e.target.matches('[data-oi-image-prompt]')){e.stopPropagation();if((e.metaKey||e.ctrlKey)&&e.key==='Enter'){e.preventDefault();submitImagePrompt();}return;}if((e.metaKey||e.ctrlKey)&&String(e.key).toLowerCase()==='z'){e.preventDefault();e.stopPropagation();undoLast();return;}if((e.metaKey||e.ctrlKey)&&String(e.key).toLowerCase()==='m'){e.preventDefault();e.stopPropagation();captureAnnotatable();return;}if(e.target&&e.target.classList&&e.target.classList.contains('oi-val')){e.stopPropagation();if(e.key==='Enter'){e.preventDefault();applyEdit(e.target);e.target.blur();}if(e.key==='Escape'){e.preventDefault();e.target.blur();}}});
+  card.addEventListener('mousedown',function(e){var h=e.target.closest&&e.target.closest('.oi-hdr');if(!h||e.target.closest('button,a,input,select,textarea'))return;e.preventDefault();var r=card.getBoundingClientRect();cardDrag={x:e.clientX-r.left,y:e.clientY-r.top};},true);
+  function cardUp(){cardDrag=null;}
+  window.addEventListener('pointerdown',pick,true);
+  document.addEventListener('pointerdown',pick,true);
+  window.addEventListener('click',swallowClick,true);
+  document.addEventListener('click',swallowClick,true);
+  window.addEventListener('dblclick',doublePick,true);
+  document.addEventListener('dblclick',doublePick,true);
+  document.addEventListener('mousemove',move);
+  document.addEventListener('mouseup',cardUp);
+  window.addEventListener('keydown',key,true);
+  window.addEventListener('scroll',scroll,{passive:true});
+  window.addEventListener('message',message);
+  window.__oiCleanup=function(){window.removeEventListener('pointerdown',pick,true);document.removeEventListener('pointerdown',pick,true);window.removeEventListener('click',swallowClick,true);document.removeEventListener('click',swallowClick,true);window.removeEventListener('dblclick',doublePick,true);document.removeEventListener('dblclick',doublePick,true);document.removeEventListener('mousemove',move);document.removeEventListener('mouseup',cardUp);window.removeEventListener('keydown',key,true);window.removeEventListener('scroll',scroll);window.removeEventListener('message',message);document.querySelectorAll('#oi-hit,#oi-sel,#oi-hov,#oi-svg,#oi-card,.oi-badge,.oi-shot,.oi-shot-fly').forEach(function(el){el.remove();});};
+  if(INITIAL_ENABLED)enter();
+}
+if(document.body)boot();else document.addEventListener('DOMContentLoaded',boot);
+})();</script>`;
+  return injectBeforeBodyEnd(doc, script);
 }


### PR DESCRIPTION
## Why

This PR preserves the local preview Edit workflow that was working before the recent main-merge cleanup. The branch keeps the user-facing annotation card, element selection, style/text/image editing, reference lines, and screenshot-to-composer behavior available so it can be reviewed and then reconciled with the latest `main` structure without losing the working implementation.

The pain being addressed is that the newer main-aligned attempt dropped the custom Edit module behavior the user was actively validating: clicking a preview element should open the parameter card, edits should apply back to the file, and screenshots should land in the chat composer.

## What users will see

In HTML preview, users can open Edit mode, click elements in the rendered preview, inspect and modify element parameters, and capture screenshots into the composer as attachments.

## Surface area

- [x] **UI** — preview toolbar Edit/screenshot behavior and preview overlay/card interactions in `apps/web`
- [x] **Keyboard shortcut** — Edit screenshot flow includes Command/Ctrl+M handling
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — restores an interactive preview Edit workflow in the preview toolbar
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from CLI. This branch is intended to preserve the local working implementation for reviewer/browser validation.

## Bug fix verification

- Test path that reproduces the bug: not added in this preservation branch.
- Did the test go red on `main` and green on this branch? no — this PR restores the known working local implementation first so it can be reconciled with current main in a follow-up pass.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
