### PR TITLE
feat(landing): reposition homepage to Vibe Design Workspace + Claude Design alternative SEO

### DIFF
--- a/apps/landing-page/AGENTS.md
+++ b/apps/landing-page/AGENTS.md
@@ -78,9 +78,14 @@ Tightly coupled with:
 - Must not depend on any non-Google web font.
 - Visible "X skills" / "Y systems" claims must read from
   `getCatalogCounts()` — never hardcode. The hero, capabilities cards,
-  labs pills, selected-work fractions, footer Library, and
-  `<meta name="description">` all derive from the same call so a
-  fresh content edit can never publish contradictory totals.
+  labs pills, selected-work fractions, and footer Library all derive
+  from the same call so a fresh content edit can never publish
+  contradictory totals. The homepage `<meta name="description">` is
+  intentionally scenario-focused and no longer states catalog totals, so
+  it is not a count-backed surface; `getHomeSeo()` still accepts the
+  counts and its `{skills}`/`{systems}` substitution stays as a no-op
+  hook, so if the description ever surfaces a count again it must route
+  through `getCatalogCounts()`.
 - When the canonical `design-templates/open-design-landing/example.html`
   changes, the corresponding section JSX in `app/page.tsx` and rules
   in `app/globals.css` must be updated to match. Those two files are

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -1398,13 +1398,19 @@ body::before {
    (18px / 125%), weight 400 body, neutral 正文文字 #434343 (= --ink-soft),
    centered short emphasis text, --spacing-32 gap to the CTAs below. */
 .hero-lead {
+  /* Eyebrow / kicker carrying the SEO entry word ("Open Source Claude Design
+     Alternative", localized). Sits above the brand as a small emphasized label
+     rather than a body paragraph, so the H1 brand + positioning stays the
+     visual focus while the entry term remains crawlable HTML text. */
   max-width: 760px;
-  margin: 0 0 32px;
+  margin: 0 0 18px;
   font-family: var(--sans);
-  font-size: 16px;
-  line-height: 1.25;
-  font-weight: 400;
-  color: var(--ink-soft);
+  font-size: 13px;
+  line-height: 1.3;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--coral, var(--ink-soft));
   text-align: center;
 }
 /* Hero sub-line beneath the CTAs. Skill spec: Albert Sans, --font-size-16
@@ -1534,6 +1540,19 @@ body::before {
   line-height: 1;
   letter-spacing: -0.01em;
   color: var(--ink);
+}
+.hero-title-main {
+  /* Category positioning line ("The Vibe Design Workspace") — the product's
+     own umbrella term and the primary on-page positioning. Sits between the
+     brand slab above and the SEO entry-word sub-line below in the visual
+     hierarchy: sans display face, prominent but a step down from the brand. */
+  font-family: var(--sans);
+  font-weight: 800;
+  font-size: clamp(22px, 4.8vw, 40px);
+  line-height: 1.06;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin-top: 0.14em;
 }
 .hero-title-sub {
   font-family: var(--sans);
@@ -2207,6 +2226,29 @@ section.tight { padding: 90px 0; }
 }
 /* Live caption laid over the the painting card baked into these about images. Uses
    container query units so the text scales in lockstep with the image width. */
+.cta-pair {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.faq-download {
+  margin-top: 30px;
+}
+.faq-download-note {
+  margin-top: 12px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--ink-soft, #595959);
+}
+.about-ctas {
+  display: flex;
+  justify-content: center;
+  margin-top: 26px;
+}
+.about-panel:has(.about-panel-img) {
+  text-align: center;
+}
 .about-panel-img-captioned {
   position: relative;
   container-type: inline-size;
@@ -2441,6 +2483,18 @@ section.tight { padding: 90px 0; }
   gap: clamp(28px, 4vw, 72px);
   /* Top-align both columns so the art's top edge lines up with the first step. */
   align-items: start;
+}
+.cap-steps-col {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(20px, 3vh, 36px);
+}
+.cap-steps-link {
+  margin-top: 4px;
+  flex-direction: column;
+  align-items: stretch;
+  width: fit-content;
 }
 .cap-steps {
   display: flex;
@@ -2810,6 +2864,17 @@ section.tight { padding: 90px 0; }
   margin-bottom: 24px;
 }
 .labs-head h2 { font-size: 48px; text-align: center; }
+/* Keyword-rich lead under the "What can you make" heading — centered section
+   subtitle, one step down from the display H2. */
+.labs-head .labs-lead {
+  max-width: 720px;
+  margin: 14px auto 0;
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.5;
+  color: var(--ink-soft, var(--ink));
+  text-align: center;
+}
 /* Unify the title color: the trailing ？ stays ink like the rest of the line
    instead of the global coral dot. */
 .labs-head .display .dot { color: inherit; }
@@ -4903,6 +4968,17 @@ section.tight { padding: 90px 0; }
   color: var(--paper);
   border-color: var(--ink);
 }
