### PR TITLE
fix(deploy): use network_mode host to fix loopback guard on Linux Docker

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -19,14 +19,11 @@ OD_API_TOKEN=
 # every request before it reaches the daemon. Set to 1 only for trusted setups;
 # when enabled, the daemon skips OD_API_TOKEN enforcement entirely.
 #
-# Linux Docker note: with bridge networking the daemon sees the Docker gateway
-# (172.17.0.1) instead of 127.0.0.1, so the loopback guard on connector
-# endpoints (Composio key save, GitHub OAuth, etc.) returns 403 even when
-# OD_API_TOKEN is set correctly. Two options:
-#   1. Set network_mode: host in docker-compose.yml (Linux only, recommended
-#      for local installs — already done in the provided compose file).
-#   2. Set OPEN_DESIGN_DISABLE_API_AUTH=1 if running behind a trusted reverse
-#      proxy that already authenticates every request.
+# Note: connector endpoints (Composio, GitHub OAuth) also require the daemon to
+# receive requests over loopback. On Linux Docker this is handled automatically
+# by docker-compose.linux.yml (network_mode: host). On macOS/Windows use
+# a reverse proxy bound to 127.0.0.1.
+
 OPEN_DESIGN_DISABLE_API_AUTH=
 
 # Container memory limit. The idle service has been verified around 18-22 MiB.

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -18,6 +18,15 @@ OD_API_TOKEN=
 # Optional escape hatch for deployments whose reverse proxy already authenticates
 # every request before it reaches the daemon. Set to 1 only for trusted setups;
 # when enabled, the daemon skips OD_API_TOKEN enforcement entirely.
+#
+# Linux Docker note: with bridge networking the daemon sees the Docker gateway
+# (172.17.0.1) instead of 127.0.0.1, so the loopback guard on connector
+# endpoints (Composio key save, GitHub OAuth, etc.) returns 403 even when
+# OD_API_TOKEN is set correctly. Two options:
+#   1. Set network_mode: host in docker-compose.yml (Linux only, recommended
+#      for local installs — already done in the provided compose file).
+#   2. Set OPEN_DESIGN_DISABLE_API_AUTH=1 if running behind a trusted reverse
+#      proxy that already authenticates every request.
 OPEN_DESIGN_DISABLE_API_AUTH=
 
 # Container memory limit. The idle service has been verified around 18-22 MiB.

--- a/deploy/docker-compose.linux.yml
+++ b/deploy/docker-compose.linux.yml
@@ -18,10 +18,15 @@ services:
     # Drop the bridge port mapping — host networking makes it irrelevant.
     ports: !reset []
     network_mode: host
+    environment:
+      # Re-declare both port vars so the daemon listener follows OPEN_DESIGN_PORT
+      # even without the bridge mapping (which normally enforced the remap).
+      OD_PORT: ${OPEN_DESIGN_PORT:-7456}
+      OD_WEB_PORT: ${OPEN_DESIGN_PORT:-7456}
     healthcheck:
       # Use wget (available in Alpine) instead of node — faster and does not
       # compete with the daemon for CPU during startup.
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:7456/api/health"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:${OPEN_DESIGN_PORT:-7456}/api/health"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/deploy/docker-compose.linux.yml
+++ b/deploy/docker-compose.linux.yml
@@ -23,6 +23,10 @@ services:
       # even without the bridge mapping (which normally enforced the remap).
       OD_PORT: ${OPEN_DESIGN_PORT:-7456}
       OD_WEB_PORT: ${OPEN_DESIGN_PORT:-7456}
+      # With host networking the daemon binds directly on the host's interfaces.
+      # Lock it to loopback so the base file's 0.0.0.0 default does not expose
+      # Open Design on the LAN or public IP.
+      OD_BIND_HOST: 127.0.0.1
     healthcheck:
       # Use wget (available in Alpine) instead of node — faster and does not
       # compete with the daemon for CPU during startup.

