### PR TITLE
fix(styles): improve dark mode contrast for toggle switches

### DIFF
--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -17,6 +17,7 @@
   --border: #e1e5eb;
   --border-strong: #c9d0da;
   --border-soft: #edf0f4;
+  --toggle-track-off: var(--border-strong);
 
   --text: #1a1916;
   --text-strong: #0d0c0a;
@@ -111,6 +112,7 @@
   --border: #333128;
   --border-strong: #46433c;
   --border-soft: #2a2825;
+  --toggle-track-off: var(--text-soft);
 
   --text: #e8e4dc;
   --text-strong: #f2ede4;
@@ -164,6 +166,7 @@
     --border: #333128;
     --border-strong: #46433c;
     --border-soft: #2a2825;
+    --toggle-track-off: var(--text-soft);
 
     --text: #e8e4dc;
     --text-strong: #f2ede4;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -3165,7 +3165,7 @@
   width: 32px;
   height: 18px;
   border-radius: var(--radius-pill);
-  background: var(--border-strong);
+  background: var(--toggle-track-off);
   transition: background 160ms var(--ease-out);
 }
 .toggle-row-switch::after {
@@ -3228,7 +3228,7 @@
   width: 28px;
   height: 16px;
   border-radius: var(--radius-pill);
-  background: var(--border-strong);
+  background: var(--toggle-track-off);
   transition: background 160ms var(--ease-out);
 }
 .compact-toggle-switch::after {


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #5298

## Why

Picked this up as a community-reported bug. In dark mode the off-state toggle track in the Quick Confirm panel (and the compact SurfaceOptions toggle) was rendered with `--border-strong` (`#46433c`), which is nearly indistinguishable from the panel background `--bg-panel` (`#222120`). Users could not reliably see the control or determine its state, which is a meaningful problem in a confirmation flow where missing a toggle could silently alter output.


## What users will see

In dark mode, the off-state toggle track in the Quick Confirm panel (e.g. the "speaker notes" toggle) is now clearly visible against the dark panel background. The track appears as a mid-grey rather than blending into the surrounding surface, so the control is discoverable and its off state is unambiguous. Behavior and on-state appearance are unchanged.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

A CSS visual regression is not cheaply automatable for this class of contrast bug. Verification was done manually:

- Switched the app to dark mode (`[data-theme="dark"]`).
- Opened a project details page and the Quick Confirm panel.
- Confirmed the off-state toggle track was invisible on `main` (track colour `#46433c` against panel `#222120`).
- On this branch the track renders as `--text-soft` (`#6e6b65`), clearly distinct from the panel background, with the white thumb remaining visible against it.
- Also verified the OS-level dark preference path (`prefers-color-scheme: dark` without `data-theme`) resolves the same `--toggle-track-off` token.
- On-state and light-mode appearance are unchanged.



## Validation
Switched to Node 24 (project requirement) via nvm
nvm install 24 && nvm use 24   # → v24.18.0

Activated pinned pnpm via Corepack
corepack enable                 # → pnpm 10.33.2

Fresh install (node_modules were absent)
pnpm install                    # 1217 packages, done in 5m 14.9s

Repo-level checks
pnpm guard                      # passed
pnpm typecheck                  # passed
pnpm --filter @open-design/web typecheck   # passed

Manual visual verification
pnpm tools-dev run web          started daemon + web at http://127.0.0.1:59882/
→ switched app to dark mode, opened project, triggered question form with a
deck prompt; confirmed the off-state toggle track is now visibly distinct
from the panel background (mid-grey track vs dark panel)