### PR TITLE
[codex] Promote AMR balance retry statuses

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -7,6 +7,10 @@ import {
   createToolCallTextSuppressor,
   type ArtifactTextSuppressor,
 } from './artifacts/text-suppression.js';
+import {
+  amrAccountFailureDetails,
+  classifyAmrAccountFailure,
+} from './integrations/vela-errors.js';
 
 const ACP_PROTOCOL_VERSION = 1;
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -482,6 +486,60 @@ function isAcpCompletedStatus(update: JsonObject): boolean {
 function isAcpTerminalFailureStatus(update: JsonObject): boolean {
   const status = acpUpdateStatus(update);
   return status === 'failed' || status === 'failure' || status === 'error' || status === 'cancelled' || status === 'canceled';
+}
+
+function isAcpRetryStatus(update: JsonObject): boolean {
+  return acpUpdateStatus(update) === 'retry';
+}
+
+function acpUpdateDiagnosticText(value: unknown, depth = 0): string[] {
+  if (depth > 4) return [];
+  if (typeof value === 'string') return value.trim() ? [value] : [];
+  if (typeof value === 'number' || typeof value === 'boolean') return [String(value)];
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => acpUpdateDiagnosticText(item, depth + 1));
+  }
+  const obj = asObject(value);
+  if (!obj) return [];
+  const parts: string[] = [];
+  for (const key of [
+    'type',
+    'status',
+    'code',
+    'message',
+    'detail',
+    'details',
+    'error',
+    'recovery',
+    'pauseReason',
+    'content',
+    'text',
+    'rawInput',
+  ]) {
+    if (key in obj) {
+      parts.push(...acpUpdateDiagnosticText(obj[key], depth + 1));
+    }
+  }
+  return parts;
+}
+
+function promotedAmrRetryStatusPayload(update: JsonObject) {
+  if (!isAcpRetryStatus(update)) return null;
+  const diagnosticText = acpUpdateDiagnosticText(update).join('\n');
+  const failure = classifyAmrAccountFailure(diagnosticText);
+  if (!failure) return null;
+  return {
+    message: failure.message,
+    error: {
+      code: failure.code,
+      message: failure.message,
+      retryable: false,
+      details: {
+        ...amrAccountFailureDetails(failure),
+        promoted_by: 'open_design_acp_retry_status',
+      },
+    },
+  };
 }
 
 function acpToolCallId(update: JsonObject): string | null {
@@ -1312,6 +1370,13 @@ export function attachAcpSession({
     }
     const update = asObject(params?.update);
     if (obj.method === 'session/update' && update) {
+      if (modelUnavailableErrorCode) {
+        const promotedPayload = promotedAmrRetryStatusPayload(update);
+        if (promotedPayload) {
+          failWithPayload(promotedPayload);
+          return;
+        }
+      }
       if (update.sessionUpdate !== 'agent_message_chunk' && update.sessionUpdate !== 'agent_thought_chunk') {
         send('agent', {
           type: 'status',

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -737,6 +737,101 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
     });
   });
 
+  it('promotes ACP retry status insufficient-balance updates to AMR recharge failures', async () => {
+    const child = spawnAcpUpdateFixture([
+      {
+        sessionUpdate: 'status',
+        type: 'retry',
+        status: 'retry',
+        message: '[code=insufficient_balance] insufficient wallet balance',
+      },
+    ]);
+    const errors: Array<{ event: string; payload: unknown }> = [];
+    try {
+      const session = attachAcpSession({
+        child: child as never,
+        prompt: 'Say hello',
+        cwd: process.cwd(),
+        model: 'claude-opus-4-6',
+        mcpServers: [],
+        modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+        send: (event, payload) => {
+          if (event === 'error') errors.push({ event, payload });
+        },
+      });
+
+      await waitForExit(child);
+      expect(session.hasFatalError()).toBe(true);
+      expect(session.completedSuccessfully()).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }
+
+    const payload = errors[0]?.payload as {
+      message?: unknown;
+      error?: { code?: unknown; retryable?: unknown; details?: Record<string, unknown> };
+    };
+    expect(payload?.error?.code).toBe('AMR_INSUFFICIENT_BALANCE');
+    expect(payload?.error?.retryable).toBe(false);
+    expect(payload?.error?.details).toMatchObject({
+      kind: 'amr_account',
+      action: 'recharge',
+    });
+    expect(String(payload?.message ?? '')).toContain('AMR Cloud reported insufficient balance');
+  });
+
+  it('promotes structured manual-topup recovery retry updates to AMR recharge failures', async () => {
+    const child = spawnAcpUpdateFixture([
+      {
+        sessionUpdate: 'status',
+        type: 'retry',
+        status: 'retry',
+        recovery: {
+          status: 'waiting_payment',
+          manualTopupRequired: true,
+          pauseReason: 'insufficient_balance',
+          error: {
+            code: 'insufficient_balance',
+            message: 'insufficient wallet balance',
+          },
+        },
+      },
+    ]);
+    const errors: Array<{ event: string; payload: unknown }> = [];
+    try {
+      const session = attachAcpSession({
+        child: child as never,
+        prompt: 'Say hello',
+        cwd: process.cwd(),
+        model: 'claude-opus-4-6',
+        mcpServers: [],
+        modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+        send: (event, payload) => {
+          if (event === 'error') errors.push({ event, payload });
+        },
+      });
+
+      await waitForExit(child);
+      expect(session.hasFatalError()).toBe(true);
+      expect(session.completedSuccessfully()).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }
+
+    const payload = errors[0]?.payload as {
+      message?: unknown;
+      error?: { code?: unknown; retryable?: unknown; details?: Record<string, unknown> };
+    };
+    expect(payload?.error?.code).toBe('AMR_INSUFFICIENT_BALANCE');
+    expect(payload?.error?.retryable).toBe(false);
+    expect(payload?.error?.details).toMatchObject({
+      kind: 'amr_account',
+      action: 'recharge',
+      promoted_by: 'open_design_acp_retry_status',
+    });
+    expect(String(payload?.message ?? '')).toContain('AMR Cloud reported insufficient balance');
+  });
+
   it('allows non-AMR ACP completions that produce no assistant text', async () => {
     const child = spawnFakeVela({ FAKE_VELA_TEXT: '' });
     const errors: Array<{ event: string; payload: unknown }> = [];

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -1126,11 +1126,12 @@ describe('ProjectView daemon reattach restore', () => {
         .map((call) => call[2] as ChatMessage)
         .filter((m) => m?.id === 'msg-amr-balance' && m.runStatus === 'failed')
         .at(-1);
-      expect(finalSave?.events?.some(
-        (event) => event.kind === 'status'
-          && event.label === 'error'
-          && (event as { code?: string }).code === 'AMR_INSUFFICIENT_BALANCE',
-      )).toBe(true);
+      const errorEvent = finalSave?.events?.find(
+        (event) => event.kind === 'status' && event.label === 'error',
+      ) as { code?: string } | undefined;
+      expect(errorEvent).toMatchObject({
+        code: 'AMR_INSUFFICIENT_BALANCE',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- promote AMR ACP retry-status insufficient-balance updates to terminal AMR_INSUFFICIENT_BALANCE errors
- include structured recovery/manual-topup payloads in ACP diagnostic classification
- keep reattached failed runs persisted with AMR_INSUFFICIENT_BALANCE so the recharge CTA path can render

## Base
- Recreated from origin/main (3ee8932c6)
- Replaces #5009, which was accidentally branched from release/v0.13.0

## Validation
- pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts
- pnpm --filter @open-design/web exec vitest run tests/components/ProjectView.reattach-restore.test.tsx tests/components/ChatPane.conversation-title.test.tsx
- pnpm --filter @open-design/daemon typecheck
- pnpm --filter @open-design/web typecheck
