### PR TITLE
fix(daemon): drop shell:true from host-tool launch (Windows command injection)

### DIFF
--- a/apps/daemon/src/routes/host-tools.ts
+++ b/apps/daemon/src/routes/host-tools.ts
@@ -16,6 +16,7 @@
 import { spawn } from 'node:child_process';
 import { access, constants as fsConstants } from 'node:fs/promises';
 import path from 'node:path';
+import { createCommandInvocation } from '@open-design/platform';
 import type { Express } from 'express';
 import type {
   HostEditor,
@@ -234,10 +235,20 @@ export function launchHostTool(
   return new Promise((resolve) => {
     // Detached so the daemon doesn't keep the child alive; same shape paseo
     // uses (CLI shim, `open -a`, Explorer, xdg-open, etc.).
-    const child = spawn(command, args, {
+    //
+    // Do NOT pass `shell: true`. On Windows that runs the launch through cmd.exe,
+    // which shell-interprets the args — and one of them is the (project-derived)
+    // directory path, so a path containing `&`, `|`, `^`, `>` etc. would inject
+    // commands. `command` is already a resolved absolute path (incl. .exe/.cmd),
+    // so route it through `createCommandInvocation`, which runs a .cmd/.bat via
+    // cmd.exe with CommandLineToArgvW-safe verbatim args and everything else
+    // directly — no shell, no metacharacter interpretation.
+    const invocation = createCommandInvocation({ command, args });
+    const child = spawn(invocation.command, invocation.args, {
       detached: true,
       stdio: 'ignore',
-      shell: process.platform === 'win32',
+      windowsHide: process.platform === 'win32',
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
     });
     let settled = false;
     child.once('spawn', () => {

--- a/apps/daemon/tests/host-tools-launch-shell.test.ts
+++ b/apps/daemon/tests/host-tools-launch-shell.test.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Capture spawn options without launching anything. The child emits `spawn` on
+// the next tick so launchHostTool resolves { ok: true }.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & { unref: () => void };
+      child.unref = () => {};
+      setImmediate(() => child.emit('spawn'));
+      return child;
+    }),
+  };
+});
+
+import { spawn } from 'node:child_process';
+import { launchHostTool } from '../src/routes/host-tools.js';
+
+const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
+
+// Regression: launchHostTool used `spawn(command, args, { shell: process.platform === 'win32' })`.
+// On Windows that runs the launch through cmd.exe, which shell-interprets the
+// args — one of which is the (project-derived) directory path — so a path with
+// cmd metacharacters (`&`, `|`, `^`, `>`) could inject commands. The fix routes
+// through `createCommandInvocation` (no shell; .cmd/.bat via cmd.exe with
+// verbatim, CommandLineToArgvW-safe args).
+describe('launchHostTool does not launch through a shell', () => {
+  const origPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+    vi.clearAllMocks();
+  });
+
+  it('never passes shell:true for a Windows .cmd editor (no command injection via the dir arg)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const result = await launchHostTool('C:\\tools\\code.cmd', ['C:\\Users\\me\\proj & calc.exe']);
+    expect(result).toEqual({ ok: true });
+
+    const opts = spawnMock.mock.calls[0]?.[2] ?? {};
+    // The vulnerable version set `shell: true` here.
+    expect(opts.shell).not.toBe(true);
+    // Routed through createCommandInvocation: a .cmd runs via cmd.exe with
+    // verbatim args (Node must not re-quote them), never a raw shell line.
+    expect(opts.windowsVerbatimArguments).toBe(true);
+  });
+
+  it('spawns a non-Windows launch without a shell and passes the dir as a literal arg', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    const dir = '/home/me/proj & rm -rf ~';
+    const result = await launchHostTool('/usr/bin/code', [dir]);
+    expect(result).toEqual({ ok: true });
+
+    const [, args, opts] = spawnMock.mock.calls[0]!;
+    expect(opts.shell).toBeFalsy();
+    // No shell → the metacharacter-laden path is one argv element, inert.
+    expect(args).toContain(dir);
+  });
+});


### PR DESCRIPTION
## Why

`launchHostTool` (the "open project in editor" host-tools route) spawns the chosen editor with `spawn(command, args, { shell: process.platform === 'win32' })`. On Windows, `shell: true` runs the launch through cmd.exe, which shell-interprets the args — and one of them is the project-derived directory path (`argsForDir(resolvedDir)`, the folder the user asked to open). A path containing cmd metacharacters (`&`, `|`, `^`, `>`) would inject commands into the launch. `command` is already a resolved absolute path (`.exe`/`.cmd`), so the shell was only there to run `.cmd` shims — which can be done safely without it.

## What users will see

Nothing changes: editors launch exactly as before on macOS, Linux, and Windows (including `.cmd`-based CLIs like VS Code's `code.cmd`). Only the shell interpretation of the launch arguments is removed.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal daemon hardening. Drops the shell from an existing spawn; launch behavior is preserved on all platforms.

## Bug fix verification

- **Bug:** `spawn(command, args, { shell: process.platform === 'win32' })` — on Windows the args (including the directory path) are shell-interpreted, allowing command injection via metacharacters in the path.
- **Fix:** route through `createCommandInvocation` (`@open-design/platform`) and drop `shell`. It runs a `.cmd`/`.bat` via `cmd.exe` with CommandLineToArgvW-safe verbatim args (`windowsVerbatimArguments`) and everything else directly — no shell, no metacharacter interpretation. This is the same helper the daemon's other spawns already use.
- **Test:** `apps/daemon/tests/host-tools-launch-shell.test.ts` fakes `process.platform` and mocks `spawn`; on Windows it asserts the launch never passes `shell: true` (the old vector) and goes through the verbatim-args path, and on non-Windows that no shell is used and a metacharacter-laden dir stays a literal argv element. Red on the old code, green with the fix.

## Validation

- `pnpm --filter @open-design/daemon test` — new `host-tools-launch-shell.test.ts` 2/2; `host-tools-routes` + `host-tools-open-in-route` 12/12.
- daemon `tsc --noEmit` for both `tsconfig.json` and `tsconfig.tests.json`.
