### PR TITLE
[codex] Polish AMR settings card

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4405,6 +4405,15 @@ export function SettingsDialog({
                                                 {benefit}
                                               </span>
                                             ))}
+                                            <PlanBadge
+                                              plan={amrCardPlanLabel}
+                                              size="sm"
+                                              title={
+                                                amrCardPlanLabel
+                                                  ? `${t('settings.amrPlan')} ${amrCardPlanLabel}`
+                                                  : undefined
+                                              }
+                                            />
                                           </span>
                                         ) : description ? (
                                           <>
@@ -4419,6 +4428,11 @@ export function SettingsDialog({
                                             </span>
                                           </>
                                         ) : null}
+                                        {isAmrAgent && amrCardPlanLabel ? (
+                                          <VisuallyHidden>
+                                            {`, ${t('settings.amrPlan')} ${amrCardPlanLabel}`}
+                                          </VisuallyHidden>
+                                        ) : null}
                                       </div>
                                       {metaLabel ? (
                                         <div className="agent-card-meta">
@@ -4432,15 +4446,6 @@ export function SettingsDialog({
                                           <span className="agent-card-amr-email-text" title={amrCardEmail}>
                                             {amrCardEmail}
                                           </span>
-                                          <PlanBadge
-                                            plan={amrCardPlanLabel}
-                                            size="sm"
-                                            title={
-                                              amrCardPlanLabel
-                                                ? `${t('settings.amrPlan')} ${amrCardPlanLabel}`
-                                                : undefined
-                                            }
-                                          />
                                           {amrCardProfileBadge ? (
                                             <span className="agent-card-amr-profile-badge">
                                               {amrCardProfileBadge}
@@ -4450,22 +4455,20 @@ export function SettingsDialog({
                                       ) : null}
                                       {amrWalletVisible ? (
                                         <div className="agent-card-amr-meta-row">
-                                          {amrWalletVisible ? (
-                                            <span className="agent-card-amr-balance">
-                                              <span className="agent-card-amr-balance-label">
-                                                {t('settings.amrBalance')}
-                                              </span>
-                                              <span className="agent-card-amr-balance-value">
-                                                {amrWalletValueLabel({
-                                                  balance: amrCardBalanceLabel,
-                                                  loadingLabel: t('common.loading'),
-                                                  ready: amrWalletReady || Boolean(amrCardBalanceLabel),
-                                                  snapshot: amrWalletSnapshot,
-                                                  unavailableLabel: t('settings.amrWalletUnavailable'),
-                                                })}
-                                              </span>
+                                          <span className="agent-card-amr-balance">
+                                            <span className="agent-card-amr-balance-label">
+                                              {t('settings.amrBalance')}
                                             </span>
-                                          ) : null}
+                                            <span className="agent-card-amr-balance-value">
+                                              {amrWalletValueLabel({
+                                                balance: amrCardBalanceLabel,
+                                                loadingLabel: t('common.loading'),
+                                                ready: amrWalletReady || Boolean(amrCardBalanceLabel),
+                                                snapshot: amrWalletSnapshot,
+                                                unavailableLabel: t('settings.amrWalletUnavailable'),
+                                              })}
+                                            </span>
+                                          </span>
                                         </div>
                                       ) : null}
                                       {!active && modelSummary ? (

--- a/apps/web/src/styles/plan-badge.css
+++ b/apps/web/src/styles/plan-badge.css
@@ -12,6 +12,7 @@
   font-weight: 700;
   letter-spacing: 0.02em;
   line-height: 1.3;
+  white-space: nowrap;
   text-transform: capitalize;
   color: var(--accent-strong);
   border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1413,24 +1413,26 @@
 .agent-card-name--amr {
   align-items: center;
   gap: 8px;
-  row-gap: 5px;
-  flex-wrap: wrap;
-  white-space: normal;
-  overflow: visible;
+  flex-wrap: nowrap;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
 }
 .agent-card-name.agent-card-name--amr .agent-card-title {
-  flex: 0 0 auto;
-  overflow: visible;
-  text-overflow: clip;
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 .agent-card-benefits {
   display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex: 0 1 auto;
+  flex-wrap: nowrap;
   gap: 5px;
-  min-width: min(100%, 220px);
-  overflow: visible;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 .agent-card-benefit {
   display: inline-flex;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2896,6 +2896,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
               email: 'signed-in@example.com',
               name: 'Signed In User',
             },
+            account: { plan: 'pro' },
             configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
@@ -2914,12 +2915,13 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
 
     expect(await screen.findByRole('button', { name: 'Sign out' })).toBeTruthy();
     expect(screen.getByRole('button', { name: /^Open Design\b/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Plan pro/ })).toBeTruthy();
     expect(screen.getByText('signed-in@example.com')).toBeTruthy();
     expect(screen.queryByText(/AMR \(vela\)/i)).toBeNull();
     expect(screen.queryByText(/^vela$/i)).toBeNull();
   });
 
-  it('shows the Settings AMR wallet fallback balance for old Vela CLI status payloads', async () => {
+  it('loads the Settings AMR wallet fallback balance without a manual card refresh button', async () => {
     let walletCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();


### PR DESCRIPTION
## Why

The previous release-targeted PR (#4979) was closed, but the Settings -> Execution mode AMR card polish still needs to land on `main`.

This fixes the user-facing layout issue where the AMR plan badge could wrap onto the email row and make the card look broken in the CLI picker.

## What users will see

In Settings -> Execution mode, the Open Design CLI card keeps the plan badge with the other top-line benefit badges. The email row stays focused on account identity, and the badge text is prevented from wrapping internally.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Validated locally through a DMG build/open flow before retargeting this fix to `main`; requester confirmed the layout is fixed.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.execution.test.tsx`
- Did the test go red on `main` and green on this branch? no; this is a focused layout regression without a cheap DOM-level red spec for rendered wrapping. The existing SettingsDialog regression test now covers that the manual wallet refresh button is absent while the wallet fallback still loads.

## Validation

- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx --maxWorkers=2`