### PR TITLE
landing: add "Request team access" CTA to the Ikigai One story

### DIFF
--- a/apps/landing-page/app/_partials/ikigai-one-main.ar.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.ar.html
@@ -7,7 +7,7 @@
     <div class="v4eye">قصة عميل &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design هو <span class="grn">ميزتنا التنافسية الحاسمة.</span>&rdquo;</h1>
     <p class="v4sub">كيف تُدير Ikigai One كامل أعمالها مع العملاء على Open Design &mdash; أنظمة العلامة التجارية، ومخرجات العملاء، بل وحتى بوابة عملاء فعلية على الإنترنت، كلّها أرخص <b>~50&times;</b> مما كانت عليه.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">حمِّل Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">حمِّل Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">اطلب وصول الفريق &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">الخطوة التالية</div>
   <h2 class="v4final-h">ميزتك التنافسية الحاسمة على بُعد عملية تنزيل واحدة.</h2>
   <p class="v4final-p">Open Design مجاني ومفتوح المصدر، ويعمل على جهازك أنت وبمفاتيحك أنت. تُدير استوديو أو فريق تسويق؟ تحدّث إلينا عن أنظمة العلامة التجارية المشتركة، وأصول العملاء، وسير عمل الفِرق.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">حمِّل تطبيق سطح المكتب &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">حمِّل تطبيق سطح المكتب &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">اطلب وصول الفريق &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.de.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.de.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Kundenstory &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design ist unser <span class="grn">unfairer Vorteil.</span>&rdquo;</h1>
     <p class="v4sub">Wie Ikigai One seine gesamte Kundenarbeit auf Open Design abwickelt &mdash; Markensysteme, Kundendeliverables, sogar ein live geschaltetes Kundenportal, alles <b>~50&times; g&uuml;nstiger</b> als zuvor.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Open Design herunterladen &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Open Design herunterladen &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Teamzugang anfragen &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">N&auml;chster Schritt</div>
   <h2 class="v4final-h">Ihr unfairer Vorteil ist nur einen Download entfernt.</h2>
   <p class="v4final-p">Open Design ist kostenlos, Open Source und l&auml;uft auf Ihrem eigenen Rechner mit Ihren eigenen Keys. Sie f&uuml;hren ein Studio oder ein Marketing-Team? Sprechen Sie mit uns &uuml;ber gemeinsame Markensysteme, Kunden-Assets und Team-Workflows.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Desktop herunterladen &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Desktop herunterladen &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Teamzugang anfragen &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.es.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.es.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Caso de cliente &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design es nuestra <span class="grn">ventaja injusta.</span>&rdquo;</h1>
     <p class="v4sub">Cómo Ikigai One gestiona todo su trabajo con clientes en Open Design &mdash; sistemas de marca, entregables para clientes e incluso un portal en producción, todo <b>~50&times; más barato</b> que antes.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Descargar Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Descargar Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Solicitar acceso para equipos &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Siguiente paso</div>
   <h2 class="v4final-h">Tu ventaja injusta está a solo una descarga de distancia.</h2>
   <p class="v4final-p">Open Design es gratuito, de código abierto y funciona en tu propia máquina con tus propias claves. ¿Llevas un estudio o un equipo de marketing? Hablemos sobre sistemas de marca compartidos, assets para clientes y flujos de trabajo en equipo.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Descargar para escritorio &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Descargar para escritorio &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Solicitar acceso para equipos &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.fr.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.fr.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Témoignage client &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design, c&rsquo;est notre <span class="grn">avantage déloyal.</span>&rdquo;</h1>
     <p class="v4sub">Comment Ikigai One gère toute sa production client sur Open Design &mdash; systèmes de marque, livrables clients, et même un portail client en ligne, le tout <b>~50&times; moins cher</b> qu&rsquo;avant.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Télécharger Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Télécharger Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Demander l'accès équipe &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Étape suivante</div>
   <h2 class="v4final-h">Votre avantage déloyal n&rsquo;est qu&rsquo;à un téléchargement.</h2>
   <p class="v4final-p">Open Design est gratuit, open source, et tourne sur votre propre machine avec vos propres clés. Vous dirigez un studio ou une équipe marketing&nbsp;? Parlons-en : systèmes de marque partagés, assets clients et workflows d&rsquo;équipe.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Télécharger l&rsquo;application desktop &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Télécharger l&rsquo;application desktop &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Demander l'accès équipe &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Customer story &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design is our <span class="grn">unfair advantage.</span>&rdquo;</h1>
     <p class="v4sub">How Ikigai One runs its client work on Open Design &mdash; brand systems, client deliverables, even a live portal, all <b>~50&times; cheaper</b> than before.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Download Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Download Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Request team access &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Next step</div>
   <h2 class="v4final-h">Your unfair advantage is one download away.</h2>
   <p class="v4final-p">Open Design is free, open-source, and runs on your own machine and your own keys. Running a studio or a marketing team? Talk to us about shared brand systems, client assets, and team workflows.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Download desktop &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Download desktop &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Request team access &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.id.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.id.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Kisah pelanggan &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design adalah <span class="grn">keunggulan tak tertandingi</span> kami.&rdquo;</h1>
     <p class="v4sub">Bagaimana Ikigai One menjalankan seluruh pekerjaan kliennya di Open Design &mdash; sistem brand, deliverable klien, bahkan portal yang benar-benar live, semuanya <b>~50&times; lebih murah</b> dari sebelumnya.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Unduh Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Unduh Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Minta akses tim &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Langkah berikutnya</div>
   <h2 class="v4final-h">Keunggulan tak tertandingi Anda tinggal satu unduhan lagi.</h2>
   <p class="v4final-p">Open Design gratis, open-source, dan berjalan di mesin Anda sendiri dengan key Anda sendiri. Menjalankan studio atau tim marketing? Mari bicara soal sistem brand bersama, aset klien, dan alur kerja tim.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Unduh versi desktop &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Unduh versi desktop &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Minta akses tim &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.it.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.it.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Storia cliente &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design &egrave; il nostro <span class="grn">vantaggio sleale.</span>&rdquo;</h1>
     <p class="v4sub">Come Ikigai One gestisce tutto il lavoro per i clienti su Open Design &mdash; sistemi di brand, deliverable per i clienti, perfino un portale live, il tutto a un costo <b>~50&times; inferiore</b> rispetto a prima.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Scarica Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Scarica Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Richiedi accesso per team &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Passo successivo</div>
   <h2 class="v4final-h">Il tuo vantaggio sleale &egrave; a un download di distanza.</h2>
   <p class="v4final-p">Open Design &egrave; gratuito, open-source e gira sulla tua macchina e sulle tue chiavi. Gestisci uno studio o un team di marketing? Parliamo di sistemi di brand condivisi, asset per i clienti e flussi di lavoro di team.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Scarica per desktop &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Scarica per desktop &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Richiedi accesso per team &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.ja.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.ja.html
