### PR TITLE
[codex] Restore stable release publish mode

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -8,12 +8,13 @@ on:
         required: true
         type: string
       dry_run:
-        description: "Dry-run boundary to validate. metadata stops after promotion metadata; prepublish runs build/smoke/report/plan without publishing."
+        description: "Release mode. metadata stops after promotion metadata; prepublish runs build/smoke/report/plan without publishing; publish performs the stable release."
         required: false
         type: choice
         options:
           - metadata
           - prepublish
+          - publish
         default: metadata
       ref:
         description: "Stable release branch to build, for example release/v0.5.1. Empty builds the dispatch ref, which must also be release/vX.Y.Z."
@@ -46,7 +47,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: "Dry-run boundary to validate: metadata or prepublish."
+        description: "Release mode: metadata, prepublish, or publish. The legacy false value is also accepted for callers."
         required: false
         type: string
         default: "metadata"
@@ -154,7 +155,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       GITHUB_REPOSITORY: ${{ github.repository }}
       OPEN_DESIGN_PRERELEASE_METADATA_URL: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}/prerelease/latest/metadata.json
-      OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run }}
+      OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run == 'publish' && 'false' || inputs.dry_run }}
       OPEN_DESIGN_RELEASE_CHANNEL: stable
       OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
       OPEN_DESIGN_STABLE_PRERELEASE_VERSION: ${{ inputs.prerelease_version }}

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1389,21 +1389,24 @@ process.stdin.on("end", () => {
     expect(script).toContain(".github/workflows/landing-page-staging.yml");
   });
 
-  it("[P2] supports stable dry-run metadata and prepublish boundaries", async () => {
+  it("[P2] supports stable metadata, prepublish, and publish dispatch modes", async () => {
     const [workflow, script] = await Promise.all([
       readFile(releaseStableWorkflowPath, "utf8"),
       readFile(releaseStableScriptPath, "utf8"),
     ]);
 
     expect(workflow).toContain("dry_run:");
-    expect(workflow).toContain("Dry-run boundary to validate. metadata stops after promotion metadata; prepublish runs build/smoke/report/plan without publishing.");
+    expect(workflow).toContain(
+      "Release mode. metadata stops after promotion metadata; prepublish runs build/smoke/report/plan without publishing; publish performs the stable release.",
+    );
     expect(workflow).toContain("group: open-design-release-stable-${{ inputs.dry_run }}");
     expect(workflow).toContain("type: choice");
     expect(workflow).toContain("- metadata");
     expect(workflow).toContain("- prepublish");
+    expect(workflow).toContain("- publish");
     expect(workflow).toContain("default: metadata");
     expect(workflow).not.toContain("inputs.channel");
-    expect(workflow).toContain("OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run }}");
+    expect(workflow).toContain("OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run == 'publish' && 'false' || inputs.dry_run }}");
     expect(workflow).toContain("dry_run: ${{ steps.stable.outputs.dry_run }}");
     expect(workflow).toContain("dry_run_mode: ${{ steps.stable.outputs.dry_run_mode }}");
     expect(workflow).toContain("if: ${{ needs.metadata.outputs.run_prepublish_jobs == 'true' }}");

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -310,7 +310,9 @@ describe("release workflows", () => {
     expect(stable).toContain("type: choice");
     expect(stable).toContain("- metadata");
     expect(stable).toContain("- prepublish");
+    expect(stable).toContain("- publish");
     expect(stable).toContain("default: metadata");
+    expect(stable).toContain("OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run == 'publish' && 'false' || inputs.dry_run }}");
     expect(stable).toContain("run_prepublish_jobs: ${{ steps.stable.outputs.run_prepublish_jobs }}");
     expect(stable).toContain("publish_side_effects_enabled: ${{ steps.stable.outputs.publish_side_effects_enabled }}");
     expect(stable).toContain("if: ${{ needs.metadata.outputs.run_prepublish_jobs == 'true' }}");

--- a/tools/release/tests/channel-prepare.test.ts
+++ b/tools/release/tests/channel-prepare.test.ts
@@ -411,6 +411,38 @@ describe("tools-release local channel prepare validation", () => {
     }
   });
 
+  it("prepares stable publish controls when dry-run is false", async () => {
+    const packagedVersion = await readPackagedVersion();
+    const prereleaseVersion = `${packagedVersion}-prerelease.2`;
+    const objects: Record<string, unknown> = {};
+    const server = await startMetadataServer(objects);
+    const ghRoot = await mkdtemp(join(tmpdir(), "od-tools-release-gh-"));
+    objects[`prerelease/versions/${prereleaseVersion}/metadata.json`] = stablePrereleaseMetadata(server.origin, packagedVersion);
+
+    try {
+      const fakeGh = await writeFakeGhScript(ghRoot);
+      const stable = await runPrepare("stable", {
+        GITHUB_REF_NAME: `release/v${packagedVersion}`,
+        GITHUB_REPOSITORY: "nexu-io/open-design",
+        GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+        OPEN_DESIGN_GH_NODE_SCRIPT: fakeGh,
+        OPEN_DESIGN_RELEASE_DRY_RUN: "false",
+        OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: server.origin,
+        OPEN_DESIGN_STABLE_PRERELEASE_VERSION: prereleaseVersion,
+      });
+
+      expect(stable.stdout).toContain("[release-stable] dry run: false");
+      expect(stable.outputs.dry_run).toBe("false");
+      expect(stable.outputs.dry_run_mode).toBe("");
+      expect(stable.outputs.github_release_enabled).toBe("true");
+      expect(stable.outputs.publish_side_effects_enabled).toBe("true");
+      expect(stable.outputs.run_prepublish_jobs).toBe("true");
+    } finally {
+      await server.close();
+      await rm(ghRoot, { force: true, recursive: true });
+    }
+  });
+
   it("rejects stable promotion inputs from non-prerelease counted channels", async () => {
     const packagedVersion = await readPackagedVersion();
     const objects: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- Restore the stable release workflow dispatch mode used for publish runs.
- Cover the stable release workflow and release channel preparation behavior with tests.
- Keep the stable release path aligned with the current automated release pipeline.

## Validation
- Not run locally; branch was inspected for a clean merge against latest `main` before opening the PR.
