### PR TITLE
feat(packaged): attach crash-scene evidence to packaged_runtime_failed

### DIFF
--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -55,6 +55,7 @@ let startupTelemetryContext:
       namespace: string;
       source: string;
       installationRoot: string;
+      nativeModulePath: string | null;
     }
   | null = null;
 
@@ -129,6 +130,18 @@ async function main(): Promise<void> {
     // Pass installationRoot explicitly: OD_INSTALLATION_DIR is only set in the
     // daemon child env, not this parent process (see startup-telemetry.ts).
     installationRoot: paths.installationRoot,
+    // Absolute path where the daemon's better-sqlite3 binding ships in the
+    // packaged bundle (`Contents/Resources/app/node_modules/...` — layout
+    // verified against the shipped 0.13.0 DMG). The fatal-exit report probes
+    // this to record whether the .node actually exists on the crashing machine.
+    nativeModulePath: join(
+      app.getAppPath(),
+      "node_modules",
+      "better-sqlite3",
+      "build",
+      "Release",
+      "better_sqlite3.node",
+    ),
   };
 
   await ensurePackagedNamespacePaths(paths);
@@ -284,6 +297,7 @@ void main().catch(async (error: unknown) => {
       appVersion: startupTelemetryContext.appVersion,
       namespace: startupTelemetryContext.namespace,
       source: startupTelemetryContext.source,
+      nativeModulePath: startupTelemetryContext.nativeModulePath,
     });
   }
   process.exit(1);

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -153,7 +153,13 @@ export function parseDaemonLogTail(logText: string): {
 export function scrubUserPaths(value: string): string {
   return value
     .replace(/\/(Users|home)\/[^/\s]+/g, "/$1/<redacted>")
-    .replace(/([A-Za-z]:\\Users\\)[^\\\s]+/g, "$1<redacted>");
+    // Consume the WHOLE Windows profile segment up to the next backslash, not
+    // just up to the first whitespace: a profile dir can contain spaces
+    // ("C:\\Users\\John Doe\\..."), and stopping at the space would leak the
+    // rest of the segment ("<redacted> Doe\\..."). POSIX home segments cannot
+    // contain spaces, and file:// URLs percent-encode them, so only this
+    // backslash form needs the whitespace-tolerant boundary.
+    .replace(/([A-Za-z]:\\Users\\)[^\\]+/g, "$1<redacted>");
 }
 
 function osName(platform: NodeJS.Platform = process.platform): string {

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -22,9 +22,15 @@
 // in apps/daemon/src/analytics.ts — stability data is retained even for
 // opted-out users (and the main process cannot read daemon consent anyway,
 // since the daemon isn't up). The Settings → Privacy copy MUST call this out.
+//
+// Payload PII: the free-form crash fields (error_message, error_stack) and every
+// path we send (log_path, native_module_path) run through `scrubUserPaths` to
+// strip the user's home dir, and the free-form text is length-capped. Startup
+// errors are module-resolution / daemon-exit messages, not user content, so this
+// bounds the exposure to build/OS strings rather than anything the user typed.
 
 import { readFile } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { release } from "node:os";
 
@@ -196,6 +202,28 @@ async function defaultReadLogTail(path: string): Promise<string | null> {
   }
 }
 
+// Keep the message/stack payload bounded (a stack can be arbitrarily long).
+const ERROR_MESSAGE_MAX = 1000;
+const ERROR_STACK_MAX = 2000;
+
+function truncateForTelemetry(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…[+${value.length - max} chars]` : value;
+}
+
+// Best-effort probe: does the native module actually exist on THIS machine, and
+// how big is it? The field crash is a subset of machines rather than a build
+// defect (the shipped .node is present + signed + resolvable), so per-machine
+// existence/size is the signal that separates "file missing" from "file present
+// but unloadable (arch/quarantine/AV)".
+function defaultStatNativeModule(path: string): { size: number } | null {
+  try {
+    const s = statSync(path);
+    return s.isFile() ? { size: s.size } : null;
+  } catch {
+    return null;
+  }
+}
+
 export interface CaptureDeps {
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
@@ -277,10 +305,15 @@ export interface ReportStartupFailureArgs {
   appVersion: string | null;
   namespace: string;
   source: string;
+  // Absolute path to the daemon's better-sqlite3 native binding, so the report
+  // can probe whether that .node exists on this machine. Optional: null skips
+  // the probe (fields report null).
+  nativeModulePath?: string | null;
 }
 
 export interface ReportDeps extends CaptureDeps {
   readLogTail?: (path: string) => Promise<string | null>;
+  statNativeModule?: (path: string) => { size: number } | null;
 }
 
 // The single entry point index.ts's fatal-exit catch calls. Orchestrates
@@ -302,6 +335,28 @@ export async function reportStartupFailure(
         missingModule = parsed.missingModule;
       }
     }
+    const rawMessage =
+      args.error instanceof Error
+        ? args.error.message
+        : args.error == null
+          ? ""
+          : String(args.error);
+    const rawStack =
+      args.error instanceof Error && typeof args.error.stack === "string"
+        ? args.error.stack
+        : null;
+    // Probe the native module on THIS machine (existence + size). This is the
+    // signal the `unknown` bucket (no daemon log to parse) otherwise lacks, and
+    // it distinguishes "file missing" from "file present but unloadable".
+    let nativeModulePresent: boolean | null = null;
+    let nativeModuleSize: number | null = null;
+    let nativeModulePath: string | null = null;
+    if (args.nativeModulePath) {
+      const stat = (deps.statNativeModule ?? defaultStatNativeModule)(args.nativeModulePath);
+      nativeModulePresent = stat != null;
+      nativeModuleSize = stat?.size ?? null;
+      nativeModulePath = scrubUserPaths(args.nativeModulePath);
+    }
     const properties: Record<string, unknown> = {
       failure_kind: classification.failureKind,
       exit_code: classification.exitCode,
@@ -309,8 +364,19 @@ export async function reportStartupFailure(
       error_name: args.error instanceof Error ? args.error.name : "unknown",
       error_code: errorCode ?? null,
       missing_module: missingModule ?? null,
-      // Structured fields only — no raw message/stack. Scrub the one path we do
-      // send so a user's home dir never reaches PostHog.
+      // Scrub every path we send (message/stack/log/native path) so a user's
+      // home dir never reaches PostHog; truncate free-form text to bound the
+      // payload. These crash-scene fields are why the mac subset can't resolve
+      // the module and what the Windows `unknown` bucket actually threw.
+      error_message: rawMessage
+        ? truncateForTelemetry(scrubUserPaths(rawMessage), ERROR_MESSAGE_MAX)
+        : null,
+      error_stack: rawStack
+        ? truncateForTelemetry(scrubUserPaths(rawStack), ERROR_STACK_MAX)
+        : null,
+      native_module_present: nativeModulePresent,
+      native_module_size: nativeModuleSize,
+      native_module_path: nativeModulePath,
       log_path: classification.logPath ? scrubUserPaths(classification.logPath) : null,
       app_version: args.appVersion,
       namespace: args.namespace,

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -152,14 +152,19 @@ export function parseDaemonLogTail(logText: string): {
 // can't import the web module anyway, so we ship a focused scrubber here.
 export function scrubUserPaths(value: string): string {
   return value
-    .replace(/\/(Users|home)\/[^/\s]+/g, "/$1/<redacted>")
-    // Consume the WHOLE Windows profile segment up to the next backslash, not
-    // just up to the first whitespace: a profile dir can contain spaces
-    // ("C:\\Users\\John Doe\\..."), and stopping at the space would leak the
-    // rest of the segment ("<redacted> Doe\\..."). POSIX home segments cannot
-    // contain spaces, and file:// URLs percent-encode them, so only this
-    // backslash form needs the whitespace-tolerant boundary.
-    .replace(/([A-Za-z]:\\Users\\)[^\\]+/g, "$1<redacted>");
+    // Windows profile dirs FIRST, either separator style (`C:\Users\…` or the
+    // slash-normalized `C:/Users/…` that JS/Electron/Node diagnostics commonly
+    // emit). Consume the WHOLE segment up to the next slash/backslash — a
+    // profile dir can contain spaces ("John Doe"), and a whitespace boundary
+    // would leak the tail ("<redacted> Doe/…"). Anchored on `<drive>:` so it
+    // only fires on a real Windows home path; `\r\n` in the class stops it from
+    // running across lines in a multi-line stack. Runs before the POSIX rule
+    // because that rule also matches the "/Users/" inside a `C:/Users/` path.
+    .replace(/([A-Za-z]:[\\/]Users[\\/])[^\\/\r\n]+/g, "$1<redacted>")
+    // POSIX home dirs. Real macOS/Linux home segments cannot contain spaces, so
+    // the whitespace boundary is correct here and avoids over-redacting a
+    // following word in free-form crash text.
+    .replace(/\/(Users|home)\/[^/\s]+/g, "/$1/<redacted>");
 }
 
 function osName(platform: NodeJS.Platform = process.platform): string {

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -103,6 +103,24 @@ describe('scrubUserPaths', () => {
       'C:\\Users\\<redacted>\\AppData\\Roaming',
     );
   });
+
+  it('redacts the FULL Windows profile segment even when it contains spaces', () => {
+    // A Windows profile dir can contain whitespace ("John Doe"). The redaction
+    // must consume the whole segment up to the next separator, not stop at the
+    // first space and leak the surname.
+    const scrubbed = scrubUserPaths('C:\\Users\\John Doe\\AppData\\Roaming');
+    expect(scrubbed).toBe('C:\\Users\\<redacted>\\AppData\\Roaming');
+    expect(scrubbed).not.toContain('Doe');
+  });
+
+  it('scrubs a spaced Windows profile embedded in a crash message/stack', () => {
+    const raw =
+      "Cannot find package 'better-sqlite3' imported from C:\\Users\\John Doe\\App\\Resources\\app\\daemon\\server.mjs";
+    const scrubbed = scrubUserPaths(raw);
+    expect(scrubbed).not.toContain('John Doe');
+    expect(scrubbed).not.toContain('Doe');
+    expect(scrubbed).toContain('C:\\Users\\<redacted>\\App\\Resources');
+  });
 });
 
 describe('resolveStartupDistinctId', () => {

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -292,4 +292,73 @@ describe('reportStartupFailure', () => {
     );
     expect(fetchImpl).not.toHaveBeenCalled();
   });
+
+  // Why these exist: the field crash is a SUBSET of machines (verified 2026-07-06
+  // — the shipped 0.13.0 DMG's better_sqlite3.node is present, signed, notarized,
+  // and resolvable, so it is NOT a build defect). To learn WHY a given machine
+  // can't load it, the event must carry on-machine evidence: the scrubbed error
+  // message/stack (the only signal for the `unknown` bucket, which has no daemon
+  // log to parse) and whether the native module file actually exists there.
+  it('captures scrubbed error message/stack + native-module probe (on-machine evidence)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    const error = new Error(
+      "Cannot find package 'better-sqlite3' imported from /Users/liudetao/App/Contents/Resources/app/prebundled/daemon/server.mjs",
+    );
+    error.stack = `${error.message}\n    at file:///Users/liudetao/App/Contents/Resources/app/prebundled/daemon/server.mjs:1:1`;
+    await reportStartupFailure(
+      {
+        error,
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.13.0',
+        namespace: 'release-stable',
+        source: 'packaged',
+        nativeModulePath:
+          '/Users/liudetao/App/Contents/Resources/app/node_modules/better-sqlite3/build/Release/better_sqlite3.node',
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        readLogTail: async () => null,
+        statNativeModule: (p) => (p.endsWith('better_sqlite3.node') ? { size: 1_234_567 } : null),
+      },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> }).properties;
+    // scrubbed message/stack: content kept, home dir gone.
+    expect(props.error_message).toContain("Cannot find package 'better-sqlite3'");
+    expect(props.error_message).not.toContain('liudetao');
+    expect(String(props.error_stack)).not.toContain('liudetao');
+    // native-module probe answers "is the .node actually on THIS machine".
+    expect(props.native_module_present).toBe(true);
+    expect(props.native_module_size).toBe(1_234_567);
+    expect(props.native_module_path).not.toContain('liudetao');
+  });
+
+  it('reports native_module_present=false when the .node is missing on the machine', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await reportStartupFailure(
+      {
+        error: new Error('boom'),
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.13.0',
+        namespace: 'release-stable',
+        source: 'packaged',
+        nativeModulePath: '/a/b/better_sqlite3.node',
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        readLogTail: async () => null,
+        statNativeModule: () => null,
+      },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> }).properties;
+    expect(props.native_module_present).toBe(false);
+    expect(props.native_module_size).toBeNull();
+  });
 });

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -121,6 +121,29 @@ describe('scrubUserPaths', () => {
     expect(scrubbed).not.toContain('Doe');
     expect(scrubbed).toContain('C:\\Users\\<redacted>\\App\\Resources');
   });