@@ -7,7 +7,7 @@
     <div class="v4eye">お客様事例 &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design は私たちの<span class="grn">アンフェアな強みです。</span>&rdquo;</h1>
     <p class="v4sub">Ikigai One が Open Design でクライアント業務を回す方法 &mdash; ブランドシステムも、納品物も、稼働中のクライアントポータルまで、すべて以前より <b>~50&times; 安く</b>。</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Open Design をダウンロード &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Open Design をダウンロード &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">チームアクセスを申請 &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">次のステップ</div>
   <h2 class="v4final-h">あなたのアンフェアな強みは、ダウンロード 1 回の先にある。</h2>
   <p class="v4final-p">Open Design は無料・オープンソースで、あなた自身のマシンと、あなた自身の API キーで動く。スタジオやマーケティングチームを率いていますか? 共有ブランドシステム、クライアントアセット、チームのワークフローについて、ぜひご相談ください。</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">デスクトップ版をダウンロード &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">デスクトップ版をダウンロード &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">チームアクセスを申請 &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.ko.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.ko.html
@@ -7,7 +7,7 @@
     <div class="v4eye">고객 사례 &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design은 우리의 <span class="grn">압도적 우위입니다.</span>&rdquo;</h1>
     <p class="v4sub">Ikigai One이 Open Design 하나로 클라이언트 업무 전체를 돌리는 법 &mdash; 브랜드 시스템, 클라이언트 산출물, 심지어 실제 운영 중인 포털까지, 전부 예전보다 <b>~50&times; 저렴하게</b>.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Open Design 다운로드 &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Open Design 다운로드 &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">팀 액세스 요청 &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">다음 단계</div>
   <h2 class="v4final-h">당신의 압도적 우위, 다운로드 한 번이면 됩니다.</h2>
   <p class="v4final-p">Open Design은 무료이자 오픈소스이며, 당신의 컴퓨터에서 당신의 키로 돌아갑니다. 스튜디오나 마케팅 팀을 운영하시나요? 공유 브랜드 시스템, 클라이언트 자산, 팀 워크플로에 대해 저희와 이야기 나눠요.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">데스크톱 다운로드 &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">데스크톱 다운로드 &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">팀 액세스 요청 &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.nl.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.nl.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Klantverhaal &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design is ons <span class="grn">oneerlijke voordeel.</span>&rdquo;</h1>
     <p class="v4sub">Hoe Ikigai One zijn volledige klantwerk draait op Open Design &mdash; merksystemen, klantdeliverables, zelfs een live portal, en dat allemaal <b>~50&times; goedkoper</b> dan voorheen.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Download Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Download Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Teamtoegang aanvragen &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Volgende stap</div>
   <h2 class="v4final-h">Jouw oneerlijke voordeel is &eacute;&eacute;n download verwijderd.</h2>
   <p class="v4final-p">Open Design is gratis, open-source en draait op je eigen machine met je eigen keys. Run je een studio of een marketingteam? Praat met ons over gedeelde merksystemen, klantassets en teamworkflows.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Download desktop &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Download desktop &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Teamtoegang aanvragen &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.pl.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.pl.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Historia klienta &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design to nasza <span class="grn">nieuczciwa przewaga.</span>&rdquo;</h1>
     <p class="v4sub">Jak Ikigai One realizuje całą pracę dla klientów na Open Design &mdash; systemy marki, materiały dla klientów, a nawet działający portal klienta, wszystko <b>~50&times; taniej</b> niż wcześniej.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Pobierz Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Pobierz Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Poproś o dostęp dla zespołu &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Następny krok</div>
   <h2 class="v4final-h">Twoja nieuczciwa przewaga jest o jedno pobranie stąd.</h2>
   <p class="v4final-p">Open Design jest darmowy, open-source i działa na Twoim własnym komputerze oraz Twoich własnych kluczach. Prowadzisz studio albo zespół marketingowy? Porozmawiajmy o współdzielonych systemach marki, zasobach dla klientów i przepływach pracy zespołu.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Pobierz wersję desktopową &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Pobierz wersję desktopową &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Poproś o dostęp dla zespołu &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.pt-br.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.pt-br.html
