### PR TITLE
fix(media): add missing withMediaRequestInit for OpenRouter fetches

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -1937,7 +1937,7 @@ async function renderOpenRouterImage(
   };
   body.image_config = imageConfig;
 
-  const resp = await fetch(`${baseUrl}/chat/completions`, {
+  const resp = await fetch(`${baseUrl}/chat/completions`, withMediaRequestInit(ctx, {
     method: 'POST',
     headers: {
       'authorization': `Bearer ${credentials.apiKey}`,
@@ -1946,7 +1946,8 @@ async function renderOpenRouterImage(
       'X-Title': 'Open Design',
     },
     body: JSON.stringify(body),
-  });
+    signal: AbortSignal.timeout(Math.max(OPENAI_IMAGE_HEADERS_TIMEOUT_MS, OPENAI_IMAGE_BODY_TIMEOUT_MS)),
+  }));
   const text = await resp.text();
   if (!resp.ok) {
     throw new Error(`openrouter image ${resp.status}: ${truncate(text, 240)}`);
@@ -1984,7 +1985,7 @@ async function renderOpenRouterImage(
     bytes = Buffer.from(b64Match[1]!, 'base64');
   } else if (dataUrl.startsWith('http')) {
     // Some models may return a plain URL instead of inline base64.
-    const imgResp = await fetch(dataUrl);
+    const imgResp = await fetch(dataUrl, withMediaRequestInit(ctx));
     if (!imgResp.ok) throw new Error(`openrouter image download ${imgResp.status}`);
     bytes = Buffer.from(await imgResp.arrayBuffer());
   } else {
@@ -2094,7 +2095,7 @@ async function renderOpenRouterVideo(
   }
 
   // ── Step 1: Submit the generation request ──────────────────────────
-  const submitResp = await fetch(`${baseUrl}/videos`, {
+  const submitResp = await fetch(`${baseUrl}/videos`, withMediaRequestInit(ctx, {
     method: 'POST',
     headers: {
       'authorization': `Bearer ${credentials.apiKey}`,
@@ -2105,7 +2106,7 @@ async function renderOpenRouterVideo(
       'X-Title': 'Open Design',
     },
     body: JSON.stringify(body),
-  });
+  }));
   const submitText = await submitResp.text();
   if (!submitResp.ok) {
     throw new Error(
@@ -2147,13 +2148,13 @@ async function renderOpenRouterVideo(
 
   while (Date.now() - startedAt < maxMs) {
     await sleep(8000);
-    const pollResp = await fetch(pollingUrl, {
+    const pollResp = await fetch(pollingUrl, withMediaRequestInit(ctx, {
       headers: {
         'authorization': `Bearer ${credentials.apiKey}`,
         'HTTP-Referer': 'https://opendesign.dev',
         'X-Title': 'Open Design',
       },
-    });
+    }));
     const pollText = await pollResp.text();
     if (!pollResp.ok) {
       throw new Error(
@@ -2215,7 +2216,7 @@ async function renderOpenRouterVideo(
     dlHeaders['authorization'] = `Bearer ${credentials.apiKey}`;
   }
 
-  const dlResp = await fetch(contentUrl, { headers: dlHeaders });
+  const dlResp = await fetch(contentUrl, withMediaRequestInit(ctx, { headers: dlHeaders }));
   if (!dlResp.ok) {
     throw new Error(`openrouter video download ${dlResp.status}`);
   }

--- a/apps/daemon/tests/media/openrouter.test.ts
+++ b/apps/daemon/tests/media/openrouter.test.ts
@@ -488,6 +488,32 @@ describe('openrouter video generation', () => {
     // doesn't regress to a lower value (e.g. 20 min).
     await expect(generateMedia(argsWithPaths())).resolves.toBeDefined();
   });
+
+  it('propagates requestInit.dispatcher to all fetch calls (submit, poll, download)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-disp',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-disp',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-disp',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dispatcher = { fake: 'dispatcher' } as any;
+    await generateMedia({ ...argsWithPaths(), requestInit: { dispatcher } });
+
+    // 1. Submit
+    expect(fetchMock.mock.calls[0]![1].dispatcher).toBe(dispatcher);
+    // 2. Poll
+    expect(fetchMock.mock.calls[1]![1].dispatcher).toBe(dispatcher);
+    // 3. Download
+    expect(fetchMock.mock.calls[2]![1].dispatcher).toBe(dispatcher);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -712,5 +738,25 @@ describe('openrouter image generation', () => {
     expect(result.providerNote).toContain('my-custom-gemini-img');
 
     delete process.env.OD_MEDIA_MODEL_ALIASES;
+  });
+
+  it('propagates requestInit.dispatcher to the fetch calls (submit, download)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        chatResp([{ type: 'image_url', image_url: { url: 'https://example.com/image.png' } }]),
+      )
+      .mockResolvedValueOnce(new Response(Buffer.from(PNG_B64, 'base64'), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dispatcher = { fake: 'dispatcher' } as any;
+    await generateMedia(imageArgs({ requestInit: { dispatcher } }));
+
+    // 1. Submit
+    expect(fetchMock.mock.calls[0]![1].dispatcher).toBe(dispatcher);
+    // 2. Download
+    expect(fetchMock.mock.calls[1]![1].dispatcher).toBe(dispatcher);
   });
 });


### PR DESCRIPTION
## Why

OpenRouter media generation (image and video) was failing silently when running locally or in the desktop app because the proxy dispatchers weren't being correctly passed down to the `fetch` calls in the OpenRouter adapter.

## What users will see

- Users running the desktop app or local dev server will now successfully generate images and videos via OpenRouter, without encountering silent network failures behind the proxy.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A - This is a backend adapter fix without direct UI changes, only ensuring successful media generation flows.

## Bug fix verification

- Test path that reproduces the bug: Generate an image or video using OpenRouter as the media provider while running the desktop daemon (`pnpm tools-dev run web`).
- Did the test go red on `main` and green on this branch? Yes, the newly added OpenRouter tests explicitly assert that `requestInit.dispatcher` successfully propagates to the adapter fetches.
- Manual verification: Ran the local preview via `pnpm tools-dev run web` and successfully generated an OpenRouter image.

## Validation

- `git diff --check`
- `pnpm --filter @open-design/daemon test tests/media/openrouter.test.ts`
