### PR TITLE
refactor(plugin-runtime): extract named helpers to cut validate/resolve/frontmatter complexity

### DIFF
--- a/packages/plugin-runtime/src/parsers/frontmatter.ts
+++ b/packages/plugin-runtime/src/parsers/frontmatter.ts
@@ -137,23 +137,10 @@ function parseYamlSubset(src: string): FrontmatterObject {
     }
 
     if (val === '|' || val === '|-' || val === '>' || val === '>-') {
-      const collected: string[] = [];
-      const childIndent = indent + 2;
-      i++;
-      while (i < lines.length) {
-        const next = lines[i] ?? '';
-        if (/^\s*$/.test(next)) {
-          collected.push('');
-          i++;
-          continue;
-        }
-        const nIndent = next.match(/^\s*/)?.[0].length ?? 0;
-        if (nIndent < childIndent) break;
-        collected.push(next.slice(childIndent));
-        i++;
-      }
+      const { value, nextIndex } = collectBlockScalar(lines, i, indent + 2);
       if (Array.isArray(top.container)) throw new Error('frontmatter object container expected');
-      top.container[key] = collected.join('\n').trimEnd();
+      top.container[key] = value;
+      i = nextIndex;
       continue;
     }
 
@@ -166,11 +153,7 @@ function parseYamlSubset(src: string): FrontmatterObject {
 
     if (val.startsWith('[') && val.endsWith(']')) {
       if (Array.isArray(top.container)) throw new Error('frontmatter object container expected');
-      top.container[key] = val
-        .slice(1, -1)
-        .split(',')
-        .map((s) => coerce(s.trim()))
-        .filter((v): v is FrontmatterValue => v !== '');
+      top.container[key] = parseInlineArray(val);
       i++;
       continue;
     }
@@ -181,6 +164,43 @@ function parseYamlSubset(src: string): FrontmatterObject {
   }
 
   return root;
+}
+
+// Collect an indented block scalar (|, |-, >, >-). This subset joins physical
+// lines with `\n` (no YAML folding for `>`) and right-trims the result.
+// `keyIndex` points at the `key: |` line; returns the joined value and the
+// line index the caller should resume parsing from.
+function collectBlockScalar(
+  lines: string[],
+  keyIndex: number,
+  childIndent: number,
+): { value: string; nextIndex: number } {
+  const collected: string[] = [];
+  let i = keyIndex + 1;
+  while (i < lines.length) {
+    const next = lines[i] ?? '';
+    if (/^\s*$/.test(next)) {
+      collected.push('');
+      i++;
+      continue;
+    }
+    const nIndent = next.match(/^\s*/)?.[0].length ?? 0;
+    if (nIndent < childIndent) break;
+    collected.push(next.slice(childIndent));
+    i++;
+  }
+  return { value: collected.join('\n').trimEnd(), nextIndex: i };
+}
+
+// Parse a single-line inline array `[a, b, c]` into coerced scalars, dropping
+// empty entries (e.g. a trailing comma). The empty-array `[]` form is handled
+// by the caller before this runs.
+function parseInlineArray(val: string): FrontmatterValue[] {
+  return val
+    .slice(1, -1)
+    .split(',')
+    .map((s) => coerce(s.trim()))
+    .filter((v): v is FrontmatterValue => v !== '');
 }
 
 function coerce(raw: string | undefined): FrontmatterValue {

--- a/packages/plugin-runtime/src/resolve.ts
+++ b/packages/plugin-runtime/src/resolve.ts
@@ -58,118 +58,165 @@ export interface ResolveResult {
   digestRefs: Array<{ kind: string; ref: string }>;
 }
 
-export function resolveContext(manifest: PluginManifest, opts: ResolveOptions): ResolveResult {
-  const warnings: string[] = [];
-  const items: ContextItem[] = [];
-  const digestRefs: Array<{ kind: string; ref: string }> = [];
+type DigestRef = { kind: string; ref: string };
+type PluginContext = NonNullable<NonNullable<PluginManifest['od']>['context']>;
 
-  const ctx = manifest.od?.context;
+// Order-stable output threaded through the per-kind resolvers. Each resolver
+// appends in a fixed sequence; digestRefs order is load-bearing because it
+// feeds the manifest source digest.
+interface ResolveAccumulator {
+  items: ContextItem[];
+  digestRefs: DigestRef[];
+  warnings: string[];
+}
+
+export function resolveContext(manifest: PluginManifest, opts: ResolveOptions): ResolveResult {
   const registry = opts.registry;
+  const warnOnMissing = opts.warnOnMissing;
+  const ctx = manifest.od?.context;
+
+  const acc: ResolveAccumulator = { items: [], digestRefs: [], warnings: [] };
 
   if (ctx) {
-    // Skills
-    for (const ref of ctx.skills ?? []) {
-      const id = (ref.ref ?? ref.path ?? '').trim();
-      if (!id) continue;
-      const skill = registry.skills.find((s) => s.id === id || s.id === stripDotSlash(id));
-      if (!skill) {
-        if (opts.warnOnMissing) warnings.push(`Unknown skill ref: '${id}'`);
-        continue;
-      }
-      items.push({ kind: 'skill', id: skill.id, label: skill.title ?? skill.id });
-      digestRefs.push({ kind: 'skill', ref: skill.id });
-    }
-
-    // Design system
-    if (ctx.designSystem) {
-      const dsRef = ctx.designSystem;
-      const explicitRef = typeof dsRef.ref === 'string' ? dsRef.ref.trim() : '';
-      if (explicitRef) {
-        const ds = registry.designSystems.find((d) => d.id === explicitRef);
-        if (ds) {
-          items.push({ kind: 'design-system', id: ds.id, label: ds.title ?? ds.id, primary: true });
-          digestRefs.push({ kind: 'design-system', ref: ds.id });
-        } else if (opts.warnOnMissing) {
-          warnings.push(`Unknown design-system ref: '${explicitRef}'`);
-        }
-      } else if (registry.activeProjectDesignSystem) {
-        const ds = registry.activeProjectDesignSystem;
-        items.push({ kind: 'design-system', id: ds.id, label: ds.title ?? ds.id, primary: true });
-        digestRefs.push({ kind: 'design-system', ref: ds.id });
-      }
-    }
-
-    // Craft
-    for (const slug of ctx.craft ?? []) {
-      const id = String(slug).trim();
-      if (!id) continue;
-      const c = registry.craft.find((x) => x.id === id);
-      if (!c) {
-        if (opts.warnOnMissing) warnings.push(`Unknown craft slug: '${id}'`);
-        continue;
-      }
-      items.push({ kind: 'craft', id: c.id, label: c.title ?? c.id });
-      digestRefs.push({ kind: 'craft', ref: c.id });
-    }
-
-    // Assets — paths are kept as-is and validated by the installer at apply
-    // time. The chip strip uses the basename as the label.
-    for (const rawPath of ctx.assets ?? []) {
-      const p = String(rawPath).trim();
-      if (!p) continue;
-      const label = p.split('/').pop() ?? p;
-      items.push({ kind: 'asset', path: p, label });
-      digestRefs.push({ kind: 'asset', ref: p });
-    }
-
-    // MCP
-    for (const mcp of ctx.mcp ?? []) {
-      if (!mcp.name) continue;
-      items.push({
-        kind: 'mcp',
-        name: mcp.name,
-        label: mcp.name,
-        command: typeof mcp.command === 'string' ? mcp.command : undefined,
-      });
-      digestRefs.push({ kind: 'mcp', ref: mcp.name });
-    }
-
-    // Claude plugins
-    for (const ref of ctx.claudePlugins ?? []) {
-      const id = (ref.ref ?? ref.path ?? '').trim();
-      if (!id) continue;
-      items.push({ kind: 'claude-plugin', id, label: id });
-      digestRefs.push({ kind: 'claude-plugin', ref: id });
-    }
-
-    // Atoms
-    for (const atomId of ctx.atoms ?? []) {
-      const id = String(atomId).trim();
-      if (!id) continue;
-      const atom = registry.atoms.find((a) => a.id === id);
-      const label = atom?.label ?? id;
-      items.push({ kind: 'atom', id, label });
-      digestRefs.push({ kind: 'atom', ref: id });
-    }
+    resolveSkills(ctx, registry, warnOnMissing, acc);
+    resolveDesignSystem(ctx, registry, warnOnMissing, acc);
+    resolveCraft(ctx, registry, warnOnMissing, acc);
+    resolveAssets(ctx, acc);
+    resolveMcp(ctx, acc);
+    resolveClaudePlugins(ctx, acc);
+    resolveAtoms(ctx, registry, acc);
   }
 
-  // Pipeline stages flag additional atoms that may not have appeared in
-  // ctx.atoms; record them as digest refs so two manifests with different
-  // pipelines produce distinct digests.
-  for (const stage of manifest.od?.pipeline?.stages ?? []) {
-    for (const atomId of stage.atoms) {
-      digestRefs.push({ kind: 'pipeline-atom', ref: `${stage.id}:${atomId}` });
-    }
-  }
+  resolvePipelineAtoms(manifest, acc);
 
   return {
     context: {
-      items,
+      items: acc.items,
       atoms: ctx?.atoms ? Array.from(ctx.atoms) : undefined,
     },
-    warnings,
-    digestRefs,
+    warnings: acc.warnings,
+    digestRefs: acc.digestRefs,
   };
+}
+
+function resolveSkills(
+  ctx: PluginContext,
+  registry: RegistryView,
+  warnOnMissing: boolean | undefined,
+  acc: ResolveAccumulator,
+): void {
+  for (const ref of ctx.skills ?? []) {
+    const id = (ref.ref ?? ref.path ?? '').trim();
+    if (!id) continue;
+    const skill = registry.skills.find((s) => s.id === id || s.id === stripDotSlash(id));
+    if (!skill) {
+      if (warnOnMissing) acc.warnings.push(`Unknown skill ref: '${id}'`);
+      continue;
+    }
+    acc.items.push({ kind: 'skill', id: skill.id, label: skill.title ?? skill.id });
+    acc.digestRefs.push({ kind: 'skill', ref: skill.id });
+  }
+}
+
+// An explicit ref wins; a blank ref falls back to the active project design
+// system (SKILL.md authors that wrote `requires: true` without a concrete ref).
+function resolveDesignSystem(
+  ctx: PluginContext,
+  registry: RegistryView,
+  warnOnMissing: boolean | undefined,
+  acc: ResolveAccumulator,
+): void {
+  if (!ctx.designSystem) return;
+  const dsRef = ctx.designSystem;
+  const explicitRef = typeof dsRef.ref === 'string' ? dsRef.ref.trim() : '';
+  if (explicitRef) {
+    const ds = registry.designSystems.find((d) => d.id === explicitRef);
+    if (ds) {
+      acc.items.push({ kind: 'design-system', id: ds.id, label: ds.title ?? ds.id, primary: true });
+      acc.digestRefs.push({ kind: 'design-system', ref: ds.id });
+    } else if (warnOnMissing) {
+      acc.warnings.push(`Unknown design-system ref: '${explicitRef}'`);
+    }
+  } else if (registry.activeProjectDesignSystem) {
+    const ds = registry.activeProjectDesignSystem;
+    acc.items.push({ kind: 'design-system', id: ds.id, label: ds.title ?? ds.id, primary: true });
+    acc.digestRefs.push({ kind: 'design-system', ref: ds.id });
+  }
+}
+
+function resolveCraft(
+  ctx: PluginContext,
+  registry: RegistryView,
+  warnOnMissing: boolean | undefined,
+  acc: ResolveAccumulator,
+): void {
+  for (const slug of ctx.craft ?? []) {
+    const id = String(slug).trim();
+    if (!id) continue;
+    const c = registry.craft.find((x) => x.id === id);
+    if (!c) {
+      if (warnOnMissing) acc.warnings.push(`Unknown craft slug: '${id}'`);
+      continue;
+    }
+    acc.items.push({ kind: 'craft', id: c.id, label: c.title ?? c.id });
+    acc.digestRefs.push({ kind: 'craft', ref: c.id });
+  }
+}
+
+// Asset paths are kept as-is and validated by the installer at apply time.
+// The chip strip uses the basename as the label.
+function resolveAssets(ctx: PluginContext, acc: ResolveAccumulator): void {
+  for (const rawPath of ctx.assets ?? []) {
+    const p = String(rawPath).trim();
+    if (!p) continue;
+    const label = p.split('/').pop() ?? p;
+    acc.items.push({ kind: 'asset', path: p, label });
+    acc.digestRefs.push({ kind: 'asset', ref: p });
+  }
+}
+
+function resolveMcp(ctx: PluginContext, acc: ResolveAccumulator): void {
+  for (const mcp of ctx.mcp ?? []) {
+    if (!mcp.name) continue;
+    acc.items.push({
+      kind: 'mcp',
+      name: mcp.name,
+      label: mcp.name,
+      command: typeof mcp.command === 'string' ? mcp.command : undefined,
+    });
+    acc.digestRefs.push({ kind: 'mcp', ref: mcp.name });
+  }
+}
+
+function resolveClaudePlugins(ctx: PluginContext, acc: ResolveAccumulator): void {
+  for (const ref of ctx.claudePlugins ?? []) {
+    const id = (ref.ref ?? ref.path ?? '').trim();
+    if (!id) continue;
+    acc.items.push({ kind: 'claude-plugin', id, label: id });
+    acc.digestRefs.push({ kind: 'claude-plugin', ref: id });
+  }
+}
+
+function resolveAtoms(ctx: PluginContext, registry: RegistryView, acc: ResolveAccumulator): void {
+  for (const atomId of ctx.atoms ?? []) {
+    const id = String(atomId).trim();
+    if (!id) continue;
+    const atom = registry.atoms.find((a) => a.id === id);
+    const label = atom?.label ?? id;
+    acc.items.push({ kind: 'atom', id, label });
+    acc.digestRefs.push({ kind: 'atom', ref: id });
+  }
+}
+
+// Pipeline stages flag additional atoms that may not have appeared in
+// ctx.atoms; record them as digest refs so two manifests with different
+// pipelines produce distinct digests.
+function resolvePipelineAtoms(manifest: PluginManifest, acc: ResolveAccumulator): void {
+  for (const stage of manifest.od?.pipeline?.stages ?? []) {
+    for (const atomId of stage.atoms) {
+      acc.digestRefs.push({ kind: 'pipeline-atom', ref: `${stage.id}:${atomId}` });
+    }
+  }
 }
 
 function stripDotSlash(value: string): string {

--- a/packages/plugin-runtime/src/validate.ts
+++ b/packages/plugin-runtime/src/validate.ts
@@ -41,53 +41,76 @@ export function validateManifest(value: unknown): ValidateResult {
 }
 
 export function validateSafe(manifest: PluginManifest): ValidateResult {
+  const od = manifest.od;
+  if (!od) return { ok: true, warnings: [], errors: [] };
+
+  const warnings = unknownCapabilityWarnings(od);
+  const errors = [...pipelineRepeatErrors(od), ...genuiOauthErrors(od)];
+
+  return { ok: errors.length === 0, warnings, errors };
+}
+
+type PluginOd = NonNullable<PluginManifest['od']>;
+
+// Pipeline stages with `repeat: true` must declare an `until` expression
+// (spec §10.2 hard constraint).
+function pipelineRepeatErrors(od: PluginOd): string[] {
+  const errors: string[] = [];
+  const stages = od.pipeline?.stages ?? [];
+  for (const stage of stages) {
+    if (stage.repeat && !stage.until) {
+      errors.push(`pipeline.stages[${stage.id}]: repeat=true requires an 'until' expression`);
+    }
+  }
+  return errors;
+}
+
+// Capability ids outside the v1 vocabulary land in `warnings[]` (not
+// `errors[]`) so a forward spec patch can introduce new caps without
+// breaking installs. `connector:*` caps are always allowed.
+function unknownCapabilityWarnings(od: PluginOd): string[] {
   const warnings: string[] = [];
+  const caps = od.capabilities ?? [];
+  for (const cap of caps) {
+    if (cap.startsWith('connector:')) continue;
+    if (!KNOWN_CAPABILITIES.has(cap)) {
+      warnings.push(`capability '${cap}' is not in the v1 vocabulary; doctor will surface this to the operator`);
+    }
+  }
+  return warnings;
+}
+
+// GenUI oauth surfaces must reference a connector/mcp server the plugin
+// actually declared (only enforced when the corresponding declarations
+// are present, so partial manifests stay installable).
+function genuiOauthErrors(od: PluginOd): string[] {
   const errors: string[] = [];
 
-  const od = manifest.od;
-  if (od) {
-    const stages = od.pipeline?.stages ?? [];
-    for (const stage of stages) {
-      if (stage.repeat && !stage.until) {
-        errors.push(`pipeline.stages[${stage.id}]: repeat=true requires an 'until' expression`);
+  const declaredConnectorIds = new Set<string>();
+  for (const ref of od.connectors?.required ?? []) declaredConnectorIds.add(ref.id);
+  for (const ref of od.connectors?.optional ?? []) declaredConnectorIds.add(ref.id);
+
+  const declaredMcpNames = new Set<string>();
+  for (const mcp of od.context?.mcp ?? []) {
+    if (typeof mcp.name === 'string') declaredMcpNames.add(mcp.name);
+  }
+
+  for (const surface of od.genui?.surfaces ?? []) {
+    const oauth = surface.oauth;
+    if (!oauth) continue;
+    if (oauth.route === 'connector') {
+      if (!oauth.connectorId) {
+        errors.push(`genui.surfaces[${surface.id}]: oauth.route='connector' requires connectorId`);
+      } else if (declaredConnectorIds.size > 0 && !declaredConnectorIds.has(oauth.connectorId)) {
+        errors.push(`genui.surfaces[${surface.id}]: oauth.connectorId='${oauth.connectorId}' is not in od.connectors.required/optional`);
       }
-    }
-
-    const caps = od.capabilities ?? [];
-    for (const cap of caps) {
-      if (cap.startsWith('connector:')) continue;
-      if (!KNOWN_CAPABILITIES.has(cap)) {
-        warnings.push(`capability '${cap}' is not in the v1 vocabulary; doctor will surface this to the operator`);
-      }
-    }
-
-    const declaredConnectorIds = new Set<string>();
-    for (const ref of od.connectors?.required ?? []) declaredConnectorIds.add(ref.id);
-    for (const ref of od.connectors?.optional ?? []) declaredConnectorIds.add(ref.id);
-
-    const declaredMcpNames = new Set<string>();
-    for (const mcp of od.context?.mcp ?? []) {
-      if (typeof mcp.name === 'string') declaredMcpNames.add(mcp.name);
-    }
-
-    for (const surface of od.genui?.surfaces ?? []) {
-      const oauth = surface.oauth;
-      if (!oauth) continue;
-      if (oauth.route === 'connector') {
-        if (!oauth.connectorId) {
-          errors.push(`genui.surfaces[${surface.id}]: oauth.route='connector' requires connectorId`);
-        } else if (declaredConnectorIds.size > 0 && !declaredConnectorIds.has(oauth.connectorId)) {
-          errors.push(`genui.surfaces[${surface.id}]: oauth.connectorId='${oauth.connectorId}' is not in od.connectors.required/optional`);
-        }
-      } else if (oauth.route === 'mcp') {
-        if (!oauth.mcpServerId) {
-          errors.push(`genui.surfaces[${surface.id}]: oauth.route='mcp' requires mcpServerId`);
-        } else if (declaredMcpNames.size > 0 && !declaredMcpNames.has(oauth.mcpServerId)) {
-          errors.push(`genui.surfaces[${surface.id}]: oauth.mcpServerId='${oauth.mcpServerId}' is not declared in od.context.mcp`);
-        }
+    } else if (oauth.route === 'mcp') {
+      if (!oauth.mcpServerId) {
+        errors.push(`genui.surfaces[${surface.id}]: oauth.route='mcp' requires mcpServerId`);
+      } else if (declaredMcpNames.size > 0 && !declaredMcpNames.has(oauth.mcpServerId)) {
+        errors.push(`genui.surfaces[${surface.id}]: oauth.mcpServerId='${oauth.mcpServerId}' is not declared in od.context.mcp`);
       }
     }
   }
-
-  return { ok: errors.length === 0, warnings, errors };
+  return errors;
 }

--- a/packages/plugin-runtime/tests/frontmatter.test.ts
+++ b/packages/plugin-runtime/tests/frontmatter.test.ts
@@ -1,0 +1,76 @@
+// Characterization test for the parseYamlSubset paths that parsers.test.ts
+// does not exercise: inline arrays, empty inline arrays, dash arrays of
+// scalars and single-line objects, nested objects, and the block-scalar
+// variants (|, >, |-). Pins the exact parsed shape so the frontmatter
+// helper extraction is provably behavior-preserving.
+
+import { describe, expect, it } from 'vitest';
+import { parseFrontmatter } from '../src/parsers/frontmatter.js';
+
+const SRC = [
+  '---',
+  'name: foo',
+  'tags: [a, b, 3, true]',
+  'empty: []',
+  'list:',
+  '  - one',
+  '  - two',
+  'objs:',
+  '  - id: x',
+  '    n: 1',
+  '  - id: y',
+  'nested:',
+  '  key: val',
+  '  deep: 2',
+  'block: |',
+  '  L1',
+  '  L2',
+  'folded: >',
+  '  F1',
+  '  F2',
+  'stripped: |-',
+  '  S1',
+  '---',
+  'body text',
+].join('\n');
+
+describe('parseFrontmatter (characterization: arrays, nesting, block scalars)', () => {
+  it('parses the full subset into a stable shape', () => {
+    const { data, body } = parseFrontmatter(SRC);
+    expect(body).toBe('body text');
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "block": "L1
+      L2",
+        "empty": [],
+        "folded": "F1
+      F2",
+        "list": [
+          "one",
+          "two",
+        ],
+        "name": "foo",
+        "nested": {
+          "deep": 2,
+          "key": "val",
+        },
+        "objs": [
+          {
+            "id": "x",
+            "n": 1,
+          },
+          {
+            "id": "y",
+          },
+        ],
+        "stripped": "S1",
+        "tags": [
+          "a",
+          "b",
+          3,
+          true,
+        ],
+      }
+    `);
+  });
+});

--- a/packages/plugin-runtime/tests/resolve.test.ts
+++ b/packages/plugin-runtime/tests/resolve.test.ts
@@ -1,0 +1,205 @@
+// Characterization test for resolveContext. Pins the full shape of the
+// resolver output — items, digestRefs order (hash-critical), and warnings —
+// across every context kind so the resolve.ts decomposition is provably
+// behavior-preserving.
+
+import { describe, expect, it } from 'vitest';
+import type { PluginManifest } from '@open-design/contracts';
+import { resolveContext, type RegistryView } from '../src/resolve.js';
+
+const baseManifest = (od: NonNullable<PluginManifest['od']> | undefined): PluginManifest =>
+  ({
+    $schema: 'https://open-design.ai/schemas/plugin.v1.json',
+    name: 'fixture',
+    version: '0.0.1',
+    ...(od ? { od } : {}),
+  }) as PluginManifest;
+
+const registry: RegistryView = {
+  skills: [{ id: 'my-skill', title: 'My Skill' }],
+  designSystems: [{ id: 'brand-a', title: 'Brand A' }],
+  craft: [{ id: 'typography', title: 'Typography' }],
+  atoms: [{ id: 'todo-write', label: 'Todo Write' }],
+};
+
+describe('resolveContext (characterization)', () => {
+  it('resolves every context kind with stable items, digestRefs order, and warnings', () => {
+    const manifest = baseManifest({
+      context: {
+        skills: [{ ref: 'my-skill' }, { ref: './missing-skill' }],
+        designSystem: { ref: 'brand-a' },
+        craft: ['typography', 'missing-craft'],
+        assets: ['assets/logo.svg'],
+        mcp: [{ name: 'notion', command: 'npx notion-mcp' }],
+        claudePlugins: [{ ref: 'cc-plugin' }],
+        atoms: ['todo-write', 'unknown-atom'],
+      },
+      pipeline: { stages: [{ id: 's1', atoms: ['todo-write', 'critique'] }] },
+    });
+
+    const out = resolveContext(manifest, { registry, warnOnMissing: true });
+    expect(out).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "atoms": [
+            "todo-write",
+            "unknown-atom",
+          ],
+          "items": [
+            {
+              "id": "my-skill",
+              "kind": "skill",
+              "label": "My Skill",
+            },
+            {
+              "id": "brand-a",
+              "kind": "design-system",
+              "label": "Brand A",
+              "primary": true,
+            },
+            {
+              "id": "typography",
+              "kind": "craft",
+              "label": "Typography",
+            },
+            {
+              "kind": "asset",
+              "label": "logo.svg",
+              "path": "assets/logo.svg",
+            },
+            {
+              "command": "npx notion-mcp",
+              "kind": "mcp",
+              "label": "notion",
+              "name": "notion",
+            },
+            {
+              "id": "cc-plugin",
+              "kind": "claude-plugin",
+              "label": "cc-plugin",
+            },
+            {
+              "id": "todo-write",
+              "kind": "atom",
+              "label": "Todo Write",
+            },
+            {
+              "id": "unknown-atom",
+              "kind": "atom",
+              "label": "unknown-atom",
+            },
+          ],
+        },
+        "digestRefs": [
+          {
+            "kind": "skill",
+            "ref": "my-skill",
+          },
+          {
+            "kind": "design-system",
+            "ref": "brand-a",
+          },
+          {
+            "kind": "craft",
+            "ref": "typography",
+          },
+          {
+            "kind": "asset",
+            "ref": "assets/logo.svg",
+          },
+          {
+            "kind": "mcp",
+            "ref": "notion",
+          },
+          {
+            "kind": "claude-plugin",
+            "ref": "cc-plugin",
+          },
+          {
+            "kind": "atom",
+            "ref": "todo-write",
+          },
+          {
+            "kind": "atom",
+            "ref": "unknown-atom",
+          },
+          {
+            "kind": "pipeline-atom",
+            "ref": "s1:todo-write",
+          },
+          {
+            "kind": "pipeline-atom",
+            "ref": "s1:critique",
+          },
+        ],
+        "warnings": [
+          "Unknown skill ref: './missing-skill'",
+          "Unknown craft slug: 'missing-craft'",
+        ],
+      }
+    `);
+  });
+
+  it('uses the active project design system when the ref is blank', () => {
+    const manifest = baseManifest({
+      context: { designSystem: { ref: '' } },
+    });
+    const out = resolveContext(manifest, {
+      registry: { ...registry, activeProjectDesignSystem: { id: 'proj-ds', title: 'Project DS' } },
+      warnOnMissing: true,
+    });
+    expect(out).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "atoms": undefined,
+          "items": [
+            {
+              "id": "proj-ds",
+              "kind": "design-system",
+              "label": "Project DS",
+              "primary": true,
+            },
+          ],
+        },
+        "digestRefs": [
+          {
+            "kind": "design-system",
+            "ref": "proj-ds",
+          },
+        ],
+        "warnings": [],
+      }
+    `);
+  });
+
+  it('silently drops missing refs when warnOnMissing is false', () => {
+    const manifest = baseManifest({
+      context: { skills: [{ ref: 'nope' }], craft: ['nope'] },
+    });
+    const out = resolveContext(manifest, { registry, warnOnMissing: false });
+    expect(out).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "atoms": undefined,
+          "items": [],
+        },
+        "digestRefs": [],
+        "warnings": [],
+      }
+    `);
+  });
+
+  it('returns an empty context when od.context is absent', () => {
+    const out = resolveContext(baseManifest({}), { registry });
+    expect(out).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "atoms": undefined,
+          "items": [],
+        },
+        "digestRefs": [],
+        "warnings": [],
+      }
+    `);
+  });
+});


### PR DESCRIPTION
<!-- This PR is a pure internal refactor and closes no issue. -->
Part of #5165.

## Why

- **My use case:** The `packages/*` cleanup campaign flagged three of
  `plugin-runtime`'s hottest functions by cognitive complexity — `validateSafe`
  (~55), `resolveContext` (~66), and `parseYamlSubset` (~71). These are the
  package's genuinely reusable core (manifest doctor + context resolver +
  SKILL.md frontmatter parser), so keeping them readable pays off for anyone
  embedding the engine.
- **The pain:** Each was one long function mixing several independent concerns,
  so a change to one doctor rule or one context kind meant reading the whole
  body. `resolveContext` also had **no direct test coverage** despite producing
  a hash-critical `digestRefs` ordering.

## What users will see

Nothing. Internal refactor only — public API and runtime behavior of
`@open-design/plugin-runtime` are identical. The hand-rolled `parseYamlSubset`
is **not** swapped for a YAML library.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Validation

Three behavior-preserving extractions, each its own commit:

1. **validateSafe** → `pipelineRepeatErrors` / `unknownCapabilityWarnings` /
   `genuiOauthErrors`. Rule bodies unchanged; orchestrator concatenates in the
   same order. Covered by the existing `validate.test.ts`.
2. **resolveContext** → per-kind resolvers threading a shared, order-stable
   accumulator so `digestRefs` append order (feeds the source digest) is
   unchanged. Adds `resolve.test.ts` — the function had no direct coverage; an
   inline snapshot pins items, digestRefs order, and warnings across every kind.
3. **parseYamlSubset** → extracts the two self-contained sub-parsers
   `collectBlockScalar` and `parseInlineArray`; the entangled list-item/dedent
   stack logic stays inline (deliberately out of scope). Adds `frontmatter.test.ts`
   covering the previously-untested inline-array, empty-array, dash-array,
   nested-object, and `>`/`|-` block-scalar paths.

- `pnpm --filter @open-design/plugin-runtime typecheck` → **exit 0** (src + tests)
- `pnpm --filter @open-design/plugin-runtime test` → **45 passed** (40 pre-existing + 5 new characterization tests)
- `pnpm --filter @open-design/plugin-runtime build` → **exit 0**
- **No export-surface change:** every new helper is a non-exported internal function.
