### PR TITLE
fix(html-ppt): correct weekly-report bar labels and proportions

### DIFF
--- a/apps/web/tests/runtime/design-template-deck-nav.test.ts
+++ b/apps/web/tests/runtime/design-template-deck-nav.test.ts
@@ -204,4 +204,23 @@ describe('design template deck navigation', () => {
     expect(labels).toEqual(['1', '5', '25']);
     expect(heights).toEqual(['4%', '20%', '100%']);
   });
+
+  it('keeps weekly-report review chips and shipped metadata on one line', () => {
+    const dom = setupWeeklyReportDeck();
+    const { window: win } = dom;
+    const targetPill = win.document.querySelector<HTMLElement>('.chart .pill');
+    const kpiDelta = win.document.querySelector<HTMLElement>('.kpi .delta');
+    const shippedTag = win.document.querySelector<HTMLElement>('.ship-item .tag');
+    const shippedOwner = win.document.querySelector<HTMLElement>('.ship-item .owner');
+
+    expect(targetPill).toBeTruthy();
+    expect(kpiDelta).toBeTruthy();
+    expect(shippedTag).toBeTruthy();
+    expect(shippedOwner).toBeTruthy();
+    expect(win.getComputedStyle(targetPill!).whiteSpace).toBe('nowrap');
+    expect(win.getComputedStyle(kpiDelta!).whiteSpace).toBe('nowrap');
+    expect(win.getComputedStyle(shippedTag!).whiteSpace).toBe('nowrap');
+    expect(win.getComputedStyle(shippedOwner!).whiteSpace).toBe('nowrap');
+    expect(win.getComputedStyle(shippedOwner!).flexShrink).toBe('0');
+  });
 });

--- a/apps/web/tests/runtime/design-template-deck-nav.test.ts
+++ b/apps/web/tests/runtime/design-template-deck-nav.test.ts
@@ -10,6 +10,9 @@ const tasteEditorialExamplePath = fileURLToPath(
 const simpleDeckExamplePath = fileURLToPath(
   new URL('../../../../design-templates/simple-deck/example.html', import.meta.url),
 );
+const weeklyReportExamplePath = fileURLToPath(
+  new URL('../../../../design-templates/html-ppt-weekly-report/example.html', import.meta.url),
+);
 
 function setupTasteEditorialDeck() {
   const html = readFileSync(tasteEditorialExamplePath, 'utf8');
@@ -84,6 +87,16 @@ function setupSimpleDeck() {
     },
   });
   return dom;
+}
+
+function setupWeeklyReportDeck() {
+  const html = readFileSync(weeklyReportExamplePath, 'utf8');
+  return new JSDOM(html, {
+    pretendToBeVisual: true,
+    runScripts: 'dangerously',
+    url: 'https://example.test/weekly-report.html',
+    virtualConsole: new VirtualConsole(),
+  });
 }
 
 function activeSlideIndex(win: DOMWindow) {
@@ -166,5 +179,29 @@ describe('design template deck navigation', () => {
 
     expect(counter?.textContent?.trim()).toBe('3 / 6');
     expect(win.document.documentElement.scrollLeft).toBe(2000);
+  });
+
+  it('renders weekly-report bar labels as real nodes and scales heights from source values', () => {
+    const dom = setupWeeklyReportDeck();
+    const { window: win } = dom;
+    const render = (win as typeof win & { renderWeeklyReportBarCharts?: (root?: ParentNode) => void })
+      .renderWeeklyReportBarCharts;
+    const host = win.document.createElement('div');
+
+    host.innerHTML = `
+      <div class="chart-bars">
+        <div class="col"><div class="bar-value"></div><div class="bar-track"><div class="b" data-value="1" data-label="1"></div></div><div class="lbl">A</div></div>
+        <div class="col"><div class="bar-value"></div><div class="bar-track"><div class="b" data-value="5" data-label="5"></div></div><div class="lbl">B</div></div>
+        <div class="col"><div class="bar-value"></div><div class="bar-track"><div class="b" data-value="25" data-label="25"></div></div><div class="lbl">C</div></div>
+      </div>
+    `;
+    win.document.body.append(host);
+    render?.(host);
+
+    const labels = Array.from(host.querySelectorAll<HTMLElement>('.bar-value')).map((el) => el.textContent?.trim());
+    const heights = Array.from(host.querySelectorAll<HTMLElement>('.b')).map((el) => el.style.getPropertyValue('--bar-height'));
+
+    expect(labels).toEqual(['1', '5', '25']);
+    expect(heights).toEqual(['4%', '20%', '100%']);
   });
 });

