### PR TITLE
Add Seedream 5 Pro image support

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -65,6 +65,7 @@ const MEDIA_GENERATE_STRING_FLAGS = new Set([
   'audio-kind',
   'composition-dir',
   'image',
+  'images',
   'daemon-url',
   'language',
 ]);
@@ -820,6 +821,15 @@ async function runMediaGenerate(rawArgs) {
     process.exit(2);
   }
 
+  let imageRefs;
+  try {
+    imageRefs = mediaReferenceImagesFromArgs(rawArgs);
+  } catch (err) {
+    console.error(err.message);
+    printMediaHelp();
+    process.exit(2);
+  }
+
   const body = {
     surface,
     model: flags.model,
@@ -829,9 +839,10 @@ async function runMediaGenerate(rawArgs) {
     voice: flags.voice,
     audioKind: flags['audio-kind'],
     compositionDir: flags['composition-dir'],
-    image: flags.image,
+    image: imageRefs.image,
     language: flags.language,
   };
+  if (imageRefs.images.length > 0) body.images = imageRefs.images;
   if (flags.length != null) body.length = Number(flags.length);
   if (flags.duration != null) body.duration = Number(flags.duration);
   if (flags['prompt-influence'] != null) body.promptInfluence = Number(flags['prompt-influence']);
@@ -1079,6 +1090,57 @@ function parseFlags(argv, opts = {}) {
   return out;
 }
 
+function collectStringFlagValues(argv, key) {
+  const out = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a || !a.startsWith('--')) continue;
+    const eq = a.indexOf('=');
+    const flagKey = eq >= 0 ? a.slice(2, eq) : a.slice(2);
+    if (flagKey !== key) continue;
+    if (eq >= 0) {
+      out.push(a.slice(eq + 1));
+      continue;
+    }
+    const next = argv[i + 1];
+    if (next == null) {
+      throw new Error(`flag --${key} requires a value`);
+    }
+    out.push(next);
+    i++;
+  }
+  return out;
+}
+
+function parseMediaImagesFlagValue(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return [];
+  if (raw.startsWith('[')) {
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error('--images must be a JSON string array or a comma-separated list');
+    }
+    if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === 'string')) {
+      throw new Error('--images JSON must be an array of strings');
+    }
+    return parsed.map((item) => item.trim()).filter(Boolean);
+  }
+  return raw.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function mediaReferenceImagesFromArgs(argv) {
+  const repeatedImages = collectStringFlagValues(argv, 'image')
+    .map((item) => String(item).trim())
+    .filter(Boolean);
+  const images = collectStringFlagValues(argv, 'images').flatMap(parseMediaImagesFlagValue);
+  return {
+    image: repeatedImages[0],
+    images: [...repeatedImages.slice(1), ...images],
+  };
+}
+
 function positionalArgs(argv, stringFlags = new Set()) {
   const out = [];
   for (let i = 0; i < argv.length; i++) {
@@ -1132,6 +1194,13 @@ Common options:
                             future image-edit endpoints). Daemon reads
                             the file from the project, base64-encodes
                             it, and forwards it to the upstream API.
+                            Repeat --image to pass multiple references;
+                            the first value is primary and the rest are
+                            forwarded as additional references.
+  --images <json|csv>       Additional reference images as a JSON string
+                            array or comma-separated list. Volcengine
+                            image generation also accepts remote http(s)
+                            reference URLs here.
   --daemon-url <url>
 
 Output: a single line of JSON: {"file": { name, size, kind, mime, ... }}

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1011,7 +1011,7 @@ async function validateLocalOpenAiModel(
 function isSenseAudioNonChatModel(model: string): boolean {
   return (
     model.startsWith('senseaudio-image-') ||
-    model.startsWith('doubao-seedream-') ||
+    (model.startsWith('doubao-seedream-') && model !== 'doubao-seedream-5-0-pro-260628') ||
     model === 'sensenova-u1-fast' ||
     model.startsWith('doubao-seedance-') ||
     model.startsWith('senseaudio-asr-') ||

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -95,7 +95,7 @@ import {
 const execFile = promisify(execFileCb);
 type ProviderConfig = { apiKey?: string; baseUrl?: string; model?: string };
 type ProgressFn = (message: string) => void;
-type ImageRef = { path: string; abs: string; mime: string; size: number; dataUrl: string };
+type ImageRef = { path: string; abs: string; mime: string; size: number; dataUrl: string; remote?: boolean };
 type MediaRequestInit = Pick<RequestInit, 'dispatcher'>;
 type MediaContext = {
   surface: MediaSurface;
@@ -140,8 +140,42 @@ type MediaContext = {
   imageRefs: ImageRef[];
   projectRoot: string;
 };
-type RenderResult = { bytes: Buffer; providerNote: string; suggestedExt?: string };
-type JsonRecord = Record<string, unknown>;
+type RenderResult = {
+  bytes: Buffer;
+  providerNote: string;
+  suggestedExt?: string;
+  metadata?: JsonRecord | undefined;
+};
+export type JsonRecord = Record<string, unknown>;
+
+export type MediaSupportingFile = {
+  name: string;
+  size: number;
+  kind: string;
+  mime: string;
+  role?: string | undefined;
+  metadata?: JsonRecord | undefined;
+};
+
+export type MediaGeneratedFile = {
+  name: string;
+  size: number;
+  mtime: number;
+  kind: string;
+  mime: string;
+  model: string;
+  surface: MediaSurface;
+  providerNote: string;
+  providerId: string;
+  providerError: string | null;
+  usedStubFallback: boolean;
+  intentionalStub: boolean;
+  metadata?: JsonRecord | undefined;
+  supportingFiles?: MediaSupportingFile[] | undefined;
+  warnings: string[];
+};
+
+const SEEDREAM_5_PRO_MODEL_ID = 'doubao-seedream-5-0-pro-260628';
 
 function isRecord(value: unknown): value is JsonRecord {
   return value !== null && typeof value === 'object';
@@ -203,10 +237,37 @@ function stubsAllowed() {
  * Without this guard, an agent (or a hallucinated arg) could ask the
  * daemon to upload `/etc/passwd` to a paid model.
  */
-async function resolveProjectImage(rel: unknown, projectDir: string): Promise<ImageRef | null> {
+function isHttpImageUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+async function resolveProjectImage(
+  rel: unknown,
+  projectDir: string,
+  options: { allowRemoteUrl?: boolean } = {},
+): Promise<ImageRef | null> {
   if (typeof rel !== 'string' || !rel.trim()) return null;
+  const raw = rel.trim();
+  if (isHttpImageUrl(raw)) {
+    if (!options.allowRemoteUrl) {
+      throw new Error('--image URL references are only supported for Volcengine image generation; use a project file path for this model.');
+    }
+    return {
+      path: raw,
+      abs: raw,
+      mime: 'image/url',
+      size: 0,
+      dataUrl: raw,
+      remote: true,
+    };
+  }
   const projectRootResolved = path.resolve(projectDir);
-  const abs = path.resolve(projectRootResolved, rel.trim());
+  const abs = path.resolve(projectRootResolved, raw);
   if (
     abs !== projectRootResolved &&
     !abs.startsWith(projectRootResolved + path.sep)
@@ -251,7 +312,7 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
     );
   }
   return {
-    path: rel.trim(),
+    path: raw,
     abs,
     mime,
     size: bytes.length,
@@ -311,14 +372,14 @@ function clampWithWarning(value: unknown, allowed: number[], flagName: string): 
  * @param {string} [args.voice]
  * @param {string} [args.audioKind]
  * @param {string} [args.language]
- * @returns {Promise<{ name: string, size: number, mtime: number, kind: string, mime: string, model: string, surface: string, providerNote: string, providerId: string }>}
+ * @returns {Promise<MediaGeneratedFile>}
  */
 export async function generateMedia(args: {
   projectRoot: string; projectsRoot: string; projectId: string; surface: MediaSurface; model: string;
   prompt?: string; output?: string; aspect?: string; length?: number; duration?: number; voice?: string;
   audioKind?: AudioKind; language?: string; loop?: boolean; promptInfluence?: number;
   compositionDir?: string; image?: string; images?: string[]; onProgress?: ProgressFn; requestInit?: MediaRequestInit;
-}) {
+}): Promise<MediaGeneratedFile> {
   const {
     projectRoot,
     projectsRoot,
@@ -435,7 +496,9 @@ export async function generateMedia(args: {
   const clampedDuration = usesProviderSpecificAudioDuration
     ? duration
     : durationClamp.value;
-  const warnings = [lengthClamp.warning, durationClamp.warning].filter(Boolean);
+  const warnings = [lengthClamp.warning, durationClamp.warning].filter(
+    (warning): warning is string => Boolean(warning),
+  );
 
   const dir = await ensureProject(projectsRoot, projectId);
   const safeOut = sanitizeName(
@@ -449,7 +512,8 @@ export async function generateMedia(args: {
   // stays inside the project, and turn it into a base64 data URL the
   // upstream APIs accept directly. Renderers consume `ctx.imageRef`
   // and decide how to splice the data URL into their request.
-  const imageRef = await resolveProjectImage(image, dir);
+  const allowRemoteImageUrl = def.provider === 'volcengine' && surface === 'image';
+  const imageRef = await resolveProjectImage(image, dir, { allowRemoteUrl: allowRemoteImageUrl });
 
   // Multi-image support: resolve additional images from the `images`
   // array param. The first resolved image (imageRef) is the primary
@@ -458,7 +522,7 @@ export async function generateMedia(args: {
   const imageRefs: ImageRef[] = [];
   if (imageRef) imageRefs.push(imageRef);
   for (const imgPath of extraImages) {
-    const ref = await resolveProjectImage(imgPath, dir);
+    const ref = await resolveProjectImage(imgPath, dir, { allowRemoteUrl: allowRemoteImageUrl });
     if (ref && !imageRefs.some((r) => r.abs === ref.abs)) {
       imageRefs.push(ref);
     }
@@ -511,6 +575,7 @@ export async function generateMedia(args: {
   let bytes: Buffer;
   let providerNote: string;
   let suggestedExt: string | undefined;
+  let metadata: JsonRecord | undefined;
   let providerId = def.provider;
   // Tracks whether the bytes came from a real provider call or from the
   // stub fallback. Surfaces in the response so the CLI/agent can tell a
@@ -609,6 +674,7 @@ export async function generateMedia(args: {
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
+      metadata = result.metadata;
     } else if (def.provider === 'grok' && surface === 'image') {
       const result = await renderGrokImage(ctx, credentials);
       bytes = result.bytes;
@@ -816,6 +882,7 @@ export async function generateMedia(args: {
     providerError,
     usedStubFallback,
     intentionalStub,
+    metadata,
     warnings,
   };
 }
@@ -1420,6 +1487,92 @@ function openaiSizeFor(model: string, aspect?: string): string {
   return '1024x1024';
 }
 
+function modelSupportsLayeredImageOutput(ctx: MediaContext): boolean {
+  return (
+    ctx.model === SEEDREAM_5_PRO_MODEL_ID ||
+    ctx.modelDef.output?.layered === true ||
+    ctx.modelDef.caps?.includes('layers') === true
+  );
+}
+
+function volcengineImagePrompt(ctx: MediaContext, size: string): string {
+  const prompt = ctx.prompt || 'A high-quality reference image.';
+  if (!modelSupportsLayeredImageOutput(ctx) || size !== '2K' || !ctx.aspect) {
+    return prompt;
+  }
+  return `${prompt}\nAspect ratio: ${ctx.aspect}.`;
+}
+
+function volcengineImageSizeFor(ctx: MediaContext): string {
+  if (modelSupportsLayeredImageOutput(ctx)) {
+    // Seedream 5.0 Pro supports resolution tokens (`1K`, `2K`) and asks for
+    // aspect hints in natural language. Use the highest documented bucket.
+    return '2K';
+  }
+  return openaiSizeFor(ctx.model, ctx.aspect);
+}
+
+function volcengineImageOutputFormatFor(ctx: MediaContext): 'png' | undefined {
+  // Seedream 5.0 Pro's design/layer workflows rely on preserving transparent
+  // pixels. The official Ark docs expose `output_format` for Pro/Lite only.
+  return modelSupportsLayeredImageOutput(ctx) ? 'png' : undefined;
+}
+
+function volcengineImageResponseFormatFor(ctx: MediaContext): 'url' | 'b64_json' {
+  // The Pro examples use URL responses. The daemon downloads the URL
+  // immediately, avoiding a large inline JSON payload without exposing the
+  // user to the provider URL's short lifetime.
+  return modelSupportsLayeredImageOutput(ctx) ? 'url' : 'b64_json';
+}
+
+function volcengineImageReferencePayload(ctx: MediaContext): string | string[] | undefined {
+  if (ctx.imageRefs.length === 0) return undefined;
+  const maxRefs = modelSupportsLayeredImageOutput(ctx) ? 10 : 14;
+  if (ctx.imageRefs.length > maxRefs) {
+    throw new Error(`volcengine/${ctx.wireModel} accepts at most ${maxRefs} reference images; got ${ctx.imageRefs.length}`);
+  }
+  const refs = ctx.imageRefs.map((ref) => ref.dataUrl);
+  return refs.length === 1 ? refs[0] : refs;
+}
+
+function volcengineImageMetadata(
+  ctx: MediaContext,
+  entry: JsonRecord,
+  response: JsonRecord,
+  request: {
+    size: string;
+    responseFormat: string;
+    stream?: boolean | undefined;
+    watermark?: boolean | undefined;
+    outputFormat?: string | undefined;
+  },
+): JsonRecord | undefined {
+  const metadata: JsonRecord = {
+    modelFamily: 'seedream',
+    request: {
+      size: request.size,
+      responseFormat: request.responseFormat,
+      ...(typeof request.stream === 'boolean' ? { stream: request.stream } : {}),
+      ...(typeof request.watermark === 'boolean' ? { watermark: request.watermark } : {}),
+      ...(request.outputFormat ? { outputFormat: request.outputFormat } : {}),
+      ...(ctx.imageRefs.length > 0 ? { referenceImages: ctx.imageRefs.length } : {}),
+    },
+  };
+  if (modelSupportsLayeredImageOutput(ctx)) {
+    metadata.capabilities = { layeredOutput: true };
+  }
+  const output: JsonRecord = {};
+  if (typeof entry.output_format === 'string') output.format = entry.output_format;
+  if (typeof entry.size === 'string') output.size = entry.size;
+  if (Object.keys(output).length > 0) metadata.output = output;
+  const responseInfo: JsonRecord = {};
+  if (typeof response.model === 'string') responseInfo.model = response.model;
+  if (typeof response.created === 'number') responseInfo.created = response.created;
+  if (Object.keys(responseInfo).length > 0) metadata.response = responseInfo;
+  if (isRecord(response.usage)) metadata.usage = response.usage;
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
 const OPENAI_TTS_VOICES = new Set([
   'alloy',
   'ash',
@@ -1688,16 +1841,27 @@ async function renderVolcengineImage(ctx: MediaContext, credentials: ProviderCon
     throw new Error('no Volcengine Ark API key — configure it in Settings or set ARK_API_KEY');
   }
   const baseUrl = (credentials.baseUrl || 'https://ark.cn-beijing.volces.com/api/v3').replace(/\/$/, '');
+  const layeredOutput = modelSupportsLayeredImageOutput(ctx);
+  const size = volcengineImageSizeFor(ctx);
+  const outputFormat = volcengineImageOutputFormatFor(ctx);
+  const responseFormat = volcengineImageResponseFormatFor(ctx);
 
-  const body = {
+  const body: Record<string, unknown> = {
     model: ctx.wireModel,
-    prompt: ctx.prompt || 'A high-quality reference image.',
-    response_format: 'b64_json',
+    prompt: volcengineImagePrompt(ctx, size),
+    response_format: responseFormat,
     // openaiSizeFor branches on the catalog id (gpt-image-* vs dall-e-*
     // accept different size enums), so it must NOT see the post-alias
     // wire name. lefarcen + codex P2 on PR #1309.
-    size: openaiSizeFor(ctx.model, ctx.aspect),
+    size,
   };
+  if (outputFormat) {
+    body.output_format = outputFormat;
+    body.stream = false;
+    body.watermark = false;
+  }
+  const referencePayload = volcengineImageReferencePayload(ctx);
+  if (referencePayload) body.image = referencePayload;
   const resp = await fetch(`${baseUrl}/images/generations`, withMediaRequestInit(ctx, {
     method: 'POST',
     headers: {
@@ -1722,16 +1886,24 @@ async function renderVolcengineImage(ctx: MediaContext, credentials: ProviderCon
   if (entry.b64_json) {
     bytes = Buffer.from(entry.b64_json, 'base64');
   } else if (entry.url) {
-    const imgResp = await fetch(entry.url, withMediaRequestInit(ctx));
+    const imgResp = await assertAndFetchExternalAsset(entry.url, withMediaRequestInit(ctx));
     if (!imgResp.ok) throw new Error(`volcengine image fetch ${imgResp.status}`);
     bytes = Buffer.from(await imgResp.arrayBuffer());
   } else {
     throw new Error('volcengine image response missing b64_json/url');
   }
+  const entryRecord = isRecord(entry) ? entry : {};
   return {
     bytes,
-    providerNote: `volcengine/${ctx.wireModel} · ${ctx.aspect} · ${bytes.length} bytes`,
-    suggestedExt: '.png',
+    providerNote: `volcengine/${ctx.wireModel} · ${ctx.aspect} · ${size}${outputFormat ? `/${outputFormat}` : ''}${layeredOutput ? ' · layer-capable' : ''} · ${bytes.length} bytes`,
+    suggestedExt: entryRecord.output_format === 'jpeg' ? '.jpg' : '.png',
+    metadata: volcengineImageMetadata(ctx, entryRecord, data, {
+      size,
+      responseFormat,
+      stream: typeof body.stream === 'boolean' ? body.stream : undefined,
+      watermark: typeof body.watermark === 'boolean' ? body.watermark : undefined,
+      outputFormat,
+    }),
   };
 }
 

--- a/apps/daemon/src/media/models.ts
+++ b/apps/daemon/src/media/models.ts
@@ -27,6 +27,9 @@ export type MediaModel = {
   hint: string;
   provider: string;
   caps: string[];
+  output?: {
+    layered?: boolean;
+  };
   default?: boolean;
 };
 
@@ -95,6 +98,7 @@ export const IMAGE_MODELS: MediaModel[] = [
 
   { id: 'doubao-seedream-3-0-t2i-250415', label: 'seedream-3.0', hint: 'ByteDance · Doubao image', provider: 'volcengine', caps: ['t2i'] },
   { id: 'doubao-seededit-3-0-i2i-250628', label: 'seededit-3.0', hint: 'ByteDance · image edit', provider: 'volcengine', caps: ['i2i'] },
+  { id: 'doubao-seedream-5-0-pro-260628', label: 'seedream-5.0-pro', hint: 'ByteDance · design-aware layers', provider: 'volcengine', caps: ['t2i', 'i2i', 'layers'], output: { layered: true } },
 
   { id: 'senseaudio-image-2.0-260319', label: 'senseaudio-image-2.0', hint: 'SenseAudio · multi-aspect, latest', provider: 'senseaudio', caps: ['t2i', 'i2i'] },
   { id: 'senseaudio-image-1.0-260319', label: 'senseaudio-image-1.0', hint: 'SenseAudio · standard', provider: 'senseaudio', caps: ['t2i', 'i2i'] },

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -348,6 +348,11 @@ showed it crashed).
   the current dispatcher writes a single preview image plus metadata. Do not
   promise editable layer files unless the returned media JSON includes an
   explicit layer manifest or supporting layer assets.
+  Seedream 5.0 Pro also accepts multiple reference images: repeat
+  \`--image <project-relative-path-or-url>\` or pass \`--images '["ref1","ref2"]'\`
+  to \`"$OD_NODE_BIN" "$OD_BIN" media generate\`. The first repeated
+  \`--image\` value is the primary reference; remaining values are forwarded
+  as additional references.
 - **video**:   ${VIDEO_IDS}
   Image-to-video (i2v): the Volcengine Seedance family
   (\`doubao-seedance-2-0-260128\`, \`doubao-seedance-2-0-fast-260128\`,

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -344,6 +344,10 @@ showed it crashed).
 ### Allowed model IDs (per surface)
 
 - **image**:   ${IMAGE_IDS}
+  Seedream 5.0 Pro (\`doubao-seedream-5-0-pro-260628\`) is layer-capable, but
+  the current dispatcher writes a single preview image plus metadata. Do not
+  promise editable layer files unless the returned media JSON includes an
+  explicit layer manifest or supporting layer assets.
 - **video**:   ${VIDEO_IDS}
   Image-to-video (i2v): the Volcengine Seedance family
   (\`doubao-seedance-2-0-260128\`, \`doubao-seedance-2-0-fast-260128\`,

--- a/apps/daemon/tests/cli-startup.test.ts
+++ b/apps/daemon/tests/cli-startup.test.ts
@@ -208,6 +208,120 @@ describe('CLI startup boundaries', () => {
     ]);
   });
 
+  it('forwards multiple media reference images through the CLI request body', async () => {
+    let resolveGenerateBody!: (body: unknown) => void;
+    let rejectGenerateBody!: (error: Error) => void;
+    const generateBody = new Promise<unknown>((resolve, reject) => {
+      resolveGenerateBody = resolve;
+      rejectGenerateBody = reject;
+    });
+    const server = http.createServer((req, res) => {
+      let raw = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
+      req.on('end', () => {
+        if (req.method === 'POST' && req.url === '/api/projects/project-1/media/generate') {
+          const body = JSON.parse(raw);
+          resolveGenerateBody(body);
+          res.writeHead(202, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ taskId: 'task-1', status: 'queued' }));
+          return;
+        }
+        if (req.method === 'POST' && req.url === '/api/media/tasks/task-1/wait') {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({
+            status: 'done',
+            nextSince: 1,
+            progress: [],
+            file: {
+              name: 'seedream.png',
+              size: 12,
+              kind: 'image',
+              mime: 'image/png',
+              warnings: [],
+            },
+          }));
+          return;
+        }
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'unexpected request' }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    const daemonUrl = `http://127.0.0.1:${port}`;
+
+    const child = spawn(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        cliEntry,
+        'media',
+        'generate',
+        '--project',
+        'project-1',
+        '--surface',
+        'image',
+        '--model',
+        'doubao-seedream-5-0-pro-260628',
+        '--prompt',
+        'swap the clothing from reference 2 onto reference 1',
+        '--image',
+        'person.png',
+        '--image',
+        'outfit.png',
+        '--images',
+        'background.png,https://example.com/style.png',
+        '--daemon-url',
+        daemonUrl,
+      ],
+      {
+        cwd: daemonRoot,
+        env: { ...process.env },
+      },
+    );
+    let childOutput = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      childOutput += chunk.toString('utf8');
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      childOutput += chunk.toString('utf8');
+    });
+    child.once('exit', (code, signal) => {
+      rejectGenerateBody(new Error(`media CLI exited before request body was captured: code=${code} signal=${signal}; output:\n${childOutput}`));
+    });
+
+    try {
+      const body = await Promise.race([
+        generateBody,
+        new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => reject(new Error(`timed out waiting for media generate body; output:\n${childOutput}`)), 10_000);
+          timer.unref?.();
+        }),
+      ]);
+      expect(body).toEqual(
+        expect.objectContaining({
+          surface: 'image',
+          model: 'doubao-seedream-5-0-pro-260628',
+          prompt: 'swap the clothing from reference 2 onto reference 1',
+          image: 'person.png',
+          images: [
+            'outfit.png',
+            'background.png',
+            'https://example.com/style.png',
+          ],
+        }),
+      );
+    } finally {
+      await terminateChild(child);
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it('prints AMR status JSON from the daemon status endpoint without wallet fallback', async () => {
     const seen: Array<{ method: string | undefined; url: string | undefined }> = [];
     const server = http.createServer((req, res) => {

--- a/apps/daemon/tests/media-volcengine-image.test.ts
+++ b/apps/daemon/tests/media-volcengine-image.test.ts
@@ -1,0 +1,227 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateMedia } from '../src/media/index.js';
+
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+const SEEDREAM_5_PRO_MODEL_ID = 'doubao-seedream-5-0-pro-260628';
+
+describe('Volcengine image generation', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const realFetch = globalThis.fetch;
+  const originalArkApiKey = process.env.ARK_API_KEY;
+  const originalVolcengineApiKey = process.env.OD_VOLCENGINE_API_KEY;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+  const originalDataDir = process.env.OD_DATA_DIR;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-volcengine-image-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(projectsRoot, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
+    delete process.env.OD_VOLCENGINE_API_KEY;
+    process.env.ARK_API_KEY = 'ark-test-key';
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    vi.unstubAllGlobals();
+    if (originalArkApiKey == null) {
+      delete process.env.ARK_API_KEY;
+    } else {
+      process.env.ARK_API_KEY = originalArkApiKey;
+    }
+    if (originalVolcengineApiKey == null) {
+      delete process.env.OD_VOLCENGINE_API_KEY;
+    } else {
+      process.env.OD_VOLCENGINE_API_KEY = originalVolcengineApiKey;
+    }
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    if (originalDataDir == null) {
+      delete process.env.OD_DATA_DIR;
+    } else {
+      process.env.OD_DATA_DIR = originalDataDir;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('routes Seedream 5.0 Pro through Volcengine and marks the output as layer-capable', async () => {
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://ark.cn-beijing.volces.com/api/v3/images/generations') {
+        expect(init?.method).toBe('POST');
+        expect(init?.headers).toMatchObject({
+          authorization: 'Bearer ark-test-key',
+          'content-type': 'application/json',
+        });
+        expect(JSON.parse(String(init?.body))).toEqual({
+          model: SEEDREAM_5_PRO_MODEL_ID,
+          prompt: 'Separate a product poster into editable design layers\nAspect ratio: 1:1.',
+          response_format: 'url',
+          size: '2K',
+          stream: false,
+          output_format: 'png',
+          watermark: false,
+        });
+        return new Response(JSON.stringify({
+          model: 'doubao-seedream-5-0-pro',
+          created: 1783526400,
+          data: [{
+            url: 'https://ark-content.example.com/result.png',
+            output_format: 'png',
+            size: '2048x2048',
+          }],
+          usage: {
+            generated_images: 1,
+            input_images: 0,
+            output_tokens: 16384,
+            total_tokens: 16384,
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      expect(url).toBe('https://ark-content.example.com/result.png');
+      expect(init?.redirect).toBe('error');
+      return new Response(Buffer.from(PNG_BASE64, 'base64'), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: SEEDREAM_5_PRO_MODEL_ID,
+      prompt: 'Separate a product poster into editable design layers',
+      aspect: '1:1',
+      output: 'seedream-pro.png',
+    });
+
+    expect(result.name).toBe('seedream-pro.png');
+    expect(result.providerId).toBe('volcengine');
+    expect(result.providerNote).toContain(`volcengine/${SEEDREAM_5_PRO_MODEL_ID}`);
+    expect(result.providerNote).toContain('layer-capable');
+    expect(result.metadata).toEqual({
+      capabilities: { layeredOutput: true },
+      modelFamily: 'seedream',
+      output: {
+        format: 'png',
+        size: '2048x2048',
+      },
+      response: {
+        created: 1783526400,
+        model: 'doubao-seedream-5-0-pro',
+      },
+      request: {
+        outputFormat: 'png',
+        responseFormat: 'url',
+        size: '2K',
+        stream: false,
+        watermark: false,
+      },
+      usage: {
+        generated_images: 1,
+        input_images: 0,
+        output_tokens: 16384,
+        total_tokens: 16384,
+      },
+    });
+
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'seedream-pro.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes reference images to Seedream 5.0 Pro as data URLs', async () => {
+    const projectDir = path.join(projectsRoot, 'project-1');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(path.join(projectDir, 'reference.png'), Buffer.from(PNG_BASE64, 'base64'));
+
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.image).toMatch(/^data:image\/png;base64,/);
+      return new Response(JSON.stringify({
+        data: [{ b64_json: PNG_BASE64, output_format: 'png', size: '2048x2048' }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: SEEDREAM_5_PRO_MODEL_ID,
+      prompt: 'Turn the reference into separated packaging design layers',
+      aspect: '1:1',
+      image: 'reference.png',
+      output: 'seedream-pro-reference.png',
+    });
+
+    expect(result.metadata).toMatchObject({
+      request: {
+        referenceImages: 1,
+      },
+    });
+  });
+
+  it('passes multiple remote reference URLs to Seedream 5.0 Pro', async () => {
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.image).toEqual([
+        'https://ark-project.tos-cn-beijing.volces.com/doc_image/seedream4_imagesToimage_1.png',
+        'https://ark-project.tos-cn-beijing.volces.com/doc_image/seedream4_imagesToimage_2.png',
+      ]);
+      return new Response(JSON.stringify({
+        data: [{ b64_json: PNG_BASE64, output_format: 'png', size: '2048x2048' }],
+        usage: { generated_images: 1, input_images: 2 },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: SEEDREAM_5_PRO_MODEL_ID,
+      prompt: '将图1的服装换为图2的服装',
+      aspect: '1:1',
+      image: 'https://ark-project.tos-cn-beijing.volces.com/doc_image/seedream4_imagesToimage_1.png',
+      images: ['https://ark-project.tos-cn-beijing.volces.com/doc_image/seedream4_imagesToimage_2.png'],
+      output: 'seedream-pro-remote-reference.png',
+    });
+
+    expect(result.metadata).toMatchObject({
+      request: {
+        referenceImages: 2,
+      },
+      usage: {
+        generated_images: 1,
+        input_images: 2,
+      },
+    });
+  });
+});

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2537,6 +2537,10 @@ export function supportedModels(surface: 'image' | 'video' | 'audio', models: Me
   });
 }
 
+function modelHasLayerOutput(model: MediaModel): boolean {
+  return model.output?.layered === true || model.caps?.includes('layers') === true;
+}
+
 function MediaModelCards({
   label,
   models,
@@ -2624,6 +2628,7 @@ function MediaModelCards({
             m.id.toLowerCase().includes(q) ||
             m.label.toLowerCase().includes(q) ||
             m.hint.toLowerCase().includes(q) ||
+            (modelHasLayerOutput(m) && 'layers layered layer-capable'.includes(q)) ||
             g.providerLabel.toLowerCase().includes(q)
           );
         }),
@@ -2745,6 +2750,9 @@ function MediaModelCards({
                               <span className="ds-picker-item-badge">
                                 {t('newproj.modelRecommended')}
                               </span>
+                            ) : null}
+                            {modelHasLayerOutput(model) ? (
+                              <span className="ds-picker-item-badge layer">Layers</span>
                             ) : null}
                           </span>
                           <span className="ds-picker-item-sub">{model.hint}</span>

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -317,6 +317,11 @@ export interface MediaModel {
    * the dispatcher to decide which provider call to make.
    */
   caps?: string[];
+  /** Optional output traits exposed by the provider/model. */
+  output?: {
+    /** Model can return layer-aware image assets once the daemon/UI consume them. */
+    layered?: boolean;
+  };
   /** Marks the default-checked card per surface in the picker. */
   default?: boolean;
 }
@@ -392,6 +397,14 @@ export const IMAGE_MODELS: MediaModel[] = [
     hint: 'ByteDance · image edit',
     provider: 'volcengine',
     caps: ['i2i'],
+  },
+  {
+    id: 'doubao-seedream-5-0-pro-260628',
+    label: 'seedream-5.0-pro',
+    hint: 'ByteDance · design-aware layers',
+    provider: 'volcengine',
+    caps: ['t2i', 'i2i', 'layers'],
+    output: { layered: true },
   },
 
   // SenseAudio — synchronous /v1/image/sync, Bearer auth, reference URL or data URI.

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -794,6 +794,11 @@
   border-radius: var(--radius-xs);
   margin-left: 6px;
 }
+.model-picker .ds-picker-item .ds-picker-item-badge.layer {
+  border-color: color-mix(in srgb, #0f8b6c 28%, transparent);
+  background: color-mix(in srgb, #0f8b6c 11%, transparent);
+  color: #0f725b;
+}
 .model-picker .ds-picker-group-head {
   position: sticky;
   top: 0;

--- a/apps/web/tests/components/NewProjectPanel.media.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.media.test.tsx
@@ -96,6 +96,42 @@ describe('NewProjectPanel media provider badges', () => {
     expect(screen.getByTestId('model-picker-option-codex-gpt-image-2')).toBeTruthy();
   });
 
+  it('labels Seedream 5.0 Pro as layer-capable in the image model picker', () => {
+    render(
+      <NewProjectPanel
+        skills={[]}
+        designSystems={[]}
+        defaultDesignSystemId={null}
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+        mediaProviders={{
+          volcengine: {
+            apiKey: '',
+            apiKeyConfigured: true,
+            apiKeyTail: '5678',
+            baseUrl: '',
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Media' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Image' }));
+    fireEvent.click(screen.getByTestId('model-picker-trigger'));
+
+    const option = screen.getByTestId('model-picker-option-doubao-seedream-5-0-pro-260628');
+    expect(option.textContent).toContain('Layers');
+
+    fireEvent.change(screen.getByTestId('model-picker-search'), {
+      target: { value: 'layered' },
+    });
+
+    expect(screen.getByTestId('model-picker-option-doubao-seedream-5-0-pro-260628')).toBeTruthy();
+    expect(screen.queryByTestId('model-picker-option-doubao-seedream-3-0-t2i-250415')).toBeNull();
+  });
+
   it('uses Codex subscription as the no-key image fallback', async () => {
     const onCreate = vi.fn();
     render(

--- a/apps/web/tests/media/model-provider.test.ts
+++ b/apps/web/tests/media/model-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { mediaModelProviderId } from '../../src/media/models';
+import { findMediaModel, mediaModelProviderId } from '../../src/media/models';
 
 // mediaModelProviderId is the decision core of ProjectView's BYOK seed guard
 // (byokModelSeedForProtocol): the project's creation-time model is only carried
@@ -24,8 +24,16 @@ describe('mediaModelProviderId', () => {
     // SenseAudio run this !== 'senseaudio', so the guard drops the seed and the
     // user's Settings default is kept.
     expect(mediaModelProviderId('gpt-image-2')).toBe('openai');
+    expect(mediaModelProviderId('doubao-seedream-5-0-pro-260628')).toBe('volcengine');
     expect(mediaModelProviderId('senseaudio-image-2.0-260319')).toBe('senseaudio');
     expect(mediaModelProviderId('senseaudio-tts')).toBe('senseaudio');
+  });
+
+  it('marks Seedream 5.0 Pro as layer-capable without moving it to SenseAudio', () => {
+    const model = findMediaModel('doubao-seedream-5-0-pro-260628');
+    expect(model?.provider).toBe('volcengine');
+    expect(model?.caps).toContain('layers');
+    expect(model?.output?.layered).toBe(true);
   });
 
   it('returns undefined for unknown ids', () => {


### PR DESCRIPTION
## Summary

Adds Volcengine Ark support for `doubao-seedream-5-0-pro-260628` as a layer-capable image model.

This keeps the first PR intentionally small: it wires the model into the registry, routes text-to-image and image-to-image requests through the existing Volcengine image path, supports one or more reference images, and surfaces model/output metadata without pretending editable layer assets exist when the provider response does not include them.

## What changed

- Register Seedream 5.0 Pro in both web and daemon media model catalogues with `t2i`, `i2i`, and `layers` capabilities.
- Send Pro requests to Ark `/images/generations` with `size: "2K"`, `response_format: "url"`, `output_format: "png"`, `stream: false`, and `watermark: false`.
- Support single and multiple image references, including repeated CLI `--image` values and `--images <json|csv>` for additional references.
- Support remote reference URLs for Volcengine image generation.
- Download URL responses through the existing external asset guard and persist the generated bytes locally.
- Return Seedream request/output/usage metadata so later layer-aware UI work has a contract to build from.
- Add a `Layers` badge and layer-related search terms in the image model picker.
- Update the media prompt contract so agents do not promise editable layer files unless a future response includes an explicit layer manifest/supporting assets.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Design discussion

Manual API smoke tests confirmed the current Ark response returns a single generated image URL plus `size`, `output_format`, and `usage`. I did not see an explicit layer manifest or separate layer asset URLs in the response shape.

A good follow-up would be to agree on the product contract before adding UI for editable layers:

1. Should layer outputs be represented as `supportingFiles`, a `metadata.layers` manifest, or a new artifact grouping primitive?
2. Should the first UI surface be a simple layer stack preview/export, or should it integrate with the existing file viewer more deeply?
3. When a model is layer-capable but a response only includes a flat preview image, is the `capabilities.layeredOutput` metadata flag acceptable, or should it use a softer naming like `layerCapable`?

## Validation

- `git diff --check`
- `node scripts/verify-media-models.mjs`
- `pnpm --filter @open-design/daemon... run build`
- `pnpm --dir apps/daemon exec vitest run tests/cli-startup.test.ts -t "forwards multiple media reference images"`
- `pnpm --dir apps/daemon exec vitest run tests/media-volcengine-image.test.ts`
- `pnpm --dir apps/web exec vitest run tests/components/NewProjectPanel.media.test.tsx tests/media/model-provider.test.ts`

Local validation used Node v24.14.0.