@@ -7,7 +7,7 @@
     <div class="v4eye">História de cliente &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;O Open Design é a nossa <span class="grn">vantagem injusta.</span>&rdquo;</h1>
     <p class="v4sub">Como a Ikigai One toca todo o trabalho de cliente no Open Design &mdash; sistemas de marca, entregáveis para clientes, até um portal no ar, tudo <b>~50&times; mais barato</b> do que antes.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Baixar o Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Baixar o Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Solicitar acesso para equipes &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Próximo passo</div>
   <h2 class="v4final-h">Sua vantagem injusta está a um download de distância.</h2>
   <p class="v4final-p">O Open Design é gratuito, open-source e roda na sua própria máquina, com as suas próprias chaves. Toca um estúdio ou um time de marketing? Fale com a gente sobre sistemas de marca compartilhados, ativos de clientes e fluxos de trabalho em equipe.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Baixar desktop &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Baixar desktop &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Solicitar acesso para equipes &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.ru.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.ru.html
@@ -7,7 +7,7 @@
     <div class="v4eye">История клиента &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design &mdash; наше <span class="grn">несправедливое преимущество.</span>&rdquo;</h1>
     <p class="v4sub">Как Ikigai One ведёт всю работу с клиентами в Open Design &mdash; брендбуки, клиентские материалы и даже работающий клиентский портал, и всё это <b>~50&times; дешевле</b>, чем раньше.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Скачать Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Скачать Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Запросить доступ для команды &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Следующий шаг</div>
   <h2 class="v4final-h">Ваше несправедливое преимущество &mdash; в одном скачивании.</h2>
   <p class="v4final-p">Open Design бесплатный, с открытым кодом и работает на вашей машине и на ваших собственных ключах. Управляете студией или маркетинговой командой? Расскажем о совместных брендовых системах, клиентских ассетах и командных рабочих процессах.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Скачать для десктопа &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Скачать для десктопа &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Запросить доступ для команды &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.tr.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.tr.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Müşteri hikayesi &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design, <span class="grn">haksız rekabet avantajımız.</span>&rdquo;</h1>
     <p class="v4sub">Ikigai One, tüm müşteri işlerini Open Design üzerinde nasıl yürütüyor &mdash; marka sistemleri, müşteri teslimatları, hatta canlı bir müşteri portalı, hepsi eskisinden <b>~50&times; daha ucuz</b>.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Open Design'ı indir &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Open Design'ı indir &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Ekip erişimi talep et &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Sonraki adım</div>
   <h2 class="v4final-h">Haksız rekabet avantajınız tek bir indirme uzağınızda.</h2>
   <p class="v4final-p">Open Design ücretsiz, açık kaynaklı ve kendi makinenizde, kendi anahtarlarınızla çalışıyor. Bir stüdyo ya da pazarlama ekibi mi yönetiyorsunuz? Paylaşılan marka sistemleri, müşteri varlıkları ve ekip iş akışları hakkında bizimle konuşun.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Masaüstü uygulamasını indir &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Masaüstü uygulamasını indir &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Ekip erişimi talep et &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.uk.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.uk.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Історія клієнта &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design &mdash; це наша <span class="grn">нечесна перевага.</span>&rdquo;</h1>
     <p class="v4sub">Як Ikigai One веде всю роботу з клієнтами на Open Design &mdash; бренд-системи, клієнтські матеріали й навіть живий портал, і все це <b>~50&times; дешевше</b>, ніж раніше.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Завантажити Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Завантажити Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Запросити доступ для команди &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Наступний крок</div>
   <h2 class="v4final-h">Ваша нечесна перевага &mdash; за одне завантаження.</h2>
   <p class="v4final-p">Open Design безкоштовний, з відкритим кодом і працює на вашій власній машині та ваших власних ключах. Керуєте студією чи маркетинговою командою? Поговорімо про спільні бренд-системи, клієнтські матеріали й командні робочі процеси.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Завантажити для десктопа &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Завантажити для десктопа &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Запросити доступ для команди &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.vi.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.vi.html
