### PR TITLE
fix(web): prevent stale dev document cache

### DIFF
--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -43,6 +43,7 @@ const WEB_STANDALONE_ROOT_ENV = "OD_WEB_STANDALONE_ROOT";
 const STANDALONE_PARENT_PID_ENV = "OD_STANDALONE_PARENT_PID";
 const STANDALONE_STARTUP_TIMEOUT_ENV = "OD_STANDALONE_STARTUP_TIMEOUT_MS";
 const DEV_CLIENT_CACHE_CONTROL = "no-store, no-cache, must-revalidate, proxy-revalidate";
+const DEV_CLIENT_CLEAR_SITE_DATA = '"cache"';
 const SHUTDOWN_TIMEOUT_MS = 3000;
 const STANDALONE_READINESS_POLL_MS = 150;
 const STANDALONE_TCP_READINESS_GRACE_MS = STANDALONE_READINESS_POLL_MS;
@@ -279,37 +280,52 @@ export function isNextStaticAssetRequest(requestUrl: string | undefined): boolea
   }
 }
 
-function devNoStoreHeaders(): OutgoingHttpHeaders {
+export function isLikelyDocumentNavigationRequest(request: IncomingMessage): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+  if (isNextStaticAssetRequest(request.url)) return false;
+  const accept = firstHeaderValue(request.headers.accept);
+  return accept?.includes("text/html") === true;
+}
+
+function devNoStoreHeaders(options: { clearSiteData?: boolean } = {}): OutgoingHttpHeaders {
   return {
     "Cache-Control": DEV_CLIENT_CACHE_CONTROL,
     Pragma: "no-cache",
     Expires: "0",
+    ...(options.clearSiteData === true ? { "Clear-Site-Data": DEV_CLIENT_CLEAR_SITE_DATA } : {}),
   };
 }
 
