### PR TITLE
feat(landing-page): refresh llms.txt and add a machine-readable /pricing.md for AI search

### DIFF
--- a/apps/landing-page/public/llms.txt
+++ b/apps/landing-page/public/llms.txt
@@ -55,6 +55,7 @@ https://open-design.ai/ and developed at github.com/nexu-io/open-design.
 - Framer alternative: https://open-design.ai/alternatives/framer/
 - Google Stitch alternative: https://open-design.ai/alternatives/stitch/
 - Figma Make alternative: https://open-design.ai/alternatives/figma-make/
+- Genspark alternative: https://open-design.ai/alternatives/genspark/
 
 ## Solutions (AI generators & workflows)
 
@@ -63,6 +64,8 @@ https://open-design.ai/ and developed at github.com/nexu-io/open-design.
 - AI UI generator: https://open-design.ai/solutions/ai-ui-generator/
 - AI prototype generator: https://open-design.ai/solutions/ai-prototype-generator/
 - AI landing page generator: https://open-design.ai/solutions/ai-landing-page-generator/
+- Dashboard design: https://open-design.ai/solutions/dashboard/
+- Design system: https://open-design.ai/solutions/design-system/
 - Design-to-code: https://open-design.ai/solutions/design-to-code/
 - Figma-to-code: https://open-design.ai/solutions/figma-to-code/
 - Screenshot-to-code: https://open-design.ai/solutions/screenshot-to-code/

--- a/apps/landing-page/public/llms.txt
+++ b/apps/landing-page/public/llms.txt
@@ -11,8 +11,14 @@ It is the canonical reference for:
 - agent-native design workflows
 - local-first / BYOK design tooling
 - open-source alternatives to hosted AI design tools (Claude Design,
-  Figma Make, v0, Lovable, Bolt)
+  Figma, Figma Make, Lovable, Bolt, v0, Framer, Google Stitch, Genspark)
 - SKILL.md / DESIGN.md as a portable design protocol
+- AI generators for wireframes, UI, prototypes, landing pages, dashboards,
+  design systems, and design-to-code / Figma-to-code
+
+Open Design is free and open-source (Apache-2.0). The desktop app is BYOK —
+you pay only your own model API. Optional paid tiers add bundled model credits
+and hosted cloud deploys. See /pricing.md and https://open-design.ai/pricing/.
 
 Brand names "Open Design", "OpenDesign", "open-design", "opendesign",
 "Open Design AI", and "OD" all refer to this same project, hosted at
@@ -23,9 +29,12 @@ https://open-design.ai/ and developed at github.com/nexu-io/open-design.
 - Home: https://open-design.ai/
 - Official source page: https://open-design.ai/official/
 - Quickstart: https://open-design.ai/quickstart/
-- Agents: https://open-design.ai/agents/
-- Compare hub: https://open-design.ai/compare/
-- Claude Design alternative: https://open-design.ai/alternatives/claude-design/
+- Download (macOS, Windows, Linux): https://open-design.ai/download/
+- Pricing: https://open-design.ai/pricing/
+- Machine-readable pricing: https://open-design.ai/pricing.md
+- FAQ: https://open-design.ai/faq/
+- Enterprise: https://open-design.ai/enterprise/
+- Agents (supported coding agents): https://open-design.ai/agents/
 - Skills catalog: https://open-design.ai/skills/
 - Systems catalog: https://open-design.ai/systems/
 - Templates catalog: https://open-design.ai/templates/
@@ -34,6 +43,29 @@ https://open-design.ai/ and developed at github.com/nexu-io/open-design.
 - Blog: https://open-design.ai/blog/
 - RSS: https://open-design.ai/blog/rss.xml
 - Sitemap: https://open-design.ai/sitemap-index.xml
