### PR TITLE
feat(launcher): Go fossil launcher foundation + opt-in mac embed

### DIFF
--- a/launcher/cmd/launcher/main.go
+++ b/launcher/cmd/launcher/main.go
@@ -1,0 +1,15 @@
+// Command launcher is the Open Design fossil launcher: one binary that runs as
+// the L0 stub (baked bundle copy, hop 0) or the L1 authority (delegated payload
+// copy, hop 1). It is network-free and sits at the OS bundle-executable slot,
+// handing off to / launching the Electron payload.
+package main
+
+import (
+	"os"
+
+	"github.com/nexu-io/open-design/launcher/internal/app"
+)
+
+func main() {
+	os.Exit(app.Run(os.Args))
+}

--- a/launcher/go.mod
+++ b/launcher/go.mod
@@ -1,0 +1,3 @@
+module github.com/nexu-io/open-design/launcher
+
+go 1.25

--- a/launcher/internal/app/decide.go
+++ b/launcher/internal/app/decide.go
@@ -1,0 +1,62 @@
+// Package app is the launcher orchestration. This file holds the pure decision
+// logic (no process/OS side effects) so the crash-safe control flow is unit
+// testable; the process spawning, health handshake, lock, and control endpoint
+// are layered on top elsewhere.
+package app
+
+import (
+	"github.com/nexu-io/open-design/launcher/internal/contract"
+	"github.com/nexu-io/open-design/launcher/internal/state"
+)
+
+// Mode is the role this single binary plays, selected by the handoff hop: the
+// baked bundle copy runs as the L0 stub (hop 0); the delegated payload copy runs
+// as the L1 authority (hop 1). Only one handoff is allowed, so hop never exceeds 1.
+type Mode int
+
+const (
+	ModeStub      Mode = iota // L0: min identity + find-newest + one handoff + fallback
+	ModeAuthority             // L1: payload select + confirm/rollback + supervise Electron
+)
+
+// ModeForHop maps a stamp hop to the binary's role.
+func ModeForHop(hop int) Mode {
+	if hop >= 1 {
+		return ModeAuthority
+	}
+	return ModeStub
+}
+
+// HandoffAction is what the L0 stub does after selecting the launcher axis.
+type HandoffAction int
+
+const (
+	// ActionNothingRunnable: genesis with no selectable launcher — L0 shows the
+	// native reinstall dialog + download link (CS4).
+	ActionNothingRunnable HandoffAction = iota
+	// ActionRunAuthorityInline: the selected launcher version IS this baked build
+	// (genesis / same-version), so run the L1 authority in-process — no handoff.
+	ActionRunAuthorityInline
+	// ActionHandoff: a delegated launcher binary newer than this baked build is on
+	// disk, so hand off to it once (spawn it at hop 1).
+	ActionHandoff
+)
+
+// DecideHandoff applies the single-handoff rule. sel is the launcher-axis A/B
+// selection (state.Select over launcher-runtime.json); selfVersion is this baked
+// build's contract.SelfVersion; delegatedBinExists reports whether
+// versions/<selected>/launcher(.exe) is present on disk.
+//
+// Hand off only when the selected launcher version is strictly newer than this
+// build AND its binary exists; otherwise this build is already the newest usable
+// launcher and runs the authority itself. This mirrors the PoC's "terminal
+// launcher = whichever no longer trampolines", bounded to exactly one hop.
+func DecideHandoff(sel state.Selection, selfVersion string, delegatedBinExists bool) HandoffAction {
+	if !sel.Selected || sel.Pointer == nil {
+		return ActionNothingRunnable
+	}
+	if delegatedBinExists && contract.CmpVersion(sel.Pointer.Version, selfVersion) > 0 {
+		return ActionHandoff
+	}
+	return ActionRunAuthorityInline
+}

--- a/launcher/internal/app/decide_test.go
+++ b/launcher/internal/app/decide_test.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/nexu-io/open-design/launcher/internal/contract"
+	"github.com/nexu-io/open-design/launcher/internal/state"
+)
+
+func TestModeForHop(t *testing.T) {
+	if ModeForHop(0) != ModeStub {
+		t.Fatal("hop 0 must be the L0 stub")
+	}
+	if ModeForHop(1) != ModeAuthority {
+		t.Fatal("hop 1 must be the L1 authority")
+	}
+}
+
+func TestDecideHandoff(t *testing.T) {
+	self := "1.0.0"
+	sel := func(v string) state.Selection {
+		return state.Selection{Pointer: &contract.Pointer{Version: v}, Reason: state.ReasonActive, Selected: true}
+	}
+
+	if got := DecideHandoff(state.Selection{Reason: state.ReasonNone}, self, false); got != ActionNothingRunnable {
+		t.Fatalf("no selection → ActionNothingRunnable, got %v", got)
+	}
+	// Newer delegated launcher present → hand off.
+	if got := DecideHandoff(sel("1.1.0"), self, true); got != ActionHandoff {
+		t.Fatalf("newer delegated + binary present → ActionHandoff, got %v", got)
+	}
+	// Newer version selected but its binary is missing → run authority inline.
+	if got := DecideHandoff(sel("1.1.0"), self, false); got != ActionRunAuthorityInline {
+		t.Fatalf("newer but no binary → run inline, got %v", got)
+	}
+	// Selected version equals this baked build (genesis) → run authority inline.
+	if got := DecideHandoff(sel("1.0.0"), self, true); got != ActionRunAuthorityInline {
+		t.Fatalf("same version → run inline, got %v", got)
+	}
+	// Selected version older than this baked build → this build is newest, run inline.
+	if got := DecideHandoff(sel("0.9.0"), self, true); got != ActionRunAuthorityInline {
+		t.Fatalf("older selected → run inline, got %v", got)
+	}
+}

--- a/launcher/internal/app/plan.go
+++ b/launcher/internal/app/plan.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"github.com/nexu-io/open-design/launcher/internal/contract"
+	"github.com/nexu-io/open-design/launcher/internal/state"
+)
+
+// L0Plan is the L0 stub's decision after reading the launcher axis: whether to
+// hand off to a newer delegated launcher, run the authority in-process, or show
+// the reinstall fallback.
+type L0Plan struct {
+	Action HandoffAction
+	Target *contract.Pointer
+}
+
+// PlanL0 is the pure L0 decision. It applies the crash-safe A/B + local schema
+// floor to the launcher axis, then the single-handoff rule. schemaOK reports
+// whether a launcher version's manifest schema is interpretable; binExists
+// reports whether versions/<v>/launcher is present on disk.
+func PlanL0(
+	launcherRT contract.Runtime,
+	launcherAttempt *contract.Attempt,
+	rollbackThreshold int,
+	selfVersion string,
+	schemaOK func(version string) bool,
+	binExists func(version string) bool,
+) L0Plan {
+	sel := state.SelectRunnable(launcherRT, launcherAttempt, rollbackThreshold, schemaOK)
+	if !sel.Selected || sel.Pointer == nil {
+		// Empty/incompatible launcher axis (genesis, or all delegated launchers
+		// blocked) — the baked binary is itself a schema-compatible launcher, so run
+		// the authority in-process. "Nothing runnable" is a PAYLOAD-axis (L1) verdict,
+		// not an L0 one: L0 can always fall back to running itself.
+		return L0Plan{Action: ActionRunAuthorityInline}
+	}
+	action := DecideHandoff(sel, selfVersion, binExists(sel.Pointer.Version))
+	return L0Plan{Action: action, Target: sel.Pointer}
+}
+
+// PlanL1 is the pure L1 payload decision: the crash-safe A/B + local schema floor
+// on the payload axis. A ReasonNone result means nothing runnable (fall back to
+// the reinstall dialog). This is computed by the authority mode before booting
+// the Electron payload it selects.
+func PlanL1(
+	payloadRT contract.Runtime,
+	payloadAttempt *contract.Attempt,
+	rollbackThreshold int,
+	schemaOK func(version string) bool,
+) state.Selection {
+	return state.SelectRunnable(payloadRT, payloadAttempt, rollbackThreshold, schemaOK)
+}

--- a/launcher/internal/app/plan_test.go
+++ b/launcher/internal/app/plan_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/nexu-io/open-design/launcher/internal/contract"
+	"github.com/nexu-io/open-design/launcher/internal/state"
+)
+
+func p(v string, gen int) *contract.Pointer { return &contract.Pointer{Version: v, Generation: gen} }
+
+func yes(string) bool { return true }
+func no(string) bool  { return false }
+
+func TestPlanL0(t *testing.T) {
+	self := "1.0.0"
+
+	// A1 genesis: active == baked build, its binary present → run authority inline
+	// (no handoff, the baked binary IS the newest launcher).
+	if pl := PlanL0(contract.Runtime{Active: p("1.0.0", 0), LastSuccessful: p("1.0.0", 0)}, nil, 2, self, yes, yes); pl.Action != ActionRunAuthorityInline {
+		t.Fatalf("A1 genesis must run authority inline, got %v", pl.Action)
+	}
+	// B3: a newer delegated launcher with its binary present → hand off.
+	if pl := PlanL0(contract.Runtime{Active: p("1.1.0", 0), LastSuccessful: p("1.0.0", 0)}, nil, 2, self, yes, yes); pl.Action != ActionHandoff || pl.Target.Version != "1.1.0" {
+		t.Fatalf("B3 newer launcher must hand off to 1.1.0, got %+v", pl)
+	}
+	// Genesis: empty launcher axis → run the baked authority inline (NOT nothing-
+	// runnable; L0 can always fall back to itself).
+	if pl := PlanL0(contract.Runtime{}, nil, 2, self, yes, yes); pl.Action != ActionRunAuthorityInline {
+		t.Fatalf("empty launcher axis must run authority inline, got %v", pl.Action)
+	}
+	// C3 on the launcher axis: newer launcher exists but its schema is too new →
+	// falls back to the compatible last-successful and runs inline (not handoff).
+	onlyOld := func(v string) bool { return v == "1.0.0" }
+	if pl := PlanL0(contract.Runtime{Active: p("1.1.0", 0), LastSuccessful: p("1.0.0", 0)}, nil, 2, self, onlyOld, yes); pl.Action != ActionRunAuthorityInline || pl.Target.Version != "1.0.0" {
+		t.Fatalf("C3 schema-too-new launcher must fall back + run inline on 1.0.0, got %+v", pl)
+	}
+	// B4 launcher rollback: newer launcher active with a stale attempt matching it
+	// (crashed before confirming) and a compatible last-successful → roll back, run
+	// the older launcher inline.
+	staleNew := &contract.Attempt{Version: "1.1.0", Generation: 0, FailCount: 1}
+	if pl := PlanL0(contract.Runtime{Active: p("1.1.0", 0), LastSuccessful: p("1.0.0", 0)}, staleNew, 2, self, yes, yes); pl.Action != ActionRunAuthorityInline || pl.Target.Version != "1.0.0" {
+		t.Fatalf("B4 crashed newer launcher must roll back to 1.0.0 inline, got %+v", pl)
+	}
+	// D3: newer launcher selected but its binary is missing on disk → run inline
+	// (never hand off to a phantom).
+	if pl := PlanL0(contract.Runtime{Active: p("1.1.0", 0), LastSuccessful: p("1.0.0", 0)}, nil, 2, self, yes, no); pl.Action != ActionRunAuthorityInline {
+		t.Fatalf("D3 missing launcher binary must run inline, got %v", pl.Action)
+	}
+}
+
+func TestPlanL1(t *testing.T) {
+	// A3 payload rollback: stale attempt matches active, compatible last-successful.
+	staleActive := &contract.Attempt{Version: "2.0.0", Generation: 1, FailCount: 1}
+	if s := PlanL1(contract.Runtime{Active: p("2.0.0", 1), LastSuccessful: p("1.0.0", 0)}, staleActive, 1, yes); s.Reason != state.ReasonLastSuccessful || s.Pointer.Version != "1.0.0" {
+		t.Fatalf("A3 payload rollback must select last-successful, got %+v", s)
+	}
+	// Healthy payload update: clean active, compatible → run it.
+	if s := PlanL1(contract.Runtime{Active: p("2.0.0", 1), LastSuccessful: p("1.0.0", 0)}, nil, 1, yes); s.Reason != state.ReasonActive {
+		t.Fatalf("healthy payload must run active, got %+v", s)
+	}
+	// C3 payload floor: active schema too new, last-successful compatible → fall back.
+	if s := PlanL1(contract.Runtime{Active: p("2.0.0", 1), LastSuccessful: p("1.0.0", 0)}, nil, 1, func(v string) bool { return v == "1.0.0" }); s.Reason != state.ReasonLastSuccessful {
+		t.Fatalf("C3 payload floor must fall back, got %+v", s)
+	}
+	// A5 nothing runnable: empty payload axis → ReasonNone (L1 surfaces the reinstall
+	// fallback; this is the payload-axis "nothing runnable", the real CS4 trigger).
+	if s := PlanL1(contract.Runtime{}, nil, 1, yes); s.Selected || s.Reason != state.ReasonNone {
+		t.Fatalf("A5 empty payload axis must be ReasonNone, got %+v", s)
+	}
+}

