### PR TITLE
fix(daemon): reject symlinks when installing extensions from GitHub

### DIFF
--- a/apps/daemon/src/design-systems/github-import.ts
+++ b/apps/daemon/src/design-systems/github-import.ts
@@ -3,6 +3,7 @@ import { mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
+import { containsSymlink } from '../library-install.js';
 import {
   LocalDesignSystemImportError,
   type LocalDesignSystemImportOptions,
@@ -53,6 +54,16 @@ export async function importGitHubDesignSystemProject(
 
   try {
     await execGit(gitBin, cloneArgs, undefined, 120_000);
+    // Refuse a clone that contains symbolic links: the design-system readers and
+    // this importer follow symlinks, so a committed in-tree symlink pointing
+    // outside the clone (e.g. `README.md -> /etc/passwd`) would exfiltrate an
+    // arbitrary file into the imported design system. Mirrors installFromGithub.
+    if (await containsSymlink(cloneDir)) {
+      throw new LocalDesignSystemImportError(
+        'BAD_REQUEST',
+        'repository contains symbolic links, which are not allowed',
+      );
+    }
     const [detectedBranch, commit] = await Promise.all([
       readGitStdout(gitBin, ['-C', cloneDir, 'rev-parse', '--abbrev-ref', 'HEAD']),
       readGitStdout(gitBin, ['-C', cloneDir, 'rev-parse', 'HEAD']),

--- a/apps/daemon/src/library-install.ts
+++ b/apps/daemon/src/library-install.ts
@@ -27,6 +27,33 @@ export function sanitizeRepoName(url) {
 }
 
 /**
+ * Recursively report whether `dir` contains any symbolic link at any depth.
+ * Uses lstat-based dirents (readdir withFileTypes) so it detects symlinks
+ * without following them and never descends through one.
+ * @param {string} dir
+ * @returns {Promise<boolean>}
+ */
+export async function containsSymlink(dir) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    // A missing dir has nothing to scan. Any other readdir failure on a tree we
+    // just cloned is unexpected; fail closed so a partially-readable clone can't
+    // slip a symlink past the scan.
+    if (err && err.code === 'ENOENT') return false;
+    return true;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) return true;
+    if (entry.isDirectory() && (await containsSymlink(path.join(dir, entry.name)))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * @param {InstallTarget} target
  * @param {string} userDir - user-installed directory (e.g. ~/.open-design/skills)
  * @param {'skill' | 'design-system'} kind
@@ -79,6 +106,16 @@ async function installFromGithub(url, userDir, manifest) {
     });
   } catch (err) {
     return { ok: false, error: `git clone failed: ${String(err).split('\n')[0]}` };
+  }
+
+  // Refuse a clone that contains symbolic links. The daemon's design-system and
+  // skill file readers follow symlinks, so a committed in-tree symlink pointing
+  // outside the install dir (e.g. `DESIGN.md -> /etc/passwd`) would let a
+  // third-party repo exfiltrate any daemon-readable file. Extensions are
+  // self-contained trees and never need symlinks.
+  if (await containsSymlink(dest)) {
+    try { fs.rmSync(dest, { recursive: true, force: true }); } catch {}
+    return { ok: false, error: 'Repository contains symbolic links, which are not allowed' };
   }
 
   // Verify manifest exists

--- a/apps/daemon/tests/library-install.test.ts
+++ b/apps/daemon/tests/library-install.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest';
-import { sanitizeRepoName, GITHUB_URL_RE, SAFE_NAME_RE } from '../src/library-install.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  containsSymlink,
+  sanitizeRepoName,
+  GITHUB_URL_RE,
+  SAFE_NAME_RE,
+} from '../src/library-install.js';
 
 describe('sanitizeRepoName', () => {
   it('extracts repo name from a github URL', () => {
@@ -79,5 +88,56 @@ describe('SAFE_NAME_RE', () => {
     expect(SAFE_NAME_RE.test('foo bar')).toBe(false);
     expect(SAFE_NAME_RE.test('测试')).toBe(false);
     expect(SAFE_NAME_RE.test('repo!')).toBe(false);
+  });
+});
+
+describe('containsSymlink', () => {
+  // A freshly cloned third-party extension must not carry symlinks: the daemon's
+  // design-system / skill readers follow them, so a committed `DESIGN.md ->
+  // /etc/passwd` would exfiltrate arbitrary files. installFromGithub rejects a
+  // clone when this returns true.
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-contains-symlink-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('returns false for a plain tree with files and nested directories', async () => {
+    await writeFile(path.join(root, 'DESIGN.md'), '# ok');
+    await mkdir(path.join(root, 'assets'), { recursive: true });
+    await writeFile(path.join(root, 'assets', 'logo.svg'), '<svg/>');
+    expect(await containsSymlink(root)).toBe(false);
+  });
+
+  it('detects a top-level symlink', async () => {
+    await writeFile(path.join(root, 'secret-target'), 'x');
+    await symlink(path.join(root, 'secret-target'), path.join(root, 'evil.md'));
+    expect(await containsSymlink(root)).toBe(true);
+  });
+
+  it('detects a symlink nested in a subdirectory', async () => {
+    await mkdir(path.join(root, 'a', 'b'), { recursive: true });
+    await symlink('/etc/hostname', path.join(root, 'a', 'b', 'link.txt'));
+    expect(await containsSymlink(root)).toBe(true);
+  });
+
+  it('detects a symlink that points at a directory without following it', async () => {
+    // A symlinked dir must be flagged, not descended into (following it could
+    // recurse outside the tree).
+    const outside = await mkdtemp(path.join(tmpdir(), 'od-symlink-outside-'));
+    try {
+      await symlink(outside, path.join(root, 'linked-dir'));
+      expect(await containsSymlink(root)).toBe(true);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false for a missing directory', async () => {
+    expect(await containsSymlink(path.join(root, 'does-not-exist'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

Skills and design systems are installed from third-party GitHub repos by `git clone`ing them into `~/.open-design/{skills,design-systems}/` — via `installFromTarget` → `installFromGithub` (the `/install` routes) and separately via `importGitHubDesignSystemProject` (`/api/design-systems/import/github`). `git clone` materializes committed symlinks verbatim, and the daemon's design-system/skill file readers confine a path lexically but then `stat()`/`readFile()` follow symlinks. So a malicious repo can ship an in-tree symlink — e.g. `DESIGN.md -> /etc/passwd`, or an allowlisted `sourceFiles.tokens -> ~/.ssh/id_ed25519` — and the daemon reads and returns the target's contents (reachable e.g. via `GET /api/design-systems/:id`, or folded into the system prompt). That is an arbitrary read of any file the daemon can access. Extensions are self-contained file trees and never need symlinks, so this refuses any install/import whose clone contains a symbolic link — closing the class at the boundary rather than hardening every reader. This mirrors how the plugin installer already refuses symlinks.

## What users will see

Installing or importing a normal design system or skill is unchanged. Installing a GitHub repo that contains a symbolic link now fails with "Repository contains symbolic links, which are not allowed" and nothing is left on disk. Local installs/imports (which point at a directory you already have on disk) are unaffected.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal daemon hardening. The `/install` and `/import/github` endpoints now reject a repository that contains symbolic links (never a legitimate extension); normal installs behave identically and no product surface changes.

## Bug fix verification

- **Bug:** `git clone` of a third-party repo preserved committed symlinks, which the daemon's design-system/skill readers then followed out of the extension dir — an arbitrary read of any daemon-readable file.
- **Fix:** after a successful clone, `containsSymlink(dir)` recursively scans with lstat-based dirents (detects symlinks without following them, fails closed on unexpected readdir errors); if any symlink exists the clone is removed and the install/import is refused. Wired into both GitHub clone paths — `installFromGithub` (skill + design-system install) and `importGitHubDesignSystemProject` (design-system GitHub import).
- **Test:** `apps/daemon/tests/library-install.test.ts` → new `containsSymlink` suite: a plain tree → false; top-level, nested, and directory-target symlinks → true (the directory target is flagged without being followed); a missing dir → false.
- **Note:** `containsSymlink`'s detection is unit-tested directly and the reject wiring in both clone paths is exercised through it (a real `git clone` can't run in a unit test).

## Validation

- `pnpm --filter @open-design/daemon test` — `tests/library-install.test.ts` 20/20.
- daemon `tsc --noEmit` for both `tsconfig.json` and `tsconfig.tests.json` (`library-install.ts` is `@ts-nocheck` in the repo; `github-import.ts` typechecks against the exported helper).
