### PR TITLE
fix(guard): make design-system manifest checks EOL-agnostic on Windows (#5175)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+design-systems/**/design-tokens.json text eol=lf
+design-systems/**/tailwind-v4.css    text eol=lf
+design-systems/**/tokens.css         text eol=lf

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tools-release": "pnpm exec tools-release",
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
-    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/web-import-isolation.test.ts scripts/check-cross-app-imports.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/lint-craft-references.test.ts",
+    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/web-import-isolation.test.ts scripts/check-cross-app-imports.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/lint-craft-references.test.ts scripts/check-design-system-manifests.test.ts",
     "lint:craft": "tsx ./scripts/lint-craft-references.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",

--- a/scripts/check-design-system-manifests.test.ts
+++ b/scripts/check-design-system-manifests.test.ts
@@ -317,6 +317,43 @@ test("design-system design tokens guard rejects prefix token source line referen
   }
 });
 
+test("design-system design tokens guard does not flag CRLF-normalized design-tokens.json as stale", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "od-design-tokens-crlf-"));
+  try {
+    writeDerivedTokenFixture(root);
+    const filePath = path.join(root, "design-tokens.json");
+    writeFileSync(filePath, readFileSync(filePath, "utf8").replace(/\n/g, "\r\n"));
+
+    const violations: string[] = [];
+    await validateDesignTokensJson(violations, "design-systems/test/manifest.json", root, "tokens.css", "design-tokens.json", REPORT_PATH);
+    assert.deepEqual(violations, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("design-system design tokens guard still rejects genuinely stale content when the file is CRLF", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "od-design-tokens-crlf-stale-"));
+  try {
+    writeDerivedTokenFixture(root);
+    const filePath = path.join(root, "design-tokens.json");
+    const stale = JSON.parse(readFileSync(filePath, "utf8")) as {
+      tokens: Array<{ value: string }>;
+    };
+    stale.tokens[0]!.value = "#abcdef";
+    const staleContent = `${JSON.stringify(stale, null, 2)}\n`;
+    writeFileSync(filePath, staleContent.replace(/\n/g, "\r\n"));
+
+    const violations: string[] = [];
+    await validateDesignTokensJson(violations, "design-systems/test/manifest.json", root, "tokens.css", "design-tokens.json", REPORT_PATH);
+    assert.deepEqual(violations, [
+      "design-systems/test/manifest.json: design-tokens.json is stale; regenerate it from source/token-contract.report.json",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("design-system tailwind v4 guard rejects swapped canonical mappings", async () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "od-tailwind-guard-"));
   try {
@@ -330,6 +367,42 @@ test("design-system tailwind v4 guard rejects swapped canonical mappings", async
       filePath,
       readFileSync(filePath, "utf8").replace("  --color-accent: var(--accent);", "  --color-accent: var(--bg);"),
     );
+    const violations: string[] = [];
+    await validateTailwindV4Css(violations, "design-systems/test/manifest.json", root, "tokens.css", "tailwind-v4.css");
+    assert.deepEqual(violations, [
+      "design-systems/test/manifest.json: tailwind-v4.css is stale; regenerate it from tokens.css",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("design-system tailwind v4 guard does not flag CRLF-normalized tailwind-v4.css as stale", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "od-tailwind-crlf-"));
+  try {
+    writeDerivedTokenFixture(root);
+    const filePath = path.join(root, "tailwind-v4.css");
+    writeFileSync(filePath, readFileSync(filePath, "utf8").replace(/\n/g, "\r\n"));
+
+    const violations: string[] = [];
+    await validateTailwindV4Css(violations, "design-systems/test/manifest.json", root, "tokens.css", "tailwind-v4.css");
+    assert.deepEqual(violations, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("design-system tailwind v4 guard still rejects genuinely stale content when the file is CRLF", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "od-tailwind-crlf-stale-"));
+  try {
+    writeDerivedTokenFixture(root);
+    const filePath = path.join(root, "tailwind-v4.css");
+    const staleContent = readFileSync(filePath, "utf8").replace(
+      "  --color-accent: var(--accent);",
+      "  --color-accent: var(--bg);",
+    );
+    writeFileSync(filePath, staleContent.replace(/\n/g, "\r\n"));
+
     const violations: string[] = [];
     await validateTailwindV4Css(violations, "design-systems/test/manifest.json", root, "tokens.css", "tailwind-v4.css");
     assert.deepEqual(violations, [

--- a/scripts/check-design-system-manifests.ts
+++ b/scripts/check-design-system-manifests.ts
@@ -30,6 +30,12 @@ const designSystemsRoot = path.join(repoRoot, "design-systems");
 const craftRoot = path.join(repoRoot, "craft");
 const SKIPPED_DIRECTORIES = new Set(["_schema"]);
 
+/** Normalize CRLF→LF so byte-exact generated-file comparisons are EOL-agnostic
+ *  (Windows core.autocrlf=true checks generated LF files out as CRLF). See #5175. */
+function normalizeEol(text: string): string {
+  return text.replace(/\r\n/g, "\n");
+}
+
 function toRepositoryPath(filePath: string): string {
   return path.relative(repoRoot, filePath).split(path.sep).join("/");
 }
@@ -210,7 +216,7 @@ export async function validateDesignTokensJson(
     bindings: report.tokens,
     report,
   });
-  if (actualText !== expected) {
+  if (normalizeEol(actualText) !== normalizeEol(expected)) {
     violations.push(`${repositoryManifestPath}: ${designTokensPath} is stale; regenerate it from ${reportPath}`);
   }
 
@@ -277,7 +283,7 @@ export async function validateTailwindV4Css(
   const expectedCss = renderTailwindV4Css(
     Array.from(parseRootTokenDeclarations(tokensCss).keys(), (name) => ({ name })),
   );
-  if (actualCss !== expectedCss) {
+  if (normalizeEol(actualCss) !== normalizeEol(expectedCss)) {
     violations.push(`${repositoryManifestPath}: ${tailwindPath} is stale; regenerate it from ${tokensPath}`);
   }
 }


### PR DESCRIPTION
Fixes #5175

## Why

I hit this myself while working on another PR (#4651) on Windows: on a **pristine `main` checkout with zero local changes**, `pnpm guard` fails on the design-system manifest staleness check for **all ~150** `design-systems/*` packages. Because the pre-push hook runs `pnpm guard`, it blocks every push on Windows until worked around.

The pain: with the standard Windows `core.autocrlf=true`, the generated `design-tokens.json` / `tailwind-v4.css` (stored LF) check out as **CRLF**, but the in-memory generators (`renderDesignTokensJson` / `renderTailwindV4Css`) emit **LF**. `check-design-system-manifests.ts` compares them with **strict byte equality**, so every line mismatches and the file is flagged "stale" even though the content is byte-identical modulo EOL. Linux/CI keeps LF working trees, so it's green there — this is Windows-local only. The only current workaround (`git config core.autocrlf input` + force-renormalizing `design-systems/**`) is per-clone and undiscoverable.

Belt-and-suspenders, matching @lefarcen's preference in the issue thread:

1. **`.gitattributes` (root cause)** — pins the generated files to `eol=lf` so they check out LF regardless of `core.autocrlf`, for every contributor, with no per-clone config.
2. **EOL-agnostic compare (defense in depth)** — a `normalizeEol` helper applied to both byte-exact staleness compares, so the guard tolerates CRLF working trees even where a `.gitattributes` rule doesn't reach.

## What users will see

No user-facing change. This is contributor/dev-tooling only: Windows contributors with the default `core.autocrlf=true` no longer get a spurious red `pnpm guard` (and blocked push) on a clean tree.

## Surface area

- [x] **None** — internal tooling + tests only (`scripts/`, root `.gitattributes`, `package.json` guard script).

## Bug fix verification

- **Test path:** `scripts/check-design-system-manifests.test.ts` (4 new cases).
- **Red on `main`, green on branch:** yes. Two cases assert a CRLF working-tree file with content identical to the LF generator output is **not** flagged stale (`validateDesignTokensJson`, `validateTailwindV4Css`) — both go red on `main`, green on branch. Two negative-control cases assert genuine content drift (a mutated token value / CSS mapping) **is** still flagged even when the file is CRLF — proving the EOL-normalization doesn't blind the check to real staleness.
- **Note on how it was proven:** the tests reproduce the exact byte-level condition by writing `\r\n` into `mkdtempSync` fixtures and calling the validators directly — deterministic on any OS/git-config. A local `pnpm guard` red→green couldn't be used as the demonstration because this repo's working tree was already LF (the `autocrlf=input` workaround was applied locally), and a machine in that state never exercises the bug. The CRLF-simulating unit tests are the correct seam.
- The regression test file was previously wired into **no** gate, so this PR also appends it to the `guard` script's test list — otherwise the new tests would never run in CI or the pre-push hook.

## Validation

- `pnpm guard` — passes (now 71 tests, up from 55, confirming the manifest test file is wired into the gate).
- `pnpm typecheck` — clean across the workspace (including `tsc -p scripts/tsconfig.json --noEmit`).
- `node --import tsx --test scripts/check-design-system-manifests.test.ts` — 16/16 pass (4 new + 12 pre-existing).

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_