### PR TITLE
Add Design System Source Context plugin

### DIFF
--- a/plugins/community/design-system-source-context-mr0bb87z/SKILL.md
+++ b/plugins/community/design-system-source-context-mr0bb87z/SKILL.md
@@ -1,0 +1,93 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Claude / Anthropic 风格设计系统
+
+非官方 Claude / Anthropic 风格整理版：温暖、克制、编辑感、适合阅读与深度思考的 AI 工作台。当前 canonical 依据包括 `assets/Claude-anthropic-DESIGN风格设计系统.md`，以及 2026-06-29 抽查的 Anthropic 官网首页、Newsroom、Company 页面公开 CSS。颜色和交互以官网 token 命名校准：`ivory-light #faf9f5`、`ivory-medium #f0eee6`、`ivory-dark #e8e6dc`、`slate-dark #141413`、`clay #d97757`。
+
+## Source Links
+
+- None linked.
+
+## GitHub Repositories
+
+- None linked.
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`: none.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Decoded Figma snapshots: none.
+Fonts, logos, and assets selected:
+- Claude-anthropic DESIGN风格设计系统.md
+
+Uploaded brand asset files under `assets/`:
+- assets/Claude-anthropic-DESIGN风格设计系统.md
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, website/source URL review, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.
+
+## Provenance
+
+Formalized by Open Design from candidate 242e9a72-9a69-4de5-91a4-67563dcf7db1.

--- a/plugins/community/design-system-source-context-mr0bb87z/open-design.json
+++ b/plugins/community/design-system-source-context-mr0bb87z/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-source-context-mr0bb87z",
+  "title": "Design System Source Context",
+  "version": "0.1.0",
+  "description": "This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/design-system-source-context-mr0bb87z/references/provenance.json
+++ b/plugins/community/design-system-source-context-mr0bb87z/references/provenance.json
@@ -1,0 +1,26 @@
+{
+  "candidateId": "242e9a72-9a69-4de5-91a4-67563dcf7db1",
+  "projectId": "brand-anthropic-a38199",
+  "runId": "30dd0eed-69ac-4975-9ca8-c659cfffeda2",
+  "conversationId": "05128f01-0c8c-43bb-9672-78ed2973b1fd",
+  "provenance": {
+    "summary": "Detected from context/source-context.md, SKILL.md after a successful run.",
+    "detectedAt": 1782803588534
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 8892,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 5815,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/design-system-source-context-mr0bb87z/references/source-1-source-context.md
+++ b/plugins/community/design-system-source-context-mr0bb87z/references/source-1-source-context.md
@@ -1,0 +1,89 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Claude / Anthropic 风格设计系统
+
+非官方 Claude / Anthropic 风格整理版：温暖、克制、编辑感、适合阅读与深度思考的 AI 工作台。当前 canonical 依据包括 `assets/Claude-anthropic-DESIGN风格设计系统.md`，以及 2026-06-29 抽查的 Anthropic 官网首页、Newsroom、Company 页面公开 CSS。颜色和交互以官网 token 命名校准：`ivory-light #faf9f5`、`ivory-medium #f0eee6`、`ivory-dark #e8e6dc`、`slate-dark #141413`、`clay #d97757`。
+
+## Source Links
+
+- None linked.
+
+## GitHub Repositories
+
+- None linked.
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`: none.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Decoded Figma snapshots: none.
+Fonts, logos, and assets selected:
+- Claude-anthropic DESIGN风格设计系统.md
+
+Uploaded brand asset files under `assets/`:
+- assets/Claude-anthropic-DESIGN风格设计系统.md
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, website/source URL review, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.

--- a/plugins/community/design-system-source-context-mr0bb87z/references/source-2-SKILL.md
+++ b/plugins/community/design-system-source-context-mr0bb87z/references/source-2-SKILL.md
@@ -1,0 +1,93 @@
+---
+name: claude-anthropic-design-system
+description: Use this Claude / Anthropic style design system for warm, restrained, editorial AI workbench interfaces.
+user-invocable: true
+---
+
+# Claude / Anthropic 风格设计系统
+
+## What's inside
+
+- `DESIGN.md` defines the source-backed visual rules.
+- `colors_and_type.css` provides reusable tokens.
+- `BRAND.md` and `PROVENANCE.json` describe the optimized package version, preserved assets, and measured/inferred evidence boundary.
+- `SYSTEM-MANIFEST.json` records stable read order, file roles, and invariants.
+- `fonts/`, `logos/`, and `imagery/` contain preserved official source assets from sampled Anthropic pages.
+- `preview/` contains focused review cards.
+- `examples/` contains detail and page-level usage examples; `examples/examples.css` is the shared fixture component layer.
+- `system/kit.html` and `ui_kits/app/index.html` show applied components.
+
+## Source Context
+
+The system is based on the pasted Anthropic-style DESIGN.md plus Anthropic public CSS sampling recorded in `anthropic-official-colors.md`.
+
+Source-backed evidence:
+
+- Ivory surface ladder: `#faf9f5`, `#f0eee6`, `#e8e6dc`
+- Slate action system: `#141413`, `#3d3d3a`
+- Clay accent: `#d97757`, sparse use only
+- Header interaction: underline hover and caret rotation
+- Focus ring: `#2c84db`
+- Local official webfont files: `fonts/` contains Anthropic Sans / Serif / Mono.
+- Asset manifest: `source_examples/official-source-manifest.json`.
+- Inference boundary: `#6ea100` is measured in source CSS and assigned here as success semantics, but it is not claimed as an official named success token.
+
+## When to use this skill
+
+Use it to design prototypes, mockups, interfaces, production artifacts, dashboards, forms, decks, and product shells that need a Claude / Anthropic visual language.
+
+## How to use
+
+1. Read `DESIGN.md`.
+2. Load `colors_and_type.css`.
+3. Check `SYSTEM-MANIFEST.json` for stable package structure.
+4. Check `PROVENANCE.json` when a value needs source proof.
+5. Start from Ivory surfaces: page `#faf9f5`, components `#f0eee6`, hover/selected `#e8e6dc`; dropdowns inherit the owning trigger/nav background.
+6. Use Slate Dark `#141413` for primary actions.
+7. Use Clay `#d97757` only for sparse emphasis.
+8. Verify against `preview/*.html`.
+9. Use `examples/index.html` for concrete details and full-page examples.
+10. Do not fork nav, dropdown, button, route-tab, sidebar, or color-library logic per page; reuse `examples/examples.css` patterns.
+
+## Highlights
+
+- Colors: warm paper surface ladder.
+- Typography: Serif display, Sans UI, Mono code.
+- Spacing: 4px / 8px baseline grid.
+- Radius: 8px standard cards, 12px controls.
+- Layout: reading-first, bordered, low-shadow surfaces.
+- Interaction: header hover uses underline and caret rotation.
+- Header hover uses underline and caret rotation.
+- Dropdowns inherit the owning trigger/nav theme background, open on hover/focus, and use subtle borders/shadow.
+- Claude.com details: use-cases card hover, pricing route tabs, Batch processing switch, startups language picker, and Contact sales / Read more button hierarchy are captured in examples.
+- Sidebar system: light rails use warm borders and Slate active states; dark overlay sidebars use Slate dark, Ivory text, and deep Slate borders.
+- Numerics: prices, counts, dates, percentages, and table metrics use the mono stack with tabular numbers.
+- No Ant Design default blue/green/yellow/red defaults.
+
+## Examples
+
+- Detail examples: `examples/details-surface-layers.html`, `details-color-library.html`, `details-hover-motion.html`, `details-scroll-route-motion.html`, `details-buttons-links.html`, `details-claude-official-interactions.html`, `details-sidebar-system.html`, `details-forms-focus.html`, `details-status-data.html`, `details-typography-cn-en.html`.
+- Page examples: `examples/page-landing.html`, `page-research.html`, `page-newsroom.html`, `page-company.html`, `page-console.html`, `page-login.html`, `page-settings-form.html`.
+- Start with `examples/index.html` when you need to see the system applied before designing.
+
+## Reuse workflow
+
+Use this package when creating or revising an Open Design artifact:
+
+1. Read `DESIGN.md` before authoring.
+2. Import `colors_and_type.css` or copy its `:root` tokens.
+3. Check `preview/colors-usage.html` for layer order. Check `preview/assets-provenance.html` for preserved fonts/icons/images.
+4. Check `preview/components-buttons.html` before shipping CTA-heavy screens.
+5. Check `preview/navigation-menus.html` for topbar and dropdown behavior.
+6. Check `preview/claude-interactions.html` for Claude.com-specific button, switch, card, language picker, and route behavior.
+7. Check the matching `examples/page-*.html` before shipping a full page.
+
+## Implementation Details
+
+- Smooth scrolling is part of the system: keep `html { scroll-behavior: smooth; }` and disable it in `prefers-reduced-motion`.
+- Product dropdowns use `.nav-demo > .nav-item + .nav-demo-panel .mega`; production opens on hover/focus-within, while `.is-open` is only for inspection fixtures.
+- Carets use the shared `.caret` SVG mask and rotate exactly `180deg`; never hand-build arrow borders.
+- Route switching uses `.route-tabs`, `.route-panels`, and overlapping `.route-panel` children. Toggle only `aria-selected` and `.active`; the CSS handles opacity + translateY. Use `examples/details-scroll-route-motion.html` as the visible fixture for smooth scrolling and route transitions.
+- Buttons use the shared `.btn` variants and official double-ring hover model. Do not substitute color-swap hover.
+- Sidebars use `details-sidebar-system.html` as the source pattern; docs sidebars follow page scroll and do not get independent persistent scrollbars.
+- Prices, dates, token counts, percentages, and table metrics use `.numeric`.


### PR DESCRIPTION
Add Design System Source Context (design-system-source-context-mr0bb87z) plugin.
Version: 0.1.0
Description: This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.