### PR TITLE
docs(resource-hub): document local vela-stack path for daemon dev

### DIFF
--- a/tools/serve/AGENTS.md
+++ b/tools/serve/AGENTS.md
@@ -36,6 +36,18 @@ od resource put ./some-dir --kind design_system --ref latest
 od resource get <resource-id> ./dest
 ```
 
+Or run against a **local vela stack** instead of the fixture, for real byte
+transport (the vela stack's MinIO) — see the vela repo's
+`docker/docker-compose.dev.yml` + `services/api/.env.example`. Start the vela api
+(`pnpm dev:docker:up` + `pnpm --filter @vela/api dev`, api on `:18080`, which is
+also the daemon's default hub URL), then set only:
+
+```
+export OD_RESOURCE_HUB_TOKEN=dev-internal-token   # matches vela CLOUD_INTERNAL_API_TOKEN
+export OD_WORKSPACE_MEMBER_ID=you OD_WORKSPACE_TEAM_ID=your-team OD_WORKSPACE_ROLE=owner
+# OD_RESOURCE_HUB_URL is optional here — it defaults to http://127.0.0.1:18080
+```
+
 - **The daemon makes no mock concessions** — it runs its real client/SDK against
   this exactly as it would against vela. The fixture is the only "fake" piece.
 - **This is disposable.** Once the vela test environment is stood up, delete


### PR DESCRIPTION
The daemon resource-hub dev docs (`tools/serve/AGENTS.md`) led only with the disposable fixture (`:18090`). This adds the alternative: run the daemon against a **local vela stack** (docker-compose + `.env.example`, api on `:18080` — which is already the daemon's default hub URL) for **real byte transport via MinIO**.

Pairs with vela's `.env.example` blob-store patch so a teammate can run the whole Spec E loop locally with real bytes — no cloud dependency. Env vars are unchanged; this just makes the no-fixture path explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)