### PR TITLE
fix(desktop): stop native file dialogs hanging on Windows (AppHangB1) when Downloads is cloud-backed

### DIFF
--- a/apps/desktop/src/main/diagnostics.ts
+++ b/apps/desktop/src/main/diagnostics.ts
@@ -1,8 +1,6 @@
 import { writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 
-import { BrowserWindow, app, dialog, ipcMain, shell } from "electron";
+import { BrowserWindow, dialog, ipcMain, shell } from "electron";
 
 import { DIAGNOSTICS_FILENAME_PREFIX, diagnosticsFileName } from "@open-design/diagnostics";
 
@@ -30,19 +28,21 @@ export async function exportDiagnosticsToFile(
   parentWindow: BrowserWindow | null,
 ): Promise<DesktopDiagnosticsExportResult> {
   const filename = diagnosticsFileName(DIAGNOSTICS_FILENAME_PREFIX);
-  const downloadsDir = (() => {
-    try {
-      return app.getPath("downloads");
-    } catch {
-      return homedir();
-    }
-  })();
-  const defaultPath = join(downloadsDir, filename);
-
+  // Seed only the filename, never a directory. Forcing `defaultPath` into the
+  // Downloads folder made the native Windows Save dialog open *inside* it, and
+  // when Downloads is OneDrive-backed the shell's folder-type discovery +
+  // cloud-provider status enumeration can stall the dialog's UI thread long
+  // enough for Windows to flag the owner window "not responding" (AppHangB1).
+  // The PDF/PPTX save flows already pass a bare filename; match them and let
+  // the OS restore the user's last-used, already-warm location.
+  // `dontAddToRecent` further avoids shell recent-items writes against that
+  // same slow folder. ponytail: mitigates the trigger; a fully wedged OneDrive
+  // shell is an OS-side stall no app option can unblock.
   const dialogOptions = {
     title: "Export Open Design diagnostics",
-    defaultPath,
+    defaultPath: filename,
     filters: [{ name: "Zip archive", extensions: ["zip"] }],
+    properties: ["dontAddToRecent" as const],
   };
   const choice = parentWindow != null
     ? await dialog.showSaveDialog(parentWindow, dialogOptions)

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -68,6 +68,7 @@ export async function exportPdfFromHtml(input: DesktopExportPdfInput): Promise<D
       { name: "All Files", extensions: ["*"] },
     ],
     title: "Save PDF",
+    properties: ["dontAddToRecent"],
   });
   if (save.canceled || !save.filePath) return { canceled: true, ok: true };
 
@@ -195,6 +196,7 @@ export function createElectronPdfTarget(): PrintReadyPdfTarget {
           { name: "All Files", extensions: ["*"] },
         ],
         title: "Save PDF",
+        properties: ["dontAddToRecent"],
       });
       return save.canceled || !save.filePath ? null : save.filePath;
     },

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1425,6 +1425,7 @@ interface SaveAsDialogOptions {
   title: string;
   defaultPath: string;
   filters: Array<{ name: string; extensions: string[] }>;
+  properties: Array<"dontAddToRecent">;
 }
 
 // Pure: the Save As dialog options for a downloaded filename, or null when the
@@ -1447,7 +1448,7 @@ export function saveAsDialogOptionsForFilename(filename: string): SaveAsDialogOp
           { name: "PowerPoint Presentation", extensions: ["pptx"] },
           { name: "All Files", extensions: ["*"] },
         ];
