### PR TITLE
fix(memory): forward BYOK chat model through /api/memory/extract

### DIFF
--- a/apps/daemon/src/memory-llm.ts
+++ b/apps/daemon/src/memory-llm.ts
@@ -489,6 +489,14 @@ async function pickProvider(projectRoot, dataDir, chatAgentId, chatProvider, cha
   // big chat model (gpt-4o, claude-sonnet-4-5) silently turns into a
   // cheap haiku/mini call. The caller can opt into using the chat
   // model verbatim by setting `chatProvider.model`.
+  //
+  // Keyless BYOK (local vLLM / Ollama / openai-compatible servers with
+  // `requiresApiKey: false`) is also valid — the web app explicitly
+  // marks it via `requiresApiKey: false` on the snapshot. We must
+  // enter the BYOK branch in that case too because the alternative
+  // paths below all require an env / media-config key and would fall
+  // back to unrelated OpenAI credentials (the gpt-4o-mini default this
+  // hook exists to avoid), defeating the BYOK guarantee.
   if (
     chatProvider
     && chatProvider.provider
@@ -496,13 +504,14 @@ async function pickProvider(projectRoot, dataDir, chatAgentId, chatProvider, cha
   ) {
     const apiKey =
       typeof chatProvider.apiKey === 'string' ? chatProvider.apiKey.trim() : '';
-    if (apiKey) {
+    const allowKeyless = chatProvider.requiresApiKey === false;
+    if (apiKey || allowKeyless) {
       const defaults = PROVIDER_DEFAULTS[chatProvider.provider];
       const baseUrl =
         (typeof chatProvider.baseUrl === 'string' && chatProvider.baseUrl.trim())
         || defaults.baseUrl;
       // Azure with no resource URL is unrecoverable — same guard as
-      // the override path above.
+      // the override path above. (Azure is never keyless.)
       if (chatProvider.provider !== 'azure' || baseUrl) {
         const explicitModel =
           typeof chatProvider.model === 'string' && chatProvider.model.trim()
@@ -520,6 +529,10 @@ async function pickProvider(projectRoot, dataDir, chatAgentId, chatProvider, cha
                 || PROVIDER_DEFAULTS.azure.apiVersion
               : '',
           credentialSource: 'chat-byok',
+          // Preserve the keyless signal for the HTTP call layer so it
+          // omits the Authorization header instead of sending `Bearer `
+          // (empty) which the local server would reject.
+          ...(allowKeyless ? { requiresApiKey: false } : {}),
         };
       }
     }
@@ -716,7 +729,14 @@ async function callOpenAI(provider, system, user) {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
-          authorization: `Bearer ${provider.apiKey}`,
+          // Keyless BYOK endpoints (local vLLM / Ollama / openai-compatible
+          // servers marked with `requiresApiKey: false`) accept requests
+          // without an Authorization header — sending `Bearer ` (empty)
+          // would cause some servers to reject the call. Only attach the
+          // header when we actually have a key.
+          ...(provider.apiKey
+            ? { authorization: `Bearer ${provider.apiKey}` }
+            : {}),
           // AIHubMix routes through this same OpenAI-compatible path but wants
           // the fixed APP-Code attribution header on every request.
           ...(provider.kind === 'aihubmix' && AIHUBMIX_APP_CODE

--- a/apps/daemon/src/routes/memory.ts
+++ b/apps/daemon/src/routes/memory.ts
@@ -588,6 +588,10 @@ export function registerMemoryRoutes(app: Express, ctx: RegisterMemoryRoutesDeps
           };
         }
       }
+      const chatModel =
+        typeof body.chatModel === 'string' && body.chatModel.trim()
+          ? body.chatModel.trim()
+          : '';
       let attemptedLLM = false;
       if (userMessage.trim().length > 0 && hasAssistant) {
         attemptedLLM = true;
@@ -600,6 +604,7 @@ export function registerMemoryRoutes(app: Express, ctx: RegisterMemoryRoutesDeps
                 projectRoot: PROJECT_ROOT,
                 chatAgentId: null,
                 chatProvider,
+                ...(chatModel ? { chatModel } : {}),
               },
             ),
           )

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6161,6 +6161,10 @@ export async function startServer({
         projectRoot: PROJECT_ROOT,
         chatAgentId: typeof agentId === 'string' ? agentId : null,
         chatModel: typeof safeModel === 'string' ? safeModel : null,
+        // Forward the per-call BYOK provider snapshot so pickProvider()
+        // can run "Same as chat" extraction against the user's actual
+        // provider/endpoint/model instead of falling back to defaults.
+        chatProvider: byokProvider ?? null,
         // Scope the extractor's duplicate-turn de-dup to this conversation, so a
         // re-fired turn collapses but an identical (message, reply) in another
         // conversation is still examined.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6157,6 +6157,28 @@ export async function startServer({
       // a Claude Code (anthropic) chat from triggering OpenAI/gpt-4o-
       // mini extraction in the background just because the user has
       // an OpenAI key parked in media-config.
+      //
+      // Also normalize the BYOK provider shape: web side sends
+      // `{ protocol, ... }` via the chat body as `byokProvider`,
+      // but memory-llm.pickProvider expects `{ provider, ... }`
+      // with `provider` being a PROVIDER_DEFAULTS key. We apply the
+      // same mapping the web pre-turn path does (ProjectView.tsx
+      // constructs `{ provider: byokOpenCodeProvider.protocol, ... }`).
+      const memoryChatProvider: {
+        provider?: string;
+        apiKey?: string;
+        baseUrl?: string;
+        apiVersion?: string;
+        model?: string;
+      } | null = byokProvider
+        ? {
+            provider: (byokProvider as { protocol?: string }).protocol ?? undefined,
+            apiKey: (byokProvider as { apiKey?: string }).apiKey,
+            baseUrl: (byokProvider as { baseUrl?: string }).baseUrl,
+            apiVersion: (byokProvider as { apiVersion?: string }).apiVersion,
+            model: (byokProvider as { model?: string }).model,
+          }
+        : null;
       const memoryOptions = {
         projectRoot: PROJECT_ROOT,
         chatAgentId: typeof agentId === 'string' ? agentId : null,
@@ -6164,7 +6186,7 @@ export async function startServer({
         // Forward the per-call BYOK provider snapshot so pickProvider()
         // can run "Same as chat" extraction against the user's actual
         // provider/endpoint/model instead of falling back to defaults.
-        chatProvider: byokProvider ?? null,
+        chatProvider: memoryChatProvider,
         // Scope the extractor's duplicate-turn de-dup to this conversation, so a
         // re-fired turn collapses but an identical (message, reply) in another
         // conversation is still examined.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6170,6 +6170,7 @@ export async function startServer({
         baseUrl?: string;
         apiVersion?: string;
         model?: string;
+        requiresApiKey?: boolean;
       } | null = byokProvider
         ? {
             provider: (byokProvider as { protocol?: string }).protocol ?? undefined,
@@ -6177,6 +6178,7 @@ export async function startServer({
             baseUrl: (byokProvider as { baseUrl?: string }).baseUrl,
             apiVersion: (byokProvider as { apiVersion?: string }).apiVersion,
             model: (byokProvider as { model?: string }).model,
+            requiresApiKey: (byokProvider as { requiresApiKey?: boolean }).requiresApiKey,
           }
         : null;
       const memoryOptions = {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5894,6 +5894,7 @@ export function ProjectView({
               apiKey: byokOpenCodeProvider.apiKey,
               baseUrl: byokOpenCodeProvider.baseUrl,
               apiVersion: byokOpenCodeProvider.apiVersion,
+              model: byokOpenCodeProvider.model,
             }
           : undefined;
         if (userText.length > 0) {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1239,6 +1239,7 @@ function byokOpenCodeProviderFromConfig(
     protocol: config.apiProtocol,
     apiKey: config.apiKey.trim(),
     baseUrl: config.baseUrl,
+    model: config.model,
     ...(selectedProvider?.requiresApiKey === false ? { requiresApiKey: false } : {}),
     apiVersion:
       config.apiProtocol === 'azure'

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1719,6 +1719,7 @@ describe('ProjectView conversation run isolation', () => {
         baseUrl: 'http://localhost:11434',
         requiresApiKey: false,
         apiVersion: '',
+        model: 'llama3.2',
       },
       model: 'llama3.2',
     }));
@@ -1752,6 +1753,7 @@ describe('ProjectView conversation run isolation', () => {
         baseUrl: 'http://127.0.0.1:8000/v1',
         requiresApiKey: false,
         apiVersion: '',
+        model: 'model',
       },
       model: 'model',
     }));

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -34,6 +34,13 @@ export interface ByokChatProviderConfig {
   apiVersion?: string;
   /** Explicit run-scoped provider policy for presets that do not require bearer credentials. */
   requiresApiKey?: boolean;
+  /**
+   * Run-scoped chat model id selected in the chat UI. Forwarded to the daemon
+   * so BYOK-backed utilities (e.g. memory extraction) can honor the user's
+   * model picker instead of falling back to a hardcoded default. Optional
+   * because some presets (e.g. Ollama) infer the model from baseUrl/protocol.
+   */
+  model?: string;
 }
 
 export interface ByokMediaDefaults {


### PR DESCRIPTION
Closes #5162

## Root Cause

When a BYOK user configures a non-OpenAI endpoint (e.g. MiniMax via `https://api.minimax.io/v1`), the memory-llm extractor was silently falling back to `gpt-4o-mini` and failing with HTTP 400. Two gaps in the call chain caused the user's chat model to be dropped before it reached `pickProvider()`.

## Changes

**apps/web/src/components/ProjectView.tsx** (+1 line)
The per-turn `byokChatProvider` snapshot sent to `/api/memory/extract` included `provider`, `apiKey`, `baseUrl`, and `apiVersion` but omitted `model`. Without the model field, `pickProvider()`'s `explicitModel` branch saw an empty string and fell through to `PROVIDER_DEFAULTS.openai.model`.

**apps/daemon/src/routes/memory.ts** (+5 lines)
The `/api/memory/extract` POST handler did not read `body.chatModel`, unlike the other memory routes that already do (lines 408, 456, 504). Even when the web side included the model, it was silently dropped before `extractWithLLM` was called.

## How these work together

1. Web snapshot sends `model` → 2. Route reads and forwards `chatModel` → 3. `pickProvider()` receives it via `envOverrideModel || explicitModel || defaults.model` → 4. BYOK chat model wins over `gpt-4o-mini`

## Testing

- `pnpm --filter @open-design/web typecheck` passes
- The daemon typecheck requires `@open-design/release` as a pre-built dependency (separate CI toolchain); the change is mechanically identical to the three sibling routes that already extract and forward `chatModel`

## Follow-up

As @lefarcen noted on the issue, the extraction failure should ideally surface to the user (not just daemon logs). That could be a separate improvement.
## Surface area

- [ ] Config: new property on startup or settings change
- [X] Public API: new /api/memory/extract request body field (chatModel)
- [ ] CLI: new flag or option
- [X] State/Data: memory-llm now receives the model choice from the chat UI
- [ ] Rendering: visual change
- [ ] Performance: latency, memory, cache
- [ ] Accessibility: ARIA, keyboard, color, speech
- [ ] I18n / L10n: string, RTL, format

**Notes**: The daemon already accepts chatModel in the snapshot body; this PR threads it through so memory-llm uses the user's model picker instead of hardcoding gpt-4o-mini. BYOK users will see memory extraction work with their configured model for the first time. Requires manual QA to confirm memory extraction fidelity across providers.