### PR TITLE
fix(web): catch SSE reader errors to enable reconnection

### DIFF
--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -490,9 +490,20 @@ async function consumeDaemonRun({
       let buf = '';
       let sawStreamProgress = false;
 
-      try {
       while (true) {
-        const { value, done } = await reader.read();
+        let readResult: ReadableStreamReadResult<Uint8Array>;
+        try {
+          readResult = await reader.read();
+        } catch (err) {
+          // Only catch reader.read() failures — a broken SSE connection
+          // (tab backgrounded, proxy idle timeout, network drop). Parsing
+          // and handler invocations stay OUTSIDE this catch so local
+          // processing bugs surface through the existing outer error path.
+          if ((err as Error).name === 'AbortError') throw err;
+          try { reader.cancel(); } catch {}
+          break;
+        }
+        const { value, done } = readResult;
         if (done) break;
         buf += decoder.decode(value, { stream: true });
         let idx: number;
@@ -570,15 +581,6 @@ async function consumeDaemonRun({
             onRunStatus?.(endStatus);
           }
         }
-      }
-      } catch (err) {
-        // Stream broke mid-read (tab backgrounded, proxy idle timeout, etc.).
-        // Don't let the error escape — treat as a normal stream end so the
-        // reconnection for-loop resumes from lastEventId. The daemon keeps
-        // the run alive independent of the SSE connection (runs.ts), so we
-        // can always reattach.
-        if ((err as Error).name === 'AbortError') throw err;
-        try { reader.cancel(); } catch {}
       }
       reconnects = sawStreamProgress ? 0 : reconnects + 1;
     }

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -490,6 +490,7 @@ async function consumeDaemonRun({
       let buf = '';
       let sawStreamProgress = false;
 
+      try {
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;
@@ -569,6 +570,15 @@ async function consumeDaemonRun({
             onRunStatus?.(endStatus);
           }
         }
+      }
+      } catch (err) {
+        // Stream broke mid-read (tab backgrounded, proxy idle timeout, etc.).
+        // Don't let the error escape — treat as a normal stream end so the
+        // reconnection for-loop resumes from lastEventId. The daemon keeps
+        // the run alive independent of the SSE connection (runs.ts), so we
+        // can always reattach.
+        if ((err as Error).name === 'AbortError') throw err;
+        try { reader.cancel(); } catch {}
       }
       reconnects = sawStreamProgress ? 0 : reconnects + 1;
     }

--- a/apps/web/tests/providers/daemon-sse-reconnect.test.ts
+++ b/apps/web/tests/providers/daemon-sse-reconnect.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { reattachDaemonRun } from '../../src/providers/daemon';
+
+// ---------------------------------------------------------------------------
+// Helpers: build a fake SSE Response with a mock reader.
+// Using direct reader mocks (instead of real ReadableStream) avoids
+// unhandled-rejection noise from controller.error() after reader.cancel().
+// ---------------------------------------------------------------------------
+
+/** Encode a string as UTF-8 bytes. */
+function enc(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+/** SSE event frame: `id: <id>\nevent: <event>\ndata: <json>\n\n`. */
+function sseEvent(id: number, event: string, data: Record<string, unknown>): string {
+  return `id: ${id}\nevent: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/** SSE comment frame (keepalive): `: <text>\n\n`. */
+function sseComment(text: string): string {
+  return `: ${text}\n\n`;
+}
+
+type ReadResult = { value: Uint8Array; done: false } | { value: undefined; done: true };
+
+/** Build a mock reader that yields chunks, then rejects (network drop). */
+function makeRejectingReader(
+  chunks: Uint8Array[],
+  rejectError: Error = new TypeError('network error'),
+) {
+  let i = 0;
+  return {
+    read: (): Promise<ReadResult> => {
+      if (i < chunks.length) {
+        return Promise.resolve({ value: chunks[i++], done: false }) as Promise<ReadResult>;
+      }
+      return Promise.reject(rejectError);
+    },
+    cancel: () => Promise.resolve(),
+  };
+}
+
+/** Build a mock reader that yields chunks, then closes normally. */
+function makeFiniteReader(chunks: Uint8Array[]) {
+  let i = 0;
+  return {
+    read: (): Promise<ReadResult> => {
+      if (i < chunks.length) {
+        return Promise.resolve({ value: chunks[i++], done: false }) as Promise<ReadResult>;
+      }
+      return Promise.resolve({ value: undefined, done: true }) as Promise<ReadResult>;
+    },
+    cancel: () => Promise.resolve(),
+  };
+}
+
+/** Build a fake Response with a mock reader body. */
+function streamResponse(reader: { read: () => Promise<unknown>; cancel: () => Promise<void> }, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: { getReader: () => reader } as unknown as ReadableStream<Uint8Array>,
+    text: () => Promise.resolve(''),
+  } as unknown as Response;
+}
+
+/** Build a fake Response with a JSON body (for status endpoint). */
+function jsonResponse(data: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('reattachDaemonRun SSE reader reconnection', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('reconnects and resumes when reader.read() rejects mid-stream', async () => {
+    // First connection: send a start event + a delta, then reader.read()
+    // rejects (simulating a network drop / tab backgrounding).
+    const firstReader = makeRejectingReader([
+      enc(sseEvent(1, 'start', { bin: 'hermes' })),
+      enc(sseEvent(2, 'stdout', { chunk: 'hello ' })),
+    ]);
+
+    // Second connection (reconnect with ?after=2): send one more delta + end.
+    const secondReader = makeFiniteReader([
+      enc(sseEvent(3, 'stdout', { chunk: 'world' })),
+      enc(sseEvent(4, 'end', { status: 'succeeded', code: 0 })),
+    ]);
+
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/events')) {
+        if (u.includes('after=2')) {
+          return streamResponse(secondReader);
+        }
+        return streamResponse(firstReader);
+      }
+      if (u.includes('/runs/') && !u.includes('/events') && !u.includes('/cancel')) {
+        return jsonResponse({ status: 'succeeded', exitCode: 0, signal: null });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const deltas: string[] = [];
+    const statuses: string[] = [];
+    let doneText: string | null = null;
+    let error: Error | null = null;
+
+    const controller = new AbortController();
+
+    await reattachDaemonRun({
+      runId: 'test-run-1',
+      signal: controller.signal,
+      handlers: {
+        onDelta: (text) => deltas.push(text),
+        onDone: (text) => { doneText = text; },
+        onError: (err) => { error = err; },
+        onAgentEvent: () => {},
+      },
+      onRunStatus: (s) => statuses.push(s),
+    });
+
+    // Should have received both deltas (from first + reconnected stream).
+    expect(deltas).toEqual(['hello ', 'world']);
+    // Should have completed successfully — no error.
+    expect(error).toBeNull();
+    expect(doneText).toBe('hello world');
+    // Should have seen running + succeeded statuses.
+    expect(statuses).toContain('running');
+    expect(statuses).toContain('succeeded');
+    // Should have made two fetch calls to /events (initial + reconnect).
+    const eventCalls = fetchMock.mock.calls.filter(
+      ([u]) => typeof u === 'string' && u.includes('/events'),
+    ) as [string, RequestInit | undefined][];
+    expect(eventCalls.length).toBe(2);
+    // The second call should include ?after=2 (resuming from last event id).
+    expect(eventCalls[1]![0]).toContain('after=2');
+  });
+
+  it('does not swallow handler exceptions as reconnection', async () => {
+    // A handler callback (onDelta) throws — this should NOT be caught as a
+    // stream break. It should propagate to the caller as an error, not
+    // trigger a reconnect.
+    const reader = makeFiniteReader([
+      enc(sseEvent(1, 'start', { bin: 'hermes' })),
+      enc(sseEvent(2, 'stdout', { chunk: 'boom' })),
+    ]);
+
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/events')) {
+        return streamResponse(reader);
+      }
+      if (u.includes('/runs/') && !u.includes('/events') && !u.includes('/cancel')) {
+        return jsonResponse({ status: 'succeeded', exitCode: 0, signal: null });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const controller = new AbortController();
+    const handlerError = new Error('handler crashed during processing');
+
+    let doneCalled = false;
+
+    // The handler exception should propagate out of reattachDaemonRun,
+    // not be swallowed as a reconnection event.
+    await expect(
+      reattachDaemonRun({
+        runId: 'test-run-2',
+        signal: controller.signal,
+        handlers: {
+          onDelta: () => { throw handlerError; },
+          onDone: () => { doneCalled = true; },
+          onError: () => {},
+          onAgentEvent: () => {},
+        },
+        onRunStatus: () => {},
+      }),
+    ).rejects.toThrow('handler crashed during processing');
+
+    // onDone should NOT have been called — the run did not complete cleanly.
+    expect(doneCalled).toBe(false);
+
+    // Only one fetch call to /events — no reconnection should have occurred
+    // because the error came from a handler, not from reader.read().
+    const eventCalls = fetchMock.mock.calls.filter(
+      ([u]) => typeof u === 'string' && u.includes('/events'),
+    ) as [string, RequestInit | undefined][];
+    expect(eventCalls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why

When a run's SSE event stream drops mid-flight (browser tab backgrounded, reverse proxy idle timeout, network switch, laptop sleep), `reader.read()` in `consumeDaemonRun` (`apps/web/src/providers/daemon.ts`) throws a network error that escapes the reconnection for-loop entirely. The run is marked **failed** and the user sees a "network error" despite the run continuing server-side.

The existing reconnection infrastructure (up to 5 retries, `Last-Event-ID` resume via `?after=<id>`, `sawStreamProgress` counter reset) was designed to handle exactly this scenario, but the error from `reader.read()` propagated past the for-loop without entering the reconnection path. The reconnection logic was effectively dead code for mid-stream disconnects.

The daemon already decouples run lifetime from the SSE connection — when the response closes, the run is not aborted (only the SSE client is removed from `run.clients`). So a disconnected client can always reattach.

## What users will see

Runs that previously showed a "network error" and transitioned to **failed** when the browser tab was backgrounded (or the connection was briefly interrupted) will now silently reconnect and resume streaming. The transcript and run status stay consistent — no missed events, no false failure state. The Stop button continues to work as before.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)

## Fix

Narrow `try/catch` to only the `await reader.read()` call:
- On **AbortError** (user-initiated Stop), rethrow to preserve cancellation behavior.
- On any other error, cancel the broken reader and `break` → falls through to the existing reconnection logic (`reconnects = sawStreamProgress ? 0 : reconnects + 1`), which resumes from `lastEventId` on the next loop iteration.
- Parsing (`parseSseFrame`), `lastEventId` advancement, and all handler callbacks stay **outside** the catch so local processing bugs surface through the existing outer error path instead of being silently swallowed as reconnection events.

~10-line change in `daemon.ts`, no new dependencies or APIs.

## Bug fix verification

- **Test path that reproduces the bug:** `tests/providers/daemon-sse-reconnect.test.ts`
  - Test 1: `reader.read()` rejects mid-stream → reconnects with `?after=<id>` and resumes successfully, receiving all events from both streams.
  - Test 2: Handler callback (`onDelta`) throws → error propagates out of `reattachDaemonRun` (not caught as reconnect), no second fetch to `/events`, `onDone` never called.
- **Did the test go red on `main` and green on this branch?** Yes — the reader-rejection test fails on `main` (error escapes, run marked failed, no reconnection) and passes on this branch. The handler-exception test guards the narrow-catch shape: it fails if the catch is broadened back to wrap the whole loop (handler error would be swallowed instead of propagating).

## Validation

- `pnpm --filter @open-design/web typecheck` — passes
- `pnpm --filter @open-design/web test -- tests/providers/daemon-sse-reconnect.test.ts` — 2/2 pass
- Manual end-to-end: run started in browser, tab backgrounded for 60s, returned to live streaming run with no "network error"