### PR TITLE
fix: finalize BYOK runs as failed when only raw tool_call markup is returned (OpenAI-compatible protocol)

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4673,7 +4673,7 @@ export function ProjectView({
             },
           }));
         },
-        onDone: (fullText = '') => {
+        onDone: async (fullText = '') => {
           // The daemon delivers onDone even for a canceled run, so a run
           // superseded by a "send now" interrupt can still land here and must
           // not apply its completion side effects over the replacement. A run
@@ -4712,13 +4712,19 @@ export function ProjectView({
             !normalizedFullText &&
             !normalizedStreamedText &&
             !normalizedLiveHtml;
-          const rawToolCallOnly =
+          const looksLikeRawToolCallOnly =
             config.mode === 'api' &&
             !parsedArtifact &&
             !normalizedLiveHtml &&
             /^\s*<tool_call>[\s\S]*<\/tool_call>\s*$/i.test(
               normalizedFullText || normalizedStreamedText,
             );
+          let rawToolCallOnly = false;
+          if (looksLikeRawToolCallOnly && !emptyApiResponse) {
+            const filesAfterToolCallCheck = await refreshProjectFiles();
+            const producedSoFar = computeProducedFiles(beforeFileNames, filesAfterToolCallCheck) ?? [];
+            rawToolCallOnly = producedSoFar.length === 0;
+          }
           if (emptyApiResponse || rawToolCallOnly) {
             const endedAt = Date.now();
             const diagnostic = t('assistant.emptyResponseMessage');

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4704,12 +4704,22 @@ export function ProjectView({
               setArtifact((prev) => (prev ? { ...prev, html: ev.fullContent } : null));
             }
           }
+          const normalizedFullText = fullText.trim();
+          const normalizedStreamedText = streamedText.trim();
+          const normalizedLiveHtml = liveHtml.trim();
           const emptyApiResponse =
             config.mode === 'api' &&
-            !fullText.trim() &&
-            !streamedText.trim() &&
-            !liveHtml.trim();
-          if (emptyApiResponse) {
+            !normalizedFullText &&
+            !normalizedStreamedText &&
+            !normalizedLiveHtml;
+          const rawToolCallOnly =
+            config.mode === 'api' &&
+            !parsedArtifact &&
+            !normalizedLiveHtml &&
+            /^\s*<tool_call>[\s\S]*<\/tool_call>\s*$/i.test(
+              normalizedFullText || normalizedStreamedText,
+            );
+          if (emptyApiResponse || rawToolCallOnly) {
             const endedAt = Date.now();
             const diagnostic = t('assistant.emptyResponseMessage');
             updateMessageById(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4673,7 +4673,7 @@ export function ProjectView({
             },
           }));
         },
-        onDone: async (fullText = '') => {
+        onDone: (fullText = '') => {
           // The daemon delivers onDone even for a canceled run, so a run
           // superseded by a "send now" interrupt can still land here and must
           // not apply its completion side effects over the replacement. A run
@@ -4681,9 +4681,8 @@ export function ProjectView({
           // (recorded before handleStop cleared the refs), which is reliable
           // even before the replacement send attaches — unlike abortRef, whose
           // terminal onRunStatus / handleStop churn make it ambiguous here.
-          const runMayFinalize =
-            !supersededRunsRef.current.has(controller);
-          if (!runMayFinalize) {
+          const runMayFinalize = () => !supersededRunsRef.current.has(controller);
+          if (!runMayFinalize()) {
             textBuffer.cancel();
             cancelSendTextBuffer();
             clearTraceTouchedFilePaths();
@@ -4719,13 +4718,12 @@ export function ProjectView({
             /^\s*<tool_call>[\s\S]*<\/tool_call>\s*$/i.test(
               normalizedFullText || normalizedStreamedText,
             );
-          let rawToolCallOnly = false;
-          if (looksLikeRawToolCallOnly && !emptyApiResponse) {
-            const filesAfterToolCallCheck = await refreshProjectFiles();
-            const producedSoFar = computeProducedFiles(beforeFileNames, filesAfterToolCallCheck) ?? [];
-            rawToolCallOnly = producedSoFar.length === 0;
-          }
-          if (emptyApiResponse || rawToolCallOnly) {
+
+          const finalizeAsFailed = () => {
+            if (!runMayFinalize()) {
+              clearTraceTouchedFilePaths();
+              return;
+            }
             const endedAt = Date.now();
             const diagnostic = t('assistant.emptyResponseMessage');
             updateMessageById(
@@ -4755,81 +4753,115 @@ export function ProjectView({
             void refreshProjectFiles();
             onProjectsRefresh();
             clearTraceTouchedFilePaths();
+          };
+
+          const finalizeAsSucceededAndPersist = () => {
+            if (!runMayFinalize()) {
+              clearTraceTouchedFilePaths();
+              return;
+            }
+            const endedAt = Date.now();
+            let finalRunStatus: ChatMessage['runStatus'] = 'succeeded';
+            updateAssistant((prev) => {
+              finalRunStatus = resolveSucceededRunStatus(prev.runStatus);
+              return {
+                ...prev,
+                endedAt,
+                runStatus: finalRunStatus,
+              };
+            });
+            if (runCommentAttachments.length > 0) {
+              void patchAttachedStatuses(runCommentAttachments, 'needs_review');
+            }
+            const ownsCurrentRun = clearCurrentRunStreamingMarker(
+              runConversationId,
+              controller,
+              cancelController,
+            );
+            if (ownsCurrentRun) updateConversationLatestRun(finalRunStatus ?? 'succeeded', endedAt);
+            // Refetch the file list directly (rather than just bumping the
+            // refresh signal) so we can diff against the pre-turn snapshot
+            // and attach the new files to the assistant message as download
+            // chips.
+            void (async () => {
+              try {
+                let nextFiles = await refreshProjectFiles();
+                const finalText = streamedText || fullText;
+                const artifactToPersist = parsedArtifact?.html
+                  ? parsedArtifact
+                  : artifactFromStandaloneHtml(finalText);
+                if (artifactToPersist?.html) {
+                  const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+                  const sameTurnHtmlWrite = await findSameTurnHtmlWriteForRecoveredArtifact({
+                    artifactHtml: resolvePersistedArtifactHtml({
+                      artifactHtml: artifactToPersist.html,
+                      identifier: artifactToPersist.identifier,
+                      sourceText: finalText,
+                    }),
+                    producedFiles: producedBeforeFallback,
+                    readProjectHtml,
+                  });
+                  if (sameTurnHtmlWrite) {
+                    savedArtifactRef.current = sameTurnHtmlWrite.name;
+                    requestOpenFile(sameTurnHtmlWrite.name);
+                  } else {
+                    await persistArtifact(artifactToPersist, nextFiles, finalText);
+                    nextFiles = await refreshProjectFiles();
+                  }
+                }
+                const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+                const traceObjectFiles = computeTraceObjectFiles(
+                  beforeFileNames,
+                  nextFiles,
+                  traceTouchedFilePaths,
+                ) ?? [];
+                const producedArtifactToOpen = selectAutoOpenProducedArtifact(produced);
+                if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
+                setMessages((curr) => {
+                  const updated = curr.map((m) =>
+                    m.id === assistantId
+                      ? { ...m, producedFiles: produced, traceObjectFiles }
+                      : m,
+                  );
+                  const finalized = updated.find((m) => m.id === assistantId);
+                  if (finalized) persistMessage(finalized, { telemetryFinalized: true });
+                  return updated;
+                });
+                await auditDesignSystemWorkspaceAfterRun(assistantId);
+              } finally {
+                clearTraceTouchedFilePaths();
+              }
+            })();
+            onProjectsRefresh();
+          };
+
+          if (emptyApiResponse) {
+            finalizeAsFailed();
             return;
           }
-          const endedAt = Date.now();
-          let finalRunStatus: ChatMessage['runStatus'] = 'succeeded';
-          updateAssistant((prev) => {
-            finalRunStatus = resolveSucceededRunStatus(prev.runStatus);
-            return {
-              ...prev,
-              endedAt,
-              runStatus: finalRunStatus,
-            };
-          });
-          if (runCommentAttachments.length > 0) {
-            void patchAttachedStatuses(runCommentAttachments, 'needs_review');
-          }
-          const ownsCurrentRun = clearCurrentRunStreamingMarker(
-            runConversationId,
-            controller,
-            cancelController,
-          );
-          if (ownsCurrentRun) updateConversationLatestRun(finalRunStatus ?? 'succeeded', endedAt);
-          // Refetch the file list directly (rather than just bumping the
-          // refresh signal) so we can diff against the pre-turn snapshot
-          // and attach the new files to the assistant message as download
-          // chips.
-          void (async () => {
-            try {
-              let nextFiles = await refreshProjectFiles();
-              const finalText = streamedText || fullText;
-              const artifactToPersist = parsedArtifact?.html
-                ? parsedArtifact
-                : artifactFromStandaloneHtml(finalText);
-              if (artifactToPersist?.html) {
-                const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
-                const sameTurnHtmlWrite = await findSameTurnHtmlWriteForRecoveredArtifact({
-                  artifactHtml: resolvePersistedArtifactHtml({
-                    artifactHtml: artifactToPersist.html,
-                    identifier: artifactToPersist.identifier,
-                    sourceText: finalText,
-                  }),
-                  producedFiles: producedBeforeFallback,
-                  readProjectHtml,
-                });
-                if (sameTurnHtmlWrite) {
-                  savedArtifactRef.current = sameTurnHtmlWrite.name;
-                  requestOpenFile(sameTurnHtmlWrite.name);
-                } else {
-                  await persistArtifact(artifactToPersist, nextFiles, finalText);
-                  nextFiles = await refreshProjectFiles();
+
+          if (looksLikeRawToolCallOnly) {
+            void (async () => {
+              try {
+                const filesAfterToolCallCheck = await refreshProjectFiles();
+                if (!runMayFinalize()) {
+                  clearTraceTouchedFilePaths();
+                  return;
                 }
+                const producedSoFar = computeProducedFiles(beforeFileNames, filesAfterToolCallCheck) ?? [];
+                if (producedSoFar.length === 0) {
+                  finalizeAsFailed();
+                } else {
+                  finalizeAsSucceededAndPersist();
+                }
+              } catch {
+                finalizeAsFailed();
               }
-              const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
-              const traceObjectFiles = computeTraceObjectFiles(
-                beforeFileNames,
-                nextFiles,
-                traceTouchedFilePaths,
-              ) ?? [];
-              const producedArtifactToOpen = selectAutoOpenProducedArtifact(produced);
-              if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
-              setMessages((curr) => {
-                const updated = curr.map((m) =>
-                  m.id === assistantId
-                    ? { ...m, producedFiles: produced, traceObjectFiles }
-                    : m,
-                );
-                const finalized = updated.find((m) => m.id === assistantId);
-                if (finalized) persistMessage(finalized, { telemetryFinalized: true });
-                return updated;
-              });
-              await auditDesignSystemWorkspaceAfterRun(assistantId);
-            } finally {
-              clearTraceTouchedFilePaths();
-            }
-          })();
-          onProjectsRefresh();
+            })();
+            return;
+          }
+
+          finalizeAsSucceededAndPersist();
         },
         onError: (err: Error) => {
           const endedAt = Date.now();

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -562,6 +562,24 @@ describe('ProjectView API empty response handling', () => {
     expect(screen.queryByText('empty_response:deepseek-chat')).toBeNull();
   });
 
+  it('fails API completions that only emit raw tool_call markup', async () => {
+    const rawToolCall = '<tool_call>do-something</tool_call>';
+    mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
+      const { handlers } = options;
+      handlers.onDelta(rawToolCall);
+      handlers.onDone(rawToolCall);
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(hasSavedAssistantMessage((message) => message.runStatus === 'failed')).toBe(true);
+    });
+    expect(hasSavedAssistantMessage((message) => message.runStatus === 'succeeded')).toBe(false);
+    expect(mockedWriteProjectTextFile).not.toHaveBeenCalled();
+  });
+
   it('opens the real HTML page instead of saving a pointer artifact as the preview entry', async () => {
     const realPage = {
       name: 'worker-edition-v2.html',

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -580,6 +580,29 @@ describe('ProjectView API empty response handling', () => {
     expect(mockedWriteProjectTextFile).not.toHaveBeenCalled();
   });
 
+  it('fails a tool-call-only run when project file refresh rejects', async () => {
+    mockedFetchProjectFiles.mockReset();
+    mockedFetchProjectFiles.mockResolvedValueOnce([]);
+    mockedFetchProjectFiles.mockRejectedValueOnce(new Error('refresh failed'));
+    mockedFetchProjectFiles.mockResolvedValue([]);
+
+    const rawToolCall = '<tool_call>do-something</tool_call>';
+    mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
+      const { handlers } = options;
+      handlers.onDelta(rawToolCall);
+      handlers.onDone(rawToolCall);
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(hasSavedAssistantMessage((message) => message.runStatus === 'failed')).toBe(true);
+    });
+    expect(hasSavedAssistantMessage((message) => message.runStatus === 'succeeded')).toBe(false);
+    expect(mockedWriteProjectTextFile).not.toHaveBeenCalled();
+  });
+
   it('keeps a run succeeded when tool-call-only text accompanies a newly produced file', async () => {
     const producedFile = {
       name: 'landing-page.html',
@@ -597,7 +620,7 @@ describe('ProjectView API empty response handling', () => {
     mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
       const { handlers } = options;
       handlers.onDelta(rawToolCall);
-      await handlers.onDone(rawToolCall);
+      handlers.onDone(rawToolCall);
     });
     renderProjectView();
 

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -580,6 +580,35 @@ describe('ProjectView API empty response handling', () => {
     expect(mockedWriteProjectTextFile).not.toHaveBeenCalled();
   });
 
+  it('keeps a run succeeded when tool-call-only text accompanies a newly produced file', async () => {
+    const producedFile = {
+      name: 'landing-page.html',
+      path: 'landing-page.html',
+      kind: 'html',
+      mime: 'text/html',
+      size: 2048,
+      mtime: 2,
+    };
+    mockedFetchProjectFiles
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([producedFile] as never);
+
+    const rawToolCall = '<tool_call>do-something</tool_call>';
+    mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
+      const { handlers } = options;
+      handlers.onDelta(rawToolCall);
+      await handlers.onDone(rawToolCall);
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(hasSavedAssistantMessage((message) => message.runStatus === 'succeeded')).toBe(true);
+    });
+    expect(hasSavedAssistantMessage((message) => message.runStatus === 'failed')).toBe(false);
+  });
+
   it('opens the real HTML page instead of saving a pointer artifact as the preview entry', async () => {
     const realPage = {
       name: 'worker-edition-v2.html',


### PR DESCRIPTION

---

## Summary

Adds a narrow guard to `ProjectView`'s `onDone` handler so that a BYOK/API completion consisting entirely of unresolved `<tool_call>...</tool_call>` markup — with no artifact and no file handoff — finalizes as `failed` (reusing the existing `empty_response` status/event shape) instead of `succeeded`.

Reuses the existing `apps/web/tests/components/ProjectView.api-empty-response.test.tsx` file and `mockedStreamViaDaemon` pattern, per @lefarcen's suggestion in #5114.

## Surface area

- [x] **Default behavior change** — changes what existing users experience without opting in (a run that previously silently finalized as succeeded with no output now correctly finalizes as failed)

## Screenshots

None — no UI surface changed.

## What this fixes (and what it doesn't)

This closes **one specific, confirmed gap**: today, the empty-response guard only fires when the stream ends with *zero* text and *zero* HTML. A response that is text-only and consists solely of a `<tool_call>` block slips through and finalizes as `succeeded`, matching the "text/plaintext returned but no artifact" failure mode described in #5114 and #4880.

I do **not** have a captured frame sequence from a real MiniMax/MiMo BYOK run, so I can't confirm this is the exact shape their endpoint emits when the bug reproduces — I built the regression test around the `<tool_call>` example @lefarcen suggested as a valid red-spec input. If the real leakage shape turns out to be different (e.g. a fenced code block with no wrapper tags, or plain unwrapped HTML), this guard won't catch it yet, and I'd want to extend it once we have real data.

@wellfitness — if you're able to capture one actual response body from a failing MiniMax/MiMo BYOK run, that would let us confirm (or extend) this fix against the real repro rather than the synthetic case here.

## Changes

- `src/components/ProjectView.tsx`: adds a `rawToolCallOnly` / `looksLikeRawToolCallOnly` check alongside the existing `emptyApiResponse` guard. Only fires when:
  - no artifact was parsed from the stream, and
  - no live HTML preview content exists, and
  - the entire trimmed response is a single anchored `<tool_call>...</tool_call>` block (not partial matches within otherwise-normal prose).
- `tests/components/ProjectView.api-empty-response.test.tsx`: adds regression tests (see Testing below).

Following three rounds of review from @nettee, the implementation went through further correctness fixes, each closed with its own regression test:

1. **Missing produced-file check.** The original guard decided failure from text/HTML shape alone, without checking whether a file had actually been written — so a run that wrote a real file but left tool-call markup as trailing text would have been wrongly marked failed. Fixed by awaiting `refreshProjectFiles()` + `computeProducedFiles()` before failing, so a run that produced a file still succeeds.
2. **Async `onDone` broke the stream-handler contract.** `StreamHandlers.onDone` is typed `void`, and every real provider (`daemon.ts`, `api-proxy.ts`, `anthropic.ts`) calls it fire-and-forget without `await`. Making `onDone` itself `async` meant a `refreshProjectFiles()` rejection would surface as an unhandled rejection with no terminal `runStatus` ever set. Fixed by keeping `onDone` synchronous and isolating the async produced-file check in its own IIFE with try/catch, extracted as `finalizeAsFailed()` / `finalizeAsSucceededAndPersist()` closures.
3. **Supersession and rejection-path hardening.** A follow-up commit meant to address (2) reintroduced the same async-`onDone` pattern while fixing an unrelated issue. Corrected again, and hardened further: both finalize closures now re-check the run-supersession guard (`supersededRunsRef`) before committing side effects, since a run can be superseded by a "send now" interrupt while the async file check is in flight.

## Bug fix verification

**Test path that reproduces the bug:** `apps/web/tests/components/ProjectView.api-empty-response.test.tsx` → `'fails API completions that only emit raw tool_call markup'`

**Did the test go red on `main` and green on this branch?** Yes — confirmed red before the fix (finalized as `succeeded` with the tool-call markup rendered as message content), green after.

## Testing

- New test passes; confirmed red before the fix (finalized as `succeeded` with the tool-call markup rendered as message content).
- Full existing suite in this file (17 tests) passes, including the neighboring "plain text, no artifact → succeeded" and "artifact tag, empty onDone text → succeeded" cases — this change does not affect either of those paths.
- Additional regression tests added across the review rounds:
  - `'keeps a run succeeded when tool-call-only text accompanies a newly produced file'`
  - `'fails a tool-call-only run when project file refresh rejects'` — forces `refreshProjectFiles()` to reject and confirms the run still finalizes as `failed` rather than being left non-terminal.
- `pnpm typecheck` — clean, all workspace packages pass with 0 errors.
- `pnpm guard` — clean aside from pre-existing `design-systems/*` manifest staleness warnings, confirmed unrelated to this change.
- Ran the full `apps/web` test suite; previously saw 5 pre-existing failures in `tests/styles/*`, unrelated to this change (confirmed failing identically on `main` without this diff applied) — worth re-confirming this still holds before merge.

Fixes #5114 (partially — see scope note above).