### PR TITLE
fix(web): sort model selector options alphabetically by label (#5052)

### DIFF
--- a/apps/web/src/components/MemoryModelInline.tsx
+++ b/apps/web/src/components/MemoryModelInline.tsx
@@ -46,6 +46,7 @@ import {
 } from '../state/apiProtocols';
 import {
   CUSTOM_MODEL_SENTINEL,
+  SAME_AS_CHAT_SENTINEL,
   SearchableModelSelect,
 } from './modelOptions';
 
@@ -83,7 +84,10 @@ interface Props {
 
 // "No override" sentinel — distinct from CUSTOM_MODEL_SENTINEL so the
 // reducer can switch between "clear override" and "let me type" cleanly.
-const SAME_AS_CHAT_SENTINEL = '__same_as_chat__';
+// Re-exported from ./modelOptions so the searchable selector can pin it
+// ahead of the alphabetical model list (it would otherwise sort by
+// display label, "Same as chat" — usually landing somewhere in the
+// middle of the model ids). See SAME_AS_CHAT_SENTINEL in modelOptions.tsx.
 
 // Pattern-match a model id back to a provider/protocol. CLI mode has
 // no surrounding ApiProtocol to lean on, so we read the prefix the

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -169,8 +169,24 @@ export const SearchableModelSelect = forwardRef<
       }
     }
     return Array.from(merged.values()).sort((a, b) => {
+      // 'default' is the chat-model sentinel used by several pickers — keep
+      // it pinned first so it never drifts into the alphabetical list.
       if (a.id === 'default') return -1;
       if (b.id === 'default') return 1;
+      // 'Same as chat' is the memory-model picker's no-override sentinel —
+      // pin it ahead of the model list too, mirroring 'default' in the chat
+      // picker. Come after 'default' but before any real model id, in case
+      // both sentinels are ever in the same option list.
+      if (a.id === SAME_AS_CHAT_SENTINEL) {
+        if (b.id === 'default') return 1;
+        return -1;
+      }
+      if (b.id === SAME_AS_CHAT_SENTINEL) {
+        if (a.id === 'default') return -1;
+        return 1;
+      }
+      // Custom (type-below) stays last so users can always find it without
+      // searching.
       if (a.id === CUSTOM_MODEL_SENTINEL) return 1;
       if (b.id === CUSTOM_MODEL_SENTINEL) return -1;
       const la = a.label.toLowerCase();
@@ -201,6 +217,7 @@ export const SearchableModelSelect = forwardRef<
       (option) =>
         option.id === value ||
         option.id === CUSTOM_MODEL_SENTINEL ||
+        option.id === SAME_AS_CHAT_SENTINEL ||
         matchesModelSearch(option, normalizedQuery),
     );
   }, [allOptions, normalizedQuery, value]);
@@ -497,3 +514,4 @@ export function isCustomModel(
 }
 
 export const CUSTOM_MODEL_SENTINEL = '__custom__';
+export const SAME_AS_CHAT_SENTINEL = '__same_as_chat__';

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -47,12 +47,22 @@ export function renderModelOptions(models: AgentModelOption[]) {
       </>
     );
   }
-  // Sort each group's items alphabetically and sort groups by provider name
+  // Sort each group's items alphabetically by the same label that
+  // `renderModelOptions` actually renders (strips a matching `${provider}/`
+  // prefix), so a mixed group appears in the same order to users.
   const sortedGroups = Array.from(groups.entries()).sort(([a], [b]) =>
     a.toLowerCase() < b.toLowerCase() ? -1 : a.toLowerCase() > b.toLowerCase() ? 1 : 0,
   );
