### PR TITLE
Team collaboration (2/3): daemon backend + CLI

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -195,6 +195,8 @@ const CONFIG_STRING_FLAGS = new Set(['daemon-url', 'value', 'value-json']);
 const CONFIG_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
 const AMR_STRING_FLAGS = new Set(['daemon-url']);
 const AMR_BOOLEAN_FLAGS = new Set(['help', 'h', 'json', 'refresh']);
+const COLLAB_STRING_FLAGS = new Set(['daemon-url', 'project', 'member', 'name', 'role', 'design-system']);
+const COLLAB_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
 const PROJECT_STRING_FLAGS = new Set([
   'daemon-url', 'name', 'skill', 'design-system', 'plugin', 'metadata-json',
   'pending-prompt', 'project', 'conversation', 'message', 'prompt',
@@ -311,6 +313,7 @@ const SUBCOMMAND_MAP = {
   media: runMedia,
   mcp: runMcp,
   amr: runAmr,
+  collab: runCollab,
   research: runResearch,
   plugin: runPlugin,
   ui: runUi,
@@ -683,6 +686,242 @@ Options:
     }
     default:
       console.error(`unknown subcommand: od amr ${sub}`);
+      process.exit(2);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: od collab …  (team-edition collaboration)
+// ---------------------------------------------------------------------------
+
+function printCollabHelp() {
+  console.log(`Usage:
+  od collab status <projectId> [--json]
+  od collab presence <projectId> [--json]
+  od collab heartbeat <projectId> --member <id> [--name <name>] [--role owner|admin|member] [--json]
+  od collab leave <projectId> --member <id> [--json]
+  od collab changed <projectId> [--json]
+  od collab publish <projectId> [--json]
+  od collab share <projectId> [--json]
+  od collab pull <projectId> [--json]
+  od collab share-resource <design-systems|plugins|skills> <id> [--json]
+  od collab team-resources <design-systems|plugins|skills> [--json]
+  od collab share-design-system <designSystemId> [--json]
+  od collab team-design-systems [--json]
+
+Team-edition collaboration: presence overlay + sync trigger. The
+client is authoritative about whether it is in a shared context, so it drives
+the trigger; the daemon coalesces author edits and flushes at a run boundary,
+advancing the published head version members poll to learn when to pull.
+\`share\` is the team-share intent: it requests the project be published so
+members can pull it, and reports the sync state (local_only / pending_upload /
+synced / sync_failed). \`share-resource <kind> <id>\` promotes a personal design
+system, plugin, or skill into the team scope through the resource hub, and
+\`team-resources <kind>\` lists the ones already shared (the \`*-design-system\`
+forms are kept as aliases).
+
+Options:
+  --project <id>          Project id (alternative to the positional argument).
+  --design-system <id>    Design system id for share-design-system.
+  --member <id>           Member id for the presence heartbeat / leave.
+  --name <name>           Display name attached to a heartbeat.
+  --role <role>           owner | admin | member.
+  --json                  Emit raw JSON.
+  --daemon-url <url>      Override daemon URL.
+
+Examples:
+  od collab presence p1 --json
+  od collab heartbeat p1 --member m-42 --name "Ma Shu" --role member
+  od collab publish p1
+  od collab share-resource plugins my-plugin --json
+  od collab team-resources skills --json
+  od collab share-design-system user:palette-x --json
+  od collab status p1 --json`);
+}
+
+async function runCollab(args) {
+  const sub = args[0];
+  if (!sub || sub === 'help' || args.includes('--help') || args.includes('-h')) {
+    printCollabHelp();
+    process.exit(!sub ? 2 : 0);
+  }
+  const rest = args.slice(1);
+  let flags;
+  try {
+    flags = parseFlags(rest, { string: COLLAB_STRING_FLAGS, boolean: COLLAB_BOOLEAN_FLAGS });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(2);
+  }
+  // Team resource sharing (design systems / plugins / skills) is workspace-scoped
+  // — it takes a resource id, not a project id — so it runs before the project-id
+  // requirement below. `share-resource <kind> <id>` / `team-resources <kind>` are
+  // the generic forms; the design-system aliases are kept for compatibility.
+  const RESOURCE_BASE_PATHS = new Set(['design-systems', 'plugins', 'skills']);
+  if (
+    sub === 'share-resource' ||
+    sub === 'team-resources' ||
+    sub === 'share-design-system' ||
+    sub === 'team-design-systems'
+  ) {
+    const base = await cliDaemonBaseUrl(flags);
+    const emit = (payload, plain) =>
+      flags.json ? process.stdout.write(JSON.stringify(payload, null, 2) + '\n') : plain();
+    const wsRequest = async (method, path, body) => {
+      let resp;
+      try {
+        resp = await fetch(`${base}${path}`, {
+          method,
+          ...(body !== undefined
+            ? { headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) }
+            : {}),
+        });
+      } catch (err) {
+        surfaceFetchError(err, base);
+        process.exit(3);
+      }
+      if (!resp.ok) return structuredHttpFailure(resp);
+      return resp.json();
+    };
+
+    // Resolve the resource kind (URL base path), whether this lists or shares,
+    // and the target id — from either the aliases or the generic <kind> <id>.
+    const positionals = positionalArgs(rest, COLLAB_STRING_FLAGS);
+    let basePath;
+    let isList;
+    let resourceId;
+    if (sub === 'team-design-systems') {
+      basePath = 'design-systems';
+      isList = true;
+    } else if (sub === 'share-design-system') {
+      basePath = 'design-systems';
+      isList = false;
+      resourceId = flags['design-system'] || positionals[0];
+    } else {
+      basePath = positionals[0];
+      if (!RESOURCE_BASE_PATHS.has(basePath)) {
+        console.error('kind must be one of: design-systems | plugins | skills');
+        process.exit(2);
+      }
+      isList = sub === 'team-resources';
+      resourceId = positionals[1];
+    }
+
+    if (isList) {
+      const body = await wsRequest('GET', `/api/workspace/${basePath}/team`);
+      return emit(body, () => {
+        const ids = Array.isArray(body?.ids) ? body.ids : [];
+        if (ids.length === 0) return console.log(`no shared ${basePath}`);
+        for (const id of ids) console.log(id);
+      });
+    }
+    if (!resourceId) {
+      console.error('missing <id>');
+      process.exit(2);
+    }
+    const body = await wsRequest(
+      'POST',
+      `/api/workspace/${basePath}/${encodeURIComponent(resourceId)}/share`,
+    );
+    return emit(body, () =>
+      console.log(`shared=${body?.shared ?? false}\tversion=${body?.version ?? '-'}`),
+    );
+  }
+
+  const projectId =
+    flags.project || positionalArgs(rest, COLLAB_STRING_FLAGS)[0] || process.env.OD_PROJECT_ID;
+  if (!projectId) {
+    console.error('missing <projectId> (positional, --project, or OD_PROJECT_ID)');
+    process.exit(2);
+  }
+  const base = await cliDaemonBaseUrl(flags);
+  const encoded = encodeURIComponent(projectId);
+
+  const request = async (method, path, body) => {
+    let resp;
+    try {
+      resp = await fetch(`${base}/api/projects/${encoded}${path}`, {
+        method,
+        ...(body !== undefined
+          ? { headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) }
+          : {}),
+      });
+    } catch (err) {
+      surfaceFetchError(err, base);
+      process.exit(3);
+    }
+    if (!resp.ok) return structuredHttpFailure(resp);
+    return resp.json();
+  };
+
+  const emit = (payload, plain) => {
+    if (flags.json) return process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return plain();
+  };
+
+  switch (sub) {
+    case 'status': {
+      const body = await request('GET', '/collab/status');
+      return emit(body, () => {
+        console.log(`publishedVersion\t${body?.publishedVersion ?? '-'}`);
+        console.log(`syncState\t${body?.syncState ?? '-'}`);
+      });
+    }
+    case 'share': {
+      // Team-share intent: request the project be published so members can pull.
+      const body = await request('POST', '/collab/sync-intent', {
+        event: 'project_team_share_requested',
+        projectId,
+      });
+      return emit(body, () => console.log(`ok\tsyncState=${body?.syncState ?? '-'}`));
+    }
+    case 'pull': {
+      // Member pull: fetch the published head (E extracts the bytes behind C's trigger).
+      const body = await request('POST', '/collab/pull');
+      return emit(body, () => console.log(`pulled\tversion=${body?.version ?? '-'}`));
+    }
+    case 'presence': {
+      const body = await request('GET', '/presence');
+      return emit(body, () => {
+        const present = Array.isArray(body?.present) ? body.present : [];
+        if (present.length === 0) return console.log('no members present');
+        for (const m of present) console.log(`${m.memberId}\t${m.name ?? '-'}\t${m.role ?? '-'}`);
+      });
+    }
+    case 'heartbeat': {
+      if (!flags.member) {
+        console.error('missing --member <id>');
+        process.exit(2);
+      }
+      const memberBody = {
+        memberId: flags.member,
+        ...(flags.name ? { name: flags.name } : {}),
+        ...(flags.role ? { role: flags.role } : {}),
+      };
+      const body = await request('POST', '/presence/heartbeat', memberBody);
+      return emit(body, () => {
+        const present = Array.isArray(body?.present) ? body.present : [];
+        console.log(`ok\t${present.length} present`);
+      });
+    }
+    case 'leave': {
+      if (!flags.member) {
+        console.error('missing --member <id>');
+        process.exit(2);
+      }
+      const body = await request('POST', '/presence/leave', { memberId: flags.member });
+      return emit(body, () => console.log('left'));
+    }
+    case 'changed': {
+      const body = await request('POST', '/collab/changed');
+      return emit(body, () => console.log('change queued'));
+    }
+    case 'publish': {
+      const body = await request('POST', '/collab/publish');
+      return emit(body, () => console.log('publish requested'));
+    }
+    default:
+      console.error(`unknown subcommand: od collab ${sub}`);
       process.exit(2);
   }
 }

