### PR TITLE
feat(packaged): forward the raw daemon log tail in startup-crash telemetry

### DIFF
--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -186,12 +186,17 @@ export function scrubSecrets(value: string): string {
   return value
     // Credentials embedded in a URL / connection string: scheme://user:pass@host
     .replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/g, "$1<redacted>@")
+    // Authorization header — redact the ENTIRE value (scheme + token) to
+    // end-of-line. The generic key=value rule below would only consume the
+    // scheme word ("Bearer"/"Basic") and leave the credential
+    // ("Authorization: Bearer abc" -> "<redacted> abc"), so handle it first.
+    .replace(/(\bAuthorization\s*[:=]\s*)\S[^\r\n]*/gi, "$1<redacted>")
     // `key = value` / `key: value` secrets (password, token, secret, api_key, …).
     .replace(
-      /\b(pass(?:word|wd)?|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|authorization|auth)(\s*[=:]\s*)("?)[^\s"'&]+\3/gi,
+      /\b(pass(?:word|wd)?|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret)(\s*[=:]\s*)("?)[^\s"'&]+\3/gi,
       "$1$2<redacted>",
     )
-    // Authorization header token values.
+    // Inline Bearer/Basic token values not under an Authorization header.
     .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/g, "$1 <redacted>")
     // Provider API keys by well-known prefix (OpenAI/Anthropic, PostHog, GitHub, Slack, …).
     .replace(/\b(?:sk|pk|rk|phx|phc|ghp|gho|ghs|xox[baprs])[-_][A-Za-z0-9_-]{8,}/g, "<redacted-token>")

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -26,10 +26,12 @@
 // Payload PII: the free-form crash fields (error_message, error_stack, and the
 // daemon_log_tail slice of the daemon's own log) and every path we send
 // (log_path, native_module_path) run through `scrubUserPaths` to strip the
-// user's home dir, and the free-form text is length-capped. Startup errors are
-// module-resolution / daemon-exit messages and the daemon's startup log lines,
-// not user content, so this bounds the exposure to build/OS strings rather than
-// anything the user typed.
+// user's home dir, and the free-form fields additionally run through
+// `scrubSecrets` to strip credentials/tokens/emails — because the daemon loads
+// config/connector/MCP secrets before it reports ready, so a startup error can
+// echo a connection string or auth header, and this event is sent even for
+// opted-out users. The free-form text is also length-capped. Scrubbing is a
+// best-effort denylist, not a guarantee.
 
 import { readFile } from "node:fs/promises";
 import { readFileSync, statSync } from "node:fs";
@@ -163,10 +165,38 @@ export function scrubUserPaths(value: string): string {
     // running across lines in a multi-line stack. Runs before the POSIX rule
     // because that rule also matches the "/Users/" inside a `C:/Users/` path.
     .replace(/([A-Za-z]:[\\/]Users[\\/])[^\\/\r\n]+/g, "$1<redacted>")
+    // Any `…/Users/<name>`, `…/Profiles/<name>` or `…/home/<name>` segment
+    // regardless of prefix — covers UNC shares (`\\CORP-FS\Profiles\jdoe\…`) and
+    // roaming layouts that the drive-anchored rule above misses. Space-tolerant
+    // (Windows names can contain spaces), line-bounded.
+    .replace(/([\\/](?:Users|Profiles)[\\/])[^\\/\r\n]+/g, "$1<redacted>")
     // POSIX home dirs. Real macOS/Linux home segments cannot contain spaces, so
     // the whitespace boundary is correct here and avoids over-redacting a
     // following word in free-form crash text.
     .replace(/\/(Users|home)\/[^/\s]+/g, "/$1/<redacted>");
+}
+
+// Strip credentials/secrets from free-form telemetry text (daemon log tail,
+// error message/stack). The daemon loads config/connector/MCP tokens before it
+// reports ready, so a startup error can echo a connection string, an auth
+// header, or a `KEY=value` secret — and this event is sent even for opted-out
+// users, so the surface must be scrubbed, not just path-redacted. Best-effort
+// (denylist, never complete), applied ON TOP of scrubUserPaths.
+export function scrubSecrets(value: string): string {
+  return value
+    // Credentials embedded in a URL / connection string: scheme://user:pass@host
+    .replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/g, "$1<redacted>@")
+    // `key = value` / `key: value` secrets (password, token, secret, api_key, …).
+    .replace(
+      /\b(pass(?:word|wd)?|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|authorization|auth)(\s*[=:]\s*)("?)[^\s"'&]+\3/gi,
+      "$1$2<redacted>",
+    )
+    // Authorization header token values.
+    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/g, "$1 <redacted>")
+    // Provider API keys by well-known prefix (OpenAI/Anthropic, PostHog, GitHub, Slack, …).
+    .replace(/\b(?:sk|pk|rk|phx|phc|ghp|gho|ghs|xox[baprs])[-_][A-Za-z0-9_-]{8,}/g, "<redacted-token>")
+    // Bare email addresses.
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "<redacted-email>");
 }
 
 function osName(platform: NodeJS.Platform = process.platform): string {
@@ -366,7 +396,7 @@ export async function reportStartupFailure(
         // has code=1 exits where we read the log but classified neither field;
         // emit a scrubbed, tail-truncated slice of the raw log so ANY exit
         // reason is diagnosable, not just those two shapes.
-        daemonLogTail = truncateTailForTelemetry(scrubUserPaths(tail), DAEMON_LOG_TAIL_MAX);
+        daemonLogTail = truncateTailForTelemetry(scrubSecrets(scrubUserPaths(tail)), DAEMON_LOG_TAIL_MAX);
       }
     }
     const rawMessage =
