### PR TITLE
docs: clarify macOS od command collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ After install: the app auto-detects every coding-agent CLI on your `PATH`, loads
 
 You can use Open Design without ever opening the GUI — call it as a skill, plugin, or MCP server inside Claude Code, Codex, Cursor, Copilot, OpenClaw, Antigravity, Hermes, Kimi, and more.
 
+If you installed the macOS desktop app via the DMG or Homebrew cask, your shell
+may still resolve `od` to Apple's built-in `/usr/bin/od` octal-dump utility. In
+that case, open **Settings → MCP server** in the desktop app and copy the
+client-specific snippet; it uses absolute paths and does not rely on the bare
+`od` command.
+
 ```bash
 # One-line install into the agent you're using:
 od mcp install <agent>
@@ -313,9 +319,10 @@ curl -fsSL https://open-design.ai/install.sh | sh -s <agent>
 hosted URL returns shell instead of the landing-page HTML fallback and fails
 fast if your shell resolves a non-Open-Design `od` binary.
 
-> **WSL2 users:** If your coding-agent CLIs run inside WSL2, follow the
-> [`WSL2 setup guide`](docs/wsl-setup.md) first. Linux's `/usr/bin/od` can
-> shadow Open Design's `od` command.
+> **macOS / WSL2 users:** `/usr/bin/od` is a system octal-dump command and can
+> shadow Open Design's `od` command. Desktop-app users should prefer the
+> **Settings → MCP server** snippet; WSL2 users should follow the
+> [`WSL2 setup guide`](docs/wsl-setup.md) first.
 
 Then, inside the agent:
 
@@ -385,7 +392,7 @@ od skill list --scenario marketing
 
 **Why MCP?** Exporting and re-attaching a zip every iteration breaks flow. MCP exposes the design source directly — the agent always sees the live file.
 
-**For an agent starting from scratch,** the installer places `~/.config/<agent>/open-design.json` (or the platform equivalent) plus a copy-paste MCP snippet. Cursor gets a one-click deeplink; Claude Code gets a `claude mcp add-json` one-liner; every other agent gets JSON in the schema its config expects. Full per-agent flow → **Settings → MCP server** in the desktop app, or [`docs/agent-adapters.md`](docs/agent-adapters.md).
+**For an agent starting from scratch,** the installer places `~/.config/<agent>/open-design.json` (or the platform equivalent) plus a copy-paste MCP snippet. Cursor gets a one-click deeplink; Claude Code gets a `claude mcp add-json` one-liner; every other agent gets JSON in the schema its config expects. On macOS desktop installs, prefer that Settings snippet over typing bare `od mcp install <agent>` in Terminal, because `/usr/bin/od` may win on PATH. Full per-agent flow → **Settings → MCP server** in the desktop app, or [`docs/agent-adapters.md`](docs/agent-adapters.md).
 
 **Security model.** Read-only by default, the daemon binds to `127.0.0.1`, and SSRF is blocked at the proxy edge. LAN exposure requires an explicit `OD_BIND_HOST` plus `OD_ALLOWED_ORIGINS`. Connector credentials and live-artifact preview routes stay loopback-only regardless.
 

--- a/apps/landing-page/public/install.sh
+++ b/apps/landing-page/public/install.sh
@@ -60,9 +60,14 @@ if [ "${od_probe}" != "open-design-cli:mcp-install:v1" ]; then
   cat >&2 <<EOF
 Open Design install.sh: '${od_path}' does not look like the Open Design CLI.
 
-On Linux and WSL2, /usr/bin/od is usually the coreutils octal-dump command and
-can shadow Open Design's CLI. Put the Open Design CLI earlier on PATH, then
-re-run this command.
+On macOS, Linux, and WSL2, /usr/bin/od is the system octal-dump command and can
+shadow Open Design's CLI. Put the Open Design CLI earlier on PATH, then re-run
+this command.
+
+If you installed the macOS desktop app via the DMG or Homebrew cask, the app
+bundle does not add an 'od' shim to your shell PATH. Launch Open Design and use
+Settings -> MCP server to copy the client-specific install snippet instead;
+that snippet uses absolute paths and avoids the system 'od' collision.
 EOF
   exit 1
 fi

--- a/apps/landing-page/tests/install-sh-static.test.ts
+++ b/apps/landing-page/tests/install-sh-static.test.ts
@@ -85,6 +85,8 @@ exit 0
 
     assert.equal(result.status, 1);
     assert.match(result.stderr, /does not look like the Open Design CLI/);
+    assert.match(result.stderr, /macOS, Linux, and WSL2/);
+    assert.match(result.stderr, /Settings -> MCP server/);
     assert.throws(() => readFileSync(argvOut, 'utf8'), /ENOENT/);
   } finally {
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- clarify that macOS, Linux, and WSL2 can resolve bare `od` to the system octal-dump binary instead of Open Design
- point macOS desktop app / Homebrew cask users to the Settings → MCP server absolute-path snippet
- extend the `install.sh` shadowed-binary test so the error guidance covers macOS and the Settings fallback

Fixes #5120.

## Surface area

- [x] README / user-facing MCP install docs
- [x] Hosted `install.sh` error guidance for shadowed `od` binaries
- [x] Landing-page `install.sh` static test coverage
- [ ] Runtime CLI / daemon behavior
- [ ] Desktop app packaging, DMG, or Homebrew cask install behavior
- [ ] User config, persisted data, or migrations

## Validation

- [x] `node --test apps/landing-page/tests/install-sh-static.test.ts`
- [x] `git diff --check`
- [x] Manual smoke of `apps/landing-page/public/install.sh` with PATH resolving to `/usr/bin/od`, confirming the stderr now mentions macOS and the Settings → MCP server absolute-path snippet fallback

## Test plan

- `node --test apps/landing-page/tests/install-sh-static.test.ts`
- `git diff --check`

## Notes

I also tried `pnpm --filter @open-design/landing-page test`, but this fresh clone has no `node_modules` and is running Node v22.22.3 while the repo declares Node `~24`, so the package-level test command fails before executing tests with `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'`.

The QA queue for the direct install path makes sense; nothing else needed from me on that piece right now.
