### PR TITLE
[codex] Align stable release notes public origin

### DIFF
--- a/.github/scripts/release/github/stable-notes.sh
+++ b/.github/scripts/release/github/stable-notes.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-for name in BRANCH_NAME CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN GITHUB_OUTPUT GITHUB_REPOSITORY GITHUB_SHA RELEASE_CHANNEL RELEASE_SIGNED RELEASE_VERSION RUNNER_TEMP VERSION_TAG; do
+for name in BRANCH_NAME GITHUB_OUTPUT GITHUB_REPOSITORY GITHUB_SHA RELEASE_CHANNEL RELEASE_SIGNED RELEASE_VERSION RUNNER_TEMP VERSION_TAG; do
   if [ -z "${!name:-}" ]; then
     echo "$name is required" >&2
     exit 1
   fi
 done
 
+release_public_origin="${RELEASE_PUBLIC_ORIGIN:-${CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN:-}}"
+if [ -z "$release_public_origin" ]; then
+  echo "RELEASE_PUBLIC_ORIGIN or CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN is required" >&2
+  exit 1
+fi
+
 notes_file="$RUNNER_TEMP/open-design-stable-notes.md"
-public_origin="${CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN%/}"
+public_origin="${release_public_origin%/}"
 cat > "$notes_file" <<EOF
 ## Summary
 - channel: $RELEASE_CHANNEL

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1261,6 +1261,8 @@ jobs:
       - name: Write stable release notes
         id: notes
         if: ${{ needs.metadata.outputs.github_release_enabled == 'true' }}
+        env:
+          RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
         run: bash .github/scripts/release/github/stable-notes.sh
 
       - name: Create draft release with tag

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -36,6 +36,7 @@ const releaseBetaSelfHostedWorkflowPath = join(workspaceRoot, ".github", "workfl
 const releasePreviewWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-preview.yml");
 const releasePrereleaseWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-prerelease.yml");
 const releaseStableWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-stable.yml");
+const releaseStableNotesScriptPath = join(workspaceRoot, ".github", "scripts", "release", "github", "stable-notes.sh");
 const releasePreviewScriptPath = join(workspaceRoot, "tools", "release", "src", "metadata", "prepare-preview.ts");
 const releaseStableScriptPath = join(workspaceRoot, "tools", "release", "src", "metadata", "prepare-stable.ts");
 const releaseBetaScriptPath = join(workspaceRoot, "tools", "release", "src", "metadata", "prepare-beta.ts");
@@ -1407,6 +1408,8 @@ process.stdin.on("end", () => {
     expect(workflow).toContain("default: metadata");
     expect(workflow).not.toContain("inputs.channel");
     expect(workflow).toContain("OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run == 'publish' && 'false' || inputs.dry_run }}");
+    expect(workflow).toContain("RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}");
+    expect(workflow).toContain("run: bash .github/scripts/release/github/stable-notes.sh");
     expect(workflow).toContain("dry_run: ${{ steps.stable.outputs.dry_run }}");
     expect(workflow).toContain("dry_run_mode: ${{ steps.stable.outputs.dry_run_mode }}");
     expect(workflow).toContain("if: ${{ needs.metadata.outputs.run_prepublish_jobs == 'true' }}");
@@ -1418,6 +1421,43 @@ process.stdin.on("end", () => {
     expect(script).toContain('setOutput("dry_run_mode", stableDryRunMode);');
     expect(script).toContain('setOutput("run_prepublish_jobs", runPrepublishJobs ? "true" : "false");');
     expect(script).toContain('setOutput("publish_side_effects_enabled", publishSideEffectsEnabled ? "true" : "false");');
+  });
+
+  it("[P2] writes stable release notes from the release public origin variable", async () => {
+    for (const [envName, origin] of [
+      ["RELEASE_PUBLIC_ORIGIN", "https://releases.open-design.ai/current/"],
+      ["CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN", "https://releases.open-design.ai/legacy/"],
+    ] as const) {
+      const runnerTemp = await mkdtemp(join(tmpdir(), "od-stable-notes-"));
+      const outputPath = join(runnerTemp, "github-output.txt");
+
+      try {
+        await execFileAsync("bash", [releaseStableNotesScriptPath], {
+          cwd: workspaceRoot,
+          env: {
+            ...process.env,
+            BRANCH_NAME: "release/v0.13.0",
+            CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN: envName === "CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN" ? origin : "",
+            GITHUB_OUTPUT: outputPath,
+            GITHUB_REPOSITORY: "nexu-io/open-design",
+            GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+            RELEASE_CHANNEL: "stable",
+            RELEASE_PUBLIC_ORIGIN: envName === "RELEASE_PUBLIC_ORIGIN" ? origin : "",
+            RELEASE_SIGNED: "true",
+            RELEASE_VERSION: "0.13.0",
+            RUNNER_TEMP: runnerTemp,
+            VERSION_TAG: "open-design-v0.13.0",
+          },
+        });
+
+        const outputs = parseGithubOutput(await readFile(outputPath, "utf8"));
+        const notes = await readFile(outputs.notes_file ?? "", "utf8");
+        expect(notes).toContain(`R2 metadata: ${origin.replace(/\/+$/, "")}/stable/latest/metadata.json`);
+        expect(notes).toContain(`E2E report: ${origin.replace(/\/+$/, "")}/stable/versions/0.13.0/report.zip`);
+      } finally {
+        await rm(runnerTemp, { force: true, recursive: true });
+      }
+    }
   });
 
   it("[P2] validates stable dry-run prerelease metadata from a release branch", async () => {


### PR DESCRIPTION
## Summary
- Align stable release notes generation with the public GitHub origin used for published releases.
- Update stable release workflow wiring for the public-origin notes path.
- Add packaged smoke coverage for the stable notes public origin behavior.

## Validation
- Not run locally; branch was inspected for a clean merge against latest `main` before opening the PR.
