### PR TITLE
[codex] Polish AMR settings card

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4225,6 +4225,15 @@ export function SettingsDialog({
                                                 {benefit}
                                               </span>
                                             ))}
+                                            <PlanBadge
+                                              plan={amrCardPlanLabel}
+                                              size="sm"
+                                              title={
+                                                amrCardPlanLabel
+                                                  ? `${t('settings.amrPlan')} ${amrCardPlanLabel}`
+                                                  : undefined
+                                              }
+                                            />
                                           </span>
                                         ) : description ? (
                                           <>
@@ -4252,15 +4261,6 @@ export function SettingsDialog({
                                           <span className="agent-card-amr-email-text" title={amrCardEmail}>
                                             {amrCardEmail}
                                           </span>
-                                          <PlanBadge
-                                            plan={amrCardPlanLabel}
-                                            size="sm"
-                                            title={
-                                              amrCardPlanLabel
-                                                ? `${t('settings.amrPlan')} ${amrCardPlanLabel}`
-                                                : undefined
-                                            }
-                                          />
                                           {amrCardProfileBadge ? (
                                             <span className="agent-card-amr-profile-badge">
                                               {amrCardProfileBadge}
@@ -4270,43 +4270,20 @@ export function SettingsDialog({
                                       ) : null}
                                       {amrWalletVisible ? (
                                         <div className="agent-card-amr-meta-row">
-                                          {amrWalletVisible ? (
-                                            <span className="agent-card-amr-balance">
-                                              <span className="agent-card-amr-balance-label">
-                                                {t('settings.amrBalance')}
-                                              </span>
-                                              <span className="agent-card-amr-balance-value">
-                                                {amrWalletValueLabel({
-                                                  balance: amrCardBalanceLabel,
-                                                  loadingLabel: t('common.loading'),
-                                                  ready: amrWalletReady || Boolean(amrCardBalanceLabel),
-                                                  snapshot: amrWalletSnapshot,
-                                                  unavailableLabel: t('settings.amrWalletUnavailable'),
-                                                })}
-                                              </span>
+                                          <span className="agent-card-amr-balance">
+                                            <span className="agent-card-amr-balance-label">
+                                              {t('settings.amrBalance')}
                                             </span>
-                                          ) : null}
-                                          <button
-                                            type="button"
-                                            className="agent-card-amr-wallet-refresh"
-                                            title={t('settings.amrWalletRefreshTitle')}
-                                            aria-label={t('settings.amrWalletRefreshTitle')}
-                                            disabled={!amrWalletReady && !amrCardBalanceLabel}
-                                            onClick={(event) => {
-                                              event.stopPropagation();
-                                              void refreshAmrWalletSnapshot({ refresh: true });
-                                            }}
-                                          >
-                                            <Icon
-                                              name={!amrWalletReady && !amrCardBalanceLabel ? 'spinner' : 'refresh'}
-                                              size={13}
-                                              className={
-                                                !amrWalletReady && !amrCardBalanceLabel
-                                                  ? 'icon-spin'
-                                                  : undefined
-                                              }
-                                            />
-                                          </button>
+                                            <span className="agent-card-amr-balance-value">
+                                              {amrWalletValueLabel({
+                                                balance: amrCardBalanceLabel,
+                                                loadingLabel: t('common.loading'),
+                                                ready: amrWalletReady || Boolean(amrCardBalanceLabel),
+                                                snapshot: amrWalletSnapshot,
+                                                unavailableLabel: t('settings.amrWalletUnavailable'),
+                                              })}
+                                            </span>
+                                          </span>
                                         </div>
                                       ) : null}
                                       {!active && modelSummary ? (

--- a/apps/web/src/styles/plan-badge.css
+++ b/apps/web/src/styles/plan-badge.css
@@ -12,6 +12,7 @@
   font-weight: 700;
   letter-spacing: 0.02em;
   line-height: 1.3;
+  white-space: nowrap;
   text-transform: capitalize;
   color: var(--accent-strong);
   border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1075,9 +1075,6 @@
   align-items: stretch;
   min-width: 0;
 }
-.agent-card-installed:has(.agent-card-amr-auth) .agent-card-main {
-  flex-wrap: wrap;
-}
 .agent-card-select {
   flex: 1;
   min-width: 0;
@@ -1091,9 +1088,6 @@
   color: inherit;
   text-align: left;
   cursor: pointer;
-}
-.agent-card-installed:has(.agent-card-amr-auth) .agent-card-select {
-  flex: 1 1 420px;
 }
 .agent-card-test-btn {
   align-self: stretch;
@@ -1289,10 +1283,9 @@
 .agent-card-name--amr {
   align-items: center;
   gap: 8px;
-  row-gap: 5px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   max-width: 100%;
-  white-space: normal;
+  white-space: nowrap;
   overflow: hidden;
 }
 .agent-card-name.agent-card-name--amr .agent-card-title {
@@ -1304,8 +1297,8 @@
 .agent-card-benefits {
   display: inline-flex;
   align-items: center;
-  flex: 1 1 180px;
-  flex-wrap: wrap;
+  flex: 0 1 auto;
+  flex-wrap: nowrap;
   gap: 5px;
   min-width: 0;
   max-width: 100%;
@@ -1416,30 +1409,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.agent-card-amr-wallet-refresh {
-  align-self: center;
-  flex: 0 0 32px;
-  width: 32px;
-  height: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border-soft);
-  border-radius: var(--radius-md);
-  background: var(--bg-panel);
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background-color 120ms var(--ease-out), border-color 120ms var(--ease-out), color 120ms var(--ease-out);
-}
-.agent-card-amr-wallet-refresh:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
-  background: color-mix(in srgb, var(--accent-tint) 62%, var(--bg-panel));
-  color: var(--accent-strong);
-}
-.agent-card-amr-wallet-refresh:disabled {
-  cursor: default;
-  opacity: 0.62;
 }
 .agent-card-amr-upgrade {
   appearance: none;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2867,7 +2867,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.queryByText(/^vela$/i)).toBeNull();
   });
 
-  it('refreshes the Settings AMR wallet fallback balance for old Vela CLI status payloads', async () => {
+  it('loads the Settings AMR wallet fallback balance without a manual card refresh button', async () => {
     let walletCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -2920,9 +2920,8 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
 
     expect(await screen.findByText('$1.00')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh AMR wallet balance' }));
-    expect(await screen.findByText('$2.00')).toBeTruthy();
-    expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/wallet?refresh=1', {
+    expect(screen.queryByRole('button', { name: 'Refresh AMR wallet balance' })).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/wallet', {
       cache: 'no-store',
     });
   });


### PR DESCRIPTION
## Why

The Settings → Execution mode AMR/Open Design card regressed visually in the current release: the plan badge could wrap onto multiple lines in the account row, and the wallet balance row still exposed a small manual refresh button that cluttered the card.

This PR tightens the existing card presentation so the account and plan badges stay compact while removing the redundant manual wallet refresh control.

## What users will see

Settings → Execution mode keeps the Open Design card badges on one line where space allows, including the plan badge such as Free or Pro. The wallet balance remains visible, but the small refresh icon beside it is gone.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Locally verified in the in-app browser at `http://127.0.0.1:17667` after binding `VELA_BIN=/Users/alche/Documents/vela/.bin/vela`. The Open Design card showed `Official`, `Lower cost`, `Many models`, the account email, plan/amount content, and no wallet refresh icon. No hosted screenshot attachment is available from this Codex environment.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.execution.test.tsx`
- Did the test go red on `main` and green on this branch? No. The cheap regression assertion was updated on this branch to cover the new expected behavior: wallet balance loads and the manual card refresh button is absent.
- Visual verification: local in-app browser check against Settings → Execution mode with live AMR/Open Design CLI detection.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx --maxWorkers=2`
- `pnpm guard`