-function mergeDevNoStoreHeaders(headers: OutgoingHttpHeaders | undefined): OutgoingHttpHeaders {
-  return { ...(headers ?? {}), ...devNoStoreHeaders() };
+function mergeDevNoStoreHeaders(
+  headers: OutgoingHttpHeaders | undefined,
+  options: { clearSiteData?: boolean } = {},
+): OutgoingHttpHeaders {
+  return { ...(headers ?? {}), ...devNoStoreHeaders(options) };
 }
 
 function withDevNoStoreWriteHeadArgs(
   statusCode: number,
   statusMessageOrHeaders?: string | OutgoingHttpHeaders,
   headers?: OutgoingHttpHeaders,
+  options: { clearSiteData?: boolean } = {},
 ): WriteHeadOverrideArgs {
   if (typeof statusMessageOrHeaders === "string") {
-    return [statusCode, statusMessageOrHeaders, mergeDevNoStoreHeaders(headers as OutgoingHttpHeaders | undefined)];
+    return [statusCode, statusMessageOrHeaders, mergeDevNoStoreHeaders(headers as OutgoingHttpHeaders | undefined, options)];
   }
-  return [statusCode, mergeDevNoStoreHeaders(statusMessageOrHeaders as OutgoingHttpHeaders | undefined)];
+  return [statusCode, mergeDevNoStoreHeaders(statusMessageOrHeaders as OutgoingHttpHeaders | undefined, options)];
 }
 
-function installDevNoStoreHeaderOverride(response: ServerResponse): void {
-  for (const [key, value] of Object.entries(devNoStoreHeaders())) {
+function installDevNoStoreHeaderOverride(
+  response: ServerResponse,
+  options: { clearSiteData?: boolean } = {},
+): void {
+  for (const [key, value] of Object.entries(devNoStoreHeaders(options))) {
     if (value == null) continue;
     response.setHeader(key, value);
   }
   const originalWriteHead = response.writeHead.bind(response) as WriteHeadOverride;
   response.writeHead = ((statusCode: number, statusMessageOrHeaders?: string | OutgoingHttpHeaders, headers?: OutgoingHttpHeaders) => {
-    const patchedArgs = withDevNoStoreWriteHeadArgs(statusCode, statusMessageOrHeaders, headers);
+    const patchedArgs = withDevNoStoreWriteHeadArgs(statusCode, statusMessageOrHeaders, headers, options);
     if (patchedArgs.length === 3) {
       return originalWriteHead(patchedArgs[0], patchedArgs[1], patchedArgs[2]);
     }
@@ -958,8 +974,12 @@ export function createDaemonProxyHandler(
       return;
     }
 
-    if (options.preventStaticAssetBrowserCache === true && isNextStaticAssetRequest(request.url)) {
-      installDevNoStoreHeaderOverride(response);
+    if (options.preventStaticAssetBrowserCache === true) {
+      if (isNextStaticAssetRequest(request.url)) {
+        installDevNoStoreHeaderOverride(response);
+      } else if (isLikelyDocumentNavigationRequest(request)) {
+        installDevNoStoreHeaderOverride(response, { clearSiteData: true });
+      }
     }
 
     void fallback(request, response).catch((error: unknown) => {

--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -3,6 +3,7 @@ import {
   createServer as createHttpServer,
   request as createHttpRequest,
   type IncomingMessage,
+  type OutgoingHttpHeaders,
   type Server as HttpServer,
   type ServerResponse,
 } from "node:http";
@@ -41,6 +42,7 @@ const WEB_OUTPUT_MODE_ENV = "OD_WEB_OUTPUT_MODE";
 const WEB_STANDALONE_ROOT_ENV = "OD_WEB_STANDALONE_ROOT";
 const STANDALONE_PARENT_PID_ENV = "OD_STANDALONE_PARENT_PID";
 const STANDALONE_STARTUP_TIMEOUT_ENV = "OD_STANDALONE_STARTUP_TIMEOUT_MS";
+const DEV_CLIENT_CACHE_CONTROL = "no-store, no-cache, must-revalidate, proxy-revalidate";
 const SHUTDOWN_TIMEOUT_MS = 3000;
 const STANDALONE_READINESS_POLL_MS = 150;
 const STANDALONE_TCP_READINESS_GRACE_MS = STANDALONE_READINESS_POLL_MS;
@@ -63,6 +65,20 @@ type StandaloneBackend = {
   origin: string;
   stop(): Promise<void>;
 };
+
+type DaemonProxyHandlerOptions = {
+  preventStaticAssetBrowserCache?: boolean;
+};
+
+type WriteHeadOverride = (
+  statusCode: number,
+  statusMessageOrHeaders?: string | OutgoingHttpHeaders,
+  headers?: OutgoingHttpHeaders,
+) => ServerResponse;
+
+type WriteHeadOverrideArgs =
+  | [statusCode: number, headers: OutgoingHttpHeaders]
+  | [statusCode: number, statusMessage: string, headers: OutgoingHttpHeaders];
 
 function createNextApp(options: { dev: boolean; dir: string } & NextBundlerOptions): NextApp {
   const createNextServer = require("next") as (nextOptions: { dev: boolean; dir: string } & NextBundlerOptions) => NextApp;
@@ -251,6 +267,54 @@ function resolveHttpProxyTarget(
   }
 
   return new URL(`${parsedRequestUrl.pathname}${parsedRequestUrl.search}`, origin);
+}
+
+export function isNextStaticAssetRequest(requestUrl: string | undefined): boolean {
+  if (requestUrl == null) return false;
+  try {
+    const parsedRequestUrl = new URL(requestUrl, `http://${HOST}`);
+    return parsedRequestUrl.pathname === "/_next/static" || parsedRequestUrl.pathname.startsWith("/_next/static/");
+  } catch {
+    return false;
+  }
+}
+
+function devNoStoreHeaders(): OutgoingHttpHeaders {
+  return {
+    "Cache-Control": DEV_CLIENT_CACHE_CONTROL,
+    Pragma: "no-cache",
+    Expires: "0",
+  };
+}
+
+function mergeDevNoStoreHeaders(headers: OutgoingHttpHeaders | undefined): OutgoingHttpHeaders {
+  return { ...(headers ?? {}), ...devNoStoreHeaders() };
+}
+
+function withDevNoStoreWriteHeadArgs(
+  statusCode: number,
+  statusMessageOrHeaders?: string | OutgoingHttpHeaders,
+  headers?: OutgoingHttpHeaders,
+): WriteHeadOverrideArgs {
+  if (typeof statusMessageOrHeaders === "string") {
+    return [statusCode, statusMessageOrHeaders, mergeDevNoStoreHeaders(headers as OutgoingHttpHeaders | undefined)];
+  }
+  return [statusCode, mergeDevNoStoreHeaders(statusMessageOrHeaders as OutgoingHttpHeaders | undefined)];
+}
+
+function installDevNoStoreHeaderOverride(response: ServerResponse): void {
+  for (const [key, value] of Object.entries(devNoStoreHeaders())) {
+    if (value == null) continue;
+    response.setHeader(key, value);
+  }
+  const originalWriteHead = response.writeHead.bind(response) as WriteHeadOverride;
+  response.writeHead = ((statusCode: number, statusMessageOrHeaders?: string | OutgoingHttpHeaders, headers?: OutgoingHttpHeaders) => {
+    const patchedArgs = withDevNoStoreWriteHeadArgs(statusCode, statusMessageOrHeaders, headers);
+    if (patchedArgs.length === 3) {
+      return originalWriteHead(patchedArgs[0], patchedArgs[1], patchedArgs[2]);
+    }
+    return originalWriteHead(patchedArgs[0], patchedArgs[1]);
+  }) as ServerResponse["writeHead"];
 }
 
 export function normalizeDaemonProxyOriginHeader(options: {
@@ -876,9 +940,10 @@ async function createWebSidecarHandle(
   };
 }
 
-function createDaemonProxyHandler(
+export function createDaemonProxyHandler(
   daemonOrigin: string | null,
   fallback: (request: IncomingMessage, response: ServerResponse) => Promise<void>,
+  options: DaemonProxyHandlerOptions = {},
 ): (request: IncomingMessage, response: ServerResponse) => void {
   return (request, response) => {
     const daemonProxyTarget = daemonOrigin == null ? null : resolveDaemonProxyTarget(daemonOrigin, request.url);
@@ -891,6 +956,10 @@ function createDaemonProxyHandler(
         response.end(error instanceof Error ? error.message : String(error));
       });
       return;
+    }
+
+    if (options.preventStaticAssetBrowserCache === true && isNextStaticAssetRequest(request.url)) {
+      installDevNoStoreHeaderOverride(response);
     }
 
     void fallback(request, response).catch((error: unknown) => {
@@ -910,7 +979,9 @@ async function startRegularNextSidecar(
 
   const daemonOrigin = resolveDaemonOrigin();
   const handleRequest = app.getRequestHandler();
-  const httpServer = createHttpServer(createDaemonProxyHandler(daemonOrigin, handleRequest));
+  const httpServer = createHttpServer(createDaemonProxyHandler(daemonOrigin, handleRequest, {
+    preventStaticAssetBrowserCache: dev,
+  }));
 
   return await createWebSidecarHandle(runtime, httpServer, async () => {
     await app.close?.();

--- a/apps/web/tests/sidecar-proxy.test.ts
+++ b/apps/web/tests/sidecar-proxy.test.ts
@@ -11,6 +11,7 @@ import {
   createStandaloneParentMonitorImport,
   createStandaloneServerArgs,
   createDaemonProxyHandler,
+  isLikelyDocumentNavigationRequest,
   normalizeDaemonProxyOriginHeader,
   resolveDaemonProxyTarget,
   resolveNextBundlerOptions,
@@ -98,6 +99,61 @@ describe('createDaemonProxyHandler', () => {
     } finally {
       await closeHttpServer(server);
     }
+  });
+
+  it('clears browser cache on dev document navigations', async () => {
+    const server = createHttpServer(createDaemonProxyHandler(
+      null,
+      async (_request, response) => {
+        response.setHeader('Cache-Control', 'no-cache, must-revalidate');
+        response.setHeader('content-type', 'text/html; charset=utf-8');
+        response.end('<!doctype html>');
+      },
+      { preventStaticAssetBrowserCache: true },
+    ));
+    await new Promise<void>((resolveListen) => {
+      server.listen(0, '127.0.0.1', resolveListen);
+    });
+    const address = server.address() as AddressInfo;
+
+    try {
+      const response = await new Promise<HttpResponseSnapshot>((resolveRequest, rejectRequest) => {
+        const request = createHttpRequest(
+          new URL('/settings/project-locations', `http://127.0.0.1:${address.port}`),
+          { headers: { accept: 'text/html,application/xhtml+xml' } },
+          (serverResponse) => {
+            serverResponse.setEncoding('utf8');
+            let body = '';
+            serverResponse.on('data', (chunk: string) => {
+              body += chunk;
+            });
+            serverResponse.on('end', () => {
+              resolveRequest({ body, headers: serverResponse.headers });
+            });
+          },
+        );
+        request.on('error', rejectRequest);
+        request.end();
+      });
+
+      expect(response.body).toBe('<!doctype html>');
+      expect(response.headers['cache-control']).toBe(DEV_CLIENT_CACHE_CONTROL);
+      expect(response.headers['clear-site-data']).toBe('"cache"');
+      expect(response.headers.pragma).toBe('no-cache');
+      expect(response.headers.expires).toBe('0');
+    } finally {
+      await closeHttpServer(server);
+    }
+  });
+
+  it('does not treat static chunk requests as document navigations', () => {
+    const request = {
+      method: 'GET',
+      url: '/_next/static/chunks/app/layout.js',
+      headers: { accept: 'text/html' },
+    } as Parameters<typeof isLikelyDocumentNavigationRequest>[0];
+
+    expect(isLikelyDocumentNavigationRequest(request)).toBe(false);
   });
 });
 

--- a/apps/web/tests/sidecar-proxy.test.ts
+++ b/apps/web/tests/sidecar-proxy.test.ts
@@ -1,6 +1,8 @@
+import { request as createHttpRequest, createServer as createHttpServer, type IncomingHttpHeaders } from 'node:http';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { AddressInfo } from 'node:net';
 
 import { describe, expect, it } from 'vitest';
 
@@ -8,6 +10,7 @@ import {
   createStandaloneBackendEnv,
   createStandaloneParentMonitorImport,
   createStandaloneServerArgs,
+  createDaemonProxyHandler,
   normalizeDaemonProxyOriginHeader,
   resolveDaemonProxyTarget,
   resolveNextBundlerOptions,
@@ -15,6 +18,36 @@ import {
   resolveStandaloneServerEntry,
   startWebSidecar,
 } from '../sidecar/server';
+
+const DEV_CLIENT_CACHE_CONTROL = 'no-store, no-cache, must-revalidate, proxy-revalidate';
+
+type HttpResponseSnapshot = {
+  body: string;
+  headers: IncomingHttpHeaders;
+};
+
+async function requestFromServer(origin: string, path: string): Promise<HttpResponseSnapshot> {
+  return await new Promise<HttpResponseSnapshot>((resolveRequest, rejectRequest) => {
+    const request = createHttpRequest(new URL(path, origin), (response) => {
+      response.setEncoding('utf8');
+      let body = '';
+      response.on('data', (chunk: string) => {
+        body += chunk;
+      });
+      response.on('end', () => {
+        resolveRequest({ body, headers: response.headers });
+      });
+    });
+    request.on('error', rejectRequest);
+    request.end();
+  });
+}
+
+async function closeHttpServer(server: ReturnType<typeof createHttpServer>): Promise<void> {
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => (error == null ? resolveClose() : rejectClose(error)));
+  });
+}
 
 describe('resolveDaemonProxyTarget', () => {
   it('proxies allowlisted relative paths to the daemon origin', () => {
@@ -34,6 +67,37 @@ describe('resolveDaemonProxyTarget', () => {
 
   it('rejects non-daemon paths', () => {
     expect(resolveDaemonProxyTarget('http://127.0.0.1:7456', '/settings')).toBeNull();
+  });
+});
+
+describe('createDaemonProxyHandler', () => {
+  it('prevents stale browser caching for Next static chunks', async () => {
+    const server = createHttpServer(createDaemonProxyHandler(
+      null,
+      async (_request, response) => {
+        response.setHeader('Cache-Control', 'max-age=14400, must-revalidate');
+        response.end('chunk');
+      },
+      { preventStaticAssetBrowserCache: true },
+    ));
+    await new Promise<void>((resolveListen) => {
+      server.listen(0, '127.0.0.1', resolveListen);
+    });
+    const address = server.address() as AddressInfo;
+
+    try {
+      const response = await requestFromServer(
+        `http://127.0.0.1:${address.port}`,
+        '/_next/static/chunks/app/%5B%5B...slug%5D%5D/page.js',
+      );
+
+      expect(response.body).toBe('chunk');
+      expect(response.headers['cache-control']).toBe(DEV_CLIENT_CACHE_CONTROL);
+      expect(response.headers.pragma).toBe('no-cache');
+      expect(response.headers.expires).toBe('0');
+    } finally {
+      await closeHttpServer(server);
+    }
   });
 });
 

--- a/e2e/lib/playwright/suite.ts
+++ b/e2e/lib/playwright/suite.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { expect, test as base } from '@playwright/test';
 
 import { createToolsDevSuite, e2eWorkspaceRoot } from '../tools-dev/runtime.ts';
+import { T } from '../timeouts.ts';
 import type { ToolsDevSuite } from '../tools-dev/types.ts';
 
 type PlaywrightToolsDevSuite = ToolsDevSuite & {
@@ -53,7 +54,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         }
       }
     },
-    { scope: 'worker', timeout: 120_000 },
+    { scope: 'worker', timeout: T.xlong * 3 },
   ],
 
   baseURL: async ({ toolsDev }, use) => {

--- a/e2e/ui/visual-entry.test.ts
+++ b/e2e/ui/visual-entry.test.ts
@@ -46,6 +46,8 @@ test('[P2] captures the onboarding cloud sign-in surface', async ({ page }) => {
 });
 
 test('[P2] captures the visual home harness', async ({ page }) => {
+  test.setTimeout(T.xlong * 3);
+
   await configureVisualPage(page, { projects: [] });
   await gotoVisualHome(page);
 


### PR DESCRIPTION
## Why

During local development, stale Next.js document and chunk responses can keep old client code in the browser after a fresh deploy/restart, which makes UI fixes appear missing even when the server is serving the new build.

## What users will see

No production UI change. In dev, browser navigation and Next static chunk responses are harder to cache accidentally.

## Surface area

- [ ] UI / visual behavior
- [ ] Keyboard shortcuts
- [ ] CLI / env
- [ ] API / contract
- [ ] Extension points
- [ ] i18n
- [ ] Dependencies
- [x] Default behavior in dev
- [x] Internal web sidecar proxy behavior

## Screenshots

Not applicable; this is a dev sidecar cache-header fix.

## Bug fix verification

- Broken case: dev browsers could retain stale Next.js document/chunk responses after code changed.
- Fixed by applying no-store headers to dev static chunks and clearing browser cache on dev document navigation.
- Confirmed static chunk requests are not misclassified as document navigations.

## Validation

- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/sidecar-proxy.test.ts --reporter=dot --maxWorkers=1`

## Known unrelated failures

None.

## Related PRs or alternatives

- Split from #4867.
- Related CI baseline: #5017.

## Scope control

Scope-frozen to dev sidecar cache headers. This branch currently includes #5017's one-file visual-harness timeout until #5017 lands; after that merges, this branch can be rebased without changing product behavior.
