### PR TITLE
fix(web): add Kiro MCP client option

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -7362,7 +7362,7 @@ function MediaProvidersSection({
 //
 // Schemas drift between clients in deliberate ways. VS Code keys
 // servers under "servers" with a required "type" field; Zed uses
-// "context_servers"; Cursor, Windsurf, and Antigravity share
+// "context_servers"; Cursor, Kiro, Windsurf, and Antigravity share
 // "mcpServers"; Claude Code is best served by its CLI which writes
 // to the local config for you. Verified against each tool's official
 // docs in May 2026.
@@ -7377,6 +7377,7 @@ type McpClientId =
   | 'claude'
   | 'codex'
   | 'cursor'
+  | 'kiro'
   | 'vscode'
   | 'zed'
   | 'windsurf'
@@ -7639,6 +7640,17 @@ function IntegrationsSection() {
         return `cursor://anysphere.cursor-deeplink/mcp/install?name=open-design&config=${encoded}`;
       },
       deeplinkLabel: () => t('settings.mcpDeeplinkInstallCursor'),
+    },
+    {
+      id: 'kiro',
+      label: 'Kiro CLI',
+      buildMethod: () => t('settings.mcpMethodJson'),
+      buildInstruction: (info) =>
+        t('settings.mcpInstructionKiro', {
+          path: homeConfigPath(info.platform, '~/.kiro/settings/mcp.json', '%USERPROFILE%\\.kiro\\settings\\mcp.json'),
+        }),
+      buildSnippet: buildSharedMcpJson,
+      buildSnippetLang: () => 'json',
     },
     {
       id: 'vscode',

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -572,6 +572,7 @@ export const ar: Dict = {
   'settings.mcpInstructionCursor': 'انقر على "Install in Cursor" للتثبيت عبر مربع حوار للموافقة، أو ادمج ملف JSON هذا في {path}.',
   'settings.mcpDeeplinkInstallCursor': 'التثبيت في Cursor',
   'settings.mcpMethodJson': 'إعداد JSON',
+  'settings.mcpInstructionKiro': 'افتح {path} وادمج ملف JSON هذا. لإعداد على مستوى مساحة العمل، استخدم .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'افتح Command Palette ({shortcut})، وشغّل "MCP: Open User Configuration"، ثم ادمج ملف JSON هذا. يجب أن يكون Copilot Chat في وضع Agent حتى تظهر الأدوات.',
   'settings.mcpInstructionAntigravity': 'في Antigravity: قائمة "..." في لوحة الوكيل ← MCP Servers ← Manage MCP Servers ← View raw config. ادمج هذا الـ JSON.',
   'settings.mcpInstructionZed': 'افتح إعدادات Zed ({shortcut}) وادمج هذا في الكائن ذي المستوى الأعلى. يستخدم Zed "context_servers" وليس "mcpServers".',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -572,6 +572,7 @@ export const de: Dict = {
   'settings.mcpInstructionCursor': 'Klicke auf "In Cursor installieren", um mit einem Bestätigungsdialog zu installieren, oder führe dieses JSON in {path} zusammen.',
   'settings.mcpDeeplinkInstallCursor': 'In Cursor installieren',
   'settings.mcpMethodJson': 'JSON-Konfiguration',
+  'settings.mcpInstructionKiro': 'Öffne {path} und führe dieses JSON zusammen. Für eine Workspace-Konfiguration verwende .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Öffne die Befehlspalette ({shortcut}), führe "MCP: Open User Configuration" aus und führe dieses JSON zusammen. Copilot Chat muss im Agent-Modus sein, damit die Tools angezeigt werden.',
   'settings.mcpInstructionAntigravity': 'In Antigravity: Agent-Panel-Menü "..." → MCP Servers → Manage MCP Servers → View raw config. Führe dieses JSON zusammen.',
   'settings.mcpInstructionZed': 'Öffne die Zed-Einstellungen ({shortcut}) und füge dies in das Objekt der obersten Ebene ein. Zed verwendet "context_servers", nicht "mcpServers".',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -572,6 +572,7 @@ export const en: Dict = {
   'settings.mcpInstructionCursor': 'Click "Install in Cursor" to install with an approval dialog, or merge this JSON into {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Install in Cursor',
   'settings.mcpMethodJson': 'JSON config',
+  'settings.mcpInstructionKiro': 'Open {path} and merge this JSON. For workspace-level config, use .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Open the Command Palette ({shortcut}), run "MCP: Open User Configuration", and merge this JSON. Copilot Chat must be in Agent mode for tools to show up.',
   'settings.mcpInstructionAntigravity': 'In Antigravity: Agent panel "..." menu → MCP Servers → Manage MCP Servers → View raw config. Merge this JSON.',
   'settings.mcpInstructionZed': 'Open Zed Settings ({shortcut}) and merge this into the top-level object. Zed uses "context_servers", not "mcpServers".',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -572,6 +572,7 @@ export const esES: Dict = {
   'settings.mcpInstructionCursor': 'Haz clic en «Install in Cursor» para instalar con un cuadro de diálogo de aprobación, o fusiona este JSON en {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Instalar en Cursor',
   'settings.mcpMethodJson': 'Configuración JSON',
+  'settings.mcpInstructionKiro': 'Abre {path} y combina este JSON. Para la configuración a nivel de workspace, usa .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Abre la paleta de comandos ({shortcut}), ejecuta «MCP: Open User Configuration» y fusiona este JSON. Copilot Chat debe estar en modo Agent para que las herramientas aparezcan.',
   'settings.mcpInstructionAntigravity': 'En Antigravity: menú «...» del panel del Agent → MCP Servers → Manage MCP Servers → View raw config. Combina este JSON.',
   'settings.mcpInstructionZed': 'Abre los Ajustes de Zed ({shortcut}) y fusiona esto en el objeto de nivel superior. Zed usa «context_servers», no «mcpServers».',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -572,6 +572,7 @@ export const fa: Dict = {
   'settings.mcpInstructionCursor': 'برای نصب با یک پنجره تأیید، روی «Install in Cursor» کلیک کنید، یا این JSON را در {path} ادغام کنید.',
   'settings.mcpDeeplinkInstallCursor': 'نصب در Cursor',
   'settings.mcpMethodJson': 'پیکربندی JSON',
+  'settings.mcpInstructionKiro': '{path} را باز کنید و این JSON را ادغام کنید. برای پیکربندی در سطح workspace از .kiro/settings/mcp.json استفاده کنید.',
   'settings.mcpInstructionCopilot': 'Command Palette ({shortcut}) را باز کنید، «MCP: Open User Configuration» را اجرا کنید و این JSON را ادغام کنید. برای نمایش ابزارها، Copilot Chat باید در حالت Agent باشد.',
   'settings.mcpInstructionAntigravity': 'در Antigravity: منوی «...» پنل Agent ← MCP Servers ← Manage MCP Servers ← View raw config. این JSON را ادغام کنید.',
   'settings.mcpInstructionZed': 'تنظیمات Zed ({shortcut}) را باز کنید و این را در شیء سطح‌بالا ادغام کنید. Zed از «context_servers» استفاده می‌کند، نه «mcpServers».',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -572,6 +572,7 @@ export const fr: Dict = {
   'settings.mcpInstructionCursor': 'Cliquez sur « Installer dans Cursor » pour installer avec une boîte de validation, ou fusionnez ce JSON dans {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Installer dans Cursor',
   'settings.mcpMethodJson': 'Configuration JSON',
+  'settings.mcpInstructionKiro': 'Ouvrez {path} et fusionnez ce JSON. Pour une configuration au niveau du workspace, utilisez .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Ouvrez la palette de commandes ({shortcut}), lancez "MCP: Open User Configuration", puis fusionnez ce JSON. Copilot Chat doit être en mode Agent pour afficher les outils.',
   'settings.mcpInstructionAntigravity': 'Dans Antigravity : panneau Agent, menu "..." → MCP Servers → Manage MCP Servers → View raw config. Fusionnez ce JSON.',
   'settings.mcpInstructionZed': 'Ouvrez les réglages Zed ({shortcut}) et fusionnez ceci dans l’objet racine. Zed utilise "context_servers", pas "mcpServers".',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -572,6 +572,7 @@ export const hu: Dict = {
   'settings.mcpInstructionCursor': 'Kattints az „Install in Cursor” gombra a jóváhagyási párbeszédpanellel történő telepítéshez, vagy egyesítsd ezt a JSON-t a következővel: {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Telepítés a Cursorba',
   'settings.mcpMethodJson': 'JSON konfiguráció',
+  'settings.mcpInstructionKiro': 'Nyisd meg ezt: {path}, és egyesítsd ezt a JSON-t. Workspace-szintű konfigurációhoz használd: .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Nyisd meg a Command Palette-et ({shortcut}), futtasd az „MCP: Open User Configuration” parancsot, és egyesítsd ezt a JSON-t. A Copilot Chatnek Agent módban kell lennie, hogy az eszközök megjelenjenek.',
   'settings.mcpInstructionAntigravity': 'Az Antigravityben: Agent panel "..." menü → MCP Servers → Manage MCP Servers → View raw config. Egyesítsd ezt a JSON-t.',
   'settings.mcpInstructionZed': 'Nyisd meg a Zed beállításait ({shortcut}), és egyesítsd ezt a legfelső szintű objektummal. A Zed a „context_servers” kulcsot használja, nem a „mcpServers” kulcsot.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -572,6 +572,7 @@ export const id: Dict = {
   'settings.mcpInstructionCursor': 'Klik "Install in Cursor" untuk memasang dengan dialog persetujuan, atau gabungkan JSON ini ke {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Install di Cursor',
   'settings.mcpMethodJson': 'Konfigurasi JSON',
+  'settings.mcpInstructionKiro': 'Buka {path} dan gabungkan JSON ini. Untuk konfigurasi level workspace, gunakan .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Buka Command Palette ({shortcut}), jalankan "MCP: Open User Configuration", dan gabungkan JSON ini. Copilot Chat harus dalam mode Agent agar tools muncul.',
   'settings.mcpInstructionAntigravity': 'Di Antigravity: panel Agent menu "..." → MCP Servers → Manage MCP Servers → View raw config. Gabungkan JSON ini.',
   'settings.mcpInstructionZed': 'Buka Zed Settings ({shortcut}) dan gabungkan ini ke dalam objek tingkat atas. Zed menggunakan "context_servers", bukan "mcpServers".',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -572,6 +572,7 @@ export const it: Dict = {
   'settings.mcpInstructionCursor': 'Fai clic su "Install in Cursor" per installare con una finestra di approvazione, oppure unisci questo JSON in {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Installa in Cursor',
   'settings.mcpMethodJson': 'Configurazione JSON',
+  'settings.mcpInstructionKiro': 'Apri {path} e unisci questo JSON. Per la configurazione a livello di workspace, usa .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Apri la Command Palette ({shortcut}), esegui "MCP: Open User Configuration" e unisci questo JSON. Copilot Chat deve essere in modalità Agent affinché gli strumenti vengano visualizzati.',
   'settings.mcpInstructionAntigravity': 'In Antigravity: pannello Agent, menu "..." → MCP Servers → Manage MCP Servers → View raw config. Unisci questo JSON.',
   'settings.mcpInstructionZed': 'Apri le impostazioni di Zed ({shortcut}) e unisci questo nell\'oggetto di livello superiore. Zed usa "context_servers", non "mcpServers".',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -572,6 +572,7 @@ export const ja: Dict = {
   'settings.mcpInstructionCursor': '「Install in Cursor」をクリックして承認ダイアログ付きでインストールするか、このJSONを {path} にマージしてください。',
   'settings.mcpDeeplinkInstallCursor': 'Cursor にインストール',
   'settings.mcpMethodJson': 'JSON設定',
+  'settings.mcpInstructionKiro': '{path} を開き、このJSONをマージしてください。ワークスペースレベルの設定には .kiro/settings/mcp.json を使用します。',
   'settings.mcpInstructionCopilot': 'コマンドパレット（{shortcut}）を開き、「MCP: Open User Configuration」を実行して、このJSONをマージしてください。ツールを表示するには、Copilot ChatがAgentモードである必要があります。',
   'settings.mcpInstructionAntigravity': 'Antigravity の場合：Agent パネルの「...」メニュー → MCP Servers → Manage MCP Servers → View raw config。この JSON をマージしてください。',
   'settings.mcpInstructionZed': 'Zedの設定（{shortcut}）を開き、これをトップレベルのオブジェクトにマージしてください。Zedは「mcpServers」ではなく「context_servers」を使用します。',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -572,6 +572,7 @@ export const ko: Dict = {
   'settings.mcpInstructionCursor': '"Install in Cursor"를 클릭하여 승인 대화상자와 함께 설치하거나, 이 JSON을 {path}에 병합하세요.',
   'settings.mcpDeeplinkInstallCursor': 'Cursor에 설치',
   'settings.mcpMethodJson': 'JSON 설정',
+  'settings.mcpInstructionKiro': '{path}을(를) 열고 이 JSON을 병합하세요. 워크스페이스 수준 설정은 .kiro/settings/mcp.json을 사용하세요.',
   'settings.mcpInstructionCopilot': 'Command Palette({shortcut})를 열고 "MCP: Open User Configuration"을 실행한 후 이 JSON을 병합하세요. 도구가 표시되려면 Copilot Chat이 Agent 모드여야 합니다.',
   'settings.mcpInstructionAntigravity': 'Antigravity에서: Agent 패널 "..." 메뉴 → MCP Servers → Manage MCP Servers → View raw config. 이 JSON을 병합하세요.',
   'settings.mcpInstructionZed': 'Zed 설정({shortcut})을 열고 이것을 최상위 객체에 병합하세요. Zed는 "mcpServers"가 아닌 "context_servers"를 사용합니다.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -572,6 +572,7 @@ export const pl: Dict = {
   'settings.mcpInstructionCursor': 'Kliknij „Install in Cursor”, aby zainstalować z oknem zatwierdzenia, lub scal ten JSON z {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Zainstaluj w Cursor',
   'settings.mcpMethodJson': 'Konfiguracja JSON',
+  'settings.mcpInstructionKiro': 'Otwórz {path} i scal ten JSON. Dla konfiguracji na poziomie workspace użyj .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Otwórz Command Palette ({shortcut}), uruchom „MCP: Open User Configuration” i scal ten JSON. Copilot Chat musi być w trybie Agent, aby narzędzia się pojawiły.',
   'settings.mcpInstructionAntigravity': 'W Antigravity: panel Agent, menu „...” → MCP Servers → Manage MCP Servers → View raw config. Scal ten JSON.',
   'settings.mcpInstructionZed': 'Otwórz Zed Settings ({shortcut}) i scal to z obiektem najwyższego poziomu. Zed używa „context_servers”, a nie „mcpServers”.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -572,6 +572,7 @@ export const ptBR: Dict = {
   'settings.mcpInstructionCursor': 'Clique em "Install in Cursor" para instalar com um diálogo de aprovação, ou mescle este JSON em {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Instalar no Cursor',
   'settings.mcpMethodJson': 'Configuração JSON',
+  'settings.mcpInstructionKiro': 'Abra {path} e mescle este JSON. Para configuração no nível do workspace, use .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Abra a Command Palette ({shortcut}), execute "MCP: Open User Configuration" e mescle este JSON. O Copilot Chat precisa estar em modo Agent para que as ferramentas apareçam.',
   'settings.mcpInstructionAntigravity': 'No Antigravity: menu "..." do painel do Agent → MCP Servers → Manage MCP Servers → View raw config. Mescle este JSON.',
   'settings.mcpInstructionZed': 'Abra as Zed Settings ({shortcut}) e mescle isto no objeto de nível superior. O Zed usa "context_servers", não "mcpServers".',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -572,6 +572,7 @@ export const ru: Dict = {
   'settings.mcpInstructionCursor': 'Нажмите «Install in Cursor», чтобы установить с диалогом подтверждения, или объедините этот JSON с {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Установить в Cursor',
   'settings.mcpMethodJson': 'Конфигурация JSON',
+  'settings.mcpInstructionKiro': 'Откройте {path} и объедините этот JSON. Для конфигурации на уровне workspace используйте .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Откройте палитру команд ({shortcut}), выполните «MCP: Open User Configuration» и объедините этот JSON. Чтобы инструменты отображались, Copilot Chat должен находиться в режиме Agent.',
   'settings.mcpInstructionAntigravity': 'В Antigravity: меню «...» панели Agent → MCP Servers → Manage MCP Servers → View raw config. Объедините этот JSON.',
   'settings.mcpInstructionZed': 'Откройте настройки Zed ({shortcut}) и объедините это с объектом верхнего уровня. Zed использует «context_servers», а не «mcpServers».',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -572,6 +572,7 @@ export const th: Dict = {
   'settings.mcpInstructionCursor': 'คลิก "Install in Cursor" เพื่อติดตั้งพร้อมกล่องโต้ตอบขออนุมัติ หรือผสาน JSON นี้เข้ากับ {path}',
   'settings.mcpDeeplinkInstallCursor': 'ติดตั้งใน Cursor',
   'settings.mcpMethodJson': 'การตั้งค่า JSON',
+  'settings.mcpInstructionKiro': 'เปิด {path} แล้วรวม JSON นี้ สำหรับการตั้งค่าระดับ workspace ให้ใช้ .kiro/settings/mcp.json',
   'settings.mcpInstructionCopilot': 'เปิด Command Palette ({shortcut}) รัน "MCP: Open User Configuration" แล้วผสาน JSON นี้ Copilot Chat ต้องอยู่ในโหมด Agent เพื่อให้เครื่องมือแสดงขึ้นมา',
   'settings.mcpInstructionAntigravity': 'ใน Antigravity: เมนู "..." ของแผง Agent → MCP Servers → Manage MCP Servers → View raw config แล้วรวม JSON นี้',
   'settings.mcpInstructionZed': 'เปิด Zed Settings ({shortcut}) แล้วผสานสิ่งนี้เข้ากับอ็อบเจกต์ระดับบนสุด Zed ใช้ "context_servers" ไม่ใช่ "mcpServers"',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -572,6 +572,7 @@ export const tr: Dict = {
   'settings.mcpInstructionCursor': 'Onay iletişim kutusuyla kurmak için "Cursor\'a Kur"a tıklayın veya bu JSON\'u {path} dosyasıyla birleştirin.',
   'settings.mcpDeeplinkInstallCursor': 'Cursor\'a Kur',
   'settings.mcpMethodJson': 'JSON yapılandırması',
+  'settings.mcpInstructionKiro': "{path} dosyasını açın ve bu JSON'u birleştirin. Workspace düzeyi yapılandırma için .kiro/settings/mcp.json kullanın.",
   'settings.mcpInstructionCopilot': 'Komut Paletini ({shortcut}) açın, "MCP: Open User Configuration" komutunu çalıştırın ve bu JSON\'u birleştirin. Araçların görünmesi için Copilot Chat\'in Agent modunda olması gerekir.',
   'settings.mcpInstructionAntigravity': 'Antigravity\'de: Agent paneli "..." menüsü → MCP Servers → Manage MCP Servers → View raw config. Bu JSON\'u birleştirin.',
   'settings.mcpInstructionZed': 'Zed Ayarlarını ({shortcut}) açın ve bunu en üst düzey nesneyle birleştirin. Zed, "mcpServers" değil "context_servers" kullanır.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -572,6 +572,7 @@ export const uk: Dict = {
   'settings.mcpInstructionCursor': 'Натисніть «Install in Cursor», щоб встановити з діалогом підтвердження, або об’єднайте цей JSON у {path}.',
   'settings.mcpDeeplinkInstallCursor': 'Встановити в Cursor',
   'settings.mcpMethodJson': 'Конфігурація JSON',
+  'settings.mcpInstructionKiro': 'Відкрийте {path} і об’єднайте цей JSON. Для конфігурації на рівні workspace використовуйте .kiro/settings/mcp.json.',
   'settings.mcpInstructionCopilot': 'Відкрийте палітру команд ({shortcut}), виконайте «MCP: Open User Configuration» і об’єднайте цей JSON. Copilot Chat має бути в режимі Agent, щоб інструменти з’явилися.',
   'settings.mcpInstructionAntigravity': 'В Antigravity: меню «...» панелі Agent → MCP Servers → Manage MCP Servers → View raw config. Об’єднайте цей JSON.',
   'settings.mcpInstructionZed': 'Відкрийте налаштування Zed ({shortcut}) і об’єднайте це з об’єктом верхнього рівня. Zed використовує «context_servers», а не «mcpServers».',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -582,6 +582,8 @@ export const zhCN: Dict = {
     '点击"在 Cursor 中安装"以通过确认对话框安装，或将此 JSON 合并到 {path}。',
   "settings.mcpDeeplinkInstallCursor": "在 Cursor 中安装",
   "settings.mcpMethodJson": "JSON 配置",
+  "settings.mcpInstructionKiro":
+    "打开 {path} 并合并此 JSON。对于 workspace 级配置，请使用 .kiro/settings/mcp.json。",
   "settings.mcpInstructionCopilot":
     '打开命令面板（{shortcut}），运行 "MCP: Open User Configuration"，然后合并此 JSON。Copilot Chat 必须处于 Agent 模式，工具才会显示。',
   "settings.mcpInstructionAntigravity":

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -584,6 +584,8 @@ export const zhTW: Dict = {
     "點擊「在 Cursor 中安裝」以透過核准對話框安裝，或將此 JSON 合併至 {path}。",
   "settings.mcpDeeplinkInstallCursor": "在 Cursor 中安裝",
   "settings.mcpMethodJson": "JSON 設定檔",
+  "settings.mcpInstructionKiro":
+    "開啟 {path} 並合併此 JSON。若要使用 workspace 層級設定，請使用 .kiro/settings/mcp.json。",
   "settings.mcpInstructionCopilot":
     "開啟 Command Palette（{shortcut}），執行「MCP: Open User Configuration」，然後合併此 JSON。Copilot Chat 必須處於 Agent 模式，工具才會顯示。",
   "settings.mcpInstructionAntigravity":

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -885,6 +885,7 @@ export interface Dict {
   'settings.mcpInstructionCursor': string;
   'settings.mcpDeeplinkInstallCursor': string;
   'settings.mcpMethodJson': string;
+  'settings.mcpInstructionKiro': string;
   'settings.mcpInstructionCopilot': string;
   'settings.mcpInstructionAntigravity': string;
   'settings.mcpInstructionZed': string;


### PR DESCRIPTION
## Summary

- Add Kiro CLI to the Settings MCP server client picker.
- Generate the shared `mcpServers` JSON snippet for `~/.kiro/settings/mcp.json`.
- Add the Kiro MCP instruction key across all web locales.

Fixes #5079

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Validation

- `git diff --check`
- `npx pnpm@10.33.2 i18n:check`
- `npx pnpm@10.33.2 typecheck`
- `npx pnpm@10.33.2 guard`

Note: local validation ran with Node v25.9.0, so the repo's `~24` engine warning appeared, but the checks exited successfully.
