### PR TITLE
[codex] Keep AMR settings card actions inline

### DIFF
--- a/apps/web/src/components/BrandPreviewCard.module.css
+++ b/apps/web/src/components/BrandPreviewCard.module.css
@@ -4,6 +4,17 @@
    identity / logo / typography / palette read cleanly inside a narrow popover
    preview pane. */
 .previewInner {
+  --logo-display-surface:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(246, 242, 232, 0.96)),
+    conic-gradient(
+      from 45deg,
+      rgba(25, 23, 19, 0.07) 0 25%,
+      rgba(255, 255, 255, 0.42) 0 50%,
+      rgba(25, 23, 19, 0.07) 0 75%,
+      rgba(255, 255, 255, 0.42) 0
+    )
+      0 0 / 22px 22px;
+  --logo-display-border: color-mix(in srgb, var(--border) 72%, #fff 28%);
   display: flex;
   flex-direction: column;
   gap: 22px;
@@ -45,8 +56,7 @@
   padding: 32px;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  background:
-    radial-gradient(120% 140% at 50% -10%, var(--bg-subtle) 0%, var(--bg) 70%);
+  background: var(--logo-display-surface);
   box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text-strong) 4%, transparent);
 }
 
@@ -54,6 +64,9 @@
   max-width: 100%;
   max-height: 140px;
   object-fit: contain;
+  filter:
+    drop-shadow(0 1px 1px rgba(0, 0, 0, 0.18))
+    drop-shadow(0 0 1px rgba(255, 255, 255, 0.45));
 }
 
 .coverLogoFallback {
@@ -143,15 +156,18 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  border: 1px solid var(--border);
+  border: 1px solid var(--logo-display-border);
   border-radius: var(--radius-sm);
-  background: var(--bg-panel);
+  background: var(--logo-display-surface);
 }
 
 .previewHeadLogoImage {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
+  filter:
+    drop-shadow(0 1px 1px rgba(0, 0, 0, 0.18))
+    drop-shadow(0 0 1px rgba(255, 255, 255, 0.45));
 }
 
 .previewHeadLogoFallback {
@@ -267,7 +283,8 @@
 
 .previewActions {
   display: flex;
-  flex-shrink: 0;
+  flex: 1 1 320px;
+  min-width: 0;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
@@ -275,6 +292,11 @@
   /* Keep actions right-aligned whether they sit beside the identity column or
      wrap onto their own row beneath it. */
   margin-left: auto;
+}
+
+.previewActions > * {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .previewHeadSticky .previewActions {
@@ -589,9 +611,9 @@
   justify-content: center;
   min-height: 158px;
   padding: 28px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--logo-display-border);
   border-radius: var(--radius);
-  background: var(--bg);
+  background: var(--logo-display-surface);
 }
 
 .logoStageButton {
@@ -614,6 +636,9 @@
   max-width: 100%;
   max-height: 96px;
   object-fit: contain;
+  filter:
+    drop-shadow(0 1px 1px rgba(0, 0, 0, 0.18))
+    drop-shadow(0 0 1px rgba(255, 255, 255, 0.45));
 }
 
 .logoThumbs {
@@ -629,9 +654,9 @@
   width: 46px;
   height: 46px;
   padding: 7px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--logo-display-border);
   border-radius: var(--radius-sm);
-  background: var(--bg);
+  background: var(--logo-display-surface);
   cursor: pointer;
   transition: border-color var(--dur-quick) var(--ease-out);
 }
@@ -649,6 +674,9 @@
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
+  filter:
+    drop-shadow(0 1px 1px rgba(0, 0, 0, 0.18))
+    drop-shadow(0 0 1px rgba(255, 255, 255, 0.45));
 }
 
 .logoNotes {

--- a/apps/web/src/components/BrandsTab.module.css
+++ b/apps/web/src/components/BrandsTab.module.css
@@ -124,6 +124,16 @@
 }
 
 .itemThumb {
+  --logo-display-surface:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(246, 242, 232, 0.96)),
+    conic-gradient(
+      from 45deg,
+      rgba(25, 23, 19, 0.07) 0 25%,
+      rgba(255, 255, 255, 0.42) 0 50%,
+      rgba(25, 23, 19, 0.07) 0 75%,
+      rgba(255, 255, 255, 0.42) 0
+    )
+      0 0 / 22px 22px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -131,9 +141,9 @@
   width: 40px;
   height: 40px;
   padding: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 72%, #fff 28%);
   border-radius: var(--radius-sm);
