### PR TITLE
ci(release): finalize-release — bump main + drop backport label after a stable ships

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -6,7 +6,17 @@ name: finalize-release
 #   2. Opens a PR bumping main's synchronized workspace versions to X.Y.(Z+1),
 #      keeping main strictly ahead of the just-shipped stable tag (the build
 #      guard requires apps/packaged version > the latest open-design-v* tag),
-#      and enables squash auto-merge so it lands through main's merge queue.
+#      arms it for the merge queue (gh pr merge --auto enqueues on green), and
+#      requests a @nexu-io/core-maintainers review.
+#
+# Why this PR still needs ONE human approval (unlike backport-automerge /
+# bake-plugin-previews-automerge, which merge bot PRs hands-free): main enforces
+# require_code_owner_review, and the bump touches CODEOWNERS-owned release
+# manifests (apps/packaged, apps/desktop, packages/platform, packages/sidecar*,
+# tools/pack, tools/dev). A bot approval cannot satisfy the code-owner gate, so
+# a core-maintainer must approve. Once they do, the armed merge queue squashes it
+# in automatically — no manual file editing, label cleanup, or enqueue. (release/v*
+# has require_code_owner_review=false, which is why backports CAN auto-approve.)
 #
 # Only release-stable.yml creates a GitHub Release; prerelease/preview/beta
 # publish to R2 only and never fire this. The job `if` still guards on the
@@ -121,7 +131,7 @@ jobs:
           echo "Bumped $changed manifests from $current to $NEXT."
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Open the bump PR + enable squash auto-merge
+      - name: Open the bump PR, arm the merge queue, request review
         if: steps.bump.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
@@ -139,15 +149,23 @@ jobs:
           git switch -c "$BRANCH"
           git commit -am "chore(release): bump main to $NEXT ahead of stable $VERSION"
           git push origin "$BRANCH"
+          head_sha=$(git rev-parse HEAD)
           body=$(printf '%s\n' \
             "Automated by \`finalize-release\` after publishing \`open-design-v$VERSION\`." \
             "" \
             "Keeps \`main\` strictly ahead of the shipped stable tag — the build guard requires \`apps/packaged\` version to be greater than the latest \`open-design-v*\` tag. Bumps only the synchronized workspace manifests (those already sharing the monorepo version); independently-versioned packages are left untouched." \
             "" \
-            "The \`backport release/v$VERSION\` label was already deleted by this same run.")
+            "The \`backport release/v$VERSION\` label was already deleted by this same run." \
+            "" \
+            "**Needs one core-maintainer approval:** this touches CODEOWNERS-owned release manifests, so \`main\`'s code-owner rule requires a human review (a bot approval can't satisfy it). The merge queue is already armed — approve and it squashes in automatically.")
           pr=$(gh pr create --repo nexu-io/open-design --base main --head "$BRANCH" \
             --title "chore(release): bump main to $NEXT ahead of stable $VERSION" \
             --body "$body")
           echo "Opened $pr"
-          # main is a squash merge-queue; --auto enqueues once required checks are green.
-          gh pr merge "$pr" --repo nexu-io/open-design --squash --auto
+          # Request the code owners who must approve (best-effort; never fail finalize on a hiccup).
+          gh pr edit "$pr" --repo nexu-io/open-design --add-reviewer nexu-io/core-maintainers || \
+            echo "::warning::could not request nexu-io/core-maintainers review on $pr"
+          # main is a squash merge queue; --auto arms enqueue-on-green (proven by
+          # bake-plugin-previews-automerge — allow_auto_merge=false does not block the queue).
+          # --match-head-commit pins the armed SHA so a later push isn't merged untested.
+          gh pr merge "$pr" --repo nexu-io/open-design --squash --auto --match-head-commit "$head_sha"

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -13,9 +13,14 @@ name: finalize-release
 # --draft=false` using GITHUB_TOKEN, and a release event minted by GITHUB_TOKEN
 # does not trigger other workflows (GitHub's loop guard). So we react to the
 # build finishing instead, exactly like backport-automerge / bake-plugin-
