### PR TITLE
fix(daemon): clarify Codex imagegen preview-only failures

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -1008,14 +1008,59 @@ function parseCodexThreadId(stdout: string): string {
   throw new Error('codex imagegen did not emit a thread.started thread_id');
 }
 
-async function readCodexGeneratedImage(generatedRoot: string, threadId: string): Promise<Buffer> {
+function summarizeCodexImagegenStdout(stdout: string): string {
+  const messages: string[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed) as { item?: { text?: unknown }; text?: unknown };
+      const text = typeof obj.item?.text === 'string'
+        ? obj.item.text
+        : typeof obj.text === 'string'
+          ? obj.text
+          : '';
+      if (text.trim()) messages.push(text.trim());
+    } catch {
+      messages.push(trimmed);
+    }
+  }
+  return truncate(messages.join('\n'), 500);
+}
+
+function codexImagegenMissingOutputError(threadDir: string, stdout: string): Error {
+  const summary = summarizeCodexImagegenStdout(stdout);
+  const suffix = summary ? ` Codex stdout summary: ${summary}` : '';
+  if (/\bpreview[- ]only\b|without saving|without writing|does not write|no file|bez przenoszenia/i.test(summary)) {
+    return new Error(
+      `Codex imagegen completed in preview-only mode and did not write an image file under ${threadDir}. Use an API-backed image provider or a Codex CLI build that writes generated_images output.${suffix}`,
+    );
+  }
+  return new Error(
+    `Codex imagegen completed but did not write an ig_* image under ${threadDir}. Use an API-backed image provider or a Codex CLI build that writes generated_images output.${suffix}`,
+  );
+}
+
+async function readCodexGeneratedImage(
+  generatedRoot: string,
+  threadId: string,
+  stdout: string,
+): Promise<Buffer> {
   const threadDir = path.join(generatedRoot, threadId);
-  const entries = await readdir(threadDir);
+  let entries: string[];
+  try {
+    entries = await readdir(threadDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      throw codexImagegenMissingOutputError(threadDir, stdout);
+    }
+    throw err;
+  }
   const match = entries
     .filter((name) => /^ig_.*\.(?:png|jpe?g|webp)$/i.test(name))
     .sort()[0];
   if (!match) {
-    throw new Error(`codex imagegen produced no ig_* image in ${threadDir}`);
+    throw codexImagegenMissingOutputError(threadDir, stdout);
   }
   const imagePath = path.join(threadDir, match);
   const bytes = await readFile(imagePath);
@@ -1068,7 +1113,7 @@ async function renderCodexImage(ctx: MediaContext): Promise<RenderResult> {
   await mkdir(generatedRoot, { recursive: true });
   const { stdout } = await runCodexImagegen(ctx, generatedRoot, env);
   const threadId = parseCodexThreadId(stdout);
-  const bytes = await readCodexGeneratedImage(generatedRoot, threadId);
+  const bytes = await readCodexGeneratedImage(generatedRoot, threadId, stdout);
   const imageModel = codexImageModelLabel(ctx.model);
   return {
     bytes,

--- a/apps/daemon/tests/media/openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media/openai-compatible-providers.test.ts
@@ -700,6 +700,41 @@ process.stdin.on('end', () => {
     expect(bytes.length).toBeGreaterThan(0);
   });
 
+  it('reports Codex preview-only imagegen output without leaking ENOENT', async () => {
+    const generatedHome = path.join(root, 'preview-only-codex-home');
+    const codexBin = path.join(root, 'preview-only-codex.mjs');
+    await writeFile(codexBin, `#!/usr/bin/env node
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { stdin += chunk; });
+process.stdin.on('end', () => {
+  if (!stdin.includes('$imagegen')) process.exit(7);
+  process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 'preview-only-thread' }) + '\\n');
+  process.stdout.write(JSON.stringify({
+    type: 'item.completed',
+    item: {
+      type: 'agent_message',
+      text: 'This is preview-only, so I generated it without saving a file to the project.'
+    }
+  }) + '\\n');
+  process.stdout.write(JSON.stringify({ type: 'turn.completed' }) + '\\n');
+});
+`, 'utf8');
+    await chmod(codexBin, 0o755);
+    process.env.CODEX_BIN = codexBin;
+    process.env.CODEX_HOME = generatedHome;
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'codex-gpt-image-2',
+      prompt: 'A compact green app icon with a folded page motif',
+      output: 'codex-preview-only.png',
+    })).rejects.toThrow(/Codex imagegen completed in preview-only mode/i);
+  });
+
   it('uses app-config Codex CLI env overrides for subscription image generation', async () => {
     const dataDir = path.join(root, 'app-data');
     const generatedHome = path.join(root, 'configured-codex-home');


### PR DESCRIPTION
Fixes #4623

## Why

I picked this up after the issue confirmed a Codex CLI compatibility break: recent Codex imagegen runs can complete in preview-only mode, emit a `thread.started` event, and never create the expected `generated_images/<thread-id>/ig_*` file. The daemon still treated that as a filesystem invariant and leaked a raw `ENOENT` when it scanned the missing thread directory.

This PR keeps the existing file-backed Codex subscription path for CLI builds that still write `ig_*` output, but turns the no-file case into an actionable provider error that includes the relevant Codex stdout summary.

## What users will see

When Codex imagegen completes without writing a generated image directory, Open Design now reports that Codex completed in preview-only mode and did not write an image file, with guidance to use an API-backed image provider or a Codex CLI build that writes `generated_images` output. Users no longer see a raw `ENOENT: no such file or directory, scandir ...` failure.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; daemon media-provider error handling only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/media/openai-compatible-providers.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new preview-only Codex regression failed on `main` with raw `ENOENT` and passes on this branch with the new provider error.

## Validation

- `fnm exec --using=24 corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/media/openai-compatible-providers.test.ts --testNamePattern "preview-only"` — red on main before the source fix, green on this branch
- `fnm exec --using=24 corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/media/openai-compatible-providers.test.ts`
- `fnm exec --using=24 corepack pnpm --filter @open-design/daemon typecheck`
- `fnm exec --using=24 corepack pnpm guard`
- `fnm exec --using=24 corepack pnpm typecheck`
