### PR TITLE
Normalize cross-agent native-resume invalidation and fallback policy

### DIFF
--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -41,6 +41,87 @@ export interface AgentResumeContext {
 
 export type CapturedAgentSessionResult = 'stored' | 'cleared' | 'skipped';
 
+export type AgentResumeTranscriptMode = 'resume-session' | 'full-transcript';
+
+export interface AgentResumePromptPolicy {
+  mode: AgentResumeTranscriptMode;
+  /** Stored upstream handle to continue this turn, or null when reseeding. */
+  resumeSessionId: string | null;
+  /** True only when the daemon also asks the agent to resume native state. */
+  skipTranscript: boolean;
+  /** True for every guard miss, missing handle, unsupported adapter, or create turn. */
+  requiresFullTranscript: boolean;
+  invalidationReason: ResumeInvalidationReason | null;
+}
+
+export interface AgentResumeFailurePolicy {
+  resumeFailed: boolean;
+  /** Clear the persisted handle before the next attempt. */
+  clearStaleSession: boolean;
+  /** Re-run this turn fresh so the daemon sends the full transcript. */
+  autoReseedFullTranscript: boolean;
+  reason: 'resume_failed' | null;
+}
+
+/**
+ * Shared transcript policy for resumable adapters. Native continuation and
+ * transcript skipping are coupled: if the daemon cannot prove it is resuming a
+ * valid upstream session this turn, the prompt path must recompose the full
+ * transcript.
+ */
+export function resolveAgentResumePromptPolicy(
+  ctx: Pick<AgentResumeContext, 'isResuming' | 'resumeSessionId' | 'invalidationReason'>,
+): AgentResumePromptPolicy {
+  const canResume =
+    ctx.isResuming === true
+    && typeof ctx.resumeSessionId === 'string'
+    && ctx.resumeSessionId.length > 0
+    && ctx.invalidationReason == null;
+  if (canResume) {
+    return {
+      mode: 'resume-session',
+      resumeSessionId: ctx.resumeSessionId,
+      skipTranscript: true,
+      requiresFullTranscript: false,
+      invalidationReason: null,
+    };
+  }
+  return {
+    mode: 'full-transcript',
+    resumeSessionId: null,
+    skipTranscript: false,
+    requiresFullTranscript: true,
+    invalidationReason: ctx.invalidationReason ?? null,
+  };
+}
+
+/**
+ * Shared fallback policy for a resume target that no longer exists upstream.
+ * Only a run that actually attempted native resume may clear the stored handle
+ * and auto-reseed; fresh/create turns must ignore matching prose in stdout.
+ */
+export function resolveAgentResumeFailurePolicy(input: {
+  agentId: string;
+  stderr: string;
+  stdout?: string;
+  isResuming: boolean;
+  resumeSessionId: string | null | undefined;
+}): AgentResumeFailurePolicy {
+  const attemptedResume =
+    input.isResuming === true
+    && typeof input.resumeSessionId === 'string'
+    && input.resumeSessionId.length > 0;
+  const resumeFailed =
+    attemptedResume &&
+    isAgentResumeFailure(input.agentId, input.stderr, input.stdout ?? '');
+  return {
+    resumeFailed,
+    clearStaleSession: resumeFailed,
+    autoReseedFullTranscript: resumeFailed,
+    reason: resumeFailed ? 'resume_failed' : null,
+  };
+}
+
 /**
  * Resume identity guard. A stored upstream session is only safe to continue
  * (and to `skipTranscript` for) when the conversation has not changed shape

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -684,9 +684,10 @@ import {
 import {
   computeIncludeStable,
   hashStableInstructions,
-  isAgentResumeFailure,
   persistCapturedAgentSession,
   resolveAgentResumeContext,
+  resolveAgentResumeFailurePolicy,
+  resolveAgentResumePromptPolicy,
 } from './agent-session-resume.js';
 import {
   initialNativeSessionRecoveryMetadata,
@@ -10482,6 +10483,7 @@ export async function startServer({
       invalidationReason: agentResumeCtx.invalidationReason,
     });
     publishNativeSessionRecoveryMetadata();
+    const agentResumePromptPolicy = resolveAgentResumePromptPolicy(agentResumeCtx);
     const userRequestPrompt = composeChatUserRequestForAgent(
       message,
       currentPrompt,
@@ -10489,7 +10491,7 @@ export async function startServer({
       // existing session. A create turn still sends the full transcript so
       // a brand-new session (incl. first turn after another agent)
       // is seeded with prior context.
-      { skipTranscript: agentResumeCtx.isResuming },
+      { skipTranscript: agentResumePromptPolicy.skipTranscript },
     );
     // The stable instruction slice (daemon prompt + tool contract + system
     // prompt = design system / skills / memory) is identical across turns of
@@ -10515,12 +10517,12 @@ export async function startServer({
     // tool-token grant's presence flips between turns (rare cwd/projectId edge
     // cases); any such change correctly forces a full re-send that turn.
     const includeStableInstructions = computeIncludeStable(
-      agentResumeCtx.isResuming,
+      agentResumePromptPolicy.skipTranscript,
       agentResumeCtx.storedStablePromptHash,
       currentStableHash,
     );
     run.promptCache = describeStablePromptCache({
-      isResuming: agentResumeCtx.isResuming,
+      isResuming: agentResumePromptPolicy.skipTranscript,
       storedStablePromptHash: agentResumeCtx.storedStablePromptHash,
       currentStableHash,
       storedStableSections: agentResumeCtx.storedStableSections,
@@ -11671,7 +11673,7 @@ export async function startServer({
           hasPriorAssistantTurn,
           agentLogFilePath,
           promptFilePath: promptFile?.path,
-          resumeSessionId: agentResumeCtx.resumeSessionId,
+          resumeSessionId: agentResumePromptPolicy.resumeSessionId,
           newSessionId: agentResumeCtx.newSessionId,
           disablePlugins:
             def.id === 'codex'
@@ -13026,15 +13028,20 @@ export async function startServer({
           // authority on how a resume failure ends.
           if (
             (runtimeResumesSessionById(def) || def.resumesSessionViaAcpLoad === true) &&
-            agentResumeCtx.isResuming &&
             !run.resumeAutoReseeded &&
-            isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
+            resolveAgentResumeFailurePolicy({
+              agentId: def.id,
+              stderr: agentStderrTail,
+              stdout: agentStdoutTail,
+              isResuming: agentResumePromptPolicy.skipTranscript,
+              resumeSessionId: agentResumePromptPolicy.resumeSessionId,
+            }).resumeFailed
           ) {
             design.runs.emit(run, 'diagnostic', {
               type: 'agent_resume_failed_suppressed',
               agent_id: def.id,
               reason: 'resume_failed',
-              previous_session_id: agentResumeCtx.resumeSessionId ?? null,
+              previous_session_id: agentResumePromptPolicy.resumeSessionId ?? null,
             });
             return;
           }
@@ -13176,8 +13183,8 @@ export async function startServer({
         prompt: composed,
         cwd: effectiveCwd,
         model: safeModel,
-        parentSession: agentResumeCtx.isResuming && agentResumeCtx.resumeSessionId
-          ? agentResumeCtx.resumeSessionId
+        parentSession: agentResumePromptPolicy.resumeSessionId
+          ? agentResumePromptPolicy.resumeSessionId
           : undefined,
         send: (channel, payload) => {
           if (channel === 'agent') {
@@ -13226,8 +13233,8 @@ export async function startServer({
         ...(def.id === 'amr' ? { modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE' } : {}),
         // Resume the prior upstream session (drives `session/load`) when the
         // resume-identity guard says it is safe; otherwise a fresh session/new.
-        ...(def.resumesSessionViaAcpLoad === true && agentResumeCtx.isResuming && agentResumeCtx.resumeSessionId
-          ? { resumeSessionId: agentResumeCtx.resumeSessionId }
+        ...(def.resumesSessionViaAcpLoad === true && agentResumePromptPolicy.resumeSessionId
+          ? { resumeSessionId: agentResumePromptPolicy.resumeSessionId }
           : {}),
         onCliReady: () => noteCliReadyAt(),
         onSessionInit: () => noteSessionInitDoneAt(),
@@ -13285,16 +13292,20 @@ export async function startServer({
           if (
             event === 'error' &&
             def.resumesSessionViaAcpLoad === true &&
-            agentResumeCtx.isResuming &&
-            agentResumeCtx.resumeSessionId &&
             !run.resumeAutoReseeded &&
-            isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
+            resolveAgentResumeFailurePolicy({
+              agentId: def.id,
+              stderr: agentStderrTail,
+              stdout: agentStdoutTail,
+              isResuming: agentResumePromptPolicy.skipTranscript,
+              resumeSessionId: agentResumePromptPolicy.resumeSessionId,
+            }).resumeFailed
           ) {
             design.runs.emit(run, 'diagnostic', {
               type: 'agent_resume_failed_suppressed',
               agent_id: def.id,
               reason: 'resume_failed',
-              previous_session_id: agentResumeCtx.resumeSessionId ?? null,
+              previous_session_id: agentResumePromptPolicy.resumeSessionId ?? null,
             });
             return;
           }
@@ -13500,9 +13511,14 @@ export async function startServer({
       if (
         !run.cancelRequested &&
         (runtimeResumesSessionById(def) || def.resumesSessionViaAcpLoad === true) &&
-        agentResumeCtx.isResuming &&
         run.conversationId &&
-        isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
+        resolveAgentResumeFailurePolicy({
+          agentId: def.id,
+          stderr: agentStderrTail,
+          stdout: agentStdoutTail,
+          isResuming: agentResumePromptPolicy.skipTranscript,
+          resumeSessionId: agentResumePromptPolicy.resumeSessionId,
+        }).autoReseedFullTranscript
       ) {
         // The resumed upstream session is gone (expired / pruned). Clear the dead
         // handle and TRANSPARENTLY re-run this same turn with a fresh session +
@@ -13515,11 +13531,11 @@ export async function startServer({
         clearAgentSession(db, run.conversationId, def.id);
         if (!run.resumeAutoReseeded) {
           run.resumeAutoReseeded = true;
-          run.resumeAutoReseededFrom = agentResumeCtx.resumeSessionId ?? null;
+          run.resumeAutoReseededFrom = agentResumePromptPolicy.resumeSessionId ?? null;
           run.nativeSessionRecovery = markNativeSessionAutoReseeded({
             previous: run.nativeSessionRecovery,
             agentId: def.id,
-            previousSessionId: agentResumeCtx.resumeSessionId,
+            previousSessionId: agentResumePromptPolicy.resumeSessionId,
           });
           publishNativeSessionRecoveryMetadata();
           // Persisted to the per-run events.jsonl that the help → diagnostics
@@ -13529,7 +13545,7 @@ export async function startServer({
             type: 'agent_resume_auto_reseed',
             agent_id: def.id,
             reason: 'resume_failed',
-            previous_session_id: agentResumeCtx.resumeSessionId ?? null,
+            previous_session_id: agentResumePromptPolicy.resumeSessionId ?? null,
             stale_session_cleared: true,
             nativeSessionRecovery: run.nativeSessionRecovery,
           });

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -23,6 +23,8 @@ import {
   isOpencodeResumeFailure,
   persistCapturedAgentSession,
   resolveAgentResumeContext,
+  resolveAgentResumeFailurePolicy,
+  resolveAgentResumePromptPolicy,
 } from '../src/agent-session-resume.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -255,6 +257,71 @@ describe('computeIncludeStable', () => {
   });
   it('includes the stable block on a resume turn with no stored hash (legacy session)', () => {
     expect(computeIncludeStable(true, null, 'h-1')).toBe(true);
+  });
+});
+
+describe('resolveAgentResumePromptPolicy', () => {
+  it('allows transcript skipping only when a valid native resume handle is selected', () => {
+    expect(
+      resolveAgentResumePromptPolicy({
+        isResuming: true,
+        resumeSessionId: 'sess-A',
+        invalidationReason: null,
+      }),
+    ).toEqual({
+      mode: 'resume-session',
+      resumeSessionId: 'sess-A',
+      skipTranscript: true,
+      requiresFullTranscript: false,
+      invalidationReason: null,
+    });
+  });
+
+  it('requires the full transcript for a fresh create turn with no stored session', () => {
+    expect(
+      resolveAgentResumePromptPolicy({
+        isResuming: false,
+        resumeSessionId: null,
+        invalidationReason: null,
+      }),
+    ).toMatchObject({
+      mode: 'full-transcript',
+      resumeSessionId: null,
+      skipTranscript: false,
+      requiresFullTranscript: true,
+      invalidationReason: null,
+    });
+  });
+
+  it('requires the full transcript for every guard failure', () => {
+    expect(
+      resolveAgentResumePromptPolicy({
+        isResuming: false,
+        resumeSessionId: null,
+        invalidationReason: 'conversation_advanced',
+      }),
+    ).toMatchObject({
+      mode: 'full-transcript',
+      resumeSessionId: null,
+      skipTranscript: false,
+      requiresFullTranscript: true,
+      invalidationReason: 'conversation_advanced',
+    });
+  });
+
+  it('treats inconsistent resume state as full-transcript reseed instead of skipping history', () => {
+    expect(
+      resolveAgentResumePromptPolicy({
+        isResuming: true,
+        resumeSessionId: null,
+        invalidationReason: null,
+      }),
+    ).toMatchObject({
+      mode: 'full-transcript',
+      resumeSessionId: null,
+      skipTranscript: false,
+      requiresFullTranscript: true,
+    });
   });
 });
 
@@ -575,5 +642,41 @@ describe('isAgentResumeFailure dispatch', () => {
   it('never reports a failure for empty output', () => {
     expect(isAgentResumeFailure('codex', '')).toBe(false);
     expect(isAgentResumeFailure('claude', '')).toBe(false);
+  });
+});
+
+describe('resolveAgentResumeFailurePolicy', () => {
+  it('clears stale state and auto-reseeds only for a failed attempted resume', () => {
+    expect(
+      resolveAgentResumeFailurePolicy({
+        agentId: 'opencode',
+        stderr: 'Error: Session not found',
+        stdout: '',
+        isResuming: true,
+        resumeSessionId: 'ses-old',
+      }),
+    ).toEqual({
+      resumeFailed: true,
+      clearStaleSession: true,
+      autoReseedFullTranscript: true,
+      reason: 'resume_failed',
+    });
+  });
+
+  it('does not clear state on a create turn even if output contains a resume-like phrase', () => {
+    expect(
+      resolveAgentResumeFailurePolicy({
+        agentId: 'opencode',
+        stderr: 'Error: Session not found',
+        stdout: '',
+        isResuming: false,
+        resumeSessionId: null,
+      }),
+    ).toEqual({
+      resumeFailed: false,
+      clearStaleSession: false,
+      autoReseedFullTranscript: false,
+      reason: null,
+    });
   });
 });


### PR DESCRIPTION
## What problem are you trying to solve?

Native resume is only safe when the stored agent session still matches the current Open Design conversation state. #4629 added important guards for model, cwd, and conversation cursor, while #3290 described additional history/epoch concerns. Now that #744 is the umbrella rather than the OpenCode tracker, the remaining risk is policy drift: each resumable agent may decide differently when to resume, reseed, clear a stale handle, or send the full transcript.

The failure mode is serious: if the daemon skips transcript replay while resuming the wrong native session, the agent can silently lose visible conversation state.

I searched existing open issues for native-resume guard / invalidation follow-ups and only found #744 as the umbrella.

## Describe the solution you'd like

Create a shared invalidation and fallback policy for native-resume agents, then back it with a focused test matrix.

Suggested scope:

- define when a stored native session is safe to resume
- define guard-fail reasons such as model changed, cwd/project changed, conversation advanced, missing cursor, history edited, run retried/truncated, stale native session, and unsupported capability
- ensure `--resume`/native continuation and transcript skipping come from the same per-run decision
- require full transcript recompose whenever a guard fails
- define when stale native handles should be cleared
- define diagnostics/telemetry fields for guard and reseed reasons
- cover cross-agent behavior: A -> B -> A should reseed unless the shared policy explicitly proves the A session still has the visible state it needs

Acceptance criteria:

- The policy is documented or encoded in a shared helper with tests.
- Existing native-resume agents are listed against the policy: Claude, Codex, OpenCode, Pi, AMR, and cursor-agent if #4790 lands first.
- Tests cover at least same-agent resume, agent switch, model drift, cwd/project drift, intervening completed turn, failed/canceled intervening turn, stale session, and guard-fail full transcript fallback.
- The policy does not weaken the current #4629 safety behavior.

## Alternatives you've considered

Rely on ad hoc per-agent checks. That keeps the first implementation small, but it makes future agents easier to wire incorrectly.

Always disable resume after any conversation change. That is safest but throws away the main performance/cost benefit for normal same-agent follow-up turns.

## Additional context

Related:

- #744 umbrella native-resume/sessionMap issue
- #3290 Claude resume spec, including history divergence guard discussion
- #4629 existing native resume guard implementation
- #4790 cursor-agent native resume slice

## Would you be willing to contribute a PR?

Yes, I can take this on.

## Agent-agnostic scope clarification

This policy must apply across resume-capable agents, including Hermes and Pi, not only OpenCode/cursor-agent.

The invalidation matrix should avoid assumptions such as `sessionID` casing, `-s <id>` argv shape, or a single kind of native handle. It should cover agents whose resume state is:

- a stream-captured opaque id
- a daemon-specified id
- a local session-file path, as with Pi-style flows
- an ACP-loaded session, as with AMR and potentially ACP-capable agents such as Hermes
- a continue-latest mode where no explicit id is available

The central invariant is agent-agnostic: transcript skipping is allowed only when the shared resume decision proves the selected agent's native session still matches the visible Open Design conversation state.




---

## PR checklist update

## Why

This PR keeps the #5269 implementation narrow while product direction is still pending: it extracts the shared policy seams that already existed implicitly in #4629. Native continuation and transcript skipping now flow through `resolveAgentResumePromptPolicy`, and resume-target-missing recovery now flows through `resolveAgentResumeFailurePolicy`.

## What users will see

No intentional UI behavior change. The safety behavior remains the same: resume when the guard proves the upstream session is valid; otherwise send the full transcript. If an upstream resume target is gone, clear the stale handle and auto-reseed with the full transcript.

## Surface area

- [ ] **UI** ? new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** ? new or changed
- [ ] **CLI / env var** ? new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** ? new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** ? new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** ? added new translation keys
- [ ] **New top-level dependency** ? adding any new entry to the root `package.json`
- [ ] **Default behavior change** ? changes what existing users experience without opting in
- [x] **None** ? internal refactor, docs, tests, or translation update only

## Adapter Coverage

| Adapter | Current path | Guard/fallback coverage in this PR |
| --- | --- | --- |
| Claude | daemon-specified `--session-id`, resume with `--resume <id>` | Uses shared prompt policy and shared resume-failure policy through existing daemon path. |
| Codebuddy | Claude-compatible session flags | Shares Claude fallback detector through `isAgentResumeFailure`; covered by policy helpers. |
| Codex | stream-captured `thread_id`, resume with `exec resume <thread_id>` | Uses shared prompt policy; stale rollout detection still dispatches through the shared failure policy. |
| OpenCode | stream-captured `sessionID`, resume with `run -s <id>` | Uses shared prompt policy; stale session detection still dispatches through the shared failure policy. |
| Pi | session-file path via `.pi/sessions/*.jsonl`, resume through RPC parent session | Uses shared prompt policy for parent session injection; stale parent failure remains cleared at Pi RPC error code boundary. |
| AMR | ACP durable session handle, resume via `session/load` | Uses shared prompt policy and shared failure policy; ACP `resume_failed` suppression stays transparent before auto-reseed. |
| cursor-agent | #4790 in flight | Not changed here; expected to use the same policy seam once/if its resume slice lands. |

## Screenshots

N/A

## Bug fix verification

-

## Validation

Rebased onto the current `main` tip (`3451bd12d`) and revalidated:

- `pnpm exec vitest run -c vitest.config.ts tests/agent-session-resume.test.ts tests/native-session-recovery.test.ts tests/run-diagnostics.test.ts tests/runtimes/runs.test.ts` from `apps/daemon`: 4 files / 114 tests passed
- `pnpm exec vitest run -c vitest.config.ts tests/server-identifier-scope.test.ts` from `e2e`: 3 tests passed (covers the previously unbound resume-failure call)
- `pnpm --filter @open-design/daemon typecheck`: passed
- `pnpm guard`: passed

The rebase resolved the conflict introduced by main's `runtimeResumesSessionById` helper (from the #5270 recovery-metadata work): both resume-failure guard sites now use `(runtimeResumesSessionById(def) || def.resumesSessionViaAcpLoad === true)` routed through the shared `resolveAgentResumeFailurePolicy` call. @nettee's review thread on the `isAgentResumeFailure` import in `server.ts` is resolved on the head.
