### PR TITLE
fix(daemon): keep MCP connected to sidecar daemon restarts

### DIFF
--- a/apps/daemon/AGENTS.md
+++ b/apps/daemon/AGENTS.md
@@ -105,6 +105,12 @@ User-facing capabilities must be reachable through both:
 
 When adding a user-facing capability, close the loop in one change: contract type, daemon route, web surface if applicable, and CLI command with `--json` plus `--prompt-file <path|->` for long prompts where relevant.
 
+## MCP Daemon Discovery
+
+- `od mcp` must treat the daemon URL as sidecar/runtime state, not a process-lifetime constant, unless the user supplied an explicit fixed `--daemon-url`.
+- Sidecar discovery changes belong in `src/daemon-url.ts`; MCP request-time base URL behavior belongs in `src/mcp.ts`. Keep both paths covered by focused tests in `tests/daemon-url.test.ts` and `tests/mcp-base-url-resolver.test.ts`.
+- Do not edit generated `dist/` output for MCP behavior changes. Source changes plus tests are the durable path; local `dist/` sync is only a temporary runtime workaround outside PR scope.
+
 ## Runtime and Agent Changes
 
 - Parser changes belong beside the matching runtime stream helper and should include focused parser tests.

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -1162,10 +1162,8 @@ async function runMcp(args) {
     return;
   }
 
-  const daemonUrl = await cliDaemonUrl(flags);
-
   const { runMcpStdio } = await import('./mcp.js');
-  await runMcpStdio({ daemonUrl });
+  await runMcpStdio({ resolveDaemonUrl: () => cliDaemonUrl(flags) });
 }
 
 function printMcpHelp() {
@@ -1180,13 +1178,10 @@ every iteration.
 Options:
   --daemon-url <url>   Open Design daemon HTTP base URL. Resolution
                        order: this flag, OD_DAEMON_URL, OD_SIDECAR_IPC_PATH,
-                       then http://127.0.0.1:7456. Each new MCP spawn
-                       discovers the live daemon URL at startup, so
-                       MCP client configs stay valid across daemon
-                       restarts even when the port is ephemeral. A
-                       running MCP server caches the URL; restart the
-                       MCP client after a daemon restart to pick up a
-                       new port.
+                       then http://127.0.0.1:7456. MCP tool calls re-resolve
+                       the live daemon URL, so sidecar-based client configs
+                       stay valid across daemon restarts even when the port
+                       is ephemeral.
 
 Tools exposed:
   list_projects                  list every Open Design project

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -1,12 +1,15 @@
 import { spawn } from "node:child_process";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
   SIDECAR_ENV,
   SIDECAR_MESSAGES,
   type DaemonStatusSnapshot,
 } from "@open-design/sidecar-proto";
-import { requestJsonIpc } from "@open-design/sidecar";
+import { requestJsonIpc, resolveAppIpcPath } from "@open-design/sidecar";
 
 export const DEFAULT_DAEMON_URL = "http://127.0.0.1:7456";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -26,8 +29,9 @@ export interface ResolveDaemonUrlOptions {
  * Spawn order: explicit `--daemon-url` flag, `OD_DAEMON_URL` env, then
  * a STATUS roundtrip to the concrete sidecar IPC endpoint supplied by
  * the lifecycle owner in `OD_SIDECAR_IPC_PATH`, then the default
- * `tools-dev status --json` runtime. Falls back to the legacy default
- * for direct `od` launches that do not run as a sidecar.
+ * `tools-dev status --json` runtime, then packaged sidecar sockets.
+ * Falls back to the legacy default for direct `od` launches that do not
+ * have a discoverable sidecar runtime.
  */
 export async function resolveDaemonUrl(
   options: ResolveDaemonUrlOptions = {},
@@ -41,6 +45,8 @@ export async function resolveDaemonUrl(
   if (discovered != null) return discovered;
   const toolsDevUrl = await discoverDaemonUrlFromToolsDev(env, options.timeoutMs ?? 800);
   if (toolsDevUrl != null) return toolsDevUrl;
+  const packagedUrl = await discoverDaemonUrlFromPackagedIpc(env, options.timeoutMs ?? 800);
+  if (packagedUrl != null) return packagedUrl;
   return DEFAULT_DAEMON_URL;
 }
 
@@ -50,16 +56,7 @@ async function discoverDaemonUrlFromIpc(
 ): Promise<string | null> {
   const socketPath = env[SIDECAR_ENV.IPC_PATH];
   if (socketPath == null || socketPath.length === 0) return null;
-  try {
-    const status = await requestJsonIpc<DaemonStatusSnapshot>(
-      socketPath,
-      { type: SIDECAR_MESSAGES.STATUS },
-      { timeoutMs },
-    );
-    return status?.url ?? null;
-  } catch {
-    return null;
-  }
+  return await readDaemonUrlFromIpc(socketPath, timeoutMs);
 }
 
 async function discoverDaemonUrlFromToolsDev(
@@ -100,6 +97,64 @@ async function discoverDaemonUrlFromToolsDev(
       done(code === 0 ? extractDaemonUrlFromToolsDevStatus(stdout) : null);
     });
   });
