### PR TITLE
[codex] Refine Open Design CLI picker controls

### DIFF
--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -8,6 +8,7 @@ import { useT } from '../i18n';
 import { AgentIcon } from './AgentIcon';
 import { PlanBadge } from './PlanBadge';
 import { RemixIcon } from './RemixIcon';
+import { orderAgentsWithOpenDesignFirst } from './agentOrdering';
 import { SearchableModelSelect } from './modelOptions';
 import type { AgentInfo, AppConfig, ExecMode, ProviderModelOption } from '../types';
 import { SUGGESTED_MODELS_BY_PROTOCOL } from '../state/apiProtocols';
@@ -24,7 +25,6 @@ import {
 } from '../providers/daemon';
 import { isMacPlatform } from '../utils/platform';
 import {
-  amrConsoleUrlForProfile,
   amrPlansUrlForProfile,
 } from '../runtime/amr-guidance';
 
@@ -171,11 +171,9 @@ export function AvatarMenu({
     [agents, config.agentId],
   );
 
-  // Pin Open Design (amr) to the top of the code-agent list; keep every other
-  // agent in its original daemon-provided order (Array.sort is stable).
-  const installedAgents = agents
-    .filter((a) => a.available)
-    .sort((a, b) => Number(b.id === 'amr') - Number(a.id === 'amr'));
+  const installedAgents = orderAgentsWithOpenDesignFirst(
+    agents.filter((a) => a.available),
+  );
   const amrAvailable = installedAgents.some((a) => a.id === 'amr');
   const amrProfile = config.agentCliEnv?.amr?.OPEN_DESIGN_AMR_PROFILE;
 
@@ -226,22 +224,9 @@ export function AvatarMenu({
         : null)
     : null;
   const amrResolvedProfile = amrAccount?.profile ?? amrProfile;
-  const amrConsoleUrl = amrConsoleUrlForProfile(amrResolvedProfile);
   const amrCanUpgrade =
     !!amrAccount?.loggedIn && canUpgradeVelaPlan(amrAccount.account?.plan);
   const amrPlansUrl = amrPlansUrlForProfile(amrResolvedProfile);
-  const handleAmrConsoleClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
-    const attribution = recordAmrEntry(analytics.track, 'avatar_amr_console', new Date(), {
-      metricsConsent: config.telemetry?.metrics === true,
-    });
-    const deviceId = amrHandoffDeviceId({
-      metricsConsent: config.telemetry?.metrics === true,
-      resolvedDeviceId: getResolvedDeviceId(),
-      installationId: config.installationId,
-    });
-    event.currentTarget.href = attributedAmrUrl(amrConsoleUrl, attribution, deviceId);
-    setOpen(false);
-  };
   const handleAmrUpgradeClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
     const attribution = recordAmrEntry(analytics.track, 'avatar_amr_upgrade', new Date(), {
       metricsConsent: config.telemetry?.metrics === true,
@@ -477,19 +462,6 @@ export function AvatarMenu({
                           ) : null}
                         </span>
                       </button>
-                      {amrAccount?.loggedIn ? (
-                        <a
-                          className="avatar-amr-row__console"
-                          href={amrConsoleUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={t('avatar.amrConsole')}
-                          title={t('avatar.amrConsoleMeta')}
-                          onClick={handleAmrConsoleClick}
-                        >
-                          <RemixIcon name="wallet-3-line" size={14} />
-                        </a>
-                      ) : null}
                       {amrCanUpgrade ? (
                         <a
                           className="avatar-amr-row__upgrade"

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -63,6 +63,7 @@ import {
   amrLoginStatusEventReason,
   notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
+import { orderAgentsWithOpenDesignFirst } from './agentOrdering';
 import { normalizeAgentModelChoice } from './agentModelSelection';
 import { SearchableModelSelect } from './modelOptions';
 import {
@@ -382,7 +383,7 @@ export function InlineModelSwitcher({
   }, [refreshAmrStatus, startAmrPolling, stopAmrPolling]);
 
   const installedAgents = useMemo(
-    () => agents.filter((a) => a.available),
+    () => orderAgentsWithOpenDesignFirst(agents.filter((a) => a.available)),
     [agents],
   );
   const currentAgent = useMemo(

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -41,6 +41,7 @@ import { AgentIcon } from './AgentIcon';
 import { AgentDiagnosticRow } from './AgentDiagnosticRow';
 import { AmrLoginPill } from './AmrLoginPill';
 import { PlanBadge } from './PlanBadge';
+import { orderAgentsWithOpenDesignFirst } from './agentOrdering';
 import {
   AMR_LOGIN_STATUS_EVENT,
   amrLoginStatusEventReason,
@@ -2932,7 +2933,9 @@ export function SettingsDialog({
     about: { title: t('settings.about'), subtitle: t('settings.aboutHint') },
   };
   const activeHeader = sectionHeader[activeSection];
-  const installedAgents = agents.filter((a) => a.available);
+  const installedAgents = orderAgentsWithOpenDesignFirst(
+    agents.filter((a) => a.available),
+  );
   const unavailableAgents = agents.filter((a) => !a.available);
   const initialAgentScanRunning = agentsLoading && agents.length === 0;
   const agentModelOptionLabel = (
@@ -3849,27 +3852,6 @@ export function SettingsDialog({
                                               </span>
                                             </span>
                                           ) : null}
-                                          <button
-                                            type="button"
-                                            className="agent-card-amr-wallet-refresh"
-                                            title={t('settings.amrWalletRefreshTitle')}
-                                            aria-label={t('settings.amrWalletRefreshTitle')}
-                                            disabled={!amrWalletReady && !amrCardBalanceLabel}
-                                            onClick={(event) => {
-                                              event.stopPropagation();
-                                              void refreshAmrWalletSnapshot({ refresh: true });
-                                            }}
-                                          >
-                                            <Icon
-                                              name={!amrWalletReady && !amrCardBalanceLabel ? 'spinner' : 'refresh'}
-                                              size={13}
-                                              className={
-                                                !amrWalletReady && !amrCardBalanceLabel
-                                                  ? 'icon-spin'
-                                                  : undefined
-                                              }
-                                            />
-                                          </button>
                                         </div>
                                       ) : null}
                                       {!active && modelSummary ? (

--- a/apps/web/src/components/agentOrdering.ts
+++ b/apps/web/src/components/agentOrdering.ts
@@ -1,0 +1,14 @@
+export function orderAgentsWithOpenDesignFirst<T extends { id: string }>(
+  agents: readonly T[],
+): T[] {
+  const openDesignAgents: T[] = [];
+  const otherAgents: T[] = [];
+  for (const agent of agents) {
+    if (agent.id === 'amr') {
+      openDesignAgents.push(agent);
+    } else {
+      otherAgents.push(agent);
+    }
+  }
+  return [...openDesignAgents, ...otherAgents];
+}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1345,9 +1345,8 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 6px;
-  /* Open Design (the account card) is pinned to the top of the 代理 group;
-     the third-party CLI grid follows it. The card sits before this grid in the
-     flex column source order, so this order keeps it on top. */
+  /* Open Design renders as `.inline-switcher__account`; keep the third-party
+     CLI grid after that account row even though their source order differs. */
   order: 1;
 }
 .inline-switcher__agent-row {
@@ -1469,6 +1468,7 @@
 /* Account row: Open Design login/plan, lifted out of the agent card so the
    agent name is never truncated. */
 .inline-switcher__account {
+  order: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1489,7 +1489,11 @@
 }
 .inline-switcher__account.is-active {
   border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
-  background: var(--accent-tint);
+  background: color-mix(in srgb, var(--bg-subtle) 82%, var(--accent-tint));
+}
+.inline-switcher__account.is-active:has(.inline-switcher__account-select:hover) {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+  background: color-mix(in srgb, var(--bg-panel) 74%, var(--accent-tint));
 }
 .inline-switcher__account-id {
   display: inline-flex;

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1145,11 +1145,11 @@
   gap: 8px;
 }
 .avatar-amr-row.active {
-  background: var(--accent-tint);
+  background: color-mix(in srgb, var(--bg-subtle) 82%, var(--accent-tint));
   color: var(--text-strong);
 }
 .avatar-amr-row.active:hover {
-  background: var(--accent-tint);
+  background: color-mix(in srgb, var(--bg-panel) 74%, var(--accent-tint));
 }
 .avatar-amr-row__select {
   flex: 1 1 auto;
@@ -1259,21 +1259,6 @@
   .avatar-amr-row__upgrade:active {
     transform: none;
   }
-}
-.avatar-amr-row__console {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: var(--radius-sm);
-  color: var(--text-muted);
-  text-decoration: none;
-}
-.avatar-amr-row__console:hover {
-  color: var(--accent-strong);
-  background: var(--bg-subtle);
 }
 .avatar-item {
   display: flex;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1408,30 +1408,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.agent-card-amr-wallet-refresh {
-  align-self: center;
-  flex: 0 0 32px;
-  width: 32px;
-  height: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border-soft);
-  border-radius: var(--radius-md);
-  background: var(--bg-panel);
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background-color 120ms var(--ease-out), border-color 120ms var(--ease-out), color 120ms var(--ease-out);
-}
-.agent-card-amr-wallet-refresh:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
-  background: color-mix(in srgb, var(--accent-tint) 62%, var(--bg-panel));
-  color: var(--accent-strong);
-}
-.agent-card-amr-wallet-refresh:disabled {
-  cursor: default;
-  opacity: 0.62;
-}
 .agent-card-amr-upgrade {
   appearance: none;
   flex: 0 0 auto;

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -141,6 +141,47 @@ describe('AvatarMenu', () => {
     expect(onOpenSettings).toHaveBeenCalledWith('execution');
   });
 
+  it('pins Open Design to the top of the CLI picker', async () => {
+    const amrAgent: AgentInfo = {
+      id: 'amr',
+      name: 'Open Design AMR',
+      bin: 'vela',
+      available: true,
+      models: [{ id: 'default', label: 'Default (CLI config)' }],
+    };
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: false,
+            loginInFlight: false,
+            profile: 'test',
+            user: null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    }));
+
+    renderMenu({ agents: [codexAgent, claudeAgent, amrAgent] });
+    const menu = openMenu();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar-agent-option-amr')).toBeTruthy();
+    });
+    expect(
+      Array.from(menu.querySelectorAll('[data-testid^="avatar-agent-option-"]'))
+        .map((row) => row.getAttribute('data-testid')),
+    ).toEqual([
+      'avatar-agent-option-amr',
+      'avatar-agent-option-codex',
+      'avatar-agent-option-claude',
+    ]);
+  });
+
   it('rescans agents and re-renders newly available CLI entries', async () => {
     function Harness() {
       const [agents, setAgents] = useState<AgentInfo[]>([
@@ -262,18 +303,7 @@ describe('AvatarMenu', () => {
       '$247.51',
     );
 
-    const consoleLink = screen.getByRole('link', {
-      name: 'avatar.amrConsole',
-    }) as HTMLAnchorElement;
-    fireEvent.click(consoleLink);
-    const consoleUrl = new URL(consoleLink.href);
-    expect(consoleUrl.searchParams.get('view')).toBeNull();
-    expect(consoleUrl.searchParams.get('od_entry_source')).toBe('avatar_amr_console');
-    expect(consoleUrl.searchParams.get('source')).toBe('open_design');
-    expect(consoleUrl.searchParams.get('od_device_id')).toBe('od-install-abc');
-
-    openMenu();
-    expect(await screen.findByText('Plus')).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'avatar.amrConsole' })).toBeNull();
     const upgrade = screen.getByRole('link', {
       name: 'settings.amrUpgrade',
     }) as HTMLAnchorElement;
@@ -285,7 +315,7 @@ describe('AvatarMenu', () => {
     expect(url.searchParams.get('od_device_id')).toBe('od-install-abc');
   });
 
-  it('keeps the avatar AMR console link for non-upgradeable plans', async () => {
+  it('omits wallet and upgrade links for non-upgradeable plans', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === '/api/integrations/vela/status') {
@@ -327,16 +357,7 @@ describe('AvatarMenu', () => {
     openMenu();
     expect(await screen.findByText('Max')).toBeTruthy();
     expect(screen.queryByRole('link', { name: 'settings.amrUpgrade' })).toBeNull();
-
-    const consoleLink = screen.getByRole('link', {
-      name: 'avatar.amrConsole',
-    }) as HTMLAnchorElement;
-    fireEvent.click(consoleLink);
-    const url = new URL(consoleLink.href);
-    expect(url.searchParams.get('view')).toBeNull();
-    expect(url.searchParams.get('od_entry_source')).toBe('avatar_amr_console');
-    expect(url.searchParams.get('source')).toBe('open_design');
-    expect(url.searchParams.get('od_device_id')).toBe('od-install-abc');
+    expect(screen.queryByRole('link', { name: 'avatar.amrConsole' })).toBeNull();
   });
 
   it('falls back to the wallet snapshot when signed-in status has no account balance', async () => {
@@ -437,14 +458,7 @@ describe('AvatarMenu', () => {
     openMenu();
     expect(await screen.findByText('Plus')).toBeTruthy();
 
-    const consoleLink = screen.getByRole('link', {
-      name: 'avatar.amrConsole',
-    }) as HTMLAnchorElement;
-    fireEvent.click(consoleLink);
-    expect(new URL(consoleLink.href).origin).toBe('https://vela.powerformer.net');
-
-    openMenu();
-    expect(await screen.findByText('Plus')).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'avatar.amrConsole' })).toBeNull();
     const upgrade = screen.getByRole('link', {
       name: 'settings.amrUpgrade',
     }) as HTMLAnchorElement;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1783,6 +1783,56 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     vi.unstubAllGlobals();
   });
 
+  it('pins Open Design to the top of the installed CLI list', () => {
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.196',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: false,
+            loginInFlight: false,
+            profile: 'local',
+            user: null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    }));
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex' },
+      { agents: [availableAgents[0]!, claudeAgent, amrAgent] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*3 installed/i }));
+
+    expect(
+      screen
+        .getAllByTestId(/^settings-agent-card-/)
+        .map((card) => card.getAttribute('data-testid')),
+    ).toEqual([
+      'settings-agent-card-amr',
+      'settings-agent-card-codex',
+      'settings-agent-card-claude',
+    ]);
+  });
+
   it('lets users switch to Local CLI, select an installed agent, and autosave', async () => {
     const installed = availableAgents[0]!;
     const unavailable: AgentInfo = {
@@ -2600,7 +2650,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.queryByText(/^vela$/i)).toBeNull();
   });
 
-  it('refreshes the Settings AMR wallet fallback balance for old Vela CLI status payloads', async () => {
+  it('shows the Settings AMR wallet fallback balance for old Vela CLI status payloads', async () => {
     let walletCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -2632,7 +2682,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
             status: 'available',
             profile: 'local',
             user: { id: 'user-1', email: 'signed-in@example.com' },
-            balanceUsd: walletCalls === 1 ? '1.0000' : '2.0000',
+            balanceUsd: '1.0000',
             updatedAt: '2026-06-29T08:00:00.000Z',
             fetchedAt: '2026-06-29T08:00:01.000Z',
             stale: false,
@@ -2653,9 +2703,9 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
 
     expect(await screen.findByText('$1.00')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh AMR wallet balance' }));
-    expect(await screen.findByText('$2.00')).toBeTruthy();
-    expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/wallet?refresh=1', {
+    expect(screen.queryByRole('button', { name: 'Refresh AMR wallet balance' })).toBeNull();
+    expect(walletCalls).toBe(1);
+    expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/wallet', {
       cache: 'no-store',
     });
   });


### PR DESCRIPTION
## Why

This ports the CLI picker refinement from the supplied `open-design-cli-picker-pr4926-code.zip` package onto the current `main` branch. The change keeps the Open Design agent pinned consistently across picker surfaces while removing redundant wallet/console controls that made the picker rows more crowded than necessary.

The pain addressed is a cluttered Open Design CLI picker experience: the account/agent rows were carrying extra action controls in multiple places, and the Open Design-first ordering was duplicated instead of shared.

## What users will see

In the avatar menu, inline model switcher, and Settings execution panel, Open Design stays first in the local code-agent list when it is installed. The Open Design account rows look calmer: active-row styling is softer, and redundant wallet/console refresh-style controls are no longer shown inside the compact picker rows.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not captured in this pass. This is a draft PR opened from the provided code package; UI validation is covered by focused component tests below, but reviewer-facing screenshots should be added before marking ready.

## Bug fix verification

-

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/AvatarMenu.test.tsx tests/components/SettingsDialog.execution.test.tsx`
