### PR TITLE
feat(updater): route to installer when a release outgrows this build

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1017,6 +1017,41 @@ function selectUpdateCandidateWithFallback(
   return selectUpdateCandidate(metadata, config);
 }
 
+function controlLauncherVersionMin(metadata: Record<string, unknown>): string | null {
+  const control = objectField(metadata, "control");
+  const launcher = control == null ? null : objectField(control, "launcher");
+  const version = launcher == null ? null : objectField(launcher, "version");
+  return version == null ? null : stringField(version, "min");
+}
+
+/**
+ * Installed-base escape hatch: decide whether the remote release is beyond what
+ * this build can adopt as an in-place payload update, forcing a full installer
+ * instead. Two orthogonal guardrails, either of which trips → installer:
+ *
+ *  - `launcher.schema` (ABI axis): the release declares a launcher-contract schema
+ *    number this build cannot interpret (`feed.launcher.schema >
+ *    LAUNCHER_SCHEMA_VERSION`). This is the reseed boundary — a pure int compare.
+ *  - `control.launcher.version.min` (recency axis): the release requires a
+ *    launcher/build version newer than this one (`min > currentVersion`).
+ *
+ * Both are feed declarations read here; a future launcher enforces the same schema
+ * floor locally against on-disk manifests. Missing/malformed fields are ignored
+ * (fail-open) so older feeds keep updating seamlessly.
+ */
+export function remoteRequiresReinstall(metadata: Record<string, unknown>, config: DesktopUpdaterConfig): boolean {
+  const launcher = objectField(metadata, "launcher");
+  const remoteLauncherSchema = launcher == null ? undefined : numberField(launcher, "schema");
+  if (remoteLauncherSchema != null && remoteLauncherSchema > LAUNCHER_SCHEMA_VERSION) {
+    return true;
+  }
+  const minVersion = controlLauncherVersionMin(metadata);
+  if (minVersion != null && compareVersions(minVersion, config.currentVersion) > 0) {
+    return true;
+  }
+  return false;
+}
+
 async function fetchJson(fetchImpl: typeof globalThis.fetch, url: string): Promise<Record<string, unknown>> {
   const response = await fetchImpl(url);
   if (!response.ok) throw new Error(`metadata request returned HTTP ${response.status}`);
@@ -2623,7 +2658,15 @@ export function createDesktopUpdater(
         lastCheckedAt,
       }));
       if (root != null) scheduleBackCleanup(root.realRoot, logger);
