### PR TITLE
feat(contracts): team-collab comment anchor state + drift fields

### DIFF
--- a/packages/contracts/src/api/comments.ts
+++ b/packages/contracts/src/api/comments.ts
@@ -34,6 +34,23 @@ export type PreviewCommentSelectionKind = 'element' | 'pod';
 export type PreviewVisualMarkKind = 'click' | 'stroke' | 'click+stroke';
 
 /**
+ * Team-collaboration comment anchor state (§D2 xpath self-anchor + drift ladder).
+ * Resolved each render from the live DOM — this is an anchor state, not a
+ * processing state. Ladder (strong → weak): exact selector/xpath hit →
+ * `anchored`; content changed but re-found via htmlHint → `reanchored`
+ * (shows a "based on older v{anchoredVersion}" badge); fuzzy match on
+ * selector + htmlHint + position → `stale` (dashed warning); nothing found →
+ * `lost` (ghost pin at `lastGoodPosition` + explicit "anchor lost" badge).
+ * The explicit `stale`/`lost` marking is load-bearing: with no injected id,
+ * drift must be surfaced, never silently mis-pointed.
+ */
+export type PreviewCommentAnchorState =
+  | 'anchored'
+  | 'reanchored'
+  | 'stale'
+  | 'lost';
+
+/**
  * An image attached to a preview comment. `path` is the project-relative file
  * path (uploaded via the normal file API) that the web app resolves to a raw
  * URL for display; `name` is the original filename for labels/alt text.
@@ -91,6 +108,22 @@ export interface PreviewComment {
   status: PreviewCommentStatus;
   createdAt: number;
   updatedAt: number;
+  /**
+   * Team-collaboration anchor fields (all optional; single-user comments omit
+   * them). See {@link PreviewCommentAnchorState}. Resolved/updated at render or
+   * sync time by the drift ladder; persisted as the last-known values.
+   */
+  anchorState?: PreviewCommentAnchorState;
+  /** Content version the comment was anchored to; drives the "based on older vN" badge. */
+  anchoredVersion?: number;
+  /** Comment author's workspaceMemberId (for cross-member attribution/display). */
+  authorMemberId?: string;
+  /**
+   * Bbox written back on each successful anchor. The `lost` ghost pin renders
+   * here (last known-good position), NOT the creation-time `position`, which
+   * may point somewhere unrelated after the author restructures the HTML.
+   */
+  lastGoodPosition?: PreviewCommentPosition;
 }
 
 export interface PreviewCommentUpsertRequest {


### PR DESCRIPTION
## Why

First contract slice of the team-edition collaboration lane (C, OPEND-444). The read-only comment layer (spec §D2) must survive the author restructuring the HTML: today comments anchor by an exact-match on a render-time positional id (`data-od-id="path-N"`, computed each render, never persisted) and are **silently dropped** when structure changes (`FileViewer.tsx` `.filter(Boolean)`). Per the reviewed design (aligned with 韩沅锡's E resource spec), we drop the injected id (it pollutes the AI's working HTML) and self-anchor via xpath/selector + htmlHint with an explicit drift ladder. This lands the contract those need.

## What users will see

Nothing yet — pure contract (TypeScript types), foundation for follow-up PRs (daemon storage + anchoring engine + UI). No runtime behavior change.

## What changed

`packages/contracts/src/api/comments.ts`:
- New `PreviewCommentAnchorState = 'anchored' | 'reanchored' | 'stale' | 'lost'` (drift-ladder states).
- Four **optional** fields on `PreviewComment`: `anchorState`, `anchoredVersion`, `authorMemberId`, `lastGoodPosition`. All optional → single-user comments unaffected (backward compatible).

## Surface area
- [x] Shared contracts (`packages/contracts`)
- [ ] UI / CLI (follow-up PRs)

## Notes
Part of a series into `feat/workspace-team`: **PR1 = contracts (this)** · PR2 = daemon storage + xpath anchoring engine (incl. migrating the `preview_comments` upsert key off the unstable `element_id`) · PR3 = comment UI (drift badges / ghost pin) · PR4 = sync trigger against E's resource API.

Typecheck green: `pnpm --filter @open-design/contracts typecheck`.