### PR TITLE
fix(media): route OpenRouter dedicated image models to /images endpoint

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -394,6 +394,25 @@ export async function generateMedia(args: {
                 ? ['tts']
                 : [],
       };
+    } else if (/^openrouter\//.test(model)) {
+      // OpenRouter models discovered live from its catalogue
+      // (GET /api/v1/images/models) may not be in the static registry.
+      // They all render through renderOpenRouterImage(), which uses
+      // isOpenRouterChatImageModel() internally to pick the correct
+      // endpoint (/chat/completions for Gemini, /images for the rest).
+      isCatalogBypass = true;
+      def = {
+        id: model,
+        label: model,
+        hint: 'OpenRouter',
+        provider: 'openrouter',
+        caps:
+          surface === 'image'
+            ? ['t2i']
+            : surface === 'video'
+              ? ['t2v', 'i2v']
+              : [],
+      };
     } else {
       throw new Error(
         `unknown model: ${model}. Pass --model from the registered list (see /api/media/models), ` +
@@ -1944,6 +1963,17 @@ function sniffImageExt(bytes: Buffer): string {
 // Model IDs follow the same `openrouter/`-prefix convention as video.
 // ---------------------------------------------------------------------------
 
+// Dedicated image-generation models use the OpenRouter /images endpoint
+// (POST /api/v1/images) which returns `{ data: [{ b64_json }] }`.
+// Multi-modal chat models (Gemini variants) continue to use
+// /chat/completions with `modalities: ["image", "text"]`.
+// This heuristic keeps the two paths in sync with the model registry
+// in models.ts — Gemini slugs contain "gemini"; everything else is a
+// dedicated image model.
+function isOpenRouterChatImageModel(wireModel: string): boolean {
+  return wireModel.includes('gemini');
+}
+
 async function renderOpenRouterImage(
   ctx: MediaContext,
   credentials: ProviderConfig,
@@ -1964,41 +1994,90 @@ async function renderOpenRouterImage(
     ? resolved.slice('openrouter/'.length)
     : resolved;
 
-  // Multi-modal models (Gemini variants) accept both image and text
-  // output; image-only models (Flux, Recraft, Sourceful) only accept
-  // ["image"]. We use a simple heuristic on the slug.
-  const modalities: string[] = wireModel.includes('gemini')
-    ? ['image', 'text']
-    : ['image'];
+  const aspectRatio = openRouterAspectFor(ctx.aspect);
+  const headers: Record<string, string> = {
+    'authorization': `Bearer ${credentials.apiKey}`,
+    'content-type': 'application/json',
+    'HTTP-Referer': 'https://opendesign.dev',
+    'X-Title': 'Open Design',
+  };
 
+  // ── Route: multi-modal chat models (Gemini) → /chat/completions ──
+  if (isOpenRouterChatImageModel(wireModel)) {
+    const modalities: string[] = ['image', 'text'];
+
+    const body: Record<string, unknown> = {
+      model: wireModel,
+      messages: [
+        {
+          role: 'user',
+          content: ctx.prompt || 'A high-quality reference image.',
+        },
+      ],
+      modalities,
+      stream: false,
+    };
+
+    // Pass aspect ratio + image size through image_config when specified.
+    const imageConfig: Record<string, unknown> = {
+      aspect_ratio: aspectRatio,
+      image_size: '1K',
+    };
+    body.image_config = imageConfig;
+
+    const resp = await fetch(`${baseUrl}/chat/completions`, withMediaRequestInit(ctx, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(Math.max(OPENAI_IMAGE_HEADERS_TIMEOUT_MS, OPENAI_IMAGE_BODY_TIMEOUT_MS)),
+    }));
+    const text = await resp.text();
+    if (!resp.ok) {
+      throw new Error(`openrouter image ${resp.status}: ${truncate(text, 240)}`);
+    }
+
+    let data: any;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error(`openrouter image non-JSON response: ${truncate(text, 200)}`);
+    }
+
+    // Extract the first generated image from the response.
+    const images: any[] | undefined =
+      data?.choices?.[0]?.message?.images;
+    if (!images || images.length === 0) {
+      throw new Error(
+        `openrouter image response contained no images for model ${wireModel}: `
+        + truncate(text, 200),
+      );
+    }
+
+    const dataUrl: string | undefined = images[0]?.image_url?.url;
+    if (!dataUrl) {
+      throw new Error(
+        `openrouter image response missing image_url.url: ${truncate(text, 200)}`,
+      );
+    }
+
+    const bytes = await decodeOpenRouterImagePayload(ctx, dataUrl);
+    return {
+      bytes,
+      providerNote: `openrouter/${wireModel} · ${aspectRatio} · ${bytes.length} bytes`,
+      suggestedExt: sniffImageExt(bytes),
+    };
+  }
+
+  // ── Route: dedicated image models → /images ──────────────────────
   const body: Record<string, unknown> = {
     model: wireModel,
-    messages: [
-      {
-        role: 'user',
-        content: ctx.prompt || 'A high-quality reference image.',
-      },
-    ],
-    modalities,
-    stream: false,
-  };
-
-  // Pass aspect ratio + image size through image_config when specified.
-  const aspectRatio = openRouterAspectFor(ctx.aspect);
-  const imageConfig: Record<string, unknown> = {
+    prompt: ctx.prompt || 'A high-quality reference image.',
     aspect_ratio: aspectRatio,
-    image_size: '1K',
   };
-  body.image_config = imageConfig;
 
-  const resp = await fetch(`${baseUrl}/chat/completions`, withMediaRequestInit(ctx, {
+  const resp = await fetch(`${baseUrl}/images`, withMediaRequestInit(ctx, {
     method: 'POST',
-    headers: {
-      'authorization': `Bearer ${credentials.apiKey}`,
-      'content-type': 'application/json',
-      'HTTP-Referer': 'https://opendesign.dev',
-      'X-Title': 'Open Design',
-    },
+    headers,
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(Math.max(OPENAI_IMAGE_HEADERS_TIMEOUT_MS, OPENAI_IMAGE_BODY_TIMEOUT_MS)),
   }));
@@ -2014,37 +2093,25 @@ async function renderOpenRouterImage(
     throw new Error(`openrouter image non-JSON response: ${truncate(text, 200)}`);
   }
 
-  // Extract the first generated image from the response.
-  const images: any[] | undefined =
-    data?.choices?.[0]?.message?.images;
-  if (!images || images.length === 0) {
+  // The /images endpoint returns { data: [{ b64_json, url }] }.
+  const items: any[] | undefined = data?.data;
+  if (!items || items.length === 0) {
     throw new Error(
       `openrouter image response contained no images for model ${wireModel}: `
       + truncate(text, 200),
     );
   }
 
-  const dataUrl: string | undefined = images[0]?.image_url?.url;
-  if (!dataUrl) {
-    throw new Error(
-      `openrouter image response missing image_url.url: ${truncate(text, 200)}`,
-    );
-  }
-
-  // Strip the data URL prefix (e.g. "data:image/png;base64,") and
-  // decode the remaining base64 payload.
-  const b64Match = dataUrl.match(/^data:image\/[^;]+;base64,(.+)$/s);
+  const item = items[0]!;
   let bytes: Buffer;
-  if (b64Match) {
-    bytes = Buffer.from(b64Match[1]!, 'base64');
-  } else if (dataUrl.startsWith('http')) {
-    // Some models may return a plain URL instead of inline base64.
-    const imgResp = await fetch(dataUrl, withMediaRequestInit(ctx));
-    if (!imgResp.ok) throw new Error(`openrouter image download ${imgResp.status}`);
-    bytes = Buffer.from(await imgResp.arrayBuffer());
+  if (item.b64_json) {
+    bytes = Buffer.from(item.b64_json, 'base64');
+  } else if (item.url) {
+    bytes = await decodeOpenRouterImagePayload(ctx, item.url);
   } else {
-    // Assume raw base64 without prefix.
-    bytes = Buffer.from(dataUrl, 'base64');
+    throw new Error(
+      `openrouter image response missing b64_json and url: ${truncate(text, 200)}`,
+    );
   }
 
   return {
@@ -2052,6 +2119,26 @@ async function renderOpenRouterImage(
     providerNote: `openrouter/${wireModel} · ${aspectRatio} · ${bytes.length} bytes`,
     suggestedExt: sniffImageExt(bytes),
   };
+}
+
+/** Decode a base64 data-URL, plain URL, or raw base64 string into bytes. */
+async function decodeOpenRouterImagePayload(
+  ctx: Pick<MediaContext, 'requestInit'>,
+  payload: string,
+): Promise<Buffer> {
+  const b64Match = payload.match(/^data:image\/[^;]+;base64,(.+)$/s);
+  if (b64Match) {
+    return Buffer.from(b64Match[1]!, 'base64');
+  }
+  if (payload.startsWith('http')) {
+    // Route the download through the shared request init so the caller's
+    // dispatcher/proxy applies to plain-URL responses too.
+    const imgResp = await fetch(payload, withMediaRequestInit(ctx));
+    if (!imgResp.ok) throw new Error(`openrouter image download ${imgResp.status}`);
+    return Buffer.from(await imgResp.arrayBuffer());
+  }
+  // Assume raw base64 without prefix.
+  return Buffer.from(payload, 'base64');
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/daemon/src/media/models.ts
+++ b/apps/daemon/src/media/models.ts
@@ -117,6 +117,7 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'black-forest-labs/FLUX-1.1-pro', label: 'FLUX-1.1-pro', hint: 'ImageRouter · Black Forest Labs', provider: 'imagerouter', caps: ['t2i'] },
 
   { id: 'openrouter/google/gemini-2.5-flash-image', label: 'gemini-flash-image (OR)', hint: 'OpenRouter · Gemini', provider: 'openrouter', caps: ['t2i'] },
+  { id: 'openrouter/openai/gpt-image-2', label: 'gpt-image-2 (OR)', hint: 'OpenRouter · OpenAI', provider: 'openrouter', caps: ['t2i'] },
   { id: 'openrouter/black-forest-labs/flux-1.1-pro', label: 'flux-1.1-pro (OR)', hint: 'OpenRouter · BFL', provider: 'openrouter', caps: ['t2i'] },
   { id: 'openrouter/recraft/recraft-v3', label: 'recraft-v3 (OR)', hint: 'OpenRouter · Recraft', provider: 'openrouter', caps: ['t2i'] },
 

--- a/apps/daemon/tests/media/openrouter.test.ts
+++ b/apps/daemon/tests/media/openrouter.test.ts
@@ -517,7 +517,7 @@ describe('openrouter video generation', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// OpenRouter IMAGE generation tests (synchronous, via chat/completions)
+// OpenRouter IMAGE generation tests
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('openrouter image generation', () => {
@@ -587,9 +587,17 @@ describe('openrouter image generation', () => {
     });
   }
 
-  // ─── tests ────────────────────────────────────────────────────────
+  /** /images endpoint response helper. */
+  function imagesResp(data: unknown[], status = 200) {
+    return new Response(JSON.stringify({ data }), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
 
-  it('generates an image via chat/completions with base64 response', async () => {
+  // ─── Gemini (chat/completions) tests ─────────────────────────────
+
+  it('generates an image via chat/completions for Gemini models', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
     );
@@ -635,7 +643,7 @@ describe('openrouter image generation', () => {
     expect(headers.authorization).toBe('Bearer sk-or-img-test-key');
   });
 
-  it('uses /chat/completions endpoint, not /videos', async () => {
+  it('uses /chat/completions endpoint for Gemini, not /images', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
     );
@@ -645,7 +653,7 @@ describe('openrouter image generation', () => {
 
     const url = fetchMock.mock.calls[0]![0] as string;
     expect(url).toBe('https://openrouter.ai/api/v1/chat/completions');
-    expect(url).not.toContain('/videos');
+    expect(url).not.toContain('/images');
   });
 
   it('uses modalities ["image", "text"] for Gemini models', async () => {
@@ -660,19 +668,7 @@ describe('openrouter image generation', () => {
     expect(body.modalities).toEqual(['image', 'text']);
   });
 
-  it('uses modalities ["image"] for non-Gemini models (Flux)', async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(
-      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
-    );
-    vi.stubGlobal('fetch', fetchMock);
-
-    await generateMedia(imageArgs({ model: 'openrouter/black-forest-labs/flux-1.1-pro' }));
-
-    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
-    expect(body.modalities).toEqual(['image']);
-  });
-
-  it('passes image_config.aspect_ratio through', async () => {
+  it('passes image_config.aspect_ratio through for Gemini', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
     );
@@ -699,7 +695,7 @@ describe('openrouter image generation', () => {
     );
   });
 
-  it('throws when response contains no images', async () => {
+  it('throws when Gemini response contains no images', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response(JSON.stringify({
         choices: [{
@@ -717,7 +713,7 @@ describe('openrouter image generation', () => {
     );
   });
 
-  it('honours OD_MEDIA_MODEL_ALIASES for image (alias contract regression)', async () => {
+  it('honours OD_MEDIA_MODEL_ALIASES for Gemini image (alias contract regression)', async () => {
     // Set an alias: the catalog id should resolve to a custom wire name.
     process.env.OD_MEDIA_MODEL_ALIASES = JSON.stringify({
       'openrouter/google/gemini-2.5-flash-image': 'my-custom-gemini-img',
@@ -758,5 +754,209 @@ describe('openrouter image generation', () => {
     expect(fetchMock.mock.calls[0]![1].dispatcher).toBe(dispatcher);
     // 2. Download
     expect(fetchMock.mock.calls[1]![1].dispatcher).toBe(dispatcher);
+  });
+
+  // ─── Dedicated image models (/images endpoint) ──────────────────
+
+  it('uses /images endpoint for non-Gemini models (Flux)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ model: 'openrouter/black-forest-labs/flux-1.1-pro' }));
+
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('https://openrouter.ai/api/v1/images');
+    expect(url).not.toContain('/chat/completions');
+  });
+
+  it('uses /images endpoint for gpt-image-2', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ model: 'openrouter/openai/gpt-image-2' }));
+
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('https://openrouter.ai/api/v1/images');
+  });
+
+  it('sends prompt (not messages) for dedicated image models', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({
+      model: 'openrouter/openai/gpt-image-2',
+      prompt: 'A serene mountain landscape',
+    }));
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.prompt).toBe('A serene mountain landscape');
+    expect(body.model).toBe('openai/gpt-image-2');
+    // Should NOT have chat-style keys
+    expect(body).not.toHaveProperty('messages');
+    expect(body).not.toHaveProperty('modalities');
+    expect(body).not.toHaveProperty('stream');
+    expect(body).not.toHaveProperty('image_config');
+  });
+
+  it('generates a complete image via /images with b64_json response', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(imageArgs({ model: 'openrouter/openai/gpt-image-2' }));
+
+    expect(result.surface).toBe('image');
+    expect(result.providerId).toBe('openrouter');
+    expect(result.providerNote).toContain('openai/gpt-image-2');
+    expect(result.name).toBe('sunset.png');
+
+    const bytes = await readFile(path.join(projectsRoot, 'project-img', 'sunset.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('sends attribution headers on /images requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ model: 'openrouter/recraft/recraft-v3' }));
+
+    const headers = fetchMock.mock.calls[0]![1].headers;
+    expect(headers['HTTP-Referer']).toBe('https://opendesign.dev');
+    expect(headers['X-Title']).toBe('Open Design');
+    expect(headers.authorization).toBe('Bearer sk-or-img-test-key');
+  });
+
+  it('strips the openrouter/ prefix for dedicated models', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ model: 'openrouter/recraft/recraft-v3' }));
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.model).toBe('recraft/recraft-v3');
+    expect(body.model).not.toContain('openrouter/');
+  });
+
+  it('passes aspect_ratio as top-level field in /images request body', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ model: 'openrouter/openai/gpt-image-2', aspect: '9:16' }));
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.aspect_ratio).toBe('9:16');
+  });
+
+  it('throws on HTTP error from /images endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { message: 'model not found' } }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia(imageArgs({ model: 'openrouter/openai/gpt-image-2' }))).rejects.toThrow(
+      /openrouter image 404/,
+    );
+  });
+
+  it('throws when /images response contains no data items', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia(imageArgs({ model: 'openrouter/openai/gpt-image-2' }))).rejects.toThrow(
+      /no images/,
+    );
+  });
+
+  // ─── Catalog bypass: dynamically discovered OpenRouter models ────
+
+  it('accepts unregistered openrouter/* models via catalog bypass', async () => {
+    // A model like openrouter/stability/sdxl might not be in the static
+    // registry but can be configured directly on the OpenRouter media
+    // provider. The dispatcher should synthesize a def and route to /images.
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(imageArgs({
+      model: 'openrouter/stability/sdxl-turbo',
+    }));
+
+    expect(result.surface).toBe('image');
+    expect(result.providerId).toBe('openrouter');
+    expect(result.providerNote).toContain('stability/sdxl-turbo');
+
+    // Should use /images endpoint, not /chat/completions
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('https://openrouter.ai/api/v1/images');
+  });
+
+  // ─── Settings-stored credentials regression (issue #4994 review) ─
+
+  it('uses Settings-stored API key when env var is absent', async () => {
+    // Clear the env-var credential so the only source is media-config.json.
+    delete process.env.OD_OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+
+    // Write a Settings-style config with a stored key.
+    const configDir = path.join(projectRoot, '.od');
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      path.join(configDir, 'media-config.json'),
+      JSON.stringify({ providers: { openrouter: { apiKey: 'sk-or-stored-settings-key' } } }),
+      'utf8',
+    );
+
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      imagesResp([{ b64_json: PNG_B64 }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ model: 'openrouter/openai/gpt-image-2' }));
+
+    // The authorization header must carry the Settings-stored key.
+    const headers = fetchMock.mock.calls[0]![1].headers;
+    expect(headers.authorization).toBe('Bearer sk-or-stored-settings-key');
+  });
+
+  it('routes unregistered openrouter/google/* models via catalog bypass to /chat/completions', async () => {
+    // A future Gemini model not yet in the static registry must still go
+    // through renderOpenRouterImage() and hit /chat/completions (not /images).
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(imageArgs({
+      model: 'openrouter/google/gemini-2.5-pro-image',
+    }));
+
+    expect(result.surface).toBe('image');
+    expect(result.providerId).toBe('openrouter');
+
+    // Must route to /chat/completions, not /images
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('https://openrouter.ai/api/v1/chat/completions');
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.modalities).toEqual(['image', 'text']);
   });
 });

--- a/apps/web/src/media/aihubmix-image-models.ts
+++ b/apps/web/src/media/aihubmix-image-models.ts
@@ -164,15 +164,15 @@ export function useAIHubMixAudioModels(enabled = true): MediaModel[] {
 export function useByokImageModelOptions(
   provider: string | undefined,
 ): MediaModel[] {
-  const dynamic = useAIHubMixImageModels(provider === 'aihubmix');
+  const aihubmixDynamic = useAIHubMixImageModels(provider === 'aihubmix');
   return useMemo(() => {
     if (provider === 'aihubmix') {
-      return mergeAihubmixModels(IMAGE_MODELS, dynamic).filter(
+      return mergeAihubmixModels(IMAGE_MODELS, aihubmixDynamic).filter(
         (m) => m.provider === 'aihubmix',
       );
     }
     return IMAGE_MODELS.filter((m) => m.provider === provider);
-  }, [provider, dynamic]);
+  }, [provider, aihubmixDynamic]);
 }
 
 /**

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -489,6 +489,7 @@ export const IMAGE_MODELS: MediaModel[] = [
 
   // OpenRouter image models.
   { id: 'openrouter/google/gemini-2.5-flash-image', label: 'gemini-flash-image (OR)', hint: 'OpenRouter · Gemini', provider: 'openrouter', caps: ['t2i'] },
+  { id: 'openrouter/openai/gpt-image-2', label: 'gpt-image-2 (OR)', hint: 'OpenRouter · OpenAI', provider: 'openrouter', caps: ['t2i'] },
   { id: 'openrouter/black-forest-labs/flux-1.1-pro', label: 'flux-1.1-pro (OR)', hint: 'OpenRouter · BFL', provider: 'openrouter', caps: ['t2i'] },
   { id: 'openrouter/recraft/recraft-v3', label: 'recraft-v3 (OR)', hint: 'OpenRouter · Recraft', provider: 'openrouter', caps: ['t2i'] },
 


### PR DESCRIPTION
Fixes #4994

## Why

OpenRouter dedicated image models (Flux, Recraft, gpt-image-2, etc.) cannot generate images because the current implementation routes **all** OpenRouter image requests to `/chat/completions`. Only multi-modal chat models like Gemini work through that endpoint; dedicated image models require the `POST /api/v1/images` endpoint with a different request/response format.

The user pain: selecting any non-Gemini OpenRouter image model silently fails or returns an error, making 3 out of 4 listed models unusable.

**Scope note:** an earlier revision of this PR also added a dynamic model catalog (`GET /api/v1/images/models`) and BYOK picker wiring. On review (thanks @AmyShang-alt) that surface turned out to be unreachable — OpenRouter is configured as an OpenAI-compatible gateway, so its `apiProtocol` is `openai` and the picker's `provider === 'openrouter'` branch never fired. That dead wiring has been removed. This PR is now narrowed to the backend routing fix, exercised through the **media-generation-provider** configuration path (`media-config.openrouter`), which is the path that actually reaches these models today.

## What users will see

- **gpt-image-2 (OR)**, **flux-1.1-pro (OR)**, **recraft-v3 (OR)** and any other dedicated OpenRouter image model configured on the OpenRouter media provider now generate images successfully instead of erroring.
- **Gemini models** continue to work unchanged — no regression.
- No new UI surface — the models are reached via the existing "media generation provider" configuration and static registry seeds.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — non-Gemini OpenRouter image models now route to `POST /images` instead of `POST /chat/completions`; Gemini routing is unchanged
- [ ] **None**

## Bug fix verification

- Test file that reproduces the bug: `apps/daemon/tests/media/openrouter.test.ts` — dedicated image model tests (`uses /images endpoint for non-Gemini models (Flux)`, `uses /images endpoint for gpt-image-2`, `sends prompt (not messages) for dedicated image models`, etc.)
- Red on `main` / green on this branch? Yes — on `main` there is no `/images` path; non-Gemini models are sent to `/chat/completions` with `modalities: ["image"]`, which dedicated image endpoints reject. The new tests assert the correct `/images` URL and `{model, prompt, aspect_ratio}` body format.

## Validation

- `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm guard` — 78/78 pass
- `npx vitest run tests/media/openrouter.test.ts` — **39 tests pass, 0 failures**
  - existing video tests — pass (no regression)
  - existing Gemini image tests — pass (routing unchanged)
  - new `/images` endpoint tests — endpoint routing, `{model, prompt}` body, top-level `aspect_ratio`, `b64_json` parsing, attribution headers, prefix stripping, HTTP errors, empty data
  - catalog bypass tests — unregistered `openrouter/*` models synthesize a def and route correctly (dedicated → `/images`, Gemini → `/chat/completions`)

### What changed (file-level)

| File | Change |
|---|---|
| `apps/daemon/src/media/index.ts` | Split `renderOpenRouterImage()`: Gemini → `/chat/completions`, others → `/images`; add `isOpenRouterChatImageModel()` heuristic; extract `decodeOpenRouterImagePayload()` helper (routes plain-URL downloads through the shared request init); pass top-level `aspect_ratio` on the `/images` body; catalog bypass for unregistered `openrouter/*` models |
| `apps/daemon/src/media/models.ts` | Add `openrouter/openai/gpt-image-2` static seed |
| `apps/web/src/media/models.ts` | Mirror: add `openrouter/openai/gpt-image-2` static seed |
| `apps/web/src/media/aihubmix-image-models.ts` | Revert the unreachable OpenRouter BYOK catalog wiring back to the AIHubMix-only shape |
| `apps/daemon/tests/media/openrouter.test.ts` | New tests: `/images` endpoint routing + request format + top-level `aspect_ratio`, and catalog bypass coverage for dedicated and Gemini slugs |
