### PR TITLE
fix(web): keep Mark on live preview state

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5377,6 +5377,7 @@ function HtmlViewer({
     isDeck: effectiveDeck,
     commentMode: boardMode,
     urlCommentBridge: urlSelectionBridgeReady,
+    urlSnapshotBridge: urlSelectionBridgeReady,
     editMode: manualEditMode,
     urlModeBridge,
     inspectMode,

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -35,9 +35,11 @@ export interface UrlLoadDecision {
   urlModeBridge?: boolean;
   /** The URL-loaded artifact response includes the comment/selection bridge. */
   urlCommentBridge?: boolean;
+  /** The URL-loaded artifact response includes the screenshot snapshot bridge. */
+  urlSnapshotBridge?: boolean;
   /** Tweaks palette popover open or palette committed — needs the palette bridge. */
   paletteActive?: boolean;
-  /** Draw annotations need the srcDoc snapshot bridge for screenshot export. */
+  /** Draw annotations need a snapshot bridge for screenshot export. */
   drawMode?: boolean;
   /**
    * Artifact ships the class based tweaks template (`.tw-panel` / `.tw-hidden`)
@@ -84,7 +86,10 @@ export function shouldUrlLoadHtmlPreview(d: UrlLoadDecision): boolean {
   // Palette tweaks need the srcDoc-side bridge — `<iframe src=URL>` has
   // no parent-injected listener to recolor against.
   if (d.paletteActive) return false;
-  if (d.drawMode) return false;
+  // Draw can stay on the URL-loaded iframe once the raw preview route has
+  // injected its snapshot bridge; otherwise fall back to srcDoc so capture
+  // still has a bridge to talk to.
+  if (d.drawMode && !d.urlSnapshotBridge) return false;
   // The class based tweaks template relies on the srcDoc tweaks bridge
   // emitting `od:tweaks-available` on mount; on the URL load path the bridge
   // is never injected, so the toolbar toggle would stay disabled even though

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -3371,7 +3371,7 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByPlaceholderText('Add a note for this mark')).toBeNull();
   });
 
-  it('uses a materialized srcDoc bridge while the Draw bar is open', async () => {
+  it('uses a materialized srcDoc bridge when Draw opens before the URL preview bridge is ready', async () => {
     render(
       <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
         liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
@@ -3398,6 +3398,38 @@ describe('FileViewer tweaks toolbar', () => {
     expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc).toBe(frame.srcdoc);
   });
 
+  it('keeps the URL-loaded iframe active when opening Draw after the URL preview bridge is ready', async () => {
+    const { container } = render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml='<html><body><button>Stateful tab</button><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const urlFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const srcDocFrame = screen.getByTestId('artifact-preview-frame-srcdoc') as HTMLIFrameElement;
+    expect(urlFrame.getAttribute('data-od-render-mode')).toBe('url-load');
+    expect(urlFrame.getAttribute('src')).toContain('odPreviewBridge=snapshot');
+    expect(srcDocFrame.getAttribute('data-od-active')).toBe('false');
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: urlFrame.contentWindow,
+        data: { type: 'od:url-selection-bridge-ready' },
+      }));
+    });
+
+    clickAgentTool('draw-overlay-toggle');
+
+    await waitFor(() => {
+      const activeFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(activeFrame).toBe(urlFrame);
+      expect(activeFrame.getAttribute('data-od-render-mode')).toBe('url-load');
+      expect(activeFrame.getAttribute('data-od-active')).toBe('true');
+      expect(srcDocFrame.getAttribute('data-od-active')).toBe('false');
+      expect(container.querySelector('canvas')).toBeTruthy();
+    });
+  });
+
   it('keeps the URL-load iframe warm while the Draw bar is open (no reload on close)', async () => {
     const { container } = render(
       <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
@@ -3412,11 +3444,11 @@ describe('FileViewer tweaks toolbar', () => {
     expect(warmSrc).not.toBe('about:blank');
     expect(warmSrc).toContain('/raw/');
 
-    // Opening Draw flips the *visible* frame to the materialized srcDoc bridge
-    // (see the test above), but the URL-load iframe must stay warm rather than
-    // park at about:blank — otherwise closing the bar re-fetches the whole
-    // artifact and the user sees a black → loading → reload after every
-    // screenshot. Regression guard for the post-screenshot refresh.
+    // Opening Draw before bridge-ready flips the *visible* frame to the
+    // materialized srcDoc bridge (see the test above), but the URL-load iframe
+    // must stay warm rather than park at about:blank — otherwise closing the
+    // bar re-fetches the whole artifact and the user sees a black → loading →
+    // reload after every screenshot.
     clickAgentTool('draw-overlay-toggle');
 
     await waitFor(() => {

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -44,8 +44,12 @@ describe('shouldUrlLoadHtmlPreview', () => {
     expect(shouldUrlLoadHtmlPreview({ ...base, inspectMode: true })).toBe(false);
   });
 
-  it('falls back to srcDoc when draw mode is active (snapshot bridge required)', () => {
+  it('falls back to srcDoc when draw mode is active without a URL snapshot bridge', () => {
     expect(shouldUrlLoadHtmlPreview({ ...base, drawMode: true })).toBe(false);
+  });
+
+  it('keeps URL-load when draw mode is active and the raw route injected the snapshot bridge', () => {
+    expect(shouldUrlLoadHtmlPreview({ ...base, drawMode: true, urlSnapshotBridge: true })).toBe(true);
   });
 
   it('falls back to srcDoc when the artifact ships the class based tweaks template', () => {
@@ -73,6 +77,7 @@ describe('shouldUrlLoadHtmlPreview', () => {
     expect(shouldUrlLoadHtmlPreview({ ...base, commentMode: true, forceInline: true })).toBe(false);
     expect(shouldUrlLoadHtmlPreview({ ...base, tweaksBridge: true, forceInline: true })).toBe(false);
     expect(shouldUrlLoadHtmlPreview({ ...base, commentMode: true, urlModeBridge: true, inspectMode: true })).toBe(false);
+    expect(shouldUrlLoadHtmlPreview({ ...base, drawMode: true, urlSnapshotBridge: true, inspectMode: true })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes #4974

## Why

I reproduced the Mark/Draw state reset path from the issue: after an HTML artifact has already loaded through the URL preview route, opening Mark still forced the visible preview over to the srcDoc transport. That avoids a reload-after-close case, but it also swaps the user onto a second browsing context, so route/tab state that exists only inside the live iframe appears to reset.

This PR keeps the fix narrow to Mark/Draw. It does not try to serialize arbitrary generated-app state or broaden the older route-preservation work for Comment/Edit/Inspect.

## What users will see

When the URL preview bridge is ready, opening Mark keeps the same live preview iframe visible. User-selected tabs, client-side routes, and other in-memory preview state stay in place while the Draw overlay opens.

If Mark opens before the URL bridge is ready, the viewer still falls back to the existing srcDoc bridge so screenshot capture keeps working.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a preview iframe transport behavior fix covered by focused regression tests; I skipped Chromium/browser UI capture per local testing constraints.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx` (`keeps the URL-loaded iframe active when opening Draw after the URL preview bridge is ready`)
- Did the test go red on `main` and green on this branch? yes — the test failed before the source change because Draw switched the active frame to `srcdoc`, then passed after the URL snapshot bridge readiness gate was added.

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/components/file-viewer-render-mode.test.ts tests/components/FileViewer.test.tsx tests/components/PreviewDrawOverlay.test.tsx --maxWorkers=2`
- `corepack pnpm exec vitest run -c vitest.config.ts tests/project-file-range.test.ts --maxWorkers=2`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm guard`

Not run: Chromium/browser UI or real-device testing, per request.