--- a/apps/daemon/src/collab/presence-tracker.ts
+++ b/apps/daemon/src/collab/presence-tracker.ts
@@ -1,0 +1,92 @@
+// Team collaboration presence — the "presence" overlay: who is currently viewing a
+// shared project. Decoupled from the resource/sync layer: it is a
+// lightweight, poll-friendly heartbeat set, not a realtime-cursor engine (live
+// cursors were cut; content is polled).
+//
+// Pure and timer-free by design. `present()` computes the live set on demand and
+// sweeps anyone whose heartbeat has aged past the TTL, so the orchestrator's
+// existing poll loop surfaces departures without a background timer. Explicit
+// join/leave fire `onChange` immediately so an active viewer's arrival/exit can
+// be broadcast without waiting for the next poll.
+
+import type { CollabPresenceMember } from '@open-design/contracts';
+
+// The presence identity shape is the shared contract DTO; keep the local name
+// for existing daemon-side imports.
+export type PresenceMember = CollabPresenceMember;
+
+export interface CollabPresenceTrackerOptions {
+  /** A member is considered gone this long after their last heartbeat. */
+  ttlMs?: number;
+  now?: () => number;
+  /** Fired when a project's present set changes via an explicit join or leave. */
+  onChange?: (result: { projectId: string; present: PresenceMember[] }) => void;
+}
+
+interface Entry {
+  member: PresenceMember;
+  lastSeen: number;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+
+export class CollabPresenceTracker {
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly onChange?: CollabPresenceTrackerOptions['onChange'];
+  private readonly projects = new Map<string, Map<string, Entry>>();
+
+  constructor(options: CollabPresenceTrackerOptions = {}) {
+    this.ttlMs = Math.max(0, options.ttlMs ?? DEFAULT_TTL_MS);
+    this.now = options.now ?? Date.now;
+    this.onChange = options.onChange;
+  }
+
+  /** Mark a member present in a project (call on view + on each poll). */
+  heartbeat(projectId: string, member: PresenceMember): void {
+    const entries = this.ensure(projectId);
+    const isNew = !entries.has(member.memberId);
+    entries.set(member.memberId, { member, lastSeen: this.now() });
+    if (isNew) this.emit(projectId);
+  }
+
+  /** Explicit departure (tab closed / left the project). */
+  leave(projectId: string, memberId: string): void {
+    const entries = this.projects.get(projectId);
+    if (!entries || !entries.delete(memberId)) return;
+    if (entries.size === 0) this.projects.delete(projectId);
+    this.emit(projectId);
+  }
+
+  /** Members present now — sweeps any whose heartbeat aged past the TTL. */
+  present(projectId: string): PresenceMember[] {
+    const entries = this.projects.get(projectId);
+    if (!entries) return [];
+    const cutoff = this.now() - this.ttlMs;
+    for (const [memberId, entry] of entries) {
+      if (entry.lastSeen < cutoff) entries.delete(memberId);
+    }
+    if (entries.size === 0) {
+      this.projects.delete(projectId);
+      return [];
+    }
+    return Array.from(entries.values(), (entry) => entry.member);
+  }
+
+  dispose(): void {
+    this.projects.clear();
+  }
+
+  private emit(projectId: string): void {
+    if (this.onChange) this.onChange({ projectId, present: this.present(projectId) });
+  }
+
+  private ensure(projectId: string): Map<string, Entry> {
+    let entries = this.projects.get(projectId);
+    if (!entries) {
+      entries = new Map();
+      this.projects.set(projectId, entries);
+    }
+    return entries;
+  }
+}

--- a/apps/daemon/src/collab/publish-scheduler.ts
+++ b/apps/daemon/src/collab/publish-scheduler.ts
@@ -1,0 +1,144 @@
+// Team collaboration sync trigger — the author-side "trigger + orchestration" that the sync trigger owns.
+//
+// It does NOT implement the resource store: publishing content + advancing the
+// `published` ref is the resource hub (the resource-hub owner, the resource hub the spec = createVersion + setRef).
+// C's job is *when* to publish: coalesce rapid author edits into one publish so
+// half-written intermediate states never reach members, flush at run boundaries,
+// and — on success — let the orchestrator notify online members to pull.
+//
+// Invariant: notification happens strictly AFTER the adapter's
+// publish resolves (content durable, pointer moved), so members are never told to
+// pull a version that is not yet durable. The adapter is expected to resolve only
+// on durable success (E's atomic write); this scheduler adds the coalescing.
+
+export interface ResourcePublishAdapter {
+  /**
+   * Publish the current state of a project's sync unit to the resource hub and
+   * advance its `published` ref. Resolves ONLY after the content is durably
+   * written (content-first / pointer-last). Returns the new version, or null if
+   * there was nothing to publish.
+   */
+  publish(input: { projectId: string; reason: string }): Promise<{ version: number } | null>;
+  /**
+   * Read the currently-published head for a project. The scheduler decides
+   * *when* a member pulls; the adapter reports what head is available. Optional:
+   * the local stub reports the in-memory head; the real hub adapter resolves the
+   * published ref. Returns null when nothing has been published yet.
+   */
+  syncLatest?(input: { projectId: string }): Promise<{ version: number } | null>;
+  /**
+   * Materialize the published tree into the member's local copy. Optional: the
+   * local stub has no bytes to fetch; the real hub adapter fetches the missing
+   * blobs and writes the files. The scheduler decides *when* to pull.
+   */
+  pull?(input: { projectId: string }): Promise<void>;
+}
+
+export interface CollabPublishSchedulerOptions {
+  adapter: ResourcePublishAdapter;
+  /** Coalesce window (ms). Rapid changes within it collapse into one publish. */
+  debounceMs?: number;
+  /** Fired after a successful publish so the orchestrator can notify members. */
+  onPublished?: (result: { projectId: string; version: number; reason: string }) => void;
+  onError?: (result: { projectId: string; error: unknown }) => void;
+}
+
+interface ProjectState {
+  timer: ReturnType<typeof setTimeout> | null;
+  reason: string;
+  publishing: boolean;
+  /** A change arrived while a publish was in flight → re-publish after it settles. */
+  dirty: boolean;
+  dirtyReason: string;
+}
+
+const DEFAULT_DEBOUNCE_MS = 400;
+
+export class CollabPublishScheduler {
+  private readonly adapter: ResourcePublishAdapter;
+  private readonly debounceMs: number;
+  private readonly onPublished?: CollabPublishSchedulerOptions['onPublished'];
+  private readonly onError?: CollabPublishSchedulerOptions['onError'];
+  private readonly projects = new Map<string, ProjectState>();
+
+  constructor(options: CollabPublishSchedulerOptions) {
+    this.adapter = options.adapter;
+    this.debounceMs = Math.max(0, options.debounceMs ?? DEFAULT_DEBOUNCE_MS);
+    this.onPublished = options.onPublished;
+    this.onError = options.onError;
+  }
+
+  /** An author-side change to a project. Publishes are coalesced within the window. */
+  notifyChanged(projectId: string, reason = 'change'): void {
+    const state = this.ensure(projectId);
+    state.reason = reason;
+    if (state.publishing) {
+      // Don't interrupt an in-flight publish — mark dirty so a fresh one runs
+      // after it settles (last-write-wins; the change is never lost).
+      state.dirty = true;
+      state.dirtyReason = reason;
+      return;
+    }
+    if (state.timer) clearTimeout(state.timer);
+    state.timer = setTimeout(() => {
+      void this.flush(projectId);
+    }, this.debounceMs);
+  }
+
+  /**
+   * Run boundary — flush any pending publish immediately instead of waiting out
+   * the debounce, so members see the stable end-of-run state promptly.
+   */
+  runBoundary(projectId: string): void {
+    const state = this.projects.get(projectId);
+    if (!state) return;
+    if (state.timer) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+    if (state.publishing) {
+      state.dirty = true;
+      state.dirtyReason = state.reason;
+      return;
+    }
+    void this.flush(projectId);
+  }
+
+  /** Cancel all pending timers (shutdown). */
+  dispose(): void {
+    for (const state of this.projects.values()) {
+      if (state.timer) clearTimeout(state.timer);
+    }
+    this.projects.clear();
+  }
+
+  private async flush(projectId: string): Promise<void> {
+    const state = this.projects.get(projectId);
+    if (!state || state.publishing) return;
+    state.timer = null;
+    state.publishing = true;
+    const reason = state.reason;
+    try {
+      const result = await this.adapter.publish({ projectId, reason });
+      if (result) this.onPublished?.({ projectId, version: result.version, reason });
+    } catch (error) {
+      this.onError?.({ projectId, error });
+    } finally {
+      state.publishing = false;
+      if (state.dirty) {
+        state.dirty = false;
+        // A change landed during the publish — schedule a fresh one.
+        this.notifyChanged(projectId, state.dirtyReason || 'change');
+      }
+    }
+  }
+
+  private ensure(projectId: string): ProjectState {
+    let state = this.projects.get(projectId);
+    if (!state) {
+      state = { timer: null, reason: 'change', publishing: false, dirty: false, dirtyReason: 'change' };
+      this.projects.set(projectId, state);
+    }
+    return state;
+  }
+}

--- a/apps/daemon/src/collab/resource-hub-publish-adapter.ts
+++ b/apps/daemon/src/collab/resource-hub-publish-adapter.ts
@@ -1,0 +1,131 @@
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import {
+  createResourceHubClient,
+  readResourceHubConfig,
+  readResourceHubPrincipal,
+  ResourceHubError,
+  type ResourceHubClient,
+  type ResourceHubPrincipal,
+} from '../integrations/resource-hub.js';
+import { materializeRef, packTree, pushTree } from '../resource-drive.js';
+import type { ResourcePublishAdapter } from './publish-scheduler.js';
+
+// Binds the sync trigger to the resource hub. The scheduler decides *when* to
+// publish/pull; this wraps the neutral resource-drive SDK (packTree + pushTree +
+// materializeRef) as the ResourcePublishAdapter. The principal is resolved
+// lazily per call (getPrincipal), so it tracks the current signed-in identity
+// and no-ops (degrades) when there is no team identity — that is the single
+// identity gate shared with the web collab surface.
+
+/** Derive the hub principal from the one workspace context. Null off-team. */
+export function contextToResourceHubPrincipal(
+  context: WorkspaceCollabContext | null,
+): ResourceHubPrincipal | null {
+  if (!context || context.workspaceType !== 'team' || !context.teamId) return null;
+  return {
+    memberId: context.workspaceMemberId,
+    teamId: context.teamId,
+    role: context.role,
+    lifecycleState: context.lifecycleState,
+  };
+}
+
+export interface ResourceHubPublishAdapterOptions {
+  client: ResourceHubClient;
+  /** Resolve the current principal (null = no team identity → degrade to no-op). */
+  getPrincipal: () => ResourceHubPrincipal | null | Promise<ResourceHubPrincipal | null>;
+  /** The project's source directory to publish (managed-project root). */
+  resolveProjectDir: (projectId: string) => string | Promise<string>;
+  /** Where a member materializes pulled content. Defaults to the project dir. */
+  resolvePullDir?: (projectId: string) => string | Promise<string>;
+  /** projectId → hub resourceId. Colon-free (the hub routes it as a path param). */
+  resourceIdFor?: (projectId: string) => string;
+  /**
+   * Hub resource kind. Defaults to `project`; a design-system or plugin share
+   * passes its own kind so the same publish/pull machinery serves every
+   * shareable resource type without a parallel adapter.
+   */
+  kind?: string;
+}
+
+const PUBLISHED_REF = 'published';
+const PROJECT_KIND = 'project';
+
+export function createResourceHubPublishAdapter(
+  options: ResourceHubPublishAdapterOptions,
+): ResourcePublishAdapter {
+  const { client, getPrincipal, resolveProjectDir } = options;
+  const resolvePullDir = options.resolvePullDir ?? resolveProjectDir;
+  const resourceIdFor = options.resourceIdFor ?? ((projectId: string) => `project-${projectId}`);
+  const kind = options.kind ?? PROJECT_KIND;
+
+  // The resource must exist before a version is published. Get-or-create keeps
+  // publish idempotent across the first and later shares of a project.
+  async function ensureResourceId(principal: ResourceHubPrincipal, projectId: string): Promise<string> {
+    const resourceId = resourceIdFor(projectId);
+    try {
+      const existing = await client.getResource(principal, resourceId);
+      return existing.id;
+    } catch (error) {
+      if (!(error instanceof ResourceHubError) || error.status !== 404) throw error;
+      const created = await client.createResource(principal, { kind, resourceId });
+      return created.id;
+    }
+  }
+
+  return {
+    async publish({ projectId }) {
+      const principal = await getPrincipal();
+      if (!principal) return null; // no team identity → nothing to publish
+      const packed = await packTree(await resolveProjectDir(projectId));
+      const resourceId = await ensureResourceId(principal, projectId);
+      // pushTree uploads only missing blobs, publishes a version, and moves the
+      // `published` ref atomically (content-first, pointer-last).
+      const version = await pushTree(client, principal, resourceId, packed, { ref: PUBLISHED_REF });
+      return { version: version.version };
+    },
+
+    async syncLatest({ projectId }) {
+      const principal = await getPrincipal();
+      if (!principal) return null;
+      const resourceId = resourceIdFor(projectId);
+      let ref;
+      try {
+        ref = await client.getRef(principal, resourceId, PUBLISHED_REF);
+      } catch {
+        return null; // nothing published yet
+      }
+      const versions = await client.listVersions(principal, resourceId);
+      const version = versions.find((candidate) => candidate.id === ref.versionId);
+      return version ? { version: version.version } : null;
+    },
+
+    // Member pull: fetch + safely land the published tree into the local copy.
+    async pull({ projectId }) {
+      const principal = await getPrincipal();
+      if (!principal) return; // no team identity → nothing to pull
+      await materializeRef(client, principal, resourceIdFor(projectId), PUBLISHED_REF, await resolvePullDir(projectId));
+    },
+  };
+}
+
+/**
+ * Build the real hub adapter, resolving the principal from a single identity
+ * source, or null when the hub is not configured (so the runtime falls back to
+ * the local stub). `getPrincipal` should read the current workspace context so
+ * the web gate and the hub principal derive from the same source; if omitted, it
+ * falls back to the provisional env principal.
+ */
+export function createResourceHubPublishAdapterFromEnv(
+  resolveProjectDir: (projectId: string) => string | Promise<string>,
+  getPrincipal?: () => ResourceHubPrincipal | null | Promise<ResourceHubPrincipal | null>,
+  env: NodeJS.ProcessEnv = process.env,
+): ResourcePublishAdapter | null {
+  if (!env.OD_RESOURCE_HUB_URL?.trim()) return null;
+  const client = createResourceHubClient({ config: readResourceHubConfig(env) });
+  return createResourceHubPublishAdapter({
+    client,
+    resolveProjectDir,
+    getPrincipal: getPrincipal ?? (() => readResourceHubPrincipal(env)),
+  });
+}

--- a/apps/daemon/src/collab/runtime.ts
+++ b/apps/daemon/src/collab/runtime.ts
@@ -1,0 +1,153 @@
+// Team collaboration daemon subsystem: bundles the author-side publish
+// scheduler and the presence tracker behind one factory so the server wires
+// them once. The resource hub itself is E's (the resource-hub owner) — this holds only C's
+// trigger + presence, talking to the hub through ResourcePublishAdapter.
+
+import {
+  CollabPresenceTracker,
+  type CollabPresenceTrackerOptions,
+  type PresenceMember,
+} from './presence-tracker.js';
+import {
+  CollabPublishScheduler,
+  type CollabPublishSchedulerOptions,
+  type ResourcePublishAdapter,
+} from './publish-scheduler.js';
+import { createStubResourcePublishAdapter } from './stub-resource-adapter.js';
+import {
+  contextToResourceHubPrincipal,
+  createResourceHubPublishAdapterFromEnv,
+} from './resource-hub-publish-adapter.js';
+import {
+  createDevWorkspaceContextProvider,
+  type WorkspaceContextProvider,
+} from './workspace-context.js';
+import {
+  createDevTeamResourceStateProvider,
+  type TeamResourceStateProvider,
+} from './team-resource-state.js';
+import type { ProjectSyncState } from '@open-design/contracts';
+
+export interface CollabRuntime {
+  presence: CollabPresenceTracker;
+  scheduler: CollabPublishScheduler;
+  /** Workspace-context provider — the B-integration seam (identity/visibility). */
+  workspaceContext: WorkspaceContextProvider;
+  /** Team-resource state provider — the E-resource-hub seam (share/freeze state). */
+  teamResources: TeamResourceStateProvider;
+  /** Last published version for a project (members poll this to know what to pull). */
+  publishedVersion(projectId: string): number | null;
+  /**  sync state for a project (`local_only` until a share is requested). */
+  projectSyncState(projectId: string): ProjectSyncState;
+  /**
+   * visibility-to-sync sync-intent seam: mark a project as awaiting upload and flush a publish.
+   * D calls this (through the route) when a project flips to team-visible; C
+   * orchestrates the publish, which drives the resource hub mechanism behind it.
+   * `ownerMemberId` is the sharer's member id — recorded so a member viewing the
+   * project can tell whether it is their own (writer) or someone else's (read-only).
+   */
+  requestTeamShare(projectId: string, ownerMemberId?: string): void;
+  /** The member who shared this project, or null if not shared here. */
+  projectOwnerMemberId(projectId: string): string | null;
+  /**
+   * Member pull trigger (the sync trigger owns *when* to pull). Reads the published head via
+   * the adapter (E's `syncLatest`); E's client also fetches + extracts the
+   * bytes locally. Returns the head version, or null if nothing is published.
+   */
+  pullLatest(projectId: string): Promise<{ version: number | null }>;
+  dispose(): void;
+}
+
+export interface CreateCollabRuntimeOptions {
+  /**
+   * Resource-hub adapter. Precedence: an explicit adapter → the real hub adapter
+   * built from env (when `resolveProjectDir` is given and OD_RESOURCE_HUB_URL +
+   * workspace member env are set) → the local stub.
+   */
+  adapter?: ResourcePublishAdapter;
+  /** Managed-project directory resolver, so the real hub adapter can pack/land. */
+  resolveProjectDir?: (projectId: string) => string;
+  /** Workspace-context provider. Defaults to a dev provider until wired to an identity source. */
+  workspaceContext?: WorkspaceContextProvider;
+  /** Team-resource state provider. Defaults to a dev provider until wired to the hub. */
+  teamResources?: TeamResourceStateProvider;
+  /** Fired after a project is published so the caller can notify online members. */
+  onPublished?: (result: { projectId: string; version: number; reason: string }) => void;
+  /** Fired when a project's presence set changes (join/leave). */
+  onPresenceChange?: (result: { projectId: string; present: PresenceMember[] }) => void;
+  onError?: (result: { projectId: string; error: unknown }) => void;
+}
+
+export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): CollabRuntime {
+  const workspaceContext = options.workspaceContext ?? createDevWorkspaceContextProvider();
+  // Single identity source: the resource-hub principal derives from the same
+  // workspace context the web gate reads, so one signed-in identity drives both.
+  const adapter =
+    options.adapter ??
+    (options.resolveProjectDir
+      ? createResourceHubPublishAdapterFromEnv(options.resolveProjectDir, async () =>
+          contextToResourceHubPrincipal(await workspaceContext.current({})),
+        )
+      : null) ??
+    createStubResourcePublishAdapter();
+  const published = new Map<string, number>();
+  const syncStates = new Map<string, ProjectSyncState>();
+  // projectId → the member who shared it (the single writer). Members compare
+  // this to their own id to know whether they view the project read-only.
+  const owners = new Map<string, string>();
+  // Always track the published head + sync state so members can poll them; also
+  // forward to any caller-supplied callback. (exactOptionalPropertyTypes forbids
+  // assigning an explicit `undefined` to an optional property, hence we always
+  // wrap onError rather than passing options.onError through conditionally.)
+  const schedulerOptions: CollabPublishSchedulerOptions = {
+    adapter,
+    onPublished: (result) => {
+      published.set(result.projectId, result.version);
+      syncStates.set(result.projectId, 'synced');
+      options.onPublished?.(result);
+    },
+    onError: (result) => {
+      // A failed publish leaves the prior head standing; surface it as a
+      // recoverable sync state rather than wedging the project.
+      syncStates.set(result.projectId, 'sync_failed');
+      options.onError?.(result);
+    },
+  };
+  const scheduler = new CollabPublishScheduler(schedulerOptions);
+  const presenceOptions: CollabPresenceTrackerOptions = {};
+  if (options.onPresenceChange) presenceOptions.onChange = options.onPresenceChange;
+  const presence = new CollabPresenceTracker(presenceOptions);
+  const teamResources = options.teamResources ?? createDevTeamResourceStateProvider();
+  return {
+    presence,
+    scheduler,
+    workspaceContext,
+    teamResources,
+    publishedVersion: (projectId) => published.get(projectId) ?? null,
+    projectSyncState: (projectId) => syncStates.get(projectId) ?? 'local_only',
+    projectOwnerMemberId: (projectId) => owners.get(projectId) ?? null,
+    requestTeamShare(projectId, ownerMemberId) {
+      // Record the sharer as the project's single writer so members can tell
+      // apart their own project from one shared to them.
+      if (ownerMemberId) owners.set(projectId, ownerMemberId);
+      // Pending until the publish confirms (onPublished → 'synced' / onError →
+      // 'sync_failed'). Flushing at a run boundary publishes the stable state.
+      syncStates.set(projectId, 'pending_upload');
+      scheduler.notifyChanged(projectId, 'share');
+      scheduler.runBoundary(projectId);
+    },
+    async pullLatest(projectId) {
+      // The real hub adapter materializes the published tree locally; the stub
+      // has no bytes. Either way, report the head version.
+      if (adapter.pull) await adapter.pull({ projectId });
+      const head = adapter.syncLatest
+        ? await adapter.syncLatest({ projectId })
+        : { version: published.get(projectId) ?? null };
+      return { version: head?.version ?? null };
+    },
+    dispose() {
+      scheduler.dispose();
+      presence.dispose();
+    },
+  };
+}

