### PR TITLE
fix(desktop): recover from first-launch document-level 502

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -224,6 +224,19 @@ export function signDesktopImportToken(
   return [options.nonce, options.exp, signature].join(DESKTOP_IMPORT_TOKEN_FIELD_SEP);
 }
 
+/**
+ * An HTTP 5xx main-frame document is a failed load. Electron resolves
+ * `loadURL` for any response that carries a body — `did-fail-load` fires
+ * only for net::ERR_* failures — so an error document (e.g. the packaged
+ * od:// proxy's synthetic 502) parks the renderer on a dead page the
+ * recovery loop never sees. Route it into the same renderer-failed
+ * reload path as a network failure. Electron reports non-HTTP
+ * navigations with 0 / -1, which must never trip this.
+ */
+export function isRendererFailureHttpStatus(httpResponseCode: number): boolean {
+  return httpResponseCode >= 500;
+}
+
 const PENDING_POLL_MS = 120;
 const RUNNING_POLL_MS = 2000;
 // Minimum time the light splash window stays on screen before we reveal the main
@@ -1888,6 +1901,20 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   window.webContents.on("did-fail-load", (_event, errorCode, _description, _url, isMainFrame) => {
     if (isMainFrame && errorCode !== -3) markRendererFailed();
   });
+  // `did-fail-load` never fires for an HTTP error *document* — a 5xx response
+  // with a body is a successful load to Electron — so a 502 page (e.g. the
+  // packaged od:// proxy's exhaustion fallback) would otherwise sit on screen
+  // until a manual reload. `did-navigate` is main-frame-only and carries the
+  // HTTP status (-1 for non-HTTP navigations); in-page SPA routing emits
+  // `did-navigate-in-page` instead, so app navigation never trips this.
+  window.webContents.on("did-navigate", (_event, url, httpResponseCode) => {
+    if (!isRendererFailureHttpStatus(httpResponseCode)) return;
+    console.error("[open-design desktop] main window loaded an HTTP error document", {
+      httpResponseCode,
+      url,
+    });
+    markRendererFailed();
+  });
 
   const sendUpdaterStatus = (status = options.updater?.snapshot() ?? unavailableUpdaterStatus()) => {
     if (window.isDestroyed()) return;
@@ -2240,13 +2267,18 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       // restored from the background recovers instead of staying blank.
       if (url != null && (url !== currentUrl || rendererFailed)) {
         pendingUrl = url;
+        // Clear the failure flag BEFORE the load: `did-navigate` (which
+        // re-flags an HTTP 5xx error document) fires before `loadURL`'s
+        // promise resolves, so clearing afterwards would clobber a failure
+        // detected mid-load. A rejecting `loadURL` re-flags via
+        // `did-fail-load`, so net-error behavior is unchanged.
+        rendererFailed = false;
         // Load the web app into the still-hidden main window as soon as it is
         // discovered; it mounts behind the splash so the swap is instant.
         console.info("[open-design desktop] main window loadURL start", { currentUrl, url });
         await window.loadURL(url);
         console.info("[open-design desktop] main window loadURL success", { url });
         currentUrl = url;
-        rendererFailed = false;
         pendingUrl = null;
         const nextPetUrl = desktopPetUrl(url);
         if (!petWindow.isDestroyed() && nextPetUrl !== currentPetUrl) {
@@ -2261,7 +2293,10 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       } else if (url == null) {
         pendingUrl = null;
       }
-      schedule(currentUrl == null ? PENDING_POLL_MS : RUNNING_POLL_MS);
+      // A renderer still flagged failed (e.g. the document that just "loaded"
+      // was an HTTP 5xx error page) re-polls at the same prompt cadence as the
+      // connection-refused recovery path.
+      schedule(currentUrl == null || rendererFailed ? PENDING_POLL_MS : RUNNING_POLL_MS);
     } catch (error) {
       pendingUrl = null;
       console.error("desktop web discovery failed", error);

--- a/apps/desktop/tests/main/http-5xx-document-recovery.test.ts
+++ b/apps/desktop/tests/main/http-5xx-document-recovery.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { isRendererFailureHttpStatus } from "../../src/main/runtime.js";
+
+// An HTTP 5xx document (e.g. the packaged od:// proxy's synthetic 502) is a
+// *successful* load to Electron: `loadURL` resolves and `did-fail-load` fires
+// only for net::ERR_* failures. Without dedicated wiring the renderer parks on
+// the error page forever, the mount marker never appears, and the splash
+// reveals a raw 502 after its ceiling. These tests pin the recovery wiring.
+//
+// The poll loop lives inside `createDesktopRuntime`, which builds real
+// Electron `BrowserWindow`s and cannot be instantiated under vitest, so the
+// wiring assertions follow the source-pinning pattern of
+// `renderer-recovery-poll-loop.test.ts`.
+const runtimeSource = readFileSync(new URL("../../src/main/runtime.ts", import.meta.url), "utf8");
+
+describe("isRendererFailureHttpStatus", () => {
+  it("treats every HTTP 5xx document as a failed load", () => {
+    expect(isRendererFailureHttpStatus(500)).toBe(true);
+    expect(isRendererFailureHttpStatus(502)).toBe(true);
+    expect(isRendererFailureHttpStatus(599)).toBe(true);
+  });
+
+  it("ignores successful, redirect, client-error, and non-HTTP navigations", () => {
+    expect(isRendererFailureHttpStatus(200)).toBe(false);
+    expect(isRendererFailureHttpStatus(302)).toBe(false);
+    expect(isRendererFailureHttpStatus(404)).toBe(false);
+    // Electron reports non-HTTP navigations with 0 / -1; they must never be
+    // routed into the reload loop.
+    expect(isRendererFailureHttpStatus(0)).toBe(false);
+    expect(isRendererFailureHttpStatus(-1)).toBe(false);
+  });
+});
+
+describe("desktop 5xx-document recovery wiring", () => {
+  it("routes 5xx main-frame documents from did-navigate into markRendererFailed", () => {
+    const didNavigateBlock =
+      /webContents\.on\("did-navigate",([\s\S]*?)\n  \}\);/.exec(runtimeSource)?.[0] ?? "";
+    expect(didNavigateBlock).toContain("isRendererFailureHttpStatus(");
+    expect(didNavigateBlock).toContain("markRendererFailed()");
+  });
+
+  it("tick clears the renderer-failed flag before awaiting loadURL, not after", () => {
+    // `did-navigate` (which re-flags a 5xx document) fires BEFORE `loadURL`'s
+    // promise resolves; clearing the flag after the await would clobber the
+    // failure the listener just recorded.
+    const tickBlock = /const tick = async \(\) => \{([\s\S]*?)\n  \};/.exec(runtimeSource)?.[0] ?? "";
+    const clearIndex = tickBlock.indexOf("rendererFailed = false;");
+    const loadIndex = tickBlock.indexOf("await window.loadURL(");
+    expect(clearIndex).toBeGreaterThan(-1);
+    expect(loadIndex).toBeGreaterThan(-1);
+    expect(clearIndex).toBeLessThan(loadIndex);
+  });
+
+  it("a still-failed renderer re-polls at the prompt cadence, not the running cadence", () => {
+    expect(runtimeSource).toContain(
+      "schedule(currentUrl == null || rendererFailed ? PENDING_POLL_MS : RUNNING_POLL_MS);",
+    );
+  });
+});

--- a/apps/packaged/src/protocol.ts
+++ b/apps/packaged/src/protocol.ts
@@ -26,6 +26,72 @@ function toWebRuntimeUrl(webRuntimeUrl: string, requestUrl: string): string {
   return target.toString();
 }
 
+const OD_PROXY_RETRYABLE_METHODS = new Set(["GET", "HEAD"]);
+const OD_PROXY_RETRY_ATTEMPTS = 3;
+const OD_PROXY_RETRY_BACKOFF_MS = 150; // 150ms, 300ms — throw path only, ~450ms worst-case added
+
+type OdProxyRetryOptions = {
+  attempts?: number;
+  backoffMs?: number;
+  delay?: (ms: number) => Promise<void>;
+};
+
+const defaultRetryDelay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Fetch the rewritten sidecar target, absorbing transient socket throws
+ * for idempotent requests.
+ *
+ * A single transient fetch failure must never become the document the
+ * window renders: undici can throw mid-fetch from socket internals (the
+ * `setTypeOfService EINVAL` family of issue #895) even while the web
+ * sidecar is healthy, and when that happens on the top navigation
+ * (`od://app/`) the synthetic 502 from `buildProxyErrorResponse` IS the
+ * whole window — the React app never mounts and nothing reloads it.
+ * GET/HEAD carry no body, so re-issuing the Request per attempt is safe;
+ * non-idempotent methods keep single-attempt semantics. Responses that
+ * resolve — including upstream 5xx — are never retried here: those are
+ * app-level answers the renderer owns.
+ *
+ * Deliberately not conditioned on `Sec-Fetch-Dest: document`: uniform
+ * idempotent retry is simpler, and Sec-Fetch header presence on a custom
+ * scheme is not a stable contract across Electron versions.
+ */
+async function fetchOdTargetWithTransientRetry(
+  request: Request,
+  target: string,
+  fetchImpl: OdProtocolFetch,
+  options: OdProxyRetryOptions,
+): Promise<Response> {
+  const attempts = OD_PROXY_RETRYABLE_METHODS.has(request.method)
+    ? (options.attempts ?? OD_PROXY_RETRY_ATTEMPTS)
+    : 1;
+  const backoffMs = options.backoffMs ?? OD_PROXY_RETRY_BACKOFF_MS;
+  const delay = options.delay ?? defaultRetryDelay;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fetchImpl(new Request(target, request));
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) break;
+      const waitMs = backoffMs * attempt;
+      // Main-process console output lands in the packaged desktop logs, so
+      // real-world transient frequency stays diagnosable.
+      console.warn("[open-design packaged] od:// proxy fetch failed; retrying", {
+        attempt,
+        attempts,
+        message: error instanceof Error ? error.message : String(error),
+        target,
+        waitMs,
+      });
+      await delay(waitMs);
+    }
+  }
+  throw lastError;
+}
+
 function buildProxyErrorResponse(error: unknown, target: string): Response {
   const message = error instanceof Error ? error.message : String(error);
   const code =
@@ -63,15 +129,21 @@ function buildProxyErrorResponse(error: unknown, target: string): Response {
  * does anything that triggers a renderer-to-sidecar fetch (e.g.
  * Settings → Pets → Community). Returning a 502 instead lets the
  * renderer see a normal failure and keeps the process alive.
+ *
+ * Idempotent requests first pass through
+ * `fetchOdTargetWithTransientRetry`, so a one-off transient throw on
+ * the top navigation cannot end up as the 502 document covering the
+ * window; the 502 remains the exhaustion fallback.
  */
 export async function handleOdRequest(
   request: Request,
   webRuntimeUrl: string,
   fetchImpl: OdProtocolFetch = fetch,
+  retryOptions: OdProxyRetryOptions = {},
 ): Promise<Response> {
   const target = toWebRuntimeUrl(webRuntimeUrl, request.url);
   try {
-    return await fetchImpl(new Request(target, request));
+    return await fetchOdTargetWithTransientRetry(request, target, fetchImpl, retryOptions);
   } catch (error) {
     return buildProxyErrorResponse(error, target);
   }

--- a/apps/packaged/tests/protocol.test.ts
+++ b/apps/packaged/tests/protocol.test.ts
@@ -130,3 +130,113 @@ describe('od:// protocol proxy', () => {
     expect(body.message).toBe('sync timeout');
   });
 });
+
+// On first launch the top navigation `od://app/` flows through the same
+// handler. If undici throws its transient socket error (#895) on that
+// single attempt, the synthetic 502 below IS the document the window
+// renders — the React app never mounts and the splash reveals a raw 502
+// after its ceiling. Idempotent requests must absorb a transient throw
+// by retrying before surfacing the 502.
+describe('od:// protocol transient retry', () => {
+  const transientSocketError = (): Error => {
+    const error = new Error('setTypeOfService EINVAL') as NodeJS.ErrnoException;
+    error.code = 'EINVAL';
+    error.syscall = 'setTypeOfService';
+    return error;
+  };
+  const noDelay = { delay: async () => {} };
+
+  it('retries a GET whose first attempt throws a transient socket error and returns the eventual success', async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = async () => {
+      calls += 1;
+      if (calls === 1) throw transientSocketError();
+      return new Response('ok', { status: 200 });
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/'),
+      'http://127.0.0.1:17579/',
+      fetchImpl,
+      noDelay,
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls).toBe(2);
+  });
+
+  it('gives up after the bounded attempt budget and returns the 502 proxy-failure document', async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = async () => {
+      calls += 1;
+      throw transientSocketError();
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/'),
+      'http://127.0.0.1:17579/',
+      fetchImpl,
+      noDelay,
+    );
+
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as { error: string; code?: string };
+    expect(body.error).toBe('OD_PROTOCOL_PROXY_FAILED');
+    expect(body.code).toBe('EINVAL');
+    expect(calls).toBe(3);
+  });
+
+  it('does not retry non-idempotent methods', async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = async () => {
+      calls += 1;
+      throw transientSocketError();
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/api/codex-pets/sync', { method: 'POST' }),
+      'http://127.0.0.1:17579/',
+      fetchImpl,
+      noDelay,
+    );
+
+    expect(response.status).toBe(502);
+    expect(calls).toBe(1);
+  });
+
+  it('does not retry when the upstream resolves with an HTTP 5xx Response', async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = async () => {
+      calls += 1;
+      return new Response('upstream says no', { status: 502 });
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/api/projects'),
+      'http://127.0.0.1:17579/',
+      fetchImpl,
+      noDelay,
+    );
+
+    // Resolved responses are app-level answers the renderer owns — the
+    // web sidecar's own daemon-proxy 502s must reach the SPA untouched.
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe('upstream says no');
+    expect(calls).toBe(1);
+  });
+
+  it('waits the configured backoff between attempts', async () => {
+    const waits: number[] = [];
+    const fetchImpl: typeof fetch = async () => {
+      throw transientSocketError();
+    };
+
+    await handleOdRequest(new Request('od://app/'), 'http://127.0.0.1:17579/', fetchImpl, {
+      delay: async (ms: number) => {
+        waits.push(ms);
+      },
+    });
+
+    expect(waits).toEqual([150, 300]);
+  });
+});


### PR DESCRIPTION
On initial packaged desktop launch the window could be covered by a raw 502 page near the end of the splash. Two root causes:

1. The od:// protocol handler proxied the top navigation to the web sidecar with a single fetch; a transient undici socket throw (setTypeOfService EINVAL, #895) on that one attempt became the 502 document the window rendered.
2. An HTTP 502 response with a body is a successful load to Electron (did-fail-load only fires for net::ERR_*), so the existing renderer- recovery loop never retried it and the splash revealed the raw 502 after its 15s ceiling.

Fixes:
- protocol.ts: retry idempotent (GET/HEAD) od:// fetches up to 3x with short backoff before surfacing the 502; resolved responses (incl. upstream 5xx) and non-idempotent methods keep single-attempt semantics.
- runtime.ts: route 5xx main-frame documents from did-navigate into the markRendererFailed reload path, clear rendererFailed before awaiting loadURL (so a mid-load did-navigate flag survives), and re-poll a still- failed renderer at the prompt cadence. The window now self-heals without a manual reload.

Red specs added first (protocol retry contract; 5xx-document recovery wiring), verified red on main and green on this branch.

<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
