### PR TITLE
Add Design System Source Context plugin

### DIFF
--- a/plugins/community/design-system-source-context-mr4pp7e1/SKILL.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/SKILL.md
@@ -1,0 +1,93 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Claude / Anthropic 风格设计系统
+
+非官方 Claude / Anthropic 风格整理版：温暖、克制、编辑感、适合阅读与深度思考的 AI 工作台。当前 canonical 依据是稳定版 `DESIGN.md`、`brand.json`、tokens、示范库，以及 Anthropic 官网公开 CSS 证据。颜色和交互以官网 token 命名校准：`ivory-light #faf9f5`、`ivory-medium #f0eee6`、`ivory-dark #e8e6dc`、`slate-dark #141413`、`clay #d97757`。
+
+## Source Links
+
+- None linked.
+
+## GitHub Repositories
+
+- None linked.
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`: none.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Decoded Figma snapshots: none.
+Fonts, logos, and assets selected:
+- Official webfonts, icon candidates, and imagery preserved under `fonts/`, `logos/`, and `imagery/`.
+
+Uploaded brand asset files under `assets/`:
+- None retained. The original pasted draft was absorbed into the stable package and removed to prevent stale rules.
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, website/source URL review, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.
+
+## Provenance
+
+Formalized by Open Design from candidate a4893bec-1f96-4fb2-aff1-a017346476dd.

--- a/plugins/community/design-system-source-context-mr4pp7e1/open-design.json
+++ b/plugins/community/design-system-source-context-mr4pp7e1/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-source-context-mr4pp7e1",
+  "title": "Design System Source Context",
+  "version": "0.1.0",
+  "description": "This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/provenance.json
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/provenance.json
@@ -1,0 +1,68 @@
+{
+  "candidateId": "a4893bec-1f96-4fb2-aff1-a017346476dd",
+  "projectId": "brand-anthropic-a38199",
+  "runId": "d8e12cc2-426d-48f9-90a3-ce29e615ab8b",
+  "conversationId": "05128f01-0c8c-43bb-9672-78ed2973b1fd",
+  "provenance": {
+    "summary": "Detected from context/source-context.md, README.md, SKILL.md, plugin-source/design-system-source-context-mr0bb87z/references/source-2-SKILL.md, plugin-source/design-system-source-context-mr0bb87z/references/source-1-source-context.md, plugin-source/design-system-source-context-mr0bb87z/SKILL.md, SECURITY.md, CONTRIBUTING.md after a successful run.",
+    "detectedAt": 1783069603071
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 8961,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 15370,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 9055,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "plugin-source/design-system-source-context-mr0bb87z/references/source-2-SKILL.md",
+      "label": "plugin-source/design-system-source-context-mr0bb87z/references/source-2-SKILL.md",
+      "size": 5815,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "plugin-source/design-system-source-context-mr0bb87z/references/source-1-source-context.md",
+      "label": "plugin-source/design-system-source-context-mr0bb87z/references/source-1-source-context.md",
+      "size": 8961,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "plugin-source/design-system-source-context-mr0bb87z/SKILL.md",
+      "label": "plugin-source/design-system-source-context-mr0bb87z/SKILL.md",
+      "size": 9056,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SECURITY.md",
+      "label": "SECURITY.md",
+      "size": 1699,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "CONTRIBUTING.md",
+      "label": "CONTRIBUTING.md",
+      "size": 2249,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/source-1-source-context.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/source-1-source-context.md
@@ -1,0 +1,89 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Claude / Anthropic 风格设计系统
+
+非官方 Claude / Anthropic 风格整理版：温暖、克制、编辑感、适合阅读与深度思考的 AI 工作台。当前 canonical 依据是稳定版 `DESIGN.md`、`brand.json`、tokens、示范库，以及 Anthropic 官网公开 CSS 证据。颜色和交互以官网 token 命名校准：`ivory-light #faf9f5`、`ivory-medium #f0eee6`、`ivory-dark #e8e6dc`、`slate-dark #141413`、`clay #d97757`。
+
+## Source Links
+
+- None linked.
+
+## GitHub Repositories
+
+- None linked.
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`: none.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Decoded Figma snapshots: none.
+Fonts, logos, and assets selected:
+- Official webfonts, icon candidates, and imagery preserved under `fonts/`, `logos/`, and `imagery/`.
+
+Uploaded brand asset files under `assets/`:
+- None retained. The original pasted draft was absorbed into the stable package and removed to prevent stale rules.
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, website/source URL review, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/source-2-README.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/source-2-README.md
@@ -1,0 +1,216 @@
+# Claude / Anthropic 风格设计系统
+
+非官方 Claude / Anthropic 风格整理版。它把官网公开 CSS 中可确认的 Ivory / Slate / Cloud / Clay 使用方式整理成可复用设计系统。
+
+This package is not affiliated with or endorsed by Anthropic. See `NOTICE.md` for the mark, asset, and evidence boundary.
+
+## Product Overview
+
+Anthropic 的公开网页是一个 product-facing design platform：它支持官网营销、研究发布、新闻内容、公司页面和 Claude-like AI workspace 表达。视觉重点是安静、可信、适合阅读的 AI tool，而不是高饱和科技感。这个 package provides reusable colors, typography, layout, navigation, buttons, dropdown, state, and motion rules for Open Design artifacts.
+
+Source product:
+
+- Anthropic public website and Claude-style AI workbench surfaces.
+- Primary evidence is public CSS token usage, preserved source files, and downloaded official site assets. Memory-only color guesses are not accepted as source evidence.
+- Package version: `2026.06.30-stable-claude-system-polished`; registered design-system id: `user:anthropic`.
+
+Primary surfaces:
+
+- 官网式 landing / editorial page
+- AI workbench / console shell
+- Research / newsroom content pages
+- Form and settings surfaces
+- Slide and email artifacts
+
+Core capabilities:
+
+- Warm paper surface hierarchy
+- Restrained Slate primary action system
+- Claude.com button tiers: Slate primary, Get help / 查看文档 large secondary with reverse hover, weak tertiary, bordered tiny Read more, rare Clay highest-signal.
+- Product dropdowns open on hover/focus only; normal previews do not ship `.is-open`.
+- Sparse Clay accent budget
+- Success semantics use `#6ea100`; Olive `#788c5d` stays as chart/support color
+- Status badges use soft semantic backgrounds with semantic text/dot and switch-like pill radius; larger state cards/alerts keep low-saturation soft backgrounds and ordinary action buttons
+- Official Latin faces with Chinese fallback stacks
+- Mono numerics with tabular numbers for prices, counts, dates, percentages, and dense tables
+- Source-backed header, dropdown, button, link, focus, and status rules
+- Light app sidebar and dark overlay sidebar patterns
+
+## Product Context: Source Product, Primary Surfaces, Core Capabilities
+
+This Claude Design-style package is for Anthropic-like public pages and product workbench UI. It covers the source product context, the primary surfaces listed above, and the core capabilities needed to reuse the style outside this extraction project.
+
+## Product Context
+
+- Source: `designmd://anthropic`
+- Evidence: `DESIGN.md`、`context/anthropic-official-usage-evidence.md`、`anthropic-official-colors.md`、Anthropic 官网公开 CSS 抽查结果。
+- Goal: 为 Open Design 项目提供温暖、克制、编辑感的 AI 工作台视觉语言。
+
+## Core Rules
+
+- 页面底：`#faf9f5`
+- 顶栏 / section / 默认组件：`#f0eee6`
+- hover / selected：`#e8e6dc`
+- dropdown / expanded surface：继承所属按钮、导航或页面的 `background-primary / control-bg`，不写死某个固定色
+- 主 CTA：`#141413` 背景，`#faf9f5` 文字
+- Clay：`#d97757`，只做少量强调，不做默认 primary
+- Focus：`#2c84db`，只做键盘焦点
+- Success：`#6ea100`，只做成功/完成/正向结果
+- Typography：Anthropic Serif/Sans/Mono for Latin, with Songti/PingFang/Noto/Source Han Chinese fallbacks
+
+## Package Contents
+
+| Path | Purpose |
+| --- | --- |
+| `DESIGN.md` | Canonical design rules |
+| `colors_and_type.css` | Reusable CSS tokens |
+| `BRAND.md` | Short brand/package summary |
+| `PROVENANCE.json` | Source, asset, and inference audit |
+| `SYSTEM-MANIFEST.json` | Stable package structure, read order, and invariants |
+| `brand.json` | Machine-readable system definition |
+| `fonts/` | Preserved official Anthropic webfont files |
+| `logos/` | Preserved favicon / webclip / mask icon candidates |
+| `imagery/` | Preserved official imagery samples |
+| `source_examples/official-source-manifest.json` | Source fetch and asset manifest |
+| `preview/*.html` | Focused review cards |
+| `examples/index.html` | Unified route hub for detail fixtures, page examples, and material directions |
+| `examples/details-color-library.html` | Full color library and forbidden defaults |
+| `examples/details-official-svg-imagery.html` | Official organic SVG imagery fixture and usage boundary |
+| `system/kit.html` | Component kit preview |
+| `system/artifacts/landing.html` | Primary Open Design preview/showcase page using shared CSS |
+| `system/artifacts/*.html` | Polished material-direction examples using shared CSS |
+| `ui_kits/app/index.html` | Applied app shell |
+| `CONTRIBUTING.md` | Contribution checklist and package boundaries |
+| `SECURITY.md` | Privacy, asset, and local registry safety notes |
+| `NOTICE.md` | Non-affiliation, asset, and evidence boundary |
+
+Preserved source-backed assets and evidence:
+
+- `DESIGN.md` is the canonical stable source; the original pasted draft has been fully absorbed and removed to avoid stale rules.
+- `anthropic-official-colors.md` preserves the raw official color audit; the current visible color library is `examples/details-color-library.html`.
+- `context/source-context.md` preserves setup context.
+- `PROVENANCE.json` records sampled pages, CSS files, measured values, inferred values, and local asset paths.
+- `source_examples/official-source-manifest.json` records the source page/CSS fetch and preserved assets.
+- `fonts/` contains preserved Anthropic Sans / Serif / Mono webfont files from sampled official CSS.
+- `logos/` contains official favicon/webclip/mask-icon candidates, including `safari-pinned-tab.svg`. No full official wordmark SVG was exposed in sampled sources; do not redraw one.
+- `imagery/` contains sampled official OG, research, careers, and company imagery for reference. `imagery/official-svg/` contains official 1000×1000 organic/editorial SVG illustrations; use them as imagery/reference assets, not logos or UI icon glyphs.
+
+Measured vs inferred:
+
+- Measured: core color literals, font-face family names and files, page titles/H1s, header/dropdown/button CSS snippets.
+- Inferred: Chinese fallback stacks and the assignment of `#6ea100` to success semantics. `#6ea100` is measured in source CSS, but the success role is an implementation choice confirmed by this project, not an official named Anthropic token.
+
+## Preview Manifest
+
+- `preview/colors-primary.html`
+- `preview/colors-usage.html`
+- `preview/typography-specimens.html`
+- `preview/spacing-tokens.html`
+- `preview/components-buttons.html`
+- `preview/navigation-menus.html`
+- `preview/claude-interactions.html`
+- `preview/assets-provenance.html`
+
+## Example Manifest
+
+Open `examples/index.html` first. It is the unified route hub for three layers:
+
+- Detail fixtures: surface layers, color library, hover motion, smooth scroll + route motion, buttons and links, Claude official interactions, sidebar system, forms and focus, status/data, Chinese/English typography.
+- Page examples: landing, research, newsroom, company, console, login, settings/form.
+- Material directions: landing/showcase, deck, poster, email, newsletter, and form. These demonstrate deliverable formats and must not override detail fixtures.
+
+## Reuse Workflow
+
+1. Open `examples/index.html` and choose the route layer: details for controls, pages for composition, materials for deliverable formats.
+2. Load `colors_and_type.css`.
+3. Use `DESIGN.md` for visual decisions.
+4. Check `SYSTEM-MANIFEST.json` for stable read order and invariants.
+5. Build primary actions with Slate, not Clay.
+6. Use Clay for one high-signal accent per view.
+7. Use `examples/examples.css` for fixture components; do not fork nav/dropdown/button logic per page.
+8. Check preview cards before shipping a new artifact.
+9. Check `examples/page-*.html` when building a page-level surface.
+
+Route contract: topbar links are global destinations, route tabs are in-page grouping, and cards/rows are the concrete targets. Do not add duplicate CTA buttons for the same target, and never ship an arrow-only button unless it is a real link or opens a real menu.
+
+## As an Agent Skill
+
+This Open Design project is the canonical editable source. To expose it through the local Obsidian `agent-skills` registry, keep the registry entry as a small stub that points back here:
+
+```text
+agent-skills/custom/claude-anthropic-design-system/
+  SKILL.md
+  agents/openai.yaml
+  design-system -> <this Open Design project>
+```
+
+Run:
+
+```bash
+AGENT_SKILLS_ROOT="/path/to/agent-skills" scripts/install-as-agent-skill.sh
+```
+
+The stub is what the registry scans; the `design-system` symlink is what keeps Open Design and agent usage on one source of truth. Do not copy the whole package into `custom/` as a second editable source. `AGENT_SKILLS_ROOT` is explicit by design so public copies do not ship a maintainer-specific registry path.
+
+`registry-stub/` is only a template for that installed stub. It is not a second design-system source and should not be copied into artifacts.
+
+## Stable Implementation Classes
+
+Agents should copy these classes instead of re-authoring variants:
+
+| Need | Copy from |
+| --- | --- |
+| Smooth page scrolling | `colors_and_type.css` / `examples/examples.css` global `html { scroll-behavior: smooth; }` plus reduced-motion override; visible fixture: `examples/details-scroll-route-motion.html` |
+| Header and product dropdown | `.topbar`, `.nav-item`, `.nav-demo`, `.nav-demo-panel`, `.mega`, `.caret` in `examples/examples.css` |
+| Button hierarchy | `.btn.primary`, `.btn.secondary`, `.btn.tertiary`, `.btn.tiny`, `.btn.brand` |
+| Hover taxonomy | `examples/details-hover-motion.html` + `SYSTEM-MANIFEST.json.hoverTaxonomy` |
+| Official SVG imagery | `examples/details-official-svg-imagery.html`; use `imagery/official-svg/` as editorial/content imagery, not logo marks or UI icons |
+| Pricing route switch | `.route-tabs`, `.route-panels`, `.route-panel.active` and the small JS in `examples/details-scroll-route-motion.html`; the single route indicator follows hover/focus and returns to the selected tab on mouseleave/focusout |
+| Use-cases cards | `.official-use-grid` and `.official-use-card` |
+| Code / terminal blocks | `examples/details-code-terminal.html`; use `.terminal-window`, `.terminal-toolbar`, `.terminal-controls`, `.terminal-tabs`, `.terminal-workspace`, `.terminal-sidebar`, `.terminal-screen`, `.terminal-stream`, `.terminal-block`, `.terminal-row`, `.terminal-output-block`, and `.terminal-cursor` for CLI sessions; use `.code-block` only for API/code snippets |
+| Sidebar system | `examples/details-sidebar-system.html` |
+| Tabular data | `.numeric` |
+
+Do not fork nav, dropdown, button, route, sidebar, or color-library logic per page. If a new artifact needs the same behavior, copy the shared class and change only content/layout around it.
+
+All package HTML files use the same outer design-system topbar content. Page identity, current route, app-specific toolbar controls, and local navigation belong inside the page body or product UI, not in the outer topbar.
+
+## Design Notes
+
+- `brand.json.colors`、`brand.json.palette`、`brand.json.previewTheme` 是 Open Design 设计系统预览/展示最可能读取的机器色板；这些字段不能为空，否则宿主可能回退到默认蓝色主题。
+- `manifest.json.previewEntry`、`displayEntry`、`showcaseEntry` 和 `brand.json.preview.entry` 都指向 `system/artifacts/landing.html`。如果 Open Design 的“预览-展示”仍显示默认蓝，先检查这些机器入口和 `brand.json.previewTheme`，不要只改 HTML。
+- 悬浮效果按组件分类选择：教程 / resources 卡使用 `.tutorial-card`，成组联动用 `.tutorial-card-group`；Cookbook 与 docs 卡共享本地纸面 hover；button 按层级区分 hover：secondary/Get help 反色，tertiary/tiny 双 ring；dropdown 有下划线型和浅色高亮型两种。不要把一种 hover 套给所有组件。
+- 官方 SVG 插图已进入 `examples/details-official-svg-imagery.html`。这些图可用于 editorial hero、research/resources 配图和空状态辅助图形；不要当作 logo、wordmark、按钮 icon 或每张卡片的机械装饰。
+- 代码 / 终端块是 developer docs 组件，不是装饰性全黑页面。CLI 使用 `examples/details-code-terminal.html` 中的 `.terminal-window` 会话结构：左上红/黄/绿 traffic-light 窗口控制点、路径栏、tab strip、会话侧栏、prompt、输入流、输出分组、状态行和光标；终端控制点是系统窗口 chrome，不使用 Clay/Oat/Cactus 品牌色。终端窗口本身不放复制胶囊，复制动作只用于 API/SDK `.code-block`。API/SDK 片段才使用 `.code-block`。
+- 示范库首页使用 Cookbook / Docs 风格的 `.cookbook-grid .tile`：本地纸面加深，不是独立 transparent-tile 模式；不要把 resources/tutorials 的组内联动套到普通 docs/cookbook 卡。
+- Use the preview cards as review fixtures, not as production layouts.
+- Use `examples/*` as concrete usage demonstrations for page composition and interaction details.
+- `brand.html`, `system/index.html`, `system/kit.html`, `system/kit.dark.html`, `examples/*`, `preview/*`, and `ui_kits/app/` all load the same shared CSS. If these disagree, fix `colors_and_type.css` or `examples/examples.css`; do not patch one page in isolation.
+- `system/artifacts/landing.html` is the primary design-system preview/showcase page; it must look like a finished Claude-style page, not a rule summary card.
+- `system/artifacts/*` are material-direction examples (deck, poster, email, newsletter, form) reached from `examples/index.html#materials`. Use `examples/details-*` for exact control behavior, and do not reintroduce per-page control overrides.
+- The applied app shell in `ui_kits/app/` demonstrates product UI usage with the same shared component layer.
+
+## Cleanup Boundary
+
+Kept as evidence or reference:
+
+- `system/artifacts/*` and `.artifact.json` metadata as stable reference deliverables.
+- `context/`, `source_examples/`, `fonts/`, `logos/`, `imagery/`, `.od-skills/`, and `plugin-source/`.
+
+Canonical implementation source:
+
+- Tokens: `colors_and_type.css`
+- Components and interaction fixtures: `examples/examples.css`
+- Machine-readable rules and manifests: `brand.json`, `SYSTEM-MANIFEST.json`
+
+## 文件结构边界
+
+规范源只有 `DESIGN.md`、`brand.json`、`colors_and_type.css`、`examples/examples.css`、`SYSTEM-MANIFEST.json` 和 `PROVENANCE.json`。视觉入口是 `brand.html`、`system/artifacts/landing.html`、`examples/index.html`、`preview/claude-interactions.html`、`ui_kits/app/index.html`。`plugin-source/`、`.od-skills/`、`*.artifact.json` 是宿主/来源 sidecar，不作为组件实现复制。
+
+去重记录：`plugin-source/design-system-source-context-mr0bb3f4/` 与 `mr0bb87z/` 内容重复，已删除前者，保留 `mr0bb87z/` 作为来源 sidecar。
+
+## Contribution and Security
+
+Before contributing this package to Open Design or moving it to another registry, read `CONTRIBUTING.md` and `SECURITY.md`.
+
+Do not publish local crawl caches, private screenshots, authorization tokens, cookies, API keys, user-specific absolute paths, or host app state. Public package metadata should contain only reproducible source URLs, relative asset paths, and measured / inferred boundaries.

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/source-3-SKILL.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/source-3-SKILL.md
@@ -1,0 +1,89 @@
+---
+name: claude-anthropic-design-system
+description: Use this when designing, reviewing, or implementing Open Design artifacts that must follow the Claude / Anthropic visual language, including warm paper surfaces, Slate primary actions, restrained Clay accents, official-style navigation/dropdowns/buttons, route motion, sidebar systems, state colors, typography, and reusable HTML/CSS examples. Also use when maintaining this Open Design design-system package or installing it as an agent skill.
+---
+
+# Claude / Anthropic Design System
+
+This folder is both:
+
+- an Open Design design-system project registered as `user:anthropic`;
+- a canonical source package that can be exposed to agents as a skill.
+
+This is a non-official style system. It is not affiliated with or endorsed by Anthropic. Read `NOTICE.md` before publishing or reusing preserved assets outside local design-system work.
+
+When this skill is installed through the local `agent-skills` registry, the registry skill should be a small stub whose `design-system/` symlink points back to this Open Design project. Do not duplicate the full package into a second canonical directory.
+
+## Read Order
+
+1. `SYSTEM-MANIFEST.json` - package structure, stable checks, file roles, and implementation classes.
+2. `DESIGN.md` - human-readable design rules and official usage guidance.
+3. `brand.json` - machine-readable tokens, palette, preview theme, rules, examples, and manifest data.
+4. `colors_and_type.css` - canonical CSS tokens, font faces, smooth scrolling, selection color, and low-level component variables.
+5. `examples/examples.css` - canonical component and interaction classes.
+6. `style-library.json` - curated overlay/import presets; ordinary example CSS is not a preset source.
+7. `examples/index.html` - unified route hub for detail fixtures, page examples, and material-direction examples.
+8. `PROVENANCE.json` and `context/anthropic-official-usage-evidence.md` - source evidence when a rule needs proof.
+
+Read only the specific `examples/details-*.html`, `examples/page-*.html`, or `system/artifacts/*.html` file needed for the current artifact. Use the materials route for deliverable formats, but keep detail fixtures higher priority for component behavior. Do not load every preview or artifact file by default.
+
+## Priority Rules
+
+- `DESIGN.md`, `brand.json`, `system/tokens.*.json`, and `colors_and_type.css` define the system.
+- `style-library.json` is the explicit style preset library for tools/plugins; add missing reusable presets there instead of relying on CSS guessing.
+- `examples/examples.css` and `examples/details-*.html` are the gold-standard implementation fixtures for controls and interactions.
+- `examples/page-*.html` shows page-level composition.
+- `preview/*.html` are quick review cards.
+- `system/artifacts/*.html` are material-direction deliverable examples reachable through `examples/index.html#materials`; they must not override canonical rules or detail fixtures.
+- `PROVENANCE.json`, `context/`, `source_examples/`, `fonts/`, `logos/`, and `imagery/` are evidence/assets, not component APIs. `logos/` has official icon/mask assets but no full wordmark; `imagery/official-svg/` has official organic SVG illustrations for editorial/reference use. Use `examples/details-official-svg-imagery.html` when deciding how to place those SVGs in real pages.
+- `*.artifact.json`, `.od-skills/`, and `plugin-source/` are Open Design/source sidecars; do not copy them into new artifacts.
+
+## Implementation Contract
+
+- Import `colors_and_type.css` before artifact-specific CSS.
+- Reuse shared classes from `examples/examples.css`; do not fork nav, dropdown, button, route, sidebar, card, switch, state, or color-library behavior per page.
+- Keep the outer design-system topbar content identical across every HTML page. Put page-specific identity, current route, app toolbars, and local navigation inside the page body, sidebar, or product UI.
+- Keep `brand.json.colors`, `brand.json.palette`, and `brand.json.previewTheme` populated. Empty machine color fields can make Open Design previews fall back to a default blue theme.
+- Treat `manifest.json.previewEntry`, `displayEntry`, `showcaseEntry`, and `brand.json.preview.entry` as the Open Design display route. They must keep pointing at `system/artifacts/landing.html`.
+- Route logic has three layers only: outer topbar links for global destinations, route tabs for in-page grouping, and cards/rows for concrete targets. Do not add duplicate CTA buttons for the same target.
+- Split CTA triggers must be real links or real menu triggers; never ship an inert arrow-only button.
+- Product dropdowns open on hover/focus. Normal showcase, preview, kit, and page files must not ship `.nav-demo.is-open`.
+- For cookbook-style index cards, copy `.cookbook-grid .tile` and treat it like `.docs-card`: local paper-depth hover, not a separate transparent-tile invention.
+- Pick hover behavior by taxonomy before styling: `.tutorial-card` is a resources/tutorials card, `.tutorial-card-group` adds grouped background-depth hover, `.cookbook-grid .tile` / `.docs-card` use local paper-depth hover, `.btn.secondary` is Get-help reverse hover, `.btn.tertiary`/`.btn.tiny` are double-ring, and `.nav-demo` is dropdown motion.
+- Official SVG illustrations are content imagery, not chrome. Use `examples/details-official-svg-imagery.html` and the manifest in `source_examples/official-svg-imagery-manifest.json`; do not turn the SVG set into a logo, wordmark, button icon library, or mechanical decoration on every card.
+- Dropdown menus have two variants: `.mega-card` underline hover for product menus, and `.mega.highlight-menu` / `.dropdown.is-highlight` for Solutions/tutorials-style shallow highlight dropdown menus. Highlight menus keep padding on every side, keep default item text readable, and only dim non-hovered sibling items while one item is hovered or focused.
+- Carets use the shared SVG-mask `.caret` and rotate exactly `180deg`.
+- Buttons use `.btn.primary`, `.btn.secondary`, `.btn.tertiary`, `.btn.tiny`, and `.btn.brand` with tier-specific official hover: secondary/Get help reverses to Slate fill, tertiary/tiny use double-ring, brand is rare Clay. Do not replace hover with arbitrary color swaps.
+- Batch switches use `#2c84db` for the checked track.
+- Route switching uses `.route-tabs + .route-panels > .route-panel.active` with opacity and translate motion, not display hard-cuts. The single route indicator follows hover/focus and returns to the selected tab on mouseleave/focusout; do not create separate hover pills per button.
+- Developer terminal blocks use `examples/details-code-terminal.html`: `.terminal-window`, `.terminal-toolbar`, `.terminal-controls`, `.terminal-tabs`, `.terminal-workspace`, `.terminal-sidebar`, `.terminal-screen`, `.terminal-stream`, `.terminal-block`, `.terminal-row`, `.terminal-output-block`, and `.terminal-cursor` for CLI session contexts. `.terminal-controls` are red/yellow/green traffic-light window controls, not Anthropic brand semantic dots. API/SDK snippets use `.code-block`, `.code-block-header`, `.code-block-body`, `.copy-button`, `.code-line.highlighted`, and `.code-line.dimmed`. Do not collapse CLI terminals back into ordinary `pre/code` blocks, keep editor-style gutters out of terminal sessions, put copy actions in the window chrome, or turn terminal components into full-page black backgrounds.
+- Docs/sidebar examples follow `examples/details-sidebar-system.html`; they should not create a persistent independent scrollbar.
+- Prices, dates, token counts, percentages, and table metrics use `.numeric` with mono tabular figures.
+- Product states use `.state-card.empty`, `.state-card.loading`, and `.state-card.error`; actions inside error panels still use ordinary button tiers, not error-colored buttons.
+- Status badges use `.status.success/.info/.warning/.error`: soft semantic background plus semantic status text/dot and switch-like pill radius. Larger state panels keep soft low-saturation backgrounds, and their actions use ordinary button tiers.
+
+## Open Design Dual-Use Setup
+
+The Open Design project directory is the canonical source. To expose it to the local Obsidian `agent-skills` registry without duplicating files, run:
+
+```bash
+scripts/install-as-agent-skill.sh
+```
+
+The script creates:
+
+```text
+agent-skills/custom/claude-anthropic-design-system/
+  SKILL.md
+  agents/openai.yaml
+  design-system -> <this Open Design project>
+```
+
+That stub is what the registry scans and installs. The symlink keeps Open Design and agent usage on the same editable source.
+
+## Contribution / Security Boundary
+
+Before publishing or moving this package, read `CONTRIBUTING.md` and `SECURITY.md`.
+Also read `NOTICE.md` for non-affiliation, mark, asset, and measured/inferred evidence boundaries.
+
+Do not include secrets, cookies, authorization tokens, raw local crawl caches, personal absolute paths, or private project screenshots in public package metadata. Keep source evidence reproducible through public URLs and relative project paths.

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/source-4-source-2-SKILL.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/source-4-source-2-SKILL.md
@@ -1,0 +1,93 @@
+---
+name: claude-anthropic-design-system
+description: Use this Claude / Anthropic style design system for warm, restrained, editorial AI workbench interfaces.
+user-invocable: true
+---
+
+# Claude / Anthropic 风格设计系统
+
+## What's inside
+
+- `DESIGN.md` defines the source-backed visual rules.
+- `colors_and_type.css` provides reusable tokens.
+- `BRAND.md` and `PROVENANCE.json` describe the optimized package version, preserved assets, and measured/inferred evidence boundary.
+- `SYSTEM-MANIFEST.json` records stable read order, file roles, and invariants.
+- `fonts/`, `logos/`, and `imagery/` contain preserved official source assets from sampled Anthropic pages.
+- `preview/` contains focused review cards.
+- `examples/` contains detail and page-level usage examples; `examples/examples.css` is the shared fixture component layer.
+- `system/kit.html` and `ui_kits/app/index.html` show applied components.
+
+## Source Context
+
+The system is based on the pasted Anthropic-style DESIGN.md plus Anthropic public CSS sampling recorded in `anthropic-official-colors.md`.
+
+Source-backed evidence:
+
+- Ivory surface ladder: `#faf9f5`, `#f0eee6`, `#e8e6dc`
+- Slate action system: `#141413`, `#3d3d3a`
+- Clay accent: `#d97757`, sparse use only
+- Header interaction: underline hover and caret rotation
+- Focus ring: `#2c84db`
+- Local official webfont files: `fonts/` contains Anthropic Sans / Serif / Mono.
+- Asset manifest: `source_examples/official-source-manifest.json`.
+- Inference boundary: `#6ea100` is measured in source CSS and assigned here as success semantics, but it is not claimed as an official named success token.
+
+## When to use this skill
+
+Use it to design prototypes, mockups, interfaces, production artifacts, dashboards, forms, decks, and product shells that need a Claude / Anthropic visual language.
+
+## How to use
+
+1. Read `DESIGN.md`.
+2. Load `colors_and_type.css`.
+3. Check `SYSTEM-MANIFEST.json` for stable package structure.
+4. Check `PROVENANCE.json` when a value needs source proof.
+5. Start from Ivory surfaces: page `#faf9f5`, components `#f0eee6`, hover/selected `#e8e6dc`; dropdowns inherit the owning trigger/nav background.
+6. Use Slate Dark `#141413` for primary actions.
+7. Use Clay `#d97757` only for sparse emphasis.
+8. Verify against `preview/*.html`.
+9. Use `examples/index.html` for concrete details and full-page examples.
+10. Do not fork nav, dropdown, button, route-tab, sidebar, or color-library logic per page; reuse `examples/examples.css` patterns.
+
+## Highlights
+
+- Colors: warm paper surface ladder.
+- Typography: Serif display, Sans UI, Mono code.
+- Spacing: 4px / 8px baseline grid.
+- Radius: 8px standard cards, 12px controls.
+- Layout: reading-first, bordered, low-shadow surfaces.
+- Interaction: header hover uses underline and caret rotation.
+- Header hover uses underline and caret rotation.
+- Dropdowns inherit the owning trigger/nav theme background, open on hover/focus, and use subtle borders/shadow.
+- Claude.com details: use-cases card hover, pricing route tabs, Batch processing switch, startups language picker, and Contact sales / Read more button hierarchy are captured in examples.
+- Sidebar system: light rails use warm borders and Slate active states; dark overlay sidebars use Slate dark, Ivory text, and deep Slate borders.
+- Numerics: prices, counts, dates, percentages, and table metrics use the mono stack with tabular numbers.
+- No Ant Design default blue/green/yellow/red defaults.
+
+## Examples
+
+- Detail examples: `examples/details-surface-layers.html`, `details-color-library.html`, `details-hover-motion.html`, `details-scroll-route-motion.html`, `details-buttons-links.html`, `details-claude-official-interactions.html`, `details-sidebar-system.html`, `details-forms-focus.html`, `details-status-data.html`, `details-typography-cn-en.html`.
+- Page examples: `examples/page-landing.html`, `page-research.html`, `page-newsroom.html`, `page-company.html`, `page-console.html`, `page-login.html`, `page-settings-form.html`.
+- Start with `examples/index.html` when you need to see the system applied before designing.
+
+## Reuse workflow
+
+Use this package when creating or revising an Open Design artifact:
+
+1. Read `DESIGN.md` before authoring.
+2. Import `colors_and_type.css` or copy its `:root` tokens.
+3. Check `preview/colors-usage.html` for layer order. Check `preview/assets-provenance.html` for preserved fonts/icons/images.
+4. Check `preview/components-buttons.html` before shipping CTA-heavy screens.
+5. Check `preview/navigation-menus.html` for topbar and dropdown behavior.
+6. Check `preview/claude-interactions.html` for Claude.com-specific button, switch, card, language picker, and route behavior.
+7. Check the matching `examples/page-*.html` before shipping a full page.
+
+## Implementation Details
+
+- Smooth scrolling is part of the system: keep `html { scroll-behavior: smooth; }` and disable it in `prefers-reduced-motion`.
+- Product dropdowns use `.nav-demo > .nav-item + .nav-demo-panel .mega`; production opens on hover/focus-within, while `.is-open` is only for inspection fixtures.
+- Carets use the shared `.caret` SVG mask and rotate exactly `180deg`; never hand-build arrow borders.
+- Route switching uses `.route-tabs`, `.route-panels`, and overlapping `.route-panel` children. Toggle only `aria-selected` and `.active`; the CSS handles opacity + translateY. Use `examples/details-scroll-route-motion.html` as the visible fixture for smooth scrolling and route transitions.
+- Buttons use the shared `.btn` variants and official double-ring hover model. Do not substitute color-swap hover.
+- Sidebars use `details-sidebar-system.html` as the source pattern; docs sidebars follow page scroll and do not get independent persistent scrollbars.
+- Prices, dates, token counts, percentages, and table metrics use `.numeric`.

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/source-5-source-1-source-context.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/source-5-source-1-source-context.md
@@ -1,0 +1,89 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Claude / Anthropic 风格设计系统
+
+非官方 Claude / Anthropic 风格整理版：温暖、克制、编辑感、适合阅读与深度思考的 AI 工作台。当前 canonical 依据是稳定版 `DESIGN.md`、`brand.json`、tokens、示范库，以及 Anthropic 官网公开 CSS 证据。颜色和交互以官网 token 命名校准：`ivory-light #faf9f5`、`ivory-medium #f0eee6`、`ivory-dark #e8e6dc`、`slate-dark #141413`、`clay #d97757`。
+
+## Source Links
+
+- None linked.
+
+## GitHub Repositories
+
+- None linked.
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`: none.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Decoded Figma snapshots: none.
+Fonts, logos, and assets selected:
+- Official webfonts, icon candidates, and imagery preserved under `fonts/`, `logos/`, and `imagery/`.
+
+Uploaded brand asset files under `assets/`:
+- None retained. The original pasted draft was absorbed into the stable package and removed to prevent stale rules.
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, website/source URL review, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/source-6-SKILL.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/source-6-SKILL.md
@@ -1,0 +1,93 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Claude / Anthropic 风格设计系统
+
+非官方 Claude / Anthropic 风格整理版：温暖、克制、编辑感、适合阅读与深度思考的 AI 工作台。当前 canonical 依据是稳定版 `DESIGN.md`、`brand.json`、tokens、示范库，以及 Anthropic 官网公开 CSS 证据。颜色和交互以官网 token 命名校准：`ivory-light #faf9f5`、`ivory-medium #f0eee6`、`ivory-dark #e8e6dc`、`slate-dark #141413`、`clay #d97757`。
+
+## Source Links
+
+- None linked.
+
+## GitHub Repositories
+
+- None linked.
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`: none.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Decoded Figma snapshots: none.
+Fonts, logos, and assets selected:
+- Official webfonts, icon candidates, and imagery preserved under `fonts/`, `logos/`, and `imagery/`.
+
+Uploaded brand asset files under `assets/`:
+- None retained. The original pasted draft was absorbed into the stable package and removed to prevent stale rules.
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, website/source URL review, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.
+
+## Provenance
+
+Formalized by Open Design from candidate 242e9a72-9a69-4de5-91a4-67563dcf7db1.

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/source-7-SECURITY.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/source-7-SECURITY.md
@@ -1,0 +1,40 @@
+# Security and Privacy
+
+This package is a non-official Claude / Anthropic style design-system bundle for Open Design.
+
+## What Is Included
+
+- Publicly reachable website/CSS evidence from Anthropic and Claude pages.
+- Preserved public webfont, favicon/icon, and imagery assets referenced by sampled public pages.
+- Local HTML/CSS examples, token files, manifests, and provenance notes.
+
+## What Must Not Be Included
+
+- API keys, bearer tokens, cookies, session IDs, provider credentials, or private headers.
+- Personal absolute paths in public manifests or documentation.
+- Screenshots or files containing private customer/project data.
+- Generated secrets or local app configuration state.
+
+## Local Registry Installation
+
+`scripts/install-as-agent-skill.sh` requires `AGENT_SKILLS_ROOT` to be set explicitly. This avoids publishing a maintainer-specific Obsidian or agent-skills path.
+
+The generated registry entry is a small stub with a `design-system` symlink back to this Open Design package. Do not copy the entire package into a second editable source.
+
+## Asset Boundary
+
+The `fonts/`, `logos/`, and `imagery/` folders contain public-source assets saved for provenance and local design-system use. The package does not claim ownership of Anthropic marks, fonts, or imagery. Do not use these assets to imply endorsement or to fabricate a full wordmark that was not present in the sampled sources.
+
+## Reporting Issues
+
+Before contributing or publishing a derivative package, run a text scan for:
+
+- `AGENT_SKILLS_ROOT`
+- `/Users/`
+- `/tmp/`
+- `Bearer`
+- `api_key`
+- `secret`
+- `password`
+
+If any hit is not an intentional public documentation example, remove or redact it before distribution.

--- a/plugins/community/design-system-source-context-mr4pp7e1/references/source-8-CONTRIBUTING.md
+++ b/plugins/community/design-system-source-context-mr4pp7e1/references/source-8-CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+This package is intended to be contribution-ready for Open Design while remaining usable as a local agent skill.
+
+## Source of Truth
+
+Use this priority order:
+
+1. `SYSTEM-MANIFEST.json` and `manifest.json` for package structure and stable invariants.
+2. `DESIGN.md`, `brand.json`, `system/tokens.*.json`, and `colors_and_type.css` for rules and tokens.
+3. `examples/examples.css` and `examples/details-*.html` for exact component behavior.
+4. `examples/page-*.html` for page composition.
+5. `system/artifacts/*.html` for material-direction examples.
+6. `preview/*.html` for quick review only.
+
+If a material example or preview conflicts with `DESIGN.md`, `brand.json`, tokens, or a detail fixture, fix the material/preview file.
+
+## Evidence Rules
+
+- Separate measured evidence from inferred design decisions.
+- Do not call inferred status colors, Chinese fallback stacks, or terminal visual calibration official Anthropic specifications.
+- Keep official SVG imagery as content imagery, not logo, wordmark, button icon, or generic UI glyph material.
+
+## Implementation Rules
+
+- Import `colors_and_type.css` before artifact-specific CSS.
+- Reuse `examples/examples.css` for navigation, dropdowns, buttons, route tabs, cards, switches, sidebars, state badges, and terminal components.
+- Do not fork shared component behavior inside a page.
+- Keep the outer topbar content identical across all package HTML pages.
+- Do not ship `.nav-demo.is-open` in normal showcase, preview, kit, or page files.
+
+## Before Submitting
+
+Run or reproduce these checks:
+
+- JSON parse for all `*.json` files.
+- HTML structure check for all `*.html` files.
+- Local `href` / `src` link check.
+- Privacy scan for local paths and secrets.
+- Topbar consistency check across package HTML files.
+- Machine color check: `brand.json.colors`, `brand.json.palette`, and `brand.json.previewTheme` must be populated and must not fall back to a default blue theme.
+
+## Local Skill Registry
+
+For local use, expose this package through a registry stub that points back to this directory. Set `AGENT_SKILLS_ROOT` explicitly when running:
+
+```bash
+AGENT_SKILLS_ROOT="/path/to/agent-skills" scripts/install-as-agent-skill.sh
+```
+
+Do not commit a user-specific registry path.


### PR DESCRIPTION
Add Design System Source Context (design-system-source-context-mr4pp7e1) plugin.
Version: 0.1.0
Description: This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.