### PR TITLE
Add Animal Island UI Skill plugin

### DIFF
--- a/plugins/community/animal-island-ui-skill-mr5p26gs/SKILL.md
+++ b/plugins/community/animal-island-ui-skill-mr5p26gs/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: animal-island-ui
+description: 使用 Animal Island UI 设计系统创建动森质感的 React/HTML 组件、页面和演示界面。
+triggers:
+  - animal island
+  - 动森组件
+  - island ui
+  - nookphone
+---
+
+# Animal Island UI Skill
+
+使用本技能时，先读取当前目录的 `DESIGN.md`、`brand.json`、`tokens.light.json`、`tokens.dark.json` 和 `system/variables.css`。
+
+## 设计姿态
+
+- 米白纸感背景、深棕文字、青绿色焦点。
+- 控件使用 2px 厚描边、大圆角和按压式底影。
+- Primary Button 使用米白面、深棕字、棕色底影；不要改成大面积实心青绿。
+- 一屏最多使用一个强装饰模块，其余保持组件可读和可操作。
+
+## 交付检查
+
+- 引用真实资产，不重画标志。
+- 保留 focus-visible 与 reduced-motion。
+- 中文文案直接、友好、轻松。
+- 如使用深色主题，标注它是本包推导主题，不是源站完整官方暗色主题。
+
+## Provenance
+
+Formalized by Open Design from candidate 8ec71912-0dd6-453d-9495-c1425358eebb.

--- a/plugins/community/animal-island-ui-skill-mr5p26gs/SKILL.md
+++ b/plugins/community/animal-island-ui-skill-mr5p26gs/SKILL.md
@@ -10,7 +10,7 @@ triggers:
 
 # Animal Island UI Skill
 
-使用本技能时，先读取当前目录的 `DESIGN.md`、`brand.json`、`tokens.light.json`、`tokens.dark.json` 和 `system/variables.css`。
+本插件只依赖随包发布的 `SKILL.md` 和 `references/` 内容。使用本技能时，先阅读本文件；如果宿主项目额外提供品牌规范、设计 token 或 CSS 变量文件，可以把它们作为补充证据读取，但不要假设它们一定存在。
 
 ## 设计姿态
 

--- a/plugins/community/animal-island-ui-skill-mr5p26gs/open-design.json
+++ b/plugins/community/animal-island-ui-skill-mr5p26gs/open-design.json
@@ -4,7 +4,7 @@
   "name": "animal-island-ui-skill-mr5p26gs",
   "title": "Animal Island UI Skill",
   "version": "0.1.0",
-  "description": "--- name: animal-island-ui description: 使用 Animal Island UI 设计系统创建动森质感的 React/HTML 组件、页面和演示界面。 triggers: - animal island - 动森组件 - island ui - nookphone ---",
+  "description": "使用 Animal Island UI 视觉规则创建动森质感的 HTML/React 页面与组件。",
   "od": {
     "kind": "skill",
     "taskKind": "new-generation",

--- a/plugins/community/animal-island-ui-skill-mr5p26gs/open-design.json
+++ b/plugins/community/animal-island-ui-skill-mr5p26gs/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "animal-island-ui-skill-mr5p26gs",
+  "title": "Animal Island UI Skill",
+  "version": "0.1.0",
+  "description": "--- name: animal-island-ui description: 使用 Animal Island UI 设计系统创建动森质感的 React/HTML 组件、页面和演示界面。 triggers: - animal island - 动森组件 - island ui - nookphone ---",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/animal-island-ui-skill-mr5p26gs/references/provenance.json
+++ b/plugins/community/animal-island-ui-skill-mr5p26gs/references/provenance.json
@@ -12,7 +12,7 @@
       "kind": "file",
       "value": "SKILL.md",
       "label": "SKILL.md",
-      "size": 959,
+      "size": 1182,
       "copied": true
     }
   ]