--- a/design-templates/html-ppt-weekly-report/example.html
+++ b/design-templates/html-ppt-weekly-report/example.html
@@ -346,10 +346,11 @@ h4,.h4{font-size:22px;line-height:1.3;font-weight:600;margin:0 0 8px}
 .tpl-weekly-report .ship-item b{color:var(--text-1);font-weight:600}
 .tpl-weekly-report .ship-item span.owner{margin-left:auto;color:var(--text-3);font-size:12px;font-family:'JetBrains Mono',monospace}
 .tpl-weekly-report .chart{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:28px}
-.tpl-weekly-report .chart-bars{display:flex;align-items:flex-end;gap:16px;height:220px;margin-top:20px}
-.tpl-weekly-report .chart-bars .col{flex:1;display:flex;flex-direction:column;align-items:center;gap:6px;position:relative}
-.tpl-weekly-report .chart-bars .col .b{width:100%;background:var(--grad);border-radius:6px 6px 0 0;min-height:6px;position:relative}
-.tpl-weekly-report .chart-bars .col .b::after{content:attr(data-v);position:absolute;top:-22px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;color:var(--text-1)}
+.tpl-weekly-report .chart-bars{display:flex;align-items:stretch;gap:16px;height:220px;margin-top:20px}
+.tpl-weekly-report .chart-bars .col{flex:1;display:grid;grid-template-rows:auto 1fr auto;align-items:end;gap:6px;min-height:0}
+.tpl-weekly-report .chart-bars .col .bar-value{font-size:12px;font-weight:700;color:var(--text-1);line-height:1;text-align:center}
+.tpl-weekly-report .chart-bars .col .bar-track{width:100%;height:100%;display:flex;align-items:flex-end}
+.tpl-weekly-report .chart-bars .col .b{width:100%;height:var(--bar-height,0%);background:var(--grad);border-radius:6px 6px 0 0}
 .tpl-weekly-report .chart-bars .col .lbl{font-size:11px;color:var(--text-3);font-family:'JetBrains Mono',monospace}
 .tpl-weekly-report .blocker{background:var(--surface);border-left:3px solid var(--bad);padding:16px 20px;border-radius:8px;margin-bottom:12px}
 .tpl-weekly-report .blocker h4{font-size:16px;margin-bottom:4px}
@@ -422,14 +423,14 @@ h4,.h4{font-size:22px;line-height:1.3;font-weight:600;margin:0 0 8px}
     <div class="chart mt-l">
       <div class="row" style="justify-content:space-between"><h4>Paid conv. rate · weekly</h4><span class="pill" style="background:var(--surface-2);color:var(--text-2)">target: 4.0%</span></div>
       <div class="chart-bars">
-        <div class="col"><div class="b" data-v="3.1%" style="height:58%"></div><div class="lbl">W08</div></div>
-        <div class="col"><div class="b" data-v="3.3%" style="height:64%"></div><div class="lbl">W09</div></div>
-        <div class="col"><div class="b" data-v="3.5%" style="height:72%"></div><div class="lbl">W10</div></div>
-        <div class="col"><div class="b" data-v="3.6%" style="height:75%"></div><div class="lbl">W11</div></div>
-        <div class="col"><div class="b" data-v="3.4%" style="height:68%"></div><div class="lbl">W12</div></div>
-        <div class="col"><div class="b" data-v="3.0%" style="height:55%"></div><div class="lbl">W13</div></div>
-        <div class="col"><div class="b" data-v="3.4%" style="height:68%"></div><div class="lbl">W14</div></div>
-        <div class="col"><div class="b" data-v="3.8%" style="height:88%"></div><div class="lbl">W15</div></div>
+        <div class="col"><div class="bar-value">3.1%</div><div class="bar-track"><div class="b" data-value="3.1" data-label="3.1%"></div></div><div class="lbl">W08</div></div>
+        <div class="col"><div class="bar-value">3.3%</div><div class="bar-track"><div class="b" data-value="3.3" data-label="3.3%"></div></div><div class="lbl">W09</div></div>
+        <div class="col"><div class="bar-value">3.5%</div><div class="bar-track"><div class="b" data-value="3.5" data-label="3.5%"></div></div><div class="lbl">W10</div></div>
+        <div class="col"><div class="bar-value">3.6%</div><div class="bar-track"><div class="b" data-value="3.6" data-label="3.6%"></div></div><div class="lbl">W11</div></div>
+        <div class="col"><div class="bar-value">3.4%</div><div class="bar-track"><div class="b" data-value="3.4" data-label="3.4%"></div></div><div class="lbl">W12</div></div>
+        <div class="col"><div class="bar-value">3.0%</div><div class="bar-track"><div class="b" data-value="3.0" data-label="3.0%"></div></div><div class="lbl">W13</div></div>
+        <div class="col"><div class="bar-value">3.4%</div><div class="bar-track"><div class="b" data-value="3.4" data-label="3.4%"></div></div><div class="lbl">W14</div></div>
+        <div class="col"><div class="bar-value">3.8%</div><div class="bar-track"><div class="b" data-value="3.8" data-label="3.8%"></div></div><div class="lbl">W15</div></div>
       </div>
       <p class="dim mt-m" style="font-size:13px;margin-top:36px">Drop in W13 tracked to a broken Stripe webhook (fixed W14). Rebound in W15 is driven by the new onboarding checklist.</p>
     </div>
