### PR TITLE
fix(daemon): fix quadratic ReDoS in design-system swatch parsers

### DIFF
--- a/apps/daemon/src/design-systems/index.ts
+++ b/apps/daemon/src/design-systems/index.ts
@@ -3594,7 +3594,11 @@ function extractSwatches(raw: string): string[] {
   // bold markers (`**Name:**`) or outside them (`**Name**:`). Both variants
   // are common in hand-authored DESIGN.md files, so we allow the colon in
   // either position around the closing `**`.
-  const reA = /^[\s>*-]*\**\s*([A-Za-z][A-Za-z0-9 /&()+_-]{1,40}?)\s*[:：]?\s*\**\s*[:：]?\s*`?(#[0-9a-fA-F]{3,8})/gm;
+  // The leading class `[\s>*-]` already covers whitespace, `>`, `*` and `-`, so
+  // the old `[\s>*-]*\**\s*` prefix had three overlapping star-consumers whose
+  // ambiguous split made a long run of `*` at a line start O(n^2). A single
+  // `[\s>*-]*` matches the same prefixes without the backtracking blowup.
+  const reA = /^[\s>*-]*([A-Za-z][A-Za-z0-9 /&()+_-]{1,40}?)\s*[:：]?\s*\**\s*[:：]?\s*`?(#[0-9a-fA-F]{3,8})/gm;
   let m;
   while ((m = reA.exec(raw)) !== null) push(m[1] ?? '', m[2] ?? '');
   // Form B: "**Stripe Purple** (`#533afd`)"

--- a/apps/daemon/src/design-systems/swift-colors.ts
+++ b/apps/daemon/src/design-systems/swift-colors.ts
@@ -111,7 +111,10 @@ function swiftColorArgsToHex(args: string): string | null {
  */
 export function extractSwiftColors(raw: string): SwiftColorToken[] {
   const tokens: SwiftColorToken[] = [];
-  const declRe = /(?:(?:static\s+|public\s+|private\s+|internal\s+)*(?:let|var)\s+([A-Za-z_]\w*)\s*(?::[^=\n]+)?=\s*)?\bColor\s*\(([^)]*)\)/gu;
+  // The modifier run is bounded ({0,4}, not *) so a long line of `static ` with
+  // no `let`/`var` can't force quadratic backtracking across the global scan.
+  // Real Swift declarations carry at most a couple of leading modifiers.
+  const declRe = /(?:(?:static\s+|public\s+|private\s+|internal\s+){0,4}(?:let|var)\s+([A-Za-z_]\w*)\s*(?::[^=\n]+)?=\s*)?\bColor\s*\(([^)]*)\)/gu;
   let match: RegExpExecArray | null;
   while ((match = declRe.exec(raw)) !== null) {
     const name = match[1] ?? '';

--- a/apps/daemon/tests/design-systems/index.test.ts
+++ b/apps/daemon/tests/design-systems/index.test.ts
@@ -49,6 +49,23 @@ describe('design systems registry', () => {
     ]);
   });
 
+  it('parses a DESIGN.md with a pathological marker run without catastrophic backtracking', async () => {
+    // Regression: the swatch parser's Form A regex had overlapping star-consumers
+    // (`[\s>*-]*\**\s*`), so a long run of `*` at a line start was O(n^2) — a large
+    // installed DESIGN.md could hang the daemon during `listDesignSystems`
+    // (reachable via GET /api/design-systems). The collapsed prefix is linear.
+    await mkdir(path.join(root, 'acme'), { recursive: true });
+    await writeFile(
+      path.join(root, 'acme', 'DESIGN.md'),
+      `# Acme\n\n${'*'.repeat(24000)}\n`,
+    );
+    const start = performance.now();
+    const systems = await listDesignSystems(root);
+    const elapsedMs = performance.now() - start;
+    expect(systems.map((s) => s.id)).toContain('acme');
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+
   it('creates, updates, reads, and deletes user design systems with prefixed ids', async () => {
     const created = await createUserDesignSystem(root, {
       title: 'Acme Product',

--- a/apps/daemon/tests/design-systems/swift-colors.test.ts
+++ b/apps/daemon/tests/design-systems/swift-colors.test.ts
@@ -55,4 +55,17 @@ describe('extractSwiftColors', () => {
   it('skips named asset colors that carry no component values', () => {
     expect(extractSwiftColors('let accent = Color("AccentColor")')).toEqual([]);
   });
+
+  it('does not backtrack catastrophically on a long modifier run', () => {
+    // Regression: the optional `(?:static|public|private|internal)*` prefix
+    // re-scanned at every offset, so a run of `static ` with no `let`/`var`
+    // was O(n^2) (a large DESIGN.md could hang the daemon during listing).
+    // Bounding the modifier group to {0,4} keeps the global scan linear.
+    const src = 'static '.repeat(16000);
+    const start = performance.now();
+    const result = extractSwiftColors(src);
+    const elapsedMs = performance.now() - start;
+    expect(result).toEqual([]);
+    expect(elapsedMs).toBeLessThan(500);
+  });
 });


### PR DESCRIPTION
## Why

`listDesignSystems` parses each installed design system's `DESIGN.md` for color swatches (reachable via `GET /api/design-systems`). Two parser regexes backtrack quadratically on adversarial input: the SwiftUI `Color(...)` extractor's optional declaration prefix `(?:static|public|private|internal)*(?:let|var)…` re-scans the modifier run at every offset, so a long line of `static ` with no `let`/`var` is O(n^2); and the Markdown swatch parser's Form A regex begins `^[\s>*-]*\**\s*` — three overlapping star-consumers (`[\s>*-]` already includes `*` and whitespace) — so a long run of `*` at a line start is O(n^2). A design system installed from a third-party repo controls its `DESIGN.md`, so a ~200KB file of the pathological shape blocks the single-threaded daemon for seconds during listing (each grows ~4x per doubling). This is an event-loop denial of service.

## What users will see

Nothing for real design systems: both parsers extract exactly the same swatches as before (verified across a battery of Swift declarations and Markdown swatch lines). Only the pathological inputs are now handled in linear time.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal daemon hardening. Both parsers are behavior-preserving for all real input; only the catastrophic-backtracking blowup is removed.

## Bug fix verification

- **Bug:** two `DESIGN.md` parser regexes were O(n^2) — swift-colors' `(?:…)*` modifier run and the swatch parser's overlapping `[\s>*-]*\**\s*` prefix.
- **Fix:** bound the modifier run to `{0,4}` (real Swift declarations carry at most a couple of leading modifiers), and collapse the swatch prefix to a single `[\s>*-]*` (which matches the same characters, unambiguously).
- **Tests:** `apps/daemon/tests/design-systems/swift-colors.test.ts` → "does not backtrack catastrophically on a long modifier run" (`'static '.repeat(16000)` completes under 500ms and still returns `[]`); `apps/daemon/tests/design-systems/index.test.ts` → "parses a DESIGN.md with a pathological marker run without catastrophic backtracking" (a DESIGN.md with 24000 `*` lists under 1000ms).
- **Red on main, green here?** Yes — on main the tests take ~1.3s and ~3.2s (over budget); with the fixes both complete in a few ms. Behavioral equivalence to the old regexes was checked across ~20 real inputs (0 differences).

## Validation

- `pnpm --filter @open-design/daemon test` — full `tests/design-systems/` 124/124 (incl. the two new cases).
- daemon `tsc --noEmit` for both `tsconfig.json` and `tsconfig.tests.json`.
