### PR TITLE
fix(daemon): reject path-traversal ids in readPromptTemplate

### DIFF
--- a/apps/daemon/src/prompt-templates.ts
+++ b/apps/daemon/src/prompt-templates.ts
@@ -72,7 +72,11 @@ export async function listPromptTemplates(root: string): Promise<PromptTemplate[
 
 export async function readPromptTemplate(root: string, surface: string, id: string): Promise<PromptTemplate | null> {
   if (!isPromptTemplateSurface(surface)) return null;
-  const filePath = path.join(root, surface, `${id}.json`);
+  const dir = path.join(root, surface);
+  const filePath = path.join(dir, `${id}.json`);
+  // `id` comes straight from the request path; a value like `../secret` would
+  // resolve outside the surface directory. Only read a direct child of it.
+  if (path.dirname(filePath) !== dir) return null;
   try {
     const raw = await readFile(filePath, 'utf8');
     const parsed = JSON.parse(raw);

--- a/apps/daemon/tests/prompt-templates.test.ts
+++ b/apps/daemon/tests/prompt-templates.test.ts
@@ -175,4 +175,15 @@ describe('readPromptTemplate', () => {
     );
     expect(await readPromptTemplate(root, 'image', 'bad')).toBeNull();
   });
+
+  it('returns null for a path-traversal id instead of reading outside the surface dir', async () => {
+    // `id` arrives straight from the request path (`/api/prompt-templates/:surface/:id`,
+    // where a percent-encoded `..%2f` decodes back to `../`). Plant a valid template one
+    // level above the surface dir and confirm a traversal id can't resolve to it.
+    await writeFile(
+      path.join(root, 'secret.json'),
+      JSON.stringify(makeTemplate({ id: '../secret' })),
+    );
+    expect(await readPromptTemplate(root, 'image', '../secret')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Why

`readPromptTemplate` joins the caller-supplied `id` straight into a filesystem path without checking that the result stays inside the surface directory. The daemon exposes it at `GET /api/prompt-templates/:surface/:id`, so a percent-encoded id such as `..%2f..%2ffoo` decodes to `../../foo` and escapes the templates directory — an arbitrary `.json` file read against the machine running the daemon. I noticed this while adding the prompt-template scanner tests in #2447 and am fixing it on its own so the containment is explicit rather than resting on the incidental `id === filename` validation.

## What users will see

Nothing changes for correctly-authored templates — every committed template id equals its filename, so all 104 still resolve. Only ids that would escape the surface directory (those containing a path separator or a `..` segment, which are never valid template ids) now return 404 instead of reading outside the directory.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal daemon hardening; no new product surface. The `/api/prompt-templates/:surface/:id` response is unchanged for every valid id; only traversal ids that never matched a real template are now rejected before the read.

## Bug fix verification

- **Bug:** `readPromptTemplate` joined `id` into the file path (`<root>/<surface>/<id>.json`) with no containment check, so a traversal id like `../secret` resolved outside the surface directory and returned its contents.
- **Test:** `apps/daemon/tests/prompt-templates.test.ts` → "returns null for a path-traversal id instead of reading outside the surface dir" plants `<root>/secret.json` one level above the `image` surface directory and asserts `readPromptTemplate(root, 'image', '../secret')` is null.
- **Red on main, green here?** Yes — on main the call returns the out-of-directory template's full contents; with the `path.dirname(filePath) !== dir` guard it returns null.

## Validation

- `pnpm --filter @open-design/daemon test` — `tests/prompt-templates.test.ts` 14/14, plus `tests/static-resource-routes.test.ts` and `tests/server-bootstrap-regression.test.ts` (which exercise the endpoint) 19/19.
- daemon `tsc --noEmit` for both `tsconfig.json` and `tsconfig.tests.json`.
