### PR TITLE
fix(daemon): prevent ReDoS in deploy-preflight doctype check

### DIFF
--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -1399,8 +1399,11 @@ export function analyzeDeployPlan(input: {
   // begin with an optional BOM, then any number of HTML comments and
   // whitespace, then the doctype. Built via `new RegExp` so the BOM
   // appears as an explicit U+FEFF escape rather than a literal
-  // zero-width character in the regex source.
-  if (!new RegExp('^\\uFEFF?\\s*(?:<!--[\\s\\S]*?-->\\s*)*<!doctype\\s+html', 'i').test(source)) {
+  // zero-width character in the regex source. The comment body is
+  // tempered (`(?:[^-]|-(?!->))*`) rather than a lazy `[\s\S]*?` so each
+  // comment matches deterministically — a lazy body inside the outer `*`
+  // backtracks 2^n ways on a comment-only prolog with no doctype (ReDoS).
+  if (!new RegExp('^\\uFEFF?\\s*(?:<!--(?:[^-]|-(?!->))*-->\\s*)*<!doctype\\s+html', 'i').test(source)) {
     pushUnique(acc, {
       code: 'no-doctype',
       path: entryPath,

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -749,6 +749,26 @@ describe('deploy plan and analyzer', () => {
     expect(warnings.map((w: any) => w.code)).not.toContain('no-doctype');
   });
 
+  it('checks the doctype prolog without catastrophic backtracking on a comment-only entry', () => {
+    // Regression: the prolog check's comment-run group used a lazy `[\s\S]*?`
+    // body inside `(?:...)*`, so a comment-only entry with no doctype forced
+    // 2^n backtracking — a ~250-byte HTML could hang the single-threaded
+    // daemon for minutes (event-loop DoS on POST /deploy/preflight). The
+    // tempered comment body makes each comment match deterministically.
+    const html = '<!---->'.repeat(28) + '<html><body></body></html>';
+    const start = performance.now();
+    const { warnings } = analyzeDeployPlan({ entryPath: 'index.html', html, files: [] });
+    const elapsedMs = performance.now() - start;
+    // Correctness is preserved (no doctype -> still flagged) and the check is
+    // linear: the tempered regex handles this in well under 1ms, whereas the
+    // old lazy-body regex grew ~2x per added comment (seconds here, minutes
+    // with a few more). The 500ms budget sits far above the fixed path (~100x
+    // headroom, no false failures) yet well below the vulnerable time, so any
+    // regression blows it.
+    expect(warnings.map((w) => w.code)).toContain('no-doctype');
+    expect(elapsedMs).toBeLessThan(500);
+  });
+
   it('flags external scripts and stylesheets', () => {
     const { warnings } = analyzeDeployPlan({
       entryPath: 'index.html',


### PR DESCRIPTION
## Why

`analyzeDeployPlan` checks the entry HTML's prolog for `<!doctype html>` with a regex whose comment-run group `(?:<!--[\s\S]*?-->\s*)*` nests a lazy `[\s\S]*?` inside an outer `*`. On an entry HTML that is a run of HTML comments with no doctype after them, the comments can be partitioned across the outer `*` in 2^n ways, so the engine backtracks catastrophically — a ~250-byte file (`<!---->` repeated) hangs the single-threaded daemon for seconds and grows ~2x per added comment (minutes with a few more). This runs during `POST /api/projects/:id/deploy/preflight` on the entry HTML, with no size cap that rejects the input, so it is an event-loop denial of service.

## What users will see

Nothing changes for real HTML: the check accepts and rejects exactly the same prologs as before — verified across BOM, uppercase, multiple leading comments, comments containing dashes / `->` / `--`, a fake doctype inside a `<script>` string, and an unterminated comment (match-equivalent to the old regex on every case). Only the pathological comment-only input is now handled in well under a millisecond instead of hanging.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal daemon hardening. The `/deploy/preflight` result is unchanged for every valid entry HTML; the prolog regex now matches the same set of prologs without catastrophic backtracking.

## Bug fix verification

- **Bug:** the prolog regex `^\uFEFF?\s*(?:<!--[\s\S]*?-->\s*)*<!doctype\s+html` backtracks 2^n on `<!---->` repeated with no doctype following.
- **Fix:** temper the comment body to `<!--(?:[^-]|-(?!->))*-->` so each comment matches deterministically and the outer `*` has a single partition; anchors, flags, and the rest of the pattern are unchanged.
- **Test:** `apps/daemon/tests/deploy.test.ts` → "checks the doctype prolog without catastrophic backtracking on a comment-only entry" feeds `'<!---->'.repeat(28)` + `<html>` and asserts `analyzeDeployPlan` still flags `no-doctype` and returns within 500ms.
- **Red on main, green here?** Yes — in vitest the test takes ~35s and fails on the current regex; with the tempered regex it completes in a few ms. Behavioral equivalence to the old regex was checked across a battery of prolog inputs (0 differences).

## Validation

- `pnpm --filter @open-design/daemon test` — `tests/deploy.test.ts` 78/78 (incl. the new case).
- daemon `tsc --noEmit` for both `tsconfig.json` and `tsconfig.tests.json`.