@@ -485,5 +486,31 @@ h4,.h4{font-size:22px;line-height:1.3;font-weight:600;margin:0 0 8px}
   </section>
 
 </div>
+<script>
+  function renderWeeklyReportBarCharts(root = document) {
+    root.querySelectorAll('.chart-bars').forEach((chart) => {
+      const bars = Array.from(chart.querySelectorAll('.b'));
+      const values = bars
+        .map((bar) => Number.parseFloat(bar.getAttribute('data-value') ?? '0'))
+        .filter((value) => Number.isFinite(value) && value >= 0);
+      const max = values.length ? Math.max(...values) : 0;
+
+      bars.forEach((bar) => {
+        const value = Number.parseFloat(bar.getAttribute('data-value') ?? '0');
+        const safeValue = Number.isFinite(value) && value >= 0 ? value : 0;
+        const height = max > 0 ? (safeValue / max) * 100 : 0;
+        bar.style.setProperty('--bar-height', `${height}%`);
+
+        const label = bar.closest('.col')?.querySelector('.bar-value');
+        if (label instanceof HTMLElement) {
+          label.textContent = bar.getAttribute('data-label') ?? `${safeValue}`;
+        }
+      });
+    });
+  }
+
+  renderWeeklyReportBarCharts();
+  window.renderWeeklyReportBarCharts = renderWeeklyReportBarCharts;
+</script>
 
 </body></html>

--- a/design-templates/html-ppt-weekly-report/example.html
+++ b/design-templates/html-ppt-weekly-report/example.html
@@ -329,7 +329,7 @@ h4,.h4{font-size:22px;line-height:1.3;font-weight:600;margin:0 0 8px}
 .tpl-weekly-report .kpi{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:24px 26px;position:relative;overflow:hidden}
 .tpl-weekly-report .kpi .label{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--text-3);font-weight:600}
 .tpl-weekly-report .kpi .value{font-size:48px;font-weight:800;letter-spacing:-.03em;margin-top:8px;line-height:1}
-.tpl-weekly-report .kpi .delta{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:6px;font-size:12px;font-weight:700;margin-top:10px}
+.tpl-weekly-report .kpi .delta{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:6px;font-size:12px;font-weight:700;margin-top:10px;white-space:nowrap;max-width:max-content}
 .tpl-weekly-report .kpi .delta.up{background:rgba(16,185,129,.12);color:var(--good)}
 .tpl-weekly-report .kpi .delta.down{background:rgba(239,68,68,.12);color:var(--bad)}
 .tpl-weekly-report .kpi .delta.flat{background:rgba(139,146,165,.14);color:var(--text-2)}
@@ -337,15 +337,19 @@ h4,.h4{font-size:22px;line-height:1.3;font-weight:600;margin:0 0 8px}
 .tpl-weekly-report .kpi.good::before{background:var(--good)}
 .tpl-weekly-report .kpi.warn::before{background:var(--warn)}
 .tpl-weekly-report .kpi.bad::before{background:var(--bad)}
