### PR TITLE
fix(daemon): stop design-system workspace project renames from reverting

### DIFF
--- a/apps/daemon/src/design-systems/index.ts
+++ b/apps/daemon/src/design-systems/index.ts
@@ -1252,17 +1252,26 @@ export function workspaceRenameDesignSystemId(project: {
   return importedFrom === 'design-system' ? id : null;
 }
 
+// 'not-applicable': the project is not a design-system workspace (or the
+// name is blank) — the rename does not involve a design system at all.
+// 'propagated': the bound design system's title now matches the new name.
+// 'failed': the project IS bound to a user design system but the title
+// could not be written through (e.g. the entry is missing on disk).
+// Callers must not persist the project-row rename on 'failed' — doing so
+// recreates the silent revert this write-through exists to prevent.
+export type WorkspaceRenamePropagation = 'not-applicable' | 'propagated' | 'failed';
+
 export async function propagateWorkspaceProjectRename(
   root: string,
   project: { designSystemId?: string | null; metadata?: unknown },
   name: unknown,
-): Promise<boolean> {
+): Promise<WorkspaceRenamePropagation> {
   const id = workspaceRenameDesignSystemId(project);
-  if (!id) return false;
+  if (!id) return 'not-applicable';
   const title = typeof name === 'string' ? name.trim() : '';
-  if (!title) return false;
+  if (!title) return 'not-applicable';
   const updated = await updateUserDesignSystem(root, id, { title });
-  return updated != null;
+  return updated != null ? 'propagated' : 'failed';
 }
 
 export async function linkUserDesignSystemProject(

--- a/apps/daemon/src/design-systems/index.ts
+++ b/apps/daemon/src/design-systems/index.ts
@@ -1231,6 +1231,40 @@ export async function updateUserDesignSystem(
   return listed.find((s) => s.id === `user:${dirId}`) ?? null;
 }
 
+// A design-system workspace project mirrors its design system's title:
+// ensureUserDesignSystemWorkspaceProject re-stamps the project name from
+// the registry title every time the workspace is ensured, so a rename
+// applied only to the project row silently reverts on the next open.
+// Renames on these projects must instead be written through to the
+// design-system title — the sync then carries the new name back onto the
+// project and both records agree.
+export function workspaceRenameDesignSystemId(project: {
+  designSystemId?: string | null;
+  metadata?: unknown;
+}): string | null {
+  const id = typeof project?.designSystemId === 'string' ? project.designSystemId : '';
+  if (!id.startsWith('user:')) return null;
+  const metadata = project?.metadata;
+  const importedFrom =
+    metadata && typeof metadata === 'object'
+      ? (metadata as Record<string, unknown>).importedFrom
+      : undefined;
+  return importedFrom === 'design-system' ? id : null;
+}
+
+export async function propagateWorkspaceProjectRename(
+  root: string,
+  project: { designSystemId?: string | null; metadata?: unknown },
+  name: unknown,
+): Promise<boolean> {
+  const id = workspaceRenameDesignSystemId(project);
+  if (!id) return false;
+  const title = typeof name === 'string' ? name.trim() : '';
+  if (!title) return false;
+  const updated = await updateUserDesignSystem(root, id, { title });
+  return updated != null;
+}
+
 export async function linkUserDesignSystemProject(
   root: string,
   id: string,

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2131,7 +2131,21 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         // system so both records agree.
         const existing = getProject(db, req.params.id);
         if (existing) {
-          await propagateWorkspaceProjectRename(USER_DESIGN_SYSTEMS_DIR, existing, patch.name);
+          // Decide from the post-patch shape (updateProject merges the
+          // patch shallowly over the row), so a PATCH that also rebinds
+          // or detaches the design system only ever renames the system
+          // the project remains bound to after this request.
+          const propagation = await propagateWorkspaceProjectRename(
+            USER_DESIGN_SYSTEMS_DIR,
+            { ...existing, ...patch },
+            patch.name,
+          );
+          if (propagation === 'failed') {
+            return sendApiError(
+              res, 409, 'CONFLICT',
+              'rename could not be written through to the bound design system; project left unchanged',
+            );
+          }
         }
       }
       const project = updateProject(db, req.params.id, patch);

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -30,6 +30,7 @@ import {
   deleteUserDesignSystem,
   linkUserDesignSystemProject,
   listDesignSystems,
+  propagateWorkspaceProjectRename,
 } from '../../design-systems/index.js';
 import {
   FIRST_PARTY_ATOMS,
@@ -2121,6 +2122,17 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           return sendApiError(res, 400, skillValidation.code, skillValidation.message);
         }
         patch.skillId = skillValidation.id;
+      }
+      if (typeof patch.name === 'string' && patch.name.trim().length > 0) {
+        // Design-system workspace projects mirror their design system's
+        // title: the workspace ensure re-stamps the project name from the
+        // registry on every open, so a rename applied only to the project
+        // row silently reverts. Write the rename through to the design
+        // system so both records agree.
+        const existing = getProject(db, req.params.id);
+        if (existing) {
+          await propagateWorkspaceProjectRename(USER_DESIGN_SYSTEMS_DIR, existing, patch.name);
+        }
       }
       const project = updateProject(db, req.params.id, patch);
       if (!project)

--- a/apps/daemon/tests/design-systems/workspace-project-rename.test.ts
+++ b/apps/daemon/tests/design-systems/workspace-project-rename.test.ts
@@ -1,0 +1,140 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  propagateWorkspaceProjectRename,
+  workspaceRenameDesignSystemId,
+} from '../../src/design-systems/index.js';
+
+// Renaming a design-system workspace project used to revert silently:
+// ensureUserDesignSystemWorkspaceProject re-stamps the project name from
+// the registry title on every workspace open, so a rename applied only to
+// the project row was overwritten by the stale title. The fix writes the
+// rename through to the design-system title; these tests pin that
+// write-through and the predicate that gates it.
+
+const DIR_ID = 'trip-journal-design-system';
+const DS_ID = `user:${DIR_ID}`;
+
+describe('workspaceRenameDesignSystemId', () => {
+  const workspaceProject = {
+    designSystemId: DS_ID,
+    metadata: { importedFrom: 'design-system' },
+  };
+
+  it('returns the design-system id for a workspace project', () => {
+    expect(workspaceRenameDesignSystemId(workspaceProject)).toBe(DS_ID);
+  });
+
+  it('ignores projects bound to non-user design systems', () => {
+    expect(
+      workspaceRenameDesignSystemId({ ...workspaceProject, designSystemId: 'agentic' }),
+    ).toBeNull();
+  });
+
+  it('ignores projects that are not design-system workspaces', () => {
+    expect(
+      workspaceRenameDesignSystemId({ ...workspaceProject, metadata: { importedFrom: 'folder' } }),
+    ).toBeNull();
+    expect(
+      workspaceRenameDesignSystemId({ ...workspaceProject, metadata: undefined }),
+    ).toBeNull();
+  });
+
+  it('ignores projects without a design-system binding', () => {
+    expect(
+      workspaceRenameDesignSystemId({ designSystemId: null, metadata: { importedFrom: 'design-system' } }),
+    ).toBeNull();
+  });
+});
+
+describe('propagateWorkspaceProjectRename', () => {
+  let root = '';
+  const project = {
+    designSystemId: DS_ID,
+    metadata: { importedFrom: 'design-system' },
+  };
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-ds-rename-'));
+    const dir = path.join(root, DIR_ID);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, 'DESIGN.md'),
+      '# Trip Journal\n\n> Category: Project Design System\n> Surface: web\n\nBody text.\n',
+      'utf8',
+    );
+    await writeFile(
+      path.join(dir, 'metadata.json'),
+      JSON.stringify(
+        {
+          title: 'Trip Journal',
+          category: 'Project Design System',
+          surface: 'web',
+          status: 'draft',
+          artifactMode: 'agent-managed',
+          projectId: 'proj-1',
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+  });
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  it('writes the new name through to the design-system title and heading', async () => {
+    const propagated = await propagateWorkspaceProjectRename(root, project, 'Earth Postcard');
+    expect(propagated).toBe(true);
+
+    const metadata = JSON.parse(
+      await readFile(path.join(root, DIR_ID, 'metadata.json'), 'utf8'),
+    ) as { title?: string };
+    expect(metadata.title).toBe('Earth Postcard');
+
+    const designMd = await readFile(path.join(root, DIR_ID, 'DESIGN.md'), 'utf8');
+    expect(designMd.startsWith('# Earth Postcard')).toBe(true);
+    // The body must survive a rename — only the header changes.
+    expect(designMd).toContain('Body text.');
+  });
+
+  it('trims the propagated name', async () => {
+    expect(await propagateWorkspaceProjectRename(root, project, '  Earth Postcard  ')).toBe(true);
+    const metadata = JSON.parse(
+      await readFile(path.join(root, DIR_ID, 'metadata.json'), 'utf8'),
+    ) as { title?: string };
+    expect(metadata.title).toBe('Earth Postcard');
+  });
+
+  it('does nothing for blank names or non-workspace projects', async () => {
+    expect(await propagateWorkspaceProjectRename(root, project, '   ')).toBe(false);
+    expect(await propagateWorkspaceProjectRename(root, project, undefined)).toBe(false);
+    expect(
+      await propagateWorkspaceProjectRename(
+        root,
+        { designSystemId: DS_ID, metadata: { importedFrom: 'folder' } },
+        'Earth Postcard',
+      ),
+    ).toBe(false);
+
+    const metadata = JSON.parse(
+      await readFile(path.join(root, DIR_ID, 'metadata.json'), 'utf8'),
+    ) as { title?: string };
+    expect(metadata.title).toBe('Trip Journal');
+  });
+
+  it('returns false when the design-system entry does not exist', async () => {
+    expect(
+      await propagateWorkspaceProjectRename(
+        root,
+        { designSystemId: 'user:missing-entry', metadata: { importedFrom: 'design-system' } },
+        'Earth Postcard',
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/daemon/tests/design-systems/workspace-project-rename.test.ts
+++ b/apps/daemon/tests/design-systems/workspace-project-rename.test.ts
@@ -1,7 +1,8 @@
+import type http from 'node:http';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   propagateWorkspaceProjectRename,
@@ -90,7 +91,7 @@ describe('propagateWorkspaceProjectRename', () => {
 
   it('writes the new name through to the design-system title and heading', async () => {
     const propagated = await propagateWorkspaceProjectRename(root, project, 'Earth Postcard');
-    expect(propagated).toBe(true);
+    expect(propagated).toBe('propagated');
 
     const metadata = JSON.parse(
       await readFile(path.join(root, DIR_ID, 'metadata.json'), 'utf8'),
@@ -104,23 +105,25 @@ describe('propagateWorkspaceProjectRename', () => {
   });
 
   it('trims the propagated name', async () => {
-    expect(await propagateWorkspaceProjectRename(root, project, '  Earth Postcard  ')).toBe(true);
+    expect(await propagateWorkspaceProjectRename(root, project, '  Earth Postcard  ')).toBe(
+      'propagated',
+    );
     const metadata = JSON.parse(
       await readFile(path.join(root, DIR_ID, 'metadata.json'), 'utf8'),
     ) as { title?: string };
     expect(metadata.title).toBe('Earth Postcard');
   });
 
-  it('does nothing for blank names or non-workspace projects', async () => {
-    expect(await propagateWorkspaceProjectRename(root, project, '   ')).toBe(false);
-    expect(await propagateWorkspaceProjectRename(root, project, undefined)).toBe(false);
+  it('is not applicable for blank names or non-workspace projects', async () => {
+    expect(await propagateWorkspaceProjectRename(root, project, '   ')).toBe('not-applicable');
+    expect(await propagateWorkspaceProjectRename(root, project, undefined)).toBe('not-applicable');
     expect(
       await propagateWorkspaceProjectRename(
         root,
         { designSystemId: DS_ID, metadata: { importedFrom: 'folder' } },
         'Earth Postcard',
       ),
-    ).toBe(false);
+    ).toBe('not-applicable');
 
     const metadata = JSON.parse(
       await readFile(path.join(root, DIR_ID, 'metadata.json'), 'utf8'),
@@ -128,13 +131,167 @@ describe('propagateWorkspaceProjectRename', () => {
     expect(metadata.title).toBe('Trip Journal');
   });
 
-  it('returns false when the design-system entry does not exist', async () => {
+  it("fails (not 'not-applicable') when the bound design-system entry does not exist", async () => {
     expect(
       await propagateWorkspaceProjectRename(
         root,
         { designSystemId: 'user:missing-entry', metadata: { importedFrom: 'design-system' } },
         'Earth Postcard',
       ),
-    ).toBe(false);
+    ).toBe('failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/projects/:id — the route that consumes the write-through.
+// Review follow-up on the original fix (PR #5134) found two holes:
+//   1. The propagation decision used the PRE-patch project row, so a PATCH
+//      that renames and rebinds/detaches in one request renamed the design
+//      system the project was leaving.
+//   2. A failed write-through was swallowed: the route still renamed the
+//      project row and returned 200, recreating the silent revert as a
+//      partial update. It must abort with an API error instead.
+// ---------------------------------------------------------------------------
+describe('PATCH /api/projects/:id design-system rename write-through', () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const { startServer } = await import('../../src/server.js');
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  afterAll(() => {
+    return new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function createWorkspaceProject(title: string): Promise<{
+    designSystemId: string;
+    projectId: string;
+  }> {
+    const createResp = await fetch(`${baseUrl}/api/design-systems`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    });
+    expect(createResp.status).toBe(201);
+    const created = (await createResp.json()) as { designSystem: { id: string } };
+    const designSystemId = created.designSystem.id;
+
+    const workspaceResp = await fetch(
+      `${baseUrl}/api/design-systems/${encodeURIComponent(designSystemId)}/workspace`,
+      { method: 'POST' },
+    );
+    expect(workspaceResp.status).toBe(201);
+    const workspace = (await workspaceResp.json()) as { project: { id: string } };
+    return { designSystemId, projectId: workspace.project.id };
+  }
+
+  async function designSystemTitle(designSystemId: string): Promise<string | undefined> {
+    const resp = await fetch(
+      `${baseUrl}/api/design-systems/${encodeURIComponent(designSystemId)}`,
+    );
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { designSystem: { title?: string } };
+    return body.designSystem.title;
+  }
+
+  it('a rename survives the next workspace ensure (the original bug)', async () => {
+    const { designSystemId, projectId } = await createWorkspaceProject('Rename Survives');
+
+    const patchResp = await fetch(`${baseUrl}/api/projects/${projectId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed Workspace' }),
+    });
+    expect(patchResp.status).toBe(200);
+    expect(await designSystemTitle(designSystemId)).toBe('Renamed Workspace');
+
+    // Re-open the workspace: the ensure-sync must reinforce the rename,
+    // not re-stamp the stale title over it.
+    const ensureResp = await fetch(
+      `${baseUrl}/api/design-systems/${encodeURIComponent(designSystemId)}/workspace`,
+      { method: 'POST' },
+    );
+    expect(ensureResp.status).toBe(201);
+    const ensured = (await ensureResp.json()) as { project: { name: string } };
+    expect(ensured.project.name).toBe('Renamed Workspace');
+  });
+
+  it('does not rename a design system the same PATCH detaches from', async () => {
+    const { designSystemId, projectId } = await createWorkspaceProject('Detach Keeps Title');
+
+    const patchResp = await fetch(`${baseUrl}/api/projects/${projectId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Detached Name', designSystemId: null }),
+    });
+    expect(patchResp.status).toBe(200);
+    const patched = (await patchResp.json()) as {
+      project: { name: string; designSystemId?: string | null };
+    };
+    expect(patched.project.name).toBe('Detached Name');
+    expect(patched.project.designSystemId ?? null).toBeNull();
+
+    // The design system the project just left keeps its own title.
+    expect(await designSystemTitle(designSystemId)).toBe('Detach Keeps Title');
+  });
+
+  it('does not rename the design system a PATCH is switching away from', async () => {
+    const { designSystemId: oldId, projectId } = await createWorkspaceProject('Old Binding');
+    const { designSystemId: newId } = await createWorkspaceProject('New Binding');
+
+    // Draft design systems cannot be bound to projects; publish the target
+    // so the rebind passes validateProjectDesignSystemId.
+    const publishResp = await fetch(
+      `${baseUrl}/api/design-systems/${encodeURIComponent(newId)}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'published' }),
+      },
+    );
+    expect(publishResp.status).toBe(200);
+
+    const patchResp = await fetch(`${baseUrl}/api/projects/${projectId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Switched Name', designSystemId: newId }),
+    });
+    expect(patchResp.status).toBe(200);
+
+    // Only the post-patch binding may receive the rename.
+    expect(await designSystemTitle(oldId)).toBe('Old Binding');
+    expect(await designSystemTitle(newId)).toBe('Switched Name');
+  });
+
+  it('aborts the PATCH when the write-through fails, leaving the project row unchanged', async () => {
+    const { projectId } = await createWorkspaceProject('Broken Binding');
+
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    // ds-<dirId> project ids mirror user:<dirId> design-system ids.
+    const dirId = projectId.replace(/^ds-/, '');
+    await rm(path.join(dataDir, 'design-systems', dirId), { recursive: true, force: true });
+
+    const patchResp = await fetch(`${baseUrl}/api/projects/${projectId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Should Not Stick' }),
+    });
+    expect(patchResp.status).toBe(409);
+    const body = (await patchResp.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('CONFLICT');
+
+    // No partial update: the project row must keep its old name.
+    const detailResp = await fetch(`${baseUrl}/api/projects/${projectId}`);
+    expect(detailResp.status).toBe(200);
+    const detail = (await detailResp.json()) as { project: { name: string } };
+    expect(detail.project.name).toBe('Broken Binding');
   });
 });


### PR DESCRIPTION
## Why

Hit this while working day-to-day in a design-system project workspace: renaming the project appeared to succeed, then silently reverted the next time the Design System tab was opened.

Root cause: for projects bound to a user design system (`metadata.importedFrom === 'design-system'`), `ensureUserDesignSystemWorkspaceProject` re-stamps the project name from the design-system registry title on every workspace open. A rename applied through `PATCH /api/projects/:id` only updated the project row, so the very next ensure-sync overwrote it with the old registry title. The pain is a rename that lies to the user — it takes effect, then quietly undoes itself.

**Repro (before this fix):**
1. Create a design system from a project (Design System workspace).
2. Rename the project in the UI.
3. Open the Design System tab — the name reverts to the old design-system title.

## What users will see

Renaming a design-system workspace project now sticks. The registry title stays the master record, but a project rename is written through to it: the `PATCH /api/projects/:id` handler calls a new `propagateWorkspaceProjectRename()` (`apps/daemon/src/design-systems/index.ts`) before updating the project row, so the ensure-sync reinforces the rename instead of undoing it. The design system's metadata title and `DESIGN.md` heading follow the new name (body preserved). Non-workspace projects and built-in design systems are unaffected.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — daemon bug fix plus tests; no new endpoint, contract shape, UI surface, or CLI flag (the existing `PATCH /api/projects/:id` request/response shapes are unchanged)

## Screenshots

Not applicable — no UI change; the fix makes the existing rename flow behave as it already appears to.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/design-systems/workspace-project-rename.test.ts` (8 new tests covering the gating predicate and the write-through: metadata title + `DESIGN.md` heading updated, body preserved, blank and non-workspace inputs ignored).
- Red on `main` / green on this branch: the tests exercise `propagateWorkspaceProjectRename()`, which does not exist on `main`, so the suite cannot pass there; all 8 pass on this branch.

## Validation

- `pnpm --filter @open-design/daemon` vitest for the new file — 8/8 green
- `tsc --noEmit` clean for both `tsconfig.json` and `tsconfig.tests.json`
- Full `tests/design-systems` suite green **except** `github-import.test.ts`, which fails with `spawn EFTYPE` on native Windows on a clean tree too (verified without this change) — pre-existing environment issue, unrelated to this PR; noting it here so it isn't misattributed.
