### PR TITLE
fix(desktop): guard render-process-gone handler against teardown crash

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1867,11 +1867,18 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   // PostHog with `device_id = installationId`. Best-effort: a failure to
   // reach the daemon must not block the crash recovery flow.
   window.webContents.on("render-process-gone", (_event, details) => {
+    // During app quit / teardown the renderer goes away and the window (and its
+    // webContents) can already be destroyed when this fires. Reading getURL()
+    // then throws "Object has been destroyed" as a fatal uncaught exception, so
+    // guard the same way `sendUpdaterStatus` does below and skip crash-report /
+    // recovery work once the window is already on its way out.
+    const gone = window.isDestroyed() || window.webContents.isDestroyed();
     console.error("[open-design desktop] main window render-process-gone", {
       exitCode: details.exitCode,
       reason: details.reason,
-      url: window.webContents.getURL(),
+      url: gone ? null : window.webContents.getURL(),
     });
+    if (gone) return;
     void reportRendererCrash(options, {
       reason: details.reason,
       exit_code: typeof details.exitCode === "number" ? details.exitCode : null,

--- a/apps/desktop/tests/main/render-process-gone-teardown-guard.test.ts
+++ b/apps/desktop/tests/main/render-process-gone-teardown-guard.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, test } from "vitest";
+
+// `createDesktopRuntime` builds real Electron `BrowserWindow`s and cannot be
+// instantiated under vitest, so — following the pattern in
+// `renderer-recovery-poll-loop.test.ts` and `window-chrome.test.ts` — these
+// tests assert on the runtime source to pin the teardown-safety invariant of the
+// `render-process-gone` handler. See nexu-io/open-design#5095: reading
+// `webContents.getURL()` after the window is destroyed during app quit throws
+// "Object has been destroyed" as a fatal uncaught exception.
+const runtimeSource = readFileSync(new URL("../../src/main/runtime.ts", import.meta.url), "utf8");
+
+const handlerBlock =
+  /window\.webContents\.on\("render-process-gone",[\s\S]*?\n {2}\}\);/.exec(runtimeSource)?.[0] ?? "";
+
+describe("desktop render-process-gone teardown guard", () => {
+  test("the handler block is present", () => {
+    expect(handlerBlock).not.toBe("");
+  });
+
+  test("computes a destroyed guard from the window and its webContents", () => {
+    expect(handlerBlock).toMatch(
+      /const gone = window\.isDestroyed\(\) \|\| window\.webContents\.isDestroyed\(\);/,
+    );
+  });
+
+  test("never reads getURL() unconditionally during teardown", () => {
+    // The pre-fix bug was a bare `url: window.webContents.getURL()`; once the
+    // window is gone the URL must be reported as null instead of touched.
+    expect(handlerBlock).not.toMatch(/url:\s*window\.webContents\.getURL\(\),/);
+    expect(handlerBlock).toMatch(/url:\s*gone \? null : window\.webContents\.getURL\(\),/);
+  });
+
+  test("short-circuits crash-report / recovery work once the window is gone", () => {
+    // Once destroyed we bail before reportRendererCrash / markRendererFailed,
+    // which would otherwise keep operating on a torn-down window.
+    const returnIndex = handlerBlock.indexOf("if (gone) return;");
+    const reportIndex = handlerBlock.indexOf("reportRendererCrash");
+    expect(returnIndex).toBeGreaterThan(-1);
+    expect(reportIndex).toBeGreaterThan(returnIndex);
+  });
+});


### PR DESCRIPTION
Fixes #5095

## Why

I run a self-built packaged macOS build of Open Design as my daily app, and it started popping Electron's default `Uncaught Exception: TypeError: Object has been destroyed` dialog, appearing to crash a few seconds after launch. Tracing it (full write-up in #5095) showed the exception fires during app quit / teardown; the auto-updater's quit-to-apply is what triggers it right after startup, but the underlying defect fires on **any** quit.

Root cause: the main window's `render-process-gone` handler reads `window.webContents.getURL()` unconditionally. During teardown the window and its `webContents` can already be destroyed when the event fires, so `getURL()` throws. `sendUpdaterStatus` a few lines below already guards the same access with `window.isDestroyed()`; this brings the crash handler in line with that pattern, per @lefarcen's confirmation on the issue.

## What users will see

The packaged desktop app no longer shows the `Uncaught Exception: Object has been destroyed` dialog when quitting (or on the auto-updater's quit-to-apply moments after launch). Quit is silent, as expected. No other user-facing change.

## Surface area

- [x] **None** — internal desktop main-process crash-handling fix plus a test. No new UI element, shortcut, CLI/env, API/contract, extension point, i18n key, or dependency; this restores intended quit behavior rather than changing a default.

## Screenshots

N/A — no UI surface. The fixed symptom is the Electron `Uncaught Exception: Object has been destroyed` dialog on quit (exact crash text and stack in #5095).

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/render-process-gone-teardown-guard.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — with only the `runtime.ts` fix stashed (working tree identical to `origin/main`), 3 of the 4 invariant assertions fail; with the fix applied all 4 pass.
- Why a source-assertion spec: `createDesktopRuntime` builds real Electron `BrowserWindow`s and cannot be instantiated under vitest, so — following the existing `renderer-recovery-poll-loop` and `window-chrome` tests — the spec asserts on the runtime source to pin the teardown-guard invariant (destroyed check computed before `getURL()`, `getURL()` gated behind it, and crash-report / recovery work short-circuited once the window is gone).

## Validation

- `pnpm install` (refresh workspace after basing the branch on current `origin/main`)
- `pnpm --filter @open-design/desktop typecheck` — pass
- `pnpm --filter @open-design/desktop test` — the 4 new specs pass; the full suite has one **pre-existing** failure (`updater.test.ts > cleans deprecated launcher payload versions on cold start from the launcher cleanup descriptor`) that reproduces identically on pristine `origin/main` with this change stashed, so it is unrelated to this diff.
- `pnpm guard` — the tracked diff is `apps/desktop` only; the local run's violations were untracked working-tree artifacts (`e2e/.DS_Store`, `tools/.DS_Store`, a leftover `tools/pr/`) that are not tracked in `origin/main` and are not part of this PR.
