### PR TITLE
Add japanese cjk font fallback

### DIFF
--- a/apps/web/src/styles/viewer/library.css
+++ b/apps/web/src/styles/viewer/library.css
@@ -440,9 +440,14 @@
 }
 .slash-item-desc { font-size: 11px; color: var(--text-muted); line-height: 1.35; }
 
-/* --- CJK (Chinese / Japanese / Korean) Comfort Pass --- */
-:lang(zh), :lang(zh-CN), :lang(zh-TW), :lang(ja), :lang(ko) {
+/* --- CJK (Chinese / Korean) Comfort Pass --- */
+:lang(zh), :lang(zh-CN), :lang(zh-TW), :lang(ko) {
   --sans: "Inter", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", "Hiragino Sans GB", "Source Han Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+/* --- Japanese Comfort Pass --- */
+:lang(ja) {
+  --sans: "Inter", "Noto Sans JP", "Hiragino Sans", "Yu Gothic", "Meiryo", "Source Han Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 }
 
 /* --- Arabic & Persian Comfort Pass --- */


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #5097 

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->
Japanese font fallbacks were grouped with Chinese and Korean using a Chinese-first font stack. For shared CJK characters, this can render Chinese-style glyphs that look unnatural or incorrect to Japanese users.

## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->
When the app language is set to Japanese, Japanese UI text will render with Japanese-first font fallbacks such as Noto Sans JP, Hiragino Sans, Yu Gothic, or Meiryo.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->
<img width="2556" height="1014" alt="Screenshot 2026-07-02 at 10 50 48 PM" src="https://github.com/user-attachments/assets/5a051aef-3af4-4bbe-9f60-22e663bf8db0" />

## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

- Test path that reproduces the bug: N/A
- Did the test go red on `main` and green on this branch? no
- Manual verification: inspected the locale-specific CSS fallback. Before this change, `:lang(ja)` used the Chinese-first CJK stack. After this change,`:lang(ja)` has its own Japanese-first font stack.


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->
- `pnpm guard`
- `pnpm typecheck`