### PR TITLE
fix(daemon): target the stalled child in watchdog forced-shutdown escalation

### DIFF
--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -297,11 +297,18 @@ export function createChatRunService({
     return Number.isFinite(raw) && raw > 0 ? raw : 500;
   };
 
-  const killChild = (run, signal) => {
-    if (!run.child || childHasExited(run.child)) return false;
-    if (process.platform !== 'win32' && Number.isInteger(run.processGroupId)) {
+  // Signal an EXPLICIT child + its captured process group, rather than
+  // whatever currently occupies `run.child`. Escalation timers (SIGTERM ->
+  // SIGKILL) that outlive a same-run retry MUST target the exact generation
+  // they were scheduled for: after a retry swaps `run.child` to a fresh
+  // child, signalling the shared field would kill the healthy new attempt and
+  // leave the stalled old child unreaped. Callers that legitimately want the
+  // current child use `killChild` below.
+  const signalChildProcess = (child, processGroupId, signal) => {
+    if (!child || childHasExited(child)) return false;
+    if (process.platform !== 'win32' && Number.isInteger(processGroupId)) {
       try {
-        process.kill(-run.processGroupId, signal);
+        process.kill(-processGroupId, signal);
         return true;
       } catch (err) {
         if (err?.code !== 'ESRCH') {
@@ -312,11 +319,14 @@ export function createChatRunService({
       }
     }
     try {
-      return run.child.kill(signal);
+      return child.kill(signal);
     } catch {
       return false;
     }
   };
+
+  const killChild = (run, signal) =>
+    signalChildProcess(run.child, run.processGroupId, signal);
 
   const cancelGraceMs = () => {
     const raw = Number(process.env.OD_CHAT_RUN_CANCEL_GRACE_MS || process.env.OD_CHAT_RUN_SHUTDOWN_GRACE_MS);
@@ -466,6 +476,7 @@ export function createChatRunService({
     drop,
     signalChild: killChild,
     statusBody,
+    signalChildProcess,
     isTerminal(status) {
       return TERMINAL_RUN_STATUSES.has(status);
     },

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7011,7 +7011,13 @@ export async function startServer({
     const runStartTimeMs = Date.now();
     const inactivityTimeoutMs = resolveChatRunInactivityTimeoutMs(def.inactivityTimeoutMs);
     const artifactQuietPeriodMs = resolveChatRunArtifactQuietPeriodMs();
-    const inactivityKillGraceMs = 3_000;
+    // Grace before the inactivity watchdog escalates a stalled child from
+    // SIGTERM to SIGKILL. Env-tunable like its OD_CHAT_RUN_* cancel-grace
+    // siblings so the escalation path can be exercised deterministically.
+    const inactivityKillGraceMs = (() => {
+      const raw = Number(process.env.OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS);
+      return Number.isFinite(raw) && raw > 0 ? raw : 3_000;
+    })();
     let inactivityTimer = null;
     let childStdoutSeen = false;
     let lastAgentEventPhase = 'spawn pending';
@@ -7077,12 +7083,20 @@ export async function startServer({
     const scheduleForcedChildShutdown = () => {
       if (!child) return;
       clearForcedChildShutdown();
+      // Capture THIS attempt's child and its process group. A same-run retry
+      // can swap `run.child` to a fresh child within the grace window; these
+      // timers must escalate the stalled child they were scheduled for, never
+      // whatever now occupies `run.child` — otherwise the healthy retry gets
+      // killed and this stalled child is left unreaped. See runs.ts
+      // `signalChildProcess`.
+      const targetChild = child;
+      const targetProcessGroupId = run.processGroupId;
       forcedChildShutdownTimers = [
         setTimeout(() => {
-          if (child) design.runs.signalChild(run, 'SIGTERM');
+          design.runs.signalChildProcess(targetChild, targetProcessGroupId, 'SIGTERM');
         }, inactivityKillGraceMs),
         setTimeout(() => {
-          if (child) design.runs.signalChild(run, 'SIGKILL');
+          design.runs.signalChildProcess(targetChild, targetProcessGroupId, 'SIGKILL');
         }, inactivityKillGraceMs * 2),
       ];
     };

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -171,7 +171,85 @@ describe('same-run retry runtime', () => {
     expect(secondAttemptSessionId).toBeTruthy();
     expect(secondAttemptSessionId).not.toBe(firstAttemptSessionId);
   });
+
+  it('does not let a stalled attempt’s forced-shutdown timers kill the healthy retry', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-retry-crossgen-bin-'));
+    const { bin: fakeClaude } = await writeCrossGenKillClaude(binDir, 'claude-crossgen');
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    // Watchdog trips the first (silent) attempt fast; the escalation grace is
+    // shortened so the stale SIGTERM/SIGKILL land while the retry child is
+    // mid-work (retry backoff is <=500ms, so 800ms grace guarantees overlap).
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '400';
+    process.env.OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS = '800';
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const run = await createAndWaitForRun(started.url);
+    // On buggy main the previous attempt's forced-shutdown timers signal the
+    // shared run.child (now the healthy retry) and kill it -> failed.
+    expect(run.status).toBe('succeeded');
+    expect(run.signal).toBeNull();
+  });
 });
+
+async function writeCrossGenKillClaude(
+  dir: string,
+  name: string,
+): Promise<{ bin: string; argsLogPath: string }> {
+  const bin = path.join(dir, name);
+  const counterPath = path.join(dir, `${name}-attempts`);
+  const argsLogPath = path.join(dir, `${name}-args.jsonl`);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const counterPath = ${JSON.stringify(counterPath)};
+const argsLogPath = ${JSON.stringify(argsLogPath)};
+if (process.argv.includes('--version')) { console.log('claude-code 1.0.0-crossgen'); process.exit(0); }
+if (process.argv.includes('--help')) { console.log('Usage: claude -p'); process.exit(0); }
+let attempts = 0;
+try { attempts = Number(fs.readFileSync(counterPath, 'utf8')) || 0; } catch {}
+fs.writeFileSync(counterPath, String(attempts + 1));
+fs.appendFileSync(argsLogPath, JSON.stringify(process.argv.slice(2)) + '\\n');
+if (attempts === 0) {
+  // First attempt: silent first-token stall so the inactivity watchdog fires,
+  // triggering the same-run retry and arming the forced-shutdown escalation
+  // timers. Long fallback so we never self-exit before the watchdog.
+  setTimeout(() => process.exit(0), 60000);
+} else {
+  // Retry attempt: a healthy child that keeps emitting (feeding its own
+  // watchdog via raw stdout bytes) well past the previous attempt's
+  // SIGTERM/SIGKILL escalation window, then finishes successfully. On buggy
+  // main the stale escalation timers signal the shared run.child — i.e. THIS
+  // child — and kill it mid-work, failing the run.
+  process.stdout.write(JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-crossgen' }) + '\\n');
+  let ticks = 0;
+  const hb = setInterval(() => {
+    process.stdout.write(' \\n');
+    if (++ticks >= 14) {
+      clearInterval(hb);
+      process.stdout.write(JSON.stringify({
+        type: 'assistant',
+        message: { id: 'msg-crossgen', content: [{ type: 'text', text: 'Survived the escalation window.' }], stop_reason: 'end_turn' },
+      }) + '\\n');
+      setTimeout(() => process.exit(0), 20);
+    }
+  }, 150);
+}
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return { bin, argsLogPath };
+}
 
 function snapshotEnv(): Record<string, string | undefined> {
   return {

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -260,6 +260,7 @@ function snapshotEnv(): Record<string, string | undefined> {
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
     OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS: process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS,
+    OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS: process.env.OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS,
   };
 }
 


### PR DESCRIPTION
## Why

Auditing the inactivity-watchdog escalation path in `server.ts`, I found a cross-generation kill: when the watchdog fails a stalled attempt and the same-run retry restarts on a fresh child, the *previous* attempt's forced-shutdown timers (`scheduleForcedChildShutdown`) still fire — and they signal the shared `run.child`, which by then points at the healthy retry.

Mechanism: the timers guard on `if (child)` (the old closure-local, always truthy) but call `design.runs.signalChild(run, …)`, which reads the mutable `run.child` / `run.processGroupId`. The retry backoff for a transient timeout is ≤500ms while the escalation grace is 3s/6s, so the new child is already live when the stale SIGTERM/SIGKILL land. Result: the retry is killed for no reason (run ends `failed`, user sees "the retry also died"), and the genuinely stalled old child — the one that ignored the first SIGTERM — is left unreaped. `tearDownAttemptForRetry` (#4588) closed the double-`close` race but not this timer-targeting one.

The invariant: **an escalation timer must signal the exact child generation it was scheduled for, never whatever now occupies `run.child`.** `scheduleForcedChildShutdown` now captures `targetChild` + `targetProcessGroupId` at schedule time and escalates *that* process via a new `runs.signalChildProcess(child, pgid, signal)` (the explicit-target core that `killChild` now delegates to). This fixes both halves at once: the healthy retry is never touched, and the stalled old child still gets its own SIGTERM→SIGKILL, so it no longer leaks.

Prior art for the same class of bug: omnigent guards retry respawns with an owner-lock + process-cmdline session tag to avoid "PID reused by a new instance killed by stale teardown" (`codex_native_process_registry.py`), and the OpenHands SDK isolates retries with a lease generation + callback unbinding. open-design lacked this generation check on the escalation path; this PR adds it.

`inactivityKillGraceMs` (previously a hardcoded 3s) is now env-tunable via `OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS`, consistent with its `OD_CHAT_RUN_CANCEL_GRACE_MS` / `OD_CHAT_RUN_CANCEL_FORCE_WAIT_MS` siblings, so the escalation window can be exercised deterministically in a red spec.

## What users will see

No UI change. A run whose first attempt stalls and is retried no longer dies a second time from the previous attempt's leftover kill timers; the retry runs to completion. Stalled child processes that ignore SIGTERM are still force-killed (no leak).

## Surface area

- [x] **CLI / env var** — new `OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS` (test/ops tunable; default unchanged at 3000ms)
- [x] **None** — otherwise internal daemon runtime + tests

## Bug fix verification

- Test path: `apps/daemon/tests/run-retry-runtime.test.ts` — new spec "does not let a stalled attempt's forced-shutdown timers kill the healthy retry": attempt 1 stalls silently (watchdog retry), attempt 2 heartbeats past the escalation window; asserts the run ends `succeeded` with `signal === null`.
- Red on the buggy targeting, green on the fix: **yes**. Verified by temporarily restoring the old `signalChild(run, …)` timer body (env knob kept as test infra): red with `expected 'failed' to be 'succeeded'` (2.4s), green after restoring the captured-target escalation. Full `run-retry-runtime` suite 3/3 (the two existing watchdog-retry specs still pass); `run-retry-policy` + `run-lifecycle-tracer` + `daemon-lifecycle` 25/25; `pnpm guard` and daemon `tsc` clean.

## Validation

Environment: Node 24.15.0, pnpm 10.33.2, macOS (arm64)

- `pnpm --filter @open-design/daemon... run build` → clean
- `pnpm --filter @open-design/daemon exec vitest run tests/run-retry-runtime.test.ts` → 3/3
- `pnpm --filter @open-design/daemon exec vitest run tests/run-retry-policy.test.ts tests/run-lifecycle-tracer.test.ts tests/daemon-lifecycle.test.ts` → 25/25
- `pnpm guard` → clean · `pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wN43EeBA72rWxSPAhRHwA
