### PR TITLE
refactor(daemon): group design lifecycle modules into design/

### DIFF
--- a/apps/daemon/src/design/claude-design-import.ts
+++ b/apps/daemon/src/design/claude-design-import.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { inflateRawSync } from 'node:zlib';
-import { validateProjectPath } from './projects.js';
+import { validateProjectPath } from '../projects.js';
 
 const EOCD_SIG = 0x06054b50;
 const CENTRAL_SIG = 0x02014b50;

--- a/apps/daemon/src/design/finalize-design.ts
+++ b/apps/daemon/src/design/finalize-design.ts
@@ -31,17 +31,17 @@ import type {
   FinalizeArtifactRef,
   FinalizeProviderProtocol,
 } from '@open-design/contracts/api/finalize';
-import { getProject } from './db.js';
-import { readDesignSystem } from './design-systems/index.js';
+import { getProject } from '../db.js';
+import { readDesignSystem } from '../design-systems/index.js';
 import {
   listFiles,
   readProjectFile,
   reconcileHtmlArtifactManifest,
   resolveProjectDir,
   validateProjectPath,
-} from './projects.js';
-import { exportProjectTranscript } from './transcript-export.js';
-import { googleGenerateContentUrl } from './integrations/google-models.js';
+} from '../projects.js';
+import { exportProjectTranscript } from '../transcript-export.js';
+import { googleGenerateContentUrl } from '../integrations/google-models.js';
 
 // Re-export the request/response types so existing daemon-internal
 // imports (and the route handler) keep their referenced names. The

--- a/apps/daemon/src/design/handoff-design.ts
+++ b/apps/daemon/src/design/handoff-design.ts
@@ -27,7 +27,7 @@ import type {
   HandoffResponse,
 } from '@open-design/contracts/api/handoff';
 import fs from 'node:fs';
-import { getProject } from './db.js';
+import { getProject } from '../db.js';
 import {
   callAnthropicWithRetry,
   DEFAULT_TIMEOUT_MS,
@@ -36,7 +36,7 @@ import {
   truncateTranscriptForPrompt,
   type AnthropicCallParams,
 } from './finalize-design.js';
-import { exportProjectTranscript } from './transcript-export.js';
+import { exportProjectTranscript } from '../transcript-export.js';
 
 // Re-export the request/response types so the route handler and other
 // daemon-internal consumers reference the canonical contracts shape via

--- a/apps/daemon/src/design/index.ts
+++ b/apps/daemon/src/design/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @module design
+ *
+ * Barrel for daemon design lifecycle modules: finalize-design (finalize an
+ * agent design run), handoff-design (synthesize a handoff prompt), and
+ * claude-design-import (import a Claude design zip).
+ */
+export * from './finalize-design.js';
+export * from './handoff-design.js';
+export * from './claude-design-import.js';

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -362,14 +362,14 @@ import {
   validateBaseUrlResolved,
 } from './connectionTest.js';
 import { listProviderModels } from './integrations/provider-models.js';
-import { importClaudeDesignZip } from './claude-design-import.js';
+import { importClaudeDesignZip } from './design/index.js';
 import {
   defaultBaseUrlForFinalizeProtocol,
   finalizeDesignPackage,
   FinalizePackageLockedError,
   FinalizeUpstreamError,
   isFinalizeProviderProtocol,
-} from './finalize-design.js';
+} from './design/index.js';
 import { buildDocumentPreview } from './document-preview.js';
 import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
 import { loadCraftSections } from './craft.js';
@@ -558,7 +558,7 @@ import { registerProjectRoutes, registerProjectArtifactRoutes, registerProjectFi
 import { registerVelaRoutes } from './routes/vela.js';
 import { registerFinalizeRoutes, registerImportRoutes, registerProjectExportRoutes } from './import-export-routes.js';
 import { registerHandoffRoutes } from './routes/handoff.js';
-import { EmptyTranscriptError, synthesizeHandoffPrompt } from './handoff-design.js';
+import { EmptyTranscriptError, synthesizeHandoffPrompt } from './design/index.js';
 import { TranscriptExportLockedError } from './transcript-export.js';
 import { registerChatRoutes } from './routes/chat.js';
 import { registerRunRoutes } from './routes/runs.js';

--- a/apps/daemon/tests/claude-design-import.test.ts
+++ b/apps/daemon/tests/claude-design-import.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { deflateRawSync } from 'node:zlib';
 import { describe, expect, it, vi } from 'vitest';
-import { importClaudeDesignZip } from '../src/claude-design-import.js';
+import { importClaudeDesignZip } from '../src/design/index.js';
 
 function buildZip(
   entries: { name: string; body: Buffer; method?: 0 | 8; falsifyCentralUncompressed?: boolean }[],

--- a/apps/daemon/tests/finalize-design.test.ts
+++ b/apps/daemon/tests/finalize-design.test.ts
@@ -31,7 +31,7 @@ import {
   FinalizeUpstreamError,
   resolveCurrentArtifact,
   truncateTranscriptForPrompt,
-} from '../src/finalize-design.js';
+} from '../src/design/index.js';
 
 void appendVersionedApiPath;
 

--- a/apps/daemon/tests/handoff-design.test.ts
+++ b/apps/daemon/tests/handoff-design.test.ts
@@ -20,8 +20,8 @@ import {
   EmptyTranscriptError,
   HANDOFF_SYSTEM_PROMPT,
   synthesizeHandoffPrompt,
-} from '../src/handoff-design.js';
-import { FinalizeUpstreamError } from '../src/finalize-design.js';
+} from '../src/design/index.js';
+import { FinalizeUpstreamError } from '../src/design/index.js';
 
 const PROJECT_ID = 'project-handoff-1';
 let tempDir: string | null = null;


### PR DESCRIPTION
<!-- This PR is a pure internal refactor and closes no issue. -->

## Why

- **My use case:** Continuing the `apps/daemon/src/` flat-file cleanup (after
  `config/`, `auth/`, `migration/`, `browser/`, `cli-help/`) — the daemon `src/`
  root holds 60+ loose top-level modules. The design-lifecycle modules form a
  cohesive group.
- **The pain:** `finalize-design.ts` (finalize an agent design run),
  `handoff-design.ts` (synthesize a handoff prompt), and `claude-design-import.ts`
  (import a Claude design zip) all drive the design-generation lifecycle — and
  `handoff-design` already depends on `finalize-design` — yet sit loose at the
  `src/` root among unrelated modules. Grouping them into `design/` behind a
  barrel makes the lifecycle findable, with zero behavior change.

## What users will see

Nothing. Internal refactor only — all three modules' public exports are
re-exported byte-identically through the new `design/index.ts` barrel; runtime
behavior is unchanged.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Validation

Behavior-preserving move of the three modules into `apps/daemon/src/design/` with
a barrel `index.ts`. Bodies moved byte-identically apart from relative-import
depth: each moved file's outward imports (`../db`, `../projects`,
`../transcript-export`, `../design-systems`, `../integrations/google-models`) were
bumped `./`→`../`, while the co-moved `handoff-design → finalize-design` edge
stays `./`. All external importers (`server.ts` and the three tests) now resolve
through `design/index.js`.

- `pnpm --filter @open-design/daemon typecheck` → **exit 0** (src + tests)
- `pnpm --filter @open-design/daemon test finalize-design handoff-design claude-design-import server-startup-smoke` → **72 passed** (4 files; the real-daemon boot smoke exercises the `@ts-nocheck` `server.ts` import paths at runtime)
- `pnpm guard` → **exit 0**
- **Byte-identity:** moved bodies unchanged apart from the `./`→`../` import
  bumps; the diff is 8 files.
