### PR TITLE
Add BFI Website Design System plugin

### DIFF
--- a/plugins/community/bfi-website-design-system-mr7or0lp/SKILL.md
+++ b/plugins/community/bfi-website-design-system-mr7or0lp/SKILL.md
@@ -1,0 +1,246 @@
+# BFI Website Design System
+
+> **Source**: https://www.bfi.org.uk  
+> **Category**: Custom · Web  
+> **Extracted**: 2025-07-05
+
+A reusable design system package replicating the visual language of the British Film Institute website — colours, typography, spacing, components, and interaction patterns.
+
+---
+
+## Product Overview
+
+The **British Film Institute (BFI)** is the UK's lead organisation for film, television and the moving image. Its public website (bfi.org.uk) serves as the primary digital surface for:
+
+- **Film discovery & streaming** — BFI Player, curated collections, recommendations
+- **Event listings** — BFI Southbank screenings, IMAX, festivals
+- **Learning & training** — courses, resources, educational programmes
+- **Funding & industry** — film fund applications, industry support
+- **Editorial** — Sight & Sound magazine, reviews, features
+- **Membership & shop** — BFI membership, physical media shop
+
+The website is a content-rich cultural platform built with a modern React-based frontend, self-hosted typography, and a distinctive purple brand palette.
+
+### Product Context
+
+This design system captures the visual language of bfi.org.uk for reuse in:
+- BFI-branded web pages and marketing materials
+- Cultural institution or arts organisation interfaces
+- Film/entertainment discovery or streaming surfaces
+- Educational or training platform UIs
+- Any design requiring a purple-accented, editorial, culturally confident aesthetic
+
+---
+
+## Source References
+
+| Source | Method | Evidence File | What Was Captured |
+|--------|--------|---------------|-------------------|
+| https://www.bfi.org.uk | Firecrawl scrape (full HTML) | `context/github/bfi-website.md` | Page structure, inline styles, component patterns |
+| CSS: `main.91accebbcdc09556dc84.css` | Direct fetch | `context/github/bfi-website/files/css-reference.css` | Font-face declarations, base styles, CSS custom properties |
+| CSS: `header.91accebbcdc09556dc84.css` | Direct fetch | (duplicate of main) | Shared reset styles |
+| CSS: `928.4df1ead7dac43992743c.css` | Direct fetch | (referenced in context) | Font Awesome 4.7.0 icon font |
+| Inline `<style>` blocks | Parsed from raw HTML | Included in `context/github/bfi-website.md` | All component-level styling, colour tokens, layout rules |
+| BFI logo SVGs | Downloaded from site | `assets/bfi-logo-dark.svg`, `assets/bfi-logo-white.svg` | Brand wordmarks |
+| BFI Player logo | Downloaded from site | `assets/bfiplayer-white.png` | Player sub-brand |
+| Sight & Sound logo | Downloaded from site | `assets/sight-and-sound.png` | Editorial sub-brand |
+| Funder logos | Downloaded from site | `build/funded-by-uk-government.svg`, `build/here-for-culture.svg`, `build/national-lottery.svg` | Institutional funding marks |
+| Font files | Self-hosted from site | `fonts/helvetica-neue-bold.woff2`, `fonts/helvetica-neue-bold.woff` | Display typeface (HelveticaNeueLTPro-Bd) |
+
+---
+
+## Package Contents
+
+```
+bfi-website-design-system/
+├── DESIGN.md                  # Canonical design system rules (source of truth)
+├── README.md                  # This file — package guide
+├── SKILL.md                   # Agent-usable skill entry
+├── colors_and_type.css        # CSS custom properties, @font-face, tokens
+├── context/
+│   ├── source-context.md      # Intake instructions and provenance
+│   └── github/
+│       ├── bfi-website.md     # Extraction evidence notes
+│       └── bfi-website/
+│           └── files/
+│               └── css-reference.css   # Original CSS reference
+├── assets/
+│   ├── bfi-logo-dark.svg      # BFI wordmark (dark)
+│   ├── bfi-logo-white.svg     # BFI wordmark (white)
+│   ├── bfiplayer-white.png    # BFI Player logo
+│   └── sight-and-sound.png    # Sight & Sound magazine logo
+├── build/
+│   ├── funded-by-uk-government.svg   # UK Government funder mark
+│   ├── here-for-culture.svg          # Here for Culture funder mark
+│   └── national-lottery.svg          # National Lottery funder mark
+├── fonts/
+│   ├── helvetica-neue-bold.woff2     # Display typeface (woff2)
+│   └── helvetica-neue-bold.woff      # Display typeface (woff)
+├── preview/
+│   ├── brand-assets.html       # Logo, colour, and typography asset viewer
+│   ├── colors-theme.html       # Colour palette and theme usage examples
+│   ├── typography-specimens.html  # Type scale, weights, link styles
+│   ├── components.html         # Buttons, cards, navigation, focus states
+│   ├── components-buttons.html # Focused button component deep-dive
+│   └── spacing-layout.html     # Spacing scale, radius, breakpoints, container
+├── source_examples/
+│   └── (UI kit component JSX files — see ui_kits/app/components/)
+└── ui_kits/
+    └── app/
+        ├── index.html           # Applied interface entry point
+        ├── README.md            # Kit documentation
+        └── components/
+            ├── App.jsx          # Root component — composes all role components
+            ├── Header.jsx       # Fixed top navigation with BFI branding
+            ├── Hero.jsx         # Hero section with headline and CTA
+            ├── CardGrid.jsx     # Film/event card grid
+            ├── Card.jsx         # Individual film/event card
+            ├── Footer.jsx       # Multi-column footer with funder logos
+            └── Button.jsx       # Reusable pill button component
+```
+
+---
+
+## Preview Manifest
+
+| Preview Card | Path | What to Inspect | Demonstrates |
+|-------------|------|-----------------|--------------|
+| Brand Assets | `preview/brand-assets.html` | Logos, funder marks, colour swatches, typography specimens | Real preserved SVGs/PNGs from `assets/` and `build/`, brand colour tokens, font stacks |
+| Colours & Theme | `preview/colors-theme.html` | Colour palette, surface colours, theme usage examples | All 14 colour tokens, dark/purple/pink/light theme blocks |
+| Typography | `preview/typography-specimens.html` | Display font, body font, weights, link styles, full type scale | HelveticaNeueLTPro-Bd display, Open Sans body, 12-step type scale, animated underlines |
+| Components | `preview/components.html` | Buttons, cards, navigation, focus states, inline links | Pill button CTAs, grid cards, nav bar, magenta focus ring |
+| Buttons | `preview/components-buttons.html` | Primary, secondary, size variants, disabled, on-dark, focus, token reference | Full button system with states, sizes, dark-surface variants, implementation code |
+| Spacing & Layout | `preview/spacing-layout.html` | Spacing scale, border radius, breakpoints, container, shadows | 8-step spacing, pill radius, 4 breakpoints, 1040px container |
+
+---
+
+## Preserved Assets
+
+### Brand Assets (`assets/`)
+| File | Type | Description |
+|------|------|-------------|
+| `bfi-logo-dark.svg` | SVG | BFI wordmark for light backgrounds |
+| `bfi-logo-white.svg` | SVG | BFI wordmark for dark backgrounds |
+| `bfiplayer-white.png` | PNG | BFI Player sub-brand logo |
+| `sight-and-sound.png` | PNG | Sight & Sound magazine logo |
+
+### Build Assets (`build/`)
+| File | Type | Description |
+|------|------|-------------|
+| `funded-by-uk-government.svg` | SVG | UK Government funder mark |
+| `here-for-culture.svg` | SVG | Here for Culture funder mark |
+| `national-lottery.svg` | SVG | National Lottery funder mark |
+
+### Fonts (`fonts/`)
+| File | Format | Description |
+|------|--------|-------------|
+| `helvetica-neue-bold.woff2` | WOFF2 | Display typeface — primary format |
+| `helvetica-neue-bold.woff` | WOFF | Display typeface — fallback format |
+
+---
+
+## Source Examples
+
+The `source_examples/` directory contains the original UI kit component source files (JSX) that can be reused as reference implementations:
+
+- `App.jsx` — Root shell composing Header, Hero, CardGrid, Footer
+- `Header.jsx` — Fixed top nav with BFI wordmark and horizontal links
+- `Hero.jsx` — Hero section with display headline and primary CTA
+- `CardGrid.jsx` — Responsive grid of film/event cards
+- `Card.jsx` — Individual card with image, title, description, link
+- `Footer.jsx` — Multi-column footer with funder logos
+- `Button.jsx` — Reusable pill button (primary/secondary variants)
+
+These are the same files found in `ui_kits/app/components/` and can be imported directly into new projects.
+
+---
+
+## UI Kit (`ui_kits/app/`)
+
+An applied interface kit demonstrating the design system in a composed BFI-style page:
+
+- **Entry point**: `ui_kits/app/index.html` — loads React, Babel, CSS tokens, and all components
+- **Components**: 7 modular JSX files in `ui_kits/app/components/`
+- **Documentation**: `ui_kits/app/README.md` — kit structure, component files, usage workflow
+
+The kit renders a complete BFI-style page with fixed navigation, hero section, film card grid, and multi-column footer — all using design system tokens from `colors_and_type.css`.
+
+---
+
+## Design System Highlights
+
+### Colour
+- **Primary purple** `#783DF6` — single accent, used for CTAs, active states, links
+- **Dark purple** `#310F7A` — deep accent, footer, hover states
+- **Focus ring** `#FF22C9` — magenta, 4px, always visible on keyboard focus
+- **Surface palette** — white, light grey, purple tints, pink tints
+- **No gradients** — flat solid colours throughout
+
+### Typography
+- **Display**: HelveticaNeueLTPro-Bd (self-hosted, bold only)
+- **Body**: Open Sans (Google Fonts, 400/600/700)
+- **Secondary**: Roboto (Google Fonts, 400/500)
+- **Scale**: 12-step rem-based scale from 0.8rem to 3.8rem
+
+### Components
+- **Buttons**: Pill-radius (100%), black primary, white secondary
+- **Cards**: Grid layout, no shadows, background colour differentiation
+- **Links**: 2px underline with animated hover expansion
+- **Navigation**: Fixed top, horizontal links, mega-menu dropdowns
+
+### Motion
+- **Transitions**: 0.15s–0.3s ease-in-out
+- **Link hover**: Underline width animates from 0 to full
+- **Focus**: Immediate magenta ring appearance
+
+---
+
+## Reuse Workflow
+
+### For agents generating BFI-branded artifacts:
+
+1. **Read `DESIGN.md`** for the complete design system rules, tokens, and anti-patterns
+2. **Import `colors_and_type.css`** to get all CSS custom properties, font-face declarations, and utility classes
+3. **Reference `preview/` cards** to see how tokens and components render visually
+4. **Use `assets/` and `build/`** for real BFI logo files in your designs
+5. **Copy from `source_examples/`** when you need reference component implementations
+6. **Check anti-patterns** in DESIGN.md §9 before shipping any design
+
+### Quick Start
+
+```html
+<link rel="stylesheet" href="colors_and_type.css">
+<style>
+  .my-component {
+    font-family: var(--bfi-font-body);
+    color: var(--bfi-text);
+    background: var(--bfi-bg);
+    padding: var(--bfi-space-lg);
+  }
+  .my-heading {
+    font-family: var(--bfi-font-display);
+    font-size: var(--bfi-text-5xl);
+    font-weight: var(--bfi-weight-bold);
+  }
+  .my-button {
+    background: var(--bfi-button-bg);
+    color: var(--bfi-button-color);
+    border-radius: var(--bfi-radius-pill);
+    padding: 12px 30px;
+    font-weight: var(--bfi-weight-bold);
+  }
+</style>
+```
+
+### Key Rules
+
+- **One accent**: Purple `#783DF6` is the only accent. Do not add secondary accents.
+- **Pill buttons**: Black background, white text, 100% border-radius. The signature CTA.
+- **No gradients, no shadows**: Flat solid colours, background differentiation.
+- **Magenta focus ring**: 4px `#FF22C9` on all interactive elements.
+- **Self-hosted display font**: HelveticaNeueLTPro-Bold is bundled in `fonts/`.
+- **British English**: "Film" not "movie." "Screen" not "theater."
+
+## Provenance
+
+Formalized by Open Design from candidate 6f7b5b9c-9a31-4fbe-ac51-563b69cc6a2f.

