### PR TITLE
fix(daemon): respect npm 0.x caret semantics in version resolver

### DIFF
--- a/apps/daemon/src/registry/versioning.ts
+++ b/apps/daemon/src/registry/versioning.ts
@@ -92,6 +92,18 @@ function resolveRequestedVersion(
     .filter((version) => {
       const parsed = parseSemver(version);
       if (!parsed) return false;
+      // npm excludes prerelease candidates from a range unless the range is
+      // itself a prerelease of the same major.minor.patch tuple (so `^0.2.0`
+      // never matches `0.2.1-beta.1`, but `^0.2.1-beta.1` matches 0.2.1-beta.2).
+      if (
+        parsed.prerelease &&
+        !(base.prerelease &&
+          parsed.major === base.major &&
+          parsed.minor === base.minor &&
+          parsed.patch === base.patch)
+      ) {
+        return false;
+      }
       if (range.startsWith('^')) {
         // npm caret locks the leftmost non-zero component: `^1.2.3` allows
         // `<2.0.0`, but `^0.2.3` only `<0.3.0` and `^0.0.3` only `<0.0.4`.
@@ -115,20 +127,58 @@ interface SemverParts {
   major: number;
   minor: number;
   patch: number;
+  prerelease: string | null;
 }
 
 function parseSemver(value: string): SemverParts | null {
-  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value);
+  // Capture an optional `-prerelease`; `+build` metadata is ignored for
+  // precedence (semver §10). The prerelease drives npm's caret/tilde exclusion.
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([^+]*))?(?:\+.*)?$/.exec(value);
   if (!match) return null;
   return {
     major: Number(match[1] ?? 0),
     minor: Number(match[2] ?? 0),
     patch: Number(match[3] ?? 0),
+    prerelease: match[4] || null,
   };
 }
 
 function compareSemver(left: SemverParts, right: SemverParts): number {
-  return left.major - right.major ||
+  const core =
+    left.major - right.major ||
     left.minor - right.minor ||
     left.patch - right.patch;
+  if (core !== 0) return core;
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+// semver §11 precedence: a normal release outranks a prerelease of the same
+// core version; otherwise compare dot-separated identifiers left to right —
+// numeric ones numerically and ranked below alphanumeric, and a longer set of
+// identifiers wins when all preceding ones are equal.
+function comparePrerelease(left: string | null, right: string | null): number {
+  if (!left && !right) return 0;
+  if (!left) return 1;
+  if (!right) return -1;
+  const a = left.split('.');
+  const b = right.split('.');
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const x = a[i];
+    const y = b[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xNum = /^\d+$/.test(x);
+    const yNum = /^\d+$/.test(y);
+    if (xNum && yNum) {
+      const d = Number(x) - Number(y);
+      if (d !== 0) return d < 0 ? -1 : 1;
+    } else if (xNum) {
+      return -1;
+    } else if (yNum) {
+      return 1;
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
 }

--- a/apps/daemon/src/registry/versioning.ts
+++ b/apps/daemon/src/registry/versioning.ts
@@ -93,7 +93,15 @@ function resolveRequestedVersion(
       const parsed = parseSemver(version);
       if (!parsed) return false;
       if (range.startsWith('^')) {
-        return parsed.major === base.major && compareSemver(parsed, base) >= 0;
+        // npm caret locks the leftmost non-zero component: `^1.2.3` allows
+        // `<2.0.0`, but `^0.2.3` only `<0.3.0` and `^0.0.3` only `<0.0.4`.
+        // Locking major alone wrongly resolves `^0.2.0` to a breaking `0.3.0`.
+        if (parsed.major !== base.major) return false;
+        if (base.major === 0) {
+          if (parsed.minor !== base.minor) return false;
+          if (base.minor === 0 && parsed.patch !== base.patch) return false;
+        }
+        return compareSemver(parsed, base) >= 0;
       }
       return parsed.major === base.major &&
         parsed.minor === base.minor &&

--- a/apps/daemon/tests/registry/versioning.test.ts
+++ b/apps/daemon/tests/registry/versioning.test.ts
@@ -121,6 +121,43 @@ describe('resolveMarketplaceEntryVersion', () => {
     expect(resolveMarketplaceEntryVersion(e, '^0.0.3')?.version).toBe('0.0.3');
   });
 
+  it('excludes prerelease candidates from a non-prerelease caret range', () => {
+    // npm excludes prereleases from `^0.2.0` / `^0.0.3` unless the range itself
+    // carries a prerelease, so a `-beta` entry must not satisfy them.
+    const e = entry({
+      version: '0.2.1-beta.1',
+      versions: [
+        { version: '0.2.0', source: 's020' },
+        { version: '0.2.1-beta.1', source: 's021b' },
+      ],
+    });
+    // Highest satisfying is the stable 0.2.0, not the newer 0.2.1-beta.1.
+    expect(resolveMarketplaceEntryVersion(e, '^0.2.0')?.version).toBe('0.2.0');
+
+    const patch = entry({
+      version: '0.0.3-beta.1',
+      versions: [{ version: '0.0.3-beta.1', source: 's003b' }],
+    });
+    // Only a prerelease exists and the range is stable, so nothing matches.
+    expect(resolveMarketplaceEntryVersion(patch, '^0.0.3')).toBeNull();
+  });
+
+  it('matches same-tuple prereleases when the caret range is itself a prerelease', () => {
+    // `^0.2.1-beta.1` => `>=0.2.1-beta.1 <0.3.0`: same-tuple prereleases and the
+    // 0.2.1 release match (release outranks its prereleases), but 0.2.5-beta.1
+    // (a different tuple) does not.
+    const e = entry({
+      version: '0.2.1',
+      versions: [
+        { version: '0.2.1-beta.1', source: 'sb1' },
+        { version: '0.2.1-beta.2', source: 'sb2' },
+        { version: '0.2.1', source: 's021' },
+        { version: '0.2.5-beta.1', source: 's025b' },
+      ],
+    });
+    expect(resolveMarketplaceEntryVersion(e, '^0.2.1-beta.1')?.version).toBe('0.2.1');
+  });
+
   it('respects tilde ranges (locks minor)', () => {
     const e = entry({
       version: '1.2.5',

--- a/apps/daemon/tests/registry/versioning.test.ts
+++ b/apps/daemon/tests/registry/versioning.test.ts
@@ -93,6 +93,34 @@ describe('resolveMarketplaceEntryVersion', () => {
     expect(resolved?.source).toBe('s120');
   });
 
+  it('locks the minor for a 0.x caret range (^0.2.0 excludes 0.3.0)', () => {
+    // npm caret semantics special-case a zero major: `^0.2.0` means
+    // `>=0.2.0 <0.3.0`, so 0.3.0 is a breaking release that must be excluded.
+    const e = entry({
+      version: '0.3.0',
+      versions: [
+        { version: '0.2.0', source: 's020' },
+        { version: '0.2.5', source: 's025' },
+        { version: '0.3.0', source: 's030' },
+      ],
+    });
+    const resolved = resolveMarketplaceEntryVersion(e, '^0.2.0');
+    expect(resolved?.version).toBe('0.2.5');
+    expect(resolved?.source).toBe('s025');
+  });
+
+  it('locks the patch for a 0.0.x caret range (^0.0.3 excludes 0.0.4)', () => {
+    // For `^0.0.3` npm resolves `>=0.0.3 <0.0.4`, i.e. only 0.0.3.
+    const e = entry({
+      version: '0.0.4',
+      versions: [
+        { version: '0.0.3', source: 's003' },
+        { version: '0.0.4', source: 's004' },
+      ],
+    });
+    expect(resolveMarketplaceEntryVersion(e, '^0.0.3')?.version).toBe('0.0.3');
+  });
+
   it('respects tilde ranges (locks minor)', () => {
     const e = entry({
       version: '1.2.5',


### PR DESCRIPTION
## Why

`resolveRequestedVersion` (the marketplace plugin version resolver) filters caret ranges by locking only the major component. That is correct for `^1.2.3` (`>=1.2.3 <2.0.0`) but wrong for 0.x versions: npm caret locks the leftmost non-zero component, so `^0.2.3` means `>=0.2.3 <0.3.0` and `^0.0.3` means `>=0.0.3 <0.0.4`. As written, `vendor/foo@^0.2.0` against a catalog offering 0.2.0 and 0.3.0 resolves to 0.3.0 — the breaking minor the 0.x rule exists to exclude. `entry.versions` comes from a third-party marketplace manifest and the range from the requested specifier, so this silently pulls a newer-than-intended, potentially breaking release.

## What users will see

Resolving a 0.x caret specifier now matches npm: `^0.2.0` stays within `0.2.x` (highest match, e.g. 0.2.5) instead of jumping to 0.3.0, and `^0.0.3` resolves to exactly 0.0.3. Caret ranges on `>=1.0.0` versions and all tilde ranges are unchanged.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — 0.x caret specifiers (`^0.x.y`) now resolve within the leftmost-non-zero bound (npm semantics) instead of only locking the major. Only `^0.x` resolution changes; `^1+` caret and all tilde ranges are unaffected. Correctness fix, no config/opt-in.
- [ ] **None**

## Bug fix verification

- **Bug:** the caret branch locked only the major, so `^0.2.0` resolved to `0.3.0` and `^0.0.3` to `0.0.4`.
- **Fix:** in the caret branch, when `base.major === 0` also require the minor to match (and when `base.minor === 0` too, the patch) — npm's leftmost-non-zero lock.
- **Test:** `apps/daemon/tests/registry/versioning.test.ts` → "locks the minor for a 0.x caret range (^0.2.0 excludes 0.3.0)" and "locks the patch for a 0.0.x caret range (^0.0.3 excludes 0.0.4)".
- **Red on main, green here?** Yes — both fail on main (`expected '0.3.0' to be '0.2.5'`, `expected '0.0.4' to be '0.0.3'`) and pass with the fix.

## Validation

- `pnpm --filter @open-design/daemon test` — `tests/registry/versioning.test.ts` 18/18.
- daemon `tsc --noEmit` for both `tsconfig.json` and `tsconfig.tests.json`.