-.tpl-weekly-report .ship-item{display:flex;gap:14px;padding:14px 0;border-bottom:1px solid var(--border)}
-.tpl-weekly-report .ship-item .tag{flex:none;padding:3px 10px;border-radius:6px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;height:22px;display:inline-flex;align-items:center}
+.tpl-weekly-report .ship-item{display:flex;align-items:flex-start;gap:14px;padding:14px 0;border-bottom:1px solid var(--border)}
+.tpl-weekly-report .ship-item .tag{flex:none;padding:3px 10px;border-radius:6px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;height:22px;display:inline-flex;align-items:center;white-space:nowrap}
+.tpl-weekly-report .ship-item > div{flex:1;min-width:0}
 .tpl-weekly-report .tag.feat{background:rgba(46,99,235,.12);color:var(--accent)}
 .tpl-weekly-report .tag.fix{background:rgba(16,185,129,.12);color:var(--good)}
 .tpl-weekly-report .tag.exp{background:rgba(245,158,11,.14);color:var(--warn)}
 .tpl-weekly-report .tag.infra{background:rgba(14,165,181,.12);color:var(--accent-2)}
 .tpl-weekly-report .ship-item b{color:var(--text-1);font-weight:600}
-.tpl-weekly-report .ship-item span.owner{margin-left:auto;color:var(--text-3);font-size:12px;font-family:'JetBrains Mono',monospace}
+.tpl-weekly-report .ship-item span.owner{margin-left:auto;flex:none;color:var(--text-3);font-size:12px;font-family:'JetBrains Mono',monospace;white-space:nowrap}
 .tpl-weekly-report .chart{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:28px}
+.tpl-weekly-report .chart .row{align-items:center;gap:16px;flex-wrap:nowrap}
+.tpl-weekly-report .chart .row h4{min-width:0}
+.tpl-weekly-report .chart .pill{flex:none;white-space:nowrap}
 .tpl-weekly-report .chart-bars{display:flex;align-items:stretch;gap:16px;height:220px;margin-top:20px}
 .tpl-weekly-report .chart-bars .col{flex:1;display:grid;grid-template-rows:auto 1fr auto;align-items:end;gap:6px;min-height:0}
 .tpl-weekly-report .chart-bars .col .bar-value{font-size:12px;font-weight:700;color:var(--text-1);line-height:1;text-align:center}

--- a/design-templates/html-ppt/templates/full-decks/weekly-report/index.html
+++ b/design-templates/html-ppt/templates/full-decks/weekly-report/index.html
@@ -60,14 +60,14 @@
     <div class="chart mt-l">
       <div class="row" style="justify-content:space-between"><h4>Paid conv. rate · weekly</h4><span class="pill" style="background:var(--surface-2);color:var(--text-2)">target: 4.0%</span></div>
       <div class="chart-bars">
-        <div class="col"><div class="b" data-v="3.1%" style="height:58%"></div><div class="lbl">W08</div></div>
-        <div class="col"><div class="b" data-v="3.3%" style="height:64%"></div><div class="lbl">W09</div></div>
-        <div class="col"><div class="b" data-v="3.5%" style="height:72%"></div><div class="lbl">W10</div></div>
-        <div class="col"><div class="b" data-v="3.6%" style="height:75%"></div><div class="lbl">W11</div></div>
-        <div class="col"><div class="b" data-v="3.4%" style="height:68%"></div><div class="lbl">W12</div></div>
-        <div class="col"><div class="b" data-v="3.0%" style="height:55%"></div><div class="lbl">W13</div></div>
-        <div class="col"><div class="b" data-v="3.4%" style="height:68%"></div><div class="lbl">W14</div></div>
-        <div class="col"><div class="b" data-v="3.8%" style="height:88%"></div><div class="lbl">W15</div></div>
+        <div class="col"><div class="bar-value">3.1%</div><div class="bar-track"><div class="b" data-value="3.1" data-label="3.1%"></div></div><div class="lbl">W08</div></div>
+        <div class="col"><div class="bar-value">3.3%</div><div class="bar-track"><div class="b" data-value="3.3" data-label="3.3%"></div></div><div class="lbl">W09</div></div>
+        <div class="col"><div class="bar-value">3.5%</div><div class="bar-track"><div class="b" data-value="3.5" data-label="3.5%"></div></div><div class="lbl">W10</div></div>
+        <div class="col"><div class="bar-value">3.6%</div><div class="bar-track"><div class="b" data-value="3.6" data-label="3.6%"></div></div><div class="lbl">W11</div></div>
+        <div class="col"><div class="bar-value">3.4%</div><div class="bar-track"><div class="b" data-value="3.4" data-label="3.4%"></div></div><div class="lbl">W12</div></div>
+        <div class="col"><div class="bar-value">3.0%</div><div class="bar-track"><div class="b" data-value="3.0" data-label="3.0%"></div></div><div class="lbl">W13</div></div>
+        <div class="col"><div class="bar-value">3.4%</div><div class="bar-track"><div class="b" data-value="3.4" data-label="3.4%"></div></div><div class="lbl">W14</div></div>
+        <div class="col"><div class="bar-value">3.8%</div><div class="bar-track"><div class="b" data-value="3.8" data-label="3.8%"></div></div><div class="lbl">W15</div></div>
       </div>
       <p class="dim mt-m" style="font-size:13px;margin-top:36px">Drop in W13 tracked to a broken Stripe webhook (fixed W14). Rebound in W15 is driven by the new onboarding checklist.</p>
     </div>