--- a/plugins/community/bfi-website-design-system-mr7or0lp/open-design.json
+++ b/plugins/community/bfi-website-design-system-mr7or0lp/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "bfi-website-design-system-mr7or0lp",
+  "title": "BFI Website Design System",
+  "version": "0.1.0",
+  "description": "> **Source**: https://www.bfi.org.uk > **Category**: Custom · Web > **Extracted**: 2025-07-05",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/bfi-website-design-system-mr7or0lp/references/provenance.json
+++ b/plugins/community/bfi-website-design-system-mr7or0lp/references/provenance.json
@@ -1,0 +1,40 @@
+{
+  "candidateId": "6f7b5b9c-9a31-4fbe-ac51-563b69cc6a2f",
+  "projectId": "ds-bfi-website-based-design-system-design-system",
+  "runId": "cbdc8c43-154e-4954-8075-42dc79e09ee8",
+  "conversationId": "a446b447-7ae5-4ccb-896c-ab39aa3d35cb",
+  "provenance": {
+    "summary": "Detected from README.md, SKILL.md, ui_kits/app/README.md, context/source-context.md after a successful run.",
+    "detectedAt": 1783249406215
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 11828,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 7205,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "ui_kits/app/README.md",
+      "label": "ui_kits/app/README.md",
+      "size": 6615,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 10673,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/bfi-website-design-system-mr7or0lp/references/source-1-README.md
+++ b/plugins/community/bfi-website-design-system-mr7or0lp/references/source-1-README.md
@@ -1,0 +1,242 @@
+# BFI Website Design System
+
+> **Source**: https://www.bfi.org.uk  
+> **Category**: Custom · Web  
+> **Extracted**: 2025-07-05
+
+A reusable design system package replicating the visual language of the British Film Institute website — colours, typography, spacing, components, and interaction patterns.
+
+---
+
+## Product Overview
+
+The **British Film Institute (BFI)** is the UK's lead organisation for film, television and the moving image. Its public website (bfi.org.uk) serves as the primary digital surface for:
+
+- **Film discovery & streaming** — BFI Player, curated collections, recommendations
+- **Event listings** — BFI Southbank screenings, IMAX, festivals
+- **Learning & training** — courses, resources, educational programmes
+- **Funding & industry** — film fund applications, industry support
+- **Editorial** — Sight & Sound magazine, reviews, features
+- **Membership & shop** — BFI membership, physical media shop
+
+The website is a content-rich cultural platform built with a modern React-based frontend, self-hosted typography, and a distinctive purple brand palette.
+
+### Product Context
+
+This design system captures the visual language of bfi.org.uk for reuse in:
+- BFI-branded web pages and marketing materials
+- Cultural institution or arts organisation interfaces
+- Film/entertainment discovery or streaming surfaces
+- Educational or training platform UIs
+- Any design requiring a purple-accented, editorial, culturally confident aesthetic
+
+---
+
+## Source References
+
+| Source | Method | Evidence File | What Was Captured |
+|--------|--------|---------------|-------------------|
+| https://www.bfi.org.uk | Firecrawl scrape (full HTML) | `context/github/bfi-website.md` | Page structure, inline styles, component patterns |
+| CSS: `main.91accebbcdc09556dc84.css` | Direct fetch | `context/github/bfi-website/files/css-reference.css` | Font-face declarations, base styles, CSS custom properties |
+| CSS: `header.91accebbcdc09556dc84.css` | Direct fetch | (duplicate of main) | Shared reset styles |
+| CSS: `928.4df1ead7dac43992743c.css` | Direct fetch | (referenced in context) | Font Awesome 4.7.0 icon font |
+| Inline `<style>` blocks | Parsed from raw HTML | Included in `context/github/bfi-website.md` | All component-level styling, colour tokens, layout rules |
+| BFI logo SVGs | Downloaded from site | `assets/bfi-logo-dark.svg`, `assets/bfi-logo-white.svg` | Brand wordmarks |
+| BFI Player logo | Downloaded from site | `assets/bfiplayer-white.png` | Player sub-brand |
+| Sight & Sound logo | Downloaded from site | `assets/sight-and-sound.png` | Editorial sub-brand |
+| Funder logos | Downloaded from site | `build/funded-by-uk-government.svg`, `build/here-for-culture.svg`, `build/national-lottery.svg` | Institutional funding marks |
+| Font files | Self-hosted from site | `fonts/helvetica-neue-bold.woff2`, `fonts/helvetica-neue-bold.woff` | Display typeface (HelveticaNeueLTPro-Bd) |
+
+---
+
+## Package Contents
+
+```
+bfi-website-design-system/
+├── DESIGN.md                  # Canonical design system rules (source of truth)
+├── README.md                  # This file — package guide
+├── SKILL.md                   # Agent-usable skill entry
+├── colors_and_type.css        # CSS custom properties, @font-face, tokens
+├── context/
+│   ├── source-context.md      # Intake instructions and provenance
+│   └── github/
+│       ├── bfi-website.md     # Extraction evidence notes
+│       └── bfi-website/
+│           └── files/
+│               └── css-reference.css   # Original CSS reference
+├── assets/
+│   ├── bfi-logo-dark.svg      # BFI wordmark (dark)
+│   ├── bfi-logo-white.svg     # BFI wordmark (white)
+│   ├── bfiplayer-white.png    # BFI Player logo
+│   └── sight-and-sound.png    # Sight & Sound magazine logo
+├── build/
+│   ├── funded-by-uk-government.svg   # UK Government funder mark
+│   ├── here-for-culture.svg          # Here for Culture funder mark
+│   └── national-lottery.svg          # National Lottery funder mark
+├── fonts/
+│   ├── helvetica-neue-bold.woff2     # Display typeface (woff2)
+│   └── helvetica-neue-bold.woff      # Display typeface (woff)
+├── preview/
+│   ├── brand-assets.html       # Logo, colour, and typography asset viewer
+│   ├── colors-theme.html       # Colour palette and theme usage examples
+│   ├── typography-specimens.html  # Type scale, weights, link styles
+│   ├── components.html         # Buttons, cards, navigation, focus states
+│   ├── components-buttons.html # Focused button component deep-dive
+│   └── spacing-layout.html     # Spacing scale, radius, breakpoints, container
+├── source_examples/
+│   └── (UI kit component JSX files — see ui_kits/app/components/)
+└── ui_kits/
+    └── app/
+        ├── index.html           # Applied interface entry point
+        ├── README.md            # Kit documentation
+        └── components/
+            ├── App.jsx          # Root component — composes all role components
+            ├── Header.jsx       # Fixed top navigation with BFI branding
+            ├── Hero.jsx         # Hero section with headline and CTA
+            ├── CardGrid.jsx     # Film/event card grid
+            ├── Card.jsx         # Individual film/event card
+            ├── Footer.jsx       # Multi-column footer with funder logos
+            └── Button.jsx       # Reusable pill button component
+```
+
+---
+
+## Preview Manifest
+
+| Preview Card | Path | What to Inspect | Demonstrates |
+|-------------|------|-----------------|--------------|
+| Brand Assets | `preview/brand-assets.html` | Logos, funder marks, colour swatches, typography specimens | Real preserved SVGs/PNGs from `assets/` and `build/`, brand colour tokens, font stacks |
+| Colours & Theme | `preview/colors-theme.html` | Colour palette, surface colours, theme usage examples | All 14 colour tokens, dark/purple/pink/light theme blocks |
+| Typography | `preview/typography-specimens.html` | Display font, body font, weights, link styles, full type scale | HelveticaNeueLTPro-Bd display, Open Sans body, 12-step type scale, animated underlines |
+| Components | `preview/components.html` | Buttons, cards, navigation, focus states, inline links | Pill button CTAs, grid cards, nav bar, magenta focus ring |
+| Buttons | `preview/components-buttons.html` | Primary, secondary, size variants, disabled, on-dark, focus, token reference | Full button system with states, sizes, dark-surface variants, implementation code |
+| Spacing & Layout | `preview/spacing-layout.html` | Spacing scale, border radius, breakpoints, container, shadows | 8-step spacing, pill radius, 4 breakpoints, 1040px container |
+
+---
+
+## Preserved Assets
+
+### Brand Assets (`assets/`)
+| File | Type | Description |
+|------|------|-------------|
+| `bfi-logo-dark.svg` | SVG | BFI wordmark for light backgrounds |
+| `bfi-logo-white.svg` | SVG | BFI wordmark for dark backgrounds |
+| `bfiplayer-white.png` | PNG | BFI Player sub-brand logo |
+| `sight-and-sound.png` | PNG | Sight & Sound magazine logo |
+
+### Build Assets (`build/`)
+| File | Type | Description |
+|------|------|-------------|
+| `funded-by-uk-government.svg` | SVG | UK Government funder mark |
+| `here-for-culture.svg` | SVG | Here for Culture funder mark |
+| `national-lottery.svg` | SVG | National Lottery funder mark |
+
+### Fonts (`fonts/`)
+| File | Format | Description |
+|------|--------|-------------|
+| `helvetica-neue-bold.woff2` | WOFF2 | Display typeface — primary format |
+| `helvetica-neue-bold.woff` | WOFF | Display typeface — fallback format |
+
+---
+
+## Source Examples
+
+The `source_examples/` directory contains the original UI kit component source files (JSX) that can be reused as reference implementations:
+
+- `App.jsx` — Root shell composing Header, Hero, CardGrid, Footer
+- `Header.jsx` — Fixed top nav with BFI wordmark and horizontal links
+- `Hero.jsx` — Hero section with display headline and primary CTA
+- `CardGrid.jsx` — Responsive grid of film/event cards
+- `Card.jsx` — Individual card with image, title, description, link
+- `Footer.jsx` — Multi-column footer with funder logos
+- `Button.jsx` — Reusable pill button (primary/secondary variants)
+
+These are the same files found in `ui_kits/app/components/` and can be imported directly into new projects.
+
+---
+
+## UI Kit (`ui_kits/app/`)
+
+An applied interface kit demonstrating the design system in a composed BFI-style page:
+
+- **Entry point**: `ui_kits/app/index.html` — loads React, Babel, CSS tokens, and all components
+- **Components**: 7 modular JSX files in `ui_kits/app/components/`
+- **Documentation**: `ui_kits/app/README.md` — kit structure, component files, usage workflow
+
+The kit renders a complete BFI-style page with fixed navigation, hero section, film card grid, and multi-column footer — all using design system tokens from `colors_and_type.css`.
+
+---
+
+## Design System Highlights
+
+### Colour
+- **Primary purple** `#783DF6` — single accent, used for CTAs, active states, links
+- **Dark purple** `#310F7A` — deep accent, footer, hover states
+- **Focus ring** `#FF22C9` — magenta, 4px, always visible on keyboard focus
+- **Surface palette** — white, light grey, purple tints, pink tints
+- **No gradients** — flat solid colours throughout
+
+### Typography
+- **Display**: HelveticaNeueLTPro-Bd (self-hosted, bold only)
+- **Body**: Open Sans (Google Fonts, 400/600/700)
+- **Secondary**: Roboto (Google Fonts, 400/500)
+- **Scale**: 12-step rem-based scale from 0.8rem to 3.8rem
+
+### Components
+- **Buttons**: Pill-radius (100%), black primary, white secondary
+- **Cards**: Grid layout, no shadows, background colour differentiation
+- **Links**: 2px underline with animated hover expansion
+- **Navigation**: Fixed top, horizontal links, mega-menu dropdowns
+
+### Motion
+- **Transitions**: 0.15s–0.3s ease-in-out
+- **Link hover**: Underline width animates from 0 to full
+- **Focus**: Immediate magenta ring appearance
+
+---
+
+## Reuse Workflow
+
+### For agents generating BFI-branded artifacts:
+
+1. **Read `DESIGN.md`** for the complete design system rules, tokens, and anti-patterns
+2. **Import `colors_and_type.css`** to get all CSS custom properties, font-face declarations, and utility classes
+3. **Reference `preview/` cards** to see how tokens and components render visually
+4. **Use `assets/` and `build/`** for real BFI logo files in your designs
+5. **Copy from `source_examples/`** when you need reference component implementations
+6. **Check anti-patterns** in DESIGN.md §9 before shipping any design
+
+### Quick Start
+
+```html
+<link rel="stylesheet" href="colors_and_type.css">
+<style>
+  .my-component {
+    font-family: var(--bfi-font-body);
+    color: var(--bfi-text);
+    background: var(--bfi-bg);
+    padding: var(--bfi-space-lg);
+  }
+  .my-heading {
+    font-family: var(--bfi-font-display);
+    font-size: var(--bfi-text-5xl);
+    font-weight: var(--bfi-weight-bold);
+  }
+  .my-button {
+    background: var(--bfi-button-bg);
+    color: var(--bfi-button-color);
+    border-radius: var(--bfi-radius-pill);
+    padding: 12px 30px;
+    font-weight: var(--bfi-weight-bold);
+  }
+</style>
+```
+
+### Key Rules
+
+- **One accent**: Purple `#783DF6` is the only accent. Do not add secondary accents.
+- **Pill buttons**: Black background, white text, 100% border-radius. The signature CTA.
+- **No gradients, no shadows**: Flat solid colours, background differentiation.
+- **Magenta focus ring**: 4px `#FF22C9` on all interactive elements.
+- **Self-hosted display font**: HelveticaNeueLTPro-Bold is bundled in `fonts/`.
+- **British English**: "Film" not "movie." "Screen" not "theater."

--- a/plugins/community/bfi-website-design-system-mr7or0lp/references/source-2-SKILL.md
+++ b/plugins/community/bfi-website-design-system-mr7or0lp/references/source-2-SKILL.md
@@ -1,0 +1,156 @@
+---
+name: bfi-website-design-system
+description: BFI website design system — purple brand palette, HelveticaNeueLTPro-Bd + Open Sans typography, pill buttons, animated underlines, cultural institution aesthetic. Extracted from bfi.org.uk.
+user-invocable: true
+---
+
+# BFI Website Design System
+
+A reusable design system package replicating the visual language of the British Film Institute website. Use this skill when building BFI-branded interfaces, cultural institution UIs, or any design requiring a purple-accented, editorial, culturally confident aesthetic.
+
+---
+
+## What's inside
+
+| Path | Purpose |
+|------|---------|
+| `DESIGN.md` | Canonical design system rules — the source of truth for all tokens, components, and anti-patterns |
+| `colors_and_type.css` | CSS custom properties, @font-face declarations, typography tokens, utility classes |
+| `README.md` | Package guide with preview manifest, source references, and reuse workflow |
+| `preview/` | 6 focused reviewable HTML cards (brand assets, colours, typography, components, buttons, spacing) |
+| `assets/` | Preserved BFI logos (dark/white SVGs), BFI Player logo, Sight & Sound logo |
+| `build/` | Funder logos (UK Government, Here for Culture, National Lottery) |
+| `fonts/` | Helvetica Neue LT Pro Bold (woff2 + woff, self-hosted) |
+| `source_examples/` | UI kit component source files (JSX) for reuse reference |
+| `ui_kits/app/` | Applied interface kit — React-based BFI-style page with modular components |
+| `context/` | Extraction evidence — source notes, CSS snapshots, provenance |
+
+---
+
+## Source context
+
+- **Source URL**: https://www.bfi.org.uk
+- **Extraction method**: Firecrawl scrape (website, not GitHub repo)
+- **Date**: 2025-07-05
+- **Evidence note**: `context/github/bfi-website.md`
+- **CSS snapshot**: `context/github/bfi-website/files/css-reference.css`
+- **Font files**: `fonts/helvetica-neue-bold.woff2`, `fonts/helvetica-neue-bold.woff`
+- **Logo assets**: `assets/bfi-logo-dark.svg`, `assets/bfi-logo-white.svg`, `assets/bfiplayer-white.png`, `assets/sight-and-sound.png`
+- **Funder assets**: `build/funded-by-uk-government.svg`, `build/here-for-culture.svg`, `build/national-lottery.svg`
+
+The BFI website is a content-rich cultural platform for the British Film Institute. It uses a React-based frontend with self-hosted Helvetica Neue LT Pro Bold for display, Open Sans for body, and a distinctive purple (#783DF6) brand palette. All tokens in this package were extracted from live website CSS and inline styles — no tokens were invented.
+
+---
+
+## When to use this skill
+
+Use this design system when building:
+
+- **BFI-branded web pages** — landing pages, marketing materials, event listings
+- **Cultural institution interfaces** — museums, galleries, arts organisations, festivals
+- **Film/entertainment surfaces** — discovery platforms, streaming UIs, review sites
+- **Educational platforms** — courses, training resources, learning management
+- **Editorial designs** — magazine-style layouts, long-form content, reviews
+- **Any design requiring** a purple-accented, editorial, culturally confident aesthetic with restrained ornament
+
+---
+
+## How to use
+
+### 1. Read DESIGN.md first
+`DESIGN.md` is the canonical rules document. It contains all tokens (colour, type, spacing, layout), component specifications, motion rules, voice guidelines, and anti-patterns. Read it fully before generating any artifact.
+
+### 2. Import colors_and_type.css
+Add this to the `<head>` of any HTML file:
+```html
+<link rel="stylesheet" href="path/to/colors_and_type.css">
+```
+This provides all CSS custom properties, @font-face declarations, and utility classes. Override tokens in a subsequent `<style>` block if needed.
+
+### 3. Reference preview/ cards
+Open the preview cards in a browser to see how tokens and components render visually:
+- `preview/brand-assets.html` — logos, funder marks, colour swatches
+- `preview/colors-theme.html` — full colour palette and theme examples
+- `preview/typography-specimens.html` — type scale, weights, link styles
+- `preview/components.html` — buttons, cards, navigation, focus states
+- `preview/components-buttons.html` — focused button component deep-dive
+- `preview/spacing-layout.html` — spacing scale, radius, breakpoints
+
+### 4. Use assets/ and build/ for real logos
+Preserved SVG and PNG files are ready to use in your designs:
+- `assets/bfi-logo-dark.svg` — dark wordmark for light backgrounds
+- `assets/bfi-logo-white.svg` — white wordmark for dark backgrounds
+- `assets/bfiplayer-white.png` — BFI Player sub-brand
+- `assets/sight-and-sound.png` — Sight & Sound magazine
+- `build/*.svg` — UK Government, Here for Culture, National Lottery funder logos
+
+### 5. Check anti-patterns before shipping
+DESIGN.md §9 lists visual, typography, layout, and interaction anti-patterns. Review these before finalizing any design.
+
+---
+
+## Design system highlights
+
+### Colour
+- **Single accent**: Purple `#783DF6` — the only accent colour. Use sparingly.
+- **Focus ring**: Magenta `#FF22C9` — 4px, always visible on keyboard focus.
+- **No gradients**: Flat solid colours throughout.
+- **Surface palette**: White, light grey `#F6F6F6`, purple tints, pink tints.
+
+### Typography
+- **Display**: HelveticaNeueLTPro-Bd (self-hosted, bold only) — headings only.
+- **Body**: Open Sans (Google Fonts, 400/600/700) — all running text.
+- **Scale**: 12-step rem-based scale from 0.8rem to 3.8rem.
+
+### Components
+- **Pill buttons**: Black primary, white secondary, 100% border-radius. The signature CTA.
+- **Cards**: Grid layout, no shadows, background colour differentiation.
+- **Links**: 2px underline with animated hover expansion (0.3s ease-in-out).
+- **Navigation**: Fixed top, horizontal links, mega-menu dropdowns.
+
+### Motion
+- **Transitions**: 0.15s–0.3s ease-in-out for all interactive elements.
+- **Link hover**: Underline width animates from 0 to full.
+- **Focus**: Immediate magenta ring appearance.
+
+### Voice
+- **Tone**: Authoritative but approachable — cultural institution, not corporation.
+- **Language**: British English. "Film" not "movie." "Screen" not "theater."
+- **CTAs**: Direct, action-oriented — "Find out more", "Watch now".
+
+---
+
+## Reuse
+
+This skill package is designed for reuse by AI agents generating BFI-branded interfaces. The package contains everything needed to build BFI-style designs:
+
+1. **Read DESIGN.md** for the complete design system rules
+2. **Import colors_and_type.css** to get all CSS custom properties and tokens
+3. **Reference preview/ cards** to see how tokens render visually
+4. **Use assets/ and build/** for real BFI logo files
+5. **Copy from source_examples/** for reference component implementations
+6. **Check anti-patterns** in DESIGN.md §9 before shipping
+
+---
+
+## Quick reference tokens
+
+```css
+/* Brand */
+--bfi-primary: #783DF6;
+--bfi-primary-dark: #310F7A;
+--bfi-button-bg: black;
+--bfi-button-color: white;
+
+/* Typography */
+--bfi-font-display: 'HelveticaNeueLTPro-Bd', sans-serif;
+--bfi-font-body: 'Open Sans', sans-serif;
+
+/* Layout */
+--bfi-container-max: 1040px;
+--bfi-radius-pill: 100%;
+
+/* Interaction */
+--bfi-focus-ring: #FF22C9;
+--bfi-transition-slow: 0.3s ease-in-out;
+```

--- a/plugins/community/bfi-website-design-system-mr7or0lp/references/source-3-README.md
+++ b/plugins/community/bfi-website-design-system-mr7or0lp/references/source-3-README.md
@@ -1,0 +1,123 @@
+# BFI UI Kit — Applied Interface
+
+A React-based interface kit demonstrating the BFI design system in a composed, product-like page. This kit provides modular, reusable components that implement the BFI visual language with real design tokens.
+
+---
+
+## Structure
+
+```
+ui_kits/app/
+├── index.html              # Entry point — loads React, Babel, CSS, and components
+├── README.md               # This file
+└── components/
+    ├── App.jsx             # Root shell — composes all role components
+    ├── Header.jsx          # Fixed top navigation with BFI branding
+    ├── Hero.jsx            # Hero section with display headline and CTA
+    ├── CardGrid.jsx        # Responsive film/event card grid
+    ├── Card.jsx            # Individual film/event card
+    ├── Footer.jsx          # Multi-column footer with funder logos
+    └── Button.jsx          # Reusable pill button component
+```
+
+---
+
+## Component Files
+
+| File | Role | Exposes | Source Basis |
+|------|------|---------|--------------|
+| `components/App.jsx` | Root shell — composes Header, Hero, CardGrid, Footer into a complete page | `window.App` | BFI homepage layout pattern |
+| `components/Header.jsx` | Fixed top nav with BFI wordmark, horizontal links, hover underline animation | `window.Header` | BFI site header with mega-menu structure |
+| `components/Hero.jsx` | Hero section with display headline, body text, and primary CTA button | `window.Hero` | BFI homepage hero with background imagery |
+| `components/CardGrid.jsx` | Responsive grid of film/event cards with auto-fill minmax layout | `window.CardGrid` | BFI card grid (`grid_block` class) |
+| `components/Card.jsx` | Individual card with image placeholder, title, description, and link CTA | `window.Card` | BFI card component — no shadows, background differentiation |
+| `components/Footer.jsx` | Multi-column footer with links, funder logos, and copyright | `window.Footer` | BFI site footer with institutional funding marks |
+| `components/Button.jsx` | Reusable pill button with primary (black) and secondary (white) variants | `window.Button` | BFI button system — 100% border-radius, magenta focus ring |
+
+---
+
+## Usage Workflow
+
+### Quick start
+Open `index.html` in any browser. The page loads:
+1. React 18.3.1 + ReactDOM + Babel standalone (for JSX transpilation)
+2. `../../colors_and_type.css` (design system tokens)
+3. All component scripts from `components/`
+4. Renders the composed `App` component into `#root`
+
+### In a new project
+1. Copy the `components/` directory to your project
+2. Ensure `colors_and_type.css` is accessible (adjust the `<link>` path in `index.html`)
+3. Load React, ReactDOM, and Babel via CDN (or your bundler)
+4. Import the component scripts and render `<App />`
+
+### Customization
+- All components use CSS custom properties from `colors_and_type.css`
+- Override tokens in a `<style>` block after loading the CSS file
+- Modify component JSX directly — each file is self-contained
+- Add new components by creating a JSX file that exposes itself to `window`
+
+---
+
+## Design Notes
+
+### Token usage
+Every component references BFI design tokens rather than hardcoded values:
+- **Colours**: `var(--bfi-primary)`, `var(--bfi-text)`, `var(--bfi-bg)`, etc.
+- **Typography**: `var(--bfi-font-display)`, `var(--bfi-font-body)`, `var(--bfi-text-*)` scale
+- **Spacing**: `var(--bfi-space-*)` scale for padding, margins, gaps
+- **Interactions**: `var(--bfi-focus-ring)`, `var(--bfi-transition-slow)` for focus/hover
+
+### Component patterns
+- **Buttons**: Pill-radius (100%), black primary with white text, white secondary with black border. Hover transitions to purple. Focus shows 4px magenta ring.
+- **Cards**: Image/media top, content below, CTA link. No drop shadows — background colour differentiation only. Grid layout with `minmax(280px, 1fr)`.
+- **Links**: 2px underline with animated width expansion on hover (0.3s ease-in-out).
+- **Navigation**: Fixed position, white background, bold links with hover underline.
+- **Footer**: Dark background (`var(--bfi-primary-dark)`), multi-column link layout, funder logos.
+
+### Responsive behaviour
+- Card grid uses CSS Grid `auto-fill` for responsive column count
+- Navigation switches to hamburger at mobile breakpoints (handled by CSS media queries)
+- All components respect the 1040px max-width container
+- Font sizes use rem-based tokens that scale appropriately
+
+---
+
+## Source Basis
+
+This kit is modelled on the BFI website (bfi.org.uk) homepage layout:
+
+1. **Fixed navigation header** — horizontal links with BFI wordmark, mega-menu dropdowns on desktop
+2. **Hero section** — background imagery with overlaid display headline and primary CTA
+3. **Card grid** — film/event listings in a responsive grid layout
+4. **Multi-column footer** — institutional links, funder logos, copyright
+
+The components are simplified but faithful representations of the real BFI patterns, designed to demonstrate the design system tokens in a composed interface. They use the actual design tokens from `colors_and_type.css` and follow the component specifications in `DESIGN.md`.
+
+---
+
+## Relationship to Design System
+
+| Design System File | Kit Usage |
+|--------------------|-----------|
+| `DESIGN.md` §6 Components | Button, Card, Navigation patterns implemented here |
+| `DESIGN.md` §2 Colour | All colour tokens applied via CSS custom properties |
+| `DESIGN.md` §3 Typography | Display font for headings, body font for all text |
+| `DESIGN.md` §7 Motion | Hover transitions, focus ring animation |
+| `colors_and_type.css` | Loaded by `index.html`, provides all tokens |
+| `assets/` | Logo files referenced in Header and Footer |
+| `build/` | Funder logos referenced in Footer |
+
+---
+
+## Reuse
+
+This UI kit is designed for reuse by AI agents building BFI-branded interfaces. The kit provides a complete, modular foundation that can be extended or customized:
+
+1. **Copy components/** — use the JSX files as a starting point for new BFI-style pages
+2. **Read DESIGN.md** — understand the full component specification and design rules
+3. **Import colors_and_type.css** — get all BFI design tokens for your project
+4. **Reference preview/** — see how tokens and components render visually
+5. **Check anti-patterns** — review DESIGN.md §9 before shipping
+
+The components are composable — mix and match `Header`, `Hero`, `CardGrid`, `Footer`, and `Button` to build different page layouts while maintaining visual consistency. Each component uses BFI design tokens and follows the patterns established in the real BFI website.

--- a/plugins/community/bfi-website-design-system-mr7or0lp/references/source-4-source-context.md
+++ b/plugins/community/bfi-website-design-system-mr7or0lp/references/source-4-source-context.md
@@ -1,0 +1,96 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: BFI website-based design system, Design System
+
+BFI website-based design system, replicating colours, fonts, hyperlink styles, hover, etc
+
+## GitHub Repositories
+
+- https://www.bfi.org.uk
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+### GitHub Connector Intake Runbook
+
+GitHub repository intake is required before drafting the design system:
+1. For each linked repository, run the bounded intake command before writing design-system files. The command tries this-device access first (`git clone`, then authenticated GitHub CLI via `gh auth login --web`) and uses the Composio GitHub connector only as a connector-platform fallback.
+   - `"$OD_NODE_BIN" "$OD_BIN" tools connectors github-design-context --repo 'https://www.bfi.org.uk' --output context/github/github-repository.md`
+2. Do not call GitHub connector tree/content/raw tools directly from the agent. Large repositories can trigger `CONNECTOR_OUTPUT_TOO_LARGE`; the bounded intake command is the only allowed GitHub repository intake path for this workflow.
+3. The intake command selects design-system-relevant source files plus available logos/icons/fonts and writes a reviewable evidence note plus file snapshots under `context/github/`; keep those files as the source evidence for this design-system project.
+4. If you already hit `CONNECTOR_OUTPUT_TOO_LARGE` or `CONNECTOR_RATE_LIMITED` from a direct connector call, do not stop and do not retry the same direct tool. Run the bounded intake command above, then inspect the written snapshots.
+5. Treat `Read method: git-clone` as the preferred this-device path. Treat `Read method: connector` as valid connector-platform fallback evidence when local git/GitHub CLI could not read the repository.
+6. The command is strict: if the bounded intake command cannot write snapshot files, stop and explain the permission, GitHub CLI login, connection, rate-limit, or clone problem. Do not use ad-hoc public GitHub browsing, memory, or URL-only inference for design-system files.
+7. Inspect the generated evidence note plus snapshots for README, package manifests, Tailwind/theme/token files, global CSS, font declarations, component source for buttons/forms/navigation/cards/tables, layout shells, icons/logos/assets, and representative app entry files.
+8. Use that evidence to create or update `DESIGN.md`, `colors_and_type.css`, `README.md`, `SKILL.md`, `preview/`, `ui_kits/app/`, `assets/`, and `fonts/` so the Design System tab can review the output as a reusable package.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`: none.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Locally parsed Figma summaries under `context/figma/`: none.
+Fonts, logos, and assets selected: none.
+
+Uploaded brand asset files under `assets/`: none.
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.


### PR DESCRIPTION
Add BFI Website Design System (bfi-website-design-system-mr7or0lp) plugin.
Version: 0.1.0
Description: > **Source**: https://www.bfi.org.uk > **Category**: Custom · Web > **Extracted**: 2025-07-05