### PR TITLE
fix(web): float annotation composer beside the latest mark

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -930,6 +930,7 @@ export function PreviewDrawOverlay({
     const nextLayout = computePreviewDrawDockLayout({
       hostWidth: hostRect.width,
       hostHeight: hostRect.height,
+      hostScroll,
       anchorRect,
       dockWidth: Math.ceil(measuredDock.width),
       dockHeight: Math.ceil(measuredDock.height),
@@ -1515,12 +1516,14 @@ function overlapRatio(
 function computePreviewDrawDockLayout({
   hostWidth,
   hostHeight,
+  hostScroll,
   anchorRect,
   dockWidth,
   dockHeight,
 }: {
   hostWidth: number;
   hostHeight: number;
+  hostScroll: { left: number; top: number };
   anchorRect: { x: number; y: number; width: number; height: number };
   dockWidth: number;
   dockHeight: number;
@@ -1535,10 +1538,10 @@ function computePreviewDrawDockLayout({
   ) {
     return { mode: 'docked', side: null, style: previewDrawDockedStyle };
   }
-  const minLeft = PREVIEW_DRAW_DOCK_EDGE_PAD;
-  const minTop = PREVIEW_DRAW_DOCK_EDGE_PAD;
-  const maxLeft = hostWidth - dockWidth - PREVIEW_DRAW_DOCK_EDGE_PAD;
-  const maxTop = hostHeight - dockHeight - PREVIEW_DRAW_DOCK_EDGE_PAD;
+  const minLeft = hostScroll.left + PREVIEW_DRAW_DOCK_EDGE_PAD;
+  const minTop = hostScroll.top + PREVIEW_DRAW_DOCK_EDGE_PAD;
+  const maxLeft = hostScroll.left + hostWidth - dockWidth - PREVIEW_DRAW_DOCK_EDGE_PAD;
+  const maxTop = hostScroll.top + hostHeight - dockHeight - PREVIEW_DRAW_DOCK_EDGE_PAD;
   if (maxLeft < minLeft || maxTop < minTop) {
     return { mode: 'docked', side: null, style: previewDrawDockedStyle };
   }
@@ -1549,32 +1552,39 @@ function computePreviewDrawDockLayout({
       side: 'right',
       left: anchorRect.x + anchorRect.width + PREVIEW_DRAW_DOCK_GAP,
       top: centerY - dockHeight / 2,
-      fits: hostWidth - (anchorRect.x + anchorRect.width) - PREVIEW_DRAW_DOCK_EDGE_PAD >= dockWidth + PREVIEW_DRAW_DOCK_GAP,
+      fits:
+        hostScroll.left + hostWidth - (anchorRect.x + anchorRect.width) - PREVIEW_DRAW_DOCK_EDGE_PAD >=
+        dockWidth + PREVIEW_DRAW_DOCK_GAP,
     },
     {
       side: 'left',
       left: anchorRect.x - dockWidth - PREVIEW_DRAW_DOCK_GAP,
       top: centerY - dockHeight / 2,
-      fits: anchorRect.x - PREVIEW_DRAW_DOCK_EDGE_PAD >= dockWidth + PREVIEW_DRAW_DOCK_GAP,
+      fits: anchorRect.x - minLeft >= dockWidth + PREVIEW_DRAW_DOCK_GAP,
     },
     {
       side: 'bottom',
       left: centerX - dockWidth / 2,
       top: anchorRect.y + anchorRect.height + PREVIEW_DRAW_DOCK_GAP,
-      fits: hostHeight - (anchorRect.y + anchorRect.height) - PREVIEW_DRAW_DOCK_EDGE_PAD >= dockHeight + PREVIEW_DRAW_DOCK_GAP,
+      fits:
+        hostScroll.top + hostHeight - (anchorRect.y + anchorRect.height) - PREVIEW_DRAW_DOCK_EDGE_PAD >=
+        dockHeight + PREVIEW_DRAW_DOCK_GAP,
     },
     {
       side: 'top',
       left: centerX - dockWidth / 2,
       top: anchorRect.y - dockHeight - PREVIEW_DRAW_DOCK_GAP,
-      fits: anchorRect.y - PREVIEW_DRAW_DOCK_EDGE_PAD >= dockHeight + PREVIEW_DRAW_DOCK_GAP,
+      fits: anchorRect.y - minTop >= dockHeight + PREVIEW_DRAW_DOCK_GAP,
     },
   ];
   for (const candidate of candidates) {
     if (!candidate.fits) continue;
     const left = clampRange(candidate.left, minLeft, maxLeft);
     const top = clampRange(candidate.top, minTop, maxTop);
-    const maxHeight = Math.max(PREVIEW_DRAW_DOCK_MIN_VISIBLE_HEIGHT, hostHeight - top - PREVIEW_DRAW_DOCK_EDGE_PAD);
+    const maxHeight = Math.max(
+      PREVIEW_DRAW_DOCK_MIN_VISIBLE_HEIGHT,
+      hostScroll.top + hostHeight - top - PREVIEW_DRAW_DOCK_EDGE_PAD,
+    );
     if (maxHeight < PREVIEW_DRAW_DOCK_MIN_VISIBLE_HEIGHT) continue;
     const overlap = overlapRatio(anchorRect, { x: left, y: top, width: dockWidth, height: dockHeight });
     if (overlap > PREVIEW_DRAW_DOCK_MAX_OVERLAP_RATIO) continue;

--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -27,6 +27,17 @@ interface PreviewSnapshot {
   h: number;
 }
 type CaptureFrameRect = Pick<DOMRect, 'left' | 'top' | 'width' | 'height'>;
+type AnnotationAnchorEntry = {
+  id: number;
+  source: 'box' | 'stroke';
+  bounds: NormalizedRect;
+};
+type DockPlacementSide = 'right' | 'left' | 'bottom' | 'top';
+type PreviewDrawDockLayout = {
+  mode: 'floating' | 'docked';
+  side: DockPlacementSide | null;
+  style: CSSProperties;
+};
 
 export const ANNOTATION_EVENT = 'opendesign:annotation';
 export type AnnotationAction = 'draft' | 'queue' | 'send';
@@ -70,6 +81,12 @@ interface Props {
 const STROKE_COLOR = '#ff3b30';
 const STROKE_WIDTH = 4;
 const TARGET_COLOR = '#1677ff';
+const PREVIEW_DRAW_DOCK_EDGE_PAD = 16;
+const PREVIEW_DRAW_DOCK_GAP = 12;
+const PREVIEW_DRAW_DOCK_BOTTOM_OFFSET = 16;
+const PREVIEW_DRAW_DOCK_MIN_WIDTH = 280;
+const PREVIEW_DRAW_DOCK_MIN_VISIBLE_HEIGHT = 120;
+const PREVIEW_DRAW_DOCK_MAX_OVERLAP_RATIO = 0.35;
 
 // Render `node` into `host` via a portal when one is provided, otherwise inline.
 function maybePortal(node: ReactNode, host: HTMLElement | null) {
@@ -93,6 +110,7 @@ export function PreviewDrawOverlay({
   const t = useT();
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const dockRef = useRef<HTMLDivElement | null>(null);
   const [note, setNote] = useState('');
   const [markTool, setMarkTool] = useState<MarkTool>('box');
   const strokesRef = useRef<Stroke[]>([]);
@@ -101,6 +119,9 @@ export function PreviewDrawOverlay({
   // Box-select accumulates: each drag commits another region, so the user can
   // mark several areas in one pass instead of one box replacing the last.
   const selectionBoxesRef = useRef<NormalizedRect[]>([]);
+  const anchorTimelineRef = useRef<AnnotationAnchorEntry[]>([]);
+  const undoneStrokeAnchorsRef = useRef<AnnotationAnchorEntry[]>([]);
+  const nextAnchorIdRef = useRef(1);
   const boxDraftRef = useRef<{ start: Point; current: Point } | null>(null);
   const composingRef = useRef(false);
   const [hasInk, setHasInk] = useState(false);
@@ -130,7 +151,18 @@ export function PreviewDrawOverlay({
     action: AnnotationAction;
     message: string;
   } | null>(null);
+  const [dockSize, setDockSize] = useState<{ width: number; height: number } | null>(null);
+  const [dockLayoutRevision, setDockLayoutRevision] = useState(0);
+  const [dockLayout, setDockLayout] = useState<PreviewDrawDockLayout>({
+    mode: 'docked',
+    side: null,
+    style: previewDrawDockedStyle,
+  });
   const sending = pendingAction !== null;
+
+  const bumpDockLayoutRevision = useCallback(() => {
+    setDockLayoutRevision((value) => value + 1);
+  }, []);
 
   const redraw = useCallback(() => {
     const cvs = canvasRef.current;
@@ -222,6 +254,27 @@ export function PreviewDrawOverlay({
     setHasBox(selectionBoxesRef.current.length > 0);
     setUndoCount(strokesRef.current.length);
     setRedoCount(undoneStrokesRef.current.length);
+  }
+
+  function pushAnchor(source: AnnotationAnchorEntry['source'], bounds: NormalizedRect) {
+    anchorTimelineRef.current = [
+      ...anchorTimelineRef.current,
+      { id: nextAnchorIdRef.current++, source, bounds },
+    ];
+    bumpDockLayoutRevision();
+  }
+
+  function popLatestAnchor(source: AnnotationAnchorEntry['source']) {
+    let index = -1;
+    for (let entryIndex = anchorTimelineRef.current.length - 1; entryIndex >= 0; entryIndex -= 1) {
+      if (anchorTimelineRef.current[entryIndex]?.source === source) {
+        index = entryIndex;
+        break;
+      }
+    }
+    if (index < 0) return;
+    anchorTimelineRef.current = anchorTimelineRef.current.filter((_, entryIndex) => entryIndex !== index);
+    bumpDockLayoutRevision();
   }
 
   function pointFromEvent(e: PointerEvent): Point {
@@ -327,6 +380,7 @@ export function PreviewDrawOverlay({
       // Commit the drawn region; ignore accidental micro-drags (click without move).
       if (next.width >= 0.006 && next.height >= 0.006) {
         selectionBoxesRef.current = [...selectionBoxesRef.current, next];
+        pushAnchor('box', next);
       }
       syncHistoryState();
       redraw();
@@ -336,6 +390,9 @@ export function PreviewDrawOverlay({
     if (drawingRef.current.points.length > 1) {
       strokesRef.current.push(drawingRef.current);
       undoneStrokesRef.current = [];
+      const nextBounds = normalizedStrokeBounds(drawingRef.current, canvasRef.current?.getBoundingClientRect());
+      if (nextBounds) pushAnchor('stroke', nextBounds);
+      undoneStrokeAnchorsRef.current = [];
       syncHistoryState();
     }
     drawingRef.current = null;
@@ -357,6 +414,9 @@ export function PreviewDrawOverlay({
     drawingRef.current = null;
     selectionBoxesRef.current = [];
     boxDraftRef.current = null;
+    anchorTimelineRef.current = [];
+    undoneStrokeAnchorsRef.current = [];
+    bumpDockLayoutRevision();
     syncHistoryState();
     redraw();
   }
@@ -444,6 +504,7 @@ export function PreviewDrawOverlay({
     }
     if (selectionBoxesRef.current.length > 0) {
       selectionBoxesRef.current = selectionBoxesRef.current.slice(0, -1);
+      popLatestAnchor('box');
       syncHistoryState();
       redraw();
       onToolbarClick?.('undo');
@@ -453,6 +514,16 @@ export function PreviewDrawOverlay({
     if (!stroke) return;
     onToolbarClick?.('undo');
     undoneStrokesRef.current.push(stroke);
+    let anchor: AnnotationAnchorEntry | null = null;
+    for (let entryIndex = anchorTimelineRef.current.length - 1; entryIndex >= 0; entryIndex -= 1) {
+      const candidate = anchorTimelineRef.current[entryIndex];
+      if (candidate?.source === 'stroke') {
+        anchor = candidate;
+        break;
+      }
+    }
+    if (anchor) undoneStrokeAnchorsRef.current.push(anchor);
+    popLatestAnchor('stroke');
     drawingRef.current = null;
     syncHistoryState();
     redraw();
@@ -464,6 +535,11 @@ export function PreviewDrawOverlay({
     if (!stroke) return;
     onToolbarClick?.('redo');
     strokesRef.current.push(stroke);
+    const anchor = undoneStrokeAnchorsRef.current.pop();
+    if (anchor) {
+      anchorTimelineRef.current = [...anchorTimelineRef.current, anchor];
+      bumpDockLayoutRevision();
+    }
     drawingRef.current = null;
     syncHistoryState();
     redraw();
@@ -480,8 +556,11 @@ export function PreviewDrawOverlay({
     drawingRef.current = null;
     selectionBoxesRef.current = [];
     boxDraftRef.current = null;
+    anchorTimelineRef.current = [];
+    undoneStrokeAnchorsRef.current = [];
     setExtraFiles([]);
     setPreviewIndex(null);
+    bumpDockLayoutRevision();
     syncHistoryState();
     redraw();
   }, [active, redraw]);
@@ -775,6 +854,85 @@ export function PreviewDrawOverlay({
     setToolbarHost((wrapRef.current?.closest('.viewer-body') as HTMLElement | null) ?? null);
   }, [active]);
 
+  useLayoutEffect(() => {
+    const node = dockRef.current;
+    if (!node) return;
+    const measure = () => {
+      const rect = node.getBoundingClientRect();
+      const next = {
+        width: Math.ceil(rect.width),
+        height: Math.ceil(rect.height),
+      };
+      if (next.width <= 0 || next.height <= 0) return;
+      setDockSize((current) =>
+        current?.width === next.width && current.height === next.height ? current : next,
+      );
+    };
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [active, imagePreviews.length, Boolean(captureWarning)]);
+
+  useEffect(() => {
+    if (!active) return;
+    const schedule = () => bumpDockLayoutRevision();
+    const wrap = wrapRef.current;
+    const host = toolbarHost ?? wrap;
+    if (!wrap || !host) return;
+    window.addEventListener('resize', schedule);
+    window.addEventListener('scroll', schedule, true);
+    if (typeof ResizeObserver === 'undefined') {
+      return () => {
+        window.removeEventListener('resize', schedule);
+        window.removeEventListener('scroll', schedule, true);
+      };
+    }
+    const observer = new ResizeObserver(schedule);
+    observer.observe(wrap);
+    observer.observe(host);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', schedule);
+      window.removeEventListener('scroll', schedule, true);
+    };
+  }, [active, toolbarHost, bumpDockLayoutRevision]);
+
+  useLayoutEffect(() => {
+    if (!active) {
+      setDockLayout({ mode: 'docked', side: null, style: previewDrawDockedStyle });
+      return;
+    }
+    const wrap = wrapRef.current;
+    const host = toolbarHost ?? wrap;
+    const measuredDock = dockSize ?? dockRef.current?.getBoundingClientRect();
+    if (!wrap || !host || !measuredDock) {
+      setDockLayout({ mode: 'docked', side: null, style: previewDrawDockedStyle });
+      return;
+    }
+    const wrapRect = wrap.getBoundingClientRect();
+    const hostRect = host.getBoundingClientRect();
+    const latestAnchor = anchorTimelineRef.current.at(-1) ?? null;
+    const anchorRect = latestAnchor
+      ? normalizedRectToHostRect(latestAnchor.bounds, wrapRect, hostRect)
+      : captureTarget
+        ? absoluteRectToHostRect(captureTarget.position, wrapRect, hostRect)
+        : null;
+    if (!anchorRect) {
+      setDockLayout({ mode: 'docked', side: null, style: previewDrawDockedStyle });
+      return;
+    }
+    const nextLayout = computePreviewDrawDockLayout({
+      hostWidth: hostRect.width,
+      hostHeight: hostRect.height,
+      anchorRect,
+      dockWidth: Math.ceil(measuredDock.width),
+      dockHeight: Math.ceil(measuredDock.height),
+    });
+    setDockLayout(nextLayout);
+  }, [active, toolbarHost, captureTarget, dockSize, dockLayoutRevision]);
+
   const overlayPointer = active ? 'auto' : 'none';
   const showCanvas = active || hasInk || hasBox;
   const canSubmit = hasInk || hasBox || Boolean(captureTarget) || captureViewport || Boolean(note.trim()) || extraFiles.length > 0;
@@ -857,7 +1015,13 @@ export function PreviewDrawOverlay({
       {active ? maybePortal(
         <>
           <style>{tooltipStyle}</style>
-          <div className="preview-draw-dock" style={previewDrawDockStyle}>
+          <div
+            ref={dockRef}
+            className="preview-draw-dock"
+            data-draw-layout={dockLayout.mode}
+            data-draw-side={dockLayout.side ?? undefined}
+            style={dockLayout.style}
+          >
           {captureWarning ? (
             <div
               role="status"
@@ -1277,6 +1441,154 @@ function drawNormalizedBox(ctx: CanvasRenderingContext2D, box: NormalizedRect, w
   ctx.restore();
 }
 
+function normalizedStrokeBounds(stroke: Stroke, rect: DOMRect | undefined | null): NormalizedRect | null {
+  if (!rect || rect.width <= 0 || rect.height <= 0 || stroke.points.length === 0) return null;
+  const xs = stroke.points.map((point) => point.x);
+  const ys = stroke.points.map((point) => point.y);
+  const padX = 8 / rect.width;
+  const padY = 8 / rect.height;
+  const minX = Math.max(0, Math.min(...xs) - padX);
+  const minY = Math.max(0, Math.min(...ys) - padY);
+  const maxX = Math.min(1, Math.max(...xs) + padX);
+  const maxY = Math.min(1, Math.max(...ys) + padY);
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(0, maxX - minX),
+    height: Math.max(0, maxY - minY),
+  };
+}
+
+function normalizedRectToHostRect(
+  rect: NormalizedRect,
+  wrapRect: DOMRect,
+  hostRect: DOMRect,
+): { x: number; y: number; width: number; height: number } | null {
+  if (wrapRect.width <= 0 || wrapRect.height <= 0) return null;
+  return {
+    x: wrapRect.left - hostRect.left + rect.x * wrapRect.width,
+    y: wrapRect.top - hostRect.top + rect.y * wrapRect.height,
+    width: Math.max(1, rect.width * wrapRect.width),
+    height: Math.max(1, rect.height * wrapRect.height),
+  };
+}
+
+function absoluteRectToHostRect(
+  rect: { x: number; y: number; width: number; height: number },
+  wrapRect: DOMRect,
+  hostRect: DOMRect,
+): { x: number; y: number; width: number; height: number } | null {
+  if (wrapRect.width <= 0 || wrapRect.height <= 0) return null;
+  return {
+    x: wrapRect.left - hostRect.left + rect.x,
+    y: wrapRect.top - hostRect.top + rect.y,
+    width: Math.max(1, rect.width),
+    height: Math.max(1, rect.height),
+  };
+}
+
+function clampRange(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+function overlapRatio(
+  anchorRect: { x: number; y: number; width: number; height: number },
+  dockRect: { x: number; y: number; width: number; height: number },
+): number {
+  const left = Math.max(anchorRect.x, dockRect.x);
+  const top = Math.max(anchorRect.y, dockRect.y);
+  const right = Math.min(anchorRect.x + anchorRect.width, dockRect.x + dockRect.width);
+  const bottom = Math.min(anchorRect.y + anchorRect.height, dockRect.y + dockRect.height);
+  if (right <= left || bottom <= top) return 0;
+  const overlapArea = (right - left) * (bottom - top);
+  const anchorArea = Math.max(1, anchorRect.width * anchorRect.height);
+  return overlapArea / anchorArea;
+}
+
+function computePreviewDrawDockLayout({
+  hostWidth,
+  hostHeight,
+  anchorRect,
+  dockWidth,
+  dockHeight,
+}: {
+  hostWidth: number;
+  hostHeight: number;
+  anchorRect: { x: number; y: number; width: number; height: number };
+  dockWidth: number;
+  dockHeight: number;
+}): PreviewDrawDockLayout {
+  if (
+    hostWidth <= 0 ||
+    hostHeight <= 0 ||
+    dockWidth <= 0 ||
+    dockHeight <= 0 ||
+    hostWidth < PREVIEW_DRAW_DOCK_MIN_WIDTH + PREVIEW_DRAW_DOCK_EDGE_PAD * 2 ||
+    dockWidth > hostWidth - PREVIEW_DRAW_DOCK_EDGE_PAD * 2
+  ) {
+    return { mode: 'docked', side: null, style: previewDrawDockedStyle };
+  }
+  const minLeft = PREVIEW_DRAW_DOCK_EDGE_PAD;
+  const minTop = PREVIEW_DRAW_DOCK_EDGE_PAD;
+  const maxLeft = hostWidth - dockWidth - PREVIEW_DRAW_DOCK_EDGE_PAD;
+  const maxTop = hostHeight - dockHeight - PREVIEW_DRAW_DOCK_EDGE_PAD;
+  if (maxLeft < minLeft || maxTop < minTop) {
+    return { mode: 'docked', side: null, style: previewDrawDockedStyle };
+  }
+  const centerX = anchorRect.x + anchorRect.width / 2;
+  const centerY = anchorRect.y + anchorRect.height / 2;
+  const candidates: { side: DockPlacementSide; left: number; top: number; fits: boolean }[] = [
+    {
+      side: 'right',
+      left: anchorRect.x + anchorRect.width + PREVIEW_DRAW_DOCK_GAP,
+      top: centerY - dockHeight / 2,
+      fits: hostWidth - (anchorRect.x + anchorRect.width) - PREVIEW_DRAW_DOCK_EDGE_PAD >= dockWidth + PREVIEW_DRAW_DOCK_GAP,
+    },
+    {
+      side: 'left',
+      left: anchorRect.x - dockWidth - PREVIEW_DRAW_DOCK_GAP,
+      top: centerY - dockHeight / 2,
+      fits: anchorRect.x - PREVIEW_DRAW_DOCK_EDGE_PAD >= dockWidth + PREVIEW_DRAW_DOCK_GAP,
+    },
+    {
+      side: 'bottom',
+      left: centerX - dockWidth / 2,
+      top: anchorRect.y + anchorRect.height + PREVIEW_DRAW_DOCK_GAP,
+      fits: hostHeight - (anchorRect.y + anchorRect.height) - PREVIEW_DRAW_DOCK_EDGE_PAD >= dockHeight + PREVIEW_DRAW_DOCK_GAP,
+    },
+    {
+      side: 'top',
+      left: centerX - dockWidth / 2,
+      top: anchorRect.y - dockHeight - PREVIEW_DRAW_DOCK_GAP,
+      fits: anchorRect.y - PREVIEW_DRAW_DOCK_EDGE_PAD >= dockHeight + PREVIEW_DRAW_DOCK_GAP,
+    },
+  ];
+  for (const candidate of candidates) {
+    if (!candidate.fits) continue;
+    const left = clampRange(candidate.left, minLeft, maxLeft);
+    const top = clampRange(candidate.top, minTop, maxTop);
+    const maxHeight = Math.max(PREVIEW_DRAW_DOCK_MIN_VISIBLE_HEIGHT, hostHeight - top - PREVIEW_DRAW_DOCK_EDGE_PAD);
+    if (maxHeight < PREVIEW_DRAW_DOCK_MIN_VISIBLE_HEIGHT) continue;
+    const overlap = overlapRatio(anchorRect, { x: left, y: top, width: dockWidth, height: dockHeight });
+    if (overlap > PREVIEW_DRAW_DOCK_MAX_OVERLAP_RATIO) continue;
+    return {
+      mode: 'floating',
+      side: candidate.side,
+      style: {
+        ...previewDrawDockBaseStyle,
+        left,
+        top,
+        bottom: 'auto',
+        transform: 'none',
+        maxWidth: Math.min(760, Math.max(160, hostWidth - PREVIEW_DRAW_DOCK_EDGE_PAD * 2)),
+        maxHeight,
+      },
+    };
+  }
+  return { mode: 'docked', side: null, style: previewDrawDockedStyle };
+}
+
 const subToolGroupStyle: CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
@@ -1374,18 +1686,22 @@ const closeButtonStyle: CSSProperties = {
 // strip, and toolbar with real spacing. Absolute per-element `bottom` offsets
 // used to collide once the toolbar wrapped taller, so the image strip visually
 // covered the controls; a flex column keeps them apart at any height.
-const previewDrawDockStyle: CSSProperties = {
+const previewDrawDockBaseStyle: CSSProperties = {
   position: 'absolute',
-  left: 'calc(50% - 52px)',
-  bottom: 16,
-  transform: 'translateX(-50%)',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   gap: 8,
-  maxWidth: 'min(760px, calc(100% - 144px))',
   zIndex: 91,
   pointerEvents: 'none',
+};
+
+const previewDrawDockedStyle: CSSProperties = {
+  ...previewDrawDockBaseStyle,
+  left: 'calc(50% - 52px)',
+  bottom: PREVIEW_DRAW_DOCK_BOTTOM_OFFSET,
+  transform: 'translateX(-50%)',
+  maxWidth: 'min(760px, calc(100% - 144px))',
 };
 
 const submitSplitStyle: CSSProperties = {

--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -913,11 +913,15 @@ export function PreviewDrawOverlay({
     }
     const wrapRect = wrap.getBoundingClientRect();
     const hostRect = host.getBoundingClientRect();
+    const hostScroll = {
+      left: host.scrollLeft,
+      top: host.scrollTop,
+    };
     const latestAnchor = anchorTimelineRef.current.at(-1) ?? null;
     const anchorRect = latestAnchor
-      ? normalizedRectToHostRect(latestAnchor.bounds, wrapRect, hostRect)
+      ? normalizedRectToHostRect(latestAnchor.bounds, wrapRect, hostRect, hostScroll)
       : captureTarget
-        ? absoluteRectToHostRect(captureTarget.position, wrapRect, hostRect)
+        ? absoluteRectToHostRect(captureTarget.position, wrapRect, hostRect, hostScroll)
         : null;
     if (!anchorRect) {
       setDockLayout({ mode: 'docked', side: null, style: previewDrawDockedStyle });
@@ -1463,11 +1467,12 @@ function normalizedRectToHostRect(
   rect: NormalizedRect,
   wrapRect: DOMRect,
   hostRect: DOMRect,
+  hostScroll: { left: number; top: number },
 ): { x: number; y: number; width: number; height: number } | null {
   if (wrapRect.width <= 0 || wrapRect.height <= 0) return null;
   return {
-    x: wrapRect.left - hostRect.left + rect.x * wrapRect.width,
-    y: wrapRect.top - hostRect.top + rect.y * wrapRect.height,
+    x: wrapRect.left - hostRect.left + hostScroll.left + rect.x * wrapRect.width,
+    y: wrapRect.top - hostRect.top + hostScroll.top + rect.y * wrapRect.height,
     width: Math.max(1, rect.width * wrapRect.width),
     height: Math.max(1, rect.height * wrapRect.height),
   };
@@ -1477,11 +1482,12 @@ function absoluteRectToHostRect(
   rect: { x: number; y: number; width: number; height: number },
   wrapRect: DOMRect,
   hostRect: DOMRect,
+  hostScroll: { left: number; top: number },
 ): { x: number; y: number; width: number; height: number } | null {
   if (wrapRect.width <= 0 || wrapRect.height <= 0) return null;
   return {
-    x: wrapRect.left - hostRect.left + rect.x,
-    y: wrapRect.top - hostRect.top + rect.y,
+    x: wrapRect.left - hostRect.left + hostScroll.left + rect.x,
+    y: wrapRect.top - hostRect.top + hostScroll.top + rect.y,
     width: Math.max(1, rect.width),
     height: Math.max(1, rect.height),
   };

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -19,6 +19,33 @@ afterEach(() => {
   vi.mocked(requestPreviewSnapshot).mockClear();
 });
 
+function setElementRect(
+  element: Element,
+  rect: Partial<DOMRect> & Pick<DOMRect, 'left' | 'top' | 'width' | 'height'>,
+) {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () =>
+      ({
+        x: rect.left,
+        y: rect.top,
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        right: rect.left + rect.width,
+        bottom: rect.top + rect.height,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  });
+}
+
+function drawSelectionBox(canvas: HTMLCanvasElement, start: { x: number; y: number }, end: { x: number; y: number }) {
+  fireEvent.pointerDown(canvas, { clientX: start.x, clientY: start.y, pointerId: 1 });
+  fireEvent.pointerMove(canvas, { clientX: end.x, clientY: end.y, pointerId: 1 });
+  fireEvent.pointerUp(canvas, { clientX: end.x, clientY: end.y, pointerId: 1 });
+}
+
 function installImageCompositeMocks() {
   const originalImage = globalThis.Image;
   class MockImage {
@@ -97,6 +124,7 @@ describe('PreviewDrawOverlay', () => {
     expect(canvas?.style.zIndex).toBe('80');
     expect(dock?.style.zIndex).toBe('91');
     expect(dock?.style.flexDirection).toBe('column');
+    expect(dock?.dataset.drawLayout).toBe('docked');
     expect(dock?.style.left).toBe('calc(50% - 52px)');
     expect(dock?.style.maxWidth).toContain('100% - 144px');
     expect(toolbar?.style.flexWrap).toBe('wrap');
@@ -109,6 +137,67 @@ describe('PreviewDrawOverlay', () => {
     expect(input?.style.flexBasis).toBe('220px');
     expect(input?.style.minWidth).toBe('0px');
     expect(input?.style.maxWidth).toBe('100%');
+  });
+
+  it('floats the composer next to the latest box annotation instead of docking it at the bottom', async () => {
+    const { container } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 640, height: 400 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const overlay = container.firstElementChild as HTMLElement;
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')!;
+    const dock = container.querySelector<HTMLElement>('.preview-draw-dock')!;
+    setElementRect(overlay, { left: 0, top: 0, width: 640, height: 400 });
+    setElementRect(canvas, { left: 0, top: 0, width: 640, height: 400 });
+    setElementRect(dock, { left: 0, top: 0, width: 280, height: 96 });
+
+    drawSelectionBox(canvas, { x: 120, y: 80 }, { x: 240, y: 180 });
+    fireEvent(window, new Event('resize'));
+
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('floating'));
+    expect(dock.dataset.drawSide).toBe('right');
+    expect(dock.style.top).not.toBe('');
+    expect(dock.style.bottom).toBe('auto');
+    expect(dock.style.transform).toBe('none');
+  });
+
+  it('flips the floating composer to the left when the selection is near the right edge', async () => {
+    const { container } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 640, height: 400 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const overlay = container.firstElementChild as HTMLElement;
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')!;
+    const dock = container.querySelector<HTMLElement>('.preview-draw-dock')!;
+    setElementRect(overlay, { left: 0, top: 0, width: 640, height: 400 });
+    setElementRect(canvas, { left: 0, top: 0, width: 640, height: 400 });
+    setElementRect(dock, { left: 0, top: 0, width: 280, height: 96 });
+
+    drawSelectionBox(canvas, { x: 540, y: 80 }, { x: 620, y: 180 });
+    fireEvent(window, new Event('resize'));
+
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('floating'));
+    expect(dock.dataset.drawSide).toBe('left');
+  });
+
+  it('falls back to the bottom dock when there is no valid annotation anchor', async () => {
+    const { container } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 320, height: 200 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const dock = container.querySelector<HTMLElement>('.preview-draw-dock')!;
+    const input = container.querySelector<HTMLInputElement>('.preview-draw-note-input')!;
+    fireEvent.change(input, { target: { value: 'note only' } });
+    fireEvent(window, new Event('resize'));
+
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('docked'));
+    expect(dock.dataset.drawSide).toBeUndefined();
   });
 
   it('queues a note when Enter submits from the draw input', async () => {
@@ -476,8 +565,16 @@ describe('PreviewDrawOverlay', () => {
 
     const body = container.querySelector('.viewer-body')!;
     const iframe = body.querySelector('iframe')!;
+    const dock = body.querySelector<HTMLElement>('.preview-draw-dock')!;
     // The overlay wrap (and its ink canvas) stays inside the clipped device frame…
     const wrap = iframe.parentElement!;
+    const canvas = wrap.querySelector<HTMLCanvasElement>('canvas')!;
+    setElementRect(body, { left: 0, top: 0, width: 720, height: 520 });
+    setElementRect(wrap, { left: 120, top: 60, width: 320, height: 200 });
+    setElementRect(canvas, { left: 120, top: 60, width: 320, height: 200 });
+    setElementRect(dock, { left: 0, top: 0, width: 260, height: 96 });
+    drawSelectionBox(canvas, { x: 160, y: 100 }, { x: 220, y: 150 });
+    fireEvent(window, new Event('resize'));
 
     await waitFor(() => {
       const input = body.querySelector<HTMLInputElement>('.preview-draw-note-input');
@@ -486,6 +583,7 @@ describe('PreviewDrawOverlay', () => {
       // the clip so it can never be cut off by the device frame (issue #3455).
       expect(wrap.contains(input!)).toBe(false);
       expect(body.contains(input!)).toBe(true);
+      expect(dock.dataset.drawLayout).toBe('floating');
     });
   });
 

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -587,6 +587,39 @@ describe('PreviewDrawOverlay', () => {
     });
   });
 
+  it('keeps the floating composer aligned in the portal host scroll space', async () => {
+    const { container } = render(
+      <div className="viewer-body">
+        <div className="comment-preview-layer">
+          <div className="comment-frame-clip">
+            <PreviewDrawOverlay active>
+              <iframe title="preview" />
+            </PreviewDrawOverlay>
+          </div>
+        </div>
+      </div>,
+    );
+
+    const body = container.querySelector('.viewer-body') as HTMLElement;
+    const wrap = body.querySelector('iframe')!.parentElement as HTMLElement;
+    const canvas = wrap.querySelector('canvas') as HTMLCanvasElement;
+    const dock = body.querySelector('.preview-draw-dock') as HTMLElement;
+    setElementRect(body, { left: 0, top: 0, width: 720, height: 520 });
+    setElementRect(wrap, { left: 120, top: 60, width: 320, height: 200 });
+    setElementRect(canvas, { left: 120, top: 60, width: 320, height: 200 });
+    setElementRect(dock, { left: 0, top: 0, width: 260, height: 96 });
+    Object.defineProperty(body, 'scrollLeft', { configurable: true, value: 40 });
+    Object.defineProperty(body, 'scrollTop', { configurable: true, value: 140 });
+
+    drawSelectionBox(canvas, { x: 160, y: 100 }, { x: 220, y: 150 });
+    fireEvent(window, new Event('scroll'));
+
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('floating'));
+    expect(dock.dataset.drawSide).toBe('right');
+    expect(dock.style.left).toBe('272px');
+    expect(dock.style.top).toBe('217px');
+  });
+
   it('hides draw chrome before a compositor annotation snapshot', async () => {
     const restoreCompositeMocks = installImageCompositeMocks();
     const annotation = vi.fn((event: Event) => {

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -609,7 +609,7 @@ describe('PreviewDrawOverlay', () => {
     setElementRect(canvas, { left: 120, top: 60, width: 320, height: 200 });
     setElementRect(dock, { left: 0, top: 0, width: 260, height: 96 });
     Object.defineProperty(body, 'scrollLeft', { configurable: true, value: 40 });
-    Object.defineProperty(body, 'scrollTop', { configurable: true, value: 140 });
+    Object.defineProperty(body, 'scrollTop', { configurable: true, value: 640 });
 
     drawSelectionBox(canvas, { x: 160, y: 100 }, { x: 220, y: 150 });
     fireEvent(window, new Event('scroll'));
@@ -617,7 +617,7 @@ describe('PreviewDrawOverlay', () => {
     await waitFor(() => expect(dock.dataset.drawLayout).toBe('floating'));
     expect(dock.dataset.drawSide).toBe('right');
     expect(dock.style.left).toBe('272px');
-    expect(dock.style.top).toBe('217px');
+    expect(dock.style.top).toBe('717px');
   });
 
   it('hides draw chrome before a compositor annotation snapshot', async () => {


### PR DESCRIPTION
Closes #690

## Why

This PR implements issue #861 from the external demand pool: after marking content in the preview, the AI input entry was easy to miss because the composer stayed fixed at the bottom of the page. The goal here is to keep the next step visually attached to the users most recent mark without touching the annotation event contract, capture flow, or chat integration.

## What users will see

After drawing a box or pen mark, the AI composer now appears beside the most recent annotation instead of defaulting to the page bottom. Near edges or in clipped device-frame previews it flips/clamps within the visible host, and when there is no valid mark anchor it falls back to the existing bottom dock.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached in this CLI flow.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/PreviewDrawOverlay.test.tsx`
- Did the test go red on `main` and green on this branch? no — the regression coverage was added directly on this branch; I validated the new cases green after the implementation.
- Additional verification: targeted floating/docked placement coverage plus portal-host regression assertions in `PreviewDrawOverlay.test.tsx`.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/PreviewDrawOverlay.test.tsx tests/components/PreviewDrawOverlay.capture-fallback.test.tsx tests/components/PreviewDrawOverlay.send-disabled.test.tsx`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>