@@ -123,5 +123,31 @@
   </section>
 
 </div>
+<script>
+  function renderWeeklyReportBarCharts(root = document) {
+    root.querySelectorAll('.chart-bars').forEach((chart) => {
+      const bars = Array.from(chart.querySelectorAll('.b'));
+      const values = bars
+        .map((bar) => Number.parseFloat(bar.getAttribute('data-value') ?? '0'))
+        .filter((value) => Number.isFinite(value) && value >= 0);
+      const max = values.length ? Math.max(...values) : 0;
+
+      bars.forEach((bar) => {
+        const value = Number.parseFloat(bar.getAttribute('data-value') ?? '0');
+        const safeValue = Number.isFinite(value) && value >= 0 ? value : 0;
+        const height = max > 0 ? (safeValue / max) * 100 : 0;
+        bar.style.setProperty('--bar-height', `${height}%`);
+
+        const label = bar.closest('.col')?.querySelector('.bar-value');
+        if (label instanceof HTMLElement) {
+          label.textContent = bar.getAttribute('data-label') ?? `${safeValue}`;
+        }
+      });
+    });
+  }
+
+  renderWeeklyReportBarCharts();
+  window.renderWeeklyReportBarCharts = renderWeeklyReportBarCharts;
+</script>
 <script src="../../../assets/runtime.js"></script>
 </body></html>

--- a/design-templates/html-ppt/templates/full-decks/weekly-report/style.css
+++ b/design-templates/html-ppt/templates/full-decks/weekly-report/style.css
@@ -38,10 +38,11 @@
 .tpl-weekly-report .ship-item b{color:var(--text-1);font-weight:600}
 .tpl-weekly-report .ship-item span.owner{margin-left:auto;color:var(--text-3);font-size:12px;font-family:'JetBrains Mono',monospace}
 .tpl-weekly-report .chart{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:28px}
-.tpl-weekly-report .chart-bars{display:flex;align-items:flex-end;gap:16px;height:220px;margin-top:20px}
-.tpl-weekly-report .chart-bars .col{flex:1;display:flex;flex-direction:column;align-items:center;gap:6px;position:relative}
-.tpl-weekly-report .chart-bars .col .b{width:100%;background:var(--grad);border-radius:6px 6px 0 0;min-height:6px;position:relative}
-.tpl-weekly-report .chart-bars .col .b::after{content:attr(data-v);position:absolute;top:-22px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;color:var(--text-1)}
+.tpl-weekly-report .chart-bars{display:flex;align-items:stretch;gap:16px;height:220px;margin-top:20px}
+.tpl-weekly-report .chart-bars .col{flex:1;display:grid;grid-template-rows:auto 1fr auto;align-items:end;gap:6px;min-height:0}
+.tpl-weekly-report .chart-bars .col .bar-value{font-size:12px;font-weight:700;color:var(--text-1);line-height:1;text-align:center}
+.tpl-weekly-report .chart-bars .col .bar-track{width:100%;height:100%;display:flex;align-items:flex-end}
+.tpl-weekly-report .chart-bars .col .b{width:100%;height:var(--bar-height,0%);background:var(--grad);border-radius:6px 6px 0 0}
 .tpl-weekly-report .chart-bars .col .lbl{font-size:11px;color:var(--text-3);font-family:'JetBrains Mono',monospace}
 .tpl-weekly-report .blocker{background:var(--surface);border-left:3px solid var(--bad);padding:16px 20px;border-radius:8px;margin-bottom:12px}
 .tpl-weekly-report .blocker h4{font-size:16px;margin-bottom:4px}