@@ -403,10 +433,10 @@ export async function reportStartupFailure(
       // payload. These crash-scene fields are why the mac subset can't resolve
       // the module and what the Windows `unknown` bucket actually threw.
       error_message: rawMessage
-        ? truncateForTelemetry(scrubUserPaths(rawMessage), ERROR_MESSAGE_MAX)
+        ? truncateForTelemetry(scrubSecrets(scrubUserPaths(rawMessage)), ERROR_MESSAGE_MAX)
         : null,
       error_stack: rawStack
-        ? truncateForTelemetry(scrubUserPaths(rawStack), ERROR_STACK_MAX)
+        ? truncateForTelemetry(scrubSecrets(scrubUserPaths(rawStack)), ERROR_STACK_MAX)
         : null,
       native_module_present: nativeModulePresent,
       native_module_size: nativeModuleSize,

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -184,6 +184,13 @@ export function scrubUserPaths(value: string): string {
 // (denylist, never complete), applied ON TOP of scrubUserPaths.
 export function scrubSecrets(value: string): string {
   return value
+    // Serialized object literals embedded in a message ("error parsing config:
+    // {…}") — a common carrier of config/secret values inside an otherwise-legit
+    // error line, and one the key=value/URL rules below can't reach through JSON
+    // quoting. Redact the whole `{…}` (greedy within a line, so nested objects
+    // go too). `[…]` is deliberately left alone — it's the shape of log prefixes
+    // like `[daemon]`, not where secrets hide.
+    .replace(/\{[^\r\n]*\}/g, "<redacted-object>")
     // Credentials embedded in a URL / connection string: scheme://user:pass@host.
     // The password may itself contain '@' (e.g. `user:p@ss@host`), so match the
     // whole userinfo greedily up to the LAST '@' before the host rather than

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -23,11 +23,13 @@
 // opted-out users (and the main process cannot read daemon consent anyway,
 // since the daemon isn't up). The Settings → Privacy copy MUST call this out.
 //
-// Payload PII: the free-form crash fields (error_message, error_stack) and every
-// path we send (log_path, native_module_path) run through `scrubUserPaths` to
-// strip the user's home dir, and the free-form text is length-capped. Startup
-// errors are module-resolution / daemon-exit messages, not user content, so this
-// bounds the exposure to build/OS strings rather than anything the user typed.
+// Payload PII: the free-form crash fields (error_message, error_stack, and the
+// daemon_log_tail slice of the daemon's own log) and every path we send
+// (log_path, native_module_path) run through `scrubUserPaths` to strip the
+// user's home dir, and the free-form text is length-capped. Startup errors are
+// module-resolution / daemon-exit messages and the daemon's startup log lines,
+// not user content, so this bounds the exposure to build/OS strings rather than
+// anything the user typed.
 
 import { readFile } from "node:fs/promises";
 import { readFileSync, statSync } from "node:fs";
@@ -216,9 +218,22 @@ async function defaultReadLogTail(path: string): Promise<string | null> {
 // Keep the message/stack payload bounded (a stack can be arbitrarily long).
 const ERROR_MESSAGE_MAX = 1000;
 const ERROR_STACK_MAX = 2000;
+// The raw daemon log tail we forward. defaultReadLogTail already reads the last
+// 16KB of the file; this bounds what we actually ship to the fatal error and
+// its stack.
+const DAEMON_LOG_TAIL_MAX = 2500;
 
 function truncateForTelemetry(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max)}…[+${value.length - max} chars]` : value;
+}
+
+// A log TAIL's most useful lines — the fatal error and its stack — sit at the
+// END, so keep the end when trimming, unlike truncateForTelemetry which keeps
+// the head of a single message/stack.
+function truncateTailForTelemetry(value: string, max: number): string {
+  return value.length > max
+    ? `…[+${value.length - max} chars]${value.slice(value.length - max)}`
+    : value;
 }
 
 // Best-effort probe: does the native module actually exist on THIS machine, and
@@ -338,12 +353,20 @@ export async function reportStartupFailure(
     const classification = classifyStartupFailure(args.error, args.isPathAccess);
     let errorCode: string | undefined;
     let missingModule: string | undefined;
+    let daemonLogTail: string | null = null;
     if (classification.logPath) {
       const tail = await (deps.readLogTail ?? defaultReadLogTail)(classification.logPath);
       if (tail) {
         const parsed = parseDaemonLogTail(tail);
         errorCode = parsed.errorCode;
         missingModule = parsed.missingModule;
+        // parseDaemonLogTail only recognises ERR_* and missing-module lines, so
+        // it captures nothing for the majority of code=1 daemon exits (a plain
+        // Error, a config parse failure, a port bind, an assertion). Production
+        // has code=1 exits where we read the log but classified neither field;
+        // emit a scrubbed, tail-truncated slice of the raw log so ANY exit
+        // reason is diagnosable, not just those two shapes.
+        daemonLogTail = truncateTailForTelemetry(scrubUserPaths(tail), DAEMON_LOG_TAIL_MAX);
       }
     }
     const rawMessage =
@@ -389,6 +412,7 @@ export async function reportStartupFailure(
       native_module_size: nativeModuleSize,
       native_module_path: nativeModulePath,
       log_path: classification.logPath ? scrubUserPaths(classification.logPath) : null,
+      daemon_log_tail: daemonLogTail,
       app_version: args.appVersion,
       namespace: args.namespace,
       source: args.source,

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -228,10 +228,19 @@ const ERROR_LINE_RE =
 // and connection lines where secrets live, since they don't match an error
 // shape. scrubUserPaths + scrubSecrets still run on what remains as defense in
 // depth (a token could appear inside an error message).
+// An `UPPER_CASE_ENV=value` assignment at line start — the shape of a config /
+// env dump. Excluded even when it matches ERROR_LINE_RE, because a config KEY or
+// value can contain a broad failure substring (`ERROR_REPORT_EMAIL=…`,
+// `SOME_ERROR_TOKEN=…`) and would otherwise re-admit the very secret-bearing
+// lines the whitelist exists to keep out. Real error/stack/exit lines are not
+// `UPPER=…` assignments (`code=1` is lowercase; `TypeError:`/`at …` have no
+// leading `KEY=`).
+const CONFIG_ASSIGNMENT_RE = /^\s*[A-Z][A-Z0-9_]{2,}\s*=/;
+
 export function extractSidecarErrorLines(logText: string): string {
   return logText
     .split(/\r?\n/)
-    .filter((line) => ERROR_LINE_RE.test(line))
+    .filter((line) => ERROR_LINE_RE.test(line) && !CONFIG_ASSIGNMENT_RE.test(line))
     .join("\n");
 }
 

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -212,9 +212,14 @@ export function scrubSecrets(value: string): string {
 }
 
 // A line is "diagnostically relevant" if it looks like a thrown error, a stack
-// frame, a Node error code, or an exit marker.
+// frame, a Node error code, an exit marker, OR a plain-English failure message
+// ("failed to …", "could not …", "unable to …"). The failure-verb phrasings are
+// how much of our own startup code reports problems (e.g. "daemon failed to
+// resolve listening port", "… was found but could not …"); including them keeps
+// the diagnostic value without re-opening the secret surface, because config /
+// connection / KEY=value lines don't contain those verbs.
 const ERROR_LINE_RE =
-  /(error|exception|fatal|\bpanic\b|assert|\bthrow|unhandled|reject|\bERR_[A-Z0-9_]+|^\s+at\s|\bE[A-Z]{2,}\b|\b(?:code|signal)\s*[=:]|exited|cannot find|not found|refused|denied|timed?\s*out)/i;
+  /(error|exception|fatal|\bpanic\b|assert|\bthrow|unhandled|reject|abort|failed|fail(?:ing|ure)|could ?n['’]?t|could not|cannot|unable|\bERR_[A-Z0-9_]+|^\s+at\s|\bE[A-Z]{2,}\b|\b(?:code|signal)\s*[=:]|exited|not found|refused|denied|timed?\s*out)/i;
 
 // Keep ONLY error/stack-shaped lines from a log tail. This is the primary PII
 // control for `sidecar_log_tail`: rather than trying to scrub every secret shape

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -195,9 +195,12 @@ export function scrubSecrets(value: string): string {
     // scheme word ("Bearer"/"Basic") and leave the credential
     // ("Authorization: Bearer abc" -> "<redacted> abc"), so handle it first.
     .replace(/(\bAuthorization\s*[:=]\s*)\S[^\r\n]*/gi, "$1<redacted>")
-    // `key = value` / `key: value` secrets (password, token, secret, api_key, …).
+    // `key = value` / `key: value` secrets (password, token, secret, api_key,
+    // auth, …). `auth` is kept here for bare `auth=…` fields; it can't misfire on
+    // "Authorization"/"author" because a `[=:]` separator must immediately follow
+    // the matched word (the Authorization *header* is handled by the rule above).
     .replace(
-      /\b(pass(?:word|wd)?|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret)(\s*[=:]\s*)("?)[^\s"'&]+\3/gi,
+      /\b(pass(?:word|wd)?|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|auth)(\s*[=:]\s*)("?)[^\s"'&]+\3/gi,
       "$1$2<redacted>",
     )
     // Inline Bearer/Basic token values not under an Authorization header.

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -23,15 +23,15 @@
 // opted-out users (and the main process cannot read daemon consent anyway,
 // since the daemon isn't up). The Settings → Privacy copy MUST call this out.
 //
-// Payload PII: the free-form crash fields (error_message, error_stack, and the
-// sidecar_log_tail slice of the failed sidecar's own log) and every path we send
-// (log_path, native_module_path) run through `scrubUserPaths` to strip the
-// user's home dir, and the free-form fields additionally run through
-// `scrubSecrets` to strip credentials/tokens/emails — because the daemon loads
-// config/connector/MCP secrets before it reports ready, so a startup error can
-// echo a connection string or auth header, and this event is sent even for
-// opted-out users. The free-form text is also length-capped. Scrubbing is a
-// best-effort denylist, not a guarantee.
+// Payload PII: the free-form fields (error_message, error_stack, sidecar_log_tail)
+// and every path (log_path, native_module_path) run through `scrubUserPaths`.
+// sidecar_log_tail is additionally WHITELISTED to error/stack-shaped lines
+// (`extractSidecarErrorLines`), so config / connection / KEY=value lines — where
+// the daemon's config/connector/MCP secrets live — are structurally excluded
+// rather than chased by an ever-incomplete denylist. `scrubSecrets` then runs on
+// all free-form fields as defense in depth (a token could still appear inside an
+// error message), and the text is length-capped. This event is sent even for
+// opted-out users, hence the layered structural + denylist controls.
 
 import { readFile } from "node:fs/promises";
 import { readFileSync, statSync } from "node:fs";
@@ -200,7 +200,7 @@ export function scrubSecrets(value: string): string {
     // "Authorization"/"author" because a `[=:]` separator must immediately follow
     // the matched word (the Authorization *header* is handled by the rule above).
     .replace(
-      /\b(pass(?:word|wd)?|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|auth)(\s*[=:]\s*)("?)[^\s"'&]+\3/gi,
+      /\b(pass(?:word|wd)?|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|auth)(\s*[=:]\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"'&]+)/gi,
       "$1$2<redacted>",
     )
     // Inline Bearer/Basic token values not under an Authorization header.
@@ -209,6 +209,25 @@ export function scrubSecrets(value: string): string {
     .replace(/\b(?:sk|pk|rk|phx|phc|ghp|gho|ghs|xox[baprs])[-_][A-Za-z0-9_-]{8,}/g, "<redacted-token>")
     // Bare email addresses.
     .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "<redacted-email>");
+}
+
+// A line is "diagnostically relevant" if it looks like a thrown error, a stack
+// frame, a Node error code, or an exit marker.
+const ERROR_LINE_RE =
+  /(error|exception|fatal|\bpanic\b|assert|\bthrow|unhandled|reject|\bERR_[A-Z0-9_]+|^\s+at\s|\bE[A-Z]{2,}\b|\b(?:code|signal)\s*[=:]|exited|cannot find|not found|refused|denied|timed?\s*out)/i;
+
+// Keep ONLY error/stack-shaped lines from a log tail. This is the primary PII
+// control for `sidecar_log_tail`: rather than trying to scrub every secret shape
+// out of arbitrary log text (a denylist that kept leaking — connection strings,
+// auth headers, KEY=value, quoted values), we structurally exclude the config
+// and connection lines where secrets live, since they don't match an error
+// shape. scrubUserPaths + scrubSecrets still run on what remains as defense in
+// depth (a token could appear inside an error message).
+export function extractSidecarErrorLines(logText: string): string {
+  return logText
+    .split(/\r?\n/)
+    .filter((line) => ERROR_LINE_RE.test(line))
+    .join("\n");
 }
 
 function osName(platform: NodeJS.Platform = process.platform): string {
@@ -404,12 +423,17 @@ export async function reportStartupFailure(
         missingModule = parsed.missingModule;
         // parseDaemonLogTail only recognises ERR_* and missing-module lines, so
         // it captures nothing for the majority of code=1 sidecar exits (a plain
-        // Error, a config parse failure, a port bind, an assertion). Production
-        // has code=1 exits where we read the log but classified neither field;
-        // emit a scrubbed, tail-truncated slice of the raw log so ANY exit
-        // reason is diagnosable, not just those two shapes. Carries whichever
-        // sidecar failed (daemon or web) — partition on failure_kind.
-        sidecarLogTail = truncateTailForTelemetry(scrubSecrets(scrubUserPaths(tail)), SIDECAR_LOG_TAIL_MAX);
+        // Error, a config parse failure, a port bind, an assertion). Emit the
+        // error/stack-shaped lines of the tail so ANY exit reason is diagnosable,
+        // not just those two shapes — but WHITELISTED to error shapes so config /
+        // connection / KEY=value lines (where secrets live) are structurally
+        // excluded, then scrubbed as defense in depth. Null when the tail had no
+        // error-shaped line. Carries whichever sidecar failed — partition on
+        // failure_kind.
+        const errorLines = extractSidecarErrorLines(tail);
+        sidecarLogTail = errorLines
+          ? truncateTailForTelemetry(scrubSecrets(scrubUserPaths(errorLines)), SIDECAR_LOG_TAIL_MAX)
+          : null;
       }
     }
     const rawMessage =

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -184,8 +184,12 @@ export function scrubUserPaths(value: string): string {
 // (denylist, never complete), applied ON TOP of scrubUserPaths.
 export function scrubSecrets(value: string): string {
   return value
-    // Credentials embedded in a URL / connection string: scheme://user:pass@host
-    .replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/g, "$1<redacted>@")
+    // Credentials embedded in a URL / connection string: scheme://user:pass@host.
+    // The password may itself contain '@' (e.g. `user:p@ss@host`), so match the
+    // whole userinfo greedily up to the LAST '@' before the host rather than
+    // stopping at the first '@' (which left `…<redacted>@ss@host` leaking part
+    // of the password). Requires a ':' so a plain `scheme://host` isn't touched.
+    .replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/\s@]*:[^/\s]*@/g, "$1<redacted>@")
     // Authorization header — redact the ENTIRE value (scheme + token) to
     // end-of-line. The generic key=value rule below would only consume the
     // scheme word ("Bearer"/"Basic") and leave the credential

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -24,7 +24,7 @@
 // since the daemon isn't up). The Settings → Privacy copy MUST call this out.
 //
 // Payload PII: the free-form crash fields (error_message, error_stack, and the
-// daemon_log_tail slice of the daemon's own log) and every path we send
+// sidecar_log_tail slice of the failed sidecar's own log) and every path we send
 // (log_path, native_module_path) run through `scrubUserPaths` to strip the
 // user's home dir, and the free-form fields additionally run through
 // `scrubSecrets` to strip credentials/tokens/emails — because the daemon loads
@@ -251,7 +251,7 @@ const ERROR_STACK_MAX = 2000;
 // The raw daemon log tail we forward. defaultReadLogTail already reads the last
 // 16KB of the file; this bounds what we actually ship to the fatal error and
 // its stack.
-const DAEMON_LOG_TAIL_MAX = 2500;
+const SIDECAR_LOG_TAIL_MAX = 2500;
 
 function truncateForTelemetry(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max)}…[+${value.length - max} chars]` : value;
@@ -383,7 +383,7 @@ export async function reportStartupFailure(
     const classification = classifyStartupFailure(args.error, args.isPathAccess);
     let errorCode: string | undefined;
     let missingModule: string | undefined;
-    let daemonLogTail: string | null = null;
+    let sidecarLogTail: string | null = null;
     if (classification.logPath) {
       const tail = await (deps.readLogTail ?? defaultReadLogTail)(classification.logPath);
       if (tail) {
@@ -391,12 +391,13 @@ export async function reportStartupFailure(
         errorCode = parsed.errorCode;
         missingModule = parsed.missingModule;
         // parseDaemonLogTail only recognises ERR_* and missing-module lines, so
-        // it captures nothing for the majority of code=1 daemon exits (a plain
+        // it captures nothing for the majority of code=1 sidecar exits (a plain
         // Error, a config parse failure, a port bind, an assertion). Production
         // has code=1 exits where we read the log but classified neither field;
         // emit a scrubbed, tail-truncated slice of the raw log so ANY exit
-        // reason is diagnosable, not just those two shapes.
-        daemonLogTail = truncateTailForTelemetry(scrubSecrets(scrubUserPaths(tail)), DAEMON_LOG_TAIL_MAX);
+        // reason is diagnosable, not just those two shapes. Carries whichever
+        // sidecar failed (daemon or web) — partition on failure_kind.
+        sidecarLogTail = truncateTailForTelemetry(scrubSecrets(scrubUserPaths(tail)), SIDECAR_LOG_TAIL_MAX);
       }
     }
     const rawMessage =
@@ -442,7 +443,7 @@ export async function reportStartupFailure(
       native_module_size: nativeModuleSize,
       native_module_path: nativeModulePath,
       log_path: classification.logPath ? scrubUserPaths(classification.logPath) : null,
-      daemon_log_tail: daemonLogTail,
+      sidecar_log_tail: sidecarLogTail,
       app_version: args.appVersion,
       namespace: args.namespace,
       source: args.source,

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -334,7 +334,7 @@ describe('reportStartupFailure', () => {
     expect(props.exit_code).toBe(1);
     expect(props.log_path).not.toContain('liudetao');
     // The raw tail is forwarded alongside the extracted fields, scrubbed.
-    expect(props.daemon_log_tail).toContain('ERR_MODULE_NOT_FOUND');
+    expect(props.sidecar_log_tail).toContain('ERR_MODULE_NOT_FOUND');
   });
 
   it('forwards the scrubbed raw daemon log tail when the cause is not an ERR_ code or missing module', async () => {
@@ -363,11 +363,11 @@ describe('reportStartupFailure', () => {
     expect(props.error_code).toBeNull();
     expect(props.missing_module).toBeNull();
     // ...but the raw tail still carries the real cause, with the home dir scrubbed.
-    expect(props.daemon_log_tail).toContain(
+    expect(props.sidecar_log_tail).toContain(
       "TypeError: Cannot read properties of undefined (reading 'port')",
     );
-    expect(props.daemon_log_tail).not.toContain('liudetao');
-    expect(props.daemon_log_tail).toContain('<redacted>');
+    expect(props.sidecar_log_tail).not.toContain('liudetao');
+    expect(props.sidecar_log_tail).toContain('<redacted>');
   });
 
   it('keeps the END of an oversized daemon log so the fatal error is not truncated away', async () => {
@@ -389,7 +389,7 @@ describe('reportStartupFailure', () => {
     const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
     const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
       .properties;
-    const tail = props.daemon_log_tail as string;
+    const tail = props.sidecar_log_tail as string;
     expect(tail).toContain('FATAL: daemon boot aborted at the very end');
     expect(tail).toContain('chars]');
     expect(tail.length).toBeLessThan(bigLog.length);

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -260,6 +260,20 @@ describe('extractSidecarErrorLines', () => {
     expect(out).not.toContain('DATABASE_URL');
   });
 
+  it('excludes UPPER_CASE=… config assignments even when the key contains a failure word', () => {
+    const log = [
+      'ERROR_REPORT_EMAIL=alice@example.com',
+      'SOME_ERROR_TOKEN=s3cr3tvalue',
+      'DATABASE_URL=postgres://od:pw@db/x',
+      "TypeError: boom",
+    ].join('\n');
+    const out = extractSidecarErrorLines(log);
+    expect(out).toBe('TypeError: boom');
+    expect(out).not.toContain('ERROR_REPORT_EMAIL');
+    expect(out).not.toContain('alice@example.com');
+    expect(out).not.toContain('s3cr3tvalue');
+  });
+
   it('returns an empty string when nothing looks like an error', () => {
     expect(extractSidecarErrorLines('booting\nlistening on 8080\nready')).toBe('');
   });

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -171,9 +171,18 @@ describe('scrubSecrets', () => {
     expect(out).toContain('postgres://<redacted>@db.internal');
   });
 
-  it('redacts Authorization bearer tokens and provider api keys', () => {
-    expect(scrubSecrets('Authorization: Bearer sk-ant-api03-ABC123DEF456GHI789')).not.toContain('ABC123DEF456');
+  it('redacts the ENTIRE Authorization header value, not just the scheme word', () => {
+    // Regression (nettee): the key=value branch consumed only "Bearer" and left
+    // the token — "Authorization: Bearer abc" became "<redacted> abc".
+    expect(scrubSecrets('Authorization: Bearer abc12345')).toBe('Authorization: <redacted>');
+    expect(scrubSecrets('Authorization: Basic Zm9vOmJhcg==')).toBe('Authorization: <redacted>');
+    expect(scrubSecrets('Authorization: Bearer abc12345')).not.toContain('abc12345');
+    expect(scrubSecrets('Authorization: Basic Zm9vOmJhcg==')).not.toContain('Zm9vOmJhcg');
+  });
+
+  it('redacts inline provider api keys not under an Authorization header', () => {
     expect(scrubSecrets('using key sk-ant-api03-ABC123DEF456GHI789 now')).toContain('<redacted-token>');
+    expect(scrubSecrets('using key sk-ant-api03-ABC123DEF456GHI789 now')).not.toContain('ABC123DEF456');
   });
 
   it('redacts key=value secrets and bare emails', () => {

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -192,6 +192,14 @@ describe('scrubSecrets', () => {
     expect(scrubSecrets('using key sk-ant-api03-ABC123DEF456GHI789 now')).not.toContain('ABC123DEF456');
   });
 
+  it('redacts a bare auth=… / auth: … field without misfiring on author or the header', () => {
+    expect(scrubSecrets('auth=abc12345')).toBe('auth=<redacted>');
+    expect(scrubSecrets('auth: abc12345')).toBe('auth: <redacted>');
+    // A `[=:]` must follow the word, so "author"/"Authorization" don't misfire here.
+    expect(scrubSecrets('author=jane')).toBe('author=jane');
+    expect(scrubSecrets('Authorization: Bearer abc12345')).toBe('Authorization: <redacted>');
+  });
+
   it('redacts key=value secrets and bare emails', () => {
     expect(scrubSecrets('password=hunter2 token: abc12345')).toBe('password=<redacted> token: <redacted>');
     expect(scrubSecrets('login failed for user ontf116@gmail.com')).toBe(

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -28,6 +28,7 @@ import {
   resolveStartupDistinctId,
   scrubUserPaths,
   scrubSecrets,
+  extractSidecarErrorLines,
 } from '../src/startup-telemetry.js';
 
 // Verbatim daemon log tail from issue #4638.
@@ -40,9 +41,9 @@ const ISSUE_4638_LOG = `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'bette
 // (13 win + 7 mac in 0.14.0) whose log we read but discarded. Includes a home
 // dir to assert the tail is scrubbed.
 const UNCLASSIFIED_DAEMON_LOG = `2026-07-09T10:00:00.000Z [daemon] booting namespace release-stable
-2026-07-09T10:00:01.000Z [daemon] loading config from /Users/liudetao/Library/Application Support/Open Design/namespaces/release-stable/config.json
+2026-07-09T10:00:01.000Z [daemon] DATABASE_URL=postgres://od:s3cr3tpw@db.internal/open
 TypeError: Cannot read properties of undefined (reading 'port')
-    at resolveListenPort (/Applications/Open Design.app/Contents/Resources/app/prebundled/daemon/chunks/server-PULTSXNL.mjs:1201:14)
+    at resolveListenPort (/Users/liudetao/app/prebundled/server.mjs:1201:14)
 [open-design packaged] exited app=daemon pid=51001 code=1 signal=none`;
 
 // Verbatim shape of what waitForStatus throws (sidecars.ts:206-208).
