### PR TITLE
fix(daemon): classify structured Vela ACP auth-required details as AMR_AUTH_REQUIRED

### DIFF
--- a/apps/daemon/src/integrations/vela-errors.ts
+++ b/apps/daemon/src/integrations/vela-errors.ts
@@ -99,6 +99,14 @@ export function classifyAmrAccountFailureDetails(details: unknown): AmrAccountFa
     };
   }
 
+  if (code === 'auth_required' || accountAction === 'relogin') {
+    return {
+      code: 'AMR_AUTH_REQUIRED',
+      message: AMR_AUTH_REQUIRED_MESSAGE,
+      action: 'relogin',
+    };
+  }
+
   return null;
 }
 

--- a/apps/daemon/tests/integrations/vela-errors.test.ts
+++ b/apps/daemon/tests/integrations/vela-errors.test.ts
@@ -82,6 +82,51 @@ describe('AMR account failure classification', () => {
     expect(failure?.message).toContain('request type');
   });
 
+  it('classifies structured Vela ACP auth-required details without relying on message text', () => {
+    const failure = classifyAmrAccountFailureDetails({
+      kind: 'opencode_prompt_error',
+      runtime: 'opencode',
+      phase: 'event_stream',
+      code: 'auth_required',
+      accountAction: 'relogin',
+      openCodeSessionId: 'ses_test',
+    });
+
+    expect(failure).toMatchObject({
+      code: 'AMR_AUTH_REQUIRED',
+      action: 'relogin',
+    });
+  });
+
+  it('classifies structured Vela ACP relogin actions even when code is absent', () => {
+    const failure = classifyAmrAccountFailureDetails({
+      kind: 'opencode_prompt_error',
+      accountAction: 'relogin',
+    });
+
+    expect(failure).toMatchObject({
+      code: 'AMR_AUTH_REQUIRED',
+      action: 'relogin',
+    });
+  });
+
+  it('classifies structured auth-required details through the signal path when the protocol message is generic', () => {
+    const failure = classifyAmrAccountFailureSignal({
+      details: {
+        kind: 'opencode_prompt_error',
+        code: 'auth_required',
+        accountAction: 'relogin',
+      },
+      message: 'json-rpc id 3: Internal error',
+      stderrTail: '',
+    });
+
+    expect(failure).toMatchObject({
+      code: 'AMR_AUTH_REQUIRED',
+      action: 'relogin',
+    });
+  });
+
   it('does not classify unrelated structured ACP details as AMR balance errors', () => {
     expect(classifyAmrAccountFailureDetails({
       kind: 'opencode_prompt_error',


### PR DESCRIPTION
## Why

While reviewing the structured AMR account-failure path that #5053 landed yesterday, I hit the symmetric gap on the auth side: `classifyAmrAccountFailureDetails` maps `insufficient_balance` / `accountAction: 'recharge'` to the rechargeable-balance card, but has no branch for `auth_required` / `accountAction: 'relogin'`.

When vela reports an authentication failure through ACP structured details while the protocol `message` is generic (e.g. `json-rpc id 3: Internal error`), the structured classifier returns `null` and the text matchers never see `details.code` — so the run falls into the opaque `AGENT_EXECUTION_FAILED` bucket instead of `AMR_AUTH_REQUIRED`.

This is the same pain #5053 addressed for balance errors, applied to the other value of the `accountAction` union: users get a dead-end generic failure card when the daemon already knows the fix is "sign in to AMR again". It also advances #982 (surface structured errors instead of generic failures) for the AMR auth case.

## What users will see

When an AMR run fails because the session needs re-authentication (structured ACP details, generic protocol message), the chat now shows the **AMR sign-in required** error card with the re-login action — instead of a generic "agent execution failed" card with no affordance toward the fix.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

(No new UI, endpoint, or contract shape: the fix routes an existing failure into the existing `AMR_AUTH_REQUIRED` card.)

## Bug fix verification

- Test path: `apps/daemon/tests/integrations/vela-errors.test.ts` — three new cases mirroring the structured insufficient-balance cases: structured `auth_required` details, `accountAction: 'relogin'` with `code` absent, and the signal path with a generic protocol message.
- Red on `main`, green on this branch: **yes** (all three returned `null` on `main`; 18/18 pass after the fix).

## Validation

- `pnpm guard` — green
- `pnpm typecheck` — green
- `pnpm --filter @open-design/daemon exec vitest run tests/integrations/vela-errors.test.ts` — 18/18 (15 existing + 3 new)
- `pnpm --filter @open-design/daemon test` — no new failures vs the `main` baseline: 28 pre-existing failures (proxy/connection/media/mocks-golden, environment-dependent) reproduce identically on a stashed clean `main`; one additional `project-watchers` chokidar timing case flaked in the full run and passes 3/3 in isolation on this branch.
