### PR TITLE
fix(landing-page): polish alternative & agent page CTAs, footer layout + i18n

### DIFF
--- a/apps/landing-page/app/_components/alternative-detail.astro
+++ b/apps/landing-page/app/_components/alternative-detail.astro
@@ -317,7 +317,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/_components/alternative-detail.astro
+++ b/apps/landing-page/app/_components/alternative-detail.astro
@@ -39,6 +39,27 @@ const features = page.features;
 const ctaHref = (a: { href: string; external?: boolean }) =>
   a.external ? a.href : href(a.href);
 
+// Comparison pages lead with the desktop download. Drop the generic
+// "get started" CTA (the /quickstart/ action) and surface only Download —
+// emphasized as the primary button — plus Star on GitHub as the secondary.
+// Actions are matched by their locale-stable hrefs (the English base uses
+// /download/, older translated copy uses the /releases link; both are kept),
+// so this holds across every translation without editing per-locale copy.
+type CtaAction = { label: string; href: string; variant?: string; external?: boolean };
+const GET_STARTED_HREF = '/quickstart/';
+const isStar = (a: CtaAction) => a.href === REPO;
+const downloadFirstCtas = (actions: readonly CtaAction[]): CtaAction[] => {
+  const kept = actions.filter((a) => a.href !== GET_STARTED_HREF);
+  const download = kept.find((a) => !isStar(a));
+  const star = kept.find(isStar);
+  if (!download) return [...actions]; // unexpected shape: leave untouched
+  const out: CtaAction[] = [{ ...download, variant: 'primary' }];
+  if (star) out.push({ ...star, variant: 'ghost' });
+  return out;
+};
+const heroCtas: CtaAction[] = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas: CtaAction[] = rich ? downloadFirstCtas(rich.ctaActions) : [];
+
 const faqEntries = (rich?.faq ?? page.faq).map(({ name, text }) => ({ name, text }));
 
 const homeUrl = new URL(href('/'), SITE).toString();