+
+  it('redacts SLASH-separated Windows home paths with spaces (forward-slash form)', () => {
+    // JS/Electron/Node diagnostics frequently normalize Windows paths to forward
+    // slashes; the profile segment can still contain a literal space. The POSIX
+    // "/Users/" rule alone would stop at the space and leak the tail.
+    expect(scrubUserPaths('C:/Users/John Doe/AppData/Roaming')).toBe(
+      'C:/Users/<redacted>/AppData/Roaming',
+    );
+  });
+
+  it('scrubs a slash-form spaced Windows profile embedded in a crash message', () => {
+    const raw =
+      "Cannot find package 'better-sqlite3' imported from C:/Users/John Doe/App/Resources/app/daemon/server.mjs";
+    const scrubbed = scrubUserPaths(raw);
+    expect(scrubbed).not.toContain('John Doe');
+    expect(scrubbed).not.toContain('Doe');
+    expect(scrubbed).toContain('C:/Users/<redacted>/App/Resources');
+  });
+
+  it('does not over-redact across lines in a multi-line stack', () => {
+    const scrubbed = scrubUserPaths('a C:\\Users\\John Doe\\x\nb /Users/bob/y');
+    expect(scrubbed).toBe('a C:\\Users\\<redacted>\\x\nb /Users/<redacted>/y');
+  });
 });
 
 describe('resolveStartupDistinctId', () => {

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -663,6 +663,20 @@ export interface PackagedRuntimeFailedProps {
   // The unresolved module when error_code is a module-resolution failure
   // (e.g. `better-sqlite3` for #4638).
   missing_module: string | null;
+  // Crash-scene evidence added for the field-crash subset (#4638 follow-up): the
+  // shipped build is verified-good, so these separate a machine-side "module
+  // missing/unloadable" from a code path, and give the Windows `unknown` bucket
+  // (which has no daemon log to parse) its only signal. All scrubbed of the
+  // user's home dir and truncated before send.
+  //
+  // Free-form error text off the top-level thrown error (not the log tail).
+  error_message?: string | null;
+  error_stack?: string | null;
+  // Probe of the daemon's better-sqlite3 native binding on THIS machine.
+  // present=null when no path was supplied; size is bytes when present.
+  native_module_present?: boolean | null;
+  native_module_size?: number | null;
+  native_module_path?: string | null;
   // Scrubbed of the user's home dir before send.
   log_path: string | null;
   app_version: string | null;


### PR DESCRIPTION
<!-- This PR adds diagnostic instrumentation to root-cause an existing crash
     class; it does not itself close the crash, so no Fixes/Closes line.
     Related: #4638 (better-sqlite3 ERR_MODULE_NOT_FOUND at startup), #4696
     (the packaged_runtime_failed event this enriches). -->

## Why

**Use case:** I was triaging the `packaged_runtime_failed` event (PostHog project 420348) to explain the 0.13.0 startup-crash population and hit a wall — the event tells me *that* startup failed but not *why on a given machine*.

**Pain:** Two of the biggest slices are un-actionable with today's fields:

- The macOS `daemon-start` failures are better-sqlite3 `ERR_MODULE_NOT_FOUND`, yet I verified the shipped 0.13.0 mac-arm DMG's `better_sqlite3.node` is present, arm64, Developer-ID signed, notarized, and resolvable from the daemon sidecar location. So the field crash is a **machine-side subset** (~a couple dozen devices), not a build defect — and we currently have zero per-machine signal to explain the subset.
- The Windows `unknown` bucket (the single largest slice, ~334/7d) carries no exit code and **no daemon log to parse**, so `error_code`/`missing_module` are both null and the row is a dead end.

This PR adds the on-machine crash evidence needed to separate those hypotheses in the dashboard instead of guessing.

## What users will see

Nothing in the UI or CLI. This is internal crash telemetry emitted automatically by the packaged **main process** on the fatal-exit path (the daemon that normally hosts PostHog never came up, which is the whole reason this path exists). The only observable change is that the `packaged_runtime_failed` event now carries more diagnostic fields:

- `error_message` / `error_stack` — the top-level thrown error, **scrubbed of the user's home dir** (`scrubUserPaths`) and length-capped. For the `unknown` bucket this is the only signal there is.
- `native_module_present` / `native_module_size` / `native_module_path` — a best-effort `statSync` probe of the daemon's `better-sqlite3` binding on that machine, which distinguishes "the `.node` is missing" from "the `.node` is present but unloadable" (arch mismatch / Gatekeeper quarantine / AV).

Startup errors are module-resolution / daemon-exit strings, not user content, and paths are scrubbed + text capped, so the exposure is bounded to build/OS strings.

## Surface area

- [x] **API / contract** — extended `PackagedRuntimeFailedProps` in `packages/contracts` with the new optional telemetry fields.
- [ ] **None**

> Capability dual-track (UI + CLI) note: not applicable. This is an automatic internal crash-telemetry event, not a user-facing capability — there is no user action to expose through `od` or the web UI.

## Bug fix verification

This is diagnostic instrumentation rather than a behavior bug fix, but I still led with a falsifiable spec per the bug-follow-up workflow:

- Test path: \`apps/packaged/tests/startup-telemetry.test.ts\` (two new cases: scrubbed message/stack + native-module probe present/missing via an injected \`statNativeModule\` dep).
- Red on the unmodified source, green on this branch? **yes** — confirmed by stashing only \`startup-telemetry.ts\` and re-running: both new cases failed (\`expected undefined to be false\`), then passed after the source change.

## Validation

- \`pnpm guard\` — pass (71/71).
- \`pnpm --filter @open-design/packaged --filter @open-design/contracts typecheck\` — pass.
- \`pnpm --filter @open-design/packaged test\` — pass (154/154, 14 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)