### PR TITLE
feat: add SiliconFlow Global BYOK preset

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2720,10 +2720,17 @@ export function SettingsDialog({
       model: '',
     },
     {
-      id: 'siliconflow',
-      title: '硅基流动',
+      id: 'siliconflow-cn',
+      title: 'SiliconFlow (CN)',
       protocol: 'openai',
       baseUrl: 'https://api.siliconflow.cn/v1',
+      model: 'deepseek-ai/DeepSeek-V3.1',
+    },
+    {
+      id: 'siliconflow-global',
+      title: 'SiliconFlow (Global)',
+      protocol: 'openai',
+      baseUrl: 'https://api.siliconflow.com/v1',
       model: 'deepseek-ai/DeepSeek-V3.1',
     },
     {

--- a/apps/web/src/providers/openai-compatible.ts
+++ b/apps/web/src/providers/openai-compatible.ts
@@ -43,6 +43,7 @@ export function isOpenAICompatible(model: string, baseUrl: string): boolean {
   if (u.includes('api.minimax.io/v1')) return true;
   if (u.includes('api.deepseek')) return true;
   if (u.includes('api.groq')) return true;
+  if (parsed.hostname === 'api.siliconflow.cn' || parsed.hostname === 'api.siliconflow.com') return true;
   if (u.includes('api.together')) return true;
   if (u.includes('openrouter')) return true;
   if (u.includes('openai.com')) return true;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -203,9 +203,20 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     ],
   },
   {
-    label: 'SiliconFlow',
+    label: 'SiliconFlow (CN)',
     protocol: 'openai',
     baseUrl: 'https://api.siliconflow.cn/v1',
+    model: 'deepseek-ai/DeepSeek-V3.1',
+    models: [
+      'deepseek-ai/DeepSeek-V3.1',
+      'deepseek-ai/DeepSeek-R1',
+      'Qwen/Qwen3-Coder-480B-A35B-Instruct',
+    ],
+  },
+  {
+    label: 'SiliconFlow (Global)',
+    protocol: 'openai',
+    baseUrl: 'https://api.siliconflow.com/v1',
     model: 'deepseek-ai/DeepSeek-V3.1',
     models: [
       'deepseek-ai/DeepSeek-V3.1',

--- a/apps/web/tests/providers/openai-compatible.test.ts
+++ b/apps/web/tests/providers/openai-compatible.test.ts
@@ -16,6 +16,11 @@ describe('isOpenAICompatible', () => {
     expect(isOpenAICompatible('mimo-v2.5-pro', 'https://token-plan-cn.xiaomimimo.com/v1')).toBe(true);
   });
 
+  it('routes SiliconFlow CN and Global endpoints through OpenAI-compatible chat completions', () => {
+    expect(isOpenAICompatible('deepseek-ai/DeepSeek-V3.1', 'https://api.siliconflow.cn/v1')).toBe(true);
+    expect(isOpenAICompatible('deepseek-ai/DeepSeek-V3.1', 'https://api.siliconflow.com/v1')).toBe(true);
+  });
+
   it('routes MiniMax Anthropic endpoint paths away from OpenAI-compatible chat completions', () => {
     expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimax.io/v1/anthropic')).toBe(false);
     expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimax.io/anthropic/v1')).toBe(false);

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -5,6 +5,7 @@ import {
   fetchMediaProvidersFromDaemon,
   isStoredMediaProviderEntryEmpty,
   isStoredMediaProviderEntryPresent,
+  KNOWN_PROVIDERS,
   loadConfig,
   mergeDaemonConfig,
   mergeDaemonMediaProviders,
@@ -18,6 +19,27 @@ import type { AppConfig } from '../../src/types';
 
 const store = new Map<string, string>();
 const originalFetch = globalThis.fetch;
+
+describe('KNOWN_PROVIDERS', () => {
+  it('includes separate SiliconFlow CN and Global presets', () => {
+    expect(
+      KNOWN_PROVIDERS.filter((provider) => provider.label.startsWith('SiliconFlow')),
+    ).toEqual([
+      expect.objectContaining({
+        label: 'SiliconFlow (CN)',
+        protocol: 'openai',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        model: 'deepseek-ai/DeepSeek-V3.1',
+      }),
+      expect.objectContaining({
+        label: 'SiliconFlow (Global)',
+        protocol: 'openai',
+        baseUrl: 'https://api.siliconflow.com/v1',
+        model: 'deepseek-ai/DeepSeek-V3.1',
+      }),
+    ]);
+  });
+});
 
 vi.stubGlobal('localStorage', {
   getItem: vi.fn((key: string) => store.get(key) ?? null),
@@ -853,6 +875,25 @@ describe('loadConfig', () => {
     expect(config.baseUrl).toBe('https://api.deepseek.com');
     expect(config.model).toBe('deepseek-chat');
     expect(config.apiProtocol).toBe('openai');
+    expect(config.configMigrationVersion).toBe(1);
+  });
+
+  it('migrates legacy SiliconFlow Global configs to the known OpenAI preset', () => {
+    const legacyConfig: Partial<AppConfig> = {
+      mode: 'api',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.siliconflow.com/v1',
+      model: 'deepseek-ai/DeepSeek-V3.1',
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(legacyConfig));
+
+    const config = loadConfig();
+
+    expect(config.apiProtocol).toBe('openai');
+    expect(config.apiProviderBaseUrl).toBe('https://api.siliconflow.com/v1');
     expect(config.configMigrationVersion).toBe(1);
   });
 


### PR DESCRIPTION
## Why

This is a focused follow-up to #4688 and #4902, based on maintainer feedback.

#4902 added the SiliconFlow China endpoint, but SiliconFlow also provides a separate Global API endpoint at `https://api.siliconflow.com/v1`. Without a dedicated preset, Global users must configure it manually.

## What users will see

The existing SiliconFlow preset is renamed to `SiliconFlow (CN)`, and a new `SiliconFlow (Global)` option is available with its Global base URL and default model prefilled.

Both endpoints are explicitly recognized as OpenAI-compatible.

## Surface area

- [x] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Attach a screenshot of Settings → Execution mode → BYOK showing both `SiliconFlow (CN)` and `SiliconFlow (Global)`.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- Focused web tests: 3 files passed, 122 tests passed