### PR TITLE
fix(landing-page): sync community static header (Pricing + login + real sub-page links)

### DIFF
--- a/apps/landing-page/public/community/_site-nav.css
+++ b/apps/landing-page/public/community/_site-nav.css
@@ -962,3 +962,173 @@
    page content down by one bar height and keep in-page anchors visible. */
 body { padding-top: 88px; }
 html { scroll-padding-top: 110px; }
+
+/* --- Open Design Cloud (AMR) account entry — ported from app/globals.css to keep the static community header in sync with the main site. --- */
+.nav-account {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+/* Sign in — an outlined pill so it sits beside the filled Download CTA
+   without competing with it as a second solid button. */
+.nav-signin {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 15px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: border-color 160ms ease, color 160ms ease;
+}
+.nav-signin:hover,
+.nav-signin:focus-visible {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+.nav-account [hidden] { display: none !important; }
+/* Sign-in focus scrim — dims the page (but not the header chrome at z-index
+   50/60) while the vela login popup is open, so the popup reads as a modal
+   step. Mounted/removed by the account block in `header-enhancer.astro`;
+   `.is-active` drives the fade. */
+.nav-login-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(8, 10, 14, 0.55);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+  opacity: 0;
+  transition: opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.nav-login-overlay.is-active { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .nav-login-overlay { transition: none; }
+}
+/* Avatar menu — a borderless <details> whose summary is the avatar disc. */
+.nav-account-menu {
+  position: relative;
+}
+.nav-account-trigger {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  list-style: none;
+  border-radius: 999px;
+}
+.nav-account-trigger::-webkit-details-marker { display: none; }
+.nav-account-trigger:focus-visible {
+  outline: 2px solid var(--coral);
+  outline-offset: 2px;
+}
+/* Circular avatar — a disc reads unmistakably as a user avatar. Dark tile +
+   single initial mirrors Open Design Cloud's identity styling. */
+.nav-avatar,
+.nav-avatar-fallback {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+.nav-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #1f1f1f;
+  color: #fafafa;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+/* Dropdown panel — mirrors `.locale-menu` so both header menus read as one
+   panel style (same border, radius, shadow, and entrance). */
+.nav-account-dropdown {
+  position: absolute;
+  top: calc(100% + var(--nav-flyout-gap, 12px));
+  right: 0;
+  z-index: 60;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px;
+  background: var(--paper);
+  border: 1px solid rgba(26, 26, 26, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 12px 36px rgba(26, 26, 26, 0.08);
+  font-family: var(--sans);
+  letter-spacing: normal;
+  text-transform: none;
+  animation: locale-menu-in 180ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+/* Hover bridge across the gap, like `.locale-menu::before`. */
+.nav-account-dropdown::before {
+  content: '';
+  position: absolute;
+  top: calc(-1 * var(--nav-flyout-gap, 12px));
+  left: 0;
+  right: 0;
+  height: var(--nav-flyout-gap, 12px);
+}
+.nav-account-id {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px 10px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.nav-account-name {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.nav-account-name:empty { display: none; }
+.nav-account-email {
+  color: var(--ink-faint);
+  font-size: 11.5px;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.nav-account-email:empty { display: none; }
+.nav-account-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 12.5px;
+  line-height: 1.2;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 140ms ease, color 140ms ease;
+}
+.nav-account-item:hover,
+.nav-account-item:focus-visible {
+  background: var(--coral-tint);
+  color: var(--ink);
+}
+.nav-account-signout {
+  color: var(--ink-mute);
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-account-dropdown { animation: none; }
+}

--- a/apps/landing-page/public/community/_site-nav.js
+++ b/apps/landing-page/public/community/_site-nav.js
@@ -14,6 +14,13 @@
   const REPO = 'https://github.com/nexu-io/open-design';
   const X_PROFILE = 'https://x.com/OpenDesignHQ';
   const AMR_URL = 'https://open-design.ai/amr/';
+  // Open Design Cloud (AMR) account entry — mirrors header.tsx defaults so the
+  // static community pages show the same sign-in / account state as the main
+  // site. These pages default to the zh locale, so the post-login home is /zh/.
+  const AMR_API_BASE = 'https://amr-api.open-design.ai';
+  const AMR_LOGIN_URL = 'https://open-design.ai/amr/login';
+  const AMR_CONSOLE_URL = 'https://open-design.ai/amr?source=open_design';
+  const AMR_HOME = '/zh/';
 
   const renderSiteNav = () => `
     <div class="site-chrome" data-chrome-headroom>
@@ -103,6 +110,9 @@
                   <li><a href="/zh/plugins/systems/"><span class="dropdown-name">设计系统</span></a></li>
                 </ul>
               </li>
+              <li>
+                <a href="/zh/pricing/">价格</a>
+              </li>
               <li class="has-dropdown">
                 <a href="/zh/blog/">
                   资源<span class="dropdown-caret" aria-hidden="true">▾</span>
@@ -119,9 +129,9 @@
                   社区<span class="dropdown-caret" aria-hidden="true">▾</span>
                 </a>
                 <ul class="nav-dropdown" aria-label="社区">
-                  <li><a href="/community/#contributors"><span class="dropdown-name">贡献者</span></a></li>
-                  <li><a href="/community/#ambassadors"><span class="dropdown-name">大使</span></a></li>
-                  <li><a href="/community/#moderators"><span class="dropdown-name">版主</span></a></li>
+                  <li><a href="/community/contributors/"><span class="dropdown-name">贡献者</span></a></li>
+                  <li><a href="/community/ambassadors/"><span class="dropdown-name">大使</span></a></li>
+                  <li><a href="/community/moderators/"><span class="dropdown-name">版主</span></a></li>
                   <li><a href="${DISCORD}" target="_blank" rel="noreferrer noopener"><span class="dropdown-name">Discord</span></a></li>
                   <li><a href="${REPO}/discussions" target="_blank" rel="noreferrer noopener"><span class="dropdown-name">Discussions</span></a></li>
                   <li><a href="${X_PROFILE}" target="_blank" rel="noreferrer noopener"><span class="dropdown-name">X</span></a></li>
@@ -157,6 +167,23 @@
               </div>
             </details>
             <a class="nav-cta ghost" href="/zh/download/" aria-label="下载桌面端" title="下载桌面端" data-download-cta data-download-page>下载</a>
+            <div class="nav-account" data-amr-account data-amr-api="${AMR_API_BASE}" data-amr-login="${AMR_LOGIN_URL}" data-amr-console="${AMR_CONSOLE_URL}" data-amr-home="${AMR_HOME}">
+              <a class="nav-signin" href="${AMR_LOGIN_URL}" data-amr-signin>登录</a>
+              <details class="nav-account-menu" data-amr-menu hidden>
+                <summary class="nav-account-trigger" aria-label="账户菜单" title="账户菜单">
+                  <img class="nav-avatar" alt="" data-amr-avatar />
+                  <span class="nav-avatar-fallback" data-amr-avatar-fallback aria-hidden="true"></span>
+                </summary>
+                <div class="nav-account-dropdown" role="menu">
+                  <div class="nav-account-id">
+                    <span class="nav-account-name" data-amr-name></span>
+                    <span class="nav-account-email" data-amr-email></span>
+                  </div>
+                  <a class="nav-account-item" role="menuitem" href="${AMR_CONSOLE_URL}" target="_blank" rel="noreferrer noopener" data-amr-console-link>控制台</a>
+                  <button type="button" class="nav-account-item nav-account-signout" role="menuitem" data-amr-signout>退出登录</button>
+                </div>
+              </details>
+            </div>
           </div>
         </div>
         <svg class="nav-glass-defs" aria-hidden="true" focusable="false" width="0" height="0">
@@ -181,6 +208,168 @@
 
   for (const placeholder of document.querySelectorAll('od-site-nav')) {
     placeholder.outerHTML = renderSiteNav();
+  }
+
+  // Open Design Cloud (AMR) header account. Ported 1:1 from
+  // `app/_components/header-enhancer.astro` so these static pages detect a cloud
+  // session, swap the "登录" link for an avatar menu, drive popup login, and
+  // handle sign-out. Every network path fails closed to the signed-out state.
+  const account = document.querySelector('[data-amr-account]');
+  if (account) {
+    const api = (account.getAttribute('data-amr-api') || '').replace(/\/$/, '');
+    const loginUrl = account.getAttribute('data-amr-login') || '';
+    const homeUrl = account.getAttribute('data-amr-home') || '';
+    const signinEl = account.querySelector('[data-amr-signin]');
+    const menuEl = account.querySelector('[data-amr-menu]');
+    const avatarImg = account.querySelector('[data-amr-avatar]');
+    const avatarFallback = account.querySelector('[data-amr-avatar-fallback]');
+    const nameEl = account.querySelector('[data-amr-name]');
+    const emailEl = account.querySelector('[data-amr-email]');
+    const signoutBtn = account.querySelector('[data-amr-signout]');
+
+    const sessionUrl = api + '/api/auth/get-session';
+    const signoutUrl = api + '/api/auth/sign-out';
+
+    const fetchSession = () =>
+      fetch(sessionUrl, {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => (data && data.user ? data.user : null))
+        .catch(() => null);
+
+    const initials = (user) => {
+      const base = (user.name || user.email || '').trim();
+      return base ? base[0].toUpperCase() : '·';
+    };
+
+    const showSignedIn = (user) => {
+      if (nameEl) nameEl.textContent = user.name || '';
+      if (emailEl) emailEl.textContent = user.email || '';
+      if (avatarImg && user.image) {
+        avatarImg.setAttribute('src', user.image);
+        avatarImg.removeAttribute('hidden');
+        if (avatarFallback) avatarFallback.setAttribute('hidden', '');
+      } else {
+        if (avatarImg) avatarImg.setAttribute('hidden', '');
+        if (avatarFallback) {
+          avatarFallback.textContent = initials(user);
+          avatarFallback.removeAttribute('hidden');
+        }
+      }
+      if (signinEl) signinEl.setAttribute('hidden', '');
+      if (menuEl) menuEl.removeAttribute('hidden');
+    };
+
+    const showSignedOut = () => {
+      if (menuEl) {
+        menuEl.setAttribute('hidden', '');
+        menuEl.removeAttribute('open');
+      }
+      if (signinEl) signinEl.removeAttribute('hidden');
+    };
+
+    let overlayEl = null;
+    const showOverlay = () => {
+      if (overlayEl) return;
+      overlayEl = document.createElement('div');
+      overlayEl.className = 'nav-login-overlay';
+      overlayEl.setAttribute('aria-hidden', 'true');
+      document.body.appendChild(overlayEl);
+      requestAnimationFrame(() => {
+        if (overlayEl) overlayEl.classList.add('is-active');
+      });
+    };
+    const hideOverlay = () => {
+      if (!overlayEl) return;
+      const el = overlayEl;
+      overlayEl = null;
+      el.classList.remove('is-active');
+      const drop = () => el.remove();
+      el.addEventListener('transitionend', drop, { once: true });
+      setTimeout(drop, 400);
+    };
+
+    const goHome = () => {
+      if (!homeUrl) return;
+      const targetUrl = new URL(homeUrl, window.location.href);
+      const here = window.location.pathname.replace(/\/+$/, '');
+      const target = targetUrl.pathname.replace(/\/+$/, '');
+      if (here !== target) window.location.assign(homeUrl);
+    };
+
+    const completeSignIn = (user) => {
+      hideOverlay();
+      showSignedIn(user);
+      goHome();
+    };
+
+    fetchSession().then((user) => {
+      if (user) showSignedIn(user);
+    });
+
+    if (signinEl && loginUrl) {
+      signinEl.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        const W = 480;
+        const H = 720;
+        const dx = window.screenLeft ?? window.screenX ?? 0;
+        const dy = window.screenTop ?? window.screenY ?? 0;
+        const vw = window.innerWidth || document.documentElement.clientWidth || screen.width;
+        const vh = window.innerHeight || document.documentElement.clientHeight || screen.height;
+        const left = Math.round(dx + (vw - W) / 2);
+        const top = Math.round(dy + (vh - H) / 2);
+        const popup = window.open(
+          loginUrl,
+          'od-amr-login',
+          `width=${W},height=${H},left=${left},top=${top},menubar=no,toolbar=no,location=yes`,
+        );
+        if (!popup) {
+          window.location.assign(loginUrl);
+          return;
+        }
+        showOverlay();
+        const started = Date.now();
+        const POLL_MS = 2000;
+        const MAX_MS = 5 * 60 * 1000;
+        const timer = setInterval(() => {
+          if (Date.now() - started > MAX_MS) {
+            clearInterval(timer);
+            hideOverlay();
+            return;
+          }
+          if (popup.closed) {
+            clearInterval(timer);
+            fetchSession().then((user) => {
+              if (user) completeSignIn(user);
+              else hideOverlay();
+            });
+            return;
+          }
+          fetchSession().then((user) => {
+            if (!user) return;
+            clearInterval(timer);
+            try {
+              if (!popup.closed) popup.close();
+            } catch {}
+            completeSignIn(user);
+          });
+        }, POLL_MS);
+      });
+    }
+
+    if (signoutBtn) {
+      signoutBtn.addEventListener('click', () => {
+        fetch(signoutUrl, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { Accept: 'application/json' },
+        })
+          .catch(() => {})
+          .then(() => showSignedOut());
+      });
+    }
   }
 
   const injectHomeFooterStyles = () => {

--- a/apps/landing-page/public/community/_site-nav.js
+++ b/apps/landing-page/public/community/_site-nav.js
@@ -16,11 +16,13 @@
   const AMR_URL = 'https://open-design.ai/amr/';
   // Open Design Cloud (AMR) account entry — mirrors header.tsx defaults so the
   // static community pages show the same sign-in / account state as the main
-  // site. These pages default to the zh locale, so the post-login home is /zh/.
+  // site. The main header derives its post-login home from `href('/')`; these
+  // community pages are the default (English) locale with no locale prefix
+  // (`<html lang="en">`), so the equivalent home is the locale-neutral root `/`.
   const AMR_API_BASE = 'https://amr-api.open-design.ai';
   const AMR_LOGIN_URL = 'https://open-design.ai/amr/login';
   const AMR_CONSOLE_URL = 'https://open-design.ai/amr?source=open_design';
-  const AMR_HOME = '/zh/';
+  const AMR_HOME = '/';
 
   const renderSiteNav = () => `
     <div class="site-chrome" data-chrome-headroom>


### PR DESCRIPTION
## Why

The `/community/*` pages render a **hand-maintained static header** (`public/community/_site-nav.js`, a "trimmed port" of the main `header-enhancer.astro`) that had drifted from the main site. On community pages the header was **missing the Pricing nav item and the login (Open Design Cloud / AMR sign-in) module** that every other page shows, and the Community dropdown pointed at same-page anchors instead of the real sub-pages.

## What changed (community static header only)

- **Pricing** nav item added (`/zh/pricing/`), between Plugins and Resources — matching the main header order.
- **Login / account module** added: the `.nav-account` markup (登录 link + avatar account menu) plus a 1:1 port of the AMR auth block from `header-enhancer.astro` (silent session probe, popup login + poll, sign-out). Fails closed to the signed-out "登录" state, exactly like the main header.
- The matching `.nav-account` / `.nav-signin` / `.nav-login-overlay` styles are brought into `_site-nav.css` from `globals.css`.
- **Community dropdown** now links to the real sub-pages (`/community/contributors/`, `/community/ambassadors/`, `/community/moderators/`) instead of index anchors (`/community/#...`), so clicking lands on the full page.

## Surface area

- [x] Static assets (`public/community/_site-nav.js`, `_site-nav.css`)

## Validation

- `node --check public/community/_site-nav.js` → OK
- `pnpm exec astro check` → 0 errors
- Verified locally on the dev server: community header now renders Pricing + 登录, and the Community dropdown links resolve to the sub-pages.
