### PR TITLE
feat(landing-page): move Mistral Vibe CLI off the vibe-design slug and 301 to the vibe-design guide

### DIFF
--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -94,7 +94,7 @@ const AGENTS: ReadonlyArray<{ name: string; route: string }> = [
   { name: 'Pi', route: 'pi-design' },
   { name: 'Kiro CLI', route: 'kiro-design' },
   { name: 'Kilo', route: 'kilo-design' },
-  { name: 'Mistral Vibe CLI', route: 'vibe-design' },
+  { name: 'Mistral Vibe CLI', route: 'vibe-cli-design' },
   { name: 'Qoder CLI', route: 'qoder-design' },
 ];
 

--- a/apps/landing-page/app/pages/[locale]/agents/vibe-cli-design/index.astro
+++ b/apps/landing-page/app/pages/[locale]/agents/vibe-cli-design/index.astro
@@ -1,5 +1,5 @@
 ---
-import AgentDetailPage from '../../../agents/vibe-design/index.astro';
+import AgentDetailPage from '../../../agents/vibe-cli-design/index.astro';
 import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../../i18n';
 
 export function getStaticPaths() {

--- a/apps/landing-page/app/pages/agents/index.astro
+++ b/apps/landing-page/app/pages/agents/index.astro
@@ -100,7 +100,7 @@ const DETAIL_ROUTES: Record<string, string> = {
   pi: 'pi-design',
   kiro: 'kiro-design',
   kilo: 'kilo-design',
-  vibe: 'vibe-design',
+  vibe: 'vibe-cli-design',
   qoder: 'qoder-design',
 };
 

--- a/apps/landing-page/app/pages/agents/vibe-cli-design/index.astro
+++ b/apps/landing-page/app/pages/agents/vibe-cli-design/index.astro
@@ -1,9 +1,12 @@
 ---
 /*
- * /agents/vibe-design/ — agent detail page (industrial long-form).
+ * /agents/vibe-cli-design/ — Mistral Vibe CLI agent detail page (long-form).
  *
- * Captures "vibe design" intent and drives to Open Design. Renders the
- * rich how-to layout from copy.agentGuides['vibe'].rich. Linked from /agents/.
+ * This is the Mistral Vibe CLI agent guide. It lives at /agents/vibe-cli-design/
+ * (not /agents/vibe-design/) so it does not squat the informational "vibe design"
+ * concept query — that intent is served by /blog/what-is-vibe-design/, which the
+ * old /agents/vibe-design/ URL now 301-redirects to (see public/_redirects).
+ * Renders the rich how-to layout from copy.agentGuides['vibe'].rich. Linked from /agents/.
  * Never fabricate URLs or facts here.
  */
 import Layout from '../../../_components/sub-page-layout.astro';
@@ -11,7 +14,7 @@ import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
 
 const SLUG = 'vibe';
-const ROUTE = 'vibe-design';
+const ROUTE = 'vibe-cli-design';
 const SITE = Astro.site?.toString() ?? 'https://open-design.ai/';
 const REPO = 'https://github.com/nexu-io/open-design';
 const REPO_RELEASES = `${REPO}/releases`;

--- a/apps/landing-page/public/_redirects
+++ b/apps/landing-page/public/_redirects
@@ -206,3 +206,45 @@
 /:loc/skills/*     /:loc/plugins/skills/     301
 /:loc/systems/*    /:loc/plugins/systems/    301
 /:loc/templates/*  /:loc/plugins/templates/  301
+
+# Mistral Vibe CLI moved from /agents/vibe-design/ to /agents/vibe-cli-design/ so the
+# exact-match 'vibe design' concept URL serves the informational blog instead of a
+# product page. 301 the old agent URL (all locales) to the what-is-vibe-design guide.
+/agents/vibe-design/  /blog/what-is-vibe-design/  301
+/agents/vibe-design  /blog/what-is-vibe-design/  301
+/en/agents/vibe-design/  /en/blog/what-is-vibe-design/  301
+/en/agents/vibe-design  /en/blog/what-is-vibe-design/  301
+/zh/agents/vibe-design/  /zh/blog/what-is-vibe-design/  301
+/zh/agents/vibe-design  /zh/blog/what-is-vibe-design/  301
+/zh-tw/agents/vibe-design/  /zh-tw/blog/what-is-vibe-design/  301
+/zh-tw/agents/vibe-design  /zh-tw/blog/what-is-vibe-design/  301
+/ja/agents/vibe-design/  /ja/blog/what-is-vibe-design/  301
+/ja/agents/vibe-design  /ja/blog/what-is-vibe-design/  301
+/ko/agents/vibe-design/  /ko/blog/what-is-vibe-design/  301
+/ko/agents/vibe-design  /ko/blog/what-is-vibe-design/  301
+/de/agents/vibe-design/  /de/blog/what-is-vibe-design/  301
+/de/agents/vibe-design  /de/blog/what-is-vibe-design/  301
+/fr/agents/vibe-design/  /fr/blog/what-is-vibe-design/  301
+/fr/agents/vibe-design  /fr/blog/what-is-vibe-design/  301
+/ru/agents/vibe-design/  /ru/blog/what-is-vibe-design/  301
+/ru/agents/vibe-design  /ru/blog/what-is-vibe-design/  301
+/es/agents/vibe-design/  /es/blog/what-is-vibe-design/  301
+/es/agents/vibe-design  /es/blog/what-is-vibe-design/  301
+/pt-br/agents/vibe-design/  /pt-br/blog/what-is-vibe-design/  301
+/pt-br/agents/vibe-design  /pt-br/blog/what-is-vibe-design/  301
+/it/agents/vibe-design/  /it/blog/what-is-vibe-design/  301
+/it/agents/vibe-design  /it/blog/what-is-vibe-design/  301
+/vi/agents/vibe-design/  /vi/blog/what-is-vibe-design/  301
+/vi/agents/vibe-design  /vi/blog/what-is-vibe-design/  301
+/pl/agents/vibe-design/  /pl/blog/what-is-vibe-design/  301
+/pl/agents/vibe-design  /pl/blog/what-is-vibe-design/  301
+/id/agents/vibe-design/  /id/blog/what-is-vibe-design/  301
+/id/agents/vibe-design  /id/blog/what-is-vibe-design/  301
+/nl/agents/vibe-design/  /nl/blog/what-is-vibe-design/  301
+/nl/agents/vibe-design  /nl/blog/what-is-vibe-design/  301
+/ar/agents/vibe-design/  /ar/blog/what-is-vibe-design/  301
+/ar/agents/vibe-design  /ar/blog/what-is-vibe-design/  301
+/tr/agents/vibe-design/  /tr/blog/what-is-vibe-design/  301
+/tr/agents/vibe-design  /tr/blog/what-is-vibe-design/  301
+/uk/agents/vibe-design/  /uk/blog/what-is-vibe-design/  301
+/uk/agents/vibe-design  /uk/blog/what-is-vibe-design/  301


### PR DESCRIPTION
## Why
The Mistral Vibe CLI agent page was auto-generated at `/agents/vibe-design/` as part of the 21-agent set (Mistral's product is named "Vibe"). That exact-match URL **squats the informational "vibe design" concept query**: GSC shows it holding **7,353 impressions at pos ~9 with 0.3% CTR** — searchers see a "Mistral Vibe CLI" title that doesn't answer "what is vibe design", so they don't click, and meanwhile the page that *does* answer it — `/blog/what-is-vibe-design/` — is suppressed by its own sibling URL (classic self-cannibalization). This surfaced in the SEO content audit as the single biggest fixable impression loss.

## What users will see
- The Mistral Vibe CLI guide now lives at **`/agents/vibe-cli-design/`** (same content, `agentGuides['vibe']`). The Agent nav dropdown and the `/agents/` hub link there.
- The old **`/agents/vibe-design/`** URL (and every locale variant) now **301-redirects to `/blog/what-is-vibe-design/`**, so the "vibe design" search intent + ranking authority land on the guide that actually answers the query. Localized versions of that guide already rank pos 4–5 (ja/ko/tr), so consolidating should lift the en page from pos ~9 toward the top-5.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point** — `skills/`, `design-systems/`, `design-templates/`, `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal refactor, docs, tests, or translation update only

<sub>Landing-site routing change (`apps/landing-page`): renamed the Mistral Vibe CLI agent route `agents/vibe-design/` → `agents/vibe-cli-design/` (+ its `[locale]` wrapper), updated the two in-repo route references (Agent nav dropdown in `_components/header.tsx`, hub route map in `pages/agents/index.astro`), and added 301 rules in `public/_redirects` for the old URL across all 18 landing locales → the localized `what-is-vibe-design` blog. No product-app surface, component, or content string changed. Hero image assets stay under their existing `/agents/vibe-design/` path (served fine — the 301 rules are exact-path, not splat).</sub>

## Verification
- `pnpm typecheck` → 0 errors
- `pnpm build:static` → 4435 pages built clean
- Verified: new `/agents/vibe-cli-design/` (incl. `zh`/`de` locale routes) renders the Mistral content; old `/agents/vibe-design/` is gone from the build; the 18-locale 301 targets (`/blog/what-is-vibe-design/`) all exist; `_redirects` ships with the rules; hub + nav link the new route; hero assets still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)