@@ -7,7 +7,7 @@
     <div class="v4eye">Câu chuyện khách hàng &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design là <span class="grn">lợi thế vượt trội</span> của chúng tôi.&rdquo;</h1>
     <p class="v4sub">Cách Ikigai One vận hành toàn bộ công việc với khách hàng trên Open Design &mdash; hệ thống thương hiệu, sản phẩm bàn giao cho khách, thậm chí một cổng thông tin chạy thật, tất cả đều rẻ hơn <b>~50&times;</b> so với trước.</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Tải Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">Tải Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">Yêu cầu quyền truy cập nhóm &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">Bước tiếp theo</div>
   <h2 class="v4final-h">Lợi thế vượt trội của bạn chỉ cách một lần tải về.</h2>
   <p class="v4final-p">Open Design miễn phí, mã nguồn mở, và chạy trên chính máy của bạn với key của bạn. Đang điều hành một studio hay một đội marketing? Hãy trò chuyện với chúng tôi về hệ thống thương hiệu dùng chung, tài sản khách hàng, và quy trình làm việc nhóm.</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Tải bản desktop &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">Tải bản desktop &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">Yêu cầu quyền truy cập nhóm &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.zh-tw.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.zh-tw.html
@@ -7,7 +7,7 @@
     <div class="v4eye">客戶故事 &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design 是我們的<span class="grn">不公平優勢。</span>&rdquo;</h1>
     <p class="v4sub">Ikigai One 如何用 Open Design 跑完整套客戶交付 &mdash; 品牌系統、客戶交付物,甚至一個上線的客戶入口網站,全都比從前便宜 <b>~50&times;</b>。</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">下載 Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">下載 Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">申請團隊版存取 &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">下一步</div>
   <h2 class="v4final-h">你的不公平優勢,只差一次下載。</h2>
   <p class="v4final-p">Open Design 免費、開源,跑在你自己的機器、用你自己的 key。手上帶著一間工作室或一支行銷團隊?來聊聊共享品牌系統、客戶素材和團隊協作流程。</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">下載桌面版 &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">下載桌面版 &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">申請團隊版存取 &nearr;</a></div>
  </div>
 </section>
 </main>

