### PR TITLE
Fix install-from-local: copy library items instead of creating a junction

### DIFF
--- a/apps/daemon/src/cwd-aliases.ts
+++ b/apps/daemon/src/cwd-aliases.ts
@@ -71,7 +71,7 @@ type SkillCopyFn = (
 // through copy_file_range. `stat()` (not `lstat`) follows symlinks, so
 // every staged entry lands as a real directory or regular file — keeping
 // `.od-skills/` a self-contained write barrier even on the fallback path.
-async function copyTreeDereferenced(srcDir: string, destDir: string): Promise<void> {
+export async function copyTreeDereferenced(srcDir: string, destDir: string): Promise<void> {
   await mkdir(destDir, { recursive: true });
   for (const entry of await readdir(srcDir, { withFileTypes: true })) {
     const from = path.join(srcDir, entry.name);

--- a/apps/daemon/src/library-install.ts
+++ b/apps/daemon/src/library-install.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { isBlocked } from './linked-dirs.js';
 import { listSkills, findSkillById } from './skills.js';
 import { listDesignSystems } from './design-systems/index.js';
+import { copyTreeDereferenced } from './cwd-aliases.js';
 
 /** @typedef {{ source: 'github', url: string } | { source: 'local', path: string }} InstallTarget */
 
@@ -133,11 +134,28 @@ async function installFromLocal(localPath, userDir, manifest) {
     // Doesn't exist — good.
   }
 
-  // Create symlink
+  // Copy the folder into the user library as a self-contained set of real
+  // files, dereferencing any symlinks inside it. Previously this created a
+  // junction to `realPath`, but the daemon's project file guard
+  // (`resolveSafeReal` in projects.ts) rejects any path that resolves outside
+  // the project via a symlink/junction, so a linked design system or skill
+  // could not be read, built, or exported ("path escapes project dir via
+  // symlink"). A dereferenced copy keeps the installed item entirely inside
+  // the managed library, matching how a GitHub install (a clone) already
+  // behaves. `copyTreeDereferenced` is used rather than
+  // `fs.cp({ dereference: true })` because the latter does not reliably
+  // dereference nested symlinks on Windows. Trade-off: the copy is a
+  // snapshot, so later edits to the source folder are not reflected.
   try {
-    fs.symlinkSync(realPath, linkPath, 'junction');
+    await copyTreeDereferenced(realPath, linkPath);
   } catch (err) {
-    return { ok: false, error: `Failed to create symlink: ${err.message}` };
+    // Remove a partial copy so the collision check doesn't block a retry.
+    try {
+      fs.rmSync(linkPath, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    return { ok: false, error: `Failed to copy: ${err.message}` };
   }
 
   return { ok: true, dir: linkPath };

--- a/apps/daemon/tests/library-install.test.ts
+++ b/apps/daemon/tests/library-install.test.ts
@@ -1,5 +1,13 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { sanitizeRepoName, GITHUB_URL_RE, SAFE_NAME_RE } from '../src/library-install.js';
+import {
+  sanitizeRepoName,
+  GITHUB_URL_RE,
+  SAFE_NAME_RE,
+  installFromTarget,
+} from '../src/library-install.js';
 
 describe('sanitizeRepoName', () => {
   it('extracts repo name from a github URL', () => {
@@ -79,5 +87,92 @@ describe('SAFE_NAME_RE', () => {
     expect(SAFE_NAME_RE.test('foo bar')).toBe(false);
     expect(SAFE_NAME_RE.test('测试')).toBe(false);
     expect(SAFE_NAME_RE.test('repo!')).toBe(false);
+  });
+});
+
+describe('installFromTarget (local install copies instead of linking)', () => {
+  it('installs a local design system as a real directory, not a junction', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'od-libinstall-'));
+    try {
+      const source = path.join(tmp, 'my-ds');
+      fs.mkdirSync(source, { recursive: true });
+      fs.writeFileSync(path.join(source, 'DESIGN.md'), '# My DS\n');
+      const userDir = path.join(tmp, 'user-design-systems');
+      fs.mkdirSync(userDir, { recursive: true });
+
+      const res = await installFromTarget(
+        { source: 'local', path: source },
+        userDir,
+        'design-system',
+      );
+      expect(res.ok).toBe(true);
+
+      // The installed item must be a real directory (not a symlink/junction)
+      // so the daemon's resolveSafeReal guard can read it inside a project.
+      const dest = path.join(userDir, 'my-ds');
+      expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
+      expect(fs.lstatSync(dest).isDirectory()).toBe(true);
+      expect(fs.readFileSync(path.join(dest, 'DESIGN.md'), 'utf8')).toBe('# My DS\n');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('dereferences symlinks inside the source so nothing resolves outside the copy', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'od-libinstall-'));
+    try {
+      const outside = path.join(tmp, 'outside');
+      fs.mkdirSync(outside, { recursive: true });
+      fs.writeFileSync(path.join(outside, 'secret.txt'), 'linked\n');
+
+      const source = path.join(tmp, 'ds-with-link');
+      fs.mkdirSync(source, { recursive: true });
+      fs.writeFileSync(path.join(source, 'DESIGN.md'), '# DS\n');
+
+      let symlinkSupported = true;
+      try {
+        fs.symlinkSync(path.join(outside, 'secret.txt'), path.join(source, 'linked.txt'));
+      } catch {
+        // Some environments (e.g. Windows without privilege) can't create
+        // symlinks; the copy-not-link behavior is still covered by the test
+        // above, so skip the dereference assertion here.
+        symlinkSupported = false;
+      }
+      if (!symlinkSupported) return;
+
+      const userDir = path.join(tmp, 'user');
+      fs.mkdirSync(userDir, { recursive: true });
+      const res = await installFromTarget(
+        { source: 'local', path: source },
+        userDir,
+        'design-system',
+      );
+      expect(res.ok).toBe(true);
+
+      const linked = path.join(userDir, 'ds-with-link', 'linked.txt');
+      expect(fs.lstatSync(linked).isSymbolicLink()).toBe(false);
+      expect(fs.readFileSync(linked, 'utf8')).toBe('linked\n');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a local source without the expected manifest', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'od-libinstall-'));
+    try {
+      const source = path.join(tmp, 'no-manifest');
+      fs.mkdirSync(source, { recursive: true });
+      const userDir = path.join(tmp, 'user');
+      fs.mkdirSync(userDir, { recursive: true });
+
+      const res = await installFromTarget(
+        { source: 'local', path: source },
+        userDir,
+        'design-system',
+      );
+      expect(res.ok).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Why

I hit this myself while working on a project built from a **local** design system. `installFromLocal` creates a **junction** from the user library to the source folder:

```js
fs.symlinkSync(realPath, linkPath, 'junction');
```

But the daemon's project file guard, `resolveSafeReal` in `apps/daemon/src/projects.ts`, `realpath()`s every project file op and rejects anything that resolves **outside** the project via a symlink/junction:

```
Error: path escapes project dir via symlink   // code EPATHESCAPE
```

Once that design system is attached to a project, the daemon can no longer read, build, or export it — reading the entry `DESIGN.md` alone trips the guard. Because the guard sits in the daemon **below the agent**, it surfaces as `AGENT_EXECUTION_FAILED` for every runtime (Claude Code, Codex, Kiro) and blocks even read-only actions like "check the design system." The guard is correct (it's a deliberate control against in-project symlinks escaping the sandbox); the install path is what's wrong for creating a junction the guard then can't follow.

## What users will see

- Installing a skill or design system **from a local folder** now works when it's attached to a project — no more `path escapes project dir via symlink` failures.
- Install-from-local is now a **snapshot copy** of the folder rather than a live junction. Consistent with how a GitHub install (a clone) already behaves. Trade-off: later edits to the original source folder aren't reflected until reinstalled.

## The fix

Copy the folder into the user library as a self-contained set of real files, dereferencing nested symlinks so nothing under the installed item resolves back outside it. This reuses the existing `copyTreeDereferenced` helper (already used by skill staging in `cwd-aliases.ts`) instead of `fs.cp({ dereference: true })` — the latter does **not** reliably dereference nested symlinks on Windows (verified: the copied entry stays a symlink and tracks the original). `uninstallById` already handles both real directories and legacy junctions, so pre-existing installs keep uninstalling cleanly.

Files:
- `apps/daemon/src/library-install.ts` — copy instead of `symlinkSync(..., 'junction')`, with partial-copy cleanup on failure.
- `apps/daemon/src/cwd-aliases.ts` — `export` the existing `copyTreeDereferenced` (no behavior change).
- `apps/daemon/tests/library-install.test.ts` — tests below.

## Surface area

- [x] **Default behavior change** — install-from-local is now a copy (snapshot), not a live junction.
- [x] **None** — otherwise an internal daemon fix + tests.

## Screenshots

N/A — no UI change.

## Bug fix verification

- Test path: `apps/daemon/tests/library-install.test.ts` — new `installFromTarget (local install copies instead of linking)` suite covering: (1) a local design system installs as a **real directory, not a symlink/junction**, (2) a symlink **inside** the source is **dereferenced** into a real file (guarded to skip where the OS can't create symlinks), and (3) a source without the expected manifest is rejected.
- Red on `main` / green on branch: the core assertion `expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false)` fails on `main` (the old code makes `dest` a link — a junction on Windows, a symlink elsewhere) and passes on this branch (real directory). So it's falsifiable against the old behavior.
- Note: I could not run the full workspace `vitest` suite in my environment (monorepo deps weren't installed locally), so CI will be the source of truth. I did verify the underlying dereference mechanism directly with a standalone Node reproduction (confirming `fs.cp({dereference})` leaves nested links on Windows while the stat-follow + stream copy used by `copyTreeDereferenced` produces real, independent files).