--- a/launcher/internal/app/run.go
+++ b/launcher/internal/app/run.go
@@ -2,36 +2,86 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/nexu-io/open-design/launcher/internal/contract"
+	"github.com/nexu-io/open-design/launcher/internal/state"
 )
 
 // RelocatedElectronName is the fixed filename the packaging afterPack hook gives
 // the real Electron binary once the launcher takes its bundle-executable slot.
-// The launcher execs its sibling of this name inside the same directory.
 const RelocatedElectronName = "od-electron"
 
-// Run is the launcher entrypoint. It currently lands the minimal robust form:
-// spawn the relocated Electron sibling as a child (resident parent, so later
-// increments can supervise it), forwarding argv + env unchanged — critically the
-// after-quit tokens and the sidecar stamp. The L0 select/handoff and the L1
-// authority (payload select, confirm/rollback, READY handshake) grow on top of
-// this, each validated end-to-end via tools-pack + tools-serve.
+// Run is the launcher entrypoint. It dispatches on the handoff hop: hop 0 runs the
+// L0 stub (select the launcher axis, hand off to a newer delegated launcher or run
+// the authority in-process); hop 1 runs the L1 authority. When identity is not yet
+// configured (dev / unconfigured), it degrades to the plain trampoline so the app
+// still comes up.
 func Run(argv []string) int {
 	stamp := contract.ParseStamp(argv)
-	_ = ModeForHop(stamp.Hop) // dispatch grows here as L0/L1 land
+	cfg, err := contract.LoadConfig(os.Getenv)
+	if err != nil {
+		// No identity floor yet: behave as a transparent trampoline.
+		return execElectron(argv, nil)
+	}
+	paths := state.Resolve(cfg.DataDir, cfg)
+	if ModeForHop(stamp.Hop) == ModeStub {
+		return runStub(cfg, paths, stamp, argv)
+	}
+	return runAuthority(cfg, paths, stamp, argv)
+}
 
+// runStub is the L0 flow: pick the launcher version and, if a newer delegated
+// launcher is on disk, hand off to it exactly once; otherwise run the authority
+// in-process. Nothing runnable → the reinstall fallback.
+func runStub(cfg contract.Config, paths state.Paths, stamp contract.Stamp, argv []string) int {
+	rt, _, err := state.ReadJSON[contract.Runtime](paths.LauncherRuntime)
+	if err != nil {
+		// Unreadable launcher axis: fall through to the authority (genesis path).
+		return runAuthority(cfg, paths, stamp, argv)
+	}
+	attempt := readAttempt(paths.LauncherAttempt)
+	plan := PlanL0(rt, attempt, contract.RollbackThreshold, contract.SelfVersion,
+		func(v string) bool { return manifestSchemaOK(paths, v) },
+		func(v string) bool { return fileExists(paths.LauncherBinary(v)) },
+	)
+	if plan.Action == ActionHandoff {
+		// Attempt-before-handoff: a broken delegated launcher is covered by rollback.
+		_ = state.WriteJSON(paths.LauncherAttempt, state.NextAttempt(attempt, cfg, *plan.Target))
+		next := stamp
+		next.Hop = stamp.Hop + 1
+		return spawnAndWait(paths.LauncherBinary(plan.Target.Version), append(next.Args(), argv[1:]...))
+	}
+	// ActionRunAuthorityInline — the baked binary is the newest usable launcher.
+	return runAuthority(cfg, paths, stamp, argv)
+}
+
+// runAuthority is the L1 flow. For now it execs the bound Electron and lets
+// Electron's existing in-process selection run (no regression); the payload-axis
+// PlanL1 select/confirm/rollback becomes authoritative in the "Electron defers to
+// L1" increment, validated via the packaged E2E harness.
+func runAuthority(cfg contract.Config, paths state.Paths, stamp contract.Stamp, argv []string) int {
+	return execElectron(argv, map[string]string{contract.EnvChannel: cfg.Channel})
+}
+
+// execElectron spawns the relocated Electron sibling, forwarding argv + env (with
+// any extra overrides) and propagating the exit code. Resident parent (room for
+// later supervision); spawn-not-exec for Windows portability.
+func execElectron(argv []string, extraEnv map[string]string) int {
 	target, err := siblingExecutable(RelocatedElectronName)
 	if err != nil {
 		return 1
 	}
-	return spawnAndWait(target, argv[1:])
+	args := []string{}
+	if len(argv) > 1 {
+		args = argv[1:]
+	}
+	return spawnAndWaitEnv(target, args, extraEnv)
 }
 