--- a/deploy/docker-compose.linux.yml
+++ b/deploy/docker-compose.linux.yml
@@ -1,0 +1,28 @@
+# Linux override for docker-compose.yml.
+#
+# Switches to host networking so the daemon sees browser connections as
+# 127.0.0.1, satisfying the loopback guard on connector endpoints
+# (Composio key save, GitHub OAuth, etc.) that bridge networking breaks.
+#
+# network_mode: host is Linux-only. macOS and Windows Docker Desktop users
+# should use the base docker-compose.yml behind a loopback-bound reverse proxy.
+#
+# Used automatically by install.sh on Linux. To apply manually:
+#   docker compose -f docker-compose.yml -f docker-compose.linux.yml up -d
+name: open-design
+
+services:
+  open-design:
+    # Cap CPU so a busy agent run does not starve the host.
+    cpus: '1.5'
+    # Drop the bridge port mapping — host networking makes it irrelevant.
+    ports: !reset []
+    network_mode: host
+    healthcheck:
+      # Use wget (available in Alpine) instead of node — faster and does not
+      # compete with the daemon for CPU during startup.
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:7456/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       OD_API_TOKEN: ${OD_API_TOKEN:-}
       OD_DISABLE_API_AUTH: ${OPEN_DESIGN_DISABLE_API_AUTH:-}
       OD_CODEX_SANDBOX: ${OD_CODEX_SANDBOX:-}
-    network_mode: host
+    ports:
+      - "127.0.0.1:${OPEN_DESIGN_PORT:-7456}:7456"
     volumes:
       - open_design_data:/app/.od
     read_only: true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -18,8 +18,7 @@ services:
       OD_API_TOKEN: ${OD_API_TOKEN:-}
       OD_DISABLE_API_AUTH: ${OPEN_DESIGN_DISABLE_API_AUTH:-}
       OD_CODEX_SANDBOX: ${OD_CODEX_SANDBOX:-}
-    ports:
-      - "127.0.0.1:${OPEN_DESIGN_PORT:-7456}:7456"
+    network_mode: host
     volumes:
       - open_design_data:/app/.od
     read_only: true

--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -469,13 +469,18 @@ if [ "$OS" = "Linux" ] && [ "$OPT_NO_SYSTEMD" = "0" ]; then
       echo "Type=oneshot"
       echo "RemainAfterExit=yes"
       echo "WorkingDirectory=${DEPLOY_DIR}"
-      if [ -f "$OVERRIDE_FILE" ]; then
-        echo "ExecStart=${CONTAINER_BIN} compose -f ${COMPOSE_FILE} -f ${OVERRIDE_FILE} up -d --no-build"
-        echo "ExecStop=${CONTAINER_BIN} compose -f ${COMPOSE_FILE} -f ${OVERRIDE_FILE} down"
-      else
-        echo "ExecStart=${CONTAINER_BIN} compose -f ${COMPOSE_FILE} up -d --no-build"
-        echo "ExecStop=${CONTAINER_BIN} compose -f ${COMPOSE_FILE} down"
+      # Build the compose -f list to match what the installer used at install
+      # time, so systemd restarts use the same file set (including the Linux
+      # host-network override when present).
+      _COMPOSE_ARGS="-f ${COMPOSE_FILE}"
+      if [ -f "$LINUX_OVERRIDE_FILE" ]; then
+        _COMPOSE_ARGS="${_COMPOSE_ARGS} -f ${LINUX_OVERRIDE_FILE}"
       fi
+      if [ -f "$OVERRIDE_FILE" ]; then
+        _COMPOSE_ARGS="${_COMPOSE_ARGS} -f ${OVERRIDE_FILE}"
+      fi
+      echo "ExecStart=${CONTAINER_BIN} compose ${_COMPOSE_ARGS} up -d --no-build"
+      echo "ExecStop=${CONTAINER_BIN} compose ${_COMPOSE_ARGS} down"
       echo "TimeoutStartSec=120"
       echo ""
       echo "[Install]"

--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -264,6 +264,26 @@ if ! detect_compose; then
   exit 1
 fi
 
