### PR TITLE
fix(web): keep bare chat URLs readable

### DIFF
--- a/apps/web/src/styles/viewer/code.css
+++ b/apps/web/src/styles/viewer/code.css
@@ -749,8 +749,8 @@
   color: var(--accent-strong);
 }
 .prose-block .md-link-bare {
-  word-break: break-all;
-  overflow-wrap: anywhere;
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 .prose-block .md-hr {
   border: none;

--- a/apps/web/tests/runtime/markdown.test.tsx
+++ b/apps/web/tests/runtime/markdown.test.tsx
@@ -62,7 +62,7 @@ describe('renderMarkdown', () => {
     expect(out).toContain('>here</a>');
   });
 
-  it('marks bare URLs with the bare-link class so CSS can break them mid-string', () => {
+  it('marks bare URLs with the bare-link class so CSS can apply URL-specific wrapping', () => {
     const out = html('See https://example.com/very/long/path?with=long&query=string');
     expect(out).toContain('md-link-bare');
   });

--- a/apps/web/tests/styles/markdown-links.test.ts
+++ b/apps/web/tests/styles/markdown-links.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const codeCss = readFileSync(
+  new URL('../../src/styles/viewer/code.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const cssWithoutComments = codeCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const rulePattern = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, 'g');
+  let declarations = '';
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    declarations += match[1] ?? '';
+  }
+  return declarations;
+}
+
+describe('markdown link wrapping styles', () => {
+  it('keeps bare URLs readable by avoiding arbitrary hostname breaks', () => {
+    const bareLink = cssDeclarations('.prose-block .md-link-bare');
+
+    expect(bareLink).toContain('word-break: normal;');
+    expect(bareLink).toContain('overflow-wrap: break-word;');
+    expect(bareLink).not.toContain('break-all');
+    expect(bareLink).not.toContain('overflow-wrap: anywhere;');
+  });
+});


### PR DESCRIPTION
Fixes #4883

## Why

I picked this up because Ask mode chat replies can render bare URLs with aggressive character-level wrapping, making common links like GitHub repo URLs look visually broken in the narrow chat pane.

The pain is user-facing readability and link trust: a hostname split as `githu` / `b.com` looks malformed even though the link target is valid.

## What users will see

Bare URLs in assistant replies still wrap when needed, but they no longer force arbitrary mid-hostname breaks before natural URL breakpoints have a chance to work.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a CSS wrapping regression covered by a focused style test; no new UI entry point was added.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/markdown-links.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new test failed before the CSS change because `.md-link-bare` still used `word-break: break-all` and `overflow-wrap: anywhere`; it passes after the fix.

## Validation

- `pnpm -r --filter './packages/**' --if-present run build`
- `cd apps/web && pnpm exec vitest run -c vitest.config.ts tests/runtime/markdown.test.tsx tests/styles/markdown-links.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