-// siblingExecutable resolves a file of the given name next to this binary.
 func siblingExecutable(name string) (string, error) {
 	self, err := os.Executable()
 	if err != nil {
@@ -40,13 +90,17 @@ func siblingExecutable(name string) (string, error) {
 	return filepath.Join(filepath.Dir(self), name), nil
 }
 
-// spawnAndWait runs bin as a child, wiring stdio and env through, and propagates
-// its exit code. Spawn-not-exec keeps the launcher resident (Windows has no
-// execve, and a resident parent is needed for later supervision/session-control).
 func spawnAndWait(bin string, args []string) int {
+	return spawnAndWaitEnv(bin, args, nil)
+}
+
+func spawnAndWaitEnv(bin string, args []string, extraEnv map[string]string) int {
 	cmd := exec.Command(bin, args...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	cmd.Env = os.Environ()
+	for k, v := range extraEnv {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
 	if err := cmd.Run(); err != nil {
 		var exit *exec.ExitError
 		if errors.As(err, &exit) {
@@ -55,4 +109,36 @@ func spawnAndWait(bin string, args []string) int {
 		return 1
 	}
 	return 0
+}
+
+// readAttempt reads an attempt marker, returning nil when absent or unreadable so
+// a missing marker reads as "no prior boot in flight".
+func readAttempt(path string) *contract.Attempt {
+	a, ok, err := state.ReadJSON[contract.Attempt](path)
+	if err != nil || !ok {
+		return nil
+	}
+	return &a
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// manifestSchemaOK reports whether a version's on-disk manifest declares a
+// launcher schema this build can interpret (the local schema floor). A missing or
+// unreadable manifest is treated as not-OK (do not run what we cannot verify).
+func manifestSchemaOK(paths state.Paths, version string) bool {
+	m, ok, err := state.ReadJSON[contract.Manifest](paths.ManifestPath(version))
+	if err != nil || !ok {
+		return false
+	}
+	return m.SchemaSupported()
+}
+
+// showReinstall is the CS4 terminal fallback: nothing runnable. For now it logs;
+// the native OS dialog + download link is a later increment validated via SPEC.
+func showReinstall(cfg contract.Config) {
+	fmt.Fprintf(os.Stderr, "[od-launcher] nothing runnable for channel %q namespace %q — reinstall required\n", cfg.Channel, cfg.Namespace)
 }

--- a/launcher/internal/app/run.go
+++ b/launcher/internal/app/run.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/nexu-io/open-design/launcher/internal/contract"
+)
+
+// RelocatedElectronName is the fixed filename the packaging afterPack hook gives
+// the real Electron binary once the launcher takes its bundle-executable slot.
+// The launcher execs its sibling of this name inside the same directory.
+const RelocatedElectronName = "od-electron"
+
+// Run is the launcher entrypoint. It currently lands the minimal robust form:
+// spawn the relocated Electron sibling as a child (resident parent, so later
+// increments can supervise it), forwarding argv + env unchanged — critically the
+// after-quit tokens and the sidecar stamp. The L0 select/handoff and the L1
+// authority (payload select, confirm/rollback, READY handshake) grow on top of
+// this, each validated end-to-end via tools-pack + tools-serve.
+func Run(argv []string) int {
+	stamp := contract.ParseStamp(argv)
+	_ = ModeForHop(stamp.Hop) // dispatch grows here as L0/L1 land
+
+	target, err := siblingExecutable(RelocatedElectronName)
+	if err != nil {
+		return 1
+	}
+	return spawnAndWait(target, argv[1:])
+}
+
+// siblingExecutable resolves a file of the given name next to this binary.
+func siblingExecutable(name string) (string, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(self), name), nil
+}
+
+// spawnAndWait runs bin as a child, wiring stdio and env through, and propagates
+// its exit code. Spawn-not-exec keeps the launcher resident (Windows has no
+// execve, and a resident parent is needed for later supervision/session-control).
+func spawnAndWait(bin string, args []string) int {
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
+			return exit.ExitCode()
+		}
+		return 1
+	}
+	return 0
+}

--- a/launcher/internal/contract/abi.go
+++ b/launcher/internal/contract/abi.go
@@ -1,0 +1,84 @@
+// Package contract is the fossil layer: the frozen handshake vocabulary and the
+// JSON document schemas that any-age launcher and any-age Electron payload agree
+// on. Changing anything here is a reseed (installer), not a seamless update.
+// Every other package is mechanism layered on top of these definitions.
+//
+// This is the Open Design port of the Go launcher PoC, adapted to OD's decisions
+// (see .task/MAIN.md). The load-bearing divergences from the PoC:
+//
+//   - The launcher is NETWORK-FREE: it never downloads. New payloads and new
+//     launcher binaries are fetched by the Electron payload's updater and arrive
+//     on disk; the launcher only selects, spawns, supervises, and rolls back.
+//   - The launcher spawns exactly ONE child — Electron — and is blind to whatever
+//     Electron spawns below it (daemon/web). Coupling is loose, by convention.
+//   - Boot health is heartbeat-during-boot (no fixed ReadyGrace): OD's daemon can
+//     take ~35s normally and up to ~30min under legacy-data migration, so the
+//     launcher acts only on a MISSED heartbeat or a process exit.
+package contract
+
+import "time"
+
+// SelfVersion is the launcher's own baked build stamp (identity; never
+// overridable). Set via:
+//
+//	-ldflags "-X github.com/nexu-io/open-design/launcher/internal/contract.SelfVersion=X.Y.Z"
+var SelfVersion = "0.0.0"
+
+// SupportedLauncherSchema is the launcher-contract grammar this build can
+// interpret — the `launcher.schema` axis of the hierarchical schema declaration.
+// A release/manifest declaring a higher launcher schema cannot be adopted and
+// routes to the installer (fail-open), never a crash. Mirrors the TypeScript
+// LAUNCHER_SCHEMA_VERSION so the two readers stay consistent (Q4 conformance).
+const SupportedLauncherSchema = 1
+
+// Frozen identity handshake vocabulary. These names are ABI: additive-only,
+// never renamed. The launcher resolves identity and injects it downward; remote
+// content never contributes to these fields.
+const (
+	EnvNamespace = "OD_NAMESPACE"
+	EnvChannel   = "OD_CHANNEL"
+	EnvDataDir   = "OD_DATA_DIR"
+
+	// Notify injection ABI: endpoint via argv, token via env (sd_notify shape;
+	// the token stays out of argv because `ps` is world-readable).
+	ArgNotifyEndpoint = "--od-notify-endpoint"
+	EnvNotifyToken    = "OD_NOTIFY_TOKEN"
+
+	// Launcher↔launcher stamp: a single frozen token carrying hop count, the
+	// after-quit wait, and the deferred adopt choice.
+	ArgStamp = "--od-stamp"
+)
+
+// After-quit hand-off argv — mirrors @open-design/launcher-proto so the Electron
+// payload's relaunch (which targets the launcher binary) is understood verbatim.
+const (
+	ArgAfterQuit          = "--od-launcher-after-quit"
+	ArgAfterQuitTargetPID = "--od-launcher-target-pid"
+	ArgAfterQuitTimeoutMs = "--od-launcher-timeout-ms"
+)
+
+// Timings (mechanism policy; kept beside the ABI so the whole handshake contract
+// reads in one place). There is deliberately NO ReadyGrace: under
+// heartbeat-during-boot the launcher never gives up on a still-heartbeating
+// payload, however long the boot takes.
+const (
+	HopCap = 4
+
+	// HeartbeatGap is the maximum silence tolerated between payload heartbeats
+	// before the payload is declared hung. The payload emits heartbeats from
+	// process start (while it waits on daemon/web) until it reaches READY.
+	HeartbeatGap = 10 * time.Second
+
+	// LivenessHold is the post-READY stability window: the payload must survive
+	// this long after READY (no exit, no dropped notify conn) before confirm.
+	LivenessHold = 2 * time.Second
+
+	// ShutdownGrace is how long a graceful stop is awaited before killing.
+	ShutdownGrace = 3 * time.Second
+
+	// DefaultAfterQuitTimeout bounds the wait for a prior instance to exit.
+	DefaultAfterQuitTimeout = 10 * time.Second
+)
+
+// Now returns an RFC3339 UTC timestamp for state documents.
+func Now() string { return time.Now().UTC().Format(time.RFC3339) }

--- a/launcher/internal/contract/abi.go
+++ b/launcher/internal/contract/abi.go
@@ -31,6 +31,16 @@ var SelfVersion = "0.0.0"
 // LAUNCHER_SCHEMA_VERSION so the two readers stay consistent (Q4 conformance).
 const SupportedLauncherSchema = 1
 
+// RuntimeSchema is the on-disk document format version stamped into runtime.json
+// and attempt.json (the launcher-proto `schemaVersion` field). Distinct from
+// SupportedLauncherSchema (the payload ABI axis); both are 1 today.
+const RuntimeSchema = 1
+
+// RollbackThreshold is the default CS2 crash-loop tolerance: roll back to
+// lastSuccessful only after this many consecutive unconfirmed boots, so a single
+// transient boot failure does not demote a good version. Contract-configurable.
+const RollbackThreshold = 2
+
 // Frozen identity handshake vocabulary. These names are ABI: additive-only,
 // never renamed. The launcher resolves identity and injects it downward; remote
 // content never contributes to these fields.

--- a/launcher/internal/contract/config.go
+++ b/launcher/internal/contract/config.go
@@ -1,0 +1,47 @@
+package contract
+
+import (
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+//go:embed default.json
+var embeddedDefault []byte
+
+// LoadConfig resolves the field-scoped layered merge — embedded default.json
+// (baked) < env overrides. This is the launcher's non-empty floor: the
+// interpreter always has coordinates to obey, even at genesis. Remote content
+// never reaches these identity fields.
+//
+// The launcher is the authority for namespace/channel/data-dir resolution and
+// injects OD_DATA_DIR downward (aligns with the AGENTS.md rule that packaged code
+// resolves the final data root before spawning the daemon).
+func LoadConfig(env func(string) string) (Config, error) {
+	if env == nil {
+		env = os.Getenv
+	}
+	var c Config
+	if err := json.Unmarshal(embeddedDefault, &c); err != nil {
+		return c, fmt.Errorf("embedded default.json: %w", err)
+	}
+	override(&c.Namespace, env(EnvNamespace))
+	override(&c.Channel, env(EnvChannel))
+	override(&c.DataDir, env(EnvDataDir))
+	if c.DataDir == "" {
+		home, _ := os.UserHomeDir()
+		c.DataDir = home
+	}
+	if c.Namespace == "" || c.Channel == "" {
+		return c, errors.New("cold-start floor incomplete: need namespace and channel")
+	}
+	return c, nil
+}
+
+func override(dst *string, value string) {
+	if value != "" {
+		*dst = value
+	}
+}

--- a/launcher/internal/contract/conformance_test.go
+++ b/launcher/internal/contract/conformance_test.go
@@ -1,0 +1,37 @@
+package contract
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestVersionConformanceFixture asserts CmpVersion matches the shared fixture that
+// the TypeScript compareLauncherVersions conformance test also verifies, so the two
+// ports never drift (Q4). The fixture lives at launcher/testdata so both runtimes
+// consume the same expected values.
+func TestVersionConformanceFixture(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "testdata", "version-conformance.json"))
+	if err != nil {
+		t.Fatalf("read conformance fixture: %v", err)
+	}
+	var fixture struct {
+		Cases []struct {
+			A        string `json:"a"`
+			B        string `json:"b"`
+			Expected int    `json:"expected"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse conformance fixture: %v", err)
+	}
+	if len(fixture.Cases) == 0 {
+		t.Fatal("conformance fixture has no cases")
+	}
+	for _, c := range fixture.Cases {
+		if got := CmpVersion(c.A, c.B); got != c.Expected {
+			t.Errorf("CmpVersion(%q, %q) = %d, fixture expects %d", c.A, c.B, got, c.Expected)
+		}
+	}
+}

--- a/launcher/internal/contract/contract_test.go
+++ b/launcher/internal/contract/contract_test.go
@@ -1,0 +1,95 @@
+package contract
+
+import "testing"
+
+func TestCmpVersion(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.1", "1.0.0", 1},
+		{"1.0.0", "1.0.1", -1},
+		{"1.0.0", "1.0.0", 0},
+		{"2.0.0", "1.9.9", 1},
+		{"v1.0.1", "1.0.0", 1},           // leading v stripped
+		{"1.0.0+build", "1.0.0", 0},      // build metadata ignored
+		{"1.0.0", "1.0.0-beta.1", 1},     // release beats prerelease
+		{"1.0.0-beta.1", "1.0.0", -1},    // and the reverse
+		{"1.0.0-beta.1", "1.0.0-beta.2", -1},
+		{"1.0.0-beta.2", "1.0.0-beta.10", -1}, // numeric identifier order
+		{"1.0.0-alpha", "1.0.0-beta", -1},     // lexical identifier order
+		{"1.0.0-beta.1", "1.0.0-beta", 1},     // longer prerelease sorts after
+		{"1.0.0-1", "1.0.0-alpha", -1},        // numeric identifier below alnum
+		{"1.2.3.nightly.5", "1.2.3.nightly.4", 1},
+		{"1.2.3.nightly.5", "1.2.3", -1}, // nightly is a prerelease
+	}
+	for _, c := range cases {
+		if got := CmpVersion(c.a, c.b); got != c.want {
+			t.Errorf("CmpVersion(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+		// Antisymmetry: reversing arguments negates the result.
+		if got := CmpVersion(c.b, c.a); got != -c.want {
+			t.Errorf("CmpVersion(%q, %q) = %d, want %d (antisymmetry)", c.b, c.a, got, -c.want)
+		}
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	env := func(m map[string]string) func(string) string {
+		return func(k string) string { return m[k] }
+	}
+
+	c, err := LoadConfig(env(map[string]string{
+		EnvNamespace: "release-beta-win",
+		EnvChannel:   "beta",
+		EnvDataDir:   "/tmp/od-data",
+	}))
+	if err != nil {
+		t.Fatalf("LoadConfig: unexpected error %v", err)
+	}
+	if c.Namespace != "release-beta-win" || c.Channel != "beta" || c.DataDir != "/tmp/od-data" {
+		t.Fatalf("LoadConfig merged unexpected config: %+v", c)
+	}
+
+	if _, err := LoadConfig(env(map[string]string{EnvChannel: "beta"})); err == nil {
+		t.Fatal("LoadConfig: expected cold-start floor error when namespace is empty")
+	}
+}
+
+func TestStampRoundTrip(t *testing.T) {
+	in := Stamp{Hop: 1, AfterQuitPID: 4242, AfterQuitTimeout: 8000, Choice: ChoiceUse}
+	args := in.Args()
+	if len(args) != 2 || args[0] != ArgStamp {
+		t.Fatalf("Args() shape wrong: %v", args)
+	}
+	got := ParseStamp(append([]string{"--other", "x"}, args...))
+	if got.Hop != 1 || got.AfterQuitPID != 4242 || got.AfterQuitTimeout != 8000 || got.Choice != ChoiceUse {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if got.Version != StampVersion {
+		t.Fatalf("Args() must stamp the schema version, got %d", got.Version)
+	}
+}
+
+func TestParseStampAbsentOrMalformed(t *testing.T) {
+	if s := ParseStamp([]string{"--foo", "bar"}); s.Hop != 0 || s.Version != 0 {
+		t.Fatalf("absent stamp must be the zero value (hop 0), got %+v", s)
+	}
+	if s := ParseStamp([]string{ArgStamp, "{not json"}); s.Hop != 0 {
+		t.Fatalf("malformed stamp must be the zero value, got %+v", s)
+	}
+}
+
+func TestManifestSchemaSupported(t *testing.T) {
+	supported := Manifest{}
+	supported.Launcher.Schema = SupportedLauncherSchema
+	if !supported.SchemaSupported() {
+		t.Fatal("manifest at the supported schema must be adoptable")
+	}
+
+	tooNew := Manifest{}
+	tooNew.Launcher.Schema = SupportedLauncherSchema + 1
+	if tooNew.SchemaSupported() {
+		t.Fatal("manifest above the supported launcher schema must trip the local floor")
+	}
+}

--- a/launcher/internal/contract/default.json
+++ b/launcher/internal/contract/default.json
@@ -1,0 +1,5 @@
+{
+  "namespace": "",
+  "channel": "",
+  "dataDir": ""
+}

--- a/launcher/internal/contract/stamp.go
+++ b/launcher/internal/contract/stamp.go
@@ -1,0 +1,56 @@
+package contract
+
+import "encoding/json"
+
+// StampVersion is the in-band additive schema of the launcher→launcher handoff
+// stamp. The stamp is the ONLY launcher→launcher channel and carries the single
+// allowed handoff (L0 baked stub → L1 delegated authority): the hop counter, the
+// after-quit wait to honour, and the deferred adopt choice. It is non-secret and
+// human-readable in `ps` (opacity is not a goal).
+const StampVersion = 1
+
+// Choice is the deferred adopt decision the payload's updater passes down through
+// L0 to L1: use (adopt the available version) or skip. Empty = defer (re-offer
+// next boot). L0 only forwards it; L1 consumes it.
+type Choice string
+
+const (
+	ChoiceUse  Choice = "use"
+	ChoiceSkip Choice = "skip"
+)
+
+// Stamp is the handoff token. Hop selects the mode of the single Go binary: hop 0
+// = the baked bundle copy running as the L0 stub; hop 1 = the delegated payload
+// copy running as the L1 authority. Only ONE handoff is allowed, so a valid Hop
+// is 0 or 1 — L1 never hands off again.
+type Stamp struct {
+	Version          int    `json:"v"`
+	Hop              int    `json:"hop"`
+	AfterQuitPID     int    `json:"aqPid,omitempty"`
+	AfterQuitTimeout int    `json:"aqTimeoutMs,omitempty"`
+	Choice           Choice `json:"choice,omitempty"`
+}
+
+// Args renders the stamp as ["--od-stamp", "<json>"], stamping the current
+// schema version.
+func (s Stamp) Args() []string {
+	s.Version = StampVersion
+	b, _ := json.Marshal(s)
+	return []string{ArgStamp, string(b)}
+}
+
+// ParseStamp scans argv for the stamp token and returns the decoded stamp; the
+// zero value (Hop 0) is returned when the stamp is absent or malformed, so the
+// baked stub with no stamp naturally reads as hop 0.
+func ParseStamp(args []string) Stamp {
+	for i := 0; i < len(args); i++ {
+		if args[i] == ArgStamp && i+1 < len(args) {
+			var s Stamp
+			if json.Unmarshal([]byte(args[i+1]), &s) == nil {
+				return s
+			}
+			return Stamp{}
+		}
+	}
+	return Stamp{}
+}

--- a/launcher/internal/contract/types.go
+++ b/launcher/internal/contract/types.go
@@ -1,0 +1,81 @@
+package contract
+
+// Config is the baked/merged identity + coordinates (the genome). Remote content
+// may never contribute to these fields. Network-free by design: there is no base
+// URL — the launcher never fetches anything.
+type Config struct {
+	Namespace string `json:"namespace"`
+	Channel   string `json:"channel"`
+	DataDir   string `json:"dataDir"`
+}
+
+// Pointer names a version + generation. JSON tags mirror
+// @open-design/launcher-proto's LauncherVersionPointer so runtime.json is shared.
+type Pointer struct {
+	Generation int    `json:"generation"`
+	Version    string `json:"version"`
+}
+
+// Runtime is a version-selection state document: active (want) and lastSuccessful
+// (last confirmed healthy). ONE shape serves BOTH axes as two separate files: the
+// payload axis (runtime.json, L1's domain — kept byte-compatible with
+// launcher-proto's LauncherRuntimeDescriptor so existing TypeScript readers keep
+// working) and the launcher axis (launcher-runtime.json, L0's domain — which
+// versioned launcher binary to hand off to).
+//
+// There is deliberately no available/skipped field: the launcher never downloads,
+// so "adopt this newer version" arrives as a stamp Choice from the payload's
+// updater, not as runtime state.
+type Runtime struct {
+	SchemaVersion  int      `json:"schemaVersion"`
+	Channel        string   `json:"channel"`
+	Namespace      string   `json:"namespace"`
+	Active         *Pointer `json:"active"`
+	LastSuccessful *Pointer `json:"lastSuccessful"`
+	UpdatedAt      string   `json:"updatedAt,omitempty"`
+}
+
+// Attempt marks an in-flight boot of active; a stale one on next boot feeds the
+// rollback decision. FailCount is the crash-loop counter (CS2): the launcher
+// rolls back to lastSuccessful only after FailCount reaches the contract
+// threshold, so a single transient boot failure does not demote a good version.
+type Attempt struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Channel       string `json:"channel"`
+	Namespace     string `json:"namespace"`
+	Version       string `json:"version"`
+	Generation    int    `json:"generation"`
+	FailCount     int    `json:"failCount,omitempty"`
+	StartedAt     string `json:"startedAt,omitempty"`
+}
+
+// LayerSchema is one arm of the hierarchical schema declaration a release feed or
+// on-disk version manifest carries, e.g. `"launcher": { "schema": 2 }`.
+type LayerSchema struct {
+	Schema int `json:"schema"`
+}
+
+// Manifest is the per-version payload descriptor written into versions/<v>/ when
+// the Electron updater extracts a payload. The launcher reads it to enforce its
+// LOCAL schema floor: never adopt/run a version whose Launcher.Schema exceeds
+// SupportedLauncherSchema. WatchdogMs opts a payload into heartbeat supervision
+// (0 = liveness-only).
+type Manifest struct {
+	Launcher   LayerSchema `json:"launcher"`
+	Payload    LayerSchema `json:"payload"`
+	Version    string      `json:"version"`
+	Channel    string      `json:"channel"`
+	Namespace  string      `json:"namespace"`
+	WatchdogMs int         `json:"watchdogMs"`
+	Entry      struct {
+		Cwd  string `json:"cwd"`
+		Exec string `json:"executable"`
+	} `json:"entry"`
+}
+
+// SchemaSupported reports whether this build can interpret the given version
+// manifest — the launcher's local reseed floor (the on-disk counterpart of the
+// feed-facing guardrail the TypeScript updater applies).
+func (m Manifest) SchemaSupported() bool {
+	return m.Launcher.Schema <= SupportedLauncherSchema
+}

--- a/launcher/internal/contract/version.go
+++ b/launcher/internal/contract/version.go
@@ -1,0 +1,137 @@
+package contract
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// CmpVersion compares semver-ish versions. Its ordering is a frozen, shared ABI:
+// it is a faithful port of `compareLauncherVersions` in
+// @open-design/launcher-proto, so the Go launcher and the TypeScript updater
+// agree on version precedence (Q4 conformance). Existing behaviour must never be
+// reordered — only extended. Rules: numeric core `X.Y.Z`; a `X.Y.Z.nightly.N`
+// form; a release (no prerelease) sorts ABOVE a prerelease; numeric prerelease
+// identifiers sort below alphanumeric ones; a shorter prerelease list sorts first.
+func CmpVersion(a, b string) int {
+	left := parseComparable(a)
+	right := parseComparable(b)
+	for i := 0; i < 3; i++ {
+		if left.nums[i] != right.nums[i] {
+			if left.nums[i] < right.nums[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	if len(left.pre) == 0 && len(right.pre) == 0 {
+		return 0
+	}
+	if len(left.pre) == 0 {
+		return 1
+	}
+	if len(right.pre) == 0 {
+		return -1
+	}
+	max := len(left.pre)
+	if len(right.pre) > max {
+		max = len(right.pre)
+	}
+	for i := 0; i < max; i++ {
+		if i >= len(left.pre) {
+			return -1
+		}
+		if i >= len(right.pre) {
+			return 1
+		}
+		if d := compareIdentifier(left.pre[i], right.pre[i]); d != 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+type parsedVersion struct {
+	nums [3]int
+	pre  []string
+}
+
+var (
+	digitsRe  = regexp.MustCompile(`^[0-9]+$`)
+	nightlyRe = regexp.MustCompile(`(?i)^(\d+)\.(\d+)\.(\d+)\.nightly\.(\d+)$`)
+)
+
+func parseComparable(value string) parsedVersion {
+	cleaned := strings.TrimSpace(value)
+	if len(cleaned) > 0 && (cleaned[0] == 'v' || cleaned[0] == 'V') {
+		cleaned = cleaned[1:]
+	}
+	cleaned = strings.SplitN(cleaned, "+", 2)[0]
+	if m := nightlyRe.FindStringSubmatch(cleaned); m != nil {
+		return parsedVersion{nums: [3]int{atoi(m[1]), atoi(m[2]), atoi(m[3])}, pre: []string{"nightly", m[4]}}
+	}
+	core := cleaned
+	pre := ""
+	if i := strings.IndexByte(cleaned, '-'); i >= 0 {
+		core = cleaned[:i]
+		pre = cleaned[i+1:]
+	}
+	parts := strings.Split(core, ".")
+	part := func(i int) string {
+		if i < len(parts) {
+			return parts[i]
+		}
+		return ""
+	}
+	var preList []string
+	if len(pre) > 0 {
+		preList = strings.Split(pre, ".")
+	}
+	return parsedVersion{nums: [3]int{numberPart(part(0)), numberPart(part(1)), numberPart(part(2))}, pre: preList}
+}
+
+func numberPart(s string) int {
+	if !digitsRe.MatchString(s) {
+		return 0
+	}
+	return atoi(s)
+}
+
+func compareIdentifier(a, b string) int {
+	aNum := digitsRe.MatchString(a)
+	bNum := digitsRe.MatchString(b)
+	if aNum && bNum {
+		x, y := atoi(a), atoi(b)
+		switch {
+		case x < y:
+			return -1
+		case x > y:
+			return 1
+		default:
+			return 0
+		}
+	}
+	if aNum {
+		return -1
+	}
+	if bNum {
+		return 1
+	}
+	return sign(strings.Compare(a, b))
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/launcher/internal/state/paths.go
+++ b/launcher/internal/state/paths.go
@@ -1,0 +1,72 @@
+// Package state is the launcher's local disk truth: the on-disk layout, atomic
+// JSON read/write, and the crash-safe A/B selection shared by both axes. It is
+// pure mechanism over the contract kernel and never touches the network.
+package state
+
+import (
+	"path/filepath"
+	"runtime"
+
+	"github.com/nexu-io/open-design/launcher/internal/contract"
+)
+
+// launcherBinaryName is the filename of a versioned delegated-launcher (L1)
+// binary inside versions/<v>/.
+var launcherBinaryName = func() string {
+	if runtime.GOOS == "windows" {
+		return "launcher.exe"
+	}
+	return "launcher"
+}()
+
+// Paths resolves the on-disk launcher layout for one (channel, namespace). It
+// mirrors @open-design/launcher-proto so the payload runtime.json stays
+// forward-compatible with the existing TypeScript readers/writers; the launcher
+// axis adds files without changing the shared ones.
+type Paths struct {
+	Root            string // <dataRoot>/launcher/channels/<ch>/namespaces/<ns>
+	PayloadRuntime  string // runtime.json — payload axis (L1), launcher-proto compatible
+	LauncherRuntime string // launcher-runtime.json — launcher axis (L0), additive
+	PayloadAttempt  string // state/attempt.json — payload boot attempt (L1)
+	LauncherAttempt string // state/launcher-attempt.json — launcher handoff attempt (L0)
+	StateDir        string
+	VersionsDir     string
+	LockDir         string
+}
+
+// Resolve derives the layout under a resolved data root (OD_DATA_DIR-derived).
+func Resolve(dataRoot string, c contract.Config) Paths {
+	root := filepath.Join(dataRoot, "launcher", "channels", c.Channel, "namespaces", c.Namespace)
+	stateDir := filepath.Join(root, "state")
+	return Paths{
+		Root:            root,
+		PayloadRuntime:  filepath.Join(root, "runtime.json"),
+		LauncherRuntime: filepath.Join(root, "launcher-runtime.json"),
+		PayloadAttempt:  filepath.Join(stateDir, "attempt.json"),
+		LauncherAttempt: filepath.Join(stateDir, "launcher-attempt.json"),
+		StateDir:        stateDir,
+		VersionsDir:     filepath.Join(root, "versions"),
+		LockDir:         filepath.Join(stateDir, "lock"),
+	}
+}
+
+// VersionDir is versions/<v>/.
+func (p Paths) VersionDir(version string) string {
+	return filepath.Join(p.VersionsDir, version)
+}
+
+// ManifestPath is versions/<v>/manifest.json.
+func (p Paths) ManifestPath(version string) string {
+	return filepath.Join(p.VersionDir(version), "manifest.json")
+}
+
+// PayloadRoot is versions/<v>/payload — the Electron payload L1 points at.
+func (p Paths) PayloadRoot(version string) string {
+	return filepath.Join(p.VersionDir(version), "payload")
+}
+
+// LauncherBinary is versions/<v>/launcher(.exe) — the delegated L1 binary that L0
+// hands off to.
+func (p Paths) LauncherBinary(version string) string {
+	return filepath.Join(p.VersionDir(version), launcherBinaryName)
+}

--- a/launcher/internal/state/select.go
+++ b/launcher/internal/state/select.go
@@ -1,0 +1,56 @@
+package state
+
+import "github.com/nexu-io/open-design/launcher/internal/contract"
+
+// Reason explains why Select chose a target.
+type Reason string
+
+const (
+	ReasonActive         Reason = "active"
+	ReasonLastSuccessful Reason = "last-successful"
+	ReasonNone           Reason = "none"
+)
+
+// Selection is the outcome of the crash-safe A/B decision.
+type Selection struct {
+	Pointer  *contract.Pointer
+	Reason   Reason
+	Selected bool
+}
+
+// Select applies the crash-safe A/B rollback shared by BOTH axes (L0's launcher
+// axis and L1's payload axis), mirroring @open-design/launcher-proto's
+// selectLauncherRuntimeTarget:
+//
+//   - no active → fall back to lastSuccessful (ReasonNone at genesis with neither);
+//   - a stale attempt still matching active (version+generation) with a
+//     lastSuccessful present means a prior boot of active crashed before
+//     confirming → roll back to lastSuccessful;
+//   - otherwise run active, and the caller (re)writes the attempt before booting.
+//
+// rollbackThreshold implements the CS2 crash-loop tolerance: roll back only after
+// that many consecutive unconfirmed boots. A stale attempt carries FailCount =
+// prior consecutive failures, so this boot is failure FailCount+1; threshold<=1
+// rolls back on the first failure (the PoC default), higher tolerates transient
+// boot failures before demoting a good new version.
+func Select(rt contract.Runtime, attempt *contract.Attempt, rollbackThreshold int) Selection {
+	if rt.Active == nil {
+		if rt.LastSuccessful == nil {
+			return Selection{Reason: ReasonNone}
+		}
+		return Selection{Pointer: rt.LastSuccessful, Reason: ReasonLastSuccessful, Selected: true}
+	}
+	if attempt != nil &&
+		attempt.Version == rt.Active.Version &&
+		attempt.Generation == rt.Active.Generation &&
+		rt.LastSuccessful != nil {
+		threshold := rollbackThreshold
+		if threshold < 1 {
+			threshold = 1
+		}
+		if attempt.FailCount+1 >= threshold {
+			return Selection{Pointer: rt.LastSuccessful, Reason: ReasonLastSuccessful, Selected: true}
+		}
+	}
+	return Selection{Pointer: rt.Active, Reason: ReasonActive, Selected: true}
+}

--- a/launcher/internal/state/select.go
+++ b/launcher/internal/state/select.go
@@ -54,3 +54,46 @@ func Select(rt contract.Runtime, attempt *contract.Attempt, rollbackThreshold in
 	}
 	return Selection{Pointer: rt.Active, Reason: ReasonActive, Selected: true}
 }
+
+// SelectRunnable is Select plus the local schema floor: a chosen version whose
+// on-disk manifest schema this build cannot interpret (schemaOK reports false) is
+// treated as not runnable, so it falls back to lastSuccessful if THAT is
+// schema-compatible, else ReasonNone. This is the launcher-side counterpart of
+// the feed-facing guardrail — the launcher never runs a version it can't govern.
+func SelectRunnable(rt contract.Runtime, attempt *contract.Attempt, rollbackThreshold int, schemaOK func(version string) bool) Selection {
+	sel := Select(rt, attempt, rollbackThreshold)
+	if !sel.Selected {
+		return sel
+	}
+	if schemaOK(sel.Pointer.Version) {
+		return sel
+	}
+	// Chosen version is schema-incompatible; try lastSuccessful if it differs and
+	// is itself compatible.
+	if rt.LastSuccessful != nil &&
+		rt.LastSuccessful.Version != sel.Pointer.Version &&
+		schemaOK(rt.LastSuccessful.Version) {
+		return Selection{Pointer: rt.LastSuccessful, Reason: ReasonLastSuccessful, Selected: true}
+	}
+	return Selection{Reason: ReasonNone}
+}
+
+// NextAttempt computes the attempt marker to persist before booting target. It
+// carries the crash-loop FailCount: incremented when the previous attempt was for
+// the same version+generation (a retry after an unconfirmed boot), reset to 0
+// otherwise (a fresh version).
+func NextAttempt(prev *contract.Attempt, c contract.Config, target contract.Pointer) contract.Attempt {
+	fails := 0
+	if prev != nil && prev.Version == target.Version && prev.Generation == target.Generation {
+		fails = prev.FailCount + 1
+	}
+	return contract.Attempt{
+		SchemaVersion: contract.RuntimeSchema,
+		Channel:       c.Channel,
+		Namespace:     c.Namespace,
+		Version:       target.Version,
+		Generation:    target.Generation,
+		FailCount:     fails,
+		StartedAt:     contract.Now(),
+	}
+}

--- a/launcher/internal/state/state_test.go
+++ b/launcher/internal/state/state_test.go
@@ -1,0 +1,124 @@
+package state
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/nexu-io/open-design/launcher/internal/contract"
+)
+
+func ptr(version string, gen int) *contract.Pointer {
+	return &contract.Pointer{Version: version, Generation: gen}
+}
+
+func TestResolvePaths(t *testing.T) {
+	p := Resolve("/data", contract.Config{Channel: "beta", Namespace: "release-beta-win"})
+	wantRoot := filepath.Join("/data", "launcher", "channels", "beta", "namespaces", "release-beta-win")
+	if p.Root != wantRoot {
+		t.Fatalf("Root = %q, want %q", p.Root, wantRoot)
+	}
+	if p.PayloadRuntime != filepath.Join(wantRoot, "runtime.json") {
+		t.Fatalf("payload runtime path wrong: %q", p.PayloadRuntime)
+	}
+	if p.LauncherRuntime != filepath.Join(wantRoot, "launcher-runtime.json") {
+		t.Fatalf("launcher runtime path wrong: %q", p.LauncherRuntime)
+	}
+	if p.ManifestPath("1.2.0") != filepath.Join(wantRoot, "versions", "1.2.0", "manifest.json") {
+		t.Fatalf("manifest path wrong: %q", p.ManifestPath("1.2.0"))
+	}
+	if p.PayloadRoot("1.2.0") != filepath.Join(wantRoot, "versions", "1.2.0", "payload") {
+		t.Fatalf("payload root wrong: %q", p.PayloadRoot("1.2.0"))
+	}
+}
+
+func TestJSONRoundTripAndMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "runtime.json")
+
+	if _, ok, err := ReadJSON[contract.Runtime](path); err != nil || ok {
+		t.Fatalf("missing file must be (zero,false,nil); got ok=%v err=%v", ok, err)
+	}
+
+	in := contract.Runtime{SchemaVersion: 1, Channel: "beta", Namespace: "ns", Active: ptr("2.0.0", 3), LastSuccessful: ptr("1.0.0", 1)}
+	if err := WriteJSON(path, in); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	got, ok, err := ReadJSON[contract.Runtime](path)
+	if err != nil || !ok {
+		t.Fatalf("ReadJSON after write: ok=%v err=%v", ok, err)
+	}
+	if got.Active == nil || got.Active.Version != "2.0.0" || got.Active.Generation != 3 || got.LastSuccessful.Version != "1.0.0" {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	if err := RemoveIfExists(path); err != nil {
+		t.Fatalf("RemoveIfExists: %v", err)
+	}
+	if err := RemoveIfExists(path); err != nil {
+		t.Fatalf("RemoveIfExists on absent must be nil: %v", err)
+	}
+}
+
+func TestForwardCompatPayloadRuntimeShape(t *testing.T) {
+	// The payload runtime.json must serialise to exactly the launcher-proto keys
+	// (no available/skipped), so existing TypeScript readers keep validating it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "runtime.json")
+	if err := WriteJSON(path, contract.Runtime{SchemaVersion: 1, Channel: "beta", Namespace: "ns", Active: ptr("1.0.0", 0), LastSuccessful: ptr("1.0.0", 0)}); err != nil {
+		t.Fatal(err)
+	}
+	raw, _, err := ReadJSON[map[string]any](path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"available", "skipped"} {
+		if _, present := raw[forbidden]; present {
+			t.Fatalf("payload runtime.json must not carry %q (breaks forward-compat)", forbidden)
+		}
+	}
+	for _, required := range []string{"schemaVersion", "channel", "namespace", "active", "lastSuccessful"} {
+		if _, present := raw[required]; !present {
+			t.Fatalf("payload runtime.json missing launcher-proto key %q", required)
+		}
+	}
+}
+
+func TestSelect(t *testing.T) {
+	stale := func(p *contract.Pointer, fails int) *contract.Attempt {
+		return &contract.Attempt{Version: p.Version, Generation: p.Generation, FailCount: fails}
+	}
+	active := ptr("2.0.0", 1)
+	last := ptr("1.0.0", 0)
+
+	// Genesis: nothing runnable.
+	if s := Select(contract.Runtime{}, nil, 1); s.Selected || s.Reason != ReasonNone {
+		t.Fatalf("genesis must be ReasonNone, got %+v", s)
+	}
+	// No active but a lastSuccessful → run it.
+	if s := Select(contract.Runtime{LastSuccessful: last}, nil, 1); !s.Selected || s.Reason != ReasonLastSuccessful || s.Pointer.Version != "1.0.0" {
+		t.Fatalf("no-active must fall back to last-successful, got %+v", s)
+	}
+	// Clean active, no attempt → run active.
+	if s := Select(contract.Runtime{Active: active, LastSuccessful: last}, nil, 1); !s.Selected || s.Reason != ReasonActive {
+		t.Fatalf("clean active must run, got %+v", s)
+	}
+	// Stale attempt matching active, threshold 1 → roll back on first failure.
+	if s := Select(contract.Runtime{Active: active, LastSuccessful: last}, stale(active, 0), 1); s.Reason != ReasonLastSuccessful {
+		t.Fatalf("threshold 1 must roll back on first stale attempt, got %+v", s)
+	}
+	// Stale attempt but no lastSuccessful → cannot roll back, retry active.
+	if s := Select(contract.Runtime{Active: active}, stale(active, 5), 1); s.Reason != ReasonActive {
+		t.Fatalf("no last-successful means retry active, got %+v", s)
+	}
+	// Threshold 2: first stale retries active, second stale rolls back.
+	if s := Select(contract.Runtime{Active: active, LastSuccessful: last}, stale(active, 0), 2); s.Reason != ReasonActive {
+		t.Fatalf("threshold 2 first failure must retry active, got %+v", s)
+	}
+	if s := Select(contract.Runtime{Active: active, LastSuccessful: last}, stale(active, 1), 2); s.Reason != ReasonLastSuccessful {
+		t.Fatalf("threshold 2 second failure must roll back, got %+v", s)
+	}
+	// A stale attempt for a DIFFERENT version than active is not a crash marker.
+	if s := Select(contract.Runtime{Active: active, LastSuccessful: last}, stale(ptr("1.5.0", 0), 9), 1); s.Reason != ReasonActive {
+		t.Fatalf("attempt for another version must not trigger rollback, got %+v", s)
+	}
+}

--- a/launcher/internal/state/state_test.go
+++ b/launcher/internal/state/state_test.go
@@ -122,3 +122,45 @@ func TestSelect(t *testing.T) {
 		t.Fatalf("attempt for another version must not trigger rollback, got %+v", s)
 	}
 }
+
+func TestSelectRunnableSchemaFloor(t *testing.T) {
+	active := ptr("2.0.0", 1)
+	last := ptr("1.0.0", 0)
+	allOK := func(string) bool { return true }
+	only := func(v string) func(string) bool {
+		return func(candidate string) bool { return candidate == v }
+	}
+
+	// Compatible active → run it (C4).
+	if s := SelectRunnable(contract.Runtime{Active: active, LastSuccessful: last}, nil, 1, allOK); s.Reason != ReasonActive {
+		t.Fatalf("compatible active must run, got %+v", s)
+	}
+	// Active schema-incompatible, lastSuccessful compatible → fall back (C3).
+	if s := SelectRunnable(contract.Runtime{Active: active, LastSuccessful: last}, nil, 1, only("1.0.0")); s.Reason != ReasonLastSuccessful || s.Pointer.Version != "1.0.0" {
+		t.Fatalf("incompatible active must fall back to compatible last-successful, got %+v", s)
+	}
+	// Both incompatible → nothing runnable (C3 → A5).
+	if s := SelectRunnable(contract.Runtime{Active: active, LastSuccessful: last}, nil, 1, func(string) bool { return false }); s.Selected || s.Reason != ReasonNone {
+		t.Fatalf("all-incompatible must be ReasonNone, got %+v", s)
+	}
+}
+
+func TestNextAttempt(t *testing.T) {
+	cfg := contract.Config{Channel: "beta", Namespace: "ns"}
+	target := contract.Pointer{Version: "2.0.0", Generation: 1}
+
+	fresh := NextAttempt(nil, cfg, target)
+	if fresh.FailCount != 0 || fresh.Version != "2.0.0" || fresh.Channel != "beta" || fresh.SchemaVersion != contract.RuntimeSchema {
+		t.Fatalf("fresh attempt wrong: %+v", fresh)
+	}
+	// A retry of the same version increments the crash-loop counter.
+	retry := NextAttempt(&contract.Attempt{Version: "2.0.0", Generation: 1, FailCount: 1}, cfg, target)
+	if retry.FailCount != 2 {
+		t.Fatalf("retry must increment FailCount to 2, got %d", retry.FailCount)
+	}
+	// A different version resets the counter.
+	reset := NextAttempt(&contract.Attempt{Version: "1.0.0", Generation: 0, FailCount: 5}, cfg, target)
+	if reset.FailCount != 0 {
+		t.Fatalf("new version must reset FailCount, got %d", reset.FailCount)
+	}
+}

--- a/launcher/internal/state/store.go
+++ b/launcher/internal/state/store.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ReadJSON reads and decodes a JSON document. A missing file returns
+// (zero, false, nil) so callers can treat absence as genesis rather than error.
+func ReadJSON[T any](path string) (T, bool, error) {
+	var v T
+	b, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return v, false, nil
+	}
+	if err != nil {
+		return v, false, err
+	}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return v, false, err
+	}
+	return v, true, nil
+}
+
+// WriteJSON atomically writes v as pretty JSON: it writes a temp sibling then
+// renames over the target, so a crash mid-write never leaves a torn document.
+func WriteJSON(path string, v any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// RemoveIfExists deletes a file, treating "not found" as success.
+func RemoveIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/launcher/testdata/version-conformance.json
+++ b/launcher/testdata/version-conformance.json
@@ -1,0 +1,22 @@
+{
+  "comment": "Shared version-ordering conformance fixture. Go CmpVersion and TypeScript compareLauncherVersions must both return `expected` (sign of a vs b) for every case, so the two ports never drift. expected: -1 (a<b), 0 (a==b), 1 (a>b).",
+  "cases": [
+    { "a": "1.0.1", "b": "1.0.0", "expected": 1 },
+    { "a": "1.0.0", "b": "1.0.1", "expected": -1 },
+    { "a": "1.0.0", "b": "1.0.0", "expected": 0 },
+    { "a": "2.0.0", "b": "1.9.9", "expected": 1 },
+    { "a": "1.10.0", "b": "1.9.0", "expected": 1 },
+    { "a": "v1.0.1", "b": "1.0.0", "expected": 1 },
+    { "a": "1.0.0+build.7", "b": "1.0.0", "expected": 0 },
+    { "a": "1.0.0", "b": "1.0.0-beta.1", "expected": 1 },
+    { "a": "1.0.0-beta.1", "b": "1.0.0-beta.2", "expected": -1 },
+    { "a": "1.0.0-beta.2", "b": "1.0.0-beta.10", "expected": -1 },
+    { "a": "1.0.0-alpha", "b": "1.0.0-beta", "expected": -1 },
+    { "a": "1.0.0-beta.1", "b": "1.0.0-beta", "expected": 1 },
+    { "a": "1.0.0-1", "b": "1.0.0-alpha", "expected": -1 },
+    { "a": "1.2.3.nightly.5", "b": "1.2.3.nightly.4", "expected": 1 },
+    { "a": "1.2.3.nightly.5", "b": "1.2.3", "expected": -1 },
+    { "a": "1.0.0-rc.1", "b": "1.0.0-rc.1", "expected": 0 },
+    { "a": "0.10.0-beta.1", "b": "0.9.0-beta.1", "expected": 1 }
+  ]
+}

--- a/packages/launcher-proto/tests/version-conformance.test.ts
+++ b/packages/launcher-proto/tests/version-conformance.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { compareLauncherVersions } from "../src/index.js";
+
+// Shared conformance fixture (also verified by the Go launcher's CmpVersion test):
+// both ports must agree on version ordering so they never drift (Q4).
+const fixturePath = fileURLToPath(new URL("../../../launcher/testdata/version-conformance.json", import.meta.url));
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as {
+  cases: Array<{ a: string; b: string; expected: number }>;
+};
+
+describe("compareLauncherVersions Go/TS conformance", () => {
+  it("has a non-empty shared fixture", () => {
+    expect(fixture.cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(fixture.cases)("orders $a vs $b as $expected", ({ a, b, expected }) => {
+    expect(Math.sign(compareLauncherVersions(a, b))).toBe(expected);
+  });
+});

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -131,6 +131,8 @@ const residualAllowedExactPaths = new Set([
   "tools/pack/resources/web-standalone-after-pack.cjs",
   // electron-builder hook path; places the Go launcher in the mac bundle exec slot.
   "tools/pack/resources/launcher-after-pack.cjs",
+  // electron-builder hook path; combined afterPack orchestrator (launcher + web-standalone).
+  "tools/pack/resources/packaged-after-pack.cjs",
 ]);
 
 const residualAllowedPathPrefixes = [

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -129,6 +129,8 @@ const residualAllowedExactPaths = new Set([
   "tools/pack/resources/mac/notarize.cjs",
   // electron-builder hook path; CJS compatibility entry used by tools-pack desktop builds.
   "tools/pack/resources/web-standalone-after-pack.cjs",
+  // electron-builder hook path; places the Go launcher in the mac bundle exec slot.
+  "tools/pack/resources/launcher-after-pack.cjs",
 ]);
 
 const residualAllowedPathPrefixes = [

--- a/tools/pack/resources/launcher-after-pack.cjs
+++ b/tools/pack/resources/launcher-after-pack.cjs
@@ -1,0 +1,103 @@
+// electron-builder afterPack hook: place the Open Design Go launcher at the
+// bundle's executable slot and relocate the real Electron binary beside it, so
+// the OS launches the fossil launcher, which then spawns Electron. macOS only for
+// now (mac-first); other platforms are a no-op. This hook must run BEFORE the
+// web-standalone adhoc bundle sign so that pass covers the swapped-in binary.
+const { execFile } = require("node:child_process");
+const { access, chmod, copyFile, readFile, rename } = require("node:fs/promises");
+const path = require("node:path");
+const { promisify } = require("node:util");
+
+const CONFIG_ENV = "OD_TOOLS_PACK_LAUNCHER_HOOK_CONFIG";
+const DEFAULT_RELOCATED_NAME = "od-electron";
+const execFileAsync = promisify(execFile);
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function pathExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readHookConfig() {
+  const configPath = process.env[CONFIG_ENV];
+  if (configPath == null || configPath.length === 0) {
+    throw new Error(`[tools-pack launcher] missing ${CONFIG_ENV}`);
+  }
+  if (!path.isAbsolute(configPath)) {
+    throw new Error(`[tools-pack launcher] ${CONFIG_ENV} must be absolute: ${configPath}`);
+  }
+  const raw = JSON.parse(await readFile(configPath, "utf8"));
+  if (!isRecord(raw) || raw.version !== 1) {
+    throw new Error("[tools-pack launcher] hook config must be an object with version=1");
+  }
+  if (typeof raw.launcherBinaryPath !== "string" || !path.isAbsolute(raw.launcherBinaryPath)) {
+    throw new Error("[tools-pack launcher] config.launcherBinaryPath must be an absolute path");
+  }
+  return {
+    adhocSign: raw.adhocSign === true,
+    launcherBinaryPath: raw.launcherBinaryPath,
+    relocatedName: typeof raw.relocatedName === "string" && raw.relocatedName.length > 0 ? raw.relocatedName : DEFAULT_RELOCATED_NAME,
+  };
+}
+
+function resolveMacAppPath(context) {
+  if (context == null || typeof context.appOutDir !== "string" || context.appOutDir.length === 0) {
+    throw new Error("[tools-pack launcher] electron-builder context.appOutDir is missing");
+  }
+  const productFilename = context.packager?.appInfo?.productFilename;
+  if (typeof productFilename !== "string" || productFilename.length === 0) {
+    throw new Error("[tools-pack launcher] electron-builder productFilename is missing");
+  }
+  return { appPath: path.join(context.appOutDir, `${productFilename}.app`), productFilename };
+}
+
+// insertMacLauncher is the testable core: relocate the real Electron binary from
+// Contents/MacOS/<product> to a sibling and drop the launcher binary in its place.
+// Idempotent — the Electron binary is relocated only once.
+async function insertMacLauncher({ appPath, productFilename, launcherBinaryPath, relocatedName = DEFAULT_RELOCATED_NAME, adhocSign = false }) {
+  const macDir = path.join(appPath, "Contents", "MacOS");
+  const slot = path.join(macDir, productFilename);
+  const relocated = path.join(macDir, relocatedName);
+  if (!(await pathExists(launcherBinaryPath))) {
+    throw new Error(`[tools-pack launcher] launcher binary not found: ${launcherBinaryPath}`);
+  }
+  if (!(await pathExists(relocated))) {
+    if (!(await pathExists(slot))) {
+      throw new Error(`[tools-pack launcher] bundle executable not found: ${slot}`);
+    }
+    await rename(slot, relocated);
+  }
+  await copyFile(launcherBinaryPath, slot);
+  await chmod(slot, 0o755);
+  if (adhocSign) {
+    await execFileAsync("codesign", ["--force", "--sign", "-", "--timestamp=none", slot], { maxBuffer: 20 * 1024 * 1024 });
+  }
+  return { relocated, slot };
+}
+
+async function runLauncherAfterPack(context) {
+  if (context?.electronPlatformName !== "darwin") return;
+  const config = await readHookConfig();
+  const { appPath, productFilename } = resolveMacAppPath(context);
+  if (!(await pathExists(appPath))) {
+    throw new Error(`[tools-pack launcher] app bundle not found: ${appPath}`);
+  }
+  await insertMacLauncher({ appPath, productFilename, ...config });
+}
+
+module.exports = async function launcherAfterPack(context) {
+  try {
+    await runLauncherAfterPack(context);
+  } catch (error) {
+    console.error("[tools-pack launcher] after-pack hook failed:", error instanceof Error ? error.message : error);
+    throw error;
+  }
+};
+module.exports.insertMacLauncher = insertMacLauncher;

--- a/tools/pack/resources/packaged-after-pack.cjs
+++ b/tools/pack/resources/packaged-after-pack.cjs
@@ -1,0 +1,19 @@
+// Combined electron-builder afterPack orchestrator. electron-builder exposes a
+// single afterPack slot, so this runs the packaged-app hooks in the required
+// order: the launcher insertion FIRST (it must precede any adhoc bundle sign so
+// that sign covers the swapped-in Go binary), then the web-standalone hook. Each
+// inner hook runs only when its own config env var is present, so this is safe to
+// wire unconditionally.
+const LAUNCHER_CONFIG_ENV = "OD_TOOLS_PACK_LAUNCHER_HOOK_CONFIG";
+const WEB_STANDALONE_CONFIG_ENV = "OD_TOOLS_PACK_WEB_STANDALONE_HOOK_CONFIG";
+
+module.exports = async function packagedAfterPack(context) {
+  const launcherConfig = process.env[LAUNCHER_CONFIG_ENV];
+  if (launcherConfig != null && launcherConfig.length > 0) {
+    await require("./launcher-after-pack.cjs")(context);
+  }
+  const webStandaloneConfig = process.env[WEB_STANDALONE_CONFIG_ENV];
+  if (webStandaloneConfig != null && webStandaloneConfig.length > 0) {
+    await require("./web-standalone-after-pack.cjs")(context);
+  }
+};

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -68,6 +68,12 @@ export type ToolPackRoots = {
 export type ToolPackConfig = {
   appVersion?: string;
   containerized: boolean;
+  /**
+   * Opt-in: embed the Go fossil launcher at the bundle executable slot (mac only
+   * for now) via the afterPack insertion hook. Off by default so existing builds
+   * are byte-identical; enabled with OD_PACK_EMBED_LAUNCHER=1.
+   */
+  embedLauncher?: boolean;
   electronBuilderCliPath: string;
   electronDistPath: string;
   electronVersion: string;
@@ -323,6 +329,7 @@ export function resolveToolPackConfig(
   return {
     appVersion,
     containerized: options.containerized === true,
+    embedLauncher: process.env.OD_PACK_EMBED_LAUNCHER === "1",
     electronBuilderCliPath: resolveElectronBuilderCliPath(),
     electronDistPath: resolveElectronDistPath(WORKSPACE_ROOT),
     electronVersion: resolveElectronVersion(WORKSPACE_ROOT),

--- a/tools/pack/src/launcher-build.ts
+++ b/tools/pack/src/launcher-build.ts
@@ -1,0 +1,57 @@
+import { execFile } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const CONTRACT_SELF_VERSION_SYMBOL = "github.com/nexu-io/open-design/launcher/internal/contract.SelfVersion";
+
+function goArchForNodeArch(nodeArch: string): string {
+  switch (nodeArch) {
+    case "arm64":
+      return "arm64";
+    case "x64":
+      return "amd64";
+    default:
+      return nodeArch;
+  }
+}
+
+/**
+ * Build the Go fossil launcher binary for the packaged app. Compiles
+ * launcher/cmd/launcher, baking the packaged version into contract.SelfVersion so
+ * the launcher knows its own version for the handoff comparison. Local mac builds
+ * target the host arch (electron-builder's default); goos/goarch can be overridden
+ * for cross-compilation.
+ */
+export async function buildLauncherBinary(input: {
+  goarch?: string;
+  goos?: string;
+  outPath: string;
+  selfVersion: string;
+  workspaceRoot: string;
+}): Promise<{ outPath: string }> {
+  const launcherModuleRoot = join(input.workspaceRoot, "launcher");
+  await mkdir(dirname(input.outPath), { recursive: true });
+  const goos = input.goos ?? "darwin";
+  const goarch = input.goarch ?? goArchForNodeArch(process.arch);
+  await execFileAsync(
+    "go",
+    [
+      "build",
+      "-trimpath",
+      "-ldflags",
+      `-X ${CONTRACT_SELF_VERSION_SYMBOL}=${input.selfVersion}`,
+      "-o",
+      input.outPath,
+      "./cmd/launcher",
+    ],
+    {
+      cwd: launcherModuleRoot,
+      env: { ...process.env, CGO_ENABLED: "0", GOOS: goos, GOARCH: goarch },
+      maxBuffer: 20 * 1024 * 1024,
+    },
+  );
+  return { outPath: input.outPath };
+}

--- a/tools/pack/src/mac/builder.ts
+++ b/tools/pack/src/mac/builder.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 
 import type { ToolPackConfig } from "../config.js";
 import { domToPptxBundleResource } from "../dom-to-pptx-resource.js";
+import { buildLauncherBinary } from "../launcher-build.js";
 import { macResources } from "../resources.js";
 import { electronBuilderVersionForAppVersion } from "../versions.js";
 import { execFileAsync } from "./commands.js";
@@ -64,6 +65,28 @@ async function writeWebStandaloneHookConfig(config: ToolPackConfig, paths: MacPa
   return paths.webStandaloneHookConfigPath;
 }
 
+// prepareLauncherInsertion builds the Go fossil launcher binary and writes the
+// afterPack hook config so the combined orchestrator drops it into the bundle's
+// executable slot. Opt-in via config.embedLauncher; returns the hook config path.
+async function prepareLauncherInsertion(config: ToolPackConfig, paths: MacPaths, packagedVersion: string): Promise<string> {
+  await buildLauncherBinary({
+    outPath: paths.launcherBinaryPath,
+    selfVersion: packagedVersion,
+    workspaceRoot: config.workspaceRoot,
+  });
+  await mkdir(dirname(paths.launcherHookConfigPath), { recursive: true });
+  await writeFile(
+    paths.launcherHookConfigPath,
+    `${JSON.stringify(
+      { adhocSign: !config.signed, launcherBinaryPath: paths.launcherBinaryPath, relocatedName: "od-electron", version: 1 },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  return paths.launcherHookConfigPath;
+}
+
 export function resolveElectronBuilderTargets(to: MacBuildOutput): ElectronBuilderTarget[] {
   switch (to) {
     case "app":
@@ -89,10 +112,15 @@ export async function runElectronBuilder(
   const webStandaloneHookConfigPath = config.webOutputMode === "standalone"
     ? await writeWebStandaloneHookConfig(config, paths)
     : null;
+  const launcherHookConfigPath = config.embedLauncher
+    ? await prepareLauncherInsertion(config, paths, packagedVersion)
+    : null;
   const builderConfig = {
     appId: identity.appId,
     artifactName: `${PRODUCT_NAME}-${namespaceToken}.\${ext}`,
-    afterPack: webStandaloneHookConfigPath == null ? undefined : macResources.webStandaloneAfterPackHook,
+    afterPack: launcherHookConfigPath != null
+      ? macResources.packagedAfterPackHook
+      : webStandaloneHookConfigPath == null ? undefined : macResources.webStandaloneAfterPackHook,
     afterSign: config.signed && config.macNotarize ? macResources.notarizeHook : undefined,
     asar: ELECTRON_BUILDER_ASAR,
     buildDependenciesFromSource: false,
@@ -163,6 +191,7 @@ export async function runElectronBuilder(
       ...process.env,
       ...(config.signed ? {} : { CSC_IDENTITY_AUTO_DISCOVERY: "false" }),
       ...(webStandaloneHookConfigPath == null ? {} : { [WEB_STANDALONE_HOOK_CONFIG_ENV]: webStandaloneHookConfigPath }),
+      ...(launcherHookConfigPath == null ? {} : { OD_TOOLS_PACK_LAUNCHER_HOOK_CONFIG: launcherHookConfigPath }),
     },
   });
 }

--- a/tools/pack/src/mac/paths.ts
+++ b/tools/pack/src/mac/paths.ts
@@ -64,6 +64,8 @@ export function resolveMacPaths(config: ToolPackConfig): MacPaths {
     installApplicationsRoot,
     installedAppPath,
     latestMacYmlPath: join(namespaceRoot, "zip", "latest-mac.yml"),
+    launcherBinaryPath: join(namespaceRoot, "launcher-bin", "od-launcher"),
+    launcherHookConfigPath: join(namespaceRoot, "launcher-hook.json"),
     mountPoint: join(namespaceRoot, "mount"),
     packagedMainPrebundleMetaPath: join(namespaceRoot, MAC_PREBUNDLE_META_DIR_NAME, "packaged-main.meta.json"),
     packagedMainPrebundlePath: join(namespaceRoot, "assembled", MAC_PREBUNDLED_PACKAGED_MAIN_RELATIVE_PATH),

--- a/tools/pack/src/mac/types.ts
+++ b/tools/pack/src/mac/types.ts
@@ -28,6 +28,8 @@ export type MacPaths = {
   installApplicationsRoot: string;
   installedAppPath: string;
   latestMacYmlPath: string;
+  launcherBinaryPath: string;
+  launcherHookConfigPath: string;
   mountPoint: string;
   packagedMainPrebundleMetaPath: string;
   packagedMainPrebundlePath: string;

--- a/tools/pack/src/resources.ts
+++ b/tools/pack/src/resources.ts
@@ -36,6 +36,8 @@ export const macResources = {
   iconPng: join(resourcesRoot, "mac", "icon.png"),
   notarizeHook: join(resourcesRoot, "mac", "notarize.cjs"),
   webStandaloneAfterPackHook: join(resourcesRoot, "web-standalone-after-pack.cjs"),
+  launcherAfterPackHook: join(resourcesRoot, "launcher-after-pack.cjs"),
+  packagedAfterPackHook: join(resourcesRoot, "packaged-after-pack.cjs"),
 } as const;
 
 export const winResources = {

--- a/tools/pack/tests/launcher-after-pack.test.ts
+++ b/tools/pack/tests/launcher-after-pack.test.ts
@@ -1,0 +1,86 @@
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const hook = require("../resources/launcher-after-pack.cjs") as {
+  (context: unknown): Promise<void>;
+  insertMacLauncher: (input: {
+    adhocSign?: boolean;
+    appPath: string;
+    launcherBinaryPath: string;
+    productFilename: string;
+    relocatedName?: string;
+  }) => Promise<{ relocated: string; slot: string }>;
+};
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function buildSyntheticBundle(): Promise<{ appPath: string; launcherBinaryPath: string; product: string; root: string }> {
+  const root = await mkdtemp(join(tmpdir(), "od-launcher-afterpack-"));
+  const product = "Open Design";
+  const appPath = join(root, `${product}.app`);
+  const macDir = join(appPath, "Contents", "MacOS");
+  await mkdir(macDir, { recursive: true });
+  await writeFile(join(macDir, product), "ELECTRON-BINARY", "utf8");
+  await chmod(join(macDir, product), 0o755);
+  const launcherBinaryPath = join(root, "go-launcher");
+  await writeFile(launcherBinaryPath, "GO-LAUNCHER-BINARY", "utf8");
+  await chmod(launcherBinaryPath, 0o755);
+  return { appPath, launcherBinaryPath, product, root };
+}
+
+describe("launcher after-pack insertion", () => {
+  it("relocates Electron and drops the launcher in the executable slot", async () => {
+    const { appPath, launcherBinaryPath, product, root } = await buildSyntheticBundle();
+    try {
+      const macDir = join(appPath, "Contents", "MacOS");
+      const { slot, relocated } = await hook.insertMacLauncher({ appPath, productFilename: product, launcherBinaryPath, relocatedName: "od-electron" });
+
+      expect(slot).toBe(join(macDir, product));
+      expect(relocated).toBe(join(macDir, "od-electron"));
+      expect(await readFile(relocated, "utf8")).toBe("ELECTRON-BINARY");
+      expect(await readFile(slot, "utf8")).toBe("GO-LAUNCHER-BINARY");
+      // The OS-launched slot must be executable.
+      const { mode } = await import("node:fs/promises").then((fs) => fs.stat(slot));
+      expect(mode & 0o100).toBeTruthy();
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("is idempotent — a second run does not clobber the relocated Electron", async () => {
+    const { appPath, launcherBinaryPath, product, root } = await buildSyntheticBundle();
+    try {
+      await hook.insertMacLauncher({ appPath, productFilename: product, launcherBinaryPath });
+      // Second run: the slot already holds the launcher; Electron must stay put.
+      await hook.insertMacLauncher({ appPath, productFilename: product, launcherBinaryPath });
+      const macDir = join(appPath, "Contents", "MacOS");
+      expect(await readFile(join(macDir, "od-electron"), "utf8")).toBe("ELECTRON-BINARY");
+      expect(await readFile(join(macDir, product), "utf8")).toBe("GO-LAUNCHER-BINARY");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("fails clearly when the launcher binary is missing", async () => {
+    const { appPath, product, root } = await buildSyntheticBundle();
+    try {
+      await expect(
+        hook.insertMacLauncher({ appPath, productFilename: product, launcherBinaryPath: join(root, "missing") }),
+      ).rejects.toThrow(/launcher binary not found/);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tools/pack/tests/packaged-after-pack.test.ts
+++ b/tools/pack/tests/packaged-after-pack.test.ts
@@ -1,0 +1,68 @@
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const packagedAfterPack = require("../resources/packaged-after-pack.cjs") as (context: unknown) => Promise<void>;
+
+const LAUNCHER_CONFIG_ENV = "OD_TOOLS_PACK_LAUNCHER_HOOK_CONFIG";
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function buildBundle(): Promise<{ appOutDir: string; context: unknown; macDir: string; product: string; root: string }> {
+  const root = await mkdtemp(join(tmpdir(), "od-packaged-afterpack-"));
+  const product = "Open Design";
+  const appOutDir = root;
+  const macDir = join(appOutDir, `${product}.app`, "Contents", "MacOS");
+  await mkdir(macDir, { recursive: true });
+  await writeFile(join(macDir, product), "ELECTRON-BINARY", "utf8");
+  await chmod(join(macDir, product), 0o755);
+  const context = { appOutDir, electronPlatformName: "darwin", packager: { appInfo: { productFilename: product } } };
+  return { appOutDir, context, macDir, product, root };
+}
+
+afterEach(() => {
+  delete process.env[LAUNCHER_CONFIG_ENV];
+});
+
+describe("combined packaged after-pack orchestrator", () => {
+  it("runs the launcher insertion when its config env is set", async () => {
+    const { context, macDir, product, root } = await buildBundle();
+    try {
+      const launcherBinaryPath = join(root, "go-launcher");
+      await writeFile(launcherBinaryPath, "GO-LAUNCHER", "utf8");
+      const configPath = join(root, "launcher-hook.json");
+      await writeFile(configPath, JSON.stringify({ launcherBinaryPath, relocatedName: "od-electron", version: 1 }), "utf8");
+      process.env[LAUNCHER_CONFIG_ENV] = configPath;
+
+      await packagedAfterPack(context);
+
+      expect(await readFile(join(macDir, "od-electron"), "utf8")).toBe("ELECTRON-BINARY");
+      expect(await readFile(join(macDir, product), "utf8")).toBe("GO-LAUNCHER");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("is a no-op when no hook config env is set", async () => {
+    const { context, macDir, product, root } = await buildBundle();
+    try {
+      await packagedAfterPack(context);
+      // Electron binary untouched; no od-electron sibling created.
+      expect(await readFile(join(macDir, product), "utf8")).toBe("ELECTRON-BINARY");
+      expect(await pathExists(join(macDir, "od-electron"))).toBe(false);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #5235 (base `launcher-go-core`). The Go fossil launcher — a small,
network-free binary that takes the packaged bundle's executable slot and
trampolines to the (relocated) Electron payload. This PR is the foundation +
an opt-in mac embed; it is **off by default** and existing builds are byte-identical.

## Why

**Use case.** Groundwork for moving Open Design's packaged cold-start onto a
policy-free launcher (the "fossil" layer), so the update authority (version
select / rollback) lives OUTSIDE the payload it governs, and the launcher's own
logic becomes hot-path-updatable via a single launcher→launcher handoff. This PR
lands the launcher core + the packaging seam so later increments (moving select
authority into the launcher, health-gated confirm) have a validated base.

**Pain.** Today the update decision (which version to run, rollback) runs *inside*
the Electron process it is meant to govern — the update brain is in the body being
updated. The fossil launcher moves that authority out. Nothing ships to users here;
it is scaffolding, entirely behind an opt-in flag.

## What users will see

**Nothing** — the launcher is off by default (`OD_PACK_EMBED_LAUNCHER` unset).
When later enabled, the OS launches a tiny Go binary that transparently starts the
same Electron app; users see no difference until the authority increments land.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — new `OD_PACK_EMBED_LAUNCHER=1` opt-in for `tools-pack mac build`.
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — no; opt-in, off by default.
- [x] **None (net)** — new `launcher/` Go module + opt-in packaging; no shipped behavior change.

## Validation

- `go vet/build/test ./...` green in the `launcher/` module: contract kernel
  (ABI, version compare, stamp), state (two-axis layout, atomic RMW, crash-safe A/B
  + schema floor + crash-loop threshold), and the L0 select/handoff decision matrix.
- Go/TS version-ordering **conformance** fixture verified by both ports.
- tools-pack afterPack insertion + combined orchestrator unit tests green; `pnpm guard`
  + `pnpm --filter @open-design/tools-pack typecheck` clean.
- **Real mac build** (`OD_PACK_EMBED_LAUNCHER=1 pnpm tools-pack mac build --to app`):
  the produced `.app` has the Go launcher at `Contents/MacOS/Open Design` and the
  real Electron relocated to `od-electron`; launching it boots the full app via the
  Go trampoline (resident parent), zero regression. Local smoke: argv/env/exit
  forwarding, genesis, and a real L0→L1 handoff (attempt-before-handoff, hop+1).

Scenario coverage map: `.task/resources/update-scenarios.md` (not in this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
