### PR TITLE
docs: fix claude stream parser links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ Hooking up a new agent (e.g. some new shop's `foo-coder` CLI) is one entry in [`
 }
 ```
 
-That's it — daemon will detect it on `PATH`, the picker shows it, the chat path works. If the CLI emits **typed events** (like Claude Code's `--output-format stream-json`), wire a parser in [`apps/daemon/src/claude-stream.ts`](apps/daemon/src/claude-stream.ts) and set `streamFormat: 'claude-stream-json'`.
+That's it — daemon will detect it on `PATH`, the picker shows it, the chat path works. If the CLI emits **typed events** (like Claude Code's `--output-format stream-json`), wire a parser in [`apps/daemon/src/runtimes/claude-stream.ts`](apps/daemon/src/runtimes/claude-stream.ts) and set `streamFormat: 'claude-stream-json'`.
 
 Bar for merging:
 

--- a/docs/i18n/CONTRIBUTING.de.md
+++ b/docs/i18n/CONTRIBUTING.de.md
@@ -181,7 +181,7 @@ Eine neue Agent-CLI ist ein Eintrag in [`apps/daemon/src/agents.ts`](../../apps/
 }
 ```
 
-Der daemon erkennt sie im `PATH`, der Picker zeigt sie an und der Chat-Pfad funktioniert. Wenn die CLI **typed events** ausgibt, ergänzen Sie einen Parser in [`apps/daemon/src/claude-stream.ts`](../../apps/daemon/src/claude-stream.ts) und setzen `streamFormat`.
+Der daemon erkennt sie im `PATH`, der Picker zeigt sie an und der Chat-Pfad funktioniert. Wenn die CLI **typed events** ausgibt, ergänzen Sie einen Parser in [`apps/daemon/src/runtimes/claude-stream.ts`](../../apps/daemon/src/runtimes/claude-stream.ts) und setzen `streamFormat`.
 
 Merge-Bar:
 

--- a/docs/i18n/CONTRIBUTING.fr.md
+++ b/docs/i18n/CONTRIBUTING.fr.md
@@ -255,7 +255,7 @@ une entrée dans [`apps/daemon/src/agents.ts`](../../apps/daemon/src/agents.ts) 
 C'est tout : le daemon la détecte dans le `PATH`, le picker l'affiche et le
 chemin chat fonctionne. Si la CLI émet des **typed events** (comme
 `--output-format stream-json` de Claude Code), ajoutez un parser dans
-[`apps/daemon/src/claude-stream.ts`](../../apps/daemon/src/claude-stream.ts) et mettez
+[`apps/daemon/src/runtimes/claude-stream.ts`](../../apps/daemon/src/runtimes/claude-stream.ts) et mettez
 `streamFormat: 'claude-stream-json'`.
 
 Critères de merge :

--- a/docs/i18n/CONTRIBUTING.ja-JP.md
+++ b/docs/i18n/CONTRIBUTING.ja-JP.md
@@ -183,7 +183,7 @@ design-systems/your-brand/
 }
 ```
 
-これだけです — daemon が `PATH` 上で検出し、ピッカーに表示され、チャットパスが動作します。CLI が**型付きイベント**を出力する場合（Claude Code の `--output-format stream-json` のように）、[`apps/daemon/src/claude-stream.ts`](../../apps/daemon/src/claude-stream.ts) にパーサーを追加して `streamFormat: 'claude-stream-json'` を設定してください。
+これだけです — daemon が `PATH` 上で検出し、ピッカーに表示され、チャットパスが動作します。CLI が**型付きイベント**を出力する場合（Claude Code の `--output-format stream-json` のように）、[`apps/daemon/src/runtimes/claude-stream.ts`](../../apps/daemon/src/runtimes/claude-stream.ts) にパーサーを追加して `streamFormat: 'claude-stream-json'` を設定してください。
 
 マージ基準：
 

--- a/docs/i18n/CONTRIBUTING.ko.md
+++ b/docs/i18n/CONTRIBUTING.ko.md
@@ -185,7 +185,7 @@ design-systems/your-brand/
 }
 ```
 
-이게 전부입니다. daemon이 `PATH`에서 감지하고, picker에 나타나며, 채팅 경로가 동작합니다. CLI가 (Claude Code의 `--output-format stream-json`처럼) **타입이 지정된 이벤트**를 내보낸다면 [`apps/daemon/src/claude-stream.ts`](../../apps/daemon/src/claude-stream.ts)에 파서를 연결하고 `streamFormat: 'claude-stream-json'`으로 설정하세요.
+이게 전부입니다. daemon이 `PATH`에서 감지하고, picker에 나타나며, 채팅 경로가 동작합니다. CLI가 (Claude Code의 `--output-format stream-json`처럼) **타입이 지정된 이벤트**를 내보낸다면 [`apps/daemon/src/runtimes/claude-stream.ts`](../../apps/daemon/src/runtimes/claude-stream.ts)에 파서를 연결하고 `streamFormat: 'claude-stream-json'`으로 설정하세요.
 
 머지 기준:
 