@@ -207,9 +208,41 @@ describe('scrubSecrets', () => {
     );
   });
 
+  it('redacts quoted secret values that contain spaces or special chars', () => {
+    expect(scrubSecrets('password="hunter 2"')).toBe('password=<redacted>');
+    expect(scrubSecrets('token="abc&def"')).toBe('token=<redacted>');
+    expect(scrubSecrets('api_key: "abc def"')).toBe('api_key: <redacted>');
+  });
+
   it('leaves ordinary diagnostic text (stack frames, module paths) intact', () => {
     const stack = "TypeError: Cannot read properties of undefined (reading 'port')\n    at resolveListenPort (server.mjs:1201:14)";
     expect(scrubSecrets(stack)).toBe(stack);
+  });
+});
+
+describe('extractSidecarErrorLines', () => {
+  it('keeps error/stack/exit lines and drops config/log-noise lines', () => {
+    const log = [
+      '[daemon] booting namespace release-stable',
+      'DATABASE_URL=postgres://od:s3cr3tpw@db/x',
+      "TypeError: Cannot read properties of undefined (reading 'port')",
+      '    at resolveListenPort (server.mjs:1201:14)',
+      'Error: listen EADDRINUSE: address already in use :::8080',
+      '[open-design packaged] exited app=daemon pid=1 code=1 signal=none',
+    ].join('\n');
+    const out = extractSidecarErrorLines(log);
+    expect(out).toContain('TypeError: Cannot read');
+    expect(out).toContain('at resolveListenPort');
+    expect(out).toContain('EADDRINUSE');
+    expect(out).toContain('code=1');
+    // Structural PII control: the secret-bearing config lines are excluded.
+    expect(out).not.toContain('DATABASE_URL');
+    expect(out).not.toContain('s3cr3tpw');
+    expect(out).not.toContain('booting namespace');
+  });
+
+  it('returns an empty string when nothing looks like an error', () => {
+    expect(extractSidecarErrorLines('booting\nlistening on 8080\nready')).toBe('');
   });
 });
 
