### PR TITLE
fix(daemon): backfill Windows CLI cache env

### DIFF
--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -83,6 +83,7 @@ export function spawnEnvForAgent(
     baseEnv,
     expandedConfiguredEnv,
   );
+  applyWindowsUserCacheEnv(env);
   if (agentId === 'amr') {
     Object.assign(env, amrVelaProfileEnv(env));
     Object.assign(env, amrAnalyticsIdentityEnv(env));
@@ -217,4 +218,51 @@ function stripKeysCaseInsensitive(
   for (const key of Object.keys(env)) {
     if (keysUpper.has(key.toUpperCase())) delete env[key];
   }
+}
+
+function applyWindowsUserCacheEnv(env: NodeJS.ProcessEnv): void {
+  if (process.platform !== 'win32') return;
+
+  // GUI-launched Windows daemons can inherit enough PATH to resolve a CLI
+  // while still missing the profile/cache variables CLIs use at startup.
+  const userProfile =
+    envValue(env, 'USERPROFILE') ||
+    envValue(env, 'HOME') ||
+    os.homedir();
+  if (!userProfile) return;
+
+  setEnvIfMissing(env, 'USERPROFILE', userProfile);
+  const localAppData =
+    envValue(env, 'LOCALAPPDATA') ||
+    path.win32.join(userProfile, 'AppData', 'Local');
+  setEnvIfMissing(env, 'LOCALAPPDATA', localAppData);
+  setEnvIfMissing(
+    env,
+    'APPDATA',
+    path.win32.join(userProfile, 'AppData', 'Roaming'),
+  );
+  const tempDir = path.win32.join(localAppData, 'Temp');
+  setEnvIfMissing(env, 'TEMP', tempDir);
+  setEnvIfMissing(env, 'TMP', tempDir);
+}
+
+function envValue(env: NodeJS.ProcessEnv, key: string): string | null {
+  const existingKey = Object.keys(env).find(
+    (candidate) => candidate.toUpperCase() === key.toUpperCase(),
+  );
+  const value = existingKey ? env[existingKey] : undefined;
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? (value as string) : null;
+}
+
+function setEnvIfMissing(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  value: string,
+): void {
+  if (envValue(env, key)) return;
+  const existingKey = Object.keys(env).find(
+    (candidate) => candidate.toUpperCase() === key.toUpperCase(),
+  );
+  env[existingKey ?? key] = value;
 }

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -83,7 +83,6 @@ export function spawnEnvForAgent(
     baseEnv,
     expandedConfiguredEnv,
   );
-  applyWindowsUserCacheEnv(env);
   if (agentId === 'amr') {
     Object.assign(env, amrVelaProfileEnv(env));
     Object.assign(env, amrAnalyticsIdentityEnv(env));
@@ -118,13 +117,13 @@ export function spawnEnvForAgent(
       const opencodeBin = resolveAmrOpenCodeExecutable(env);
       if (opencodeBin) env.VELA_OPENCODE_BIN = opencodeBin;
     }
-    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
+    return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'claude') {
-    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
+    return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'codex') {
-    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
+    return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'opencode' || agentId === 'byok-opencode') {
     stripKeysCaseInsensitive(env, [
@@ -144,7 +143,7 @@ export function spawnEnvForAgent(
     if (!env.OPENCODE_DISABLE_PROJECT_CONFIG?.trim()) {
       env.OPENCODE_DISABLE_PROJECT_CONFIG = 'true';
     }
-    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
+    return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'mimo') {
     stripKeysCaseInsensitive(env, [
@@ -160,9 +159,9 @@ export function spawnEnvForAgent(
     if (!env.MIMOCODE_DISABLE_PROJECT_CONFIG?.trim()) {
       env.MIMOCODE_DISABLE_PROJECT_CONFIG = 'true';
     }
-    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
+    return finalizeRuntimeEnv(env, sandboxRuntime);
   }
-  return reapplySandboxRuntimeEnv(env, sandboxRuntime);
+  return finalizeRuntimeEnv(env, sandboxRuntime);
 }
 
 export function openDesignAmrTraceEnv(input: {
@@ -208,6 +207,15 @@ function reapplySandboxRuntimeEnv(
 ): NodeJS.ProcessEnv {
   if (!sandboxRuntime) return env;
   return applySandboxRuntimeEnv(env, sandboxRuntime);
+}
+
+function finalizeRuntimeEnv(
+  env: NodeJS.ProcessEnv,
+  sandboxRuntime: SandboxRuntimeConfig | null,
+): NodeJS.ProcessEnv {
+  const finalizedEnv = reapplySandboxRuntimeEnv(env, sandboxRuntime);
+  applyWindowsUserCacheEnv(finalizedEnv);
+  return finalizedEnv;
 }
 
 function stripKeysCaseInsensitive(

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -82,6 +82,26 @@ test('spawnEnvForAgent applies configured Codex env without mutating the base en
   assert.equal('CODEX_BIN' in base, false);
 });
 
+test('spawnEnvForAgent backfills Windows cache directory env for Trae CLI launches', () => {
+  const env = withPlatform('win32', () =>
+    spawnEnvForAgent(
+      'trae-cli',
+      {
+        Path: 'C:\\Windows\\System32',
+        USERPROFILE: 'C:\\Users\\ai',
+      },
+      {},
+      {},
+    ),
+  );
+
+  assert.equal(env.USERPROFILE, 'C:\\Users\\ai');
+  assert.equal(env.APPDATA, 'C:\\Users\\ai\\AppData\\Roaming');
+  assert.equal(env.LOCALAPPDATA, 'C:\\Users\\ai\\AppData\\Local');
+  assert.equal(env.TEMP, 'C:\\Users\\ai\\AppData\\Local\\Temp');
+  assert.equal(env.TMP, 'C:\\Users\\ai\\AppData\\Local\\Temp');
+});
+
 test('spawnEnvForAgent reapplies sandbox state roots after configured env overrides', () => {
   const dataDir = mkdtempSync(join(tmpdir(), 'od-agent-env-sandbox-'));
   try {

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -102,6 +102,40 @@ test('spawnEnvForAgent backfills Windows cache directory env for Trae CLI launch
   assert.equal(env.TMP, 'C:\\Users\\ai\\AppData\\Local\\Temp');
 });
 
+test('spawnEnvForAgent keeps Windows cache directory env inside sandbox roots', () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'od-agent-env-sandbox-win-cache-'));
+  try {
+    const env = withPlatform('win32', () =>
+      spawnEnvForAgent(
+        'trae-cli',
+        {
+          OD_DATA_DIR: dataDir,
+          OD_SANDBOX_MODE: '1',
+          Path: 'C:\\Windows\\System32',
+          USERPROFILE: 'C:\\Users\\ai',
+        },
+        {},
+        {},
+      ),
+    );
+
+    const agentHome = join(dataDir, 'sandbox', 'agent-home');
+    const tempDir = join(dataDir, 'sandbox', 'tmp');
+    const normalize = (value: string | undefined): string =>
+      (value ?? '').replaceAll('\\', '/');
+
+    assert.equal(env.USERPROFILE, agentHome);
+    assert.ok(normalize(env.APPDATA).startsWith(`${normalize(agentHome)}/`));
+    assert.ok(normalize(env.LOCALAPPDATA).startsWith(`${normalize(agentHome)}/`));
+    assert.equal(env.TEMP, tempDir);
+    assert.equal(env.TMP, tempDir);
+    assert.ok(!normalize(env.APPDATA).includes('C:/Users/ai'));
+    assert.ok(!normalize(env.LOCALAPPDATA).includes('C:/Users/ai'));
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
 test('spawnEnvForAgent reapplies sandbox state roots after configured env overrides', () => {
   const dataDir = mkdtempSync(join(tmpdir(), 'od-agent-env-sandbox-'));
   try {


### PR DESCRIPTION
Fixes #5274

## Why

I picked this up from the Windows Trae CLI report in #5274. The user can run `traecli` directly from PowerShell, but Open Design's Local CLI Test launches it from the daemon process environment and Trae exits with `failed to get cache directory`.

The pain is that a GUI/packaged Windows launch can have enough PATH state to resolve the CLI while still missing the profile/cache variables (`APPDATA`, `LOCALAPPDATA`, `TEMP`, `TMP`, `USERPROFILE`) that the CLI expects during startup.

## What users will see

On Windows, Local CLI connection tests and runs inherit sane user profile/cache env values when the daemon's launch environment is sparse. Trae CLI should no longer fail at startup just because Open Design was launched without those cache-directory variables.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; daemon runtime environment fix with no UI surface change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/env-and-detection.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new `spawnEnvForAgent backfills Windows cache directory env for Trae CLI launches` regression failed before the fix because `APPDATA` was `undefined`; it passes on this branch.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/env-and-detection.test.ts --reporter=verbose` — 61 passed
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/env-and-detection.test.ts tests/runtimes/trae-cli.test.ts tests/runtimes/launch.test.ts` — 74 passed, 1 skipped
- `pnpm --filter @open-design/daemon typecheck`
- `git diff --check`
- `pnpm guard`
- `pnpm typecheck`

Local shell prints the existing Node v22.14.0 versus repo Node ~24 engine warning.
