### PR TITLE
fix: prevent carousel progress indicator from overlapping template cards

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2185,7 +2185,7 @@
   gap: 10px;
   overflow-x: auto;
   overscroll-behavior-x: contain;
-  padding: 1px 2px 8px;
+  padding: 1px 2px 14px;
   scrollbar-width: thin;
 }
 


### PR DESCRIPTION
## Summary

Fixes #4609

The horizontal scrollbar on the home page plugin presets carousel was rendered directly on top of template card content. This PR increases the bottom padding from 8px to 14px, providing enough breathing room for the thin scrollbar to sit below the card row without overlapping card thumbnails, titles, or borders.

## Changes

- `.home-hero__plugin-presets`: `padding: 1px 2px 8px` → `padding: 1px 2px 14px`

## Surface area

- [x] UI (visual changes)
- [ ] i18n keys
- [ ] CLI / daemon
- [ ] Code structure
- [ ] API surface
- [ ] Documentation

Closes #4609