### PR TITLE
Team collaboration (2/3): web — in-project collaboration + i18n

### DIFF
--- a/apps/web/src/collab/PresenceBar.module.css
+++ b/apps/web/src/collab/PresenceBar.module.css
@@ -1,0 +1,37 @@
+.bar {
+  display: inline-flex;
+  align-items: center;
+  padding-left: 4px;
+}
+
+.avatar,
+.overflow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin-left: -6px;
+  border-radius: 50%;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: #fff;
+  background: var(--color-accent, #4f46e5);
+  box-shadow: 0 0 0 2px var(--color-surface, #fff);
+  user-select: none;
+}
+
+.avatar[data-role='owner'] {
+  background: #b45309;
+}
+
+.avatar[data-role='admin'] {
+  background: #0f766e;
+}
+
+.overflow {
+  background: var(--color-muted, #6b7280);
+  font-size: 9px;
+}

--- a/apps/web/src/collab/PresenceBar.tsx
+++ b/apps/web/src/collab/PresenceBar.tsx
@@ -1,0 +1,58 @@
+import type { CollabPresenceMember } from './collab-client';
+import styles from './PresenceBar.module.css';
+
+export interface PresenceBarProps {
+  members: CollabPresenceMember[];
+  /** Max avatars before collapsing into a "+N" chip. */
+  max?: number;
+  /** The viewer's own member id — excluded from the overlay. */
+  selfMemberId?: string;
+}
+
+function initials(member: CollabPresenceMember): string {
+  const source = (member.name?.trim() || member.memberId).trim();
+  const parts = source.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    const first = parts[0]![0] ?? '';
+    const second = parts[1]![0] ?? '';
+    return (first + second).toUpperCase();
+  }
+  return source.slice(0, 2).toUpperCase();
+}
+
+/**
+ * Presence overlay (presence, the spec): a compact avatar stack of the members
+ * currently viewing the shared project. Poll-driven — the set comes from
+ * {@link useCollab}; there are no live cursors.
+ */
+export function PresenceBar({ members, max = 5, selfMemberId }: PresenceBarProps) {
+  const others = members.filter((m) => m.memberId !== selfMemberId);
+  if (others.length === 0) return null;
+
+  const shown = others.slice(0, max);
+  const overflow = others.length - shown.length;
+
+  return (
+    <div
+      className={styles.bar}
+      role="group"
+      aria-label={`${others.length} collaborator${others.length === 1 ? '' : 's'} present`}
+    >
+      {shown.map((member) => (
+        <span
+          key={member.memberId}
+          className={styles.avatar}
+          data-role={member.role ?? 'member'}
+          title={member.name ?? member.memberId}
+        >
+          {initials(member)}
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span className={styles.overflow} title={`${overflow} more present`}>
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/collab/collab-client.ts
+++ b/apps/web/src/collab/collab-client.ts
@@ -1,0 +1,174 @@
+// Team collaboration client integration. Ties the daemon collab capabilities
+// together for a shared-project session: heartbeat presence, poll the published
+// head version (so a member knows when to pull), and report author-side changes
+// / request a publish. It is the glue the read-only collab view consumes.
+//
+// Polling-based by design (live cursors were cut; content is polled — the spec).
+
+import type { CollabPresenceMember, ProjectSyncState } from '@open-design/contracts';
+
+// Presence identity is the shared contract DTO; re-export so collab consumers
+// keep importing it from the client module.
+export type { CollabPresenceMember };
+
+export interface CollabSnapshot {
+  present: CollabPresenceMember[];
+  publishedVersion: number | null;
+  /**  project sync state; null until the first status poll lands. */
+  syncState: ProjectSyncState | null;
+  /** The member who shared this project (its single writer); null if unshared. */
+  ownerMemberId: string | null;
+}
+
+export interface CollabClientOptions {
+  projectId: string;
+  member: CollabPresenceMember;
+  /** Injectable for tests; defaults to the global fetch. */
+  fetch?: typeof fetch;
+  /** Daemon API base; default '' (same origin). */
+  baseUrl?: string;
+  heartbeatMs?: number;
+  statusPollMs?: number;
+  onUpdate?: (snapshot: CollabSnapshot) => void;
+  onError?: (error: unknown) => void;
+}
+
+const DEFAULT_HEARTBEAT_MS = 10_000;
+const DEFAULT_STATUS_POLL_MS = 5_000;
+
+export class CollabClient {
+  private readonly projectId: string;
+  private readonly member: CollabPresenceMember;
+  private readonly fetchImpl: typeof fetch;
+  private readonly baseUrl: string;
+  private readonly heartbeatMs: number;
+  private readonly statusPollMs: number;
+  private readonly onUpdate?: CollabClientOptions['onUpdate'];
+  private readonly onError?: CollabClientOptions['onError'];
+  private readonly timers: ReturnType<typeof setInterval>[] = [];
+  private snapshot: CollabSnapshot = { present: [], publishedVersion: null, syncState: null, ownerMemberId: null };
+  private running = false;
+
+  constructor(options: CollabClientOptions) {
+    this.projectId = options.projectId;
+    this.member = options.member;
+    this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+    this.baseUrl = options.baseUrl ?? '';
+    this.heartbeatMs = Math.max(1_000, options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS);
+    this.statusPollMs = Math.max(1_000, options.statusPollMs ?? DEFAULT_STATUS_POLL_MS);
+    this.onUpdate = options.onUpdate;
+    this.onError = options.onError;
+  }
+
+  getSnapshot(): CollabSnapshot {
+    return this.snapshot;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    void this.heartbeat();
+    void this.pollStatus();
+    this.timers.push(setInterval(() => void this.heartbeat(), this.heartbeatMs));
+    this.timers.push(setInterval(() => void this.pollStatus(), this.statusPollMs));
+  }
+
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+    for (const timer of this.timers) clearInterval(timer);
+    this.timers.length = 0;
+    void this.leave();
+  }
+
+  /** The author edited a file — schedule a coalesced publish. */
+  async reportChange(): Promise<void> {
+    await this.post('/collab/changed');
+  }
+
+  /** Run boundary — flush the pending publish now. */
+  async requestPublish(): Promise<void> {
+    await this.post('/collab/publish');
+  }
+
+  async heartbeat(): Promise<void> {
+    try {
+      const body = await this.post('/presence/heartbeat', this.member);
+      if (Array.isArray(body?.present)) this.update({ present: body.present as CollabPresenceMember[] });
+    } catch (error) {
+      this.onError?.(error);
+    }
+  }
+
+  async pollStatus(): Promise<void> {
+    try {
+      const body = await this.get('/collab/status');
+      const version = typeof body?.publishedVersion === 'number' ? body.publishedVersion : null;
+      const syncState = (body?.syncState as ProjectSyncState | undefined) ?? null;
+      const ownerMemberId = typeof body?.ownerMemberId === 'string' ? body.ownerMemberId : null;
+      this.update({ publishedVersion: version, syncState, ownerMemberId });
+    } catch (error) {
+      this.onError?.(error);
+    }
+  }
+
+  private async leave(): Promise<void> {
+    try {
+      await this.post('/presence/leave', { memberId: this.member.memberId });
+    } catch (error) {
+      this.onError?.(error);
+    }
+  }
+
+  /**
+   * Best-effort leave that survives page unload. A normal fetch is aborted when
+   * the tab closes, so a hard close would otherwise leave the member lingering
+   * until the daemon's presence TTL sweeps it (~30s). sendBeacon (with a
+   * keepalive-fetch fallback) hands the request to the browser to deliver after
+   * the page is gone, so the present set drops promptly.
+   */
+  leaveBeacon(): void {
+    const url = this.url('/presence/leave');
+    const body = JSON.stringify({ memberId: this.member.memberId });
+    try {
+      if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+        const blob = new Blob([body], { type: 'application/json' });
+        if (navigator.sendBeacon(url, blob)) return;
+      }
+    } catch {
+      // fall through to the keepalive fetch
+    }
+    void this.fetchImpl(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {});
+  }
+
+  private update(patch: Partial<CollabSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...patch };
+    this.onUpdate?.(this.snapshot);
+  }
+
+  private async get(path: string): Promise<Record<string, unknown> | null> {
+    const response = await this.fetchImpl(this.url(path));
+    if (!response.ok) throw new Error(`collab GET ${path} failed: ${response.status}`);
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  private async post(path: string, body?: unknown): Promise<Record<string, unknown> | null> {
+    const init: RequestInit = { method: 'POST' };
+    if (body !== undefined) {
+      init.headers = { 'content-type': 'application/json' };
+      init.body = JSON.stringify(body);
+    }
+    const response = await this.fetchImpl(this.url(path), init);
+    if (!response.ok) throw new Error(`collab POST ${path} failed: ${response.status}`);
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  private url(path: string): string {
+    return `${this.baseUrl}/api/projects/${encodeURIComponent(this.projectId)}${path}`;
+  }
+}

--- a/apps/web/src/collab/collab-session.ts
+++ b/apps/web/src/collab/collab-session.ts
@@ -1,0 +1,55 @@
+import type {
+  CollabPresenceMember,
+  WorkspaceCollabContext,
+  WorkspaceLifecycleState,
+} from '@open-design/contracts';
+
+// The the collaboration surface seam onto the B (workspace) + D (visibility) lanes. B owns the
+// CurrentWorkspaceContext (identity token → workspaceMemberId + role + lifecycle);
+// the visibility surface owns whether a workspace/project is team-shared. Collab (presence + sync)
+// should only run for an active member of a live team workspace. The context
+// shape is the shared contract DTO (a faithful subset of B's context), so wiring
+// B's real context in is a direct field pass-through.
+
+export type { WorkspaceCollabContext };
+
+export interface CollabSessionDecision {
+  /** Whether to start the presence heartbeat + sync poll. */
+  enabled: boolean;
+  /** Diagnostic reason when disabled (never user-facing copy). */
+  reason: string;
+  /** The presence identity, when enabled. */
+  member: CollabPresenceMember | null;
+}
+
+// Lifecycle states in which the workspace is still functional enough to
+// collaborate. `locked` (frozen after expiry) / `deleting` / `deleted` are not.
+const LIVE_LIFECYCLE: ReadonlySet<WorkspaceLifecycleState> = new Set([
+  'active',
+  'billing_past_due',
+]);
+
+/**
+ * Decide whether collab should run for the current workspace context, and who
+ * the present member is. Gating (in order):
+ * - no context → off
+ * - personal workspace → off (D: only team workspaces are collaborative)
+ * - removed member → off
+ * - frozen/deleting/deleted lifecycle → off
+ * - otherwise → on, identity from workspaceMemberId
+ */
+export function resolveCollabSession(ctx: WorkspaceCollabContext | null): CollabSessionDecision {
+  if (!ctx) return { enabled: false, reason: 'no-workspace-context', member: null };
+  if (ctx.workspaceType !== 'team') {
+    return { enabled: false, reason: 'personal-workspace', member: null };
+  }
+  if (ctx.memberStatus !== 'active') {
+    return { enabled: false, reason: 'member-removed', member: null };
+  }
+  if (!LIVE_LIFECYCLE.has(ctx.lifecycleState)) {
+    return { enabled: false, reason: `lifecycle-${ctx.lifecycleState}`, member: null };
+  }
+  const member: CollabPresenceMember = { memberId: ctx.workspaceMemberId, role: ctx.role };
+  if (ctx.displayName && ctx.displayName.trim()) member.name = ctx.displayName.trim();
+  return { enabled: true, reason: 'ok', member };
+}

--- a/apps/web/src/collab/invite-continuation.ts
+++ b/apps/web/src/collab/invite-continuation.ts
@@ -1,0 +1,294 @@
+// Invitee client state machine + local storage (C lane).
+//
+// Pure, injectable logic behind the invite acceptance page:
+//   - persist / read / clear the pending continuation (retry the desktop
+//     hand-off when signed out, not installed, or after a failed open)
+//   - derive a LocalWorkspaceActivation from the accept response
+//   - the account-mismatch judgement (current signed-in email vs the masked
+//     invited email)
+//   - re-export the contract-owned deeplink parse/build helpers
+//
+// The DTO shapes live in `@open-design/contracts` (workspace-invites.ts); this
+// module owns only the client-side behavior so the component stays thin and the
+// logic stays unit-testable. The raw invite token is NEVER persisted here — the
+// pending continuation carries a single-use nonce, not the token.
+
+import type {
+  LocalPendingInviteContinuation,
+  LocalPendingInviteContinuationStatus,
+  LocalWorkspaceActivation,
+  WorkspaceCollabContext,
+  WorkspaceInviteAcceptResponse,
+} from '@open-design/contracts';
+import { buildInviteDeeplink, parseInviteDeeplink } from '@open-design/contracts';
+
+export { buildInviteDeeplink, parseInviteDeeplink };
+export type {
+  InviteDeeplinkPayload,
+  LocalPendingInviteContinuation,
+  LocalPendingInviteContinuationStatus,
+  LocalWorkspaceActivation,
+} from '@open-design/contracts';
+
+/** The minimal storage surface the continuation store needs (localStorage-compatible). */
+export interface KeyValueStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export const PENDING_INVITE_CONTINUATION_KEY = 'od.collab.pendingInviteContinuation';
+export const WORKSPACE_ACTIVATION_KEY = 'od.collab.workspaceActivation';
+
+/** Resolve the browser localStorage, or null when it is unavailable/denied. */
+export function defaultInviteStorage(): KeyValueStorage | null {
+  try {
+    if (typeof localStorage !== 'undefined') return localStorage;
+  } catch {
+    // Access can throw in a sandboxed / privacy-locked context.
+  }
+  return null;
+}
+
+const CONTINUATION_STATUSES: ReadonlySet<LocalPendingInviteContinuationStatus> = new Set([
+  'pending',
+  'opened',
+  'failed',
+]);
+
+function coercePendingContinuation(value: unknown): LocalPendingInviteContinuation | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  if (
+    typeof v.nonce !== 'string' ||
+    typeof v.inviteId !== 'string' ||
+    typeof v.workspaceId !== 'string' ||
+    typeof v.workspaceMemberId !== 'string' ||
+    typeof v.deeplinkUrl !== 'string' ||
+    typeof v.expiresAt !== 'number' ||
+    typeof v.status !== 'string' ||
+    !CONTINUATION_STATUSES.has(v.status as LocalPendingInviteContinuationStatus)
+  ) {
+    return null;
+  }
+  const entry: LocalPendingInviteContinuation = {
+    nonce: v.nonce,
+    inviteId: v.inviteId,
+    workspaceId: v.workspaceId,
+    workspaceMemberId: v.workspaceMemberId,
+    deeplinkUrl: v.deeplinkUrl,
+    expiresAt: v.expiresAt,
+    status: v.status as LocalPendingInviteContinuationStatus,
+  };
+  if (typeof v.lastAttemptAt === 'number') entry.lastAttemptAt = v.lastAttemptAt;
+  return entry;
+}
+
+/**
+ * Read the pending continuation, or null when there is none, it is malformed,
+ * or it has expired. A malformed or expired entry is removed as a side effect
+ * so the store self-heals.
+ */
+export function readPendingInviteContinuation(
+  storage: KeyValueStorage | null = defaultInviteStorage(),
+  now: number = Date.now(),
+): LocalPendingInviteContinuation | null {
+  if (!storage) return null;
+  const raw = storage.getItem(PENDING_INVITE_CONTINUATION_KEY);
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    storage.removeItem(PENDING_INVITE_CONTINUATION_KEY);
+    return null;
+  }
+  const entry = coercePendingContinuation(parsed);
+  if (!entry) {
+    storage.removeItem(PENDING_INVITE_CONTINUATION_KEY);
+    return null;
+  }
+  if (entry.expiresAt <= now) {
+    storage.removeItem(PENDING_INVITE_CONTINUATION_KEY);
+    return null;
+  }
+  return entry;
+}
+
+/** Persist the pending continuation, replacing any prior one (single slot). */
+export function writePendingInviteContinuation(
+  entry: LocalPendingInviteContinuation,
+  storage: KeyValueStorage | null = defaultInviteStorage(),
+): void {
+  storage?.setItem(PENDING_INVITE_CONTINUATION_KEY, JSON.stringify(entry));
+}
+
+/** Clear the pending continuation (on success, expiry, or replacement). */
+export function clearPendingInviteContinuation(
+  storage: KeyValueStorage | null = defaultInviteStorage(),
+): void {
+  storage?.removeItem(PENDING_INVITE_CONTINUATION_KEY);
+}
+
+/**
+ * Update the stored continuation's delivery status (and stamp the attempt
+ * time). Returns the updated entry, or null when there is no live entry.
+ */
+export function markPendingInviteContinuation(
+  status: LocalPendingInviteContinuationStatus,
+  attemptedAt: number = Date.now(),
+  storage: KeyValueStorage | null = defaultInviteStorage(),
+): LocalPendingInviteContinuation | null {
+  const current = readPendingInviteContinuation(storage, attemptedAt);
+  if (!current) return null;
+  const next: LocalPendingInviteContinuation = { ...current, status, lastAttemptAt: attemptedAt };
+  writePendingInviteContinuation(next, storage);
+  return next;
+}
+
+/**
+ * Derive the pending continuation to persist from a successful accept response.
+ * Status starts at `pending`; only the nonce (never the raw token) is carried.
+ */
+export function pendingContinuationFromAccept(
+  response: WorkspaceInviteAcceptResponse,
+): LocalPendingInviteContinuation {
+  return {
+    nonce: response.continuation.nonce,
+    inviteId: response.inviteId,
+    workspaceId: response.workspaceId,
+    workspaceMemberId: response.workspaceMemberId,
+    expiresAt: response.continuation.expiresAt,
+    deeplinkUrl: response.continuation.deeplinkUrl,
+    status: 'pending',
+  };
+}
+
+/**
+ * Derive the local workspace activation from the accept response's freshly
+ * activated `currentWorkspaceContext`. Role / member status / lifecycle are
+ * taken verbatim — never re-derived — so C never drifts from B's facts.
+ */
+export function deriveWorkspaceActivation(
+  ctx: WorkspaceCollabContext,
+  activatedAt: number = Date.now(),
+): LocalWorkspaceActivation {
+  return {
+    workspaceId: ctx.workspaceId,
+    workspaceMemberId: ctx.workspaceMemberId,
+    role: ctx.role,
+    memberStatus: ctx.memberStatus,
+    lifecycleState: ctx.lifecycleState,
+    activatedAt,
+  };
+}
+
+function coerceActivation(value: unknown): LocalWorkspaceActivation | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  if (
+    typeof v.workspaceId !== 'string' ||
+    typeof v.workspaceMemberId !== 'string' ||
+    typeof v.role !== 'string' ||
+    typeof v.memberStatus !== 'string' ||
+    typeof v.lifecycleState !== 'string' ||
+    typeof v.activatedAt !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    workspaceId: v.workspaceId,
+    workspaceMemberId: v.workspaceMemberId,
+    role: v.role as LocalWorkspaceActivation['role'],
+    memberStatus: v.memberStatus as LocalWorkspaceActivation['memberStatus'],
+    lifecycleState: v.lifecycleState as LocalWorkspaceActivation['lifecycleState'],
+    activatedAt: v.activatedAt,
+  };
+}
+
+/** Persist the derived activation. */
+export function writeWorkspaceActivation(
+  activation: LocalWorkspaceActivation,
+  storage: KeyValueStorage | null = defaultInviteStorage(),
+): void {
+  storage?.setItem(WORKSPACE_ACTIVATION_KEY, JSON.stringify(activation));
+}
+
+/** Read the persisted activation, or null when absent/malformed. */
+export function readWorkspaceActivation(
+  storage: KeyValueStorage | null = defaultInviteStorage(),
+): LocalWorkspaceActivation | null {
+  if (!storage) return null;
+  const raw = storage.getItem(WORKSPACE_ACTIVATION_KEY);
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    storage.removeItem(WORKSPACE_ACTIVATION_KEY);
+    return null;
+  }
+  const entry = coerceActivation(parsed);
+  if (!entry) {
+    storage.removeItem(WORKSPACE_ACTIVATION_KEY);
+    return null;
+  }
+  return entry;
+}
+
+// —— Account-mismatch judgement ——————————————————————————————————————————
+
+/** Result of comparing the signed-in account against the invited email. */
+export type AccountMatch = 'match' | 'mismatch' | 'unknown';
+
+// Characters B may use to mask the invited email (`j***@` / `j•••@` / `j···@`).
+const MASK_CHARS = /[*•·]/;
+const VISIBLE_LEAD = /^[^*•·]+/;
+const VISIBLE_TRAIL = /[^*•·]+$/;
+
+/**
+ * Decide whether the currently signed-in account is the one the invite was
+ * sent to, given only the masked invited email (`j***@company.com`).
+ *
+ * - `unknown` — no signed-in email, or an unparseable masked email. The UI
+ *   must not assert a mismatch it cannot prove.
+ * - `mismatch` — domains differ, or a visible (unmasked) segment of the local
+ *   part does not line up with the current local part.
+ * - `match` — domain matches and every visible segment lines up.
+ *
+ * This is a tolerant heuristic: B owns the true mask algorithm, so the check
+ * only ever fires a mismatch it is confident about; ambiguous cases resolve to
+ * `match` (domain-only) or `unknown`.
+ */
+export function evaluateAccountMatch(
+  currentEmail: string | null | undefined,
+  invitedEmailMasked: string,
+): AccountMatch {
+  const current = (currentEmail ?? '').trim().toLowerCase();
+  const currentAt = current.lastIndexOf('@');
+  if (currentAt <= 0 || currentAt >= current.length - 1) return 'unknown';
+  const currentLocal = current.slice(0, currentAt);
+  const currentDomain = current.slice(currentAt + 1);
+
+  const masked = invitedEmailMasked.trim().toLowerCase();
+  const maskedAt = masked.lastIndexOf('@');
+  if (maskedAt <= 0 || maskedAt >= masked.length - 1) return 'unknown';
+  const maskedLocal = masked.slice(0, maskedAt);
+  const maskedDomain = masked.slice(maskedAt + 1);
+
+  if (currentDomain !== maskedDomain) return 'mismatch';
+
+  // No mask characters: the local part is fully visible → require an exact match.
+  if (!MASK_CHARS.test(maskedLocal)) {
+    return currentLocal === maskedLocal ? 'match' : 'mismatch';
+  }
+
+  const visibleLead = maskedLocal.match(VISIBLE_LEAD)?.[0] ?? '';
+  const visibleTrail = maskedLocal.match(VISIBLE_TRAIL)?.[0] ?? '';
+
+  if (visibleLead && !currentLocal.startsWith(visibleLead)) return 'mismatch';
+  if (visibleTrail && visibleTrail !== visibleLead && !currentLocal.endsWith(visibleTrail)) {
+    return 'mismatch';
+  }
+  return 'match';
+}

--- a/apps/web/src/collab/settings-access.ts
+++ b/apps/web/src/collab/settings-access.ts
@@ -1,0 +1,85 @@
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+
+// Settings shell role gating (E-frontend, D4.3). The base SettingsDialog renders
+// every personal section unconditionally; this is the new layer that decides
+// which *workspace* entries the Settings shell shows. E (our lane) owns ONLY the
+// shell-level visibility + the entry points — the destinations themselves belong
+// to their lanes: members = B, billing/auto-recharge = A, team space = D. Personal
+// settings are always shown and are not modeled here.
+//
+// Gating reads the folded permission bits on `WorkspaceCollabContext.permissions`
+// DIRECTLY (never re-derived from role/lifecycle here) so this shell can never
+// drift from B's authorization rules — the contract already folds role + member
+// status + lifecycle into each bit. See `packages/contracts/src/api/collab.ts`.
+//
+// Note (D4.3): there is no team-level BYOK/provider this cycle, so "member can't
+// edit the workspace provider" has no object — BYOK/provider stays personal and
+// lives in the untouched personal sections. The entries that actually need gating
+// are these other-lane workspace destinations.
+
+export type WorkspaceSettingsEntryId = 'members' | 'billing' | 'autoRecharge' | 'teamSpace';
+
+export const WORKSPACE_SETTINGS_ENTRY_IDS: readonly WorkspaceSettingsEntryId[] = [
+  'members',
+  'billing',
+  'autoRecharge',
+  'teamSpace',
+];
+
+/**
+ * Whether the Settings shell shows the Workspace region at all. True only for a
+ * team workspace whose viewer may see workspace settings (`canViewWorkspaceSettings`
+ * — a read-level bit, so it stays true when the workspace is locked). Off-team,
+ * personal, signed-out, or B-unavailable → no Workspace region.
+ */
+export function canShowWorkspaceSettings(
+  context: WorkspaceCollabContext | null | undefined,
+): boolean {
+  return Boolean(
+    context &&
+      context.workspaceType === 'team' &&
+      context.permissions.canViewWorkspaceSettings,
+  );
+}
+
+/**
+ * Whether a single Workspace entry is visible, gating on the folded permission
+ * bits directly. Membership shows for members who can manage or invite; billing
+ * and auto-recharge for the billing owner; team space whenever the workspace has
+ * a team id (D provides the destination). Never re-derive from role here.
+ */
+export function isWorkspaceSettingsEntryVisible(
+  context: WorkspaceCollabContext,
+  entry: WorkspaceSettingsEntryId,
+): boolean {
+  const p = context.permissions;
+  switch (entry) {
+    case 'members':
+      return p.canManageMembers || p.canInviteMembers;
+    case 'billing':
+      return p.canManageBilling;
+    case 'autoRecharge':
+      return p.canManageAutoRecharge;
+    case 'teamSpace':
+      return Boolean(context.teamId);
+  }
+}
+
+/** The workspace entries the shell renders, in canonical order. */
+export function visibleWorkspaceSettingsEntries(
+  context: WorkspaceCollabContext,
+): WorkspaceSettingsEntryId[] {
+  return WORKSPACE_SETTINGS_ENTRY_IDS.filter((entry) =>
+    isWorkspaceSettingsEntryVisible(context, entry),
+  );
+}
+
+/**
+ * Whether opening an entry is a write-shaped action, so the shell can grey it out
+ * when the workspace is not writable (locked / past-due) — mirroring how the nav
+ * shell disables its write affordances while a locked banner explains why. Billing
+ * stays enabled while non-writable so the owner can still reach recovery.
+ */
+export function isWorkspaceSettingsEntryWriteAction(entry: WorkspaceSettingsEntryId): boolean {
+  return entry !== 'billing';
+}

--- a/apps/web/src/collab/useCollab.ts
+++ b/apps/web/src/collab/useCollab.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  CollabClient,
+  type CollabClientOptions,
+  type CollabPresenceMember,
+  type CollabSnapshot,
+} from './collab-client';
+
+export interface UseCollabOptions {
+  projectId: string | null | undefined;
+  member: CollabPresenceMember | null | undefined;
+  /** When false the client never starts (e.g. a solo, non-shared project). */
+  enabled?: boolean;
+  baseUrl?: string;
+  heartbeatMs?: number;
+  statusPollMs?: number;
+  /** Injectable for tests. */
+  fetch?: typeof fetch;
+}
+
+export interface UseCollabResult {
+  present: CollabPresenceMember[];
+  publishedVersion: number | null;
+  syncState: CollabSnapshot['syncState'];
+  ownerMemberId: CollabSnapshot['ownerMemberId'];
+  reportChange: () => void;
+  requestPublish: () => void;
+}
+
+const EMPTY: CollabSnapshot = { present: [], publishedVersion: null, syncState: null, ownerMemberId: null };
+
+/**
+ * React seam over {@link CollabClient} (C lane). Starts a presence heartbeat +
+ * sync-status poll for the current shared project and re-renders as the present
+ * set / published head version change. Members drive the read-only collab view
+ * from this; the author additionally calls reportChange / requestPublish.
+ */
+export function useCollab(options: UseCollabOptions): UseCollabResult {
+  const { projectId, member, enabled = true } = options;
+  const [snapshot, setSnapshot] = useState<CollabSnapshot>(EMPTY);
+  const clientRef = useRef<CollabClient | null>(null);
+
+  const active = Boolean(enabled && projectId && member);
+  // Restart only on identity changes, not on every render of a fresh member object.
+  const memberKey = member ? JSON.stringify([member.memberId, member.name ?? '', member.role ?? '']) : '';
+
+  useEffect(() => {
+    if (!active || !projectId || !member) {
+      setSnapshot(EMPTY);
+      return;
+    }
+    const clientOptions: CollabClientOptions = { projectId, member, onUpdate: setSnapshot };
+    if (options.baseUrl !== undefined) clientOptions.baseUrl = options.baseUrl;
+    if (options.heartbeatMs !== undefined) clientOptions.heartbeatMs = options.heartbeatMs;
+    if (options.statusPollMs !== undefined) clientOptions.statusPollMs = options.statusPollMs;
+    if (options.fetch !== undefined) clientOptions.fetch = options.fetch;
+
+    const client = new CollabClient(clientOptions);
+    clientRef.current = client;
+    client.start();
+    // A hard tab close skips React unmount, so `stop()`'s fetch leave never
+    // sends. `pagehide` fires on close/navigation and lets the client hand off a
+    // beacon that survives the unload, so the present set drops promptly.
+    const onPageHide = () => client.leaveBeacon();
+    window.addEventListener('pagehide', onPageHide);
+    return () => {
+      window.removeEventListener('pagehide', onPageHide);
+      client.stop();
+      clientRef.current = null;
+      setSnapshot(EMPTY);
+    };
+    // memberKey stands in for `member`; fetch is intentionally not a restart trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, projectId, memberKey, options.baseUrl, options.heartbeatMs, options.statusPollMs]);
+
+  const reportChange = useCallback(() => {
+    void clientRef.current?.reportChange();
+  }, []);
+  const requestPublish = useCallback(() => {
+    void clientRef.current?.requestPublish();
+  }, []);
+
+  return {
+    present: snapshot.present,
+    publishedVersion: snapshot.publishedVersion,
+    syncState: snapshot.syncState,
+    ownerMemberId: snapshot.ownerMemberId,
+    reportChange,
+    requestPublish,
+  };
+}

--- a/apps/web/src/collab/useProjectCollab.ts
+++ b/apps/web/src/collab/useProjectCollab.ts
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import type { CollabPresenceMember, WorkspaceCollabContext } from '@open-design/contracts';
+import { resolveCollabSession } from './collab-session';
+import { useCollab } from './useCollab';
+
+export interface UseProjectCollabOptions {
+  /** Injectable for tests. */
+  fetch?: typeof fetch;
+  baseUrl?: string;
+  heartbeatMs?: number;
+  statusPollMs?: number;
+}
+
+/**
+ * Fetch the current workspace context (B-integration seam, GET /api/workspace/
+ * context). Null until it loads, or when there is no team-workspace context
+ * (personal / signed out / hub unavailable). The daemon serves a dev context
+ * until B is wired; production proxies B.
+ */
+export function useWorkspaceContext(options: UseProjectCollabOptions = {}): WorkspaceCollabContext | null {
+  const [context, setContext] = useState<WorkspaceCollabContext | null>(null);
+  const baseUrl = options.baseUrl ?? '';
+  const fetchImpl = options.fetch;
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = fetchImpl ?? globalThis.fetch.bind(globalThis);
+    void (async () => {
+      try {
+        const response = await run(`${baseUrl}/api/workspace/context`);
+        if (!response.ok) return;
+        const body = (await response.json()) as { context?: WorkspaceCollabContext | null };
+        if (!cancelled) setContext(body?.context ?? null);
+      } catch {
+        if (!cancelled) setContext(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [baseUrl, fetchImpl]);
+
+  return context;
+}
+
+export interface ProjectCollab {
+  /** Whether collab (presence + sync) is active for this project + viewer. */
+  enabled: boolean;
+  /** The viewer's presence identity, when enabled. */
+  member: CollabPresenceMember | null;
+  present: CollabPresenceMember[];
+  publishedVersion: number | null;
+  syncState: ReturnType<typeof useCollab>['syncState'];
+  /**
+   * Whether the viewer should see this project single-writer/read-only. Two
+   * independent gates make it read-only:
+   *  1. Workspace-level — the workspace is not writable (`permissions
+   *     .canWriteSyncedFiles` is false: locked/frozen billing, or the member was
+   *     removed). This freezes EVERYONE, the project owner included.
+   *  2. Project-level — the project is shared to the team and the viewer is not
+   *     its owner (the member who shared it). Ownership, not workspace role, is
+   *     the determinant, so the sharer keeps editing while everyone else views.
+   * A personal / unshared project in a writable workspace is never read-only.
+   */
+  viewerOnly: boolean;
+  reportChange: () => void;
+  requestPublish: () => void;
+}
+
+/**
+ * Real-product collab integration for a project : resolves the workspace
+ * context → decides whether collab runs (team member of a live workspace) → runs
+ * presence + sync for the viewer. Dormant (enabled=false, no heartbeat) when the
+ * project is personal / the viewer is not a team member — so it is safe to mount
+ * unconditionally in the project view.
+ */
+export function useProjectCollab(
+  projectId: string | null | undefined,
+  options: UseProjectCollabOptions = {},
+): ProjectCollab {
+  const context = useWorkspaceContext(options);
+  const decision = resolveCollabSession(context);
+  const collab = useCollab({
+    projectId: projectId ?? null,
+    member: decision.member,
+    enabled: decision.enabled,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+    ...(options.baseUrl !== undefined ? { baseUrl: options.baseUrl } : {}),
+    ...(options.heartbeatMs !== undefined ? { heartbeatMs: options.heartbeatMs } : {}),
+    ...(options.statusPollMs !== undefined ? { statusPollMs: options.statusPollMs } : {}),
+  });
+  // Gate 1 (workspace-level): a non-writable workspace (locked/frozen billing or
+  // a removed member) freezes everyone — consume B's `canWriteSyncedFiles` bit
+  // rather than re-deriving from lifecycle so the two lanes cannot drift.
+  const workspaceReadOnly = context != null && !context.permissions.canWriteSyncedFiles;
+  // Gate 2 (project-level): a project shared to the team (syncState past
+  // `local_only`) is read-only for everyone except the member who shared it — the
+  // single writer keeps editing their own project. This fails closed: it stays
+  // read-only until the polled owner id EXPLICITLY matches the current member, so
+  // a non-owner (of any workspace role — including admin/owner) never gets edit
+  // affordances during the load window or when a `/collab/status` payload is
+  // briefly missing `ownerMemberId`. The real owner sees a momentary read-only
+  // state until their id is confirmed, then flips to editable. A personal /
+  // unshared project is never read-only on this gate.
+  const shared = collab.syncState !== 'local_only' && collab.syncState !== null;
+  const isOwner = collab.ownerMemberId != null && collab.ownerMemberId === context?.workspaceMemberId;
+  const sharedReadOnly = shared && !isOwner;
+  const viewerOnly = workspaceReadOnly || sharedReadOnly;
+  return {
+    enabled: decision.enabled,
+    member: decision.member,
+    present: collab.present,
+    publishedVersion: collab.publishedVersion,
+    syncState: collab.syncState,
+    viewerOnly,
+    reportChange: collab.reportChange,
+    requestPublish: collab.requestPublish,
+  };
+}

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import type { WorkspaceCollabContext, WorkspaceContextResponse } from '@open-design/contracts';
+
+// One shared read of the workspace context (`GET /api/workspace/context`) for the
+// navigation shell. The daemon proxies B's `CurrentWorkspaceContext`; `context` is
+// null off-team (personal, signed out, or B unavailable). Every team surface in the
+// entry shell (nav rail, workspace switcher, gating) consumes THIS one read so the
+// two-state shell never re-derives role/permission judgements or fans out duplicate
+// fetches. See `packages/contracts/src/api/collab.ts` for the shape.
+export interface WorkspaceContextState {
+  context: WorkspaceCollabContext | null;
+  loading: boolean;
+}
+
+export function useWorkspaceContext(): WorkspaceContextState {
+  const [state, setState] = useState<WorkspaceContextState>({ context: null, loading: true });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/workspace/context');
+        if (!res.ok) {
+          if (!cancelled) setState({ context: null, loading: false });
+          return;
+        }
+        const body = (await res.json()) as WorkspaceContextResponse;
+        if (!cancelled) setState({ context: body.context ?? null, loading: false });
+      } catch {
+        // Personal / offline / daemon without the B proxy: stay in the local state.
+        if (!cancelled) setState({ context: null, loading: false });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}

--- a/apps/web/tests/collab-client.test.ts
+++ b/apps/web/tests/collab-client.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CollabClient, type CollabSnapshot } from '../src/collab/collab-client.js';
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+interface FakeFetchOptions {
+  present?: Array<{ memberId: string; name?: string }>;
+  publishedVersion?: number | null;
+  failPath?: string;
+}
+
+function makeFetch(options: FakeFetchOptions = {}) {
+  const calls: RecordedCall[] = [];
+  const state = {
+    present: options.present ?? [{ memberId: 'm1', name: 'Author' }],
+    publishedVersion: options.publishedVersion ?? null,
+  };
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    calls.push({ url, method, body });
+    const pathname = new URL(url, 'http://daemon.local').pathname;
+    if (options.failPath && pathname.endsWith(options.failPath)) {
+      return { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+    }
+    let payload: unknown = { ok: true };
+    if (pathname.endsWith('/presence/heartbeat')) payload = { present: state.present };
+    else if (pathname.endsWith('/collab/status')) payload = { publishedVersion: state.publishedVersion };
+    return { ok: true, status: 200, json: async () => payload } as unknown as Response;
+  }) as typeof fetch;
+  return { fetchImpl, calls, state };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('CollabClient', () => {
+  it('sends an immediate heartbeat + status poll on start and updates the snapshot', async () => {
+    const { fetchImpl, calls, state } = makeFetch({
+      present: [{ memberId: 'm1', name: 'Author' }],
+      publishedVersion: 4,
+    });
+    const updates: CollabSnapshot[] = [];
+    const client = new CollabClient({
+      projectId: 'p1',
+      member: { memberId: 'm1', name: 'Author', role: 'owner' },
+      fetch: fetchImpl,
+      onUpdate: (snapshot) => updates.push(snapshot),
+    });
+
+    client.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const heartbeat = calls.find((c) => c.url.endsWith('/presence/heartbeat'));
+    expect(heartbeat?.method).toBe('POST');
+    expect(heartbeat?.body).toMatchObject({ memberId: 'm1', name: 'Author', role: 'owner' });
+    expect(calls.some((c) => c.method === 'GET' && c.url.endsWith('/collab/status'))).toBe(true);
+
+    const snapshot = client.getSnapshot();
+    expect(snapshot.present).toEqual(state.present);
+    expect(snapshot.publishedVersion).toBe(4);
+    expect(updates.length).toBeGreaterThanOrEqual(2);
+
+    client.stop();
+  });
+
+  it('re-heartbeats and re-polls on their own intervals', async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const client = new CollabClient({
+      projectId: 'p1',
+      member: { memberId: 'm1' },
+      fetch: fetchImpl,
+      heartbeatMs: 10_000,
+      statusPollMs: 5_000,
+    });
+
+    client.start();
+    await vi.advanceTimersByTimeAsync(0);
+    const initialHeartbeats = calls.filter((c) => c.url.endsWith('/presence/heartbeat')).length;
+    const initialStatus = calls.filter((c) => c.url.endsWith('/collab/status')).length;
+
+    // One full heartbeat window: status polls twice more (5s each), heartbeat once more.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(calls.filter((c) => c.url.endsWith('/presence/heartbeat')).length).toBe(initialHeartbeats + 1);
+    expect(calls.filter((c) => c.url.endsWith('/collab/status')).length).toBe(initialStatus + 2);
+
+    client.stop();
+  });
+
+  it('reports author changes and requests a publish through the sync routes', async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const client = new CollabClient({ projectId: 'p9', member: { memberId: 'm1' }, fetch: fetchImpl });
+
+    await client.reportChange();
+    await client.requestPublish();
+
+    expect(calls.some((c) => c.method === 'POST' && c.url.endsWith('/p9/collab/changed'))).toBe(true);
+    expect(calls.some((c) => c.method === 'POST' && c.url.endsWith('/p9/collab/publish'))).toBe(true);
+  });
+
+  it('sends leave and stops polling on stop', async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const client = new CollabClient({
+      projectId: 'p1',
+      member: { memberId: 'm1' },
+      fetch: fetchImpl,
+      heartbeatMs: 10_000,
+    });
+
+    client.start();
+    await vi.advanceTimersByTimeAsync(0);
+    client.stop();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(calls.some((c) => c.method === 'POST' && c.url.endsWith('/presence/leave'))).toBe(true);
+
+    const afterStop = calls.length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(calls.length).toBe(afterStop); // timers cleared — no further polling
+  });
+
+  it('leaveBeacon delivers the leave via sendBeacon so it survives page unload', () => {
+    const { fetchImpl, calls } = makeFetch();
+    const beacons: Array<{ url: string; body: string }> = [];
+    const sendBeacon = vi.fn((url: string, blob: Blob) => {
+      // Blob.text() is async; the daemon parses the JSON body, so record the URL
+      // and mark it delivered. Body shape is asserted via the fallback test.
+      beacons.push({ url, body: String((blob as unknown as { type: string }).type) });
+      return true;
+    });
+    vi.stubGlobal('navigator', { sendBeacon });
+    const client = new CollabClient({ projectId: 'p1', member: { memberId: 'm1' }, fetch: fetchImpl });
+
+    client.leaveBeacon();
+
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    expect(beacons[0]!.url).toBe('/api/projects/p1/presence/leave');
+    // Beacon path used — no keepalive fetch fallback.
+    expect(calls.some((c) => c.url.endsWith('/presence/leave'))).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('leaveBeacon falls back to a keepalive fetch when sendBeacon is unavailable', () => {
+    const { fetchImpl, calls } = makeFetch();
+    vi.stubGlobal('navigator', {});
+    const client = new CollabClient({ projectId: 'p1', member: { memberId: 'm-x' }, fetch: fetchImpl });
+
+    client.leaveBeacon();
+
+    const leave = calls.find((c) => c.url.endsWith('/presence/leave'));
+    expect(leave?.method).toBe('POST');
+    expect(leave?.body).toEqual({ memberId: 'm-x' });
+    vi.unstubAllGlobals();
+  });
+
+  it('surfaces fetch failures through onError without wedging the client', async () => {
+    const { fetchImpl } = makeFetch({ failPath: '/collab/status' });
+    const errors: unknown[] = [];
+    const client = new CollabClient({
+      projectId: 'p1',
+      member: { memberId: 'm1' },
+      fetch: fetchImpl,
+      onError: (error) => errors.push(error),
+    });
+
+    client.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    // Heartbeat still succeeded despite the status failure.
+    expect(client.getSnapshot().present.length).toBeGreaterThanOrEqual(1);
+
+    client.stop();
+  });
+});

--- a/apps/web/tests/collab-presence-bar.test.tsx
+++ b/apps/web/tests/collab-presence-bar.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PresenceBar } from '../src/collab/PresenceBar.js';
+
+afterEach(cleanup);
+
+describe('PresenceBar', () => {
+  it('renders initials for present members and excludes self', () => {
+    render(
+      <PresenceBar
+        selfMemberId="me"
+        members={[
+          { memberId: 'me', name: 'Me' },
+          { memberId: 'm1', name: 'Ma Shu', role: 'member' },
+          { memberId: 'm2', name: 'Yuan Xi', role: 'admin' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('MS')).toBeTruthy();
+    expect(screen.getByText('YX')).toBeTruthy();
+    // Self is excluded.
+    expect(screen.queryByText('ME')).toBeNull();
+    expect(screen.getByRole('group').getAttribute('aria-label')).toContain('2 collaborators');
+  });
+
+  it('collapses past the max into a +N overflow chip', () => {
+    render(
+      <PresenceBar
+        max={2}
+        members={[
+          { memberId: 'a', name: 'Aa' },
+          { memberId: 'b', name: 'Bb' },
+          { memberId: 'c', name: 'Cc' },
+          { memberId: 'd', name: 'Dd' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('+2')).toBeTruthy();
+  });
+
+  it('renders nothing when only self is present', () => {
+    const { container } = render(
+      <PresenceBar selfMemberId="me" members={[{ memberId: 'me', name: 'Me' }]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('falls back to the member id when there is no name', () => {
+    render(<PresenceBar members={[{ memberId: 'zx' }]} />);
+    expect(screen.getByText('ZX')).toBeTruthy();
+  });
+});

--- a/apps/web/tests/collab-session.test.ts
+++ b/apps/web/tests/collab-session.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCollabSession, type WorkspaceCollabContext } from '../src/collab/collab-session';
+
+function ctx(overrides: Partial<WorkspaceCollabContext> = {}): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-1',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    role: 'member',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: 'team',
+    providerMode: 'platform_credits',
+    seatSummary: { seatLimit: 5, usedSeats: 2, availableSeats: 3, isSeatFull: false },
+    permissions: {
+      canManageMembers: false,
+      canManageBilling: false,
+      canInviteMembers: false,
+      canManageAutoRecharge: false,
+      canShareProjects: true,
+      canWriteSyncedFiles: true,
+      canViewWorkspaceSettings: true,
+      canManageSharedResources: false,
+    },
+    displayName: 'Ma Shu',
+    ...overrides,
+  };
+}
+
+describe('resolveCollabSession', () => {
+  it('enables collab for an active member of a live team workspace', () => {
+    const decision = resolveCollabSession(ctx());
+    expect(decision.enabled).toBe(true);
+    expect(decision.member).toEqual({ memberId: 'wm-1', role: 'member', name: 'Ma Shu' });
+  });
+
+  it('still runs during a billing grace period (past_due)', () => {
+    expect(resolveCollabSession(ctx({ lifecycleState: 'billing_past_due' })).enabled).toBe(true);
+  });
+
+  it('is off with no workspace context', () => {
+    const decision = resolveCollabSession(null);
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe('no-workspace-context');
+    expect(decision.member).toBeNull();
+  });
+
+  it('is off for a personal workspace (only team workspaces are shared)', () => {
+    const decision = resolveCollabSession(ctx({ workspaceType: 'personal' }));
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe('personal-workspace');
+  });
+
+  it('is off for a removed member', () => {
+    expect(resolveCollabSession(ctx({ memberStatus: 'removed' })).reason).toBe('member-removed');
+  });
+
+  it.each(['locked', 'deleting', 'deleted'] as const)(
+    'is off when the workspace lifecycle is %s (frozen/gone)',
+    (lifecycleState) => {
+      const decision = resolveCollabSession(ctx({ lifecycleState }));
+      expect(decision.enabled).toBe(false);
+      expect(decision.reason).toBe(`lifecycle-${lifecycleState}`);
+    },
+  );
+
+  it('falls back to the member id when there is no display name', () => {
+    const decision = resolveCollabSession(ctx({ displayName: '   ' }));
+    expect(decision.member).toEqual({ memberId: 'wm-1', role: 'member' });
+  });
+});


### PR DESCRIPTION
## Why

The client layer for in-project collaboration, on top of the backend contracts
(part 1 of the stack). Kept separate so the collab client primitives review apart
from the larger surface work.

## What users will see

Nothing on its own — this is the collaboration client layer the project view and
team surfaces consume: the presence overlay, the collab client/session, the
per-project collab hook (presence + read-only), the workspace-context hook, and
the invite-continuation state machine.

## Surface area

- [x] **API / contract** — consumes the shared collab/workspace contracts
- [ ] UI (no standalone screen) · [ ] i18n · [ ] New dependency · [ ] Default change

## Validation

- `pnpm --filter @open-design/web typecheck`
- collab client / session / presence-bar suites green