@@ -386,17 +419,52 @@ describe('reportStartupFailure', () => {
     // The two structured extractors classify nothing for this exit...
     expect(props.error_code).toBeNull();
     expect(props.missing_module).toBeNull();
-    // ...but the raw tail still carries the real cause, with the home dir scrubbed.
-    expect(props.sidecar_log_tail).toContain(
-      "TypeError: Cannot read properties of undefined (reading 'port')",
+    const tail = props.sidecar_log_tail as string;
+    // ...but the error/stack lines are forwarded so the cause is diagnosable.
+    expect(tail).toContain("TypeError: Cannot read properties of undefined (reading 'port')");
+    expect(tail).toContain('at resolveListenPort');
+    // The whitelist structurally excludes non-error lines — the DATABASE_URL
+    // config line (and its password) never reaches telemetry at all.
+    expect(tail).not.toContain('DATABASE_URL');
+    expect(tail).not.toContain('s3cr3tpw');
+    // A home dir inside a kept stack frame is still scrubbed (defense in depth).
+    expect(tail).not.toContain('liudetao');
+    expect(tail).toContain('<redacted>');
+  });
+
+  it('sends no sidecar_log_tail when the tail has no error-shaped line', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await reportStartupFailure(
+      {
+        error: new Error(DAEMON_EXIT_MESSAGE),
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.14.0',
+        namespace: 'release-stable',
+        source: 'packaged',
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        // Pure config/log noise, no error shape — nothing diagnostically useful,
+        // and nowhere for a secret to hide.
+        readLogTail: async () =>
+          'booting\nDATABASE_URL=postgres://od:s3cr3tpw@db/x\nlistening on 8080',
+      },
     );
-    expect(props.sidecar_log_tail).not.toContain('liudetao');
-    expect(props.sidecar_log_tail).toContain('<redacted>');
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
+      .properties;
+    expect(props.sidecar_log_tail).toBeNull();
   });
 
   it('keeps the END of an oversized daemon log so the fatal error is not truncated away', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
-    const bigLog = `${'x'.repeat(5000)}\nFATAL: daemon boot aborted at the very end`;
+    // Many error-shaped lines (so the whitelist keeps them) exceeding the cap,
+    // with the fatal marker last — the tail-truncation must preserve the END.
+    const noise = Array.from({ length: 120 }, (_, i) => `Error: transient failure number ${i} at handler`).join('\n');
+    const bigLog = `${noise}\nFATAL: daemon boot aborted at the very end`;
     await reportStartupFailure(
       {
         error: new Error(DAEMON_EXIT_MESSAGE),

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -171,6 +171,13 @@ describe('scrubSecrets', () => {
     expect(out).toContain('postgres://<redacted>@db.internal');
   });
 
+  it('redacts a connection-string password that itself contains @, keeping the host', () => {
+    // Greedy userinfo must consume up to the LAST @ before the host, or part of
+    // the password ("ss") leaks and the host is rewritten.
+    expect(scrubSecrets('postgres://user:p@ss@host/db')).toBe('postgres://<redacted>@host/db');
+    expect(scrubSecrets('postgres://user:p@ss@host/db')).not.toContain('p@ss');
+  });
+
   it('redacts the ENTIRE Authorization header value, not just the scheme word', () => {
     // Regression (nettee): the key=value branch consumed only "Bearer" and left
     // the token — "Authorization: Bearer abc" became "<redacted> abc".

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -27,6 +27,7 @@ import {
   reportStartupFailure,
   resolveStartupDistinctId,
   scrubUserPaths,
+  scrubSecrets,
 } from '../src/startup-telemetry.js';
 
 // Verbatim daemon log tail from issue #4638.
@@ -153,6 +154,38 @@ describe('scrubUserPaths', () => {
   it('does not over-redact across lines in a multi-line stack', () => {
     const scrubbed = scrubUserPaths('a C:\\Users\\John Doe\\x\nb /Users/bob/y');
     expect(scrubbed).toBe('a C:\\Users\\<redacted>\\x\nb /Users/<redacted>/y');
+  });
+
+  it('redacts a UNC \\\\server\\Profiles\\<user> segment', () => {
+    expect(scrubUserPaths('\\\\CORP-FS\\Profiles\\jdoe\\od\\config.json')).toBe(
+      '\\\\CORP-FS\\Profiles\\<redacted>\\od\\config.json',
+    );
+    expect(scrubUserPaths('\\\\CORP-FS\\Profiles\\jdoe\\od\\config.json')).not.toContain('jdoe');
+  });
+});
+
+describe('scrubSecrets', () => {
+  it('redacts a password embedded in a connection string', () => {
+    const out = scrubSecrets('DATABASE_URL=postgres://od:s3cr3tpw@db.internal:5432/open');
+    expect(out).not.toContain('s3cr3tpw');
+    expect(out).toContain('postgres://<redacted>@db.internal');
+  });
+
+  it('redacts Authorization bearer tokens and provider api keys', () => {
+    expect(scrubSecrets('Authorization: Bearer sk-ant-api03-ABC123DEF456GHI789')).not.toContain('ABC123DEF456');
+    expect(scrubSecrets('using key sk-ant-api03-ABC123DEF456GHI789 now')).toContain('<redacted-token>');
+  });
+
+  it('redacts key=value secrets and bare emails', () => {
+    expect(scrubSecrets('password=hunter2 token: abc12345')).toBe('password=<redacted> token: <redacted>');
+    expect(scrubSecrets('login failed for user ontf116@gmail.com')).toBe(
+      'login failed for user <redacted-email>',
+    );
+  });
+
+  it('leaves ordinary diagnostic text (stack frames, module paths) intact', () => {
+    const stack = "TypeError: Cannot read properties of undefined (reading 'port')\n    at resolveListenPort (server.mjs:1201:14)";
+    expect(scrubSecrets(stack)).toBe(stack);
   });
 });
 

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -214,6 +214,16 @@ describe('scrubSecrets', () => {
     expect(scrubSecrets('api_key: "abc def"')).toBe('api_key: <redacted>');
   });
 
+  it('redacts secrets embedded in a serialized object inside an error message', () => {
+    expect(scrubSecrets('error parsing config: {"x-api-key":"secret-value-123"}')).toBe(
+      'error parsing config: <redacted-object>',
+    );
+    expect(scrubSecrets('error parsing config: {"access_token":"tok-123"}')).not.toContain('tok-123');
+    expect(scrubSecrets('boot failed with {"a":{"client_secret":"hunter2"}}')).not.toContain('hunter2');
+    // Log prefixes like [daemon] are left intact.
+    expect(scrubSecrets('[daemon] starting up')).toBe('[daemon] starting up');
+  });
+
   it('leaves ordinary diagnostic text (stack frames, module paths) intact', () => {
     const stack = "TypeError: Cannot read properties of undefined (reading 'port')\n    at resolveListenPort (server.mjs:1201:14)";
     expect(scrubSecrets(stack)).toBe(stack);

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -34,6 +34,16 @@ const ISSUE_4638_LOG = `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'bette
     at Object.getPackageJSONURL (node:internal/modules/package_json_reader:301:9)
 [open-design packaged] exited app=daemon pid=45305 code=1 signal=none`;
 
+// A daemon that exits 1 for a reason parseDaemonLogTail cannot classify: no
+// ERR_* code, no "Cannot find module". This is the production code=1 bucket
+// (13 win + 7 mac in 0.14.0) whose log we read but discarded. Includes a home
+// dir to assert the tail is scrubbed.
+const UNCLASSIFIED_DAEMON_LOG = `2026-07-09T10:00:00.000Z [daemon] booting namespace release-stable
+2026-07-09T10:00:01.000Z [daemon] loading config from /Users/liudetao/Library/Application Support/Open Design/namespaces/release-stable/config.json
+TypeError: Cannot read properties of undefined (reading 'port')
+    at resolveListenPort (/Applications/Open Design.app/Contents/Resources/app/prebundled/daemon/chunks/server-PULTSXNL.mjs:1201:14)
+[open-design packaged] exited app=daemon pid=51001 code=1 signal=none`;
+
 // Verbatim shape of what waitForStatus throws (sidecars.ts:206-208).
 const DAEMON_EXIT_MESSAGE =
   'daemon exited before reporting status (code=1, signal=none); see /Users/liudetao/Library/Application Support/Open Design/namespaces/release-stable/logs/daemon/latest.log for details';
@@ -290,6 +300,66 @@ describe('reportStartupFailure', () => {
     expect(props.app_version).toBe('0.11.0');
     expect(props.exit_code).toBe(1);
     expect(props.log_path).not.toContain('liudetao');
+    // The raw tail is forwarded alongside the extracted fields, scrubbed.
+    expect(props.daemon_log_tail).toContain('ERR_MODULE_NOT_FOUND');
+  });
+
+  it('forwards the scrubbed raw daemon log tail when the cause is not an ERR_ code or missing module', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await reportStartupFailure(
+      {
+        error: new Error(DAEMON_EXIT_MESSAGE),
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'install-123',
+        appVersion: '0.14.0',
+        namespace: 'release-stable',
+        source: 'packaged',
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        readLogTail: async () => UNCLASSIFIED_DAEMON_LOG,
+        now: () => '2026-06-23T00:00:00.000Z',
+      },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
+      .properties;
+    // The two structured extractors classify nothing for this exit...
+    expect(props.error_code).toBeNull();
+    expect(props.missing_module).toBeNull();
+    // ...but the raw tail still carries the real cause, with the home dir scrubbed.
+    expect(props.daemon_log_tail).toContain(
+      "TypeError: Cannot read properties of undefined (reading 'port')",
+    );
+    expect(props.daemon_log_tail).not.toContain('liudetao');
+    expect(props.daemon_log_tail).toContain('<redacted>');
+  });
+
+  it('keeps the END of an oversized daemon log so the fatal error is not truncated away', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    const bigLog = `${'x'.repeat(5000)}\nFATAL: daemon boot aborted at the very end`;
+    await reportStartupFailure(
+      {
+        error: new Error(DAEMON_EXIT_MESSAGE),
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.14.0',
+        namespace: 'release-stable',
+        source: 'packaged',
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, readLogTail: async () => bigLog },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
+      .properties;
+    const tail = props.daemon_log_tail as string;
+    expect(tail).toContain('FATAL: daemon boot aborted at the very end');
+    expect(tail).toContain('chars]');
+    expect(tail.length).toBeLessThan(bigLog.length);
   });
 
   it('never throws even when the log read blows up', async () => {

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -241,6 +241,25 @@ describe('extractSidecarErrorLines', () => {
     expect(out).not.toContain('booting namespace');
   });
 
+  it('keeps plain-English failure messages (failed to / could not / cannot / unable)', () => {
+    const log = [
+      '[daemon] booting',
+      'DATABASE_URL=postgres://od:s3cr3tpw@db/x',
+      '[od] daemon failed to resolve listening port 8080',
+      'better-sqlite3 was found but could not be loaded',
+      'cannot open config',
+      'unable to bind socket',
+    ].join('\n');
+    const out = extractSidecarErrorLines(log);
+    expect(out).toContain('failed to resolve listening port');
+    expect(out).toContain('could not be loaded');
+    expect(out).toContain('cannot open config');
+    expect(out).toContain('unable to bind socket');
+    // Broadening to failure verbs must not re-admit the secret-bearing config line.
+    expect(out).not.toContain('s3cr3tpw');
+    expect(out).not.toContain('DATABASE_URL');
+  });
+
   it('returns an empty string when nothing looks like an error', () => {
     expect(extractSidecarErrorLines('booting\nlistening on 8080\nready')).toBe('');
   });

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -712,6 +712,12 @@ export interface PackagedRuntimeFailedProps {
   native_module_path?: string | null;
   // Scrubbed of the user's home dir before send.
   log_path: string | null;
+  // A scrubbed, tail-truncated slice of the daemon's own startup log. error_code
+  // / missing_module only classify ERR_* and missing-module lines, so this is
+  // the only signal for the many code=1 daemon exits whose cause is a plain
+  // Error / config parse / port bind / assertion the log was read for but could
+  // not be classified into a field. Null when there was no daemon log to read.
+  daemon_log_tail?: string | null;
   app_version: string | null;
   namespace: string;
   source: string;

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -712,12 +712,14 @@ export interface PackagedRuntimeFailedProps {
   native_module_path?: string | null;
   // Scrubbed of the user's home dir before send.
   log_path: string | null;
-  // A scrubbed, tail-truncated slice of the FAILED sidecar's own startup log —
-  // daemon or web, whichever `failure_kind` names (partition on `failure_kind`
-  // when querying). error_code / missing_module only classify ERR_* and
-  // missing-module lines, so this is the only signal for the many code=1 exits
-  // whose cause is a plain Error / config parse / port bind / assertion the log
-  // was read for but could not be classified. Null when there was no log to read.
+  // The error/stack-shaped lines of the FAILED sidecar's startup log — daemon or
+  // web, whichever `failure_kind` names (partition on `failure_kind`). Only lines
+  // that look like an error / stack frame / exit marker are kept (config and
+  // KEY=value lines are excluded as a PII control), then scrubbed and
+  // tail-truncated. error_code / missing_module only classify ERR_* and
+  // missing-module cases, so this is the only signal for the many code=1 exits
+  // whose cause is a plain Error / port bind / assertion. Null when the log had
+  // no error-shaped line (or no log to read).
   sidecar_log_tail?: string | null;
   app_version: string | null;
   namespace: string;

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -712,12 +712,13 @@ export interface PackagedRuntimeFailedProps {
   native_module_path?: string | null;
   // Scrubbed of the user's home dir before send.
   log_path: string | null;
-  // A scrubbed, tail-truncated slice of the daemon's own startup log. error_code
-  // / missing_module only classify ERR_* and missing-module lines, so this is
-  // the only signal for the many code=1 daemon exits whose cause is a plain
-  // Error / config parse / port bind / assertion the log was read for but could
-  // not be classified into a field. Null when there was no daemon log to read.
-  daemon_log_tail?: string | null;
+  // A scrubbed, tail-truncated slice of the FAILED sidecar's own startup log —
+  // daemon or web, whichever `failure_kind` names (partition on `failure_kind`
+  // when querying). error_code / missing_module only classify ERR_* and
+  // missing-module lines, so this is the only signal for the many code=1 exits
+  // whose cause is a plain Error / config parse / port bind / assertion the log
+  // was read for but could not be classified. Null when there was no log to read.
+  sidecar_log_tail?: string | null;
   app_version: string | null;
   namespace: string;
   source: string;


### PR DESCRIPTION
## Why

Follow-up to #5224 (which added crash-scene evidence to `packaged_runtime_failed`). Slicing the first 0.14.0 field data revealed a precise blind spot. For the "daemon exited before reporting status (code=N)" family, the event already reads the dead daemon's log tail and `has_logpath` is true — so the log **is** being read on-device. But `parseDaemonLogTail` only extracts two shapes: an `ERR_*` code and a `Cannot find module` line. That's enough for the mac `better-sqlite3` case (17 events resolve to `ERR_MODULE_NOT_FOUND` / `better-sqlite3`), but it classifies **nothing** for the **20 `code=1` daemon exits (13 win + 7 mac)** whose cause is a plain `Error` / config parse failure / port bind / assertion:

```
os      code  has_logpath  error_code  missing_module  n
win32   1     yes          (null)      (null)          13   ← log read, cause discarded
darwin  1     yes          (null)      (null)          7    ← same
```

We read the log that explains each of these and then throw it away. These ~20 code=1 exits are a real opaque bucket where we read the log but classified nothing — the thing standing between "code=1" and a root-cause fix. (The *larger* Windows `unknown` bucket is a different failure: the daemon never created its status pipe, so there is no daemon log to read — `sidecar_log_tail` can't help it, and that needs its own probe. See follow-ups.)

## What users will see

No user-visible change. This is diagnostic-only enrichment on the already-existing fatal-exit telemetry path — it runs solely inside `main().catch(...)` when startup has already failed, never on the happy path.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — n/a. Internal telemetry on the packaged fatal-exit path, not a user-invokable capability (same as #5224); no CLI/UI surface.
- [x] **API / contract** — new optional `sidecar_log_tail` field on `PackagedRuntimeFailedProps` in `packages/contracts`. Optional, so `EVENT_SCHEMA_VERSION` is not bumped.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Bug fix verification

This is an observability gap, encoded as a falsifiable red spec at the daemon-report boundary:

- Test path: `apps/packaged/tests/startup-telemetry.test.ts`
- New tests: **"forwards the scrubbed raw daemon log tail when the cause is not an ERR_ code or missing module"** and **"keeps the END of an oversized daemon log so the fatal error is not truncated away"**, plus a `sidecar_log_tail` assertion on the existing #4638 test.
- Went **red on unmodified `startup-telemetry.ts`** (the property doesn't exist → `expect(props.sidecar_log_tail).toContain(...)` fails; verified by stashing only the src change and running the two tests) and **green on this branch**.

## Validation

- `pnpm guard` — 78/78 pass
- `pnpm --filter @open-design/packaged --filter @open-design/contracts typecheck` — clean
- `pnpm --filter @open-design/packaged test` — **166 passed (14 files)**

### What it does

When the classifier finds a daemon log path (the "daemon exited (code=N); see &lt;path&gt;" family), we now also forward a **scrubbed, tail-truncated slice of the raw log** as `sidecar_log_tail`:

- **Scrubbed** through the same `scrubUserPaths` as `error_message` / `error_stack` (home dir → `<redacted>`, both separator styles).
- **Tail-preserving truncation** (`truncateTailForTelemetry`, cap 2500 chars) keeps the **END** of the log — where the fatal error and its stack live — instead of the head; `defaultReadLogTail` already reads only the last 16 KB of the file.
- Coexists with the existing `error_code` / `missing_module` extractors (the #4638 mac case still classifies `ERR_MODULE_NOT_FOUND`; the tail just rides along).

The next triage can then slice `packaged_runtime_failed` where `error_code IS NULL AND exit_code = 1` and read `sidecar_log_tail` to see what those 20 daemon exits actually threw — after which a targeted fix (mac vs. Windows) becomes possible.

### Follow-ups (not in this PR)

- Windows `connect ENOENT` on the status pipe (the larger `unknown` bucket) is a *different* failure — the daemon never created the pipe, so there is no daemon log to read. Whether that's a slow first-launch (AV scanning fresh binaries) vs. a daemon that never started is exactly what a robustness change should be gated on; deferring it until this field confirms which.
- A user-facing graceful-recovery screen for the daemon-won't-start family is tracked separately.