-  background: var(--bg);
+  background: var(--logo-display-surface);
   overflow: hidden;
 }
 
@@ -141,6 +151,9 @@
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
+  filter:
+    drop-shadow(0 1px 1px rgba(0, 0, 0, 0.18))
+    drop-shadow(0 0 1px rgba(255, 255, 255, 0.45));
 }
 
 .itemLogoFallback {

--- a/apps/web/src/components/DesignSystemsTab.module.css
+++ b/apps/web/src/components/DesignSystemsTab.module.css
@@ -364,13 +364,23 @@
 }
 
 .itemThumb {
+  --logo-display-surface:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(246, 242, 232, 0.96)),
+    conic-gradient(
+      from 45deg,
+      rgba(25, 23, 19, 0.07) 0 25%,
+      rgba(255, 255, 255, 0.42) 0 50%,
+      rgba(25, 23, 19, 0.07) 0 75%,
+      rgba(255, 255, 255, 0.42) 0
+    )
+      0 0 / 22px 22px;
   display: flex;
   flex: 0 0 auto;
   width: 40px;
   height: 40px;
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 72%, #fff 28%);
   border-radius: var(--radius-sm);
-  background: var(--bg);
+  background: var(--logo-display-surface);
   overflow: hidden;
 }
 
@@ -402,6 +412,9 @@
   height: 100%;
   object-fit: contain;
   padding: 6px;
