### PR TITLE
fix(web): show full workspace tab labels and capitalize Design System

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3674,7 +3674,7 @@ export const en: Dict = {
   'automations.tpl.liveStatusBoard.title': 'Keep a live status artifact fresh.',
   'automations.tpl.liveStatusBoard.desc': 'Updates one persistent artifact instead of creating a new report each run.',
   'dsManager.areaAria': 'Design systems area',
-  'dsManager.tabDesignSystem': 'Design system',
+  'dsManager.tabDesignSystem': 'Design System',
   'dsManager.tabTemplate': 'Template',
   'dsManager.sourceAria': 'Design system source',
   'dsManager.templateSourceAria': 'Template source',

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -1482,7 +1482,11 @@
   font-size: 12.5px;
   cursor: pointer;
   flex-shrink: 0;
-  max-width: 110px;
+  /* Tabs take their natural label width so short names ("Design System",
+     "Design Files") render in full; the cap only truncates genuinely long
+     file names. When many tabs open, the strip falls back to its existing
+     horizontal scroll instead of squeezing tabs. */
+  max-width: 220px;
   min-width: 0;
   color: var(--text-muted);
   transition: background 120ms var(--ease-out), color 120ms var(--ease-out);


### PR DESCRIPTION
## Why

Hit this while using the app day-to-day: in a design-system project workspace, the right-pane tab strip renders "Design sy…", "Design Fil…", and "canva…" even when the strip is almost entirely empty. Every tab was hard-capped at `max-width: 110px` regardless of available space, so the two always-present tabs never showed their full (short) names. Separately, the "Design system" tab label was inconsistently cased next to "Design Files".

The pain is purely user-facing polish: needless ellipses in labels that would comfortably fit, and inconsistent capitalization between two sibling tabs.

## What users will see

- The workspace tabs ("Design System", "Design Files", "Questions", and file tabs) now render their full labels when the strip has room. Only genuinely long names truncate (new cap 220px), and when many tabs are open the strip falls back to its existing horizontal scroll — tab-squeezing behavior is unchanged.
- The design-system tab now reads **Design System** (capital S), matching "Design Files". The same label is used as the kicker next to the project title and in the design-systems manager, so those read "Design System" too.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (no new keys; only the `en` value of the existing `dsManager.tabDesignSystem` key changed)
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before (empty strip, all three chips clipped at 110px):

> `[ Design sy… ] [ Design Fil… ] [ canva… ]` — with the rest of the tab bar empty.

After: `[ Design System ] [ Design Files ] [ canvas.html ]` render in full; long file names still ellipsize at 220px. Author will attach before/after captures in a comment.

## Bug fix verification

- This is a visual styling tweak (a CSS `max-width` and an i18n string value). A red spec wasn't cheap: the web unit suite runs in jsdom, which does not compute CSS layout, so a test cannot observe the truncation. Verified instead by driving the change in a running `tools-dev` web session: with a design-system project open, the previously clipped "Design sy…" / "Design Fil…" tabs render their full labels, and opening many tabs still overflows into the existing horizontal scroll.

## Validation

- `pnpm typecheck` (repo-wide, all 25 projects) — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm guard` — TypeScript-only, style-policy, boundary, and layout checks pass. The design-system manifest staleness check fails on this machine, but identically on a clean tree with this diff stashed (verified), so it is a pre-existing local/Windows-checkout artifact unrelated to this change; this PR touches neither `design-systems/` nor any generated artifact.
