### PR TITLE
feat: improve design system preview modal

### DIFF
--- a/apps/web/src/components/DesignSystemPicker.tsx
+++ b/apps/web/src/components/DesignSystemPicker.tsx
@@ -425,6 +425,9 @@ export function DesignSystemPicker({
   const previewModal: ReactNode = previewModalSystem ? (
     <DesignSystemPreviewModal
       system={previewModalSystem}
+      designSystems={designSystems}
+      selectedId={selectedId}
+      onUseSystem={onChange}
       onClose={() => setPreviewModalSystem(null)}
     />
   ) : null;

--- a/apps/web/src/components/DesignSystemPreviewModal.tsx
+++ b/apps/web/src/components/DesignSystemPreviewModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useAnalytics } from '../analytics/provider';
 import {
@@ -6,7 +6,11 @@ import {
   trackDesignSystemsTemplatesModalSharePopoverClick,
   trackDesignSystemsTemplatesModalSurfaceView,
 } from '../analytics/events';
-import { useT } from '../i18n';
+import { useI18n } from '../i18n';
+import {
+  localizeDesignSystemCategory,
+  localizeDesignSystemSummary,
+} from '../i18n/content';
 import {
   fetchDesignSystem,
   fetchDesignSystemPreview,
@@ -15,12 +19,17 @@ import {
 import type { DesignSystemDetail, DesignSystemSummary } from '../types';
 import { DesignSpecView } from './DesignSpecView';
 import { DesignSystemKitPreview } from './DesignSystemKitPreview';
+import { isUserSystem } from './design-system-metadata';
+import { Icon } from './Icon';
 import { PreviewModal } from './PreviewModal';
 
 interface Props {
   system: DesignSystemSummary;
   onClose: () => void;
   initialViewId?: 'showcase' | 'kit' | 'tokens';
+  designSystems?: DesignSystemSummary[];
+  selectedId?: string | null;
+  onUseSystem?: (id: string) => void;
 }
 
 function isDesignSystemDetail(system: DesignSystemSummary): system is DesignSystemDetail {
@@ -30,20 +39,40 @@ function isDesignSystemDetail(system: DesignSystemSummary): system is DesignSyst
 // Full DS preview: keep the brand-kit-style module stack as the default view,
 // while retaining the lazy showcase/tokens tabs and DESIGN.md side panel from
 // the richer modal flow.
-export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'kit' }: Props) {
-  const t = useT();
+export function DesignSystemPreviewModal({
+  system,
+  onClose,
+  initialViewId = 'kit',
+  designSystems,
+  selectedId,
+  onUseSystem,
+}: Props) {
+  const { locale, t } = useI18n();
   const analytics = useAnalytics();
+  const [activeSystem, setActiveSystem] = useState<DesignSystemSummary>(system);
+  const [navQuery, setNavQuery] = useState('');
+  const activeSystemIdRef = useRef(system.id);
+  const initialViewIdRef = useRef<string | null>(null);
   const surfaceViewFiredRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (surfaceViewFiredRef.current === system.id) return;
-    surfaceViewFiredRef.current = system.id;
+    setActiveSystem(system);
+  }, [system]);
+
+  useEffect(() => {
+    activeSystemIdRef.current = activeSystem.id;
+  }, [activeSystem.id]);
+
+  useEffect(() => {
+    if (surfaceViewFiredRef.current === activeSystem.id) return;
+    surfaceViewFiredRef.current = activeSystem.id;
     trackDesignSystemsTemplatesModalSurfaceView(analytics.track, {
       page_name: 'design_systems',
       area: 'templates_modal',
-      templates_id: system.id,
-      templates_type: system.source ?? 'library',
+      templates_id: activeSystem.id,
+      templates_type: activeSystem.source ?? 'library',
     });
-  }, [analytics.track, system.id, system.source]);
+  }, [analytics.track, activeSystem.id, activeSystem.source]);
 
   const [showcaseHtml, setShowcaseHtml] = useState<string | null | undefined>(undefined);
   const [tokensHtml, setTokensHtml] = useState<string | null | undefined>(undefined);
@@ -51,21 +80,72 @@ export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'kit
   const [detail, setDetail] = useState<DesignSystemDetail | null | undefined>(
     () => (isDesignSystemDetail(system) ? system : undefined),
   );
-  const detailBody = detail?.body ?? (isDesignSystemDetail(system) ? system.body : undefined);
+  const detailBody = detail?.body ?? (
+    isDesignSystemDetail(activeSystem) ? activeSystem.body : undefined
+  );
 
   useEffect(() => {
     let cancelled = false;
-    setDetail(isDesignSystemDetail(system) ? system : undefined);
-    void fetchDesignSystem(system.id).then((next) => {
-      if (cancelled) return;
+    const systemId = activeSystem.id;
+    setDetail(isDesignSystemDetail(activeSystem) ? activeSystem : undefined);
+    void fetchDesignSystem(systemId).then((next) => {
+      if (cancelled || activeSystemIdRef.current !== systemId) return;
       if (next) setDetail(next);
     });
     return () => {
       cancelled = true;
     };
-  }, [system]);
+  }, [activeSystem]);
 
-  const initialViewIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    setShowcaseHtml(undefined);
+    setTokensHtml(undefined);
+    setSpecBody(undefined);
+  }, [activeSystem.id]);
+
+  const availableSystems = useMemo(() => {
+    if (!designSystems || designSystems.length === 0) return [];
+    const byId = new Map<string, DesignSystemSummary>();
+    for (const item of designSystems) byId.set(item.id, item);
+    if (!byId.has(activeSystem.id)) byId.set(activeSystem.id, activeSystem);
+    return Array.from(byId.values());
+  }, [activeSystem, designSystems]);
+
+  const filteredSystems = useMemo(() => {
+    const q = navQuery.trim().toLowerCase();
+    if (!q) return availableSystems;
+    return availableSystems.filter((item) => {
+      const localizedSummary = localizeDesignSystemSummary(locale, item);
+      const localizedCategory = localizeDesignSystemCategory(locale, item.category);
+      const haystack = [
+        item.title,
+        item.category,
+        item.summary,
+        localizedCategory,
+        localizedSummary,
+      ].join(' ').toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [availableSystems, locale, navQuery]);
+
+  const { userSystems, officialSystems } = useMemo(() => {
+    const mine: DesignSystemSummary[] = [];
+    const official: DesignSystemSummary[] = [];
+    for (const item of filteredSystems) (isUserSystem(item) ? mine : official).push(item);
+    return { userSystems: mine, officialSystems: official };
+  }, [filteredSystems]);
+
+  const previewSystem = useCallback((next: DesignSystemSummary) => {
+    if (next.id === activeSystemIdRef.current) return;
+    activeSystemIdRef.current = next.id;
+    initialViewIdRef.current = null;
+    setShowcaseHtml(undefined);
+    setTokensHtml(undefined);
+    setSpecBody(undefined);
+    setDetail(isDesignSystemDetail(next) ? next : undefined);
+    setActiveSystem(next);
+  }, []);
+
   const handleView = useCallback(
     (viewId: string) => {
       if (initialViewIdRef.current === null) {
@@ -77,21 +157,33 @@ export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'kit
             page_name: 'design_systems',
             area: 'templates_modal',
             element: viewId === 'kit' ? 'open_design_set' : viewId,
-            templates_id: system.id,
-            templates_type: system.source ?? 'library',
+            templates_id: activeSystem.id,
+            templates_type: activeSystem.source ?? 'library',
           });
         }
       }
       if (viewId === 'showcase' && showcaseHtml === undefined) {
+        const systemId = activeSystem.id;
         setShowcaseHtml(null);
-        void fetchDesignSystemShowcase(system.id).then((html) => setShowcaseHtml(html));
+        void fetchDesignSystemShowcase(systemId).then((html) => {
+          if (activeSystemIdRef.current === systemId) setShowcaseHtml(html);
+        });
       }
       if (viewId === 'tokens' && tokensHtml === undefined) {
+        const systemId = activeSystem.id;
         setTokensHtml(null);
-        void fetchDesignSystemPreview(system.id).then((html) => setTokensHtml(html));
+        void fetchDesignSystemPreview(systemId).then((html) => {
+          if (activeSystemIdRef.current === systemId) setTokensHtml(html);
+        });
       }
     },
-    [analytics.track, system.id, system.source, showcaseHtml, tokensHtml],
+    [
+      analytics.track,
+      activeSystem.id,
+      activeSystem.source,
+      showcaseHtml,
+      tokensHtml,
+    ],
   );
 
   const handleSidebarToggle = useCallback(
@@ -102,28 +194,110 @@ export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'kit
         return;
       }
       setSpecBody(null);
-      void fetchDesignSystem(system.id).then((detail) => setSpecBody(detail?.body ?? null));
+      const systemId = activeSystem.id;
+      void fetchDesignSystem(systemId).then((detail) => {
+        if (activeSystemIdRef.current === systemId) {
+          setSpecBody(detail?.body ?? null);
+        }
+      });
     },
-    [detailBody, system.id, specBody],
+    [activeSystem.id, detailBody, specBody],
   );
 
