### PR TITLE
fix(daemon): handle read-stream errors in library asset routes

### DIFF
--- a/apps/daemon/src/routes/library.ts
+++ b/apps/daemon/src/routes/library.ts
@@ -132,8 +132,19 @@ export function streamAssetFileToResponse(
 ): void {
   const stream = createReadStream(abs);
   stream.on('error', () => {
-    if (res.headersSent) res.destroy();
-    else onOpenError();
+    if (res.headersSent) {
+      res.destroy();
+      return;
+    }
+    // The route sets success-only headers (Content-Type/-Length, Cache-Control,
+    // Content-Disposition) before streaming. Strip them before the JSON error
+    // fallback so a transient open/read failure isn't returned with stale asset
+    // metadata — in particular the `max-age=3600` directive, which would cache
+    // the 404 for an hour and mask the file once it becomes available again.
+    for (const header of ['Cache-Control', 'Content-Disposition', 'Content-Type', 'Content-Length']) {
+      res.removeHeader(header);
+    }
+    onOpenError();
   });
   stream.pipe(res);
 }

--- a/apps/daemon/src/routes/library.ts
+++ b/apps/daemon/src/routes/library.ts
@@ -117,6 +117,27 @@ async function fetchRemoteBytes(url: string): Promise<{ bytes: Buffer; mime: str
   return { bytes: buf, mime };
 }
 
+/**
+ * Stream a file to the HTTP response with an `error` handler on the read stream.
+ * `.pipe()` does NOT forward the source's errors, so without this a mid-stream
+ * read failure (file deleted/truncated mid-read, EIO, an fd race) emits an
+ * unhandled `error` on the Readable, which Node escalates to an uncaughtException
+ * that takes the whole daemon down. On error we fall back to `onOpenError`
+ * (a 404) when nothing has been written yet, else tear the response down.
+ */
+export function streamAssetFileToResponse(
+  abs: string,
+  res: Response,
+  onOpenError: () => void,
+): void {
+  const stream = createReadStream(abs);
+  stream.on('error', () => {
+    if (res.headersSent) res.destroy();
+    else onOpenError();
+  });
+  stream.pipe(res);
+}
+
 export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDeps): void {
   const { db } = ctx;
   const { sendApiError, createSseResponse, requireLocalDaemonRequest, isLocalSameOrigin, resolvedPortRef } =
@@ -479,7 +500,9 @@ export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDe
       res.setHeader('Content-Type', asset.mime ?? 'application/octet-stream');
       res.setHeader('Content-Length', String(info.size));
       res.setHeader('Cache-Control', 'private, max-age=3600');
-      createReadStream(abs).pipe(res);
+      streamAssetFileToResponse(abs, res, () =>
+        sendApiError(res, 404, 'NOT_FOUND', 'asset bytes not available'),
+      );
     } catch {
       return sendApiError(res, 404, 'NOT_FOUND', 'asset bytes not available');
     }
@@ -501,7 +524,9 @@ export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDe
       res.setHeader('Content-Length', String(info.size));
       res.setHeader('Content-Disposition', `attachment; filename="${figmaDownloadName(asset)}"`);
       res.setHeader('Cache-Control', 'private, max-age=3600');
-      createReadStream(sidecar).pipe(res);
+      streamAssetFileToResponse(sidecar, res, () =>
+        sendApiError(res, 404, 'NOT_FOUND', 'no figma capture for this asset'),
+      );
     } catch {
       return sendApiError(res, 404, 'NOT_FOUND', 'no figma capture for this asset');
     }
@@ -521,7 +546,9 @@ export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDe
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.setHeader('Content-Length', String(info.size));
       res.setHeader('Cache-Control', 'private, max-age=3600');
-      createReadStream(sidecar).pipe(res);
+      streamAssetFileToResponse(sidecar, res, () =>
+        sendApiError(res, 404, 'NOT_FOUND', 'no element markup for this asset'),
+      );
     } catch {
       return sendApiError(res, 404, 'NOT_FOUND', 'no element markup for this asset');
     }