+.faq-more {
+  margin-top: 10px;
+  font-size: 14px;
+}
+.faq-more a {
+  color: var(--coral, var(--accent, inherit));
+  text-decoration: none;
+  font-weight: 600;
+  border-bottom: 1px solid transparent;
+}
+.faq-more a:hover { border-bottom-color: currentColor; }
 .faq-a {
   grid-column: 2 / 3;
   margin: 0 0 16px;
@@ -5090,6 +5166,7 @@ footer .container {
 }
 
 /* Shared compact footer used by sub-pages and mirrored on the homepage. */
+
 .sub-footer {
   border-top: 1px solid var(--line);
   background: var(--paper);

--- a/apps/landing-page/app/home-translations.ts
+++ b/apps/landing-page/app/home-translations.ts
@@ -62,7 +62,7 @@ const en: HomeExtra = {
     'From idea to prototype, web, slides, and HTML video — the entire product-design flow, finished on your own machine.',
   heroTitleSub: 'Open Source Claude Design Alternative',
   heroSub:
-    'Open Design is the open-source, local vibe design workspace — it turns the coding agents you already run into a design engine that carries you from idea to prototype, web, slides, and HTML video, all finished on your own machine. Agent-native and BYOK, with 21 coding agents, 129 design systems, and an Apache-2.0 license.',
+    'Open Design is the open-source, local vibe design workspace — it turns the coding agents you already run into a design engine that carries you from idea to prototype, web, slides, and HTML video, all finished on your own machine. Agent-native, with 21 coding agents, 129 design systems, and an Apache-2.0 license.',
   aboutKicker: 'Why Open Design?',
   aboutStatement:
     'Open Design is the open-source, agentic vibe design workspace — it turns the coding agent you already run into a design engine whose output you fully own. When an LLM first proved it can truly design — real design work, not just copy — that capability arrived closed, hosted, and model-locked. Open Design opens it up: local, BYOK, Apache-2.0.',
@@ -99,7 +99,7 @@ const en: HomeExtra = {
   newsBtn: 'Subscribe',
   newsDone: 'Thanks — you’re on the list!',
   newsError: 'Couldn’t subscribe just now — please try again.',
-  faqTitle: 'Open Design FAQ — open source, BYOK, and Claude Design alternative',
+  faqTitle: 'Open Design FAQ — open source, local-first, and Claude Design alternative',
   footProduct: 'Product',
   footCommunity: 'Community',
   footLegal: 'Legal',
@@ -110,7 +110,7 @@ const zh: HomeExtra = {
   heroLead: '从想法到原型、网页、Slides、HTML 视频——产品设计全流程，在你自己的设备上完成。',
   heroTitleSub: 'Claude Design最佳开源平替',
   heroSub:
-    'Open Design 是开源、本地的 vibe design workspace——把你已经在用的 coding agent 变成设计引擎，从想法到原型、网页、Slides、HTML 视频，全流程在你自己的设备上完成。\nAgent-native、BYOK，接入 21 个 Coding Agent、129 个 Design System，Apache-2.0。',
+    'Open Design 是开源、本地的 vibe design workspace——把你已经在用的 coding agent 变成设计引擎，从想法到原型、网页、Slides、HTML 视频，全流程在你自己的设备上完成。\nAgent-native，接入 21 个 Coding Agent、129 个 Design System，Apache-2.0。',
   aboutKicker: '为什么选择 Open Design？',
   aboutStatement:
     'Open Design 是开源、agentic 的 vibe design workspace——把你已经在用的 coding agent 变成一台产出完全归你的设计引擎。当 LLM 第一次证明它能真正做设计——是真的设计稿，不是写文案——这份能力却是闭源、托管、锁模型的。Open Design 把它打开：本地、BYOK、Apache-2.0。',
@@ -143,7 +143,7 @@ const zh: HomeExtra = {
   newsBtn: '订阅',
   newsDone: '已收到，感谢关注！',
   newsError: '订阅失败，请稍后重试。',
-  faqTitle: 'Open Design 常见问题 —— 开源、BYOK、Claude Design 替代',
+  faqTitle: 'Open Design 常见问题 —— 开源、本地优先、Claude Design 替代',
   footProduct: '产品',
   footCommunity: '社区',
   footLegal: '法律',
@@ -196,7 +196,7 @@ const ja: HomeExtra = {
     'アイデアからプロトタイプ、Web、スライド、HTML 動画まで——プロダクトデザインの全工程を、あなたの手元のマシンで完結。',
   heroTitleSub: 'Claude Design の最良のオープンソース代替',
   heroSub:
-    'Open Design はオープンソースでローカルな vibe design workspace——すでに使っているコーディングエージェントを設計エンジンに変え、アイデアからプロトタイプ、Web、スライド、HTML 動画まで、すべて自分のマシン上で完結します。\nエージェントネイティブかつ BYOK、21 のコーディングエージェント、129 のデザインシステム、Apache-2.0。',
+    'Open Design はオープンソースでローカルな vibe design workspace——すでに使っているコーディングエージェントを設計エンジンに変え、アイデアからプロトタイプ、Web、スライド、HTML 動画まで、すべて自分のマシン上で完結します。\nエージェントネイティブ、21 のコーディングエージェント、129 のデザインシステム、Apache-2.0。',
   aboutKicker: 'なぜ Open Design なのか？',
   aboutStatement:
     'Open Design はオープンソースで agentic な vibe design workspace です。すでに使っているコーディングエージェントを、成果物が完全に自分のものになる設計エンジンに変えます。LLM が初めて本当に設計できる——コピーではなく本物の設計——と証明したとき、その能力はクローズドでホスト型、モデル固定でした。Open Design はそれを開きます：ローカル、BYOK、Apache-2.0。',
@@ -231,7 +231,7 @@ const ja: HomeExtra = {
     '新しいテンプレート、デザインシステムの更新、アンバサダーイベント、プロダクトの最新情報を、あなたの受信箱へ直接お届けします。',
   newsBtn: '購読する',
   newsDone: 'ご登録ありがとうございます！',
-  faqTitle: 'Open Design のよくある質問 — オープンソース・BYOK・Claude Design 代替',
+  faqTitle: 'Open Design のよくある質問 — オープンソース・ローカルファースト・Claude Design 代替',
   footProduct: '製品',
   footCommunity: 'コミュニティ',
   footLegal: '法的情報',
@@ -243,7 +243,7 @@ const ko: HomeExtra = {
     '아이디어에서 프로토타입, 웹, 슬라이드, HTML 영상까지 — 제품 디자인 전 과정을 내 컴퓨터에서 완성합니다.',
   heroTitleSub: 'Claude Design의 최고의 오픈소스 대안',
   heroSub:
-    'Open Design는 오픈소스이자 로컬로 동작하는 vibe design workspace입니다——이미 사용 중인 코딩 에이전트를 디자인 엔진으로 바꿔, 아이디어에서 프로토타입, 웹, 슬라이드, HTML 비디오까지 전 과정을 내 컴퓨터에서 끝냅니다.\n에이전트 네이티브 및 BYOK, 21개 코딩 에이전트, 129개 디자인 시스템, Apache-2.0.',
+    'Open Design는 오픈소스이자 로컬로 동작하는 vibe design workspace입니다——이미 사용 중인 코딩 에이전트를 디자인 엔진으로 바꿔, 아이디어에서 프로토타입, 웹, 슬라이드, HTML 비디오까지 전 과정을 내 컴퓨터에서 끝냅니다.\n에이전트 네이티브, 21개 코딩 에이전트, 129개 디자인 시스템, Apache-2.0.',
   aboutKicker: '왜 Open Design인가?',
   aboutStatement:
     'Open Design은 오픈소스이자 agentic한 vibe design workspace입니다. 이미 쓰는 코딩 에이전트를, 결과물이 온전히 내 것이 되는 디자인 엔진으로 바꿉니다. LLM이 처음으로 진짜 디자인을——카피가 아니라 실제 디자인을——해낼 수 있음을 증명했을 때, 그 능력은 폐쇄적이고 호스팅형이며 모델에 묶여 있었습니다. Open Design은 그것을 엽니다: 로컬, BYOK, Apache-2.0.',
@@ -278,7 +278,7 @@ const ko: HomeExtra = {
     '새 템플릿, 디자인 시스템 업데이트, 앰배서더 이벤트, 제품 소식을 받은편지함으로 바로 보내드립니다.',
   newsBtn: '구독',
   newsDone: '구독해 주셔서 감사합니다!',
-  faqTitle: 'Open Design FAQ — 오픈소스, BYOK, Claude Design 대안',
+  faqTitle: 'Open Design FAQ — 오픈소스, 로컬 우선, Claude Design 대안',
   footProduct: '제품',
   footCommunity: '커뮤니티',
   footLegal: '법적 고지',
@@ -290,7 +290,7 @@ const de: HomeExtra = {
     'Von der Idee zu Prototyp, Web, Slides und HTML-Video — der gesamte Produktdesign-Flow, fertig auf deinem eigenen Rechner.',
   heroTitleSub: 'Die beste Open-Source-Alternative zu Claude Design',
   heroSub:
-    'Open Design ist der quelloffene, lokale vibe design workspace — er verwandelt die Coding-Agents, die du bereits nutzt, in eine Design-Engine, die dich von der Idee bis zu Prototyp, Web, Slides und HTML-Video bringt, alles auf deinem eigenen Rechner.\nAgent-native und BYOK, mit 21 Coding-Agents, 129 Design-Systemen und Apache-2.0-Lizenz.',
+    'Open Design ist der quelloffene, lokale vibe design workspace — er verwandelt die Coding-Agents, die du bereits nutzt, in eine Design-Engine, die dich von der Idee bis zu Prototyp, Web, Slides und HTML-Video bringt, alles auf deinem eigenen Rechner.\nAgent-native, mit 21 Coding-Agents, 129 Design-Systemen und Apache-2.0-Lizenz.',
   aboutKicker: 'Warum Open Design?',
   aboutStatement:
     'Open Design ist der quelloffene, agentische Vibe Design Workspace – er verwandelt den Coding-Agent, den du bereits nutzt, in eine Design-Engine, deren Ergebnisse ganz dir gehören. Als ein LLM erstmals bewies, dass es wirklich gestalten kann – echte Designarbeit, nicht nur Text –, kam diese Fähigkeit geschlossen, gehostet und modellgebunden. Open Design öffnet sie: lokal, BYOK, Apache-2.0.',
@@ -325,7 +325,7 @@ const de: HomeExtra = {
     'Neue Vorlagen, Design-System-Updates, Ambassador-Events und Produktneuigkeiten — direkt in dein Postfach.',
   newsBtn: 'Abonnieren',
   newsDone: 'Danke — du bist dabei!',
-  faqTitle: 'Open Design FAQ – Open Source, BYOK und Claude-Design-Alternative',
+  faqTitle: 'Open Design FAQ – Open Source, lokal und Claude-Design-Alternative',
   footProduct: 'Produkt',
   footCommunity: 'Community',
   footLegal: 'Rechtliches',
@@ -337,7 +337,7 @@ const fr: HomeExtra = {
     'De l’idée au prototype, au web, aux slides et à la vidéo HTML — tout le flux de design produit, réalisé sur votre propre machine.',
   heroTitleSub: "La meilleure alternative open source à Claude Design",
   heroSub:
-    'Open Design est le vibe design workspace open source et local — il transforme les agents de code que vous utilisez déjà en moteur de design, de l’idée au prototype, au web, aux slides et à la vidéo HTML, le tout sur votre propre machine.\nAgent-native et BYOK, avec 21 agents de code, 129 design systems et une licence Apache-2.0.',
+    'Open Design est le vibe design workspace open source et local — il transforme les agents de code que vous utilisez déjà en moteur de design, de l’idée au prototype, au web, aux slides et à la vidéo HTML, le tout sur votre propre machine.\nAgent-native, avec 21 agents de code, 129 design systems et une licence Apache-2.0.',
   aboutKicker: 'Pourquoi Open Design ?',
   aboutStatement:
     'Open Design est le vibe design workspace open source et agentique — il transforme l’agent de code que vous utilisez déjà en un moteur de design dont vous possédez entièrement le résultat. Quand un LLM a prouvé pour la première fois qu’il pouvait vraiment concevoir — du vrai design, pas juste du texte —, cette capacité est arrivée fermée, hébergée et verrouillée à un modèle. Open Design l’ouvre : local, BYOK, Apache-2.0.',
@@ -372,7 +372,7 @@ const fr: HomeExtra = {
     'Nouveaux modèles, mises à jour des design systems, événements ambassadeurs et actualités produit — directement dans votre boîte mail.',
   newsBtn: 'S’abonner',
   newsDone: 'Merci — vous êtes inscrit !',
-  faqTitle: 'FAQ Open Design — open source, BYOK et alternative à Claude Design',
+  faqTitle: 'FAQ Open Design — open source, local-first et alternative à Claude Design',
   footProduct: 'Produit',
   footCommunity: 'Communauté',
   footLegal: 'Mentions légales',
@@ -384,7 +384,7 @@ const ru: HomeExtra = {
     'От идеи до прототипа, веба, слайдов и HTML-видео — весь процесс продуктового дизайна, завершённый на вашей машине.',
   heroTitleSub: 'Лучшая open-source альтернатива Claude Design',
   heroSub:
-    'Open Design — это открытый локальный vibe design workspace: он превращает кодинг-агентов, которыми вы уже пользуетесь, в движок дизайна, ведущий от идеи к прототипу, вебу, слайдам и HTML-видео — всё на вашей машине.\nAgent-native и BYOK, 21 кодинг-агент, 129 дизайн-систем, лицензия Apache-2.0.',
+    'Open Design — это открытый локальный vibe design workspace: он превращает кодинг-агентов, которыми вы уже пользуетесь, в движок дизайна, ведущий от идеи к прототипу, вебу, слайдам и HTML-видео — всё на вашей машине.\nAgent-native, 21 кодинг-агент, 129 дизайн-систем, лицензия Apache-2.0.',
   aboutKicker: 'Почему Open Design?',
   aboutStatement:
     'Open Design — это открытый, агентный vibe design workspace: он превращает кодинг-агента, которым вы уже пользуетесь, в движок дизайна, результат которого полностью принадлежит вам. Когда LLM впервые доказал, что действительно умеет проектировать — настоящий дизайн, а не просто текст, — эта способность пришла закрытой, облачной и привязанной к модели. Open Design открывает её: локально, BYOK, Apache-2.0.',
@@ -419,7 +419,7 @@ const ru: HomeExtra = {
     'Новые шаблоны, обновления дизайн-систем, события амбассадоров и новости продукта — прямо на вашу почту.',
   newsBtn: 'Подписаться',
   newsDone: 'Спасибо — вы подписаны!',
-  faqTitle: 'FAQ Open Design — open source, BYOK и альтернатива Claude Design',
+  faqTitle: 'FAQ Open Design — open source, локальный и альтернатива Claude Design',
   footProduct: 'Продукт',
   footCommunity: 'Сообщество',
   footLegal: 'Правовая информация',
@@ -431,7 +431,7 @@ const es: HomeExtra = {
     'De la idea al prototipo, web, slides y vídeo HTML — todo el flujo de diseño de producto, terminado en tu propia máquina.',
   heroTitleSub: 'La mejor alternativa open source a Claude Design',
   heroSub:
-    'Open Design es el vibe design workspace open source y local: convierte los agentes de código que ya usas en un motor de diseño que te lleva de la idea al prototipo, la web, las slides y el vídeo HTML, todo en tu propia máquina.\nAgent-native y BYOK, con 21 agentes de código, 129 design systems y licencia Apache-2.0.',
+    'Open Design es el vibe design workspace open source y local: convierte los agentes de código que ya usas en un motor de diseño que te lleva de la idea al prototipo, la web, las slides y el vídeo HTML, todo en tu propia máquina.\nAgent-native, con 21 agentes de código, 129 design systems y licencia Apache-2.0.',
   aboutKicker: '¿Por qué Open Design?',
   aboutStatement:
     'Open Design es el vibe design workspace open source y agéntico: convierte el agente de código que ya usas en un motor de diseño cuyo resultado es totalmente tuyo. Cuando un LLM demostró por primera vez que podía diseñar de verdad —diseño real, no solo texto—, esa capacidad llegó cerrada, alojada y atada a un modelo. Open Design la abre: local, BYOK, Apache-2.0.',
@@ -466,7 +466,7 @@ const es: HomeExtra = {
     'Nuevas plantillas, actualizaciones de design systems, eventos de embajadores y novedades del producto — directo a tu bandeja de entrada.',
   newsBtn: 'Suscribirse',
   newsDone: '¡Gracias — ya estás en la lista!',
-  faqTitle: 'FAQ de Open Design — open source, BYOK y alternativa a Claude Design',
+  faqTitle: 'FAQ de Open Design — open source, local-first y alternativa a Claude Design',
   footProduct: 'Producto',
   footCommunity: 'Comunidad',
   footLegal: 'Legal',
@@ -478,7 +478,7 @@ const ptBr: HomeExtra = {
     'Da ideia ao protótipo, web, slides e vídeo HTML — todo o fluxo de design de produto, finalizado na sua própria máquina.',
   heroTitleSub: 'A melhor alternativa open source ao Claude Design',
   heroSub:
-    'Open Design é o vibe design workspace open source e local: transforma os agentes de código que você já usa em um motor de design que vai da ideia ao protótipo, web, slides e vídeo HTML, tudo na sua própria máquina.\nAgent-native e BYOK, com 21 agentes de código, 129 design systems e licença Apache-2.0.',
+    'Open Design é o vibe design workspace open source e local: transforma os agentes de código que você já usa em um motor de design que vai da ideia ao protótipo, web, slides e vídeo HTML, tudo na sua própria máquina.\nAgent-native, com 21 agentes de código, 129 design systems e licença Apache-2.0.',
   aboutKicker: 'Por que Open Design?',
   aboutStatement:
     'O Open Design é o vibe design workspace open source e agêntico: transforma o coding agent que você já usa em um motor de design cujo resultado é totalmente seu. Quando um LLM provou pela primeira vez que sabia projetar de verdade — design real, não só texto —, essa capacidade chegou fechada, hospedada e presa a um modelo. O Open Design a abre: local, BYOK, Apache-2.0.',
@@ -513,7 +513,7 @@ const ptBr: HomeExtra = {
     'Novos templates, atualizações de design systems, eventos de embaixadores e novidades do produto — direto na sua caixa de entrada.',
   newsBtn: 'Assinar',
   newsDone: 'Obrigado — você está na lista!',
-  faqTitle: 'FAQ do Open Design — open source, BYOK e alternativa ao Claude Design',
+  faqTitle: 'FAQ do Open Design — open source, local-first e alternativa ao Claude Design',
   footProduct: 'Produto',
   footCommunity: 'Comunidade',
   footLegal: 'Legal',
@@ -525,7 +525,7 @@ const it: HomeExtra = {
     'Dall’idea al prototipo, web, slide e video HTML — l’intero flusso di product design, completato sulla tua macchina.',
   heroTitleSub: "La migliore alternativa open source a Claude Design",
   heroSub:
-    'Open Design è il vibe design workspace open source e locale: trasforma i coding agent che già usi in un motore di design che ti porta dall’idea al prototipo, al web, alle slide e al video HTML, tutto sulla tua macchina.\nAgent-native e BYOK, con 21 coding agent, 129 design system e licenza Apache-2.0.',
+    'Open Design è il vibe design workspace open source e locale: trasforma i coding agent che già usi in un motore di design che ti porta dall’idea al prototipo, al web, alle slide e al video HTML, tutto sulla tua macchina.\nAgent-native, con 21 coding agent, 129 design system e licenza Apache-2.0.',
   aboutKicker: 'Perché Open Design?',
   aboutStatement:
     'Open Design è il vibe design workspace open source e agentico: trasforma il coding agent che già usi in un motore di design il cui risultato è interamente tuo. Quando un LLM ha dimostrato per la prima volta di saper progettare davvero — vero design, non solo testo —, quella capacità è arrivata chiusa, ospitata e legata a un modello. Open Design la apre: locale, BYOK, Apache-2.0.',
@@ -560,7 +560,7 @@ const it: HomeExtra = {
     'Nuovi template, aggiornamenti dei design system, eventi ambassador e novità di prodotto — direttamente nella tua casella.',
   newsBtn: 'Iscriviti',
   newsDone: 'Grazie — sei in lista!',
-  faqTitle: 'FAQ di Open Design — open source, BYOK e alternativa a Claude Design',
+  faqTitle: 'FAQ di Open Design — open source, local-first e alternativa a Claude Design',
   footProduct: 'Prodotto',
   footCommunity: 'Community',
   footLegal: 'Note legali',
@@ -797,7 +797,7 @@ const tr: HomeExtra = {
     'Fikirden prototipe, web’e, slaytlara ve HTML videoya — tüm ürün tasarım akışı, kendi makinende tamamlanır.',
   heroTitleSub: "Claude Design'ın en iyi açık kaynak alternatifi",
   heroSub:
-    'Open Design, açık kaynaklı ve yerel çalışan vibe design workspace’tir — hâlihazırda kullandığın kodlama ajanlarını, fikirden prototipe, web’e, slaytlara ve HTML videoya kadar her şeyi kendi makinende tamamlayan bir tasarım motoruna dönüştürür.\nAgent-native ve BYOK; 21 kodlama ajanı, 129 tasarım sistemi ve Apache-2.0 lisansı.',
+    'Open Design, açık kaynaklı ve yerel çalışan vibe design workspace’tir — hâlihazırda kullandığın kodlama ajanlarını, fikirden prototipe, web’e, slaytlara ve HTML videoya kadar her şeyi kendi makinende tamamlayan bir tasarım motoruna dönüştürür.\nAgent-native; 21 kodlama ajanı, 129 tasarım sistemi ve Apache-2.0 lisansı.',
   aboutKicker: 'Neden Open Design?',
   aboutStatement:
     'Open Design, açık kaynaklı ve agentic bir vibe design workspace’tir: hâlihazırda kullandığın kodlama ajanını, çıktısı tamamen sana ait olan bir tasarım motoruna dönüştürür. Bir LLM ilk kez gerçekten tasarlayabildiğini — metin değil, gerçek tasarım — kanıtladığında, bu yetenek kapalı, barındırılan ve modele kilitli geldi. Open Design onu açar: yerel, BYOK, Apache-2.0.',
@@ -832,7 +832,7 @@ const tr: HomeExtra = {
     'Yeni şablonlar, tasarım sistemi güncellemeleri, elçi etkinlikleri ve ürün haberleri — doğrudan gelen kutuna.',
   newsBtn: 'Abone ol',
   newsDone: 'Teşekkürler — listedesin!',
-  faqTitle: 'Open Design SSS — açık kaynak, BYOK ve Claude Design alternatifi',
+  faqTitle: 'Open Design SSS — açık kaynak, yerel öncelikli ve Claude Design alternatifi',
   footProduct: 'Ürün',
   footCommunity: 'Topluluk',
   footLegal: 'Yasal',

--- a/apps/landing-page/app/home-translations.ts
+++ b/apps/landing-page/app/home-translations.ts
@@ -925,6 +925,7 @@ export interface HomeCta {
   systems: string;
   learnMore: string;
   statsTitle: string;
+  downloadProof: string;
 }
 
 const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
@@ -936,6 +937,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'Explore design systems',
     learnMore: 'Learn more →',
     statsTitle: 'The open-source vibe design workspace, by the numbers',
+    downloadProof: '74K+ stars · Apache-2.0 · Free',
   },
   zh: {
     solutions: '浏览全部解决方案',
@@ -945,6 +947,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: '浏览设计系统',
     learnMore: '了解更多 →',
     statsTitle: '开源 vibe design workspace，用数据说话',
+    downloadProof: '74K+ Star · Apache-2.0 · 免费',
   },
   ja: {
     solutions: 'すべてのソリューションを見る',
@@ -954,6 +957,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'デザインシステムを見る',
     learnMore: '詳しく見る →',
     statsTitle: 'オープンソースの vibe design workspace を数字で',
+    downloadProof: '74K+ スター · Apache-2.0 · 無料',
   },
   ko: {
     solutions: '모든 솔루션 둘러보기',
@@ -963,6 +967,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: '디자인 시스템 둘러보기',
     learnMore: '자세히 보기 →',
     statsTitle: '오픈소스 vibe design workspace, 숫자로 보기',
+    downloadProof: '74K+ 스타 · Apache-2.0 · 무료',
   },
   de: {
     solutions: 'Alle Lösungen ansehen',
@@ -972,6 +977,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'Design-Systeme ansehen',
     learnMore: 'Mehr erfahren →',
     statsTitle: 'Der quelloffene Vibe Design Workspace in Zahlen',
+    downloadProof: '74K+ Sterne · Apache-2.0 · Kostenlos',
   },
   fr: {
     solutions: 'Voir toutes les solutions',
@@ -981,6 +987,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'Voir les design systems',
     learnMore: 'En savoir plus →',
     statsTitle: 'Le vibe design workspace open source en chiffres',
+    downloadProof: '74K+ étoiles · Apache-2.0 · Gratuit',
   },
   ru: {
     solutions: 'Все решения',
@@ -990,6 +997,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'Дизайн-системы',
     learnMore: 'Подробнее →',
     statsTitle: 'Открытый vibe design workspace в цифрах',
+    downloadProof: '74K+ звёзд · Apache-2.0 · Бесплатно',
   },
   es: {
     solutions: 'Ver todas las soluciones',
@@ -999,6 +1007,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'Ver los design systems',
     learnMore: 'Más información →',
     statsTitle: 'El vibe design workspace open source en cifras',
+    downloadProof: '74K+ estrellas · Apache-2.0 · Gratis',
   },
   'pt-br': {
     solutions: 'Ver todas as soluções',
@@ -1008,6 +1017,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'Ver os design systems',
     learnMore: 'Saiba mais →',
     statsTitle: 'O vibe design workspace open source em números',
+    downloadProof: '74K+ estrelas · Apache-2.0 · Grátis',
   },
   it: {
     solutions: 'Esplora tutte le soluzioni',
@@ -1017,6 +1027,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'Esplora i design system',
     learnMore: 'Scopri di più →',
     statsTitle: 'Il vibe design workspace open source in numeri',
+    downloadProof: '74K+ stelle · Apache-2.0 · Gratis',
   },
   tr: {
     solutions: 'Tüm çözümleri gör',
@@ -1026,6 +1037,7 @@ const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
     systems: 'Tasarım sistemlerini keşfet',
     learnMore: 'Daha fazla bilgi →',
     statsTitle: 'Sayılarla açık kaynaklı vibe design workspace',
+    downloadProof: '74K+ yıldız · Apache-2.0 · Ücretsiz',
   },
 };
 

--- a/apps/landing-page/app/home-translations.ts
+++ b/apps/landing-page/app/home-translations.ts
@@ -909,3 +909,127 @@ const TABLE: Partial<Record<LandingLocaleCode, HomeExtra>> = {
 export function getHomeExtra(locale: LandingLocaleCode): HomeExtra {
   return TABLE[locale] ?? en;
 }
+
+/**
+ * Localized CTA / hub-link labels for the homepage. Kept separate from
+ * `HomeExtra` so only the 11 live locales need entries (retired locales fall
+ * back to English via `getHomeCta`). Replaces the old `tt(zh, en)` helper,
+ * which only distinguished zh from English and left the other 9 locales in
+ * English. The umbrella term "vibe design workspace" stays in English.
+ */
+export interface HomeCta {
+  solutions: string;
+  templates: string;
+  agents: string;
+  contributors: string;
+  systems: string;
+  learnMore: string;
+  statsTitle: string;
+}
+
+const HOME_CTA: Partial<Record<LandingLocaleCode, HomeCta>> = {
+  en: {
+    solutions: 'Explore solutions',
+    templates: 'Browse all templates',
+    agents: 'Browse all 21+ agents',
+    contributors: 'View all contributors',
+    systems: 'Explore design systems',
+    learnMore: 'Learn more →',
+    statsTitle: 'The open-source vibe design workspace, by the numbers',
+  },
+  zh: {
+    solutions: '浏览全部解决方案',
+    templates: '浏览全部模板',
+    agents: '浏览全部 Agent',
+    contributors: '查看全部贡献者',
+    systems: '浏览设计系统',
+    learnMore: '了解更多 →',
+    statsTitle: '开源 vibe design workspace，用数据说话',
+  },
+  ja: {
+    solutions: 'すべてのソリューションを見る',
+    templates: 'すべてのテンプレートを見る',
+    agents: '21+ のエージェントをすべて見る',
+    contributors: 'すべてのコントリビューターを見る',
+    systems: 'デザインシステムを見る',
+    learnMore: '詳しく見る →',
+    statsTitle: 'オープンソースの vibe design workspace を数字で',
+  },
+  ko: {
+    solutions: '모든 솔루션 둘러보기',
+    templates: '모든 템플릿 둘러보기',
+    agents: '21개+ 에이전트 모두 보기',
+    contributors: '모든 기여자 보기',
+    systems: '디자인 시스템 둘러보기',
+    learnMore: '자세히 보기 →',
+    statsTitle: '오픈소스 vibe design workspace, 숫자로 보기',
+  },
+  de: {
+    solutions: 'Alle Lösungen ansehen',
+    templates: 'Alle Vorlagen ansehen',
+    agents: 'Alle 21+ Agents ansehen',
+    contributors: 'Alle Mitwirkenden ansehen',
+    systems: 'Design-Systeme ansehen',
+    learnMore: 'Mehr erfahren →',
+    statsTitle: 'Der quelloffene Vibe Design Workspace in Zahlen',
+  },
+  fr: {
+    solutions: 'Voir toutes les solutions',
+    templates: 'Voir tous les modèles',
+    agents: 'Voir les 21+ agents',
+    contributors: 'Voir tous les contributeurs',
+    systems: 'Voir les design systems',
+    learnMore: 'En savoir plus →',
+    statsTitle: 'Le vibe design workspace open source en chiffres',
+  },
+  ru: {
+    solutions: 'Все решения',
+    templates: 'Все шаблоны',
+    agents: 'Все 21+ агентов',
+    contributors: 'Все участники',
+    systems: 'Дизайн-системы',
+    learnMore: 'Подробнее →',
+    statsTitle: 'Открытый vibe design workspace в цифрах',
+  },
+  es: {
+    solutions: 'Ver todas las soluciones',
+    templates: 'Ver todas las plantillas',
+    agents: 'Ver los 21+ agentes',
+    contributors: 'Ver todos los colaboradores',
+    systems: 'Ver los design systems',
+    learnMore: 'Más información →',
+    statsTitle: 'El vibe design workspace open source en cifras',
+  },
+  'pt-br': {
+    solutions: 'Ver todas as soluções',
+    templates: 'Ver todos os templates',
+    agents: 'Ver os 21+ agentes',
+    contributors: 'Ver todos os contribuidores',
+    systems: 'Ver os design systems',
+    learnMore: 'Saiba mais →',
+    statsTitle: 'O vibe design workspace open source em números',
+  },
+  it: {
+    solutions: 'Esplora tutte le soluzioni',
+    templates: 'Esplora tutti i template',
+    agents: 'Vedi tutti i 21+ agent',
+    contributors: 'Vedi tutti i contributori',
+    systems: 'Esplora i design system',
+    learnMore: 'Scopri di più →',
+    statsTitle: 'Il vibe design workspace open source in numeri',
+  },
+  tr: {
+    solutions: 'Tüm çözümleri gör',
+    templates: 'Tüm şablonları gör',
+    agents: '21+ agent’ın tümünü gör',
+    contributors: 'Tüm katkıda bulunanları gör',
+    systems: 'Tasarım sistemlerini keşfet',
+    learnMore: 'Daha fazla bilgi →',
+    statsTitle: 'Sayılarla açık kaynaklı vibe design workspace',
+  },
+};
+
+/** Localized homepage CTA labels; falls back to English for retired locales. */
+export function getHomeCta(locale: LandingLocaleCode): HomeCta {
+  return HOME_CTA[locale] ?? (HOME_CTA.en as HomeCta);
+}

--- a/apps/landing-page/app/home-translations.ts
+++ b/apps/landing-page/app/home-translations.ts
@@ -32,6 +32,11 @@ export interface HomeExtra {
   capTitle: string;
   labsPre: string; // before <em>Open Design</em>
   labsPost: string; // after <em>Open Design</em> (incl. punctuation)
+  // Lead paragraph under the "What can you make with Open Design?" heading.
+  // Keyword-rich list of the artifact types (crawlable HTML, not baked into
+  // the showcase images). Optional so locales fall through until translated;
+  // en is authored below and every live locale is filled in the i18n pass.
+  labsLead?: string;
   methodTitle: string;
   ctaTitle: string;
   testiPre: string; // before the contributor count
@@ -55,12 +60,12 @@ export interface HomeExtra {
 const en: HomeExtra = {
   heroLead:
     'From idea to prototype, web, slides, and HTML video — the entire product-design flow, finished on your own machine.',
-  heroTitleSub: 'The Open-source Claude Design alternative',
+  heroTitleSub: 'Open Source Claude Design Alternative',
   heroSub:
-    'Open Design is the open-source, local, agent-native design platform — and an agent-native Figma alternative. Desktop-first, with 21 coding agents, 129 design systems, and an Apache-2.0 license.',
+    'Open Design is the open-source, local vibe design workspace — it turns the coding agents you already run into a design engine that carries you from idea to prototype, web, slides, and HTML video, all finished on your own machine. Agent-native and BYOK, with 21 coding agents, 129 design systems, and an Apache-2.0 license.',
   aboutKicker: 'Why Open Design?',
   aboutStatement:
-    'In April 2026, Claude Design first proved an LLM can truly design — not write copy, but produce real design work. But it’s closed-source, paid, and cloud-only, locked to Anthropic models — no agent switching, no self-hosting, no BYOK. Open Design opens that capability up.',
+    'Open Design is the open-source, agentic vibe design workspace — it turns the coding agent you already run into a design engine whose output you fully own. When an LLM first proved it can truly design — real design work, not just copy — that capability arrived closed, hosted, and model-locked. Open Design opens it up: local, BYOK, Apache-2.0.',
   aboutTab1: 'Desktop-native',
   aboutTab2: 'We don’t build agents, we plug them in',
   aboutTab3: 'It learns you over time',
@@ -78,13 +83,15 @@ const en: HomeExtra = {
   stepDesc2: 'Once a direction is set, palette, type, and spacing flow into generation automatically.',
   stepDesc3: 'The agent reads all context, produces real runnable files, and previews and edits them live in a sandbox.',
   stepDesc4: 'Export it to engineering to keep building, or turn it into a marketing video with HyperFrames.',
-  capTitle: 'From idea to delivery, done with ease',
+  capTitle: 'From idea to prototype, web, slides, and HTML video',
   labsPre: 'What can you make with ',
   labsPost: '?',
+  labsLead:
+    'Prototypes, landing pages, slide decks, dashboards, brand and design systems — even HTML video. Open Design turns each into real, runnable files, driven by your own coding agent and ready to ship or hand off to engineering.',
   methodTitle: 'Plug in 21+ coding agents, zero config',
   ctaTitle: 'Bring frontier AI design power back to every creator’s desk',
   testiPre: 'From around the world, ',
-  testiMid: ' contributors',
+  testiMid: ' contributors ',
   testiPost: 'are building Open Design together',
   newsTitle: 'The Open Design newsletter',
   newsDesc:
@@ -92,7 +99,7 @@ const en: HomeExtra = {
   newsBtn: 'Subscribe',
   newsDone: 'Thanks — you’re on the list!',
   newsError: 'Couldn’t subscribe just now — please try again.',
-  faqTitle: 'FAQ',
+  faqTitle: 'Open Design FAQ — open source, BYOK, and Claude Design alternative',
   footProduct: 'Product',
   footCommunity: 'Community',
   footLegal: 'Legal',
@@ -103,10 +110,10 @@ const zh: HomeExtra = {
   heroLead: '从想法到原型、网页、Slides、HTML 视频——产品设计全流程，在你自己的设备上完成。',
   heroTitleSub: 'Claude Design最佳开源平替',
   heroSub:
-    'Figma 和 Claude Design 的 Agent-native 替代。\n桌面客户端优先，接入 21 个 Coding Agent，129 个 Design System，Apache-2.0。',
+    'Open Design 是开源、本地的 vibe design workspace——把你已经在用的 coding agent 变成设计引擎，从想法到原型、网页、Slides、HTML 视频，全流程在你自己的设备上完成。\nAgent-native、BYOK，接入 21 个 Coding Agent、129 个 Design System，Apache-2.0。',
   aboutKicker: '为什么选择 Open Design？',
   aboutStatement:
-    '2026 年 4 月，Claude Design 首次证明 LLM 能真正做设计，不是写文章，是直接产出设计稿。但它闭源、付费、只跑在云端，模型锁 Anthropic，换 Agent、自部署、BYOK 全做不到。Open Design 让这套能力变得开放。',
+    'Open Design 是开源、agentic 的 vibe design workspace——把你已经在用的 coding agent 变成一台产出完全归你的设计引擎。当 LLM 第一次证明它能真正做设计——是真的设计稿，不是写文案——这份能力却是闭源、托管、锁模型的。Open Design 把它打开：本地、BYOK、Apache-2.0。',
   aboutTab1: '桌面端原生',
   aboutTab2: '不造 Agent，接入 Agent',
   aboutTab3: '越用越懂你',
@@ -121,9 +128,11 @@ const zh: HomeExtra = {
   stepDesc2: '选定方向后，色板、字体、间距自动带入生成流程',
   stepDesc3: 'Agent 读取所有 context，产出真实可运行的文件，沙盒内即时预览和修改',
   stepDesc4: '导出给工程继续开发，或用 HyperFrames 直接转为营销视频',
-  capTitle: '从想法到交付，轻松搞定',
+  capTitle: '从想法到原型、网页、Slides、HTML 视频',
   labsPre: '用 ',
   labsPost: ' 能产出什么？',
+  labsLead:
+    '原型、落地页、Slides、仪表盘、品牌与设计系统——甚至 HTML 视频。Open Design 把每一样都变成可运行的真实文件，由你自己的 coding agent 驱动，随时交付或交接给工程。',
   methodTitle: '接入 21+ Coding Agent，零配置',
   ctaTitle: '让最前沿的 AI 设计能力回到每一个创作者的桌上',
   testiPre: '来自全球，',
@@ -134,7 +143,7 @@ const zh: HomeExtra = {
   newsBtn: '订阅',
   newsDone: '已收到，感谢关注！',
   newsError: '订阅失败，请稍后重试。',
-  faqTitle: '常见问题',
+  faqTitle: 'Open Design 常见问题 —— 开源、BYOK、Claude Design 替代',
   footProduct: '产品',
   footCommunity: '社区',
   footLegal: '法律',
@@ -187,10 +196,10 @@ const ja: HomeExtra = {
     'アイデアからプロトタイプ、Web、スライド、HTML 動画まで——プロダクトデザインの全工程を、あなたの手元のマシンで完結。',
   heroTitleSub: 'Claude Design の最良のオープンソース代替',
   heroSub:
-    'Figma と Claude Design のエージェントネイティブな代替。\nデスクトップ優先、21 のコーディングエージェント、129 のデザインシステム、Apache-2.0。',
+    'Open Design はオープンソースでローカルな vibe design workspace——すでに使っているコーディングエージェントを設計エンジンに変え、アイデアからプロトタイプ、Web、スライド、HTML 動画まで、すべて自分のマシン上で完結します。\nエージェントネイティブかつ BYOK、21 のコーディングエージェント、129 のデザインシステム、Apache-2.0。',
   aboutKicker: 'なぜ Open Design なのか？',
   aboutStatement:
-    '2026 年 4 月、Claude Design は LLM が本当にデザインできることを初めて証明しました。文章ではなく、実際のデザイン成果物を生み出すのです。しかしクローズドソースで有料、クラウド専用、Anthropic モデルに固定——エージェントの切り替え、セルフホスト、BYOK はすべて不可。Open Design はその能力をオープンにします。',
+    'Open Design はオープンソースで agentic な vibe design workspace です。すでに使っているコーディングエージェントを、成果物が完全に自分のものになる設計エンジンに変えます。LLM が初めて本当に設計できる——コピーではなく本物の設計——と証明したとき、その能力はクローズドでホスト型、モデル固定でした。Open Design はそれを開きます：ローカル、BYOK、Apache-2.0。',
   aboutTab1: 'デスクトップネイティブ',
   aboutTab2: 'エージェントは作らず、つなぐ',
   aboutTab3: '使うほどあなたを理解する',
@@ -207,9 +216,11 @@ const ja: HomeExtra = {
   stepDesc2: '方向が決まれば、カラーパレット・フォント・余白が自動で生成フローに反映される。',
   stepDesc3: 'エージェントがすべてのコンテキストを読み、実際に動くファイルを生成。サンドボックス内で即時プレビューと編集。',
   stepDesc4: 'エンジニアリングにエクスポートして開発を続けるか、HyperFrames でそのままマーケティング動画に。',
-  capTitle: 'アイデアから納品まで、らくらく',
+  capTitle: 'アイデアからプロトタイプ、Web、スライド、HTML 動画まで',
   labsPre: '',
   labsPost: ' で何が作れる？',
+  labsLead:
+    'プロトタイプ、ランディングページ、スライド、ダッシュボード、ブランド／デザインシステム、さらに HTML 動画まで。Open Design はそれぞれを実際に動くファイルに変換し、自分の coding agent で駆動、そのまま納品や開発への引き継ぎができます。',
   methodTitle: '21+ のコーディングエージェントを設定ゼロで接続',
   ctaTitle: '最先端の AI デザイン能力を、すべての作り手の手元へ',
   testiPre: '世界中から、',
@@ -220,7 +231,7 @@ const ja: HomeExtra = {
     '新しいテンプレート、デザインシステムの更新、アンバサダーイベント、プロダクトの最新情報を、あなたの受信箱へ直接お届けします。',
   newsBtn: '購読する',
   newsDone: 'ご登録ありがとうございます！',
-  faqTitle: 'よくある質問',
+  faqTitle: 'Open Design のよくある質問 — オープンソース・BYOK・Claude Design 代替',
   footProduct: '製品',
   footCommunity: 'コミュニティ',
   footLegal: '法的情報',
@@ -232,10 +243,10 @@ const ko: HomeExtra = {
     '아이디어에서 프로토타입, 웹, 슬라이드, HTML 영상까지 — 제품 디자인 전 과정을 내 컴퓨터에서 완성합니다.',
   heroTitleSub: 'Claude Design의 최고의 오픈소스 대안',
   heroSub:
-    'Figma와 Claude Design의 에이전트 네이티브 대안.\n데스크톱 우선, 21개 코딩 에이전트, 129개 디자인 시스템, Apache-2.0.',
+    'Open Design는 오픈소스이자 로컬로 동작하는 vibe design workspace입니다——이미 사용 중인 코딩 에이전트를 디자인 엔진으로 바꿔, 아이디어에서 프로토타입, 웹, 슬라이드, HTML 비디오까지 전 과정을 내 컴퓨터에서 끝냅니다.\n에이전트 네이티브 및 BYOK, 21개 코딩 에이전트, 129개 디자인 시스템, Apache-2.0.',
   aboutKicker: '왜 Open Design인가?',
   aboutStatement:
-    '2026년 4월, Claude Design은 LLM이 글이 아니라 실제 디자인 결과물을 만들 수 있음을 처음으로 증명했습니다. 하지만 폐쇄형에 유료, 클라우드 전용이며 Anthropic 모델에 묶여 있어 에이전트 교체, 셀프 호스팅, BYOK가 모두 불가능합니다. Open Design은 그 능력을 개방합니다.',
+    'Open Design은 오픈소스이자 agentic한 vibe design workspace입니다. 이미 쓰는 코딩 에이전트를, 결과물이 온전히 내 것이 되는 디자인 엔진으로 바꿉니다. LLM이 처음으로 진짜 디자인을——카피가 아니라 실제 디자인을——해낼 수 있음을 증명했을 때, 그 능력은 폐쇄적이고 호스팅형이며 모델에 묶여 있었습니다. Open Design은 그것을 엽니다: 로컬, BYOK, Apache-2.0.',
   aboutTab1: '데스크톱 네이티브',
   aboutTab2: '에이전트를 만들지 않고, 연결합니다',
   aboutTab3: '쓸수록 당신을 이해합니다',
@@ -252,9 +263,11 @@ const ko: HomeExtra = {
   stepDesc2: '방향이 정해지면 팔레트, 폰트, 간격이 자동으로 생성 흐름에 반영됩니다.',
   stepDesc3: '에이전트가 모든 컨텍스트를 읽어 실제로 실행 가능한 파일을 생성하고, 샌드박스에서 즉시 미리보기·수정합니다.',
   stepDesc4: '엔지니어링으로 내보내 계속 개발하거나, HyperFrames로 바로 마케팅 영상으로 만드세요.',
-  capTitle: '아이디어에서 전달까지, 손쉽게',
+  capTitle: '아이디어에서 프로토타입, 웹, 슬라이드, HTML 비디오까지',
   labsPre: '',
   labsPost: '(으)로 무엇을 만들 수 있나요?',
+  labsLead:
+    '프로토타입, 랜딩 페이지, 슬라이드, 대시보드, 브랜드 및 디자인 시스템, 그리고 HTML 비디오까지. Open Design은 각각을 실제로 실행되는 파일로 만들며, 내 coding agent로 구동해 바로 배포하거나 엔지니어링에 넘길 수 있습니다.',
   methodTitle: '21개 이상의 코딩 에이전트를 설정 없이 연결',
   ctaTitle: '최첨단 AI 디자인 역량을 모든 창작자의 책상으로',
   testiPre: '전 세계에서, ',
@@ -265,7 +278,7 @@ const ko: HomeExtra = {
     '새 템플릿, 디자인 시스템 업데이트, 앰배서더 이벤트, 제품 소식을 받은편지함으로 바로 보내드립니다.',
   newsBtn: '구독',
   newsDone: '구독해 주셔서 감사합니다!',
-  faqTitle: '자주 묻는 질문',
+  faqTitle: 'Open Design FAQ — 오픈소스, BYOK, Claude Design 대안',
   footProduct: '제품',
   footCommunity: '커뮤니티',
   footLegal: '법적 고지',
@@ -277,10 +290,10 @@ const de: HomeExtra = {
     'Von der Idee zu Prototyp, Web, Slides und HTML-Video — der gesamte Produktdesign-Flow, fertig auf deinem eigenen Rechner.',
   heroTitleSub: 'Die beste Open-Source-Alternative zu Claude Design',
   heroSub:
-    'Eine agent-native Alternative zu Figma und Claude Design.\nDesktop-first, mit 21 Coding-Agents, 129 Design-Systemen und Apache-2.0-Lizenz.',
+    'Open Design ist der quelloffene, lokale vibe design workspace — er verwandelt die Coding-Agents, die du bereits nutzt, in eine Design-Engine, die dich von der Idee bis zu Prototyp, Web, Slides und HTML-Video bringt, alles auf deinem eigenen Rechner.\nAgent-native und BYOK, mit 21 Coding-Agents, 129 Design-Systemen und Apache-2.0-Lizenz.',
   aboutKicker: 'Warum Open Design?',
   aboutStatement:
-    'Im April 2026 bewies Claude Design erstmals, dass ein LLM wirklich gestalten kann — keine Texte, sondern echte Design-Arbeit. Aber es ist Closed Source, kostenpflichtig und nur in der Cloud, an Anthropic-Modelle gebunden — kein Agent-Wechsel, kein Self-Hosting, kein BYOK. Open Design öffnet diese Fähigkeit.',
+    'Open Design ist der quelloffene, agentische Vibe Design Workspace – er verwandelt den Coding-Agent, den du bereits nutzt, in eine Design-Engine, deren Ergebnisse ganz dir gehören. Als ein LLM erstmals bewies, dass es wirklich gestalten kann – echte Designarbeit, nicht nur Text –, kam diese Fähigkeit geschlossen, gehostet und modellgebunden. Open Design öffnet sie: lokal, BYOK, Apache-2.0.',
   aboutTab1: 'Desktop-nativ',
   aboutTab2: 'Wir bauen keine Agents, wir binden sie ein',
   aboutTab3: 'Es lernt dich mit der Zeit',
@@ -297,9 +310,11 @@ const de: HomeExtra = {
   stepDesc2: 'Sobald die Richtung steht, fließen Palette, Typo und Abstände automatisch in die Generierung ein.',
   stepDesc3: 'Der Agent liest den gesamten Kontext, erzeugt echte lauffähige Dateien und zeigt sie live in einer Sandbox zum Bearbeiten.',
   stepDesc4: 'Exportiere ins Engineering zum Weiterbauen oder mach mit HyperFrames direkt ein Marketing-Video daraus.',
-  capTitle: 'Von der Idee zur Auslieferung, mühelos',
+  capTitle: 'Von der Idee zu Prototyp, Web, Slides und HTML-Video',
   labsPre: 'Was kannst du mit ',
   labsPost: ' erstellen?',
+  labsLead:
+    'Prototypen, Landingpages, Slides, Dashboards, Marken- und Design-Systeme – sogar HTML-Video. Open Design macht daraus echte, lauffähige Dateien, angetrieben von deinem eigenen Coding-Agent, bereit zum Ausliefern oder zur Übergabe an die Entwicklung.',
   methodTitle: '21+ Coding-Agents anbinden, ohne Konfiguration',
   ctaTitle: 'Modernste KI-Designkraft zurück auf den Schreibtisch jedes Kreativen',
   testiPre: 'Aus aller Welt bauen ',
@@ -310,7 +325,7 @@ const de: HomeExtra = {
     'Neue Vorlagen, Design-System-Updates, Ambassador-Events und Produktneuigkeiten — direkt in dein Postfach.',
   newsBtn: 'Abonnieren',
   newsDone: 'Danke — du bist dabei!',
-  faqTitle: 'FAQ',
+  faqTitle: 'Open Design FAQ – Open Source, BYOK und Claude-Design-Alternative',
   footProduct: 'Produkt',
   footCommunity: 'Community',
   footLegal: 'Rechtliches',
@@ -322,10 +337,10 @@ const fr: HomeExtra = {
     'De l’idée au prototype, au web, aux slides et à la vidéo HTML — tout le flux de design produit, réalisé sur votre propre machine.',
   heroTitleSub: "La meilleure alternative open source à Claude Design",
   heroSub:
-    'Une alternative agent-native à Figma et Claude Design.\nDesktop d’abord, avec 21 agents de code, 129 design systems et une licence Apache-2.0.',
+    'Open Design est le vibe design workspace open source et local — il transforme les agents de code que vous utilisez déjà en moteur de design, de l’idée au prototype, au web, aux slides et à la vidéo HTML, le tout sur votre propre machine.\nAgent-native et BYOK, avec 21 agents de code, 129 design systems et une licence Apache-2.0.',
   aboutKicker: 'Pourquoi Open Design ?',
   aboutStatement:
-    'En avril 2026, Claude Design a prouvé pour la première fois qu’un LLM pouvait vraiment concevoir — non pas écrire, mais produire un véritable travail de design. Mais il est propriétaire, payant et uniquement cloud, verrouillé aux modèles Anthropic — pas de changement d’agent, pas d’auto-hébergement, pas de BYOK. Open Design ouvre cette capacité.',
+    'Open Design est le vibe design workspace open source et agentique — il transforme l’agent de code que vous utilisez déjà en un moteur de design dont vous possédez entièrement le résultat. Quand un LLM a prouvé pour la première fois qu’il pouvait vraiment concevoir — du vrai design, pas juste du texte —, cette capacité est arrivée fermée, hébergée et verrouillée à un modèle. Open Design l’ouvre : local, BYOK, Apache-2.0.',
   aboutTab1: 'Natif desktop',
   aboutTab2: 'On ne crée pas d’agents, on les branche',
   aboutTab3: 'Il vous comprend avec le temps',
@@ -342,9 +357,11 @@ const fr: HomeExtra = {
   stepDesc2: 'Une fois la direction choisie, palette, typo et espacements alimentent automatiquement la génération.',
   stepDesc3: 'L’agent lit tout le contexte, produit de vrais fichiers exécutables et les prévisualise et édite en direct dans un bac à sable.',
   stepDesc4: 'Exportez vers l’ingénierie pour continuer, ou transformez-le en vidéo marketing avec HyperFrames.',
-  capTitle: 'De l’idée à la livraison, en toute simplicité',
+  capTitle: 'De l’idée au prototype, web, slides et vidéo HTML',
   labsPre: 'Que pouvez-vous créer avec ',
   labsPost: ' ?',
+  labsLead:
+    'Prototypes, landing pages, slides, dashboards, systèmes de marque et de design — et même vidéo HTML. Open Design transforme chacun en fichiers réels et exécutables, pilotés par votre propre agent de code, prêts à livrer ou à transmettre à l’ingénierie.',
   methodTitle: 'Branchez 21+ agents de code, sans configuration',
   ctaTitle: 'Ramener la puissance du design IA de pointe sur le bureau de chaque créateur',
   testiPre: 'Du monde entier, ',
@@ -355,7 +372,7 @@ const fr: HomeExtra = {
     'Nouveaux modèles, mises à jour des design systems, événements ambassadeurs et actualités produit — directement dans votre boîte mail.',
   newsBtn: 'S’abonner',
   newsDone: 'Merci — vous êtes inscrit !',
-  faqTitle: 'FAQ',
+  faqTitle: 'FAQ Open Design — open source, BYOK et alternative à Claude Design',
   footProduct: 'Produit',
   footCommunity: 'Communauté',
   footLegal: 'Mentions légales',
@@ -367,10 +384,10 @@ const ru: HomeExtra = {
     'От идеи до прототипа, веба, слайдов и HTML-видео — весь процесс продуктового дизайна, завершённый на вашей машине.',
   heroTitleSub: 'Лучшая open-source альтернатива Claude Design',
   heroSub:
-    'Agent-native альтернатива Figma и Claude Design.\nDesktop-first, 21 кодинг-агентов, 129 дизайн-систем, лицензия Apache-2.0.',
+    'Open Design — это открытый локальный vibe design workspace: он превращает кодинг-агентов, которыми вы уже пользуетесь, в движок дизайна, ведущий от идеи к прототипу, вебу, слайдам и HTML-видео — всё на вашей машине.\nAgent-native и BYOK, 21 кодинг-агент, 129 дизайн-систем, лицензия Apache-2.0.',
   aboutKicker: 'Почему Open Design?',
   aboutStatement:
-    'В апреле 2026 года Claude Design впервые доказал, что LLM может действительно проектировать — не писать тексты, а создавать настоящую дизайн-работу. Но он закрытый, платный и только в облаке, привязан к моделям Anthropic — никакой смены агента, самостоятельного хостинга или BYOK. Open Design делает эту возможность открытой.',
+    'Open Design — это открытый, агентный vibe design workspace: он превращает кодинг-агента, которым вы уже пользуетесь, в движок дизайна, результат которого полностью принадлежит вам. Когда LLM впервые доказал, что действительно умеет проектировать — настоящий дизайн, а не просто текст, — эта способность пришла закрытой, облачной и привязанной к модели. Open Design открывает её: локально, BYOK, Apache-2.0.',
   aboutTab1: 'Нативно для десктопа',
   aboutTab2: 'Мы не создаём агентов, мы их подключаем',
   aboutTab3: 'Со временем он понимает вас',
@@ -387,9 +404,11 @@ const ru: HomeExtra = {
   stepDesc2: 'Когда направление задано, палитра, шрифты и отступы автоматически попадают в генерацию.',
   stepDesc3: 'Агент читает весь контекст, создаёт реально работающие файлы и тут же показывает и редактирует их в песочнице.',
   stepDesc4: 'Экспортируйте в разработку для продолжения или превратите в маркетинговое видео с HyperFrames.',
-  capTitle: 'От идеи до сдачи — легко',
+  capTitle: 'От идеи до прототипа, веба, слайдов и HTML-видео',
   labsPre: 'Что можно создать с ',
   labsPost: '?',
+  labsLead:
+    'Прототипы, лендинги, слайды, дашборды, бренд- и дизайн-системы — и даже HTML-видео. Open Design превращает каждый в реальные рабочие файлы на вашем кодинг-агенте, готовые к сдаче или передаче разработке.',
   methodTitle: 'Подключите 21+ кодинг-агентов без настройки',
   ctaTitle: 'Вернуть передовую силу ИИ-дизайна на стол каждого автора',
   testiPre: 'Со всего мира ',
@@ -400,7 +419,7 @@ const ru: HomeExtra = {
     'Новые шаблоны, обновления дизайн-систем, события амбассадоров и новости продукта — прямо на вашу почту.',
   newsBtn: 'Подписаться',
   newsDone: 'Спасибо — вы подписаны!',
-  faqTitle: 'Частые вопросы',
+  faqTitle: 'FAQ Open Design — open source, BYOK и альтернатива Claude Design',
   footProduct: 'Продукт',
   footCommunity: 'Сообщество',
   footLegal: 'Правовая информация',
@@ -412,10 +431,10 @@ const es: HomeExtra = {
     'De la idea al prototipo, web, slides y vídeo HTML — todo el flujo de diseño de producto, terminado en tu propia máquina.',
   heroTitleSub: 'La mejor alternativa open source a Claude Design',
   heroSub:
-    'Una alternativa agent-native a Figma y Claude Design.\nDesktop-first, con 21 agentes de código, 129 design systems y licencia Apache-2.0.',
+    'Open Design es el vibe design workspace open source y local: convierte los agentes de código que ya usas en un motor de diseño que te lleva de la idea al prototipo, la web, las slides y el vídeo HTML, todo en tu propia máquina.\nAgent-native y BYOK, con 21 agentes de código, 129 design systems y licencia Apache-2.0.',
   aboutKicker: '¿Por qué Open Design?',
   aboutStatement:
-    'En abril de 2026, Claude Design demostró por primera vez que un LLM puede diseñar de verdad — no escribir textos, sino producir trabajo de diseño real. Pero es de código cerrado, de pago y solo en la nube, atado a los modelos de Anthropic — sin cambio de agente, sin self-hosting, sin BYOK. Open Design abre esa capacidad.',
+    'Open Design es el vibe design workspace open source y agéntico: convierte el agente de código que ya usas en un motor de diseño cuyo resultado es totalmente tuyo. Cuando un LLM demostró por primera vez que podía diseñar de verdad —diseño real, no solo texto—, esa capacidad llegó cerrada, alojada y atada a un modelo. Open Design la abre: local, BYOK, Apache-2.0.',
   aboutTab1: 'Nativo de escritorio',
   aboutTab2: 'No creamos agentes, los conectamos',
   aboutTab3: 'Te entiende con el tiempo',
@@ -432,9 +451,11 @@ const es: HomeExtra = {
   stepDesc2: 'Una vez fijada la dirección, paleta, tipografía y espaciado entran automáticamente en la generación.',
   stepDesc3: 'El agente lee todo el contexto, produce archivos reales ejecutables y los previsualiza y edita en vivo en un sandbox.',
   stepDesc4: 'Expórtalo a ingeniería para seguir construyendo, o conviértelo en un vídeo de marketing con HyperFrames.',
-  capTitle: 'De la idea a la entrega, sin esfuerzo',
+  capTitle: 'De la idea al prototipo, web, slides y vídeo HTML',
   labsPre: '¿Qué puedes crear con ',
   labsPost: '?',
+  labsLead:
+    'Prototipos, landing pages, slides, dashboards, sistemas de marca y de diseño — incluso vídeo HTML. Open Design convierte cada uno en archivos reales y ejecutables, impulsados por tu propio agente de código, listos para entregar o pasar a ingeniería.',
   methodTitle: 'Conecta 21+ agentes de código, sin configuración',
   ctaTitle: 'Devuelve el poder del diseño con IA de vanguardia al escritorio de cada creador',
   testiPre: 'Desde todo el mundo, ',
@@ -445,7 +466,7 @@ const es: HomeExtra = {
     'Nuevas plantillas, actualizaciones de design systems, eventos de embajadores y novedades del producto — directo a tu bandeja de entrada.',
   newsBtn: 'Suscribirse',
   newsDone: '¡Gracias — ya estás en la lista!',
-  faqTitle: 'Preguntas frecuentes',
+  faqTitle: 'FAQ de Open Design — open source, BYOK y alternativa a Claude Design',
   footProduct: 'Producto',
   footCommunity: 'Comunidad',
   footLegal: 'Legal',
@@ -457,10 +478,10 @@ const ptBr: HomeExtra = {
     'Da ideia ao protótipo, web, slides e vídeo HTML — todo o fluxo de design de produto, finalizado na sua própria máquina.',
   heroTitleSub: 'A melhor alternativa open source ao Claude Design',
   heroSub:
-    'Uma alternativa agent-native ao Figma e ao Claude Design.\nDesktop-first, com 21 agentes de código, 129 design systems e licença Apache-2.0.',
+    'Open Design é o vibe design workspace open source e local: transforma os agentes de código que você já usa em um motor de design que vai da ideia ao protótipo, web, slides e vídeo HTML, tudo na sua própria máquina.\nAgent-native e BYOK, com 21 agentes de código, 129 design systems e licença Apache-2.0.',
   aboutKicker: 'Por que Open Design?',
   aboutStatement:
-    'Em abril de 2026, o Claude Design provou pela primeira vez que um LLM pode realmente projetar — não escrever textos, mas produzir trabalho de design real. Mas é de código fechado, pago e só na nuvem, preso aos modelos da Anthropic — sem troca de agente, sem self-hosting, sem BYOK. O Open Design abre essa capacidade.',
+    'O Open Design é o vibe design workspace open source e agêntico: transforma o coding agent que você já usa em um motor de design cujo resultado é totalmente seu. Quando um LLM provou pela primeira vez que sabia projetar de verdade — design real, não só texto —, essa capacidade chegou fechada, hospedada e presa a um modelo. O Open Design a abre: local, BYOK, Apache-2.0.',
   aboutTab1: 'Nativo de desktop',
   aboutTab2: 'Não criamos agentes, nós os conectamos',
   aboutTab3: 'Ele entende você com o tempo',
@@ -477,9 +498,11 @@ const ptBr: HomeExtra = {
   stepDesc2: 'Definida a direção, paleta, tipografia e espaçamento entram automaticamente na geração.',
   stepDesc3: 'O agente lê todo o contexto, produz arquivos reais executáveis e os pré-visualiza e edita ao vivo em um sandbox.',
   stepDesc4: 'Exporte para a engenharia continuar, ou transforme em vídeo de marketing com o HyperFrames.',
-  capTitle: 'Da ideia à entrega, sem esforço',
+  capTitle: 'Da ideia ao protótipo, web, slides e vídeo HTML',
   labsPre: 'O que você pode criar com ',
   labsPost: '?',
+  labsLead:
+    'Protótipos, landing pages, slides, dashboards, sistemas de marca e de design — até vídeo HTML. O Open Design transforma cada um em arquivos reais e executáveis, movidos pelo seu próprio coding agent, prontos para entregar ou repassar à engenharia.',
   methodTitle: 'Conecte 21+ agentes de código, sem configuração',
   ctaTitle: 'Traga o poder do design com IA de ponta de volta à mesa de cada criador',
   testiPre: 'De todo o mundo, ',
@@ -490,7 +513,7 @@ const ptBr: HomeExtra = {
     'Novos templates, atualizações de design systems, eventos de embaixadores e novidades do produto — direto na sua caixa de entrada.',
   newsBtn: 'Assinar',
   newsDone: 'Obrigado — você está na lista!',
-  faqTitle: 'Perguntas frequentes',
+  faqTitle: 'FAQ do Open Design — open source, BYOK e alternativa ao Claude Design',
   footProduct: 'Produto',
   footCommunity: 'Comunidade',
   footLegal: 'Legal',
@@ -502,10 +525,10 @@ const it: HomeExtra = {
     'Dall’idea al prototipo, web, slide e video HTML — l’intero flusso di product design, completato sulla tua macchina.',
   heroTitleSub: "La migliore alternativa open source a Claude Design",
   heroSub:
-    'Un’alternativa agent-native a Figma e Claude Design.\nDesktop-first, con 21 coding agent, 129 design system e licenza Apache-2.0.',
+    'Open Design è il vibe design workspace open source e locale: trasforma i coding agent che già usi in un motore di design che ti porta dall’idea al prototipo, al web, alle slide e al video HTML, tutto sulla tua macchina.\nAgent-native e BYOK, con 21 coding agent, 129 design system e licenza Apache-2.0.',
   aboutKicker: 'Perché Open Design?',
   aboutStatement:
-    'Ad aprile 2026, Claude Design ha dimostrato per la prima volta che un LLM può davvero progettare — non scrivere testi, ma produrre vero lavoro di design. Ma è closed-source, a pagamento e solo cloud, legato ai modelli Anthropic — niente cambio di agente, niente self-hosting, niente BYOK. Open Design apre questa capacità.',
+    'Open Design è il vibe design workspace open source e agentico: trasforma il coding agent che già usi in un motore di design il cui risultato è interamente tuo. Quando un LLM ha dimostrato per la prima volta di saper progettare davvero — vero design, non solo testo —, quella capacità è arrivata chiusa, ospitata e legata a un modello. Open Design la apre: locale, BYOK, Apache-2.0.',
   aboutTab1: 'Nativo desktop',
   aboutTab2: 'Non costruiamo agenti, li colleghiamo',
   aboutTab3: 'Ti capisce col tempo',
@@ -522,9 +545,11 @@ const it: HomeExtra = {
   stepDesc2: 'Definita la direzione, palette, font e spaziature entrano automaticamente nella generazione.',
   stepDesc3: 'L’agente legge tutto il contesto, produce file realmente eseguibili e li mostra e modifica in tempo reale in una sandbox.',
   stepDesc4: 'Esportalo all’ingegneria per continuare, o trasformalo in un video marketing con HyperFrames.',
-  capTitle: 'Dall’idea alla consegna, senza sforzo',
+  capTitle: 'Dall’idea al prototipo, web, slide e video HTML',
   labsPre: 'Cosa puoi creare con ',
   labsPost: '?',
+  labsLead:
+    'Prototipi, landing page, slide, dashboard, sistemi di marca e di design — persino video HTML. Open Design trasforma ciascuno in file reali ed eseguibili, guidati dal tuo coding agent, pronti da consegnare o passare all’ingegneria.',
   methodTitle: 'Collega 21+ coding agent, zero configurazione',
   ctaTitle: 'Riporta la potenza del design con AI di frontiera sulla scrivania di ogni creativo',
   testiPre: 'Da tutto il mondo, ',
@@ -535,7 +560,7 @@ const it: HomeExtra = {
     'Nuovi template, aggiornamenti dei design system, eventi ambassador e novità di prodotto — direttamente nella tua casella.',
   newsBtn: 'Iscriviti',
   newsDone: 'Grazie — sei in lista!',
-  faqTitle: 'FAQ',
+  faqTitle: 'FAQ di Open Design — open source, BYOK e alternativa a Claude Design',
   footProduct: 'Prodotto',
   footCommunity: 'Community',
   footLegal: 'Note legali',
@@ -772,10 +797,10 @@ const tr: HomeExtra = {
     'Fikirden prototipe, web’e, slaytlara ve HTML videoya — tüm ürün tasarım akışı, kendi makinende tamamlanır.',
   heroTitleSub: "Claude Design'ın en iyi açık kaynak alternatifi",
   heroSub:
-    'Figma ve Claude Design’a agent-native bir alternatif.\nÖnce masaüstü; 21 kodlama ajanı, 129 tasarım sistemi ve Apache-2.0 lisansı.',
+    'Open Design, açık kaynaklı ve yerel çalışan vibe design workspace’tir — hâlihazırda kullandığın kodlama ajanlarını, fikirden prototipe, web’e, slaytlara ve HTML videoya kadar her şeyi kendi makinende tamamlayan bir tasarım motoruna dönüştürür.\nAgent-native ve BYOK; 21 kodlama ajanı, 129 tasarım sistemi ve Apache-2.0 lisansı.',
   aboutKicker: 'Neden Open Design?',
   aboutStatement:
-    'Nisan 2026’da Claude Design, bir LLM’in gerçekten tasarım yapabildiğini ilk kez kanıtladı — metin yazmak değil, gerçek tasarım işi üretmek. Ama kapalı kaynak, ücretli ve yalnızca bulutta, Anthropic modellerine kilitli — ajan değiştirme yok, self-hosting yok, BYOK yok. Open Design bu yeteneği açar.',
+    'Open Design, açık kaynaklı ve agentic bir vibe design workspace’tir: hâlihazırda kullandığın kodlama ajanını, çıktısı tamamen sana ait olan bir tasarım motoruna dönüştürür. Bir LLM ilk kez gerçekten tasarlayabildiğini — metin değil, gerçek tasarım — kanıtladığında, bu yetenek kapalı, barındırılan ve modele kilitli geldi. Open Design onu açar: yerel, BYOK, Apache-2.0.',
   aboutTab1: 'Masaüstü yerel',
   aboutTab2: 'Ajan üretmiyoruz, onları bağlıyoruz',
   aboutTab3: 'Kullandıkça seni anlar',
@@ -792,9 +817,11 @@ const tr: HomeExtra = {
   stepDesc2: 'Yön belirlenince palet, tipografi ve boşluklar otomatik olarak üretime akar.',
   stepDesc3: 'Ajan tüm bağlamı okur, gerçekten çalışan dosyalar üretir ve bunları bir sandbox’ta anında önizleyip düzenler.',
   stepDesc4: 'Geliştirmeyi sürdürmek için mühendisliğe aktar ya da HyperFrames ile doğrudan pazarlama videosuna dönüştür.',
-  capTitle: 'Fikirden teslimata, zahmetsizce',
+  capTitle: 'Fikirden prototipe, web’e, slaytlara ve HTML videoya',
   labsPre: '',
   labsPost: ' ile neler üretebilirsin?',
+  labsLead:
+    'Prototipler, açılış sayfaları, slaytlar, dashboardlar, marka ve tasarım sistemleri — hatta HTML video. Open Design her birini kendi kodlama ajanınla çalışan gerçek, çalıştırılabilir dosyalara dönüştürür; teslime ya da mühendisliğe devretmeye hazır.',
   methodTitle: '21+ kodlama ajanını sıfır yapılandırmayla bağla',
   ctaTitle: 'İleri seviye yapay zeka tasarım gücünü her üreticinin masasına geri getir',
   testiPre: 'Dünyanın her yerinden ',
@@ -805,7 +832,7 @@ const tr: HomeExtra = {
     'Yeni şablonlar, tasarım sistemi güncellemeleri, elçi etkinlikleri ve ürün haberleri — doğrudan gelen kutuna.',
   newsBtn: 'Abone ol',
   newsDone: 'Teşekkürler — listedesin!',
-  faqTitle: 'SSS',
+  faqTitle: 'Open Design SSS — açık kaynak, BYOK ve Claude Design alternatifi',
   footProduct: 'Ürün',
   footCommunity: 'Topluluk',
   footLegal: 'Yasal',

--- a/apps/landing-page/app/i18n.ts
+++ b/apps/landing-page/app/i18n.ts
@@ -1047,6 +1047,8 @@ export interface HomeSeoCopy {
 export interface HomeFaqEntry {
   q: string;
   a: string;
+  /** Optional hub link to the page that explains this answer in depth. */
+  href?: string;
 }
 
 export interface HomePageCopy {
@@ -1600,6 +1602,8 @@ type HomeFaqTemplate = {
   q: string;
   a: string;
   official?: boolean;
+  /** Optional hub link to the page that explains this answer in depth. */
+  href?: string;
 };
 
 const COMMON_COPY: Record<LandingLocaleCode, CommonCopy> = {
@@ -2435,14 +2439,14 @@ const COMMON_COPY: Record<LandingLocaleCode, CommonCopy> = {
 
 const HOME_SEO_COPY: Record<LandingLocaleCode, HomeSeoCopy> = {
   en: {
-    title: 'Open Design — Best open-source Claude Design alternative',
+    title: 'Open Design — Best Open Source Claude Design Alternative',
     description:
-      'Open Design is the best open-source, local-first Claude Design alternative. Generate decks, landing pages, dashboards, and brand systems with Claude Code, Codex, Cursor, Gemini, OpenCode, or Qwen — driven by {skills} composable skills and {systems} portable DESIGN.md systems.',
+      'Open-source vibe design workspace & Claude Design alternative — build prototypes, landing pages, dashboards, slides & HTML video with your own coding agent.',
   },
   zh: {
     title: 'Open Design —— 最佳 Claude Design 开源替代',
     description:
-      'Open Design 是最佳的开源、本地优先 Claude Design 替代方案。用 Claude Code、Codex、Cursor、Gemini、OpenCode 或 Qwen 生成演示文稿、落地页和仪表盘，背后由 {skills} 个可组合 SKILL.md 工作流驱动。',
+      'Open Design 是开源的 vibe design workspace，也是 Claude Design 的开源替代——用你自己的 coding agent 做原型、落地页、仪表盘、Slides 和 HTML 视频。',
   },
   'zh-tw': {
     title: 'Open Design —— 最佳 Claude Design 開源替代',
@@ -2452,42 +2456,42 @@ const HOME_SEO_COPY: Record<LandingLocaleCode, HomeSeoCopy> = {
   ja: {
     title: 'Open Design — 最高のオープンソース Claude Design 代替',
     description:
-      'Open Design は最高のオープンソースかつローカル優先の Claude Design 代替です。Claude Code、Codex、Cursor、Gemini、OpenCode、Qwen と {skills} 個のスキル、{systems} 個の DESIGN.md システムでデッキ、ランディングページ、ダッシュボード、ブランドシステムを生成します。',
+      'オープンソースの vibe design workspace であり Claude Design の代替。自分の coding agent でプロトタイプ、ランディングページ、ダッシュボード、スライド、HTML 動画を作成。',
   },
   ko: {
     title: 'Open Design — 최고의 오픈소스 Claude Design 대안',
     description:
-      'Open Design은 최고의 오픈소스, 로컬 우선 Claude Design 대안입니다. Claude Code, Codex, Cursor, Gemini, OpenCode, Qwen과 {skills}개의 조합형 스킬, {systems}개의 DESIGN.md 시스템으로 덱, 랜딩 페이지, 대시보드, 브랜드 시스템을 만듭니다.',
+      '오픈소스 vibe design workspace이자 Claude Design 대안. 내 coding agent로 프로토타입, 랜딩 페이지, 대시보드, 슬라이드, HTML 비디오를 만드세요.',
   },
   de: {
     title: 'Open Design — beste Open-Source-Alternative zu Claude Design',
     description:
-      'Open Design ist die beste Open-Source- und Local-first-Alternative zu Claude Design. Erzeuge Decks, Landingpages, Dashboards und Brand-Systeme mit Claude Code, Codex, Cursor, Gemini, OpenCode oder Qwen — mit {skills} kombinierbaren Skills und {systems} portablen DESIGN.md-Systemen.',
+      'Open-Source Vibe Design Workspace und Claude-Design-Alternative – Prototypen, Landingpages, Dashboards, Slides & HTML-Video mit deinem eigenen Coding-Agent.',
   },
   fr: {
     title: "Open Design — la meilleure alternative open source à Claude Design",
     description:
-      "Open Design est la meilleure alternative open source et local-first à Claude Design. Générez des decks, landing pages, dashboards et systèmes de marque avec Claude Code, Codex, Cursor, Gemini, OpenCode ou Qwen — grâce à {skills} skills composables et {systems} systèmes DESIGN.md portables.",
+      'Vibe design workspace open source et alternative à Claude Design — créez prototypes, landing pages, dashboards, slides et vidéo HTML avec votre agent de code.',
   },
   ru: {
     title: 'Open Design — лучшая open-source альтернатива Claude Design',
     description:
-      'Open Design — лучшая open-source и local-first альтернатива Claude Design. Создавайте презентации, лендинги, дашборды и бренд-системы через Claude Code, Codex, Cursor, Gemini, OpenCode или Qwen на базе {skills} skills и {systems} DESIGN.md-систем.',
+      'Open-source vibe design workspace и альтернатива Claude Design — прототипы, лендинги, дашборды, слайды и HTML-видео с вашим кодинг-агентом.',
   },
   es: {
     title: 'Open Design — la mejor alternativa open source a Claude Design',
     description:
-      'Open Design es la mejor alternativa open source y local-first a Claude Design. Genera decks, landing pages, dashboards y sistemas de marca con Claude Code, Codex, Cursor, Gemini, OpenCode o Qwen, impulsado por {skills} skills componibles y {systems} sistemas DESIGN.md portables.',
+      'Vibe design workspace open source y alternativa a Claude Design: crea prototipos, landing pages, dashboards, slides y vídeo HTML con tu agente de código.',
   },
   'pt-br': {
     title: 'Open Design — a melhor alternativa open source ao Claude Design',
     description:
-      'Open Design é a melhor alternativa open source e local-first ao Claude Design. Gere decks, landing pages, dashboards e sistemas de marca com Claude Code, Codex, Cursor, Gemini, OpenCode ou Qwen, usando {skills} skills combináveis e {systems} sistemas DESIGN.md portáteis.',
+      'Vibe design workspace open source e alternativa ao Claude Design — crie protótipos, landing pages, dashboards, slides e vídeo HTML com seu coding agent.',
   },
   it: {
     title: "Open Design — la migliore alternativa open source a Claude Design",
     description:
-      "Open Design è la migliore alternativa open source e local-first a Claude Design. Genera deck, landing page, dashboard e sistemi di marca con Claude Code, Codex, Cursor, Gemini, OpenCode o Qwen, usando {skills} skill componibili e {systems} sistemi DESIGN.md portabili.",
+      'Vibe design workspace open source e alternativa a Claude Design: crea prototipi, landing page, dashboard, slide e video HTML con il tuo coding agent.',
   },
   vi: {
     title: 'Open Design — lựa chọn mã nguồn mở tốt nhất thay Claude Design',
@@ -2517,7 +2521,7 @@ const HOME_SEO_COPY: Record<LandingLocaleCode, HomeSeoCopy> = {
   tr: {
     title: "Open Design — Claude Design'ın en iyi açık kaynak alternatifi",
     description:
-      "Open Design, Claude Design'ın en iyi, açık kaynak ve local-first alternatifidir. Claude Code, Codex, Cursor, Gemini, OpenCode veya Qwen ile deck, landing page, dashboard ve marka sistemleri üretin; {skills} birleştirilebilir skill ve {systems} taşınabilir DESIGN.md sistemiyle çalışır.",
+      'Açık kaynaklı vibe design workspace ve Claude Design alternatifi — kendi kodlama ajanınla prototip, açılış sayfası, dashboard, slayt ve HTML video oluştur.',
   },
   uk: {
     title: 'Open Design — найкраща open-source альтернатива Claude Design',
@@ -2540,6 +2544,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
     {
       q: 'How is Open Design different from Claude Design?',
       a: 'Claude Design is a hosted product tied to a single vendor. Open Design is local-first, open source under Apache-2.0, and BYOK: you bring your own agent, credentials, and DESIGN.md system.',
+    },
+    {
+      q: 'Is Open Design an open-source Claude Design alternative?',
+      a: 'Yes — Open Design is the open-source, local-first Claude Design alternative. Where Claude Design is closed, hosted, and locked to Anthropic models, Open Design is Apache-2.0, runs on your own machine, and is BYOK, so you drive it with Claude Code, Codex, Cursor, Gemini, OpenCode, or Qwen and keep every artifact as files you own.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'What is a vibe design workspace?',
+      a: 'A vibe design workspace is where you design by describing intent to an AI agent — from prompt to prototype, web page, slides, or HTML video — instead of hand-placing every element. Open Design is an open-source, agent-native vibe design workspace: it wires the coding agent you already run into a full design workflow, so one tool takes you from a rough idea to production-ready output you own.',
+      href: '/blog/what-is-vibe-design/',
     },
     {
       q: 'Does Open Design run locally?',
@@ -2587,6 +2601,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
     },
   ],
   zh: [
+    {
+      q: 'Open Design 是开源的 Claude Design 替代品吗？',
+      a: '是的——Open Design 是开源、本地优先的 Claude Design 替代方案。Claude Design 闭源、托管、锁定 Anthropic 模型；Open Design 是 Apache-2.0，跑在你自己的机器上，且 BYOK，你可以用 Claude Code、Codex、Cursor、Gemini、OpenCode 或 Qwen 驱动它，产出的每个文件都归你所有。',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: '什么是 vibe design workspace？',
+      a: 'vibe design workspace 是通过向 AI agent 描述意图来做设计——从 prompt 到原型、网页、slides、HTML 视频——而不是手动摆放每个元素。Open Design 是一个开源、agent-native 的 vibe design workspace：把你已经在用的 coding agent 接进完整设计工作流，一个工具就把你从粗略想法带到可交付、归你所有的成品。',
+      href: '/blog/what-is-vibe-design/',
+    },
     {
       q: 'Open Design 是什么？',
       a: 'Open Design 是 nexu-io/open-design 项目的官方开源 AI 设计工作台。它把本地编码 Agent（Claude Code、Codex、Cursor、Gemini CLI、OpenCode 或 Qwen）变成设计引擎，并由可组合 SKILL.md 工作流驱动。',
@@ -2698,6 +2722,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
   ],
   ja: [
     {
+      q: 'Open Design はオープンソースの Claude Design 代替ですか？',
+      a: 'はい——Open Design はオープンソースかつローカル優先の Claude Design 代替です。Claude Design はクローズドでホスト型、Anthropic モデルに固定されていますが、Open Design は Apache-2.0 で自分のマシン上で動き、BYOK。Claude Code、Codex、Cursor、Gemini、OpenCode、Qwen で駆動でき、生成物はすべて自分のファイルとして手元に残ります。',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'vibe design workspace とは？',
+      a: 'vibe design workspace とは、要素を一つずつ手で配置する代わりに、AI エージェントに意図を伝えて設計する場です——prompt からプロトタイプ、Web ページ、スライド、HTML 動画まで。Open Design はオープンソースで agent-native な vibe design workspace で、すでに使っているコーディングエージェントを完全な設計ワークフローに組み込み、ひとつのツールでラフなアイデアから自分のものになる完成物まで導きます。',
+      href: '/blog/what-is-vibe-design/',
+    },
+    {
       q: 'Open Design とは何ですか？',
       a: 'Open Design は nexu-io/open-design プロジェクト公式のオープンソース AI デザインワークスペースです。Claude Code、Codex、Cursor、Gemini CLI、OpenCode、Qwen などのローカル coding agent を、スキルと DESIGN.md システムで動くデザインエンジンにします。',
     },
@@ -2752,6 +2786,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
     },
   ],
   ko: [
+    {
+      q: 'Open Design은 오픈소스 Claude Design 대안인가요?',
+      a: '네——Open Design은 오픈소스, 로컬 우선 Claude Design 대안입니다. Claude Design은 폐쇄형·호스팅형이며 Anthropic 모델에 묶여 있지만, Open Design은 Apache-2.0이고 내 컴퓨터에서 실행되며 BYOK입니다. Claude Code, Codex, Cursor, Gemini, OpenCode, Qwen으로 구동할 수 있고 생성된 모든 산출물은 내 파일로 남습니다.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'vibe design workspace란 무엇인가요?',
+      a: 'vibe design workspace는 모든 요소를 손으로 배치하는 대신 AI 에이전트에 의도를 설명해 디자인하는 공간입니다 — prompt에서 프로토타입, 웹 페이지, 슬라이드, HTML 비디오까지. Open Design은 오픈소스이자 agent-native한 vibe design workspace로, 이미 쓰는 코딩 에이전트를 완전한 디자인 워크플로에 연결해 하나의 도구로 거친 아이디어에서 내 것이 되는 완성물까지 이끕니다.',
+      href: '/blog/what-is-vibe-design/',
+    },
     {
       q: 'Open Design은 무엇인가요?',
       a: 'Open Design은 nexu-io/open-design 프로젝트의 공식 오픈소스 AI 디자인 워크스페이스입니다. Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Qwen 같은 로컬 coding agent를 조합형 skill과 DESIGN.md 시스템으로 구동되는 디자인 엔진으로 바꿉니다.',
@@ -2808,6 +2852,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
   ],
   de: [
     {
+      q: 'Ist Open Design eine quelloffene Claude-Design-Alternative?',
+      a: 'Ja — Open Design ist die quelloffene, lokale Claude-Design-Alternative. Wo Claude Design geschlossen, gehostet und an Anthropic-Modelle gebunden ist, ist Open Design Apache-2.0, läuft auf deinem eigenen Rechner und ist BYOK: Du steuerst es mit Claude Code, Codex, Cursor, Gemini, OpenCode oder Qwen und behältst jedes Ergebnis als eigene Dateien.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'Was ist ein Vibe Design Workspace?',
+      a: 'Ein Vibe Design Workspace ist ein Ort, an dem du gestaltest, indem du einem KI-Agent deine Absicht beschreibst — vom Prompt zu Prototyp, Webseite, Slides oder HTML-Video — statt jedes Element von Hand zu platzieren. Open Design ist ein quelloffener, agent-nativer Vibe Design Workspace: Er bindet den Coding-Agent, den du bereits nutzt, in einen vollständigen Design-Workflow ein, sodass ein Werkzeug dich von der groben Idee zum fertigen, dir gehörenden Ergebnis bringt.',
+      href: '/blog/what-is-vibe-design/',
+    },
+    {
       q: 'Was ist Open Design?',
       a: 'Open Design ist der offizielle Open-Source-AI-Design-Workspace des Projekts nexu-io/open-design. Es macht lokale Coding-Agents wie Claude Code, Codex, Cursor, Gemini CLI, OpenCode oder Qwen zu einer Design-Engine auf Basis von Skills und DESIGN.md-Systemen.',
     },
@@ -2862,6 +2916,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
     },
   ],
   fr: [
+    {
+      q: 'Open Design est-il une alternative open source à Claude Design ?',
+      a: 'Oui — Open Design est l’alternative open source et locale à Claude Design. Là où Claude Design est fermé, hébergé et verrouillé aux modèles Anthropic, Open Design est en Apache-2.0, s’exécute sur votre propre machine et fonctionne en BYOK : pilotez-le avec Claude Code, Codex, Cursor, Gemini, OpenCode ou Qwen et gardez chaque livrable sous forme de fichiers qui vous appartiennent.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'Qu’est-ce qu’un vibe design workspace ?',
+      a: 'Un vibe design workspace est un espace où l’on conçoit en décrivant son intention à un agent IA — du prompt au prototype, page web, slides ou vidéo HTML — plutôt qu’en plaçant chaque élément à la main. Open Design est un vibe design workspace open source et agent-native : il intègre l’agent de code que vous utilisez déjà dans un flux de design complet, pour passer d’une idée brute à un résultat livrable et bien à vous.',
+      href: '/blog/what-is-vibe-design/',
+    },
     {
       q: "Qu'est-ce qu'Open Design ?",
       a: "Open Design est l'espace de travail officiel et open source du projet nexu-io/open-design. Il transforme un agent local — Claude Code, Codex, Cursor, Gemini CLI, OpenCode ou Qwen — en moteur de design piloté par des skills composables et des systèmes DESIGN.md portables.",
@@ -2918,6 +2982,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
   ],
   ru: [
     {
+      q: 'Open Design — это open-source альтернатива Claude Design?',
+      a: 'Да — Open Design это открытая, локальная альтернатива Claude Design. Claude Design закрыт, работает в облаке и привязан к моделям Anthropic, а Open Design — Apache-2.0, запускается на вашей машине и работает по BYOK: управляйте им через Claude Code, Codex, Cursor, Gemini, OpenCode или Qwen и храните каждый результат как свои файлы.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'Что такое vibe design workspace?',
+      a: 'Vibe design workspace — это среда, где вы проектируете, описывая замысел ИИ-агенту — от промпта до прототипа, веб-страницы, слайдов или HTML-видео — вместо расстановки каждого элемента вручную. Open Design это открытый, agent-native vibe design workspace: он встраивает кодинг-агента, которым вы уже пользуетесь, в полный дизайн-процесс, и один инструмент ведёт вас от черновой идеи к готовому результату, который принадлежит вам.',
+      href: '/blog/what-is-vibe-design/',
+    },
+    {
       q: 'Что такое Open Design?',
       a: 'Open Design — официальный open-source AI design workspace проекта nexu-io/open-design. Он превращает локальный coding agent — Claude Code, Codex, Cursor, Gemini CLI, OpenCode или Qwen — в design-движок на базе composable skills и переносимых DESIGN.md-систем.',
     },
@@ -2972,6 +3046,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
     },
   ],
   es: [
+    {
+      q: '¿Open Design es una alternativa open source a Claude Design?',
+      a: 'Sí — Open Design es la alternativa open source y local a Claude Design. Donde Claude Design es cerrado, alojado y atado a los modelos de Anthropic, Open Design es Apache-2.0, se ejecuta en tu propia máquina y es BYOK: contrólalo con Claude Code, Codex, Cursor, Gemini, OpenCode o Qwen y conserva cada resultado como archivos que son tuyos.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: '¿Qué es un vibe design workspace?',
+      a: 'Un vibe design workspace es un espacio donde diseñas describiendo tu intención a un agente de IA — del prompt al prototipo, página web, slides o vídeo HTML — en lugar de colocar cada elemento a mano. Open Design es un vibe design workspace open source y agent-native: conecta el agente de código que ya usas a un flujo de diseño completo, de modo que una sola herramienta te lleva de una idea en bruto a un resultado listo y tuyo.',
+      href: '/blog/what-is-vibe-design/',
+    },
     {
       q: '¿Qué es Open Design?',
       a: 'Open Design es el workspace oficial y open source de IA de diseño del proyecto nexu-io/open-design. Convierte un coding agent local — Claude Code, Codex, Cursor, Gemini CLI, OpenCode o Qwen — en un motor de diseño con skills componibles y sistemas DESIGN.md portables.',
@@ -3028,6 +3112,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
   ],
   'pt-br': [
     {
+      q: 'O Open Design é uma alternativa open source ao Claude Design?',
+      a: 'Sim — o Open Design é a alternativa open source e local ao Claude Design. Enquanto o Claude Design é fechado, hospedado e preso aos modelos da Anthropic, o Open Design é Apache-2.0, roda na sua própria máquina e é BYOK: use Claude Code, Codex, Cursor, Gemini, OpenCode ou Qwen para conduzi-lo e mantenha cada entrega como arquivos que são seus.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'O que é um vibe design workspace?',
+      a: 'Um vibe design workspace é onde você projeta descrevendo a intenção a um agente de IA — do prompt ao protótipo, página web, slides ou vídeo HTML — em vez de posicionar cada elemento à mão. O Open Design é um vibe design workspace open source e agent-native: integra o coding agent que você já usa a um fluxo de design completo, então uma ferramenta leva você de uma ideia bruta a um resultado pronto e seu.',
+      href: '/blog/what-is-vibe-design/',
+    },
+    {
       q: 'O que é Open Design?',
       a: 'Open Design é o workspace oficial, open source, de design com IA do projeto nexu-io/open-design. Ele transforma um coding agent local — Claude Code, Codex, Cursor, Gemini CLI, OpenCode ou Qwen — em um motor de design movido por skills componíveis e sistemas DESIGN.md portáteis.',
     },
@@ -3082,6 +3176,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
     },
   ],
   it: [
+    {
+      q: 'Open Design è un’alternativa open source a Claude Design?',
+      a: 'Sì — Open Design è l’alternativa open source e locale a Claude Design. Dove Claude Design è chiuso, ospitato e legato ai modelli Anthropic, Open Design è Apache-2.0, gira sulla tua macchina ed è BYOK: guidalo con Claude Code, Codex, Cursor, Gemini, OpenCode o Qwen e conserva ogni risultato come file tuoi.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'Che cos’è un vibe design workspace?',
+      a: 'Un vibe design workspace è uno spazio in cui progetti descrivendo l’intento a un agente IA — dal prompt al prototipo, pagina web, slide o video HTML — invece di posizionare ogni elemento a mano. Open Design è un vibe design workspace open source e agent-native: collega il coding agent che già usi a un flusso di design completo, così un solo strumento ti porta da un’idea grezza a un risultato pronto e tuo.',
+      href: '/blog/what-is-vibe-design/',
+    },
     {
       q: "Cos'è Open Design?",
       a: 'Open Design è il workspace ufficiale e open source di AI design del progetto nexu-io/open-design. Trasforma un coding agent locale — Claude Code, Codex, Cursor, Gemini CLI, OpenCode o Qwen — in un motore di design guidato da skill componibili e sistemi DESIGN.md portabili.',
@@ -3412,6 +3516,16 @@ const HOME_FAQ_COPY: Record<LandingLocaleCode, HomeFaqTemplate[]> = {
     },
   ],
   tr: [
+    {
+      q: 'Open Design açık kaynaklı bir Claude Design alternatifi mi?',
+      a: 'Evet — Open Design açık kaynaklı, yerel çalışan Claude Design alternatifidir. Claude Design kapalı, barındırılan ve Anthropic modellerine kilitliyken; Open Design Apache-2.0’dır, kendi makinende çalışır ve BYOK’tur: Claude Code, Codex, Cursor, Gemini, OpenCode veya Qwen ile çalıştır, her çıktıyı sana ait dosyalar olarak sakla.',
+      href: '/alternatives/claude-design/',
+    },
+    {
+      q: 'Vibe design workspace nedir?',
+      a: 'Vibe design workspace, her öğeyi elle yerleştirmek yerine bir yapay zeka ajanına niyetini anlatarak tasarım yaptığın yerdir — prompttan prototipe, web sayfasına, slaytlara veya HTML videoya. Open Design açık kaynaklı, agent-native bir vibe design workspace’tir: hâlihazırda kullandığın kodlama ajanını eksiksiz bir tasarım akışına bağlar; tek bir araç seni kaba bir fikirden sana ait, teslime hazır bir sonuca götürür.',
+      href: '/blog/what-is-vibe-design/',
+    },
     {
       q: 'Open Design nedir?',
       a: "Open Design, nexu-io/open-design projesinin resmi açık kaynak AI design workspace'idir. Claude Code, Codex, Cursor, Gemini CLI, OpenCode veya Qwen gibi yerel coding agent'ları, birleştirilebilir skill'ler ve taşınabilir DESIGN.md sistemleriyle çalışan bir tasarım motoruna dönüştürür.",
@@ -6897,6 +7011,7 @@ export function getHomeFaq(
     a: entry.a
       .replaceAll('{origin}', replacements.origin)
       .replaceAll('{repo}', replacements.repo),
+    ...(entry.href ? { href: entry.href } : {}),
   }));
 }
 

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -31,7 +31,7 @@ import {
   heroProductSrcset,
   PRECISE_LAZY_PLACEHOLDER,
 } from './image-assets';
-import { getHomeExtra } from './home-translations';
+import { getHomeExtra, getHomeCta } from './home-translations';
 
 /**
  * `<img>` wrapper for non-hero homepage images. Outputs `data-precise-src`
@@ -316,6 +316,7 @@ export default function Page({
   // once (the Chinese design); `t` supplies the translated text per locale so
   // all languages render the same structure. CJK locales use per-letter blur.
   const t = getHomeExtra(locale);
+  const cta = getHomeCta(locale);
   const cjk = locale === 'zh' || locale === 'zh-tw' || locale === 'ja' || locale === 'ko';
   // Short inline labels still fall back to English for non-Chinese locales.
   const tt = (zh: string, en: string) => (locale === 'zh' ? zh : en);
@@ -629,7 +630,7 @@ export default function Page({
                       they're intentionally not repeated here. */}
                   <div className='about-ctas cta-pair'>
                     <a className='btn btn-ghost' href={href('/plugins/systems/')}>
-                      {tt('浏览设计系统', 'Explore design systems')}
+                      {cta.systems}
                       <span className='arrow'>{arrowOut}</span>
                     </a>
                     <a className='btn btn-primary' href={href('/download/')} data-download-cta data-download-chip-target data-download-placement='about'>
@@ -715,7 +716,7 @@ export default function Page({
                       </ol>
                       <div className='cta-pair cap-steps-link'>
                         <a className='btn btn-ghost' href={href('/solutions/')}>
-                          {tt('浏览全部解决方案', 'Explore solutions')}
+                          {cta.solutions}
                           <span className='arrow'>{arrowOut}</span>
                         </a>
                         <a
@@ -775,7 +776,7 @@ export default function Page({
                 ) : null}
                 <div className='cta-pair' style={{ justifyContent: 'center', marginTop: 20 }}>
                   <a className='btn btn-ghost' href={href('/plugins/templates/')}>
-                    {tt('浏览全部模板', 'Browse all templates')}
+                    {cta.templates}
                     <span className='arrow'>{arrowOut}</span>
                   </a>
                   <a
@@ -887,7 +888,7 @@ export default function Page({
                 style={{ marginTop: 16 }}
                 data-reveal
               >
-                {tt('浏览全部 Agent', 'Browse all 21+ agents')}
+                {cta.agents}
                 <span className='arrow'>{arrowOut}</span>
               </a>
             </div>
@@ -936,7 +937,7 @@ export default function Page({
                 </h2>
                 <div className='cta-pair' style={{ marginTop: 16 }}>
                   <a className='btn btn-ghost' href='/community/contributors/'>
-                    {tt('查看全部贡献者', 'View all contributors')}
+                    {cta.contributors}
                     <span className='arrow'>{arrowOut}</span>
                   </a>
                   <a
@@ -973,7 +974,7 @@ export default function Page({
         {/* ====== SELECTED WORK ====== */}
         <section className='tight' data-od-id='work'>
           <h2 className='work-stats-title' data-reveal>
-            {tt('开源 vibe design workspace，用数据说话', 'The open-source vibe design workspace, by the numbers')}
+            {cta.statsTitle}
           </h2>
           <div className='work'>
             <div className='work-stats-grid' data-reveal>
@@ -1153,7 +1154,7 @@ export default function Page({
                       <p className='faq-a'>{a}</p>
                       {faqHref ? (
                         <p className='faq-more'>
-                          <a href={href(faqHref)}>{tt('了解更多 →', 'Learn more →')}</a>
+                          <a href={href(faqHref)}>{cta.learnMore}</a>
                         </p>
                       ) : null}
                     </details>

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -1134,7 +1134,7 @@ export default function Page({
                     {home.hero.download}
                   </a>
                   <p className='faq-download-note'>
-                    {tt('74K+ Star · Apache-2.0 · 免费', '74K+ stars · Apache-2.0 · Free')}
+                    {cta.downloadProof}
                   </p>
                 </div>
               </div>

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -161,7 +161,6 @@ const NBSP = '\u00A0';
 const REPO = 'https://github.com/nexu-io/open-design';
 const REPO_RELEASES = `${REPO}/releases`;
 const REPO_ISSUES = `${REPO}/issues`;
-const REPO_CONTRIBUTORS = `${REPO}/graphs/contributors`;
 const REPO_DAEMON = `${REPO}/tree/main/apps/daemon`;
 const REPO_SKILLS = `${REPO}/tree/main/skills`;
 const REPO_DOCS = `${REPO}#readme`;
@@ -444,8 +443,13 @@ export default function Page({
           />
           <div className='container hero-grid'>
             <div className='hero-copy'>
+              {/* Eyebrow = the competitor entry word ("Open Source Claude
+                  Design Alternative", localized per locale). Kept as real,
+                  crawlable HTML text above the title so it carries the SEO
+                  entry term while the H1 stays focused on the brand name and
+                  the product's own one-line positioning. */}
               <p className='hero-lead' data-reveal>
-                {t.heroLead}
+                {t.heroTitleSub}
               </p>
               <h1 className='hero-title' data-reveal>
                 <span className='hero-title-corner tl' aria-hidden='true' />
@@ -455,8 +459,11 @@ export default function Page({
                 <span className='hero-title-brand'>
                   <BlurText text='Open Design' by='words' start={0} />
                 </span>
-                <span className='hero-title-sub'>
-                  <BlurText text={t.heroTitleSub} by={cjk ? 'letters' : 'words'} start={2} />
+                {/* One-line category positioning (the product's own umbrella
+                    term). Kept as the canonical English category label across
+                    every locale — the narrative anchor, not translated. */}
+                <span className='hero-title-main'>
+                  <BlurText text='The Vibe Design Workspace' by='words' start={1} />
                 </span>
               </h1>
               <div className='hero-actions' data-reveal>
@@ -581,7 +588,7 @@ export default function Page({
                       <div className='about-panel-img about-panel-img-bare about-panel-img-captioned'>
                         <LazyImg
                           src='/about/desktop-native.webp'
-                          alt='设计在桌面端发生。本地文件、Figma 导出、代码仓库直接可读，Agent 拥有终端执行全部能力。'
+                          alt={t.aboutCap1.replace(/\n/g, ' ')}
                         />
                         <p className='about-panel-caption'>
                           <BreakText text={t.aboutCap1} />
@@ -592,7 +599,7 @@ export default function Page({
                       <div className='about-panel-img about-panel-img-bare about-panel-img-captioned'>
                         <LazyImg
                           src='/about/access-agent.webp'
-                          alt='你电脑上的 Claude Code / Codex / Cursor 已经够强。OD 做的是把它们接进完整设计工作流。'
+                          alt={t.aboutCap2.replace(/\n/g, ' ')}
                         />
                         {/* Caption laid over the image's baked-in white card. */}
                         <p className='about-panel-caption'>
@@ -604,7 +611,7 @@ export default function Page({
                       <div className='about-panel-img about-panel-img-bare about-panel-img-captioned'>
                         <LazyImg
                           src='/about/self-evolution.webp?v=4'
-                          alt='每次选择都沉淀为 Design System、偏好和记忆，下次生成更接近你要的结果。'
+                          alt={t.aboutCap3.replace(/\n/g, ' ')}
                         />
                         <p className='about-panel-caption'>
                           {t.aboutCap3}
@@ -612,6 +619,23 @@ export default function Page({
                       </div>
                     </div>
                     </div>
+                  </div>
+                  {/* Per-tab hub link. OUTSIDE .about-panels (overflow:hidden +
+                      image-height-locked, so a link inside a panel is clipped).
+                      As a sibling of the tab radios, the active tab reveals its
+                      matching CTA via `:checked ~` in globals.css. */}
+                  {/* One static CTA row for the whole About block: design-system
+                      link + download. Agents live in the Method section now, so
+                      they're intentionally not repeated here. */}
+                  <div className='about-ctas cta-pair'>
+                    <a className='btn btn-ghost' href={href('/plugins/systems/')}>
+                      {tt('浏览设计系统', 'Explore design systems')}
+                      <span className='arrow'>{arrowOut}</span>
+                    </a>
+                    <a className='btn btn-primary' href={href('/download/')} data-download-cta data-download-chip-target data-download-placement='about'>
+                      <span className='arrow'>{iconDownload}</span>
+                      {home.hero.download}
+                    </a>
                   </div>
                 </div>
                 </div>
@@ -675,6 +699,7 @@ export default function Page({
                       </p>
                     </div>
                     <div className='cap-row'>
+                      <div className='cap-steps-col'>
                       <ol className='cap-steps'>
                         {capabilityCards.map((card, index) => (
                           <li
@@ -688,6 +713,22 @@ export default function Page({
                           </li>
                         ))}
                       </ol>
+                      <div className='cta-pair cap-steps-link'>
+                        <a className='btn btn-ghost' href={href('/solutions/')}>
+                          {tt('浏览全部解决方案', 'Explore solutions')}
+                          <span className='arrow'>{arrowOut}</span>
+                        </a>
+                        <a
+                          className='btn btn-primary'
+                          href={href('/download/')}
+                          data-download-cta
+                          data-download-placement='capabilities'
+                        >
+                          <span className='arrow'>{iconDownload}</span>
+                          {home.hero.download}
+                        </a>
+                      </div>
+                      </div>
                       <div className='cap-visual'>
                         {capabilityCards.map((card, index) => (
                           <div
@@ -729,6 +770,25 @@ export default function Page({
                   <em>Open Design</em>
                   {t.labsPost}
                 </h2>
+                {t.labsLead ? (
+                  <p className='labs-lead'>{t.labsLead}</p>
+                ) : null}
+                <div className='cta-pair' style={{ justifyContent: 'center', marginTop: 20 }}>
+                  <a className='btn btn-ghost' href={href('/plugins/templates/')}>
+                    {tt('浏览全部模板', 'Browse all templates')}
+                    <span className='arrow'>{arrowOut}</span>
+                  </a>
+                  <a
+                    className='btn btn-primary'
+                    href={href('/download/')}
+                    data-download-cta
+                    data-download-chip-target
+                    data-download-placement='labs'
+                  >
+                    <span className='arrow'>{iconDownload}</span>
+                    {home.hero.download}
+                  </a>
+                </div>
               </div>
             </div>
             {/* Labs — a clean image preview driven by the mode Dock below it.
@@ -821,6 +881,15 @@ export default function Page({
               <div className='right' data-reveal='right'>
                 <p>{home.method.lead}</p>
               </div>
+              <a
+                className='btn btn-ghost method-link'
+                href={href('/agents/')}
+                style={{ marginTop: 16 }}
+                data-reveal
+              >
+                {tt('浏览全部 Agent', 'Browse all 21+ agents')}
+                <span className='arrow'>{arrowOut}</span>
+              </a>
             </div>
             {/* FallingText (React Bits, matter-js) — the coding-agent names
                 drop into a physics playground on hover; driven by the
@@ -860,20 +929,27 @@ export default function Page({
               <div className='testimonial-copy' data-reveal>
                 <h2 style={{ marginTop: 30 }}>
                   {t.testiPre}
-                  <span data-github-contributors>326</span>
+                  <span data-github-contributors>343</span>
                   {t.testiMid}
                   <br />
                   <span style={{ whiteSpace: 'nowrap' }}>{t.testiPost}</span>
                 </h2>
-                <a
-                  className='btn btn-ghost'
-                  href={REPO_CONTRIBUTORS}
-                  style={{ marginTop: 16 }}
-                  {...ext}
-                >
-                  {tt('查看全部贡献者', 'View all contributors')}
-                  <span className='arrow'>{arrowOut}</span>
-                </a>
+                <div className='cta-pair' style={{ marginTop: 16 }}>
+                  <a className='btn btn-ghost' href='/community/contributors/'>
+                    {tt('查看全部贡献者', 'View all contributors')}
+                    <span className='arrow'>{arrowOut}</span>
+                  </a>
+                  <a
+                    className='btn btn-primary'
+                    href={href('/download/')}
+                    data-download-cta
+                    data-download-chip-target
+                    data-download-placement='contributors'
+                  >
+                    <span className='arrow'>{iconDownload}</span>
+                    {home.hero.download}
+                  </a>
+                </div>
               </div>
               <div className='testimonial-globe' data-reveal='right' data-testimonial-globe>
                 <canvas
@@ -897,7 +973,7 @@ export default function Page({
         {/* ====== SELECTED WORK ====== */}
         <section className='tight' data-od-id='work'>
           <h2 className='work-stats-title' data-reveal>
-            {tt('我们的项目获得了：', 'What this project has earned')}
+            {tt('开源 vibe design workspace，用数据说话', 'The open-source vibe design workspace, by the numbers')}
           </h2>
           <div className='work'>
             <div className='work-stats-grid' data-reveal>
@@ -906,11 +982,11 @@ export default function Page({
                   // [data-github-stars] / [data-github-contributors] enhancers in
                   // index.astro); the hard-coded `num` is only the SSR fallback
                   // shown until the API responds. The rest count up from 0.
-                  { src: 'card-1.webp', num: '52K+', to: '52', suffix: 'K+', alt: 'GitHub Stars', href: REPO, live: 'stars' as const },
-                  { src: 'card-2.webp', num: '280+', to: '280', suffix: '+', alt: tt('贡献者', 'Contributors'), href: `${REPO}/graphs/contributors`, live: 'contributors' as const },
+                  { src: 'card-1.webp', num: '74K+', to: '74', suffix: 'K+', alt: 'GitHub Stars', href: REPO, live: 'stars' as const },
+                  { src: 'card-2.webp', num: '340+', to: '340', suffix: '+', alt: tt('贡献者', 'Contributors'), href: `${REPO}/graphs/contributors`, live: 'contributors' as const },
                   { src: 'card-3.webp', num: '217+', to: '217', suffix: '+', alt: 'Plugins', href: href('/plugins/') },
                   { src: 'card-4.webp', num: '129+', to: '129', suffix: '+', alt: 'Design Systems', href: href('/plugins/systems/') },
-                  { src: 'card-5.webp', num: '21', to: '21', suffix: '', alt: tt('Coding Agent 支持', 'Coding Agents'), href: REPO },
+                  { src: 'card-5.webp', num: '21', to: '21', suffix: '', alt: tt('Coding Agent 支持', 'Coding Agents'), href: href('/agents/') },
                   { src: 'card-6.webp', num: null, to: null, suffix: '', alt: 'Star us', href: REPO, cta: true },
                 ] as ReadonlyArray<{ src: string; num: string | null; to: string | null; suffix: string; alt: string; href: string; live?: 'stars' | 'contributors'; cta?: boolean }>).map((item, index) => (
                   <a
@@ -938,7 +1014,7 @@ export default function Page({
                           {item.num}
                         </span>
                       ) : null}
-                      <em>{item.alt}</em>
+                      {item.num ? ' ' : ''}<em>{item.alt}</em>
                     </h3>
                   </a>
                 ))}
@@ -1041,9 +1117,28 @@ export default function Page({
             <div className='faq-layout'>
               <div className='faq-head' data-reveal>
                 <h2 className='display faq-title-zh'>{t.faqTitle}</h2>
+                {/* High-intent download CTA filling the FAQ left column's blank
+                    space — readers here are evaluating. Platform-aware direct
+                    download (same `data-download-cta` enhancer as hero/CTA);
+                    social proof below to lift conversion. */}
+                <div className='faq-download'>
+                  <a
+                    className='btn btn-primary'
+                    href={href('/download/')}
+                    data-download-cta
+                    data-download-chip-target
+                    data-download-placement='faq'
+                  >
+                    <span className='arrow'>{iconDownload}</span>
+                    {home.hero.download}
+                  </a>
+                  <p className='faq-download-note'>
+                    {tt('74K+ Star · Apache-2.0 · 免费', '74K+ stars · Apache-2.0 · Free')}
+                  </p>
+                </div>
               </div>
               <ol className='faq-list'>
-                {faq.map(({ q, a }, idx) => (
+                {faq.map(({ q, a, href: faqHref }, idx) => (
                   <li className='faq-item' key={q} data-reveal>
                     <details>
                       <summary>
@@ -1056,6 +1151,11 @@ export default function Page({
                         </span>
                       </summary>
                       <p className='faq-a'>{a}</p>
+                      {faqHref ? (
+                        <p className='faq-more'>
+                          <a href={href(faqHref)}>{tt('了解更多 →', 'Learn more →')}</a>
+                        </p>
+                      ) : null}
                     </details>
                   </li>
                 ))}


### PR DESCRIPTION
## Why

The homepage headlined *Claude Design alternative* — a competitor keyword. That undersells the product and pins the page to someone else's brand. This change makes the page lead with the product's own category, **The Vibe Design Workspace**, and keeps the alternative keyword in smaller SEO spots (eyebrow, page title, meta) so it still ranks without headlining. It also turns the homepage into an in-site routing hub and adds download CTAs to help conversion.

## Changes

- **Hero** — headline is now *The Vibe Design Workspace*; the eyebrow above it says *Open Source Claude Design Alternative*; the description is one shorter paragraph.
- **Title & meta** — title puts the keyword first (kept *Best*); meta rewritten to 156 chars with real use cases, no cut-off.
- **Body copy** — same *vibe design workspace* wording across section headings; added a short "what you can make" line for search; two new FAQs.
- **Links** — every section links to its matching page (agents, solutions, templates, design systems, contributors). The contributors link points to the site, not GitHub.
- **Download buttons** — added in more places (About, Capabilities, Labs, contributors, FAQ).
- **Agents link** — now in one place only (was two).
- **Numbers** — 74K+ stars, 340+ / 343 contributors.
- **All 11 languages** updated.

## Surface area

- `apps/landing-page/app/page.tsx` — hero, section headings, hub links, download CTAs, agents dedup, stats.
- `apps/landing-page/app/home-translations.ts` — heroSub / aboutStatement / capTitle / faqTitle / labsLead across the 11 locales.
- `apps/landing-page/app/i18n.ts` — homepage title/meta + 2 FAQs across the 11 locales.
- `apps/landing-page/app/globals.css` — eyebrow, cta-pair, about-ctas, faq-download and capability button styles.
- Homepage only — no routing, data, or shared-component changes.

## Validation

- `astro check` — 0 errors / 0 warnings.
- `pnpm run build:static` — 4252 pages, no errors.
- Previewed across locales on the PR staging deploy.