--- a/apps/landing-page/app/_partials/ikigai-one-main.zh.html
+++ b/apps/landing-page/app/_partials/ikigai-one-main.zh.html
@@ -7,7 +7,7 @@
     <div class="v4eye">客户故事 &middot; Ikigai One</div>
     <h1 class="v4h1">&ldquo;Open Design 是我们的<span class="grn">不公平优势。</span>&rdquo;</h1>
     <p class="v4sub">Ikigai One 如何用 Open Design 跑通整条客户交付 &mdash; 品牌系统、客户物料,甚至一个上线的客户门户,全都比从前便宜 <b>~50&times;</b>。</p>
-    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">下载 Open Design &nearr;</a></div>
+    <div class="v4cta-row"><a class="v4btn-p" href="https://open-design.ai/download/">下载 Open Design &nearr;</a><a class="v4btn-g" href="https://open-design.ai/enterprise/">申请团队版访问 &nearr;</a></div>
    </div>
    <aside class="v4snap">
     <div class="v4snap-head"><img class="v4snap-logo" src="/stories/ikigai-one-logo.png" alt="Ikigai One logo" width="38" height="38"><div class="v4snap-name"><a href="https://ikigai.one/" target="_blank" rel="noopener">Ikigai One</a></div></div>
@@ -107,7 +107,7 @@
   <div class="v4eye grn-eye">下一步</div>
   <h2 class="v4final-h">你的不公平优势,只差一次下载。</h2>
   <p class="v4final-p">Open Design 免费、开源,跑在你自己的机器、用你自己的 key。在带工作室或营销团队?来聊聊共享品牌系统、客户素材和团队协作工作流。</p>
-  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">下载桌面端 &nearr;</a></div>
+  <div class="v4cta-row"><a class="v4btn-coral" href="https://open-design.ai/download/">下载桌面端 &nearr;</a><a class="v4btn-gd" href="https://open-design.ai/enterprise/">申请团队版访问 &nearr;</a></div>
  </div>
 </section>
 </main>


### PR DESCRIPTION
## Why

The Ikigai One customer story is entirely about a *team* running its client work on Open Design — shared brand system, client deliverables, even a live portal. Now that the **Workspace for Teams** lead page (`/enterprise/`) is live, the story's hero and final CTA cards should give team-shaped readers a way in, not just "Download".

The final CTA copy already pitches teams ("Running a studio or a marketing team? Talk to us about shared brand systems, client assets, and team workflows") but had **no button**; the hero had none at all. At launch we intentionally shipped Download-only because the team lead form wasn't live yet — this restores the intended secondary CTA now that it is.

## What users will see

On the customer-story page (and every localized variant), each CTA row now shows a **secondary button next to Download**:

- **Hero**: `Download Open Design` + a light ghost `Request team access`
- **Final (dark) CTA**: `Download desktop` + a white-outline `Request team access`

Both link to **https://open-design.ai/enterprise/** (Workspace for Teams early access). The primary Download buttons and all existing copy are unchanged; the hero stays light (button only, no extra sentence) so it doesn't interrupt the read.

## Surface area

- [x] **None** — content only.

> Clarification: `apps/landing-page` marketing content (the public customer-story page). User-visible on the live marketing site (see preview) but touches no `apps/web`/`apps/desktop` UI, no CLI/env, no API/contract, no app i18n keys, and no dependencies.

## Screenshots

CF staging preview → open `/stories/ikigai-one/`: the hero row and the final dark CTA row each now carry a `Request team access` secondary button linking to `/enterprise/`. Applies across all 18 language variants.

## Bug fix verification

N/A — not a bug fix.

## Validation

- `apps/landing-page` typecheck: `astro check` → **0 errors, 0 warnings** (pre-existing unrelated hints only).
- Verified every one of the 18 partials gets exactly one hero (`v4btn-g`) + one final (`v4btn-gd`) `/enterprise/` CTA; ran the story locally (`astro dev`) and confirmed **en** and **zh** render the new button in both spots.
- ⚠️ The localized **button label** ("Request team access") is **machine-translated** across the 17 non-English locales — worth a native / team check before merge. English copy and the existing (already-localized) team pitch copy are unchanged.
