### PR TITLE
Add Apple 设计系统 Skill plugin

### DIFF
--- a/plugins/community/apple-skill-mr95pga5/SKILL.md
+++ b/plugins/community/apple-skill-mr95pga5/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: apple-design-system
+description: 使用这个本地指南，从已补强的 Apple 品牌包生成 Apple 风格 HTML 资产。
+---
+
+# Apple 设计系统 Skill
+
+生成 Apple 风格 HTML 前，以 `brand.json` 为事实源，再读取 `DESIGN.md` 与 `BRAND.md`。
+
+## 规则
+
+- 使用 `brand.json` 中的七个实测颜色角色，不新增品牌色。
+- 标题使用 SF Pro Display，正文/UI 使用 SF Pro Text，并保留声明的 fallback 链。
+- 让产品摄影承担第一视觉印象。
+- 每个 section 或 slide 只表达一个简洁产品想法。
+- 蓝色动作色保持稀少，只用于主 CTA、链接或焦点状态。
+- UI chrome 保持轻薄：1px 线、克制阴影、充足留白。
+
+## 避免
+
+- 用抽象渐变替代产品摄影。
+- 把旧的误分类 `logos/header-img-1.jpg` 当成品牌 Logo。
+- 添加 emoji、通用功能图标或未经验证的性能承诺。
+
+## Provenance
+
+Formalized by Open Design from candidate db0dc485-6721-42a6-a41b-541a0b7173eb.

--- a/plugins/community/apple-skill-mr95pga5/open-design.json
+++ b/plugins/community/apple-skill-mr95pga5/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "apple-skill-mr95pga5",
+  "title": "Apple 设计系统 Skill",
+  "version": "0.1.0",
+  "description": "--- name: apple-design-system description: 使用这个本地指南，从已补强的 Apple 品牌包生成 Apple 风格 HTML 资产。 ---",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/apple-skill-mr95pga5/references/provenance.json
+++ b/plugins/community/apple-skill-mr95pga5/references/provenance.json
@@ -1,0 +1,19 @@
+{
+  "candidateId": "db0dc485-6721-42a6-a41b-541a0b7173eb",
+  "projectId": "brand-apple-7a815d",
+  "runId": "dd4fb988-b067-46b1-a4c0-3fbafc21402c",
+  "conversationId": "f247a2bc-76a2-49d4-ae85-b18fe3e1519d",
+  "provenance": {
+    "summary": "Detected from SKILL.md after a successful run.",
+    "detectedAt": 1783337627775
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 899,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/apple-skill-mr95pga5/references/source-1-SKILL.md
+++ b/plugins/community/apple-skill-mr95pga5/references/source-1-SKILL.md
@@ -1,0 +1,23 @@
+---
+name: apple-design-system
+description: 使用这个本地指南，从已补强的 Apple 品牌包生成 Apple 风格 HTML 资产。
+---
+
+# Apple 设计系统 Skill
+
+生成 Apple 风格 HTML 前，以 `brand.json` 为事实源，再读取 `DESIGN.md` 与 `BRAND.md`。
+
+## 规则
+
+- 使用 `brand.json` 中的七个实测颜色角色，不新增品牌色。
+- 标题使用 SF Pro Display，正文/UI 使用 SF Pro Text，并保留声明的 fallback 链。
+- 让产品摄影承担第一视觉印象。
+- 每个 section 或 slide 只表达一个简洁产品想法。
+- 蓝色动作色保持稀少，只用于主 CTA、链接或焦点状态。
+- UI chrome 保持轻薄：1px 线、克制阴影、充足留白。
+
+## 避免
+
+- 用抽象渐变替代产品摄影。
+- 把旧的误分类 `logos/header-img-1.jpg` 当成品牌 Logo。
+- 添加 emoji、通用功能图标或未经验证的性能承诺。


### PR DESCRIPTION
Add Apple 设计系统 Skill (apple-skill-mr95pga5) plugin.
Version: 0.1.0
Description: --- name: apple-design-system description: 使用这个本地指南，从已补强的 Apple 品牌包生成 Apple 风格 HTML 资产。 ---