--- a/docs/i18n/CONTRIBUTING.pt-BR.md
+++ b/docs/i18n/CONTRIBUTING.pt-BR.md
@@ -183,7 +183,7 @@ Plugar um novo agente (por exemplo, o CLI `foo-coder` de alguma loja nova) é um
 }
 ```
 
-É só isso — o daemon detecta no `PATH`, o picker mostra, o caminho de chat funciona. Se o CLI emite **eventos tipados** (como o `--output-format stream-json` do Claude Code), conecte um parser em [`apps/daemon/src/claude-stream.ts`](../../apps/daemon/src/claude-stream.ts) e defina `streamFormat: 'claude-stream-json'`.
+É só isso — o daemon detecta no `PATH`, o picker mostra, o caminho de chat funciona. Se o CLI emite **eventos tipados** (como o `--output-format stream-json` do Claude Code), conecte um parser em [`apps/daemon/src/runtimes/claude-stream.ts`](../../apps/daemon/src/runtimes/claude-stream.ts) e defina `streamFormat: 'claude-stream-json'`.
 
 Barra para mergear:
 

--- a/docs/i18n/CONTRIBUTING.th.md
+++ b/docs/i18n/CONTRIBUTING.th.md
@@ -185,7 +185,7 @@ Product systems 69 ชุดที่เรา ship import จาก [`VoltAgent
 }
 ```
 
-เท่านี้ — daemon จะ detect บน `PATH`, picker จะแสดง, chat path จะใช้งานได้. ถ้า CLI emit **typed events** (เหมือน `--output-format stream-json` ของ Claude Code), ให้ wire parser ใน [`apps/daemon/src/claude-stream.ts`](../../apps/daemon/src/claude-stream.ts) และตั้ง `streamFormat: 'claude-stream-json'`.
+เท่านี้ — daemon จะ detect บน `PATH`, picker จะแสดง, chat path จะใช้งานได้. ถ้า CLI emit **typed events** (เหมือน `--output-format stream-json` ของ Claude Code), ให้ wire parser ใน [`apps/daemon/src/runtimes/claude-stream.ts`](../../apps/daemon/src/runtimes/claude-stream.ts) และตั้ง `streamFormat: 'claude-stream-json'`.
 
 Bar สำหรับ merge:
 

--- a/docs/i18n/CONTRIBUTING.zh-CN.md
+++ b/docs/i18n/CONTRIBUTING.zh-CN.md
@@ -182,7 +182,7 @@ design-systems/your-brand/
 }
 ```
 
-完事 —— daemon 会在 `PATH` 上检测到它、picker 显示出来、对话路径就通了。如果这个 CLI 吐 **类型化事件**（像 Claude Code 的 `--output-format stream-json`），在 [`apps/daemon/src/claude-stream.ts`](../../apps/daemon/src/claude-stream.ts) 里写一个 parser，并把 `streamFormat` 设成 `'claude-stream-json'`。
+完事 —— daemon 会在 `PATH` 上检测到它、picker 显示出来、对话路径就通了。如果这个 CLI 吐 **类型化事件**（像 Claude Code 的 `--output-format stream-json`），在 [`apps/daemon/src/runtimes/claude-stream.ts`](../../apps/daemon/src/runtimes/claude-stream.ts) 里写一个 parser，并把 `streamFormat` 设成 `'claude-stream-json'`。
 
 合并硬线：
 


### PR DESCRIPTION
## Why

The contributing guide still pointed adapter contributors to `apps/daemon/src/claude-stream.ts`, but the Claude stream parser now lives at `apps/daemon/src/runtimes/claude-stream.ts`. That made the parser link stale in the root guide and localized contributing docs.

## What users will see

No product UI change. Contributors reading the contributing docs get a working link to the Claude stream parser file.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A, docs-only change.

## Bug fix verification

N/A, docs-only link fix.

## Validation

- `git diff --cached --check`
- `test -f apps/daemon/src/runtimes/claude-stream.ts`
- `rg -n "apps/daemon/src/claude-stream\\.ts|apps/daemon/src/runtimes/claude-stream\\.ts" CONTRIBUTING.md docs/i18n/CONTRIBUTING.*.md`