-  return { title: "Save As", defaultPath: filename, filters };
+  return { title: "Save As", defaultPath: filename, filters, properties: ["dontAddToRecent"] };
 }
 
 function attachDownloadSaveAsDialog(window: BrowserWindow): void {
@@ -1574,7 +1575,11 @@ async function showDirectoryPickerForSender(
   const parent =
     BrowserWindow.fromWebContents(sender) ?? BrowserWindow.getFocusedWindow();
   const pickerOptions: Electron.OpenDialogOptions = {
-    properties: ["openDirectory", "createDirectory"],
+    // `dontAddToRecent` avoids shell recent-items / jump-list writes against
+    // the browsed folder. Combined with not seeding a cloud-backed default
+    // location, this trims the shell work that stalls the native picker on
+    // OneDrive-backed folders (see AppHangB1 note in diagnostics.ts).
+    properties: ["openDirectory", "createDirectory", "dontAddToRecent"],
   };
   return parent
     ? dialog.showOpenDialog(parent, pickerOptions)

--- a/apps/desktop/tests/main/diagnostics-save-dialog.test.ts
+++ b/apps/desktop/tests/main/diagnostics-save-dialog.test.ts
@@ -1,0 +1,47 @@
+import { sep } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+// Regression for AppHangB1 on Windows: the diagnostics export used to seed the
+// Save dialog with `join(app.getPath("downloads"), filename)`, opening the
+// native dialog *inside* Downloads. When Downloads is OneDrive-backed the
+// shell's folder-type discovery + cloud-provider status enumeration can stall
+// the dialog's UI thread long enough for Windows to flag the owner window
+// "not responding". The fix seeds only a bare filename and opts out of shell
+// recent-items writes; this test locks both.
+const { showSaveDialog } = vi.hoisted(() => ({
+  showSaveDialog: vi.fn(
+    async (_options: { defaultPath: string; properties?: string[] }) => ({
+      canceled: true as const,
+      filePath: undefined,
+    }),
+  ),
+}));
+
+vi.mock("electron", () => ({
+  BrowserWindow: { fromWebContents: vi.fn(() => null) },
+  app: { getPath: vi.fn(() => `${sep}home${sep}user${sep}Downloads`) },
+  dialog: { showSaveDialog },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  shell: { showItemInFolder: vi.fn() },
+}));
+
+import { exportDiagnosticsToFile } from "../../src/main/diagnostics.js";
+
+describe("exportDiagnosticsToFile save dialog", () => {
+  it("seeds a bare filename (never a directory) and opts out of recent items", async () => {
+    const result = await exportDiagnosticsToFile(
+      { discoverDaemonBaseUrl: vi.fn() },
+      null,
+    );
+
+    // Canceled dialog short-circuits before any daemon fetch.
+    expect(result).toEqual({ ok: false, cancelled: true });
+    expect(showSaveDialog).toHaveBeenCalledTimes(1);
+
+    const opts = showSaveDialog.mock.calls[0]![0];
+    expect(opts.defaultPath).not.toContain(sep);
+    expect(opts.defaultPath).not.toContain("Downloads");
+    expect(opts.properties).toContain("dontAddToRecent");
+  });
+});

--- a/apps/desktop/tests/main/save-as-dialog-extensions.test.ts
+++ b/apps/desktop/tests/main/save-as-dialog-extensions.test.ts
@@ -14,6 +14,16 @@ describe('saveAsDialogOptionsForFilename', () => {
     expect(opts!.filters[0]).toEqual({ name: 'PDF Document', extensions: ['pdf'] });
   });
 
+  // The Save As dialog must opt out of shell recent-items writes. On Windows a
+  // OneDrive-backed Downloads folder can stall the native dialog's UI thread
+  // (AppHangB1); `dontAddToRecent` trims that shell work. Every intercepted
+  // extension shares the same options builder, so one assertion guards them all.
+  test('every intercepted download opts out of recent items', () => {
+    for (const name of ['a.pdf', 'a.pptx', 'a.png']) {
+      expect(saveAsDialogOptionsForFilename(name)!.properties).toContain('dontAddToRecent');
+    }
+  });
+
   test('PPTX still prompts with a PowerPoint filter', () => {
     const opts = saveAsDialogOptionsForFilename('deck.pptx');
     expect(opts!.filters[0]).toEqual({ name: 'PowerPoint Presentation', extensions: ['pptx'] });


### PR DESCRIPTION
## Why

**Use case.** A Windows user reported that opening the app and triggering a
native file dialog freezes it: the picker goes to "not responding" and no file
can be selected. Windows Error Reporting logged it as `AppHangB1` against
`Open Design.exe` `0.14.0.0` — the app's UI thread stopped pumping window
messages for >5s.

**The pain.** The native Windows file dialog (`IFileDialog`) is a COM STA
object; rendering a folder synchronously asks the shell to enumerate it. The
**Downloads folder is the worst case**: Windows runs Automatic Folder Type
Discovery, queries cloud file-provider status (OneDrive reparse points /
online-only files), and generates thumbnails. When that stalls, the dialog's
owner window — which Electron disables to make the dialog window-modal — sits
blocked, and WER records `AppHangB1` against it.

Open Design doesn't cause the shell stall, but it aggravated it and offered no
mitigation in two concrete ways this PR fixes:

1. `apps/desktop/src/main/diagnostics.ts` seeded the Save dialog with
   `defaultPath = join(app.getPath("downloads"), filename)`, forcing the dialog
   to open *inside* the exact slow, cloud-backed folder.
2. No dialog opted out of shell recent-items / jump-list bookkeeping, adding
   more shell work against that folder.

## What users will see

- Native Save/Open dialogs no longer open *into* the Downloads folder by
  default — the diagnostics export dialog now seeds only a filename and lets
  Windows restore the last-used, already-warm location (matching the existing
  PDF/PPTX save flows).
- Import-folder / working-directory pickers and every Save dialog now pass
  `dontAddToRecent`, trimming the shell work that stalls on OneDrive-backed
  folders.

## Surface area

- [x] **UI** — behavior of the native Save/Open dialogs in `apps/desktop` (no new UI element; existing dialogs behave differently)
- [x] **Default behavior change** — the diagnostics Save dialog no longer defaults into the Downloads folder

## Bug fix verification

- Tests:
  - `apps/desktop/tests/main/diagnostics-save-dialog.test.ts` (new) — asserts the diagnostics Save dialog seeds a bare filename (no separator, never `Downloads`) and includes `dontAddToRecent`.
  - `apps/desktop/tests/main/save-as-dialog-extensions.test.ts` (extended) — asserts every intercepted download's Save-As options include `dontAddToRecent`.
- Red on `main` / green on branch: **yes** — the new diagnostics assertions fail against the old `join(downloadsDir, filename)` + missing `properties`, and pass after the change.
- OS-side limit: a fully wedged OneDrive shell is an OS stall no app dialog option can force-unblock. This PR removes the app-side triggers (opening into the slow folder, extra recent-items writes); it does not claim to fix a broken cloud provider. Marked with a `ponytail:`-style comment at the source. Final confirmation of the responsive dialog belongs to the manual Windows check below.

## Validation

- `pnpm guard` → 78/78 pass
- `pnpm --filter @open-design/desktop typecheck` → pass
- `pnpm --filter @open-design/desktop exec vitest run save-as-dialog-extensions diagnostics-save-dialog` → 7/7 pass
- `pnpm --filter @open-design/desktop test` → 173 pass (adds one passing test over the baseline's 172). The single `updater.test.ts` "metadata-channel-mismatch" failure reproduces identically on clean `main` under Node 22 full-suite runs and is unrelated to this change.
- Manual (pending, on affected hardware): on a Windows box with an OneDrive-backed Downloads folder, trigger the import-folder picker and the diagnostics export; confirm the dialog opens and stays responsive.

> Note: developed on Node 22 locally; the repo targets Node 24. All changes are dialog-option-only and type-checked.
