### PR TITLE
fix docker GHCR public pull verification

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -67,6 +67,8 @@ jobs:
             type=raw,value=${{ inputs.release_version }},enable=${{ inputs.release_version != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=latest,enable=${{ inputs.publish_latest == true }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -86,3 +88,26 @@ jobs:
           # the Dockerfile's apk lines re-cast for apt.
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify public GHCR pull access
+        if: github.event_name != 'pull_request'
+        shell: bash
+        env:
+          PUBLISHED_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          docker logout ghcr.io >/dev/null 2>&1 || true
+
+          while IFS= read -r image; do
+            [ -n "$image" ] || continue
+            echo "Verifying anonymous access for $image"
+            if ! docker buildx imagetools inspect "$image" >/dev/null; then
+              printf '%s\n' \
+                "Published image is not anonymously pullable: $image" \
+                "" \
+                "Make the GHCR package public before cutting a public Docker release:" \
+                "GitHub organization -> Packages -> od -> Package settings -> Change visibility -> Public." >&2
+              exit 1
+            fi
+          done <<< "$PUBLISHED_TAGS"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,6 +34,13 @@ OPEN_DESIGN_IMAGE=ghcr.io/nexu-io/od:latest docker compose up -d --no-build
 Use `ghcr.io/nexu-io/od:latest` for the latest stable image, or
 `ghcr.io/nexu-io/od:<version>` to pin a supported release.
 
+The published `ghcr.io/nexu-io/od` package must be public for anonymous
+`docker pull`, Docker Compose, and Dokploy installs to work. If GHCR returns an
+authentication or access-denied error for this image, an organization maintainer
+must open GitHub -> Packages -> `od` -> Package settings and change visibility
+to Public. GitHub treats that as a one-way visibility change for container
+packages, so confirm the package is intended to stay public before switching it.
+
 Defaults:
 
 - Host port: `127.0.0.1:7456` (`OPEN_DESIGN_PORT=8080` to publish on `127.0.0.1:8080`)

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -93,5 +93,6 @@ You should see the Open Design interface.
 - `failed to connect to the docker API`: Docker Desktop is not running yet
 - `address already in use`: Port `7456` is occupied by another process
 - `curl: (7) Failed to connect`: container is still starting; wait 10-20 seconds and retry
+- `pull access denied` or `authentication required` for `ghcr.io/nexu-io/od`: the GHCR package must be public for anonymous Docker, Compose, and Dokploy pulls. An organization maintainer must open GitHub -> Packages -> `od` -> Package settings and change visibility to Public.
 - reverse proxy + `OD_API_TOKEN`: either inject `Authorization: Bearer <OD_API_TOKEN>` at the proxy, or set `OPEN_DESIGN_DISABLE_API_AUTH=1` only when that proxy already authenticates every request and the daemon is not directly exposed.
 - `Authorization: Bearer <OD_API_TOKEN> required` on macOS: Docker Desktop bridge networking makes the daemon see requests as non-loopback. See [Docker Desktop on macOS](../../deploy/README.md#docker-desktop-on-macos) for the host networking workaround.


### PR DESCRIPTION
Fixes #4940

## Why

`ghcr.io/nexu-io/od` is the default self-hosting image in the Docker docs and deploy examples, but private GHCR package visibility makes anonymous Docker, Compose, and Dokploy pulls fail even when the release workflow successfully pushes tags.

## What users will see

Release image publishing now verifies that each published GHCR tag is anonymously inspectable after logging out of GHCR. Docker docs also call out the maintainer-only package visibility setting when users see pull access or authentication errors.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: GHCR package visibility is maintainer-only, so I could not make `ghcr.io/nexu-io/od` private/public from this fork. The release workflow now logs out of GHCR and runs `docker buildx imagetools inspect` against every published tag, which fails when anonymous pulls are blocked.
- Did the test go red on `main` and green on this branch? no, the failing state depends on org package visibility and only runs after an upstream Docker publish.
- If a red spec wasn't cheap to write, explain why and what verification you did instead. Added release-time anonymous pull verification and documented the maintainer package-visibility setting.

## Validation

- `git diff --check`
- `actionlint -color .github/workflows/docker-image.yml` (not run: `actionlint` is not installed in this Windows environment)
- `corepack pnpm guard` (fails on unrelated stale design-system generated files)
- `corepack pnpm typecheck` (fails because lifecycle execution uses global pnpm 11.7.0 despite Corepack pnpm 10.33.2)
- `./node_modules/.bin/tsc.cmd -p scripts/tsconfig.json --noEmit` (fails on unrelated `apps/daemon/src/prompts/system.ts` TS2367)
