### PR TITLE
fix(web): move conversation count next to conversations header (#3848)

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2081,12 +2081,12 @@ export function ChatPane({
               <div className="chat-history-menu-head">
                 <span className="chat-history-menu-title">
                   {t('chat.conversationsHeading')}
-                </span>
-                <span className="chat-history-menu-count">
-                  <span data-testid="conversation-history-count">
-                  {filteredConversations.length === conversations.length
-                    ? compactCount(conversations.length)
-                    : `${compactCount(filteredConversations.length)} / ${compactCount(conversations.length)}`}
+                  <span className="chat-history-menu-count">
+                    <span data-testid="conversation-history-count">
+                    {filteredConversations.length === conversations.length
+                      ? compactCount(conversations.length)
+                      : `${compactCount(filteredConversations.length)} / ${compactCount(conversations.length)}`}
+                    </span>
                   </span>
                 </span>
                 {onNewConversation ? (

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -2432,6 +2432,10 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   font-size: 10.5px;
   font-weight: 500;
   line-height: 1;
+  margin-left: 6px;
+}
+.chat-history-menu-head .chat-history-new {
+  margin-left: auto;
 }
 .chat-history-search {
   display: flex;


### PR DESCRIPTION
## Summary

Move the conversation count from a centered position between the header title and the '+ New' button, to immediately after the title so it reads as a natural label.

### Before
`CONVERSATIONS` &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `6` &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `+ New`

### After
`CONVERSATIONS 6` &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `+ New`

## Changes

- **ChatPane.tsx**: Nest `chat-history-menu-count` inside `chat-history-menu-title` so the count appears as a suffix to the title text
- **composio.css**: Add `margin-left: 6px` to the count span for spacing, and `margin-left: auto` on the '+ New' button to push it to the right end of the flex container