### PR TITLE
fix: ensure Dialog modals render above popovers and edit overlays

### DIFF
--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -1479,11 +1479,11 @@
   position: fixed;
   right: 16px;
   bottom: 16px;
-  /* Above modal backdrops (z-index 100) so the banner remains visible and
+  /* Above modal backdrops (z-index 2000) so the banner remains visible and
      actionable even while Settings or any other modal is open. The banner
      uses pointer-events:none on the card itself with opt-in on interactive
      children, so it never intercepts clicks meant for the layer below. */
-  z-index: 110;
+  z-index: 2010;
   width: 380px;
   max-width: calc(100vw - 32px);
   display: flex;

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -287,7 +287,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: 2000;
   animation: fade-in 160ms ease-out;
 }
 .modal {

--- a/packages/components/src/dialog.module.css
+++ b/packages/components/src/dialog.module.css
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: 2000;
   animation: dialog-backdrop-fade-in 160ms ease-out;
 }
 


### PR DESCRIPTION
## Summary

Fixes #4447

Settings and other modal dialogs could open behind the canvas edit popover because the shared Dialog backdrop had z-index 100 — well below popover tiers (1500-1900). This PR raises the Dialog backdrop, the privacy consent banner, and the legacy Settings `modal-backdrop` to a proper stacking tier.

## Changes

| File | Change |
|---|---|
| `packages/components/src/dialog.module.css` | `.backdrop` z-index: 100 → 2000 |
| `apps/web/src/styles/viewer/memory.css` | `.privacy-consent-banner` z-index: 110 → 2010 |
| `apps/web/src/styles/workspace/mention-home.css` | `.modal-backdrop` (Settings) z-index: 100 → 2000 |

## Stacking order after fix

| Tier | Element |
|---|---|
| 100 | base canvas |
| 1500–1900 | popovers / edit overlays |
| 2000 | Dialog backdrop + Settings `.modal-backdrop` |
| 2010 | privacy consent banner |
| 9000 | shared component overlays (e.g. toast) |

## Surface area

- [x] UI (visual changes — layer ordering)
- [ ] i18n keys
- [ ] CLI / daemon
- [ ] Code structure
- [ ] API surface
- [ ] Documentation

## Validation

- `pnpm --filter @open-design/web typecheck` — passes
- Visual regression baseline: 0 changed / 53 unchanged (per bot comment)
- Manual smoke (Settings + popover + edit overlay co-existence): Settings now renders above 1500–1900 popover tiers and the canvas edit overlay

Closes #4447