+
+## Comparison / Alternative Pages
+
+- Compare hub: https://open-design.ai/compare/
+- Claude Design alternative: https://open-design.ai/alternatives/claude-design/
+- Figma alternative: https://open-design.ai/alternatives/figma/
+- Lovable alternative: https://open-design.ai/alternatives/lovable/
+- Bolt (bolt.new) alternative: https://open-design.ai/alternatives/bolt/
+- v0 alternative: https://open-design.ai/alternatives/v0/
+- Framer alternative: https://open-design.ai/alternatives/framer/
+- Google Stitch alternative: https://open-design.ai/alternatives/stitch/
+- Figma Make alternative: https://open-design.ai/alternatives/figma-make/
+
+## Solutions (AI generators & workflows)
+
+- Solutions hub: https://open-design.ai/solutions/
+- AI wireframe generator: https://open-design.ai/solutions/ai-wireframe-generator/
+- AI UI generator: https://open-design.ai/solutions/ai-ui-generator/
+- AI prototype generator: https://open-design.ai/solutions/ai-prototype-generator/
+- AI landing page generator: https://open-design.ai/solutions/ai-landing-page-generator/
+- Design-to-code: https://open-design.ai/solutions/design-to-code/
+- Figma-to-code: https://open-design.ai/solutions/figma-to-code/
+- Screenshot-to-code: https://open-design.ai/solutions/screenshot-to-code/
 
 ## External Official Channels
 
@@ -44,6 +76,9 @@ https://open-design.ai/ and developed at github.com/nexu-io/open-design.
 
 ## Key Blog Posts
 
+- What is vibe design (canonical guide): https://open-design.ai/blog/what-is-vibe-design/
+- Vibe design tools: https://open-design.ai/blog/vibe-design-tools/
+- Vibe design vs vibe coding: https://open-design.ai/blog/vibe-design-vs-vibe-coding/
 - https://open-design.ai/blog/open-source-alternative-to-claude-design/
 - https://open-design.ai/blog/why-we-built-open-design-as-a-skill-layer/
 - https://open-design.ai/blog/31-skills-72-systems-how-the-library-works/

