### PR TITLE
Keep AMR settings card actions inline

### DIFF
--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1205,9 +1205,6 @@
   align-items: stretch;
   min-width: 0;
 }
-.agent-card-installed:has(.agent-card-amr-auth) .agent-card-main {
-  flex-wrap: wrap;
-}
 .agent-card-select {
   flex: 1;
   min-width: 0;
@@ -1221,9 +1218,6 @@
   color: inherit;
   text-align: left;
   cursor: pointer;
-}
-.agent-card-installed:has(.agent-card-amr-auth) .agent-card-select {
-  flex: 1 1 420px;
 }
 .agent-card-test-btn {
   align-self: stretch;


### PR DESCRIPTION
## Why

The `0.13.0-prerelease.13` DMG includes the plan-badge and wallet-refresh fixes, but the AMR settings card actions still wrap onto a second row in the release build.

Root cause: release/v0.13.0 contains a release-only AMR card layout rule from #4952 that does not exist on `main`, so the #4984 -> #4989 backport could not remove it.

## What users will see

In Settings -> Execution mode, the Open Design CLI card keeps `Upgrade`, `Manage`, and the sign-out icon inline with the top card row instead of wrapping below the account/balance block.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified by inspecting `open-design-0.13.0-prerelease.13-mac-arm64.dmg`; that package still contains the removed CSS rules. This PR removes only those rules from release.

## Bug fix verification

- Test path that reproduces the bug: visual package inspection; the behavior depends on release-only CSS from #4952.
- Did the test go red on `main` and green on this branch? no; main does not contain the problematic release-only rules.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx --maxWorkers=2`