### PR TITLE
docs: keep the README leading with 'the open-source Claude Design alternative'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<h1 align="center">Open Design: The Vibe Design Workspace &amp; the open-source Claude Design alternative</h1>
-
-<p align="center">Your coding agent becomes the design engine.</p>
+<h1 align="center">Open Design: The open-source Claude Design alternative</h1>
 
 > 🔥 **Open Design 0.13.0 — _Stay in Flow_ is here.** Long design sessions used to break on every interruption — a run lost its place, a model picker made you guess, an export needed one more detour. 0.13.0 keeps the session alive: resume Codex / OpenCode / Pi / Open Design Cloud runs across turns, pick the right model faster, and hand off screenshot-backed PPTX / PDF without leaving the app. [Download 0.13.0](https://github.com/nexu-io/open-design/releases) · [Release notes](https://github.com/nexu-io/open-design/releases/tag/open-design-v0.13.0)
 >
@@ -33,7 +31,7 @@
 
 ## What is Open Design
 
-🎨 **The open-source vibe design workspace — and a Claude Design alternative.** &nbsp;🖥️ **Local-first native desktop app for macOS and Windows.** &nbsp;⚡ **Composable skills, brand-grade `DESIGN.md` design systems, and ready-to-use plugins.** &nbsp;🖼️ Generates **web · desktop · mobile prototypes**, **live dashboards / artifacts**, **decks**, **images**, **video**, plus **HyperFrames** motion graphics. 🔒 Sandboxed iframe preview · HTML / PDF / PPTX / MP4 export. &nbsp;🤖 **Runs on Claude Code · OpenClaw · Codex · Cursor · OpenCode · Qwen · Copilot · Amp · Hermes · Kimi · Antigravity and 22 local CLIs**, or any OpenAI-compatible endpoint via BYOK.
+🎨 **The open-source Claude Design alternative.** &nbsp;🖥️ **Local-first native desktop app for macOS and Windows.** &nbsp;⚡ **Composable skills, brand-grade `DESIGN.md` design systems, and ready-to-use plugins.** &nbsp;🖼️ Generates **web · desktop · mobile prototypes**, **live dashboards / artifacts**, **decks**, **images**, **video**, plus **HyperFrames** motion graphics. 🔒 Sandboxed iframe preview · HTML / PDF / PPTX / MP4 export. &nbsp;🤖 **Runs on Claude Code · OpenClaw · Codex · Cursor · OpenCode · Qwen · Copilot · Amp · Hermes · Kimi · Antigravity and 22 local CLIs**, or any OpenAI-compatible endpoint via BYOK.
 
 Open Design is what you get when the **agent-native** loop Anthropic shipped with Claude Design — discover the brief, lock the direction, stream the artifact, critique, deliver — stops being closed and becomes a **filesystem of skills, design systems, and plugins** that the coding agents already on your laptop can read, write, and remix. Your CLI becomes the design engine, your laptop becomes the studio, and your team's `DESIGN.md` becomes the brand contract.
 
@@ -592,6 +590,10 @@ Full architecture → [`docs/architecture.md`](docs/architecture.md). Skill prot
 - [x] Artifact lint API + 5-dim self-critique pre-emit gate
 - [x] **0.8.0** — plugin marketplace infrastructure (261 official plugins, manifest spec, per-agent install scripts)
 - [x] **0.9.0** — Open Design Cloud (official model service built into the app: zero config, one-click sign-in)
+- [x] **0.10.0** — the all-in-one design workspace: the whole craft loop in one window (references → material → interactive editing → motion → handoff)
+- [x] **0.11.0** — _The Bazaar_: built in the open — a community marketplace of plugins and design systems anyone can pick from and contribute to
+- [x] **0.12.0** — _Brand-backed Design System_: turn the brand you already own into a reusable, portable `DESIGN.md` system
+- [x] **0.13.0** — _Stay in Flow_: native session resume, faster model picking, and export straight to screenshot-backed PPTX / PDF
 - [x] Packaged Electron builds — macOS (Apple Silicon + Intel) + Windows (x64) + Linux AppImage (optional lane)
 - [ ] Comment-mode surgical edits — partially shipped; reliable targeted patching in progress
 - [ ] AI-emitted tweaks panel UX — not yet implemented


### PR DESCRIPTION
## Why

GitHub is a developer audience, so the README should keep leading with the SEO keyword **the open-source Claude Design alternative**. The umbrella framing "The Vibe Design Workspace" now lives on the website (open-design.ai), not the repo README. A recent PR had pushed the Vibe framing into the README H1/intro; this restores the Claude-Design-alternative lead for the repo while leaving the website positioning as-is.

## What users will see

- **H1** — back to `Open Design: The open-source Claude Design alternative` (drops the "The Vibe Design Workspace &" prefix and the extra tagline line).
- **"What is Open Design" intro** — leads with *The open-source Claude Design alternative* again (kept the earlier improvements: local-first describes the desktop app, no hard-coded counts).
- **Roadmap** — adds the shipped **0.10.0 → 0.13.0** milestones (they were missing after 0.9.0).
- Everything else from the previous README pass stays: 0.13.0 release callout, AMR → Open Design Cloud rename, unlinked Claude Design mentions, descriptive hero alt.

## Surface area

- `README.md` only (H1, intro line, roadmap). No code; translated READMEs already lead with Claude Design alternative, so they're untouched.

## Validation

- Docs-only change; no `vibe design workspace` wording remains in the README.
