### PR TITLE
feat(desktop): observe abnormal exits (runtime 闪退) + child-process crashes

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -39,7 +39,7 @@ import {
 import { readProcessStamp } from "@open-design/platform";
 
 import { createDesktopRuntime, type DesktopRuntime } from "./runtime.js";
-import { beginDesktopSession, endDesktopSessionCleanly, markDesktopSessionRunning } from "./session-lifecycle.js";
+import { beginDesktopSession, clearReportedCrash, endDesktopSessionCleanly, markDesktopSessionRunning } from "./session-lifecycle.js";
 import { attachDesktopProcessErrorFilter } from "./uncaught-exception.js";
 import { createDesktopUpdater, createDesktopUpdaterScheduler, type DesktopUpdaterScheduler } from "./updater.js";
 import {
@@ -231,16 +231,18 @@ async function reportDesktopObservabilityEvent(
   discoverBaseUrl: () => Promise<string>,
   event: string,
   properties: Record<string, unknown>,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const baseUrl = await discoverBaseUrl();
-    await fetch(new URL("/api/observability/event", baseUrl).toString(), {
+    const res = await fetch(new URL("/api/observability/event", baseUrl).toString(), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ event, properties }),
     });
+    return res.ok;
   } catch {
     // best-effort observability, never a failure path
+    return false;
   }
 }
 
@@ -888,6 +890,10 @@ export async function runDesktopMain(
       previous_session_id: previousUncleanSession.sessionId,
       previous_started_at: previousUncleanSession.startedAt,
       current_version: app.getVersion(),
+    }).then((reported) => {
+      // Only drop the carried-forward crash once the daemon acked it; a failed
+      // report is retried on the next launch (it stays in unreportedCrash).
+      if (reported) clearReportedCrash({ stateFilePath: sessionStatePath });
     });
   }
   // GPU / utility child-process crashes: the window keeps running but degraded

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -766,10 +766,6 @@ export async function runDesktopMain(
   async function shutdown(): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
-    // Mark this run's session marker clean so the next launch doesn't report it
-    // as an abnormal exit. Synchronous + best-effort so it lands even if the
-    // rest of shutdown is interrupted.
-    endDesktopSessionCleanly({ stateFilePath: sessionStatePath });
     await options.beforeShutdown?.().catch((error: unknown) => {
       console.error("desktop beforeShutdown failed", error);
     });
@@ -778,6 +774,11 @@ export async function runDesktopMain(
     removeDiagnosticsIpc();
     await ipcServer?.close().catch(() => undefined);
     await desktop?.close().catch(() => undefined);
+    // Mark the session clean only AFTER teardown actually completed, right
+    // before app.quit(). Doing it at the start of shutdown would flag a quit as
+    // clean even if a later await hangs and the process is then force-quit or
+    // OS-killed — which is itself an abnormal exit worth reporting.
+    endDesktopSessionCleanly({ stateFilePath: sessionStatePath });
     app.quit();
   }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -39,6 +39,7 @@ import {
 import { readProcessStamp } from "@open-design/platform";
 
 import { createDesktopRuntime, type DesktopRuntime } from "./runtime.js";
+import { beginDesktopSession, endDesktopSessionCleanly } from "./session-lifecycle.js";
 import { attachDesktopProcessErrorFilter } from "./uncaught-exception.js";
 import { createDesktopUpdater, createDesktopUpdaterScheduler, type DesktopUpdaterScheduler } from "./updater.js";
 import {
@@ -220,6 +221,27 @@ function resolveDaemonBaseUrl(
     }
     return baseUrl;
   };
+}
+
+// Best-effort POST of a desktop observability event (abnormal exit, child-process
+// crash) to the daemon's safety-event bridge — the same path desktop_renderer_crash
+// uses; the daemon relays it to PostHog with device_id = installationId. Never
+// throws: failing to report must not affect startup or shutdown.
+async function reportDesktopObservabilityEvent(
+  discoverBaseUrl: () => Promise<string>,
+  event: string,
+  properties: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const baseUrl = await discoverBaseUrl();
+    await fetch(new URL("/api/observability/event", baseUrl).toString(), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event, properties }),
+    });
+  } catch {
+    // best-effort observability, never a failure path
+  }
 }
 
 export function normalizeAmrEnvironmentProfile(profile: unknown): AmrEnvironmentProfile {
@@ -678,6 +700,21 @@ export async function runDesktopMain(
   });
   const rendererLogPath = join(dirname(desktopLogPath), "renderer.log");
 
+  // Abnormal-exit detection: read the previous run's marker (unclean if the app
+  // died without a graceful quit — a main-process crash, OS kill, force-quit
+  // after a hang, or power loss), then stamp a fresh dirty marker for this run.
+  // The renderer-crash and startup-crash events don't cover this "runtime 闪退"
+  // class, and a dead process can't report itself, so this is the only way to
+  // observe it. Reported below once the daemon is reachable; marked clean on a
+  // graceful shutdown.
+  const sessionStatePath = join(dirname(desktopLogPath), "session-state.json");
+  const { previousUncleanSession } = beginDesktopSession({
+    stateFilePath: sessionStatePath,
+    sessionId: randomUUID(),
+    version: app.getVersion(),
+    now: () => new Date(),
+  });
+
   let desktop: DesktopRuntime | null = null;
   let disposeMenu: () => void = () => undefined;
   let updateScheduler: DesktopUpdaterScheduler | null = null;
@@ -729,6 +766,10 @@ export async function runDesktopMain(
   async function shutdown(): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
+    // Mark this run's session marker clean so the next launch doesn't report it
+    // as an abnormal exit. Synchronous + best-effort so it lands even if the
+    // rest of shutdown is interrupted.
+    endDesktopSessionCleanly({ stateFilePath: sessionStatePath });
     await options.beforeShutdown?.().catch((error: unknown) => {
       console.error("desktop beforeShutdown failed", error);
     });
@@ -826,6 +867,38 @@ export async function runDesktopMain(
   });
   console.info("[open-design desktop] desktop runtime created");
   options.onDesktopReady?.({ show: () => desktop?.show() });
