### PR TITLE
fix(web): keep consuming recovered daemon retries

### DIFF
--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -1135,35 +1135,13 @@ async function consumeDaemonRun({
             const data = event.data as SseErrorPayload;
             const structuredError = daemonSseError(data);
             pendingStructuredError = structuredError;
-            // The daemon emits this error frame from the child-close handler
-            // BEFORE `finishWithRetryDecision()` runs, so a transient failure it
-            // can recover via a same-run retry is reported here first and only
-            // resolved later. `run.resumable` is also computed at that same
-            // finalize step. Read the run status ONCE to classify, and let the
-            // SSE `end` frame (always emitted on terminal) resolve in-flight
-            // runs — this has no timeout, so even a slow retry is handled:
-            //  - failed / canceled    -> surface the error now, with the
-            //    finalized `resumable` bit (set just before status flips to
-            //    failed, so a `failed` read already has it);
-            //  - status unreachable   -> surface the structured error (safe
-            //    default; never drop a real failure);
-            //  - succeeded (recovered) or still running/queued (retry in
-            //    flight) -> do NOT surface; keep consuming so the stream's
-            //    `end` frame resolves it (succeeded -> onDone; failed ->
-            //    the failure path below, carrying `end`'s resumable bit).
-            const status = await fetchChatRunStatus(runId).catch(() => null);
-            if (status && (status.status === 'failed' || status.status === 'canceled')) {
-              onRunStatus?.('failed');
-              handlers.onError(
-                markErrorResumable(structuredError, status.resumable === true),
-              );
-              return;
-            }
-            if (!status) {
-              onRunStatus?.('failed');
-              handlers.onError(structuredError);
-              return;
-            }
+            // Error frames can be emitted for a failed first attempt before the
+            // same run's retry has completed. Do not classify the run from a
+            // point-in-time status probe here: that can catch a transient
+            // failed state, surface a stale error, and disconnect before the
+            // later successful retry frames arrive. Cache the structured error
+            // and let the terminal `end` event or the post-stream status
+            // fallback below decide whether it should be surfaced.
             continue;
           }
 
@@ -1181,7 +1159,30 @@ async function consumeDaemonRun({
           }
         }
       }
-      reconnects = sawStreamProgress ? 0 : reconnects + 1;
+      let shouldResetReconnects = sawStreamProgress;
+      if (pendingStructuredError && endStatus === null) {
+        const status = await fetchChatRunStatus(runId).catch(() => null);
+        if (status && isChatRunStatus(status.status) && status.status !== 'queued' && status.status !== 'running') {
+          endStatus = status.status;
+          exitCode = status.exitCode ?? null;
+          exitSignal = status.signal ?? null;
+          serverDeclaredSuccess = status.status === 'succeeded';
+          if (status.resumable === true) endResumable = true;
+          onRunStatus?.(endStatus);
+          break;
+        }
+        if (!status) {
+          onRunStatus?.('failed');
+          handlers.onError(pendingStructuredError);
+          return;
+        }
+        // The connection closed after an error frame but before a terminal
+        // frame. If the run is still active, retry the SSE stream, but count
+        // this as a reconnect attempt instead of letting the error frame reset
+        // the budget forever.
+        shouldResetReconnects = false;
+      }
+      reconnects = shouldResetReconnects ? 0 : reconnects + 1;
     }
 
     if (endStatus === null) {

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -105,6 +105,45 @@ describe('streamViaDaemon', () => {
     expect(handlers.onDone).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps consuming when a same-run retry succeeds after the transient error status briefly reads failed', async () => {
+    // Regression for #5110: the daemon can emit an empty-output error for a
+    // failed first attempt, then recover the SAME run through the retry path.
+    // If the status probe observes the transient failed state and returns
+    // immediately, the browser never sees the later successful write/text/end
+    // frames and the chat keeps showing the stale empty-output failure.
+    const handlers = createDaemonHandlers();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-1' });
+      if (url === '/api/runs/run-1/events') {
+        return sseResponse(
+          'event: error\ndata: {"code":"AGENT_EXECUTION_FAILED","message":"Agent completed without producing any output.","retryable":true}\n\n' +
+          'event: agent\ndata: {"type":"tool_use","id":"call_1","name":"write","input":{"filePath":"index.html"}}\n\n' +
+          'event: agent\ndata: {"type":"tool_result","toolUseId":"call_1","content":"Wrote file successfully.","isError":false}\n\n' +
+          'event: agent\ndata: {"type":"text_delta","delta":"Landing page saved to `index.html`."}\n\n' +
+          'event: end\ndata: {"code":0,"status":"succeeded"}\n\n',
+        );
+      }
+      if (url === '/api/runs/run-1') {
+        return jsonResponse({ id: 'run-1', status: 'failed' });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'opencode',
+      history: [{ id: '1', role: 'user', content: 'make a landing page' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onDelta).toHaveBeenCalledWith('Landing page saved to `index.html`.');
+    expect(handlers.onDone).toHaveBeenCalledWith('Landing page saved to `index.html`.');
+  });
+
   it('prefers a structured daemon error over the lifecycle exit fallback when the run later fails', async () => {
     const handlers = createDaemonHandlers();
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {


### PR DESCRIPTION
Fixes #5110

## Why

I picked this up from the OpenCode/Ollama empty-output report. The attached run events showed a first attempt emitting `Agent completed without producing any output`, then the same run recovered through retry frames, wrote `index.html`, emitted final text, and ended as `succeeded`.

The pain was user-facing: the web client could observe the transient failed status from the first attempt, surface the stale empty-output error, and disconnect before the later successful retry frames arrived.

## What users will see

When an OpenCode/Ollama run recovers after an initial empty-output attempt, the chat keeps consuming the same run's retry stream and shows the final successful output instead of getting stuck on the stale empty-output error.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/sse.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new regression failed before the fix because `handlers.onError` was called with `Agent completed without producing any output`; it passes after the fix.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/providers/sse.test.ts -t "keeps consuming when a same-run retry succeeds after the transient error status briefly reads failed"`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/providers/sse.test.ts -t "surfaces a terminal failure with the finalized resumable flag|prefers a structured daemon error over the lifecycle exit fallback|does not surface an error when a still-running same-run retry later succeeds"`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/providers/sse.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`

Note: this machine still reports the repo's expected Node `~24` engine warning because the local shell is on Node `v22.14.0`; the green commands above exited successfully after that warning. The first `pnpm guard` run also found local untracked `.DS_Store` files under `e2e/` and `tools/`; after deleting those local files, `pnpm guard` passed.