### PR TITLE
fix(web): float the annotation composer near the active selection

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -11,7 +11,10 @@ import { isImeComposing } from '../utils/imeComposing';
 interface Point { x: number; y: number }
 interface Stroke { points: Point[] }
 interface NormalizedRect { x: number; y: number; width: number; height: number }
+interface Rect { x: number; y: number; width: number; height: number }
 type MarkTool = 'box' | 'pen';
+type DrawDockLayout = 'floating' | 'docked';
+type DrawDockSide = 'right' | 'left' | 'bottom' | 'top';
 interface CaptureTarget {
   filePath?: string;
   elementId?: string;
@@ -70,10 +73,38 @@ interface Props {
 const STROKE_COLOR = '#ff3b30';
 const STROKE_WIDTH = 4;
 const TARGET_COLOR = '#1677ff';
+const DRAW_DOCK_GAP = 12;
+const DRAW_DOCK_MARGIN = 16;
+const DRAW_DOCK_MIN_WIDTH = 320;
+const DRAW_DOCK_MIN_HEIGHT = 120;
 
 // Render `node` into `host` via a portal when one is provided, otherwise inline.
 function maybePortal(node: ReactNode, host: HTMLElement | null) {
   return host ? createPortal(node, host) : node;
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function rectsOverlap(a: Rect, b: Rect) {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+function dockPlacementEquals(
+  a: { layout: DrawDockLayout; side: DrawDockSide | null; style: CSSProperties },
+  b: { layout: DrawDockLayout; side: DrawDockSide | null; style: CSSProperties },
+) {
+  return (
+    a.layout === b.layout &&
+    a.side === b.side &&
+    a.style.left === b.style.left &&
+    a.style.top === b.style.top &&
+    a.style.bottom === b.style.bottom &&
+    a.style.transform === b.style.transform &&
+    a.style.maxWidth === b.style.maxWidth
+  );
 }
 
 export function PreviewDrawOverlay({
@@ -130,7 +161,22 @@ export function PreviewDrawOverlay({
     action: AnnotationAction;
     message: string;
   } | null>(null);
+  const dockRef = useRef<HTMLDivElement | null>(null);
+  const [layoutRevision, setLayoutRevision] = useState(0);
+  const [dockPlacement, setDockPlacement] = useState<{
+    layout: DrawDockLayout;
+    side: DrawDockSide | null;
+    style: CSSProperties;
+  }>({
+    layout: 'docked',
+    side: null,
+    style: previewDrawDockDockedStyle,
+  });
   const sending = pendingAction !== null;
+
+  const bumpLayoutRevision = useCallback(() => {
+    setLayoutRevision((value) => value + 1);
+  }, []);
 
   const redraw = useCallback(() => {
     const cvs = canvasRef.current;
@@ -327,6 +373,7 @@ export function PreviewDrawOverlay({
       // Commit the drawn region; ignore accidental micro-drags (click without move).
       if (next.width >= 0.006 && next.height >= 0.006) {
         selectionBoxesRef.current = [...selectionBoxesRef.current, next];
+        bumpLayoutRevision();
       }
       syncHistoryState();
       redraw();
@@ -336,6 +383,7 @@ export function PreviewDrawOverlay({
     if (drawingRef.current.points.length > 1) {
       strokesRef.current.push(drawingRef.current);
       undoneStrokesRef.current = [];
+      bumpLayoutRevision();
       syncHistoryState();
     }
     drawingRef.current = null;
@@ -359,6 +407,7 @@ export function PreviewDrawOverlay({
     boxDraftRef.current = null;
     syncHistoryState();
     redraw();
+    bumpLayoutRevision();
   }
 
   function addExtraFiles(files: FileList | File[] | null) {
@@ -439,6 +488,7 @@ export function PreviewDrawOverlay({
       boxDraftRef.current = null;
       syncHistoryState();
       redraw();
+      bumpLayoutRevision();
       onToolbarClick?.('undo');
       return;
     }
@@ -446,6 +496,7 @@ export function PreviewDrawOverlay({
       selectionBoxesRef.current = selectionBoxesRef.current.slice(0, -1);
       syncHistoryState();
       redraw();
+      bumpLayoutRevision();
       onToolbarClick?.('undo');
       return;
     }
@@ -456,6 +507,7 @@ export function PreviewDrawOverlay({
     drawingRef.current = null;
     syncHistoryState();
     redraw();
+    bumpLayoutRevision();
   }
 
   function redoStroke() {
@@ -467,6 +519,7 @@ export function PreviewDrawOverlay({
     drawingRef.current = null;
     syncHistoryState();
     redraw();
+    bumpLayoutRevision();
   }
 
   function closeOverlay() {
@@ -484,18 +537,29 @@ export function PreviewDrawOverlay({
     setPreviewIndex(null);
     syncHistoryState();
     redraw();
+    bumpLayoutRevision();
   }, [active, redraw]);
 
-  function boxBounds(): { x: number; y: number; width: number; height: number } | null {
+  function normalizedRectToCanvasRect(box: NormalizedRect): Rect | null {
     const rect = canvasRef.current?.getBoundingClientRect();
-    const boxes = selectionBoxesRef.current;
-    if (!rect || rect.width <= 0 || rect.height <= 0 || boxes.length === 0) return null;
+    if (!rect || rect.width <= 0 || rect.height <= 0) return null;
+    return {
+      x: box.x * rect.width,
+      y: box.y * rect.height,
+      width: Math.max(1, box.width * rect.width),
+      height: Math.max(1, box.height * rect.height),
+    };
+  }
+
+  function boxBounds(): Rect | null {
+    const boxes = selectionBoxesRef.current.map((box) => normalizedRectToCanvasRect(box)).filter((box): box is Rect => Boolean(box));
+    if (boxes.length === 0) return null;
     // Collapse every committed box into one enclosing rect so the annotation
     // bounds still describe a single region for the downstream capture crop.
-    const left = Math.min(...boxes.map((box) => box.x)) * rect.width;
-    const top = Math.min(...boxes.map((box) => box.y)) * rect.height;
-    const right = Math.max(...boxes.map((box) => box.x + box.width)) * rect.width;
-    const bottom = Math.max(...boxes.map((box) => box.y + box.height)) * rect.height;
+    const left = Math.min(...boxes.map((box) => box.x));
+    const top = Math.min(...boxes.map((box) => box.y));
+    const right = Math.max(...boxes.map((box) => box.x + box.width));
+    const bottom = Math.max(...boxes.map((box) => box.y + box.height));
     return {
       x: left,
       y: top,
@@ -504,11 +568,15 @@ export function PreviewDrawOverlay({
     };
   }
 
-  function strokeBounds(): { x: number; y: number; width: number; height: number } | null {
+  function lastBoxBounds(): Rect | null {
+    const last = selectionBoxesRef.current.at(-1);
+    return last ? normalizedRectToCanvasRect(last) : null;
+  }
+
+  function strokeRect(stroke: Stroke | null | undefined): Rect | null {
     const rect = canvasRef.current?.getBoundingClientRect();
-    if (!rect || rect.width <= 0 || rect.height <= 0) return null;
-    const points = strokesRef.current.flatMap((stroke) => stroke.points);
-    if (points.length === 0) return null;
+    const points = stroke?.points ?? [];
+    if (!rect || rect.width <= 0 || rect.height <= 0 || points.length === 0) return null;
     const xs = points.map((point) => point.x * rect.width);
     const ys = points.map((point) => point.y * rect.height);
     const minX = Math.min(...xs);
@@ -522,6 +590,19 @@ export function PreviewDrawOverlay({
       width: Math.max(1, maxX - minX + pad * 2),
       height: Math.max(1, maxY - minY + pad * 2),
     };
+  }
+
+  function strokeBounds(): Rect | null {
+    const points = strokesRef.current.flatMap((stroke) => stroke.points);
+    return strokeRect(points.length > 0 ? { points } : null);
+  }
+
+  function lastStrokeBounds(): Rect | null {
+    return strokeRect(strokesRef.current.at(-1));
+  }
+
+  function anchorBounds(): Rect | null {
+    return lastBoxBounds() ?? lastStrokeBounds() ?? captureTarget?.position ?? null;
   }
 
   function annotationBounds(): { x: number; y: number; width: number; height: number } | undefined {
@@ -775,6 +856,147 @@ export function PreviewDrawOverlay({
     setToolbarHost((wrapRef.current?.closest('.viewer-body') as HTMLElement | null) ?? null);
   }, [active]);
 
+  useLayoutEffect(() => {
+    if (!active) {
+      setDockPlacement((current) => (
+        current.layout === 'docked' && current.side === null && dockPlacementEquals(current, {
+          layout: 'docked',
+          side: null,
+          style: previewDrawDockDockedStyle,
+        })
+          ? current
+          : { layout: 'docked', side: null, style: previewDrawDockDockedStyle }
+      ));
+      return;
+    }
+
+    const wrap = wrapRef.current;
+    const dock = dockRef.current;
+    const host = toolbarHost ?? wrap;
+    const anchor = anchorBounds();
+    if (!wrap || !dock || !host || !anchor) {
+      setDockPlacement((current) => (
+        current.layout === 'docked' && current.side === null && current.style === previewDrawDockDockedStyle
+          ? current
+          : { layout: 'docked', side: null, style: previewDrawDockDockedStyle }
+      ));
+      return;
+    }
+
+    const hostRect = host.getBoundingClientRect();
+    const wrapRect = wrap.getBoundingClientRect();
+    const dockRect = dock.getBoundingClientRect();
+    if (
+      hostRect.width <= DRAW_DOCK_MARGIN * 2 ||
+      hostRect.height <= DRAW_DOCK_MARGIN * 2 ||
+      dockRect.width <= 0 ||
+      dockRect.height <= 0 ||
+      hostRect.width < Math.max(DRAW_DOCK_MIN_WIDTH, dockRect.width) + DRAW_DOCK_MARGIN * 2 ||
+      hostRect.height < Math.max(DRAW_DOCK_MIN_HEIGHT, dockRect.height) + DRAW_DOCK_MARGIN * 2
+    ) {
+      setDockPlacement((current) => (
+        current.layout === 'docked' && current.side === null && current.style === previewDrawDockDockedStyle
+          ? current
+          : { layout: 'docked', side: null, style: previewDrawDockDockedStyle }
+      ));
+      return;
+    }
+
+    const anchorInHost: Rect = {
+      x: wrapRect.left - hostRect.left + anchor.x,
+      y: wrapRect.top - hostRect.top + anchor.y,
+      width: anchor.width,
+      height: anchor.height,
+    };
+    const safeLeft = DRAW_DOCK_MARGIN;
+    const safeTop = DRAW_DOCK_MARGIN;
+    const safeRight = Math.max(safeLeft, hostRect.width - dockRect.width - DRAW_DOCK_MARGIN);
+    const safeBottom = Math.max(safeTop, hostRect.height - dockRect.height - DRAW_DOCK_MARGIN);
+    const centeredLeft = anchorInHost.x + anchorInHost.width / 2 - dockRect.width / 2;
+    const centeredTop = anchorInHost.y + anchorInHost.height / 2 - dockRect.height / 2;
+    const candidates: Array<{ side: DrawDockSide; left: number; top: number; fits: boolean }> = [
+      {
+        side: 'right',
+        left: anchorInHost.x + anchorInHost.width + DRAW_DOCK_GAP,
+        top: centeredTop,
+        fits: anchorInHost.x + anchorInHost.width + DRAW_DOCK_GAP + dockRect.width <= hostRect.width - DRAW_DOCK_MARGIN,
+      },
+      {
+        side: 'left',
+        left: anchorInHost.x - DRAW_DOCK_GAP - dockRect.width,
+        top: centeredTop,
+        fits: anchorInHost.x - DRAW_DOCK_GAP - dockRect.width >= DRAW_DOCK_MARGIN,
+      },
+      {
+        side: 'bottom',
+        left: centeredLeft,
+        top: anchorInHost.y + anchorInHost.height + DRAW_DOCK_GAP,
+        fits: anchorInHost.y + anchorInHost.height + DRAW_DOCK_GAP + dockRect.height <= hostRect.height - DRAW_DOCK_MARGIN,
+      },
+      {
+        side: 'top',
+        left: centeredLeft,
+        top: anchorInHost.y - DRAW_DOCK_GAP - dockRect.height,
+        fits: anchorInHost.y - DRAW_DOCK_GAP - dockRect.height >= DRAW_DOCK_MARGIN,
+      },
+    ];
+
+    let nextPlacement: { layout: DrawDockLayout; side: DrawDockSide | null; style: CSSProperties } = {
+      layout: 'docked',
+      side: null,
+      style: previewDrawDockDockedStyle,
+    };
+
+    for (const candidate of candidates) {
+      if (!candidate.fits) continue;
+      const clampedLeft = clamp(candidate.left, safeLeft, safeRight);
+      const clampedTop = clamp(candidate.top, safeTop, safeBottom);
+      const candidateRect: Rect = {
+        x: clampedLeft,
+        y: clampedTop,
+        width: dockRect.width,
+        height: dockRect.height,
+      };
+      if (rectsOverlap(candidateRect, anchorInHost)) continue;
+      nextPlacement = {
+        layout: 'floating',
+        side: candidate.side,
+        style: {
+          position: 'absolute',
+          left: `${Math.round(clampedLeft)}px`,
+          top: `${Math.round(clampedTop)}px`,
+          transform: 'none',
+          bottom: 'auto',
+          maxWidth: `${Math.max(0, hostRect.width - DRAW_DOCK_MARGIN * 2)}px`,
+        },
+      };
+      break;
+    }
+
+    setDockPlacement((current) => (dockPlacementEquals(current, nextPlacement) ? current : nextPlacement));
+  }, [
+    active,
+    toolbarHost,
+    captureTarget,
+    layoutRevision,
+    imagePreviews.length,
+    captureWarning?.message,
+  ]);
+
+  useLayoutEffect(() => {
+    if (!active || typeof ResizeObserver === 'undefined') return undefined;
+    const wrap = wrapRef.current;
+    const dock = dockRef.current;
+    const host = toolbarHost ?? wrap;
+    if (!wrap || !dock || !host) return undefined;
+    const recompute = () => setLayoutRevision((value) => value + 1);
+    const ro = new ResizeObserver(recompute);
+    ro.observe(wrap);
+    ro.observe(dock);
+    if (host !== wrap) ro.observe(host);
+    return () => ro.disconnect();
+  }, [active, toolbarHost]);
+
   const overlayPointer = active ? 'auto' : 'none';
   const showCanvas = active || hasInk || hasBox;
   const canSubmit = hasInk || hasBox || Boolean(captureTarget) || captureViewport || Boolean(note.trim()) || extraFiles.length > 0;
@@ -857,7 +1079,16 @@ export function PreviewDrawOverlay({
       {active ? maybePortal(
         <>
           <style>{tooltipStyle}</style>
-          <div className="preview-draw-dock" style={previewDrawDockStyle}>
+          <div
+            ref={dockRef}
+            className="preview-draw-dock"
+            data-draw-layout={dockPlacement.layout}
+            data-draw-side={dockPlacement.side ?? undefined}
+            style={{
+              ...previewDrawDockBaseStyle,
+              ...dockPlacement.style,
+            }}
+          >
           {captureWarning ? (
             <div
               role="status"
@@ -1374,18 +1605,21 @@ const closeButtonStyle: CSSProperties = {
 // strip, and toolbar with real spacing. Absolute per-element `bottom` offsets
 // used to collide once the toolbar wrapped taller, so the image strip visually
 // covered the controls; a flex column keeps them apart at any height.
-const previewDrawDockStyle: CSSProperties = {
+const previewDrawDockBaseStyle: CSSProperties = {
   position: 'absolute',
-  left: 'calc(50% - 52px)',
-  bottom: 16,
-  transform: 'translateX(-50%)',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   gap: 8,
-  maxWidth: 'min(760px, calc(100% - 144px))',
   zIndex: 91,
   pointerEvents: 'none',
+};
+
+const previewDrawDockDockedStyle: CSSProperties = {
+  left: 'calc(50% - 52px)',
+  bottom: 16,
+  transform: 'translateX(-50%)',
+  maxWidth: 'min(760px, calc(100% - 144px))',
 };
 
 const submitSplitStyle: CSSProperties = {

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -19,6 +19,50 @@ afterEach(() => {
   vi.mocked(requestPreviewSnapshot).mockClear();
 });
 
+function mockElementRect(
+  element: Element,
+  rect: Partial<DOMRect> & Pick<DOMRect, 'left' | 'top' | 'width' | 'height'>,
+) {
+  const fullRect = {
+    x: rect.left,
+    y: rect.top,
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+    right: rect.left + rect.width,
+    bottom: rect.top + rect.height,
+    toJSON: () => ({}),
+  } as DOMRect;
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => fullRect,
+  });
+}
+
+function drawSelectionBox(
+  canvas: HTMLCanvasElement,
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+) {
+  fireEvent.pointerDown(canvas, { clientX: start.x, clientY: start.y, pointerId: 1 });
+  fireEvent.pointerMove(canvas, { clientX: end.x, clientY: end.y, pointerId: 1 });
+  fireEvent.pointerUp(canvas, { clientX: end.x, clientY: end.y, pointerId: 1 });
+}
+
+function drawPenStroke(
+  canvas: HTMLCanvasElement,
+  points: Array<{ x: number; y: number }>,
+) {
+  const [first, ...rest] = points;
+  fireEvent.pointerDown(canvas, { clientX: first!.x, clientY: first!.y, pointerId: 1 });
+  for (const point of rest) {
+    fireEvent.pointerMove(canvas, { clientX: point.x, clientY: point.y, pointerId: 1 });
+  }
+  const last = points[points.length - 1]!;
+  fireEvent.pointerUp(canvas, { clientX: last.x, clientY: last.y, pointerId: 1 });
+}
+
 function installImageCompositeMocks() {
   const originalImage = globalThis.Image;
   class MockImage {
@@ -96,6 +140,7 @@ describe('PreviewDrawOverlay', () => {
 
     expect(canvas?.style.zIndex).toBe('80');
     expect(dock?.style.zIndex).toBe('91');
+    expect(dock?.dataset.drawLayout).toBe('docked');
     expect(dock?.style.flexDirection).toBe('column');
     expect(dock?.style.left).toBe('calc(50% - 52px)');
     expect(dock?.style.maxWidth).toContain('100% - 144px');
@@ -305,6 +350,136 @@ describe('PreviewDrawOverlay', () => {
     expect(undo.disabled).toBe(true);
   });
 
+  it('floats the draw composer next to the latest box selection', async () => {
+    const { container } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 700, height: 320 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')!;
+    const dock = container.querySelector<HTMLElement>('.preview-draw-dock')!;
+    const wrap = canvas.parentElement as HTMLElement;
+    mockElementRect(canvas, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(wrap, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(dock, { left: 0, top: 0, width: 180, height: 96 });
+
+    drawSelectionBox(canvas, { x: 80, y: 80 }, { x: 180, y: 160 });
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('floating'));
+    expect(dock.dataset.drawSide).toBe('right');
+    expect(dock.style.left).toBe('192px');
+    expect(dock.style.top).toBe('72px');
+
+    drawSelectionBox(canvas, { x: 320, y: 180 }, { x: 420, y: 260 });
+    await waitFor(() => expect(dock.style.left).toBe('432px'));
+    expect(dock.style.top).toBe('172px');
+  });
+
+  it('flips the floating composer away from the nearest clipped edge', async () => {
+    const { container, getByRole } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 700, height: 320 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')!;
+    const dock = container.querySelector<HTMLElement>('.preview-draw-dock')!;
+    const wrap = canvas.parentElement as HTMLElement;
+    mockElementRect(canvas, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(wrap, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(dock, { left: 0, top: 0, width: 180, height: 96 });
+
+    drawSelectionBox(canvas, { x: 520, y: 120 }, { x: 620, y: 200 });
+    await waitFor(() => expect(dock.dataset.drawSide).toBe('left'));
+    expect(dock.style.left).toBe('328px');
+
+    fireEvent.click(getByRole('button', { name: 'Undo' }));
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('docked'));
+
+    drawSelectionBox(canvas, { x: 12, y: 100 }, { x: 112, y: 180 });
+    await waitFor(() => expect(dock.dataset.drawSide).toBe('right'));
+    expect(dock.style.left).toBe('124px');
+  });
+
+  it('follows the latest pen stroke instead of the aggregate stroke bounds', async () => {
+    const { container, getByRole } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 700, height: 320 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')!;
+    const dock = container.querySelector<HTMLElement>('.preview-draw-dock')!;
+    const wrap = canvas.parentElement as HTMLElement;
+    mockElementRect(canvas, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(wrap, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(dock, { left: 0, top: 0, width: 180, height: 96 });
+
+    fireEvent.click(getByRole('button', { name: 'Pen' }));
+    drawPenStroke(canvas, [{ x: 40, y: 40 }, { x: 100, y: 90 }]);
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('floating'));
+    const firstPosition = dock.style.left;
+
+    drawPenStroke(canvas, [{ x: 360, y: 200 }, { x: 420, y: 240 }, { x: 470, y: 250 }]);
+    await waitFor(() => expect(dock.style.left).not.toBe(firstPosition));
+    expect(dock.dataset.drawSide).toBe('right');
+    expect(dock.style.left).toBe('490px');
+  });
+
+  it('returns to the previous box after undo and docks after clearing all marks', async () => {
+    const { container, getByRole } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 700, height: 320 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')!;
+    const dock = container.querySelector<HTMLElement>('.preview-draw-dock')!;
+    const wrap = canvas.parentElement as HTMLElement;
+    mockElementRect(canvas, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(wrap, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(dock, { left: 0, top: 0, width: 180, height: 96 });
+
+    drawSelectionBox(canvas, { x: 60, y: 70 }, { x: 160, y: 150 });
+    await waitFor(() => expect(dock.style.left).toBe('172px'));
+
+    drawSelectionBox(canvas, { x: 340, y: 100 }, { x: 440, y: 180 });
+    await waitFor(() => expect(dock.style.left).toBe('452px'));
+
+    fireEvent.click(getByRole('button', { name: 'Undo' }));
+    await waitFor(() => expect(dock.style.left).toBe('172px'));
+
+    fireEvent.click(getByRole('button', { name: 'Undo' }));
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('docked'));
+  });
+
+  it('keeps the input mounted and preserves its value while the floating position updates', async () => {
+    const { container, getByRole } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 700, height: 320 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')!;
+    const dock = container.querySelector<HTMLElement>('.preview-draw-dock')!;
+    const wrap = canvas.parentElement as HTMLElement;
+    mockElementRect(canvas, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(wrap, { left: 0, top: 0, width: 700, height: 320 });
+    mockElementRect(dock, { left: 0, top: 0, width: 180, height: 96 });
+
+    const input = container.querySelector<HTMLInputElement>('.preview-draw-note-input')!;
+    fireEvent.change(input, { target: { value: 'keep me here' } });
+    fireEvent.click(getByRole('button', { name: 'Submit options' }));
+
+    drawSelectionBox(canvas, { x: 80, y: 80 }, { x: 180, y: 160 });
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('floating'));
+
+    const inputAfter = container.querySelector<HTMLInputElement>('.preview-draw-note-input')!;
+    expect(inputAfter).toBe(input);
+    expect(inputAfter.value).toBe('keep me here');
+    expect(getByRole('menu')).toBeTruthy();
+  });
+
   it('remembers the submit action chosen from the dropdown', async () => {
     const annotation = vi.fn((event: Event) => {
       const detail = (event as CustomEvent<{ ack?: (result: { ok: boolean }) => void }>).detail;
@@ -487,6 +662,37 @@ describe('PreviewDrawOverlay', () => {
       expect(wrap.contains(input!)).toBe(false);
       expect(body.contains(input!)).toBe(true);
     });
+  });
+
+  it('positions the floating dock in viewer-body coordinates when portaled', async () => {
+    const { container } = render(
+      <div className="viewer-body">
+        <div className="comment-preview-layer">
+          <div className="comment-frame-clip">
+            <PreviewDrawOverlay active>
+              <div style={{ width: 400, height: 280 }} />
+            </PreviewDrawOverlay>
+          </div>
+        </div>
+      </div>,
+    );
+
+    const body = container.querySelector<HTMLElement>('.viewer-body')!;
+    const canvas = container.querySelector<HTMLCanvasElement>('canvas')!;
+    const dock = body.querySelector<HTMLElement>('.preview-draw-dock')!;
+    const wrap = canvas.parentElement as HTMLElement;
+    mockElementRect(body, { left: 0, top: 0, width: 900, height: 700 });
+    mockElementRect(wrap, { left: 120, top: 160, width: 400, height: 280 });
+    mockElementRect(canvas, { left: 120, top: 160, width: 400, height: 280 });
+    mockElementRect(dock, { left: 0, top: 0, width: 180, height: 96 });
+
+    drawSelectionBox(canvas, { x: 160, y: 220 }, { x: 260, y: 300 });
+    await waitFor(() => expect(dock.dataset.drawLayout).toBe('floating'));
+    expect(dock.dataset.drawSide).toBe('right');
+    expect(dock.style.left).toBe('272px');
+    expect(dock.style.top).toBe('212px');
+    expect(body.contains(dock)).toBe(true);
+    expect(wrap.contains(dock)).toBe(false);
   });
 
   it('hides draw chrome before a compositor annotation snapshot', async () => {


### PR DESCRIPTION
Closes #690

## Why

我在处理 issue #690 / 外部需求池 #861 时，针对设计稿框选后的下一步操作链路做收口。当前用户完成 box mark 或 pen mark 后，AI 输入入口固定出现在预览底部，视线需要离开刚操作的选区去找输入框，发现成本高，交互连续性差。

这次改动只解决这个表现层问题：保留原有 annotation 提交流程、截图合成、warning 和 queue/send 语义，把输入区整体改成优先贴近当前选区浮现，并在空间不足时自动回退到底部停靠。

## What users will see

在预览里完成框选或手绘标注后，AI 输入框、附图条、warning 和提交按钮会整体出现在刚操作的选区附近，而不是固定钉在页面底部。

当选区靠近边缘或设备框可用空间不足时，浮层会自动翻到另一侧，仍然放不下时再回退到底部，原来的输入、附图、Queue / Send / Add to input 行为保持不变。

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

未附截图。此次执行未启动稳定的本地预览运行时，但已补齐组件级定位回归测试，覆盖浮层、翻边、portal host 坐标换算与 dock fallback。

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/PreviewDrawOverlay.test.tsx`
- Did the test go red on `main` and green on this branch? yes
- Added focused cases for latest box / latest pen anchoring, edge flipping, undo fallback, portal coordinate translation, and preserving the mounted input while the dock repositions.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/PreviewDrawOverlay.test.tsx tests/components/PreviewDrawOverlay.capture-fallback.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>