### PR TITLE
fix byok-opencode: route non-OpenAI openai-protocol hosts to @ai-sdk/openai-compatible

### DIFF
--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -158,6 +158,15 @@ function isExactOrigin(value: string, origin: string): boolean {
   }
 }
 
+function isRealOpenAIHost(baseUrl: string): boolean {
+  if (!baseUrl) return true;
+  try {
+    return new URL(baseUrl).hostname === 'api.openai.com';
+  } catch {
+    return true;
+  }
+}
+
 function buildProviderEntry(
   protocol: ByokChatProviderConfig['protocol'],
   baseUrl: string,
@@ -207,11 +216,23 @@ function buildProviderEntry(
         },
       };
     case 'openai':
+      // Real OpenAI speaks the Responses API via @ai-sdk/openai. Every other
+      // host under the "openai" protocol (DeepSeek, vLLM, etc.) only serves
+      // /chat/completions, so route it through @ai-sdk/openai-compatible.
+      if (isRealOpenAIHost(baseUrl)) {
+        return {
+          npm: '@ai-sdk/openai',
+          options: {
+            ...apiKeyOption,
+            ...(baseUrl ? { baseURL: baseUrl } : {}),
+          },
+        };
+      }
       return {
-        npm: '@ai-sdk/openai',
+        npm: '@ai-sdk/openai-compatible',
         options: {
+          baseURL: baseUrl,
           ...apiKeyOption,
-          ...(baseUrl ? { baseURL: baseUrl } : {}),
         },
       };
     case 'senseaudio':

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -74,6 +74,29 @@ describe('byok-opencode runtime config', () => {
     });
   });
 
+  it('routes OpenAI-protocol BYOK with a non-OpenAI base URL to the OpenAI-compatible provider package', () => {
+    expect(buildOpenCodeByokProviderConfig(
+      { protocol: 'openai', apiKey: 'sk-deepseek', baseUrl: 'https://api.deepseek.com' },
+      'deepseek-v4-pro',
+    )?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            baseURL: 'https://api.deepseek.com',
+            apiKey: `{env:${BYOK_OPENCODE_API_KEY_ENV}}`,
+          },
+        },
+      },
+    });
+    expect(buildOpenCodeByokProviderConfig(
+      { protocol: 'openai', apiKey: 'sk-openai', baseUrl: 'https://api.openai.com' },
+      'deepseek-v4-pro',
+    )?.config).toMatchObject({
+      provider: { [BYOK_OPENCODE_PROVIDER_ID]: { npm: '@ai-sdk/openai' } },
+    });
+  });
+
   it('normalizes origin-only native provider base URLs for OpenCode provider packages', () => {
     expect(buildOpenCodeByokProviderConfig(
       { protocol: 'anthropic', apiKey: 'sk-ant', baseUrl: 'https://api.anthropic.com' },
@@ -272,7 +295,7 @@ describe('byok-opencode runtime config', () => {
     expect(out?.config).toMatchObject({
       provider: {
         [BYOK_OPENCODE_PROVIDER_ID]: {
-          npm: '@ai-sdk/openai',
+          npm: '@ai-sdk/openai-compatible',
           options: {
             baseURL: 'http://127.0.0.1:8000/v1',
           },


### PR DESCRIPTION
Fixes #5338

## Why

Hit this myself using Open Design with a DeepSeek key: the built-in **DeepSeek** BYOK preset (Settings → Execution mode → BYOK) 404s on the first run. The daemon's OpenCode BYOK path maps protocol `openai` straight to `@ai-sdk/openai`, which calls the OpenAI **Responses API** (`{baseURL}/responses`). DeepSeek (and other OpenAI-compatible providers) only serve `/chat/completions`, so the request 404s. The web path already treats these as OpenAI-compatible via `isOpenAICompatible(...)`; the OpenCode path didn't, so the two disagreed. Full trace in #5338.

## What users will see

BYOK custom models on the `openai` protocol pointed at a non-`api.openai.com` endpoint (the DeepSeek preset, vLLM, and other OpenAI-compatible chat-completions hosts) now work instead of failing with `Not Found`. Real OpenAI (`api.openai.com`) is unchanged.

## Surface area

- [x] **Default behavior change** — for the `openai` BYOK protocol, non-`api.openai.com` hosts now use `@ai-sdk/openai-compatible` (`/chat/completions`) instead of `@ai-sdk/openai` (`/responses`). This fixes DeepSeek and also switches vLLM / local OpenAI-compatible servers to the chat-completions package (which is what they actually serve). `api.openai.com` keeps using `@ai-sdk/openai`.

## Screenshots

n/a — no UI.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/byok-opencode.test.ts` → `routes OpenAI-protocol BYOK with a non-OpenAI base URL to the OpenAI-compatible provider package`
- Did the test go red on `main` and green on this branch? **yes** — on `main` the DeepSeek case returns `@ai-sdk/openai`; after the fix it returns `@ai-sdk/openai-compatible`. The existing vLLM test is updated to match (it is openai-compatible by nature — the test is even named that).

## Validation

Ran under Node 24 / pnpm 10.33.2:
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/byok-opencode.test.ts` → 13/13 pass (new test red before the source change, green after).
- `pnpm --filter @open-design/daemon run typecheck` → pass.
- `pnpm guard` → 78/78 pass.

Note: `connection-test.test.ts` / `chat-route.test.ts` have a few pre-existing failures on a clean `main` in my local sandbox — flaky `withFakeAgent` process-spawn flows, unrelated to this change (which only affects `buildProviderEntry`'s provider-package selection). Left to CI.

Optional follow-ups (kept out of this PR for one-concern): (1) the proxy path normalizes DeepSeek to `/v1/chat/completions`; this path resolves to `/chat/completions` (both are served by DeepSeek) — happy to add a `/v1` normalization for parity if preferred; (2) surfacing the actual failing request URL instead of a bare `Not Found`.
