### PR TITLE
fix(daemon): support Kiro MCP install

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Inside a project's Studio, the same design system streams out multiple artifact 
 | [Cline](https://github.com/cline/cline) | ✅ Supported | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Supported | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Supported | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Supported | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Supported | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Supported | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Supported | `od mcp install hermes` |

--- a/apps/daemon/src/mcp-agent-install.ts
+++ b/apps/daemon/src/mcp-agent-install.ts
@@ -15,7 +15,7 @@
 //   - 'json'   : the agent reads a JSON config file with a known schema.
 //                We deep-merge one server entry, never clobbering the
 //                rest of the file. Used for cursor / copilot / cline /
-//                opencode / openclaw / antigravity / trae.
+//                opencode / openclaw / antigravity / kiro / trae.
 //   - 'manual' : we could not verify the agent's config path/format
 //                authoritatively (pi / hermes / vibe). We refuse to write
 //                a guessed path and instead print a ready-to-paste
@@ -41,6 +41,7 @@ export const AGENT_SLUGS = [
   'hermes',
   'cline',
   'kimi',
+  'kiro',
   'trae',
   'opencode',
 ] as const;
@@ -251,6 +252,15 @@ export function planAgentInstall(
         kind: 'json',
         slug,
         configPath: path.join(home, '.gemini', 'antigravity', 'mcp_config.json'),
+        keyPath: ['mcpServers'],
+        serverKey: serverName,
+        entry: jsonEntry(spec),
+      };
+    case 'kiro':
+      return {
+        kind: 'json',
+        slug,
+        configPath: path.join(home, '.kiro', 'settings', 'mcp.json'),
         keyPath: ['mcpServers'],
         serverKey: serverName,
         entry: jsonEntry(spec),

--- a/apps/daemon/tests/mcp-agent-install.test.ts
+++ b/apps/daemon/tests/mcp-agent-install.test.ts
@@ -28,7 +28,8 @@ describe('agent slug guard', () => {
   it('accepts every documented slug and rejects others', () => {
     for (const s of AGENT_SLUGS) expect(isAgentSlug(s)).toBe(true);
     expect(isAgentSlug('not-an-agent')).toBe(false);
-    expect(AGENT_SLUGS).toHaveLength(13);
+    expect(AGENT_SLUGS).toHaveLength(14);
+    expect(isAgentSlug('kiro')).toBe(true);
   });
 });
 
@@ -89,6 +90,19 @@ describe('JSON-config agents', () => {
     if (plan.kind !== 'json') throw new Error('expected json');
     expect(plan.keyPath).toEqual(['mcp', 'servers']);
     expect(plan.entry).toEqual({ command: SPEC.command, args: SPEC.args });
+  });
+
+  it('kiro merges a stdio entry into the user MCP settings file', () => {
+    const plan = planAgentInstall('kiro', SPEC, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.configPath).toBe('/home/u/.kiro/settings/mcp.json');
+    expect(plan.keyPath).toEqual(['mcpServers']);
+    expect(plan.serverKey).toBe('open-design');
+    expect(plan.entry).toEqual({
+      command: SPEC.command,
+      args: SPEC.args,
+      env: SPEC.env,
+    });
   });
 
   it('omits env entirely when the launch spec has no env', () => {

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -128,6 +128,7 @@
 | [Cline](https://github.com/cline/cline) | ✅ مدعوم | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ مدعوم | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ مدعوم | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ مدعوم | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ مدعوم | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ مدعوم | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ مدعوم | `od mcp install hermes` |

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -126,6 +126,7 @@ Im Studio eines Projekts streamt dasselbe Designsystem mehrere Artefakttypen her
 | [Cline](https://github.com/cline/cline) | ✅ Unterstützt | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Unterstützt | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Unterstützt | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Unterstützt | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Unterstützt | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Unterstützt | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Unterstützt | `od mcp install hermes` |

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -126,6 +126,7 @@ Dentro del Studio de un proyecto, el mismo sistema de diseño produce múltiples
 | [Cline](https://github.com/cline/cline) | ✅ Compatible | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Compatible | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Compatible | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Compatible | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Compatible | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Compatible | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Compatible | `od mcp install hermes` |

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -126,6 +126,7 @@ Un aperçu rapide de ce qu'est Open Design et de ce qu'il fait. Partez de la pag
 | [Cline](https://github.com/cline/cline) | ✅ Pris en charge | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Pris en charge | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Pris en charge | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Pris en charge | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Pris en charge | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Pris en charge | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Pris en charge | `od mcp install hermes` |

--- a/docs/i18n/README.ja-JP.md
+++ b/docs/i18n/README.ja-JP.md
@@ -126,6 +126,7 @@ Open Design が何であり、何ができるのかを手早く見ていきま�
 | [Cline](https://github.com/cline/cline) | ✅ 対応済み | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ 対応済み | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ 対応済み | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ 対応済み | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ 対応済み | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ 対応済み | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ 対応済み | `od mcp install hermes` |

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -126,6 +126,7 @@ Open Design가 무엇이고 무엇을 하는지 빠르게 살펴봅니다. **Hom
 | [Cline](https://github.com/cline/cline) | ✅ 지원됨 | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ 지원됨 | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ 지원됨 | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ 지원됨 | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ 지원됨 | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ 지원됨 | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ 지원됨 | `od mcp install hermes` |

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -126,6 +126,7 @@ Dentro do Studio de um projeto, o mesmo design system produz múltiplos tipos de
 | [Cline](https://github.com/cline/cline) | ✅ Suportado | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Suportado | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Suportado | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Suportado | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Suportado | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Suportado | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Suportado | `od mcp install hermes` |

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -126,6 +126,7 @@ Open Design — это то, что получается, когда **аген�
 | [Cline](https://github.com/cline/cline) | ✅ Поддерживается | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Поддерживается | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Поддерживается | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Поддерживается | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Поддерживается | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Поддерживается | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Поддерживается | `od mcp install hermes` |

--- a/docs/i18n/README.th.md
+++ b/docs/i18n/README.th.md
@@ -126,6 +126,7 @@ Open Design คือสิ่งที่เกิดขึ้นเมื่�
 | [Cline](https://github.com/cline/cline) | ✅ Supported | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Supported | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Supported | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Supported | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Supported | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Supported | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Supported | `od mcp install hermes` |

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -126,6 +126,7 @@ Bir projenin Studio'su içinde, aynı tasarım sistemi birden çok artifact tür
 | [Cline](https://github.com/cline/cline) | ✅ Destekleniyor | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Destekleniyor | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Destekleniyor | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Destekleniyor | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Destekleniyor | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Destekleniyor | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Destekleniyor | `od mcp install hermes` |

--- a/docs/i18n/README.uk.md
+++ b/docs/i18n/README.uk.md
@@ -126,6 +126,7 @@ Open Design — це те, що ви отримуєте, коли **agent-native
 | [Cline](https://github.com/cline/cline) | ✅ Підтримується | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ Підтримується | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ Підтримується | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ Підтримується | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Підтримується | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Підтримується | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Підтримується | `od mcp install hermes` |

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -126,6 +126,7 @@ Open Design 是这样一种产物：Anthropic 随 Claude Design 推出的 **Agen
 | [Cline](https://github.com/cline/cline) | ✅ 支持 | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ 支持 | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ 支持 | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ 支持 | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ 支持 | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ 支持 | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ 支持 | `od mcp install hermes` |

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -126,6 +126,7 @@ Open Design 是這樣誕生的：當 Anthropic 隨 Claude Design 推出的那套
 | [Cline](https://github.com/cline/cline) | ✅ 已支援 | `od mcp install cline` |
 | [Trae](https://www.trae.ai/) | ✅ 已支援 | `od mcp install trae` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | ✅ 已支援 | `od mcp install kimi` |
+| [Kiro](https://kiro.dev) | ✅ 已支援 | `od mcp install kiro` |
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ 已支援 | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ 已支援 | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ 已支援 | `od mcp install hermes` |


### PR DESCRIPTION
Fixes #5082

## Why

Kiro is already wired as a supported ACP runtime in Open Design, but `od mcp install kiro` was rejected by the MCP installer slug gate. This left Kiro users with only the manual Settings copy/paste path while other supported agents could use the documented one-line MCP setup.

This PR closes that parity gap by making Kiro a first-class MCP install target and documenting the command in the compatibility table.

## What users will see

Users can run `od mcp install kiro` to merge the Open Design MCP server into their Kiro user MCP settings at `~/.kiro/settings/mcp.json`. The README compatibility tables now list Kiro with the same one-line install command.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/mcp-agent-install.test.ts`
- Did the test go red on `main` and green on this branch? yes — the new `kiro` slug/planner assertions failed before implementation with `AGENT_SLUGS` length 14 and `unknown agent slug: kiro`, then passed after adding the installer plan.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp-agent-install.test.ts`
- `pnpm --filter @open-design/diagnostics build`
- `pnpm --filter @open-design/registry-protocol build`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`

Note: this local shell reports Node `v22.14.0` while the repo requires `~24`, so pnpm emitted engine warnings. The commands above exited successfully after refreshing stale workspace build output for `@open-design/diagnostics`.