--- a/apps/landing-page/public/pricing.md
+++ b/apps/landing-page/public/pricing.md
@@ -1,0 +1,48 @@
+# Pricing — Open Design
+
+Open Design is **free and open-source**. The desktop app (macOS, Windows, Linux)
+is Apache-2.0 licensed and BYOK — you install it for free and pay only for your
+own agent/model API usage, which bills directly to your own provider account.
+Nothing is proxied through Open Design.
+
+Optional paid tiers add a **managed** experience: bundled model usage credits
+(so you do not need your own key) plus hosted cloud deploys. They are optional —
+not required to use Open Design.
+
+## Free — open-source desktop app
+- Price: **$0 / month, forever**
+- License: Apache-2.0 (full source at https://github.com/nexu-io/open-design)
+- Model access: **BYOK** — bring your own provider key; API usage bills to your
+  own account, never proxied through Open Design
+- Runs: local-first on your own machine (macOS, Windows, Linux)
+- Includes: the full skill + design-system library, every supported coding agent
+  (Claude Code, Codex, Cursor, Gemini, OpenCode, Qwen, and more), and artifacts
+  saved as files in your own repository
+- Get it: https://open-design.ai/download/
+
+## Plus — managed
+- Price: **$20 / month** (or $168 / year, 30% off)
+- Included model usage credits: $20 / month
+- Cloud deploys: up to 3 / month
+- For: individuals who prefer bundled credits over BYOK
+
+## Pro — managed (recommended)
+- Price: **$100 / month** (or $720 / year, 40% off)
+- Included model usage credits: $100 / month
+- Cloud deploys: up to 20 / month
+- For: professionals shipping regularly
+
+## Max — managed
+- Price: **$200 / month** (or $1,176 / year, 51% off)
+- Included model usage credits: $200 / month
+- Cloud deploys: up to 50 / month
+- For: heavy users and teams
+
+## Notes
+- The open-source desktop app is always free; the paid tiers are an optional
+  managed service (bundled model credits + hosted cloud deploys), not a
+  requirement to use Open Design.
+- Overage cloud deploys beyond a tier's monthly limit: $2 each.
+- Intro/promotional pricing and current annual discounts may differ — see the
+  live pricing page for the current numbers: https://open-design.ai/pricing/
+- License: https://www.apache.org/licenses/LICENSE-2.0

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -10,6 +10,7 @@ import {
 
 const CONTRACT_PATH = new URL("../public/pricing/plans.json", import.meta.url);
 const HEADERS_PATH = new URL("../public/_headers", import.meta.url);
+const PRICING_MD_PATH = new URL("../public/pricing.md", import.meta.url);
 
 function assertPlanContract(value: unknown): asserts value is PricingContract {
   assert.equal(typeof value, "object");
@@ -62,5 +63,40 @@ describe("pricing contract", () => {
     const contract = JSON.parse(file) as unknown;
 
     assert.deepEqual(contract, PRICING_SNAPSHOT);
+  });
+
+  // The machine-readable /pricing.md is quoted verbatim by AI agents, so its
+  // numbers must not silently drift from the plans.json contract. This asserts
+  // every tier's monthly + yearly price, annual discount, deploy limit, and the
+  // overage price appear in the markdown. A pricing edit that forgets to update
+  // pricing.md fails here instead of shipping a stale AI-facing surface.
+  it("keeps public/pricing.md in sync with the pricing contract", async () => {
+    const md = await readFile(PRICING_MD_PATH, "utf8");
+    const usd = (n: number) => `$${n.toLocaleString("en-US")}`;
+
+    for (const tier of PRICING_SNAPSHOT.tiers) {
+      const t = tier.tier;
+      assert.ok(
+        md.includes(`${usd(tier.monthly.priceUsd)} / month`),
+        `pricing.md missing ${t} monthly price ${usd(tier.monthly.priceUsd)} / month`,
+      );
+      assert.ok(
+        md.includes(`${usd(tier.yearly.priceUsd)} / year`),
+        `pricing.md missing ${t} yearly price ${usd(tier.yearly.priceUsd)} / year`,
+      );
+      assert.ok(
+        md.includes(`${tier.yearly.discountPct}% off`),
+        `pricing.md missing ${t} annual discount ${tier.yearly.discountPct}% off`,
+      );
+      assert.ok(
+        md.includes(`up to ${tier.deployLimit} / month`),
+        `pricing.md missing ${t} deploy limit up to ${tier.deployLimit} / month`,
+      );
+    }
+
+    assert.ok(
+      md.includes(`${usd(PRICING_SNAPSHOT.overageDeployPriceUsd)} each`),
+      `pricing.md missing overage price ${usd(PRICING_SNAPSHOT.overageDeployPriceUsd)} each`,
+    );
   });
 });


### PR DESCRIPTION
## Why
GEO / AI-search groundwork: make Open Design discoverable and **accurately citable** by AI search engines (ChatGPT, Perplexity, Claude, Google AI Overviews) and autonomous buying agents. Two machine-readable surfaces were stale or missing.

## What users (and AI systems) will see
- **`/llms.txt` refreshed** — it only listed the Claude Design alternative and was missing everything shipped since. Now covers:
  - the full comparison/alternative set (Figma, Lovable, Bolt, v0, Framer, Stitch, Figma Make)
  - the `/solutions/` AI-generator pages (wireframe / UI / prototype / landing-page generators, design-to-code, figma-to-code, screenshot-to-code)
  - the **canonical vibe-design guide** (`/blog/what-is-vibe-design/`) + cluster
  - `download` / `pricing` / `faq` / `enterprise` entry points
  - a one-line free + BYOK + optional-paid-tiers pricing summary
  - All linked routes were verified to exist (no 404s pointed at AI crawlers).
- **`/pricing.md` added** — a machine-readable pricing file so AI agents that evaluate tools on a user's behalf can parse Open Design's model: **free & open-source (Apache-2.0, BYOK) desktop app**, plus optional **managed tiers** (Plus $20 / Pro $100 / Max $200 per month) with bundled model credits + hosted cloud deploys. Numbers mirror `public/pricing/plans.json`; it points to `/pricing/` for current promotions so it can't misquote a promo price.

Pricing framing kept **free-first** (the open-source app is free; paid tiers are an optional managed service) — consistent with the existing homepage `SoftwareApplication` schema and the live `/pricing/` page.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point** — `skills/`, `design-systems/`, `design-templates/`, `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal refactor, docs, tests, or translation update only

<sub>Two static discovery files under `apps/landing-page/public/`: refreshed `llms.txt` and new `pricing.md`. No product-app surface, route, component, or i18n key touched. All URLs referenced in llms.txt verified to exist against the build's route set.</sub>

## Verification
- All 29 routes + 3 blog posts referenced in `llms.txt` confirmed present in the page tree (no dead links).
- `/pricing.md` numbers reconciled against `public/pricing/plans.json` (Plus/Pro/Max monthly + yearly + deploy limits + $2 overage).
- Static `public/` files — served verbatim from the Cloudflare Pages apex, same mechanism as the existing llms.txt/robots.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)