### PR TITLE
Classify AMR account errors from ACP details

### DIFF
--- a/apps/daemon/src/integrations/vela-errors.ts
+++ b/apps/daemon/src/integrations/vela-errors.ts
@@ -7,6 +7,15 @@ export interface AmrAccountFailure {
   actionUrl?: string;
 }
 
+export interface AmrAccountFailureSignal {
+  details?: unknown;
+  message?: unknown;
+  errorMessage?: unknown;
+  errorCode?: unknown;
+  stdoutTail?: unknown;
+  stderrTail?: unknown;
+}
+
 // `source=open_design` tags the wallet landing page_view so vela analytics can
 // attribute the recharge visit to Open Design.
 export const DEFAULT_AMR_RECHARGE_URL =
@@ -44,6 +53,52 @@ function containsInsufficientBalanceSignal(value: string): boolean {
     return true;
   }
   return value.includes('quota') && /\b(wallet|balance|credit|billing|funds?)\b/.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function classifyAmrAccountFailureDetails(details: unknown): AmrAccountFailure | null {
+  if (!isRecord(details)) return null;
+  const code = typeof details.code === 'string' ? details.code.toLowerCase() : '';
+  const accountAction =
+    typeof details.accountAction === 'string' ? details.accountAction.toLowerCase() : '';
+
+  if (code === 'insufficient_balance' || accountAction === 'recharge') {
+    return {
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      message: AMR_INSUFFICIENT_BALANCE_MESSAGE,
+      action: 'recharge',
+      actionUrl: DEFAULT_AMR_RECHARGE_URL,
+    };
+  }
+
+  return null;
+}
+
+function stringPart(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+export function classifyAmrAccountFailureSignal(
+  signal: AmrAccountFailureSignal,
+): AmrAccountFailure | null {
+  const structured = classifyAmrAccountFailureDetails(signal.details);
+  if (structured) return structured;
+
+  const primaryText = [
+    stringPart(signal.message),
+    stringPart(signal.errorMessage),
+    stringPart(signal.errorCode),
+    stringPart(signal.stdoutTail),
+  ].join('\n');
+  const primary = classifyAmrAccountFailure(primaryText);
+  if (primary) return primary;
+
+  // Stderr is intentionally last. Prefer ACP structured details and protocol
+  // messages so AMR account errors are managed through one stable channel.
+  return classifyAmrAccountFailure(stringPart(signal.stderrTail));
 }
 
 export function classifyAmrAccountFailure(text: string): AmrAccountFailure | null {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -160,7 +160,7 @@ import {
 } from './integrations/vela.js';
 import {
   amrAccountFailureDetails,
-  classifyAmrAccountFailure,
+  classifyAmrAccountFailureSignal,
 } from './integrations/vela-errors.js';
 import { amrModelLoadingCache } from './runtimes/amr-model-cache.js';
 import {
@@ -8171,15 +8171,14 @@ export async function startServer({
           noteAgentActivity();
           if (event === 'error') flushVisibleAgentStderr();
           if (def.id === 'amr' && event === 'error') {
-            const failure = classifyAmrAccountFailure(
-              [
-                typeof data?.message === 'string' ? data.message : '',
-                typeof data?.error?.message === 'string' ? data.error.message : '',
-                typeof data?.error?.code === 'string' ? data.error.code : '',
-                agentStdoutTail,
-                agentStderrTail,
-              ].join('\n'),
-            );
+            const failure = classifyAmrAccountFailureSignal({
+              details: data?.error?.details,
+              message: data?.message,
+              errorMessage: data?.error?.message,
+              errorCode: data?.error?.code,
+              stdoutTail: agentStdoutTail,
+              stderrTail: agentStderrTail,
+            });
             if (failure) {
               sendAmrAccountFailure(failure);
               return;
@@ -8382,9 +8381,10 @@ export async function startServer({
         !run.cancelRequested
       ) {
         if (def.id === 'amr') {
-          const amrFailure = classifyAmrAccountFailure(
-            `${agentStderrTail}\n${agentStdoutTail}`,
-          );
+          const amrFailure = classifyAmrAccountFailureSignal({
+            stdoutTail: agentStdoutTail,
+            stderrTail: agentStderrTail,
+          });
           if (amrFailure) {
             sendAmrAccountFailure(amrFailure);
             return finishWithRetryDecision('failed', code ?? 1, signal ?? null);

--- a/apps/daemon/tests/integrations/vela-errors.test.ts
+++ b/apps/daemon/tests/integrations/vela-errors.test.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_AMR_RECHARGE_URL,
   amrAccountFailureDetails,
   classifyAmrAccountFailure,
+  classifyAmrAccountFailureDetails,
+  classifyAmrAccountFailureSignal,
 } from '../../src/integrations/vela-errors.js';
 
 describe('AMR account failure classification', () => {
@@ -22,6 +24,88 @@ describe('AMR account failure classification', () => {
       kind: 'amr_account',
       action: 'recharge',
       actionUrl: DEFAULT_AMR_RECHARGE_URL,
+    });
+  });
+
+  it('classifies structured Vela ACP insufficient-balance details without relying on message text', () => {
+    const failure = classifyAmrAccountFailureDetails({
+      kind: 'opencode_prompt_error',
+      runtime: 'opencode',
+      phase: 'event_stream',
+      code: 'insufficient_balance',
+      accountAction: 'recharge',
+      openCodeSessionId: 'ses_test',
+    });
+
+    expect(failure).toMatchObject({
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      action: 'recharge',
+      actionUrl: DEFAULT_AMR_RECHARGE_URL,
+    });
+  });
+
+  it('classifies structured Vela ACP recharge actions even when code is absent', () => {
+    const failure = classifyAmrAccountFailureDetails({
+      kind: 'opencode_prompt_error',
+      accountAction: 'recharge',
+    });
+
+    expect(failure).toMatchObject({
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      action: 'recharge',
+    });
+  });
+
+  it('does not classify unrelated structured ACP details as AMR balance errors', () => {
+    expect(classifyAmrAccountFailureDetails({
+      kind: 'opencode_prompt_error',
+      code: 'model_unavailable',
+      accountAction: 'choose_model',
+    })).toBeNull();
+    expect(classifyAmrAccountFailureDetails(null)).toBeNull();
+  });
+
+  it('classifies AMR account failures through the unified structured-first signal path', () => {
+    const failure = classifyAmrAccountFailureSignal({
+      details: {
+        kind: 'opencode_prompt_error',
+        code: 'insufficient_balance',
+        accountAction: 'recharge',
+      },
+      message: 'json-rpc id 4: request failed',
+      stderrTail: '',
+    });
+
+    expect(failure).toMatchObject({
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      action: 'recharge',
+    });
+  });
+
+  it('uses stderr only as the final AMR account failure fallback', () => {
+    const failure = classifyAmrAccountFailureSignal({
+      message: 'json-rpc id 4: request failed',
+      errorMessage: 'request failed',
+      errorCode: 'AGENT_EXECUTION_FAILED',
+      stdoutTail: '',
+      stderrTail: 'opencode_event_stream_failure: [code=insufficient_balance] insufficient wallet balance',
+    });
+
+    expect(failure).toMatchObject({
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      action: 'recharge',
+    });
+  });
+
+  it('does not use stderr when structured or protocol text already classifies the failure', () => {
+    const failure = classifyAmrAccountFailureSignal({
+      message: 'invalid session for AMR profile',
+      stderrTail: 'opencode_event_stream_failure: [code=insufficient_balance] insufficient wallet balance',
+    });
+
+    expect(failure).toMatchObject({
+      code: 'AMR_AUTH_REQUIRED',
+      action: 'relogin',
     });
   });
 


### PR DESCRIPTION
## Why

Vela now returns AMR insufficient-balance failures through structured ACP response details, while older clients may still see protocol text or stderr tails. Open Design should prefer the structured response so the recharge error can be managed through one stable client path, with stderr kept only as a compatibility fallback.

## What users will see

When AMR reports insufficient balance, Open Design continues to show the existing insufficient-balance recovery card with the recharge action, but detection no longer depends on stderr output when structured ACP details are present.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/integrations/vela-errors.test.ts`
- Did the test go red on `main` and green on this branch? No. I added regression coverage for the new structured ACP detail path and the stderr-last fallback behavior.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run -c vitest.config.ts tests/integrations/vela-errors.test.ts`
- `pnpm --filter @open-design/diagnostics build && pnpm --filter @open-design/daemon typecheck`