+  filter:
+    drop-shadow(0 1px 1px rgba(0, 0, 0, 0.18))
+    drop-shadow(0 0 1px rgba(255, 255, 255, 0.45));
 }
 
 .itemMeta {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4273,7 +4273,6 @@ export function SettingsDialog({
                           const modelSummary = agentModelSummary(a);
                           const amrBenefits = [
                             t('settings.amrBenefitOfficial'),
-                            t('settings.amrBenefitLowerPrice'),
                             t('settings.amrBenefitManyModels'),
                           ];
                           const versionLabel =

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4419,23 +4419,6 @@ export function SettingsDialog({
                                             </span>
                                           </>
                                         ) : null}
-                                        {isAmrAgent ? (
-                                          <span
-                                            className="agent-card-plan-badge-slot"
-                                            aria-hidden="true"
-                                          >
-                                            <PlanBadge
-                                              plan={amrCardPlanLabel}
-                                              size="sm"
-                                              className="agent-card-plan-badge"
-                                              title={
-                                                amrCardPlanLabel
-                                                  ? `${t('settings.amrPlan')} ${amrCardPlanLabel}`
-                                                  : undefined
-                                              }
-                                            />
-                                          </span>
-                                        ) : null}
                                         {isAmrAgent && amrCardPlanLabel ? (
                                           <VisuallyHidden>
                                             {`, ${t('settings.amrPlan')} ${amrCardPlanLabel}`}
@@ -4454,6 +4437,23 @@ export function SettingsDialog({
                                           <span className="agent-card-amr-email-text" title={amrCardEmail}>
                                             {amrCardEmail}
                                           </span>
+                                          {amrCardPlanLabel ? (
+                                            <span
+                                              className="agent-card-plan-badge-slot"
+                                              aria-hidden="true"
+                                            >
+                                              <PlanBadge
+                                                plan={amrCardPlanLabel}
+                                                size="sm"
+                                                className="agent-card-plan-badge"
+                                                title={
+                                                  amrCardPlanLabel
+                                                    ? `${t('settings.amrPlan')} ${amrCardPlanLabel}`
+                                                    : undefined
+                                                }
+                                              />
+                                            </span>
+                                          ) : null}
                                           {amrCardProfileBadge ? (
                                             <span className="agent-card-amr-profile-badge">
                                               {amrCardProfileBadge}

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4405,15 +4405,6 @@ export function SettingsDialog({
                                                 {benefit}
                                               </span>
                                             ))}
-                                            <PlanBadge
-                                              plan={amrCardPlanLabel}
-                                              size="sm"
-                                              title={
-                                                amrCardPlanLabel
-                                                  ? `${t('settings.amrPlan')} ${amrCardPlanLabel}`
-                                                  : undefined
-                                              }
-                                            />
                                           </span>
                                         ) : description ? (
                                           <>
@@ -4427,6 +4418,23 @@ export function SettingsDialog({
                                               {description}
                                             </span>
                                           </>
+                                        ) : null}
+                                        {isAmrAgent ? (
+                                          <span
+                                            className="agent-card-plan-badge-slot"
+                                            aria-hidden="true"
+                                          >
+                                            <PlanBadge
+                                              plan={amrCardPlanLabel}
+                                              size="sm"
+                                              className="agent-card-plan-badge"
+                                              title={
+                                                amrCardPlanLabel
+                                                  ? `${t('settings.amrPlan')} ${amrCardPlanLabel}`
+                                                  : undefined
+                                              }
+                                            />
+                                          </span>
                                         ) : null}
                                         {isAmrAgent && amrCardPlanLabel ? (
                                           <VisuallyHidden>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -327,7 +327,7 @@ export const ar: Dict = {
   'settings.amrActivationOpen': 'فتح صفحة تسجيل الدخول',
   'settings.amrCancelSignIn': 'إلغاء تسجيل الدخول',
   'settings.amrAccountStatus': 'حالة حساب Open Design',
-  'settings.amrConsole': 'وحدة تحكّم',
+  'settings.amrConsole': 'إدارة',
   'settings.amrBalance': 'الرصيد',
   'settings.amrPlan': 'الخطة',
   'settings.amrUpgrade': 'ترقية',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -327,7 +327,7 @@ export const de: Dict = {
   'settings.amrActivationOpen': 'Anmeldeseite öffnen',
   'settings.amrCancelSignIn': 'Anmeldung abbrechen',
   'settings.amrAccountStatus': 'Open Design-Kontostatus',
-  'settings.amrConsole': 'Konsole',
+  'settings.amrConsole': 'Verwalten',
   'settings.amrBalance': 'Guthaben',
   'settings.amrPlan': 'Tarif',
   'settings.amrUpgrade': 'Upgrade',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -327,7 +327,7 @@ export const en: Dict = {
   'settings.amrActivationOpen': 'Open sign-in page',
   'settings.amrCancelSignIn': 'Cancel sign-in',
   'settings.amrAccountStatus': 'Open Design account status',
-  'settings.amrConsole': 'Console',
+  'settings.amrConsole': 'Manage',
   'settings.amrBalance': 'Balance',
   'settings.amrPlan': 'Plan',
   'settings.amrUpgrade': 'Upgrade',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -327,7 +327,7 @@ export const esES: Dict = {
   'settings.amrActivationOpen': 'Abrir página de inicio de sesión',
   'settings.amrCancelSignIn': 'Cancelar inicio de sesión',
   'settings.amrAccountStatus': 'Estado de la cuenta Open Design',
-  'settings.amrConsole': 'Consola',
+  'settings.amrConsole': 'Gestionar',
   'settings.amrBalance': 'Saldo',
   'settings.amrPlan': 'Plan',
   'settings.amrUpgrade': 'Mejorar',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -327,7 +327,7 @@ export const fa: Dict = {
   'settings.amrActivationOpen': 'باز کردن صفحهٔ ورود',
   'settings.amrCancelSignIn': 'لغو ورود',
   'settings.amrAccountStatus': 'وضعیت حساب Open Design',
-  'settings.amrConsole': 'کنسول',
+  'settings.amrConsole': 'مدیریت',
   'settings.amrBalance': 'موجودی',
   'settings.amrPlan': 'طرح',
   'settings.amrUpgrade': 'ارتقا',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -327,7 +327,7 @@ export const fr: Dict = {
   'settings.amrActivationOpen': 'Ouvrir la page de connexion',
   'settings.amrCancelSignIn': 'Annuler la connexion',
   'settings.amrAccountStatus': 'Statut du compte Open Design',
-  'settings.amrConsole': 'Console',
+  'settings.amrConsole': 'Gérer',
   'settings.amrBalance': 'Solde',
   'settings.amrPlan': 'Forfait',
   'settings.amrUpgrade': 'Mettre à niveau',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -327,7 +327,7 @@ export const hu: Dict = {
   'settings.amrActivationOpen': 'Bejelentkezési oldal megnyitása',
   'settings.amrCancelSignIn': 'Bejelentkezés megszakítása',
   'settings.amrAccountStatus': 'Open Design fiók állapota',
-  'settings.amrConsole': 'Konzol',
+  'settings.amrConsole': 'Kezelés',
   'settings.amrBalance': 'Egyenleg',
   'settings.amrPlan': 'Csomag',
   'settings.amrUpgrade': 'Frissítés',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -327,7 +327,7 @@ export const id: Dict = {
   'settings.amrActivationOpen': 'Buka halaman masuk',
   'settings.amrCancelSignIn': 'Batalkan proses masuk',
   'settings.amrAccountStatus': 'Status akun Open Design',
-  'settings.amrConsole': 'Konsol',
+  'settings.amrConsole': 'Kelola',
   'settings.amrBalance': 'Saldo',
   'settings.amrPlan': 'Paket',
   'settings.amrUpgrade': 'Tingkatkan',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -327,7 +327,7 @@ export const it: Dict = {
   'settings.amrActivationOpen': 'Apri la pagina di accesso',
   'settings.amrCancelSignIn': 'Annulla accesso',
   'settings.amrAccountStatus': 'Stato account Open Design',
-  'settings.amrConsole': 'Console',
+  'settings.amrConsole': 'Gestisci',
   'settings.amrBalance': 'Saldo',
   'settings.amrPlan': 'Piano',
   'settings.amrUpgrade': 'Esegui upgrade',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -327,7 +327,7 @@ export const ja: Dict = {
   'settings.amrActivationOpen': 'サインインページを開く',
   'settings.amrCancelSignIn': 'サインインをキャンセル',
   'settings.amrAccountStatus': 'Open Design アカウントの状態',
-  'settings.amrConsole': 'コンソール',
+  'settings.amrConsole': '管理',
   'settings.amrBalance': '残高',
   'settings.amrPlan': 'プラン',
   'settings.amrUpgrade': 'アップグレード',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -327,7 +327,7 @@ export const ko: Dict = {
   'settings.amrActivationOpen': '로그인 페이지 열기',
   'settings.amrCancelSignIn': '로그인 취소',
   'settings.amrAccountStatus': 'Open Design 계정 상태',
-  'settings.amrConsole': '콘솔',
+  'settings.amrConsole': '관리',
   'settings.amrBalance': '잔액',
   'settings.amrPlan': '플랜',
   'settings.amrUpgrade': '업그레이드',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -327,7 +327,7 @@ export const pl: Dict = {
   'settings.amrActivationOpen': 'Otwórz stronę logowania',
   'settings.amrCancelSignIn': 'Anuluj logowanie',
   'settings.amrAccountStatus': 'Status konta Open Design',
-  'settings.amrConsole': 'Konsola',
+  'settings.amrConsole': 'Zarządzaj',
   'settings.amrBalance': 'Saldo',
   'settings.amrPlan': 'Plan',
   'settings.amrUpgrade': 'Ulepsz',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -327,7 +327,7 @@ export const ptBR: Dict = {
   'settings.amrActivationOpen': 'Abrir página de login',
   'settings.amrCancelSignIn': 'Cancelar login',
   'settings.amrAccountStatus': 'Status da conta Open Design',
-  'settings.amrConsole': 'Console',
+  'settings.amrConsole': 'Gerenciar',
   'settings.amrBalance': 'Saldo',
   'settings.amrPlan': 'Plano',
   'settings.amrUpgrade': 'Fazer upgrade',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -327,7 +327,7 @@ export const ru: Dict = {
   'settings.amrActivationOpen': 'Открыть страницу входа',
   'settings.amrCancelSignIn': 'Отменить вход',
   'settings.amrAccountStatus': 'Статус аккаунта Open Design',
-  'settings.amrConsole': 'Консоль',
+  'settings.amrConsole': 'Управлять',
   'settings.amrBalance': 'Баланс',
   'settings.amrPlan': 'Тариф',
   'settings.amrUpgrade': 'Улучшить',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -327,7 +327,7 @@ export const th: Dict = {
   'settings.amrActivationOpen': 'เปิดหน้าเข้าสู่ระบบ',
   'settings.amrCancelSignIn': 'ยกเลิกการลงชื่อเข้าใช้',
   'settings.amrAccountStatus': 'สถานะบัญชี Open Design',
-  'settings.amrConsole': 'Console',
+  'settings.amrConsole': 'จัดการ',
   'settings.amrBalance': 'ยอดคงเหลือ',
   'settings.amrPlan': 'แพ็กเกจ',
   'settings.amrUpgrade': 'อัปเกรด',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -327,7 +327,7 @@ export const tr: Dict = {
   'settings.amrActivationOpen': 'Oturum açma sayfasını aç',
   'settings.amrCancelSignIn': 'Oturum açmayı iptal et',
   'settings.amrAccountStatus': 'Open Design hesap durumu',
-  'settings.amrConsole': 'Konsol',
+  'settings.amrConsole': 'Yönet',
   'settings.amrBalance': 'Bakiye',
   'settings.amrPlan': 'Plan',
   'settings.amrUpgrade': 'Yükselt',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -327,7 +327,7 @@ export const uk: Dict = {
   'settings.amrActivationOpen': 'Відкрити сторінку входу',
   'settings.amrCancelSignIn': 'Скасувати вхід',
   'settings.amrAccountStatus': 'Статус облікового запису Open Design',
-  'settings.amrConsole': 'Консоль',
+  'settings.amrConsole': 'Керувати',
   'settings.amrBalance': 'Баланс',
   'settings.amrPlan': 'Тариф',
   'settings.amrUpgrade': 'Покращити',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -328,7 +328,7 @@ export const zhCN: Dict = {
   "settings.amrActivationOpen": "打开登录页",
   "settings.amrCancelSignIn": "取消登录",
   "settings.amrAccountStatus": "AMR 账户状态",
-  "settings.amrConsole": "AMR 控制台",
+  "settings.amrConsole": "管理",
   "settings.amrLoginErrorCompact": "AMR 登录失败。",
   "settings.advanced": "高级设置",
   "settings.amrLogin": "登录",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -329,7 +329,7 @@ export const zhTW: Dict = {
   "settings.amrActivationOpen": "開啟登入頁",
   "settings.amrCancelSignIn": "取消登入",
   "settings.amrAccountStatus": "AMR 帳戶狀態",
-  "settings.amrConsole": "控制台",
+  "settings.amrConsole": "管理",
   "settings.amrLoginErrorCompact": "AMR 登入失敗。",
   "settings.advanced": "進階",
   "settings.amrLogin": "登入",

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1433,7 +1433,7 @@
 .agent-card-benefits {
   display: inline-flex;
   align-items: center;
-  flex: 0 1 auto;
+  flex: 0 0 auto;
   flex-wrap: nowrap;
   gap: 5px;
   min-width: 0;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1440,6 +1440,14 @@
   max-width: 100%;
   overflow: hidden;
 }
+.agent-card-plan-badge-slot {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+}
+.agent-card-plan-badge {
+  flex: 0 0 auto;
+}
 .agent-card-benefit {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1262,9 +1262,15 @@
       color-mix(in srgb, var(--accent-tint) 10%, var(--bg-panel))
     );
 }
+.agent-card-installed:has(.agent-card-amr-auth) .agent-card-main {
+  flex-wrap: nowrap;
+}
 .agent-card-installed.active .agent-card-select {
   min-height: 78px;
   padding: 14px 18px 12px 22px;
+}
+.agent-card-installed:has(.agent-card-amr-auth) .agent-card-select {
+  flex: 1;
 }
 .agent-card-installed.active .agent-icon {
   border-radius: var(--radius-md);

--- a/apps/web/tests/components/AmrLoginPill.test.tsx
+++ b/apps/web/tests/components/AmrLoginPill.test.tsx
@@ -248,7 +248,7 @@ describe('AmrLoginPill', () => {
 
     expect(screen.getByText('leaf@example.com')).toBeTruthy();
     expect(screen.getByText('TEST')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Console' }).getAttribute('href')).toBe(
+    expect(screen.getByRole('link', { name: 'Manage' }).getAttribute('href')).toBe(
       'https://vela.powerformer.net/wallet?source=open_design',
     );
   });
@@ -263,7 +263,7 @@ describe('AmrLoginPill', () => {
     });
 
     expect(screen.getByText('LOCAL')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Console' }).getAttribute('href')).toBe(
+    expect(screen.getByRole('link', { name: 'Manage' }).getAttribute('href')).toBe(
       'http://localhost:5173/wallet?source=open_design',
     );
   });
@@ -278,7 +278,7 @@ describe('AmrLoginPill', () => {
     });
 
     expect(screen.queryByText('PROD')).toBeNull();
-    expect(screen.getByRole('link', { name: 'Console' }).getAttribute('href')).toBe(
+    expect(screen.getByRole('link', { name: 'Manage' }).getAttribute('href')).toBe(
       'https://open-design.ai/amr/wallet?source=open_design',
     );
   });
@@ -305,7 +305,7 @@ describe('AmrLoginPill', () => {
       </I18nProvider>,
     );
 
-    const link = screen.getByRole('link', { name: 'Console' }) as HTMLAnchorElement;
+    const link = screen.getByRole('link', { name: 'Manage' }) as HTMLAnchorElement;
     fireEvent.click(link);
 
     const url = new URL(link.href);

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2574,7 +2574,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.queryByText(/vela/i)).toBeNull();
     expect(screen.queryByText(/Not signed in/i)).toBeNull();
     expect(screen.getByText('Official')).toBeTruthy();
-    expect(screen.getByText('Lower cost')).toBeTruthy();
+    expect(screen.queryByText('Lower cost')).toBeNull();
     expect(screen.getByText('Many models')).toBeTruthy();
     expect(screen.queryByText('Limited bonus: +100%')).toBeNull();
     expect(await screen.findByRole('button', { name: 'Authorize' })).toBeTruthy();

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2921,7 +2921,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.queryByText(/^vela$/i)).toBeNull();
   });
 
-  it('keeps the AMR plan badge outside the clipped benefits row', async () => {
+  it('keeps the AMR plan badge on the account row outside the clipped benefits row', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === '/api/memory') {
@@ -2961,9 +2961,12 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     const planBadge = within(amrCardButton).getByText('pro');
     const benefits = amrCardButton.querySelector('.agent-card-benefits');
     const planSlot = planBadge.closest('.agent-card-plan-badge-slot');
+    const accountRow = planBadge.closest('.agent-card-amr-email');
 
     expect(benefits).toBeTruthy();
     expect(planSlot).toBeTruthy();
+    expect(accountRow).toBeTruthy();
+    expect(accountRow?.textContent).toContain('signed-in@example.com');
     expect(planSlot?.getAttribute('aria-hidden')).toBe('true');
     expect(benefits?.contains(planBadge)).toBe(false);
   });

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2921,6 +2921,53 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.queryByText(/^vela$/i)).toBeNull();
   });
 
+  it('keeps the AMR plan badge outside the clipped benefits row', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: true,
+            profile: 'local',
+            user: {
+              id: 'user-1',
+              email: 'signed-in@example.com',
+              name: 'Signed In User',
+            },
+            account: { plan: 'pro' },
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [amrAgent] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+
+    const amrCardButton = await screen.findByRole('button', { name: /Plan pro/ });
+    const planBadge = within(amrCardButton).getByText('pro');
+    const benefits = amrCardButton.querySelector('.agent-card-benefits');
+    const planSlot = planBadge.closest('.agent-card-plan-badge-slot');
+
+    expect(benefits).toBeTruthy();
+    expect(planSlot).toBeTruthy();
+    expect(planSlot?.getAttribute('aria-hidden')).toBe('true');
+    expect(benefits?.contains(planBadge)).toBe(false);
+  });
+
   it('loads the Settings AMR wallet fallback balance without a manual card refresh button', async () => {
     let walletCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -504,7 +504,7 @@ test('[P0] @critical Settings preserves AMR account, recharge shortcut, and mode
   await expect(settings.getByTestId('settings-agent-select-amr')).toHaveAttribute('aria-pressed', 'true');
   await expect(settings.getByTestId('settings-agent-select-amr')).toContainText('settings-amr-switch@example.com');
   await expect(settings.locator('.agent-card-amr-profile-badge')).toContainText(/test/i);
-  await expect(settings.getByRole('link', { name: /Console|控制台/i })).toBeVisible();
+  await expect(settings.getByRole('link', { name: /Manage|管理/i })).toBeVisible();
 
   await settings.getByRole('combobox', { name: 'Model', exact: true }).click();
   let modelPopover = page.getByTestId('settings-agent-model-popover-amr');
@@ -521,7 +521,7 @@ test('[P0] @critical Settings preserves AMR account, recharge shortcut, and mode
   await expect(settings.getByTestId('settings-agent-select-amr')).toHaveAttribute('aria-pressed', 'true');
   await expect(settings.getByTestId('settings-agent-select-amr')).toContainText('settings-amr-switch@example.com');
   await expect(settings.locator('.agent-card-amr-profile-badge')).toContainText(/test/i);
-  const amrConsole = settings.getByRole('link', { name: /Console|控制台/i });
+  const amrConsole = settings.getByRole('link', { name: /Manage|管理/i });
   await expect(amrConsole).toBeVisible();
   await expect(amrConsole).toHaveAttribute('href', /source=open_design/);
 


### PR DESCRIPTION
## Why

The latest prerelease package contains the plan-badge and wallet-refresh fixes, but the AMR/Open Design settings card can still wrap the action buttons onto a second row after the change is backported to `release/v0.13.0`.

Root cause: `release/v0.13.0` has an older release-only AMR card layout override from #4952. Because that selector does not exist on `main`, the previous main PR/backport could not remove or override it through the normal release flow.

## What users will see

In Settings -> Execution mode, the Open Design CLI card keeps `Upgrade`, `Manage`, and the sign-out icon on the same top row as the account area instead of wrapping under it.

## What changed

This adds an explicit AMR-card layout guard on `main`:

- keep the AMR installed card main row `nowrap`
- keep the AMR select/account area at `flex: 1`

When this PR is merged and backported normally, these rules apply after the older release-only override and restore the intended one-row layout without touching the badge or wallet-refresh behavior.

## Surface area

- [x] **UI** — settings execution mode card layout in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Package inspection of `/Users/alche/Desktop/open-design-0.13.0-prerelease.13-mac-arm64.dmg` showed the bad release CSS still present:

- `.agent-card-installed:has(.agent-card-amr-auth) .agent-card-main { flex-wrap: wrap }`
- `.agent-card-installed:has(.agent-card-amr-auth) .agent-card-select { flex: 420px }`

This PR adds the normal main-branch rule that will override those after backport.

## Bug fix verification

- Checked the `0.13.0-prerelease.13` DMG contents directly and confirmed the package includes the badge nowrap fix and no JS usage of `agent-card-amr-wallet-refresh`, but still includes the action-row wrapping CSS.
- Verified this patch applies cleanly to `origin/release/v0.13.0` and lands after the older release-only selectors, so the cascade overrides them.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx --maxWorkers=2`