### PR TITLE
[codex] Handle AMR stderr balance retries

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -35,6 +35,7 @@ const ACP_ARTIFACT_ECHO_START_RE = new RegExp(
   'i',
 );
 const ACP_RAW_EVENT_SHAPE_DIAGNOSTIC_LIMIT = 8;
+const AMR_STDERR_RETRY_TAIL_LIMIT = 16_000;
 
 type JsonRpcId = string | number;
 type JsonObject = Record<string, unknown>;
@@ -1032,6 +1033,7 @@ export function attachAcpSession({
   let emittedTextBuffer = '';
   let rawAcpShapeDiagnosticCount = 0;
   let artifactSuppressionDiagnosticCount = 0;
+  let amrStderrRetryTail = '';
   let finished = false;
   let fatal = false;
   let aborted = false;
@@ -1670,8 +1672,11 @@ export function attachAcpSession({
   stdout.on('data', (chunk: string) => parser.feed(chunk));
   child.stderr?.setEncoding('utf8');
   child.stderr?.on('data', (chunk: string) => {
-    if (!modelUnavailableErrorCode) return;
-    const promotedPayload = promotedAmrStderrPayload(String(chunk));
+    if (!modelUnavailableErrorCode || finished) return;
+    amrStderrRetryTail = `${amrStderrRetryTail}${String(chunk)}`.slice(
+      -AMR_STDERR_RETRY_TAIL_LIMIT,
+    );
+    const promotedPayload = promotedAmrStderrPayload(amrStderrRetryTail);
     if (promotedPayload) failWithPayload(promotedPayload);
   });
   child.on('close', (code, signal) => {

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -542,6 +542,25 @@ function promotedAmrRetryStatusPayload(update: JsonObject) {
   };
 }
 
+function promotedAmrStderrPayload(chunk: string) {
+  if (!/opencode_event_stream_failure|session\.status/i.test(chunk)) return null;
+  if (!/\bretry\b/i.test(chunk)) return null;
+  const failure = classifyAmrAccountFailure(chunk);
+  if (!failure) return null;
+  return {
+    message: failure.message,
+    error: {
+      code: failure.code,
+      message: failure.message,
+      retryable: false,
+      details: {
+        ...amrAccountFailureDetails(failure),
+        promoted_by: 'open_design_acp_stderr_retry_status',
+      },
+    },
+  };
+}
+
 function acpToolCallId(update: JsonObject): string | null {
   return typeof update.toolCallId === 'string' && update.toolCallId.trim()
     ? update.toolCallId.trim()
@@ -1649,6 +1668,12 @@ export function attachAcpSession({
   });
 
   stdout.on('data', (chunk: string) => parser.feed(chunk));
+  child.stderr?.setEncoding('utf8');
+  child.stderr?.on('data', (chunk: string) => {
+    if (!modelUnavailableErrorCode) return;
+    const promotedPayload = promotedAmrStderrPayload(String(chunk));
+    if (promotedPayload) failWithPayload(promotedPayload);
+  });
   child.on('close', (code, signal) => {
     clearStageTimer();
     parser.flush();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6644,7 +6644,7 @@ export async function startServer({
         failure.code,
         failure.message,
         {
-          retryable: true,
+          retryable: false,
           details: amrAccountFailureDetails(failure),
         },
       ));

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -85,9 +85,11 @@ function spawnAcpUpdateFixture(updates: unknown[], usage: unknown = {}): ChildPr
   `);
 }
 
-function spawnAcpStderrRetryFixture(stderrLine: string): ChildProcess {
+function spawnAcpStderrRetryFixture(stderrChunks: string | string[]): ChildProcess {
   return spawnFixtureScript(`
-    const stderrLine = ${JSON.stringify(stderrLine)};
+    const stderrChunks = ${JSON.stringify(
+      typeof stderrChunks === 'string' ? [stderrChunks] : stderrChunks,
+    )};
     function write(obj) { process.stdout.write(JSON.stringify(obj) + '\\n'); }
     process.stdin.setEncoding('utf8');
     let buffer = '';
@@ -106,8 +108,15 @@ function spawnAcpStderrRetryFixture(stderrLine: string): ChildProcess {
         } else if (msg.method === 'session/set_model' || msg.method === 'session/set_config_option') {
           write({ jsonrpc: '2.0', id: msg.id, result: {} });
         } else if (msg.method === 'session/prompt') {
-          process.stderr.write(stderrLine + '\\n');
-          setTimeout(() => process.exit(0), 25);
+          stderrChunks.forEach((stderrChunk, index) => {
+            setTimeout(() => {
+              process.stderr.write(stderrChunk);
+              if (index === stderrChunks.length - 1) {
+                process.stderr.write('\\n');
+                setTimeout(() => process.exit(0), 25);
+              }
+            }, index * 5);
+          });
         } else if (msg.method === 'session/cancel') {
           write({ jsonrpc: '2.0', id: msg.id, result: {} });
         }
@@ -901,6 +910,45 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
       promoted_by: 'open_design_acp_stderr_retry_status',
     });
     expect(String(payload?.message ?? '')).toContain('AMR Cloud reported insufficient balance');
+  });
+
+  it('promotes OpenCode stderr retry status when the balance log is split across chunks', async () => {
+    const child = spawnAcpStderrRetryFixture([
+      'opencode_event_stream_failure: phase=event_stream session=ses_123 error="{\\"id\\":\\"evt_123\\",\\"properties\\":{\\"sessionID\\":\\"ses_123\\",\\"status\\":{\\"attempt\\":1,\\"message\\":\\"[code=',
+      'insufficient_balance] insufficient wallet balance\\",\\"next\\":1782915664490,\\"type\\":\\"retry\\"}},\\"type\\":\\"session.status\\"}"',
+    ]);
+    const errors: Array<{ event: string; payload: unknown }> = [];
+    try {
+      const session = attachAcpSession({
+        child: child as never,
+        prompt: 'Say hello',
+        cwd: process.cwd(),
+        model: 'claude-opus-4-6',
+        mcpServers: [],
+        modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+        send: (event, payload) => {
+          if (event === 'error') errors.push({ event, payload });
+        },
+      });
+
+      await waitForExit(child);
+      expect(session.hasFatalError()).toBe(true);
+      expect(session.completedSuccessfully()).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }
+
+    const payload = errors[0]?.payload as {
+      message?: unknown;
+      error?: { code?: unknown; retryable?: unknown; details?: Record<string, unknown> };
+    };
+    expect(payload?.error?.code).toBe('AMR_INSUFFICIENT_BALANCE');
+    expect(payload?.error?.retryable).toBe(false);
+    expect(payload?.error?.details).toMatchObject({
+      kind: 'amr_account',
+      action: 'recharge',
+      promoted_by: 'open_design_acp_stderr_retry_status',
+    });
   });
 
   it('allows non-AMR ACP completions that produce no assistant text', async () => {

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -85,6 +85,38 @@ function spawnAcpUpdateFixture(updates: unknown[], usage: unknown = {}): ChildPr
   `);
 }
 
+function spawnAcpStderrRetryFixture(stderrLine: string): ChildProcess {
+  return spawnFixtureScript(`
+    const stderrLine = ${JSON.stringify(stderrLine)};
+    function write(obj) { process.stdout.write(JSON.stringify(obj) + '\\n'); }
+    process.stdin.setEncoding('utf8');
+    let buffer = '';
+    process.stdin.on('data', (chunk) => {
+      buffer += chunk;
+      const lines = buffer.split('\\n');
+      buffer = lines.pop() || '';
+      for (const raw of lines) {
+        const line = raw.trim();
+        if (!line) continue;
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          write({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: 1 } });
+        } else if (msg.method === 'session/new') {
+          write({ jsonrpc: '2.0', id: msg.id, result: { sessionId: 's1', models: { currentModelId: null, availableModels: [] } } });
+        } else if (msg.method === 'session/set_model' || msg.method === 'session/set_config_option') {
+          write({ jsonrpc: '2.0', id: msg.id, result: {} });
+        } else if (msg.method === 'session/prompt') {
+          process.stderr.write(stderrLine + '\\n');
+          setTimeout(() => process.exit(0), 25);
+        } else if (msg.method === 'session/cancel') {
+          write({ jsonrpc: '2.0', id: msg.id, result: {} });
+        }
+      }
+    });
+    process.stdin.on('end', () => process.exit(0));
+  `);
+}
+
 async function waitForExit(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null) return;
   await new Promise<void>((resolve) => {
@@ -828,6 +860,45 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
       kind: 'amr_account',
       action: 'recharge',
       promoted_by: 'open_design_acp_retry_status',
+    });
+    expect(String(payload?.message ?? '')).toContain('AMR Cloud reported insufficient balance');
+  });
+
+  it('promotes OpenCode stderr retry status insufficient-balance logs to AMR recharge failures', async () => {
+    const child = spawnAcpStderrRetryFixture(
+      'opencode_event_stream_failure: phase=event_stream session=ses_123 error="{\\"id\\":\\"evt_123\\",\\"properties\\":{\\"sessionID\\":\\"ses_123\\",\\"status\\":{\\"attempt\\":1,\\"message\\":\\"[code=insufficient_balance] insufficient wallet balance\\",\\"next\\":1782915664490,\\"type\\":\\"retry\\"}},\\"type\\":\\"session.status\\"}"',
+    );
+    const errors: Array<{ event: string; payload: unknown }> = [];
+    try {
+      const session = attachAcpSession({
+        child: child as never,
+        prompt: 'Say hello',
+        cwd: process.cwd(),
+        model: 'claude-opus-4-6',
+        mcpServers: [],
+        modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+        send: (event, payload) => {
+          if (event === 'error') errors.push({ event, payload });
+        },
+      });
+
+      await waitForExit(child);
+      expect(session.hasFatalError()).toBe(true);
+      expect(session.completedSuccessfully()).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }
+
+    const payload = errors[0]?.payload as {
+      message?: unknown;
+      error?: { code?: unknown; retryable?: unknown; details?: Record<string, unknown> };
+    };
+    expect(payload?.error?.code).toBe('AMR_INSUFFICIENT_BALANCE');
+    expect(payload?.error?.retryable).toBe(false);
+    expect(payload?.error?.details).toMatchObject({
+      kind: 'amr_account',
+      action: 'recharge',
+      promoted_by: 'open_design_acp_stderr_retry_status',
     });
     expect(String(payload?.message ?? '')).toContain('AMR Cloud reported insufficient balance');
   });


### PR DESCRIPTION
## Summary

- Promote OpenCode `session.status` retry logs on stderr into AMR account failures when they contain insufficient-balance signals.
- Keep AMR account failures non-retryable at the daemon/server boundary so clients can show the recharge path instead of continuing automatic retry behavior.
- Add AMR ACP coverage for the stderr retry shape observed in the packaged app.

## Root cause

The previous AMR insufficient-balance handling covered structured ACP `session/update` retry events. The packaged Vela/OpenCode runtime can also report the same wallet failure through `stderr` as an `opencode_event_stream_failure` / `session.status` retry log. That path bypassed the ACP retry promotion. Server-side AMR account failure wrapping also forced `retryable: true`, which could undo the non-retryable wallet error shape.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts --pool=forks --fileParallelism=false`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/run-failure-classification.test.ts --pool=forks --fileParallelism=false`
- `pnpm --filter @open-design/daemon typecheck`
- `git diff --check`
- Local packaged v2 smoke with a 0-balance AMR account: run failed with `AMR_INSUFFICIENT_BALANCE`, `retryable: false`, `details.action: recharge`, and retry suppressed.
