### PR TITLE
fix(web): seed Document chip required inputs so Home Send stays enabled

### DIFF
--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -193,6 +193,20 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
       kind: 'apply-scenario',
       pluginId: 'od-new-generation',
       projectKind: 'other',
+      // od-new-generation declares `artifactKind` / `audience` / `topic` as
+      // required inputs with NO manifest defaults. The Home composer dropped
+      // its inline plugin-inputs form (`footerInputNamesForChip` returns []),
+      // so an unseeded bind leaves `pluginInputsAreValid` false forever, which
+      // gates the composer via `submitDisabled` — Send stays dead even after
+      // the user types a brief. Seed generic document defaults so the required
+      // inputs are satisfied on bind; the user's typed brief still drives the
+      // actual content. (Every other create chip binds a plugin that ships
+      // defaults — this is the one generic-router chip that must seed them.)
+      inputs: {
+        artifactKind: 'document',
+        audience: 'readers',
+        topic: 'the user brief',
+      },
       projectMetadata: {
         kind: 'other',
         // Analytics-only tag: splits this card's projects out of generic

--- a/apps/web/tests/components/home-hero/document-chip-send-gate.test.ts
+++ b/apps/web/tests/components/home-hero/document-chip-send-gate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { InputFieldSpec } from '@open-design/contracts';
+
+import { findChip } from '../../../src/components/home-hero/chips';
+import { pluginInputsAreValid } from '../../../src/utils/pluginRequiredInputs';
+
+// Regression guard for the "Document template can't send" bug.
+//
+// The Document chip binds the generic `od-new-generation` scenario, whose
+// manifest declares `artifactKind` / `audience` / `topic` as REQUIRED inputs
+// with NO defaults. The Home composer dropped its inline plugin-inputs form
+// (`footerInputNamesForChip` returns []), so an apply-scenario chip that binds
+// a required-input plugin without seeding those inputs leaves
+// `pluginInputsAreValid` false forever. That flips `active.inputsValid` false,
+// which HomeView forwards as `submitDisabled` — the Send button stays disabled
+// ("Type something to run") even after the user types a brief.
+//
+// The invariant: the Document chip must SEED od-new-generation's required
+// inputs on bind. Mirrors plugins/_official/scenarios/od-new-generation
+// (required, no manifest default).
+const OD_NEW_GENERATION_REQUIRED_INPUTS: InputFieldSpec[] = [
+  { name: 'artifactKind', type: 'string', required: true },
+  { name: 'audience', type: 'string', required: true },
+  { name: 'topic', type: 'string', required: true },
+];
+
+describe('Document chip send gate', () => {
+  it('seeds every required od-new-generation input so Home Send is not dead-locked', () => {
+    const document = findChip('document');
+    expect(document, 'the Document chip must exist in the catalog').toBeTruthy();
+    expect(document?.action.kind).toBe('apply-scenario');
+
+    const seeded =
+      document?.action.kind === 'apply-scenario' ? document.action.inputs ?? {} : {};
+
+    // This is the exact production gate: HomeView computes
+    // `active.inputsValid = pluginInputsAreValid(inputFields, inputs)` and
+    // disables the composer when it is false. Without the seed the required
+    // inputs are missing and this returns false → Send permanently disabled.
+    expect(pluginInputsAreValid(OD_NEW_GENERATION_REQUIRED_INPUTS, seeded)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

A teammate running the `release/v0.13.0` build hit a dead end: on the home
screen ("What will you design today?"), selecting the **Document** template and
typing a brief leaves the **Send** button permanently disabled with the tooltip
"Type something to run". Every other template (Prototype, Wireframe, Deck, …)
sends fine — only Document is stuck.

Root cause: the Document chip binds the generic `od-new-generation` scenario,
whose manifest declares `artifactKind` / `audience` / `topic` as **required**
inputs with **no defaults**. The home composer removed its inline plugin-inputs
form (`footerInputNamesForChip` returns `[]`), so a chip that binds a
required-input plugin without seeding those inputs leaves
`pluginInputsAreValid()` false forever → `active.inputsValid` false →
`HomeView` forwards `submitDisabled: true` → Send never enables, no matter what
the user types. Prototype/Wireframe/Deck work because their bound plugins
(`example-web-prototype`, `example-simple-deck`) ship defaults for every
required input; Document is the one generic-router chip that must seed them.

`main` already fixed this in #4777 (`ca89845d0`, 2026-06-30) by seeding the
Document chip's inputs — but that landed inside a large `feat(brands)` PR that
was **not** backported, so `release/v0.13.0` never got it. This PR ports just
the seed (plus a regression guard) to the release branch. Nothing needs to go
back to `main` — `main` already carries the seed.

## What users will see

On `release/v0.13.0`, selecting the **Document** template and typing a brief now
enables **Send** exactly like every other template. Previously Send stayed
greyed out ("Type something to run") and Document was unusable.

## Surface area

- [x] **None** — this restores intended behavior of an existing chip via a
  config seed + regression test. No new UI/CLI/API surface is added, and no CLI
  counterpart is needed (the `od` create path already accepts explicit inputs).

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/home-hero/document-chip-send-gate.test.ts`
- Did the test go red on the base branch and green on this branch? **yes** —
  asserted red on `release/v0.13.0` (seed absent → `pluginInputsAreValid` false),
  green after the seed. The test exercises the exact production gate
  (`pluginInputsAreValid`) that disables the composer, mirroring
  `od-new-generation`'s required inputs.

## Validation

- `pnpm guard` — pass (55/55)
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm exec vitest run` on the new test — red without seed, green with seed
- Related home-hero/chip suites (`HomeHero.rail`, `HomeHero.example-chip-filter`,
  `home-hero/*`) — 39/39 pass
