### PR TITLE
fix(daemon): stop the memory extractor re-mining turns and mining raw transport

### DIFF
--- a/apps/daemon/src/memory-llm.ts
+++ b/apps/daemon/src/memory-llm.ts
@@ -1143,10 +1143,18 @@ async function collectProposedEntries(dataDir, input, options) {
   // retry produces its reply on that attempt, and must still be mined. The
   // signature is recorded only AFTER a successful provider call (below), so a
   // failed or no-provider extraction never permanently marks the turn as seen.
+  //
+  // Gate is scoped to a REAL conversation id. Callers that don't thread one —
+  // e.g. the BYOK/API-mode `/api/memory/extract` post-turn path — get no
+  // de-dup at all, because an empty fallback key would be shared across every
+  // such caller and collapse identical (message, reply) pairs from unrelated
+  // conversations into a single skipped extraction. The chat close hook that
+  // caused the re-fire storm always passes `run.conversationId`, so its
+  // protection is preserved.
   const conversationKey =
     typeof options?.conversationId === 'string' ? options.conversationId : '';
   let turnSignature = null;
-  if (extractionKind === 'llm') {
+  if (extractionKind === 'llm' && conversationKey) {
     turnSignature = llmTurnSignature(conversationKey, userMessage, input?.assistantMessage);
     if (recentLlmTurnSignatures.has(turnSignature)) {
       return { status: 'skipped', attemptId: null, proposed: [], existingEntries: [] };

--- a/apps/daemon/src/memory-llm.ts
+++ b/apps/daemon/src/memory-llm.ts
@@ -64,6 +64,7 @@ import { resolveProviderConfig } from './media/config.js';
 import { AIHUBMIX_APP_CODE } from './integrations/aihubmix.js';
 import { spawn } from 'node:child_process';
 import os from 'node:os';
+import { createHash } from 'node:crypto';
 import { createCommandInvocation } from '@open-design/platform';
 import {
   applyAgentLaunchEnv,
@@ -1062,6 +1063,46 @@ function toMemoryDraft(candidate) {
   };
 }
 
+// Duplicate-turn de-duplication for chat ('llm') extraction. The daemon fires
+// the extractor from a run's child-close hook, so a turn that is re-fed —
+// retried, re-posted, or re-ground during a long build — re-enters here with the
+// same (conversation, user message, rendered reply). A failed/out-of-credits
+// attempt yields an empty reply, so the whole re-fire storm shares one signature
+// and collapses to a single pass. The signature is keyed by conversation, so an
+// identical message+reply in a different conversation is still examined, and it
+// is recorded only AFTER a provider call succeeds (see collectProposedEntries) —
+// a failed or no-provider attempt must not permanently mark a turn as seen. The
+// set is bounded, and process-lifetime only: a restart is a fine reason to
+// re-examine a turn.
+const RECENT_LLM_TURN_LIMIT = 256;
+const recentLlmTurnSignatures = new Set();
+
+function llmTurnSignature(conversationKey, userMessage, assistantMessage) {
+  // JSON-encode the parts so the (conversation, message, reply) boundaries are
+  // unambiguous without a separator byte the content itself could contain.
+  return createHash('sha256')
+    .update(JSON.stringify([
+      String(conversationKey ?? ''),
+      String(userMessage ?? ''),
+      String(assistantMessage ?? ''),
+    ]))
+    .digest('hex');
+}
+
+function rememberLlmTurnSignature(signature) {
+  recentLlmTurnSignatures.add(signature);
+  if (recentLlmTurnSignatures.size > RECENT_LLM_TURN_LIMIT) {
+    // Evict the oldest (insertion order) so the working set stays bounded.
+    const oldest = recentLlmTurnSignatures.values().next().value;
+    if (oldest !== undefined) recentLlmTurnSignatures.delete(oldest);
+  }
+}
+
+// Test-only — reset the duplicate-turn de-dup set so specs start from a clean slate.
+export function __resetMemoryTurnDedupeForTests() {
+  recentLlmTurnSignatures.clear();
+}
+
 async function collectProposedEntries(dataDir, input, options) {
   const projectRoot = options?.projectRoot ?? null;
   const chatAgentId = options?.chatAgentId ?? null;
@@ -1090,6 +1131,26 @@ async function collectProposedEntries(dataDir, input, options) {
   if (userMessage.length === 0) {
     recordSkip({ userMessage, reason: 'empty-message', kind: extractionKind });
     return { status: 'skipped', attemptId: null, proposed: [], existingEntries: [] };
+  }
+
+  // Duplicate-turn gate — skip BEFORE picking a provider so no LLM call is spent
+  // re-mining a turn already extracted. The daemon fires this from the run's
+  // child-close hook, which re-runs on every retry / re-fed attempt of the same
+  // turn (a long out-of-credits build re-analyzed one turn dozens of times). A
+  // failed attempt has an empty reply, so its (conversation, message, "")
+  // signature is identical across the storm and collapses to a single pass.
+  // Deliberately NOT gated on retryAttemptCount: a turn that only succeeds on a
+  // retry produces its reply on that attempt, and must still be mined. The
+  // signature is recorded only AFTER a successful provider call (below), so a
+  // failed or no-provider extraction never permanently marks the turn as seen.
+  const conversationKey =
+    typeof options?.conversationId === 'string' ? options.conversationId : '';
+  let turnSignature = null;
+  if (extractionKind === 'llm') {
+    turnSignature = llmTurnSignature(conversationKey, userMessage, input?.assistantMessage);
+    if (recentLlmTurnSignatures.has(turnSignature)) {
+      return { status: 'skipped', attemptId: null, proposed: [], existingEntries: [] };
+    }
   }
 
   const provider = await pickProvider(
@@ -1177,6 +1238,10 @@ async function collectProposedEntries(dataDir, input, options) {
     return { status: 'failed', attemptId, proposed: [], existingEntries };
   }
   markProposed(attemptId, proposed.length);
+  // Provider call succeeded (even an empty extraction) — now safe to remember
+  // this turn so identical re-fires skip. Recording here, not before the call,
+  // means a failed / no-provider attempt can still be retried for this turn.
+  if (turnSignature) rememberLlmTurnSignature(turnSignature);
   return { status: 'ok', attemptId, proposed, existingEntries };
 }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6181,6 +6181,17 @@ export async function startServer({
     const CLARIFYING_QUESTION_BUFFER_CAP = 256 * 1024;
     let clarifyingQuestionText = '';
     let visibleAssistantText = '';
+    // Reply text handed to the background memory extractor at child-close.
+    // Captures the GUARDED, visible reply from BOTH channels a run can emit on:
+    // structured agents' `agent` `text_delta` (Claude/Codex/Gemini/Copilot/ACP/
+    // qoder/pi-rpc) and the plain/BYOK/antigravity family's `stdout` chunks. So
+    // every agent family contributes its actual reply, and none leak raw
+    // transport frames (system:init, stream_event, hooks). Kept separate from
+    // `visibleAssistantText` so the filesystem empty-output guard that reads
+    // that variable keeps its text_delta-only semantics. Bounded — the
+    // extractor only needs the head of the reply.
+    const MEMORY_REPLY_CAP = 32 * 1024;
+    let memoryReplyText = '';
     const send = (event, data) => {
       const lifecycleMarkers = runLifecycleMarkersForStreamEvent(event, data);
       if (lifecycleMarkers.firstModelEventType) {
@@ -6211,6 +6222,22 @@ export async function startServer({
         typeof data.delta === 'string'
       ) {
         visibleAssistantText += data.delta;
+      }
+      // Accumulate the visible reply for the memory extractor from whichever
+      // channel this agent family uses: `agent` text_delta (structured streams)
+      // or `stdout` chunks (plain/BYOK/antigravity). Both carry already-guarded,
+      // user-visible text, so this never captures thinking, tool traffic, or raw
+      // transport frames.
+      if (memoryReplyText.length < MEMORY_REPLY_CAP) {
+        const replyPiece =
+          event === 'agent' && data && data.type === 'text_delta' && typeof data.delta === 'string'
+            ? data.delta
+            : event === 'stdout' && data && typeof data.chunk === 'string'
+              ? data.chunk
+              : '';
+        if (replyPiece) {
+          memoryReplyText = (memoryReplyText + replyPiece).slice(0, MEMORY_REPLY_CAP);
+        }
       }
       persistRunEventToAssistantMessage(db, run, event, data);
       design.runs.emit(run, event, data);
@@ -7456,22 +7483,15 @@ export async function startServer({
       agentStdoutTail = `${agentStdoutTail}${chunk}`.slice(-2000);
     });
 
-    // ---- Memory: assistant-reply buffer for LLM extraction --------------
-    // Capture up to 32 KiB of raw stdout. The LLM extractor (fired in the
-    // close handler) trims further; we only need enough to ground the
-    // model. Multiple `on('data')` listeners coexist — the wrapper-stream
-    // handlers below also subscribe and that's fine.
-    const MEMORY_BUFFER_CAP = 32 * 1024;
-    let memoryAssistantBuffer = '';
-    child.stdout.on('data', (chunk) => {
-      if (memoryAssistantBuffer.length >= MEMORY_BUFFER_CAP) return;
-      memoryAssistantBuffer += String(chunk);
-      if (memoryAssistantBuffer.length > MEMORY_BUFFER_CAP) {
-        memoryAssistantBuffer = memoryAssistantBuffer.slice(0, MEMORY_BUFFER_CAP);
-      }
-    });
+    // ---- Memory: assistant-reply capture for LLM extraction --------------
+    // Hand the extractor the guarded, rendered reply (`memoryReplyText`, fed
+    // through `send()` from either the `agent` text_delta or the `stdout`
+    // channel), NOT the child's raw stdout. For stream-json agents (Claude Code)
+    // raw stdout is JSONL transport — system:init, stream_event thinking deltas,
+    // hook_started/hook_response frames — none of which is the reply; mining it
+    // produced empty extractions that, near-identical across a build's re-fires,
+    // caused the same turn to be re-analyzed dozens of times.
     child.on('close', () => {
-      const captured = memoryAssistantBuffer;
       const userMsg = typeof message === 'string' ? message : '';
       // Forward the chat agent id so memory-llm.pickProvider can
       // constrain its auto-pick to the chat protocol's family — keeps
@@ -7482,9 +7502,19 @@ export async function startServer({
         projectRoot: PROJECT_ROOT,
         chatAgentId: typeof agentId === 'string' ? agentId : null,
         chatModel: typeof safeModel === 'string' ? safeModel : null,
+        // Scope the extractor's duplicate-turn de-dup to this conversation, so a
+        // re-fired turn collapses but an identical (message, reply) in another
+        // conversation is still examined.
+        conversationId: run.conversationId ?? null,
       };
       void import('./memory-llm.js')
         .then(({ extractWithLLM, distillAnnotationsToMemory }) => {
+          // Read the reply HERE, in the post-import microtask, not in the
+          // synchronous close handler: the Claude stream flush is a later
+          // 'close' listener, so deferring the read lets flush() emit the reply's
+          // final buffered frame first and a reply that ends without a trailing
+          // newline isn't truncated.
+          const captured = memoryReplyText;
           const generalPass = extractWithLLM(
             RUNTIME_DATA_DIR,
             {

--- a/apps/daemon/tests/memory-llm-dedupe.test.ts
+++ b/apps/daemon/tests/memory-llm-dedupe.test.ts
@@ -1,0 +1,192 @@
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  extractWithLLM,
+  __resetMemoryTurnDedupeForTests,
+} from '../src/memory-llm.js';
+import { memoryDir, writeMemoryConfig } from '../src/memory.js';
+import { __resetExtractionsForTests } from '../src/memory-extractions.js';
+import { createClaudeStreamHandler } from '../src/runtimes/claude-stream.js';
+
+// These specs pin the two halves of the memory-extractor fix:
+//   - the cost half: a turn already extracted (a retry / re-fed build re-fire)
+//     must NOT reach the provider a second time; and
+//   - the correctness half: the "## Assistant reply" the extractor mines must be
+//     the model's rendered reply, never the child's raw stdout (JSONL transport:
+//     system:init, stream_event, hook_started/hook_response).
+// They also cover the guards found in review: a failed extraction must not
+// permanently skip the turn, and the de-dup must be scoped per conversation.
+
+const dataDir = path.join(
+  process.env.OD_DATA_DIR ?? process.cwd(),
+  'memory-llm-dedupe-test',
+);
+const originalFetch = globalThis.fetch;
+
+// An OpenAI chat-completions success returning an empty (valid) extraction.
+function okResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({ entries: [] }) } }],
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+function mockOpenAiOk(): void {
+  globalThis.fetch = vi.fn(async () => okResponse()) as typeof fetch;
+}
+
+// Reduce a Claude stream-json transcript to the visible reply exactly the way
+// the daemon does: parse the raw stdout frames and keep only `text_delta`
+// deltas. `memoryReplyText` in server.ts is this same concatenation (plus the
+// plain/BYOK `stdout` channel, which structured agents don't use).
+function renderVisibleReply(rawStdout: string): string {
+  const events: Array<Record<string, unknown>> = [];
+  const handler = createClaudeStreamHandler((ev) => events.push(ev));
+  handler.feed(rawStdout);
+  handler.flush();
+  return events
+    .filter((e) => e.type === 'text_delta' && typeof e.delta === 'string')
+    .map((e) => e.delta as string)
+    .join('');
+}
+
+describe('memory-llm chat extraction: duplicate-turn gate + reply serialization', () => {
+  beforeEach(async () => {
+    await fsp.rm(memoryDir(dataDir), { recursive: true, force: true });
+    __resetExtractionsForTests();
+    __resetMemoryTurnDedupeForTests();
+    await writeMemoryConfig(dataDir, {
+      extraction: { provider: 'openai', apiKey: 'sk-test', model: 'gpt-4o-mini' },
+    });
+    mockOpenAiOk();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('re-invoking with an unchanged turn early-returns with no second LLM call', async () => {
+    const turn = {
+      userMessage: 'I always work in dark mode — keep UIs dark by default.',
+      assistantMessage: 'Understood — I will default new UIs to dark mode.',
+    };
+    const opts = { projectRoot: process.cwd(), conversationId: 'conv-1' };
+
+    await extractWithLLM(dataDir, turn, opts);
+    await extractWithLLM(dataDir, turn, opts);
+
+    // The second pass over the identical turn is skipped before the provider call.
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT permanently skip a turn whose extraction failed (records only after success)', async () => {
+    // First provider call fails (rate-limited / out of credits); second succeeds.
+    let calls = 0;
+    globalThis.fetch = vi.fn(async () => {
+      calls += 1;
+      return calls === 1 ? new Response('upstream error', { status: 500 }) : okResponse();
+    }) as typeof fetch;
+
+    const turn = { userMessage: 'Remember I ship on Fridays.', assistantMessage: 'Noted.' };
+    const opts = { projectRoot: process.cwd(), conversationId: 'conv-2' };
+
+    await extractWithLLM(dataDir, turn, opts); // fails — must not record the signature
+    await extractWithLLM(dataDir, turn, opts); // retried — must reach the provider again
+
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it('still extracts a genuinely different reply to the same user message', async () => {
+    const opts = { projectRoot: process.cwd(), conversationId: 'conv-3' };
+    await extractWithLLM(
+      dataDir,
+      { userMessage: 'What did you change?', assistantMessage: 'Renamed the primary button.' },
+      opts,
+    );
+    await extractWithLLM(
+      dataDir,
+      { userMessage: 'What did you change?', assistantMessage: 'Reworked the entire nav layout.' },
+      opts,
+    );
+
+    // Distinct replies are distinct turns — both reach the provider.
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not skip an identical turn that occurs in a different conversation', async () => {
+    const turn = { userMessage: 'Same message.', assistantMessage: 'Same reply.' };
+    await extractWithLLM(dataDir, turn, { projectRoot: process.cwd(), conversationId: 'conv-A' });
+    await extractWithLLM(dataDir, turn, { projectRoot: process.cwd(), conversationId: 'conv-B' });
+
+    // De-dup is scoped per conversation, so a different conversation is examined.
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it('feeds the rendered reply — not raw stream transport — as "## Assistant reply"', async () => {
+    // A realistic Claude stream-json stdout capture: session bootstrap noise,
+    // a resume hook, extended thinking, then the actual reply text.
+    const rawStdout = [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sess-1',
+        tools: ['Read', 'Edit', 'Bash'],
+        mcp_servers: [],
+      }),
+      JSON.stringify({
+        type: 'system',
+        subtype: 'hook_started',
+        hook_name: 'SessionStart:resume',
+        session_id: 'sess-1',
+      }),
+      JSON.stringify({ type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-1' } } }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'thinking_delta', thinking: 'They want the CTA in the brand green token.' },
+        },
+      }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'text_delta', text: 'I set the primary CTA to the brand green token.' },
+        },
+      }),
+    ].join('\n') + '\n';
+
+    const rendered = renderVisibleReply(rawStdout);
+    // Sanity: the parser yields the reply text and strips all transport frames.
+    expect(rendered).toBe('I set the primary CTA to the brand green token.');
+    expect(rendered).not.toContain('"type":"system"');
+    expect(rendered).not.toContain('hook_started');
+
+    await extractWithLLM(
+      dataDir,
+      { userMessage: 'Make the CTA pop.', assistantMessage: rendered },
+      { projectRoot: process.cwd(), conversationId: 'conv-serialize' },
+    );
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    const body = JSON.parse(String((init as RequestInit)?.body));
+    const userPayload: string = body.messages[1].content;
+
+    // The reply the model is asked to mine is the rendered text under the
+    // "## Assistant reply" heading — and carries none of the raw JSONL
+    // transport that the old raw-stdout capture leaked in.
+    expect(userPayload).toContain('## Assistant reply');
+    expect(userPayload).toContain('I set the primary CTA to the brand green token.');
+    expect(userPayload).not.toContain('"subtype":"init"');
+    expect(userPayload).not.toContain('hook_started');
+    expect(userPayload).not.toContain('stream_event');
+    expect(userPayload).not.toContain('"type":"system"');
+  });
+});

--- a/apps/daemon/tests/memory-llm-dedupe.test.ts
+++ b/apps/daemon/tests/memory-llm-dedupe.test.ts
@@ -127,6 +127,19 @@ describe('memory-llm chat extraction: duplicate-turn gate + reply serialization'
     expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
   });
 
+  it('does NOT de-dup when no conversation id is supplied (BYOK/API-mode HTTP path)', async () => {
+    // The `/api/memory/extract` post-turn path invokes extractWithLLM without a
+    // conversationId. An empty fallback key would be shared across every such
+    // caller, so an identical (message, reply) pair from two unrelated
+    // conversations would collide and the second would be wrongly skipped.
+    // With no real conversation id the gate is disabled, so both are examined.
+    const turn = { userMessage: 'Same HTTP message.', assistantMessage: 'Same HTTP reply.' };
+    await extractWithLLM(dataDir, turn, { projectRoot: process.cwd() });
+    await extractWithLLM(dataDir, turn, { projectRoot: process.cwd() });
+
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+  });
+
   it('feeds the rendered reply — not raw stream transport — as "## Assistant reply"', async () => {
     // A realistic Claude stream-json stdout capture: session bootstrap noise,
     // a resume hook, extended thinking, then the actual reply text.


### PR DESCRIPTION
## Why

While auditing background LLM spend I found the daemon's memory extractor
(headless SDK sessions that decide what to persist to typed memory) was the
single largest source of wasted tokens over Jul 2–4: ~3.66M tokens across 38
runs, ~3.4M of it wasted, during a period the account was out of credits.

Two defects combined to cause it:

1. **Duplicate re-fires.** The extractor is fired from a run's child-close
   hook, so a turn that is retried or re-ground during a long autonomous build
   re-enters extraction with the *same* user message + reply. One turn was
   re-analyzed ~33 times. Each pass paid for a full provider call to
   re-confirm "nothing new."
2. **Wrong reply content.** The "## Assistant reply" the extractor mines was
   built from the child's raw stdout — i.e. JSONL transport frames
   (`system:init`, `stream_event`, `hook_started`/`hook_response`) — instead of
   the model's rendered reply. So every extraction was both wasteful *and*
   mining the wrong text.

## What users will see

No visible UI or CLI change. This is an internal correctness + cost fix to the
background memory extractor:

- A turn that has already been extracted is no longer re-sent to the provider,
  so long autonomous builds and retries stop silently burning tokens.
- The extractor now mines the model's actual rendered reply, so the memories it
  proposes reflect what the assistant really said rather than transport noise.

Extraction that genuinely has new content to mine (a different reply, the same
turn in a different conversation, or a turn that only succeeds on retry) still
runs exactly as before.

## Surface area

- [x] **None** — internal daemon bug fix (background memory extractor) + its
  red-spec test. No UI, CLI, API/contract, i18n, or dependency surface.

## Bug fix verification

- Test path: `apps/daemon/tests/memory-llm-dedupe.test.ts` (5 specs).
- Red/green: the test depends on a new test-only export
  (`__resetMemoryTurnDedupeForTests`), so it can't run against unmodified
  `main` directly. Instead each fix was confirmed falsifiable on the branch by
  neutralizing it and watching its spec go red:
  - dedup gate (cost half) — re-invoking an unchanged turn must not call the
    provider twice;
  - record-after-success — a failed/out-of-credits attempt must NOT permanently
    skip the turn;
  - per-conversation scope — an identical turn in a different conversation is
    still examined;
  - reply serialization (correctness half) — the "## Assistant reply" payload
    contains the rendered text and none of the raw JSONL transport
    (`"type":"system"`, `hook_started`, `stream_event`).

## Validation

- `pnpm guard` — green (71/71).
- `pnpm --filter @open-design/daemon typecheck` — green.
- Memory suite (the changed source's blast radius) —
  `vitest run tests/memory-*.test.ts`: 41 passed, only the 2 pre-existing
  `memory-connectors` specs fail (they import neither changed module).
- Full `pnpm --filter @open-design/daemon test` on Windows native: the 177
  failures are real-daemon integration/smoke suites (POSIX IPC sockets, live
  subprocess spawns — `run … did not finish`), i.e. the Windows-native
  best-effort surface; 5187 pass, including the run/streaming tests that
  exercise the `send()` path this PR touches. CI (Linux) is the authoritative
  full-suite gate.
- Pre-existing failures, not introduced here:
  - `apps/web` `FileViewer.srcdoc-reload-races.test.tsx` typecheck
    (`toBeInTheDocument` matcher typing) — web-only, untouched by this diff.
  - 2 `memory-connectors` specs (Local-CLI runner path) — red on `main`.

## Adjacent issues (out of scope)

- #5162 — memory-llm hardcoded to `gpt-4o-mini`, breaks silently for
  non-OpenAI BYOK providers. Same file, different defect; left for its own PR.
- The 2 pre-existing `memory-connectors` failures above.
