### PR TITLE
fix(landing-page): add the Careers link to the homepage footer

### DIFF
--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -192,9 +192,9 @@ const FOOTER_AGENTS = [
 // Legal / company labels — small inline map (en/zh/zh-tw, fallback en) kept
 // identical to `site-footer.astro` so the two footers never drift.
 const FOOTER_LEGAL = {
-  en: { company: 'Company', about: 'About', faq: 'FAQ', privacy: 'Privacy Policy', terms: 'Terms', allAgents: 'All agents' },
-  zh: { company: '公司', about: '关于', faq: '常见问题', privacy: '隐私政策', terms: '服务条款', allAgents: '全部 Agent' },
-  'zh-tw': { company: '公司', about: '關於', faq: '常見問題', privacy: '隱私政策', terms: '服務條款', allAgents: '全部 Agent' },
+  en: { company: 'Company', about: 'About', careers: 'Careers', faq: 'FAQ', privacy: 'Privacy Policy', terms: 'Terms', allAgents: 'All agents' },
+  zh: { company: '公司', about: '关于', careers: '招聘', faq: '常见问题', privacy: '隐私政策', terms: '服务条款', allAgents: '全部 Agent' },
+  'zh-tw': { company: '公司', about: '關於', careers: '招聘', faq: '常見問題', privacy: '隱私政策', terms: '服務條款', allAgents: '全部 Agent' },
 } satisfies Record<string, Record<string, string>>;
 
 const ext = {
@@ -1247,6 +1247,7 @@ export default function Page({
                 <h5>{footL.company}</h5>
                 <ul>
                   <li><a href={href('/about/')}>{footL.about}</a></li>
+                  <li><a href={href('/careers/')}>{footL.careers}</a></li>
                   <li><a href={href('/faq/')}>{footL.faq}</a></li>
                   <li><a href={href('/privacy/')}>{footL.privacy}</a></li>
                   <li><a href={href('/terms/')}>{footL.terms}</a></li>

--- a/apps/landing-page/tests/footer-parity.test.ts
+++ b/apps/landing-page/tests/footer-parity.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+// The homepage renders its own React footer (app/page.tsx), while every
+// sub-page renders app/_components/site-footer.astro. page.tsx explicitly
+// promises the two "never drift". This test enforces that promise at the
+// label level so a link added to one footer (e.g. Careers) can't silently be
+// missing from the other. It would have gone red on the commit that added the
+// Careers link to site-footer.astro only.
+const HOMEPAGE_FOOTER = new URL("../app/page.tsx", import.meta.url);
+const SUBPAGE_FOOTER = new URL("../app/_components/site-footer.astro", import.meta.url);
+
+// site-footer.astro also carries an `allSolutions` label for a column the
+// homepage footer expresses differently; it is legitimately sub-page-only.
+const SUBPAGE_ONLY_LABELS = new Set(["allSolutions"]);
+
+// Extract the keys of the `en: { company: ... }` footer-label object literal.
+function footerEnLabelKeys(source: string): string[] {
+  const anchor = source.indexOf("en: { company:");
+  assert.ok(anchor >= 0, "could not find the `en: { company: ... }` footer dict");
+  const open = source.indexOf("{", anchor);
+  const close = source.indexOf("}", open);
+  assert.ok(open >= 0 && close > open, "malformed footer dict object literal");
+  return source
+    .slice(open + 1, close)
+    .split(",")
+    .map((pair) => pair.split(":")[0]?.trim())
+    .filter((key): key is string => Boolean(key));
+}
+
+describe("footer parity", () => {
+  it("keeps the homepage footer in sync with the sub-page footer labels", async () => {
+    const [homepage, subpage] = await Promise.all([
+      readFile(HOMEPAGE_FOOTER, "utf8"),
+      readFile(SUBPAGE_FOOTER, "utf8"),
+    ]);
+
+    const homeKeys = new Set(footerEnLabelKeys(homepage));
+    const subKeys = footerEnLabelKeys(subpage);
+
+    // Every sub-page footer label (minus the intentionally sub-page-only ones)
+    // must also exist on the homepage footer.
+    const expected = subKeys.filter((key) => !SUBPAGE_ONLY_LABELS.has(key)).sort();
+    assert.deepEqual(
+      [...homeKeys].sort(),
+      expected,
+      "homepage footer (page.tsx) drifted from site-footer.astro — add the missing label(s) to FOOTER_LEGAL and the Company column",
+    );
+
+    // Concrete anchor for the Careers link that originally regressed.
+    assert.ok(homeKeys.has("careers"), "homepage footer is missing the Careers label");
+  });
+});


### PR DESCRIPTION
## Why
PR #5141 added the **Careers** footer entry to `site-footer.astro` (the sub-page footer) but missed the homepage's **parallel React footer** in `page.tsx` — even though `page.tsx` explicitly documents that the two footers must *"never drift"*. So the Careers link showed on `/about/` and every sub-page but was **absent from the homepage footer** (`/` and `/zh/`), contradicting that PR's "footer Careers on every page" claim (caught in QA on the #5141 branch).

## What users will see
The homepage footer's **Company** column now includes **Careers** (→ `/careers/`), matching every sub-page. Localized: `/` shows "Careers", `/zh/` shows "招聘" → `/zh/careers/`.

## How
- Added the `careers` label to `FOOTER_LEGAL` (en / zh / zh-tw) and a `<li>` for Careers in the homepage footer's Company column, mirroring `site-footer.astro`.
- Added **`tests/footer-parity.test.ts`** — asserts the homepage footer (`page.tsx`) and the sub-page footer (`site-footer.astro`) expose the same label set, so this class of drift fails CI instead of shipping. It **goes red on `main`** (the homepage footer is missing `careers` there) and green on this branch.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point** — `skills/`, `design-systems/`, `design-templates/`, `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal refactor, docs, tests, or translation update only

<sub>Landing-page marketing footer: added the existing Careers route to the homepage React footer to match the sub-page footer, plus a parity test. No product-app surface, route, component, or i18n key touched.</sub>

## Verification
- `pnpm --filter @open-design/landing-page typecheck` → 0 errors
- `pnpm --filter @open-design/landing-page build:static` → 4435 pages built clean
- Built HTML: `/` footer → `href="/careers/">Careers`; `/zh/` footer → `href="/zh/careers/">招聘`; `/about/` still has it (no regression).
- `node --test tests/footer-parity.test.ts` → pass (and red on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)