--- a/apps/daemon/src/collab/stub-resource-adapter.ts
+++ b/apps/daemon/src/collab/stub-resource-adapter.ts
@@ -1,0 +1,26 @@
+import type { ResourcePublishAdapter } from './publish-scheduler.js';
+
+/**
+ * Placeholder resource-hub adapter until E's `services/resource-hub` (the resource-hub owner,
+ * ) ships its client. It assigns a monotonic in-memory version per
+ * project so the author-side publish flow (coalesce → publish → notify) is
+ * exercisable end-to-end locally, but it does NOT durably store content. Swap
+ * for the real E client (the resource hub the spec = createVersion + setRef('published')) when
+ * it lands; the {@link ResourcePublishAdapter} interface is the seam.
+ */
+export function createStubResourcePublishAdapter(): ResourcePublishAdapter {
+  const versions = new Map<string, number>();
+  return {
+    async publish({ projectId }) {
+      const next = (versions.get(projectId) ?? 0) + 1;
+      versions.set(projectId, next);
+      return { version: next };
+    },
+    // Read-only: report the current head without advancing it (getRef stand-in).
+    // The real E client also fetches + extracts the missing blobs locally.
+    async syncLatest({ projectId }) {
+      const current = versions.get(projectId);
+      return current === undefined ? null : { version: current };
+    },
+  };
+}

