### PR TITLE
feat(daemon): Spec E resource sharing — client/SDK/CLI + local fixture

### DIFF
--- a/apps/daemon/AGENTS.md
+++ b/apps/daemon/AGENTS.md
@@ -25,6 +25,7 @@ The daemon is not a shared library for the web app. Do not import daemon private
 - `src/runtimes/` owns agent runtime definitions, spawning, parser integration, executable discovery, and runtime environment shaping. Agent argument definitions belong in `src/runtimes/defs/`.
 - `src/prompts/` owns daemon-side prompt construction. Keep mirrored BYOK/API wording in `packages/contracts/src/prompts/` when the same text is exposed outside the daemon.
 - `src/plugins/`, `src/connectors/`, `src/registry/`, `src/research/`, `src/media-adapters/`, `src/live-artifacts/`, `src/storage/`, and `src/critique/` own their named domains. Prefer adding code inside the existing domain folder before creating a new top-level folder.
+- Spec E team resource sharing (cloud storage) lives in three files: the hub HTTP client `src/integrations/resource-hub.ts`, the neutral cloud-drive SDK `src/resource-drive.ts` (kind-agnostic tree⇄manifest+blobs), and the `od resource` CLI `src/resource-cli.ts`. The daemon speaks the real resource-hub wire protocol — no mocks. For local dev without the vela stack, run the fixture (`pnpm tools-serve start resource-hub`) and set `OD_RESOURCE_HUB_URL` (see `tools/serve/AGENTS.md`). Feature-specific sharing (e.g. design-system share, the `routes/resources/*` share/pull endpoints) is a consumer layer built on top of the SDK, not part of it.
 - `tests/` contains daemon tests. Keep test paths roughly parallel to `src/` when useful.
 
 Do not edit generated `dist/` output.

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -5,6 +5,7 @@ import { basename } from 'node:path';
 import { runDaemonCliStartup, startDaemonRuntime } from './daemon-startup.js';
 import { runLiveArtifactsMcpServer } from './mcp-live-artifacts-server.js';
 import { runArtifactsCli } from './artifacts-cli.js';
+import { runResource } from './resource-cli.js';
 import { runProjectHandoff } from './handoff-cli.js';
 import { runConnectorsToolCli } from './tools-connectors-cli.js';
 import { runDesignSystemsToolCli } from './tools-design-systems-cli.js';
@@ -330,6 +331,7 @@ const SUBCOMMAND_MAP = {
   atoms: runAtoms,
   skills: runSkills,
   'design-systems': runDesignSystems,
+  resource: runResource,
   craft: runCraft,
   diagnostics: runDiagnostics,
   export: runExport,

--- a/apps/daemon/src/integrations/resource-hub.ts
+++ b/apps/daemon/src/integrations/resource-hub.ts
@@ -3,19 +3,17 @@
 // env-scoped config (so this file — not app-config.ts — owns OD_RESOURCE_HUB_*),
 // and a default singleton.
 //
-// SCOPE (Tier-1 skeleton): the INDEX surface the hub already serves is wired for
-// real (resources / versions / refs / find-missing). Two things are deliberate
-// seams, not final:
-//   - Auth: how the daemon proves the workspace principal to the hub is an open
-//     topology decision (daemon-direct + services/api-issued scoped token, vs
-//     internal-token forwarding). Here it attaches whatever env-configured
-//     credentials it has; swapping schemes changes only buildAuthHeaders.
-//   - Blob BYTE transfer: pending the transport decision (presigned vs proxy).
-//     Only find-missing (index) is implemented; byte push/pull throw until then.
-// Shared DTOs will move to @open-design/contracts once the platform publishes
-// the canonical resource contracts; the local types below are provisional.
+// The index surface (resources / versions / refs / manifests) and blob byte
+// transfer (presigned client-direct: pushBlob/pullBlob) are both wired for real.
+// One deliberate seam remains: auth — how the daemon proves the workspace
+// principal is an open topology decision (services/api authenticates the daemon
+// and resolves the principal, vs internal-token forwarding). It currently
+// attaches whatever env-configured credentials it has; swapping schemes changes
+// only buildAuthHeaders. Shared DTOs will move to @open-design/contracts once
+// the platform publishes the canonical resource contracts; the local types
+// below are provisional.
 
-const DEFAULT_RESOURCE_HUB_URL = 'http://127.0.0.1:18082';
+const DEFAULT_RESOURCE_HUB_URL = 'http://127.0.0.1:18080';
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
 
 type FetchLike = typeof fetch;

--- a/apps/daemon/src/integrations/resource-hub.ts
+++ b/apps/daemon/src/integrations/resource-hub.ts
@@ -1,0 +1,295 @@
+// Client for the Vela resource hub (Spec E cloud storage). Mirrors the
+// vela-wallet integration shape: a factory with injectable fetch/env/timeout,
+// env-scoped config (so this file — not app-config.ts — owns OD_RESOURCE_HUB_*),
+// and a default singleton.
+//
+// SCOPE (Tier-1 skeleton): the INDEX surface the hub already serves is wired for
+// real (resources / versions / refs / find-missing). Two things are deliberate
+// seams, not final:
+//   - Auth: how the daemon proves the workspace principal to the hub is an open
+//     topology decision (daemon-direct + services/api-issued scoped token, vs
+//     internal-token forwarding). Here it attaches whatever env-configured
+//     credentials it has; swapping schemes changes only buildAuthHeaders.
+//   - Blob BYTE transfer: pending the transport decision (presigned vs proxy).
+//     Only find-missing (index) is implemented; byte push/pull throw until then.
+// Shared DTOs will move to @open-design/contracts once the platform publishes
+// the canonical resource contracts; the local types below are provisional.
+
+const DEFAULT_RESOURCE_HUB_URL = 'http://127.0.0.1:18082';
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+
+type FetchLike = typeof fetch;
+
+export type ResourceKind = 'design_system' | 'plugin' | 'skill' | 'project';
+
+// Provisional — to be replaced by the platform's canonical workspace principal
+// (地基 contracts). The daemon does not yet own a member table (link B), so the
+// principal is sourced from env for now (see readResourceHubPrincipal).
+export interface ResourceHubPrincipal {
+  memberId: string;
+  teamId: string;
+  role: 'owner' | 'admin' | 'member';
+  lifecycleState: string | null;
+}
+
+export interface ResourceRecord {
+  id: string;
+  teamId: string;
+  kind: string;
+  ownerMemberId: string;
+  createdAt: string;
+  deletedAt: string | null;
+}
+
+export interface VersionRecord {
+  id: string;
+  resourceId: string;
+  version: number;
+  manifestDigest: string;
+  createdByMemberId: string;
+  createdAt: string;
+}
+
+export interface RefRecord {
+  resourceId: string;
+  name: string;
+  versionId: string;
+  updatedAt: string;
+  updatedByMemberId: string;
+}
+
+export interface ManifestEntryInput {
+  path: string;
+  type: 'file' | 'dir' | 'symlink';
+  executable?: boolean;
+  blobDigest?: string | null;
+  symlinkTarget?: string | null;
+}
+
+export interface PublishVersionInput {
+  manifestDigest: string;
+  entries: ManifestEntryInput[];
+  ref?: string;
+  expectedVersionId?: string | null;
+}
+
+export class ResourceHubError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message?: string,
+  ) {
+    super(message ?? `resource hub error ${status} (${code})`);
+    this.name = 'ResourceHubError';
+  }
+}
+
+export interface ResourceHubConfig {
+  baseUrl: string;
+  internalToken: string | null;
+}
+
+export function readResourceHubConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ResourceHubConfig {
+  const baseUrl = env.OD_RESOURCE_HUB_URL?.trim() || DEFAULT_RESOURCE_HUB_URL;
+  const internalToken = env.OD_RESOURCE_HUB_TOKEN?.trim() || null;
+  return { baseUrl, internalToken };
+}
+
+// Provisional principal source. Real sourcing joins the signed-in Vela identity
+// (integrations/vela.ts) with the workspace membership from link B; until that
+// lands, dev/local reads it from env so the loop is drivable.
+export function readResourceHubPrincipal(
+  env: NodeJS.ProcessEnv = process.env,
+): ResourceHubPrincipal | null {
+  const memberId = env.OD_WORKSPACE_MEMBER_ID?.trim();
+  const teamId = env.OD_WORKSPACE_TEAM_ID?.trim();
+  if (!memberId || !teamId) return null;
+  const rawRole = env.OD_WORKSPACE_ROLE?.trim();
+  const role =
+    rawRole === 'owner' || rawRole === 'admin' || rawRole === 'member'
+      ? rawRole
+      : 'member';
+  return {
+    memberId,
+    teamId,
+    role,
+    lifecycleState: env.OD_WORKSPACE_LIFECYCLE_STATE?.trim() || null,
+  };
+}
+
+interface ResourceHubClientOptions {
+  config?: ResourceHubConfig;
+  fetch?: FetchLike;
+  timeoutMs?: number;
+}
+
+export function createResourceHubClient(options: ResourceHubClientOptions = {}) {
+  const config = options.config ?? readResourceHubConfig();
+  const fetchImpl = options.fetch ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+
+  function buildAuthHeaders(
+    principal: ResourceHubPrincipal,
+  ): Record<string, string> {
+    // Seam: the final scheme (services/api-issued scoped token vs internal-token
+    // forwarding) is undecided. For now forward the principal under the header
+    // contract the hub's auth seam consumes, gated by the internal token.
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      'x-workspace-member-id': principal.memberId,
+      'x-workspace-team-id': principal.teamId,
+      'x-workspace-role': principal.role,
+    };
+    if (principal.lifecycleState) {
+      headers['x-workspace-lifecycle-state'] = principal.lifecycleState;
+    }
+    if (config.internalToken) {
+      headers['x-internal-token'] = config.internalToken;
+    }
+    return headers;
+  }
+
+  async function request<T>(
+    principal: ResourceHubPrincipal,
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchImpl(new URL(path, config.baseUrl), {
+        method,
+        headers: buildAuthHeaders(principal),
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: controller.signal,
+      });
+      const text = await response.text();
+      const payload = text ? JSON.parse(text) : {};
+      if (!response.ok) {
+        const code =
+          typeof payload?.error === 'string' ? payload.error : 'unknown';
+        throw new ResourceHubError(response.status, code, payload?.message);
+      }
+      return payload as T;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  return {
+    isConfigured(): boolean {
+      return Boolean(config.baseUrl);
+    },
+
+    async listResources(
+      principal: ResourceHubPrincipal,
+    ): Promise<ResourceRecord[]> {
+      const body = await request<{ resources: ResourceRecord[] }>(
+        principal,
+        'GET',
+        '/api/v1/resources',
+      );
+      return body.resources ?? [];
+    },
+
+    async getResource(
+      principal: ResourceHubPrincipal,
+      resourceId: string,
+    ): Promise<ResourceRecord> {
+      return request<ResourceRecord>(
+        principal,
+        'GET',
+        `/api/v1/resources/${encodeURIComponent(resourceId)}`,
+      );
+    },
+
+    async createResource(
+      principal: ResourceHubPrincipal,
+      input: { kind: ResourceKind; resourceId?: string },
+    ): Promise<ResourceRecord> {
+      return request<ResourceRecord>(
+        principal,
+        'POST',
+        '/api/v1/resources',
+        input,
+      );
+    },
+
+    async findMissingBlobs(
+      principal: ResourceHubPrincipal,
+      digests: string[],
+    ): Promise<string[]> {
+      const body = await request<{ missing: string[] }>(
+        principal,
+        'POST',
+        '/api/v1/resources/blobs/find-missing',
+        { digests },
+      );
+      return body.missing ?? [];
+    },
+
+    async publishVersion(
+      principal: ResourceHubPrincipal,
+      resourceId: string,
+      input: PublishVersionInput,
+    ): Promise<VersionRecord> {
+      return request<VersionRecord>(
+        principal,
+        'POST',
+        `/api/v1/resources/${encodeURIComponent(resourceId)}/versions`,
+        input,
+      );
+    },
+
+    async getRef(
+      principal: ResourceHubPrincipal,
+      resourceId: string,
+      ref: string,
+    ): Promise<RefRecord> {
+      return request<RefRecord>(
+        principal,
+        'GET',
+        `/api/v1/resources/${encodeURIComponent(resourceId)}/refs/${encodeURIComponent(ref)}`,
+      );
+    },
+
+    async setRef(
+      principal: ResourceHubPrincipal,
+      resourceId: string,
+      ref: string,
+      input: { versionId: string; expectedVersionId?: string | null },
+    ): Promise<RefRecord> {
+      return request<RefRecord>(
+        principal,
+        'PUT',
+        `/api/v1/resources/${encodeURIComponent(resourceId)}/refs/${encodeURIComponent(ref)}`,
+        input,
+      );
+    },
+
+    // Blob byte transfer is pending the transport decision (presigned vs proxy).
+    // Only the index (find-missing above) is wired; the byte path throws so a
+    // premature caller fails loudly rather than silently no-oping.
+    async pushBlob(): Promise<never> {
+      throw new ResourceHubError(
+        501,
+        'not_implemented',
+        'blob byte upload is pending the transport decision (presigned vs proxy)',
+      );
+    },
+    async pullBlob(): Promise<never> {
+      throw new ResourceHubError(
+        501,
+        'not_implemented',
+        'blob byte download is pending the transport decision (presigned vs proxy)',
+      );
+    },
+  };
+}
+
+export type ResourceHubClient = ReturnType<typeof createResourceHubClient>;
+
+export const resourceHubClient = createResourceHubClient();