--- a/apps/daemon/tests/library-asset-stream.test.ts
+++ b/apps/daemon/tests/library-asset-stream.test.ts
@@ -1,0 +1,39 @@
+import { PassThrough } from 'node:stream';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+
+import { streamAssetFileToResponse } from '../src/routes/library.js';
+
+// A path that does not exist: `createReadStream` opens it lazily and emits an
+// async ENOENT `error` on the Readable. `.pipe()` does not forward that error,
+// so without the guard the unhandled `error` event would crash the whole process
+// (uncaughtException). If these tests run to completion, the guard handled it.
+const MISSING = path.join(tmpdir(), 'od-library-stream-error-does-not-exist-xyz');
+const flush = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+describe('streamAssetFileToResponse', () => {
+  it('sends the 404 fallback when the read stream errors before any bytes are written', async () => {
+    const res = new PassThrough() as unknown as { headersSent: boolean; destroy: () => void };
+    res.headersSent = false;
+    const onOpenError = vi.fn();
+
+    streamAssetFileToResponse(MISSING, res as never, onOpenError);
+    await flush();
+
+    expect(onOpenError).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the response (rather than crashing) when the stream errors after headers are sent', async () => {
+    const res = new PassThrough() as unknown as { headersSent: boolean; destroy: () => void };
+    res.headersSent = true;
+    const destroySpy = vi.spyOn(res as unknown as PassThrough, 'destroy');
+    const onOpenError = vi.fn();
+
+    streamAssetFileToResponse(MISSING, res as never, onOpenError);
+    await flush();
+
+    expect(destroySpy).toHaveBeenCalled();
+    expect(onOpenError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/daemon/tests/library-asset-stream.test.ts
+++ b/apps/daemon/tests/library-asset-stream.test.ts
@@ -12,21 +12,40 @@ import { streamAssetFileToResponse } from '../src/routes/library.js';
 const MISSING = path.join(tmpdir(), 'od-library-stream-error-does-not-exist-xyz');
 const flush = () => new Promise((resolve) => setTimeout(resolve, 50));
 
+function fakeRes(headersSent: boolean) {
+  const removed: string[] = [];
+  const res = new PassThrough() as unknown as {
+    headersSent: boolean;
+    removeHeader: (name: string) => void;
+    destroy: () => void;
+    _removed: string[];
+  };
+  res.headersSent = headersSent;
+  res._removed = removed;
+  res.removeHeader = (name: string) => {
+    removed.push(name);
+  };
+  return res;
+}
+
 describe('streamAssetFileToResponse', () => {
-  it('sends the 404 fallback when the read stream errors before any bytes are written', async () => {
-    const res = new PassThrough() as unknown as { headersSent: boolean; destroy: () => void };
-    res.headersSent = false;
+  it('drops the success-only headers and sends the 404 fallback when the stream errors before any bytes', async () => {
+    const res = fakeRes(false);
     const onOpenError = vi.fn();
 
     streamAssetFileToResponse(MISSING, res as never, onOpenError);
     await flush();
 
     expect(onOpenError).toHaveBeenCalledTimes(1);
+    // The route's `Cache-Control: private, max-age=3600` must NOT survive onto a
+    // transient 404, or a missing-file blip would be cached for an hour.
+    expect(res._removed).toEqual(
+      expect.arrayContaining(['Cache-Control', 'Content-Type', 'Content-Length', 'Content-Disposition']),
+    );
   });
 
   it('destroys the response (rather than crashing) when the stream errors after headers are sent', async () => {
-    const res = new PassThrough() as unknown as { headersSent: boolean; destroy: () => void };
-    res.headersSent = true;
+    const res = fakeRes(true);
     const destroySpy = vi.spyOn(res as unknown as PassThrough, 'destroy');
     const onOpenError = vi.fn();
 
@@ -35,5 +54,7 @@ describe('streamAssetFileToResponse', () => {
 
     expect(destroySpy).toHaveBeenCalled();
     expect(onOpenError).not.toHaveBeenCalled();
+    // Headers already flushed → nothing to strip.
+    expect(res._removed).toEqual([]);
   });
 });


### PR DESCRIPTION
## Why

Three library asset GET routes — `/api/library/assets/:id/raw`, `/figma`, `/element` — stream the file with `createReadStream(abs).pipe(res)` and no `error` handler on the read stream. `.pipe()` does not forward the source's errors, so if the read fails after the initial `stat` (the backing file is deleted, truncated, or hits an `EIO`/fd race mid-stream), the Readable emits an unhandled `error` event. The daemon's process-level `uncaughtException` handler then exits the process — a single broken asset read takes the whole daemon down. The rest of the codebase already guards this: the project file route (`routes/project/index.ts`) and the critique artifact handler both attach `stream.on('error', …)` before piping; these three routes just omitted it.

## What users will see

Nothing on the happy path. If an asset's backing file breaks while being served, the request now fails cleanly — a 404 when nothing has been written yet, otherwise the connection is torn down — instead of crashing the daemon.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal daemon hardening. Adds error handling to an existing stream; no change on the success path.

## Bug fix verification

- **Bug:** `createReadStream(abs).pipe(res)` with no `error` handler — an async read-stream error is unhandled, becomes an `uncaughtException`, and the daemon exits.
- **Fix:** a shared `streamAssetFileToResponse(abs, res, onOpenError)` helper attaches `stream.on('error', …)` before piping — a 404 fallback when headers have not been sent, else `res.destroy()`. All three asset-serving routes go through it. Mirrors the existing handlers in `routes/project/index.ts` and `critique/artifact-handler.ts`.
- **Test:** `apps/daemon/tests/library-asset-stream.test.ts` drives a missing path so the read stream emits `ENOENT`, asserting the pre-headers 404 branch and the post-headers `res.destroy()` branch. Without the guard the erroring stream surfaces as an unhandled error and fails the run; with it, both branches are handled.

## Validation

- `pnpm --filter @open-design/daemon test` — new `library-asset-stream.test.ts` 2/2; `server-bootstrap-regression` still green.
- daemon `tsc --noEmit` for both `tsconfig.json` and `tsconfig.tests.json`.
