### PR TITLE
[AFK] 把 Home 外层工作区容器从按视口 `100vw` 撑宽改成按父容器 `100%` 跟随，避免把滚动条宽度也算进布局，导致内容明明没超宽却

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -18,8 +18,8 @@
 
 .workspace-shell {
   --workspace-tabs-chrome-height: 38px;
-  width: 100vw;
-  max-width: 100vw;
+  width: 100%;
+  max-width: 100%;
   height: 100vh;
   min-width: 0;
   min-height: 0;

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -27,6 +27,14 @@ function ruleValue(block: string, property: string): string {
 }
 
 describe('workspace tabs chrome styles', () => {
+  it('sizes the workspace shell from its parent instead of the viewport width', () => {
+    const workspaceShell = cssDeclarations(shellCss, '.workspace-shell');
+
+    expect(ruleValue(workspaceShell, 'width')).toBe('100%');
+    expect(ruleValue(workspaceShell, 'max-width')).toBe('100%');
+    expect(ruleValue(workspaceShell, 'overflow')).toBe('hidden');
+  });
+
   it('keeps only a small intentional inset before the first tab', () => {
     const chrome = cssDeclarations(shellCss, '.workspace-tabs-chrome.app-chrome-header');
     const traffic = cssDeclarations(shellCss, '.workspace-tabs-chrome .workspace-tabs-traffic');


### PR DESCRIPTION
把 Home 外层工作区容器从按视口 `100vw` 撑宽改成按父容器 `100%` 跟随，避免把滚动条宽度也算进布局，导致内容明明没超宽却冒出横向滚动条。
同时补了一个样式回归测试，专门锁定这个壳层宽度约束，防止类似的假滚动条问题再次回归。

改动文件:
- `apps/web/src/styles/shell.css`
- `apps/web/tests/styles/workspace-tabs-chrome.test.ts`

> 🤖 AFK 生成,待人工 code review + QA 验收。