-      const selected = selectUpdateCandidateWithFallback(body, config, await hasValidLauncherPayloadContext(config));
+      const launcherPayloadContextValid = await hasValidLauncherPayloadContext(config);
+      const reseedRequired = launcherPayloadContextValid && remoteRequiresReinstall(body, config);
+      if (reseedRequired) {
+        logUpdateEvent("reseed-required-installer-route", {
+          currentVersion: config.currentVersion,
+          supportedLauncherSchema: LAUNCHER_SCHEMA_VERSION,
+        });
+      }
+      const selected = selectUpdateCandidateWithFallback(body, config, launcherPayloadContextValid && !reseedRequired);
       if (!selected.ok) return setState(selected.state, selected.error);
       if (compareVersions(selected.candidate.version, config.currentVersion) <= 0) {
         logUpdateEvent("check-not-available", { candidateVersion: selected.candidate.version });

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -87,9 +87,11 @@ function channelMetadata(channel: FixtureChannel, version: string): Record<strin
 async function createUpdaterFixture(options: {
   artifactBody?: string;
   channel?: FixtureChannel;
+  controlLauncherVersionMin?: string;
   failArtifactAttempts?: number;
   failFirstArtifactWithTerminated?: boolean;
   includePayload?: boolean;
+  launcherSchema?: number;
   platform?: FixturePlatform;
   payloadBody?: string;
   version?: string;
@@ -124,6 +126,10 @@ async function createUpdaterFixture(options: {
       response.end(JSON.stringify({
         channel,
         ...channelMetadata(channel, version),
+        ...(options.launcherSchema != null ? { launcher: { schema: options.launcherSchema } } : {}),
+        ...(options.controlLauncherVersionMin != null
+          ? { control: { launcher: { version: { min: options.controlLauncherVersionMin } } } }
+          : {}),
         platforms: {
           [platformKey]: {
             arch,
@@ -611,6 +617,120 @@ describe("desktop updater", () => {
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  // Stone 1 — installed-base escape hatch: a feed that declares a launcher-contract
+  // schema this build cannot interpret, or a minimum launcher/build version newer
+  // than this build, must route to the full installer instead of an in-place
+  // payload update — even when a payload artifact exists and the launcher payload
+  // context validates (which would otherwise apply in place).
+  async function runLauncherReseedCheck(
+    fixtureOptions: Parameters<typeof createUpdaterFixture>[0],
+    currentVersion = "1.0.0-beta.1",
+  ): Promise<{ close: () => Promise<void>; snapshot: Awaited<ReturnType<ReturnType<typeof createDesktopUpdater>["checkForUpdates"]>> }> {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture({
+      channel: "beta",
+      includePayload: true,
+      platform: "win",
+      version: "1.0.0-beta.2",
+      ...fixtureOptions,
+    });
+    const launcherRuntimePath = join(root, "launcher", "runtime.json");
+    const launcherLaunchPath = join(root, "installed", "Open Design Beta.exe");
+    await mkdir(join(root, "installed"), { recursive: true });
+    await writeFile(launcherLaunchPath, "");
+    await mkdir(join(root, "launcher"), { recursive: true });
+    await writeFile(
+      launcherRuntimePath,
+      `${JSON.stringify({
+        active: { generation: 0, version: "1.0.0-beta.1" },
+        channel: "beta",
+        lastSuccessful: { generation: 0, version: "1.0.0-beta.1" },
+        namespace: "release-beta-win",
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`,
+    );
+    const updater = createDesktopUpdater({
+      arch: "x64",
+      currentVersion,
+      downloadRoot: join(root, "updates"),
+      env: {
+        ...updaterEnv(fixture.metadataUrl, "win32"),
+        [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: currentVersion,
+        [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+      },
+      launcherRoot: root,
+      launcherLaunchPath,
+      launcherRuntimePath,
+      namespace: "release-beta-win",
+      source: SIDECAR_SOURCES.PACKAGED,
+    }, {
+      extractLauncherPayloadArchive: async ({ destinationRoot }) => {
+        await mkdir(join(destinationRoot, "payload", "resources", "open-design"), { recursive: true });
+        await writeFile(join(destinationRoot, "payload", "Open Design.exe"), "");
+        await writeFile(
+          join(destinationRoot, "manifest.json"),
+          `${JSON.stringify({
+            channel: "beta",
+            entry: { cwd: "payload", executable: "payload/Open Design.exe" },
+            namespace: "release-beta-win",
+            payloadRoot: "payload",
+            platform: "win32",
+            schemaVersion: LAUNCHER_SCHEMA_VERSION,
+            version: "1.0.0-beta.2",
+          })}\n`,
+        );
+        await writeFile(join(destinationRoot, "payload", "resources", "open-design-config.json"), "{}\n");
+      },
+      launchAppAfterQuit: async () => ({ helperLogPath: join(root, "updates", "helpers", "test.log") }),
+      processExecPath: "C:\\Program Files\\Open Design Beta\\Open Design Beta.exe",
+      processPid: 4242,
+    });
+    const snapshot = await updater.checkForUpdates();
+    return {
+      snapshot,
+      close: async () => {
+        await fixture.close();
+        rmSync(root, { force: true, recursive: true });
+      },
+    };
+  }
+
+  it("routes to the installer when the feed launcher.schema exceeds this build", async () => {
+    const { snapshot, close } = await runLauncherReseedCheck({ launcherSchema: LAUNCHER_SCHEMA_VERSION + 1 });
+    try {
+      expect(snapshot.artifact?.type).toBe("installer");
+      expect(snapshot.capabilities.canApplyInPlace).toBe(false);
+      expect(snapshot.capabilities.requiresManualInstall).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it("routes to the installer when control.launcher.version.min exceeds this build", async () => {
+    const { snapshot, close } = await runLauncherReseedCheck({ controlLauncherVersionMin: "9.9.9" });
+    try {
+      expect(snapshot.artifact?.type).toBe("installer");
+      expect(snapshot.capabilities.canApplyInPlace).toBe(false);
+      expect(snapshot.capabilities.requiresManualInstall).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it("still applies the payload in place when schema is supported and min-version is met", async () => {
+    const { snapshot, close } = await runLauncherReseedCheck({
+      launcherSchema: LAUNCHER_SCHEMA_VERSION,
+      controlLauncherVersionMin: "0.9.0-beta.1",
+    });
+    try {
+      expect(snapshot.artifact?.type).toBe("payload");
+      expect(snapshot.capabilities.canApplyInPlace).toBe(true);
+      expect(snapshot.capabilities.requiresManualInstall).toBe(false);
+    } finally {
+      await close();
     }
   });
 

--- a/tools/serve/src/updater-fixture.ts
+++ b/tools/serve/src/updater-fixture.ts
@@ -17,8 +17,10 @@ export type UpdaterFixtureOptions = {
   artifactBody?: Buffer | string;
   artifactPath?: string;
   channel?: UpdaterFixtureChannel;
+  controlLauncherVersionMin?: string;
   host?: string;
   includePayload?: boolean;
+  launcherSchema?: number;
   platform?: "mac" | "win";
   payloadBody?: Buffer | string;
   payloadPath?: string;
@@ -265,6 +267,10 @@ export async function startUpdaterFixtureServer(options: UpdaterFixtureOptions =
         channel,
         generatedAt: new Date().toISOString(),
         ...channelMetadata(channel, version),
+        ...(options.launcherSchema != null ? { launcher: { schema: options.launcherSchema } } : {}),
+        ...(options.controlLauncherVersionMin != null
+          ? { control: { launcher: { version: { min: options.controlLauncherVersionMin } } } }
+          : {}),
         platforms: {
           [platformKey]: {
             arch: platform === "win" ? "x64" : "arm64",


### PR DESCRIPTION
## Why

**Use case.** This is the first slice of a larger effort to move Open Design's
packaged cold-start/updater onto a small, policy-free launcher. Before any of
that lands, the already-installed base needs a way to *self-route* to a full
reinstall when it meets a release it cannot adopt in place — otherwise a future
launcher-era release (a packaging-level schema break) would leave old builds
attempting an in-place update they can't run.

**Pain.** Today the desktop updater has no notion of a minimum-supported version
or a launcher-contract schema. It always prefers an in-place payload update when
a payload artifact exists and the launcher payload context validates. There is
no escape hatch: a release that outgrows a build has no way to tell that build
"stop, download the installer instead."

This PR adds that escape hatch as two orthogonal, fail-open guardrails read from
the release feed, both funnelling to the *existing* installer path:

- `launcher.schema` (ABI axis): `feed.launcher.schema > LAUNCHER_SCHEMA_VERSION`
  → this build cannot interpret the launcher contract the payload expects.
- `control.launcher.version.min` (recency axis): `min > currentVersion` → the
  release requires a newer launcher/build.

Either trip forces `preferPayload=false`, reusing the installer download + open
path that already exists. Missing/malformed fields are ignored, so every current
feed keeps updating exactly as before.

## What users will see

**Nothing today** — this is dormant groundwork. No production feed emits the new
fields yet, and with the fields absent the updater is byte-for-byte unchanged
(fail-open). Once a future release feed opts in, users on a too-old build will be
routed to the manual installer (the existing "requires manual install" flow in
the updater UI) instead of an in-place update that would fail.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — no: the new decision path is gated on feed
      fields no current feed emits; existing users experience no change.
- [x] **None** — forward-looking updater infrastructure + tests only.

## Bug fix verification

Not a bug fix, but built red-spec-first per AGENTS.md discipline:

- Test path: `apps/desktop/tests/main/updater.test.ts` — three specs added.
- The two guardrail specs went **red** before the source change
  (`expected 'payload' to be 'installer'`) and **green** after; a third spec
  asserts a supported-schema + met-min release still applies in place (guards
  against the gate over-firing).

## Validation

- `pnpm --filter @open-design/desktop test` — 3 new specs green.
- `pnpm --filter @open-design/desktop typecheck`, `pnpm --filter @open-design/tools-serve typecheck`, `pnpm typecheck` — all clean.
- `pnpm guard` — 55/55.

**Adjacent issue (not in scope, pre-existing on `main`):** the spec "cleans
deprecated launcher payload versions on cold start from the launcher cleanup
descriptor" fails independently of this change (confirmed via stash against the
branch base). It is date-sensitive (`removedAt` hard-coded to 2026-06-09). Left
for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