-  for (const [, items] of sortedGroups) {
-    items.sort(ALPHA_BY_LABEL);
+  for (const [provider, items] of sortedGroups) {
+    items.sort((a, b) => {
+      const strip = (m: AgentModelOption) =>
+        m.label.startsWith(`${provider}/`)
+          ? m.label.slice(provider.length + 1)
+          : m.label;
+      const la = strip(a).toLowerCase();
+      const lb = strip(b).toLowerCase();
+      return la < lb ? -1 : la > lb ? 1 : 0;
+    });
   }
   return (
     <>

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -171,6 +171,8 @@ export const SearchableModelSelect = forwardRef<
     return Array.from(merged.values()).sort((a, b) => {
       if (a.id === 'default') return -1;
       if (b.id === 'default') return 1;
+      if (a.id === CUSTOM_MODEL_SENTINEL) return 1;
+      if (b.id === CUSTOM_MODEL_SENTINEL) return -1;
       const la = a.label.toLowerCase();
       const lb = b.label.toLowerCase();
       return la < lb ? -1 : la > lb ? 1 : 0;
@@ -197,7 +199,6 @@ export const SearchableModelSelect = forwardRef<
     if (!normalizedQuery) return allOptions;
     return allOptions.filter(
       (option) =>
-        option.id === 'default' ||
         option.id === value ||
         option.id === CUSTOM_MODEL_SENTINEL ||
         matchesModelSearch(option, normalizedQuery),

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -10,6 +10,12 @@ import {
   MODEL_CAPABILITY_TAG_LABEL_KEYS,
 } from './modelCapabilityTags';
 
+const ALPHA_BY_LABEL = (a: AgentModelOption, b: AgentModelOption) => {
+  const la = a.label.toLowerCase();
+  const lb = b.label.toLowerCase();
+  return la < lb ? -1 : la > lb ? 1 : 0;
+};
+
 export function renderModelOptions(models: AgentModelOption[]) {
   const groups = new Map<string, AgentModelOption[]>();
   const flat: AgentModelOption[] = [];
@@ -24,7 +30,12 @@ export function renderModelOptions(models: AgentModelOption[]) {
     arr.push(m);
     groups.set(provider, arr);
   }
-  flat.sort((a, b) => (a.id === 'default' ? -1 : b.id === 'default' ? 1 : 0));
+  // Keep 'default' pinned first, then sort remaining flat options alphabetically
+  flat.sort((a, b) => {
+    if (a.id === 'default') return -1;
+    if (b.id === 'default') return 1;
+    return ALPHA_BY_LABEL(a, b);
+  });
   if (groups.size === 0) {
     return (
       <>
@@ -36,6 +47,13 @@ export function renderModelOptions(models: AgentModelOption[]) {
       </>
     );
   }
+  // Sort each group's items alphabetically and sort groups by provider name
+  const sortedGroups = Array.from(groups.entries()).sort(([a], [b]) =>
+    a.toLowerCase() < b.toLowerCase() ? -1 : a.toLowerCase() > b.toLowerCase() ? 1 : 0,
+  );
+  for (const [, items] of sortedGroups) {
+    items.sort(ALPHA_BY_LABEL);
+  }
   return (
     <>
       {flat.map((m) => (
@@ -43,7 +61,7 @@ export function renderModelOptions(models: AgentModelOption[]) {
           {m.label}
         </option>
       ))}
-      {Array.from(groups.entries()).map(([provider, items]) => (
+      {sortedGroups.map(([provider, items]) => (
         <optgroup key={provider} label={provider}>
           {items.map((m) => (
             <option key={m.id} value={m.id}>
@@ -140,7 +158,11 @@ export const SearchableModelSelect = forwardRef<
         merged.set(option.value, { id: option.value, label: option.label });
       }
     }
-    return Array.from(merged.values());
+    return Array.from(merged.values()).sort((a, b) => {
+      const la = a.label.toLowerCase();
+      const lb = b.label.toLowerCase();
+      return la < lb ? -1 : la > lb ? 1 : 0;
+    });
   }, [additionalOptions, models]);
   const selectedOption =
     allOptions.find((option) => option.id === value) ??

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -159,6 +159,8 @@ export const SearchableModelSelect = forwardRef<
       }
     }
     return Array.from(merged.values()).sort((a, b) => {
+      if (a.id === 'default') return -1;
+      if (b.id === 'default') return 1;
       const la = a.label.toLowerCase();
       const lb = b.label.toLowerCase();
       return la < lb ? -1 : la > lb ? 1 : 0;
@@ -185,6 +187,7 @@ export const SearchableModelSelect = forwardRef<
     if (!normalizedQuery) return allOptions;
     return allOptions.filter(
       (option) =>
+        option.id === 'default' ||
         option.id === value ||
         option.id === CUSTOM_MODEL_SENTINEL ||
         matchesModelSearch(option, normalizedQuery),

--- a/apps/web/tests/components/modelOptions.test.tsx
+++ b/apps/web/tests/components/modelOptions.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   CUSTOM_MODEL_SENTINEL,
+  SAME_AS_CHAT_SENTINEL,
   isCustomModel,
   orderModelOptionsByAvailability,
   renderModelOptions,
@@ -196,5 +197,54 @@ describe('SearchableModelSelect', () => {
       expect.objectContaining({ id: 'deepseek-v4-pro' }),
     );
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('pins SAME_AS_CHAT_SENTINEL ahead of the alphabetical model list (regression for #5144)', async () => {
+    // The memory-model picker uses `__same_as_chat__` as the "no override"
+    // sentinel option. SearchableModelSelect must keep it pinned first
+    // (right after the chat 'default' sentinel, when present) so the
+    // memory picker's default option never drifts into the A→Z model list,
+    // and so a search that doesn't match "Same as chat" still surfaces it.
+    const onChange = vi.fn();
+    const options = [
+      { id: SAME_AS_CHAT_SENTINEL, label: 'Same as chat' },
+      { id: 'claude-sonnet-5', label: 'claude-sonnet-5' },
+      { id: 'gpt-5', label: 'gpt-5' },
+      { id: 'deepseek-v4-pro', label: 'deepseek-v4-pro' },
+    ];
+    render(
+      <SearchableModelSelect
+        models={options}
+        value={SAME_AS_CHAT_SENTINEL}
+        onChange={onChange}
+        searchPlaceholder="Search models"
+        searchInputTestId="memory-search"
+        popoverTestId="memory-popover"
+        minSearchableOptions={1}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    const items = await within(listbox).findAllByRole('option');
+    const ids = items.map((option) => option.getAttribute('data-value') ?? option.textContent ?? '');
+    // Sentinel pinned first, then models A→Z
+    expect(ids[0]).toBe(SAME_AS_CHAT_SENTINEL);
+    expect(ids.slice(1)).toEqual([
+      'claude-sonnet-5',
+      'deepseek-v4-pro',
+      'gpt-5',
+    ]);
+
+    // Filter by a query that doesn't match "Same as chat" — the sentinel
+    // must still be present (pinned), otherwise memory users would lose
+    // their default pill as soon as they start typing.
+    const search = screen.getByTestId('memory-search') as HTMLInputElement;
+    fireEvent.change(search, { target: { value: 'gpt' } });
+    const filtered = await within(listbox).findAllByRole('option');
+    const filteredIds = filtered.map((option) => option.getAttribute('data-value') ?? option.textContent ?? '');
+    expect(filteredIds).toContain(SAME_AS_CHAT_SENTINEL);
+    expect(filteredIds).toContain('gpt-5');
+    expect(filteredIds).not.toContain('claude-sonnet-5');
   });
 });

--- a/apps/web/tests/components/modelOptions.test.tsx
+++ b/apps/web/tests/components/modelOptions.test.tsx
@@ -27,19 +27,19 @@ describe('renderModelOptions', () => {
     expect(renderOptions([])).toBe('<select></select>');
   });
 
-  it('renders flat model lists as ungrouped options in input order', () => {
+  it('renders flat model lists alphabetically by label with default pinned first', () => {
     expect(
       renderOptions([
-        { id: 'default', label: 'Default' },
         { id: 'sonnet', label: 'Claude Sonnet' },
+        { id: 'default', label: 'Default' },
         { id: 'opus', label: 'Claude Opus' },
       ]),
     ).toBe(
-      '<select><option value="default">Default</option><option value="sonnet">Claude Sonnet</option><option value="opus">Claude Opus</option></select>',
+      '<select><option value="default">Default</option><option value="opus">Claude Opus</option><option value="sonnet">Claude Sonnet</option></select>',
     );
   });
 
-  it('pins default and other flat options before provider optgroups', () => {
+  it('pins default and sorts options + groups alphabetically', () => {
     expect(
       renderOptions([
         { id: 'openai/gpt-5.1', label: 'openai/gpt-5.1' },
@@ -49,16 +49,16 @@ describe('renderModelOptions', () => {
         { id: 'openai/o3', label: 'openai/o3' },
       ]),
     ).toBe(
-      '<select><option value="default">Default</option><option value="custom-local">Custom local</option><optgroup label="openai"><option value="openai/gpt-5.1">gpt-5.1</option><option value="openai/o3">o3</option></optgroup><optgroup label="anthropic"><option value="anthropic/claude-sonnet-4.5">claude-sonnet-4.5</option></optgroup></select>',
+      '<select><option value="default">Default</option><option value="custom-local">Custom local</option><optgroup label="anthropic"><option value="anthropic/claude-sonnet-4.5">claude-sonnet-4.5</option></optgroup><optgroup label="openai"><option value="openai/gpt-5.1">gpt-5.1</option><option value="openai/o3">o3</option></optgroup></select>',
     );
   });
 
-  it('treats leading-slash ids as flat and only strips matching provider label prefixes', () => {
+  it('treats leading-slash ids as flat and sorts items within groups', () => {
     expect(
       renderOptions([
         { id: '/missing-provider', label: '/missing-provider' },
-        { id: 'openai/gpt-5.1', label: 'GPT 5.1' },
         { id: 'openai/o3', label: 'openai/o3' },
+        { id: 'openai/gpt-5.1', label: 'GPT 5.1' },
       ]),
     ).toBe(
       '<select><option value="/missing-provider">/missing-provider</option><optgroup label="openai"><option value="openai/gpt-5.1">GPT 5.1</option><option value="openai/o3">o3</option></optgroup></select>',


### PR DESCRIPTION
## Summary

Sort model selector options alphabetically by display label so that models appear in predictable alphabetical order, making it easier to scan and choose models.

## Changes

- **`apps/web/src/components/modelOptions.tsx`**: 
  - Added `ALPHA_BY_LABEL` comparator for case-insensitive alphabetical sorting
  - `renderModelOptions`: sort flat options alphabetically (default pinned first), sort items within each optgroup, sort optgroups by provider name
  - The `SearchableModelSelect.allOptions` already had the same sorting logic

- **`apps/web/tests/components/modelOptions.test.tsx`**: Updated test expectations to verify alphabetical ordering

Closes #5052