### PR TITLE
fix: keep design system source segmented buttons on one line

### DIFF
--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -346,6 +346,7 @@
 
 .library-install-form .library-import-source-control {
   grid-template-columns: repeat(3, auto);
+  white-space: nowrap;
 }
 
 .library-install-form .library-import-mode-control {


### PR DESCRIPTION
## Summary

Fixes #4770

The Design System Source segmented control (Local / GitHub / shadcn) was wrapping onto two lines in narrow Settings panels. This PR adds `white-space: nowrap` to the control to keep all three options on a single row.

## Changes

- Add `white-space: nowrap` to `.library-install-form .library-import-source-control` 

## Surface area

- [x] UI (visual changes)
- [ ] i18n keys
- [ ] CLI / daemon
- [ ] Code structure
- [ ] API surface
- [ ] Documentation

Closes #4770