@@ -93,7 +114,7 @@ const jsonLd = [
             <h1 class="v4h1">{page.heading}</h1>
             <p class="v4dek">{rich.heroCtaLead}</p>
             <div class="v4cta-row">
-              {rich.heroCtaActions.map((a) => (
+              {heroCtas.map((a) => (
                 <a
                   class={a.variant === 'primary' ? 'v4btn-p' : 'v4btn-g'}
                   href={ctaHref(a)}
@@ -203,7 +224,7 @@ const jsonLd = [
             <h2 class="v4final-h">{rich.ctaTitle}</h2>
             <p class="v4final-p">{rich.ctaBody}</p>
             <div class="v4cta-row">
-              {rich.ctaActions.map((a) => (
+              {finalCtas.map((a) => (
                 <a
                   class={a.variant === 'primary' ? 'v4btn-coral' : 'v4btn-gd'}
                   href={ctaHref(a)}

--- a/apps/landing-page/app/_components/alternative-detail.astro
+++ b/apps/landing-page/app/_components/alternative-detail.astro
@@ -13,6 +13,7 @@
 import Layout from './sub-page-layout.astro';
 import { getInfoPageCopy, getAlternativeCopy } from '../info-page-i18n';
 import { localeFromPath, localizedHref } from '../i18n';
+import { downloadFirstCtas } from '../cta-actions';
 import '../_partials/comparison-v4.css';
 
 interface Props {
@@ -39,26 +40,9 @@ const features = page.features;
 const ctaHref = (a: { href: string; external?: boolean }) =>
   a.external ? a.href : href(a.href);
 
-// Comparison pages lead with the desktop download. Drop the generic
-// "get started" CTA (the /quickstart/ action) and surface only Download —
-// emphasized as the primary button — plus Star on GitHub as the secondary.
-// Actions are matched by their locale-stable hrefs (the English base uses
-// /download/, older translated copy uses the /releases link; both are kept),
-// so this holds across every translation without editing per-locale copy.
-type CtaAction = { label: string; href: string; variant?: string; external?: boolean };
-const GET_STARTED_HREF = '/quickstart/';
-const isStar = (a: CtaAction) => a.href === REPO;
-const downloadFirstCtas = (actions: readonly CtaAction[]): CtaAction[] => {
-  const kept = actions.filter((a) => a.href !== GET_STARTED_HREF);
-  const download = kept.find((a) => !isStar(a));
-  const star = kept.find(isStar);
-  if (!download) return [...actions]; // unexpected shape: leave untouched
-  const out: CtaAction[] = [{ ...download, variant: 'primary' }];
-  if (star) out.push({ ...star, variant: 'ghost' });
-  return out;
-};
-const heroCtas: CtaAction[] = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
-const finalCtas: CtaAction[] = rich ? downloadFirstCtas(rich.ctaActions) : [];
+// Comparison pages lead with the desktop download — see cta-actions.ts.
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 const faqEntries = (rich?.faq ?? page.faq).map(({ name, text }) => ({ name, text }));
 
@@ -333,9 +317,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/_components/site-footer.astro
+++ b/apps/landing-page/app/_components/site-footer.astro
@@ -126,26 +126,31 @@ const l = L[locale as keyof typeof L] ?? L.en;
         </ul>
       </div>
 
-      <div class='sub-footer-col'>
-        <h5><a href={href('/community/')}>{menu.community}</a></h5>
-        <ul>
-          <li><a href={href('/community/contributors/')}>{menu.communityItems.contributors}</a></li>
-          <li><a href={href('/community/ambassadors/')}>{menu.communityItems.ambassadors}</a></li>
-          <li><a href={href('/community/moderators/')}>{menu.communityItems.moderators}</a></li>
-        </ul>
-      </div>
+      {/* Community + Company share one grid column, stacked vertically. Eight
+          nav sections into a 7-track grid used to orphan Company onto a second
+          row; pairing the two shortest sections keeps everything on one row. */}
+      <div class='sub-footer-col-stack'>
+        <div class='sub-footer-col'>
+          <h5><a href={href('/community/')}>{menu.community}</a></h5>
+          <ul>
+            <li><a href={href('/community/contributors/')}>{menu.communityItems.contributors}</a></li>
+            <li><a href={href('/community/ambassadors/')}>{menu.communityItems.ambassadors}</a></li>
+            <li><a href={href('/community/moderators/')}>{menu.communityItems.moderators}</a></li>
+          </ul>
+        </div>
 
-      <div class='sub-footer-col'>
-        <h5>{l.company}</h5>
-        <ul>
-          <li><a href={href('/about/')}>{l.about}</a></li>
-          <li><a href={href('/careers/')}>{l.careers}</a></li>
-          <li><a href={href('/faq/')}>{l.faq}</a></li>
-          <li><a href={href('/privacy/')}>{l.privacy}</a></li>
-          <li><a href={href('/terms/')}>{l.terms}</a></li>
-          <li><a href={REPO} target='_blank' rel='noopener'>{ui.footer.github}</a></li>
-          <li><a href={DISCORD} target='_blank' rel='noopener'>{ui.footer.discord}</a></li>
-        </ul>
+        <div class='sub-footer-col'>
+          <h5>{l.company}</h5>
+          <ul>
+            <li><a href={href('/about/')}>{l.about}</a></li>
+            <li><a href={href('/careers/')}>{l.careers}</a></li>
+            <li><a href={href('/faq/')}>{l.faq}</a></li>
+            <li><a href={href('/privacy/')}>{l.privacy}</a></li>
+            <li><a href={href('/terms/')}>{l.terms}</a></li>
+            <li><a href={REPO} target='_blank' rel='noopener'>{ui.footer.github}</a></li>
+            <li><a href={DISCORD} target='_blank' rel='noopener'>{ui.footer.discord}</a></li>
+          </ul>
+        </div>
       </div>
     </div>
 

--- a/apps/landing-page/app/_components/site-footer.astro
+++ b/apps/landing-page/app/_components/site-footer.astro
@@ -8,6 +8,7 @@ import {
   isLandingLocale,
   localizedHref,
 } from '../i18n';
+import { getFooterLegalCopy } from '../footer-legal-i18n';
 
 interface Props {
   counts: HeaderProps['counts'];
@@ -48,14 +49,9 @@ const FOOTER_AGENTS = [
   { name: 'OpenCode', route: 'opencode-design' },
 ] as const;
 
-// Legal / company labels — small inline map (en/zh/zh-tw, fallback en) so
-// this stays out of the larger footer i18n surface.
-const L = {
-  en: { company: 'Company', about: 'About', careers: 'Careers', faq: 'FAQ', privacy: 'Privacy Policy', terms: 'Terms', allAgents: 'All agents', allSolutions: 'All use cases' },
-  zh: { company: '公司', about: '关于', careers: '招聘', faq: '常见问题', privacy: '隐私政策', terms: '服务条款', allAgents: '全部 Agent', allSolutions: '全部场景' },
-  'zh-tw': { company: '公司', about: '關於', careers: '招聘', faq: '常見問題', privacy: '隱私政策', terms: '服務條款', allAgents: '全部 Agent', allSolutions: '全部場景' },
-} satisfies Record<string, Record<string, string>>;
-const l = L[locale as keyof typeof L] ?? L.en;
+// Legal / company labels — localized for every landing locale (see
+// footer-legal-i18n.ts), falling back to English for any unknown code.
+const l = getFooterLegalCopy(locale);
 ---
 
 <footer class='sub-footer' data-od-id='footer'>

--- a/apps/landing-page/app/_partials/comparison-v4.css
+++ b/apps/landing-page/app/_partials/comparison-v4.css
@@ -17,8 +17,16 @@
 .v4sub{font-size:18px;line-height:1.55;color:var(--ink-soft);font-weight:500;margin:0 0 24px;max-width:520px}
 .v4dek{font-size:18px;line-height:1.65;color:var(--ink-soft);max-width:660px;margin:0 0 34px}
 .v4cta-row{display:flex;gap:14px;flex-wrap:wrap;align-items:center}
-.v4btn-p{background:var(--ink);color:#fff;font-weight:600;font-size:15px;padding:15px 28px;border-radius:var(--spacing-8);text-decoration:none;display:inline-flex;align-items:center;white-space:nowrap}
-.v4btn-g{color:var(--ink);font-weight:600;font-size:15px;padding:15px 24px;border-radius:var(--spacing-8);border:1px solid var(--line);text-decoration:none;display:inline-flex;align-items:center}
+/* Both CTA buttons share one box model (equal padding + a 1px border on each,
+   the primary's border matching its fill) so the filled and outlined buttons
+   stay the same height/shape across every locale — long translated labels no
+   longer make the outlined button wrap or drift out of alignment. The outlined
+   border uses --ink-faint (not the faint --line) so it reads as a real button
+   edge on the near-white paper, not a hairline. */
+.v4btn-p{background:var(--ink);color:#fff;border:1px solid var(--ink);font-weight:600;font-size:15px;padding:14px 27px;border-radius:var(--spacing-8);text-decoration:none;display:inline-flex;align-items:center;white-space:nowrap;transition:background .16s ease,border-color .16s ease}
+.v4btn-p:hover{background:#000;border-color:#000}
+.v4btn-g{color:var(--ink);background:transparent;border:1px solid var(--ink-faint);font-weight:600;font-size:15px;padding:14px 27px;border-radius:var(--spacing-8);text-decoration:none;display:inline-flex;align-items:center;white-space:nowrap;transition:background .16s ease,border-color .16s ease}
+.v4btn-g:hover{border-color:var(--ink);background:var(--paper-warm)}
 /* stats band */
 .v4stats{display:grid;grid-template-columns:repeat(4,1fr);gap:40px}
 .v4stats .n{font-size:clamp(34px,4.4vw,52px);line-height:1;font-weight:800;letter-spacing:-.035em;color:var(--ink)}
@@ -77,8 +85,12 @@
 .v4final>.v4in{position:relative;z-index:1}
 .v4final-h{font-size:clamp(30px,4vw,46px);line-height:1.1;letter-spacing:-.025em;font-weight:780;color:#fff;margin:0 0 16px;max-width:760px}
 .v4final-p{font-size:18px;line-height:1.6;color:rgba(255,255,255,.72);margin:0 0 30px;max-width:560px}
-.v4btn-coral{background:var(--coral);color:#0a0a0a;font-weight:700;font-size:15px;padding:15px 28px;border-radius:var(--spacing-8);text-decoration:none;display:inline-flex;align-items:center}
-.v4btn-gd{background:transparent;color:#fff;border:1px solid rgba(255,255,255,.35);font-weight:600;font-size:15px;padding:15px 26px;border-radius:var(--spacing-8);text-decoration:none;display:inline-flex;align-items:center}
+/* Final-CTA pair on the dark band: same equal-box treatment as the hero pair.
+   The outlined button's border is lifted to .55 alpha so it stays legible
+   against the ink background when a translated label makes it wider. */
+.v4btn-coral{background:var(--coral);color:#0a0a0a;border:1px solid var(--coral);font-weight:700;font-size:15px;padding:14px 27px;border-radius:var(--spacing-8);text-decoration:none;display:inline-flex;align-items:center;white-space:nowrap}
+.v4btn-gd{background:transparent;color:#fff;border:1px solid rgba(255,255,255,.55);font-weight:600;font-size:15px;padding:14px 27px;border-radius:var(--spacing-8);text-decoration:none;display:inline-flex;align-items:center;white-space:nowrap;transition:border-color .16s ease,background .16s ease}
+.v4btn-gd:hover{border-color:#fff;background:rgba(255,255,255,.08)}
 /* hero image (promo moved up) */
 .v4heroimg{margin:44px auto 0;max-width:740px}
 .v4heroimg img{width:100%;border-radius:var(--spacing-8);box-shadow:0 30px 64px -36px rgba(20,20,30,.5);display:block}

--- a/apps/landing-page/app/cta-actions.ts
+++ b/apps/landing-page/app/cta-actions.ts
@@ -5,12 +5,17 @@
 // CTA (the /quickstart/ action) and surface only two buttons — Download,
 // emphasized as the primary, and Star on GitHub as the secondary. Actions are
 // matched by their locale-stable hrefs, so this holds across every translation
-// without editing per-locale copy. The English base uses /download/ for the
-// download action while older translated copy uses the /releases link; both
-// are treated as the download (i.e. the non-Star, non-get-started action).
+// without editing per-locale copy.
+//
+// The download button always points at the on-site download page
+// (DOWNLOAD_HREF), regardless of what the (drifted) per-locale copy had — the
+// English base used /download/ while older translated copy linked straight to
+// GitHub /releases; both are normalised here to the localized download page.
 
 export const CTA_REPO = 'https://github.com/nexu-io/open-design';
 export const CTA_REPO_RELEASES = `${CTA_REPO}/releases`;
+// On-site download page; ctaHref() localizes this per locale.
+export const DOWNLOAD_HREF = '/download/';
 const GET_STARTED_HREF = '/quickstart/';
 
 export type CtaAction = {
@@ -27,7 +32,9 @@ export const downloadFirstCtas = (actions: readonly CtaAction[]): CtaAction[] =>
   const download = kept.find((a) => !isStar(a));
   const star = kept.find(isStar);
   if (!download) return [...actions]; // unexpected shape: leave untouched
-  const out: CtaAction[] = [{ ...download, variant: 'primary' }];
+  const out: CtaAction[] = [
+    { ...download, href: DOWNLOAD_HREF, external: false, variant: 'primary' },
+  ];
   if (star) out.push({ ...star, variant: 'ghost' });
   return out;
 };

--- a/apps/landing-page/app/cta-actions.ts
+++ b/apps/landing-page/app/cta-actions.ts
@@ -1,0 +1,33 @@
+// Shared CTA-action shaping for the comparison (/alternatives/*) and agent
+// (/agents/*-design/) landing pages.
+//
+// These pages lead with the desktop download: drop the generic "get started"
+// CTA (the /quickstart/ action) and surface only two buttons — Download,
+// emphasized as the primary, and Star on GitHub as the secondary. Actions are
+// matched by their locale-stable hrefs, so this holds across every translation
+// without editing per-locale copy. The English base uses /download/ for the
+// download action while older translated copy uses the /releases link; both
+// are treated as the download (i.e. the non-Star, non-get-started action).
+
+export const CTA_REPO = 'https://github.com/nexu-io/open-design';
+export const CTA_REPO_RELEASES = `${CTA_REPO}/releases`;
+const GET_STARTED_HREF = '/quickstart/';
+
+export type CtaAction = {
+  label: string;
+  href: string;
+  variant?: string;
+  external?: boolean;
+};
+
+const isStar = (a: CtaAction) => a.href === CTA_REPO;
+
+export const downloadFirstCtas = (actions: readonly CtaAction[]): CtaAction[] => {
+  const kept = actions.filter((a) => a.href !== GET_STARTED_HREF);
+  const download = kept.find((a) => !isStar(a));
+  const star = kept.find(isStar);
+  if (!download) return [...actions]; // unexpected shape: leave untouched
+  const out: CtaAction[] = [{ ...download, variant: 'primary' }];
+  if (star) out.push({ ...star, variant: 'ghost' });
+  return out;
+};

--- a/apps/landing-page/app/footer-legal-i18n.ts
+++ b/apps/landing-page/app/footer-legal-i18n.ts
@@ -1,0 +1,55 @@
+// Localized labels for the footer's Company / legal column, shared by the
+// sub-page footer (site-footer.astro) and the homepage footer (page.tsx).
+//
+// These used to live in a small inline map that only covered en/zh/zh-tw, so
+// every other locale silently fell back to English in the Company column.
+// This module carries all landing locales; getFooterLegalCopy() falls back to
+// English for any code not present.
+import type { LandingLocaleCode } from './i18n';
+
+export interface FooterLegalCopy {
+  company: string;
+  about: string;
+  careers: string;
+  faq: string;
+  privacy: string;
+  terms: string;
+  allAgents: string;
+  allSolutions: string;
+}
+
+const EN: FooterLegalCopy = {
+  company: 'Company',
+  about: 'About',
+  careers: 'Careers',
+  faq: 'FAQ',
+  privacy: 'Privacy Policy',
+  terms: 'Terms',
+  allAgents: 'All agents',
+  allSolutions: 'All use cases',
+};
+
+const FOOTER_LEGAL_COPY = {
+  en: EN,
+  zh: { company: '公司', about: '关于', careers: '招聘', faq: '常见问题', privacy: '隐私政策', terms: '服务条款', allAgents: '全部 Agent', allSolutions: '全部场景' },
+  'zh-tw': { company: '公司', about: '關於', careers: '招聘', faq: '常見問題', privacy: '隱私政策', terms: '服務條款', allAgents: '全部 Agent', allSolutions: '全部場景' },
+  ja: { company: '会社情報', about: '概要', careers: '採用情報', faq: 'よくある質問', privacy: 'プライバシーポリシー', terms: '利用規約', allAgents: 'すべてのエージェント', allSolutions: 'すべてのユースケース' },
+  ko: { company: '회사', about: '소개', careers: '채용', faq: '자주 묻는 질문', privacy: '개인정보 처리방침', terms: '이용약관', allAgents: '모든 에이전트', allSolutions: '모든 사용 사례' },
+  de: { company: 'Unternehmen', about: 'Über uns', careers: 'Karriere', faq: 'FAQ', privacy: 'Datenschutz', terms: 'Nutzungsbedingungen', allAgents: 'Alle Agents', allSolutions: 'Alle Anwendungsfälle' },
+  fr: { company: 'Entreprise', about: 'À propos', careers: 'Carrières', faq: 'FAQ', privacy: 'Confidentialité', terms: 'Conditions', allAgents: 'Tous les agents', allSolutions: 'Tous les cas d’usage' },
+  ru: { company: 'Компания', about: 'О нас', careers: 'Вакансии', faq: 'Частые вопросы', privacy: 'Конфиденциальность', terms: 'Условия', allAgents: 'Все агенты', allSolutions: 'Все сценарии' },
+  es: { company: 'Empresa', about: 'Acerca de', careers: 'Empleo', faq: 'Preguntas frecuentes', privacy: 'Privacidad', terms: 'Términos', allAgents: 'Todos los agentes', allSolutions: 'Todos los casos de uso' },
+  'pt-br': { company: 'Empresa', about: 'Sobre', careers: 'Carreiras', faq: 'Perguntas frequentes', privacy: 'Privacidade', terms: 'Termos', allAgents: 'Todos os agentes', allSolutions: 'Todos os casos de uso' },
+  it: { company: 'Azienda', about: 'Chi siamo', careers: 'Lavora con noi', faq: 'FAQ', privacy: 'Privacy', terms: 'Termini', allAgents: 'Tutti gli agenti', allSolutions: 'Tutti i casi d’uso' },
+  vi: { company: 'Công ty', about: 'Giới thiệu', careers: 'Tuyển dụng', faq: 'Câu hỏi thường gặp', privacy: 'Quyền riêng tư', terms: 'Điều khoản', allAgents: 'Tất cả agent', allSolutions: 'Tất cả trường hợp dùng' },
+  pl: { company: 'Firma', about: 'O nas', careers: 'Kariera', faq: 'FAQ', privacy: 'Prywatność', terms: 'Regulamin', allAgents: 'Wszystkie agenty', allSolutions: 'Wszystkie zastosowania' },
+  id: { company: 'Perusahaan', about: 'Tentang', careers: 'Karier', faq: 'FAQ', privacy: 'Privasi', terms: 'Ketentuan', allAgents: 'Semua agent', allSolutions: 'Semua kasus penggunaan' },
+  nl: { company: 'Bedrijf', about: 'Over ons', careers: 'Vacatures', faq: 'FAQ', privacy: 'Privacy', terms: 'Voorwaarden', allAgents: 'Alle agents', allSolutions: 'Alle toepassingen' },
+  ar: { company: 'الشركة', about: 'من نحن', careers: 'الوظائف', faq: 'الأسئلة الشائعة', privacy: 'سياسة الخصوصية', terms: 'الشروط', allAgents: 'كل الوكلاء', allSolutions: 'كل حالات الاستخدام' },
+  tr: { company: 'Şirket', about: 'Hakkımızda', careers: 'Kariyer', faq: 'SSS', privacy: 'Gizlilik', terms: 'Şartlar', allAgents: 'Tüm agent’lar', allSolutions: 'Tüm kullanım senaryoları' },
+  uk: { company: 'Компанія', about: 'Про нас', careers: 'Кар’єра', faq: 'Часті запитання', privacy: 'Конфіденційність', terms: 'Умови', allAgents: 'Усі агенти', allSolutions: 'Усі сценарії' },
+} satisfies Record<LandingLocaleCode, FooterLegalCopy>;
+
+export function getFooterLegalCopy(locale: string): FooterLegalCopy {
+  return (FOOTER_LEGAL_COPY as Record<string, FooterLegalCopy>)[locale] ?? EN;
+}

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -5191,6 +5191,15 @@ footer .container {
   grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 28px;
   margin-bottom: 36px;
+  align-items: start;
+}
+/* A grid cell that stacks two short nav sections vertically so the sub-page
+   footer's eight sections fit the 7-track grid without a section orphaning
+   onto a second row (used for Community + Company in site-footer.astro). */
+.sub-footer-col-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 .sub-footer-col h5 {
   font-family: var(--mono);

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -32,6 +32,7 @@ import {
   PRECISE_LAZY_PLACEHOLDER,
 } from './image-assets';
 import { getHomeExtra, getHomeCta } from './home-translations';
+import { getFooterLegalCopy } from './footer-legal-i18n';
 
 /**
  * `<img>` wrapper for non-hero homepage images. Outputs `data-precise-src`
@@ -189,13 +190,6 @@ const FOOTER_AGENTS = [
   { name: 'OpenCode', route: 'opencode-design' },
 ] as const;
 
-// Legal / company labels — small inline map (en/zh/zh-tw, fallback en) kept
-// identical to `site-footer.astro` so the two footers never drift.
-const FOOTER_LEGAL = {
-  en: { company: 'Company', about: 'About', careers: 'Careers', faq: 'FAQ', privacy: 'Privacy Policy', terms: 'Terms', allAgents: 'All agents' },
-  zh: { company: '公司', about: '关于', careers: '招聘', faq: '常见问题', privacy: '隐私政策', terms: '服务条款', allAgents: '全部 Agent' },
-  'zh-tw': { company: '公司', about: '關於', careers: '招聘', faq: '常見問題', privacy: '隱私政策', terms: '服務條款', allAgents: '全部 Agent' },
-} satisfies Record<string, Record<string, string>>;
 
 const ext = {
   target: '_blank',
@@ -334,8 +328,7 @@ export default function Page({
   const home = getHomePageCopy(locale);
   const ui = getLandingUiCopy(locale);
   const menu = getHeaderProductMenuCopy(locale);
-  const footL =
-    FOOTER_LEGAL[locale as keyof typeof FOOTER_LEGAL] ?? FOOTER_LEGAL.en;
+  const footL = getFooterLegalCopy(locale);
   const localeDef = getLocaleDefinition(locale);
   const localeOptions = LANDING_LOCALES.map((entry) => ({
     ...entry,

--- a/apps/landing-page/app/pages/agents/aider-design/index.astro
+++ b/apps/landing-page/app/pages/agents/aider-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/aider-design/index.astro
+++ b/apps/landing-page/app/pages/agents/aider-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'aider';
 const ROUTE = 'aider-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/antigravity-design/index.astro
+++ b/apps/landing-page/app/pages/agents/antigravity-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/antigravity-design/index.astro
+++ b/apps/landing-page/app/pages/agents/antigravity-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'antigravity';
 const ROUTE = 'antigravity-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/claude-code-design/index.astro
+++ b/apps/landing-page/app/pages/agents/claude-code-design/index.astro
@@ -288,7 +288,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/claude-code-design/index.astro
+++ b/apps/landing-page/app/pages/agents/claude-code-design/index.astro
@@ -13,6 +13,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'claude-code';
 const ROUTE = 'claude-code-design';
@@ -26,6 +27,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -88,7 +93,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -186,7 +191,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -283,9 +288,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/codex-design/index.astro
+++ b/apps/landing-page/app/pages/agents/codex-design/index.astro
@@ -289,7 +289,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/codex-design/index.astro
+++ b/apps/landing-page/app/pages/agents/codex-design/index.astro
@@ -14,6 +14,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'codex';
 const ROUTE = 'codex-design';
@@ -27,6 +28,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -89,7 +94,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -187,7 +192,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -284,9 +289,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/copilot-design/index.astro
+++ b/apps/landing-page/app/pages/agents/copilot-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/copilot-design/index.astro
+++ b/apps/landing-page/app/pages/agents/copilot-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'copilot';
 const ROUTE = 'copilot-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/cursor-design/index.astro
+++ b/apps/landing-page/app/pages/agents/cursor-design/index.astro
@@ -288,7 +288,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/cursor-design/index.astro
+++ b/apps/landing-page/app/pages/agents/cursor-design/index.astro
@@ -13,6 +13,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'cursor';
 const ROUTE = 'cursor-design';
@@ -26,6 +27,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -88,7 +93,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -186,7 +191,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -283,9 +288,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/deepseek-design/index.astro
+++ b/apps/landing-page/app/pages/agents/deepseek-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/deepseek-design/index.astro
+++ b/apps/landing-page/app/pages/agents/deepseek-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'deepseek';
 const ROUTE = 'deepseek-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/devin-design/index.astro
+++ b/apps/landing-page/app/pages/agents/devin-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/devin-design/index.astro
+++ b/apps/landing-page/app/pages/agents/devin-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'devin';
 const ROUTE = 'devin-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/gemini-design/index.astro
+++ b/apps/landing-page/app/pages/agents/gemini-design/index.astro
@@ -288,7 +288,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/gemini-design/index.astro
+++ b/apps/landing-page/app/pages/agents/gemini-design/index.astro
@@ -13,6 +13,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'gemini';
 const ROUTE = 'gemini-design';
@@ -26,6 +27,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -88,7 +93,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -186,7 +191,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -283,9 +288,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/grok-design/index.astro
+++ b/apps/landing-page/app/pages/agents/grok-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/grok-design/index.astro
+++ b/apps/landing-page/app/pages/agents/grok-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'grok';
 const ROUTE = 'grok-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/hermes-design/index.astro
+++ b/apps/landing-page/app/pages/agents/hermes-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/hermes-design/index.astro
+++ b/apps/landing-page/app/pages/agents/hermes-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'hermes';
 const ROUTE = 'hermes-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/kilo-design/index.astro
+++ b/apps/landing-page/app/pages/agents/kilo-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/kilo-design/index.astro
+++ b/apps/landing-page/app/pages/agents/kilo-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'kilo';
 const ROUTE = 'kilo-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/kimi-design/index.astro
+++ b/apps/landing-page/app/pages/agents/kimi-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/kimi-design/index.astro
+++ b/apps/landing-page/app/pages/agents/kimi-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'kimi';
 const ROUTE = 'kimi-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/kiro-design/index.astro
+++ b/apps/landing-page/app/pages/agents/kiro-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/kiro-design/index.astro
+++ b/apps/landing-page/app/pages/agents/kiro-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'kiro';
 const ROUTE = 'kiro-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/opencode-design/index.astro
+++ b/apps/landing-page/app/pages/agents/opencode-design/index.astro
@@ -288,7 +288,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/opencode-design/index.astro
+++ b/apps/landing-page/app/pages/agents/opencode-design/index.astro
@@ -13,6 +13,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'opencode';
 const ROUTE = 'opencode-design';
@@ -26,6 +27,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -88,7 +93,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -186,7 +191,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -283,9 +288,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/pi-design/index.astro
+++ b/apps/landing-page/app/pages/agents/pi-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/pi-design/index.astro
+++ b/apps/landing-page/app/pages/agents/pi-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'pi';
 const ROUTE = 'pi-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/qoder-design/index.astro
+++ b/apps/landing-page/app/pages/agents/qoder-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/qoder-design/index.astro
+++ b/apps/landing-page/app/pages/agents/qoder-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'qoder';
 const ROUTE = 'qoder-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/qwen-design/index.astro
+++ b/apps/landing-page/app/pages/agents/qwen-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/qwen-design/index.astro
+++ b/apps/landing-page/app/pages/agents/qwen-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'qwen';
 const ROUTE = 'qwen-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/reasonix-design/index.astro
+++ b/apps/landing-page/app/pages/agents/reasonix-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/reasonix-design/index.astro
+++ b/apps/landing-page/app/pages/agents/reasonix-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'reasonix';
 const ROUTE = 'reasonix-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/trae-cli-design/index.astro
+++ b/apps/landing-page/app/pages/agents/trae-cli-design/index.astro
@@ -284,7 +284,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/trae-cli-design/index.astro
+++ b/apps/landing-page/app/pages/agents/trae-cli-design/index.astro
@@ -9,6 +9,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'trae-cli';
 const ROUTE = 'trae-cli-design';
@@ -22,6 +23,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -84,7 +89,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -182,7 +187,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -279,9 +284,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>

--- a/apps/landing-page/app/pages/agents/vibe-cli-design/index.astro
+++ b/apps/landing-page/app/pages/agents/vibe-cli-design/index.astro
@@ -287,7 +287,7 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={href('/download/')}>{common.downloadDesktop}</a>
             <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">

--- a/apps/landing-page/app/pages/agents/vibe-cli-design/index.astro
+++ b/apps/landing-page/app/pages/agents/vibe-cli-design/index.astro
@@ -12,6 +12,7 @@
 import Layout from '../../../_components/sub-page-layout.astro';
 import { getInfoPageCopy } from '../../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../../i18n';
+import { downloadFirstCtas } from '../../../cta-actions';
 
 const SLUG = 'vibe';
 const ROUTE = 'vibe-cli-design';
@@ -25,6 +26,10 @@ const common = copy.common;
 // Compact locales fall back to the English guide rather than crash on undefined.
 const page = copy.agentGuides[SLUG] ?? getInfoPageCopy('en').agentGuides[SLUG]!;
 const rich = page.rich;
+
+// Lead the CTAs with the desktop download (drop the get-started action).
+const heroCtas = rich ? downloadFirstCtas(rich.heroCtaActions) : [];
+const finalCtas = rich ? downloadFirstCtas(rich.ctaActions) : [];
 
 // Localize CTA action hrefs while leaving external links untouched.
 const ctaHref = (a: { href: string; external?: boolean }) =>
@@ -87,7 +92,7 @@ const jsonLd = [
           <h1 class="display">{page.heading}</h1>
           <p class="lead">{page.lead}</p>
           <div class="solution-hero-cta">
-            {rich.heroCtaActions.map((a) => (
+            {heroCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -185,7 +190,7 @@ const jsonLd = [
             <p>{rich.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            {rich.ctaActions.map((a) => (
+            {finalCtas.map((a) => (
               <a
                 class={`btn ${a.variant === 'primary' ? 'btn-primary' : 'btn-ghost'}`}
                 href={ctaHref(a)}
@@ -282,9 +287,8 @@ const jsonLd = [
             <p>{page.ctaBody}</p>
           </div>
           <div class="info-cta-actions">
-            <a class="btn btn-primary" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
-            <a class="btn btn-ghost" href={href('/quickstart/')}>{common.quickstart}</a>
-            <a class="btn btn-ghost" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-primary" href={REPO_RELEASES} target="_blank" rel="noreferrer noopener">{common.downloadDesktop}</a>
+            <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer noopener">{common.starOnGithub}</a>
           </div>
           <div class="info-cta-meta">
             <span class="stamp">● {common.apache}</span>


### PR DESCRIPTION
## Why

Feedback on the freshly-merged `/alternatives/*` listicle pages surfaced a
cluster of CTA / footer polish issues that were visible across the marketing
site, plus a multilingual regression in the footer:

- The hero and final CTA buttons used **mismatched box models** — the filled
  button had no border + `white-space:nowrap`, the outlined button had a faint
  `--line` border, no nowrap, and less padding. On non-English locales the
  longer labels made the outlined button wrap and drift out of alignment, and
  its hairline border barely registered on the near-white paper.
- These comparison pages led with a generic **"get started" CTA** as the
  emphasized primary; the intended conversion is installing the desktop client.
- The download button's target **differed by locale** (English → `/download/`,
  older translated copy → GitHub `/releases`).
- The sub-page footer packed **eight nav sections into a 7-track grid**, so the
  Company section orphaned onto a second row.
- The footer **Company column** (Company / About / Careers / FAQ / Privacy /
  Terms) was driven by an inline map covering only en/zh/zh-tw, so every other
  active locale (ko, ja, de, fr, ru, es, pt-br, it) rendered those labels in
  English while the rest of the footer was translated.

## What users will see

- **Alternative & agent pages** now show exactly two CTAs — **Download**
  (emphasized primary) and **Star on GitHub** (secondary) — same height/shape
  in every language, with a clearly visible outlined border. The download
  button always goes to the localized on-site `/download/` page.
- The **footer** keeps all its sections on one clean row (Community + Company
  stack in the last column, mirroring the reference footer), and the Company
  column is now translated in every active locale.

## How

- `_partials/comparison-v4.css`: both CTA pairs share one box (equal padding, a
  1px border on each with the primary's matching its fill, `nowrap`); the
  outlined border moves from `--line` to `--ink-faint` / `.55`-alpha white.
- `cta-actions.ts` (new, shared): `downloadFirstCtas()` drops the `/quickstart/`
  action, makes Download the primary and rewrites its href to the localized
  `/download/` page, and keeps Star as the secondary — matched by locale-stable
  hrefs so it holds across every translation. Consumed by `alternative-detail`
  and all 21 `/agents/*-design/` pages (which previously inlined the 3-button
  hero).
- `site-footer.astro` + `globals.css`: Community + Company share one grid cell
  via `.sub-footer-col-stack`; `align-items: start` keeps columns top-aligned.
- `footer-legal-i18n.ts` (new, shared): Company/legal labels for every landing
  locale, typed against `LandingLocaleCode` so a missing locale fails
  typecheck. Consumed by both `site-footer.astro` and the homepage footer in
  `page.tsx`, so the two footers can no longer drift.

## Surface area

- [x] Marketing/landing-page UI (`apps/landing-page`)
- [x] i18n copy (new `footer-legal-i18n.ts`; all active landing locales)
- [x] No CLI / daemon / contracts / schema changes

## Validation

- `pnpm --filter @open-design/landing-page typecheck` (astro check): **0 errors**
  (354 files). The footer i18n map is typed `satisfies Record<LandingLocaleCode,
  …>`, so completeness is enforced at build time.
- Static build (`build:static`) succeeds (4435 pages).
- Spot-checked rendered pages across page types and locales (en/zh/ja/de/ko/fr):
  every page 200, zero `/quickstart/` CTAs, Download as primary → `/download/`,
  Company column localized, footer on one row.

## Notes

- 7 landing locales were retired in 2026-06 (zh-tw/vi/pl/id/nl/ar/uk, 301'd to
  English); the new i18n map still carries them for type completeness but they
  render as English via the existing redirect behavior.
- The footer Company labels are standard UI terms translated for all locales; a
  native reviewer is welcome to refine wording.
