### PR TITLE
fix(daemon): surface Claude is_error result terminations instead of classifying the run as succeeded

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1821,7 +1821,15 @@ function attachAgentStreamHandlers(
   child.stdout?.setEncoding('utf8');
   child.stderr?.setEncoding('utf8');
   if (def.streamFormat === 'claude-stream-json') {
-    const claude = createClaudeStreamHandler((ev: unknown) => send('agent', ev));
+    const claude = createClaudeStreamHandler((ev: unknown) => {
+      const data = (ev ?? {}) as { type?: unknown; terminal?: unknown };
+      // Terminal result-frame errors are already classified by this sink's own
+      // result-frame parse (#4501) with the accurate `output_parse` phase;
+      // forwarding the parser's error event would race it into the generic
+      // spawn-phase stream-error path first.
+      if (data.type === 'error' && data.terminal === true) return;
+      send('agent', ev);
+    });
     child.stdout?.on('data', (chunk: string) => {
       appendRawStdout?.(chunk);
       claude.feed(chunk);

--- a/apps/daemon/src/runtimes/chat-run-lifecycle.ts
+++ b/apps/daemon/src/runtimes/chat-run-lifecycle.ts
@@ -92,14 +92,24 @@ export function applyClaudeStreamJsonRunBookkeeping(
     name?: unknown;
     id?: unknown;
     stopReason?: unknown;
+    isError?: unknown;
   };
 
-  const cleanTerminalTurn =
+  const terminalTurn =
     (event.type === 'turn_end' && event.stopReason !== 'tool_use') ||
     (event.type === 'usage' && event.stopReason !== 'tool_use');
-  if (!cleanTerminalTurn) return;
+  if (!terminalTurn) return;
 
-  run.turnCompletedCleanly = true;
+  // An error termination (is_error result frame) ends the turn — stdin must
+  // still close — but it is NOT a clean completion: marking it clean lets
+  // classifyChatRunCloseStatus translate the CLI's non-zero exit into
+  // 'succeeded' and the failure never reaches the user. A SessionEnd-hook
+  // non-zero exit after a normal result (#3373) carries no isError flag and
+  // keeps taking the clean path.
+  const errorTermination = event.type === 'usage' && event.isError === true;
+  if (!errorTermination) {
+    run.turnCompletedCleanly = true;
+  }
   if (run.stdinOpen) {
     if (run.child?.stdin && !run.child.stdin.destroyed) {
       try { run.child.stdin.end(); } catch {}

--- a/apps/daemon/src/runtimes/claude-stream.ts
+++ b/apps/daemon/src/runtimes/claude-stream.ts
@@ -484,6 +484,13 @@ export function createClaudeStreamHandler(
     }
 
     if (obj.type === 'result') {
+      // An is_error result is an error termination, not a clean turn: the CLI
+      // is about to exit non-zero (error_during_execution, error_max_turns,
+      // resume failures) and the human-readable cause lives in errors[], not
+      // in any assistant message. Washing it into a plain usage event lets the
+      // close handler classify the run as succeeded with nothing surfaced.
+      // Mirrors the qoder-stream result contract.
+      const isError = obj.is_error === true;
       onEvent({
         type: 'usage',
         usage: obj.usage ?? null,
@@ -493,9 +500,33 @@ export function createClaudeStreamHandler(
           (typeof obj.stop_reason === 'string' && obj.stop_reason) ||
           (typeof obj.terminal_reason === 'string' && obj.terminal_reason) ||
           null,
+        ...(isError ? { isError: true } : {}),
       });
+      if (isError) {
+        onEvent({
+          type: 'error',
+          message: errorResultMessage(obj),
+          code: typeof obj.subtype === 'string' && obj.subtype ? obj.subtype : 'result_error',
+          // Marks this as the run's terminal error (the CLI is exiting), not an
+          // in-stream hiccup. Consumers with their own result-frame
+          // classification (connection test #4501) skip terminal errors.
+          terminal: true,
+        });
+      }
       return;
     }
+  }
+
+  function errorResultMessage(obj: Record<string, unknown>): string {
+    if (Array.isArray(obj.errors)) {
+      const parts = obj.errors.filter(
+        (entry): entry is string => typeof entry === 'string' && entry.length > 0,
+      );
+      if (parts.length > 0) return parts.join('\n');
+    }
+    if (typeof obj.result === 'string' && obj.result.trim()) return obj.result;
+    if (typeof obj.subtype === 'string' && obj.subtype) return `Claude run failed: ${obj.subtype}`;
+    return 'Claude run failed';
   }
 
   function assistantText(content: unknown[]): string {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8028,6 +8028,28 @@ export async function startServer({
         noteCliReadyAt();
         if (ev?.type === 'error') {
           if (agentStreamError) return;
+          // Hold back a resume-failure error so the close handler's transparent
+          // reseed stays invisible. An is_error result frame on a dead --resume
+          // now surfaces here as a stream error; the resume-target-missing
+          // block in the close handler clears the stale handle and re-runs the
+          // turn fresh, so forwarding this error would flash an execution
+          // failure a beat before the invisible recovery. Mirrors the ACP
+          // resume_failed suppression below; the close handler stays the sole
+          // authority on how a resume failure ends.
+          if (
+            (def.resumesSessionViaCli === true || def.resumesSessionViaAcpLoad === true) &&
+            agentResumeCtx.isResuming &&
+            !run.resumeAutoReseeded &&
+            isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
+          ) {
+            design.runs.emit(run, 'diagnostic', {
+              type: 'agent_resume_failed_suppressed',
+              agent_id: def.id,
+              reason: 'resume_failed',
+              previous_session_id: agentResumeCtx.resumeSessionId ?? null,
+            });
+            return;
+          }
           flushVisibleAgentStderr();
           const message = String((ev as any).message || 'Claude Code stream error');
           const failureText = [

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -571,6 +571,46 @@ describe('applyClaudeStreamJsonRunBookkeeping', () => {
     expect(run.child.stdin.end).not.toHaveBeenCalled();
   });
 
+  it('closes stdin without recording clean completion when usage reports an error termination', () => {
+    // Real Claude CLI error terminations (error_during_execution,
+    // error_max_turns, resume failures — the #4275 fixture family) emit a
+    // result frame with is_error true and stop_reason null. The turn IS over,
+    // so stdin must close — but it did not complete cleanly: marking it clean
+    // lets classifyChatRunCloseStatus translate the CLI's exit code 1 into
+    // 'succeeded' and the run fails silently with no error surfaced.
+    const run = {
+      stdinOpen: true,
+      turnCompletedCleanly: false,
+      child: {
+        stdin: {
+          destroyed: false,
+          end: vi.fn(),
+        },
+      },
+    };
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'usage',
+      usage: null,
+      stopReason: null,
+      isError: true,
+    });
+
+    expect(run.stdinOpen).toBe(false);
+    expect(run.child.stdin.end).toHaveBeenCalled();
+    expect(run.turnCompletedCleanly).toBe(false);
+
+    expect(classifyChatRunCloseStatus({
+      cancelRequested: false,
+      code: 1,
+      signal: null,
+      acpCleanCompletion: false,
+      artifactQuietShutdownRequested: false,
+      turnCompletedCleanly: run.turnCompletedCleanly,
+      artifactProducedThisRun: false,
+    })).toBe('failed');
+  });
+
   it('closes stdin and records clean completion after an AskUserQuestion tool_use followed by end_turn (#4273)', () => {
     // Regression test: the dead AskUserQuestion detection branch used to add
     // the tool_use id to pendingHostAnswers and return early, preventing stdin

--- a/apps/daemon/tests/runtimes/structured-streams.test.ts
+++ b/apps/daemon/tests/runtimes/structured-streams.test.ts
@@ -917,6 +917,56 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
+  it('surfaces an is_error result as an error, not a silent success', () => {
+    // Real installed Claude CLI error-termination shape, locked by the #4275
+    // regression fixtures: is_error true, stop_reason null, human string in
+    // errors[]. The parser must not wash this frame into a plain usage event —
+    // qoder-stream already honors this contract for the same frame family.
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createClaudeStreamHandler((event: unknown) => {
+      events.push(event as Record<string, unknown>);
+    });
+
+    handler.feed(`${JSON.stringify({
+      type: 'result',
+      subtype: 'error_during_execution',
+      duration_ms: 0,
+      duration_api_ms: 0,
+      is_error: true,
+      num_turns: 0,
+      stop_reason: null,
+      session_id: '00000000-0000-0000-0000-000000000000',
+      total_cost_usd: 0,
+      errors: ['No conversation found with session ID: 00000000-0000-0000-0000-000000000000'],
+    })}\n`);
+    handler.flush();
+
+    const usage = events.find((event) => event.type === 'usage');
+    expect(usage).toMatchObject({ isError: true });
+
+    const error = events.find((event) => event.type === 'error');
+    expect(error).toBeDefined();
+    expect(String(error?.message)).toContain('No conversation found with session ID');
+  });
+
+  it('does not flag a successful result as an error', () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createClaudeStreamHandler((event: unknown) => {
+      events.push(event as Record<string, unknown>);
+    });
+
+    handler.feed(`${JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 42,
+      is_error: false,
+      stop_reason: 'end_turn',
+    })}\n`);
+    handler.flush();
+
+    expect(events.find((event) => event.type === 'error')).toBeUndefined();
+  });
+
   it('emits TodoWrite tool_use from Pi RPC tool_execution events', () => {
     const events: unknown[] = [];
     const send = (_channel: string, payload: unknown) => { events.push(payload); };


### PR DESCRIPTION
## Why

While working on AMR error classification (#5158), I audited the neighboring claude-stream error paths and found a silent-failure chain: when the Claude CLI terminates with an error — `error_during_execution`, `error_max_turns`, a failed `--resume` — it emits a result frame with `is_error: true`, `stop_reason: null`, and the human-readable cause in `errors[]` (the exact real-CLI shape the #4275 regression fixtures lock), then exits 1. The daemon classifies that run as **succeeded**:

1. `claude-stream.ts` forwards the result frame as a plain `usage` event, dropping `is_error` and `errors[]` — `qoder-stream.ts` already honors the error contract for the same frame family.
2. `applyClaudeStreamJsonRunBookkeeping` treats the `null` stop_reason as a clean terminal turn and sets `turnCompletedCleanly`.
3. `classifyChatRunCloseStatus` translates the CLI's exit code 1 into `'succeeded'` via `turnCompletedCleanly`, and the `diagnoseClaudeCliFailure` path (which would name the real cause) never runs.

The user sees a turn that "completed" with possibly no output at all — the most trust-damaging failure mode, because nothing signals that anything went wrong. #4501 fixed this frame's handling on the connection-test path; the chat-run path was still open.

## What users will see

When a Claude Code run dies mid-turn, the chat now shows an error card with the CLI's actual failure reason (from `errors[]`) and the run is recorded as failed — instead of a silently empty "successful" turn.

Two adjacent behaviors are explicitly preserved:

- **SessionEnd-hook non-zero exits after a normal result (#3373)** — those results carry no `is_error`, so they keep taking the clean-completion path.
- **Transparent resume reseed (#4438)** — a dead `--resume` also produces an `is_error` frame; the chat path suppresses that error event during a resume attempt (mirroring the existing ACP `resume_failed` suppression) so the close handler's invisible reseed stays invisible.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

(No new endpoint or contract shape. The parser's `usage` event gains an `isError` flag only on error frames; success-frame event shapes are unchanged — verified against the claude mocks golden.)

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/runtimes/structured-streams.test.ts` — feeding the #4275-locked real CLI error frame must produce an error event (message from `errors[]`) and an `isError` usage flag; a success frame must not.
  - `apps/daemon/tests/chat-run-artifact-quiet-period.test.ts` — an error-termination usage event must close stdin without setting `turnCompletedCleanly`, and `classifyChatRunCloseStatus` with exit code 1 must return `'failed'`.
- Red on `main`, green on this branch: **yes** (on `main` the error frame produces no error signal and the run classifies as `'succeeded'`).

## Validation

- `pnpm guard` — green
- `pnpm typecheck` — green
- Targeted: `structured-streams`, `chat-run-artifact-quiet-period`, `agent-session-resume` (#4275 fixtures), `codex-session-resume` + `opencode-session-resume` (reseed integration), `connection-test` (#4501 cases), `mocks-golden` (claude trace unchanged) — all green.
- `pnpm --filter @open-design/daemon test` — no new failures vs the `main` baseline: 28 pre-existing environment-dependent failures (proxy/connection/media/golden codex+opencode) reproduce identically on a stashed clean `main`; one `brand-routes` network-gated case flaked in the full run and passes 3/3 in isolation on this branch.