--- a/apps/daemon/src/collab/team-resource-share.ts
+++ b/apps/daemon/src/collab/team-resource-share.ts
@@ -1,0 +1,87 @@
+// Team resource sharing. A member with publish rights promotes a personal
+// resource — a design system, plugin, or skill — into the team scope: the
+// resource's directory is packed and pushed to the resource hub under its kind,
+// so teammates can pull it into their own workspace. This reuses the same
+// content-addressed publish machinery as project sync — only the resource kind
+// and id namespace differ — and degrades to a no-op when there is no team
+// identity or the hub is not configured (the same identity gate as the rest of
+// the collab surface).
+
+import {
+  createResourceHubClient,
+  readResourceHubConfig,
+  type ResourceHubClient,
+  type ResourceHubPrincipal,
+} from '../integrations/resource-hub.js';
+import { createResourceHubPublishAdapter } from './resource-hub-publish-adapter.js';
+
+export interface TeamResourceShareService {
+  /** Share a resource to the team. Returns the published version, or null off-team. */
+  share(resourceId: string): Promise<{ version: number } | null>;
+  /** Ids of resources shared to the team in this session. */
+  sharedIds(): string[];
+  /** True once a resource has been shared to the team. */
+  isShared(resourceId: string): boolean;
+  /** Whether the hub is reachable (share is a no-op otherwise). */
+  readonly configured: boolean;
+}
+
+export interface CreateTeamResourceShareOptions {
+  /** Resource hub kind, e.g. `design_system` | `plugin` | `skill`. */
+  kind: string;
+  /** Colon-free id-namespace prefix distinguishing this kind on the shared hub. */
+  idPrefix: string;
+  /** Resolve a resource's source directory (what gets packed and pushed). */
+  resolveDir: (resourceId: string) => string;
+  /** Resolve the current principal (null = no team identity → share no-ops). */
+  getPrincipal: () => ResourceHubPrincipal | null | Promise<ResourceHubPrincipal | null>;
+  /** Injectable client for tests; built from env when omitted. */
+  client?: ResourceHubClient;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function createTeamResourceShareService(
+  options: CreateTeamResourceShareOptions,
+): TeamResourceShareService {
+  const env = options.env ?? process.env;
+  const client =
+    options.client ??
+    (env.OD_RESOURCE_HUB_URL?.trim()
+      ? createResourceHubClient({ config: readResourceHubConfig(env) })
+      : null);
+  // Ids shared this session. The published resources are the durable record on
+  // the hub; this is the fast local view the team collection reads until a hub
+  // listing query lands.
+  const shared = new Set<string>();
+
+  if (!client) {
+    return {
+      share: async () => null,
+      sharedIds: () => [],
+      isShared: () => false,
+      configured: false,
+    };
+  }
+
+  const adapter = createResourceHubPublishAdapter({
+    client,
+    getPrincipal: options.getPrincipal,
+    resolveProjectDir: options.resolveDir,
+    // Distinct, colon-free id namespace on the shared hub. The caller's id (e.g.
+    // `user:palette-x`) is sanitized to path-safe chars — the hub routes the
+    // resource id as a path param, so a colon would 404.
+    resourceIdFor: (id) => `${options.idPrefix}-${id.replace(/[^a-zA-Z0-9_-]/g, '-')}`,
+    kind: options.kind,
+  });
+
+  return {
+    async share(resourceId) {
+      const result = await adapter.publish({ projectId: resourceId, reason: 'share' });
+      if (result) shared.add(resourceId);
+      return result;
+    },
+    sharedIds: () => [...shared],
+    isShared: (resourceId) => shared.has(resourceId),
+    configured: true,
+  };
+}

--- a/apps/daemon/src/collab/team-resource-state.ts
+++ b/apps/daemon/src/collab/team-resource-state.ts
@@ -1,0 +1,66 @@
+import {
+  assertTeamResourceCopyAllowed,
+  type TeamResourceCopyTarget,
+  type TeamResourceState,
+} from '@open-design/contracts';
+
+// Team-resource state seam (D1 state model). Reports whether a design system /
+// plugin / skill is a team resource and its lifecycle state, so the copy
+// red-line guard (D3, assertTeamResourceCopyAllowed) can be enforced at the
+// copy-out routes. In production this resolves against E's resource-hub (the resource-hub owner,
+// which owns whether a resource is team-shared + frozen); until it is reachable,
+// the dev provider holds an in-memory map a demo/test can seed. Swapping the
+// provider is the only change when the hub ships.
+
+export type TeamResourceKind = 'design-system' | 'plugin' | 'skill';
+
+export interface TeamResourceKey {
+  kind: TeamResourceKind;
+  resourceId: string;
+}
+
+export interface TeamResourceStateProvider {
+  /** The copy-guard view of a resource. Unknown resources default to personal. */
+  resolve(key: TeamResourceKey): Promise<TeamResourceCopyTarget>;
+  /** Dev/demo seam: mark a resource team-shared with a state (absent on the real hub-backed provider). */
+  set?(key: TeamResourceKey, target: TeamResourceCopyTarget): void;
+}
+
+function mapKey(key: TeamResourceKey): string {
+  return `${key.kind}:${key.resourceId}`;
+}
+
+/**
+ * Dev/demo provider: an in-memory registry of team-shared resources. A resource
+ * not in the registry is treated as `personal` (copies freely) — so with no team
+ * resources registered the guard is a no-op, exactly as production is until E's
+ * hub reports real team resources. A test seeds a `frozen` resource to prove the
+ * guard actually rejects.
+ */
+export function createDevTeamResourceStateProvider(): TeamResourceStateProvider {
+  const registry = new Map<string, TeamResourceState>();
+  return {
+    async resolve(key) {
+      const state = registry.get(mapKey(key));
+      return state === undefined ? { scope: 'personal' } : { scope: 'team', state };
+    },
+    set(key, target) {
+      if (target.scope === 'team' && target.state) registry.set(mapKey(key), target.state);
+      else registry.delete(mapKey(key));
+    },
+  };
+}
+
+/**
+ * Resolve a resource's state and enforce the copy red-line (D3) at a copy-out
+ * route. Throws {@link TeamResourceCopyForbiddenError} (which routes map to 403)
+ * when the resource is a frozen/deleted team resource. A one-liner the escape
+ * routes (plugin duplicate, DS copy, skill edit-shadow) call before copying.
+ */
+export async function enforceTeamResourceCopyAllowed(
+  provider: TeamResourceStateProvider,
+  key: TeamResourceKey,
+): Promise<void> {
+  const target = await provider.resolve(key);
+  assertTeamResourceCopyAllowed(target);
+}

--- a/apps/daemon/src/collab/workspace-context.ts
+++ b/apps/daemon/src/collab/workspace-context.ts
@@ -1,0 +1,99 @@
+import type {
+  CollabMemberRole,
+  WorkspaceCollabContext,
+  WorkspaceLifecycleState,
+  WorkspaceMemberStatus,
+  WorkspaceType,
+} from '@open-design/contracts';
+
+// The daemon's single B-integration point . Presence + sync need the
+// caller's workspace identity (workspaceMemberId + role + lifecycle). In
+// production this provider verifies the request's auth against the B service and
+// returns B's CurrentWorkspaceContext for that user; until B is reachable, the
+// dev provider below holds an in-memory context that a demo/tools-dev run can
+// set. Swapping the provider is the only change when B ships — routes and the
+// web client stay put.
+
+export interface WorkspaceContextRequest {
+  /** The caller's bearer token (a real provider verifies this against B). */
+  authorization?: string | undefined;
+}
+
+export interface WorkspaceContextProvider {
+  current(req: WorkspaceContextRequest): Promise<WorkspaceCollabContext | null>;
+  /**
+   * Dev/demo seam: override the returned context. Absent on a real B-backed
+   * provider (whose context is derived per-request from the token).
+   */
+  set?(context: WorkspaceCollabContext | null): void;
+}
+
+const WORKSPACE_TYPES: ReadonlySet<WorkspaceType> = new Set(['personal', 'team']);
+const ROLES: ReadonlySet<CollabMemberRole> = new Set(['owner', 'admin', 'member']);
+const MEMBER_STATUSES: ReadonlySet<WorkspaceMemberStatus> = new Set(['active', 'removed']);
+const LIFECYCLE_STATES: ReadonlySet<WorkspaceLifecycleState> = new Set([
+  'active',
+  'billing_past_due',
+  'locked',
+  'deleting',
+  'deleted',
+]);
+
+/**
+ * Validate an untrusted workspace-context payload (dev PUT body / env). Returns
+ * the typed context or null if any required field is missing or out of enum.
+ */
+export function parseWorkspaceCollabContext(input: unknown): WorkspaceCollabContext | null {
+  if (!input || typeof input !== 'object') return null;
+  const raw = input as Record<string, unknown>;
+  const workspaceMemberId = typeof raw.workspaceMemberId === 'string' ? raw.workspaceMemberId.trim() : '';
+  if (!workspaceMemberId) return null;
+  if (!WORKSPACE_TYPES.has(raw.workspaceType as WorkspaceType)) return null;
+  if (!ROLES.has(raw.role as CollabMemberRole)) return null;
+  if (!MEMBER_STATUSES.has(raw.memberStatus as WorkspaceMemberStatus)) return null;
+  if (!LIFECYCLE_STATES.has(raw.lifecycleState as WorkspaceLifecycleState)) return null;
+  const context: WorkspaceCollabContext = {
+    workspaceType: raw.workspaceType as WorkspaceType,
+    workspaceMemberId,
+    role: raw.role as CollabMemberRole,
+    memberStatus: raw.memberStatus as WorkspaceMemberStatus,
+    lifecycleState: raw.lifecycleState as WorkspaceLifecycleState,
+  };
+  if (typeof raw.teamId === 'string' && raw.teamId.trim()) {
+    context.teamId = raw.teamId.trim();
+  }
+  if (typeof raw.teamName === 'string' && raw.teamName.trim()) {
+    context.teamName = raw.teamName.trim();
+  }
+  if (typeof raw.displayName === 'string' && raw.displayName.trim()) {
+    context.displayName = raw.displayName.trim();
+  }
+  return context;
+}
+
+/**
+ * Dev/demo provider: holds a single in-memory context, optionally seeded from
+ * `OD_DEV_WORKSPACE_CONTEXT` (JSON). Ignores the request — a real B-backed
+ * provider derives the context per-caller from the token instead.
+ */
+export function createDevWorkspaceContextProvider(
+  seed?: WorkspaceCollabContext | null,
+): WorkspaceContextProvider {
+  let context: WorkspaceCollabContext | null = seed ?? readEnvContext();
+  return {
+    current: () => Promise.resolve(context),
+    set: (next) => {
+      context = next;
+    },
+  };
+}
+
+function readEnvContext(): WorkspaceCollabContext | null {
+  const raw = process.env.OD_DEV_WORKSPACE_CONTEXT;
+  if (!raw) return null;
+  try {
+    return parseWorkspaceCollabContext(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -156,6 +156,10 @@ function migrate(db: SqliteDb): void {
       status TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
+      anchor_state TEXT,
+      anchored_version INTEGER,
+      author_member_id TEXT,
+      last_good_position_json TEXT,
       UNIQUE(project_id, conversation_id, file_path, element_id, slide_key),
       FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
       FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
@@ -329,6 +333,21 @@ function migrate(db: SqliteDb): void {
     db.exec(`ALTER TABLE preview_comments ADD COLUMN slide_index INTEGER`);
   }
   migratePreviewCommentsSlideKey(db);
+  // Team collaboration anchor columns — added after the slide-key rebuild so a legacy
+  // table rebuild cannot drop them.
+  const previewCommentAnchorCols = db.prepare(`PRAGMA table_info(preview_comments)`).all() as DbRow[];
+  if (!previewCommentAnchorCols.some((c: DbRow) => c.name === 'anchor_state')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN anchor_state TEXT`);
+  }
+  if (!previewCommentAnchorCols.some((c: DbRow) => c.name === 'anchored_version')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN anchored_version INTEGER`);
+  }
+  if (!previewCommentAnchorCols.some((c: DbRow) => c.name === 'author_member_id')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN author_member_id TEXT`);
+  }
+  if (!previewCommentAnchorCols.some((c: DbRow) => c.name === 'last_good_position_json')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN last_good_position_json TEXT`);
+  }
   const deploymentCols = db.prepare(`PRAGMA table_info(deployments)`).all() as DbRow[];
   if (!deploymentCols.some((c: DbRow) => c.name === 'status')) {
     db.exec(`ALTER TABLE deployments ADD COLUMN status TEXT NOT NULL DEFAULT 'ready'`);
@@ -1610,6 +1629,8 @@ export function listPreviewComments(db: SqliteDb, projectId: string, conversatio
               pod_members_json AS podMembersJson, style_json AS styleJson,
               attachments_json AS attachmentsJson,
               slide_index AS slideIndex,
+              anchor_state AS anchorState, anchored_version AS anchoredVersion,
+              author_member_id AS authorMemberId, last_good_position_json AS lastGoodPositionJson,
               note, status, created_at AS createdAt, updated_at AS updatedAt
          FROM preview_comments
         WHERE project_id = ? AND conversation_id = ?
@@ -1643,6 +1664,15 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
     : 0;
   const slideIndex = Number.isFinite(target.slideIndex) ? Math.max(0, Math.round(target.slideIndex)) : null;
   const slideKey = slideIndex ?? -1;
+  // Team collaboration creation metadata. anchor_state / last_good_position stay null at
+  // creation — the drift ladder resolves and writes them back (updatePreviewCommentAnchor).
+  const anchoredVersion = Number.isFinite(target.anchoredVersion)
+    ? Math.max(0, Math.round(target.anchoredVersion))
+    : null;
+  const authorMemberId =
+    typeof input?.authorMemberId === 'string' && input.authorMemberId.trim()
+      ? input.authorMemberId.trim()
+      : null;
   const now = Date.now();
   const existing = db
     .prepare(
@@ -1661,8 +1691,9 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
     `INSERT INTO preview_comments
        (id, project_id, conversation_id, file_path, element_id, selector, label,
         text, position_json, html_hint, selection_kind, member_count, pod_members_json,
-        style_json, attachments_json, slide_index, slide_key, note, status, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        style_json, attachments_json, slide_index, slide_key, note, status, created_at, updated_at,
+        anchored_version, author_member_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(project_id, conversation_id, file_path, element_id, slide_key) DO UPDATE SET
        selector = excluded.selector,
        label = excluded.label,
@@ -1677,6 +1708,8 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
        slide_index = excluded.slide_index,
        note = excluded.note,
        status = 'open',
+       anchored_version = excluded.anchored_version,
+       author_member_id = excluded.author_member_id,
        updated_at = excluded.updated_at`,
   ).run(
     id,
@@ -1700,6 +1733,8 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
     'open',
     createdAt,
     now,
+    anchoredVersion,
+    authorMemberId,
   );
   return getPreviewComment(db, projectId, conversationId, id);
 }
@@ -1712,6 +1747,41 @@ export function updatePreviewCommentStatus(db: SqliteDb, projectId: string, conv
         SET status = ?, updated_at = ?
       WHERE id = ? AND project_id = ? AND conversation_id = ?`,
   ).run(status, now, id, projectId, conversationId);
+  return getPreviewComment(db, projectId, conversationId, id);
+}
+
+/**
+ * Team collaboration drift-ladder write-back: persist how a comment resolved this render.
+ * `lastGoodPosition`/`anchoredVersion` are COALESCEd so a `lost` resolve (which omits
+ * them) keeps the last known-good values instead of wiping them. Does not bump
+ * `updated_at` — anchor resolution is a derived read, not a content edit.
+ */
+export function updatePreviewCommentAnchor(
+  db: SqliteDb,
+  projectId: string,
+  conversationId: string,
+  id: string,
+  input: DbRow,
+) {
+  const anchorState = typeof input?.anchorState === 'string' ? input.anchorState : null;
+  const lastGoodPosition = input?.lastGoodPosition ? normalizePosition(input.lastGoodPosition) : null;
+  const anchoredVersion = Number.isFinite(input?.anchoredVersion)
+    ? Math.max(0, Math.round(input.anchoredVersion))
+    : null;
+  db.prepare(
+    `UPDATE preview_comments
+        SET anchor_state = ?,
+            last_good_position_json = COALESCE(?, last_good_position_json),
+            anchored_version = COALESCE(?, anchored_version)
+      WHERE id = ? AND project_id = ? AND conversation_id = ?`,
+  ).run(
+    anchorState,
+    lastGoodPosition ? JSON.stringify(lastGoodPosition) : null,
+    anchoredVersion,
+    id,
+    projectId,
+    conversationId,
+  );
   return getPreviewComment(db, projectId, conversationId, id);
 }
 
@@ -1735,6 +1805,8 @@ function getPreviewComment(db: SqliteDb, projectId: string, conversationId: stri
               pod_members_json AS podMembersJson, style_json AS styleJson,
               attachments_json AS attachmentsJson,
               slide_index AS slideIndex,
+              anchor_state AS anchorState, anchored_version AS anchoredVersion,
+              author_member_id AS authorMemberId, last_good_position_json AS lastGoodPositionJson,
               note, status, created_at AS createdAt, updated_at AS updatedAt
          FROM preview_comments
         WHERE id = ? AND project_id = ? AND conversation_id = ?`,
@@ -1772,6 +1844,10 @@ function normalizePreviewComment(row: DbRow) {
     status: row.status,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    anchorState: typeof row.anchorState === 'string' ? row.anchorState : undefined,
+    anchoredVersion: Number.isFinite(row.anchoredVersion) ? row.anchoredVersion : undefined,
+    authorMemberId: typeof row.authorMemberId === 'string' ? row.authorMemberId : undefined,
+    lastGoodPosition: parseJsonOrUndef(row.lastGoodPositionJson),
   };
 }
 

--- a/apps/daemon/src/design-systems/index.ts
+++ b/apps/daemon/src/design-systems/index.ts
@@ -2390,7 +2390,7 @@ window.Composer = Composer;
 `;
 }
 
-function stripPrefixAndValidateId(id: string, prefix = ''): string | null {
+export function stripPrefixAndValidateId(id: string, prefix = ''): string | null {
   if (typeof id !== 'string') return null;
   if (prefix && !id.startsWith(prefix)) return null;
   const dirId = prefix ? id.slice(prefix.length) : id;

--- a/apps/daemon/src/routes/collab-context.ts
+++ b/apps/daemon/src/routes/collab-context.ts
@@ -1,0 +1,48 @@
+import type { Express } from 'express';
+import type { WorkspaceContextResponse } from '@open-design/contracts';
+import {
+  parseWorkspaceCollabContext,
+  type WorkspaceContextProvider,
+} from '../collab/workspace-context.js';
+
+export interface RegisterCollabContextRoutesDeps {
+  workspaceContext: WorkspaceContextProvider;
+}
+
+/**
+ * Workspace-context route : the daemon's single B-integration seam. The
+ * web client fetches the current caller's workspace context here to decide
+ * whether collab runs and who the present member is (resolveCollabSession). In
+ * production the provider proxies B; the dev provider is settable via PUT so a
+ * demo/tools-dev run can exercise the full path before B is reachable.
+ */
+export function registerCollabContextRoutes(app: Express, deps: RegisterCollabContextRoutesDeps): void {
+  const { workspaceContext } = deps;
+
+  app.get('/api/workspace/context', async (req, res) => {
+    const authorization = req.header('authorization') ?? undefined;
+    const context = await workspaceContext.current({ authorization });
+    const body: WorkspaceContextResponse = { context };
+    res.json(body);
+  });
+
+  // Dev/demo seam: override the in-memory context. A real B-backed provider does
+  // not expose `set`, so this 404s in production instead of spoofing identity.
+  app.put('/api/workspace/context', (req, res) => {
+    if (!workspaceContext.set) {
+      return res.status(404).json({ error: 'workspace context is not settable' });
+    }
+    const body = req.body as unknown;
+    // `null` explicitly clears the context (sign-out / leave team).
+    if (body === null || (body && typeof body === 'object' && Object.keys(body).length === 0)) {
+      workspaceContext.set(null);
+      const cleared: WorkspaceContextResponse = { context: null };
+      return res.json(cleared);
+    }
+    const context = parseWorkspaceCollabContext(body);
+    if (!context) return res.status(400).json({ error: 'invalid workspace context' });
+    workspaceContext.set(context);
+    const response: WorkspaceContextResponse = { context };
+    res.json(response);
+  });
+}

--- a/apps/daemon/src/routes/collab-presence.ts
+++ b/apps/daemon/src/routes/collab-presence.ts
@@ -1,0 +1,46 @@
+import type { Express } from 'express';
+import type { CollabRuntime } from '../collab/runtime.js';
+import type { PresenceMember } from '../collab/presence-tracker.js';
+
+export interface RegisterCollabPresenceRoutesDeps {
+  collab: Pick<CollabRuntime, 'presence'>;
+}
+
+function readMember(body: unknown): PresenceMember | null {
+  const raw = (body ?? {}) as Record<string, unknown>;
+  const memberId = typeof raw.memberId === 'string' ? raw.memberId.trim() : '';
+  if (!memberId) return null;
+  const member: PresenceMember = { memberId };
+  if (typeof raw.name === 'string' && raw.name.trim()) member.name = raw.name.trim();
+  if (raw.role === 'owner' || raw.role === 'admin' || raw.role === 'member') member.role = raw.role;
+  return member;
+}
+
+/**
+ * Team collaboration presence (presence) capability. Members heartbeat while viewing a
+ * shared project; clients poll the present set (live cursors were cut, content
+ * is polled — the spec). The set is process-local in {@link CollabRuntime}.
+ */
+export function registerCollabPresenceRoutes(app: Express, deps: RegisterCollabPresenceRoutesDeps): void {
+  const { presence } = deps.collab;
+
+  app.get('/api/projects/:id/presence', (req, res) => {
+    res.json({ present: presence.present(req.params.id) });
+  });
+
+  app.post('/api/projects/:id/presence/heartbeat', (req, res) => {
+    const member = readMember(req.body);
+    if (!member) return res.status(400).json({ error: 'memberId required' });
+    presence.heartbeat(req.params.id, member);
+    res.json({ present: presence.present(req.params.id) });
+  });
+
+  app.post('/api/projects/:id/presence/leave', (req, res) => {
+    const memberId = typeof (req.body as Record<string, unknown> | undefined)?.memberId === 'string'
+      ? ((req.body as Record<string, unknown>).memberId as string).trim()
+      : '';
+    if (!memberId) return res.status(400).json({ error: 'memberId required' });
+    presence.leave(req.params.id, memberId);
+    res.json({ ok: true, present: presence.present(req.params.id) });
+  });
+}

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -1,0 +1,92 @@
+import type { Express } from 'express';
+import type { ProjectSyncIntentEvent } from '@open-design/contracts';
+import type { CollabRuntime } from '../collab/runtime.js';
+
+export interface RegisterCollabSyncRoutesDeps {
+  collab: Pick<
+    CollabRuntime,
+    | 'scheduler'
+    | 'publishedVersion'
+    | 'projectSyncState'
+    | 'projectOwnerMemberId'
+    | 'requestTeamShare'
+    | 'pullLatest'
+    | 'workspaceContext'
+  >;
+}
+
+const SYNC_INTENT_EVENTS: ReadonlySet<ProjectSyncIntentEvent> = new Set([
+  'project_visibility_changed',
+  'project_team_share_requested',
+]);
+
+/**
+ * Team collaboration sync trigger, exposed as a client-driven capability . The client is authoritative about whether it is in a shared context, so
+ * it drives the trigger — the daemon does not need D's visibility fact to gate
+ * this. Publishing content + advancing the published ref is the resource hub; here
+ * we only coalesce and flush.
+ */
+export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncRoutesDeps): void {
+  const {
+    scheduler,
+    publishedVersion,
+    projectSyncState,
+    projectOwnerMemberId,
+    requestTeamShare,
+    pullLatest,
+    workspaceContext,
+  } = deps.collab;
+
+  // An author-side edit landed. The publish is coalesced within the scheduler's
+  // window so a burst of edits collapses into one publish.
+  app.post('/api/projects/:id/collab/changed', (req, res) => {
+    scheduler.notifyChanged(req.params.id, 'change');
+    res.json({ ok: true });
+  });
+
+  // Run boundary — flush any pending publish immediately (publish the stable
+  // end-of-run state rather than waiting out the debounce).
+  app.post('/api/projects/:id/collab/publish', (req, res) => {
+    scheduler.notifyChanged(req.params.id, 'run');
+    scheduler.runBoundary(req.params.id);
+    res.json({ ok: true });
+  });
+
+  // visibility-to-sync orchestration seam. The visibility surface flips project visibility and emits a
+  // ProjectSyncIntent here; the sync trigger owns the reaction. `project_team_share_requested`
+  // marks the project pending and flushes a publish (which drives E's resource
+  // mechanism behind the scheduler). `project_visibility_changed` is accepted as
+  // a no-op signal for now (the share request is the actionable one).
+  app.post('/api/projects/:id/collab/sync-intent', async (req, res) => {
+    const event = (req.body as { event?: unknown } | undefined)?.event;
+    if (typeof event !== 'string' || !SYNC_INTENT_EVENTS.has(event as ProjectSyncIntentEvent)) {
+      return res.status(400).json({ error: 'invalid sync intent event' });
+    }
+    if (event === 'project_team_share_requested') {
+      // The caller sharing the project is its single writer; record their id so
+      // members can distinguish it from a project of their own.
+      const context = await workspaceContext.current({
+        authorization: req.headers.authorization,
+      });
+      requestTeamShare(req.params.id, context?.workspaceMemberId);
+    }
+    res.json({ ok: true, syncState: projectSyncState(req.params.id) });
+  });
+
+  // Member pull trigger (the sync trigger owns *when*; the resource hub fetches + extracts the bytes behind the
+  // adapter). Returns the head version that was pulled.
+  app.post('/api/projects/:id/collab/pull', async (req, res) => {
+    const result = await pullLatest(req.params.id);
+    res.json({ ok: true, version: result.version });
+  });
+
+  // Members poll this to learn the published head version they should pull and
+  // the current sync state (local_only / pending_upload / synced / sync_failed).
+  app.get('/api/projects/:id/collab/status', (req, res) => {
+    res.json({
+      publishedVersion: publishedVersion(req.params.id),
+      syncState: projectSyncState(req.params.id),
+      ownerMemberId: projectOwnerMemberId(req.params.id),
+    });
+  });
+}

--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -6,10 +6,15 @@ import type {
   Project,
   ProjectMetadata,
 } from '@open-design/contracts';
+import { TeamResourceCopyForbiddenError } from '@open-design/contracts';
 import {
   duplicatePluginExampleIntoProject,
   PluginDuplicateProjectError,
 } from '../../plugins/duplicate-project.js';
+import {
+  enforceTeamResourceCopyAllowed,
+  type TeamResourceStateProvider,
+} from '../../collab/team-resource-state.js';
 import type { PluginShareAction } from '../../services/plugin-share-tasks.js';
 
 export interface RegisterPluginEventRoutesDeps {
@@ -105,6 +110,9 @@ interface PluginRouteHelpers {
 
 export interface RegisterPluginRoutesDeps {
   db: SqliteDbLike;
+  /** Team-resource copy red-line (D3). When present, a frozen team plugin cannot
+   *  be duplicated into a personal project. Omit to skip the guard (no-op). */
+  teamResources?: TeamResourceStateProvider;
   paths: { PROJECTS_DIR: string; PLUGIN_REGISTRY_ROOTS: string[]; PLUGIN_LOCKFILE_PATH: string };
   ids: { randomId(): string };
   projectStore: {
@@ -169,7 +177,7 @@ export function registerPluginEventRoutes(app: Express, deps: RegisterPluginEven
 }
 
 export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDeps): void {
-  const { db, paths, ids, projectStore, conversations, plugins, helpers } = deps;
+  const { db, paths, ids, projectStore, conversations, plugins, helpers, teamResources } = deps;
   app.get('/api/plugins', async (_req, res) => { try { res.json({ plugins: helpers.applyBakedPreviews(plugins.listInstalledPlugins(db), helpers.PLUGIN_PREVIEWS_DIR) }); } catch (err) { res.status(500).json({ error: String(err) }); } });
   app.get('/api/plugins/:id', async (req, res) => { try { const plugin = plugins.getInstalledPlugin(db, req.params.id); if (!plugin) return res.status(404).json({ error: 'plugin not found' }); res.json(plugin); } catch (err) { res.status(500).json({ error: String(err) }); } });
   app.post('/api/plugins/upload-zip', (req, res) => helpers.pluginUpload.single('file')(req, res, async (err: unknown) => { if (err) return helpers.sendMulterError(res, err); try { const file = req.file; if (!file?.buffer) return res.status(400).json({ error: 'file is required' }); const result = await helpers.pluginInstallation.stageUploadedPluginZip(file.buffer, `upload:zip:${helpers.decodeMultipartFilename(file.originalname || 'plugin.zip')}`); res.status((result as { ok?: boolean }).ok ? 200 : 400).json(result); } catch (uploadErr: unknown) { res.status(400).json({ ok: false, warnings: [], message: uploadErr instanceof Error ? uploadErr.message : String(uploadErr), log: [] }); } }));
@@ -187,6 +195,13 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
       if (!plugin) return res.status(404).json({ error: { code: 'plugin-not-found', message: 'plugin not found' } });
       if (typeof plugin.id !== 'string' || typeof plugin.fsPath !== 'string') {
         return res.status(422).json({ error: { code: 'plugin-not-duplicable', message: 'plugin record is missing a filesystem source' } });
+      }
+      // AC-9 copy red-line (D3): a frozen team plugin cannot be duplicated into a
+      // personal project. Runs before any project is created (nothing to clean up
+      // if it throws). No-op until the resource-hub reports this plugin as a
+      // frozen team resource.
+      if (teamResources) {
+        await enforceTeamResourceCopyAllowed(teamResources, { kind: 'plugin', resourceId: plugin.id });
       }
       const body = req.body && typeof req.body === 'object'
         ? req.body as PluginDuplicateProjectRequest
@@ -257,6 +272,9 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
       if (cleanupProjectId) {
         if (insertedProject) projectStore.dbDeleteProject(db, cleanupProjectId);
         await projectStore.removeProjectDir(paths.PROJECTS_DIR, cleanupProjectId).catch(() => {});
+      }
+      if (err instanceof TeamResourceCopyForbiddenError) {
+        return res.status(403).json({ error: { code: err.code, message: err.message } });
       }
       if (err instanceof PluginDuplicateProjectError) {
         return res.status(err.status).json({ error: { code: err.code, message: err.message } });

--- a/apps/daemon/src/routes/project/comments.ts
+++ b/apps/daemon/src/routes/project/comments.ts
@@ -11,6 +11,7 @@ export function registerProjectCommentRoutes(app: Express, ctx: RegisterProjectC
     listPreviewComments,
     upsertPreviewComment,
     updatePreviewCommentStatus,
+    updatePreviewCommentAnchor,
     deletePreviewComment,
   } = ctx.conversations;
 
@@ -63,6 +64,32 @@ export function registerProjectCommentRoutes(app: Express, ctx: RegisterProjectC
         if (!comment)
           return res.status(404).json({ error: 'comment not found' });
         updateProject(db, req.params.id, {});
+        res.json({ comment });
+      } catch (err: any) {
+        res.status(400).json({ error: String(err?.message || err) });
+      }
+    },
+  );
+
+  app.patch(
+    '/api/projects/:id/conversations/:cid/comments/:commentId/anchor',
+    (req, res) => {
+      const conv = getConversation(db, req.params.cid);
+      if (!conv || conv.projectId !== req.params.id) {
+        return res.status(404).json({ error: 'conversation not found' });
+      }
+      try {
+        // Drift-ladder write-back: the client resolves anchor state each render
+        // and reports it here. No updateProject() — anchor resolution is a
+        // derived read-back, not a content edit.
+        const comment = updatePreviewCommentAnchor(
+          db,
+          req.params.id,
+          req.params.cid,
+          req.params.commentId,
+          req.body || {},
+        );
+        if (!comment) return res.status(404).json({ error: 'comment not found' });
         res.json({ comment });
       } catch (err: any) {
         res.status(400).json({ error: String(err?.message || err) });

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -3,6 +3,11 @@ import type Database from 'better-sqlite3';
 import path from 'node:path';
 import fs from 'node:fs';
 import type { DesignSystemTokenContractRebuildJobResponse } from '@open-design/contracts';
+import { TeamResourceCopyForbiddenError } from '@open-design/contracts';
+import {
+  enforceTeamResourceCopyAllowed,
+  type TeamResourceStateProvider,
+} from '../collab/team-resource-state.js';
 import { detectAgents, detectAgentsStream } from '../agents.js';
 import {
   SkillImportError,
@@ -40,6 +45,9 @@ export interface RegisterStaticResourceRoutesDeps extends RouteDeps<'http' | 'pa
       designSystemId: string,
     ) => Promise<DesignSystemTokenContractRebuildJobResponse | undefined>;
   };
+  /** Team-resource copy red-line (D3). When present, a frozen team skill cannot
+   *  be edit-shadowed into a personal editable copy. Omit to skip (no-op). */
+  teamResources?: TeamResourceStateProvider;
 }
 
 export function registerAtomRoutes(app: Express, ctx: RegisterAtomRoutesDeps) {
@@ -90,6 +98,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
     mimeFor,
   } = ctx.resources;
   const { isLocalSameOrigin, resolvedPortRef, sendApiError } = ctx.http;
+  const teamResources = ctx.teamResources;
   const requireLocalOrigin = (req: any, res: any) => {
     if (isLocalSameOrigin(req, resolvedPortRef.current)) return true;
     sendApiError(res, 403, 'FORBIDDEN', 'local origin required');
@@ -263,6 +272,12 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       if (!skill) {
         return sendApiError(res, 404, 'NOT_FOUND', 'skill not found');
       }
+      // AC-9 copy red-line (D3): a frozen team skill cannot be edit-shadowed into
+      // a personal editable copy. No-op until the resource-hub reports this skill
+      // as a frozen team resource.
+      if (teamResources) {
+        await enforceTeamResourceCopyAllowed(teamResources, { kind: 'skill', resourceId: skill.id });
+      }
       const result = await updateUserSkill(USER_SKILLS_DIR, {
         ...(req.body || {}),
         id: skill.id,
@@ -286,6 +301,9 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
         },
       });
     } catch (err: any) {
+      if (err instanceof TeamResourceCopyForbiddenError) {
+        return sendApiError(res, 403, err.code, err.message);
+      }
       if (err instanceof SkillImportError) {
         const status = err.code === 'NOT_FOUND' ? 404 : err.code === 'BAD_REQUEST' ? 400 : 500;
         return sendApiError(res, status, err.code, err.message);

--- a/apps/daemon/src/routes/team-resource-share.ts
+++ b/apps/daemon/src/routes/team-resource-share.ts
@@ -1,0 +1,42 @@
+import type { Express } from 'express';
+import type { TeamResourceShareService } from '../collab/team-resource-share.js';
+
+export interface RegisterTeamResourceShareRoutesDeps {
+  /** URL segment for this resource kind: `design-systems` | `plugins` | `skills`. */
+  basePath: string;
+  share: TeamResourceShareService;
+}
+
+/**
+ * Team resource sharing routes for one resource kind. A member promotes a
+ * personal resource into the team scope; the share service packs its directory
+ * and pushes it to the resource hub so teammates can pull it. When there is no
+ * team identity (or the hub is not configured), share returns `shared: false`
+ * so the client keeps a local-only view instead of erroring. Mounted once per
+ * kind (design systems, plugins, skills).
+ */
+export function registerTeamResourceShareRoutes(
+  app: Express,
+  deps: RegisterTeamResourceShareRoutesDeps,
+): void {
+  const { basePath, share } = deps;
+  const root = `/api/workspace/${basePath}`;
+
+  // Ids shared to the team — drives the "team" collection for this kind.
+  app.get(`${root}/team`, (_req, res) => {
+    res.json({ ids: share.sharedIds() });
+  });
+
+  // Share a personal resource to the team.
+  app.post(`${root}/:id/share`, async (req, res) => {
+    const id = typeof req.params.id === 'string' ? decodeURIComponent(req.params.id) : '';
+    if (!id) return res.status(400).json({ error: 'invalid resource id' });
+    try {
+      const result = await share.share(id);
+      if (!result) return res.json({ shared: false });
+      res.json({ shared: true, version: result.version });
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : 'share failed' });
+    }
+  });
+}

--- a/apps/daemon/src/routes/team-resources.ts
+++ b/apps/daemon/src/routes/team-resources.ts
@@ -1,0 +1,77 @@
+import type { Express } from 'express';
+import {
+  assertTeamResourceCopyAllowed,
+  createApiError,
+  createApiErrorResponse,
+  TeamResourceCopyForbiddenError,
+  type TeamResourceState,
+} from '@open-design/contracts';
+import type {
+  TeamResourceKind,
+  TeamResourceKey,
+  TeamResourceStateProvider,
+} from '../collab/team-resource-state.js';
+
+export interface RegisterTeamResourceRoutesDeps {
+  teamResources: TeamResourceStateProvider;
+}
+
+const KINDS: ReadonlySet<TeamResourceKind> = new Set(['design-system', 'plugin', 'skill']);
+const STATES: ReadonlySet<TeamResourceState> = new Set(['active', 'frozen', 'deleted']);
+
+function readKey(params: { kind?: string; id?: string }): TeamResourceKey | null {
+  const kind = params.kind;
+  const resourceId = typeof params.id === 'string' ? decodeURIComponent(params.id) : '';
+  if (!kind || !KINDS.has(kind as TeamResourceKind) || !resourceId) return null;
+  return { kind: kind as TeamResourceKind, resourceId };
+}
+
+/**
+ * Team-resource routes (D1 state model + D3 enforcement). The copy-check runs
+ * the real copy red-line guard against the resolved resource state, so a frozen
+ * team resource is rejected with a 403 the same way the copy-out routes will be.
+ * The state provider is the E-resource-hub seam (the resource-hub owner).
+ */
+export function registerTeamResourceRoutes(app: Express, deps: RegisterTeamResourceRoutesDeps): void {
+  const { teamResources } = deps;
+
+  app.get('/api/workspace/resources/:kind/:id/state', async (req, res) => {
+    const key = readKey(req.params);
+    if (!key) return res.status(400).json({ error: 'invalid resource key' });
+    res.json(await teamResources.resolve(key));
+  });
+
+  // Enforce the AC-9 copy red-line for a resource about to be copied to personal.
+  app.post('/api/workspace/resources/:kind/:id/copy-check', async (req, res) => {
+    const key = readKey(req.params);
+    if (!key) return res.status(400).json({ error: 'invalid resource key' });
+    const target = await teamResources.resolve(key);
+    try {
+      assertTeamResourceCopyAllowed(target);
+      res.json({ allowed: true });
+    } catch (error) {
+      if (error instanceof TeamResourceCopyForbiddenError) {
+        return res.status(403).json(createApiErrorResponse(createApiError(error.code, error.message)));
+      }
+      throw error;
+    }
+  });
+
+  // Dev/demo seam: mark a resource team-shared with a state (real hub-backed
+  // provider omits `set`, so this 404s in production instead of spoofing state).
+  app.put('/api/workspace/resources/:kind/:id/state', (req, res) => {
+    const key = readKey(req.params);
+    if (!key) return res.status(400).json({ error: 'invalid resource key' });
+    if (!teamResources.set) return res.status(404).json({ error: 'resource state is not settable' });
+    const body = (req.body ?? {}) as { scope?: unknown; state?: unknown };
+    if (body.scope === 'personal') {
+      teamResources.set(key, { scope: 'personal' });
+      return res.json({ scope: 'personal' });
+    }
+    if (body.scope === 'team' && typeof body.state === 'string' && STATES.has(body.state as TeamResourceState)) {
+      teamResources.set(key, { scope: 'team', state: body.state as TeamResourceState });
+      return res.json({ scope: 'team', state: body.state });
+    }
+    res.status(400).json({ error: 'invalid resource state' });
+  });
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -231,6 +231,7 @@ import {
   readDesignSystemStaticFile,
   readUserDesignSystemFile,
   resolveDesignSystemAssets,
+  stripPrefixAndValidateId,
   updateUserDesignSystem,
   updateUserDesignSystemRevisionStatus,
 } from './design-systems/index.js';
@@ -506,6 +507,7 @@ import {
   openDatabase,
   setTabs,
   updateConversation,
+  updatePreviewCommentAnchor,
   updatePreviewCommentStatus,
   updateProject,
   updateRoutine,
@@ -568,6 +570,14 @@ import { createTerminalService } from './terminals.js';
 import { registerSocialShareRoutes } from './routes/social-share.js';
 import { registerOpenDesignPublicMetadataRoutes } from './routes/open-design-public-metadata.js';
 import { registerMemoryRoutes } from './routes/memory.js';
+import { registerCollabPresenceRoutes } from './routes/collab-presence.js';
+import { registerCollabSyncRoutes } from './routes/collab-sync.js';
+import { registerCollabContextRoutes } from './routes/collab-context.js';
+import { registerTeamResourceRoutes } from './routes/team-resources.js';
+import { registerTeamResourceShareRoutes } from './routes/team-resource-share.js';
+import { createCollabRuntime } from './collab/runtime.js';
+import { createTeamResourceShareService } from './collab/team-resource-share.js';
+import { contextToResourceHubPrincipal } from './collab/resource-hub-publish-adapter.js';
 import { registerTelemetryRoutes } from './routes/telemetry.js';
 import {
   assembleExample,
@@ -3792,6 +3802,62 @@ export async function startServer({
   // ---- Projects (DB-backed) -------------------------------------------------
 
 
+  // Team collaboration subsystem: presence + author-side publish scheduler.
+  // The scheduler publishes/pulls through the resource-hub adapter — the real
+  // hub when OD_RESOURCE_HUB_URL + workspace member env are set, else a local
+  // stub. resolveProjectDir lets the hub adapter pack/land managed projects.
+  const collab = createCollabRuntime({
+    resolveProjectDir: (projectId) => resolveProjectDir(PROJECTS_DIR, projectId),
+  });
+  registerCollabPresenceRoutes(app, { collab });
+  registerCollabSyncRoutes(app, { collab });
+  registerCollabContextRoutes(app, { workspaceContext: collab.workspaceContext });
+  registerTeamResourceRoutes(app, { teamResources: collab.teamResources });
+
+  // Team resource sharing: promote a personal design system, plugin, or skill
+  // into the team scope through the resource hub. All three derive the principal
+  // from the same one workspace context the project sync uses, so a single
+  // signed-in identity drives every share; each packs the resource's own
+  // directory under its own hub kind.
+  const teamShareGetPrincipal = async () =>
+    contextToResourceHubPrincipal(await collab.workspaceContext.current({}));
+  registerTeamResourceShareRoutes(app, {
+    basePath: 'design-systems',
+    share: createTeamResourceShareService({
+      kind: 'design_system',
+      idPrefix: 'ds',
+      resolveDir: (id) =>
+        path.join(USER_DESIGN_SYSTEMS_DIR, stripPrefixAndValidateId(id, 'user:') ?? '__invalid__'),
+      getPrincipal: teamShareGetPrincipal,
+    }),
+  });
+  registerTeamResourceShareRoutes(app, {
+    basePath: 'plugins',
+    share: createTeamResourceShareService({
+      kind: 'plugin',
+      idPrefix: 'plugin',
+      resolveDir: (id) => {
+        const plugin = getInstalledPlugin(db, id);
+        if (!plugin || typeof plugin.fsPath !== 'string') throw new Error('plugin not found');
+        return plugin.fsPath;
+      },
+      getPrincipal: teamShareGetPrincipal,
+    }),
+  });
+  registerTeamResourceShareRoutes(app, {
+    basePath: 'skills',
+    share: createTeamResourceShareService({
+      kind: 'skill',
+      idPrefix: 'skill',
+      resolveDir: async (id) => {
+        const skill = findSkillById(await listAllSkills(), id);
+        if (!skill || typeof skill.dir !== 'string') throw new Error('skill not found');
+        return skill.dir;
+      },
+      getPrincipal: teamShareGetPrincipal,
+    }),
+  });
+
   registerMemoryRoutes(app, {
     http: { createSseResponse, requireLocalDaemonRequest },
     paths: { RUNTIME_DATA_DIR, PROJECT_ROOT, PROJECTS_DIR },
@@ -4038,6 +4104,7 @@ export async function startServer({
     listPreviewComments,
     upsertPreviewComment,
     updatePreviewCommentStatus,
+    updatePreviewCommentAnchor,
     deletePreviewComment,
   };
   const templateDeps = { getTemplate, listTemplates, deleteTemplate, insertTemplate, findTemplateByNameAndProject, updateTemplate };
@@ -4293,6 +4360,7 @@ export async function startServer({
   registerStaticResourceRoutes(app, {
     http: httpDeps,
     paths: pathDeps,
+    teamResources: collab.teamResources,
     resources: {
       listAllSkills,
       listAllDesignTemplates,
@@ -4688,6 +4756,7 @@ export async function startServer({
 
   registerPluginRoutes(app, {
     db,
+    teamResources: collab.teamResources,
     paths: { PROJECTS_DIR, PLUGIN_REGISTRY_ROOTS, PLUGIN_LOCKFILE_PATH },
     ids: idDeps,
     projectStore: projectStoreDeps,

--- a/apps/daemon/tests/collab-cli.test.ts
+++ b/apps/daemon/tests/collab-cli.test.ts
@@ -1,0 +1,172 @@
+import { execFile } from 'node:child_process';
+import http from 'node:http';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileP = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DAEMON_ROOT = pathResolve(__dirname, '..');
+const REPO_ROOT = pathResolve(__dirname, '../../..');
+const CLI_SRC = pathResolve(__dirname, '../src/cli.ts');
+const TSX_CLI = pathResolve(REPO_ROOT, 'node_modules/tsx/dist/cli.mjs');
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  body: string;
+}
+
+interface StubServer {
+  baseUrl: string;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+}
+
+let stub: StubServer | null = null;
+
+afterEach(async () => {
+  if (stub) await stub.close();
+  stub = null;
+});
+
+// Mirrors the daemon's collab presence + sync routes so the CLI exercises the
+// real SUBCOMMAND_MAP dispatch and request shaping against a live socket.
+async function startCollabStubServer(): Promise<StubServer> {
+  const requests: CapturedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => {
+      raw += chunk;
+    });
+    req.on('end', () => {
+      requests.push({ method: req.method ?? '', url: req.url ?? '', body: raw });
+      res.setHeader('content-type', 'application/json');
+      const { method, url } = { method: req.method ?? '', url: req.url ?? '' };
+      if (method === 'GET' && url === '/api/projects/p1/presence') {
+        res.end(JSON.stringify({ present: [{ memberId: 'm-42', name: 'Ma Shu', role: 'member' }] }));
+        return;
+      }
+      if (method === 'POST' && url === '/api/projects/p1/presence/heartbeat') {
+        res.end(JSON.stringify({ present: [{ memberId: 'm-42', name: 'Ma Shu', role: 'member' }] }));
+        return;
+      }
+      if (method === 'GET' && url === '/api/projects/p1/collab/status') {
+        res.end(JSON.stringify({ publishedVersion: 7, syncState: 'synced' }));
+        return;
+      }
+      if (method === 'POST' && url === '/api/projects/p1/collab/publish') {
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+      if (method === 'POST' && url === '/api/projects/p1/collab/sync-intent') {
+        res.end(JSON.stringify({ ok: true, syncState: 'pending_upload' }));
+        return;
+      }
+      if (method === 'POST' && url === '/api/projects/p1/collab/pull') {
+        res.end(JSON.stringify({ ok: true, version: 3 }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: { code: 'unexpected-request', message: url } }));
+    });
+  });
+  await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('stub server has no address');
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolveClose, rejectClose) => {
+        server.close((err) => (err ? rejectClose(err) : resolveClose()));
+      }),
+  };
+}
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.NODE_OPTIONS;
+  try {
+    const { stdout, stderr } = await execFileP(process.execPath, [TSX_CLI, CLI_SRC, ...args], {
+      cwd: DAEMON_ROOT,
+      env,
+      timeout: 15_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (err) {
+    const failed = err as { stdout?: string; stderr?: string; code?: number | null };
+    return { stdout: failed.stdout ?? '', stderr: failed.stderr ?? '', code: failed.code ?? 1 };
+  }
+}
+
+describe('od collab CLI', () => {
+  it('lists the present member set as JSON', async () => {
+    stub = await startCollabStubServer();
+    const result = await runCli(['collab', 'presence', 'p1', '--json', '--daemon-url', stub.baseUrl]);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      present: [{ memberId: 'm-42', name: 'Ma Shu', role: 'member' }],
+    });
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0]).toMatchObject({ method: 'GET', url: '/api/projects/p1/presence' });
+  });
+
+  it('sends a heartbeat with the member identity in the body', async () => {
+    stub = await startCollabStubServer();
+    const result = await runCli([
+      'collab', 'heartbeat', 'p1',
+      '--member', 'm-42', '--name', 'Ma Shu', '--role', 'member',
+      '--daemon-url', stub.baseUrl,
+    ]);
+    expect(result.code).toBe(0);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0]).toMatchObject({ method: 'POST', url: '/api/projects/p1/presence/heartbeat' });
+    expect(JSON.parse(stub.requests[0]!.body)).toEqual({ memberId: 'm-42', name: 'Ma Shu', role: 'member' });
+  });
+
+  it('requests a publish and prints the published version', async () => {
+    stub = await startCollabStubServer();
+    const publish = await runCli(['collab', 'publish', 'p1', '--json', '--daemon-url', stub.baseUrl]);
+    expect(publish.code).toBe(0);
+    expect(JSON.parse(publish.stdout)).toEqual({ ok: true });
+
+    const status = await runCli(['collab', 'status', 'p1', '--daemon-url', stub.baseUrl]);
+    expect(status.code).toBe(0);
+    expect(status.stdout).toContain('7');
+    expect(stub.requests.map((r) => `${r.method} ${r.url}`)).toEqual([
+      'POST /api/projects/p1/collab/publish',
+      'GET /api/projects/p1/collab/status',
+    ]);
+  });
+
+  it('sends the visibility-to-sync team-share intent and reports the sync state', async () => {
+    stub = await startCollabStubServer();
+    const share = await runCli(['collab', 'share', 'p1', '--json', '--daemon-url', stub.baseUrl]);
+    expect(share.code).toBe(0);
+    expect(JSON.parse(share.stdout)).toEqual({ ok: true, syncState: 'pending_upload' });
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0]).toMatchObject({ method: 'POST', url: '/api/projects/p1/collab/sync-intent' });
+    expect(JSON.parse(stub.requests[0]!.body)).toEqual({
+      event: 'project_team_share_requested',
+      projectId: 'p1',
+    });
+  });
+
+  it('surfaces the sync state in status output', async () => {
+    stub = await startCollabStubServer();
+    const status = await runCli(['collab', 'status', 'p1', '--daemon-url', stub.baseUrl]);
+    expect(status.code).toBe(0);
+    expect(status.stdout).toContain('synced');
+  });
+
+  it('rejects a heartbeat with no --member', async () => {
+    stub = await startCollabStubServer();
+    const result = await runCli(['collab', 'heartbeat', 'p1', '--daemon-url', stub.baseUrl]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('--member');
+    expect(stub.requests).toHaveLength(0);
+  });
+});

--- a/apps/daemon/tests/collab-context-routes.test.ts
+++ b/apps/daemon/tests/collab-context-routes.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { registerCollabContextRoutes } from '../src/routes/collab-context.js';
+import {
+  createDevWorkspaceContextProvider,
+  parseWorkspaceCollabContext,
+} from '../src/collab/workspace-context.js';
+
+let server: http.Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+});
+
+const TEAM_CONTEXT = {
+  workspaceType: 'team',
+  workspaceMemberId: 'wm-1',
+  role: 'member',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  displayName: 'Ma Shu',
+};
+
+async function startContextServer() {
+  const app = express();
+  app.use(express.json());
+  registerCollabContextRoutes(app, { workspaceContext: createDevWorkspaceContextProvider() });
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+  const base = `http://127.0.0.1:${address.port}`;
+  return {
+    async req(route: string, options: { method?: string; body?: unknown } = {}) {
+      const init: RequestInit = { method: options.method ?? 'GET' };
+      if (options.body !== undefined) {
+        init.headers = { 'content-type': 'application/json' };
+        init.body = JSON.stringify(options.body);
+      }
+      const response = await fetch(`${base}${route}`, init);
+      return { status: response.status, body: (await response.json()) as Record<string, any> };
+    },
+  };
+}
+
+describe('parseWorkspaceCollabContext', () => {
+  it('accepts a well-formed team context', () => {
+    expect(parseWorkspaceCollabContext(TEAM_CONTEXT)).toEqual(TEAM_CONTEXT);
+  });
+
+  it('rejects a bad enum or a missing member id', () => {
+    expect(parseWorkspaceCollabContext({ ...TEAM_CONTEXT, role: 'viewer' })).toBeNull();
+    expect(parseWorkspaceCollabContext({ ...TEAM_CONTEXT, lifecycleState: 'frozen' })).toBeNull();
+    expect(parseWorkspaceCollabContext({ ...TEAM_CONTEXT, workspaceMemberId: '' })).toBeNull();
+  });
+});
+
+describe('collab context routes', () => {
+  it('returns null context before any is set', async () => {
+    const api = await startContextServer();
+    expect((await api.req('/api/workspace/context')).body).toEqual({ context: null });
+  });
+
+  it('round-trips a context set via the dev PUT', async () => {
+    const api = await startContextServer();
+    const put = await api.req('/api/workspace/context', { method: 'PUT', body: TEAM_CONTEXT });
+    expect(put.status).toBe(200);
+    expect(put.body).toEqual({ context: TEAM_CONTEXT });
+    expect((await api.req('/api/workspace/context')).body).toEqual({ context: TEAM_CONTEXT });
+  });
+
+  it('clears the context on an empty PUT body', async () => {
+    const api = await startContextServer();
+    await api.req('/api/workspace/context', { method: 'PUT', body: TEAM_CONTEXT });
+    const cleared = await api.req('/api/workspace/context', { method: 'PUT', body: {} });
+    expect(cleared.body).toEqual({ context: null });
+    expect((await api.req('/api/workspace/context')).body).toEqual({ context: null });
+  });
+
+  it('rejects an invalid context body', async () => {
+    const api = await startContextServer();
+    const res = await api.req('/api/workspace/context', { method: 'PUT', body: { workspaceType: 'team' } });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/daemon/tests/collab-presence-routes.test.ts
+++ b/apps/daemon/tests/collab-presence-routes.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { createCollabRuntime } from '../src/collab/runtime.js';
+import { registerCollabPresenceRoutes } from '../src/routes/collab-presence.js';
+
+let server: http.Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+});
+
+async function startPresenceServer() {
+  const app = express();
+  app.use(express.json());
+  registerCollabPresenceRoutes(app, { collab: createCollabRuntime() });
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+  const base = `http://127.0.0.1:${address.port}`;
+  return {
+    async json(route: string, options: { method?: string; body?: unknown } = {}) {
+      const init: RequestInit = { method: options.method ?? 'GET' };
+      if (options.body !== undefined) {
+        init.headers = { 'content-type': 'application/json' };
+        init.body = JSON.stringify(options.body);
+      }
+      const response = await fetch(`${base}${route}`, init);
+      return { status: response.status, body: (await response.json()) as Record<string, any> };
+    },
+  };
+}
+
+function presentIds(body: Record<string, any>): string[] {
+  return (body.present as { memberId: string }[]).map((member) => member.memberId).sort();
+}
+
+describe('collab presence routes', () => {
+  it('heartbeats a member and lists the present set', async () => {
+    const api = await startPresenceServer();
+    const hb = await api.json('/api/projects/p1/presence/heartbeat', {
+      method: 'POST',
+      body: { memberId: 'm1', name: 'Ada', role: 'owner' },
+    });
+    expect(hb.status).toBe(200);
+    expect(hb.body.present).toEqual([{ memberId: 'm1', name: 'Ada', role: 'owner' }]);
+
+    const list = await api.json('/api/projects/p1/presence');
+    expect(list.status).toBe(200);
+    expect(presentIds(list.body)).toEqual(['m1']);
+  });
+
+  it('removes a member on leave', async () => {
+    const api = await startPresenceServer();
+    await api.json('/api/projects/p1/presence/heartbeat', { method: 'POST', body: { memberId: 'm1' } });
+    await api.json('/api/projects/p1/presence/heartbeat', { method: 'POST', body: { memberId: 'm2' } });
+    const left = await api.json('/api/projects/p1/presence/leave', { method: 'POST', body: { memberId: 'm1' } });
+    expect(left.status).toBe(200);
+    expect(presentIds(left.body)).toEqual(['m2']);
+  });
+
+  it('rejects a heartbeat without a memberId', async () => {
+    const api = await startPresenceServer();
+    const res = await api.json('/api/projects/p1/presence/heartbeat', { method: 'POST', body: {} });
+    expect(res.status).toBe(400);
+  });
+
+  it('scopes presence per project', async () => {
+    const api = await startPresenceServer();
+    await api.json('/api/projects/p1/presence/heartbeat', { method: 'POST', body: { memberId: 'm1' } });
+    const other = await api.json('/api/projects/p2/presence');
+    expect(other.body.present).toEqual([]);
+  });
+});

--- a/apps/daemon/tests/collab-presence-tracker.test.ts
+++ b/apps/daemon/tests/collab-presence-tracker.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CollabPresenceTracker } from '../src/collab/presence-tracker.js';
+
+let clock = 0;
+const now = () => clock;
+
+beforeEach(() => {
+  clock = 1_000;
+});
+
+function ids(members: { memberId: string }[]): string[] {
+  return members.map((member) => member.memberId).sort();
+}
+
+describe('CollabPresenceTracker', () => {
+  it('lists members that have recently heartbeat', () => {
+    const tracker = new CollabPresenceTracker({ ttlMs: 100, now });
+    tracker.heartbeat('p1', { memberId: 'm1', role: 'owner' });
+    tracker.heartbeat('p1', { memberId: 'm2', role: 'member' });
+    expect(ids(tracker.present('p1'))).toEqual(['m1', 'm2']);
+    expect(tracker.present('other')).toEqual([]);
+  });
+
+  it('drops a member whose heartbeat aged past the TTL', () => {
+    const tracker = new CollabPresenceTracker({ ttlMs: 100, now });
+    tracker.heartbeat('p1', { memberId: 'm1' });
+    clock += 99;
+    expect(ids(tracker.present('p1'))).toEqual(['m1']); // still inside TTL
+    clock += 2; // now 101ms since heartbeat, past TTL
+    expect(tracker.present('p1')).toEqual([]);
+  });
+
+  it('keeps a member present as long as they keep heartbeating', () => {
+    const tracker = new CollabPresenceTracker({ ttlMs: 100, now });
+    tracker.heartbeat('p1', { memberId: 'm1' });
+    clock += 90;
+    tracker.heartbeat('p1', { memberId: 'm1' }); // refresh
+    clock += 90; // 90ms since the refresh — still present despite 180ms total
+    expect(ids(tracker.present('p1'))).toEqual(['m1']);
+  });
+
+  it('removes a member immediately on explicit leave', () => {
+    const tracker = new CollabPresenceTracker({ ttlMs: 10_000, now });
+    tracker.heartbeat('p1', { memberId: 'm1' });
+    tracker.heartbeat('p1', { memberId: 'm2' });
+    tracker.leave('p1', 'm1');
+    expect(ids(tracker.present('p1'))).toEqual(['m2']);
+  });
+
+  it('fires onChange on join and leave, but not on a refresh heartbeat', () => {
+    const onChange = vi.fn();
+    const tracker = new CollabPresenceTracker({ ttlMs: 10_000, now, onChange });
+
+    tracker.heartbeat('p1', { memberId: 'm1' }); // join
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(ids(onChange.mock.calls[0]![0].present)).toEqual(['m1']);
+
+    tracker.heartbeat('p1', { memberId: 'm1' }); // refresh — no membership change
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    tracker.heartbeat('p1', { memberId: 'm2' }); // join
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    tracker.leave('p1', 'm1'); // leave
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(ids(onChange.mock.calls[2]![0].present)).toEqual(['m2']);
+  });
+
+  it('ignores a leave for an unknown member', () => {
+    const onChange = vi.fn();
+    const tracker = new CollabPresenceTracker({ ttlMs: 10_000, now, onChange });
+    tracker.leave('p1', 'ghost');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/daemon/tests/collab-publish-scheduler.test.ts
+++ b/apps/daemon/tests/collab-publish-scheduler.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CollabPublishScheduler } from '../src/collab/publish-scheduler.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('CollabPublishScheduler', () => {
+  it('coalesces rapid changes into a single publish', async () => {
+    vi.useFakeTimers();
+    const publish = vi.fn().mockResolvedValue({ version: 1 });
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 100 });
+
+    scheduler.notifyChanged('p1');
+    scheduler.notifyChanged('p1');
+    scheduler.notifyChanged('p1');
+    expect(publish).not.toHaveBeenCalled(); // still inside the coalesce window
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith({ projectId: 'p1', reason: 'change' });
+  });
+
+  it('flushes immediately at a run boundary instead of waiting out the debounce', async () => {
+    vi.useFakeTimers();
+    const publish = vi.fn().mockResolvedValue({ version: 2 });
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 10_000 });
+
+    scheduler.notifyChanged('p1', 'run');
+    expect(publish).not.toHaveBeenCalled();
+
+    scheduler.runBoundary('p1');
+    // flush() calls the adapter synchronously up to its first await.
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith({ projectId: 'p1', reason: 'run' });
+  });
+
+  it('re-publishes when a change arrives while a publish is in flight (no lost change)', async () => {
+    vi.useFakeTimers();
+    let settleFirst: (value: { version: number }) => void = () => {};
+    const publish = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<{ version: number }>((resolve) => {
+        settleFirst = resolve;
+      }))
+      .mockResolvedValue({ version: 2 });
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 100 });
+
+    scheduler.notifyChanged('p1', 'first');
+    await vi.advanceTimersByTimeAsync(100); // fires publish #1, which stays pending
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    scheduler.notifyChanged('p1', 'later'); // lands mid-publish → marked dirty
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    settleFirst({ version: 1 }); // publish #1 settles → dirty re-schedules
+    await vi.advanceTimersByTimeAsync(100);
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(publish).toHaveBeenLastCalledWith({ projectId: 'p1', reason: 'later' });
+  });
+
+  it('reports the published version so the orchestrator can notify members', async () => {
+    vi.useFakeTimers();
+    const onPublished = vi.fn();
+    const scheduler = new CollabPublishScheduler({
+      adapter: { publish: vi.fn().mockResolvedValue({ version: 7 }) },
+      debounceMs: 50,
+      onPublished,
+    });
+
+    scheduler.notifyChanged('p1', 'save');
+    await vi.advanceTimersByTimeAsync(50);
+    expect(onPublished).toHaveBeenCalledWith({ projectId: 'p1', version: 7, reason: 'save' });
+  });
+
+  it('routes a publish failure to onError and stays usable', async () => {
+    vi.useFakeTimers();
+    const onError = vi.fn();
+    const boom = new Error('hub down');
+    const publish = vi.fn().mockRejectedValueOnce(boom).mockResolvedValue({ version: 1 });
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 50, onError });
+
+    scheduler.notifyChanged('p1');
+    await vi.advanceTimersByTimeAsync(50);
+    expect(onError).toHaveBeenCalledWith({ projectId: 'p1', error: boom });
+
+    // A later change still publishes — a failed publish must not wedge the scheduler.
+    scheduler.notifyChanged('p1');
+    await vi.advanceTimersByTimeAsync(50);
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps per-project publishes independent', async () => {
+    vi.useFakeTimers();
+    const publish = vi.fn().mockResolvedValue({ version: 1 });
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 100 });
+
+    scheduler.notifyChanged('a');
+    scheduler.notifyChanged('b');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(publish.mock.calls.map((call) => call[0].projectId).sort()).toEqual(['a', 'b']);
+  });
+});

