### PR TITLE
fix(release): Thursday patch cut fails when main already matches the patch version

### DIFF
--- a/.github/workflows/cut-patch-release.yml
+++ b/.github/workflows/cut-patch-release.yml
@@ -180,7 +180,12 @@ jobs:
           git config user.email 'open-design-release-bot[bot]@users.noreply.github.com'
           git switch -c "$BRANCH"
           ( cd apps/packaged && npm pkg set version="$VERSION" )
-          git commit -am "chore(release): v$VERSION"
+          # main leads stable by exactly this patch in steady state (finalize-release
+          # bumps main to X.Y.(Z+1) after X.Y.Z ships), so apps/packaged is often
+          # already at $VERSION and the bump is a no-op. --allow-empty commits a
+          # release marker anyway instead of dying on "nothing to commit"; either way
+          # the branch is cut + pushed, which is what triggers notify-release-feishu.
+          git commit --allow-empty -am "chore(release): v$VERSION"
           git push origin "$BRANCH"   # App token push -> triggers notify-release-feishu (prerelease + Feishu)
 
       - name: Create backport label

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1390,6 +1390,10 @@ process.stdin.on("end", () => {
     expect(workflow).toContain("ref: main");
     expect(workflow).toContain("token: ${{ steps.app.outputs.token }}");
     expect(workflow).toContain('git push origin "$BRANCH"');
+    // The version bump is a no-op whenever main already leads stable by this exact
+    // patch (apps/packaged == $VERSION), so the release commit MUST tolerate an empty
+    // tree — otherwise `git commit` dies on "nothing to commit" and no branch is cut.
+    expect(workflow).toContain('git commit --allow-empty -am "chore(release): v$VERSION"');
 
     // The notice card is a standalone poster with the same signed-webhook contract.
     expect(notice).toContain("msg_type: \"interactive\"");


### PR DESCRIPTION
## Why

- **Use case.** I set up the Thursday `cut-patch-release` cadence (merged in #5294). Its **first real scheduled run this morning (2026-07-09) FAILED**, so no `release/v0.14.1` was cut, no prerelease built, no Feishu card sent.
- **Pain.** The failure is **structural, not a fluke** — it recurs every Thursday whenever main's dev version already equals the patch being cut, which is the normal steady state. Left unfixed, the whole Thursday automation is dead on arrival.

### Root cause (confirmed from the failed run log)

Run [28988070923](https://github.com/nexu-io/open-design/actions/runs/28988070923) — event `schedule`, fired 01:41 UTC (09:41 CST; ~41 min of GitHub best-effort cron delay, which is normal). The steps:

```
Compute next patch version          success   → "Cutting patch v0.14.1 ... gating on stable v0.14.0"
Check the Tuesday minor is published success   → "release open-design-v0.14.0 -> published=true"  (happy path)
Bail out if the branch already exists success   (release/v0.14.1 did not exist)
Create branch + bump version + push  FAILURE
  Switched to a new branch 'release/v0.14.1'
  On branch release/v0.14.1
  nothing to commit, working tree clean          ← set -euo pipefail → exit 1
```

main's `apps/packaged/package.json` was **already `0.14.1`** (in steady state main leads stable by exactly one patch — finalize-release bumps main to `X.Y.(Z+1)` after `X.Y.Z` ships), and the computed Thursday patch is that same `0.14.1`. So `npm pkg set version=0.14.1` is an **idempotent no-op**, `git commit -am` hits an empty tree, and the step dies before `git push` — the branch is never cut. `cut-release` (minor) never trips this because a minor number always differs from main.

## What users will see

No user-facing product change. For the team watching the release Feishu group: the Thursday patch cut will now actually produce its `release/vX.Y.Z` branch + prerelease + card (or the skip card) instead of silently failing on a red run.

## Surface area

- [x] **CLI / env var** — edits the scheduled `cut-patch-release.yml` workflow only. No product UI/CLI surface (same category as `cut-release.yml`).
- [x] **None** — one-line workflow fix + a topology assertion.

## The fix

Commit the release marker with `git commit --allow-empty` so the branch is **always** cut and pushed (that push is what triggers `notify-release-feishu`). A real version bump still commits the change normally; only the no-op case now yields an empty marker commit instead of a hard failure.

## Bug fix verification

- **Red spec:** `e2e/tests/packaged-smoke-workflow.test.ts` now asserts the release commit uses `--allow-empty`; without the fix this assertion is red.
- **Reproduced + fixed locally** with a real idempotent `npm pkg set version=<same>` (no diff, exactly like CI): old `git commit -am` → `nothing to commit, working tree clean` (fails); `git commit --allow-empty -am` → succeeds with a marker commit. A *differing* version still commits the bump (`1 file changed`).

## Validation

- `actionlint` on `cut-patch-release.yml` — clean.
- Local git simulation of both paths (no-op → empty marker commit; real bump → normal commit), matching the CI failure signature.
- `pnpm typecheck` + `pnpm guard` run in CI Preflight; topology assertion replay-verified against the file.

## Follow-up

Today's `v0.14.1` cut still needs to be completed once this merges (re-dispatch `cut-patch-release` — it will now cut `release/v0.14.1`). `cut-release` (minor) has the same latent `git commit -am` pattern but cannot currently hit it (minor ≠ main's patch); noting it as an adjacent issue, not fixing it here to keep scope tight.