### PR TITLE
fix(daemon): revoke run tool token on startup failure

### DIFF
--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -202,6 +202,16 @@ export function createChatRunService({
     run.exitCode = code;
     run.signal = signal;
     run.updatedAt = Date.now();
+    // Release run-scoped resources the starter registered (e.g. the minted
+    // tool-token grant + agent event-sink entries). This runs on EVERY
+    // terminal path — including a startup throw that never reached the child
+    // lifecycle cleanup — so a failed run can never leave its capability token
+    // live for the token TTL. Best-effort + one-shot.
+    if (typeof run.onFinalize === 'function') {
+      const finalize = run.onFinalize;
+      run.onFinalize = null;
+      try { finalize(); } catch { /* best-effort */ }
+    }
     emit(run, 'end', { code, signal, status, resumable: run.resumable ?? false });
     for (const sse of run.clients) sse.end();
     run.clients.clear();
@@ -437,6 +447,11 @@ export function createChatRunService({
   const drop = (run) => {
     if (!run) return;
     if (TERMINAL_RUN_STATUSES.has(run.status)) return;
+    if (typeof run.onFinalize === 'function') {
+      const finalize = run.onFinalize;
+      run.onFinalize = null;
+      try { finalize(); } catch { /* best-effort */ }
+    }
     runs.delete(run.id);
     for (const sse of run.clients) {
       try { sse.end(); } catch { /* best-effort detach */ }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5662,6 +5662,21 @@ export async function startServer({
       toolTokenRevoked = true;
       toolTokenRegistry.revokeToken(toolTokenGrant.token, reason);
     };
+    // The async startup phase below (compose prompt, prepare prompt file,
+    // probe models, …) has many awaits and no blanket try/finally; an
+    // exception there finalizes the run via runs.fail() without running the
+    // per-attempt cleanup wired to the child lifecycle. Register the grant +
+    // sink release on the run's terminal chokepoint so any exit path — startup
+    // throw included — revokes the capability token instead of leaking it for
+    // the token TTL. Idempotent with the explicit pre-spawn/child-close cleanup.
+    if (toolTokenGrant) {
+      run.onFinalize = () => {
+        revokeToolToken('run_finalized');
+        const sinkRunId = toolTokenGrant.runId ?? runId;
+        activeChatAgentEventSinks.delete(sinkRunId);
+        activeChatRunHandles.delete(sinkRunId);
+      };
+    }
     const runtimeToolPrompt = createAgentRuntimeToolPrompt(daemonUrl, toolTokenGrant);
     const commentHint = renderCommentAttachmentHint(safeCommentAttachments);
 

--- a/apps/daemon/tests/tool-token-startup-leak.test.ts
+++ b/apps/daemon/tests/tool-token-startup-leak.test.ts
@@ -1,0 +1,117 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { startServer } from '../src/server.js';
+import { toolTokenRegistry } from '../src/tool-tokens.js';
+
+// Force a deterministic failure in the run startup phase, AFTER the tool token
+// is minted but BEFORE the child process is spawned. `preparePromptFileForAgent`
+// is awaited at that point in `startChatRun`, so rejecting it reproduces "any
+// startup exception" without needing an unwritable filesystem.
+vi.mock('../src/runtimes/prompt-file.js', () => ({
+  preparePromptFileForAgent: () =>
+    Promise.reject(new Error('injected startup failure')),
+}));
+
+type StartedServer = { url: string; server: Server; shutdown?: () => Promise<void> | void };
+
+let started: StartedServer | null = null;
+let binDir: string | null = null;
+
+afterEach(async () => {
+  await Promise.resolve(started?.shutdown?.());
+  if (started?.server) {
+    await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+  }
+  started = null;
+  if (binDir) await rm(binDir, { recursive: true, force: true });
+  binDir = null;
+});
+
+async function writeFakeClaude(dir: string): Promise<string> {
+  const bin = path.join(dir, 'claude');
+  await writeFile(
+    bin,
+    `#!/usr/bin/env node
+if (process.argv.includes('--version')) { console.log('claude-code 1.0.0-token-leak'); process.exit(0); }
+if (process.argv.includes('--help')) { console.log('Usage: claude -p'); process.exit(0); }
+setTimeout(() => process.exit(0), 200);
+`,
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+it('revokes the run tool token when startup fails before spawn', async () => {
+  binDir = await mkdtemp(path.join(os.tmpdir(), 'od-token-leak-bin-'));
+  const fakeClaude = await writeFakeClaude(binDir);
+
+  started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+  await fetch(`${started.url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    }),
+  });
+
+  const projectId = `token_leak_${randomUUID()}`;
+  const projectRes = await fetch(`${started.url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Token leak smoke',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectRes.status).toBe(200);
+  const { conversationId } = (await projectRes.json()) as { conversationId: string };
+
+  const runRes = await fetch(`${started.url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'token-leak-test',
+      'x-od-analytics-session-id': 'token-leak-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId,
+      assistantMessageId: `assistant_${randomUUID()}`,
+      clientRequestId: `client_${randomUUID()}`,
+      agentId: 'claude',
+      message: 'trigger a startup failure',
+      currentPrompt: 'trigger a startup failure',
+    }),
+  });
+  expect(runRes.status).toBe(202);
+  const { runId } = (await runRes.json()) as { runId: string };
+
+  // Poll until the run reaches a terminal state (it should fail on the
+  // injected startup error).
+  let status = '';
+  for (let i = 0; i < 100; i++) {
+    const res = await fetch(`${started.url}/api/runs/${runId}`);
+    if (res.status === 200) {
+      status = ((await res.json()) as { status: string }).status;
+      if (status === 'failed' || status === 'succeeded' || status === 'canceled') break;
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  expect(status).toBe('failed');
+
+  // The failed run's minted tool token must be revoked. On the buggy path the
+  // startup throw skips revocation and the capability stays live for its TTL.
+  expect(toolTokenRegistry.activeRunTokenCount(runId)).toBe(0);
+});

--- a/apps/daemon/tests/tool-token-startup-leak.test.ts
+++ b/apps/daemon/tests/tool-token-startup-leak.test.ts
@@ -11,10 +11,17 @@ import { toolTokenRegistry } from '../src/tool-tokens.js';
 // Force a deterministic failure in the run startup phase, AFTER the tool token
 // is minted but BEFORE the child process is spawned. `preparePromptFileForAgent`
 // is awaited at that point in `startChatRun`, so rejecting it reproduces "any
-// startup exception" without needing an unwritable filesystem.
+// startup exception" without needing an unwritable filesystem. The test-body
+// probe runs synchronously at the injection point so the spec can prove the
+// token was minted and live BEFORE the failure (guarding against a vacuous
+// pass where no token existed in the first place).
+const injection = vi.hoisted(() => ({ probe: null as null | (() => void) }));
+
 vi.mock('../src/runtimes/prompt-file.js', () => ({
-  preparePromptFileForAgent: () =>
-    Promise.reject(new Error('injected startup failure')),
+  preparePromptFileForAgent: () => {
+    injection.probe?.();
+    return Promise.reject(new Error('injected startup failure'));
+  },
 }));
 
 type StartedServer = { url: string; server: Server; shutdown?: () => Promise<void> | void };
@@ -23,6 +30,8 @@ let started: StartedServer | null = null;
 let binDir: string | null = null;
 
 afterEach(async () => {
+  injection.probe = null;
+  vi.restoreAllMocks();
   await Promise.resolve(started?.shutdown?.());
   if (started?.server) {
     await new Promise<void>((resolve) => started?.server.close(() => resolve()));
@@ -77,6 +86,22 @@ it('revokes the run tool token when startup fails before spawn', async () => {
   expect(projectRes.status).toBe(200);
   const { conversationId } = (await projectRes.json()) as { conversationId: string };
 
+  // Record every grant minted through the registry, and snapshot the live
+  // per-run token counts at the exact injection point. The probe fires inside
+  // the mocked `preparePromptFileForAgent`, i.e. synchronously BEFORE the
+  // startup failure propagates, so the snapshot proves the run's token existed
+  // and was still live when startup blew up.
+  const mintSpy = vi.spyOn(toolTokenRegistry, 'mint');
+  let liveAtFailure: Array<{ runId: string; count: number }> | null = null;
+  injection.probe = () => {
+    liveAtFailure = mintSpy.mock.results
+      .map((r) => r.value as { runId: string })
+      .map((grant) => ({
+        runId: grant.runId,
+        count: toolTokenRegistry.activeRunTokenCount(grant.runId),
+      }));
+  };
+
   const runRes = await fetch(`${started.url}/api/runs`, {
     method: 'POST',
     headers: {
@@ -110,6 +135,15 @@ it('revokes the run tool token when startup fails before spawn', async () => {
     await new Promise((r) => setTimeout(r, 20));
   }
   expect(status).toBe('failed');
+
+  // Non-vacuity guard: at the injected failure point this run had already
+  // minted its tool token and the grant was still live. Without this, the
+  // final zero-count assertion could pass trivially on a refactor that stops
+  // minting (or mints after prompt-file preparation).
+  expect(liveAtFailure).not.toBeNull();
+  const mintedForRun = liveAtFailure!.filter((entry) => entry.runId === runId);
+  expect(mintedForRun.length).toBeGreaterThan(0);
+  for (const entry of mintedForRun) expect(entry.count).toBeGreaterThan(0);
 
   // The failed run's minted tool token must be revoked. On the buggy path the
   // startup throw skips revocation and the capability stays live for its TTL.


### PR DESCRIPTION
## Why

Auditing the run tool-token lifecycle, I found a capability leak: when a project-scoped run (one that mints a tool token) throws anywhere in its async startup phase — between minting the token and spawning the child — the run is finalized as `failed` but the token is **not revoked**. The capability stays valid for its full 15-minute TTL (`DEFAULT_TOOL_TOKEN_TTL_MS`), and if the throw happens after the agent event sink is registered, the `activeChatAgentEventSinks` / `activeChatRunHandles` entries (no TTL) leak permanently until process restart.

`startChatRun` mints the token (`server.ts:5651`) and defines `revokeToolToken` (`:5660`), and the three pre-spawn early returns (`:7223/:7256/:7281`) all pair `revokeToolToken('child_exit')` + `unregisterChatAgentEventSink()` — proving the intended contract. But the async startup phase between mint and spawn has many awaits (`composeDaemonSystemPrompt`, `preparePromptFileForAgent`, model probes, …) and **no blanket try/finally**; a rejection there propagates to `runs.start().catch → fail() → finish()`, and `fail()`/`finish()` are generic run-service functions that don't know about the token registry, so nothing revokes the grant.

The invariant: **every terminal path of a run releases its minted grant, not just the ones that remembered to.** Rather than wrap a 3.4k-line function in try/finally, I register the release on the run's single terminal chokepoint. `finish()` (and `drop()`) now invoke a one-shot `run.onFinalize`, and `startChatRun` sets `run.onFinalize` right after mint to revoke the token and drop the sink/handle entries. It's idempotent with the existing explicit pre-spawn/child-close cleanup (`revokeToolToken` is guarded; the map deletes are no-ops when absent), so no existing path changes behavior.

## What users will see

No user-visible change. Internally, a run that fails during startup no longer leaves a live `/api/tools/*` capability token behind, and the daemon no longer accumulates orphaned event-sink/run-handle entries on repeated startup failures.

## Surface area

- [x] **None** — internal daemon runtime + tests (security/resource-leak hardening)

## Bug fix verification

- Test path: `apps/daemon/tests/tool-token-startup-leak.test.ts` — mocks `preparePromptFileForAgent` to reject (a deterministic startup throw after mint, before spawn), runs a project-scoped run, waits for `failed`, and asserts `toolTokenRegistry.activeRunTokenCount(runId) === 0`.
- Red on `main`, green on this branch: **yes** (`expected 1 to be 0` on main → passing on branch). Regression: tool-tokens / plugins-tool-token-gate / headless-runs / run-retry-runtime all green; `pnpm guard` and daemon `tsc` clean.

## Validation

Environment: Node 24.15.0, pnpm 10.33.2, macOS (arm64)

- `pnpm --filter @open-design/daemon... run build` → clean
- `pnpm --filter @open-design/daemon exec vitest run tests/tool-token-startup-leak.test.ts` → red on main / green on branch
- `pnpm --filter @open-design/daemon exec vitest run tests/tool-tokens.test.ts tests/plugins-tool-token-gate.test.ts tests/headless-runs.test.ts tests/run-retry-runtime.test.ts` → all green
- `pnpm guard` → clean · `pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wN43EeBA72rWxSPAhRHwA