-# previews-automerge react to ci. The "was this a real publish?" signal is
-# authoritative: a real run leaves the open-design-vX.Y.Z release published
-# (draft=false); a dry-run (metadata/prepublish) does not, so finalize no-ops.
+# previews-automerge react to ci. The version is read from the LATEST published
+# release — release-stable promotes its release with `--latest`, so after a real
+# publish that IS the just-shipped stable. We deliberately do NOT parse
+# workflow_run.head_branch: release-stable can be dispatched from one ref while
+# building another via its `ref` input, so head_branch may be the dispatch ref,
+# not the built release branch. A dry-run (metadata/prepublish) publishes nothing,
+# so `--latest` stays the previous (already-finalized) stable and every step
+# no-ops by idempotency. The draft/prerelease/X.Y.Z guards add belt-and-braces.
 #
 # Why the bump PR still needs ONE human approval (unlike the other automerge
 # bots, which merge hands-free): main enforces require_code_owner_review, and the
@@ -45,8 +50,7 @@ jobs:
     if: >-
       github.repository == 'nexu-io/open-design' &&
       (github.event_name == 'workflow_dispatch' ||
-       (github.event.workflow_run.conclusion == 'success' &&
-        startsWith(github.event.workflow_run.head_branch, 'release/v')))
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2
@@ -55,39 +59,38 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - name: Resolve the shipped version (and confirm it really published)
+      - name: Resolve the shipped version (latest published stable, or the dispatch tag)
         id: ver
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           EVENT: ${{ github.event_name }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          # workflow_dispatch -> the tag input; workflow_run -> the release branch it built.
+          # workflow_dispatch backfill -> finalize the exact tag asked for.
+          # workflow_run -> the latest published release, which release-stable marked --latest;
+          # NEVER parse workflow_run.head_branch (it can be the dispatch ref, not the built
+          # release branch, when release-stable runs with a `ref` input).
           if [ "$EVENT" = "workflow_dispatch" ]; then
-            ver="${INPUT_TAG#open-design-v}"
+            req="$INPUT_TAG"
+            case "$req" in open-design-v*) : ;; *) req="open-design-v$req" ;; esac   # allow a bare X.Y.Z
+            state=$(gh release view "$req" --repo nexu-io/open-design --json tagName,isDraft,isPrerelease 2>/dev/null || echo '')
           else
-            ver="${HEAD_BRANCH#release/v}"
+            state=$(gh release view --repo nexu-io/open-design --json tagName,isDraft,isPrerelease 2>/dev/null || echo '')
           fi
-          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Could not resolve a stable X.Y.Z version (event=$EVENT, branch='$HEAD_BRANCH', tag='$INPUT_TAG')."
-            exit 1
-          fi
-          tag="open-design-v$ver"
-          # Real-publish gate: release-stable only flips the release to published (draft=false)
-          # on a real run. A dry-run (metadata/prepublish) leaves no published release, so a
-          # build that "succeeded" as a dry-run must NOT finalize. This is the authoritative
-          # discriminator — not the build conclusion alone.
-          state=$(gh release view "$tag" --repo nexu-io/open-design --json isDraft,isPrerelease 2>/dev/null || echo '')
           if [ -z "$state" ]; then
-            echo "No release $tag (dry-run, failed publish, or not shipped) — nothing to finalize."
+            echo "No release to finalize (no published stable / dry-run / not shipped)."
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
+          tag=$(printf '%s' "$state" | jq -r '.tagName')
           draft=$(printf '%s' "$state" | jq -r '.isDraft')
           pre=$(printf '%s' "$state" | jq -r '.isPrerelease')
