### PR TITLE
fix(release): populate github.commit in prerelease metadata so the changelog has a baseline

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -215,6 +215,7 @@ jobs:
     runs-on: macos-14
     env:
       GH_TOKEN: ${{ github.token }}
+      RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -561,6 +562,7 @@ jobs:
     runs-on: macos-15-intel
     env:
       GH_TOKEN: ${{ github.token }}
+      RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -793,6 +795,7 @@ jobs:
     runs-on: windows-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -1036,6 +1039,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -1127,6 +1131,7 @@ jobs:
       linux_url: ${{ steps.outputs.outputs.linux_x64_appImage_url }}
     env:
       GH_TOKEN: ${{ github.token }}
+      RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
       GITHUB_SHA: ${{ needs.metadata.outputs.commit }}
       BASE_VERSION: ${{ needs.metadata.outputs.base_version }}
       BRANCH_NAME: ${{ needs.metadata.outputs.branch }}

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -952,6 +952,37 @@ describe("packaged smoke workflow", () => {
     expectWindowsUpdaterSmokeContract(releaseStableWorkflow, "stable");
   });
 
+  it("[P2] prerelease publishes github.commit so its changelog has a baseline", async () => {
+    // The Feishu release card computes its changelog as `git log <previous>..<current>`,
+    // where <previous> is read from prerelease/latest/metadata.json's `.github.commit`
+    // (notify-release-feishu.yml). That field is written by githubInfo() from the
+    // RELEASE_COMMIT env. release-beta sets RELEASE_COMMIT on every build + publish job,
+    // but release-prerelease historically set it on none, so every prerelease published an
+    // empty github.commit and the card could never diff against the prior prerelease
+    // ("首个 Prerelease 包"). Require RELEASE_COMMIT on the prerelease build + publish jobs
+    // so the per-platform manifests and the final metadata.json carry the built commit and
+    // stay mutually consistent (publish-metadata rejects a manifest whose commit disagrees).
+    const [prereleaseWorkflow, betaWorkflow] = await Promise.all([
+      readFile(releasePrereleaseWorkflowPath, "utf8"),
+      readFile(releaseBetaWorkflowPath, "utf8"),
+    ]);
+
+    const releaseCommitEnv = "RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}";
+    // Beta is the working reference that already populates the commit.
+    expect(betaWorkflow).toContain(releaseCommitEnv);
+
+    const jobBounds: Array<[string, string]> = [
+      ["  build_mac:", "  build_mac_intel:"],
+      ["  build_mac_intel:", "  build_win:"],
+      ["  build_win:", "  build_linux:"],
+      ["  build_linux:", "  publish:"],
+      ["  publish:", "  cleanup_partial_release_assets:"],
+    ];
+    for (const [start, end] of jobBounds) {
+      expect(sectionBetween(prereleaseWorkflow, start, end)).toContain(releaseCommitEnv);
+    }
+  });
+
   it("[P2] keeps counted release workflow calls on a consistent ref and output contract", async () => {
     const [previewWorkflow, prereleaseWorkflow, previewScript] = await Promise.all([
       readFile(releasePreviewWorkflowPath, "utf8"),


### PR DESCRIPTION
## Why

**Author's use case:** While confirming the daily beta + Tuesday `cut-release` runs went green, the Feishu prerelease card for `0.13.0-prerelease.3` showed "首个 Prerelease 包,无上个版本可对比" — it couldn't summarize new commits even though `.1`/`.2` already shipped.

**Pain being addressed:** The Feishu release card (`notify-release-feishu.yml`) builds its changelog as `git log <previous>..<current>`, where `<previous>` is read from the published `prerelease/latest/metadata.json` `.github.commit`. That field is written by `githubInfo()` (`tools/release/src/storage/common.ts`), which reads the **`RELEASE_COMMIT`** env. `release-beta.yml` sets `RELEASE_COMMIT` on every build + publish job; **`release-prerelease.yml` set it on none**, so every prerelease published an *empty* `github.commit`. Each subsequent prerelease then found no baseline and the card always rendered the "first prerelease" fallback. This was never release-line-specific — **every prerelease changelog has been empty**.

## What I changed

Added `RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}` to the four prerelease build jobs (`build_mac`, `build_mac_intel`, `build_win`, `build_linux`) and the `publish` job, mirroring `release-beta.yml`.

Both layers are required: `publish-metadata.ts` rejects a per-platform manifest whose `github.commit` disagrees with the metadata commit, so the build jobs (which write per-platform manifests via `publish-platform`) and the publish job (which writes the final `metadata.json`) must stamp the **same** built commit. Setting it on only one side would flip the feed from "consistently empty" to a mismatch that fails publish.

`metadata` and `cleanup_partial_release_assets` jobs are intentionally left untouched — they don't publish manifests/metadata.

## What users will see

The next prerelease's Feishu card will list the commits since the previous prerelease (linkified PRs/commits) instead of "首个 Prerelease 包,无上个版本可对比". No user-facing app change.

## Verification

Red spec in `e2e/tests/packaged-smoke-workflow.test.ts` (`[P2] prerelease publishes github.commit so its changelog has a baseline`) asserts each prerelease build + publish job carries `RELEASE_COMMIT`. Verified by section: **red on `main`** (all 5 job sections lack it), **green on this branch** (all 5 present); the beta-as-reference assertion also passes.

## Surface area

- [x] GitHub Actions / release automation (`.github/workflows/release-prerelease.yml`)
- [x] Tests (`e2e/tests/packaged-smoke-workflow.test.ts`)

## Backport

Labeled `backport release/v0.13.0`: prerelease builds run from the **pushed** `release/**` branch's copy of these workflows, so the active `release/v0.13.0` line needs the fix directly. `main` covers future release branches (cut from main).