### PR TITLE
Define shared native session-map contract for resumable agents

### DIFF
--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 
 import type Database from 'better-sqlite3';
+import type { AgentSessionInvalidationReason } from '@open-design/contracts';
 
 import {
   clearAgentSession,
@@ -11,16 +12,7 @@ import {
 
 type SqliteDb = Database.Database;
 
-/**
- * Why a stored session was NOT resumed this turn. `null` means it WAS resumed
- * (or there was no stored session to begin with). Surfaced for tests and
- * analytics; the daemon reseeds the full transcript for every non-null reason.
- */
-export type ResumeInvalidationReason =
-  | 'model_changed'
-  | 'cwd_changed'
-  | 'conversation_advanced'
-  | 'missing_cursor';
+export type ResumeInvalidationReason = AgentSessionInvalidationReason;
 
 export interface AgentResumeContext {
   /** Stored CLI session id to resume, or null when starting fresh. */

--- a/packages/contracts/src/api/agent-sessions.ts
+++ b/packages/contracts/src/api/agent-sessions.ts
@@ -4,6 +4,8 @@ export const AGENT_SESSION_HANDLE_KINDS = [
   'acp-session-handle',
   'session-file-path',
   'continue-latest',
+  'none',
+  'unknown',
 ] as const;
 
 export type AgentSessionHandleKind = (typeof AGENT_SESSION_HANDLE_KINDS)[number];
@@ -14,6 +16,8 @@ export const AGENT_SESSION_HANDLE_ACQUISITION_MODES = [
   'acp-session-load',
   'session-file-discovered',
   'continue-latest',
+  'none',
+  'unknown',
 ] as const;
 
 export type AgentSessionHandleAcquisitionMode =

--- a/packages/contracts/src/api/agent-sessions.ts
+++ b/packages/contracts/src/api/agent-sessions.ts
@@ -1,0 +1,120 @@
+export const AGENT_SESSION_HANDLE_KINDS = [
+  'opaque-id',
+  'cli-thread-id',
+  'acp-session-handle',
+  'session-file-path',
+  'continue-latest',
+] as const;
+
+export type AgentSessionHandleKind = (typeof AGENT_SESSION_HANDLE_KINDS)[number];
+
+export const AGENT_SESSION_HANDLE_ACQUISITION_MODES = [
+  'daemon-specified',
+  'stream-captured',
+  'acp-session-load',
+  'session-file-discovered',
+  'continue-latest',
+] as const;
+
+export type AgentSessionHandleAcquisitionMode =
+  (typeof AGENT_SESSION_HANDLE_ACQUISITION_MODES)[number];
+
+export const AGENT_SESSION_CONTINUATION_MODES = [
+  'native-resume-by-id',
+  'native-continue-latest',
+  'acp-session-load',
+  'session-file-resume',
+  'none',
+] as const;
+
+export type AgentSessionContinuationMode =
+  (typeof AGENT_SESSION_CONTINUATION_MODES)[number];
+
+export const AGENT_SESSION_HANDLE_VISIBILITIES = [
+  'persist-only',
+  'diagnostics-redacted',
+  'safe-display',
+] as const;
+
+export type AgentSessionHandleVisibility =
+  (typeof AGENT_SESSION_HANDLE_VISIBILITIES)[number];
+
+export const AGENT_SESSION_INVALIDATION_REASONS = [
+  'model_changed',
+  'cwd_changed',
+  'conversation_advanced',
+  'missing_cursor',
+] as const;
+
+export type AgentSessionInvalidationReason =
+  (typeof AGENT_SESSION_INVALIDATION_REASONS)[number];
+
+export interface AgentSessionMapKey {
+  conversationId: string;
+  agentId: string;
+  /**
+   * Logical project identity for the binding. The current daemon schema stores
+   * this through conversations.project_id rather than duplicating it in
+   * agent_sessions.
+   */
+  projectId: string | null;
+}
+
+export interface AgentSessionHandleRef {
+  kind: AgentSessionHandleKind;
+  acquisition: AgentSessionHandleAcquisitionMode;
+  continuation: AgentSessionContinuationMode;
+  /**
+   * Raw upstream handle value. Daemon persistence may store this, but public
+   * run details should expose only a sanitized display form unless the handle
+   * kind is explicitly safe to show.
+   */
+  value: string | null;
+  visibility: AgentSessionHandleVisibility;
+}
+
+export interface AgentSessionBindingRecord {
+  key: AgentSessionMapKey;
+  handle: AgentSessionHandleRef;
+  model: string | null;
+  cwd: string | null;
+  lastMessageId: string | null;
+  stablePromptHash: string | null;
+  /**
+   * Optional monotonic binding revision for future schemas. Current
+   * agent_sessions rows use updatedAt plus lastMessageId as the active cursor.
+   */
+  revision?: number | null;
+  updatedAt: number;
+}
+
+export interface AgentSessionCapabilityFlags {
+  resumeById: boolean;
+  continueLatest: boolean;
+  acpSessionLoad: boolean;
+  streamCapturedHandle: boolean;
+  daemonSpecifiedHandle: boolean;
+  sessionFileHandle: boolean;
+  headlessPromptInjection: boolean;
+  modelOverride: boolean;
+  modeOverride: boolean;
+}
+
+export type AgentSessionImplementationStatus =
+  | 'implemented'
+  | 'in-flight'
+  | 'candidate'
+  | 'unsupported'
+  | 'unknown';
+
+export interface AgentSessionCapabilityMatrixRow {
+  agentId: string;
+  agentName: string;
+  status: AgentSessionImplementationStatus;
+  handleKind: AgentSessionHandleKind;
+  acquisition: AgentSessionHandleAcquisitionMode;
+  continuation: AgentSessionContinuationMode;
+  capabilities: AgentSessionCapabilityFlags;
+  related?: string[];
+  notes?: string;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,6 +2,7 @@ export * from './common.js';
 export * from './errors.js';
 export * from './tasks.js';
 export * from './api/app-config.js';
+export * from './api/agent-sessions.js';
 export * from './api/amrWallet.js';
 export * from './api/automations.js';
 export * from './api/artifacts.js';

--- a/specs/change/20260618-stability-performance-3408/agent-cli-session-resume.md
+++ b/specs/change/20260618-stability-performance-3408/agent-cli-session-resume.md
@@ -2,6 +2,9 @@
 
 Design doc (human/reviewer-facing). Implementation runbooks per slice are written separately at build time.
 
+Shared contract note: the agent-agnostic session-map contract now lives in
+`specs/change/20260707-agent-session-map-contract/spec.md`.
+
 Status: proposed · Parent: #3408 · Upstream background: amr-latency-session-reuse-prompt-cache.md
 
 ## Why

--- a/specs/change/20260707-agent-session-map-contract/spec.md
+++ b/specs/change/20260707-agent-session-map-contract/spec.md
@@ -66,12 +66,16 @@ Core enums:
   - `acp-session-handle`
   - `session-file-path`
   - `continue-latest`
+  - `none`
+  - `unknown`
 - `AgentSessionHandleAcquisitionMode`
   - `daemon-specified`
   - `stream-captured`
   - `acp-session-load`
   - `session-file-discovered`
   - `continue-latest`
+  - `none`
+  - `unknown`
 - `AgentSessionContinuationMode`
   - `native-resume-by-id`
   - `native-continue-latest`
@@ -183,10 +187,10 @@ shape before the adapter work starts.
 | Kiro | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate. |
 | Vibe | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate. |
 | Devin | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate from the #730 direction. |
-| Gemini / Antigravity | unknown | TBD | TBD | `none` | Current `agy -c` path is deliberately not used by OD because it weakens prompt control. |
-| Qoder | unknown | TBD | TBD | `none` | No shared resume contract wired yet. |
-| Copilot | unknown | TBD | TBD | `none` | No shared resume contract wired yet. |
-| Qwen | unknown | TBD | TBD | `none` | No shared resume contract wired yet. |
+| Gemini / Antigravity | unknown | `unknown` | `unknown` | `none` | Current `agy -c` path is deliberately not used by OD because it weakens prompt control. |
+| Qoder | unknown | `unknown` | `unknown` | `none` | No shared resume contract wired yet. |
+| Copilot | unknown | `unknown` | `unknown` | `none` | No shared resume contract wired yet. |
+| Qwen | unknown | `unknown` | `unknown` | `none` | No shared resume contract wired yet. |
 
 Minimum capability expectations for implementation rows:
 

--- a/specs/change/20260707-agent-session-map-contract/spec.md
+++ b/specs/change/20260707-agent-session-map-contract/spec.md
@@ -1,0 +1,252 @@
+---
+id: 20260707-agent-session-map-contract
+name: Agent-Agnostic Session Map Contract
+status: proposed
+created: '2026-07-07'
+related:
+  - '#744'
+  - '#5268'
+  - '#5269'
+  - '#5270'
+  - '#5271'
+---
+
+# Agent-Agnostic Session Map Contract
+
+## Overview
+
+#744 now tracks the shared native/ACP session-continuity layer above the
+per-agent resume slices. OpenCode, Codex, Pi, and AMR have shipped session
+continuity paths in #4629, Claude has the earlier #3290 design, and
+cursor-agent is in flight in #4790. Those slices proved the value of resuming an
+upstream agent session, but the shared contract should not be shaped like any
+one adapter.
+
+This spec defines the shared session-map contract that resumable adapters plug
+into. It is intentionally behavior-light: no new adapter starts resuming because
+of this spec alone. The goal is to name the durable binding shape, the handle
+acquisition/continuation modes, capability flags, privacy boundary, and current
+agent matrix so future implementation PRs can review against one source of
+truth.
+
+## Goals
+
+- Define the canonical logical key and fields for a session binding.
+- Reconcile the contract with the current `agent_sessions` table and runtime
+  definition flags.
+- Model heterogeneous handle shapes: opaque ids, CLI thread ids, ACP handles,
+  local session-file paths, and continue-latest agents.
+- Model acquisition and continuation separately so the daemon can support
+  daemon-specified ids, stream-captured ids, ACP `session/load`, native
+  `--resume <id>`, native `--continue`, and future variants.
+- Preserve the fallback invariant: a failed resume guard falls back to full
+  transcript recompose rather than skipping history.
+- Include Hermes and other ACP/native candidates in the first matrix without
+  promising first-wave implementation for every adapter.
+
+## Non-Goals
+
+- No new per-agent resume behavior.
+- No UI or CLI recovery action. That belongs to #5271 after #5270 defines safe
+  recovery metadata.
+- No public exposure of raw native handles. #5270 owns sanitized run details and
+  diagnostics export.
+- No production migration unless a later implementation needs one.
+
+## Contract Types
+
+The typed contract lives in `packages/contracts/src/api/agent-sessions.ts` and
+is exported from `@open-design/contracts`.
+
+Core enums:
+
+- `AgentSessionHandleKind`
+  - `opaque-id`
+  - `cli-thread-id`
+  - `acp-session-handle`
+  - `session-file-path`
+  - `continue-latest`
+- `AgentSessionHandleAcquisitionMode`
+  - `daemon-specified`
+  - `stream-captured`
+  - `acp-session-load`
+  - `session-file-discovered`
+  - `continue-latest`
+- `AgentSessionContinuationMode`
+  - `native-resume-by-id`
+  - `native-continue-latest`
+  - `acp-session-load`
+  - `session-file-resume`
+  - `none`
+- `AgentSessionHandleVisibility`
+  - `persist-only`
+  - `diagnostics-redacted`
+  - `safe-display`
+
+Core records:
+
+- `AgentSessionMapKey`
+  - `projectId`
+  - `conversationId`
+  - `agentId`
+- `AgentSessionHandleRef`
+  - `kind`
+  - `acquisition`
+  - `continuation`
+  - `value`
+  - `visibility`
+- `AgentSessionBindingRecord`
+  - `key`
+  - `handle`
+  - `model`
+  - `cwd`
+  - `lastMessageId`
+  - `stablePromptHash`
+  - optional `revision`
+  - `updatedAt`
+- `AgentSessionCapabilityFlags`
+  - `resumeById`
+  - `continueLatest`
+  - `acpSessionLoad`
+  - `streamCapturedHandle`
+  - `daemonSpecifiedHandle`
+  - `sessionFileHandle`
+  - `headlessPromptInjection`
+  - `modelOverride`
+  - `modeOverride`
+
+The `value` field is a daemon-side persisted handle, not a safe public display
+field. Public run details should use a sanitized shape from #5270.
+
+## Current Schema Mapping
+
+The existing daemon schema is sufficient for the current shipped slices. No
+backward-incompatible migration is required for this contract pass.
+
+| Contract field | Current source | Notes |
+| --- | --- | --- |
+| `projectId` | `conversations.project_id` | Logical key field, normalized through the conversation row instead of duplicated into `agent_sessions`. |
+| `conversationId` | `agent_sessions.conversation_id` | Part of the persisted primary key. |
+| `agentId` | `agent_sessions.agent_id` | Part of the persisted primary key. |
+| `handle.value` | `agent_sessions.session_id` | Stores opaque ids, thread ids, ACP handles, or Pi session-file paths depending on adapter. |
+| `stablePromptHash` | `agent_sessions.stable_prompt_hash` | Used to decide whether the stable instruction block must be resent on resume. |
+| `model` | `agent_sessions.model` | Resume identity guard. |
+| `cwd` | `agent_sessions.cwd` | Resume identity guard and workspace identity. |
+| `lastMessageId` | `agent_sessions.last_message_id` | Conversation cursor guard. |
+| `updatedAt` | `agent_sessions.updated_at` | Last binding write time. |
+| `revision` | None today | Optional future field. Current guard uses `lastMessageId` plus `updatedAt`. |
+
+Current invalidation reasons are exported as `AgentSessionInvalidationReason`:
+
+| Reason | Meaning |
+| --- | --- |
+| `model_changed` | Stored session model differs from the current run model. |
+| `cwd_changed` | Stored session cwd differs from the current run cwd. |
+| `conversation_advanced` | Another turn changed the conversation cursor after the stored session. |
+| `missing_cursor` | Legacy or incomplete row cannot prove the conversation cursor. |
+
+Every non-null invalidation reason means the run must start fresh and send the
+full transcript.
+
+## Runtime Flag Mapping
+
+The current runtime definitions use three opt-in flags:
+
+| Runtime flag | Contract meaning |
+| --- | --- |
+| `resumesSessionViaCli` | Adapter can continue upstream memory through a CLI/RPC native session path and may skip transcript only when the per-run resume decision is safe. |
+| `capturesSessionIdFromStream` | Adapter is capture-style: the upstream process mints the handle and reports it on the stream. |
+| `resumesSessionViaAcpLoad` | Adapter resumes via ACP `session/load`; the durable handle is obtained from ACP session setup rather than a CLI argv flag. |
+
+The existing flags remain valid. Future cleanup may collapse them into a single
+structured runtime field, but that should be a follow-up and must preserve
+today's behavior.
+
+## Capability Matrix
+
+This matrix is a contract-accounting table, not an implementation promise. Rows
+marked `candidate` or `unknown` are included so the contract accounts for their
+shape before the adapter work starts.
+
+| Agent | Status | Handle kind | Acquisition | Continuation | Capability notes |
+| --- | --- | --- | --- | --- | --- |
+| Claude | implemented | `opaque-id` | `daemon-specified` | `native-resume-by-id` | `--session-id` on create, `--resume <id>` on resume. |
+| Codebuddy | implemented | `opaque-id` | `daemon-specified` | `native-resume-by-id` | Claude-compatible session flags. |
+| Codex | implemented | `cli-thread-id` | `stream-captured` | `native-resume-by-id` | Captures `thread.started.thread_id`; resumes with `exec resume <thread_id>`. |
+| OpenCode | implemented | `opaque-id` | `stream-captured` | `native-resume-by-id` | Captures OpenCode `sessionID`; resumes with `run -s <id>`. |
+| Pi | implemented | `session-file-path` | `session-file-discovered` | `session-file-resume` | Captures the single `.pi/sessions/*.jsonl` file changed by the run; path-like handle is persist-only/redacted. |
+| AMR | implemented | `acp-session-handle` | `acp-session-load` | `acp-session-load` | Captures durable ACP session handle and maps `resume_failed` to reseed. |
+| cursor-agent | in-flight | `opaque-id` | `stream-captured` | `native-resume-by-id` | #4790 captures emitted `session_id` and resumes with `--resume <chatId>`. |
+| Hermes | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate; include in matrix before implementation. |
+| Kimi | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate. |
+| Kilo | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate. |
+| Kiro | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate. |
+| Vibe | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate. |
+| Devin | candidate | `acp-session-handle` | `acp-session-load` | `acp-session-load` | ACP-native candidate from the #730 direction. |
+| Gemini / Antigravity | unknown | TBD | TBD | `none` | Current `agy -c` path is deliberately not used by OD because it weakens prompt control. |
+| Qoder | unknown | TBD | TBD | `none` | No shared resume contract wired yet. |
+| Copilot | unknown | TBD | TBD | `none` | No shared resume contract wired yet. |
+| Qwen | unknown | TBD | TBD | `none` | No shared resume contract wired yet. |
+
+Minimum capability expectations for implementation rows:
+
+- If `continuation` is `native-resume-by-id`, `resumeById` must be true.
+- If `continuation` is `native-continue-latest`, `continueLatest` must be true
+  and the guard must prove the target conversation cannot drift across projects,
+  agents, or cwd.
+- If `continuation` is `acp-session-load`, `acpSessionLoad` must be true and
+  `resume_failed` must route to the reseed path.
+- If `acquisition` is `stream-captured`, `streamCapturedHandle` must be true and
+  a missing capture on success must clear or avoid writing stale state.
+- If `handleKind` is `session-file-path`, the public visibility must default to
+  `diagnostics-redacted` or `persist-only`.
+
+## Privacy Boundary
+
+Raw handles are operational pointers, not user-facing data.
+
+- Safe to persist: raw handle values in daemon-owned storage when they are
+  needed to resume an upstream session.
+- Safe to show by default: capability status, acquisition mode, continuation
+  mode, and coarse resume state.
+- Requires redaction or diagnostics-only handling: local file paths, ACP handles,
+  opaque session ids that could correlate user activity, and any handle whose
+  vendor semantics are unknown.
+- Never derive user-visible continuity from the raw handle alone. The daemon's
+  conversation messages remain the authoritative history.
+
+## Fallback Invariant
+
+Transcript skipping is permitted only when the same per-run decision also
+provides a safe continuation handle. The valid pairings are:
+
+| Resume decision | Continuation argv/RPC | Prompt sent |
+| --- | --- | --- |
+| Safe resume | Native/ACP resume is requested | Latest user turn plus current stable instructions as needed |
+| Guard failure | No native/ACP resume | Full transcript recompose |
+| Missing/expired upstream handle | Clear stale handle, retry or reseed | Full transcript recompose |
+| Unsupported adapter | No native/ACP resume | Full transcript recompose |
+
+The broken state "no resume requested and transcript skipped" must remain
+unrepresentable.
+
+## Review Checklist for Future Adapter PRs
+
+- Add or update the agent's matrix row.
+- Identify handle kind, acquisition mode, continuation mode, and display
+  visibility.
+- Prove how the handle is captured or specified.
+- Prove how model, cwd, and conversation cursor guards are enforced.
+- Prove resume-target-missing fallback clears stale state and reseeds the full
+  transcript.
+- Keep raw handles out of public run responses unless #5270 defines a safe
+  display form for that handle kind.
+
+## References
+
+- `packages/contracts/src/api/agent-sessions.ts`
+- `apps/daemon/src/db.ts` (`agent_sessions`)
+- `apps/daemon/src/agent-session-resume.ts`
+- `apps/daemon/src/runtimes/types.ts`
+- `specs/change/20260529-claude-session-resume/spec.md`
+- `specs/change/20260618-stability-performance-3408/agent-cli-session-resume.md`


### PR DESCRIPTION
﻿## What problem are you trying to solve?

#744 is now the umbrella for native session continuity, but the per-agent slices are landing independently: OpenCode/Codex/Pi/AMR shipped in #4629 and cursor-agent is in flight in #4790. Without a documented shared session-map contract, future agents can drift on keying, stored fields, invalidation semantics, and whether a stored native handle is safe to expose.

The original #744 design called for a durable mapping keyed at least by `(conversationId, agentId, projectId)` with native session id, model/mode binding, update time, and revision. Current `main` has working `agent_sessions` infrastructure, but the shared contract is still implicit in code and PR descriptions.

I searched existing open issues for session-map / native resume follow-ups and only found the #744 umbrella, not a concrete contract issue.

## Describe the solution you'd like

Define the shared native session-map contract for resumable agents before adding more per-agent slices.

Suggested scope:

- document the canonical key and fields for a native session binding
- reconcile the documented contract with the existing `agent_sessions` table and runtime def flags
- distinguish session id acquisition modes: daemon-specified, stream-captured, ACP `session/load`, and future continue-latest agents
- define capability metadata for resume-by-id, continue-latest, headless prompt injection, model override, mode override, and stream-captured handle support
- map existing shipped agents onto the contract: Claude, Codex, OpenCode, Pi, AMR, and cursor-agent once #4790 lands
- explicitly call out what is safe to persist, what is safe to show, and what must stay diagnostics-only or redacted

Acceptance criteria:

- The contract is documented in the owning spec/docs location and linked from #744.
- Existing `agent_sessions` fields are either confirmed as sufficient or a backwards-compatible migration path is described.
- The contract names required fields, optional fields, and per-agent capability flags.
- The write-up preserves the current fallback guarantee: a failed guard must fall back to full transcript recompose rather than skip history.
- No new agent-specific resume behavior is required in this issue.

## Alternatives you've considered

Keep letting each adapter encode its own shape. That worked for initial proof points, but it makes #744 harder to close because reviewers have to rediscover the invariants from scattered PRs.

Make ACP the only shared abstraction. That does not cover non-ACP native CLIs, which is the compatibility path this issue exists to track.

## Additional context

Related:

- #744 umbrella native-resume/sessionMap issue
- #730 ACP session reuse direction
- #3290 Claude session-resume spec
- #4629 Codex/OpenCode/Pi/AMR native resume implementation
- #4790 cursor-agent native resume slice

## Would you be willing to contribute a PR?

Yes, I can take this on.

## Agent-agnostic scope clarification

This contract must be agent-agnostic. OpenCode and cursor-agent are proof points, not the shape of the abstraction.

The contract should explicitly account for:

- shipped native/ACP resume paths such as Claude, Codex, OpenCode, Pi, and AMR
- in-flight cursor-agent work in #4790
- future ACP/native candidates such as Hermes, Kimi, Kilo, Kiro, Vibe, Gemini, Qoder, Copilot, Qwen, and similar adapters
- different handle shapes: opaque ids, CLI thread ids, ACP session handles, local session-file paths, and continue-latest modes
- different continuation modes: daemon-specified id, stream-captured id, ACP `session/load`, native `--resume <id>`, native `--continue`, and future per-agent variants

The output should be a shared Open Design session-map contract that adapters plug into, not an OpenCode-shaped contract with agent-specific exceptions.




---

## PR checklist update

## Why

This PR turns the accepted #5268 scope into the shared session-map contract/spec for #744. It is behavior-light and exists to prevent future resumable agent slices from drifting on keying, handle kinds, acquisition/continuation modes, privacy, and fallback invariants.

## What users will see

No direct user-facing behavior change. This defines the contract that later recovery metadata and UI/CLI recovery actions can build on.

## Surface area

- [ ] **UI** ? new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** ? new or changed
- [ ] **CLI / env var** ? new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** ? new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** ? new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** ? added new translation keys
- [ ] **New top-level dependency** ? adding any new entry to the root `package.json`
- [ ] **Default behavior change** ? changes what existing users experience without opting in
- [ ] **None** ? internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

-

## Validation

- `pnpm --filter @open-design/contracts typecheck` with Node v24.14.0 + pnpm 10.33.2
- `pnpm --filter @open-design/daemon typecheck` with Node v24.14.0 + pnpm 10.33.2
- `pnpm exec vitest run -c vitest.config.ts tests/agent-session-resume.test.ts` from `apps/daemon` with Node v24.14.0 + pnpm 10.33.2: 38 passed
