### PR TITLE
fix(home): drop letterbox band on deck example-prompt previews

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2398,6 +2398,32 @@
   transform: none;
 }
 
+/* The baked deck preview (od.bakedPreview) is captured at the 1.31 tile aspect,
+   so the deck's fixed 16:9 stage self-letterboxes with a dark --stage-bg band
+   baked into the poster/clip. The iframe rule above only fixes the LIVE surface;
+   these preset tiles render the BAKED media (preferBaked), so mirror the same
+   treatment for it: render the clip in a native 16:9 box centered in the
+   standard cell and center-crop it, so object-fit:cover strips exactly the baked
+   letterbox and the slide reads edge-to-edge with no dark band. (Non-deck tiles
+   keep the top-anchored 1.31 clip below so web-page hero headlines stay in
+   frame.) */
+.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__preview--media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media {
+  position: relative;
+  inset: auto;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+}
+.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media-img,
+.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media-video {
+  object-position: center;
+}
+
 /* Baked clips are framed 1.31:1 for the Community grid; the wider preset tiles
    would otherwise object-fit:cover-crop the hero out of the middle. Anchor to
    the top so the hero headline stays in frame. Scoped to the preset cards. */


### PR DESCRIPTION
## Why

QA flagged that on **Home → "Example prompts"** with the **Slide deck** template selected, every deck preview thumbnail (Creative Voltage, Electric Studio, Emerald Editorial, Editorial Forest, …) has a black strip across the top of the tile. It's on the very first screen users land on, and it makes the curated deck examples look broken.

Root cause: the Home example-prompt tiles render the daemon-baked preview (`od.bakedPreview`), which is captured at the **1.31 tile aspect**. A deck ships a fixed **16:9** stage that scales-to-fit its viewport, so inside the taller 1.31 capture window the deck self-letterboxes with a dark `--stage-bg` band **baked into the poster/clip** (top + bottom). The existing `data-od-mode="deck"` override only reframes the *live* `.plugins-home__html-iframe` surface — but these tiles use `preferBaked`, so they show the baked `<img>`/`<video>` instead, which was `object-fit: cover` + `object-position: top center`. Cover crops the bottom band and keeps the top one → black strip above every slide.

(The Community gallery is unaffected: its deck tile puts the media in a 16:9 `gallery-frame` and center-crops, which trims both bands.)

## What users will see

On Home, with the Slide deck template active, the deck example thumbnails now show the slide **edge-to-edge with no black band at the top** — the full 16:9 slide reads cleanly. Non-deck tiles (prototypes, web pages, images, video) are unchanged.

## Surface area

- [x] **UI** — deck example-prompt preview thumbnails in `apps/web` Home hero
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Verified on a live local dev runtime (Home → Slide deck template → "Example prompts"):

- **Before:** every deck example tile (创意伏特 / 钻蓝工作室 / 祖母绿封面故事 / 林间编辑部 …) has a black strip across the top.
- **After:** the slide reads edge-to-edge with no black band; the same tiles (祖母绿封面故事, 林间编辑部) that showed a band now show the full slide.

(Before/after PNGs captured locally; happy to attach — GitHub inline-image upload isn't available from the CLI.)

## Bug fix verification

This is a pixel-level visual defect (a letterbox band baked into a poster then cropped by `object-fit`), so a cheap falsifiable unit/e2e red spec isn't practical. Verification done instead:

- Pulled the **real baked poster** the daemon serves (`repo-assets…/example-fs-electric-studio…poster.jpg`, 640×488 ≈ 1.31:1) and confirmed the dark `--stage-bg` letterbox is baked in (top + bottom).
- Rendered that real poster in the **exact preset geometry** (248px card / 150px cell): current CSS shows the top black band; this fix removes it and reveals the full 16:9 slide.
- Confirmed the served record carries both `manifest.od.mode: "deck"` and `manifest.od.bakedPreview`, so the tile really does take the baked-media path.
- The fix mirrors the existing iframe deck treatment: the baked clip is placed in a native 16:9 box centered in the standard cell and center-cropped, so `cover()` strips exactly the baked letterbox. The math is exact — a 1.31:1 poster cover-fit into a 16:9 box removes precisely the 64px top/bottom letterbox and shows the pure 16:9 slide.
- The 150px preview row is kept, so deck cards stay the same height as sibling tiles (this is why the existing code deliberately centers a native 16:9 rather than switching the row to `auto`).

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- Local dev runtime + manual check of the Home deck example tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
