### PR TITLE
fix: add Kiro CLI to MCP client dropdown in Settings

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -7407,7 +7407,8 @@ type McpClientId =
   | 'vscode'
   | 'zed'
   | 'windsurf'
-  | 'antigravity';
+  | 'antigravity'
+  | 'kiro';
 
 interface McpInstallInfo {
   command: string;
@@ -7704,6 +7705,17 @@ function IntegrationsSection() {
       buildInstruction: (info) =>
         t('settings.mcpInstructionWindsurf', {
           path: homeConfigPath(info.platform, '~/.codeium/windsurf/mcp_config.json', '%USERPROFILE%\\.codeium\\windsurf\\mcp_config.json'),
+        }),
+      buildSnippet: buildSharedMcpJson,
+      buildSnippetLang: () => 'json',
+    },
+    {
+      id: 'kiro',
+      label: 'Kiro CLI',
+      buildMethod: () => t('settings.mcpMethodJson'),
+      buildInstruction: (info) =>
+        t('settings.mcpInstructionKiro', {
+          path: homeConfigPath(info.platform, '~/.kiro/settings/mcp.json', '%USERPROFILE%\\.kiro\\settings\\mcp.json'),
         }),
       buildSnippet: buildSharedMcpJson,
       buildSnippetLang: () => 'json',

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -586,6 +586,7 @@ export const ar: Dict = {
   'settings.mcpInstructionAntigravity': 'في Antigravity: قائمة "..." في لوحة الوكيل ← MCP Servers ← Manage MCP Servers ← View raw config. ادمج هذا الـ JSON.',
   'settings.mcpInstructionZed': 'افتح إعدادات Zed ({shortcut}) وادمج هذا في الكائن ذي المستوى الأعلى. يستخدم Zed "context_servers" وليس "mcpServers".',
   'settings.mcpInstructionWindsurf': 'افتح {path} (أو استخدم أيقونة MCPs في Cascade ← Configure) وادمج:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'نسخ مقتطف إعداد MCP',
   'settings.mcpResolvingFailed': '# فشل تحديد المسارات، راجع الخطأ أعلاه',
   'settings.mcpLoadingPaths': '# جارٍ تحميل مسارات التثبيت من الخدمة المحلية…',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -586,6 +586,7 @@ export const de: Dict = {
   'settings.mcpInstructionAntigravity': 'In Antigravity: Agent-Panel-Menü "..." → MCP Servers → Manage MCP Servers → View raw config. Führe dieses JSON zusammen.',
   'settings.mcpInstructionZed': 'Öffne die Zed-Einstellungen ({shortcut}) und füge dies in das Objekt der obersten Ebene ein. Zed verwendet "context_servers", nicht "mcpServers".',
   'settings.mcpInstructionWindsurf': 'Öffne {path} (oder verwende das MCPs-Symbol in Cascade → Configure) und führe zusammen:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'MCP-Konfigurations-Snippet kopieren',
   'settings.mcpResolvingFailed': '# Auflösen der Pfade fehlgeschlagen, siehe den Fehler oben',
   'settings.mcpLoadingPaths': '# Installationspfade werden vom lokalen Daemon geladen…',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -586,6 +586,7 @@ export const en: Dict = {
   'settings.mcpInstructionAntigravity': 'In Antigravity: Agent panel "..." menu → MCP Servers → Manage MCP Servers → View raw config. Merge this JSON.',
   'settings.mcpInstructionZed': 'Open Zed Settings ({shortcut}) and merge this into the top-level object. Zed uses "context_servers", not "mcpServers".',
   'settings.mcpInstructionWindsurf': 'Open {path} (or use the MCPs icon in Cascade → Configure) and merge:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Copy MCP configuration snippet',
   'settings.mcpResolvingFailed': '# resolving paths failed, see the error above',
   'settings.mcpLoadingPaths': '# loading install paths from the local daemon…',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -586,6 +586,7 @@ export const esES: Dict = {
   'settings.mcpInstructionAntigravity': 'En Antigravity: menú «...» del panel del Agent → MCP Servers → Manage MCP Servers → View raw config. Combina este JSON.',
   'settings.mcpInstructionZed': 'Abre los Ajustes de Zed ({shortcut}) y fusiona esto en el objeto de nivel superior. Zed usa «context_servers», no «mcpServers».',
   'settings.mcpInstructionWindsurf': 'Abre {path} (o usa el icono de MCP en Cascade → Configure) y combina:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Copiar fragmento de configuración de MCP',
   'settings.mcpResolvingFailed': '# error al resolver las rutas, consulta el error anterior',
   'settings.mcpLoadingPaths': '# cargando rutas de instalación desde el daemon local…',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -586,6 +586,7 @@ export const fa: Dict = {
   'settings.mcpInstructionAntigravity': 'در Antigravity: منوی «...» پنل Agent ← MCP Servers ← Manage MCP Servers ← View raw config. این JSON را ادغام کنید.',
   'settings.mcpInstructionZed': 'تنظیمات Zed ({shortcut}) را باز کنید و این را در شیء سطح‌بالا ادغام کنید. Zed از «context_servers» استفاده می‌کند، نه «mcpServers».',
   'settings.mcpInstructionWindsurf': '{path} را باز کنید (یا از آیکون MCPها در Cascade ← Configure استفاده کنید) و ادغام کنید:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'کپی قطعه پیکربندی MCP',
   'settings.mcpResolvingFailed': '# حل مسیرها ناموفق بود، خطای بالا را ببینید',
   'settings.mcpLoadingPaths': '# در حال بارگذاری مسیرهای نصب از daemon محلی…',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -586,6 +586,7 @@ export const fr: Dict = {
   'settings.mcpInstructionAntigravity': 'Dans Antigravity : panneau Agent, menu "..." → MCP Servers → Manage MCP Servers → View raw config. Fusionnez ce JSON.',
   'settings.mcpInstructionZed': 'Ouvrez les réglages Zed ({shortcut}) et fusionnez ceci dans l’objet racine. Zed utilise "context_servers", pas "mcpServers".',
   'settings.mcpInstructionWindsurf': 'Ouvrez {path} (ou utilisez l’icône MCPs dans Cascade → Configure), puis fusionnez :',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Copier l’extrait de configuration MCP',
   'settings.mcpResolvingFailed': '# échec de résolution des chemins, voir l’erreur ci-dessus',
   'settings.mcpLoadingPaths': '# chargement des chemins d’installation depuis le daemon local…',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -586,6 +586,7 @@ export const hu: Dict = {
   'settings.mcpInstructionAntigravity': 'Az Antigravityben: Agent panel "..." menü → MCP Servers → Manage MCP Servers → View raw config. Egyesítsd ezt a JSON-t.',
   'settings.mcpInstructionZed': 'Nyisd meg a Zed beállításait ({shortcut}), és egyesítsd ezt a legfelső szintű objektummal. A Zed a „context_servers” kulcsot használja, nem a „mcpServers” kulcsot.',
   'settings.mcpInstructionWindsurf': 'Nyisd meg ezt: {path} (vagy használd az MCPs ikont a Cascade-ben → Configure), majd egyesítsd:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'MCP konfigurációs részlet másolása',
   'settings.mcpResolvingFailed': '# az útvonalak feloldása sikertelen, lásd a fenti hibát',
   'settings.mcpLoadingPaths': '# telepítési útvonalak betöltése a helyi daemonból…',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -586,6 +586,7 @@ export const id: Dict = {
   'settings.mcpInstructionAntigravity': 'Di Antigravity: panel Agent menu "..." → MCP Servers → Manage MCP Servers → View raw config. Gabungkan JSON ini.',
   'settings.mcpInstructionZed': 'Buka Zed Settings ({shortcut}) dan gabungkan ini ke dalam objek tingkat atas. Zed menggunakan "context_servers", bukan "mcpServers".',
   'settings.mcpInstructionWindsurf': 'Buka {path} (atau gunakan ikon MCPs di Cascade → Configure) lalu gabungkan:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Salin cuplikan konfigurasi MCP',
   'settings.mcpResolvingFailed': '# penentuan jalur gagal, lihat error di atas',
   'settings.mcpLoadingPaths': '# memuat jalur instalasi dari daemon lokal…',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -586,6 +586,7 @@ export const it: Dict = {
   'settings.mcpInstructionAntigravity': 'In Antigravity: pannello Agent, menu "..." → MCP Servers → Manage MCP Servers → View raw config. Unisci questo JSON.',
   'settings.mcpInstructionZed': 'Apri le impostazioni di Zed ({shortcut}) e unisci questo nell\'oggetto di livello superiore. Zed usa "context_servers", non "mcpServers".',
   'settings.mcpInstructionWindsurf': 'Apri {path} (oppure usa l\'icona MCP in Cascade → Configure) e unisci:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Copia lo snippet di configurazione MCP',
   'settings.mcpResolvingFailed': '# risoluzione dei percorsi non riuscita, vedi l\'errore sopra',
   'settings.mcpLoadingPaths': '# caricamento dei percorsi di installazione dal daemon locale…',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -586,6 +586,7 @@ export const ja: Dict = {
   'settings.mcpInstructionAntigravity': 'Antigravity の場合：Agent パネルの「...」メニュー → MCP Servers → Manage MCP Servers → View raw config。この JSON をマージしてください。',
   'settings.mcpInstructionZed': 'Zedの設定（{shortcut}）を開き、これをトップレベルのオブジェクトにマージしてください。Zedは「mcpServers」ではなく「context_servers」を使用します。',
   'settings.mcpInstructionWindsurf': '{path} を開く（または Cascade の MCPs アイコン → Configure を使用）してマージしてください：',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'MCP設定スニペットをコピー',
   'settings.mcpResolvingFailed': '# パスの解決に失敗しました。上記のエラーを参照してください',
   'settings.mcpLoadingPaths': '# ローカルデーモンからインストールパスを読み込み中…',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -586,6 +586,7 @@ export const ko: Dict = {
   'settings.mcpInstructionAntigravity': 'Antigravity에서: Agent 패널 "..." 메뉴 → MCP Servers → Manage MCP Servers → View raw config. 이 JSON을 병합하세요.',
   'settings.mcpInstructionZed': 'Zed 설정({shortcut})을 열고 이것을 최상위 객체에 병합하세요. Zed는 "mcpServers"가 아닌 "context_servers"를 사용합니다.',
   'settings.mcpInstructionWindsurf': '{path}을(를) 열거나(또는 Cascade의 MCPs 아이콘 → Configure 사용) 다음을 병합하세요:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'MCP 설정 스니펫 복사',
   'settings.mcpResolvingFailed': '# 경로 확인에 실패했습니다. 위의 오류를 참고하세요',
   'settings.mcpLoadingPaths': '# 로컬 데몬에서 설치 경로를 불러오는 중…',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -586,6 +586,7 @@ export const pl: Dict = {
   'settings.mcpInstructionAntigravity': 'W Antigravity: panel Agent, menu „...” → MCP Servers → Manage MCP Servers → View raw config. Scal ten JSON.',
   'settings.mcpInstructionZed': 'Otwórz Zed Settings ({shortcut}) i scal to z obiektem najwyższego poziomu. Zed używa „context_servers”, a nie „mcpServers”.',
   'settings.mcpInstructionWindsurf': 'Otwórz {path} (lub użyj ikony MCP w Cascade → Configure) i scal:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Skopiuj fragment konfiguracji MCP',
   'settings.mcpResolvingFailed': '# rozpoznawanie ścieżek nie powiodło się, zobacz błąd powyżej',
   'settings.mcpLoadingPaths': '# wczytywanie ścieżek instalacji z lokalnego daemona…',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -586,6 +586,7 @@ export const ptBR: Dict = {
   'settings.mcpInstructionAntigravity': 'No Antigravity: menu "..." do painel do Agent → MCP Servers → Manage MCP Servers → View raw config. Mescle este JSON.',
   'settings.mcpInstructionZed': 'Abra as Zed Settings ({shortcut}) e mescle isto no objeto de nível superior. O Zed usa "context_servers", não "mcpServers".',
   'settings.mcpInstructionWindsurf': 'Abra {path} (ou use o ícone de MCPs no Cascade → Configure) e mescle:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Copiar trecho de configuração do MCP',
   'settings.mcpResolvingFailed': '# a resolução de caminhos falhou, veja o erro acima',
   'settings.mcpLoadingPaths': '# carregando caminhos de instalação do daemon local…',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -586,6 +586,7 @@ export const ru: Dict = {
   'settings.mcpInstructionAntigravity': 'В Antigravity: меню «...» панели Agent → MCP Servers → Manage MCP Servers → View raw config. Объедините этот JSON.',
   'settings.mcpInstructionZed': 'Откройте настройки Zed ({shortcut}) и объедините это с объектом верхнего уровня. Zed использует «context_servers», а не «mcpServers».',
   'settings.mcpInstructionWindsurf': 'Откройте {path} (или используйте значок MCP в Cascade → Configure) и объедините:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Скопировать фрагмент конфигурации MCP',
   'settings.mcpResolvingFailed': '# не удалось определить пути, см. ошибку выше',
   'settings.mcpLoadingPaths': '# загрузка путей установки из локального демона…',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -586,6 +586,7 @@ export const th: Dict = {
   'settings.mcpInstructionAntigravity': 'ใน Antigravity: เมนู "..." ของแผง Agent → MCP Servers → Manage MCP Servers → View raw config แล้วรวม JSON นี้',
   'settings.mcpInstructionZed': 'เปิด Zed Settings ({shortcut}) แล้วผสานสิ่งนี้เข้ากับอ็อบเจกต์ระดับบนสุด Zed ใช้ "context_servers" ไม่ใช่ "mcpServers"',
   'settings.mcpInstructionWindsurf': 'เปิด {path} (หรือใช้ไอคอน MCPs ใน Cascade → Configure) แล้วรวม:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'คัดลอกสคริปต์การตั้งค่า MCP',
   'settings.mcpResolvingFailed': '# resolving paths failed, see the error above',
   'settings.mcpLoadingPaths': '# loading install paths from the local daemon…',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -586,6 +586,7 @@ export const tr: Dict = {
   'settings.mcpInstructionAntigravity': 'Antigravity\'de: Agent paneli "..." menüsü → MCP Servers → Manage MCP Servers → View raw config. Bu JSON\'u birleştirin.',
   'settings.mcpInstructionZed': 'Zed Ayarlarını ({shortcut}) açın ve bunu en üst düzey nesneyle birleştirin. Zed, "mcpServers" değil "context_servers" kullanır.',
   'settings.mcpInstructionWindsurf': '{path} dosyasını açın (veya Cascade → Configure içindeki MCPs simgesini kullanın) ve birleştirin:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'MCP yapılandırma parçacığını kopyala',
   'settings.mcpResolvingFailed': '# yollar çözümlenemedi, yukarıdaki hataya bakın',
   'settings.mcpLoadingPaths': '# yerel daemon\'dan kurulum yolları yükleniyor…',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -586,6 +586,7 @@ export const uk: Dict = {
   'settings.mcpInstructionAntigravity': 'В Antigravity: меню «...» панелі Agent → MCP Servers → Manage MCP Servers → View raw config. Об’єднайте цей JSON.',
   'settings.mcpInstructionZed': 'Відкрийте налаштування Zed ({shortcut}) і об’єднайте це з об’єктом верхнього рівня. Zed використовує «context_servers», а не «mcpServers».',
   'settings.mcpInstructionWindsurf': 'Відкрийте {path} (або скористайтеся піктограмою MCP у Cascade → Configure) і об’єднайте:',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
   'settings.mcpCopyAria': 'Копіювати фрагмент конфігурації MCP',
   'settings.mcpResolvingFailed': '# не вдалося визначити шляхи, див. помилку вище',
   'settings.mcpLoadingPaths': '# завантаження шляхів встановлення з локального демона…',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -597,8 +597,10 @@ export const zhCN: Dict = {
     '在 Antigravity 中：Agent 面板 "..." 菜单 → MCP Servers → Manage MCP Servers → View raw config。合并此 JSON。',
   "settings.mcpInstructionZed":
     '打开 Zed Settings（{shortcut}），然后将此配置合并到顶层对象中。Zed 使用 "context_servers"，而非 "mcpServers"。',
-  "settings.mcpInstructionWindsurf":
-    "打开 {path}（或在 Cascade 中使用 MCPs 图标 → Configure）并合并：",
+  'settings.mcpInstructionWindsurf':
+    '打开 {path}（或在 Cascade 中使用 MCPs 图标 → Configure）并合并：',
+  'settings.mcpInstructionKiro':
+    '打开 {path}，将此 JSON 合并到文件中。项目专用服务器请使用工作区级配置 (.kiro/settings/mcp.json)。',
   "settings.mcpCopyAria": "复制 MCP 配置片段",
   "settings.mcpResolvingFailed": "# 解析路径失败，请查看上方错误",
   "settings.mcpLoadingPaths": "# 正在从本地守护进程加载安装路径…",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -600,6 +600,7 @@ export const zhTW: Dict = {
   "settings.mcpInstructionZed":
     "開啟 Zed Settings（{shortcut}），然後將此內容合併至最上層物件。Zed 使用「context_servers」，而非「mcpServers」。",
   "settings.mcpInstructionWindsurf":
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
     "開啟 {path}（或使用 Cascade 中的 MCPs 圖示 → Configure）並合併：",
   "settings.mcpCopyAria": "複製 MCP 設定片段",
   "settings.mcpResolvingFailed": "# 解析路徑失敗，請見上方錯誤",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -600,8 +600,9 @@ export const zhTW: Dict = {
   "settings.mcpInstructionZed":
     "開啟 Zed Settings（{shortcut}），然後將此內容合併至最上層物件。Zed 使用「context_servers」，而非「mcpServers」。",
   "settings.mcpInstructionWindsurf":
-  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. Use mcpServers at workspace level (.kiro/settings/mcp.json) for project-specific servers.',
     "開啟 {path}（或使用 Cascade 中的 MCPs 圖示 → Configure）並合併：",
+  "settings.mcpInstructionKiro":
+    "開啟 {path} 並合併此 JSON。專案專用伺服器請使用工作區級設定 (.kiro/settings/mcp.json)。",
   "settings.mcpCopyAria": "複製 MCP 設定片段",
   "settings.mcpResolvingFailed": "# 解析路徑失敗，請見上方錯誤",
   "settings.mcpLoadingPaths": "# 正在從本地守護行程載入安裝路徑…",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -884,6 +884,7 @@ export interface Dict {
   'settings.mcpInstructionAntigravity': string;
   'settings.mcpInstructionZed': string;
   'settings.mcpInstructionWindsurf': string;
+  'settings.mcpInstructionKiro': string;
   'settings.mcpCopyAria': string;
   'settings.mcpResolvingFailed': string;
   'settings.mcpLoadingPaths': string;


### PR DESCRIPTION
## Summary

Fixes #5079

Adds Kiro CLI as an MCP client option in the Settings → Integrations dropdown, so Kiro users can install the Open Design MCP server through the UI.

## Changes

### Code
- Add `'kiro'` to `McpClientId` union type
- Add Kiro CLI entry to `MCP_CLIENTS` array with standard `mcpServers` JSON config
- Config paths: `~/.kiro/settings/mcp.json` (user-level) and `.kiro/settings/mcp.json` (workspace-level)

### i18n
- Add `settings.mcpInstructionKiro` key to `types.ts` and all 19 locale files

## Surface area

- [x] UI (visual changes — new dropdown option)
- [x] i18n keys (translations added/changed)
- [ ] CLI / daemon (backend changes)
- [ ] Code structure (utils/config/types)
- [ ] API surface (endpoints, contracts)
- [ ] Documentation

Closes #5079