-  useEffect(() => {
-    setShowcaseHtml(undefined);
-    setTokensHtml(undefined);
-    setSpecBody(undefined);
-  }, [system.id]);
+  const renderNavigationGroup = (label: string, items: DesignSystemSummary[]) => {
+    if (items.length === 0) return null;
+    return (
+      <>
+        <div className="ds-preview-system-nav__group" role="presentation">
+          {label}
+        </div>
+        {items.map((item) => {
+          const active = item.id === activeSystem.id;
+          const selected = item.id === selectedId;
+          const meta =
+            localizeDesignSystemCategory(locale, item.category) ||
+            localizeDesignSystemSummary(locale, item);
+          return (
+            <button
+              key={item.id}
+              type="button"
+              role="option"
+              aria-selected={active}
+              className={`ds-preview-system-nav__option${active ? ' is-active' : ''}${
+                selected ? ' is-selected' : ''
+              }`}
+              onClick={() => previewSystem(item)}
+            >
+              <span className="ds-preview-system-nav__option-copy">
+                <span className="ds-preview-system-nav__option-title">{item.title}</span>
+                {meta ? (
+                  <span className="ds-preview-system-nav__option-meta">{meta}</span>
+                ) : null}
+              </span>
+              {selected ? (
+                <span
+                  className="ds-preview-system-nav__option-check"
+                  aria-label={t('common.selected')}
+                >
+                  <Icon name="check" size={13} strokeWidth={2} />
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </>
+    );
+  };
+
+  const navigation = availableSystems.length > 1 ? (
+    <div className="ds-preview-system-nav" data-testid="design-system-preview-nav">
+      <div className="ds-preview-system-nav__search">
+        <Icon name="search" size={13} />
+        <input
+          type="text"
+          value={navQuery}
+          onChange={(event) => setNavQuery(event.target.value)}
+          placeholder={t('designSystemPicker.searchCompactPlaceholder')}
+          aria-label={t('designSystemPicker.searchCompactPlaceholder')}
+        />
+        {navQuery ? (
+          <button
+            type="button"
+            className="ds-preview-system-nav__clear"
+            aria-label={t('common.clear')}
+            onClick={() => setNavQuery('')}
+          >
+            <Icon name="close" size={12} />
+          </button>
+        ) : null}
+      </div>
+      <div
+        className="ds-preview-system-nav__list"
+        role="listbox"
+        aria-label={t('dsManager.areaAria')}
+      >
+        {renderNavigationGroup(t('dsManager.yourSystems'), userSystems)}
+        {renderNavigationGroup(t('dsManager.officialPresets'), officialSystems)}
+        {filteredSystems.length === 0 ? (
+          <div className="ds-preview-system-nav__empty">
+            {t('designSystemPicker.empty')}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  ) : undefined;
 
   const modal = (
     <PreviewModal
-      title={system.title}
-      subtitle={system.summary || system.category}
+      title={activeSystem.title}
+      subtitle={activeSystem.summary || activeSystem.category}
       views={[
         {
           id: 'kit',
           label: t('ds.kitVisualize'),
           custom: (
             <DesignSystemKitPreview
-              system={system}
+              system={activeSystem}
               variant="panel"
               showCover={false}
               className="ds-modal-kit-preview"
@@ -136,15 +310,29 @@ export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'kit
       ]}
       initialViewId={initialViewId}
       onView={handleView}
-      exportTitleFor={(viewId) => (viewId === 'kit' ? system.title : `${system.title} - ${viewId}`)}
+      exportTitleFor={(viewId) => (
+        viewId === 'kit' ? activeSystem.title : `${activeSystem.title} - ${viewId}`
+      )}
       onClose={onClose}
+      navigation={navigation}
+      hideSidebarToggle="always"
+      shareTriggerVariant="icon"
+      primaryAction={onUseSystem ? {
+        label: t('designSystemPicker.useCurrent'),
+        onClick: () => {
+          onUseSystem(activeSystem.id);
+          onClose();
+        },
+        testId: 'design-system-preview-use',
+        className: 'ds-modal-primary-action--trailing',
+      } : undefined}
       onFullscreenClick={() =>
         trackDesignSystemsTemplatesModalClick(analytics.track, {
           page_name: 'design_systems',
           area: 'templates_modal',
           element: 'fullscreen',
-          templates_id: system.id,
-          templates_type: system.source ?? 'library',
+          templates_id: activeSystem.id,
+          templates_type: activeSystem.source ?? 'library',
         })
       }
       onShareClick={() =>
@@ -152,8 +340,8 @@ export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'kit
           page_name: 'design_systems',
           area: 'templates_modal',
           element: 'share',
-          templates_id: system.id,
-          templates_type: system.source ?? 'library',
+          templates_id: activeSystem.id,
+          templates_type: activeSystem.source ?? 'library',
         })
       }
       onSidebarToggleClick={() =>
@@ -161,8 +349,8 @@ export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'kit
           page_name: 'design_systems',
           area: 'templates_modal',
           element: 'design_md',
-          templates_id: system.id,
-          templates_type: system.source ?? 'library',
+          templates_id: activeSystem.id,
+          templates_type: activeSystem.source ?? 'library',
         })
       }
       onSharePopoverItemClick={(item) =>
@@ -170,15 +358,17 @@ export function DesignSystemPreviewModal({ system, onClose, initialViewId = 'kit
           page_name: 'design_systems',
           area: 'templates_modal_share_popover',
           element: item,
-          templates_id: system.id,
-          templates_type: system.source ?? 'library',
+          templates_id: activeSystem.id,
+          templates_type: activeSystem.source ?? 'library',
         })
       }
       sidebar={{
         label: t('ds.specToggle'),
+        header: t('ds.specToggle'),
         defaultOpen: true,
         onToggle: handleSidebarToggle,
-        contentKey: system.id,
+        contentKey: activeSystem.id,
+        className: 'ds-modal-sidebar--design-spec',
         content: (
           <DesignSpecView
             source={specBody}

--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -56,6 +56,9 @@ export interface PreviewView {
 export interface PreviewSidebar {
   // Header label and toggle button label.
   label: string;
+  // Optional title shown inside the side pane itself. Useful when the
+  // toolbar toggle is hidden and the pane still needs a visible identity.
+  header?: ReactNode;
   // Side-pane content — caller renders whatever it likes (markdown source
   // view, swatch grid, etc.). Always optional; when absent the toggle is
   // not shown.
@@ -70,6 +73,8 @@ export interface PreviewSidebar {
   // can prime a fresh fetch — e.g. swapping between design systems while the
   // DESIGN.md panel stays open.
   contentKey?: string | number;
+  // Optional style hook for surface-specific width/content treatments.
+  className?: string;
 }
 
 // Optional accent CTA rendered on the left side of the action row,
@@ -92,6 +97,7 @@ export interface PreviewPrimaryAction {
   busyLabel?: string;
   disabled?: boolean;
   testId?: string;
+  className?: string;
   // When present, the primary button becomes a split button: clicking the
   // main face still runs `onClick`, while a caret toggle opens this menu of
   // secondary variants (e.g. "Use plugin" vs "Use with query"). Mirrors the
@@ -205,6 +211,9 @@ interface Props {
   // Used by the design-system preview to surface the raw DESIGN.md beside
   // the rendered showcase, matching the styles.refero.design layout.
   sidebar?: PreviewSidebar;
+  // Optional left-side navigation shown beside the preview stage. Kept
+  // separate from `sidebar`, which is the right-side companion pane.
+  navigation?: ReactNode;
   // Logical viewport width the iframe content is rendered at. The iframe is
   // then visually scaled (transform: scale) to fit the actual stage width
   // so squeezing the preview behind a sidebar never reflows the inner page
@@ -229,10 +238,13 @@ interface Props {
   onFullscreenClick?: () => void;
   onShareClick?: () => void;
   onSidebarToggleClick?: (open: boolean) => void;
-  // Hide the header sidebar-toggle button (the plugin detail opens its
-  // collapsed info panel via the preview-edge handle instead). Other
-  // variants — design-system "DESIGN.md", media, scenario — keep it.
-  hideSidebarToggle?: boolean;
+  // Hide the header sidebar-toggle button when the preview-edge handle is
+  // the preferred control. `true` keeps the small-screen fallback; `always`
+  // omits the header toggle entirely.
+  hideSidebarToggle?: boolean | 'always';
+  // Compact surfaces can render the share trigger as a single icon while
+  // keeping the same popover, title, and screen-reader label.
+  shareTriggerVariant?: 'default' | 'icon';
   // Fires when the user picks any share-popover item — social platforms,
   // "copy_link" / "copy_share_text" and the file exports ("pdf" / "zip" /
   // "html" / "image" / "open_in_new_tab"). Used by callers that want to
@@ -253,11 +265,13 @@ export function PreviewModal({
   onView,
   onClose,
   sidebar,
+  navigation,
   designWidth = 1280,
   primaryAction,
   headerExtras,
   shareTarget,
   hideSidebarToggle = false,
+  shareTriggerVariant = 'default',
   onFullscreenClick,
   onShareClick,
   onSidebarToggleClick,
@@ -550,6 +564,8 @@ export function PreviewModal({
   const showTabs = views.length > 1;
   const showTemplateShareMenu = !isCustomView || Boolean(shareTarget?.url);
   const canOpenTemplateShareMenu = canExportFiles || Boolean(previewShareUrl);
+  const omitHeaderSidebarToggle = hideSidebarToggle === 'always';
+  const compactOnlySidebarToggle = hideSidebarToggle === true;
 
   return (
     <div
@@ -559,558 +575,594 @@ export function PreviewModal({
       aria-label={`${title} preview`}
     >
       <div
-        className={`ds-modal ${fullscreen ? 'ds-modal-fullscreen' : ''}`}
+        className={`ds-modal ${fullscreen ? 'ds-modal-fullscreen' : ''}${
+          navigation ? ' has-navigation' : ''
+        }`}
       >
-        <header className="ds-modal-header">
-          <div className="ds-modal-header-top">
-            <div className="ds-modal-title-block">
-              <div className="ds-modal-title">{title}</div>
-              {subtitle ? (
-                <div className="ds-modal-subtitle">{subtitle}</div>
-              ) : null}
-            </div>
-            {showTabs ? (
-              <div className="ds-modal-tabs" role="tablist">
-                {views.map((v) => (
-                  <button
-                    key={v.id}
-                    role="tab"
-                    aria-selected={activeId === v.id}
-                    className={`ds-modal-tab ${activeId === v.id ? 'active' : ''}`}
-                    onClick={() => setActiveId(v.id)}
-                  >
-                    {v.label}
-                  </button>
-                ))}
-              </div>
-            ) : null}
-            <div className="ds-modal-actions">
-              {primaryAction ? (
-                primaryAction.menu && primaryAction.menu.length > 0 ? (
-                  <div
-                    className="ds-modal-primary-action-group"
-                    ref={primaryMenuRef}
-                  >
-                    <button
-                      type="button"
-                      className="ds-modal-primary-action ds-modal-primary-action--split"
-                      onClick={primaryAction.onClick}
-                      disabled={primaryAction.disabled || primaryAction.busy}
-                      aria-busy={primaryAction.busy ? 'true' : undefined}
-                      {...(primaryAction.testId
-                        ? { 'data-testid': primaryAction.testId }
-                        : {})}
-                    >
-                      {primaryAction.busy
-                        ? primaryAction.busyLabel ?? primaryAction.label
-                        : primaryAction.label}
-                    </button>
-                    <button
-                      type="button"
-                      className="ds-modal-primary-action ds-modal-primary-action-caret"
-                      onClick={() => setPrimaryMenuOpen((v) => !v)}
-                      disabled={primaryAction.disabled || primaryAction.busy}
-                      aria-haspopup="menu"
-                      aria-expanded={primaryMenuOpen}
-                      aria-label={`More ways to ${primaryAction.label}`}
-                      {...(primaryAction.testId
-                        ? { 'data-testid': `${primaryAction.testId}-menu` }
-                        : {})}
-                    >
-                      <Icon name="chevron-down" size={12} />
-                    </button>
-                    {primaryMenuOpen ? (
-                      <div
-                        className="share-menu-popover ds-modal-primary-action-popover"
-                        role="menu"
+        <div className={`ds-modal-shell${navigation ? ' has-navigation' : ''}`}>
+          {navigation ? (
+            <aside className="ds-modal-navigation">
+              {navigation}
+            </aside>
+          ) : null}
+          <div className="ds-modal-main">
+            <header className="ds-modal-header">
+              <div className="ds-modal-header-top">
+                <div className="ds-modal-title-block">
+                  <div className="ds-modal-title">{title}</div>
+                  {subtitle ? (
+                    <div className="ds-modal-subtitle">{subtitle}</div>
+                  ) : null}
+                </div>
+                {showTabs ? (
+                  <div className="ds-modal-tabs" role="tablist">
+                    {views.map((v) => (
+                      <button
+                        key={v.id}
+                        role="tab"
+                        aria-selected={activeId === v.id}
+                        className={`ds-modal-tab ${activeId === v.id ? 'active' : ''}`}
+                        onClick={() => setActiveId(v.id)}
                       >
-                        {primaryAction.menu.map((item, index) => (
-                          <button
-                            key={item.testId ?? `${item.label}-${index}`}
-                            type="button"
-                            role="menuitem"
-                            className="share-menu-item ds-modal-primary-action-option"
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => {
-                              setPrimaryMenuOpen(false);
-                              item.onClick();
-                            }}
-                            {...(item.testId
-                              ? { 'data-testid': item.testId }
-                              : {})}
-                          >
-                            <span className="ds-modal-primary-action-option__body">
-                              <span className="ds-modal-primary-action-option__label">
-                                {item.label}
-                              </span>
-                              {item.description ? (
-                                <span className="ds-modal-primary-action-option__desc">
-                                  {item.description}
-                                </span>
-                              ) : null}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    ) : null}
+                        {v.label}
+                      </button>
+                    ))}
                   </div>
-                ) : (
-                  <button
-                    type="button"
-                    className="ds-modal-primary-action"
-                    onClick={primaryAction.onClick}
-                    disabled={primaryAction.disabled || primaryAction.busy}
-                    aria-busy={primaryAction.busy ? 'true' : undefined}
-                    {...(primaryAction.testId
-                      ? { 'data-testid': primaryAction.testId }
-                      : {})}
-                  >
-                    {primaryAction.busy
-                      ? primaryAction.busyLabel ?? primaryAction.label
-                      : primaryAction.label}
-                  </button>
-                )
-              ) : null}
-              {sidebar ? (
-                <button
-                  className={`ghost ${sidebarOpen ? 'is-active' : ''}${
-                    hideSidebarToggle ? ' ds-modal-sidebar-toggle--compact-only' : ''
-                  }`}
-                  onClick={() => {
-                    setSidebarOpen((v) => {
-                      const next = !v;
-                      onSidebarToggleClick?.(next);
-                      return next;
-                    });
-                  }}
-                  aria-pressed={sidebarOpen}
-                  title={sidebar.label}
-                >
-                  {sidebar.label}
-                </button>
-              ) : null}
-              {showTemplateShareMenu ? (
-                <div className="share-menu template-share-menu" ref={templateShareRef}>
-                  <button
-                    className="ghost template-share-trigger"
-                    aria-haspopup="menu"
-                    aria-expanded={templateShareOpen}
-                    onClick={() => {
-                      onShareClick?.();
-                      setTemplateShareOpen((v) => !v);
-                    }}
-                    disabled={!canOpenTemplateShareMenu}
-                  >
-                    <Icon name="share" size={12} />
-                    <span>{t('preview.shareMenu')}</span>
-                    <Icon name="chevron-down" size={12} />
-                  </button>
-                  {templateShareOpen ? (
-                    <div className="share-menu-popover template-share-popover" role="menu">
-                      <div className="template-share-summary">
-                        <span className="template-share-summary__eyebrow">
-                          {t('preview.shareTemplateBadge')}
-                        </span>
-                        <strong>{previewShareTitle}</strong>
-                        {previewShareUrlDisplay ? (
-                          <span>{previewShareUrlDisplay}</span>
+                ) : null}
+                <div className="ds-modal-actions">
+                  {primaryAction ? (
+                    primaryAction.menu && primaryAction.menu.length > 0 ? (
+                      <div
+                        className={`ds-modal-primary-action-group${
+                          primaryAction.className ? ` ${primaryAction.className}` : ''
+                        }`}
+                        ref={primaryMenuRef}
+                      >
+                        <button
+                          type="button"
+                          className="ds-modal-primary-action ds-modal-primary-action--split"
+                          onClick={primaryAction.onClick}
+                          disabled={primaryAction.disabled || primaryAction.busy}
+                          aria-busy={primaryAction.busy ? 'true' : undefined}
+                          {...(primaryAction.testId
+                            ? { 'data-testid': primaryAction.testId }
+                            : {})}
+                        >
+                          {primaryAction.busy
+                            ? primaryAction.busyLabel ?? primaryAction.label
+                            : primaryAction.label}
+                        </button>
+                        <button
+                          type="button"
+                          className="ds-modal-primary-action ds-modal-primary-action-caret"
+                          onClick={() => setPrimaryMenuOpen((v) => !v)}
+                          disabled={primaryAction.disabled || primaryAction.busy}
+                          aria-haspopup="menu"
+                          aria-expanded={primaryMenuOpen}
+                          aria-label={`More ways to ${primaryAction.label}`}
+                          {...(primaryAction.testId
+                            ? { 'data-testid': `${primaryAction.testId}-menu` }
+                            : {})}
+                        >
+                          <Icon name="chevron-down" size={12} />
+                        </button>
+                        {primaryMenuOpen ? (
+                          <div
+                            className="share-menu-popover ds-modal-primary-action-popover"
+                            role="menu"
+                          >
+                            {primaryAction.menu.map((item, index) => (
+                              <button
+                                key={item.testId ?? `${item.label}-${index}`}
+                                type="button"
+                                role="menuitem"
+                                className="share-menu-item ds-modal-primary-action-option"
+                                onMouseDown={(e) => e.preventDefault()}
+                                onClick={() => {
+                                  setPrimaryMenuOpen(false);
+                                  item.onClick();
+                                }}
+                                {...(item.testId
+                                  ? { 'data-testid': item.testId }
+                                  : {})}
+                              >
+                                <span className="ds-modal-primary-action-option__body">
+                                  <span className="ds-modal-primary-action-option__label">
+                                    {item.label}
+                                  </span>
+                                  {item.description ? (
+                                    <span className="ds-modal-primary-action-option__desc">
+                                      {item.description}
+                                    </span>
+                                  ) : null}
+                                </span>
+                              </button>
+                            ))}
+                          </div>
                         ) : null}
                       </div>
-                      {previewShareUrl ? (
-                        <>
-                          <section className="template-share-section">
-                            <div className="template-share-section__label">
-                              {t('preview.shareSocialGroup')}
-                            </div>
-                            <div className="template-share-platform-grid">
-                              {socialShareTargets.map((item) => (
-                                <a
-                                  key={item.platform}
-                                  className={`template-share-platform template-share-platform--${item.platform}`}
-                                  role="menuitem"
-                                  href={item.href || undefined}
-                                  target={item.href ? '_blank' : undefined}
-                                  rel={item.href ? 'noreferrer noopener' : undefined}
-                                  aria-disabled={item.href ? undefined : 'true'}
-                                  tabIndex={item.href ? undefined : -1}
-                                  onClick={(event) => {
-                                    if (!item.href) {
-                                      event.preventDefault();
-                                      return;
-                                    }
-                                    onSharePopoverItemClick?.(item.platform);
-                                    if (item.mode === 'copy-open') {
-                                      event.preventDefault();
-                                      const shareWindow = window.open('about:blank', '_blank');
-                                      const feedbackKey = `social-${item.platform}`;
-                                      void copyPreviewShare(previewShareCopy, feedbackKey).then((ok) => {
-                                        if (!ok || !item.href) {
-                                          shareWindow?.close();
+                    ) : (
+                      <button
+                        type="button"
+                        className={`ds-modal-primary-action${
+                          primaryAction.className ? ` ${primaryAction.className}` : ''
+                        }`}
+                        onClick={primaryAction.onClick}
+                        disabled={primaryAction.disabled || primaryAction.busy}
+                        aria-busy={primaryAction.busy ? 'true' : undefined}
+                        {...(primaryAction.testId
+                          ? { 'data-testid': primaryAction.testId }
+                          : {})}
+                      >
+                        {primaryAction.busy
+                          ? primaryAction.busyLabel ?? primaryAction.label
+                          : primaryAction.label}
+                      </button>
+                    )
+                  ) : null}
+                  {sidebar && !omitHeaderSidebarToggle ? (
+                    <button
+                      className={`ghost ${sidebarOpen ? 'is-active' : ''}${
+                        compactOnlySidebarToggle ? ' ds-modal-sidebar-toggle--compact-only' : ''
+                      }`}
+                      onClick={() => {
+                        setSidebarOpen((v) => {
+                          const next = !v;
+                          onSidebarToggleClick?.(next);
+                          return next;
+                        });
+                      }}
+                      aria-pressed={sidebarOpen}
+                      title={sidebar.label}
+                    >
+                      {sidebar.label}
+                    </button>
+                  ) : null}
+                  {showTemplateShareMenu ? (
+                    <div className="share-menu template-share-menu" ref={templateShareRef}>
+                      <button
+                        type="button"
+                        className={`ghost template-share-trigger${
+                          shareTriggerVariant === 'icon' ? ' is-icon-only' : ''
+                        }`}
+                        aria-haspopup="menu"
+                        aria-expanded={templateShareOpen}
+                        aria-label={t('preview.shareMenu')}
+                        title={t('preview.shareMenu')}
+                        onClick={() => {
+                          onShareClick?.();
+                          setTemplateShareOpen((v) => !v);
+                        }}
+                        disabled={!canOpenTemplateShareMenu}
+                      >
+                        <Icon name="share" size={shareTriggerVariant === 'icon' ? 14 : 12} />
+                        {shareTriggerVariant === 'icon' ? (
+                          <Icon name="chevron-down" size={12} />
+                        ) : (
+                          <>
+                            <span>{t('preview.shareMenu')}</span>
+                            <Icon name="chevron-down" size={12} />
+                          </>
+                        )}
+                      </button>
+                      {templateShareOpen ? (
+                        <div className="share-menu-popover template-share-popover" role="menu">
+                          <div className="template-share-summary">
+                            <span className="template-share-summary__eyebrow">
+                              {t('preview.shareTemplateBadge')}
+                            </span>
+                            <strong>{previewShareTitle}</strong>
+                            {previewShareUrlDisplay ? (
+                              <span>{previewShareUrlDisplay}</span>
+                            ) : null}
+                          </div>
+                          {previewShareUrl ? (
+                            <>
+                              <section className="template-share-section">
+                                <div className="template-share-section__label">
+                                  {t('preview.shareSocialGroup')}
+                                </div>
+                                <div className="template-share-platform-grid">
+                                  {socialShareTargets.map((item) => (
+                                    <a
+                                      key={item.platform}
+                                      className={`template-share-platform template-share-platform--${item.platform}`}
+                                      role="menuitem"
+                                      href={item.href || undefined}
+                                      target={item.href ? '_blank' : undefined}
+                                      rel={item.href ? 'noreferrer noopener' : undefined}
+                                      aria-disabled={item.href ? undefined : 'true'}
+                                      tabIndex={item.href ? undefined : -1}
+                                      onClick={(event) => {
+                                        if (!item.href) {
+                                          event.preventDefault();
+                                          return;
+                                        }
+                                        onSharePopoverItemClick?.(item.platform);
+                                        if (item.mode === 'copy-open') {
+                                          event.preventDefault();
+                                          const shareWindow = window.open('about:blank', '_blank');
+                                          const feedbackKey = `social-${item.platform}`;
+                                          void copyPreviewShare(previewShareCopy, feedbackKey).then((ok) => {
+                                            if (!ok || !item.href) {
+                                              shareWindow?.close();
+                                              return;
+                                            }
+                                            setTemplateShareOpen(false);
+                                            openShareDestination(item.href, shareWindow);
+                                          });
                                           return;
                                         }
                                         setTemplateShareOpen(false);
-                                        openShareDestination(item.href, shareWindow);
-                                      });
-                                      return;
-                                    }
-                                    setTemplateShareOpen(false);
+                                      }}
+                                    >
+                                      <span className="template-share-platform__mark">
+                                        {item.mark}
+                                      </span>
+                                      <span>
+                                        {copyShareFeedback?.key === `social-${item.platform}`
+                                          ? copyShareFeedback.ok
+                                            ? t('preview.shareCopied')
+                                            : t('preview.shareCopyFailed')
+                                          : t(item.labelKey)}
+                                      </span>
+                                    </a>
+                                  ))}
+                                </div>
+                              </section>
+                              <section className="template-share-section">
+                                <div className="template-share-section__label">
+                                  {t('preview.shareCopyGroup')}
+                                </div>
+                                <button
+                                  type="button"
+                                  className="share-menu-item"
+                                  role="menuitem"
+                                  onClick={() => {
+                                    onSharePopoverItemClick?.('copy_link');
+                                    void copyPreviewShare(previewShareUrl, 'link');
                                   }}
                                 >
-                                  <span className="template-share-platform__mark">
-                                    {item.mark}
+                                  <span className="share-menu-icon">
+                                    <Icon
+                                      name={
+                                        copyShareFeedback?.key === 'link'
+                                          ? copyShareFeedback.ok
+                                            ? 'check'
+                                            : 'close'
+                                          : 'link'
+                                      }
+                                      size={14}
+                                    />
                                   </span>
                                   <span>
-                                    {copyShareFeedback?.key === `social-${item.platform}`
+                                    {copyShareFeedback?.key === 'link'
                                       ? copyShareFeedback.ok
                                         ? t('preview.shareCopied')
                                         : t('preview.shareCopyFailed')
-                                      : t(item.labelKey)}
+                                      : t('preview.copyTemplateLink')}
                                   </span>
-                                </a>
-                              ))}
-                            </div>
-                          </section>
-                          <section className="template-share-section">
-                            <div className="template-share-section__label">
-                              {t('preview.shareCopyGroup')}
-                            </div>
-                            <button
-                              type="button"
-                              className="share-menu-item"
-                              role="menuitem"
-                              onClick={() => {
-                                onSharePopoverItemClick?.('copy_link');
-                                void copyPreviewShare(previewShareUrl, 'link');
-                              }}
-                            >
-                              <span className="share-menu-icon">
-                                <Icon
-                                  name={
-                                    copyShareFeedback?.key === 'link'
+                                </button>
+                                <button
+                                  type="button"
+                                  className="share-menu-item"
+                                  role="menuitem"
+                                  onClick={() => {
+                                    onSharePopoverItemClick?.('copy_share_text');
+                                    void copyPreviewShare(previewShareCopy, 'text');
+                                  }}
+                                >
+                                  <span className="share-menu-icon">
+                                    <Icon
+                                      name={
+                                        copyShareFeedback?.key === 'text'
+                                          ? copyShareFeedback.ok
+                                            ? 'check'
+                                            : 'close'
+                                          : 'copy'
+                                      }
+                                      size={14}
+                                    />
+                                  </span>
+                                  <span>
+                                    {copyShareFeedback?.key === 'text'
                                       ? copyShareFeedback.ok
-                                        ? 'check'
-                                        : 'close'
-                                      : 'link'
+                                        ? t('preview.shareCopied')
+                                        : t('preview.shareCopyFailed')
+                                      : t('preview.copyShareText')}
+                                  </span>
+                                </button>
+                              </section>
+                            </>
+                          ) : null}
+                          {canExportFiles ? (
+                            <section className="template-share-section">
+                              <div className="template-share-section__label">
+                                {t('preview.shareExportGroup')}
+                              </div>
+                              <button
+                                type="button"
+                                className="share-menu-item"
+                                role="menuitem"
+                                onClick={() => {
+                                  onSharePopoverItemClick?.('pdf');
+                                  setTemplateShareOpen(false);
+                                  if (activeHtml) {
+                                    exportAsPdf(activeHtml, exportTitle, { deck: activeDeck });
                                   }
-                                  size={14}
-                                />
-                              </span>
-                              <span>
-                                {copyShareFeedback?.key === 'link'
-                                  ? copyShareFeedback.ok
-                                    ? t('preview.shareCopied')
-                                    : t('preview.shareCopyFailed')
-                                  : t('preview.copyTemplateLink')}
-                              </span>
-                            </button>
-                            <button
-                              type="button"
-                              className="share-menu-item"
-                              role="menuitem"
-                              onClick={() => {
-                                onSharePopoverItemClick?.('copy_share_text');
-                                void copyPreviewShare(previewShareCopy, 'text');
-                              }}
-                            >
-                              <span className="share-menu-icon">
-                                <Icon
-                                  name={
-                                    copyShareFeedback?.key === 'text'
-                                      ? copyShareFeedback.ok
-                                        ? 'check'
-                                        : 'close'
-                                      : 'copy'
+                                }}
+                              >
+                                <span className="share-menu-icon">
+                                  <Icon name="file" size={14} />
+                                </span>
+                                <span>{t('common.exportPdf')}</span>
+                              </button>
+                              <button
+                                type="button"
+                                className="share-menu-item"
+                                role="menuitem"
+                                onClick={() => {
+                                  onSharePopoverItemClick?.('zip');
+                                  setTemplateShareOpen(false);
+                                  if (activeHtml) exportAsZip(activeHtml, exportTitle);
+                                }}
+                              >
+                                <span className="share-menu-icon">
+                                  <Icon name="download" size={14} />
+                                </span>
+                                <span>{t('common.exportZip')}</span>
+                              </button>
+                              <button
+                                type="button"
+                                className="share-menu-item"
+                                role="menuitem"
+                                onClick={() => {
+                                  onSharePopoverItemClick?.('html');
+                                  setTemplateShareOpen(false);
+                                  if (activeHtml) exportAsHtml(activeHtml, exportTitle);
+                                }}
+                              >
+                                <span className="share-menu-icon">
+                                  <Icon name="file-code" size={14} />
+                                </span>
+                                <span>{t('common.exportHtml')}</span>
+                              </button>
+                              <button
+                                type="button"
+                                className="share-menu-item"
+                                role="menuitem"
+                                onClick={async () => {
+                                  onSharePopoverItemClick?.('image');
+                                  setTemplateShareOpen(false);
+                                  const iframe = previewIframeRef.current;
+                                  if (!iframe) return;
+                                  const snap =
+                                    (await captureHostIframeSnapshot(iframe)) ??
+                                    (await requestPreviewSnapshot(iframe));
+                                  try {
+                                    if (snap) {
+                                      exportAsImage(snap.dataUrl, exportTitle);
+                                    } else {
+                                      console.warn('[PreviewModal] snapshot capture returned null');
+                                      alert(t('common.exportImageFailed'));
+                                    }
+                                  } catch (err) {
+                                    console.warn('[PreviewModal] failed to convert snapshot:', err);
+                                    alert(t('common.exportImageFailed'));
                                   }
-                                  size={14}
-                                />
-                              </span>
-                              <span>
-                                {copyShareFeedback?.key === 'text'
-                                  ? copyShareFeedback.ok
-                                    ? t('preview.shareCopied')
-                                    : t('preview.shareCopyFailed')
-                                  : t('preview.copyShareText')}
-                              </span>
-                            </button>
-                          </section>
-                        </>
-                      ) : null}
-                      {canExportFiles ? (
-                        <section className="template-share-section">
-                          <div className="template-share-section__label">
-                            {t('preview.shareExportGroup')}
-                          </div>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            onClick={() => {
-                              onSharePopoverItemClick?.('pdf');
-                              setTemplateShareOpen(false);
-                              if (activeHtml) {
-                                exportAsPdf(activeHtml, exportTitle, { deck: activeDeck });
-                              }
-                            }}
-                          >
-                            <span className="share-menu-icon">
-                              <Icon name="file" size={14} />
-                            </span>
-                            <span>{t('common.exportPdf')}</span>
-                          </button>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            onClick={() => {
-                              onSharePopoverItemClick?.('zip');
-                              setTemplateShareOpen(false);
-                              if (activeHtml) exportAsZip(activeHtml, exportTitle);
-                            }}
-                          >
-                            <span className="share-menu-icon">
-                              <Icon name="download" size={14} />
-                            </span>
-                            <span>{t('common.exportZip')}</span>
-                          </button>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            onClick={() => {
-                              onSharePopoverItemClick?.('html');
-                              setTemplateShareOpen(false);
-                              if (activeHtml) exportAsHtml(activeHtml, exportTitle);
-                            }}
-                          >
-                            <span className="share-menu-icon">
-                              <Icon name="file-code" size={14} />
-                            </span>
-                            <span>{t('common.exportHtml')}</span>
-                          </button>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            onClick={async () => {
-                              onSharePopoverItemClick?.('image');
-                              setTemplateShareOpen(false);
-                              const iframe = previewIframeRef.current;
-                              if (!iframe) return;
-                              const snap =
-                                (await captureHostIframeSnapshot(iframe)) ??
-                                (await requestPreviewSnapshot(iframe));
-                              try {
-                                if (snap) {
-                                  exportAsImage(snap.dataUrl, exportTitle);
-                                } else {
-                                  console.warn('[PreviewModal] snapshot capture returned null');
-                                  alert(t('common.exportImageFailed'));
-                                }
-                              } catch (err) {
-                                console.warn('[PreviewModal] failed to convert snapshot:', err);
-                                alert(t('common.exportImageFailed'));
-                              }
-                            }}
-                          >
-                            <span className="share-menu-icon">
-                              <Icon name="image" size={14} />
-                            </span>
-                            <span>{t('common.exportImage')}</span>
-                          </button>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            onClick={() => {
-                              onSharePopoverItemClick?.('open_in_new_tab');
-                              setTemplateShareOpen(false);
-                              openInNewTab();
-                            }}
-                          >
-                            <span className="share-menu-icon">
-                              <Icon name="external-link" size={14} />
-                            </span>
-                            <span>{t('preview.openInNewTab')}</span>
-                          </button>
-                        </section>
+                                }}
+                              >
+                                <span className="share-menu-icon">
+                                  <Icon name="image" size={14} />
+                                </span>
+                                <span>{t('common.exportImage')}</span>
+                              </button>
+                              <button
+                                type="button"
+                                className="share-menu-item"
+                                role="menuitem"
+                                onClick={() => {
+                                  onSharePopoverItemClick?.('open_in_new_tab');
+                                  setTemplateShareOpen(false);
+                                  openInNewTab();
+                                }}
+                              >
+                                <span className="share-menu-icon">
+                                  <Icon name="external-link" size={14} />
+                                </span>
+                                <span>{t('preview.openInNewTab')}</span>
+                              </button>
+                            </section>
+                          ) : null}
+                        </div>
                       ) : null}
                     </div>
                   ) : null}
+                  {headerExtras}
                 </div>
-              ) : null}
-              {headerExtras}
-            </div>
-            <button
-              type="button"
-              className="ds-modal-close"
-              onClick={onClose}
-              title={t('preview.closeTitle')}
-              aria-label={t('common.close')}
-            >
-              <Icon name="close" size={14} />
-            </button>
-          </div>
-        </header>
-        <div
-          className={`ds-modal-stage ${sidebar && sidebarOpen ? 'has-sidebar' : ''}`}
-          ref={stageRef}
-        >
-          <div className="ds-modal-stage-iframe" ref={stageFrameRef}>
-            {/* Also render for custom-stage views (media players: image /
-                video / audio) — the header no longer carries fullscreen, so
-                this hover icon is their only fullscreen affordance. */}
-            {!activeUnavailable && !activeError ? (
-              <button
-                type="button"
-                className="ds-modal-stage-fullscreen"
-                onClick={() => {
-                  onFullscreenClick?.();
-                  if (fullscreen) exitFullscreen();
-                  else enterFullscreen();
-                }}
-                title={fullscreen ? t('common.exitFullscreen') : t('common.fullscreen')}
-                aria-label={fullscreen ? t('common.exitFullscreen') : t('common.fullscreen')}
-              >
-                <svg
-                  width="15"
-                  height="15"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
+                <button
+                  type="button"
+                  className="ds-modal-close"
+                  onClick={onClose}
+                  title={t('preview.closeTitle')}
+                  aria-label={t('common.close')}
                 >
-                  {fullscreen ? (
-                    <path d="M9 3v6H3M3 9l6-6M15 21v-6h6M21 15l-6 6" />
-                  ) : (
-                    <path d="M3 9V3h6M3 3l6 6M21 15v6h-6M21 21l-6-6" />
-                  )}
-                </svg>
-              </button>
-            ) : null}
-            {isCustomView ? (
-              // Caller-rendered ReactNode (e.g. plugin media player).
-              // The modal still owns chrome (header, sidebar toggle,
-              // fullscreen, close) so every plugin variant shares the
-              // same layout language.
-              <div className="ds-modal-stage-custom">{activeCustom}</div>
-            ) : activeUnavailable ? (
-              // Skills declared as `image` / `markdown` / etc. ship no
-              // HTML preview, so the daemon's `/example` endpoint would
-              // 404 into the generic "Couldn't load this example." copy
-              // — misleading, since nothing failed: there's just no
-              // preview to render. Show a calm placeholder pointing the
-              // user at "Use this prompt" instead. Issues #897, #2840.
-              //
-              // `noun` lets the same placeholder read with the right
-              // word per surface — Skills tab, Community/Plugins,
-              // design-template (deck) cards. Defaults to 'skill' so
-              // pre-noun callers keep their existing copy. Issue #3216.
-              (() => {
-                const nounKey = ((): 'preview.nounSkill' | 'preview.nounPlugin' | 'preview.nounTemplate' => {
-                  switch (activeUnavailable.noun) {
-                    case 'plugin':
-                      return 'preview.nounPlugin';
-                    case 'template':
-                      return 'preview.nounTemplate';
-                    case 'skill':
-                    default:
-                      return 'preview.nounSkill';
-                  }
-                })();
-                const noun = t(nounKey);
-                return (
-                  <div
-                    className="ds-modal-empty ds-modal-unavailable"
-                    data-testid="preview-unavailable"
+                  <Icon name="close" size={14} />
+                </button>
+              </div>
+            </header>
+            <div className="ds-modal-body">
+              <div
+                className={`ds-modal-stage ${sidebar && sidebarOpen ? 'has-sidebar' : ''}`}
+                ref={stageRef}
+              >
+                <div className="ds-modal-stage-iframe" ref={stageFrameRef}>
+              {/* Also render for custom-stage views (media players: image /
+                  video / audio) — the header no longer carries fullscreen, so
+                  this hover icon is their only fullscreen affordance. */}
+              {!activeUnavailable && !activeError ? (
+                <button
+                  type="button"
+                  className="ds-modal-stage-fullscreen"
+                  onClick={() => {
+                    onFullscreenClick?.();
+                    if (fullscreen) exitFullscreen();
+                    else enterFullscreen();
+                  }}
+                  title={fullscreen ? t('common.exitFullscreen') : t('common.fullscreen')}
+                  aria-label={fullscreen ? t('common.exitFullscreen') : t('common.fullscreen')}
+                >
+                  <svg
+                    width="15"
+                    height="15"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
                   >
-                    <div className="ds-modal-unavailable-title">
-                      {t('preview.unavailableTitle', { noun })}
+                    {fullscreen ? (
+                      <path d="M9 3v6H3M3 9l6-6M15 21v-6h6M21 15l-6 6" />
+                    ) : (
+                      <path d="M3 9V3h6M3 3l6 6M21 15v6h-6M21 21l-6-6" />
+                    )}
+                  </svg>
+                </button>
+              ) : null}
+              {isCustomView ? (
+                // Caller-rendered ReactNode (e.g. plugin media player).
+                // The modal still owns chrome (header, sidebar toggle,
+                // fullscreen, close) so every plugin variant shares the
+                // same layout language.
+                <div className="ds-modal-stage-custom">{activeCustom}</div>
+              ) : activeUnavailable ? (
+                // Skills declared as `image` / `markdown` / etc. ship no
+                // HTML preview, so the daemon's `/example` endpoint would
+                // 404 into the generic "Couldn't load this example." copy
+                // — misleading, since nothing failed: there's just no
+                // preview to render. Show a calm placeholder pointing the
+                // user at "Use this prompt" instead. Issues #897, #2840.
+                //
+                // `noun` lets the same placeholder read with the right
+                // word per surface — Skills tab, Community/Plugins,
+                // design-template (deck) cards. Defaults to 'skill' so
+                // pre-noun callers keep their existing copy. Issue #3216.
+                (() => {
+                  const nounKey = ((): 'preview.nounSkill' | 'preview.nounPlugin' | 'preview.nounTemplate' => {
+                    switch (activeUnavailable.noun) {
+                      case 'plugin':
+                        return 'preview.nounPlugin';
+                      case 'template':
+                        return 'preview.nounTemplate';
+                      case 'skill':
+                      default:
+                        return 'preview.nounSkill';
+                    }
+                  })();
+                  const noun = t(nounKey);
+                  return (
+                    <div
+                      className="ds-modal-empty ds-modal-unavailable"
+                      data-testid="preview-unavailable"
+                    >
+                      <div className="ds-modal-unavailable-title">
+                        {t('preview.unavailableTitle', { noun })}
+                      </div>
+                      <div className="ds-modal-unavailable-body">
+                        {t('preview.unavailableBody', {
+                          kind: activeUnavailable.kind || 'preview',
+                          noun,
+                        })}
+                      </div>
                     </div>
-                    <div className="ds-modal-unavailable-body">
-                      {t('preview.unavailableBody', {
-                        kind: activeUnavailable.kind || 'preview',
-                        noun,
-                      })}
-                    </div>
+                  );
+                })()
+              ) : activeError ? (
+                // Distinct error state so a fetch failure stops looking
+                // like an indefinite "Loading…". The Retry button re-fires
+                // onView for this view id; the caller is responsible for
+                // clearing the error state and re-running the fetch.
+                // Issue #860.
+                <div className="ds-modal-empty ds-modal-error">
+                  <div className="ds-modal-error-title">
+                    {t('preview.errorTitle')}
                   </div>
-                );
-              })()
-            ) : activeError ? (
-              // Distinct error state so a fetch failure stops looking
-              // like an indefinite "Loading…". The Retry button re-fires
-              // onView for this view id; the caller is responsible for
-              // clearing the error state and re-running the fetch.
-              // Issue #860.
-              <div className="ds-modal-empty ds-modal-error">
-                <div className="ds-modal-error-title">
-                  {t('preview.errorTitle')}
+                  <div className="ds-modal-error-body">
+                    {t('preview.errorBody')}
+                  </div>
+                  {onView && activeView ? (
+                    <button
+                      type="button"
+                      className="ghost"
+                      onClick={() => onView(activeView.id)}
+                    >
+                      {t('preview.retry')}
+                    </button>
+                  ) : null}
                 </div>
-                <div className="ds-modal-error-body">
-                  {t('preview.errorBody')}
+              ) : activeHtml === null || activeHtml === undefined ? (
+                <div className="ds-modal-empty">
+                  {t('preview.loading', {
+                    label:
+                      activeView?.label.toLowerCase() ?? t('common.preview').toLowerCase(),
+                  })}
                 </div>
-                {onView && activeView ? (
-                  <button
-                    type="button"
-                    className="ghost"
-                    onClick={() => onView(activeView.id)}
+              ) : (
+                <div className="ds-modal-stage-iframe-scaler" style={scalerStyle}>
+                  <iframe
+                    key={activeView?.id ?? 'view'}
+                    ref={previewIframeRef}
+                    title={`${title} ${activeView?.label ?? ''}`}
+                    sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+                    srcDoc={srcDoc}
+                  />
+                </div>
+              )}
+              {sidebar && !sidebarOpen ? (
+                <button
+                  type="button"
+                  className="ds-modal-stage-handle is-expand"
+                  onClick={() => {
+                    onSidebarToggleClick?.(true);
+                    setSidebarOpen(true);
+                  }}
+                  data-tooltip={t('preview.showSidebar', { label: sidebar.label })}
+                  aria-label={t('preview.showSidebar', { label: sidebar.label })}
+                >
+                  <span aria-hidden="true">‹</span>
+                </button>
+              ) : null}
+                </div>
+                {sidebar && sidebarOpen ? (
+                  <aside
+                    className={`ds-modal-sidebar${sidebar.className ? ` ${sidebar.className}` : ''}`}
+                    aria-label={sidebar.label}
                   >
-                    {t('preview.retry')}
-                  </button>
+                    <button
+                      type="button"
+                      className="ds-modal-stage-handle is-collapse"
+                      onClick={() => {
+                        onSidebarToggleClick?.(false);
+                        setSidebarOpen(false);
+                      }}
+                      data-tooltip={t('preview.hideSidebar', { label: sidebar.label })}
+                      aria-label={t('preview.hideSidebar', { label: sidebar.label })}
+                    >
+                      <span aria-hidden="true">›</span>
+                    </button>
+                    {sidebar.header ? (
+                      <div className="ds-modal-sidebar-header">
+                        <span className="ds-modal-sidebar-title">{sidebar.header}</span>
+                      </div>
+                    ) : null}
+                    {sidebar.content}
+                  </aside>
                 ) : null}
               </div>
-            ) : activeHtml === null || activeHtml === undefined ? (
-              <div className="ds-modal-empty">
-                {t('preview.loading', {
-                  label:
-                    activeView?.label.toLowerCase() ?? t('common.preview').toLowerCase(),
-                })}
-              </div>
-            ) : (
-              <div className="ds-modal-stage-iframe-scaler" style={scalerStyle}>
-                <iframe
-                  key={activeView?.id ?? 'view'}
-                  ref={previewIframeRef}
-                  title={`${title} ${activeView?.label ?? ''}`}
-                  sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
-                  srcDoc={srcDoc}
-                />
-              </div>
-            )}
-            {sidebar && !sidebarOpen ? (
-              <button
-                type="button"
-                className="ds-modal-stage-handle is-expand"
-                onClick={() => {
-                  onSidebarToggleClick?.(true);
-                  setSidebarOpen(true);
-                }}
-                title={t('preview.showSidebar', { label: sidebar.label })}
-                aria-label={t('preview.showSidebar', { label: sidebar.label })}
-              >
-                <span aria-hidden="true">‹</span>
-              </button>
-            ) : null}
+            </div>
           </div>
-          {sidebar && sidebarOpen ? (
-            <aside className="ds-modal-sidebar" aria-label={sidebar.label}>
-              <button
-                type="button"
-                className="ds-modal-stage-handle is-collapse"
-                onClick={() => {
-                  onSidebarToggleClick?.(false);
-                  setSidebarOpen(false);
-                }}
-                title={t('preview.hideSidebar', { label: sidebar.label })}
-                aria-label={t('preview.hideSidebar', { label: sidebar.label })}
-              >
-                <span aria-hidden="true">›</span>
-              </button>
-              {sidebar.content}
-            </aside>
-          ) : null}
         </div>
       </div>
     </div>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -776,6 +776,7 @@ export const ar: Dict = {
   'handoff.notInstalled': 'غير مُثبَّت',
   'handoff.notDetectedTitle': '{target} - لم يُكتشف في $PATH',
   'designSystemPicker.select': 'اختر نظام التصميم',
+  'designSystemPicker.useCurrent': 'استخدم نظام التصميم هذا',
   'designSystemPicker.loading': 'جارٍ تحميل أنظمة التصميم…',
   'designSystemPicker.searchPlaceholder': 'البحث في أنظمة التصميم (العنوان / الفئة / الملخص)',
   'designSystemPicker.searchCompactPlaceholder': 'البحث في أنظمة التصميم',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -776,6 +776,7 @@ export const de: Dict = {
   'handoff.notInstalled': 'Nicht installiert',
   'handoff.notDetectedTitle': '{target} – nicht im $PATH erkannt',
   'designSystemPicker.select': 'Designsystem auswählen',
+  'designSystemPicker.useCurrent': 'Dieses Designsystem verwenden',
   'designSystemPicker.loading': 'Design Systems werden geladen…',
   'designSystemPicker.searchPlaceholder': 'Designsysteme durchsuchen (Titel / Kategorie / Zusammenfassung)',
   'designSystemPicker.searchCompactPlaceholder': 'Designsysteme durchsuchen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -776,6 +776,7 @@ export const en: Dict = {
   'handoff.notInstalled': 'Not installed',
   'handoff.notDetectedTitle': '{target} - not detected on $PATH',
   'designSystemPicker.select': 'Choose design system',
+  'designSystemPicker.useCurrent': 'Use this design system',
   'designSystemPicker.loading': 'Loading design systems…',
   'designSystemPicker.searchPlaceholder': 'Search design systems (title / category / summary)',
   'designSystemPicker.searchCompactPlaceholder': 'Search design systems',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -776,6 +776,7 @@ export const esES: Dict = {
   'handoff.notInstalled': 'No instalado',
   'handoff.notDetectedTitle': '{target}: no detectado en $PATH',
   'designSystemPicker.select': 'Elegir sistema de diseño',
+  'designSystemPicker.useCurrent': 'Usar este sistema de diseño',
   'designSystemPicker.loading': 'Cargando sistemas de diseño…',
   'designSystemPicker.searchPlaceholder': 'Buscar sistemas de diseño (título / categoría / resumen)',
   'designSystemPicker.searchCompactPlaceholder': 'Buscar sistemas de diseño',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -776,6 +776,7 @@ export const fa: Dict = {
   'handoff.notInstalled': 'نصب نشده',
   'handoff.notDetectedTitle': '{target} - در $PATH شناسایی نشد',
   'designSystemPicker.select': 'انتخاب سیستم طراحی',
+  'designSystemPicker.useCurrent': 'استفاده از این سیستم طراحی',
   'designSystemPicker.loading': 'در حال بارگذاری سیستم‌های طراحی…',
   'designSystemPicker.searchPlaceholder': 'جستجوی سیستم‌های طراحی (عنوان / دسته‌بندی / خلاصه)',
   'designSystemPicker.searchCompactPlaceholder': 'جستجوی سیستم‌های طراحی',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -776,6 +776,7 @@ export const fr: Dict = {
   'handoff.notInstalled': 'Non détecté',
   'handoff.notDetectedTitle': '{target} - non détecté dans $PATH',
   'designSystemPicker.select': 'Choisir un système de design',
+  'designSystemPicker.useCurrent': 'Utiliser ce système de design',
   'designSystemPicker.loading': 'Chargement des systèmes de design…',
   'designSystemPicker.searchPlaceholder': 'Rechercher des systèmes de design (titre / catégorie / résumé)',
   'designSystemPicker.searchCompactPlaceholder': 'Rechercher des systèmes de design',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -776,6 +776,7 @@ export const hu: Dict = {
   'handoff.notInstalled': 'Nincs telepítve',
   'handoff.notDetectedTitle': '{target} – nem észlelhető a $PATH útvonalon',
   'designSystemPicker.select': 'Válassz tervezési rendszert',
+  'designSystemPicker.useCurrent': 'Használd ezt a tervezési rendszert',
   'designSystemPicker.loading': 'Design rendszerek betöltése…',
   'designSystemPicker.searchPlaceholder': 'Tervezési rendszerek keresése (cím / kategória / összegzés)',
   'designSystemPicker.searchCompactPlaceholder': 'Tervezési rendszerek keresése',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -776,6 +776,7 @@ export const id: Dict = {
   'handoff.notInstalled': 'Belum terpasang',
   'handoff.notDetectedTitle': '{target} - tidak terdeteksi di $PATH',
   'designSystemPicker.select': 'Pilih design system',
+  'designSystemPicker.useCurrent': 'Gunakan design system ini',
   'designSystemPicker.loading': 'Memuat design system…',
   'designSystemPicker.searchPlaceholder': 'Cari sistem desain (judul / kategori / ringkasan)',
   'designSystemPicker.searchCompactPlaceholder': 'Cari sistem desain',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -776,6 +776,7 @@ export const it: Dict = {
   'handoff.notInstalled': 'Non installato',
   'handoff.notDetectedTitle': '{target} - non rilevato in $PATH',
   'designSystemPicker.select': 'Scegli design system',
+  'designSystemPicker.useCurrent': 'Usa questo design system',
   'designSystemPicker.loading': 'Caricamento dei design system…',
   'designSystemPicker.searchPlaceholder': 'Cerca design system (titolo / categoria / riepilogo)',
   'designSystemPicker.searchCompactPlaceholder': 'Cerca design system',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -776,6 +776,7 @@ export const ja: Dict = {
   'handoff.notInstalled': '未インストール',
   'handoff.notDetectedTitle': '{target} - $PATH上で検出されませんでした',
   'designSystemPicker.select': 'デザインシステムを選択',
+  'designSystemPicker.useCurrent': 'このデザインシステムを使用',
   'designSystemPicker.loading': 'デザインシステムを読み込み中…',
   'designSystemPicker.searchPlaceholder': 'デザインシステムを検索（タイトル / カテゴリ / 概要）',
   'designSystemPicker.searchCompactPlaceholder': 'デザインシステムを検索',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -776,6 +776,7 @@ export const ko: Dict = {
   'handoff.notInstalled': '설치되지 않음',
   'handoff.notDetectedTitle': '{target} - $PATH에서 감지되지 않음',
   'designSystemPicker.select': '디자인 시스템 선택',
+  'designSystemPicker.useCurrent': '이 디자인 시스템 사용',
   'designSystemPicker.loading': '디자인 시스템을 불러오는 중…',
   'designSystemPicker.searchPlaceholder': '디자인 시스템 검색 (제목 / 카테고리 / 요약)',
   'designSystemPicker.searchCompactPlaceholder': '디자인 시스템 검색',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -776,6 +776,7 @@ export const pl: Dict = {
   'handoff.notInstalled': 'Nie zainstalowano',
   'handoff.notDetectedTitle': '{target} - nie wykryto w $PATH',
   'designSystemPicker.select': 'Wybierz system projektowy',
+  'designSystemPicker.useCurrent': 'Użyj tego systemu projektowego',
   'designSystemPicker.loading': 'Wczytywanie systemów projektowych…',
   'designSystemPicker.searchPlaceholder': 'Szukaj systemów projektowych (tytuł / kategoria / podsumowanie)',
   'designSystemPicker.searchCompactPlaceholder': 'Szukaj systemów projektowych',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -776,6 +776,7 @@ export const ptBR: Dict = {
   'handoff.notInstalled': 'Não instalado',
   'handoff.notDetectedTitle': '{target} - não detectado no $PATH',
   'designSystemPicker.select': 'Escolher design system',
+  'designSystemPicker.useCurrent': 'Usar este design system',
   'designSystemPicker.loading': 'Carregando design systems…',
   'designSystemPicker.searchPlaceholder': 'Pesquisar design systems (título / categoria / resumo)',
   'designSystemPicker.searchCompactPlaceholder': 'Pesquisar design systems',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -776,6 +776,7 @@ export const ru: Dict = {
   'handoff.notInstalled': 'Не установлено',
   'handoff.notDetectedTitle': '{target} — не обнаружено в $PATH',
   'designSystemPicker.select': 'Выберите дизайн-систему',
+  'designSystemPicker.useCurrent': 'Использовать эту дизайн-систему',
   'designSystemPicker.loading': 'Загрузка дизайн-систем…',
   'designSystemPicker.searchPlaceholder': 'Поиск дизайн-систем (название / категория / описание)',
   'designSystemPicker.searchCompactPlaceholder': 'Поиск дизайн-систем',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -776,6 +776,7 @@ export const th: Dict = {
   'handoff.notInstalled': 'ยังไม่ได้ติดตั้ง',
   'handoff.notDetectedTitle': '{target} - ไม่พบบน $PATH',
   'designSystemPicker.select': 'เลือกดีไซน์ซิสเต็ม',
+  'designSystemPicker.useCurrent': 'ใช้ดีไซน์ซิสเต็มนี้',
   'designSystemPicker.loading': 'กำลังโหลด design systems…',
   'designSystemPicker.searchPlaceholder': 'ค้นหาดีไซน์ซิสเต็ม (ชื่อ / หมวดหมู่ / สรุป)',
   'designSystemPicker.searchCompactPlaceholder': 'ค้นหาดีไซน์ซิสเต็ม',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -776,6 +776,7 @@ export const tr: Dict = {
   'handoff.notInstalled': 'Yüklü değil',
   'handoff.notDetectedTitle': '{target} - $PATH üzerinde algılanmadı',
   'designSystemPicker.select': 'Tasarım sistemi seçin',
+  'designSystemPicker.useCurrent': 'Bu tasarım sistemini kullan',
   'designSystemPicker.loading': 'Tasarım sistemleri yükleniyor…',
   'designSystemPicker.searchPlaceholder': 'Tasarım sistemlerinde ara (başlık / kategori / özet)',
   'designSystemPicker.searchCompactPlaceholder': 'Tasarım sistemlerinde ara',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -776,6 +776,7 @@ export const uk: Dict = {
   'handoff.notInstalled': 'Не встановлено',
   'handoff.notDetectedTitle': '{target} — не виявлено в $PATH',
   'designSystemPicker.select': 'Виберіть дизайн-систему',
+  'designSystemPicker.useCurrent': 'Використати цю дизайн-систему',
   'designSystemPicker.loading': 'Завантаження дизайн-систем…',
   'designSystemPicker.searchPlaceholder': 'Пошук дизайн-систем (назва / категорія / опис)',
   'designSystemPicker.searchCompactPlaceholder': 'Пошук дизайн-систем',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -805,6 +805,7 @@ export const zhCN: Dict = {
   "handoff.notInstalled": "未安装",
   "handoff.notDetectedTitle": "{target} - 未在 $PATH 中检测到",
   "designSystemPicker.select": "选择设计系统",
+  "designSystemPicker.useCurrent": "使用该设计系统",
   "designSystemPicker.loading": "正在加载设计系统…",
   "designSystemPicker.searchPlaceholder": "搜索设计系统（标题 / 分类 / 摘要）",
   "designSystemPicker.searchCompactPlaceholder": "搜索设计系统",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -808,6 +808,7 @@ export const zhTW: Dict = {
   "handoff.notInstalled": "未安裝",
   "handoff.notDetectedTitle": "{target} - 未在 $PATH 中偵測到",
   "designSystemPicker.select": "選擇設計系統",
+  "designSystemPicker.useCurrent": "使用此設計系統",
   "designSystemPicker.loading": "正在載入設計系統…",
   "designSystemPicker.searchPlaceholder": "搜尋設計系統（標題 / 分類 / 摘要）",
   "designSystemPicker.searchCompactPlaceholder": "搜尋設計系統",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1173,6 +1173,7 @@ export interface Dict {
   'handoff.notInstalled': string;
   'handoff.notDetectedTitle': string;
   'designSystemPicker.select': string;
+  'designSystemPicker.useCurrent': string;
   'designSystemPicker.loading': string;
   'designSystemPicker.searchPlaceholder': string;
   'designSystemPicker.searchCompactPlaceholder': string;

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -1397,6 +1397,19 @@
   max-width: none;
   border-radius: 0;
 }
+.ds-modal-shell {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+.ds-modal-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
 /* Two-row header: title row keeps the title/subtitle + close together at
    the top; toolbar row hosts tabs (left) and the action cluster (right).
    This split lets the title breathe even when the toolbar carries a busy
@@ -1436,7 +1449,7 @@
 .ds-modal-title {
   font-size: 16px;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1500,6 +1513,31 @@
 .ds-modal-actions .share-menu > button {
   white-space: nowrap;
   flex-shrink: 0;
+}
+.ds-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+.ds-modal-navigation {
+  flex: 0 0 160px;
+  width: 160px;
+  min-width: 146px;
+  max-width: 172px;
+  min-height: 0;
+  border-right: 1px solid var(--border);
+  background: var(--bg-panel);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.ds-modal-body > .ds-modal-stage {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ds-modal-fullscreen .ds-modal-navigation {
+  display: none;
 }
 .ds-modal-stage {
   flex: 1;
@@ -1583,6 +1621,27 @@
      slightly longer ease-out keeps it from snapping. */
   animation: ds-modal-sidebar-in 340ms cubic-bezier(0.16, 1, 0.3, 1);
 }
+.ds-modal-sidebar--design-spec {
+  flex: 0 1 32%;
+  min-width: 300px;
+  max-width: 460px;
+}
+.ds-modal-sidebar-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-panel);
+}
+.ds-modal-sidebar-title {
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
 @keyframes ds-modal-sidebar-in {
   from {
     opacity: 0;
@@ -1634,16 +1693,45 @@
   transition: color 120ms var(--ease-out), background 120ms var(--ease-out);
 }
 .ds-modal-stage-handle:hover { color: var(--text); background: var(--bg-subtle); }
+.ds-modal-stage-handle[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: 50%;
+  z-index: 5;
+  transform: translateY(-50%);
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  padding: 6px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  color: var(--text);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.16);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.25;
+}
+.ds-modal-stage-handle[data-tooltip]:hover::after,
+.ds-modal-stage-handle[data-tooltip]:focus-visible::after {
+  opacity: 1;
+}
 .ds-modal-stage-handle.is-expand {
   right: 0;
   border-right: none;
   border-radius: 8px 0 0 8px;
 }
+.ds-modal-stage-handle.is-expand::after {
+  right: calc(100% + 8px);
+}
 .ds-modal-stage-handle.is-collapse {
-  position: sticky;
+  position: absolute;
   left: 0;
   border-left: none;
   border-radius: 0 8px 8px 0;
+}
+.ds-modal-stage-handle.is-collapse::after {
+  left: calc(100% + 8px);
 }
 .ds-modal-fullscreen .ds-modal-stage:fullscreen .ds-modal-stage-iframe-scaler,
 .ds-modal-stage:fullscreen .ds-modal-stage-iframe-scaler {
@@ -1858,6 +1946,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  height: 35px;
   padding: 7px 16px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--accent);
@@ -1878,8 +1967,14 @@
   transform: translateY(0.5px);
 }
 .ds-modal-primary-action:disabled {
-  cursor: progress;
+  cursor: default;
   opacity: 0.6;
+}
+.ds-modal-primary-action[aria-busy='true'] {
+  cursor: progress;
+}
+.ds-modal-primary-action--trailing {
+  order: 20;
 }
 /* Split-button variant: the "Use plugin" CTA grows a caret toggle that opens
    a menu of use-variants ("Use plugin" / "Use with query"). Mirrors the home
@@ -1974,7 +2069,7 @@
 }
 .design-spec-pre {
   margin: 0;
-  padding: 16px 18px;
+  padding: 10px 14px 16px;
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
   font-size: 12px;
   line-height: 1.6;
@@ -2037,6 +2132,16 @@
   .ds-modal { border-radius: 0; }
   .ds-modal-header { gap: 10px; padding: 12px 14px; }
   .ds-modal-actions { justify-content: flex-start; }
+  .ds-modal-shell.has-navigation { flex-direction: column; }
+  .ds-modal-navigation {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    flex: 0 0 auto;
+    max-height: 220px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
   .ds-modal-stage { flex-direction: column; }
   .ds-modal-stage.has-sidebar .ds-modal-stage-iframe { flex: 1 1 50%; }
   .ds-modal-sidebar {

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -3066,6 +3066,158 @@ body.od-quick-switcher-open .chat-composer-fixed-layer .composer-send:disabled {
   padding: 24px;
   background: var(--bg);
 }
+.ds-preview-system-nav {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+}
+.ds-preview-system-nav__search {
+  flex: 0 0 auto;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+}
+.ds-preview-system-nav__search input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  line-height: 1.3;
+}
+.ds-preview-system-nav__search input:focus,
+.ds-preview-system-nav__search input:focus-visible {
+  outline: none;
+  border-color: transparent;
+  box-shadow: none;
+}
+.ds-preview-system-nav__clear {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition:
+    background-color 120ms var(--ease-out),
+    border-color 120ms var(--ease-out),
+    color 120ms var(--ease-out);
+}
+.ds-preview-system-nav__clear:hover,
+.ds-preview-system-nav__clear:focus-visible {
+  outline: none;
+  background: var(--bg-subtle);
+  border-color: var(--border);
+  color: var(--text);
+}
+.ds-preview-system-nav__list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ds-preview-system-nav__group {
+  position: sticky;
+  top: -6px;
+  z-index: 1;
+  padding: 9px 8px 5px;
+  background: var(--bg-panel);
+  color: var(--text-faint);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.ds-preview-system-nav__option {
+  appearance: none;
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 9px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 120ms var(--ease-out),
+    border-color 120ms var(--ease-out),
+    color 120ms var(--ease-out);
+}
+.ds-preview-system-nav__option:hover,
+.ds-preview-system-nav__option:focus-visible {
+  outline: none;
+  background: color-mix(in srgb, var(--text-muted) 8%, transparent);
+}
+.ds-preview-system-nav__option.is-active {
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.ds-preview-system-nav__option-copy {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ds-preview-system-nav__option-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-strong, var(--text));
+  font-size: 12.5px;
+  font-weight: 650;
+  line-height: 1.25;
+}
+.ds-preview-system-nav__option-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+}
+.ds-preview-system-nav__option-check {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  color: var(--accent);
+  background: var(--accent-tint);
+}
+.ds-preview-system-nav__empty {
+  padding: 16px 10px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: center;
+}
 .project-ds-picker-preview-head {
   display: flex;
   align-items: center;

--- a/apps/web/src/styles/viewer/tools.css
+++ b/apps/web/src/styles/viewer/tools.css
@@ -580,6 +580,13 @@
   align-items: center;
   gap: 6px;
 }
+.template-share-trigger.is-icon-only {
+  width: 54px;
+  min-width: 54px;
+  height: 35px;
+  padding-inline: 10px;
+  gap: 4px;
+}
 .template-share-trigger[aria-expanded='true'] {
   background: var(--accent-tint);
   border-color: var(--accent);


### PR DESCRIPTION
## Summary
- Add design-system navigation to the full preview modal
- Move DESIGN.md into the right panel header and simplify top actions
- Compact and align preview actions, including the share menu trigger

## Surface area checklist
- [x] Design system picker
- [x] Design system full preview modal
- [x] DESIGN.md side panel
- [x] Preview modal toolbar/actions
- [x] i18n strings
- [ ] Backend/API changes
- [ ] Database or migration changes

## Validation
- [x] `pnpm --filter @open-design/web typecheck`
- [x] `git diff --check`
- [x] Manual browser QA: opened the design-system picker, expanded the full preview modal, switched design systems from the left navigation, verified DESIGN.md panel collapse/expand, verified “使用该设计系统” selects and closes the modal, and verified share trigger alignment.