+# The Linux host-network override uses the !reset YAML tag (Docker Compose
+# v2.17+). Reject legacy docker-compose v1 and podman-compose early so users
+# get a clear message instead of a YAML parse error mid-install.
+if [ "$OS" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
+  if [ "$COMPOSE_CMD" != "docker compose" ]; then
+    error "The Linux host-network override requires 'docker compose' v2."
+    error "Found: ${COMPOSE_CMD}"
+    step "Install the Docker Compose plugin: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+  _compose_ver="$($COMPOSE_CMD version --short 2>/dev/null || echo "0.0.0")"
+  _compose_major="$(echo "$_compose_ver" | cut -d. -f1)"
+  _compose_minor="$(echo "$_compose_ver" | cut -d. -f2)"
+  if [ "$_compose_major" -lt 2 ] || { [ "$_compose_major" -eq 2 ] && [ "$_compose_minor" -lt 17 ]; }; then
+    error "Docker Compose v2.17 or later required for the Linux override (found v${_compose_ver})."
+    step "Upgrade: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+fi
+
 if ! check_runtime_running; then
   warn "${CONTAINER_RUNTIME} is not running."
   case "$DISTRO" in

--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -19,10 +19,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEPLOY_DIR="$(dirname "$SCRIPT_DIR")"
 COMPOSE_FILE="${DEPLOY_DIR}/docker-compose.yml"
 OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.override.yml"
+LINUX_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.linux.yml"
 
 # Build the -f argument list: always include the base file,
-# and add the override if it exists (used by tests for isolation).
+# add the Linux host-network override, and add docker-compose.override.yml if present
+# (used by tests for isolation).
 COMPOSE_FILES=(-f "$COMPOSE_FILE")
+if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
+  COMPOSE_FILES+=(-f "$LINUX_OVERRIDE_FILE")
+fi
 if [ -f "$OVERRIDE_FILE" ]; then
   COMPOSE_FILES+=(-f "$OVERRIDE_FILE")
 fi

--- a/deploy/scripts/update.sh
+++ b/deploy/scripts/update.sh
@@ -52,6 +52,24 @@ else
   exit 1
 fi
 
+# Same guard as install.sh: the Linux override uses !reset (Docker Compose v2.17+).
+if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
+  if [ "$COMPOSE_CMD" != "docker compose" ]; then
+    error "The Linux host-network override requires 'docker compose' v2."
+    error "Found: ${COMPOSE_CMD}"
+    step "Install the Docker Compose plugin: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+  _compose_ver="$($COMPOSE_CMD version --short 2>/dev/null || echo "0.0.0")"
+  _compose_major="$(echo "$_compose_ver" | cut -d. -f1)"
+  _compose_minor="$(echo "$_compose_ver" | cut -d. -f2)"
+  if [ "$_compose_major" -lt 2 ] || { [ "$_compose_major" -eq 2 ] && [ "$_compose_minor" -lt 17 ]; }; then
+    error "Docker Compose v2.17 or later required for the Linux override (found v${_compose_ver})."
+    step "Upgrade: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+fi
+
 OPT_IMAGE=""
 NON_INTERACTIVE=0
 

--- a/deploy/scripts/update.sh
+++ b/deploy/scripts/update.sh
@@ -9,9 +9,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEPLOY_DIR="$(dirname "$SCRIPT_DIR")"
 COMPOSE_FILE="${DEPLOY_DIR}/docker-compose.yml"
 OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.override.yml"
+LINUX_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.linux.yml"
 HEALTH_TIMEOUT=60
 
 COMPOSE_FILES=(-f "$COMPOSE_FILE")
+if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
+  COMPOSE_FILES+=(-f "$LINUX_OVERRIDE_FILE")
+fi
 if [ -f "$OVERRIDE_FILE" ]; then
   COMPOSE_FILES+=(-f "$OVERRIDE_FILE")
 fi


### PR DESCRIPTION
**Why**

  I hit this while setting up Open Design via Docker on Linux. With bridge
  networking, the daemon sees 172.17.0.1 (Docker gateway) as the peer address
  instead of 127.0.0.1, so two guards fail:
  1. Bearer auth → 401 on every /api/* call
  2. requireLocalDaemonRequest → 403 on connector endpoints (Composio key save,
  GitHub OAuth) — the loopback check is hardcoded and not bypassable via env var

  Also found that the original .env.example had OD_API_TOKEN=$(openssl rand -hex
  32) — Docker Compose reads .env as plain text, so that lands as a literal
  string and every request returns 401 silently.

  **What users will see**

  - Docker on Linux works without manual workarounds: no 401 on load, no 403
  when saving the Composio key or connecting GitHub
  - .env.example now makes it clear that OD_API_TOKEN needs a real pasted value,
  not a shell substitution

  **Surface area**

  - [x] CLI / env var — .env.example updated
  - [x] Default behavior change — docker-compose.yml uses network_mode: host
  instead of bridge port mapping

  **Bug fix verification**

  No automated test — the bug lives at the Docker network layer, not something
  Vitest or Playwright can reach without a real Linux Docker bridge setup.
  Verified manually with curl before and after the fix.

  **Validation**

  Tested on Linux (Ubuntu), Docker 24. curl http://127.0.0.1:7456/api/health and
  curl -X PUT /api/connectors/composio/config both return 200 after the fix.
  Composio key save and GitHub connect work in the UI.