### PR TITLE
Expose sanitized native-session recovery metadata in run details

### DIFF
--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -23,6 +23,8 @@ export type ResumeInvalidationReason =
   | 'missing_cursor';
 
 export interface AgentResumeContext {
+  /** Stored CLI session id if one exists, even when a guard rejects resuming it. */
+  storedSessionId: string | null;
   /** Stored CLI session id to resume, or null when starting fresh. */
   resumeSessionId: string | null;
   /** Freshly minted UUID to open a new session with when not resuming. */
@@ -113,6 +115,7 @@ export function resolveAgentResumeContext(
       : null;
   const resumable = storedSessionId != null && invalidationReason == null;
   return {
+    storedSessionId,
     resumeSessionId: resumable ? storedSessionId : null,
     newSessionId: randomUUID(),
     isResuming: resumable,

--- a/apps/daemon/src/native-session-recovery.ts
+++ b/apps/daemon/src/native-session-recovery.ts
@@ -1,0 +1,164 @@
+import { createHash } from 'node:crypto';
+
+import type {
+  NativeSessionAcquisitionMode,
+  NativeSessionContinuationMode,
+  NativeSessionHandleKind,
+  NativeSessionRecoveryHandle,
+  NativeSessionRecoveryMetadata,
+  NativeSessionRecoveryReason,
+} from '@open-design/contracts';
+import type { ResumeInvalidationReason } from './agent-session-resume.js';
+import type { RuntimeAgentDef } from './runtimes/types.js';
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function handleKindForAgent(agentId: string | null): NativeSessionHandleKind {
+  if (agentId === 'codex') return 'cli-thread-id';
+  if (agentId === 'amr') return 'acp-session-handle';
+  if (agentId === 'pi') return 'session-file-path';
+  if (agentId) return 'opaque-id';
+  return 'unknown';
+}
+
+export function redactNativeSessionHandle(input: {
+  agentId: string | null;
+  sessionId: string | null | undefined;
+}): NativeSessionRecoveryHandle {
+  const value = typeof input.sessionId === 'string' && input.sessionId.length > 0
+    ? input.sessionId
+    : null;
+  return {
+    present: value !== null,
+    kind: handleKindForAgent(input.agentId),
+    display: null,
+    sha256: value ? sha256(value) : null,
+    redacted: value !== null,
+  };
+}
+
+function acquisitionForRuntime(
+  def: Pick<RuntimeAgentDef, 'id' | 'resumesSessionViaCli' | 'capturesSessionIdFromStream' | 'resumesSessionViaAcpLoad'>,
+  supported: boolean,
+): NativeSessionAcquisitionMode {
+  if (!supported) return 'none';
+  if (def.resumesSessionViaAcpLoad === true) return 'acp-session-load';
+  if (def.id === 'pi') return 'session-file-discovered';
+  if (def.capturesSessionIdFromStream === true) return 'stream-captured';
+  if (def.resumesSessionViaCli === true) return 'daemon-specified';
+  return 'unknown';
+}
+
+function continuationForRuntime(
+  def: Pick<RuntimeAgentDef, 'id' | 'resumesSessionViaCli' | 'resumesSessionViaAcpLoad'>,
+  supported: boolean,
+): NativeSessionContinuationMode {
+  if (!supported) return 'none';
+  if (def.resumesSessionViaAcpLoad === true) return 'acp-session-load';
+  if (def.id === 'pi') return 'session-file-resume';
+  if (def.resumesSessionViaCli === true) return 'native-resume-by-id';
+  return 'unknown';
+}
+
+function guardReason(reason: ResumeInvalidationReason | null | undefined): NativeSessionRecoveryReason | null {
+  return reason ?? null;
+}
+
+export function initialNativeSessionRecoveryMetadata(input: {
+  agent: Pick<RuntimeAgentDef, 'id' | 'resumesSessionViaCli' | 'capturesSessionIdFromStream' | 'resumesSessionViaAcpLoad'>;
+  supportsSessionResume: boolean;
+  isResuming: boolean;
+  resumeSessionId: string | null | undefined;
+  invalidationReason: ResumeInvalidationReason | null | undefined;
+  updatedAt?: number;
+}): NativeSessionRecoveryMetadata {
+  const now = input.updatedAt ?? Date.now();
+  if (!input.supportsSessionResume) {
+    return {
+      agentId: input.agent.id,
+      state: 'not_applicable',
+      acquisition: 'none',
+      continuation: 'none',
+      handle: redactNativeSessionHandle({ agentId: input.agent.id, sessionId: null }),
+      guardReason: 'unsupported',
+      fallbackReason: null,
+      updatedAt: now,
+    };
+  }
+  const handle = redactNativeSessionHandle({
+    agentId: input.agent.id,
+    sessionId: input.resumeSessionId ?? null,
+  });
+  const state: NativeSessionRecoveryMetadata['state'] =
+    input.isResuming && handle.present
+      ? 'resume_attempted'
+      : input.invalidationReason
+        ? 'resume_skipped'
+        : 'no_recoverable_session';
+  return {
+    agentId: input.agent.id,
+    state,
+    acquisition: acquisitionForRuntime(input.agent, input.supportsSessionResume),
+    continuation: continuationForRuntime(input.agent, input.supportsSessionResume),
+    handle,
+    guardReason: state === 'resume_skipped' ? guardReason(input.invalidationReason) : null,
+    fallbackReason: null,
+    updatedAt: now,
+  };
+}
+
+export function markNativeSessionCaptured(input: {
+  previous: NativeSessionRecoveryMetadata | null | undefined;
+  agentId: string | null;
+  sessionId: string | null | undefined;
+  resumed: boolean;
+  updatedAt?: number;
+}): NativeSessionRecoveryMetadata {
+  const previous = input.previous ?? initialNativeSessionRecoveryMetadata({
+    agent: { id: input.agentId ?? 'unknown' },
+    supportsSessionResume: true,
+    isResuming: false,
+    resumeSessionId: null,
+    invalidationReason: null,
+    ...(input.updatedAt !== undefined ? { updatedAt: input.updatedAt } : {}),
+  });
+  const handle = redactNativeSessionHandle({ agentId: input.agentId, sessionId: input.sessionId });
+  return {
+    ...previous,
+    state: handle.present
+      ? (input.resumed ? 'resumed' : 'captured_not_resumed')
+      : 'no_recoverable_session',
+    handle,
+    guardReason: null,
+    fallbackReason: null,
+    updatedAt: input.updatedAt ?? Date.now(),
+  };
+}
+
+export function markNativeSessionAutoReseeded(input: {
+  previous: NativeSessionRecoveryMetadata | null | undefined;
+  agentId: string | null;
+  previousSessionId: string | null | undefined;
+  updatedAt?: number;
+}): NativeSessionRecoveryMetadata {
+  const previous = input.previous ?? initialNativeSessionRecoveryMetadata({
+    agent: { id: input.agentId ?? 'unknown' },
+    supportsSessionResume: true,
+    isResuming: false,
+    resumeSessionId: null,
+    invalidationReason: null,
+    ...(input.updatedAt !== undefined ? { updatedAt: input.updatedAt } : {}),
+  });
+  return {
+    ...previous,
+    state: 'auto_reseeded',
+    handle: redactNativeSessionHandle({
+      agentId: input.agentId,
+      sessionId: input.previousSessionId,
+    }),
+    fallbackReason: 'resume_failed',
+    updatedAt: input.updatedAt ?? Date.now(),
+  };
+}

--- a/apps/daemon/src/native-session-recovery.ts
+++ b/apps/daemon/src/native-session-recovery.ts
@@ -23,16 +23,26 @@ function handleKindForAgent(agentId: string | null): NativeSessionHandleKind {
   return 'unknown';
 }
 
+function handleKindForRuntime(
+  def: Pick<RuntimeAgentDef, 'id' | 'capturesSessionIdFromStream' | 'resumesSessionViaAcpLoad'>,
+): NativeSessionHandleKind {
+  if (def.resumesSessionViaAcpLoad === true) return 'acp-session-handle';
+  if (def.id === 'pi') return 'session-file-path';
+  if (def.capturesSessionIdFromStream === true) return 'cli-thread-id';
+  return handleKindForAgent(def.id);
+}
+
 export function redactNativeSessionHandle(input: {
   agentId: string | null;
   sessionId: string | null | undefined;
+  kind?: NativeSessionHandleKind;
 }): NativeSessionRecoveryHandle {
   const value = typeof input.sessionId === 'string' && input.sessionId.length > 0
     ? input.sessionId
     : null;
   return {
     present: value !== null,
-    kind: handleKindForAgent(input.agentId),
+    kind: input.kind ?? handleKindForAgent(input.agentId),
     display: null,
     sha256: value ? sha256(value) : null,
     redacted: value !== null,
@@ -71,25 +81,31 @@ export function initialNativeSessionRecoveryMetadata(input: {
   supportsSessionResume: boolean;
   isResuming: boolean;
   resumeSessionId: string | null | undefined;
+  storedSessionId?: string | null | undefined;
   invalidationReason: ResumeInvalidationReason | null | undefined;
   updatedAt?: number;
 }): NativeSessionRecoveryMetadata {
   const now = input.updatedAt ?? Date.now();
+  const handleKind = handleKindForRuntime(input.agent);
   if (!input.supportsSessionResume) {
     return {
       agentId: input.agent.id,
       state: 'not_applicable',
       acquisition: 'none',
       continuation: 'none',
-      handle: redactNativeSessionHandle({ agentId: input.agent.id, sessionId: null }),
+      handle: redactNativeSessionHandle({ agentId: input.agent.id, sessionId: null, kind: handleKind }),
       guardReason: 'unsupported',
       fallbackReason: null,
       updatedAt: now,
     };
   }
+  const diagnosticSessionId = input.invalidationReason
+    ? (input.storedSessionId ?? input.resumeSessionId ?? null)
+    : (input.resumeSessionId ?? null);
   const handle = redactNativeSessionHandle({
     agentId: input.agent.id,
-    sessionId: input.resumeSessionId ?? null,
+    sessionId: diagnosticSessionId,
+    kind: handleKind,
   });
   const state: NativeSessionRecoveryMetadata['state'] =
     input.isResuming && handle.present
@@ -124,7 +140,11 @@ export function markNativeSessionCaptured(input: {
     invalidationReason: null,
     ...(input.updatedAt !== undefined ? { updatedAt: input.updatedAt } : {}),
   });
-  const handle = redactNativeSessionHandle({ agentId: input.agentId, sessionId: input.sessionId });
+  const handle = redactNativeSessionHandle({
+    agentId: input.agentId,
+    sessionId: input.sessionId,
+    kind: previous.handle.kind,
+  });
   return {
     ...previous,
     state: handle.present
@@ -157,6 +177,7 @@ export function markNativeSessionAutoReseeded(input: {
     handle: redactNativeSessionHandle({
       agentId: input.agentId,
       sessionId: input.previousSessionId,
+      kind: previous.handle.kind,
     }),
     fallbackReason: 'resume_failed',
     updatedAt: input.updatedAt ?? Date.now(),

--- a/apps/daemon/src/run-diagnostics.ts
+++ b/apps/daemon/src/run-diagnostics.ts
@@ -187,6 +187,16 @@ export function summarizeRunDiagnosticsForAnalytics(args: {
     if (event.event === 'diagnostic' && data.type === 'agent_resume_auto_reseed') {
       resumeAutoReseeded = true;
     }
+    if (
+      event.event === 'diagnostic' &&
+      data.type === 'native_session_recovery' &&
+      data.nativeSessionRecovery &&
+      typeof data.nativeSessionRecovery === 'object' &&
+      !Array.isArray(data.nativeSessionRecovery) &&
+      (data.nativeSessionRecovery as Record<string, unknown>).state === 'auto_reseeded'
+    ) {
+      resumeAutoReseeded = true;
+    }
     if (data.type === 'artifact') artifactWriteSeen = true;
     if (data.type === 'live_artifact' || event.event === 'live_artifact') {
       liveArtifactSeen = true;

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -193,6 +193,7 @@ export function createChatRunService({
     mediaExecution: run.mediaExecution ?? normalizeMediaExecutionPolicyForRun(null),
     toolBundle: summarizeRunToolBundle(run.toolBundle),
     ...(run.promptCache ? { promptCache: run.promptCache } : {}),
+    ...(run.nativeSessionRecovery ? { nativeSessionRecovery: run.nativeSessionRecovery } : {}),
     ...(run.browserUse ? { browserUse: run.browserUse } : {}),
   });
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4544,7 +4544,7 @@ export async function startServer({
             currentCwd: effectiveCwd,
             currentAssistantMessageId: run.assistantMessageId ?? null,
           })
-        : { resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null, invalidationReason: null };
+        : { storedSessionId: null as string | null, resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null, invalidationReason: null };
     const publishNativeSessionRecoveryMetadata = () => {
       if (!run.nativeSessionRecovery) return;
       design.runs.emit(run, 'diagnostic', {
@@ -4557,6 +4557,7 @@ export async function startServer({
       supportsSessionResume: agentSupportsSessionResume,
       isResuming: agentResumeCtx.isResuming,
       resumeSessionId: agentResumeCtx.resumeSessionId,
+      storedSessionId: agentResumeCtx.storedSessionId,
       invalidationReason: agentResumeCtx.invalidationReason,
     });
     publishNativeSessionRecoveryMetadata();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5025,6 +5025,13 @@ export async function startServer({
           cwd: effectiveCwd,
           lastMessageId: run.assistantMessageId ?? null,
         });
+        run.nativeSessionRecovery = markNativeSessionCaptured({
+          previous: run.nativeSessionRecovery,
+          agentId: def.id,
+          sessionId: liveSessionId,
+          resumed: agentResumeCtx.isResuming,
+        });
+        publishNativeSessionRecoveryMetadata();
       }
       finalizeRetryTelemetry(status, decision, failure, errorCode);
       const rpcCloseReason = deriveRpcCloseReason(status, code, signal);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -542,6 +542,11 @@ import {
   resolveAgentResumeContext,
 } from './agent-session-resume.js';
 import {
+  initialNativeSessionRecoveryMetadata,
+  markNativeSessionAutoReseeded,
+  markNativeSessionCaptured,
+} from './native-session-recovery.js';
+import {
   createLiveArtifact,
   deleteLiveArtifact,
   ensureLiveArtifactPreview,
@@ -4540,6 +4545,21 @@ export async function startServer({
             currentAssistantMessageId: run.assistantMessageId ?? null,
           })
         : { resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null, invalidationReason: null };
+    const publishNativeSessionRecoveryMetadata = () => {
+      if (!run.nativeSessionRecovery) return;
+      design.runs.emit(run, 'diagnostic', {
+        type: 'native_session_recovery',
+        nativeSessionRecovery: run.nativeSessionRecovery,
+      });
+    };
+    run.nativeSessionRecovery = initialNativeSessionRecoveryMetadata({
+      agent: def,
+      supportsSessionResume: agentSupportsSessionResume,
+      isResuming: agentResumeCtx.isResuming,
+      resumeSessionId: agentResumeCtx.resumeSessionId,
+      invalidationReason: agentResumeCtx.invalidationReason,
+    });
+    publishNativeSessionRecoveryMetadata();
     const userRequestPrompt = composeChatUserRequestForAgent(
       message,
       currentPrompt,
@@ -5511,6 +5531,15 @@ export async function startServer({
             cwd: effectiveCwd,
             lastMessageId: run.assistantMessageId ?? null,
           });
+          if (!agentCapturesSessionId) {
+            run.nativeSessionRecovery = markNativeSessionCaptured({
+              previous: run.nativeSessionRecovery,
+              agentId: def.id,
+              sessionId: createTurnSessionId,
+              resumed: false,
+            });
+            publishNativeSessionRecoveryMetadata();
+          }
           return;
         }
         if (agentResumeCtx.isResuming && agentResumeCtx.resumeSessionId) {
@@ -5528,6 +5557,15 @@ export async function startServer({
             cwd: effectiveCwd,
             lastMessageId: run.assistantMessageId ?? null,
           });
+          if (!agentCapturesSessionId) {
+            run.nativeSessionRecovery = markNativeSessionCaptured({
+              previous: run.nativeSessionRecovery,
+              agentId: def.id,
+              sessionId: agentResumeCtx.resumeSessionId,
+              resumed: true,
+            });
+            publishNativeSessionRecoveryMetadata();
+          }
         }
       };
     }
@@ -6514,6 +6552,13 @@ export async function startServer({
         ev.sessionId.length > 0
       ) {
         capturedSessionId = ev.sessionId;
+        run.nativeSessionRecovery = markNativeSessionCaptured({
+          previous: run.nativeSessionRecovery,
+          agentId: def.id,
+          sessionId: capturedSessionId,
+          resumed: agentResumeCtx.isResuming,
+        });
+        publishNativeSessionRecoveryMetadata();
       }
       lastAgentEventPhase = summarizeAgentEventForInactivity(ev);
       noteAgentActivity();
@@ -6902,6 +6947,12 @@ export async function startServer({
         if (!run.resumeAutoReseeded) {
           run.resumeAutoReseeded = true;
           run.resumeAutoReseededFrom = agentResumeCtx.resumeSessionId ?? null;
+          run.nativeSessionRecovery = markNativeSessionAutoReseeded({
+            previous: run.nativeSessionRecovery,
+            agentId: def.id,
+            previousSessionId: agentResumeCtx.resumeSessionId,
+          });
+          publishNativeSessionRecoveryMetadata();
           // Persisted to the per-run events.jsonl that the help → diagnostics
           // export bundles, so the whole resume → fail → auto-reseed chain is
           // visible in a support bundle without any user-facing signal.
@@ -6911,6 +6962,7 @@ export async function startServer({
             reason: 'resume_failed',
             previous_session_id: agentResumeCtx.resumeSessionId ?? null,
             stale_session_cleared: true,
+            nativeSessionRecovery: run.nativeSessionRecovery,
           });
           scheduleRetryRestart(0);
           return;
@@ -7249,6 +7301,13 @@ export async function startServer({
             cwd: effectiveCwd,
             lastMessageId: run.assistantMessageId ?? null,
           });
+          run.nativeSessionRecovery = markNativeSessionCaptured({
+            previous: run.nativeSessionRecovery,
+            agentId: def.id,
+            sessionId: sessionPath,
+            resumed: agentResumeCtx.isResuming,
+          });
+          publishNativeSessionRecoveryMetadata();
         }
       }
       // ACP session/load adapters (AMR/vela) report a durable upstream handle
@@ -7271,6 +7330,13 @@ export async function startServer({
           cwd: effectiveCwd,
           lastMessageId: run.assistantMessageId ?? null,
         });
+        run.nativeSessionRecovery = markNativeSessionCaptured({
+          previous: run.nativeSessionRecovery,
+          agentId: def.id,
+          sessionId: acpSession.getDurableSessionId(),
+          resumed: agentResumeCtx.isResuming,
+        });
+        publishNativeSessionRecoveryMetadata();
       }
       if (status === 'succeeded') {
         try {

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -130,6 +130,7 @@ describe('resolveAgentResumeContext', () => {
     });
     expect(ctx.isResuming).toBe(false);
     expect(ctx.resumeSessionId).toBeNull();
+    expect(ctx.storedSessionId).toBe('sess-A');
     expect(ctx.invalidationReason).toBe('model_changed');
   });
 

--- a/apps/daemon/tests/native-session-recovery.test.ts
+++ b/apps/daemon/tests/native-session-recovery.test.ts
@@ -83,12 +83,45 @@ describe('native session recovery metadata', () => {
     expect(JSON.stringify(acp)).not.toContain('vela-durable-session');
   });
 
+  it('classifies stream-captured CLI handles from runtime capabilities', () => {
+    const rawSessionId = 'ses_opencode_capture_123';
+    const initial = initialNativeSessionRecoveryMetadata({
+      agent: { id: 'opencode', resumesSessionViaCli: true, capturesSessionIdFromStream: true },
+      supportsSessionResume: true,
+      isResuming: false,
+      resumeSessionId: null,
+      invalidationReason: null,
+      updatedAt: 350,
+    });
+    const captured = markNativeSessionCaptured({
+      previous: initial,
+      agentId: 'opencode',
+      sessionId: rawSessionId,
+      resumed: false,
+      updatedAt: 360,
+    });
+
+    expect(initial).toMatchObject({
+      acquisition: 'stream-captured',
+      continuation: 'native-resume-by-id',
+      handle: { present: false, kind: 'cli-thread-id' },
+    });
+    expect(captured).toMatchObject({
+      agentId: 'opencode',
+      state: 'captured_not_resumed',
+      handle: { present: true, kind: 'cli-thread-id', display: null, redacted: true },
+    });
+    expect(captured.handle.sha256).toBe(createHash('sha256').update(rawSessionId, 'utf8').digest('hex'));
+    expect(JSON.stringify(captured)).not.toContain(rawSessionId);
+  });
+
   it('distinguishes skipped, captured, resumed, and auto-reseeded states', () => {
     const skipped = initialNativeSessionRecoveryMetadata({
       agent: { id: 'codex', resumesSessionViaCli: true, capturesSessionIdFromStream: true },
       supportsSessionResume: true,
       isResuming: false,
-      resumeSessionId: 'stored-thread-id',
+      resumeSessionId: null,
+      storedSessionId: 'stored-thread-id',
       invalidationReason: 'model_changed',
       updatedAt: 400,
     });
@@ -116,6 +149,7 @@ describe('native session recovery metadata', () => {
     expect(skipped).toMatchObject({
       state: 'resume_skipped',
       guardReason: 'model_changed',
+      handle: { present: true, kind: 'cli-thread-id', display: null, redacted: true },
     });
     expect(captured).toMatchObject({
       state: 'captured_not_resumed',
@@ -128,5 +162,6 @@ describe('native session recovery metadata', () => {
       fallbackReason: 'resume_failed',
     });
     expect(JSON.stringify(reseeded)).not.toContain('new-thread-id');
+    expect(JSON.stringify(skipped)).not.toContain('stored-thread-id');
   });
 });

--- a/apps/daemon/tests/native-session-recovery.test.ts
+++ b/apps/daemon/tests/native-session-recovery.test.ts
@@ -1,0 +1,132 @@
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  initialNativeSessionRecoveryMetadata,
+  markNativeSessionAutoReseeded,
+  markNativeSessionCaptured,
+  redactNativeSessionHandle,
+} from '../src/native-session-recovery.js';
+
+describe('native session recovery metadata', () => {
+  it('redacts raw native session handles while preserving a support correlation hash', () => {
+    const rawSessionId = 'codex-thread-secret-123';
+    const handle = redactNativeSessionHandle({
+      agentId: 'codex',
+      sessionId: rawSessionId,
+    });
+
+    expect(handle).toEqual({
+      present: true,
+      kind: 'cli-thread-id',
+      display: null,
+      sha256: createHash('sha256').update(rawSessionId, 'utf8').digest('hex'),
+      redacted: true,
+    });
+    expect(JSON.stringify(handle)).not.toContain(rawSessionId);
+  });
+
+  it('marks unsupported agents as not applicable without a handle', () => {
+    const metadata = initialNativeSessionRecoveryMetadata({
+      agent: { id: 'hermes' },
+      supportsSessionResume: false,
+      isResuming: false,
+      resumeSessionId: null,
+      invalidationReason: null,
+      updatedAt: 100,
+    });
+
+    expect(metadata).toMatchObject({
+      agentId: 'hermes',
+      state: 'not_applicable',
+      acquisition: 'none',
+      continuation: 'none',
+      guardReason: 'unsupported',
+      handle: { present: false, kind: 'opaque-id', display: null, sha256: null, redacted: false },
+      updatedAt: 100,
+    });
+  });
+
+  it('describes Pi and ACP recovery modes without leaking handles', () => {
+    const pi = initialNativeSessionRecoveryMetadata({
+      agent: { id: 'pi' },
+      supportsSessionResume: true,
+      isResuming: false,
+      resumeSessionId: null,
+      invalidationReason: null,
+      updatedAt: 200,
+    });
+    const acp = initialNativeSessionRecoveryMetadata({
+      agent: { id: 'amr', resumesSessionViaAcpLoad: true },
+      supportsSessionResume: true,
+      isResuming: true,
+      resumeSessionId: 'vela-durable-session',
+      invalidationReason: null,
+      updatedAt: 300,
+    });
+
+    expect(pi).toMatchObject({
+      agentId: 'pi',
+      state: 'no_recoverable_session',
+      acquisition: 'session-file-discovered',
+      continuation: 'session-file-resume',
+      handle: { present: false, kind: 'session-file-path' },
+    });
+    expect(acp).toMatchObject({
+      agentId: 'amr',
+      state: 'resume_attempted',
+      acquisition: 'acp-session-load',
+      continuation: 'acp-session-load',
+      handle: { present: true, kind: 'acp-session-handle', display: null, redacted: true },
+    });
+    expect(JSON.stringify(acp)).not.toContain('vela-durable-session');
+  });
+
+  it('distinguishes skipped, captured, resumed, and auto-reseeded states', () => {
+    const skipped = initialNativeSessionRecoveryMetadata({
+      agent: { id: 'codex', resumesSessionViaCli: true, capturesSessionIdFromStream: true },
+      supportsSessionResume: true,
+      isResuming: false,
+      resumeSessionId: 'stored-thread-id',
+      invalidationReason: 'model_changed',
+      updatedAt: 400,
+    });
+    const captured = markNativeSessionCaptured({
+      previous: skipped,
+      agentId: 'codex',
+      sessionId: 'new-thread-id',
+      resumed: false,
+      updatedAt: 500,
+    });
+    const resumed = markNativeSessionCaptured({
+      previous: captured,
+      agentId: 'codex',
+      sessionId: 'new-thread-id',
+      resumed: true,
+      updatedAt: 600,
+    });
+    const reseeded = markNativeSessionAutoReseeded({
+      previous: resumed,
+      agentId: 'codex',
+      previousSessionId: 'new-thread-id',
+      updatedAt: 700,
+    });
+
+    expect(skipped).toMatchObject({
+      state: 'resume_skipped',
+      guardReason: 'model_changed',
+    });
+    expect(captured).toMatchObject({
+      state: 'captured_not_resumed',
+      guardReason: null,
+      handle: { present: true, kind: 'cli-thread-id' },
+    });
+    expect(resumed).toMatchObject({ state: 'resumed' });
+    expect(reseeded).toMatchObject({
+      state: 'auto_reseeded',
+      fallbackReason: 'resume_failed',
+    });
+    expect(JSON.stringify(reseeded)).not.toContain('new-thread-id');
+  });
+});

--- a/apps/daemon/tests/run-diagnostics.test.ts
+++ b/apps/daemon/tests/run-diagnostics.test.ts
@@ -39,6 +39,24 @@ describe('run diagnostics', () => {
     expect(result.rpc_close_reason).toBe('exit_0');
   });
 
+  it('flags resume_auto_reseeded from native session recovery diagnostics', () => {
+    const result = summarizeRunDiagnosticsForAnalytics({
+      events: [
+        {
+          event: 'diagnostic',
+          data: {
+            type: 'native_session_recovery',
+            nativeSessionRecovery: { state: 'auto_reseeded' },
+          },
+        },
+      ],
+      exitCode: 0,
+      signal: null,
+    });
+
+    expect(result.resume_auto_reseeded).toBe(true);
+  });
+
   it('returns only low-cardinality stderr fields for PostHog analytics', () => {
     const result = summarizeRunDiagnosticsForAnalytics({
       events: [

--- a/apps/daemon/tests/run-resume-on-failure.test.ts
+++ b/apps/daemon/tests/run-resume-on-failure.test.ts
@@ -32,6 +32,17 @@ type RunStatus = {
   errorCode: string | null;
   eventsLogPath: string;
   resumable?: boolean;
+  nativeSessionRecovery?: {
+    agentId: string | null;
+    state: string;
+    handle: {
+      present: boolean;
+      kind: string;
+      display: string | null;
+      sha256: string | null;
+      redacted: boolean;
+    };
+  };
 };
 
 describe('resume-on-failure runtime', () => {
@@ -79,6 +90,17 @@ describe('resume-on-failure runtime', () => {
     const failed = await sendRunAndWait(started.url, conversationId);
     expect(failed.status).toBe('failed');
     expect(failed.resumable).toBe(true);
+    expect(failed.nativeSessionRecovery).toMatchObject({
+      agentId: 'claude',
+      state: 'captured_not_resumed',
+      handle: {
+        present: true,
+        kind: 'opaque-id',
+        display: null,
+        redacted: true,
+      },
+    });
+    expect(failed.nativeSessionRecovery?.handle.sha256).toMatch(/^[a-f0-9]{64}$/);
 
     // Turn 2: a follow-up in the SAME conversation must resume the persisted
     // session rather than starting fresh.
@@ -93,6 +115,7 @@ describe('resume-on-failure runtime', () => {
     const firstSessionId = flagValue(attempts[0] ?? [], '--session-id');
     expect(firstSessionId).toBeTruthy();
     expect(attempts[0]).not.toContain('--resume');
+    expect(JSON.stringify(failed.nativeSessionRecovery)).not.toContain(firstSessionId);
 
     const resumedSessionId = flagValue(attempts[1] ?? [], '--resume');
     expect(resumedSessionId).toBe(firstSessionId);

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -258,6 +258,39 @@ describe('chat run service shutdown', () => {
     });
   });
 
+  it('stores native session recovery metadata on run status bodies', () => {
+    const runs = createRuns();
+    const run = runs.create({ projectId: 'project-1', conversationId: 'conv-a' });
+    (run as any).nativeSessionRecovery = {
+      agentId: 'codex',
+      state: 'captured_not_resumed',
+      acquisition: 'stream-captured',
+      continuation: 'native-resume-by-id',
+      handle: {
+        present: true,
+        kind: 'cli-thread-id',
+        display: null,
+        sha256: 'a'.repeat(64),
+        redacted: true,
+      },
+      guardReason: null,
+      fallbackReason: null,
+      updatedAt: 123,
+    };
+
+    expect(runs.statusBody(run)).toMatchObject({
+      nativeSessionRecovery: {
+        agentId: 'codex',
+        state: 'captured_not_resumed',
+        handle: {
+          display: null,
+          sha256: 'a'.repeat(64),
+          redacted: true,
+        },
+      },
+    });
+  });
+
   it('summarizes OD-owned project storage on run status bodies', () => {
     const runs = createRuns();
     const run = runs.create({ projectId: 'project-1', conversationId: 'conv-a' });
@@ -671,6 +704,55 @@ describe('run event log persistence', () => {
     expect(parsed[0]).toMatchObject({ event: 'agent', data: { type: 'text_delta', delta: 'hello' } });
     expect(parsed[1]).toMatchObject({ event: 'agent', data: { type: 'text_delta', delta: ' world' } });
     expect(parsed[2]).toMatchObject({ event: 'end', data: { status: 'succeeded' } });
+  });
+
+  it('persists native session recovery diagnostics in the run event log', async () => {
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({ projectId: 'p1' });
+
+    runs.emit(run, 'diagnostic', {
+      type: 'native_session_recovery',
+      nativeSessionRecovery: {
+        agentId: 'amr',
+        state: 'resumed',
+        acquisition: 'acp-session-load',
+        continuation: 'acp-session-load',
+        handle: {
+          present: true,
+          kind: 'acp-session-handle',
+          display: null,
+          sha256: 'b'.repeat(64),
+          redacted: true,
+        },
+        guardReason: null,
+        fallbackReason: null,
+        updatedAt: 456,
+      },
+    });
+    runs.finish(run, 'succeeded', 0, null);
+
+    const logPath = path.join(tmpDir, run.id, 'events.jsonl');
+    let text = '';
+    for (let i = 0; i < 50; i++) {
+      if (fs.existsSync(logPath)) {
+        text = fs.readFileSync(logPath, 'utf8');
+        if (text.includes('native_session_recovery')) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    const parsed = text.trim().split('\n').map((line) => JSON.parse(line));
+    expect(parsed[0]).toMatchObject({
+      event: 'diagnostic',
+      data: {
+        type: 'native_session_recovery',
+        nativeSessionRecovery: {
+          agentId: 'amr',
+          state: 'resumed',
+          handle: { display: null, redacted: true },
+        },
+      },
+    });
   });
 
   it('exposes eventsLogPath on statusBody when runsLogDir is configured', () => {

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -361,6 +361,67 @@ export interface ChatRunCreateResponse {
   pluginId?: string | null;
 }
 
+export type NativeSessionRecoveryState =
+  | 'not_applicable'
+  | 'no_recoverable_session'
+  | 'captured_not_resumed'
+  | 'resume_attempted'
+  | 'resumed'
+  | 'resume_skipped'
+  | 'auto_reseeded';
+
+export type NativeSessionHandleKind =
+  | 'opaque-id'
+  | 'cli-thread-id'
+  | 'acp-session-handle'
+  | 'session-file-path'
+  | 'unknown';
+
+export type NativeSessionAcquisitionMode =
+  | 'daemon-specified'
+  | 'stream-captured'
+  | 'acp-session-load'
+  | 'session-file-discovered'
+  | 'none'
+  | 'unknown';
+
+export type NativeSessionContinuationMode =
+  | 'native-resume-by-id'
+  | 'acp-session-load'
+  | 'session-file-resume'
+  | 'none'
+  | 'unknown';
+
+export type NativeSessionRecoveryReason =
+  | 'model_changed'
+  | 'cwd_changed'
+  | 'conversation_advanced'
+  | 'missing_cursor'
+  | 'resume_failed'
+  | 'unsupported'
+  | 'none';
+
+export interface NativeSessionRecoveryHandle {
+  present: boolean;
+  kind: NativeSessionHandleKind;
+  /** Always null unless a future per-agent rule declares the handle safe. */
+  display: string | null;
+  /** Stable correlation value for support without exposing the raw handle. */
+  sha256: string | null;
+  redacted: boolean;
+}
+
+export interface NativeSessionRecoveryMetadata {
+  agentId: string | null;
+  state: NativeSessionRecoveryState;
+  acquisition: NativeSessionAcquisitionMode;
+  continuation: NativeSessionContinuationMode;
+  handle: NativeSessionRecoveryHandle;
+  guardReason: NativeSessionRecoveryReason | null;
+  fallbackReason: NativeSessionRecoveryReason | null;
+  updatedAt: number;
+}
+
 export interface ChatRunStatusResponse {
   id: string;
   projectId: string | null;
@@ -410,6 +471,8 @@ export interface ChatRunStatusResponse {
     hit: boolean;
     missReason: 'new-session' | 'missing-stored-hash' | 'stable-prompt-changed' | null;
   };
+  /** Sanitized native-session recovery state for resume-capable agents. */
+  nativeSessionRecovery?: NativeSessionRecoveryMetadata;
   /** Browser Use availability for runs that requested in-app browser automation. */
   browserUse?: BrowserUseRunState;
   /** Effective storage/provenance for the workspace used by this run. */


### PR DESCRIPTION
﻿## What problem are you trying to solve?

When a resumable native agent run is interrupted, canceled, auto-reseeded, or skipped because of a guard, users and support tooling do not have a consistent recovery/debug surface. The original OpenCode case in #744 was confusing because useful work and a native `sessionID` existed, but the run result did not clearly show how to continue or what the daemon knew.

#4629 now handles normal follow-up resume and transparent stale-session reseed for several agents, but the remaining #744 umbrella work needs a consistent way to inspect native-session state without leaking sensitive local paths or raw handles unnecessarily.

I searched existing open issues for run details / native session recovery metadata and only found #744 as the umbrella.

## Describe the solution you'd like

Add sanitized native-session recovery metadata to the run details/debug/diagnostics surfaces.

Suggested scope:

- expose whether a native session was captured for the run
- expose whether the run attempted resume, succeeded via resume, skipped resume, or auto-reseeded
- expose the guard or fallback reason when resume was not used
- expose a safe display form of the native handle: redacted, hashed, or omitted depending on agent type
- include agent id, session acquisition mode, and updated timestamp when safe
- make the data available through the same daemon API used by UI and CLI surfaces, preserving the repo's UI/CLI dual-track rule for user-facing capabilities
- include the data in diagnostics export if that is the existing support path

Acceptance criteria:

- The metadata is defined in the proper contract/API layer before UI/CLI consumption.
- Raw local paths, tokens, config values, and sensitive host-only data are not exposed accidentally.
- Existing agents with native resume are represented consistently.
- A canceled/interrupted run with a captured native session is distinguishable from a run with no recoverable native session.
- Tests cover redaction and at least one captured-session path.

## Alternatives you've considered

Only log this in daemon stderr. That helps maintainers but does not help users or issue reports.

Expose raw session ids everywhere. That is useful for debugging, but unsafe for agents whose handles may be local file paths or otherwise host-specific.

## Additional context

Related:

- #744 umbrella native-resume/sessionMap issue
- #2760 output-preservation bug related to interrupted useful output
- #4629 native resume implementation for Codex/OpenCode/Pi/AMR
- #4790 cursor-agent native resume slice

## Would you be willing to contribute a PR?

Yes, I can take this on.

## Agent-agnostic scope clarification

The recovery metadata should be generic across resumable agents. It must not assume every native handle is a harmless opaque id.

For example:

- OpenCode/cursor-agent style handles may be opaque session ids.
- Pi-style handles may be local session-file paths and should be redacted or summarized carefully.
- Hermes or other ACP-capable agents may expose ACP/native session ids with different lifetime and privacy expectations.

The metadata shape should describe resume state, acquisition mode, guard/fallback reason, and safe display fields in an agent-neutral way, with per-agent redaction rules where needed.




---

## PR checklist

Issue-backed PR: #5270 was converted directly into this ready-for-review PR.

## Why

This implements the contract/API and daemon diagnostics layer requested by #5270 as a safe first slice before any UI or CLI recovery affordance consumes the data. It gives support tooling a consistent, sanitized view of native-session recovery state across resume-capable agents.

## What users will see

No new UI or CLI controls in this PR. Daemon run status responses may now include optional `nativeSessionRecovery` metadata, and per-run diagnostics logs include `native_session_recovery` diagnostic events that the existing diagnostics export already bundles.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** - adds `nativeSessionRecovery` to `ChatRunStatusResponse` and emits a new daemon diagnostic event shape.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

N/A - no UI surface in this contract/daemon slice.

## Bug fix verification

- This is feature/debug surface work, not a bug fix. Redaction and captured-session behavior are covered by focused tests.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/native-session-recovery.test.ts tests/runtimes/runs.test.ts tests/run-diagnostics.test.ts` from `apps/daemon` - 42 passed.
- `pnpm --filter @open-design/contracts typecheck` - passed.
- `pnpm --filter @open-design/daemon typecheck` - passed.

## Agent coverage notes

- Capture-style CLI agents such as Codex/OpenCode map stream-captured handles to redacted `cli-thread-id` metadata.
- Pi maps session-file recovery to `session-file-path` handle kind with no raw path display.
- AMR/ACP-style agents map durable handles to `acp-session-handle` metadata.
- Unsupported or future agents fall back to `not_applicable`, `unknown`, or redacted opaque-id states instead of assuming a specific resume mechanism.
