### PR TITLE
fix daemon opencode headless permissions

### DIFF
--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_MODEL_OPTION, parseLineSeparatedModels } from './shared.js';
+import { agentCapabilities } from '../capabilities.js';
 import type { RuntimeAgentDef } from '../types.js';
+
+const SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 
 export const opencodeAgentDef = {
     id: 'opencode',
@@ -7,6 +10,10 @@ export const opencodeAgentDef = {
     bin: 'opencode-cli',
     fallbackBins: ['opencode'],
     versionArgs: ['--version'],
+    helpArgs: ['run', '--help'],
+    capabilityFlags: {
+      [SKIP_PERMISSIONS_FLAG]: 'skipPermissions',
+    },
     // `opencode models` prints `provider/model` per line. Real-world
     // `opencode models` calls can take >8s (network round-trip to the
     // provider registry), so the previous 8s budget timed out and fell back
@@ -43,6 +50,9 @@ export const opencodeAgentDef = {
         '--format',
         'json',
       ];
+      if (agentCapabilities.get('opencode')?.skipPermissions) {
+        args.push(SKIP_PERMISSIONS_FLAG);
+      }
       // Capture-style resume: OpenCode mints its own session id (reported on
       // the stream as `sessionID`, e.g. `ses_...`). On a follow-up turn the
       // daemon continues that session with `-s <id>` instead of re-sending the

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -73,10 +73,13 @@ test('cursor-agent declares the --trust capability probe (issue #4461 root cause
 });
 
 test('opencode args keep the documented run/json argv and ignore unsupported reasoning options', () => {
+  agentCapabilities.delete('opencode');
   const prompt = 'design a dashboard';
   const baseArgs = opencode.buildArgs(prompt, [], [], {});
   assert.equal(opencode.promptViaStdin, true);
   assert.equal(opencode.reasoningOptions, undefined);
+  assert.deepEqual(opencode.helpArgs, ['run', '--help']);
+  assert.deepEqual(opencode.capabilityFlags?.['--dangerously-skip-permissions'], 'skipPermissions');
   assert.equal(baseArgs.includes('-'), false);
   assert.equal(baseArgs.includes(prompt), false);
   assert.deepEqual(baseArgs, [
@@ -112,6 +115,21 @@ test('opencode args keep the documented run/json argv and ignore unsupported rea
   assert.deepEqual(withReasoning, withModel);
   assert.equal(withModel.includes('--dangerously-skip-permissions'), false);
   assert.equal(withModel.includes('--model'), false);
+});
+
+test('opencode passes --dangerously-skip-permissions when the help probe finds it', () => {
+  agentCapabilities.set('opencode', { skipPermissions: true });
+  try {
+    const args = opencode.buildArgs('design a dashboard', [], [], {});
+    assert.deepEqual(args, [
+      'run',
+      '--format',
+      'json',
+      '--dangerously-skip-permissions',
+    ]);
+  } finally {
+    agentCapabilities.delete('opencode');
+  }
 });
 
 // Copilot reads the prompt from stdin when `-p` is omitted entirely

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -195,6 +195,7 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 ### 5.7 OpenCode / OpenClaw
 
 - Less-matured CLIs. Targeting P2. Expect bumps; adapter implementations will likely be the thinnest possible "shell out, parse output, synthesize events" approach.
+- OpenCode runs as `opencode run --format json` with the prompt on stdin. Newer OpenCode builds that advertise `--dangerously-skip-permissions` from `opencode run --help` receive that flag so headless runs do not stop on edit approval prompts; older builds keep the 1.3-compatible argv.
 
 ### 5.8 GitHub Copilot CLI
 


### PR DESCRIPTION
﻿Fixes #4923.

## Why

I picked this up from the issue thread. Newer OpenCode supports `--dangerously-skip-permissions`, and the reporter confirmed it works on the failing 1.17.10 install. Without it, Open Design can launch OpenCode headlessly and then hit edit approval prompts that get auto-rejected.

## What users will see

OpenCode runs on newer builds should keep moving through edit/write steps instead of stopping with unfinished tasks. Older OpenCode builds keep the old `run --format json` argv because the flag is only added after `opencode run --help` advertises it.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`)
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI change.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/agent-args.test.ts`
- I did not rerun the new spec on `main`; it would fail there because the adapter never reads a `skipPermissions` capability today.

## Validation

- `pnpm install` completed. This machine is on Node 25.2.1, while the repo asks for Node ~24.
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts tests/runtimes/opencode-resume-args.test.ts`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts --testNamePattern OpenCode --hookTimeout 30000`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard` still fails on pre-existing stale generated design-system manifest files; I left that out of this focused adapter fix.
