### PR TITLE
ci(release): Thursday patch-release cut, gated on the Tuesday minor shipping

### DIFF
--- a/.github/workflows/cut-patch-release.yml
+++ b/.github/workflows/cut-patch-release.yml
@@ -73,17 +73,8 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          latest=$(git ls-remote --heads origin 'release/v*' \
-            | sed -E 's#.*/release/v##' \
-            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-            | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
-          if [ -z "$latest" ]; then
-            echo "::error::No release/vX.Y.Z branch found to base a patch on."
-            exit 1
-          fi
-          major=${latest%%.*}; rest=${latest#*.}; minor=${rest%%.*}; patch=${rest#*.}
-          # The "Tuesday version" whose publish we gate on: this line's minor base.
-          MINOR_BASE="${major}.${minor}.0"
+          # Decide the final version V FIRST: a validated manual override wins,
+          # otherwise bump the patch of the highest release branch.
           if [ -n "$INPUT_VERSION" ]; then
             # Strict x.y.z, digits only — rejects shell metacharacters, newlines, etc.
             if ! printf '%s' "$INPUT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -92,9 +83,23 @@ jobs:
             fi
             V="$INPUT_VERSION"
           else
+            latest=$(git ls-remote --heads origin 'release/v*' \
+              | sed -E 's#.*/release/v##' \
+              | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+            if [ -z "$latest" ]; then
+              echo "::error::No release/vX.Y.Z branch found to base a patch on."
+              exit 1
+            fi
+            major=${latest%%.*}; rest=${latest#*.}; minor=${rest%%.*}; patch=${rest#*.}
             V="${major}.${minor}.$((patch+1))"
           fi
-          # V is now guaranteed to match ^[0-9]+\.[0-9]+\.[0-9]+$
+          # V is now guaranteed to match ^[0-9]+\.[0-9]+\.[0-9]+$.
+          # Gate on the minor base of the FINAL V — never the highest branch — so a
+          # manual `version=` on a different line is checked against ITS own minor
+          # (e.g. version=0.15.1 gates open-design-v0.15.0, not the latest 0.14.0).
+          vmajor=${V%%.*}; vrest=${V#*.}; vminor=${vrest%%.*}
+          MINOR_BASE="${vmajor}.${vminor}.0"
           echo "version=$V"                          >> "$GITHUB_OUTPUT"
           echo "branch=release/v$V"                  >> "$GITHUB_OUTPUT"
           echo "minor_base=$MINOR_BASE"              >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cut-patch-release.yml
+++ b/.github/workflows/cut-patch-release.yml
@@ -1,0 +1,192 @@
+name: cut-patch-release
+# Every Thursday 09:00 Asia/Shanghai, cut the next PATCH release — but only once
+# this week's minor (the branch cut-release created on Tuesday) has actually
+# shipped stable.
+#
+# This is the Tuesday cut-release flow with three deltas:
+#   1. It bumps the PATCH, not the minor: highest release/vX.Y.Z -> X.Y.(Z+1)
+#      (e.g. 0.14.0 -> 0.14.1). Like cut-release, the branch is cut from main HEAD.
+#   2. A pre-flight guard: the current line's minor base X.Y.0 must be a PUBLISHED
+#      stable GitHub Release (tag open-design-vX.Y.0, isDraft=false, isPrerelease=false
+#      — i.e. release-stable ran `gh release edit --draft=false --latest`). If it is
+#      not published yet, do NOT cut a branch or build anything; instead post a
+#      Feishu notice that the patch cut was skipped, and stop.
+#   3. On the happy path it is otherwise identical to cut-release: create
+#      release/vX.Y.(Z+1), bump apps/packaged/package.json, push with the App token
+#      (which triggers notify-release-feishu -> prerelease build + Feishu card), and
+#      create the "backport release/vX.Y.(Z+1)" label.
+#
+# "Cut a patch" here means "cut a new point-release branch + build a prerelease +
+# announce it", exactly like Tuesday. It deliberately does NOT auto-promote to
+# stable; that stays a human-gated release-stable dispatch.
+#
+# NOTE: schedule triggers only fire from the default branch (main), so this file
+# must live on main to run on its cron.
+
+on:
+  schedule:
+    - cron: '0 1 * * 4'        # 01:00 UTC = 09:00 Asia/Shanghai, Thursday
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Full patch version x.y.z (empty = bump patch of the highest release branch)'
+        required: false
+        default: ''
+      force:
+        description: 'Skip the "Tuesday minor is published" guard and cut anyway'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read               # actual writes go through the App token below
+
+concurrency:
+  group: cut-patch-release
+  cancel-in-progress: false
+
+jobs:
+  cut:
+    if: github.repository == 'nexu-io/open-design'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main            # always cut from main HEAD, even on a manual dispatch from another branch
+          fetch-depth: 0
+          token: ${{ steps.app.outputs.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Compute next patch version
+        id: ver
+        env:
+          # Never interpolate the raw input into the shell; pass via env and validate.
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          latest=$(git ls-remote --heads origin 'release/v*' \
+            | sed -E 's#.*/release/v##' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+          if [ -z "$latest" ]; then
+            echo "::error::No release/vX.Y.Z branch found to base a patch on."
+            exit 1
+          fi
+          major=${latest%%.*}; rest=${latest#*.}; minor=${rest%%.*}; patch=${rest#*.}
+          # The "Tuesday version" whose publish we gate on: this line's minor base.
+          MINOR_BASE="${major}.${minor}.0"
+          if [ -n "$INPUT_VERSION" ]; then
+            # Strict x.y.z, digits only — rejects shell metacharacters, newlines, etc.
+            if ! printf '%s' "$INPUT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error::Invalid version '$INPUT_VERSION' (expected x.y.z, digits only)"
+              exit 1
+            fi
+            V="$INPUT_VERSION"
+          else
+            V="${major}.${minor}.$((patch+1))"
+          fi
+          # V is now guaranteed to match ^[0-9]+\.[0-9]+\.[0-9]+$
+          echo "version=$V"                          >> "$GITHUB_OUTPUT"
+          echo "branch=release/v$V"                  >> "$GITHUB_OUTPUT"
+          echo "minor_base=$MINOR_BASE"              >> "$GITHUB_OUTPUT"
+          echo "minor_tag=open-design-v$MINOR_BASE"  >> "$GITHUB_OUTPUT"
+          echo "Cutting patch v$V (branch release/v$V); gating on stable v$MINOR_BASE"
+
+      # Guard: the minor this patch sits on (the Tuesday cut) must already be a
+      # PUBLISHED stable GitHub Release. release-stable publishes with
+      # `gh release edit --draft=false --latest` and rolls the tag back on failure,
+      # so a non-draft, non-prerelease release is the ground-truth "shipped" signal.
+      - name: Check the Tuesday minor is published
+        id: guard
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          MINOR_TAG: ${{ steps.ver.outputs.minor_tag }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+          if [ "${FORCE:-false}" = "true" ]; then
+            echo "force=true: skipping the publish guard"
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # "published" = the release exists AND is neither a draft nor a prerelease.
+          # gh's --jq evaluates `(.isDraft or .isPrerelease) | not` to true only when
+          # both are false. A missing release makes `gh release view` exit non-zero,
+          # so the `|| published=false` fallback treats "not found" as "not published".
+          published=$(gh release view "$MINOR_TAG" \
+            --repo nexu-io/open-design \
+            --json isDraft,isPrerelease \
+            --jq '(.isDraft or .isPrerelease) | not' 2>/dev/null) || published=false
+          echo "release $MINOR_TAG -> published=$published"
+          echo "published=$published" >> "$GITHUB_OUTPUT"
+
+      # ---- Skip path: minor not published yet -> notify Feishu and stop ----
+      # feishu-notice.ts imports only node:crypto (no workspace deps), so the
+      # setup-node above is all it needs — no pnpm install, same as feishu.ts.
+      - name: Notify Feishu that the patch cut was skipped
+        if: steps.guard.outputs.published != 'true'
+        env:
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
+          NOTICE_TITLE: "⏭️ 周四小版本已跳过"
+          NOTICE_TEMPLATE: "orange"
+          NOTICE_BODY: |
+            本周周二的 release **v${{ steps.ver.outputs.minor_base }}** 还没发布成功（stable GitHub Release 尚未 published），本次周四小版本 **v${{ steps.ver.outputs.version }}** 的自动切分支与构建已跳过。
+
+            待 v${{ steps.ver.outputs.minor_base }} promote 到 stable 后，可手动重新触发本工作流（或用 `force` 强制切分支）。
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node --experimental-strip-types tools/release/src/notifications/feishu-notice.ts
+
+      - name: Stop here when skipping
+        if: steps.guard.outputs.published != 'true'
+        run: |
+          echo "::notice::Tuesday minor v${{ steps.ver.outputs.minor_base }} is not published; patch cut skipped."
+          exit 0
+
+      # ---- Happy path: minor published -> cut the patch, same as cut-release ----
+      - name: Bail out if the branch already exists
+        if: steps.guard.outputs.published == 'true'
+        env:
+          BRANCH: ${{ steps.ver.outputs.branch }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::error::$BRANCH already exists, skipping"
+            exit 1
+          fi
+
+      - name: Create branch + bump version + push
+        if: steps.guard.outputs.published == 'true'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git config user.name  'open-design-release-bot[bot]'
+          git config user.email 'open-design-release-bot[bot]@users.noreply.github.com'
+          git switch -c "$BRANCH"
+          ( cd apps/packaged && npm pkg set version="$VERSION" )
+          git commit -am "chore(release): v$VERSION"
+          git push origin "$BRANCH"   # App token push -> triggers notify-release-feishu (prerelease + Feishu)
+
+      - name: Create backport label
+        if: steps.guard.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh label create "backport release/v$VERSION" \
+            --repo nexu-io/open-design \
+            --color 0E8A16 \
+            --description "Backport this fix to release/v$VERSION" \
+            --force

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1360,6 +1360,14 @@ process.stdin.on("end", () => {
     expect(workflow).toContain('V="${major}.${minor}.$((patch+1))"');
     expect(workflow).not.toContain("minor+1");
 
+    // The guard target (MINOR_BASE) must derive from the FINAL version V, not from
+    // the highest branch — otherwise a manual `version=` on another line is gated
+    // against the wrong minor (e.g. version=0.15.1 while latest is 0.14.0 would
+    // wrongly check open-design-v0.14.0). Assert V's own major/minor drive it.
+    expect(workflow).toContain('vmajor=${V%%.*}; vrest=${V#*.}; vminor=${vrest%%.*}');
+    expect(workflow).toContain('MINOR_BASE="${vmajor}.${vminor}.0"');
+    expect(workflow).not.toContain('MINOR_BASE="${major}.${minor}.0"');
+
     // The guard reads the minor base's stable release and requires it published
     // (neither draft nor prerelease); a missing release falls back to not published.
     const guard = sectionBetween(workflow, "- name: Check the Tuesday minor is published", "# ---- Skip path");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -44,6 +44,8 @@ const packagedPackageJsonPath = join(workspaceRoot, "apps", "packaged", "package
 const scopesScriptPath = join(workspaceRoot, "scripts", "scopes.ts");
 const runnersScriptPath = join(workspaceRoot, ".github", "scripts", "runners.py");
 const notifyDailyFeishuWorkflowPath = join(workspaceRoot, ".github", "workflows", "notify-daily-feishu.yml");
+const cutPatchReleaseWorkflowPath = join(workspaceRoot, ".github", "workflows", "cut-patch-release.yml");
+const feishuNoticeScriptPath = join(workspaceRoot, "tools", "release", "src", "notifications", "feishu-notice.ts");
 const landingPageDailyFeishuWorkflowPath = join(workspaceRoot, ".github", "workflows", "landing-page-daily-feishu.yml");
 const landingPageProductionWorkflowPath = join(workspaceRoot, ".github", "workflows", "landing-page-production.yml");
 const landingPageDailyFeishuScriptPath = join(workspaceRoot, ".github", "scripts", "landing-page-daily-feishu.ts");
@@ -1336,6 +1338,55 @@ process.stdin.on("end", () => {
     // Default path: an empty input builds main, never a release branch.
     expect(resolveJob).toContain('echo "ref=main" >> "$GITHUB_OUTPUT"');
     expect(resolveJob).not.toContain("refs/heads/release/v*");
+  });
+
+  it("[P2] gates the Thursday patch cut on the Tuesday minor being published", async () => {
+    // cut-patch-release is the Tuesday cut-release flow, one weekday later, with a
+    // PATCH bump and a publish guard. Lock the three properties that make it safe:
+    //   1. It fires Thursday and bumps patch (not minor) from the highest release branch.
+    //   2. It only cuts when this line's minor base X.Y.0 is a PUBLISHED stable
+    //      GitHub Release (non-draft, non-prerelease) — otherwise it must NOT create
+    //      a branch or build; it posts a Feishu notice and stops.
+    //   3. The happy path still cuts from main and pushes with the App token, so the
+    //      existing notify-release-feishu push trigger produces the prerelease + card.
+    const [workflow, notice] = await Promise.all([
+      readFile(cutPatchReleaseWorkflowPath, "utf8"),
+      readFile(feishuNoticeScriptPath, "utf8"),
+    ]);
+
+    // Thursday cron, and a patch (not minor) bump.
+    const trigger = sectionBetween(workflow, "on:", "\npermissions:");
+    expect(trigger).toContain("cron: '0 1 * * 4'");
+    expect(workflow).toContain('V="${major}.${minor}.$((patch+1))"');
+    expect(workflow).not.toContain("minor+1");
+
+    // The guard reads the minor base's stable release and requires it published
+    // (neither draft nor prerelease); a missing release falls back to not published.
+    const guard = sectionBetween(workflow, "- name: Check the Tuesday minor is published", "# ---- Skip path");
+    expect(guard).toContain('gh release view "$MINOR_TAG"');
+    expect(guard).toContain("--jq '(.isDraft or .isPrerelease) | not'");
+    expect(guard).toContain("|| published=false");
+    expect(workflow).toContain('echo "minor_tag=open-design-v$MINOR_BASE"');
+
+    // Skip path: no branch, no build — only the Feishu notice runs, gated on !published.
+    const noticeStep = sectionBetween(workflow, "- name: Notify Feishu that the patch cut was skipped", "- name: Stop here when skipping");
+    expect(noticeStep).toContain("if: steps.guard.outputs.published != 'true'");
+    expect(noticeStep).toContain("tools/release/src/notifications/feishu-notice.ts");
+    // Every branch-cutting step must be gated on the guard passing: assert the
+    // guard `if:` is the line immediately after each step name.
+    for (const step of ["Bail out if the branch already exists", "Create branch + bump version + push", "Create backport label"]) {
+      expect(workflow).toContain(`- name: ${step}\n        if: steps.guard.outputs.published == 'true'`);
+    }
+
+    // Happy path keeps cut-release's mechanics: cut from main, App-token push.
+    expect(workflow).toContain("ref: main");
+    expect(workflow).toContain("token: ${{ steps.app.outputs.token }}");
+    expect(workflow).toContain('git push origin "$BRANCH"');
+
+    // The notice card is a standalone poster with the same signed-webhook contract.
+    expect(notice).toContain("msg_type: \"interactive\"");
+    expect(notice).toContain('required("NOTICE_TITLE")');
+    expect(notice).toContain('required("NOTICE_BODY")');
   });
 
   it("[P2] sends the daily landing PR summary to Feishu with staging deployment status", async () => {

--- a/tools/release/src/notifications/feishu-notice.ts
+++ b/tools/release/src/notifications/feishu-notice.ts
@@ -1,0 +1,113 @@
+// Posts a generic notice to a Feishu (Lark) custom-bot webhook as an interactive
+// card: a colored header title plus a markdown body, with no download buttons.
+//
+// This is the lightweight sibling of feishu.ts (the build/download card). It is
+// for events that are NOT a package build — e.g. cut-patch-release announcing
+// that the Thursday patch cut was skipped because the week's minor has not
+// shipped stable yet. The signing + retry transport mirrors feishu.ts so both
+// notifiers behave identically against the same bot.
+//
+// Inputs (all via env):
+//   FEISHU_WEBHOOK        (required) custom-bot webhook URL
+//   FEISHU_SIGN_SECRET    (optional) signing secret when the bot enables 签名校验
+//   NOTICE_TITLE          (required) header title, e.g. "⏭️ 周四小版本已跳过"
+//   NOTICE_TEMPLATE       (optional) header color: blue | orange | red | grey | green … (default "orange")
+//   NOTICE_BODY           (required) card body, rendered as lark_md markdown
+//   RUN_URL               (optional) link back to the GitHub Actions run
+
+import { createHmac } from "node:crypto";
+
+type FeishuCard = Record<string, unknown>;
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (value == null || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function optional(name: string, fallback = ""): string {
+  const value = process.env[name];
+  return value == null || value.length === 0 ? fallback : value;
+}
+
+const webhook = required("FEISHU_WEBHOOK");
+const signSecret = optional("FEISHU_SIGN_SECRET");
+const title = required("NOTICE_TITLE");
+const template = optional("NOTICE_TEMPLATE", "orange");
+const body = required("NOTICE_BODY");
+const runUrl = optional("RUN_URL");
+
+function buildCard(): FeishuCard {
+  const elements: Record<string, unknown>[] = [{ tag: "div", text: { tag: "lark_md", content: body } }];
+  if (runUrl.length > 0) {
+    elements.push({
+      tag: "note",
+      elements: [{ tag: "lark_md", content: `[GitHub Actions run](${runUrl})` }],
+    });
+  }
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      template,
+      title: { tag: "plain_text", content: title },
+    },
+    elements,
+  };
+}
+
+function signedEnvelope(card: FeishuCard): Record<string, unknown> {
+  const envelope = { msg_type: "interactive", card };
+  if (signSecret.length === 0) return envelope;
+  // Feishu signing: HMAC-SHA256 over empty bytes, keyed by `${timestamp}\n${secret}`.
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const stringToSign = `${timestamp}\n${signSecret}`;
+  const sign = createHmac("sha256", stringToSign).update("").digest("base64");
+  return { timestamp, sign, ...envelope };
+}
+
+function sleep(attempt: number): Promise<void> {
+  const ms = Math.min(1000 * 2 ** (attempt - 1), 15000);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function post(payload: Record<string, unknown>): Promise<void> {
+  const attempts = 5;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    let res;
+    try {
+      res = await fetch(webhook, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      console.warn(`[feishu] POST attempt ${attempt}/${attempts} threw: ${error instanceof Error ? error.message : String(error)}`);
+      if (attempt === attempts) throw error;
+      await sleep(attempt);
+      continue;
+    }
+    const text = await res.text();
+    let code = null;
+    try {
+      const parsed = JSON.parse(text);
+      code = parsed.code ?? parsed.StatusCode ?? null;
+    } catch {
+      // non-JSON body
+    }
+    if (res.ok && (code === 0 || code === null)) {
+      console.log(`[feishu] delivered (HTTP ${res.status}, code ${code ?? "n/a"})`);
+      return;
+    }
+    console.warn(`[feishu] POST attempt ${attempt}/${attempts} HTTP ${res.status} code ${code}: ${text.slice(0, 500)}`);
+    // Bot rate-limit (code 9499) and 5xx are retryable; a 4xx config error is not.
+    const retryable = res.status === 429 || res.status >= 500 || code === 9499;
+    if (!retryable || attempt === attempts) {
+      throw new Error(`Feishu webhook failed: HTTP ${res.status} code ${code}`);
+    }
+    await sleep(attempt);
+  }
+}
+
+await post(signedEnvelope(buildCard()));


### PR DESCRIPTION
## Why

- **Use case.** We already cut a minor every **Tuesday** (`cut-release.yml`, 09:00 Asia/Shanghai): it branches `release/vX.(Y+1).0` off main, and the `release/**` push fires `notify-release-feishu` → a prerelease build + a Feishu card. I want a second, symmetric cadence on **Thursday** that cuts a *patch* mid-week so hotfixes on top of an already-shipped minor get their own point-release branch, build, and announcement — without anyone doing it by hand.
- **Pain.** A patch only makes sense once the week's minor is actually out to users; cutting `0.14.1` while `0.14.0` is still in prerelease would stack an unreleased patch on an unreleased minor. So the Thursday job must be self-gating: proceed only when the minor has shipped stable, otherwise skip loudly instead of silently producing a nonsensical branch.

## What users will see

This is release automation — the "users" are the team watching the release Feishu group, not product end-users.

- **Every Thursday 09:00 (Asia/Shanghai)**, if this week's minor `vX.Y.0` has already been published as a stable GitHub Release, a new `release/vX.Y.(Z+1)` branch is cut (e.g. `0.14.0 → 0.14.1`) and — exactly like Tuesday — a **prerelease build + Feishu card** appear in the group.
- **If the minor hasn't shipped yet**, nothing is cut or built. Instead an orange **"⏭️ 周四小版本已跳过"** card is posted to the same group explaining that `release vX.Y.0` isn't published yet and the patch cut was skipped (with a hint to re-run manually, or use `force`, once it ships).
- Manual `workflow_dispatch` is available with an optional exact `version` and a `force` toggle that bypasses the guard.

## Surface area

- [x] **CLI / env var** — new **scheduled workflow** `cut-patch-release.yml` (`workflow_dispatch` inputs `version` / `force`). Not an `od`/tools CLI surface; it mirrors the existing `cut-release.yml` release-automation shape, which likewise has no UI/CLI product surface. UI and product CLI are **not applicable** to a release-cut workflow, so neither is checked.
- [x] **None** — beyond the workflow, changes are CI/release infra + a standalone notifier + a topology test.

Why UI/CLI dual-track (AGENTS.md) doesn't apply: this is repository release automation (GitHub Actions), not a daemon/web/`od` product capability — same category as `cut-release.yml`, `notify-release-feishu.yml`, and `notify-daily-feishu.yml`.

## Bug fix verification

Not a bug fix. New capability, but it ships with a red-anchored topology spec in `e2e/tests/packaged-smoke-workflow.test.ts` that pins the guard semantics (Thursday cron + patch bump, the published-stable predicate, and that **every** branch-cutting step is gated on the guard so the skip path posts the notice without cutting or building).

## Validation

- `actionlint` on `cut-patch-release.yml` — clean.
- Shell logic simulated with real inputs: version math (`0.14.0 → 0.14.1`, gate on `open-design-v0.14.0`; two-digit patch `1.2.9 → 1.2.10`; patch-line `0.14.1 → 0.14.2` still gates on `.0`), the `gh --jq '(.isDraft or .isPrerelease) | not'` predicate (published only when neither draft nor prerelease), and the missing-release `|| published=false` fallback.
- `node --experimental-strip-types --check` on `feishu-notice.ts` — syntax OK. It is a near-verbatim structural subset of the already-shipping `feishu.ts` (same signed-webhook + retry transport, only `node:crypto`), so strict typecheck is safe.
- Every `e2e/tests/packaged-smoke-workflow.test.ts` assertion I added was replayed against the real files with the same `sectionBetween`/`indexOf` logic the test uses — all pass.
- `pnpm guard` / `pnpm typecheck` / the vitest suite were **not** run locally (isolated worktree without a full monorepo install); they run as required PR checks. `guard` only flags residual `.js/.mjs/.cjs`, and this PR adds a `.yml` + a `.ts`.