+
+  const discoverDaemonBaseUrl = resolveDaemonBaseUrl(runtime, options);
+  // Report an abnormal exit of the PREVIOUS run now that the daemon is up to
+  // relay it (best-effort; the event carries no user content).
+  if (previousUncleanSession != null) {
+    console.warn("[open-design desktop] previous session ended abnormally (no clean shutdown)", {
+      previousVersion: previousUncleanSession.version,
+      previousStartedAt: previousUncleanSession.startedAt,
+    });
+    void reportDesktopObservabilityEvent(discoverDaemonBaseUrl, "desktop_unclean_exit", {
+      previous_version: previousUncleanSession.version,
+      previous_session_id: previousUncleanSession.sessionId,
+      previous_started_at: previousUncleanSession.startedAt,
+      current_version: app.getVersion(),
+    });
+  }
+  // GPU / utility child-process crashes: the window keeps running but degraded
+  // (a GPU-process crash is a common cause of a window that then goes blank or
+  // vanishes), and the child can't report itself. `clean-exit` is normal teardown.
+  app.on("child-process-gone", (_event, details) => {
+    if (details.reason === "clean-exit") return;
+    console.error("[open-design desktop] child-process-gone", {
+      type: details.type,
+      reason: details.reason,
+      exitCode: details.exitCode,
+    });
+    void reportDesktopObservabilityEvent(discoverDaemonBaseUrl, "desktop_child_process_crash", {
+      process_type: details.type,
+      reason: details.reason,
+      exit_code: typeof details.exitCode === "number" ? details.exitCode : null,
+    });
+  });
   disposeMenu = installDesktopMenu(runtime, options);
   removeDiagnosticsIpc = registerDesktopDiagnosticsIpc({
     discoverDaemonBaseUrl: resolveDaemonBaseUrl(runtime, options),

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -860,6 +860,12 @@ export async function runDesktopMain(
     // protection still works) and POSTs once more.
     registerDesktopAuthWithDaemon: () => registerDesktopAuthWithDaemon(runtime, desktopAuthSecret),
     rendererLogPath,
+    // Mark "reached running" only when the window is ACTUALLY revealed (web app
+    // mounted + shown), not when createDesktopRuntime returns — it starts async
+    // bootstrap via `void tick()` and returns before the first load. Until this
+    // fires, a crash is still a startup failure (covered by
+    // packaged_runtime_failed), not a runtime abnormal exit.
+    onRevealed: () => markDesktopSessionRunning({ stateFilePath: sessionStatePath }),
     requestQuit: shutdownAndExit,
     splashWindow: options.splashWindow,
     splashStartedAt: options.splashStartedAt,
@@ -868,12 +874,6 @@ export async function runDesktopMain(
   });
   console.info("[open-design desktop] desktop runtime created");
   options.onDesktopReady?.({ show: () => desktop?.show() });
-
-  // The app is up now — only from here does a subsequent dirty marker mean a
-  // RUNTIME crash. A bootstrap failure before this point never reached running,
-  // so it isn't misreported as an abnormal exit (it's a startup failure, which
-  // packaged_runtime_failed already covers).
-  markDesktopSessionRunning({ stateFilePath: sessionStatePath });
 
   const discoverDaemonBaseUrl = resolveDaemonBaseUrl(runtime, options);
   // Report an abnormal exit of the PREVIOUS run now that the daemon is up to

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -710,7 +710,7 @@ export async function runDesktopMain(
   // observe it. Reported below once the daemon is reachable; marked clean on a
   // graceful shutdown.
   const sessionStatePath = join(dirname(desktopLogPath), "session-state.json");
-  const { previousUncleanSession } = beginDesktopSession({
+  const { previousUncleanSessions } = beginDesktopSession({
     stateFilePath: sessionStatePath,
     sessionId: randomUUID(),
     version: app.getVersion(),
@@ -878,23 +878,23 @@ export async function runDesktopMain(
   options.onDesktopReady?.({ show: () => desktop?.show() });
 
   const discoverDaemonBaseUrl = resolveDaemonBaseUrl(runtime, options);
-  // Report an abnormal exit of the PREVIOUS run now that the daemon is up to
-  // relay it (best-effort; the event carries no user content).
-  if (previousUncleanSession != null) {
-    console.warn("[open-design desktop] previous session ended abnormally (no clean shutdown)", {
-      previousVersion: previousUncleanSession.version,
-      previousStartedAt: previousUncleanSession.startedAt,
+  // Report each abnormal exit of a prior run now that the daemon is up to relay
+  // it (best-effort; the events carry no user content). Each is dropped from the
+  // queue only once the daemon acks it, so a failed report is retried next launch.
+  if (previousUncleanSessions.length > 0) {
+    console.warn("[open-design desktop] prior session(s) ended abnormally (no clean shutdown)", {
+      count: previousUncleanSessions.length,
     });
-    void reportDesktopObservabilityEvent(discoverDaemonBaseUrl, "desktop_unclean_exit", {
-      previous_version: previousUncleanSession.version,
-      previous_session_id: previousUncleanSession.sessionId,
-      previous_started_at: previousUncleanSession.startedAt,
-      current_version: app.getVersion(),
-    }).then((reported) => {
-      // Only drop the carried-forward crash once the daemon acked it; a failed
-      // report is retried on the next launch (it stays in unreportedCrash).
-      if (reported) clearReportedCrash({ stateFilePath: sessionStatePath });
-    });
+    for (const crash of previousUncleanSessions) {
+      void reportDesktopObservabilityEvent(discoverDaemonBaseUrl, "desktop_unclean_exit", {
+        previous_version: crash.version,
+        previous_session_id: crash.sessionId,
+        previous_started_at: crash.startedAt,
+        current_version: app.getVersion(),
+      }).then((reported) => {
+        if (reported) clearReportedCrash({ stateFilePath: sessionStatePath }, crash.sessionId);
+      });
+    }
   }
   // GPU / utility child-process crashes: the window keeps running but degraded
   // (a GPU-process crash is a common cause of a window that then goes blank or

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -39,7 +39,7 @@ import {
 import { readProcessStamp } from "@open-design/platform";
 
 import { createDesktopRuntime, type DesktopRuntime } from "./runtime.js";
-import { beginDesktopSession, endDesktopSessionCleanly } from "./session-lifecycle.js";
+import { beginDesktopSession, endDesktopSessionCleanly, markDesktopSessionRunning } from "./session-lifecycle.js";
 import { attachDesktopProcessErrorFilter } from "./uncaught-exception.js";
 import { createDesktopUpdater, createDesktopUpdaterScheduler, type DesktopUpdaterScheduler } from "./updater.js";
 import {
@@ -867,6 +867,12 @@ export async function runDesktopMain(
   });
   console.info("[open-design desktop] desktop runtime created");
   options.onDesktopReady?.({ show: () => desktop?.show() });
+
+  // The app is up now — only from here does a subsequent dirty marker mean a
+  // RUNTIME crash. A bootstrap failure before this point never reached running,
+  // so it isn't misreported as an abnormal exit (it's a startup failure, which
+  // packaged_runtime_failed already covers).
+  markDesktopSessionRunning({ stateFilePath: sessionStatePath });
 
   const discoverDaemonBaseUrl = resolveDaemonBaseUrl(runtime, options);
   // Report an abnormal exit of the PREVIOUS run now that the daemon is up to

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -415,6 +415,14 @@ export type DesktopRuntimeOptions = {
    */
   splashStartedAt?: number;
   updater?: DesktopUpdater;
+  /**
+   * Fired once the main window is actually revealed (the web app mounted and
+   * the window is shown) — the real "app is running" moment, distinct from
+   * `createDesktopRuntime` returning (which starts async bootstrap via
+   * `void tick()` and returns before the first load). Used to mark the session
+   * as having reached running for abnormal-exit detection.
+   */
+  onRevealed?: () => void;
 };
 
 const DESKTOP_IMPORT_TOKEN_HEADER = "X-OD-Desktop-Import-Token";
@@ -2199,6 +2207,13 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     window.focus();
     ensureWindowVisible(window);
     if (splash != null && !splash.isDestroyed()) splash.close();
+    // The app is now truly up (mounted + shown). Fire once — revealed guards
+    // re-entry — so callers can mark "reached running".
+    try {
+      options.onRevealed?.();
+    } catch {
+      // A callback fault must not break reveal.
+    }
   };
 
   // Hold the splash until BOTH (a) the web bundle reports it has mounted — it

--- a/apps/desktop/src/main/session-lifecycle.ts
+++ b/apps/desktop/src/main/session-lifecycle.ts
@@ -2,19 +2,29 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 /**
+ * A prior run's abnormal exit, carried across launches until its telemetry has
+ * actually been acked. Persisting it (rather than holding it only in memory)
+ * means a failed report — e.g. the daemon isn't reachable yet — retries on the
+ * next launch instead of losing the signal this whole mechanism exists to catch.
+ */
+export interface DesktopCrashSummary {
+  sessionId: string;
+  version: string | null;
+  startedAt: string;
+}
+
+/**
  * Persisted marker for one desktop run.
  *
- *  - `reachedRunning` flips true once the app is actually up (window + runtime),
- *    so a bootstrap failure BEFORE that (already covered by
- *    `packaged_runtime_failed`) is never mistaken for a runtime crash.
+ *  - `reachedRunning` flips true once the window is actually revealed, so a
+ *    bootstrap failure BEFORE that (already covered by `packaged_runtime_failed`)
+ *    isn't mistaken for a runtime crash.
  *  - `clean` flips true on a graceful quit.
+ *  - `unreportedCrash` holds a prior abnormal exit until its report is acked.
  *
- * A previous run counts as an abnormal "runtime 闪退" only when it
- * `reachedRunning` but never went `clean` — the app was up, then the whole
- * process died without a graceful shutdown (main-process crash, OS kill,
- * force-quit after a hang, power loss). That class reaches no other telemetry:
- * a dead process can't report itself, and renderer/startup crashes are separate
- * events.
+ * A run counts as an abnormal "runtime 闪退" when it `reachedRunning` but never
+ * went `clean` — the app was up, then the process died without a graceful
+ * shutdown. That class reaches no other telemetry.
  */
 export interface DesktopSessionState {
   sessionId: string;
@@ -22,6 +32,7 @@ export interface DesktopSessionState {
   startedAt: string;
   reachedRunning: boolean;
   clean: boolean;
+  unreportedCrash?: DesktopCrashSummary | null;
 }
 
 function defaultRead(path: string): string {
@@ -36,12 +47,17 @@ function defaultWrite(path: string, data: string): void {
 function parseState(raw: string): DesktopSessionState | null {
   const parsed = JSON.parse(raw) as Partial<DesktopSessionState>;
   if (parsed == null || typeof parsed.sessionId !== "string") return null;
+  const uc = parsed.unreportedCrash;
   return {
     sessionId: parsed.sessionId,
     version: typeof parsed.version === "string" ? parsed.version : null,
     startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : "",
     reachedRunning: parsed.reachedRunning === true,
     clean: parsed.clean === true,
+    unreportedCrash:
+      uc != null && typeof uc.sessionId === "string"
+        ? { sessionId: uc.sessionId, version: typeof uc.version === "string" ? uc.version : null, startedAt: typeof uc.startedAt === "string" ? uc.startedAt : "" }
+        : null,
   };
 }
 
@@ -56,28 +72,32 @@ export interface BeginDesktopSessionDeps {
 }
 
 /**
- * Read the previous run's marker, then write a fresh marker for this run
- * (`reachedRunning: false`, `clean: false`). Returns the previous state ONLY
- * when it ended as an abnormal RUNTIME exit — it had reached running and never
- * went clean. Overwriting the marker here means the previous state is reported
- * at most once. Best-effort: any fs/parse failure yields no signal and never
- * throws — this must not be able to block startup.
+ * Read the previous run's marker, carry forward any not-yet-reported abnormal
+ * exit, then write a fresh marker for this run. Returns the crash to report
+ * (this launch's newly-detected one, or an earlier one whose report never
+ * acked). The returned summary is ALSO persisted in the new marker's
+ * `unreportedCrash`, so it survives a failed report and is retried next launch;
+ * `clearReportedCrash` removes it once the report succeeds. Best-effort — never
+ * throws.
  */
 export function beginDesktopSession(
   deps: BeginDesktopSessionDeps,
-): { previousUncleanSession: DesktopSessionState | null } {
+): { previousUncleanSession: DesktopCrashSummary | null } {
   const read = deps.readFile ?? defaultRead;
   const write = deps.writeFile ?? defaultWrite;
 
-  let previousUncleanSession: DesktopSessionState | null = null;
+  let crashToReport: DesktopCrashSummary | null = null;
   try {
-    const previous = parseState(read(deps.stateFilePath));
-    if (previous != null && previous.reachedRunning && !previous.clean) {
-      previousUncleanSession = previous;
+    const prev = parseState(read(deps.stateFilePath));
+    if (prev != null) {
+      if (prev.reachedRunning && !prev.clean) {
+        crashToReport = { sessionId: prev.sessionId, version: prev.version, startedAt: prev.startedAt };
+      } else if (prev.unreportedCrash != null) {
+        crashToReport = prev.unreportedCrash;
+      }
     }
   } catch {
-    // No marker (first run), unreadable, or a run that never reached running —
-    // not a runtime-crash signal.
+    // No marker (first run), unreadable, or a run that never reached running.
   }
 
   const state: DesktopSessionState = {
@@ -86,14 +106,14 @@ export function beginDesktopSession(
     startedAt: deps.now().toISOString(),
     reachedRunning: false,
     clean: false,
+    unreportedCrash: crashToReport,
   };
   try {
     write(deps.stateFilePath, JSON.stringify(state));
   } catch {
-    // Best-effort: without a marker we simply won't detect a crash of THIS run
-    // next time — never a reason to fail startup.
+    // Best-effort.
   }
-  return { previousUncleanSession };
+  return { previousUncleanSession: crashToReport };
 }
 
 function updateState(
@@ -112,7 +132,7 @@ function updateState(
 }
 
 /**
- * Flip this run's marker to `reachedRunning: true` once the app is actually up.
+ * Flip this run's marker to `reachedRunning: true` once the window is revealed.
  * Only after this does a subsequent dirty marker count as a runtime crash.
  */
 export function markDesktopSessionRunning(deps: {
@@ -133,4 +153,16 @@ export function endDesktopSessionCleanly(deps: {
   writeFile?: (path: string, data: string) => void;
 }): void {
   updateState(deps.stateFilePath, { clean: true }, deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
+}
+
+/**
+ * Clear the carried-forward `unreportedCrash` once its telemetry has been acked,
+ * so it isn't reported again next launch.
+ */
+export function clearReportedCrash(deps: {
+  stateFilePath: string;
+  readFile?: (path: string) => string;
+  writeFile?: (path: string, data: string) => void;
+}): void {
+  updateState(deps.stateFilePath, { unreportedCrash: null }, deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
 }

--- a/apps/desktop/src/main/session-lifecycle.ts
+++ b/apps/desktop/src/main/session-lifecycle.ts
@@ -2,16 +2,20 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 /**
- * A prior run's abnormal exit, carried across launches until its telemetry has
- * actually been acked. Persisting it (rather than holding it only in memory)
- * means a failed report — e.g. the daemon isn't reachable yet — retries on the
- * next launch instead of losing the signal this whole mechanism exists to catch.
+ * A run's abnormal exit, carried across launches until its telemetry has been
+ * acked. Persisting these (rather than holding them only in memory) means a
+ * failed report — e.g. the daemon isn't reachable yet — retries on the next
+ * launch instead of losing the signal this mechanism exists to catch.
  */
 export interface DesktopCrashSummary {
   sessionId: string;
   version: string | null;
   startedAt: string;
 }
+
+// Bound how many un-acked crashes we carry, so a device that crashes AND fails
+// to report repeatedly can't grow the marker without limit. Oldest are dropped.
+const MAX_UNREPORTED_CRASHES = 20;
 
 /**
  * Persisted marker for one desktop run.
@@ -20,7 +24,7 @@ export interface DesktopCrashSummary {
  *    bootstrap failure BEFORE that (already covered by `packaged_runtime_failed`)
  *    isn't mistaken for a runtime crash.
  *  - `clean` flips true on a graceful quit.
- *  - `unreportedCrash` holds a prior abnormal exit until its report is acked.
+ *  - `unreportedCrashes` is the queue of prior abnormal exits awaiting an ack.
  *
  * A run counts as an abnormal "runtime 闪退" when it `reachedRunning` but never
  * went `clean` — the app was up, then the process died without a graceful
@@ -32,7 +36,7 @@ export interface DesktopSessionState {
   startedAt: string;
   reachedRunning: boolean;
   clean: boolean;
-  unreportedCrash?: DesktopCrashSummary | null;
+  unreportedCrashes: DesktopCrashSummary[];
 }
 
 function defaultRead(path: string): string {
@@ -44,20 +48,30 @@ function defaultWrite(path: string, data: string): void {
   writeFileSync(path, data, "utf8");
 }
 
+function parseCrash(value: unknown): DesktopCrashSummary | null {
+  if (value == null || typeof value !== "object") return null;
+  const c = value as Partial<DesktopCrashSummary>;
+  if (typeof c.sessionId !== "string") return null;
+  return {
+    sessionId: c.sessionId,
+    version: typeof c.version === "string" ? c.version : null,
+    startedAt: typeof c.startedAt === "string" ? c.startedAt : "",
+  };
+}
+
 function parseState(raw: string): DesktopSessionState | null {
   const parsed = JSON.parse(raw) as Partial<DesktopSessionState>;
   if (parsed == null || typeof parsed.sessionId !== "string") return null;
-  const uc = parsed.unreportedCrash;
+  const queue = Array.isArray(parsed.unreportedCrashes)
+    ? parsed.unreportedCrashes.map(parseCrash).filter((c): c is DesktopCrashSummary => c != null)
+    : [];
   return {
     sessionId: parsed.sessionId,
     version: typeof parsed.version === "string" ? parsed.version : null,
     startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : "",
     reachedRunning: parsed.reachedRunning === true,
     clean: parsed.clean === true,
-    unreportedCrash:
-      uc != null && typeof uc.sessionId === "string"
-        ? { sessionId: uc.sessionId, version: typeof uc.version === "string" ? uc.version : null, startedAt: typeof uc.startedAt === "string" ? uc.startedAt : "" }
-        : null,
+    unreportedCrashes: queue,
   };
 }
 
@@ -72,33 +86,34 @@ export interface BeginDesktopSessionDeps {
 }
 
 /**
- * Read the previous run's marker, carry forward any not-yet-reported abnormal
- * exit, then write a fresh marker for this run. Returns the crash to report
- * (this launch's newly-detected one, or an earlier one whose report never
- * acked). The returned summary is ALSO persisted in the new marker's
- * `unreportedCrash`, so it survives a failed report and is retried next launch;
- * `clearReportedCrash` removes it once the report succeeds. Best-effort — never
- * throws.
+ * Read the previous run's marker, carry forward every not-yet-reported abnormal
+ * exit (plus the previous run itself if it crashed), then write a fresh marker
+ * for this run. Returns the full queue of crashes to report. Each is persisted
+ * in the new marker's `unreportedCrashes` so it survives a failed report and is
+ * retried next launch; `clearReportedCrash(id)` removes one once acked. The
+ * queue is capped (oldest dropped) so it can't grow without bound. Best-effort —
+ * never throws.
  */
 export function beginDesktopSession(
   deps: BeginDesktopSessionDeps,
-): { previousUncleanSession: DesktopCrashSummary | null } {
+): { previousUncleanSessions: DesktopCrashSummary[] } {
   const read = deps.readFile ?? defaultRead;
   const write = deps.writeFile ?? defaultWrite;
 
-  let crashToReport: DesktopCrashSummary | null = null;
+  let pending: DesktopCrashSummary[] = [];
   try {
     const prev = parseState(read(deps.stateFilePath));
     if (prev != null) {
+      pending = [...prev.unreportedCrashes];
       if (prev.reachedRunning && !prev.clean) {
-        crashToReport = { sessionId: prev.sessionId, version: prev.version, startedAt: prev.startedAt };
-      } else if (prev.unreportedCrash != null) {
-        crashToReport = prev.unreportedCrash;
+        pending.push({ sessionId: prev.sessionId, version: prev.version, startedAt: prev.startedAt });
       }
     }
   } catch {
     // No marker (first run), unreadable, or a run that never reached running.
   }
+  // Keep the newest if we somehow exceed the cap.
+  if (pending.length > MAX_UNREPORTED_CRASHES) pending = pending.slice(pending.length - MAX_UNREPORTED_CRASHES);
 
   const state: DesktopSessionState = {
     sessionId: deps.sessionId,
@@ -106,26 +121,26 @@ export function beginDesktopSession(
     startedAt: deps.now().toISOString(),
     reachedRunning: false,
     clean: false,
-    unreportedCrash: crashToReport,
+    unreportedCrashes: pending,
   };
   try {
     write(deps.stateFilePath, JSON.stringify(state));
   } catch {
     // Best-effort.
   }
-  return { previousUncleanSession: crashToReport };
+  return { previousUncleanSessions: pending };
 }
 
 function updateState(
   stateFilePath: string,
-  patch: Partial<DesktopSessionState>,
+  patch: (state: DesktopSessionState) => DesktopSessionState,
   readFile: (path: string) => string,
   writeFile: (path: string, data: string) => void,
 ): void {
   try {
     const state = parseState(readFile(stateFilePath));
     if (state == null) return;
-    writeFile(stateFilePath, JSON.stringify({ ...state, ...patch }));
+    writeFile(stateFilePath, JSON.stringify(patch(state)));
   } catch {
     // Best-effort.
   }
@@ -140,7 +155,7 @@ export function markDesktopSessionRunning(deps: {
   readFile?: (path: string) => string;
   writeFile?: (path: string, data: string) => void;
 }): void {
-  updateState(deps.stateFilePath, { reachedRunning: true }, deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
+  updateState(deps.stateFilePath, (s) => ({ ...s, reachedRunning: true }), deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
 }
 
 /**
@@ -152,17 +167,25 @@ export function endDesktopSessionCleanly(deps: {
   readFile?: (path: string) => string;
   writeFile?: (path: string, data: string) => void;
 }): void {
-  updateState(deps.stateFilePath, { clean: true }, deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
+  updateState(deps.stateFilePath, (s) => ({ ...s, clean: true }), deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
 }
 
 /**
- * Clear the carried-forward `unreportedCrash` once its telemetry has been acked,
- * so it isn't reported again next launch.
+ * Remove one crash from the queue once its telemetry has been acked, so it isn't
+ * reported again. Keyed by sessionId so acks land independently.
  */
-export function clearReportedCrash(deps: {
-  stateFilePath: string;
-  readFile?: (path: string) => string;
-  writeFile?: (path: string, data: string) => void;
-}): void {
-  updateState(deps.stateFilePath, { unreportedCrash: null }, deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
+export function clearReportedCrash(
+  deps: {
+    stateFilePath: string;
+    readFile?: (path: string) => string;
+    writeFile?: (path: string, data: string) => void;
+  },
+  sessionId: string,
+): void {
+  updateState(
+    deps.stateFilePath,
+    (s) => ({ ...s, unreportedCrashes: s.unreportedCrashes.filter((c) => c.sessionId !== sessionId) }),
+    deps.readFile ?? defaultRead,
+    deps.writeFile ?? defaultWrite,
+  );
 }

--- a/apps/desktop/src/main/session-lifecycle.ts
+++ b/apps/desktop/src/main/session-lifecycle.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+/**
+ * Persisted marker for one desktop run. On a graceful quit we set `clean: true`;
+ * on the NEXT launch, a marker that is still `clean: false` means the previous
+ * run died without a graceful shutdown — a main-process crash, an OS kill, a
+ * force-quit after a hang, or power loss. That "runtime 闪退" class is otherwise
+ * invisible to telemetry (the renderer-crash and startup-crash events don't
+ * cover it, and a dead process can't report itself).
+ */
+export interface DesktopSessionState {
+  sessionId: string;
+  version: string | null;
+  startedAt: string;
+  clean: boolean;
+}
+
+export interface BeginDesktopSessionDeps {
+  stateFilePath: string;
+  sessionId: string;
+  version: string | null;
+  now: () => Date;
+  /** Injectable for tests; defaults to fs. */
+  readFile?: (path: string) => string;
+  writeFile?: (path: string, data: string) => void;
+}
+
+function defaultRead(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function defaultWrite(path: string, data: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, data, "utf8");
+}
+
+function parsePreviousState(raw: string): DesktopSessionState | null {
+  const parsed = JSON.parse(raw) as Partial<DesktopSessionState>;
+  if (parsed == null || typeof parsed.sessionId !== "string") return null;
+  return {
+    sessionId: parsed.sessionId,
+    version: typeof parsed.version === "string" ? parsed.version : null,
+    startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : "",
+    clean: parsed.clean === true,
+  };
+}
+
+/**
+ * Read the previous run's marker, then write a fresh `clean: false` marker for
+ * this run. Returns the previous state ONLY when it ended uncleanly (marker
+ * present and not clean). Best-effort: any fs/parse failure yields no signal and
+ * never throws — this must not be able to block startup.
+ */
+export function beginDesktopSession(
+  deps: BeginDesktopSessionDeps,
+): { previousUncleanSession: DesktopSessionState | null } {
+  const read = deps.readFile ?? defaultRead;
+  const write = deps.writeFile ?? defaultWrite;
+
+  let previousUncleanSession: DesktopSessionState | null = null;
+  try {
+    const previous = parsePreviousState(read(deps.stateFilePath));
+    if (previous != null && !previous.clean) previousUncleanSession = previous;
+  } catch {
+    // No marker (first run) or unreadable — not an unclean-exit signal.
+  }
+
+  const state: DesktopSessionState = {
+    sessionId: deps.sessionId,
+    version: deps.version,
+    startedAt: deps.now().toISOString(),
+    clean: false,
+  };
+  try {
+    write(deps.stateFilePath, JSON.stringify(state));
+  } catch {
+    // Best-effort: if we can't write the marker we simply won't detect a crash
+    // of THIS run next time — never a reason to fail startup.
+  }
+  return { previousUncleanSession };
+}
+
+/**
+ * Flip this run's marker to `clean: true` on a graceful quit, so the next launch
+ * does not misreport it as an abnormal exit. Best-effort and idempotent.
+ */
+export function endDesktopSessionCleanly(deps: {
+  stateFilePath: string;
+  readFile?: (path: string) => string;
+  writeFile?: (path: string, data: string) => void;
+}): void {
+  const read = deps.readFile ?? defaultRead;
+  const write = deps.writeFile ?? defaultWrite;
+  try {
+    const state = parsePreviousState(read(deps.stateFilePath));
+    if (state == null) return;
+    write(deps.stateFilePath, JSON.stringify({ ...state, clean: true }));
+  } catch {
+    // Best-effort — a failure here at worst produces one false unclean-exit
+    // event next launch, never a crash.
+  }
+}

--- a/apps/desktop/src/main/session-lifecycle.ts
+++ b/apps/desktop/src/main/session-lifecycle.ts
@@ -2,18 +2,47 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 /**
- * Persisted marker for one desktop run. On a graceful quit we set `clean: true`;
- * on the NEXT launch, a marker that is still `clean: false` means the previous
- * run died without a graceful shutdown — a main-process crash, an OS kill, a
- * force-quit after a hang, or power loss. That "runtime 闪退" class is otherwise
- * invisible to telemetry (the renderer-crash and startup-crash events don't
- * cover it, and a dead process can't report itself).
+ * Persisted marker for one desktop run.
+ *
+ *  - `reachedRunning` flips true once the app is actually up (window + runtime),
+ *    so a bootstrap failure BEFORE that (already covered by
+ *    `packaged_runtime_failed`) is never mistaken for a runtime crash.
+ *  - `clean` flips true on a graceful quit.
+ *
+ * A previous run counts as an abnormal "runtime 闪退" only when it
+ * `reachedRunning` but never went `clean` — the app was up, then the whole
+ * process died without a graceful shutdown (main-process crash, OS kill,
+ * force-quit after a hang, power loss). That class reaches no other telemetry:
+ * a dead process can't report itself, and renderer/startup crashes are separate
+ * events.
  */
 export interface DesktopSessionState {
   sessionId: string;
   version: string | null;
   startedAt: string;
+  reachedRunning: boolean;
   clean: boolean;
+}
+
+function defaultRead(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function defaultWrite(path: string, data: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, data, "utf8");
+}
+
+function parseState(raw: string): DesktopSessionState | null {
+  const parsed = JSON.parse(raw) as Partial<DesktopSessionState>;
+  if (parsed == null || typeof parsed.sessionId !== "string") return null;
+  return {
+    sessionId: parsed.sessionId,
+    version: typeof parsed.version === "string" ? parsed.version : null,
+    startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : "",
+    reachedRunning: parsed.reachedRunning === true,
+    clean: parsed.clean === true,
+  };
 }
 
 export interface BeginDesktopSessionDeps {
@@ -26,31 +55,13 @@ export interface BeginDesktopSessionDeps {
   writeFile?: (path: string, data: string) => void;
 }
 
-function defaultRead(path: string): string {
-  return readFileSync(path, "utf8");
-}
-
-function defaultWrite(path: string, data: string): void {
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, data, "utf8");
-}
-
-function parsePreviousState(raw: string): DesktopSessionState | null {
-  const parsed = JSON.parse(raw) as Partial<DesktopSessionState>;
-  if (parsed == null || typeof parsed.sessionId !== "string") return null;
-  return {
-    sessionId: parsed.sessionId,
-    version: typeof parsed.version === "string" ? parsed.version : null,
-    startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : "",
-    clean: parsed.clean === true,
-  };
-}
-
 /**
- * Read the previous run's marker, then write a fresh `clean: false` marker for
- * this run. Returns the previous state ONLY when it ended uncleanly (marker
- * present and not clean). Best-effort: any fs/parse failure yields no signal and
- * never throws — this must not be able to block startup.
+ * Read the previous run's marker, then write a fresh marker for this run
+ * (`reachedRunning: false`, `clean: false`). Returns the previous state ONLY
+ * when it ended as an abnormal RUNTIME exit — it had reached running and never
+ * went clean. Overwriting the marker here means the previous state is reported
+ * at most once. Best-effort: any fs/parse failure yields no signal and never
+ * throws — this must not be able to block startup.
  */
 export function beginDesktopSession(
   deps: BeginDesktopSessionDeps,
@@ -60,44 +71,66 @@ export function beginDesktopSession(
 
   let previousUncleanSession: DesktopSessionState | null = null;
   try {
-    const previous = parsePreviousState(read(deps.stateFilePath));
-    if (previous != null && !previous.clean) previousUncleanSession = previous;
+    const previous = parseState(read(deps.stateFilePath));
+    if (previous != null && previous.reachedRunning && !previous.clean) {
+      previousUncleanSession = previous;
+    }
   } catch {
-    // No marker (first run) or unreadable — not an unclean-exit signal.
+    // No marker (first run), unreadable, or a run that never reached running —
+    // not a runtime-crash signal.
   }
 
   const state: DesktopSessionState = {
     sessionId: deps.sessionId,
     version: deps.version,
     startedAt: deps.now().toISOString(),
+    reachedRunning: false,
     clean: false,
   };
   try {
     write(deps.stateFilePath, JSON.stringify(state));
   } catch {
-    // Best-effort: if we can't write the marker we simply won't detect a crash
-    // of THIS run next time — never a reason to fail startup.
+    // Best-effort: without a marker we simply won't detect a crash of THIS run
+    // next time — never a reason to fail startup.
   }
   return { previousUncleanSession };
 }
 
+function updateState(
+  stateFilePath: string,
+  patch: Partial<DesktopSessionState>,
+  readFile: (path: string) => string,
+  writeFile: (path: string, data: string) => void,
+): void {
+  try {
+    const state = parseState(readFile(stateFilePath));
+    if (state == null) return;
+    writeFile(stateFilePath, JSON.stringify({ ...state, ...patch }));
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Flip this run's marker to `reachedRunning: true` once the app is actually up.
+ * Only after this does a subsequent dirty marker count as a runtime crash.
+ */
+export function markDesktopSessionRunning(deps: {
+  stateFilePath: string;
+  readFile?: (path: string) => string;
+  writeFile?: (path: string, data: string) => void;
+}): void {
+  updateState(deps.stateFilePath, { reachedRunning: true }, deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
+}
+
 /**
  * Flip this run's marker to `clean: true` on a graceful quit, so the next launch
- * does not misreport it as an abnormal exit. Best-effort and idempotent.
+ * doesn't misreport it as an abnormal exit. Best-effort and idempotent.
  */
 export function endDesktopSessionCleanly(deps: {
   stateFilePath: string;
   readFile?: (path: string) => string;
   writeFile?: (path: string, data: string) => void;
 }): void {
-  const read = deps.readFile ?? defaultRead;
-  const write = deps.writeFile ?? defaultWrite;
-  try {
-    const state = parsePreviousState(read(deps.stateFilePath));
-    if (state == null) return;
-    write(deps.stateFilePath, JSON.stringify({ ...state, clean: true }));
-  } catch {
-    // Best-effort — a failure here at worst produces one false unclean-exit
-    // event next launch, never a crash.
-  }
+  updateState(deps.stateFilePath, { clean: true }, deps.readFile ?? defaultRead, deps.writeFile ?? defaultWrite);
 }

--- a/apps/desktop/tests/main/session-lifecycle.test.ts
+++ b/apps/desktop/tests/main/session-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   beginDesktopSession,
+  clearReportedCrash,
   endDesktopSessionCleanly,
   markDesktopSessionRunning,
   type DesktopSessionState,
@@ -21,77 +22,76 @@ function makeStore(initial?: string) {
       files.set(p, d);
     },
     state: () => JSON.parse(files.get("state.json")!) as DesktopSessionState,
-    raw: () => files.get("state.json"),
   };
 }
 
 const FIXED = new Date("2026-07-09T12:00:00.000Z");
+const io = (store: ReturnType<typeof makeStore>) => ({ readFile: store.readFile, writeFile: store.writeFile });
 
 function begin(store: ReturnType<typeof makeStore>, sessionId: string, version = "0.14.0") {
-  return beginDesktopSession({
-    stateFilePath: "state.json",
-    sessionId,
-    version,
-    now: () => FIXED,
-    readFile: store.readFile,
-    writeFile: store.writeFile,
-  });
+  return beginDesktopSession({ stateFilePath: "state.json", sessionId, version, now: () => FIXED, ...io(store) });
 }
-const running = (store: ReturnType<typeof makeStore>) =>
-  markDesktopSessionRunning({ stateFilePath: "state.json", readFile: store.readFile, writeFile: store.writeFile });
-const quit = (store: ReturnType<typeof makeStore>) =>
-  endDesktopSessionCleanly({ stateFilePath: "state.json", readFile: store.readFile, writeFile: store.writeFile });
+const running = (s: ReturnType<typeof makeStore>) => markDesktopSessionRunning({ stateFilePath: "state.json", ...io(s) });
+const quit = (s: ReturnType<typeof makeStore>) => endDesktopSessionCleanly({ stateFilePath: "state.json", ...io(s) });
+const clear = (s: ReturnType<typeof makeStore>) => clearReportedCrash({ stateFilePath: "state.json", ...io(s) });
 
 describe("desktop session lifecycle", () => {
   test("first run reports nothing and writes a not-yet-running marker", () => {
     const store = makeStore();
     expect(begin(store, "s1").previousUncleanSession).toBeNull();
-    expect(store.state()).toMatchObject({ sessionId: "s1", reachedRunning: false, clean: false });
+    expect(store.state()).toMatchObject({ sessionId: "s1", reachedRunning: false, clean: false, unreportedCrash: null });
   });
 
-  test("a previous run that reached running and never went clean is a runtime crash", () => {
-    const store = makeStore(
-      JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", reachedRunning: true, clean: false }),
-    );
-    expect(begin(store, "s2").previousUncleanSession).toMatchObject({ sessionId: "prev", reachedRunning: true });
-  });
-
-  test("a previous run that never reached running is NOT reported (startup failure, not a crash)", () => {
-    const store = makeStore(
-      JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", reachedRunning: false, clean: false }),
-    );
-    expect(begin(store, "s3").previousUncleanSession).toBeNull();
-  });
-
-  test("a previous clean exit is not reported", () => {
-    const store = makeStore(
-      JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", reachedRunning: true, clean: true }),
-    );
-    expect(begin(store, "s4").previousUncleanSession).toBeNull();
-  });
-
-  test("markDesktopSessionRunning then a graceful quit → next launch reports nothing", () => {
+  test("reached-running then crashed → next launch reports it and persists it as unreportedCrash", () => {
     const store = makeStore();
     begin(store, "a");
     running(store);
-    expect(store.state().reachedRunning).toBe(true);
+    // 'a' crashes (no clean). Next launch:
+    const { previousUncleanSession } = begin(store, "b");
+    expect(previousUncleanSession).toMatchObject({ sessionId: "a", version: "0.14.0" });
+    // ...and it's persisted so a failed report can retry.
+    expect(store.state().unreportedCrash).toMatchObject({ sessionId: "a" });
+  });
+
+  test("never reached running → not reported (startup failure, not a crash)", () => {
+    const store = makeStore();
+    begin(store, "a"); // no markDesktopSessionRunning
+    expect(begin(store, "b").previousUncleanSession).toBeNull();
+  });
+
+  test("graceful quit → next launch reports nothing", () => {
+    const store = makeStore();
+    begin(store, "a");
+    running(store);
     quit(store);
     expect(store.state().clean).toBe(true);
     expect(begin(store, "b").previousUncleanSession).toBeNull();
   });
 
-  test("reached running then crashed (no clean) → next launch reports it", () => {
+  test("a failed report retries next launch; clearReportedCrash stops it", () => {
     const store = makeStore();
     begin(store, "a");
     running(store);
-    // 'a' crashes — no endDesktopSessionCleanly.
+    // 'a' crashed; 'b' launches and detects it but the report FAILS (never cleared).
     expect(begin(store, "b").previousUncleanSession?.sessionId).toBe("a");
+    running(store); // b runs fine
+    // 'b' quits cleanly, but a's crash was never reported → 'c' still retries it.
+    quit(store);
+    expect(begin(store, "c").previousUncleanSession?.sessionId).toBe("a");
+    // Now the report succeeds → clear it → 'd' reports nothing.
+    clear(store);
+    expect(begin(store, "d").previousUncleanSession).toBeNull();
   });
 
-  test("bootstrap failure before running is not reported next launch", () => {
+  test("markRunning and clean preserve a carried-forward unreportedCrash", () => {
     const store = makeStore();
-    begin(store, "a"); // never calls markDesktopSessionRunning (crashed during bootstrap)
-    expect(begin(store, "b").previousUncleanSession).toBeNull();
+    begin(store, "a");
+    running(store);
+    begin(store, "b"); // carries a's crash into b's marker
+    running(store); // must not drop unreportedCrash
+    expect(store.state().unreportedCrash).toMatchObject({ sessionId: "a" });
+    quit(store); // must not drop it either
+    expect(store.state().unreportedCrash).toMatchObject({ sessionId: "a" });
   });
 
   test("never throws on a corrupt marker and still stamps this run", () => {

--- a/apps/desktop/tests/main/session-lifecycle.test.ts
+++ b/apps/desktop/tests/main/session-lifecycle.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  beginDesktopSession,
+  endDesktopSessionCleanly,
+  type DesktopSessionState,
+} from "../../src/main/session-lifecycle.js";
+
+// In-memory fs so the pure lifecycle logic is exercised without touching disk.
+function makeStore(initial?: string) {
+  const files = new Map<string, string>();
+  if (initial != null) files.set("state.json", initial);
+  return {
+    readFile: (p: string) => {
+      const v = files.get(p);
+      if (v == null) throw new Error("ENOENT");
+      return v;
+    },
+    writeFile: (p: string, d: string) => {
+      files.set(p, d);
+    },
+    get: () => files.get("state.json"),
+  };
+}
+
+const FIXED = new Date("2026-07-09T12:00:00.000Z");
+
+function begin(store: ReturnType<typeof makeStore>, sessionId: string, version = "0.14.0") {
+  return beginDesktopSession({
+    stateFilePath: "state.json",
+    sessionId,
+    version,
+    now: () => FIXED,
+    readFile: store.readFile,
+    writeFile: store.writeFile,
+  });
+}
+
+describe("desktop session lifecycle", () => {
+  test("first run reports no previous session and writes a dirty marker", () => {
+    const store = makeStore();
+    const { previousUncleanSession } = begin(store, "s1");
+    expect(previousUncleanSession).toBeNull();
+    const written = JSON.parse(store.get()!) as DesktopSessionState;
+    expect(written).toMatchObject({ sessionId: "s1", version: "0.14.0", clean: false });
+  });
+
+  test("detects a previous UNCLEAN exit (marker left dirty)", () => {
+    // Previous run wrote a dirty marker and never marked it clean = it crashed.
+    const store = makeStore(JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", clean: false }));
+    const { previousUncleanSession } = begin(store, "s2");
+    expect(previousUncleanSession).toMatchObject({ sessionId: "prev", version: "0.13.0", clean: false });
+    // ...and it stamps a fresh dirty marker for this run.
+    expect((JSON.parse(store.get()!) as DesktopSessionState).sessionId).toBe("s2");
+  });
+
+  test("a previous CLEAN exit is not reported", () => {
+    const store = makeStore(JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", clean: true }));
+    expect(begin(store, "s3").previousUncleanSession).toBeNull();
+  });
+
+  test("endDesktopSessionCleanly flips the current marker to clean", () => {
+    const store = makeStore();
+    begin(store, "s4");
+    endDesktopSessionCleanly({ stateFilePath: "state.json", readFile: store.readFile, writeFile: store.writeFile });
+    expect((JSON.parse(store.get()!) as DesktopSessionState).clean).toBe(true);
+  });
+
+  test("full cycle: clean shutdown then next launch reports nothing; a crash is caught", () => {
+    const store = makeStore();
+    begin(store, "a");
+    endDesktopSessionCleanly({ stateFilePath: "state.json", readFile: store.readFile, writeFile: store.writeFile });
+    // Next launch after a clean quit: no abnormal-exit signal.
+    expect(begin(store, "b").previousUncleanSession).toBeNull();
+    // 'b' now runs and crashes (no endDesktopSessionCleanly). Next launch catches it.
+    expect(begin(store, "c").previousUncleanSession?.sessionId).toBe("b");
+  });
+
+  test("never throws on unreadable/corrupt marker and still stamps this run", () => {
+    const store = makeStore("}{ not json");
+    expect(() => begin(store, "s5")).not.toThrow();
+    expect((JSON.parse(store.get()!) as DesktopSessionState).sessionId).toBe("s5");
+  });
+});

--- a/apps/desktop/tests/main/session-lifecycle.test.ts
+++ b/apps/desktop/tests/main/session-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   beginDesktopSession,
   endDesktopSessionCleanly,
+  markDesktopSessionRunning,
   type DesktopSessionState,
 } from "../../src/main/session-lifecycle.js";
 
@@ -19,7 +20,8 @@ function makeStore(initial?: string) {
     writeFile: (p: string, d: string) => {
       files.set(p, d);
     },
-    get: () => files.get("state.json"),
+    state: () => JSON.parse(files.get("state.json")!) as DesktopSessionState,
+    raw: () => files.get("state.json"),
   };
 }
 
@@ -35,50 +37,66 @@ function begin(store: ReturnType<typeof makeStore>, sessionId: string, version =
     writeFile: store.writeFile,
   });
 }
+const running = (store: ReturnType<typeof makeStore>) =>
+  markDesktopSessionRunning({ stateFilePath: "state.json", readFile: store.readFile, writeFile: store.writeFile });
+const quit = (store: ReturnType<typeof makeStore>) =>
+  endDesktopSessionCleanly({ stateFilePath: "state.json", readFile: store.readFile, writeFile: store.writeFile });
 
 describe("desktop session lifecycle", () => {
-  test("first run reports no previous session and writes a dirty marker", () => {
+  test("first run reports nothing and writes a not-yet-running marker", () => {
     const store = makeStore();
-    const { previousUncleanSession } = begin(store, "s1");
-    expect(previousUncleanSession).toBeNull();
-    const written = JSON.parse(store.get()!) as DesktopSessionState;
-    expect(written).toMatchObject({ sessionId: "s1", version: "0.14.0", clean: false });
+    expect(begin(store, "s1").previousUncleanSession).toBeNull();
+    expect(store.state()).toMatchObject({ sessionId: "s1", reachedRunning: false, clean: false });
   });
 
-  test("detects a previous UNCLEAN exit (marker left dirty)", () => {
-    // Previous run wrote a dirty marker and never marked it clean = it crashed.
-    const store = makeStore(JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", clean: false }));
-    const { previousUncleanSession } = begin(store, "s2");
-    expect(previousUncleanSession).toMatchObject({ sessionId: "prev", version: "0.13.0", clean: false });
-    // ...and it stamps a fresh dirty marker for this run.
-    expect((JSON.parse(store.get()!) as DesktopSessionState).sessionId).toBe("s2");
+  test("a previous run that reached running and never went clean is a runtime crash", () => {
+    const store = makeStore(
+      JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", reachedRunning: true, clean: false }),
+    );
+    expect(begin(store, "s2").previousUncleanSession).toMatchObject({ sessionId: "prev", reachedRunning: true });
   });
 
-  test("a previous CLEAN exit is not reported", () => {
-    const store = makeStore(JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", clean: true }));
+  test("a previous run that never reached running is NOT reported (startup failure, not a crash)", () => {
+    const store = makeStore(
+      JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", reachedRunning: false, clean: false }),
+    );
     expect(begin(store, "s3").previousUncleanSession).toBeNull();
   });
 
-  test("endDesktopSessionCleanly flips the current marker to clean", () => {
-    const store = makeStore();
-    begin(store, "s4");
-    endDesktopSessionCleanly({ stateFilePath: "state.json", readFile: store.readFile, writeFile: store.writeFile });
-    expect((JSON.parse(store.get()!) as DesktopSessionState).clean).toBe(true);
+  test("a previous clean exit is not reported", () => {
+    const store = makeStore(
+      JSON.stringify({ sessionId: "prev", version: "0.13.0", startedAt: "t0", reachedRunning: true, clean: true }),
+    );
+    expect(begin(store, "s4").previousUncleanSession).toBeNull();
   });
 
-  test("full cycle: clean shutdown then next launch reports nothing; a crash is caught", () => {
+  test("markDesktopSessionRunning then a graceful quit → next launch reports nothing", () => {
     const store = makeStore();
     begin(store, "a");
-    endDesktopSessionCleanly({ stateFilePath: "state.json", readFile: store.readFile, writeFile: store.writeFile });
-    // Next launch after a clean quit: no abnormal-exit signal.
+    running(store);
+    expect(store.state().reachedRunning).toBe(true);
+    quit(store);
+    expect(store.state().clean).toBe(true);
     expect(begin(store, "b").previousUncleanSession).toBeNull();
-    // 'b' now runs and crashes (no endDesktopSessionCleanly). Next launch catches it.
-    expect(begin(store, "c").previousUncleanSession?.sessionId).toBe("b");
   });
 
-  test("never throws on unreadable/corrupt marker and still stamps this run", () => {
+  test("reached running then crashed (no clean) → next launch reports it", () => {
+    const store = makeStore();
+    begin(store, "a");
+    running(store);
+    // 'a' crashes — no endDesktopSessionCleanly.
+    expect(begin(store, "b").previousUncleanSession?.sessionId).toBe("a");
+  });
+
+  test("bootstrap failure before running is not reported next launch", () => {
+    const store = makeStore();
+    begin(store, "a"); // never calls markDesktopSessionRunning (crashed during bootstrap)
+    expect(begin(store, "b").previousUncleanSession).toBeNull();
+  });
+
+  test("never throws on a corrupt marker and still stamps this run", () => {
     const store = makeStore("}{ not json");
     expect(() => begin(store, "s5")).not.toThrow();
-    expect((JSON.parse(store.get()!) as DesktopSessionState).sessionId).toBe("s5");
+    expect(store.state().sessionId).toBe("s5");
   });
 });

--- a/apps/desktop/tests/main/session-lifecycle.test.ts
+++ b/apps/desktop/tests/main/session-lifecycle.test.ts
@@ -33,30 +33,27 @@ function begin(store: ReturnType<typeof makeStore>, sessionId: string, version =
 }
 const running = (s: ReturnType<typeof makeStore>) => markDesktopSessionRunning({ stateFilePath: "state.json", ...io(s) });
 const quit = (s: ReturnType<typeof makeStore>) => endDesktopSessionCleanly({ stateFilePath: "state.json", ...io(s) });
-const clear = (s: ReturnType<typeof makeStore>) => clearReportedCrash({ stateFilePath: "state.json", ...io(s) });
+const ids = (r: { previousUncleanSessions: { sessionId: string }[] }) => r.previousUncleanSessions.map((c) => c.sessionId);
 
 describe("desktop session lifecycle", () => {
   test("first run reports nothing and writes a not-yet-running marker", () => {
     const store = makeStore();
-    expect(begin(store, "s1").previousUncleanSession).toBeNull();
-    expect(store.state()).toMatchObject({ sessionId: "s1", reachedRunning: false, clean: false, unreportedCrash: null });
+    expect(ids(begin(store, "s1"))).toEqual([]);
+    expect(store.state()).toMatchObject({ sessionId: "s1", reachedRunning: false, clean: false, unreportedCrashes: [] });
   });
 
-  test("reached-running then crashed → next launch reports it and persists it as unreportedCrash", () => {
+  test("reached-running then crashed → next launch reports it and queues it", () => {
     const store = makeStore();
     begin(store, "a");
     running(store);
-    // 'a' crashes (no clean). Next launch:
-    const { previousUncleanSession } = begin(store, "b");
-    expect(previousUncleanSession).toMatchObject({ sessionId: "a", version: "0.14.0" });
-    // ...and it's persisted so a failed report can retry.
-    expect(store.state().unreportedCrash).toMatchObject({ sessionId: "a" });
+    expect(ids(begin(store, "b"))).toEqual(["a"]);
+    expect(store.state().unreportedCrashes.map((c) => c.sessionId)).toEqual(["a"]);
   });
 
   test("never reached running → not reported (startup failure, not a crash)", () => {
     const store = makeStore();
-    begin(store, "a"); // no markDesktopSessionRunning
-    expect(begin(store, "b").previousUncleanSession).toBeNull();
+    begin(store, "a");
+    expect(ids(begin(store, "b"))).toEqual([]);
   });
 
   test("graceful quit → next launch reports nothing", () => {
@@ -64,34 +61,45 @@ describe("desktop session lifecycle", () => {
     begin(store, "a");
     running(store);
     quit(store);
-    expect(store.state().clean).toBe(true);
-    expect(begin(store, "b").previousUncleanSession).toBeNull();
+    expect(ids(begin(store, "b"))).toEqual([]);
   });
 
-  test("a failed report retries next launch; clearReportedCrash stops it", () => {
+  test("consecutive crashes with failed reports keep EVERY crash (nettee's sequence)", () => {
+    const store = makeStore();
+    // A runs and crashes.
+    begin(store, "a");
+    running(store);
+    // B launches, detects A (report fails → not cleared), then B runs and crashes.
+    expect(ids(begin(store, "b"))).toEqual(["a"]);
+    running(store);
+    // C launches: BOTH A and B must be reported — neither dropped.
+    expect(ids(begin(store, "c"))).toEqual(["a", "b"]);
+    expect(store.state().unreportedCrashes.map((c) => c.sessionId)).toEqual(["a", "b"]);
+  });
+
+  test("clearReportedCrash(id) drops only the acked crash", () => {
     const store = makeStore();
     begin(store, "a");
     running(store);
-    // 'a' crashed; 'b' launches and detects it but the report FAILS (never cleared).
-    expect(begin(store, "b").previousUncleanSession?.sessionId).toBe("a");
-    running(store); // b runs fine
-    // 'b' quits cleanly, but a's crash was never reported → 'c' still retries it.
+    begin(store, "b");
+    running(store);
+    begin(store, "c"); // queue now [a, b]
+    clearReportedCrash({ stateFilePath: "state.json", ...io(store) }, "a");
+    expect(store.state().unreportedCrashes.map((x) => x.sessionId)).toEqual(["b"]);
+    // c quits cleanly but b was never acked → d still retries b.
     quit(store);
-    expect(begin(store, "c").previousUncleanSession?.sessionId).toBe("a");
-    // Now the report succeeds → clear it → 'd' reports nothing.
-    clear(store);
-    expect(begin(store, "d").previousUncleanSession).toBeNull();
+    expect(ids(begin(store, "d"))).toEqual(["b"]);
   });
 
-  test("markRunning and clean preserve a carried-forward unreportedCrash", () => {
+  test("markRunning and clean preserve the queued crashes", () => {
     const store = makeStore();
     begin(store, "a");
     running(store);
-    begin(store, "b"); // carries a's crash into b's marker
-    running(store); // must not drop unreportedCrash
-    expect(store.state().unreportedCrash).toMatchObject({ sessionId: "a" });
-    quit(store); // must not drop it either
-    expect(store.state().unreportedCrash).toMatchObject({ sessionId: "a" });
+    begin(store, "b"); // carries [a]
+    running(store);
+    expect(store.state().unreportedCrashes.map((c) => c.sessionId)).toEqual(["a"]);
+    quit(store);
+    expect(store.state().unreportedCrashes.map((c) => c.sessionId)).toEqual(["a"]);
   });
 
   test("never throws on a corrupt marker and still stamps this run", () => {


### PR DESCRIPTION
## Why

Users report the app "闪退" — running fine, then the whole window suddenly gone. Auditing our crash telemetry showed we can't see that class at all: 0.14.0 has exactly two crash-ish events, `desktop_renderer_crash` (renderer process) and `packaged_runtime_failed` (startup fails before the daemon is up). A **main-process crash / OS kill / force-quit after a hang / power loss while running** hits neither — a dead process can't report itself, and the desktop's `uncaughtException` / `unresponsive` handlers are log-only. So "how often does the app crash while running, and on which versions/devices" is answerable only from anecdote.

## What users will see

No user-facing behavior change. Two things happen under the hood:
- A tiny `session-state.json` marker is written next to the desktop log at launch and flipped "clean" on a graceful quit.
- If a launch finds the previous run's marker still dirty (it never shut down cleanly → it crashed / was killed), we emit one `desktop_unclean_exit` analytics event once the daemon is up to relay it. GPU/utility child-process crashes emit `desktop_child_process_crash`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — n/a. Internal desktop observability, not a user-invokable capability (same as `desktop_renderer_crash`).
- [ ] **API / contract** — none. Both events ride the existing free-form `POST /api/observability/event` (`event`/`properties` are already `Record<string, unknown>`); no typed-contract change.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — writes a small `session-state.json` marker and emits new abnormal-exit / child-process-crash telemetry.
- [ ] **None**

## How it works

- `beginDesktopSession` (pure, injectable fs/clock) reads the previous run's marker, returns it **only when it ended uncleanly** (present and `clean: false`), then stamps a fresh dirty marker for this run.
- `shutdown()` calls `endDesktopSessionCleanly` → flips the marker clean, so a normal quit is never misreported.
- After the runtime is up, a dirty previous marker → `desktop_unclean_exit` (`previous_version` / `previous_session_id` / `previous_started_at` / `current_version`).
- `app.on("child-process-gone")` (non-`clean-exit`) → `desktop_child_process_crash` (`process_type` / `reason` / `exit_code`).
- Everything is best-effort: any fs or network failure is swallowed and can never block startup or shutdown.

This completes the crash-observability picture: renderer crashes, startup failures, **and now runtime abnormal exits** — so "runtime 闪退 rate" becomes a dashboard number instead of anecdote. (A later follow-up can join `desktop_unclean_exit` to a crashReporter minidump once #5322 lands, and add an uptime-before-crash heartbeat.)

## Bug fix verification / testing

New value, not a bug fix — encoded as behavior tests on the pure lifecycle module.

- Test path: `apps/desktop/tests/main/session-lifecycle.test.ts` (6 tests): first run → no signal; dirty previous marker → reported; clean previous → not reported; `endDesktopSessionCleanly` flips clean; full cycle (clean quit → silent next launch; crash → caught next launch); corrupt marker never throws.

## Validation

- `pnpm guard` — 78/78 pass
- `pnpm --filter @open-design/desktop typecheck` — clean
- `pnpm --filter @open-design/desktop test` — **179 pass, 1 fail**. The lone failure (`updater.test.ts > cleans deprecated launcher payload versions…`) is **pre-existing and unrelated** (launcher version cleanup; reproduces on a pristine `origin/main`).
