### PR TITLE
fix(landing): reserve about-panel image aspect-ratio so the lazy-swap can't collapse

### DIFF
--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -2254,6 +2254,14 @@ section.tight { padding: 90px 0; }
   display: block;
   width: 100%;
   height: auto;
+  /* Reserve the painting's real 1768×1144 box up front. Without an explicit
+     ratio the lazy-swap first renders the 1×1 placeholder as a full-width 1:1
+     SQUARE (~320px too tall, showing the browser's broken-image/alt glyph)
+     until the webp decodes, then snaps to the real ratio — a visible collapse
+     the tighter homepage lazy-load margin now exposes on slower connections.
+     A faint skeleton fill keeps the reserved box clean until the art paints. */
+  aspect-ratio: 1768 / 1144;
+  background: rgba(0, 0, 0, 0.04);
 }
 .about .footer-row {
   display: flex;


### PR DESCRIPTION
## Why

Follow-up to #4987. That PR tightened the homepage lazy-load margin (1500px → 600px) so below-the-fold art no longer joins the initial LCP burst. A side effect: the about-section paintings now swap in as you scroll to them instead of being pre-loaded a full screen early — which exposed a latent bug.

`.about-panel-img img` was `width:100%; height:auto` with **no reserved aspect-ratio**. Between the 1×1 transparent placeholder and the decoded webp, the box rendered as a full-width **1:1 square** (~320px too tall), showing the browser's broken-image/alt glyph and overlapping the caption, then snapping to the real ratio once the image landed. On a fast connection with the old 1500px pre-load you'd never see it; with the tighter margin (and on slower connections / staging) it's visible as a "broken then jumps" load.

## What users will see

The three about-section paintings (Desktop-native / We don't build agents / It learns you over time) now hold their correct shape from first paint: a clean faint skeleton while the image streams, then the painting fades in with **no layout jump and no broken-image glyph**. Previously they briefly showed a tall empty/broken box that collapsed when the image loaded.

## Surface area

- [x] **None** — landing-site CSS fix (`apps/landing-page`), no product UI / CLI / API change.

## Screenshots

Before (loading): a ~900px-tall broken/empty box with the caption floating in it, collapsing when the webp lands.
After (loading): a correctly-proportioned 900×582 skeleton; the painting fills it exactly with zero shift.

## Bug fix verification

Visual/layout regression (the loading state of a lazy image), so verified by driving the built site in a throttled headless browser rather than a unit spec:
- Mid-load: box renders **900×582** with `aspect-ratio: 1768 / 1144` (was **900×900**, a 1:1 square).
- On decode: rendered box unchanged at 900×582 → **layout shift 0px** (was ~320px collapse).
- Loaded painting fills the box exactly (`object-fit: fill`, box ratio == image ratio 1768×1144), matching the pre-existing loaded look.

## Validation

`astro build` clean; the `aspect-ratio: 1768 / 1144` rule is present in the built HTML. The three about images are all 1768×1144, so one rule covers all panels.