### PR TITLE
feat(guard): catch @ts-nocheck files with unresolved relative imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tools-release": "pnpm exec tools-release",
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
-    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/web-import-isolation.test.ts scripts/check-cross-app-imports.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/lint-craft-references.test.ts scripts/check-design-system-manifests.test.ts scripts/check-plugin-preview-manifest.test.ts",
+    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/web-import-isolation.test.ts scripts/check-cross-app-imports.test.ts scripts/check-ts-nocheck-imports.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/lint-craft-references.test.ts scripts/check-design-system-manifests.test.ts scripts/check-plugin-preview-manifest.test.ts",
     "lint:craft": "tsx ./scripts/lint-craft-references.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",

--- a/scripts/check-ts-nocheck-imports.test.ts
+++ b/scripts/check-ts-nocheck-imports.test.ts
@@ -83,6 +83,31 @@ test("resolvesRelativeSpecifier maps .js specifiers to their real sibling and fo
   await rm(root, { force: true, recursive: true });
 });
 
+test("resolvesRelativeSpecifier keeps .mjs/.cjs resolution extension-specific", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "od-tsnocheck-"));
+  // NodeNext: .mts emits .mjs, .cts emits .cjs, a same-basename .ts emits .js.
+  await writeFile(path.join(root, "esm.mts"), "export const a = 1;", "utf8");
+  await writeFile(path.join(root, "cjs.cts"), "export const a = 1;", "utf8");
+  await writeFile(path.join(root, "plain.ts"), "export const a = 1;", "utf8");
+
+  // Correct matches resolve.
+  assert.equal(resolvesRelativeSpecifier(root, "./esm.mjs"), true);
+  assert.equal(resolvesRelativeSpecifier(root, "./cjs.cjs"), true);
+
+  // Mismatches must be REJECTED: a `.ts` emits `.js`, never `.mjs`/`.cjs`, so
+  // an import of `./plain.mjs` / `./plain.cjs` would fail at runtime and the
+  // guard must catch it (this was the reviewed false negative).
+  assert.equal(resolvesRelativeSpecifier(root, "./plain.mjs"), false);
+  assert.equal(resolvesRelativeSpecifier(root, "./plain.cjs"), false);
+  // ...and a `.mts` (emits `.mjs`) must not satisfy a `.cjs` import, or vice-versa.
+  assert.equal(resolvesRelativeSpecifier(root, "./esm.cjs"), false);
+  assert.equal(resolvesRelativeSpecifier(root, "./cjs.mjs"), false);
+  // A plain `.js` import still resolves to the `.ts` source.
+  assert.equal(resolvesRelativeSpecifier(root, "./plain.js"), true);
+
+  await rm(root, { force: true, recursive: true });
+});
+
 test("collectTsNocheckImportViolationsFromSource flags only the unresolved import in a @ts-nocheck file", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "od-tsnocheck-"));
   await writeFile(path.join(root, "present.ts"), "export const a = 1;", "utf8");

