### PR TITLE
fix(web): report specific export error_code instead of generic "Error"

### DIFF
--- a/apps/web/src/analytics/export-error-code.ts
+++ b/apps/web/src/analytics/export-error-code.ts
@@ -1,0 +1,31 @@
+/**
+ * Classify a failed-export error into a stable, queryable analytics code for
+ * `artifact_export_result.error_code`.
+ *
+ * The export UI used to report `err.name` for every failure, which collapses
+ * to the generic `"Error"` for the common case (a plain `Error` thrown from
+ * the export runtime). That made distinct failure modes indistinguishable in
+ * analytics — in particular the daemon↔desktop sidecar version skew, where a
+ * freshly-updated daemon sends a `render-slides` message an older desktop
+ * process doesn't understand and the daemon surfaces
+ * `desktop renderer unavailable: unknown desktop sidecar message: render-slides`.
+ *
+ * This maps the known daemon/runtime failure signatures to specific codes so
+ * `error_code` separates "version-skewed mesh" from ordinary render failures
+ * (timeouts, unreadable payloads, etc.). A structured `.code` on the error
+ * (e.g. a future typed daemon error) always wins over message classification.
+ */
+export function exportErrorCode(err: unknown): string {
+  const structured = (err as { code?: unknown } | null | undefined)?.code;
+  if (typeof structured === 'string' && structured.length > 0) return structured;
+  if (!(err instanceof Error)) return 'UNKNOWN';
+  const message = err.message ?? '';
+  // The daemon rejected a desktop sidecar message it doesn't recognize — the
+  // fingerprint of a version-skewed mesh (new daemon → old desktop). Check this
+  // BEFORE the broader "renderer unavailable" branch: the daemon wraps the skew
+  // as "desktop renderer unavailable: unknown desktop sidecar message: <type>",
+  // so the raw text matches both patterns.
+  if (/unknown \w+ sidecar message/i.test(message)) return 'DESKTOP_SIDECAR_UNKNOWN_MESSAGE';
+  if (/renderer (?:is )?unavailable/i.test(message)) return 'DESKTOP_RENDERER_UNAVAILABLE';
+  return err.name || 'UNKNOWN';
+}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -17,6 +17,7 @@ import {
   type TrackingDeployProvider,
 } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