-          if [ "$draft" != "false" ] || [ "$pre" != "false" ]; then
-            echo "$tag is draft=$draft prerelease=$pre — not a published stable; skipping."
+          ver="${tag#open-design-v}"
+          # Only a published (draft=false), non-prerelease, open-design-vX.Y.Z release finalizes.
+          # On a dry-run the latest published release is the previous (already-finalized) stable,
+          # which the bump idempotency + tolerant label delete below turn into a clean no-op.
+          if [ "$draft" != "false" ] || [ "$pre" != "false" ] || ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Latest release '$tag' is draft=$draft prerelease=$pre — not a stable X.Y.Z; skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           major=${ver%%.*}; rest=${ver#*.}; minor=${rest%%.*}; patch=${rest##*.}

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -1,0 +1,153 @@
+name: finalize-release
+# Post-publish bookend to cut-release.yml. When a STABLE GitHub Release
+# (open-design-vX.Y.Z) is published, this finalizes the release:
+#   1. Deletes the now-obsolete "backport release/vX.Y.Z" label — a shipped
+#      release takes no more backports, so the label only invites mistakes.
+#   2. Opens a PR bumping main's synchronized workspace versions to X.Y.(Z+1),
+#      keeping main strictly ahead of the just-shipped stable tag (the build
+#      guard requires apps/packaged version > the latest open-design-v* tag),
+#      and enables squash auto-merge so it lands through main's merge queue.
+#
+# Only release-stable.yml creates a GitHub Release; prerelease/preview/beta
+# publish to R2 only and never fire this. The job `if` still guards on the
+# open-design-vX.Y.Z tag shape and !prerelease so a stray release can't trip it.
+#
+# release-stable.yml creates the Release as a DRAFT; publishing the draft (after
+# the owner writes the real release note) is the moment this runs.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Stable release tag, e.g. open-design-v0.12.0'
+        required: true
+        default: ''
+
+permissions:
+  contents: read               # actual writes go through the App token below
+
+jobs:
+  finalize:
+    if: >-
+      github.repository == 'nexu-io/open-design' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.release.prerelease == false &&
+        startsWith(github.event.release.tag_name, 'open-design-v')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Resolve + validate the shipped version
+        id: ver
+        env:
+          # Never interpolate the raw tag into the shell; pass via env and validate.
+          RAW_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          ver="${RAW_TAG#open-design-v}"
+          # Strict x.y.z, digits only — rejects prerelease/preview tags, shell metacharacters, etc.
+          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Tag '$RAW_TAG' is not a stable open-design-vX.Y.Z tag; nothing to finalize."
+            exit 1
+          fi
+          major=${ver%%.*}; rest=${ver#*.}; minor=${rest%%.*}; patch=${rest##*.}
+          next="${major}.${minor}.$((patch+1))"
+          {
+            echo "version=$ver"
+            echo "next=$next"
+            echo "branch=release-bot/bump-main-v$next"
+          } >> "$GITHUB_OUTPUT"
+          echo "Shipped stable v$ver -> bump main to v$next"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main            # we bump main, regardless of which ref the release tag points at
+          fetch-depth: 0
+          token: ${{ steps.app.outputs.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Delete the shipped release's backport label
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          label="backport release/v$VERSION"
+          if gh label list --repo nexu-io/open-design --json name --jq '.[].name' | grep -qxF "$label"; then
+            gh label delete "$label" --repo nexu-io/open-design --yes
+            echo "Deleted label: $label"
+          else
+            echo "Label '$label' not present; nothing to delete."
+          fi
+
+      - name: Bump main's synchronized workspace versions
+        id: bump
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          current=$(node -p "require('./package.json').version")
+          # Idempotency: only ever move main forward. If main is already at or ahead
+          # of NEXT (re-publish, or a later cut already moved it), do nothing.
+          lower=$(printf '%s\n%s\n' "$current" "$NEXT" | sort -V | head -1)
+          if [ "$current" = "$NEXT" ] || [ "$lower" = "$NEXT" ]; then
+            echo "main is at $current (>= $NEXT); no bump needed."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Bump only the synchronized set: every workspace package.json whose version
+          # equals the current monorepo version. Independently-versioned packages
+          # (telemetry-worker, components, agui-adapter, tools/serve, …) keep their own
+          # version. `npm pkg set version` touches only the top-level "version" field,
+          # never a pinned dependency that happens to share the number (e.g. @xterm/addon-fit).
+          changed=0
+          for f in package.json apps/*/package.json packages/*/package.json tools/*/package.json e2e/package.json; do
+            [ -f "$f" ] || continue
+            v=$(node -p "require('./$f').version" 2>/dev/null || echo '')
+            if [ "$v" = "$current" ]; then
+              ( cd "$(dirname "$f")" && npm pkg set version="$NEXT" )
+              changed=$((changed+1))
+            fi
+          done
+          echo "Bumped $changed manifests from $current to $NEXT."
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open the bump PR + enable squash auto-merge
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          NEXT: ${{ steps.ver.outputs.next }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::warning::$BRANCH already exists; a bump PR is likely already open. Skipping."
+            exit 0
+          fi
+          git config user.name  'open-design-release-bot[bot]'
+          git config user.email 'open-design-release-bot[bot]@users.noreply.github.com'
+          git switch -c "$BRANCH"
+          git commit -am "chore(release): bump main to $NEXT ahead of stable $VERSION"
+          git push origin "$BRANCH"
+          body=$(printf '%s\n' \
+            "Automated by \`finalize-release\` after publishing \`open-design-v$VERSION\`." \
+            "" \
+            "Keeps \`main\` strictly ahead of the shipped stable tag — the build guard requires \`apps/packaged\` version to be greater than the latest \`open-design-v*\` tag. Bumps only the synchronized workspace manifests (those already sharing the monorepo version); independently-versioned packages are left untouched." \
+            "" \
+            "The \`backport release/v$VERSION\` label was already deleted by this same run.")
+          pr=$(gh pr create --repo nexu-io/open-design --base main --head "$BRANCH" \
+            --title "chore(release): bump main to $NEXT ahead of stable $VERSION" \
+            --body "$body")
+          echo "Opened $pr"
+          # main is a squash merge-queue; --auto enqueues once required checks are green.
+          gh pr merge "$pr" --repo nexu-io/open-design --squash --auto

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -1,6 +1,5 @@
 name: finalize-release
-# Post-publish bookend to cut-release.yml. When a STABLE GitHub Release
-# (open-design-vX.Y.Z) is published, this finalizes the release:
+# Post-publish bookend to cut-release.yml. When a STABLE release ships, this:
 #   1. Deletes the now-obsolete "backport release/vX.Y.Z" label — a shipped
 #      release takes no more backports, so the label only invites mistakes.
 #   2. Opens a PR bumping main's synchronized workspace versions to X.Y.(Z+1),
@@ -9,29 +8,32 @@ name: finalize-release
 #      arms it for the merge queue (gh pr merge --auto enqueues on green), and
 #      requests a @nexu-io/core-maintainers review.
 #
-# Why this PR still needs ONE human approval (unlike backport-automerge /
-# bake-plugin-previews-automerge, which merge bot PRs hands-free): main enforces
-# require_code_owner_review, and the bump touches CODEOWNERS-owned release
-# manifests (apps/packaged, apps/desktop, packages/platform, packages/sidecar*,
-# tools/pack, tools/dev). A bot approval cannot satisfy the code-owner gate, so
-# a core-maintainer must approve. Once they do, the armed merge queue squashes it
-# in automatically — no manual file editing, label cleanup, or enqueue. (release/v*
-# has require_code_owner_review=false, which is why backports CAN auto-approve.)
+# Trigger: workflow_run on release-stable completing — NOT `release: published`.
+# release-stable.yml promotes its own draft to published with `gh release edit
+# --draft=false` using GITHUB_TOKEN, and a release event minted by GITHUB_TOKEN
+# does not trigger other workflows (GitHub's loop guard). So we react to the
+# build finishing instead, exactly like backport-automerge / bake-plugin-
+# previews-automerge react to ci. The "was this a real publish?" signal is
+# authoritative: a real run leaves the open-design-vX.Y.Z release published
+# (draft=false); a dry-run (metadata/prepublish) does not, so finalize no-ops.
 #
-# Only release-stable.yml creates a GitHub Release; prerelease/preview/beta
-# publish to R2 only and never fire this. The job `if` still guards on the
-# open-design-vX.Y.Z tag shape and !prerelease so a stray release can't trip it.
-#
-# release-stable.yml creates the Release as a DRAFT; publishing the draft (after
-# the owner writes the real release note) is the moment this runs.
+# Why the bump PR still needs ONE human approval (unlike the other automerge
+# bots, which merge hands-free): main enforces require_code_owner_review, and the
+# bump touches CODEOWNERS-owned release manifests (apps/packaged, apps/desktop,
+# packages/platform, packages/sidecar*, tools/pack, tools/dev). A bot approval
+# can't satisfy the code-owner gate, so a core-maintainer must approve. Once they
+# do, the armed merge queue squashes it in automatically — no manual file editing,
+# label cleanup, or enqueue. (release/v* has require_code_owner_review=false,
+# which is why backports CAN auto-approve.)
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["release-stable"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Stable release tag, e.g. open-design-v0.12.0'
+        description: 'Stable release tag to finalize, e.g. open-design-v0.12.0'
         required: true
         default: ''
 
@@ -43,8 +45,8 @@ jobs:
     if: >-
       github.repository == 'nexu-io/open-design' &&
       (github.event_name == 'workflow_dispatch' ||
-       (github.event.release.prerelease == false &&
-        startsWith(github.event.release.tag_name, 'open-design-v')))
+       (github.event.workflow_run.conclusion == 'success' &&
+        startsWith(github.event.workflow_run.head_branch, 'release/v')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2
@@ -53,39 +55,66 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - name: Resolve + validate the shipped version
+      - name: Resolve the shipped version (and confirm it really published)
         id: ver
         env:
-          # Never interpolate the raw tag into the shell; pass via env and validate.
-          RAW_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          EVENT: ${{ github.event_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          ver="${RAW_TAG#open-design-v}"
-          # Strict x.y.z, digits only — rejects prerelease/preview tags, shell metacharacters, etc.
+          # workflow_dispatch -> the tag input; workflow_run -> the release branch it built.
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            ver="${INPUT_TAG#open-design-v}"
+          else
+            ver="${HEAD_BRANCH#release/v}"
+          fi
           if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Tag '$RAW_TAG' is not a stable open-design-vX.Y.Z tag; nothing to finalize."
+            echo "::error::Could not resolve a stable X.Y.Z version (event=$EVENT, branch='$HEAD_BRANCH', tag='$INPUT_TAG')."
             exit 1
+          fi
+          tag="open-design-v$ver"
+          # Real-publish gate: release-stable only flips the release to published (draft=false)
+          # on a real run. A dry-run (metadata/prepublish) leaves no published release, so a
+          # build that "succeeded" as a dry-run must NOT finalize. This is the authoritative
+          # discriminator — not the build conclusion alone.
+          state=$(gh release view "$tag" --repo nexu-io/open-design --json isDraft,isPrerelease 2>/dev/null || echo '')
+          if [ -z "$state" ]; then
+            echo "No release $tag (dry-run, failed publish, or not shipped) — nothing to finalize."
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          draft=$(printf '%s' "$state" | jq -r '.isDraft')
+          pre=$(printf '%s' "$state" | jq -r '.isPrerelease')
+          if [ "$draft" != "false" ] || [ "$pre" != "false" ]; then
+            echo "$tag is draft=$draft prerelease=$pre — not a published stable; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           major=${ver%%.*}; rest=${ver#*.}; minor=${rest%%.*}; patch=${rest##*.}
           next="${major}.${minor}.$((patch+1))"
           {
+            echo "skip=false"
             echo "version=$ver"
             echo "next=$next"
             echo "branch=release-bot/bump-main-v$next"
           } >> "$GITHUB_OUTPUT"
           echo "Shipped stable v$ver -> bump main to v$next"
 
-      - uses: actions/checkout@v4
+      - name: Checkout main
+        if: steps.ver.outputs.skip != 'true'
+        uses: actions/checkout@v4
         with:
           ref: main            # we bump main, regardless of which ref the release tag points at
           fetch-depth: 0
           token: ${{ steps.app.outputs.token }}
 
       - uses: actions/setup-node@v4
+        if: steps.ver.outputs.skip != 'true'
         with:
           node-version: 24
 
       - name: Delete the shipped release's backport label
+        if: steps.ver.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           VERSION: ${{ steps.ver.outputs.version }}
@@ -101,13 +130,14 @@ jobs:
 
       - name: Bump main's synchronized workspace versions
         id: bump
+        if: steps.ver.outputs.skip != 'true'
         env:
           NEXT: ${{ steps.ver.outputs.next }}
         run: |
           set -euo pipefail
           current=$(node -p "require('./package.json').version")
           # Idempotency: only ever move main forward. If main is already at or ahead
-          # of NEXT (re-publish, or a later cut already moved it), do nothing.
+          # of NEXT (re-run, or a later cut already moved it), do nothing.
           lower=$(printf '%s\n%s\n' "$current" "$NEXT" | sort -V | head -1)
           if [ "$current" = "$NEXT" ] || [ "$lower" = "$NEXT" ]; then
             echo "main is at $current (>= $NEXT); no bump needed."
@@ -132,7 +162,7 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Open the bump PR, arm the merge queue, request review
-        if: steps.bump.outputs.changed == 'true'
+        if: steps.ver.outputs.skip != 'true' && steps.bump.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           VERSION: ${{ steps.ver.outputs.version }}

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -29,6 +29,7 @@ const bakePreviewsAutomergeWorkflowPath = join(
   "bake-plugin-previews-automerge.yml",
 );
 const bakePreviewsWorkflowPath = join(workspaceRoot, ".github", "workflows", "bake-plugin-previews.yml");
+const finalizeReleaseWorkflowPath = join(workspaceRoot, ".github", "workflows", "finalize-release.yml");
 const handoffScriptPath = join(workspaceRoot, ".github", "scripts", "handoff.py");
 const releaseBetaWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-beta.yml");
 const releaseBetaSelfHostedWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-beta-s.yml");
@@ -384,6 +385,53 @@ describe("packaged smoke workflow", () => {
       "(github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out')",
     );
     expect(feishuStep).not.toContain("'cancelled'");
+  });
+
+  it("[P2] gates the finalize-release follow-up as a trusted workflow_run consumer", async () => {
+    const workflow = await readFile(finalizeReleaseWorkflowPath, "utf8");
+
+    // Reacts to release-stable completing (not release: published — release-stable promotes its
+    // own draft with GITHUB_TOKEN, which cannot trigger workflows), plus a manual backfill.
+    expect(workflow).toContain('workflows: ["release-stable"]');
+    expect(workflow).toContain("types: [completed]");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
+    expect(workflow).toContain("github.event.workflow_run.conclusion == 'success'");
+
+    // It mints the privileged release App token for label deletion, branch push, PR + merge-queue.
+    expect(workflow).toContain("actions/create-github-app-token");
+    expect(workflow).toContain("secrets.RELEASE_BOT_APP_ID");
+
+    // The shipped version is resolved from the LATEST published release (release-stable marks it
+    // --latest) or the dispatch tag — NEVER from workflow_run.head_branch, which can be the
+    // dispatch ref rather than the built release branch when release-stable runs with a `ref` input.
+    expect(workflow).toContain("gh release view --repo nexu-io/open-design --json tagName,isDraft,isPrerelease");
+    expect(workflow).not.toContain("github.event.workflow_run.head_branch");
+    expect(workflow).not.toContain("HEAD_BRANCH");
+
+    // Only a published (draft=false), non-prerelease, open-design-vX.Y.Z release finalizes; a
+    // dry-run completion (latest stays the previous, already-finalized stable) must no-op.
+    expect(workflow).toContain("isDraft");
+    expect(workflow).toContain("isPrerelease");
+    expect(workflow).toContain("^[0-9]+\\.[0-9]+\\.[0-9]+$");
+    expect(workflow).toContain('echo "skip=true"');
+    expect(workflow).toContain("steps.ver.outputs.skip != 'true'");
+
+    // Idempotent forward-only bump of the synchronized manifests (patch, not the next minor that
+    // cut-release owns); independently-versioned packages are skipped via npm pkg set version.
+    expect(workflow).toContain("sort -V");
+    expect(workflow).toContain("npm pkg set version");
+    expect(workflow).toContain("changed=true");
+
+    // The bump PR needs one core-maintainer approval (code-owned manifests + require_code_owner_review
+    // on main), so finalize requests that review and arms the merge queue pinned to the pushed SHA.
+    expect(workflow).toContain("--add-reviewer nexu-io/core-maintainers");
+    expect(workflow).toContain("--squash --auto --match-head-commit");
+    expect(workflow).toContain("head_sha=$(git rev-parse HEAD)");
+
+    // The shipped release's backport label is cleaned up (tolerant of an already-deleted label).
+    expect(workflow).toContain('label="backport release/v$VERSION"');
+    expect(workflow).toContain("gh label delete");
   });
 
   it("[P2] keeps the backport patch-equivalence gate whitespace-sensitive", async () => {


### PR DESCRIPTION
## Why

**Author's use case:** As the release owner, after I publish a stable `open-design-vX.Y.Z` I always do two manual chores by hand — bump `main` forward so it stays ahead of the freshly-shipped tag, and delete the dead `backport release/vX.Y.Z` label. Today the bump is a hand-opened, hand-edited PR every cycle (#4900 `bump main to 0.12.1 ahead of stable 0.12.0`, #4387, #4381) and the label cleanup is a manual `gh label delete`.

**Pain addressed:** This is the missing *closing* bookend of the release automation. We already have `cut-release.yml` (opens the cycle: cuts `release/vX.Y.Z`, bumps the branch, **creates** the `backport release/vX.Y.Z` label) and `release-gate.yml` (readiness check). Nothing automated the close. The manual bump is easy to forget — and if `main` ever falls at/behind the latest `open-design-v*` tag, the next build trips the guard that requires `apps/packaged` version strictly greater than the latest stable tag.

## What users will see

Nothing in the product. For the release owner: after you publish the draft GitHub Release, a CI run automatically (1) deletes the `backport release/vX.Y.Z` label, and (2) opens the `chore(release): bump main to X.Y.(Z+1) ahead of stable X.Y.Z` PR — already version-bumped across the synchronized manifests, with the merge queue armed and `@nexu-io/core-maintainers` requested for review. **One approval and the queue squashes it in.** No more hand-editing 18 manifests, no manual label deletion, no manual enqueue.

## Why it still needs one approval (and isn't fully hands-free like the other automerge bots)

`backport-automerge.yml` and `bake-plugin-previews-automerge.yml` merge bot PRs with zero human touch, so the obvious question is why this one can't. The difference is the merge rules of the target + the files touched:

- Backports target `release/v*`, whose ruleset has `require_code_owner_review: false` → a `github-actions[bot]` approval satisfies the single required review.
- The bake PR targets `main` but touches **only** `data/plugin-previews/manifest.json`, which **no CODEOWNERS entry covers** → the code-owner rule has nothing to require, so a bot approval is enough.
- This bump targets `main` **and** touches CODEOWNERS-owned release manifests (`apps/packaged`, `apps/desktop`, `packages/platform`, `packages/sidecar*`, `tools/pack`, `tools/dev`). `main` enforces `require_code_owner_review: true`, and a bot cannot be a code owner → a `@nexu-io/core-maintainers` human must approve. That's exactly why #4900 needed a maintainer's review.

So this reuses the same infra (App authors the PR, `gh pr merge --squash --auto` arms `main`'s merge queue — proven by `bake-plugin-previews-automerge`) and reduces the chore to a single approval click. Fully zero-touch would require a governance change (bot bypass on `main`, or carving version files out of CODEOWNERS) — deliberately left out of scope.

## How it works

- Trigger: `workflow_run` on **release-stable** completing — *not* `release: published`. `release-stable.yml` promotes its own draft to published with `gh release edit --draft=false` using `GITHUB_TOKEN`, and a release event minted by `GITHUB_TOKEN` does not trigger other workflows (GitHub's loop guard), so a `release: published` trigger would never fire. This mirrors how `backport-automerge` / `bake-plugin-previews-automerge` react to `ci`. The real-publish discriminator is authoritative: a real run leaves `open-design-vX.Y.Z` **published** (`draft=false`); a dry-run (`metadata`/`prepublish`) does not, so finalize no-ops. `workflow_dispatch` with a `tag` input is provided for backfill.
- Bumps **only the synchronized workspace manifests** — every `package.json` whose `version` equals the current monorepo version (the 18 that move together, matching #4900). Independently-versioned packages (`telemetry-worker`, `components`, `agui-adapter`, `tools/serve`, …) are left alone. `npm pkg set version` touches only the top-level `"version"`, never a pinned dependency that shares the number (e.g. `@xterm/addon-fit`).
- Version is a **patch** bump (`X.Y.Z → X.Y.(Z+1)`), not minor: `cut-release.yml` already owns the next minor on its own branch, so main stays one patch ahead of the last stable and never collides with the upcoming release's minor.
- Idempotent: only ever moves `main` forward (`sort -V`); a re-publish or stale old tag is a no-op. `--match-head-commit` pins the armed SHA so a post-CI push isn't merged untested.
- Writes go through the same `RELEASE_BOT_APP` App token as `cut-release.yml` / the automerge workflows.

## Validation

- YAML parses clean; the version-compute, synchronized-set selector, and idempotency logic were dry-run locally against real repo state — selector picks exactly the 18 synchronized manifests; finalizing an already-shipped/stale tag correctly no-ops.
- Bump is a version-only `package.json` change (no `pnpm-lock.yaml` churn → no Nix hash refresh), matching #4900 which merged green; the version-pinned e2e fixtures in `packaged-smoke-workflow.test.ts` use fixed historical `0.10.x` values, not `main`'s live version, so the bump does not touch them.

## Surface area

- [x] CI / GitHub Actions workflows (`.github/workflows/finalize-release.yml`)

Release-lifecycle workflow, sibling to `cut-release.yml` / `release-gate.yml` — not a PR follow-on/handoff workflow, so the `comment`/`autofix`/`report` atomic-capability topology doesn't apply.