--- a/scripts/check-ts-nocheck-imports.test.ts
+++ b/scripts/check-ts-nocheck-imports.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  collectRelativeSpecifiers,
+  collectTsNocheckImportViolationsFromSource,
+  hasLeadingTsNocheck,
+  resolvesRelativeSpecifier,
+} from "./check-ts-nocheck-imports.ts";
+
+test("hasLeadingTsNocheck detects a leading pragma, including after an author comment", () => {
+  assert.equal(hasLeadingTsNocheck("// @ts-nocheck\nimport x from './x.js';"), true);
+  assert.equal(
+    hasLeadingTsNocheck("// Authors: someone\n// @ts-nocheck — carried over\nexport const a = 1;"),
+    true,
+  );
+});
+
+test("hasLeadingTsNocheck ignores @ts-nocheck that is not leading trivia", () => {
+  assert.equal(hasLeadingTsNocheck("export const a = 1;\n// @ts-nocheck\n"), false);
+  assert.equal(hasLeadingTsNocheck("const s = '@ts-nocheck';\n"), false);
+  assert.equal(hasLeadingTsNocheck("import x from './x.js';\n"), false);
+});
+
+test("collectRelativeSpecifiers gathers every relative import edge, with line numbers", () => {
+  const refs = collectRelativeSpecifiers(
+    "a.ts",
+    [
+      "import { a } from './static.js';",
+      "export { b } from './reexport.js';",
+      "import type { C } from './type-only.js';",
+      "const d = await import('./dynamic.js');",
+      "type E = import('./import-type.js').E;",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(
+    refs.map((reference) => reference.specifier),
+    ["./static.js", "./reexport.js", "./type-only.js", "./dynamic.js", "./import-type.js"],
+  );
+  assert.deepEqual(
+    refs.map((reference) => reference.lineNumber),
+    [1, 2, 3, 4, 5],
+  );
+});
+
+test("collectRelativeSpecifiers ignores external specifiers and string literals in comments/expressions", () => {
+  const refs = collectRelativeSpecifiers(
+    "a.ts",
+    [
+      "import path from 'node:path';",
+      "import { Button } from '@open-design/components';",
+      "// import { x } from './commented.js';",
+      "const label = './not-an-import.js';",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(refs, []);
+});
+
+test("resolvesRelativeSpecifier maps .js specifiers to their real sibling and follows directory barrels", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "od-tsnocheck-"));
+  await writeFile(path.join(root, "sibling.ts"), "export const a = 1;", "utf8");
+  await mkdir(path.join(root, "domain"), { recursive: true });
+  await writeFile(path.join(root, "domain", "index.ts"), "export const b = 2;", "utf8");
+  await writeFile(path.join(root, "data.json"), "{}", "utf8");
+
+  // `./sibling.js` resolves to sibling.ts (NodeNext .js -> .ts).
+  assert.equal(resolvesRelativeSpecifier(root, "./sibling.js"), true);
+  // `./domain/index.js` resolves to the barrel file.
+  assert.equal(resolvesRelativeSpecifier(root, "./domain/index.js"), true);
+  // extensionless directory import resolves via index.*
+  assert.equal(resolvesRelativeSpecifier(root, "./domain"), true);
+  // asset import must exist verbatim.
+  assert.equal(resolvesRelativeSpecifier(root, "./data.json"), true);
+  // a barrel-move casualty: the flat file no longer exists.
+  assert.equal(resolvesRelativeSpecifier(root, "./sibling-moved.js"), false);
+  assert.equal(resolvesRelativeSpecifier(root, "./domain/missing.js"), false);
+
+  await rm(root, { force: true, recursive: true });
+});
+
+test("collectTsNocheckImportViolationsFromSource flags only the unresolved import in a @ts-nocheck file", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "od-tsnocheck-"));
+  await writeFile(path.join(root, "present.ts"), "export const a = 1;", "utf8");
+
+  const violations = collectTsNocheckImportViolationsFromSource(
+    "module.ts",
+    ["// @ts-nocheck", "import { a } from './present.js';", "import { b } from './gone.js';"].join("\n"),
+    root,
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0]?.specifier, "./gone.js");
+  assert.equal(violations[0]?.lineNumber, 3);
+
+  await rm(root, { force: true, recursive: true });
+});
+
+test("collectTsNocheckImportViolationsFromSource ignores files without a leading @ts-nocheck", () => {
+  // Same broken import, but the file is type-checked normally, so tsc already
+  // guards it — this check must not double-report it.
+  const violations = collectTsNocheckImportViolationsFromSource(
+    "module.ts",
+    "import { b } from './definitely-gone.js';",
+    "/tmp/does-not-matter",
+  );
+
+  assert.deepEqual(violations, []);
+});