+import { exportErrorCode } from '../analytics/export-error-code';
 import { trackIframeLoad } from '../observability/iframe-error';
 import {
   trackArtifactExportResult,
@@ -5532,7 +5533,7 @@ function HtmlViewer({
             if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
           },
           (err) => {
-            finish('failed', err instanceof Error ? err.name : 'UNKNOWN');
+            finish('failed', exportErrorCode(err));
             failToast(err);
           },
         );
@@ -5547,7 +5548,7 @@ function HtmlViewer({
         if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
       }
     } catch (err) {
-      finish('failed', err instanceof Error ? err.name : 'UNKNOWN');
+      finish('failed', exportErrorCode(err));
       failToast(err);
     }
   };

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -9272,7 +9272,7 @@ function HtmlViewer({
       console.warn('[exportAsImage] failed to save snapshot:', err);
       const message = err instanceof Error && err.message ? err.message : t('fileViewer.exportImageFailed');
       setExportToast({ message, tone: 'error' });
-      fireImageExportResult('failed', err instanceof Error ? err.name : 'UNKNOWN');
+      fireImageExportResult('failed', exportErrorCode(err));
     } finally {
       imageExportInFlightRef.current = false;
     }

--- a/apps/web/tests/analytics/export-error-code.test.ts
+++ b/apps/web/tests/analytics/export-error-code.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { exportErrorCode } from '../../src/analytics/export-error-code';
+
+describe('exportErrorCode', () => {
+  it('classifies the daemon↔desktop sidecar version skew from its wrapped message', () => {
+    // The exact string the daemon surfaces when a freshly-updated daemon sends
+    // `render-slides` to an older desktop that predates the message. Before this
+    // helper it was reported as the generic "Error", hiding the skew in analytics.
+    const err = new Error(
+      'desktop renderer unavailable: unknown desktop sidecar message: render-slides',
+    );
+    expect(exportErrorCode(err)).toBe('DESKTOP_SIDECAR_UNKNOWN_MESSAGE');
+  });
+
+  it('classifies a plain renderer-unavailable failure separately from the skew', () => {
+    expect(exportErrorCode(new Error('desktop renderer unavailable: connection refused'))).toBe(
+      'DESKTOP_RENDERER_UNAVAILABLE',
+    );
+  });
+
+  it('prefers a structured .code over message classification', () => {
+    const err = Object.assign(new Error('desktop renderer unavailable: unknown desktop sidecar message: render-slides'), {
+      code: 'UPSTREAM_UNAVAILABLE',
+    });
+    expect(exportErrorCode(err)).toBe('UPSTREAM_UNAVAILABLE');
+  });
+
+  it('falls back to the error name for unclassified failures', () => {
+    expect(exportErrorCode(new TypeError('boom'))).toBe('TypeError');
+    expect(exportErrorCode(new Error('export request failed (500)'))).toBe('Error');
+  });
+
+  it('returns UNKNOWN for non-Error throwables', () => {
+    expect(exportErrorCode('nope')).toBe('UNKNOWN');
+    expect(exportErrorCode(undefined)).toBe('UNKNOWN');
+  });
+});


### PR DESCRIPTION
## Why

**Use case:** I was investigating a production export failure — a colleague hit `desktop renderer unavailable: unknown desktop sidecar message: render-slides` when exporting a deck to PPTX. Digging into it (diagnostics bundle + PostHog), this turned out to be a daemon↔desktop **sidecar version skew**: after an auto-update, a freshly-updated 0.13.0 daemon sends the new `render-slides` message to an older desktop process still serving the same namespace socket, which rejects it.

**Pain:** When I went to size the problem in PostHog, I couldn't. `artifact_export_result.error_code` is `err.name`, which collapses to the generic `"Error"` for the common plain-`Error` case. So every export failure — the version skew, a render timeout, an unreadable payload — looks identical in analytics. The telemetry showed a large, real problem (0.13.0 pdf/pptx/image exports failing 27–47%, ~0% on 0.10–0.12, format-specific, strongly bimodal per user — the fingerprint of a state/version problem), but the coarse `error_code` makes it impossible to separate the version skew from ordinary render failures or to confirm a fix lands. This PR unblocks that measurement.

## What users will see

Nothing user-visible — this is a telemetry-classification change only. The export toast/UX is unchanged. In analytics, `artifact_export_result.error_code` now carries a specific value (`DESKTOP_SIDECAR_UNKNOWN_MESSAGE`, `DESKTOP_RENDERER_UNAVAILABLE`, or the error name) instead of the generic `"Error"`.

## Surface area

- [x] **None** — telemetry-only classification change. `ArtifactExportResultProps.error_code` was already typed `string`; no contract, UI, CLI, or default-behavior change.

## Bug fix verification

- Test path: `apps/web/tests/analytics/export-error-code.test.ts` — asserts the render-slides skew message → `DESKTOP_SIDECAR_UNKNOWN_MESSAGE`, a plain unavailable renderer → `DESKTOP_RENDERER_UNAVAILABLE`, a structured `.code` wins, and generic failures fall back to the error name.
- Red-on-main: the classifier is new code (the "bug" is the *absence* of classification), so a red-on-main spec doesn't apply cleanly. The test pins the intended behavior of the new helper.
- **Note on local test run:** this worktree's full `@open-design/web` vitest suite currently fails to transform *all* 382 files (a pre-existing, change-independent env issue — existing untouched tests fail identically). I verified the classifier logic against every test case with a standalone harness (all pass) and confirmed `typecheck` reports no errors for the changed files. CI runs the suite in a clean environment.

## Validation

- `exportErrorCode` logic verified against all 7 test cases via a standalone Node harness — all pass.
- `pnpm --filter @open-design/web typecheck`: no errors in the changed files (`export-error-code.ts`, `FileViewer.tsx`, the test). The pre-existing unrelated errors in the worktree (`ByokChatProviderConfig` from a stale contracts dist; `toBeInTheDocument` matcher types) are not touched by this change.
- Full local vitest suite could not be run — see the note above.
