### PR TITLE
Add drag-and-drop support to plugin imports

### DIFF
--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -3946,16 +3946,24 @@ function FileImportPanel({
   const [dropError, setDropError] = useState<string | null>(null);
 
   function handleDragEnter(event: ReactDragEvent<HTMLLabelElement>) {
-    if (!dragEventHasFiles(event) || working) return;
+    if (!dragEventHasFiles(event)) return;
     event.preventDefault();
-    event.dataTransfer.dropEffect = 'copy';
+    event.dataTransfer.dropEffect = working ? 'none' : 'copy';
+    if (working) {
+      setDragOver(false);
+      return;
+    }
     setDragOver(true);
   }
 
   function handleDragOver(event: ReactDragEvent<HTMLLabelElement>) {
-    if (!dragEventHasFiles(event) || working) return;
+    if (!dragEventHasFiles(event)) return;
     event.preventDefault();
-    event.dataTransfer.dropEffect = 'copy';
+    event.dataTransfer.dropEffect = working ? 'none' : 'copy';
+    if (working) {
+      setDragOver(false);
+      return;
+    }
     setDragOver(true);
   }
 
@@ -3966,10 +3974,14 @@ function FileImportPanel({
   }
 
   async function handleDrop(event: ReactDragEvent<HTMLLabelElement>) {
-    if (!dragEventHasFiles(event) || working) return;
+    if (!dragEventHasFiles(event)) return;
     event.preventDefault();
     event.stopPropagation();
     setDragOver(false);
+    if (working) {
+      event.dataTransfer.dropEffect = 'none';
+      return;
+    }
     const { dataTransfer } = event;
     try {
       const droppedFiles = await filesFromPluginDrop(dataTransfer);

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type CSSProperties,
   type Dispatch,
+  type DragEvent as ReactDragEvent,
   type KeyboardEvent,
   type SetStateAction,
 } from 'react';
@@ -3656,6 +3657,31 @@ function SourcesPanel({
 
 type ImportKind = 'github' | 'zip' | 'folder';
 
+interface PluginDropEntry {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+}
+
+interface PluginDropFileEntry extends PluginDropEntry {
+  isFile: true;
+  file: (success: (file: File) => void, error?: (error: DOMException) => void) => void;
+}
+
+interface PluginDropDirectoryEntry extends PluginDropEntry {
+  isDirectory: true;
+  createReader: () => {
+    readEntries: (
+      success: (entries: PluginDropEntry[]) => void,
+      error?: (error: DOMException) => void,
+    ) => void;
+  };
+}
+
+type DataTransferItemWithEntry = DataTransferItem & {
+  webkitGetAsEntry?: () => PluginDropEntry | null;
+};
+
 function PluginImportModal({
   onClose,
   onInstallSource,
@@ -3916,13 +3942,76 @@ function FileImportPanel({
   onChange: (files: File[]) => void;
   onImport: () => void;
 }) {
+  const [dragOver, setDragOver] = useState(false);
+  const [dropError, setDropError] = useState<string | null>(null);
+
+  function handleDragEnter(event: ReactDragEvent<HTMLLabelElement>) {
+    if (!dragEventHasFiles(event) || working) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setDragOver(true);
+  }
+
+  function handleDragOver(event: ReactDragEvent<HTMLLabelElement>) {
+    if (!dragEventHasFiles(event) || working) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setDragOver(true);
+  }
+
+  function handleDragLeave(event: ReactDragEvent<HTMLLabelElement>) {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+    setDragOver(false);
+  }
+
+  async function handleDrop(event: ReactDragEvent<HTMLLabelElement>) {
+    if (!dragEventHasFiles(event) || working) return;
+    event.preventDefault();
+    event.stopPropagation();
+    setDragOver(false);
+    const { dataTransfer } = event;
+    try {
+      const droppedFiles = await filesFromPluginDrop(dataTransfer);
+      if (folder) {
+        if (droppedFiles.length === 0) {
+          onChange([]);
+          setDropError('Drop a plugin folder or files.');
+          return;
+        }
+        onChange(droppedFiles);
+        setDropError(null);
+        return;
+      }
+
+      const zip = droppedFiles.find(isZipPluginFile) ?? null;
+      if (!zip) {
+        onChange([]);
+        setDropError('Drop a .zip plugin archive.');
+        return;
+      }
+      onChange([zip]);
+      setDropError(null);
+    } catch {
+      onChange([]);
+      setDropError('Could not read dropped files. Try choosing the folder instead.');
+    }
+  }
+
   return (
     <section className="plugins-view__install-card">
       <div>
         <h3>{title}</h3>
         <p>{body}</p>
       </div>
-      <label className="plugins-import-modal__file">
+      <label
+        className={`plugins-import-modal__file${dragOver ? ' is-drag-over' : ''}`}
+        data-testid={folder ? 'plugins-folder-dropzone' : 'plugins-zip-dropzone'}
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={(event) => void handleDrop(event)}
+      >
         <input
           type="file"
           data-testid={folder ? 'plugins-folder-input' : 'plugins-zip-input'}
@@ -3930,10 +4019,18 @@ function FileImportPanel({
           {...(folder ? { webkitdirectory: '', directory: '' } : {})}
           multiple={folder}
           disabled={working}
-          onChange={(event) => onChange(Array.from(event.currentTarget.files ?? []))}
+          onChange={(event) => {
+            setDropError(null);
+            onChange(Array.from(event.currentTarget.files ?? []));
+          }}
         />
         <span>{fileLabel}</span>
       </label>
+      {dropError ? (
+        <p className="plugins-import-modal__file-error" role="alert">
+          {dropError}
+        </p>
+      ) : null}
       <button
         type="button"
         className="plugins-view__primary"
@@ -3944,6 +4041,99 @@ function FileImportPanel({
       </button>
     </section>
   );
+}
+
+function dragEventHasFiles(event: ReactDragEvent<HTMLElement>): boolean {
+  return Array.from(event.dataTransfer.types ?? []).includes('Files');
+}
+
+async function filesFromPluginDrop(dataTransfer: DataTransfer): Promise<File[]> {
+  const fallbackFiles = Array.from(dataTransfer.files ?? []);
+  const items = Array.from(dataTransfer.items ?? []);
+  if (items.length === 0) return fallbackFiles;
+
+  const results = await Promise.allSettled(items.map(filesFromPluginDropItem));
+  const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+  if (rejected) {
+    if (fallbackFiles.length > 0) return fallbackFiles;
+    throw rejected.reason;
+  }
+  const files = results.flatMap((result) => (result.status === 'fulfilled' ? result.value : []));
+  return files.length > 0 ? files : fallbackFiles;
+}
+
+async function filesFromPluginDropItem(item: DataTransferItem): Promise<File[]> {
+  const entry = (item as DataTransferItemWithEntry).webkitGetAsEntry?.();
+  if (entry && isPluginDropEntry(entry)) return filesFromPluginDropEntry(entry, entry.name);
+
+  const file = item.kind === 'file' ? item.getAsFile() : null;
+  return file ? [file] : [];
+}
+
+function isPluginDropEntry(entry: unknown): entry is PluginDropEntry {
+  if (!entry || typeof entry !== 'object') return false;
+  const candidate = entry as Partial<PluginDropEntry>;
+  return (
+    typeof candidate.name === 'string' &&
+    typeof candidate.isFile === 'boolean' &&
+    typeof candidate.isDirectory === 'boolean'
+  );
+}
+
+async function filesFromPluginDropEntry(entry: PluginDropEntry, relativePath: string): Promise<File[]> {
+  if (entry.isFile) {
+    const file = await fileFromPluginDropEntry(entry as PluginDropFileEntry);
+    return [withPluginDropRelativePath(file, relativePath)];
+  }
+  if (!entry.isDirectory) return [];
+
+  const children = await readPluginDropDirectoryEntries(entry as PluginDropDirectoryEntry);
+  const nested = await Promise.all(
+    children.map((child) => filesFromPluginDropEntry(child, `${relativePath}/${child.name}`)),
+  );
+  return nested.flat();
+}
+
+function fileFromPluginDropEntry(entry: PluginDropFileEntry): Promise<File> {
+  return new Promise((resolve, reject) => {
+    entry.file(resolve, reject);
+  });
+}
+
+function readPluginDropDirectoryEntries(entry: PluginDropDirectoryEntry): Promise<PluginDropEntry[]> {
+  const reader = entry.createReader();
+  const entries: PluginDropEntry[] = [];
+  return new Promise((resolve, reject) => {
+    function readNextBatch() {
+      reader.readEntries((batch) => {
+        if (batch.length === 0) {
+          resolve(entries);
+          return;
+        }
+        entries.push(...batch);
+        readNextBatch();
+      }, reject);
+    }
+    readNextBatch();
+  });
+}
+
+function withPluginDropRelativePath(file: File, relativePath: string): File {
+  const currentPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+  if (currentPath) return file;
+  Object.defineProperty(file, 'webkitRelativePath', {
+    value: normalizePluginDropPath(relativePath),
+    configurable: true,
+  });
+  return file;
+}
+
+function normalizePluginDropPath(input: string): string {
+  return input.replace(/\\/g, '/').split('/').filter(Boolean).join('/');
+}
+
+function isZipPluginFile(file: File): boolean {
+  return /\.zip$/i.test(file.name);
 }
 
 function buildAvailablePlugins(

--- a/apps/web/src/styles/home/plugins-view.css
+++ b/apps/web/src/styles/home/plugins-view.css
@@ -867,11 +867,16 @@
   display: none;
 }
 
-.plugins-import-modal__file-error {
-  margin: -2px 0 0;
-  color: var(--danger, #d4543b);
-  font-size: 12px;
-  line-height: 1.35;
+.plugins-view__install-card .plugins-import-modal__file-error {
+  margin: 2px 0 0;
+  padding: 8px 10px;
+  border: 1px solid var(--red-border);
+  border-radius: var(--radius-sm);
+  background: var(--red-bg);
+  color: var(--red);
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 1.4;
 }
 
 .plugins-view__install-card p,

--- a/apps/web/src/styles/home/plugins-view.css
+++ b/apps/web/src/styles/home/plugins-view.css
@@ -852,13 +852,26 @@
   cursor: pointer;
 }
 
-.plugins-import-modal__file:hover {
+.plugins-import-modal__file:hover,
+.plugins-import-modal__file.is-drag-over {
   border-color: var(--border-strong);
   color: var(--text);
 }
 
+.plugins-import-modal__file.is-drag-over {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent-tint) 62%, var(--bg-subtle));
+}
+
 .plugins-import-modal__file input {
   display: none;
+}
+
+.plugins-import-modal__file-error {
+  margin: -2px 0 0;
+  color: var(--danger, #d4543b);
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 .plugins-view__install-card p,

--- a/apps/web/tests/components/PluginsView.test.tsx
+++ b/apps/web/tests/components/PluginsView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, createEvent, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { InstalledPluginRecord, PluginSourceKind, TrustTier } from '@open-design/contracts';
 import { PluginsView } from '../../src/components/PluginsView';
@@ -121,6 +121,7 @@ function fileDropDataTransfer(file: File): DataTransfer {
     types: ['Files'],
     files: [file],
     items: [],
+    dropEffect: 'copy',
   } as unknown as DataTransfer;
 }
 
@@ -851,6 +852,55 @@ describe('PluginsView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     await waitFor(() => expect(mockedUploadPluginZip).toHaveBeenCalledWith(zip));
+  });
+
+  it('prevents busy zip drag-over and drop without replacing the selected file', async () => {
+    let resolveUpload: ((outcome: Awaited<ReturnType<typeof uploadPluginZip>>) => void) | undefined;
+    mockedUploadPluginZip.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveUpload = resolve;
+        }),
+    );
+    render(<PluginsView />);
+
+    fireEvent.click(await screen.findByTestId('plugins-import-button'));
+    fireEvent.click(screen.getByRole('button', { name: /upload zip/i }));
+    const selected = new File(['selected'], 'selected-plugin.zip', { type: 'application/zip' });
+    fireEvent.change(screen.getByTestId('plugins-zip-input'), {
+      target: { files: [selected] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    await waitFor(() => expect(mockedUploadPluginZip).toHaveBeenCalledWith(selected));
+
+    const dropzone = screen.getByTestId('plugins-zip-dropzone');
+    const replacement = new File(['replacement'], 'replacement-plugin.zip', {
+      type: 'application/zip',
+    });
+    const dragOverTransfer = fileDropDataTransfer(replacement);
+    const dragOverEvent = createEvent.dragOver(dropzone, { dataTransfer: dragOverTransfer });
+    fireEvent(dropzone, dragOverEvent);
+
+    expect(dragOverEvent.defaultPrevented).toBe(true);
+    expect(dragOverTransfer.dropEffect).toBe('none');
+
+    const dropTransfer = fileDropDataTransfer(replacement);
+    const dropEvent = createEvent.drop(dropzone, { dataTransfer: dropTransfer });
+    const stopPropagation = vi.spyOn(dropEvent, 'stopPropagation');
+    fireEvent(dropzone, dropEvent);
+
+    expect(dropEvent.defaultPrevented).toBe(true);
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(dropTransfer.dropEffect).toBe('none');
+    expect(screen.getByText('selected-plugin.zip')).toBeTruthy();
+    expect(screen.queryByText('replacement-plugin.zip')).toBeNull();
+
+    resolveUpload?.({
+      ok: false,
+      warnings: [],
+      message: 'Import stopped for test.',
+      log: [],
+    });
   });
 
   it('preserves dropped folder relative paths before importing', async () => {

--- a/apps/web/tests/components/PluginsView.test.tsx
+++ b/apps/web/tests/components/PluginsView.test.tsx
@@ -103,6 +103,71 @@ const mockedApplyPlugin = vi.mocked(applyPlugin);
 const mockedUploadPluginFolder = vi.mocked(uploadPluginFolder);
 const mockedUploadPluginZip = vi.mocked(uploadPluginZip);
 
+interface MockPluginDropEntry {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+  file?: (success: (file: File) => void, error?: (error: DOMException) => void) => void;
+  createReader?: () => {
+    readEntries: (
+      success: (entries: MockPluginDropEntry[]) => void,
+      error?: (error: DOMException) => void,
+    ) => void;
+  };
+}
+
+function fileDropDataTransfer(file: File): DataTransfer {
+  return {
+    types: ['Files'],
+    files: [file],
+    items: [],
+  } as unknown as DataTransfer;
+}
+
+function entryDropDataTransfer(entry: MockPluginDropEntry): DataTransfer {
+  return {
+    types: ['Files'],
+    files: [],
+    items: [
+      {
+        kind: 'file',
+        getAsFile: () => null,
+        webkitGetAsEntry: () => entry,
+      },
+    ],
+  } as unknown as DataTransfer;
+}
+
+function mockFileEntry(name: string, file: File): MockPluginDropEntry {
+  return {
+    isFile: true,
+    isDirectory: false,
+    name,
+    file: (success) => success(file),
+  };
+}
+
+function mockDirectoryEntry(name: string, entries: MockPluginDropEntry[]): MockPluginDropEntry {
+  return {
+    isFile: false,
+    isDirectory: true,
+    name,
+    createReader: () => {
+      let read = false;
+      return {
+        readEntries: (success) => {
+          if (read) {
+            success([]);
+            return;
+          }
+          read = true;
+          success(entries);
+        },
+      };
+    },
+  };
+}
+
 beforeEach(() => {
   analyticsTrack.mockClear();
   mockedListPlugins.mockResolvedValue([
@@ -770,6 +835,66 @@ describe('PluginsView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Import' }));
     await waitFor(() => expect(mockedUploadPluginFolder).toHaveBeenCalledWith([folderFile]));
     expect(await screen.findByText('Installed Folder Plugin.')).toBeTruthy();
+  });
+
+  it('selects a dropped zip plugin before importing', async () => {
+    render(<PluginsView />);
+
+    fireEvent.click(await screen.findByTestId('plugins-import-button'));
+    fireEvent.click(screen.getByRole('button', { name: /upload zip/i }));
+    const zip = new File(['zip-bytes'], 'dragged-plugin.zip', { type: 'application/zip' });
+    fireEvent.drop(screen.getByTestId('plugins-zip-dropzone'), {
+      dataTransfer: fileDropDataTransfer(zip),
+    });
+
+    expect(await screen.findByText('dragged-plugin.zip')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => expect(mockedUploadPluginZip).toHaveBeenCalledWith(zip));
+  });
+
+  it('preserves dropped folder relative paths before importing', async () => {
+    render(<PluginsView />);
+
+    fireEvent.click(await screen.findByTestId('plugins-import-button'));
+    fireEvent.click(screen.getByRole('button', { name: /upload folder/i }));
+    const manifest = new File(['{}'], 'open-design.json', { type: 'application/json' });
+    const skill = new File(['# Skill'], 'SKILL.md', { type: 'text/markdown' });
+    const root = mockDirectoryEntry('sample-plugin', [
+      mockFileEntry('open-design.json', manifest),
+      mockDirectoryEntry('docs', [mockFileEntry('SKILL.md', skill)]),
+    ]);
+
+    fireEvent.drop(screen.getByTestId('plugins-folder-dropzone'), {
+      dataTransfer: entryDropDataTransfer(root),
+    });
+
+    expect(await screen.findByText('2 files selected')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => expect(mockedUploadPluginFolder).toHaveBeenCalledTimes(1));
+    const files = mockedUploadPluginFolder.mock.calls[0]?.[0] ?? [];
+    expect(files.map((file) => (file as File & { webkitRelativePath?: string }).webkitRelativePath)).toEqual([
+      'sample-plugin/open-design.json',
+      'sample-plugin/docs/SKILL.md',
+    ]);
+  });
+
+  it('rejects non-zip drops in the zip import panel', async () => {
+    render(<PluginsView />);
+
+    fireEvent.click(await screen.findByTestId('plugins-import-button'));
+    fireEvent.click(screen.getByRole('button', { name: /upload zip/i }));
+    const textFile = new File(['not a zip'], 'plugin.txt', { type: 'text/plain' });
+    fireEvent.drop(screen.getByTestId('plugins-zip-dropzone'), {
+      dataTransfer: fileDropDataTransfer(textFile),
+    });
+
+    expect(await screen.findByText('Drop a .zip plugin archive.')).toBeTruthy();
+    const importButton = screen.getByRole('button', { name: 'Import' });
+    expect(importButton.getAttribute('disabled')).not.toBeNull();
+    fireEvent.click(importButton);
+    expect(mockedUploadPluginZip).not.toHaveBeenCalled();
   });
 
   it('confirms a plugin share action before starting the GitHub repo task', async () => {

--- a/apps/web/tests/styles/plugin-import-error.test.ts
+++ b/apps/web/tests/styles/plugin-import-error.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const pluginsViewCss = readFileSync(
+  new URL('../../src/styles/home/plugins-view.css', import.meta.url),
+  'utf8',
+);
+
+function cssBlock(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(pluginsViewCss);
+  if (!match) throw new Error(`Missing CSS block for ${selector}`);
+  return match[1] ?? '';
+}
+
+function ruleValue(block: string, property: string): string {
+  const match = new RegExp(`(?:^|;)\\s*${property}:\\s*([^;]+);`).exec(block);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('plugin import error styles', () => {
+  it('keeps invalid-drop feedback prominent over generic install-card copy', () => {
+    const error = cssBlock('.plugins-view__install-card .plugins-import-modal__file-error');
+
+    expect(ruleValue(error, 'margin')).toBe('2px 0 0');
+    expect(ruleValue(error, 'padding')).toBe('8px 10px');
+    expect(ruleValue(error, 'border')).toBe('1px solid var(--red-border)');
+    expect(ruleValue(error, 'border-radius')).toBe('var(--radius-sm)');
+    expect(ruleValue(error, 'background')).toBe('var(--red-bg)');
+    expect(ruleValue(error, 'color')).toBe('var(--red)');
+    expect(ruleValue(error, 'font-size')).toBe('12.5px');
+    expect(ruleValue(error, 'font-weight')).toBe('600');
+  });
+});


### PR DESCRIPTION
Fixes #5230

## Why

I hit this while improving the Plugins import flow: when a plugin archive or folder is already visible in Finder or another file manager, the current `Import plugin` modal still forces users through the OS file picker.

The pain is small but frequent: the upload area looks like a natural drop target, yet dropping a plugin zip or folder there currently does nothing. This PR keeps the existing picker flow but makes that same area accept drag-and-drop selection.

## What users will see

In Plugins → Import plugin:

- `Upload zip` still opens the existing file picker, and the upload area now also accepts a dropped `.zip` file.
- `Upload folder` still opens the existing folder picker, and the upload area now also accepts a dropped folder or multiple dropped files.
- Dropping files only selects them. Users still click `Import` to install, matching the existing picker behavior.
- Invalid non-zip drops in the zip tab show a small inline error and keep `Import` disabled.
- While dragging over the upload area, the drop target is visually highlighted.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

**Upload zip drop zone**

<img width="760" height="456" alt="image" src="https://github.com/user-attachments/assets/7b507e1a-2625-4ac6-bf9f-5ee846a69b17" />

**Upload folder drop zone**

<img width="760" height="456" alt="image" src="https://github.com/user-attachments/assets/578ee84a-9d7b-4522-bcca-26c06f0a6116" />


## Bug fix verification

-

## Validation

- `pnpm --dir apps/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/PluginsView.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