--- a/scripts/check-ts-nocheck-imports.ts
+++ b/scripts/check-ts-nocheck-imports.ts
@@ -40,9 +40,23 @@ const skippedDirectories = new Set([
 // Files that can carry a meaningful `@ts-nocheck` (TypeScript sources).
 const scannedExtensions = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
-// Candidate source extensions a `./x.js`-style specifier may resolve to under
-// NodeNext (a `.js` specifier maps to its `.ts` sibling), plus the raw JS forms.
+// Every source/JS extension a bare (extensionless) or directory-index import
+// may resolve to.
 const moduleResolutionExtensions = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"];
+
+// The source extensions each *emitted* JS extension can legitimately come from
+// under NodeNext. This is extension-specific on purpose: `.mts` emits `.mjs`
+// and `.cts` emits `.cjs`, while a same-basename `.ts` emits `.js`. So a
+// `./x.mjs` import must NOT be satisfied by a sibling `x.ts` (its output is
+// `x.js`, not `x.mjs`) — sharing one broad list would let that dead import
+// pass, defeating the guard. Keys are checked by suffix; `.mjs`/`.cjs`/`.jsx`
+// never end with `.js`, so ordering is irrelevant.
+const sourceCandidatesByJsExtension: Record<string, readonly string[]> = {
+  ".js": [".ts", ".tsx", ".js", ".jsx"],
+  ".jsx": [".tsx", ".jsx"],
+  ".mjs": [".mts", ".mjs"],
+  ".cjs": [".cts", ".cjs"],
+};
 
 export type TsNocheckImportViolation = {
   filePath: string;
@@ -78,8 +92,9 @@ export function hasLeadingTsNocheck(source: string): boolean {
  * Resolve a relative import specifier the way NodeNext + this repo's TS build
  * do, returning whether a real module exists for it.
  *
- * - `./x.js` / `.mjs` / `.cjs` map to a sibling TypeScript or JS source file.
- * - `./x.jsx` maps to `.tsx`/`.jsx`.
+ * - A JS-flavored specifier resolves only to the source extensions NodeNext
+ *   emits it from: `./x.js` from `.ts`/`.tsx`/`.js`/`.jsx`, `./x.mjs` from
+ *   `.mts`/`.mjs`, `./x.cjs` from `.cts`/`.cjs`, `./x.jsx` from `.tsx`/`.jsx`.
  * - An explicit `.ts`/`.tsx`/`.mts`/`.cts` or a non-code asset extension
  *   (`.json`, `.css`, ...) must exist verbatim.
  * - An extensionless specifier resolves to a source file or a directory
@@ -88,15 +103,11 @@ export function hasLeadingTsNocheck(source: string): boolean {
 export function resolvesRelativeSpecifier(fromDirectory: string, specifier: string): boolean {
   const target = path.resolve(fromDirectory, specifier);
 
-  for (const jsExtension of [".js", ".mjs", ".cjs"]) {
+  for (const [jsExtension, candidates] of Object.entries(sourceCandidatesByJsExtension)) {
     if (specifier.endsWith(jsExtension)) {
       const base = target.slice(0, -jsExtension.length);
-      return moduleResolutionExtensions.some((extension) => existsSync(base + extension));
+      return candidates.some((extension) => existsSync(base + extension));
     }
-  }
-  if (specifier.endsWith(".jsx")) {
-    const base = target.slice(0, -".jsx".length);
-    return [".tsx", ".jsx"].some((extension) => existsSync(base + extension));
   }
   if (path.extname(specifier) !== "") {
     // Explicit .ts/.tsx/.mts/.cts source or a non-code asset (.json/.css/...).

--- a/scripts/check-ts-nocheck-imports.ts
+++ b/scripts/check-ts-nocheck-imports.ts
@@ -1,0 +1,214 @@
+import { readdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+// `// @ts-nocheck` disables *all* type checking for a file, including
+// TS2307 "Cannot find module". That is convenient for large legacy modules
+// mid-refactor, but it silently hides broken relative imports: a barrel move
+// or file rename can leave a `@ts-nocheck` file importing a path that no
+// longer resolves, and `pnpm typecheck` stays green while the module fails to
+// load at runtime. (A combined-barrel integration once shipped 51 such dead
+// imports across server.ts / cli.ts / start-chat-run.ts, all masked by
+// @ts-nocheck.) tsc also never verifies the specifier of a *dynamic*
+// `import()` even in a checked file, so those are checked here too.
+//
+// This guard re-establishes the one guarantee @ts-nocheck takes away: every
+// relative import/export/dynamic-import specifier in a @ts-nocheck TypeScript
+// source file must resolve to a real module on disk.
+
+const skippedDirectories = new Set([
+  ".git",
+  ".next",
+  ".od",
+  ".od-data",
+  ".od-e2e",
+  ".tmp",
+  ".turbo",
+  ".vite",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+  "reports",
+  "test-results",
+  "vendor",
+]);
+
+// Files that can carry a meaningful `@ts-nocheck` (TypeScript sources).
+const scannedExtensions = new Set([".ts", ".tsx", ".mts", ".cts"]);
+
+// Candidate source extensions a `./x.js`-style specifier may resolve to under
+// NodeNext (a `.js` specifier maps to its `.ts` sibling), plus the raw JS forms.
+const moduleResolutionExtensions = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"];
+
+export type TsNocheckImportViolation = {
+  filePath: string;
+  lineNumber: number;
+  specifier: string;
+};
+
+function scriptKindForPath(filePath: string): ts.ScriptKind {
+  switch (path.extname(filePath)) {
+    case ".tsx":
+      return ts.ScriptKind.TSX;
+    case ".mts":
+    case ".cts":
+      return ts.ScriptKind.TS;
+    default:
+      return ts.ScriptKind.TS;
+  }
+}
+
+/**
+ * True when the file opts out of type checking via a leading `@ts-nocheck`
+ * pragma. Mirrors tsc: the pragma is only honored in the comment block that
+ * precedes the first statement, so only leading trivia is inspected.
+ */
+export function hasLeadingTsNocheck(source: string): boolean {
+  const sourceFile = ts.createSourceFile("probe.ts", source, ts.ScriptTarget.Latest, true);
+  const firstStatement = sourceFile.statements[0];
+  const leadingEnd = firstStatement ? firstStatement.getFullStart() + firstStatement.getLeadingTriviaWidth(sourceFile) : source.length;
+  return /@ts-nocheck\b/.test(source.slice(0, leadingEnd));
+}
+
+/**
+ * Resolve a relative import specifier the way NodeNext + this repo's TS build
+ * do, returning whether a real module exists for it.
+ *
+ * - `./x.js` / `.mjs` / `.cjs` map to a sibling TypeScript or JS source file.
+ * - `./x.jsx` maps to `.tsx`/`.jsx`.
+ * - An explicit `.ts`/`.tsx`/`.mts`/`.cts` or a non-code asset extension
+ *   (`.json`, `.css`, ...) must exist verbatim.
+ * - An extensionless specifier resolves to a source file or a directory
+ *   `index.*` barrel.
+ */
+export function resolvesRelativeSpecifier(fromDirectory: string, specifier: string): boolean {
+  const target = path.resolve(fromDirectory, specifier);
+
+  for (const jsExtension of [".js", ".mjs", ".cjs"]) {
+    if (specifier.endsWith(jsExtension)) {
+      const base = target.slice(0, -jsExtension.length);
+      return moduleResolutionExtensions.some((extension) => existsSync(base + extension));
+    }
+  }
+  if (specifier.endsWith(".jsx")) {
+    const base = target.slice(0, -".jsx".length);
+    return [".tsx", ".jsx"].some((extension) => existsSync(base + extension));
+  }
+  if (path.extname(specifier) !== "") {
+    // Explicit .ts/.tsx/.mts/.cts source or a non-code asset (.json/.css/...).
+    return existsSync(target);
+  }
+  // Extensionless: a source file or a directory index barrel.
+  return (
+    moduleResolutionExtensions.some((extension) => existsSync(target + extension)) ||
+    moduleResolutionExtensions.some((extension) => existsSync(path.join(target, `index${extension}`)))
+  );
+}
+
+export type RelativeSpecifierReference = {
+  specifier: string;
+  lineNumber: number;
+};
+
+/**
+ * Collect every *relative* module specifier that TypeScript treats as a real
+ * import edge: static `import`/`export … from`, `import type`, `import x =
+ * require(...)`, and dynamic `import(...)`. String literals in comments or in
+ * ordinary expressions are not import edges and are ignored (the AST only
+ * yields the specifier positions). Source-only and side-effect free, so the
+ * extraction is unit-testable without the filesystem.
+ */
+export function collectRelativeSpecifiers(filePath: string, source: string): RelativeSpecifierReference[] {
+  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, scriptKindForPath(filePath));
+  const found: RelativeSpecifierReference[] = [];
+
+  const push = (node: ts.Node | undefined): void => {
+    if (node != null && ts.isStringLiteralLike(node) && node.text.startsWith(".")) {
+      found.push({
+        specifier: node.text,
+        lineNumber: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+      });
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      push(node.moduleSpecifier);
+    } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+      push(node.moduleReference.expression);
+    } else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
+      push(node.argument.literal);
+    } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      push(node.arguments[0]);
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * Collect unresolved relative imports for a single `@ts-nocheck` source file,
+ * resolving specifiers against `fromDirectory`. Non-`@ts-nocheck` files return
+ * no violations. `fromDirectory` defaults to the file's directory under the
+ * repository root; tests pass a temp directory instead.
+ */
+export function collectTsNocheckImportViolationsFromSource(
+  repositoryPath: string,
+  source: string,
+  fromDirectory: string = path.dirname(path.resolve(repoRoot, repositoryPath)),
+): TsNocheckImportViolation[] {
+  if (!hasLeadingTsNocheck(source)) return [];
+
+  const violations: TsNocheckImportViolation[] = [];
+  for (const { specifier, lineNumber } of collectRelativeSpecifiers(repositoryPath, source)) {
+    if (resolvesRelativeSpecifier(fromDirectory, specifier)) continue;
+    violations.push({ filePath: repositoryPath, lineNumber, specifier });
+  }
+
+  return violations.sort((left, right) => left.lineNumber - right.lineNumber);
+}
+
+async function collectScannedFiles(directory: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (skippedDirectories.has(entry.name)) continue;
+      files.push(...(await collectScannedFiles(fullPath)));
+    } else if (entry.isFile() && scannedExtensions.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+export async function checkTsNocheckImports(): Promise<boolean> {
+  const violations: TsNocheckImportViolation[] = [];
+
+  for (const fullPath of await collectScannedFiles(repoRoot)) {
+    const source = await readFile(fullPath, "utf8");
+    if (!source.includes("@ts-nocheck")) continue;
+    const repositoryPath = path.relative(repoRoot, fullPath).split(path.sep).join("/");
+    violations.push(...collectTsNocheckImportViolationsFromSource(repositoryPath, source));
+  }
+
+  if (violations.length > 0) {
+    console.error("@ts-nocheck files with unresolved relative imports:");
+    for (const violation of violations) {
+      console.error(`- ${violation.filePath}:${violation.lineNumber} \`${violation.specifier}\` does not resolve to a module on disk`);
+    }
+    console.error(
+      "@ts-nocheck suppresses TS2307, so these dead imports pass typecheck but fail at runtime. Repoint each specifier to the module's current path (usually a capability-barrel index), or remove the import.",
+    );
+    return false;
+  }
+
+  console.log("@ts-nocheck import check passed: every @ts-nocheck file's relative imports resolve.");
+  return true;
+}

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 import ts from "typescript";
 
 import { checkCrossAppImports } from "./check-cross-app-imports.ts";
+import { checkTsNocheckImports } from "./check-ts-nocheck-imports.ts";
 import { checkDesignSystemManifests } from "./check-design-system-manifests.ts";
 import { checkDesignSystemPackageQuality } from "./check-design-system-package-quality.ts";
 import { checkDesignSystemComponentFixtureReport } from "./check-components-fixtures.ts";
@@ -1303,6 +1304,7 @@ const checks: GuardCheck[] = [
   { name: "package dependency specs", run: checkPackageDependencySpecs },
   { name: "product neutrality", run: checkProductNeutrality },
   { name: "cross-app imports", run: checkCrossAppImports },
+  { name: "@ts-nocheck import resolution", run: checkTsNocheckImports },
   { name: "test layout", run: checkTestLayout },
   { name: "e2e layout", run: checkE2eLayout },
   { name: "web test layout", run: checkWebTestLayout },


### PR DESCRIPTION
## Why

**Use case:** I hit this while combining several capability-barrel refactor branches onto one buildable trunk. `pnpm typecheck` was green, but the daemon would not actually load — `server.ts` (and `cli.ts`, `start-chat-run.ts`, …) carried **51 stale relative imports** left over from barrel file-moves, and every one was invisible.

**The pain (technical debt / silent runtime breakage):** `// @ts-nocheck` disables *all* type checking for a file, including `TS2307 "Cannot find module"`. So when a barrel move or rename changes a module's path, a `@ts-nocheck` importer keeps the old path, typecheck stays green, and the module explodes at runtime instead. tsc *also* never verifies the specifier of a dynamic `import()` — even in a fully type-checked file — so those are a blind spot regardless of `@ts-nocheck`. There was no gate that would catch either class.

## What users will see

Nothing at runtime — this is a repo dev-tooling guard. Contributors get one new failure mode in `pnpm guard`: if a `@ts-nocheck` file imports a relative path that doesn't resolve to a real module, guard fails with the file, line, and dead specifier, e.g.

```
@ts-nocheck files with unresolved relative imports:
- apps/daemon/src/server.ts:23 `./project-root.js` does not resolve to a module on disk
```

## Surface area

- [x] **None** — internal dev-tooling: adds one `pnpm guard` check plus its unit test. No product/UI/API/CLI surface.

## Bug fix verification

Not a single-bug fix, but a preventive guard motivated by a real one. The falsifiable spec lives in `scripts/check-ts-nocheck-imports.test.ts`:

- `collectTsNocheckImportViolationsFromSource flags only the unresolved import in a @ts-nocheck file` goes **red** without the check logic and **green** with it.
- A companion test confirms the check does **not** double-report broken imports in files that are *not* `@ts-nocheck` (tsc already guards those).

## What this does

Adds `scripts/check-ts-nocheck-imports.ts`, wired into `pnpm guard` (and its `node --import tsx --test` list). It re-establishes the one guarantee `@ts-nocheck` removes: every relative `import` / `export … from` / `import type` / `import x = require()` / dynamic `import()` specifier in a `@ts-nocheck` TypeScript source must resolve to a real module on disk. Resolution mirrors NodeNext + this repo's build: `./x.js` → `x.ts`, extensionless directory-index barrels, and asset extensions (`.json`, `.css`, …) are all handled; string literals in comments or ordinary expressions are ignored (AST-based, not regex).

## Scope / boundary

Runtime-agnostic static check under `scripts/`, following the exact shape of `check-cross-app-imports.ts`. Scans TypeScript sources repo-wide (`.ts/.tsx/.mts/.cts`), skipping `node_modules`, `dist`, `out`, etc.

## Validation

- `pnpm guard` — **green** (my check reports `@ts-nocheck import check passed`; 33 `@ts-nocheck` files, 0 violations on `main`).
- `node --import tsx --test scripts/check-ts-nocheck-imports.test.ts` — **7/7 pass**.
- `tsc -p scripts/tsconfig.json --noEmit` — clean.
