### PR TITLE
refactor(host): split index.ts into cohesive sibling modules (part of #5165)

### DIFF
--- a/packages/host/src/actions.ts
+++ b/packages/host/src/actions.ts
@@ -1,0 +1,245 @@
+import { OPEN_DESIGN_HOST_UPDATER_ACTIONS } from "./protocol.js";
+import type {
+  OpenDesignHostActionResult,
+  OpenDesignHostBrowserClearDataOptions,
+  OpenDesignHostCaptureOptions,
+  OpenDesignHostCaptureResult,
+  OpenDesignHostFailure,
+  OpenDesignHostGlobalScope,
+  OpenDesignHostPdfPrintOptions,
+  OpenDesignHostPickWorkingDirResult,
+  OpenDesignHostProjectImportInit,
+  OpenDesignHostProjectImportResult,
+  OpenDesignHostProjectReplaceWorkingDirResult,
+  OpenDesignHostUpdaterActionOptions,
+  OpenDesignHostUpdaterResult,
+  OpenDesignHostUpdaterStatusAction,
+  OpenDesignHostUpdaterStatusListener,
+} from "./protocol.js";
+import { getOpenDesignHost } from "./detection.js";
+
+/**
+ * @module actions
+ *
+ * Renderer-facing wrappers over the host bridge. Each resolves the bridge from
+ * scope, invokes the capability, and returns a host-owned result (or a uniform
+ * "host is not available" failure). Covers shell, browser, capture, project,
+ * pdf, pet, and the full updater action surface.
+ */
+
+/** @internal Build a normalized host failure result. */
+function failure(reason: string, details?: unknown): OpenDesignHostFailure {
+  return {
+    ...(details === undefined ? {} : { details }),
+    ok: false,
+    reason,
+  };
+}
+
+/** @internal Uniform failure for when the host bridge is absent. */
+function unavailable(reason: string): OpenDesignHostFailure {
+  return failure(reason);
+}
+
+/** Open an external URL through the host shell. */
+export async function openHostExternalUrl(url: string, scope: OpenDesignHostGlobalScope = globalThis): Promise<OpenDesignHostActionResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.shell.openExternal(url);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Reveal a project's path through the host shell. */
+export async function openHostProjectPath(projectId: string, scope: OpenDesignHostGlobalScope = globalThis): Promise<OpenDesignHostActionResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.shell.openPath(projectId);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Clear host browser data (cookies and/or storage). */
+export async function clearHostBrowserData(
+  options?: OpenDesignHostBrowserClearDataOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostActionResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.browser.clearData(options);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Capture the host page (optionally clipped) as a data URL. */
+export async function captureHostPage(
+  options?: OpenDesignHostCaptureOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostCaptureResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.capture.page(options);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Pick and import a project through the host's native dialog. */
+export async function pickAndImportHostProject(
+  init?: OpenDesignHostProjectImportInit,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostProjectImportResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.project.pickAndImport(init);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Pick and replace a project's working directory through the host. */
+export async function pickAndReplaceHostProjectWorkingDir(
+  projectId: string,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostProjectReplaceWorkingDirResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.project.pickAndReplaceWorkingDir(projectId);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+// Picks a folder via the host's native dialog and returns the chosen path
+// plus a single-use token, WITHOUT touching any project. The Home flow uses
+// this to let the user choose a working directory before the project exists;
+// the token is later spent on POST /api/projects/:id/working-dir.
+export async function pickHostWorkingDir(
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostPickWorkingDirResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  if (typeof host.project.pickWorkingDir !== "function") {
+    return unavailable("host build does not support pickWorkingDir");
+  }
+  try {
+    return await host.project.pickWorkingDir();
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Print HTML to PDF through the host. */
+export async function printHostPdf(
+  html: string,
+  nonce?: string,
+  options?: OpenDesignHostPdfPrintOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostActionResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.pdf.print(html, nonce, options);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Toggle host pet visibility. */
+export function setHostPetVisible(visible: boolean, scope: OpenDesignHostGlobalScope = globalThis): OpenDesignHostActionResult {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    host.pet.setVisible(visible);
+    return { ok: true };
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** @internal Run a status-returning updater action and wrap the result. */
+async function runHostUpdaterAction(
+  action: OpenDesignHostUpdaterStatusAction,
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return {
+      ok: true,
+      status: await host.updater[action](options),
+    };
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Get the host updater status. */
+export async function getHostUpdaterStatus(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.STATUS, options, scope);
+}
+
+/** Trigger a host updater check. */
+export async function checkHostUpdater(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.CHECK, options, scope);
+}
+
+/** Trigger a host updater download. */
+export async function downloadHostUpdater(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.DOWNLOAD, options, scope);
+}
+
+/** Trigger a host updater install. */
+export async function installHostUpdater(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.INSTALL, options, scope);
+}
+
+/** Quit the host after its updater installer has opened. */
+export async function quitHostAfterUpdaterInstallerOpen(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostActionResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.updater.quit(options);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Subscribe to host updater status changes; returns an unsubscribe fn. */
+export function subscribeHostUpdater(
+  listener: OpenDesignHostUpdaterStatusListener,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): () => void {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return () => undefined;
+  try {
+    return host.updater.subscribe(listener);
+  } catch {
+    return () => undefined;
+  }
+}

--- a/packages/host/src/detection.ts
+++ b/packages/host/src/detection.ts
@@ -1,0 +1,107 @@
+import {
+  OPEN_DESIGN_HOST_GLOBAL,
+  OPEN_DESIGN_HOST_VERSION,
+  OPEN_DESIGN_HOST_CLIENT_TYPES,
+  type OpenDesignHostBridge,
+  type OpenDesignHostClientType,
+  type OpenDesignHostGlobalScope,
+} from "./protocol.js";
+
+/**
+ * @module detection
+ *
+ * Locates the host bridge on a global scope and structurally validates it.
+ * Owns the {@link isOpenDesignHostBridge} type guard plus the scope-lookup
+ * helpers used by every renderer-facing accessor.
+ */
+
+/** @internal Narrow an unknown value to a plain record. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+/** @internal True when `record[key]` is a function. */
+function hasFunction(record: Record<string, unknown>, key: string): boolean {
+  return typeof record[key] === "function";
+}
+
+/**
+ * Structural type guard for a fully-formed {@link OpenDesignHostBridge}: checks
+ * version, client type, and the presence of every required capability method.
+ */
+export function isOpenDesignHostBridge(value: unknown): value is OpenDesignHostBridge {
+  if (!isRecord(value)) return false;
+  if (value.version !== OPEN_DESIGN_HOST_VERSION) return false;
+  const client = value.client;
+  if (!isRecord(client) || client.type !== OPEN_DESIGN_HOST_CLIENT_TYPES.DESKTOP) return false;
+  if (client.platform != null && typeof client.platform !== "string") return false;
+  if (client.osLocale != null && typeof client.osLocale !== "string") return false;
+
+  const shell = value.shell;
+  if (!isRecord(shell) || !hasFunction(shell, "openExternal") || !hasFunction(shell, "openPath")) return false;
+
+  const browser = value.browser;
+  if (!isRecord(browser) || !hasFunction(browser, "clearData")) return false;
+
+  const capture = value.capture;
+  if (!isRecord(capture) || !hasFunction(capture, "page")) return false;
+
+  const project = value.project;
+  if (
+    !isRecord(project) ||
+    !hasFunction(project, "pickAndImport") ||
+    !hasFunction(project, "pickAndReplaceWorkingDir")
+  ) {
+    return false;
+  }
+
+  const pdf = value.pdf;
+  if (!isRecord(pdf) || !hasFunction(pdf, "print")) return false;
+
+  const pet = value.pet;
+  if (!isRecord(pet) || !hasFunction(pet, "setVisible")) return false;
+
+  const updater = value.updater;
+  if (
+    !isRecord(updater) ||
+    !hasFunction(updater, "status") ||
+    !hasFunction(updater, "check") ||
+    !hasFunction(updater, "download") ||
+    !hasFunction(updater, "install") ||
+    !hasFunction(updater, "quit") ||
+    !hasFunction(updater, "subscribe")
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/** @internal Read the host-bridge candidate from a scope (or its `window`). */
+function candidateFromScope(scope: OpenDesignHostGlobalScope): unknown {
+  if (OPEN_DESIGN_HOST_GLOBAL in scope) return scope[OPEN_DESIGN_HOST_GLOBAL];
+  const windowValue = scope.window;
+  if (isRecord(windowValue) && OPEN_DESIGN_HOST_GLOBAL in windowValue) {
+    return windowValue[OPEN_DESIGN_HOST_GLOBAL];
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the validated host bridge from `scope`, or `null` when absent or
+ * malformed.
+ */
+export function getOpenDesignHost(scope: OpenDesignHostGlobalScope = globalThis): OpenDesignHostBridge | null {
+  const candidate = candidateFromScope(scope);
+  return isOpenDesignHostBridge(candidate) ? candidate : null;
+}
+
+/** True when a valid Open Design host bridge is present on `scope`. */
+export function isOpenDesignHostAvailable(scope: OpenDesignHostGlobalScope = globalThis): boolean {
+  return getOpenDesignHost(scope) != null;
+}
+
+/** Detect the host client type on `scope`, falling back to web. */
+export function detectOpenDesignHostClientType(scope: OpenDesignHostGlobalScope = globalThis): OpenDesignHostClientType | "web" {
+  return getOpenDesignHost(scope)?.client.type ?? "web";
+}

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -1,674 +1,94 @@
-import type { ReleaseChannel } from "@open-design/release";
-
-export const OPEN_DESIGN_HOST_GLOBAL = "__od__";
-export const OPEN_DESIGN_HOST_VERSION = 2;
-
-export const OPEN_DESIGN_HOST_CLIENT_TYPES = Object.freeze({
-  DESKTOP: "desktop",
-} as const);
-
-export type OpenDesignHostClientType =
-  (typeof OPEN_DESIGN_HOST_CLIENT_TYPES)[keyof typeof OPEN_DESIGN_HOST_CLIENT_TYPES];
-
-export type OpenDesignHostClient = {
-  // BCP-47 locale string (e.g. "zh-CN", "pt-BR") the host process read from
-  // the OS at startup. The renderer uses this so the packaged desktop app
-  // can follow the OS language even when Chromium's built-in
-  // `navigator.language` would have defaulted to en-US.
-  osLocale?: string;
-  platform?: string;
-  type: OpenDesignHostClientType;
-};
-
-export type OpenDesignHostFailure = {
-  details?: unknown;
-  ok: false;
-  reason: string;
-};
-
-export type OpenDesignHostActionResult =
-  | { ok: true }
-  | OpenDesignHostFailure;
-
-export type OpenDesignHostProjectImportInit = {
-  designSystemId?: string | null;
-  name?: string;
-  skillId?: string | null;
-};
-
-export type OpenDesignHostProjectImportSuccess = {
-  conversationId: string;
-  entryFile: string | null;
-  ok: true;
-  projectId: string;
-};
-
-export type OpenDesignHostProjectImportResult =
-  | OpenDesignHostProjectImportSuccess
-  | {
-      canceled: true;
-      ok: false;
-    }
-  | OpenDesignHostFailure;
-
-export type OpenDesignHostProjectReplaceWorkingDirSuccess = {
-  baseDir: string;
-  entryFile: string | null;
-  ok: true;
-};
-
-export type OpenDesignHostProjectReplaceWorkingDirResult =
-  | OpenDesignHostProjectReplaceWorkingDirSuccess
-  | {
-      canceled: true;
-      ok: false;
-    }
-  | OpenDesignHostFailure;
-
-export type OpenDesignHostPickWorkingDirSuccess = {
-  baseDir: string;
-  ok: true;
-  // Single-use HMAC token (minted by the host main process for `baseDir`)
-  // that the renderer threads into POST /api/projects/:id/working-dir once
-  // the project exists. Lets the Home flow pick a folder before the project
-  // is created without exposing the daemon's desktop-auth gate.
-  token: string;
-};
-
-export type OpenDesignHostPickWorkingDirResult =
-  | OpenDesignHostPickWorkingDirSuccess
-  | {
-      canceled: true;
-      ok: false;
-    }
-  | OpenDesignHostFailure;
-
-export type OpenDesignHostPdfPrintOptions = {
-  deck?: boolean;
-};
-
-export type OpenDesignHostCaptureClip = { x: number; y: number; width: number; height: number };
-export type OpenDesignHostCaptureOptions = { clip?: OpenDesignHostCaptureClip };
-export type OpenDesignHostCaptureSuccess = { dataUrl: string; h: number; ok: true; w: number };
-export type OpenDesignHostCaptureResult = OpenDesignHostCaptureSuccess | OpenDesignHostFailure;
-
-export type OpenDesignHostBrowserClearDataOptions = {
-  cookies?: boolean;
-  storage?: boolean;
-};
-
-export const OPEN_DESIGN_HOST_UPDATER_ACTIONS = Object.freeze({
-  CHECK: "check",
-  DOWNLOAD: "download",
-  INSTALL: "install",
-  QUIT: "quit",
-  STATUS: "status",
-} as const);
-
-export type OpenDesignHostUpdaterAction =
-  (typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS)[keyof typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS];
-type OpenDesignHostUpdaterStatusAction = Exclude<
-  OpenDesignHostUpdaterAction,
-  typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS.QUIT
->;
-
-export const OPEN_DESIGN_HOST_UPDATER_STATES = Object.freeze({
-  AVAILABLE: "available",
-  CHECKING: "checking",
-  DOWNLOADED: "downloaded",
-  DOWNLOADING: "downloading",
-  ERROR: "error",
-  IDLE: "idle",
-  INSTALLING: "installing",
-  NOT_AVAILABLE: "not-available",
-  UNSUPPORTED: "unsupported",
-} as const);
-
-export type OpenDesignHostUpdaterState =
-  (typeof OPEN_DESIGN_HOST_UPDATER_STATES)[keyof typeof OPEN_DESIGN_HOST_UPDATER_STATES];
-
-export type OpenDesignHostUpdaterMode = "js-incremental" | "package-launcher";
-export type OpenDesignHostUpdaterChannel = ReleaseChannel;
-
-export type OpenDesignHostUpdaterActionOptions = {
-  payload?: Record<string, unknown>;
-};
-
-export type OpenDesignHostUpdaterCapabilitySet = {
-  canApplyInPlace: boolean;
-  canDownload: boolean;
-  canOpenInstaller: boolean;
-  requiresManualInstall: boolean;
-};
-
-export type OpenDesignHostUpdaterPathSnapshot = {
-  downloadRoot?: string;
-  manifestPath?: string;
-};
-
-export type OpenDesignHostUpdaterChecksumSnapshot = {
-  algorithm: "sha256" | "sha512";
-  url?: string;
-  value?: string;
-};
-
-export type OpenDesignHostUpdaterArtifactSnapshot = {
-  name?: string;
-  platformKey?: string;
-  size?: number;
-  type?: string;
-  url: string;
-};
-
-export type OpenDesignHostUpdaterProgressSnapshot = {
-  receivedBytes: number;
-  totalBytes?: number;
-};
-
-export type OpenDesignHostUpdaterErrorSnapshot = {
-  code: string;
-  details?: unknown;
-  message: string;
-};
-
-export type OpenDesignHostUpdaterInstallResult = {
-  activeVersion?: string;
-  artifactPath?: string;
-  dryRun?: boolean;
-  helperLogPath?: string;
-  launcherRuntimePath?: string;
-  launchPath?: string;
-  openedAt: string;
-  path: string;
-};
-
-export type OpenDesignHostUpdaterReleaseSnapshot = {
-  arch: string;
-  artifact: OpenDesignHostUpdaterArtifactSnapshot;
-  checksum: OpenDesignHostUpdaterChecksumSnapshot;
-  channel: OpenDesignHostUpdaterChannel;
-  downloadedAt: string;
-  key: string;
-  metadata?: Record<string, unknown>;
-  path: string;
-  platformKey: string;
-  version: string;
-};
-
-export type OpenDesignHostUpdaterIncomingSnapshot = {
-  arch: string;
-  artifact: OpenDesignHostUpdaterArtifactSnapshot;
-  channel: OpenDesignHostUpdaterChannel;
-  key?: string;
-  metadata?: Record<string, unknown>;
-  progress?: OpenDesignHostUpdaterProgressSnapshot;
-  startedAt: string;
-  version: string;
-};
-
-export type OpenDesignHostUpdaterCacheLifecycleTrigger = "cold-start" | "next-version-ready";
-
-export type OpenDesignHostUpdaterReleaseLifecycleState =
-  | "cleanup-deferred"
-  | "cleanup-removed"
-  | "deprecated"
-  | "retained"
-  | "unknown";
-
-export type OpenDesignHostUpdaterCacheLifecycleSummary = {
-  lastRunAt?: string;
-  lastTrigger?: OpenDesignHostUpdaterCacheLifecycleTrigger;
-  platform: string;
-  releases: {
-    cleanupDeferred: number;
-    cleanupRemoved: number;
-    deprecated: number;
-    errors: number;
-    retained: number;
-    total: number;
-    unknown: number;
-  };
-};
-
-export type OpenDesignHostUpdaterCacheSnapshot = {
-  lifecycle?: OpenDesignHostUpdaterCacheLifecycleSummary;
-};
-
-export type OpenDesignHostUpdaterStatusSnapshot = {
-  active?: OpenDesignHostUpdaterReleaseSnapshot;
-  arch: string;
-  artifact?: OpenDesignHostUpdaterArtifactSnapshot;
-  artifactUrl?: string;
-  availableVersion?: string;
-  cache?: OpenDesignHostUpdaterCacheSnapshot;
-  capabilities: OpenDesignHostUpdaterCapabilitySet;
-  channel: OpenDesignHostUpdaterChannel;
-  checksum?: OpenDesignHostUpdaterChecksumSnapshot;
-  currentVersion: string;
-  downloadPath?: string;
-  enabled: boolean;
-  error?: OpenDesignHostUpdaterErrorSnapshot;
-  incoming?: OpenDesignHostUpdaterIncomingSnapshot;
-  installResult?: OpenDesignHostUpdaterInstallResult;
-  lastCheckedAt?: string;
-  metadata?: Record<string, unknown>;
-  mode: OpenDesignHostUpdaterMode;
-  paths?: OpenDesignHostUpdaterPathSnapshot;
-  platform: string;
-  progress?: OpenDesignHostUpdaterProgressSnapshot;
-  state: OpenDesignHostUpdaterState;
-  supported: boolean;
-};
-
-export type OpenDesignHostUpdaterResult =
-  | { ok: true; status: OpenDesignHostUpdaterStatusSnapshot }
-  | OpenDesignHostFailure;
-
-export type OpenDesignHostUpdaterStatusListener = (status: OpenDesignHostUpdaterStatusSnapshot) => void;
-
-export type OpenDesignHostBridge = {
-  browser: {
-    clearData(options?: OpenDesignHostBrowserClearDataOptions): Promise<OpenDesignHostActionResult>;
-  };
-  capture: {
-    page(options?: OpenDesignHostCaptureOptions): Promise<OpenDesignHostCaptureResult>;
-  };
-  client: OpenDesignHostClient;
-  pdf: {
-    print(html: string, nonce?: string, options?: OpenDesignHostPdfPrintOptions): Promise<OpenDesignHostActionResult>;
-  };
-  pet: {
-    setVisible(visible: boolean): void;
-  };
-  project: {
-    pickAndImport(init?: OpenDesignHostProjectImportInit): Promise<OpenDesignHostProjectImportResult>;
-    pickAndReplaceWorkingDir(projectId: string): Promise<OpenDesignHostProjectReplaceWorkingDirResult>;
-    // Optional so older host builds still satisfy the bridge shape; callers
-    // must feature-detect before invoking.
-    pickWorkingDir?(): Promise<OpenDesignHostPickWorkingDirResult>;
-  };
-  shell: {
-    openExternal(url: string): Promise<OpenDesignHostActionResult>;
-    openPath(projectId: string): Promise<OpenDesignHostActionResult>;
-  };
-  updater: {
-    check(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
-    download(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
-    install(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
-    quit(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostActionResult>;
-    status(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
-    subscribe(listener: OpenDesignHostUpdaterStatusListener): () => void;
-  };
-  version: typeof OPEN_DESIGN_HOST_VERSION;
-};
-
-export type OpenDesignHostGlobalScope = Record<string, unknown> & {
-  window?: unknown;
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value != null && !Array.isArray(value);
-}
-
-function failure(reason: string, details?: unknown): OpenDesignHostFailure {
-  return {
-    ...(details === undefined ? {} : { details }),
-    ok: false,
-    reason,
-  };
-}
-
-function hasFunction(record: Record<string, unknown>, key: string): boolean {
-  return typeof record[key] === "function";
-}
-
-export function isOpenDesignHostBridge(value: unknown): value is OpenDesignHostBridge {
-  if (!isRecord(value)) return false;
-  if (value.version !== OPEN_DESIGN_HOST_VERSION) return false;
-  const client = value.client;
-  if (!isRecord(client) || client.type !== OPEN_DESIGN_HOST_CLIENT_TYPES.DESKTOP) return false;
-  if (client.platform != null && typeof client.platform !== "string") return false;
-  if (client.osLocale != null && typeof client.osLocale !== "string") return false;
-
-  const shell = value.shell;
-  if (!isRecord(shell) || !hasFunction(shell, "openExternal") || !hasFunction(shell, "openPath")) return false;
-
-  const browser = value.browser;
-  if (!isRecord(browser) || !hasFunction(browser, "clearData")) return false;
-
-  const capture = value.capture;
-  if (!isRecord(capture) || !hasFunction(capture, "page")) return false;
-
-  const project = value.project;
-  if (
-    !isRecord(project) ||
-    !hasFunction(project, "pickAndImport") ||
-    !hasFunction(project, "pickAndReplaceWorkingDir")
-  ) {
-    return false;
-  }
-
-  const pdf = value.pdf;
-  if (!isRecord(pdf) || !hasFunction(pdf, "print")) return false;
-
-  const pet = value.pet;
-  if (!isRecord(pet) || !hasFunction(pet, "setVisible")) return false;
-
-  const updater = value.updater;
-  if (
-    !isRecord(updater) ||
-    !hasFunction(updater, "status") ||
-    !hasFunction(updater, "check") ||
-    !hasFunction(updater, "download") ||
-    !hasFunction(updater, "install") ||
-    !hasFunction(updater, "quit") ||
-    !hasFunction(updater, "subscribe")
-  ) {
-    return false;
-  }
-
-  return true;
-}
-
 /**
- * Converts a privileged host adapter's raw project-import result into the
- * host-owned renderer contract. The adapter may internally call daemon APIs,
- * but only project identifiers cross the host bridge.
+ * @module host
+ *
+ * Public barrel for `@open-design/host` — the Open Design renderer host-bridge
+ * protocol. Re-exports the exact prior flat surface from the cohesive sibling
+ * modules: the wire protocol (constants + types), bridge detection/validation,
+ * adapter-result normalizers, and the renderer-facing action wrappers. This
+ * file contains no logic.
  */
-export function normalizeOpenDesignHostProjectImportResult(input: unknown): OpenDesignHostProjectImportResult {
-  if (!isRecord(input)) {
-    return failure("desktop import returned an invalid response", input);
-  }
-  if (input.ok !== true) {
-    if (input.canceled === true) return { canceled: true, ok: false };
-    const reason = typeof input.reason === "string" && input.reason.length > 0
-      ? input.reason
-      : "unknown failure";
-    return failure(reason, input.details);
-  }
 
-  const response = input.response;
-  if (!isRecord(response)) {
-    return failure("daemon import response was not an object", response);
-  }
-  const project = response.project;
-  const rawProjectId = isRecord(project) ? project.id : null;
-  const projectId = typeof rawProjectId === "string" ? rawProjectId : null;
-  const conversationId = typeof response.conversationId === "string" ? response.conversationId : null;
-  const entryFile =
-    typeof response.entryFile === "string" || response.entryFile === null
-      ? response.entryFile
-      : undefined;
-  if (projectId == null || conversationId == null || entryFile === undefined) {
-    return failure("daemon import response did not include host project identifiers", response);
-  }
+// --- protocol: constant registries + wire types ---
+export {
+  OPEN_DESIGN_HOST_GLOBAL,
+  OPEN_DESIGN_HOST_VERSION,
+  OPEN_DESIGN_HOST_CLIENT_TYPES,
+  OPEN_DESIGN_HOST_UPDATER_ACTIONS,
+  OPEN_DESIGN_HOST_UPDATER_STATES,
+} from "./protocol.js";
+export type {
+  OpenDesignHostClientType,
+  OpenDesignHostClient,
+  OpenDesignHostFailure,
+  OpenDesignHostActionResult,
+  OpenDesignHostProjectImportInit,
+  OpenDesignHostProjectImportSuccess,
+  OpenDesignHostProjectImportResult,
+  OpenDesignHostProjectReplaceWorkingDirSuccess,
+  OpenDesignHostProjectReplaceWorkingDirResult,
+  OpenDesignHostPickWorkingDirSuccess,
+  OpenDesignHostPickWorkingDirResult,
+  OpenDesignHostPdfPrintOptions,
+  OpenDesignHostCaptureClip,
+  OpenDesignHostCaptureOptions,
+  OpenDesignHostCaptureSuccess,
+  OpenDesignHostCaptureResult,
+  OpenDesignHostBrowserClearDataOptions,
+  OpenDesignHostUpdaterAction,
+  OpenDesignHostUpdaterState,
+  OpenDesignHostUpdaterMode,
+  OpenDesignHostUpdaterChannel,
+  OpenDesignHostUpdaterActionOptions,
+  OpenDesignHostUpdaterCapabilitySet,
+  OpenDesignHostUpdaterPathSnapshot,
+  OpenDesignHostUpdaterChecksumSnapshot,
+  OpenDesignHostUpdaterArtifactSnapshot,
+  OpenDesignHostUpdaterProgressSnapshot,
+  OpenDesignHostUpdaterErrorSnapshot,
+  OpenDesignHostUpdaterInstallResult,
+  OpenDesignHostUpdaterReleaseSnapshot,
+  OpenDesignHostUpdaterIncomingSnapshot,
+  OpenDesignHostUpdaterCacheLifecycleTrigger,
+  OpenDesignHostUpdaterReleaseLifecycleState,
+  OpenDesignHostUpdaterCacheLifecycleSummary,
+  OpenDesignHostUpdaterCacheSnapshot,
+  OpenDesignHostUpdaterStatusSnapshot,
+  OpenDesignHostUpdaterResult,
+  OpenDesignHostUpdaterStatusListener,
+  OpenDesignHostBridge,
+  OpenDesignHostGlobalScope,
+} from "./protocol.js";
 
-  return {
-    conversationId,
-    entryFile,
-    ok: true,
-    projectId,
-  };
-}
+// --- detection: locate + validate the injected bridge ---
+export {
+  isOpenDesignHostBridge,
+  getOpenDesignHost,
+  isOpenDesignHostAvailable,
+  detectOpenDesignHostClientType,
+} from "./detection.js";
 
-export function normalizeOpenDesignHostProjectReplaceWorkingDirResult(
-  input: unknown,
-): OpenDesignHostProjectReplaceWorkingDirResult {
-  if (!isRecord(input)) {
-    return failure("desktop working-dir replace returned an invalid response", input);
-  }
-  if (input.ok !== true) {
-    if (input.canceled === true) return { canceled: true, ok: false };
-    const reason = typeof input.reason === "string" && input.reason.length > 0
-      ? input.reason
-      : "unknown failure";
-    return failure(reason, input.details);
-  }
+// --- normalize: adapter result -> renderer contract ---
+export {
+  normalizeOpenDesignHostProjectImportResult,
+  normalizeOpenDesignHostProjectReplaceWorkingDirResult,
+  normalizeOpenDesignHostPickWorkingDirResult,
+} from "./normalize.js";
 
-  const response = input.response;
-  if (!isRecord(response)) {
-    return failure("daemon working-dir response was not an object", response);
-  }
-  const baseDir = typeof response.baseDir === "string" ? response.baseDir : null;
-  const entryFile = typeof response.entryFile === "string" ? response.entryFile : null;
-  if (baseDir == null) {
-    return failure("daemon working-dir response did not include baseDir", response);
-  }
-
-  return { baseDir, entryFile, ok: true };
-}
-
-export function normalizeOpenDesignHostPickWorkingDirResult(
-  input: unknown,
-): OpenDesignHostPickWorkingDirResult {
-  if (!isRecord(input)) {
-    return failure("desktop working-dir pick returned an invalid response", input);
-  }
-  if (input.ok !== true) {
-    if (input.canceled === true) return { canceled: true, ok: false };
-    const reason = typeof input.reason === "string" && input.reason.length > 0
-      ? input.reason
-      : "unknown failure";
-    return failure(reason, input.details);
-  }
-  const baseDir = typeof input.baseDir === "string" ? input.baseDir : null;
-  const token = typeof input.token === "string" ? input.token : null;
-  if (baseDir == null || token == null) {
-    return failure("desktop working-dir pick did not include baseDir and token", input);
-  }
-  return { baseDir, ok: true, token };
-}
-
-function candidateFromScope(scope: OpenDesignHostGlobalScope): unknown {
-  if (OPEN_DESIGN_HOST_GLOBAL in scope) return scope[OPEN_DESIGN_HOST_GLOBAL];
-  const windowValue = scope.window;
-  if (isRecord(windowValue) && OPEN_DESIGN_HOST_GLOBAL in windowValue) {
-    return windowValue[OPEN_DESIGN_HOST_GLOBAL];
-  }
-  return undefined;
-}
-
-export function getOpenDesignHost(scope: OpenDesignHostGlobalScope = globalThis): OpenDesignHostBridge | null {
-  const candidate = candidateFromScope(scope);
-  return isOpenDesignHostBridge(candidate) ? candidate : null;
-}
-
-export function isOpenDesignHostAvailable(scope: OpenDesignHostGlobalScope = globalThis): boolean {
-  return getOpenDesignHost(scope) != null;
-}
-
-export function detectOpenDesignHostClientType(scope: OpenDesignHostGlobalScope = globalThis): OpenDesignHostClientType | "web" {
-  return getOpenDesignHost(scope)?.client.type ?? "web";
-}
-
-function unavailable(reason: string): OpenDesignHostFailure {
-  return failure(reason);
-}
-
-export async function openHostExternalUrl(url: string, scope: OpenDesignHostGlobalScope = globalThis): Promise<OpenDesignHostActionResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return await host.shell.openExternal(url);
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export async function openHostProjectPath(projectId: string, scope: OpenDesignHostGlobalScope = globalThis): Promise<OpenDesignHostActionResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return await host.shell.openPath(projectId);
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export async function clearHostBrowserData(
-  options?: OpenDesignHostBrowserClearDataOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostActionResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return await host.browser.clearData(options);
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export async function captureHostPage(
-  options?: OpenDesignHostCaptureOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostCaptureResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return await host.capture.page(options);
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export async function pickAndImportHostProject(
-  init?: OpenDesignHostProjectImportInit,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostProjectImportResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return await host.project.pickAndImport(init);
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export async function pickAndReplaceHostProjectWorkingDir(
-  projectId: string,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostProjectReplaceWorkingDirResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return await host.project.pickAndReplaceWorkingDir(projectId);
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-// Picks a folder via the host's native dialog and returns the chosen path
-// plus a single-use token, WITHOUT touching any project. The Home flow uses
-// this to let the user choose a working directory before the project exists;
-// the token is later spent on POST /api/projects/:id/working-dir.
-export async function pickHostWorkingDir(
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostPickWorkingDirResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  if (typeof host.project.pickWorkingDir !== "function") {
-    return unavailable("host build does not support pickWorkingDir");
-  }
-  try {
-    return await host.project.pickWorkingDir();
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export async function printHostPdf(
-  html: string,
-  nonce?: string,
-  options?: OpenDesignHostPdfPrintOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostActionResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return await host.pdf.print(html, nonce, options);
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export function setHostPetVisible(visible: boolean, scope: OpenDesignHostGlobalScope = globalThis): OpenDesignHostActionResult {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    host.pet.setVisible(visible);
-    return { ok: true };
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-async function runHostUpdaterAction(
-  action: OpenDesignHostUpdaterStatusAction,
-  options?: OpenDesignHostUpdaterActionOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostUpdaterResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return {
-      ok: true,
-      status: await host.updater[action](options),
-    };
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export async function getHostUpdaterStatus(
-  options?: OpenDesignHostUpdaterActionOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostUpdaterResult> {
-  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.STATUS, options, scope);
-}
-
-export async function checkHostUpdater(
-  options?: OpenDesignHostUpdaterActionOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostUpdaterResult> {
-  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.CHECK, options, scope);
-}
-
-export async function downloadHostUpdater(
-  options?: OpenDesignHostUpdaterActionOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostUpdaterResult> {
-  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.DOWNLOAD, options, scope);
-}
-
-export async function installHostUpdater(
-  options?: OpenDesignHostUpdaterActionOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostUpdaterResult> {
-  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.INSTALL, options, scope);
-}
-
-export async function quitHostAfterUpdaterInstallerOpen(
-  options?: OpenDesignHostUpdaterActionOptions,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): Promise<OpenDesignHostActionResult> {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return unavailable("Open Design host is not available");
-  try {
-    return await host.updater.quit(options);
-  } catch (error) {
-    return unavailable(error instanceof Error ? error.message : String(error));
-  }
-}
-
-export function subscribeHostUpdater(
-  listener: OpenDesignHostUpdaterStatusListener,
-  scope: OpenDesignHostGlobalScope = globalThis,
-): () => void {
-  const host = getOpenDesignHost(scope);
-  if (host == null) return () => undefined;
-  try {
-    return host.updater.subscribe(listener);
-  } catch {
-    return () => undefined;
-  }
-}
+// --- actions: renderer-facing host action wrappers ---
+export {
+  openHostExternalUrl,
+  openHostProjectPath,
+  clearHostBrowserData,
+  captureHostPage,
+  pickAndImportHostProject,
+  pickAndReplaceHostProjectWorkingDir,
+  pickHostWorkingDir,
+  printHostPdf,
+  setHostPetVisible,
+  getHostUpdaterStatus,
+  checkHostUpdater,
+  downloadHostUpdater,
+  installHostUpdater,
+  quitHostAfterUpdaterInstallerOpen,
+  subscribeHostUpdater,
+} from "./actions.js";

--- a/packages/host/src/normalize.ts
+++ b/packages/host/src/normalize.ts
@@ -1,0 +1,125 @@
+import type {
+  OpenDesignHostFailure,
+  OpenDesignHostProjectImportResult,
+  OpenDesignHostProjectReplaceWorkingDirResult,
+  OpenDesignHostPickWorkingDirResult,
+} from "./protocol.js";
+
+/**
+ * @module normalize
+ *
+ * Converts a privileged host adapter's raw responses into the host-owned
+ * renderer contracts. The adapter may call daemon APIs internally, but only the
+ * whitelisted identifiers cross the host bridge.
+ */
+
+/** @internal Narrow an unknown value to a plain record. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+/** @internal Build a normalized host failure result. */
+function failure(reason: string, details?: unknown): OpenDesignHostFailure {
+  return {
+    ...(details === undefined ? {} : { details }),
+    ok: false,
+    reason,
+  };
+}
+
+/**
+ * Converts a privileged host adapter's raw project-import result into the
+ * host-owned renderer contract. The adapter may internally call daemon APIs,
+ * but only project identifiers cross the host bridge.
+ */
+export function normalizeOpenDesignHostProjectImportResult(input: unknown): OpenDesignHostProjectImportResult {
+  if (!isRecord(input)) {
+    return failure("desktop import returned an invalid response", input);
+  }
+  if (input.ok !== true) {
+    if (input.canceled === true) return { canceled: true, ok: false };
+    const reason = typeof input.reason === "string" && input.reason.length > 0
+      ? input.reason
+      : "unknown failure";
+    return failure(reason, input.details);
+  }
+
+  const response = input.response;
+  if (!isRecord(response)) {
+    return failure("daemon import response was not an object", response);
+  }
+  const project = response.project;
+  const rawProjectId = isRecord(project) ? project.id : null;
+  const projectId = typeof rawProjectId === "string" ? rawProjectId : null;
+  const conversationId = typeof response.conversationId === "string" ? response.conversationId : null;
+  const entryFile =
+    typeof response.entryFile === "string" || response.entryFile === null
+      ? response.entryFile
+      : undefined;
+  if (projectId == null || conversationId == null || entryFile === undefined) {
+    return failure("daemon import response did not include host project identifiers", response);
+  }
+
+  return {
+    conversationId,
+    entryFile,
+    ok: true,
+    projectId,
+  };
+}
+
+/**
+ * Converts a privileged host adapter's raw working-dir replace result into the
+ * host-owned renderer contract.
+ */
+export function normalizeOpenDesignHostProjectReplaceWorkingDirResult(
+  input: unknown,
+): OpenDesignHostProjectReplaceWorkingDirResult {
+  if (!isRecord(input)) {
+    return failure("desktop working-dir replace returned an invalid response", input);
+  }
+  if (input.ok !== true) {
+    if (input.canceled === true) return { canceled: true, ok: false };
+    const reason = typeof input.reason === "string" && input.reason.length > 0
+      ? input.reason
+      : "unknown failure";
+    return failure(reason, input.details);
+  }
+
+  const response = input.response;
+  if (!isRecord(response)) {
+    return failure("daemon working-dir response was not an object", response);
+  }
+  const baseDir = typeof response.baseDir === "string" ? response.baseDir : null;
+  const entryFile = typeof response.entryFile === "string" ? response.entryFile : null;
+  if (baseDir == null) {
+    return failure("daemon working-dir response did not include baseDir", response);
+  }
+
+  return { baseDir, entryFile, ok: true };
+}
+
+/**
+ * Converts a privileged host adapter's raw working-dir pick result into the
+ * host-owned renderer contract (chosen path plus single-use token).
+ */
+export function normalizeOpenDesignHostPickWorkingDirResult(
+  input: unknown,
+): OpenDesignHostPickWorkingDirResult {
+  if (!isRecord(input)) {
+    return failure("desktop working-dir pick returned an invalid response", input);
+  }
+  if (input.ok !== true) {
+    if (input.canceled === true) return { canceled: true, ok: false };
+    const reason = typeof input.reason === "string" && input.reason.length > 0
+      ? input.reason
+      : "unknown failure";
+    return failure(reason, input.details);
+  }
+  const baseDir = typeof input.baseDir === "string" ? input.baseDir : null;
+  const token = typeof input.token === "string" ? input.token : null;
+  if (baseDir == null || token == null) {
+    return failure("desktop working-dir pick did not include baseDir and token", input);
+  }
+  return { baseDir, ok: true, token };
+}

--- a/packages/host/src/protocol.ts
+++ b/packages/host/src/protocol.ts
@@ -1,0 +1,318 @@
+import type { ReleaseChannel } from "@open-design/release";
+
+/**
+ * @module protocol
+ *
+ * The Open Design renderer host-bridge wire contract: the injected-global name
+ * and version, client/updater constant registries, and every request/result
+ * type that crosses the host bridge — including the {@link OpenDesignHostBridge}
+ * shape itself. Pure declarations only; depends on nothing else in the package.
+ */
+
+export const OPEN_DESIGN_HOST_GLOBAL = "__od__";
+export const OPEN_DESIGN_HOST_VERSION = 2;
+
+export const OPEN_DESIGN_HOST_CLIENT_TYPES = Object.freeze({
+  DESKTOP: "desktop",
+} as const);
+
+export type OpenDesignHostClientType =
+  (typeof OPEN_DESIGN_HOST_CLIENT_TYPES)[keyof typeof OPEN_DESIGN_HOST_CLIENT_TYPES];
+
+export type OpenDesignHostClient = {
+  // BCP-47 locale string (e.g. "zh-CN", "pt-BR") the host process read from
+  // the OS at startup. The renderer uses this so the packaged desktop app
+  // can follow the OS language even when Chromium's built-in
+  // `navigator.language` would have defaulted to en-US.
+  osLocale?: string;
+  platform?: string;
+  type: OpenDesignHostClientType;
+};
+
+export type OpenDesignHostFailure = {
+  details?: unknown;
+  ok: false;
+  reason: string;
+};
+
+export type OpenDesignHostActionResult =
+  | { ok: true }
+  | OpenDesignHostFailure;
+
+export type OpenDesignHostProjectImportInit = {
+  designSystemId?: string | null;
+  name?: string;
+  skillId?: string | null;
+};
+
+export type OpenDesignHostProjectImportSuccess = {
+  conversationId: string;
+  entryFile: string | null;
+  ok: true;
+  projectId: string;
+};
+
+export type OpenDesignHostProjectImportResult =
+  | OpenDesignHostProjectImportSuccess
+  | {
+      canceled: true;
+      ok: false;
+    }
+  | OpenDesignHostFailure;
+
+export type OpenDesignHostProjectReplaceWorkingDirSuccess = {
+  baseDir: string;
+  entryFile: string | null;
+  ok: true;
+};
+
+export type OpenDesignHostProjectReplaceWorkingDirResult =
+  | OpenDesignHostProjectReplaceWorkingDirSuccess
+  | {
+      canceled: true;
+      ok: false;
+    }
+  | OpenDesignHostFailure;
+
+export type OpenDesignHostPickWorkingDirSuccess = {
+  baseDir: string;
+  ok: true;
+  // Single-use HMAC token (minted by the host main process for `baseDir`)
+  // that the renderer threads into POST /api/projects/:id/working-dir once
+  // the project exists. Lets the Home flow pick a folder before the project
+  // is created without exposing the daemon's desktop-auth gate.
+  token: string;
+};
+
+export type OpenDesignHostPickWorkingDirResult =
+  | OpenDesignHostPickWorkingDirSuccess
+  | {
+      canceled: true;
+      ok: false;
+    }
+  | OpenDesignHostFailure;
+
+export type OpenDesignHostPdfPrintOptions = {
+  deck?: boolean;
+};
+
+export type OpenDesignHostCaptureClip = { x: number; y: number; width: number; height: number };
+export type OpenDesignHostCaptureOptions = { clip?: OpenDesignHostCaptureClip };
+export type OpenDesignHostCaptureSuccess = { dataUrl: string; h: number; ok: true; w: number };
+export type OpenDesignHostCaptureResult = OpenDesignHostCaptureSuccess | OpenDesignHostFailure;
+
+export type OpenDesignHostBrowserClearDataOptions = {
+  cookies?: boolean;
+  storage?: boolean;
+};
+
+export const OPEN_DESIGN_HOST_UPDATER_ACTIONS = Object.freeze({
+  CHECK: "check",
+  DOWNLOAD: "download",
+  INSTALL: "install",
+  QUIT: "quit",
+  STATUS: "status",
+} as const);
+
+export type OpenDesignHostUpdaterAction =
+  (typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS)[keyof typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS];
+
+/** @internal Updater actions that return a status snapshot (every action except `quit`). */
+export type OpenDesignHostUpdaterStatusAction = Exclude<
+  OpenDesignHostUpdaterAction,
+  typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS.QUIT
+>;
+
+export const OPEN_DESIGN_HOST_UPDATER_STATES = Object.freeze({
+  AVAILABLE: "available",
+  CHECKING: "checking",
+  DOWNLOADED: "downloaded",
+  DOWNLOADING: "downloading",
+  ERROR: "error",
+  IDLE: "idle",
+  INSTALLING: "installing",
+  NOT_AVAILABLE: "not-available",
+  UNSUPPORTED: "unsupported",
+} as const);
+
+export type OpenDesignHostUpdaterState =
+  (typeof OPEN_DESIGN_HOST_UPDATER_STATES)[keyof typeof OPEN_DESIGN_HOST_UPDATER_STATES];
+
+export type OpenDesignHostUpdaterMode = "js-incremental" | "package-launcher";
+export type OpenDesignHostUpdaterChannel = ReleaseChannel;
+
+export type OpenDesignHostUpdaterActionOptions = {
+  payload?: Record<string, unknown>;
+};
+
+export type OpenDesignHostUpdaterCapabilitySet = {
+  canApplyInPlace: boolean;
+  canDownload: boolean;
+  canOpenInstaller: boolean;
+  requiresManualInstall: boolean;
+};
+
+export type OpenDesignHostUpdaterPathSnapshot = {
+  downloadRoot?: string;
+  manifestPath?: string;
+};
+
+export type OpenDesignHostUpdaterChecksumSnapshot = {
+  algorithm: "sha256" | "sha512";
+  url?: string;
+  value?: string;
+};
+
+export type OpenDesignHostUpdaterArtifactSnapshot = {
+  name?: string;
+  platformKey?: string;
+  size?: number;
+  type?: string;
+  url: string;
+};
+
+export type OpenDesignHostUpdaterProgressSnapshot = {
+  receivedBytes: number;
+  totalBytes?: number;
+};
+
+export type OpenDesignHostUpdaterErrorSnapshot = {
+  code: string;
+  details?: unknown;
+  message: string;
+};
+
+export type OpenDesignHostUpdaterInstallResult = {
+  activeVersion?: string;
+  artifactPath?: string;
+  dryRun?: boolean;
+  helperLogPath?: string;
+  launcherRuntimePath?: string;
+  launchPath?: string;
+  openedAt: string;
+  path: string;
+};
+
+export type OpenDesignHostUpdaterReleaseSnapshot = {
+  arch: string;
+  artifact: OpenDesignHostUpdaterArtifactSnapshot;
+  checksum: OpenDesignHostUpdaterChecksumSnapshot;
+  channel: OpenDesignHostUpdaterChannel;
+  downloadedAt: string;
+  key: string;
+  metadata?: Record<string, unknown>;
+  path: string;
+  platformKey: string;
+  version: string;
+};
+
+export type OpenDesignHostUpdaterIncomingSnapshot = {
+  arch: string;
+  artifact: OpenDesignHostUpdaterArtifactSnapshot;
+  channel: OpenDesignHostUpdaterChannel;
+  key?: string;
+  metadata?: Record<string, unknown>;
+  progress?: OpenDesignHostUpdaterProgressSnapshot;
+  startedAt: string;
+  version: string;
+};
+
+export type OpenDesignHostUpdaterCacheLifecycleTrigger = "cold-start" | "next-version-ready";
+
+export type OpenDesignHostUpdaterReleaseLifecycleState =
+  | "cleanup-deferred"
+  | "cleanup-removed"
+  | "deprecated"
+  | "retained"
+  | "unknown";
+
+export type OpenDesignHostUpdaterCacheLifecycleSummary = {
+  lastRunAt?: string;
+  lastTrigger?: OpenDesignHostUpdaterCacheLifecycleTrigger;
+  platform: string;
+  releases: {
+    cleanupDeferred: number;
+    cleanupRemoved: number;
+    deprecated: number;
+    errors: number;
+    retained: number;
+    total: number;
+    unknown: number;
+  };
+};
+
+export type OpenDesignHostUpdaterCacheSnapshot = {
+  lifecycle?: OpenDesignHostUpdaterCacheLifecycleSummary;
+};
+
+export type OpenDesignHostUpdaterStatusSnapshot = {
+  active?: OpenDesignHostUpdaterReleaseSnapshot;
+  arch: string;
+  artifact?: OpenDesignHostUpdaterArtifactSnapshot;
+  artifactUrl?: string;
+  availableVersion?: string;
+  cache?: OpenDesignHostUpdaterCacheSnapshot;
+  capabilities: OpenDesignHostUpdaterCapabilitySet;
+  channel: OpenDesignHostUpdaterChannel;
+  checksum?: OpenDesignHostUpdaterChecksumSnapshot;
+  currentVersion: string;
+  downloadPath?: string;
+  enabled: boolean;
+  error?: OpenDesignHostUpdaterErrorSnapshot;
+  incoming?: OpenDesignHostUpdaterIncomingSnapshot;
+  installResult?: OpenDesignHostUpdaterInstallResult;
+  lastCheckedAt?: string;
+  metadata?: Record<string, unknown>;
+  mode: OpenDesignHostUpdaterMode;
+  paths?: OpenDesignHostUpdaterPathSnapshot;
+  platform: string;
+  progress?: OpenDesignHostUpdaterProgressSnapshot;
+  state: OpenDesignHostUpdaterState;
+  supported: boolean;
+};
+
+export type OpenDesignHostUpdaterResult =
+  | { ok: true; status: OpenDesignHostUpdaterStatusSnapshot }
+  | OpenDesignHostFailure;
+
+export type OpenDesignHostUpdaterStatusListener = (status: OpenDesignHostUpdaterStatusSnapshot) => void;
+
+export type OpenDesignHostBridge = {
+  browser: {
+    clearData(options?: OpenDesignHostBrowserClearDataOptions): Promise<OpenDesignHostActionResult>;
+  };
+  capture: {
+    page(options?: OpenDesignHostCaptureOptions): Promise<OpenDesignHostCaptureResult>;
+  };
+  client: OpenDesignHostClient;
+  pdf: {
+    print(html: string, nonce?: string, options?: OpenDesignHostPdfPrintOptions): Promise<OpenDesignHostActionResult>;
+  };
+  pet: {
+    setVisible(visible: boolean): void;
+  };
+  project: {
+    pickAndImport(init?: OpenDesignHostProjectImportInit): Promise<OpenDesignHostProjectImportResult>;
+    pickAndReplaceWorkingDir(projectId: string): Promise<OpenDesignHostProjectReplaceWorkingDirResult>;
+    // Optional so older host builds still satisfy the bridge shape; callers
+    // must feature-detect before invoking.
+    pickWorkingDir?(): Promise<OpenDesignHostPickWorkingDirResult>;
+  };
+  shell: {
+    openExternal(url: string): Promise<OpenDesignHostActionResult>;
+    openPath(projectId: string): Promise<OpenDesignHostActionResult>;
+  };
+  updater: {
+    check(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
+    download(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
+    install(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
+    quit(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostActionResult>;
+    status(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
+    subscribe(listener: OpenDesignHostUpdaterStatusListener): () => void;
+  };
+  version: typeof OPEN_DESIGN_HOST_VERSION;
+};
+
+export type OpenDesignHostGlobalScope = Record<string, unknown> & {
+  window?: unknown;
+};


### PR DESCRIPTION
<!-- This PR is a pure internal refactor and closes no issue. -->
Part of #5165.

## Why

- **My use case:** Continuing the `packages/*` single-file-barrel cleanup after
  `platform` (#5166), `download` (#5167), `sidecar` (#5168), and `sidecar-proto`
  (#5169). `packages/host/src/index.ts` was 674 lines holding the entire
  `window.__od__` host-bridge surface — the protocol constants/types, the bridge
  detection guard + scope accessors, the adapter→renderer result normalizers, and
  every renderer-facing action wrapper (shell/browser/capture/project/pdf/updater).
- **The pain:** A 674-line bridge god-file mixes wire-protocol types with runtime
  action wrappers and normalizers, so the blast radius of any change is unclear.
  Splitting into cohesive concern modules makes each independently reviewable with
  zero behavior change. The separate `./testing` entrypoint (`testing.ts`) is
  untouched and still imports only public names from the barrel.

## What users will see

Nothing. Internal refactor only — the public API of `@open-design/host` and its
runtime behavior are identical. The barrel `index.ts` re-exports the exact same
67 names.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Validation

Behavior-preserving split of `index.ts` (674 LOC) into a pure barrel plus 4
cohesive concern modules: `protocol` (wire kernel), `detection` (bridge guard +
scope accessors), `normalize` (result normalizers), `actions` (renderer-facing
wrappers). Every body moved byte-identically (only import-path rewrites +
`@module`/JSDoc added); the two tiny private helpers `isRecord` and `failure` are
duplicated privately rather than introducing new exported names; no mutable
module-level state. Import graph is acyclic (`protocol` ← `detection`,
`normalize`; `actions → protocol, detection`).

- `pnpm --filter @open-design/host typecheck` → **exit 0** (src + tests)
- `pnpm --filter @open-design/host test` → **14 passed**
- `pnpm --filter @open-design/host build` → **exit 0**
- **Export-surface identity:** original 67 names == new barrel == emitted `dist/index.d.ts`; diff empty both directions. One previously-private type (`OpenDesignHostUpdaterStatusAction`) is now exported from `protocol.ts` for cross-file use but is deliberately NOT re-exported by the barrel.
- **Byte-identity proof:** normalized multiset diff of every code line shows zero original lines lost and no added logic (only the intentional `isRecord`/`failure` duplication and cross-file import members differ).
- **No deep imports:** nothing imports `@open-design/host/src/*`.