--- a/plugins/community/animal-island-ui-skill-mr5p26gs/references/provenance.json
+++ b/plugins/community/animal-island-ui-skill-mr5p26gs/references/provenance.json
@@ -1,0 +1,19 @@
+{
+  "candidateId": "8ec71912-0dd6-453d-9495-c1425358eebb",
+  "projectId": "brand-guokaigdg-f6133b",
+  "runId": "09103e1c-e3c5-44fb-a414-1c817ea9656e",
+  "conversationId": "60886791-ac05-4896-bc08-9103bf9a1c6b",
+  "provenance": {
+    "summary": "Detected from SKILL.md after a successful run.",
+    "detectedAt": 1783129119626
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 959,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/animal-island-ui-skill-mr5p26gs/references/source-1-SKILL.md
+++ b/plugins/community/animal-island-ui-skill-mr5p26gs/references/source-1-SKILL.md
@@ -1,0 +1,27 @@
+---
+name: animal-island-ui
+description: 使用 Animal Island UI 设计系统创建动森质感的 React/HTML 组件、页面和演示界面。
+triggers:
+  - animal island
+  - 动森组件
+  - island ui
+  - nookphone
+---
+
+# Animal Island UI Skill
+
+使用本技能时，先读取当前目录的 `DESIGN.md`、`brand.json`、`tokens.light.json`、`tokens.dark.json` 和 `system/variables.css`。
+
+## 设计姿态
+
+- 米白纸感背景、深棕文字、青绿色焦点。
+- 控件使用 2px 厚描边、大圆角和按压式底影。
+- Primary Button 使用米白面、深棕字、棕色底影；不要改成大面积实心青绿。
+- 一屏最多使用一个强装饰模块，其余保持组件可读和可操作。
+
+## 交付检查
+
+- 引用真实资产，不重画标志。
+- 保留 focus-visible 与 reduced-motion。
+- 中文文案直接、友好、轻松。
+- 如使用深色主题，标注它是本包推导主题，不是源站完整官方暗色主题。

--- a/plugins/community/animal-island-ui-skill-mr5p26gs/references/source-1-SKILL.md
+++ b/plugins/community/animal-island-ui-skill-mr5p26gs/references/source-1-SKILL.md
@@ -10,7 +10,7 @@ triggers:
 
 # Animal Island UI Skill
 
-使用本技能时，先读取当前目录的 `DESIGN.md`、`brand.json`、`tokens.light.json`、`tokens.dark.json` 和 `system/variables.css`。
+本插件只依赖随包发布的 `SKILL.md` 和 `references/` 内容。使用本技能时，先阅读本文件；如果宿主项目额外提供品牌规范、设计 token 或 CSS 变量文件，可以把它们作为补充证据读取，但不要假设它们一定存在。
 
 ## 设计姿态
 


### PR DESCRIPTION
## Why

Add a community skill generated from the Animal Island UI brand extraction so agents can create Animal Island-inspired HTML/React components, pages, and demos without depending on the original extraction project files.

## What users will see

A new `Animal Island UI Skill` community plugin with triggers for `animal island`, `动森组件`, `island ui`, and `nookphone`. The skill guides output toward warm off-white paper surfaces, deep brown text, teal focus accents, 2px outlined controls, large radii, and pressed bottom-shadow buttons.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under the community plugin/skill surface
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This PR adds a community skill plugin and does not introduce a new application UI entry point.

## Bug fix verification

Not applicable. This PR adds a new community plugin rather than fixing an application bug.

## Validation

- Parsed `open-design.json` and `references/provenance.json` successfully.
- Confirmed the packaged skill no longer names unshipped companion files such as extraction-only design/token/CSS files.
- Confirmed the plugin bundle only relies on files shipped in the plugin folder: `SKILL.md`, `open-design.json`, and `references/`.
- Re-review approved the packaging fix on head `77bdf83440bab41d8092fb559bc096108c10b85f`.