+}
+
+async function discoverDaemonUrlFromPackagedIpc(
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+): Promise<string | null> {
+  const stablePath = resolveAppIpcPath({
+    app: APP_KEYS.DAEMON,
+    contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+    env,
+    namespace: "release-stable",
+  });
+  const stableUrl = await readDaemonUrlFromIpc(stablePath, timeoutMs);
+  if (stableUrl != null) return stableUrl;
+  if (process.platform === "win32") return null;
+
+  const ipcBase = path.resolve(
+    env[SIDECAR_ENV.IPC_BASE] ?? OPEN_DESIGN_SIDECAR_CONTRACT.defaults.ipcBase,
+  );
+  let entries;
+  try {
+    entries = await readdir(ipcBase, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const socketPaths = entries
+    .filter((entry) => entry.isDirectory() && entry.name !== "release-stable")
+    .map((entry) =>
+      resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env,
+        namespace: entry.name,
+      }),
+    )
+    .sort();
+  for (const socketPath of socketPaths) {
+    const url = await readDaemonUrlFromIpc(socketPath, timeoutMs);
+    if (url != null) return url;
+  }
+  return null;
+}
+
+async function readDaemonUrlFromIpc(
+  socketPath: string,
+  timeoutMs: number,
+): Promise<string | null> {
+  try {
+    const status = await requestJsonIpc<DaemonStatusSnapshot>(
+      socketPath,
+      { type: SIDECAR_MESSAGES.STATUS },
+      { timeoutMs },
+    );
+    return status?.url ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function extractDaemonUrlFromToolsDevStatus(stdout: string): string | null {

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -5,7 +5,7 @@
 // export-zip-import dance.
 //
 // The server itself holds no state and never touches the filesystem;
-// every tool resolves to a fetch() against `OD_DAEMON_URL`. Spawn the
+// every tool resolves to a fetch() against the discovered daemon URL. Spawn the
 // MCP server with no daemon running and tool calls return a clear
 // "daemon not reachable" error - the server itself still launches so
 // the client can list its tool schema.
@@ -28,10 +28,12 @@ const SERVER_VERSION = '0.2.0';
 const MCP_STDIO_IDLE_EXIT_MS = 30 * 60 * 1000;
 
 type JsonObject = Record<string, unknown>;
-interface RunMcpOptions { daemonUrl: string | URL }
+type DaemonUrlResolver = () => string | URL | Promise<string | URL>;
+type RunMcpOptions =
+  | { readonly daemonUrl: string | URL; readonly resolveDaemonUrl?: never }
+  | { readonly resolveDaemonUrl: DaemonUrlResolver; readonly daemonUrl?: never };
 interface CatalogItem { id: string; name?: string; title?: string; description?: string; summary?: string }
 interface SkillsPayload { skills?: CatalogItem[] }
-interface PluginsPayload { plugins?: CatalogItem[] }
 interface DesignSystemsPayload { designSystems?: CatalogItem[] }
 interface ResourcePayload { skill?: { body?: string; content?: string }; designSystem?: { body?: string; content?: string }; body?: string; content?: string }
 interface ProjectSummary { id: string; name: string; metadata?: JsonObject }
@@ -48,6 +50,21 @@ interface ErrorWithCode { message?: string; code?: string; cause?: { code?: stri
 interface McpIdleExitControllerOptions {
   idleMs: number;
   onIdle: () => void;
+}
+
+function normalizeBaseUrl(daemonUrl: string | URL): string {
+  return String(daemonUrl).replace(/\/$/, '');
+}
+
+export function _createMcpBaseUrlResolver({ daemonUrl, resolveDaemonUrl }: RunMcpOptions): () => Promise<string> {
+  if (resolveDaemonUrl) {
+    return async () => normalizeBaseUrl(await resolveDaemonUrl());
+  }
+  if (daemonUrl !== undefined) {
+    const baseUrl = normalizeBaseUrl(daemonUrl);
+    return async () => baseUrl;
+  }
+  throw new Error('runMcpStdio requires daemonUrl or resolveDaemonUrl');
 }
 
 export function _createMcpIdleExitController({
@@ -496,8 +513,8 @@ const TOOL_DEFS = [
   },
 ];
 
-export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
-  const baseUrl = String(daemonUrl).replace(/\/$/, '');
+export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
+  const getBaseUrl = _createMcpBaseUrlResolver(options);
   let closeTransportForIdle: (() => void) | null = null;
   const idleExit = _createMcpIdleExitController({
     idleMs: MCP_STDIO_IDLE_EXIT_MS,
@@ -611,6 +628,7 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
   })));
 
   server.setRequestHandler(ListResourcesRequestSchema, withMcpActivity(async () => {
+    const baseUrl = await getBaseUrl();
     const [skillsData, dsData] = await Promise.all([
       getJson<SkillsPayload>(`${baseUrl}/api/skills`).catch((): SkillsPayload => ({ skills: [] })),
       getJson<DesignSystemsPayload>(`${baseUrl}/api/design-systems`).catch((): DesignSystemsPayload => ({ designSystems: [] })),
@@ -643,6 +661,7 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
   }));
 
   server.setRequestHandler(ReadResourceRequestSchema, withMcpActivity(async (req) => {
+    const baseUrl = await getBaseUrl();
     const uri = req.params?.uri;
     if (uri === 'od://focus/active') {
       const data = await getJson<ActiveContext>(`${baseUrl}/api/active`);
@@ -685,6 +704,7 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
   }));
 
   server.setRequestHandler(CallToolRequestSchema, withMcpActivity(async (req) => {
+    const baseUrl = await getBaseUrl();
     const name = req.params?.name;
     const args: McpArgs = (req.params?.arguments ?? {}) as McpArgs;
     return handleMcpToolCall(baseUrl, name, args);

--- a/apps/daemon/tests/daemon-url.test.ts
+++ b/apps/daemon/tests/daemon-url.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { createJsonIpcServer, type JsonIpcServerHandle } from "@open-design/sidecar";
-import { SIDECAR_ENV, SIDECAR_MESSAGES } from "@open-design/sidecar-proto";
+import { createJsonIpcServer, resolveAppIpcPath, type JsonIpcServerHandle } from "@open-design/sidecar";
+import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT, SIDECAR_ENV, SIDECAR_MESSAGES } from "@open-design/sidecar-proto";
 import { resolveDaemonUrl, DEFAULT_DAEMON_URL } from "../src/daemon-url.js";
 
 // Verifies the resolution chain: --daemon-url > OD_DAEMON_URL > sidecar
@@ -49,14 +49,20 @@ describe("resolveDaemonUrl", () => {
   });
 
   it("returns the legacy default when no flag/env/socket is available", async () => {
-    const url = await resolveDaemonUrl({
-      env: {
-        PATH: emptyBinDir,
-        [SIDECAR_ENV.IPC_PATH]: path.join(ipcBaseDir, "missing.sock"),
-      },
-      timeoutMs: 200,
-    });
-    expect(url).toBe(DEFAULT_DAEMON_URL);
+    const emptyIpcBaseDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-mcp-resolve-empty-"));
+    try {
+      const url = await resolveDaemonUrl({
+        env: {
+          PATH: emptyBinDir,
+          [SIDECAR_ENV.IPC_PATH]: path.join(emptyIpcBaseDir, "missing.sock"),
+          [SIDECAR_ENV.IPC_BASE]: emptyIpcBaseDir,
+        },
+        timeoutMs: 200,
+      });
+      expect(url).toBe(DEFAULT_DAEMON_URL);
+    } finally {
+      fs.rmSync(emptyIpcBaseDir, { recursive: true, force: true });
+    }
   });
 
   it("discovers the default tools-dev daemon URL when no sidecar IPC path is available", async () => {
@@ -116,6 +122,88 @@ describe("resolveDaemonUrl", () => {
         timeoutMs: 1000,
       });
       expect(url).toBe("http://127.0.0.1:54321");
+    } finally {
+      await ipc?.close();
+    }
+  });
+
+  it("discovers the packaged stable daemon URL when no sidecar IPC path is available", async () => {
+    const socketPath = resolveAppIpcPath({
+      app: APP_KEYS.DAEMON,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      env: { [SIDECAR_ENV.IPC_BASE]: ipcBaseDir },
+      namespace: "release-stable",
+    });
+    let ipc: JsonIpcServerHandle | null = null;
+    try {
+      ipc = await createJsonIpcServer({
+        socketPath,
+        handler: (message) => {
+          if (
+            message != null &&
+            typeof message === "object" &&
+            (message as { type?: unknown }).type === SIDECAR_MESSAGES.STATUS
+          ) {
+            return {
+              pid: 4242,
+              state: "running",
+              updatedAt: new Date().toISOString(),
+              url: "http://127.0.0.1:65432",
+            };
+          }
+          throw new Error("unexpected message");
+        },
+      });
+
+      const url = await resolveDaemonUrl({
+        env: {
+          PATH: emptyBinDir,
+          [SIDECAR_ENV.IPC_BASE]: ipcBaseDir,
+        },
+        timeoutMs: 1000,
+      });
+      expect(url).toBe("http://127.0.0.1:65432");
+    } finally {
+      await ipc?.close();
+    }
+  });
+
+  it("discovers a packaged daemon URL by scanning IPC namespace directories", async () => {
+    const socketPath = resolveAppIpcPath({
+      app: APP_KEYS.DAEMON,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      env: { [SIDECAR_ENV.IPC_BASE]: ipcBaseDir },
+      namespace: "p",
+    });
+    let ipc: JsonIpcServerHandle | null = null;
+    try {
+      ipc = await createJsonIpcServer({
+        socketPath,
+        handler: (message) => {
+          if (
+            message != null &&
+            typeof message === "object" &&
+            (message as { type?: unknown }).type === SIDECAR_MESSAGES.STATUS
+          ) {
+            return {
+              pid: 4343,
+              state: "running",
+              updatedAt: new Date().toISOString(),
+              url: "http://127.0.0.1:65433",
+            };
+          }
+          throw new Error("unexpected message");
+        },
+      });
+
+      const url = await resolveDaemonUrl({
+        env: {
+          PATH: emptyBinDir,
+          [SIDECAR_ENV.IPC_BASE]: ipcBaseDir,
+        },
+        timeoutMs: 1000,
+      });
+      expect(url).toBe("http://127.0.0.1:65433");
     } finally {
       await ipc?.close();
     }

--- a/apps/daemon/tests/mcp-base-url-resolver.test.ts
+++ b/apps/daemon/tests/mcp-base-url-resolver.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { _createMcpBaseUrlResolver } from '../src/mcp.js';
+
+describe('MCP daemon base URL resolver', () => {
+  it('re-resolves dynamic daemon URLs on every request', async () => {
+    const resolveDaemonUrl = vi
+      .fn<() => string>()
+      .mockReturnValueOnce('http://127.0.0.1:7456/')
+      .mockReturnValueOnce('http://127.0.0.1:57844/');
+    const resolveBaseUrl = _createMcpBaseUrlResolver({ resolveDaemonUrl });
+
+    const first = await resolveBaseUrl();
+    const second = await resolveBaseUrl();
+
+    expect(first).toBe('http://127.0.0.1:7456');
+    expect(second).toBe('http://127.0.0.1:57844');
+    expect(resolveDaemonUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps explicit daemon URLs fixed for the MCP process lifetime', async () => {
+    const resolveBaseUrl = _createMcpBaseUrlResolver({ daemonUrl: 'http://127.0.0.1:7456/' });
+
+    await expect(resolveBaseUrl()).resolves.toBe('http://127.0.0.1:7456');
+    await expect(resolveBaseUrl()).resolves.toBe('http://127.0.0.1:7456');
+  });
+});


### PR DESCRIPTION
## Summary
- re-resolve the Open Design daemon URL for each MCP resource/tool request instead of caching it at MCP process startup
- discover packaged sidecar daemon sockets when MCP is launched without OD_SIDECAR_IPC_PATH, before falling back to the legacy 127.0.0.1:7456 URL
- add focused regression coverage for dynamic URL resolution and packaged sidecar IPC discovery

## Tests
- pnpm exec vitest run -c vitest.config.ts tests/daemon-url.test.ts tests/mcp-base-url-resolver.test.ts tests/mcp-stdio-idle.test.ts