--- a/apps/daemon/tests/collab-sync-routes.test.ts
+++ b/apps/daemon/tests/collab-sync-routes.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { createCollabRuntime, type CollabRuntime } from '../src/collab/runtime.js';
+import { registerCollabSyncRoutes } from '../src/routes/collab-sync.js';
+
+let server: http.Server | null = null;
+let runtime: CollabRuntime | null = null;
+
+afterEach(async () => {
+  runtime?.dispose(); // cancel any pending debounce timers
+  runtime = null;
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+});
+
+async function startSyncServer() {
+  const app = express();
+  app.use(express.json());
+  runtime = createCollabRuntime();
+  registerCollabSyncRoutes(app, { collab: runtime });
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+  const base = `http://127.0.0.1:${address.port}`;
+  return {
+    async json(route: string, options: { method?: string; body?: unknown } = {}) {
+      const init: RequestInit = { method: options.method ?? 'GET' };
+      if (options.body !== undefined) {
+        init.headers = { 'content-type': 'application/json' };
+        init.body = JSON.stringify(options.body);
+      }
+      const response = await fetch(`${base}${route}`, init);
+      return { status: response.status, body: (await response.json()) as Record<string, any> };
+    },
+    // Publishing is async (flush → adapter → onPublished); poll until it lands.
+    async awaitPublishedVersion(route: string, notEqualTo: number | null): Promise<number | null> {
+      let version = notEqualTo;
+      for (let i = 0; i < 40 && version === notEqualTo; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        version = (await this.json(route)).body.publishedVersion;
+      }
+      return version;
+    },
+  };
+}
+
+describe('collab sync routes', () => {
+  it('publishes on request and advances the published version monotonically', async () => {
+    const api = await startSyncServer();
+    expect((await api.json('/api/projects/p1/collab/status')).body.publishedVersion).toBeNull();
+
+    const pub = await api.json('/api/projects/p1/collab/publish', { method: 'POST' });
+    expect(pub.status).toBe(200);
+    expect(pub.body.ok).toBe(true);
+
+    const v1 = await api.awaitPublishedVersion('/api/projects/p1/collab/status', null);
+    expect(v1).toBe(1);
+
+    await api.json('/api/projects/p1/collab/publish', { method: 'POST' });
+    const v2 = await api.awaitPublishedVersion('/api/projects/p1/collab/status', v1);
+    expect(v2).toBe(2);
+  });
+
+  it('accepts a coalesced change notification', async () => {
+    const api = await startSyncServer();
+    const res = await api.json('/api/projects/p1/collab/changed', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('keeps published versions independent per project', async () => {
+    const api = await startSyncServer();
+    await api.json('/api/projects/a/collab/publish', { method: 'POST' });
+    await api.awaitPublishedVersion('/api/projects/a/collab/status', null);
+    expect((await api.json('/api/projects/b/collab/status')).body.publishedVersion).toBeNull();
+  });
+
+  it('reports local_only sync state before any share', async () => {
+    const api = await startSyncServer();
+    expect((await api.json('/api/projects/p1/collab/status')).body.syncState).toBe('local_only');
+  });
+
+  it('drives the visibility-to-sync team-share intent through to synced', async () => {
+    const api = await startSyncServer();
+    const intent = await api.json('/api/projects/p1/collab/sync-intent', {
+      method: 'POST',
+      body: { event: 'project_team_share_requested', projectId: 'p1' },
+    });
+    expect(intent.status).toBe(200);
+    // The intent marks it pending immediately; the publish confirms asynchronously.
+    expect(['pending_upload', 'synced']).toContain(intent.body.syncState);
+
+    // Poll until the publish confirms → synced.
+    let state = intent.body.syncState;
+    for (let i = 0; i < 40 && state !== 'synced'; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      state = (await api.json('/api/projects/p1/collab/status')).body.syncState;
+    }
+    expect(state).toBe('synced');
+    expect((await api.json('/api/projects/p1/collab/status')).body.publishedVersion).toBe(1);
+  });
+
+  it('accepts a visibility-changed intent as a no-op signal', async () => {
+    const api = await startSyncServer();
+    const res = await api.json('/api/projects/p1/collab/sync-intent', {
+      method: 'POST',
+      body: { event: 'project_visibility_changed', projectId: 'p1' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.syncState).toBe('local_only'); // visibility change alone doesn't publish
+  });
+
+  it('rejects an unknown sync intent event', async () => {
+    const api = await startSyncServer();
+    const res = await api.json('/api/projects/p1/collab/sync-intent', {
+      method: 'POST',
+      body: { event: 'nonsense', projectId: 'p1' },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('pulls the published head for a member (null before any publish)', async () => {
+    const api = await startSyncServer();
+    const before = await api.json('/api/projects/p1/collab/pull', { method: 'POST' });
+    expect(before.status).toBe(200);
+    expect(before.body.version).toBeNull();
+
+    await api.json('/api/projects/p1/collab/publish', { method: 'POST' });
+    await api.awaitPublishedVersion('/api/projects/p1/collab/status', null);
+    const after = await api.json('/api/projects/p1/collab/pull', { method: 'POST' });
+    expect(after.body.version).toBe(1);
+  });
+});

--- a/apps/daemon/tests/comment-attachments.test.ts
+++ b/apps/daemon/tests/comment-attachments.test.ts
@@ -13,6 +13,7 @@ import {
   listMessages,
   listPreviewComments,
   openDatabase,
+  updatePreviewCommentAnchor,
   updatePreviewCommentStatus,
   upsertMessage,
   upsertPreviewComment,
@@ -55,6 +56,67 @@ describe('preview comment persistence', () => {
       expect.arrayContaining(['selection_kind', 'member_count', 'pod_members_json', 'slide_index', 'slide_key']),
     );
     expect(critiqueTable?.name).toBe('critique_runs');
+  });
+
+  it('adds the team-collab anchor columns on a fresh database', () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-comments-'));
+    const db = openDatabase(tempDir);
+    expect(tableColumnNames(db.prepare(`PRAGMA table_info(preview_comments)`).all())).toEqual(
+      expect.arrayContaining([
+        'anchor_state',
+        'anchored_version',
+        'author_member_id',
+        'last_good_position_json',
+      ]),
+    );
+  });
+
+  it('round-trips team-collab anchor creation metadata and defers resolved state', () => {
+    const db = seededDb();
+    const saved = upsertPreviewComment(db, 'project-1', 'conversation-1', {
+      target: target({ elementId: 'hero-title', anchoredVersion: 7 }),
+      note: 'Anchor me',
+      authorMemberId: 'member-42',
+    });
+    if (!saved) throw new Error('comment upsert failed');
+    // Creation metadata persists...
+    expect(saved.anchoredVersion).toBe(7);
+    expect(saved.authorMemberId).toBe('member-42');
+    // ...while the resolved state is left for the drift ladder to fill in.
+    expect(saved.anchorState).toBeUndefined();
+    expect(saved.lastGoodPosition).toBeUndefined();
+    // Survives the re-fetch (the list read path).
+    const [listed] = listPreviewComments(db, 'project-1', 'conversation-1');
+    expect(listed?.anchoredVersion).toBe(7);
+    expect(listed?.authorMemberId).toBe('member-42');
+  });
+
+  it('writes back resolved anchor state and keeps last-good position on a lost resolve', () => {
+    const db = seededDb();
+    const saved = upsertPreviewComment(db, 'project-1', 'conversation-1', {
+      target: target({ elementId: 'hero-title' }),
+      note: 'Anchor me',
+    });
+    if (!saved) throw new Error('comment upsert failed');
+
+    // Engine resolves it (anchored) and writes back a known-good position.
+    const good = { x: 5, y: 15, width: 120, height: 40 };
+    const anchored = updatePreviewCommentAnchor(db, 'project-1', 'conversation-1', saved.id, {
+      anchorState: 'anchored',
+      lastGoodPosition: good,
+      anchoredVersion: 3,
+    });
+    expect(anchored?.anchorState).toBe('anchored');
+    expect(anchored?.lastGoodPosition).toEqual(good);
+    expect(anchored?.anchoredVersion).toBe(3);
+
+    // Later the element vanishes → 'lost' with no new position. Last-good must survive.
+    const lost = updatePreviewCommentAnchor(db, 'project-1', 'conversation-1', saved.id, {
+      anchorState: 'lost',
+    });
+    expect(lost?.anchorState).toBe('lost');
+    expect(lost?.lastGoodPosition).toEqual(good); // COALESCE preserved it
+    expect(lost?.anchoredVersion).toBe(3); // COALESCE preserved it
   });
 
   it('upserts the latest comment by conversation, file, and element', () => {
@@ -275,6 +337,16 @@ describe('preview comment persistence', () => {
     expect(table?.sql).toMatch(/slide_key INTEGER NOT NULL DEFAULT -1/);
     expect(table?.sql).toMatch(/UNIQUE\(project_id, conversation_id, file_path, element_id, slide_key\)/);
     expect(listPreviewComments(db, 'project-1', 'conversation-1')[0]?.slideIndex).toBe(0);
+    // Anchor columns are backfilled even though the table was rebuilt for the
+    // slide-key migration (the ALTERs run after the rebuild).
+    expect(tableColumnNames(db.prepare(`PRAGMA table_info(preview_comments)`).all())).toEqual(
+      expect.arrayContaining([
+        'anchor_state',
+        'anchored_version',
+        'author_member_id',
+        'last_good_position_json',
+      ]),
+    );
 
     const secondSlide = upsertPreviewComment(db, 'project-1', 'conversation-1', {
       target: target({ elementId: 'hero-title', slideIndex: 1, text: 'Slide two title' }),

--- a/apps/daemon/tests/team-resource-routes.test.ts
+++ b/apps/daemon/tests/team-resource-routes.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { TeamResourceCopyForbiddenError } from '@open-design/contracts';
+import { registerTeamResourceRoutes } from '../src/routes/team-resources.js';
+import {
+  createDevTeamResourceStateProvider,
+  enforceTeamResourceCopyAllowed,
+} from '../src/collab/team-resource-state.js';
+
+let server: http.Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+});
+
+async function startServer() {
+  const app = express();
+  app.use(express.json());
+  registerTeamResourceRoutes(app, { teamResources: createDevTeamResourceStateProvider() });
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+  const base = `http://127.0.0.1:${address.port}`;
+  return {
+    async req(route: string, options: { method?: string; body?: unknown } = {}) {
+      const init: RequestInit = { method: options.method ?? 'GET' };
+      if (options.body !== undefined) {
+        init.headers = { 'content-type': 'application/json' };
+        init.body = JSON.stringify(options.body);
+      }
+      const response = await fetch(`${base}${route}`, init);
+      return { status: response.status, body: (await response.json()) as Record<string, any> };
+    },
+  };
+}
+
+describe('team resource routes (D1 state + D3 enforcement)', () => {
+  it('treats an unregistered resource as personal and allows the copy', async () => {
+    const api = await startServer();
+    expect((await api.req('/api/workspace/resources/plugin/p1/state')).body).toEqual({ scope: 'personal' });
+    const check = await api.req('/api/workspace/resources/plugin/p1/copy-check', { method: 'POST' });
+    expect(check.status).toBe(200);
+    expect(check.body.allowed).toBe(true);
+  });
+
+  it('allows copying an active team resource', async () => {
+    const api = await startServer();
+    await api.req('/api/workspace/resources/design-system/ds1/state', {
+      method: 'PUT',
+      body: { scope: 'team', state: 'active' },
+    });
+    const check = await api.req('/api/workspace/resources/design-system/ds1/copy-check', { method: 'POST' });
+    expect(check.status).toBe(200);
+    expect(check.body.allowed).toBe(true);
+  });
+
+  it('REJECTS copying a frozen team resource with a 403 WORKSPACE_RESOURCE_FROZEN', async () => {
+    const api = await startServer();
+    await api.req('/api/workspace/resources/skill/s1/state', {
+      method: 'PUT',
+      body: { scope: 'team', state: 'frozen' },
+    });
+    expect((await api.req('/api/workspace/resources/skill/s1/state')).body).toEqual({
+      scope: 'team',
+      state: 'frozen',
+    });
+    const check = await api.req('/api/workspace/resources/skill/s1/copy-check', { method: 'POST' });
+    expect(check.status).toBe(403);
+    expect(check.body.error.code).toBe('WORKSPACE_RESOURCE_FROZEN');
+  });
+
+  it('rejects an invalid resource kind', async () => {
+    const api = await startServer();
+    const res = await api.req('/api/workspace/resources/nonsense/x/state');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('enforceTeamResourceCopyAllowed (route-layer guard the copy-out routes call)', () => {
+  it('passes for an unregistered (personal) resource', async () => {
+    const provider = createDevTeamResourceStateProvider();
+    await expect(
+      enforceTeamResourceCopyAllowed(provider, { kind: 'plugin', resourceId: 'p1' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws a coded error for a frozen team resource', async () => {
+    const provider = createDevTeamResourceStateProvider();
+    provider.set?.({ kind: 'plugin', resourceId: 'p1' }, { scope: 'team', state: 'frozen' });
+    await expect(
+      enforceTeamResourceCopyAllowed(provider, { kind: 'plugin', resourceId: 'p1' }),
+    ).rejects.toBeInstanceOf(TeamResourceCopyForbiddenError);
+  });
+});


### PR DESCRIPTION
Part 2 of 3 splitting #5258 for review. Stacks on **(1/3)** #contracts.

The daemon subsystem for team collaboration: presence tracker, comment drift-ladder anchor persistence + resolution, the sync trigger (publish scheduler, sync-intent seam, member pull), the workspace-context identity seam, the resource-hub publish adapter and a kind-parametrized team-resource share service (design systems / plugins / skills), the team-resource copy red-line guard, and the `od collab` CLI. Gated on a team workspace context; degrades to a no-op off-team.

Verified against a local resource-hub fixture: owner shares a resource -> member pulls byte-identical content, for project / design-system / plugin / skill kinds.

## Surface area
- [x] **CLI** — `od collab presence/heartbeat/leave/publish/share/pull`, `share-resource`/`team-resources`
- [x] **API / contract** — collab presence/sync/context routes, `/api/workspace/{design-systems,plugins,skills}/{team,:id/share}`, copy-guard routes
- [ ] None