--- a/apps/daemon/src/integrations/resource-hub.ts
+++ b/apps/daemon/src/integrations/resource-hub.ts
@@ -66,6 +66,19 @@ export interface ManifestEntryInput {
   symlinkTarget?: string | null;
 }
 
+export interface ManifestEntry {
+  path: string;
+  type: 'file' | 'dir' | 'symlink';
+  executable: boolean;
+  blobDigest: string | null;
+  symlinkTarget: string | null;
+}
+
+export interface Manifest {
+  digest: string;
+  entries: ManifestEntry[];
+}
+
 export interface PublishVersionInput {
   manifestDigest: string;
   entries: ManifestEntryInput[];
@@ -226,7 +239,7 @@ export function createResourceHubClient(options: ResourceHubClientOptions = {}) 
 
     async createResource(
       principal: ResourceHubPrincipal,
-      input: { kind: ResourceKind; resourceId?: string },
+      input: { kind: string; resourceId?: string },
     ): Promise<ResourceRecord> {
       return request<ResourceRecord>(
         principal,
@@ -259,6 +272,29 @@ export function createResourceHubClient(options: ResourceHubClientOptions = {}) 
         'POST',
         `/api/v1/resources/${encodeURIComponent(resourceId)}/versions`,
         input,
+      );
+    },
+
+    async listVersions(
+      principal: ResourceHubPrincipal,
+      resourceId: string,
+    ): Promise<VersionRecord[]> {
+      const body = await request<{ versions: VersionRecord[] }>(
+        principal,
+        'GET',
+        `/api/v1/resources/${encodeURIComponent(resourceId)}/versions`,
+      );
+      return body.versions ?? [];
+    },
+
+    async getManifest(
+      principal: ResourceHubPrincipal,
+      digest: string,
+    ): Promise<Manifest> {
+      return request<Manifest>(
+        principal,
+        'GET',
+        `/api/v1/resources/manifests/${encodeURIComponent(digest)}`,
       );
     },
 

--- a/apps/daemon/src/integrations/resource-hub.ts
+++ b/apps/daemon/src/integrations/resource-hub.ts
@@ -73,6 +73,24 @@ export interface PublishVersionInput {
   expectedVersionId?: string | null;
 }
 
+export interface BlobDescriptor {
+  digest: string;
+  size: number;
+}
+
+export interface PreparedUpload {
+  digest: string;
+  url: string;
+  method: string;
+  expiresInSeconds: number;
+}
+
+export interface PrepareUploadResult {
+  uploads: PreparedUpload[];
+  present: string[];
+  storeLive: boolean;
+}
+
 export class ResourceHubError extends Error {
   constructor(
     readonly status: number,
@@ -270,22 +288,80 @@ export function createResourceHubClient(options: ResourceHubClientOptions = {}) 
       );
     },
 
-    // Blob byte transfer is pending the transport decision (presigned vs proxy).
-    // Only the index (find-missing above) is wired; the byte path throws so a
-    // premature caller fails loudly rather than silently no-oping.
-    async pushBlob(): Promise<never> {
-      throw new ResourceHubError(
-        501,
-        'not_implemented',
-        'blob byte upload is pending the transport decision (presigned vs proxy)',
+    // Blob byte transfer: presigned + client-direct (transport decision
+    // 2026-07-07). The hub issues short-TTL URLs; bytes flow daemon<->store
+    // without passing through the hub.
+    async prepareUpload(
+      principal: ResourceHubPrincipal,
+      blobs: BlobDescriptor[],
+    ): Promise<PrepareUploadResult> {
+      return request<PrepareUploadResult>(
+        principal,
+        'POST',
+        '/api/v1/resources/blobs/uploads',
+        { blobs },
       );
     },
-    async pullBlob(): Promise<never> {
-      throw new ResourceHubError(
-        501,
-        'not_implemented',
-        'blob byte download is pending the transport decision (presigned vs proxy)',
+
+    async commitUpload(
+      principal: ResourceHubPrincipal,
+      blobs: BlobDescriptor[],
+    ): Promise<void> {
+      await request(principal, 'POST', '/api/v1/resources/blobs/uploads/commit', {
+        blobs,
+      });
+    },
+
+    // Push one blob: prepare (skips if the store already has it), PUT the bytes
+    // straight to the presigned URL, then commit so the hub verifies + indexes.
+    async pushBlob(
+      principal: ResourceHubPrincipal,
+      input: { digest: string; bytes: Uint8Array },
+    ): Promise<void> {
+      const descriptor: BlobDescriptor = {
+        digest: input.digest,
+        size: input.bytes.byteLength,
+      };
+      const prepared = await this.prepareUpload(principal, [descriptor]);
+      const upload = prepared.uploads.find(
+        (candidate) => candidate.digest === input.digest,
       );
+      if (upload) {
+        const response = await fetchImpl(upload.url, {
+          method: upload.method,
+          body: input.bytes,
+        });
+        if (!response.ok) {
+          throw new ResourceHubError(
+            response.status,
+            'blob_upload_failed',
+            `PUT to object store failed (${response.status})`,
+          );
+        }
+      }
+      await this.commitUpload(principal, [descriptor]);
+    },
+
+    // Pull one blob: resolve a presigned GET from the hub, then read bytes
+    // straight from the store.
+    async pullBlob(
+      principal: ResourceHubPrincipal,
+      digest: string,
+    ): Promise<Uint8Array> {
+      const signed = await request<{ url: string; method: string }>(
+        principal,
+        'GET',
+        `/api/v1/resources/blobs/${encodeURIComponent(digest)}/download`,
+      );
+      const response = await fetchImpl(signed.url, { method: signed.method });
+      if (!response.ok) {
+        throw new ResourceHubError(
+          response.status,
+          'blob_download_failed',
+          `GET from object store failed (${response.status})`,
+        );
+      }
+      return new Uint8Array(await response.arrayBuffer());
     },
   };
 }

--- a/apps/daemon/src/resource-cli.ts
+++ b/apps/daemon/src/resource-cli.ts
@@ -1,0 +1,80 @@
+import {
+  ResourceHubError,
+  createResourceHubClient,
+  readResourceHubPrincipal,
+} from './integrations/resource-hub.js';
+
+// `od resource …` — team resource sharing CLI (Spec E, daemon side). Tier-1
+// skeleton: `list` is wired to the hub index for real; `share`/`pull` are stubs
+// pending the blob transport decision and the local wrap logic. Kept in its own
+// module so cli.ts only gains one import + one SUBCOMMAND_MAP entry.
+
+const USAGE = `Usage:
+  od resource list                 List team resources from the hub
+  od resource share <kind> <id>    Share a local resource to the team (not yet implemented)
+  od resource pull <kind> <id>     Pull a shared team resource locally (not yet implemented)
+
+Environment (dev/local, provisional until link B lands the member table):
+  OD_RESOURCE_HUB_URL              Hub base URL (default http://127.0.0.1:18082)
+  OD_RESOURCE_HUB_TOKEN            Internal token the hub trusts
+  OD_WORKSPACE_MEMBER_ID / OD_WORKSPACE_TEAM_ID / OD_WORKSPACE_ROLE
+`;
+
+function printUsage(): void {
+  console.log(USAGE);
+}
+
+async function runList(): Promise<void> {
+  const principal = readResourceHubPrincipal();
+  if (!principal) {
+    console.error(
+      'workspace principal unavailable; set OD_WORKSPACE_MEMBER_ID and OD_WORKSPACE_TEAM_ID',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const client = createResourceHubClient();
+  try {
+    const resources = await client.listResources(principal);
+    if (resources.length === 0) {
+      console.log('no team resources');
+      return;
+    }
+    for (const resource of resources) {
+      console.log(`${resource.kind}\t${resource.id}\t${resource.ownerMemberId}`);
+    }
+  } catch (error) {
+    if (error instanceof ResourceHubError) {
+      console.error(`resource hub error (${error.status} ${error.code})`);
+    } else {
+      console.error('resource hub unreachable');
+    }
+    process.exitCode = 1;
+  }
+}
+
+export async function runResource(args: string[]): Promise<void> {
+  const sub = args[0];
+  switch (sub) {
+    case 'list':
+      await runList();
+      return;
+    case 'share':
+    case 'pull':
+      console.error(
+        `od resource ${sub}: not yet implemented (pending blob transport decision and local wrap logic)`,
+      );
+      process.exitCode = 1;
+      return;
+    case undefined:
+    case 'help':
+    case '--help':
+    case '-h':
+      printUsage();
+      return;
+    default:
+      console.error(`unknown subcommand: od resource ${sub}`);
+      printUsage();
+      process.exitCode = 1;
+  }
+}

--- a/apps/daemon/src/resource-cli.ts
+++ b/apps/daemon/src/resource-cli.ts
@@ -3,20 +3,22 @@ import {
   createResourceHubClient,
   readResourceHubPrincipal,
 } from './integrations/resource-hub.js';
+import { materializeRef, packTree, pushTree } from './resource-drive.js';
 
-// `od resource …` — team resource sharing CLI (Spec E, daemon side). Tier-1
-// skeleton: `list` is wired to the hub index for real; `share`/`pull` are stubs
-// pending the blob transport decision and the local wrap logic. Kept in its own
-// module so cli.ts only gains one import + one SUBCOMMAND_MAP entry.
+// `od resource …` — neutral cloud-drive CLI over the resource hub. It moves
+// directory trees to/from the hub (put/get) and lists team resources; it is
+// kind-agnostic. Feature-specific sharing ("share a design system") belongs to
+// a consumer layer built on top, not here.
 
 const USAGE = `Usage:
-  od resource list                 List team resources from the hub
-  od resource share <kind> <id>    Share a local resource to the team (not yet implemented)
-  od resource pull <kind> <id>     Pull a shared team resource locally (not yet implemented)
+  od resource list                              List team resources
+  od resource put <dir> --kind <kind> [--resource <id>] [--ref <name>]
+                                                Upload a directory tree as a new version
+  od resource get <resource-id> <dest-dir> [--ref <name>]
+                                                Materialize a version's tree locally
 
 Environment (dev/local, provisional until link B lands the member table):
-  OD_RESOURCE_HUB_URL              Hub base URL (default http://127.0.0.1:18082)
-  OD_RESOURCE_HUB_TOKEN            Internal token the hub trusts
+  OD_RESOURCE_HUB_URL / OD_RESOURCE_HUB_TOKEN
   OD_WORKSPACE_MEMBER_ID / OD_WORKSPACE_TEAM_ID / OD_WORKSPACE_ROLE
 `;
 
@@ -24,18 +26,59 @@ function printUsage(): void {
   console.log(USAGE);
 }
 
-async function runList(): Promise<void> {
+function parseFlags(args: string[]): {
+  positionals: string[];
+  flags: Map<string, string>;
+} {
+  const positionals: string[] = [];
+  const flags = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === undefined) continue;
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = args[index + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        flags.set(key, next);
+        index += 1;
+      } else {
+        flags.set(key, 'true');
+      }
+    } else {
+      positionals.push(arg);
+    }
+  }
+  return { positionals, flags };
+}
+
+function requirePrincipalOrExit() {
   const principal = readResourceHubPrincipal();
   if (!principal) {
     console.error(
       'workspace principal unavailable; set OD_WORKSPACE_MEMBER_ID and OD_WORKSPACE_TEAM_ID',
     );
     process.exitCode = 1;
-    return;
+    return null;
   }
-  const client = createResourceHubClient();
+  return principal;
+}
+
+function reportError(error: unknown): void {
+  if (error instanceof ResourceHubError) {
+    console.error(`resource hub error (${error.status} ${error.code})`);
+  } else if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error('resource hub operation failed');
+  }
+  process.exitCode = 1;
+}
+
+async function runList(): Promise<void> {
+  const principal = requirePrincipalOrExit();
+  if (!principal) return;
   try {
-    const resources = await client.listResources(principal);
+    const resources = await createResourceHubClient().listResources(principal);
     if (resources.length === 0) {
       console.log('no team resources');
       return;
@@ -44,27 +87,82 @@ async function runList(): Promise<void> {
       console.log(`${resource.kind}\t${resource.id}\t${resource.ownerMemberId}`);
     }
   } catch (error) {
-    if (error instanceof ResourceHubError) {
-      console.error(`resource hub error (${error.status} ${error.code})`);
-    } else {
-      console.error('resource hub unreachable');
-    }
+    reportError(error);
+  }
+}
+
+async function runPut(args: string[]): Promise<void> {
+  const principal = requirePrincipalOrExit();
+  if (!principal) return;
+  const { positionals, flags } = parseFlags(args);
+  const dir = positionals[0];
+  const kind = flags.get('kind');
+  if (!dir || !kind) {
+    console.error(
+      'usage: od resource put <dir> --kind <kind> [--resource <id>] [--ref <name>]',
+    );
     process.exitCode = 1;
+    return;
+  }
+  try {
+    const client = createResourceHubClient();
+    const resourceId = flags.get('resource');
+    const resource = await client.createResource(principal, {
+      kind,
+      ...(resourceId ? { resourceId } : {}),
+    });
+    const packed = await packTree(dir);
+    const version = await pushTree(client, principal, resource.id, packed, {
+      ref: flags.get('ref') ?? 'latest',
+    });
+    console.log(
+      `pushed ${packed.blobs.size} blob(s) -> resource ${resource.id} version ${version.version} (${version.id})`,
+    );
+  } catch (error) {
+    reportError(error);
+  }
+}
+
+async function runGet(args: string[]): Promise<void> {
+  const principal = requirePrincipalOrExit();
+  if (!principal) return;
+  const { positionals, flags } = parseFlags(args);
+  const resourceId = positionals[0];
+  const dest = positionals[1];
+  if (!resourceId || !dest) {
+    console.error(
+      'usage: od resource get <resource-id> <dest-dir> [--ref <name>]',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const ref = flags.get('ref') ?? 'latest';
+  try {
+    await materializeRef(
+      createResourceHubClient(),
+      principal,
+      resourceId,
+      ref,
+      dest,
+    );
+    console.log(`materialized resource ${resourceId} (ref ${ref}) -> ${dest}`);
+  } catch (error) {
+    reportError(error);
   }
 }
 
 export async function runResource(args: string[]): Promise<void> {
   const sub = args[0];
+  const rest = args.slice(1);
   switch (sub) {
     case 'list':
       await runList();
       return;
-    case 'share':
-    case 'pull':
-      console.error(
-        `od resource ${sub}: not yet implemented (pending blob transport decision and local wrap logic)`,
-      );
-      process.exitCode = 1;
+    case 'put':
+      await runPut(rest);
+      return;
+    case 'get':
+      await runGet(rest);
       return;
     case undefined:
     case 'help':

--- a/apps/daemon/src/resource-drive.ts
+++ b/apps/daemon/src/resource-drive.ts
@@ -1,0 +1,192 @@
+import { createHash } from 'node:crypto';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+import type {
+  ManifestEntryInput,
+  ResourceHubClient,
+  ResourceHubPrincipal,
+  VersionRecord,
+} from './integrations/resource-hub.js';
+
+// Neutral cloud-drive SDK over the resource hub. Kind-agnostic: it moves
+// directory trees to/from the hub as content-addressed manifests + blobs, and
+// knows nothing about design-systems / plugins / skills or WHEN to sync — that
+// is the consumer's concern. Consumers build features ("share a design system")
+// on top of these primitives; this layer stays a neutral cloud drive.
+
+const DIGEST_ALGORITHM = 'sha256';
+
+function digestBytes(bytes: Uint8Array): string {
+  return `${DIGEST_ALGORITHM}:${createHash(DIGEST_ALGORITHM)
+    .update(bytes)
+    .digest('hex')}`;
+}
+
+export interface PackedTree {
+  manifestDigest: string;
+  entries: ManifestEntryInput[];
+  // Content-addressed file bytes, deduped by digest — the blobs to upload.
+  blobs: Map<string, Uint8Array>;
+}
+
+// Canonical manifest digest: sort entries by path and hash a stable
+// serialization. The hub trusts (does not recompute) this digest, so the only
+// requirement is that the daemon computes it deterministically.
+export function computeManifestDigest(entries: ManifestEntryInput[]): string {
+  const canonical = [...entries]
+    .sort(byPath)
+    .map((entry) =>
+      [
+        entry.type,
+        entry.executable ? '1' : '0',
+        entry.blobDigest ?? '',
+        entry.symlinkTarget ?? '',
+        entry.path,
+      ].join('\t'),
+    )
+    .join('\n');
+  return `${DIGEST_ALGORITHM}:${createHash(DIGEST_ALGORITHM)
+    .update(canonical)
+    .digest('hex')}`;
+}
+
+function byPath(a: { path: string }, b: { path: string }): number {
+  if (a.path < b.path) return -1;
+  if (a.path > b.path) return 1;
+  return 0;
+}
+
+// Walk a directory into a content-addressed tree. Paths are stored relative to
+// rootDir with forward slashes (canonical). Directories are recorded explicitly
+// so empty dirs survive; symlinks are stored by target without following.
+export async function packTree(rootDir: string): Promise<PackedTree> {
+  const entries: ManifestEntryInput[] = [];
+  const blobs = new Map<string, Uint8Array>();
+
+  async function walk(absDir: string, relDir: string): Promise<void> {
+    const dirents = await fsp.readdir(absDir, { withFileTypes: true });
+    for (const dirent of dirents) {
+      const abs = path.join(absDir, dirent.name);
+      const rel = relDir ? `${relDir}/${dirent.name}` : dirent.name;
+      if (dirent.isSymbolicLink()) {
+        entries.push({
+          path: rel,
+          type: 'symlink',
+          symlinkTarget: await fsp.readlink(abs),
+        });
+      } else if (dirent.isDirectory()) {
+        entries.push({ path: rel, type: 'dir' });
+        await walk(abs, rel);
+      } else if (dirent.isFile()) {
+        const bytes = new Uint8Array(await fsp.readFile(abs));
+        const digest = digestBytes(bytes);
+        if (!blobs.has(digest)) blobs.set(digest, bytes);
+        const stat = await fsp.stat(abs);
+        entries.push({
+          path: rel,
+          type: 'file',
+          executable: (stat.mode & 0o111) !== 0,
+          blobDigest: digest,
+        });
+      }
+      // Other node types (sockets/fifos/devices) are not representable — skip.
+    }
+  }
+
+  await walk(rootDir, '');
+  return { manifestDigest: computeManifestDigest(entries), entries, blobs };
+}
+
+// Push a packed tree as a new version: upload only the blobs the store is
+// missing, then publish. Optionally move a ref (with optimistic concurrency).
+export async function pushTree(
+  client: ResourceHubClient,
+  principal: ResourceHubPrincipal,
+  resourceId: string,
+  packed: PackedTree,
+  options: { ref?: string; expectedVersionId?: string | null } = {},
+): Promise<VersionRecord> {
+  const missing = await client.findMissingBlobs(principal, [
+    ...packed.blobs.keys(),
+  ]);
+  for (const digest of missing) {
+    const bytes = packed.blobs.get(digest);
+    if (!bytes) continue;
+    await client.pushBlob(principal, { digest, bytes });
+  }
+  return client.publishVersion(principal, resourceId, {
+    manifestDigest: packed.manifestDigest,
+    entries: packed.entries,
+    ...(options.ref === undefined ? {} : { ref: options.ref }),
+    ...(options.expectedVersionId === undefined
+      ? {}
+      : { expectedVersionId: options.expectedVersionId }),
+  });
+}
+
+// Materialize a manifest's tree into destDir. Pulls only file blobs. Uses a
+// hardened join so a hostile path or symlink target cannot escape destDir
+// (Spec E §2.7 safe landing).
+export async function materializeTree(
+  client: ResourceHubClient,
+  principal: ResourceHubPrincipal,
+  manifestDigest: string,
+  destDir: string,
+): Promise<void> {
+  const manifest = await client.getManifest(principal, manifestDigest);
+  const root = path.resolve(destDir);
+  // Sort by path so parent directories are created before their children.
+  for (const entry of [...manifest.entries].sort(byPath)) {
+    const target = safeJoin(root, entry.path);
+    if (entry.type === 'dir') {
+      await fsp.mkdir(target, { recursive: true });
+    } else if (entry.type === 'symlink') {
+      await fsp.mkdir(path.dirname(target), { recursive: true });
+      assertContained(
+        root,
+        path.resolve(path.dirname(target), entry.symlinkTarget ?? ''),
+      );
+      await fsp.symlink(entry.symlinkTarget ?? '', target);
+    } else if (entry.type === 'file' && entry.blobDigest) {
+      await fsp.mkdir(path.dirname(target), { recursive: true });
+      await fsp.writeFile(
+        target,
+        await client.pullBlob(principal, entry.blobDigest),
+      );
+      if (entry.executable) await fsp.chmod(target, 0o755);
+    }
+  }
+}
+
+// Resolve a ref to its version's manifest and materialize it. Convenience over
+// getRef + listVersions so consumers don't re-implement the lookup.
+export async function materializeRef(
+  client: ResourceHubClient,
+  principal: ResourceHubPrincipal,
+  resourceId: string,
+  ref: string,
+  destDir: string,
+): Promise<void> {
+  const refRecord = await client.getRef(principal, resourceId, ref);
+  const versions = await client.listVersions(principal, resourceId);
+  const version = versions.find((candidate) => candidate.id === refRecord.versionId);
+  if (!version) {
+    throw new Error(`ref ${ref} points at unknown version ${refRecord.versionId}`);
+  }
+  await materializeTree(client, principal, version.manifestDigest, destDir);
+}
+
+function safeJoin(root: string, relPath: string): string {
+  const resolved = path.resolve(root, relPath);
+  assertContained(root, resolved);
+  return resolved;
+}
+
+function assertContained(root: string, resolved: string): void {
+  const rel = path.relative(root, resolved);
+  if (rel === '') return;
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(`unsafe path escapes destination: ${resolved}`);
+  }
+}

--- a/apps/daemon/src/routes/resources/index.ts
+++ b/apps/daemon/src/routes/resources/index.ts
@@ -1,0 +1,82 @@
+import type { Express, Request, Response } from 'express';
+
+import {
+  ResourceHubError,
+  createResourceHubClient,
+  readResourceHubPrincipal,
+  type ResourceHubClient,
+} from '../../integrations/resource-hub.js';
+
+// Daemon-local team-resource-sharing surface (Spec E, daemon side). Thin: it
+// resolves the workspace principal and proxies the INDEX operations to the hub.
+// The capability operations (share/pull) that wrap the local design-system /
+// plugin / skill managers into blobs + manifests are stubbed 501 — they depend
+// on the blob transport decision (presigned vs proxy) and the shared_resources
+// local mapping, which are not built yet. Self-contained on purpose so the
+// server.ts wiring is a single dep-free call.
+
+interface RegisterResourceSharingRoutesOptions {
+  client?: ResourceHubClient;
+}
+
+function resolvePrincipalOr401(res: Response) {
+  const principal = readResourceHubPrincipal();
+  if (!principal) {
+    res.status(401).json({ error: 'workspace_principal_unavailable' });
+    return null;
+  }
+  return principal;
+}
+
+function handleHubError(res: Response, error: unknown) {
+  if (error instanceof ResourceHubError) {
+    res.status(error.status).json({ error: error.code });
+    return;
+  }
+  res.status(502).json({ error: 'resource_hub_unreachable' });
+}
+
+export function registerResourceSharingRoutes(
+  app: Express,
+  options: RegisterResourceSharingRoutesOptions = {},
+): void {
+  const client = options.client ?? createResourceHubClient();
+
+  // Readiness probe: confirms wiring (hub URL configured, principal resolvable)
+  // without touching data — useful for the local closed-loop check.
+  app.get('/api/resources/_status', (_req: Request, res: Response) => {
+    res.json({
+      configured: client.isConfigured(),
+      principalAvailable: readResourceHubPrincipal() !== null,
+    });
+  });
+
+  app.get('/api/resources', async (_req: Request, res: Response) => {
+    const principal = resolvePrincipalOr401(res);
+    if (!principal) return;
+    try {
+      res.json({ resources: await client.listResources(principal) });
+    } catch (error) {
+      handleHubError(res, error);
+    }
+  });
+
+  // Capability ops pending wrap logic + transport decision.
+  app.post(
+    '/api/resources/:kind/:id/share',
+    (_req: Request, res: Response) => {
+      res.status(501).json({
+        error: 'not_implemented',
+        detail:
+          'sharing wraps the local resource into blobs+manifest; pending blob transport decision and shared_resources mapping',
+      });
+    },
+  );
+
+  app.post('/api/resources/:kind/:id/pull', (_req: Request, res: Response) => {
+    res.status(501).json({
+      error: 'not_implemented',
+      detail: 'pull materializes a hub version locally; pending blob transport decision',
+    });
+  });
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -556,6 +556,7 @@ import { registerDeployRoutes, registerDeploymentCheckRoutes } from './routes/de
 import { registerMediaRoutes } from './routes/media.js';
 import { registerProjectRoutes, registerProjectArtifactRoutes, registerProjectFileRoutes, registerProjectUploadRoutes } from './routes/project/index.js';
 import { registerVelaRoutes } from './routes/vela.js';
+import { registerResourceSharingRoutes } from './routes/resources/index.js';
 import { registerFinalizeRoutes, registerImportRoutes, registerProjectExportRoutes } from './import-export-routes.js';
 import { registerHandoffRoutes } from './routes/handoff.js';
 import { EmptyTranscriptError, synthesizeHandoffPrompt } from './handoff-design.js';
@@ -4463,6 +4464,7 @@ export async function startServer({
     research: researchDeps,
   });
 
+  registerResourceSharingRoutes(app);
   registerVelaRoutes(app, {
     paths: { RUNTIME_DATA_DIR },
     appConfig: { readAppConfig },

--- a/tools/serve/AGENTS.md
+++ b/tools/serve/AGENTS.md
@@ -6,9 +6,41 @@ Follow the root `AGENTS.md` and `tools/AGENTS.md` first. This tool owns small lo
 
 - `tools-serve` CLI.
 - Local static updater fixtures for desktop update IPC and packaged-runtime debugging.
+- `resource-hub` fixture — a self-contained, in-memory stand-in for the Spec E
+  resource storage service (see below).
 
 ## Rules
 
 - Keep services self-contained and local-first.
 - Do not put product update runtime logic here; this tool serves deterministic fixtures only.
 - New services should use explicit subcommands under `tools-serve start <service>`.
+
+## resource-hub fixture (TEMPORARY)
+
+An infra-free, in-memory local backend for the daemon's Spec E resource
+features. Lets you develop against the resource API without standing up the real
+vela stack (services/api + postgres + MinIO). It faithfully implements the same
+wire contract (endpoints, error codes, `x-internal-token` + `x-workspace-*`
+auth, freeze, cross-team isolation, content-addressed dedup, presigned-style
+blob transport served from the same process).
+
+Run it, then point the daemon at it:
+
+```
+pnpm tools-serve start resource-hub --port 18090
+# then, for the daemon / od CLI:
+export OD_RESOURCE_HUB_URL=http://localhost:18090
+export OD_RESOURCE_HUB_TOKEN=dev-internal-token
+export OD_WORKSPACE_MEMBER_ID=you OD_WORKSPACE_TEAM_ID=your-team OD_WORKSPACE_ROLE=owner
+od resource put ./some-dir --kind design_system --ref latest
+od resource get <resource-id> ./dest
+```
+
+- **The daemon makes no mock concessions** — it runs its real client/SDK against
+  this exactly as it would against vela. The fixture is the only "fake" piece.
+- **This is disposable.** Once the vela test environment is stood up, delete
+  `src/resource-hub-fixture.ts` (and its wiring in `src/index.ts`) and repoint
+  `OD_RESOURCE_HUB_URL` at the real test API. The daemon needs zero code changes.
+- **Keep the contract in sync** with `services/api/src/resources/routes.ts` in
+  the vela repo — change one, mirror the other. `tests/resource-hub-fixture.test.ts`
+  locks the fixture's half of the contract.

--- a/tools/serve/src/index.ts
+++ b/tools/serve/src/index.ts
@@ -2,6 +2,7 @@ import { cac } from "cac";
 import type { ReleaseChannel } from "@open-design/release";
 
 import { startReleaseStorageFixtureServer } from "./release-storage-fixture.js";
+import { startResourceHubFixtureServer } from "./resource-hub-fixture.js";
 import { startUpdaterFixtureServer } from "./updater-fixture.js";
 
 type CliOptions = {
@@ -14,6 +15,7 @@ type CliOptions = {
   includePayload?: boolean;
   payloadPath?: string;
   version?: string;
+  internalToken?: string;
 };
 
 function parsePort(value: string | undefined): number {
@@ -45,6 +47,28 @@ async function start(service: string, options: CliOptions): Promise<void> {
       printJson(server.info);
     } else {
       process.stdout.write(`tools-serve release-storage: ${server.info.endpointUrl} bucket=${server.info.bucket}\n`);
+    }
+
+    const shutdown = () => {
+      void server.close().finally(() => process.exit(0));
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+    return;
+  }
+
+  if (service === "resource-hub") {
+    const server = await startResourceHubFixtureServer({
+      host: options.host,
+      port: parsePort(options.port),
+      internalToken: options.internalToken,
+    });
+    if (options.json === true) {
+      printJson(server.info);
+    } else {
+      process.stdout.write(
+        `tools-serve resource-hub: ${server.info.endpointUrl} (token=${server.info.internalToken})\n`,
+      );
     }
 
     const shutdown = () => {
@@ -99,6 +123,7 @@ cli
   .option("--include-payload", "Include launcher payload metadata")
   .option("--payload-path <path>", "Serve launcher payload bytes from a real archive")
   .option("--platform <platform>", "Updater platform: mac|win", { default: "mac" })
+  .option("--internal-token <token>", "resource-hub: internal token clients must present")
   .option("--port <port>", "Port to bind, 0 for dynamic", { default: "0" })
   .option("--version <version>", "Fixture update version", { default: "99.0.0" })
   .action((service: string, options: CliOptions) => {

--- a/tools/serve/src/resource-hub-fixture.ts
+++ b/tools/serve/src/resource-hub-fixture.ts
@@ -1,0 +1,589 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+
+// TEMPORARY local resource-hub fixture. A self-contained, in-memory, infra-free
+// stand-in for the real resource storage service (Spec E, which lives in the
+// vela repo at services/api/src/resources/*). It lets teammates develop the
+// daemon's resource features locally without standing up vela + postgres +
+// MinIO: point OD_RESOURCE_HUB_URL at this fixture and everything works.
+//
+// It faithfully implements the SAME wire contract the daemon client speaks
+// (endpoints, error codes, x-internal-token + x-workspace-* auth, freeze,
+// cross-team isolation, content-addressed dedup, presigned-style blob transport
+// served from this process). The daemon makes NO mock concessions — it runs its
+// real client/SDK against this exactly as it would against vela.
+//
+// DISPOSABLE: this whole file is deleted once the vela test environment is
+// stood up; the only migration is repointing OD_RESOURCE_HUB_URL at the real
+// test api. The daemon needs zero code changes. Keep the contract in sync with
+// services/api/src/resources/routes.ts — change one, mirror the other.
+
+export type ResourceHubFixtureOptions = {
+  host?: string;
+  port?: number;
+  internalToken?: string;
+};
+
+export type ResourceHubFixtureInfo = {
+  origin: string;
+  endpointUrl: string;
+  internalToken: string;
+};
+
+export type ResourceHubFixtureServer = {
+  close(): Promise<void>;
+  info: ResourceHubFixtureInfo;
+  reset(): void;
+};
+
+const DEFAULT_INTERNAL_TOKEN = "dev-internal-token";
+const DIGEST_RE = /^[a-z0-9]+:[0-9a-f]+$/u;
+const WORKSPACE_ROLES = new Set(["owner", "admin", "member"]);
+
+type Principal = {
+  memberId: string;
+  teamId: string;
+  role: string;
+  lifecycleState: string | null;
+};
+
+type Resource = {
+  id: string;
+  teamId: string;
+  kind: string;
+  ownerMemberId: string;
+  createdAt: string;
+  deletedAt: string | null;
+};
+
+type ManifestEntry = {
+  path: string;
+  type: "file" | "dir" | "symlink";
+  executable: boolean;
+  blobDigest: string | null;
+  symlinkTarget: string | null;
+};
+
+type Version = {
+  id: string;
+  resourceId: string;
+  teamId: string;
+  version: number;
+  manifestDigest: string;
+  createdByMemberId: string;
+  createdAt: string;
+};
+
+type Ref = {
+  resourceId: string;
+  name: string;
+  versionId: string;
+  updatedAt: string;
+  updatedByMemberId: string;
+};
+
+let idCounter = 0;
+function nextId(prefix: string): string {
+  idCounter += 1;
+  return `${prefix}_${idCounter.toString(36)}${Math.floor(idCounter * 2654435761).toString(36)}`;
+}
+
+function listen(server: Server, port: number, host: string): Promise<void> {
+  return new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(port, host, () => {
+      server.off("error", rejectListen);
+      resolveListen();
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => (error == null ? resolveClose() : rejectClose(error)));
+  });
+}
+
+function serverOrigin(server: Server): string {
+  const address = server.address();
+  if (address == null || typeof address === "string") {
+    throw new Error("resource hub fixture did not listen on TCP");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function readBody(request: IncomingMessage): Promise<Buffer> {
+  return new Promise<Buffer>((resolveRead, rejectRead) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("error", rejectRead);
+    request.on("end", () => resolveRead(Buffer.concat(chunks)));
+  });
+}
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+  const body = await readBody(request);
+  if (body.byteLength === 0) return {};
+  return JSON.parse(body.toString("utf8"));
+}
+
+function sendJson(response: ServerResponse, status: number, payload: unknown): void {
+  const body = JSON.stringify(payload);
+  response.statusCode = status;
+  response.setHeader("content-type", "application/json");
+  response.end(body);
+}
+
+function header(request: IncomingMessage, name: string): string | null {
+  const value = request.headers[name];
+  if (Array.isArray(value)) return value[0]?.trim() ?? null;
+  return typeof value === "string" ? value.trim() || null : null;
+}
+
+function isFrozen(lifecycleState: string | null): boolean {
+  return lifecycleState === "locked";
+}
+
+export async function startResourceHubFixtureServer(
+  options: ResourceHubFixtureOptions = {},
+): Promise<ResourceHubFixtureServer> {
+  const host = options.host ?? "127.0.0.1";
+  const port = options.port ?? 0;
+  const internalToken = options.internalToken ?? DEFAULT_INTERNAL_TOKEN;
+
+  // In-memory state. blobBytes = object store; blobIndex = committed rows
+  // (what find-missing checks), mirroring the real blobs table vs bucket split.
+  const resources = new Map<string, Resource>();
+  const manifests = new Map<string, ManifestEntry[]>(); // key: team\0digest
+  const versions: Version[] = [];
+  const refs = new Map<string, Ref>(); // key: resourceId\0name
+  const blobIndex = new Set<string>(); // team\0digest
+  const blobBytes = new Map<string, Buffer>(); // team/digest
+
+  function reset(): void {
+    resources.clear();
+    manifests.clear();
+    versions.length = 0;
+    refs.clear();
+    blobIndex.clear();
+    blobBytes.clear();
+  }
+
+  function authenticate(
+    request: IncomingMessage,
+  ): { ok: true; principal: Principal } | { ok: false; status: number; error: string } {
+    const token = header(request, "x-internal-token");
+    if (!token || token !== internalToken) {
+      return { ok: false, status: 401, error: "untrusted_caller" };
+    }
+    const memberId = header(request, "x-workspace-member-id");
+    const teamId = header(request, "x-workspace-team-id");
+    const role = header(request, "x-workspace-role");
+    if (!memberId || !teamId || !role) {
+      return { ok: false, status: 403, error: "missing_principal" };
+    }
+    if (!WORKSPACE_ROLES.has(role)) {
+      return { ok: false, status: 403, error: "invalid_role" };
+    }
+    return {
+      ok: true,
+      principal: {
+        memberId,
+        teamId,
+        role,
+        lifecycleState: header(request, "x-workspace-lifecycle-state"),
+      },
+    };
+  }
+
+  function toResourceResponse(resource: Resource) {
+    return {
+      id: resource.id,
+      teamId: resource.teamId,
+      kind: resource.kind,
+      ownerMemberId: resource.ownerMemberId,
+      createdAt: resource.createdAt,
+      deletedAt: resource.deletedAt,
+    };
+  }
+
+  const server = createServer((request, response) => {
+    void handle(request, response).catch((error: unknown) => {
+      sendJson(response, 500, {
+        error: "fixture_error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    });
+  });
+
+  async function handle(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    const url = new URL(request.url ?? "/", "http://fixture.local");
+    const path = url.pathname;
+    const method = request.method ?? "GET";
+
+    // --- self-served "object store" (presigned PUT/GET target) -------------
+    if (path.startsWith("/_blob/")) {
+      const key = path.slice("/_blob/".length); // team/digest (may contain ':')
+      if (method === "PUT") {
+        blobBytes.set(key, await readBody(request));
+        response.statusCode = 200;
+        response.end("ok");
+        return;
+      }
+      if (method === "GET" || method === "HEAD") {
+        const bytes = blobBytes.get(key);
+        if (bytes == null) {
+          response.statusCode = 404;
+          response.end("not found");
+          return;
+        }
+        response.statusCode = 200;
+        response.setHeader("content-length", String(bytes.byteLength));
+        response.end(method === "HEAD" ? undefined : bytes);
+        return;
+      }
+      response.statusCode = 405;
+      response.end("method not allowed");
+      return;
+    }
+
+    if (path === "/health") {
+      sendJson(response, 200, { ok: true });
+      return;
+    }
+
+    if (!path.startsWith("/api/v1/resources")) {
+      sendJson(response, 404, { error: "not_found" });
+      return;
+    }
+
+    const auth = authenticate(request);
+    if (!auth.ok) {
+      sendJson(response, auth.status, { error: auth.error });
+      return;
+    }
+    const principal = auth.principal;
+    const origin = serverOrigin(server);
+    const segments = path.split("/").filter((s) => s.length > 0); // ["api","v1","resources",...]
+    const rest = segments.slice(3); // after /api/v1/resources
+
+    // --- blob endpoints ----------------------------------------------------
+    if (rest[0] === "blobs") {
+      if (method === "POST" && rest[1] === "find-missing") {
+        const body = (await readJson(request)) as { digests?: unknown };
+        const digests = Array.isArray(body.digests) ? body.digests : [];
+        for (const digest of digests) {
+          if (typeof digest !== "string" || !DIGEST_RE.test(digest)) {
+            return invalidRequest(response, "digests", "digest must be algorithm-prefixed hex");
+          }
+        }
+        const missing = [...new Set(digests as string[])].filter(
+          (digest) => !blobIndex.has(`${principal.teamId} ${digest}`),
+        );
+        sendJson(response, 200, { missing });
+        return;
+      }
+
+      if (method === "POST" && rest[1] === "uploads" && rest[2] === undefined) {
+        if (frozen(response, principal)) return;
+        const body = (await readJson(request)) as { blobs?: { digest?: unknown; size?: unknown }[] };
+        const blobs = Array.isArray(body.blobs) ? body.blobs : [];
+        const uploads: { digest: string; url: string; method: string; expiresInSeconds: number }[] = [];
+        const present: string[] = [];
+        for (const blob of blobs) {
+          const digest = blob.digest;
+          if (typeof digest !== "string" || !DIGEST_RE.test(digest)) {
+            return invalidRequest(response, "blobs", "digest must be algorithm-prefixed hex");
+          }
+          if (blobIndex.has(`${principal.teamId} ${digest}`)) {
+            present.push(digest);
+          } else {
+            uploads.push({
+              digest,
+              url: `${origin}/_blob/${encodeURIComponent(principal.teamId)}/${digest}`,
+              method: "PUT",
+              expiresInSeconds: 900,
+            });
+          }
+        }
+        sendJson(response, 200, { uploads, present, storeLive: true });
+        return;
+      }
+
+      if (method === "POST" && rest[1] === "uploads" && rest[2] === "commit") {
+        if (frozen(response, principal)) return;
+        const body = (await readJson(request)) as { blobs?: { digest?: unknown; size?: unknown }[] };
+        const blobs = Array.isArray(body.blobs) ? body.blobs : [];
+        const notUploaded: string[] = [];
+        for (const blob of blobs) {
+          if (typeof blob.digest !== "string" || !DIGEST_RE.test(blob.digest)) {
+            return invalidRequest(response, "blobs", "digest must be algorithm-prefixed hex");
+          }
+          if (!blobBytes.has(`${principal.teamId}/${blob.digest}`)) notUploaded.push(blob.digest);
+        }
+        if (notUploaded.length > 0) {
+          sendJson(response, 409, { error: "blob_not_uploaded", digests: notUploaded });
+          return;
+        }
+        for (const blob of blobs) {
+          blobIndex.add(`${principal.teamId} ${blob.digest as string}`);
+        }
+        sendJson(response, 200, { recorded: blobs.length });
+        return;
+      }
+
+      if (method === "GET" && rest[2] === "download") {
+        const digest = decodeURIComponent(rest[1] ?? "");
+        if (!blobIndex.has(`${principal.teamId} ${digest}`)) {
+          sendJson(response, 404, { error: "blob_not_found" });
+          return;
+        }
+        sendJson(response, 200, {
+          digest,
+          url: `${origin}/_blob/${encodeURIComponent(principal.teamId)}/${digest}`,
+          method: "GET",
+          expiresInSeconds: 900,
+          storeLive: true,
+        });
+        return;
+      }
+    }
+
+    // --- manifests ---------------------------------------------------------
+    if (rest[0] === "manifests" && method === "GET" && rest[1] !== undefined) {
+      const digest = decodeURIComponent(rest[1]);
+      const entries = manifests.get(`${principal.teamId} ${digest}`);
+      if (entries == null) {
+        sendJson(response, 404, { error: "manifest_not_found" });
+        return;
+      }
+      sendJson(response, 200, { digest, entries });
+      return;
+    }
+
+    // --- resources collection ---------------------------------------------
+    if (rest.length === 0) {
+      if (method === "GET") {
+        const list = [...resources.values()].filter(
+          (r) => r.teamId === principal.teamId && r.deletedAt == null,
+        );
+        sendJson(response, 200, { resources: list.map(toResourceResponse) });
+        return;
+      }
+      if (method === "POST") {
+        if (frozen(response, principal)) return;
+        const body = (await readJson(request)) as { kind?: unknown; resourceId?: unknown };
+        if (typeof body.kind !== "string" || body.kind.length === 0) {
+          return invalidRequest(response, "kind", "kind is required");
+        }
+        const id = typeof body.resourceId === "string" && body.resourceId.length > 0 ? body.resourceId : nextId("res");
+        const existing = resources.get(id);
+        const resource: Resource =
+          existing ?? {
+            id,
+            teamId: principal.teamId,
+            kind: body.kind,
+            ownerMemberId: principal.memberId,
+            createdAt: new Date().toISOString(),
+            deletedAt: null,
+          };
+        resources.set(id, resource);
+        sendJson(response, 201, toResourceResponse(resource));
+        return;
+      }
+    }
+
+    // --- resource-scoped ---------------------------------------------------
+    const resourceId = rest[0];
+    if (resourceId !== undefined && resourceId !== "blobs" && resourceId !== "manifests") {
+      const resource = resources.get(resourceId);
+      const visible = resource != null && resource.teamId === principal.teamId && resource.deletedAt == null;
+      if (!visible) {
+        sendJson(response, 404, { error: "resource_not_found" });
+        return;
+      }
+      const isOwner = resource.ownerMemberId === principal.memberId;
+      const frozenNow = isFrozen(principal.lifecycleState);
+      const canEdit = isOwner && !frozenNow;
+
+      // GET /:id
+      if (rest.length === 1 && method === "GET") {
+        sendJson(response, 200, toResourceResponse(resource));
+        return;
+      }
+
+      // versions
+      if (rest[1] === "versions") {
+        if (method === "GET") {
+          const list = versions
+            .filter((v) => v.resourceId === resourceId)
+            .sort((a, b) => b.version - a.version)
+            .map((v) => ({
+              id: v.id,
+              resourceId: v.resourceId,
+              version: v.version,
+              manifestDigest: v.manifestDigest,
+              createdByMemberId: v.createdByMemberId,
+              createdAt: v.createdAt,
+            }));
+          sendJson(response, 200, { versions: list });
+          return;
+        }
+        if (method === "POST") {
+          if (!canEdit) {
+            sendJson(response, 403, { error: frozenNow && isOwner ? "resource_frozen" : "forbidden" });
+            return;
+          }
+          const body = (await readJson(request)) as {
+            manifestDigest?: unknown;
+            entries?: unknown;
+            ref?: unknown;
+            expectedVersionId?: unknown;
+          };
+          if (typeof body.manifestDigest !== "string" || !DIGEST_RE.test(body.manifestDigest)) {
+            return invalidRequest(response, "manifestDigest", "digest must be algorithm-prefixed hex");
+          }
+          const entries = normalizeEntries(body.entries);
+          const manifestKey = `${principal.teamId} ${body.manifestDigest}`;
+          if (!manifests.has(manifestKey)) manifests.set(manifestKey, entries);
+          const nextVersion =
+            versions.filter((v) => v.resourceId === resourceId).reduce((max, v) => Math.max(max, v.version), 0) + 1;
+          const version: Version = {
+            id: nextId("ver"),
+            resourceId,
+            teamId: principal.teamId,
+            version: nextVersion,
+            manifestDigest: body.manifestDigest,
+            createdByMemberId: principal.memberId,
+            createdAt: new Date().toISOString(),
+          };
+          versions.push(version);
+          if (typeof body.ref === "string" && body.ref.length > 0) {
+            const conflict = setRef(
+              resourceId,
+              body.ref,
+              version.id,
+              principal.memberId,
+              body.expectedVersionId,
+            );
+            if (conflict != null) {
+              sendJson(response, 409, {
+                error: "ref_conflict",
+                currentVersionId: conflict,
+                createdVersionId: version.id,
+              });
+              return;
+            }
+          }
+          sendJson(response, 201, {
+            id: version.id,
+            resourceId: version.resourceId,
+            version: version.version,
+            manifestDigest: version.manifestDigest,
+            createdByMemberId: version.createdByMemberId,
+            createdAt: version.createdAt,
+          });
+          return;
+        }
+      }
+
+      // refs
+      if (rest[1] === "refs" && rest[2] !== undefined) {
+        const name = decodeURIComponent(rest[2]);
+        if (method === "GET") {
+          const ref = refs.get(`${resourceId} ${name}`);
+          if (ref == null) {
+            sendJson(response, 404, { error: "ref_not_found" });
+            return;
+          }
+          sendJson(response, 200, ref);
+          return;
+        }
+        if (method === "PUT") {
+          if (!canEdit) {
+            sendJson(response, 403, { error: frozenNow && isOwner ? "resource_frozen" : "forbidden" });
+            return;
+          }
+          const body = (await readJson(request)) as { versionId?: unknown; expectedVersionId?: unknown };
+          if (typeof body.versionId !== "string" || body.versionId.length === 0) {
+            return invalidRequest(response, "versionId", "versionId is required");
+          }
+          const conflict = setRef(resourceId, name, body.versionId, principal.memberId, body.expectedVersionId);
+          if (conflict !== null && body.expectedVersionId !== undefined) {
+            sendJson(response, 409, { error: "ref_conflict", currentVersionId: conflict });
+            return;
+          }
+          sendJson(response, 200, refs.get(`${resourceId} ${name}`));
+          return;
+        }
+      }
+    }
+
+    sendJson(response, 404, { error: "not_found" });
+  }
+
+  // Returns the current versionId (conflict) when expectedVersionId is given and
+  // does not match; otherwise applies the update and returns null.
+  function setRef(
+    resourceId: string,
+    name: string,
+    versionId: string,
+    memberId: string,
+    expectedVersionId: unknown,
+  ): string | null {
+    const key = `${resourceId} ${name}`;
+    const current = refs.get(key) ?? null;
+    if (expectedVersionId !== undefined) {
+      const currentVersionId = current?.versionId ?? null;
+      const expected = expectedVersionId === null ? null : String(expectedVersionId);
+      if (currentVersionId !== expected) return currentVersionId ?? "";
+    }
+    refs.set(key, {
+      resourceId,
+      name,
+      versionId,
+      updatedByMemberId: memberId,
+      updatedAt: new Date().toISOString(),
+    });
+    return null;
+  }
+
+  function frozen(response: ServerResponse, principal: Principal): boolean {
+    if (isFrozen(principal.lifecycleState)) {
+      sendJson(response, 403, { error: "resource_frozen" });
+      return true;
+    }
+    return false;
+  }
+
+  function invalidRequest(response: ServerResponse, path: string, message: string): void {
+    sendJson(response, 400, { error: "invalid_request", issues: [{ path, message }] });
+  }
+
+  await listen(server, port, host);
+  const origin = serverOrigin(server);
+
+  return {
+    close: () => close(server),
+    info: { origin, endpointUrl: origin, internalToken },
+    reset,
+  };
+}
+
+function normalizeEntries(raw: unknown): ManifestEntry[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((entry) => {
+    const e = entry as Record<string, unknown>;
+    return {
+      path: String(e.path ?? ""),
+      type: (e.type === "dir" || e.type === "symlink" ? e.type : "file") as ManifestEntry["type"],
+      executable: e.executable === true,
+      blobDigest: typeof e.blobDigest === "string" ? e.blobDigest : null,
+      symlinkTarget: typeof e.symlinkTarget === "string" ? e.symlinkTarget : null,
+    };
+  });
+}

--- a/tools/serve/tests/resource-hub-fixture.test.ts
+++ b/tools/serve/tests/resource-hub-fixture.test.ts
@@ -1,0 +1,157 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type ResourceHubFixtureServer,
+  startResourceHubFixtureServer,
+} from "../src/resource-hub-fixture.js";
+
+type Principal = { member: string; team: string; role?: string; life?: string };
+
+const TOKEN = "dev-internal-token";
+
+function headers(principal?: Principal, token: string | null = TOKEN): Record<string, string> {
+  const h: Record<string, string> = { "content-type": "application/json" };
+  if (token != null) h["x-internal-token"] = token;
+  if (principal) {
+    h["x-workspace-member-id"] = principal.member;
+    h["x-workspace-team-id"] = principal.team;
+    h["x-workspace-role"] = principal.role ?? "owner";
+    if (principal.life) h["x-workspace-lifecycle-state"] = principal.life;
+  }
+  return h;
+}
+
+async function call(
+  server: ResourceHubFixtureServer,
+  method: string,
+  path: string,
+  principal?: Principal,
+  body?: unknown,
+  token: string | null = TOKEN,
+): Promise<{ status: number; json: any }> {
+  const res = await fetch(`${server.info.origin}${path}`, {
+    method,
+    headers: headers(principal, token),
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : {} };
+}
+
+const sha256 = (s: string) => `sha256:${createHash("sha256").update(s).digest("hex")}`;
+
+describe("resource-hub fixture", () => {
+  it("runs the full index + presigned byte loop", async () => {
+    const server = await startResourceHubFixtureServer();
+    const owner: Principal = { member: "m1", team: "t1" };
+    try {
+      const created = await call(server, "POST", "/api/v1/resources", owner, {
+        kind: "design_system",
+      });
+      expect(created.status).toBe(201);
+      const resourceId = created.json.id as string;
+
+      const content = "tokens";
+      const digest = sha256(content);
+      const missing = await call(server, "POST", "/api/v1/resources/blobs/find-missing", owner, {
+        digests: [digest],
+      });
+      expect(missing.json.missing).toEqual([digest]);
+
+      const prep = await call(server, "POST", "/api/v1/resources/blobs/uploads", owner, {
+        blobs: [{ digest, size: content.length }],
+      });
+      expect(prep.json.storeLive).toBe(true);
+      const uploadUrl = prep.json.uploads[0].url as string;
+
+      // Presigned PUT straight to the fixture's own object store.
+      const put = await fetch(uploadUrl, { method: "PUT", body: content });
+      expect(put.ok).toBe(true);
+
+      const commit = await call(server, "POST", "/api/v1/resources/blobs/uploads/commit", owner, {
+        blobs: [{ digest, size: content.length }],
+      });
+      expect(commit.status).toBe(200);
+
+      const manifestDigest = sha256("manifest");
+      const publish = await call(server, "POST", `/api/v1/resources/${resourceId}/versions`, owner, {
+        manifestDigest,
+        entries: [{ path: "tokens.json", type: "file", blobDigest: digest }],
+        ref: "latest",
+      });
+      expect(publish.status).toBe(201);
+      const versionId = publish.json.id as string;
+
+      const ref = await call(server, "GET", `/api/v1/resources/${resourceId}/refs/latest`, owner);
+      expect(ref.json.versionId).toBe(versionId);
+
+      const manifest = await call(server, "GET", `/api/v1/resources/manifests/${manifestDigest}`, owner);
+      expect(manifest.json.entries[0].blobDigest).toBe(digest);
+
+      const dl = await call(server, "GET", `/api/v1/resources/blobs/${digest}/download`, owner);
+      const got = await fetch(dl.json.url as string);
+      expect(await got.text()).toBe(content);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("enforces auth, freeze, isolation and optimistic concurrency", async () => {
+    const server = await startResourceHubFixtureServer();
+    const owner: Principal = { member: "m1", team: "t1" };
+    try {
+      // auth
+      expect((await call(server, "GET", "/api/v1/resources", owner, undefined, "wrong")).status).toBe(401);
+      expect((await call(server, "GET", "/api/v1/resources", undefined)).status).toBe(403);
+
+      // not-found + bad input
+      expect((await call(server, "GET", "/api/v1/resources/nope", owner)).json.error).toBe("resource_not_found");
+      expect(
+        (await call(server, "POST", "/api/v1/resources/blobs/find-missing", owner, { digests: ["bad"] })).status,
+      ).toBe(400);
+
+      // frozen
+      const frozen = await call(server, "POST", "/api/v1/resources", { ...owner, life: "locked" }, {
+        kind: "design_system",
+      });
+      expect(frozen.status).toBe(403);
+      expect(frozen.json.error).toBe("resource_frozen");
+
+      // set up a resource + version
+      const res = await call(server, "POST", "/api/v1/resources", owner, { kind: "design_system" });
+      const id = res.json.id as string;
+      const md = sha256("m");
+      const v1 = await call(server, "POST", `/api/v1/resources/${id}/versions`, owner, {
+        manifestDigest: md,
+        entries: [],
+        ref: "latest",
+      });
+      expect(v1.status).toBe(201);
+
+      // 409 stale ref
+      const conflict = await call(server, "POST", `/api/v1/resources/${id}/versions`, owner, {
+        manifestDigest: md,
+        entries: [],
+        ref: "latest",
+        expectedVersionId: "stale",
+      });
+      expect(conflict.status).toBe(409);
+      expect(conflict.json.error).toBe("ref_conflict");
+
+      // forbidden: same team, non-creator cannot publish
+      const forbidden = await call(server, "POST", `/api/v1/resources/${id}/versions`, { member: "m2", team: "t1" }, {
+        manifestDigest: md,
+        entries: [],
+      });
+      expect(forbidden.status).toBe(403);
+      expect(forbidden.json.error).toBe("forbidden");
+
+      // cross-team isolation
+      expect((await call(server, "GET", `/api/v1/resources/${id}`, { member: "x", team: "t2" })).status).toBe(404);
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## What

Daemon side of **Spec E team resource sharing** (cloud storage), plus a
temporary local backend so teammates can start building on it immediately —
without standing up the vela stack.

**Permanent (the real capability):**
- `src/integrations/resource-hub.ts` — HTTP client for the resource storage
  service (resources / versions / manifests / refs / find-missing + presigned
  client-direct blob transport). Faithful to the wire protocol; no mocks.
- `src/resource-drive.ts` — neutral, **kind-agnostic** cloud-drive SDK:
  `packTree` (content-address a directory) · `pushTree` (upload only missing
  blobs + publish a version) · `materializeTree`/`materializeRef` (safe §2.7
  landing). Knows nothing about design-systems/plugins/skills or *when* to sync.
- `src/resource-cli.ts` — `od resource put/get/list` (neutral directory
  round-trip).
- Hot-file footprint kept to 4 lines (`cli.ts` + `server.ts`); `app-config.ts`
  untouched.

**Temporary (disposable local backend):**
- `tools/serve/src/resource-hub-fixture.ts` — self-contained, in-memory,
  infra-free stand-in for the real service, exposed as
  `pnpm tools-serve start resource-hub`. Same wire contract (auth, freeze,
  isolation, dedup, presigned blob transport served in-process). **Deleted once
  the vela test environment is stood up** — repoint `OD_RESOURCE_HUB_URL` and
  the daemon needs zero code changes.

## Use it locally

```
pnpm tools-serve start resource-hub --port 18090
export OD_RESOURCE_HUB_URL=http://localhost:18090 OD_RESOURCE_HUB_TOKEN=dev-internal-token
export OD_WORKSPACE_MEMBER_ID=you OD_WORKSPACE_TEAM_ID=your-team OD_WORKSPACE_ROLE=owner
od resource put ./some-dir --kind design_system --ref latest
od resource get <resource-id> ./dest
```

## Verified

- **Real `od` binary E2E** against the fixture: `put` → `list` → `get`, byte
  round-trip byte-for-byte, error path surfaces `404 resource_not_found`.
- **Error matrix (11 checks)** through the real daemon client — 401 untrusted /
  403 missing-principal / 404 not-found + cross-team / 400 bad-digest / 403
  frozen / 409 ref-conflict / 403 forbidden — **identical against the fixture and
  the real vela api**, proving contract equivalence.
- **Daemon body** (a real `tools-dev start daemon` process pointed at the
  fixture): `GET /api/resources/_status` → `200 {configured, principalAvailable}`,
  `GET /api/resources` proxies through the running daemon to the fixture and
  returns the seeded resource, `share`/`pull` → `501` (intentional stubs — the
  consumer layer is not in this PR).
- Hermetic `tools/serve/tests/resource-hub-fixture.test.ts` locks the fixture's
  half of the contract.

## Scope / follow-ups (not in this PR)

- Feature-specific sharing (design-system share, the `routes/resources/*`
  share/pull endpoints) is a **consumer layer** built on top of the SDK — kept
  as stubs here.
- The workspace principal is a provisional **env seam** pending the member table
  (link B); the final auth topology is unchanged by this PR.
- The full daemon → real vela api → object store chain is verified separately
  (not required for teammates to start against the fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
