### PR TITLE
Add user-facing continue/recover action for interrupted native sessions

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -29,6 +29,13 @@ import {
 
 const argv = process.argv.slice(2);
 
+const RESUME_CONTINUE_PROMPT =
+  'The previous turn was interrupted by a transient failure. ' +
+  'If your last response was cut off, continue it from where you left off ' +
+  'and keep any work already completed; otherwise complete the original ' +
+  'request. Inspect the current project files as needed before making ' +
+  'further changes.';
+
 // ---- Subcommand router ----------------------------------------------------
 //
 // `od` is two CLIs glued together:
@@ -5986,6 +5993,7 @@ async function runRun(args) {
                [--agent claude] [--model <id>] [--follow] [--json]
   od run watch  <runId>                     ND-JSON event stream on stdout.
   od run cancel <runId>                     Request cancellation.
+  od run continue <runId> [--follow]        Continue a resumable failed run.
   od run list   [--project <id>]            List recent runs.
   od run info   <runId>                     One run's status.
   od run result-package <runId> [--json]    Inspect run outputs and workspace
@@ -6060,6 +6068,56 @@ Common options:
       const resp = await fetch(`${base}/api/runs/${encodeURIComponent(id)}/cancel`, { method: 'POST' });
       if (!resp.ok) return structuredHttpFailure(resp, 'run-not-found');
       console.log(`[run] cancelled ${id}`);
+      return;
+    }
+    case 'continue': {
+      const id = positionalArgs(rest, PROJECT_STRING_FLAGS)[0];
+      if (!id) {
+        console.error('Usage: od run continue <runId> [--message "<text>"] [--follow] [--json]');
+        process.exit(2);
+      }
+      const statusResp = await fetch(`${base}/api/runs/${encodeURIComponent(id)}`);
+      if (!statusResp.ok) return structuredHttpFailure(statusResp, 'run-not-found');
+      const status = await statusResp.json();
+      if (status?.resumable !== true) {
+        const payload = {
+          error: {
+            code: 'run-not-resumable',
+            message: `Run ${id} does not have a safe recoverable native session.`,
+          },
+        };
+        if (flags.json) process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+        else console.error(payload.error.message);
+        process.exit(1);
+      }
+      if (!status.projectId || !status.conversationId) {
+        const payload = {
+          error: {
+            code: 'run-missing-context',
+            message: `Run ${id} is missing project or conversation context.`,
+          },
+        };
+        if (flags.json) process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+        else console.error(payload.error.message);
+        process.exit(1);
+      }
+      const message = await readRunMessageFromFlags(flags, RESUME_CONTINUE_PROMPT);
+      const body = {
+        projectId: status.projectId,
+        conversationId: status.conversationId,
+        message,
+        analyticsHints: { entryFrom: 'resume_continue' },
+        ...(status.agentId ? { agentId: status.agentId } : {}),
+      };
+      const data = await postJsonToDaemon(base, '/api/runs', body);
+      if (flags.json && !flags.follow) {
+        return process.stdout.write(JSON.stringify({
+          ...data,
+          continuedFromRunId: id,
+        }, null, 2) + '\n');
+      }
+      console.log(`[run] continued ${id} as ${data.runId}`);
+      if (flags.follow) await streamRunEvents(base, data.runId);
       return;
     }
     case 'watch': {

--- a/apps/daemon/tests/run-cli.test.ts
+++ b/apps/daemon/tests/run-cli.test.ts
@@ -1,0 +1,156 @@
+import { execFile } from 'node:child_process';
+import http from 'node:http';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileP = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DAEMON_ROOT = pathResolve(__dirname, '..');
+const REPO_ROOT = pathResolve(__dirname, '../../..');
+const CLI_SRC = pathResolve(__dirname, '../src/cli.ts');
+const TSX_CLI = pathResolve(REPO_ROOT, 'node_modules/tsx/dist/cli.mjs');
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  body: string;
+}
+
+interface StubServer {
+  baseUrl: string;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+}
+
+let stub: StubServer | null = null;
+
+afterEach(async () => {
+  if (stub) await stub.close();
+  stub = null;
+});
+
+async function startRunStubServer(resumable: boolean): Promise<StubServer> {
+  const requests: CapturedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => {
+      raw += chunk;
+    });
+    req.on('end', () => {
+      const captured: CapturedRequest = {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        body: raw,
+      };
+      requests.push(captured);
+      res.setHeader('content-type', 'application/json');
+
+      if (captured.method === 'GET' && captured.url === '/api/runs/run-1') {
+        res.statusCode = 200;
+        res.end(JSON.stringify({
+          id: 'run-1',
+          projectId: 'project-1',
+          conversationId: 'conversation-1',
+          agentId: 'claude',
+          status: 'failed',
+          resumable,
+        }));
+        return;
+      }
+
+      if (captured.method === 'POST' && captured.url === '/api/runs') {
+        res.statusCode = 200;
+        res.end(JSON.stringify({ runId: 'run-2' }));
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: { code: 'unexpected-request', message: captured.url } }));
+    });
+  });
+
+  await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('stub server has no address');
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolveClose, rejectClose) => {
+        server.close((err) => (err ? rejectClose(err) : resolveClose()));
+      }),
+  };
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.NODE_OPTIONS;
+  try {
+    const { stdout, stderr } = await execFileP(process.execPath, [TSX_CLI, CLI_SRC, ...args], {
+      cwd: DAEMON_ROOT,
+      env,
+      timeout: 15_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (err) {
+    const failed = err as { stdout?: string; stderr?: string; code?: number | null };
+    return {
+      stdout: failed.stdout ?? '',
+      stderr: failed.stderr ?? '',
+      code: failed.code ?? 1,
+    };
+  }
+}
+
+describe('od run CLI', () => {
+  it('continues a resumable run through the normal run creation API', async () => {
+    stub = await startRunStubServer(true);
+
+    const result = await runCli([
+      'run',
+      'continue',
+      'run-1',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('[run] continued run-1 as run-2\n');
+    expect(stub.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+      'GET /api/runs/run-1',
+      'POST /api/runs',
+    ]);
+    expect(JSON.parse(stub.requests[1]!.body)).toMatchObject({
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      agentId: 'claude',
+      analyticsHints: { entryFrom: 'resume_continue' },
+    });
+    expect(JSON.parse(stub.requests[1]!.body).message).toContain(
+      'The previous turn was interrupted by a transient failure.',
+    );
+  });
+
+  it('refuses to continue a run without a safe recoverable native session', async () => {
+    stub = await startRunStubServer(false);
+
+    const result = await runCli([
+      'run',
+      'continue',
+      'run-1',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Run run-1 does not have a safe recoverable native session.');
+    expect(stub.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+      'GET /api/runs/run-1',
+    ]);
+  });
+});


### PR DESCRIPTION
﻿## What problem are you trying to solve?

The concrete OpenCode report in #744 was not only about token reuse. A run produced useful work and exposed a native OpenCode `sessionID`, but then ended canceled, leaving the user without an obvious way to continue from the actual agent session that did the work.

#4629 solves normal follow-up session reuse for OpenCode/Codex/Pi/AMR, but it does not by itself define a user-facing recovery action for interrupted runs. Once sanitized recovery metadata exists, users need a clear action when a run has a safe recoverable native session.

I searched existing open issues for user-facing native-session continue/recover actions and only found #744 as the umbrella.

## Describe the solution you'd like

Add a user-facing recovery action for interrupted native sessions, available from both the web UI and the `od` CLI when applicable.

Suggested behavior:

- show a continue/recover action only when the daemon has a safe recoverable native session for the run/conversation/agent
- start the next run using the stored native session when all resume guards pass
- fall back to full transcript recompose if the stored native session is stale or unsafe
- make the action understandable without exposing raw native session handles by default
- preserve normal chat follow-up behavior from #4629; this issue is for explicit recovery from interrupted/canceled/ambiguous runs
- keep output preservation concerns linked to #2760 rather than hiding them inside this action

Acceptance criteria:

- Web UI exposes the action from the appropriate run details/debug/recovery surface.
- CLI exposes the same capability through an `od` command or flag using the same daemon API.
- The action is hidden or disabled when no safe native session is available.
- Guard failure falls back safely instead of skipping transcript history.
- Tests cover at least one recoverable native-session run and one stale/unsafe session fallback.

## Alternatives you've considered

Tell users to manually copy the native session id and run the CLI themselves. That is not a coherent Open Design recovery experience and breaks the local-first product abstraction.

Only rely on the next normal chat turn. That handles happy-path follow-ups after #4629, but it does not address the interrupted-run UX that motivated the OpenCode case in #744.

## Additional context

Related:

- #744 umbrella native-resume/sessionMap issue
- #2760 output-preservation bug for useful output dropped after canceled runs
- #4629 OpenCode/Codex/Pi/AMR native resume implementation
- #4790 cursor-agent native resume slice

## Would you be willing to contribute a PR?

Yes, I can take this on.

## Agent-agnostic scope clarification

The recovery action should be a generic Open Design capability, not an OpenCode-specific button.

The UI/CLI wording can use the selected agent's label, but the daemon API should work for any adapter that satisfies the shared session-map and invalidation policy, including Pi and ACP/native agents such as Hermes. The action should ask the shared resume layer whether continuation is safe, then let the adapter perform its own continuation mode (`--resume`, `--continue`, ACP `session/load`, session-file resume, etc.).




---

## PR checklist

Issue-backed PR: #5271 was converted directly into this ready-for-review PR.

## Why

The web chat already exposes the guarded Continue action for resumable failed runs on `main`. This PR adds the matching headless CLI action so users and agents can recover a resumable native-session run without copying raw native handles or replaying the original prompt from scratch.

## What users will see

`od run continue <runId>` checks the daemon run status, refuses runs without `resumable: true`, and starts a normal follow-up run in the same project/conversation/agent with the same `resume_continue` analytics marker used by the web action. `--follow`, `--json`, `--message`, and `--prompt-file` are supported through the existing run CLI flag patterns.

## Surface area

- [ ] **UI** - existing web Continue CTA remains unchanged and was covered by its focused test.
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** - adds `od run continue <runId>`.
- [ ] **API / contract** - uses existing `GET /api/runs/:id` and `POST /api/runs`.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

N/A - no new UI surface in this PR.

## Bug fix verification

- This is a recovery capability slice, not a bug fix. The new CLI tests cover a resumable native-session run and refusal of a stale/unsafe non-resumable run.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/run-cli.test.ts` from `apps/daemon` - 2 passed.
- `pnpm exec vitest run -c vitest.config.ts tests/components/ChatPane.resume-failed.test.tsx` from `apps/web` - 3 passed.
- `pnpm --filter @open-design/daemon typecheck` - passed.

## Validation note

I also attempted `pnpm exec vitest run -c vitest.config.ts tests/run-cli.test.ts tests/run-resume-on-failure.test.ts` from `apps/daemon`. The new `run-cli.test.ts` passed there, but the pre-existing fake-Claude runtime resume test failed locally while not exercising the new CLI command. I kept the focused CLI and web CTA validations above as the relevant checks for this PR.
