### PR TITLE
fix design-system showcase asset loading

### DIFF
--- a/apps/daemon/src/routes/design-systems.ts
+++ b/apps/daemon/src/routes/design-systems.ts
@@ -1,5 +1,6 @@
 import type { Express } from 'express';
 import fsp from 'node:fs/promises';
+import path from 'node:path';
 import type { RouteDeps } from '../server-context.js';
 import type {
   DesignSystemFileDetail,
@@ -28,6 +29,8 @@ type DesignSystemWorkspaceProject = {
 type AvailableDesignSystemSummary = DesignSystemSummary & {
   source?: 'built-in' | 'installed' | 'user';
 };
+
+const PACKAGED_SHOWCASE_PATH = 'system/kit.html';
 
 export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths' | 'projectFiles' | 'projectStore'> {
   designSystems: {
@@ -235,6 +238,18 @@ export function registerDesignSystemRoutes(app: Express, ctx: RegisterDesignSyst
 
   app.get('/api/design-systems/:id/showcase', async (req, res) => {
     try {
+      const packaged = await readAvailableDesignSystemStaticFile(req.params.id, PACKAGED_SHOWCASE_PATH);
+      if (packaged?.contentType.startsWith('text/html')) {
+        res.setHeader('Cache-Control', 'no-store');
+        res.setHeader('Last-Modified', packaged.updatedAt);
+        return res.type('text/html').send(
+          rewriteDesignSystemShowcaseAssetUrls(
+            packaged.bytes.toString('utf8'),
+            req.params.id,
+            path.posix.dirname(PACKAGED_SHOWCASE_PATH),
+          ),
+        );
+      }
       const body = await readAvailableDesignSystem(req.params.id);
       if (body === null) return res.status(404).type('text/plain').send('not found');
       const html = renderDesignSystemShowcase(req.params.id, body);
@@ -405,4 +420,54 @@ export function registerDesignSystemRoutes(app: Express, ctx: RegisterDesignSyst
       res.status(500).json({ error: String(err) });
     }
   });
+}
+
+export function rewriteDesignSystemShowcaseAssetUrls(
+  html: string,
+  designSystemId: string,
+  baseDir: string,
+): string {
+  if (!html) return html;
+  return html
+    .replace(/\b(src|href)=(["'])([^"']+)\2/gi, (match, attr: string, quote: string, raw: string) => {
+      const rewritten = rewriteDesignSystemShowcaseAssetUrl(raw, designSystemId, baseDir);
+      return rewritten === raw ? match : `${attr}=${quote}${rewritten}${quote}`;
+    })
+    .replace(/url\(\s*(["']?)([^"')]+)\1\s*\)/gi, (match, quote: string, raw: string) => {
+      const rewritten = rewriteDesignSystemShowcaseAssetUrl(raw, designSystemId, baseDir);
+      return rewritten === raw ? match : `url(${quote}${rewritten}${quote})`;
+    });
+}
+
+function rewriteDesignSystemShowcaseAssetUrl(
+  rawUrl: string,
+  designSystemId: string,
+  baseDir: string,
+): string {
+  const value = rawUrl.trim();
+  if (
+    value.length === 0
+    || value.startsWith('#')
+    || value.startsWith('/')
+    || /^[a-z][a-z0-9+.-]*:/i.test(value)
+  ) {
+    return rawUrl;
+  }
+
+  const match = /^([^?#]+)([?#].*)?$/.exec(value);
+  if (!match) return rawUrl;
+  const [, rawPath, suffix = ''] = match;
+  if (!rawPath) return rawUrl;
+  const relativePath = path.posix.normalize(path.posix.join(baseDir, rawPath));
+  if (
+    relativePath === '.'
+    || relativePath.startsWith('../')
+    || path.posix.isAbsolute(relativePath)
+  ) {
+    return rawUrl;
+  }
+
+  const staticUrl = `/api/design-systems/${encodeURIComponent(designSystemId)}/static?path=${encodeURIComponent(relativePath)}`;
+  if (suffix.startsWith('?')) return `${staticUrl}&${suffix.slice(1)}`;
+  return `${staticUrl}${suffix}`;
 }

--- a/apps/daemon/tests/routes/design-system-showcase-assets.test.ts
+++ b/apps/daemon/tests/routes/design-system-showcase-assets.test.ts
@@ -1,0 +1,103 @@
+import type http from 'node:http';
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerDesignSystemRoutes } from '../../src/routes/design-systems.js';
+
+let server: http.Server | null = null;
+
+afterEach(async () => {
+  if (!server) return;
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  server = null;
+});
+
+function listen(app: express.Express): Promise<string> {
+  return new Promise((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server?.address() as { port: number };
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function registerRoutes(app: express.Express, staticHtml: string | null) {
+  registerDesignSystemRoutes(app, {
+    db: {} as never,
+    paths: {
+      CRAFT_DIR: '',
+      USER_DESIGN_SYSTEMS_DIR: '',
+    } as never,
+    projectFiles: {} as never,
+    projectStore: {} as never,
+    designSystems: {
+      buildUserDesignSystemArchive: async () => null,
+      createUserDesignSystem: async () => ({}) as never,
+      deleteUserDesignSystem: async () => false,
+      ensureUserDesignSystemWorkspaceProject: async () => null,
+      listAllDesignSystems: async () => [],
+      listUserDesignSystemFiles: async () => null,
+      listUserDesignSystemRevisions: async () => null,
+      prepareDesignTokenContractRebuild: async () => ({ decision: { available: false } }) as never,
+      readAvailableDesignSystem: async (id: string) => (id === 'bento' ? '# Bento' : null),
+      readAvailableDesignSystemPackageInfo: async () => null,
+      readAvailableDesignSystemStaticFile: async (_id: string, filePath: string) =>
+        staticHtml && filePath === 'system/kit.html'
+          ? {
+              bytes: Buffer.from(staticHtml, 'utf8'),
+              contentType: 'text/html; charset=utf-8',
+              updatedAt: 'Tue, 30 Jun 2026 00:00:00 GMT',
+            }
+          : null,
+      readDesignSystemWorkspaceTextFile: async () => null,
+      readUserDesignSystemFile: async () => null,
+      renderDesignSystemPreview: () => '<!doctype html><title>preview</title>',
+      renderDesignSystemShowcase: (id: string, body: string) =>
+        `<!doctype html><title>${id} synthetic</title><main>${body}</main>`,
+      updateUserDesignSystem: async () => null,
+      updateUserDesignSystemRevisionStatus: async () => null,
+    },
+    generationJobs: {
+      get: () => null,
+      rebuildTokenContract: () => ({}) as never,
+      revise: () => ({}) as never,
+      start: () => ({}) as never,
+    },
+  });
+}
+
+describe('design-system showcase route', () => {
+  it('serves packaged kit HTML and rewrites relative package assets', async () => {
+    const app = express();
+    registerRoutes(
+      app,
+      [
+        '<!doctype html>',
+        '<link rel="stylesheet" href="../tokens.css">',
+        '<img src="./assets/logo.svg">',
+        '<style>@font-face{src:url("../fonts/display.woff2?v=1")}</style>',
+      ].join(''),
+    );
+    const baseUrl = await listen(app);
+
+    const res = await fetch(`${baseUrl}/api/design-systems/bento/showcase`);
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain('/api/design-systems/bento/static?path=tokens.css');
+    expect(html).toContain('/api/design-systems/bento/static?path=system%2Fassets%2Flogo.svg');
+    expect(html).toContain('/api/design-systems/bento/static?path=fonts%2Fdisplay.woff2&v=1');
+    expect(html).not.toContain('bento synthetic');
+  });
+
+  it('keeps the generated showcase fallback when no packaged kit exists', async () => {
+    const app = express();
+    registerRoutes(app, null);
+    const baseUrl = await listen(app);
+
+    const res = await fetch(`${baseUrl}/api/design-systems/bento/showcase`);
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain('bento synthetic');
+  });
+});


### PR DESCRIPTION
﻿Fixes #4949.

## Why

I found the picker showcase was still showing the generated DESIGN.md preview even when a design system shipped a real `system/kit.html`. That made packaged systems look flatter than they should, because their bundled tokens, fonts, and assets were not the thing users were actually seeing.

## What users will see

In the design-system picker, packaged systems should now show their real kit preview with the bundled styling/assets. Older DESIGN.md-only systems still get the generated fallback, so this should not break existing lightweight packages.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`)
- [x] **Default behavior change** - changes what existing users experience without opting in
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

No UI controls changed. This is the HTML served into the existing design-system showcase iframe.

## Bug fix verification

Added a route regression that proves packaged `system/kit.html` wins over the synthetic fallback and that relative `href`, `src`, and CSS `url(...)` assets are rewritten to `/api/design-systems/:id/static?path=...`. The same test also keeps the old generated fallback covered when no packaged kit exists.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/routes/design-system-showcase-assets.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `git diff --check`
