### PR TITLE
fix(claude-stream): surface an error when a result frame reports is_error

### DIFF
--- a/apps/daemon/src/runtimes/claude-stream.ts
+++ b/apps/daemon/src/runtimes/claude-stream.ts
@@ -41,6 +41,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+// Extract a human-facing message from a Claude `result` frame that reported
+// `is_error`. Claude Code carries the error text in `result` (e.g. "API Error:
+// Unable to connect to API (ECONNRESET)"); fall back to nested error shapes
+// and finally the stop reason so the surfaced error is never empty.
+function messageFromClaudeResult(obj: Record<string, unknown>): string {
+  if (typeof obj.result === 'string' && obj.result.length > 0) return obj.result;
+  if (typeof obj.error === 'string' && obj.error.length > 0) return obj.error;
+  if (
+    isRecord(obj.error) &&
+    typeof obj.error.message === 'string' &&
+    obj.error.message.length > 0
+  ) {
+    return obj.error.message;
+  }
+  if (typeof obj.stop_reason === 'string' && obj.stop_reason.length > 0) {
+    return `Claude run failed: ${obj.stop_reason}`;
+  }
+  return 'Claude run failed';
+}
+
 interface ClaudeStreamHandlerOptions {
   suppressHtmlArtifactsAfterFileWrite?: boolean;
 }
@@ -357,7 +377,7 @@ export function createClaudeStreamHandler(
         onEvent({ type: 'raw', line });
         continue;
       }
-      handleObject(obj);
+      handleObject(obj, line);
     }
   }
 
@@ -366,7 +386,7 @@ export function createClaudeStreamHandler(
     buffer = '';
     if (rem) {
       try {
-        handleObject(JSON.parse(rem));
+        handleObject(JSON.parse(rem), rem);
       } catch {
         onEvent({ type: 'raw', line: rem });
       }
@@ -374,7 +394,7 @@ export function createClaudeStreamHandler(
     flushPendingArtifactText();
   }
 
-  function handleObject(obj: unknown) {
+  function handleObject(obj: unknown, rawLine?: string) {
     if (!isRecord(obj)) return;
 
     if (obj.type === 'system' && obj.subtype === 'init') {
@@ -494,6 +514,19 @@ export function createClaudeStreamHandler(
           (typeof obj.terminal_reason === 'string' && obj.terminal_reason) ||
           null,
       });
+      // A result frame can report `is_error` (e.g. a mid-turn connection drop
+      // prints `is_error:true` with subtype "success" and the CLI exits 1).
+      // The usage event above would otherwise mark the turn cleanly completed
+      // and the run would be misclassified as succeeded. Surface an error so
+      // the close handler routes it through the failure/retry path — mirrors
+      // qoder-stream's result handling.
+      if (obj.is_error === true) {
+        onEvent({
+          type: 'error',
+          message: messageFromClaudeResult(obj),
+          raw: rawLine,
+        });
+      }
       return;
     }
   }

--- a/apps/daemon/tests/runtimes/structured-streams.test.ts
+++ b/apps/daemon/tests/runtimes/structured-streams.test.ts
@@ -5,6 +5,28 @@ import { mapPiRpcEvent } from '../../src/pi-rpc.js';
 import { createToolLoopGuard } from '../../src/tool-loop-guard.js';
 
 describe('structured agent stream fixtures', () => {
+  it('surfaces an error event when a Claude result frame reports is_error', () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createClaudeStreamHandler((event: unknown) =>
+      events.push(event as Record<string, unknown>),
+    );
+    // Real transcript shape: a mid-turn connection drop makes the CLI print a
+    // result frame with is_error:true (subtype still "success") and exit 1.
+    // Without surfacing an error the run is misclassified as succeeded.
+    handler.feed(`${JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      result: 'API Error: Unable to connect to API (ECONNRESET)',
+      stop_reason: 'stop_sequence',
+    })}\n`);
+    handler.flush();
+
+    const errorEvent = events.find((event) => event.type === 'error');
+    expect(errorEvent).toBeTruthy();
+    expect(String(errorEvent?.message)).toContain('ECONNRESET');
+  });
+
   it('emits TodoWrite tool_use from Claude Code stream JSON', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler((event: unknown) => events.push(event));


### PR DESCRIPTION
## Why

Auditing the structured stream parsers, I found that `claude-stream.ts` drops the `is_error` flag on `result` frames, so a failed turn is misclassified as a successful run. A real, common failure has this shape: a mid-turn connection drop makes the Claude CLI print `{"type":"result","subtype":"success","is_error":true,"result":"API Error: Unable to connect to API (ECONNRESET)","stop_reason":"stop_sequence"}` and exit 1 (this exact transcript already lives in `claude-diagnostics.test.ts:230`).

The result handler only reads `usage`/`stop_reason` and emits a `usage` event, discarding `is_error`. That `usage` event unconditionally sets `turnCompletedCleanly = true` (`chat-run-lifecycle.ts:97`), and `classifyChatRunCloseStatus` returns `succeeded` on `turnCompletedCleanly` before the exit-code failure path (`chat-run-lifecycle.ts:70`). So with exit 1 and no artifact, the run is reported **succeeded** with truncated/empty output, the `AGENT_CONNECTION_DROPPED` diagnostic (`server.ts:8588`, gated behind `status === 'failed'`) is skipped, and the run is not auto-retried.

`qoder-stream.ts:122-140` already handles this correctly — it surfaces a `type:'error'` event when `is_error` is set, which the generic close handler turns into a failed+retryable run (`server.ts:7946` → `:8418`). This PR gives `claude-stream.ts` the same treatment: on `is_error`, emit an `error` event (message extracted from the `result`/`error`/`stop_reason` fields, plus the raw line for diagnostic classification). No downstream change is needed — the failure/retry wiring already exists and is exercised for qoder.

The invariant: **a result frame reporting `is_error` must surface an error event, not just a usage event.**

## What users will see

No UI change. A Claude chat whose upstream connection drops mid-turn now ends as a failed (retryable) run with the real error reason, instead of a green "success" with empty/truncated output that silently swallows the failure.

## Surface area

- [x] **None** — internal daemon stream parser + tests

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/structured-streams.test.ts` — new spec "surfaces an error event when a Claude result frame reports is_error" feeds the real ECONNRESET result frame and asserts a `type:'error'` event carrying the reason.
- Red on `main`, green on this branch: **yes** (`expected undefined to be truthy` on main → passing on branch). Regression: structured-streams + claude-stream-thinking + claude-diagnostics 49/49, `chat-route` 68/68, `pnpm guard` and daemon `tsc` clean.

## Validation

Environment: Node 24.15.0, pnpm 10.33.2, macOS (arm64)

- `pnpm --filter @open-design/daemon... run build` → clean
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/structured-streams.test.ts tests/runtimes/claude-stream-thinking.test.ts tests/claude-diagnostics.test.ts` → 49/49
- `pnpm --filter @open-design/daemon exec vitest run tests/chat-route.test.ts` → 68/68
- `pnpm guard` → clean · `pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wN43EeBA72rWxSPAhRHwA