--- a/design-templates/html-ppt/templates/full-decks/weekly-report/style.css
+++ b/design-templates/html-ppt/templates/full-decks/weekly-report/style.css
@@ -21,7 +21,7 @@
 .tpl-weekly-report .kpi{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:24px 26px;position:relative;overflow:hidden}
 .tpl-weekly-report .kpi .label{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--text-3);font-weight:600}
 .tpl-weekly-report .kpi .value{font-size:48px;font-weight:800;letter-spacing:-.03em;margin-top:8px;line-height:1}
-.tpl-weekly-report .kpi .delta{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:6px;font-size:12px;font-weight:700;margin-top:10px}
+.tpl-weekly-report .kpi .delta{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:6px;font-size:12px;font-weight:700;margin-top:10px;white-space:nowrap;max-width:max-content}
 .tpl-weekly-report .kpi .delta.up{background:rgba(16,185,129,.12);color:var(--good)}
 .tpl-weekly-report .kpi .delta.down{background:rgba(239,68,68,.12);color:var(--bad)}
 .tpl-weekly-report .kpi .delta.flat{background:rgba(139,146,165,.14);color:var(--text-2)}
@@ -29,15 +29,19 @@
 .tpl-weekly-report .kpi.good::before{background:var(--good)}
 .tpl-weekly-report .kpi.warn::before{background:var(--warn)}
 .tpl-weekly-report .kpi.bad::before{background:var(--bad)}
-.tpl-weekly-report .ship-item{display:flex;gap:14px;padding:14px 0;border-bottom:1px solid var(--border)}
-.tpl-weekly-report .ship-item .tag{flex:none;padding:3px 10px;border-radius:6px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;height:22px;display:inline-flex;align-items:center}
+.tpl-weekly-report .ship-item{display:flex;align-items:flex-start;gap:14px;padding:14px 0;border-bottom:1px solid var(--border)}
+.tpl-weekly-report .ship-item .tag{flex:none;padding:3px 10px;border-radius:6px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;height:22px;display:inline-flex;align-items:center;white-space:nowrap}
+.tpl-weekly-report .ship-item > div{flex:1;min-width:0}
 .tpl-weekly-report .tag.feat{background:rgba(46,99,235,.12);color:var(--accent)}
 .tpl-weekly-report .tag.fix{background:rgba(16,185,129,.12);color:var(--good)}
 .tpl-weekly-report .tag.exp{background:rgba(245,158,11,.14);color:var(--warn)}
 .tpl-weekly-report .tag.infra{background:rgba(14,165,181,.12);color:var(--accent-2)}
 .tpl-weekly-report .ship-item b{color:var(--text-1);font-weight:600}
-.tpl-weekly-report .ship-item span.owner{margin-left:auto;color:var(--text-3);font-size:12px;font-family:'JetBrains Mono',monospace}
+.tpl-weekly-report .ship-item span.owner{margin-left:auto;flex:none;color:var(--text-3);font-size:12px;font-family:'JetBrains Mono',monospace;white-space:nowrap}
 .tpl-weekly-report .chart{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:28px}
+.tpl-weekly-report .chart .row{align-items:center;gap:16px;flex-wrap:nowrap}
+.tpl-weekly-report .chart .row h4{min-width:0}
+.tpl-weekly-report .chart .pill{flex:none;white-space:nowrap}
 .tpl-weekly-report .chart-bars{display:flex;align-items:stretch;gap:16px;height:220px;margin-top:20px}
 .tpl-weekly-report .chart-bars .col{flex:1;display:grid;grid-template-rows:auto 1fr auto;align-items:end;gap:6px;min-height:0}
 .tpl-weekly-report .chart-bars .col .bar-value{font-size:12px;font-weight:700;color:var(--text-1);line-height:1;text-align:center}


### PR DESCRIPTION
## Summary
- replace the weekly-report bar charts pseudo-element labels with real DOM label nodes so every bar keeps a visible value label
- derive bar heights from the same numeric source data at render time instead of maintaining hand-written height percentages
- add a runtime regression test that covers small values like `1` and `5` and asserts the resulting rendered heights stay proportional

## Why
- the repo exposes `html-ppt-weekly-report` as a public design-template card and preview example, and its chart implementation matched both reported failure modes: labels depended on `::after`, and bar heights were manually drift-prone
- this keeps the fix scoped to the concrete static bar-chart path we could verify from source without changing unrelated chart implementations

## Validation
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/runtime/design-template-deck-nav.test.ts`
- `pnpm --filter @open-design/web typecheck`

Closes #954

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>