### PR TITLE
fix(daemon): keep the artifact verdict when the event ring buffer truncates

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -84,12 +84,14 @@ import {
 } from '../run-tool-bundle.js';
 import type { DetectedAgent, RuntimeAgentDef } from '../runtimes/types.js';
 import {
-  countDesignSystemPreviewModules,
-  countNewArtifacts,
   deriveActivationMilestones,
-  didRunCreateDesignSystemFile,
   runAskedUserQuestion,
 } from '../runtimes/run-artifacts.js';
+import {
+  runArtifactCountForRun,
+  runDesignSystemCreatedForRun,
+  runPreviewModuleCountForRun,
+} from '../runtimes/run-lifecycle-analytics.js';
 
 type SqliteDb = Database.Database;
 type JsonRecord = Record<string, unknown>;
@@ -1088,11 +1090,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         ...(run.analyticsTelemetry ? { telemetry: run.analyticsTelemetry } : {}),
           events: run.events,
         });
-        const toolStreamArtifactCount = (): number => countNewArtifacts(run.events);
+        const toolStreamArtifactCount = (): number => runArtifactCountForRun(run);
         const toolStreamDesignSystemCreated = (): boolean =>
-          didRunCreateDesignSystemFile(run.events);
+          runDesignSystemCreatedForRun(run);
         const toolStreamPreviewModuleCount = (): number =>
-          countDesignSystemPreviewModules(run.events);
+          runPreviewModuleCountForRun(run);
         const artifactBaseline = runArtifactBaselines.take(run.id);
         let artifactCount: number;
         let artifactsCreated: number | undefined;

--- a/apps/daemon/src/runtimes/run-artifacts.ts
+++ b/apps/daemon/src/runtimes/run-artifacts.ts
@@ -38,7 +38,10 @@ import { emittedRenderableQuestionForm } from '../question-form-detect.js';
 // Tool names cover Claude-style, Codex-style, and the ACP/MCP shapes
 // the daemon proxies. Keep aligned with the web-side `WRITE_NAMES` /
 // `EDIT_NAMES` sets in `apps/web/src/runtime/file-ops.ts`.
-const WRITE_OR_EDIT_TOOL_NAMES: ReadonlySet<string> = new Set([
+// Exported so the incremental side-effect ledger
+// (`run-lifecycle-analytics.ts`) pairs write/edit tool calls by the same
+// tool-name set the batch counter uses, keeping the two in lock-step.
+export const WRITE_OR_EDIT_TOOL_NAMES: ReadonlySet<string> = new Set([
   'Write',
   'create_file',
   'Edit',
@@ -47,7 +50,8 @@ const WRITE_OR_EDIT_TOOL_NAMES: ReadonlySet<string> = new Set([
   'multi_edit',
 ]);
 
-function extractToolFilePath(input: unknown): string | null {
+// Exported so the incremental ledger extracts the written path identically.
+export function extractToolFilePath(input: unknown): string | null {
   if (!input || typeof input !== 'object') return null;
   const obj = input as { file_path?: unknown; path?: unknown };
   if (typeof obj.file_path === 'string' && obj.file_path) return obj.file_path;
@@ -121,13 +125,13 @@ export interface RunEventLike {
 // event and reference it via `toolUseId` on the subsequent
 // `tool_result`; see `apps/daemon/src/langfuse-bridge.ts#collectToolCalls`
 // for the canonical implementation.
-function readToolUseId(data: unknown): string | null {
+export function readToolUseId(data: unknown): string | null {
   if (!data || typeof data !== 'object') return null;
   const obj = data as { id?: unknown };
   return typeof obj.id === 'string' && obj.id ? obj.id : null;
 }
 
-function readToolResultId(data: unknown): string | null {
+export function readToolResultId(data: unknown): string | null {
   if (!data || typeof data !== 'object') return null;
   const obj = data as { toolUseId?: unknown };
   return typeof obj.toolUseId === 'string' && obj.toolUseId
@@ -135,7 +139,7 @@ function readToolResultId(data: unknown): string | null {
     : null;
 }
 
-function readToolResultIsError(data: unknown): boolean {
+export function readToolResultIsError(data: unknown): boolean {
   if (!data || typeof data !== 'object') return false;
   return (data as { isError?: unknown }).isError === true;
 }

--- a/apps/daemon/src/runtimes/run-lifecycle-analytics.ts
+++ b/apps/daemon/src/runtimes/run-lifecycle-analytics.ts
@@ -146,10 +146,13 @@ export interface RunSideEffectLedger {
   artifactPaths: Set<string>;
   designSystemFileWritten: boolean;
   previewModulePaths: Set<string>;
-  // tool_use / tool_result can arrive in either order and arbitrarily far
-  // apart; hold the unpaired half here so pairing survives truncation.
+  // Only WRITE/EDIT tool_use ids awaiting their tool_result live here, and each
+  // is removed the moment its result arrives. A tool_result cannot precede its
+  // tool_use within a run, so we never need to buffer results — an ordinary
+  // (non-write) tool_result finds nothing pending and is dropped, keeping this
+  // map bounded by the small number of outstanding artifact writes rather than
+  // by the run's total tool_result count.
   pendingWritePathById: Map<string, string>;
-  pendingResultIsErrorById: Map<string, boolean>;
 }
 
 export function createRunSideEffectLedger(): RunSideEffectLedger {
@@ -162,21 +165,7 @@ export function createRunSideEffectLedger(): RunSideEffectLedger {
     designSystemFileWritten: false,
     previewModulePaths: new Set(),
     pendingWritePathById: new Map(),
-    pendingResultIsErrorById: new Map(),
   };
-}
-
-function resolveWritePairing(ledger: RunSideEffectLedger, toolUseId: string) {
-  const path = ledger.pendingWritePathById.get(toolUseId);
-  if (path === undefined) return;
-  if (!ledger.pendingResultIsErrorById.has(toolUseId)) return;
-  const isError = ledger.pendingResultIsErrorById.get(toolUseId) === true;
-  ledger.pendingWritePathById.delete(toolUseId);
-  ledger.pendingResultIsErrorById.delete(toolUseId);
-  if (isError) return;
-  if (isArtifactPath(path)) ledger.artifactPaths.add(path);
-  if (isDesignSystemFile(path)) ledger.designSystemFileWritten = true;
-  if (isPreviewModulePath(path)) ledger.previewModulePaths.add(path);
 }
 
 export function foldEventIntoRunSideEffectLedger(
@@ -209,12 +198,18 @@ export function foldEventIntoRunSideEffectLedger(
     const id = readToolUseId(data);
     if (!path || !id) return;
     ledger.pendingWritePathById.set(id, path);
-    resolveWritePairing(ledger, id);
   } else if (data.type === 'tool_result' && event === 'agent') {
     const id = readToolResultId(data);
     if (!id) return;
-    ledger.pendingResultIsErrorById.set(id, readToolResultIsError(data));
-    resolveWritePairing(ledger, id);
+    const path = ledger.pendingWritePathById.get(id);
+    // Non-write tool_result (Read/Bash/Grep/…): nothing pending, drop it — this
+    // is what keeps the ledger bounded on long tool-heavy runs.
+    if (path === undefined) return;
+    ledger.pendingWritePathById.delete(id);
+    if (readToolResultIsError(data)) return; // a failed write does not count
+    if (isArtifactPath(path)) ledger.artifactPaths.add(path);
+    if (isDesignSystemFile(path)) ledger.designSystemFileWritten = true;
+    if (isPreviewModulePath(path)) ledger.previewModulePaths.add(path);
   }
 }
 

--- a/apps/daemon/src/runtimes/run-lifecycle-analytics.ts
+++ b/apps/daemon/src/runtimes/run-lifecycle-analytics.ts
@@ -3,6 +3,14 @@ import {
   countDesignSystemPreviewModules,
   countNewArtifacts,
   didRunCreateDesignSystemFile,
+  extractToolFilePath,
+  isArtifactPath,
+  isDesignSystemFile,
+  isPreviewModulePath,
+  readToolResultId,
+  readToolResultIsError,
+  readToolUseId,
+  WRITE_OR_EDIT_TOOL_NAMES,
 } from './run-artifacts.js';
 import { scanRunEventsForUsageAnalytics } from '../run-analytics-observability.js';
 import { runResultFromStatus } from '../run-result.js';
@@ -112,6 +120,161 @@ export function scanRunEventsForRetrySideEffects(events: unknown): RunRetrySideE
     sideEffects.artifactWriteSeen = true;
   }
   return sideEffects;
+}
+
+// Incremental side-effect ledger.
+//
+// The batch `scanRunEventsForRetrySideEffects` / `countNewArtifacts` above read
+// `run.events`, which is a bounded in-memory ring buffer (createChatRunService
+// maxEvents). On a long run the earliest events — including an artifact's
+// `tool_use` / `tool_result` pair — are spliced out of that buffer, so a
+// finalization-time scan of `run.events` no longer sees committed work that the
+// run genuinely did (and that the on-disk events.jsonl still records). That
+// silently flips the retry safety gate, `artifact_count`, and the close-status
+// `artifactProducedThisRun` verdict.
+//
+// The ledger folds each event into a fixed-size accumulator AT EMIT TIME, before
+// truncation can drop it, so the finalization consumers read a verdict that
+// survives the whole run. It mirrors the batch semantics exactly: a write/edit
+// tool_use paired with a NON-error tool_result counts once per distinct path,
+// and `artifactWriteSeen` also flips on a direct `artifact` event.
+export interface RunSideEffectLedger {
+  userVisibleOutputSeen: boolean;
+  toolCallSeen: boolean;
+  directArtifactEventSeen: boolean;
+  liveArtifactSeen: boolean;
+  artifactPaths: Set<string>;
+  designSystemFileWritten: boolean;
+  previewModulePaths: Set<string>;
+  // tool_use / tool_result can arrive in either order and arbitrarily far
+  // apart; hold the unpaired half here so pairing survives truncation.
+  pendingWritePathById: Map<string, string>;
+  pendingResultIsErrorById: Map<string, boolean>;
+}
+
+export function createRunSideEffectLedger(): RunSideEffectLedger {
+  return {
+    userVisibleOutputSeen: false,
+    toolCallSeen: false,
+    directArtifactEventSeen: false,
+    liveArtifactSeen: false,
+    artifactPaths: new Set(),
+    designSystemFileWritten: false,
+    previewModulePaths: new Set(),
+    pendingWritePathById: new Map(),
+    pendingResultIsErrorById: new Map(),
+  };
+}
+
+function resolveWritePairing(ledger: RunSideEffectLedger, toolUseId: string) {
+  const path = ledger.pendingWritePathById.get(toolUseId);
+  if (path === undefined) return;
+  if (!ledger.pendingResultIsErrorById.has(toolUseId)) return;
+  const isError = ledger.pendingResultIsErrorById.get(toolUseId) === true;
+  ledger.pendingWritePathById.delete(toolUseId);
+  ledger.pendingResultIsErrorById.delete(toolUseId);
+  if (isError) return;
+  if (isArtifactPath(path)) ledger.artifactPaths.add(path);
+  if (isDesignSystemFile(path)) ledger.designSystemFileWritten = true;
+  if (isPreviewModulePath(path)) ledger.previewModulePaths.add(path);
+}
+
+export function foldEventIntoRunSideEffectLedger(
+  ledger: RunSideEffectLedger,
+  record: { event?: unknown; data?: unknown },
+) {
+  const event = record?.event;
+  const data = isRecord(record?.data) ? record.data : null;
+  if (event === 'stdout') {
+    const chunk = data?.chunk;
+    if (typeof chunk === 'string' ? chunk.length > 0 : chunk !== undefined) {
+      ledger.userVisibleOutputSeen = true;
+    }
+  }
+  if (event === 'live_artifact') ledger.liveArtifactSeen = true;
+  if (!data) return;
+  if (data.type === 'text_delta' || data.type === 'thinking_delta') {
+    if (typeof data.delta === 'string' && data.delta.length > 0) {
+      ledger.userVisibleOutputSeen = true;
+    }
+  }
+  if (data.type === 'live_artifact') ledger.liveArtifactSeen = true;
+  if (data.type === 'artifact') ledger.directArtifactEventSeen = true;
+  if (data.type === 'tool_use') {
+    ledger.toolCallSeen = true;
+    if (event !== 'agent') return;
+    if (typeof data.name !== 'string') return;
+    if (!WRITE_OR_EDIT_TOOL_NAMES.has(data.name)) return;
+    const path = extractToolFilePath(data.input);
+    const id = readToolUseId(data);
+    if (!path || !id) return;
+    ledger.pendingWritePathById.set(id, path);
+    resolveWritePairing(ledger, id);
+  } else if (data.type === 'tool_result' && event === 'agent') {
+    const id = readToolResultId(data);
+    if (!id) return;
+    ledger.pendingResultIsErrorById.set(id, readToolResultIsError(data));
+    resolveWritePairing(ledger, id);
+  }
+}
+
+function ledgerArtifactWriteSeen(ledger: RunSideEffectLedger): boolean {
+  return (
+    ledger.directArtifactEventSeen ||
+    ledger.artifactPaths.size > 0 ||
+    ledger.designSystemFileWritten ||
+    ledger.previewModulePaths.size > 0
+  );
+}
+
+export function sideEffectsFromLedger(
+  ledger: RunSideEffectLedger,
+): RunRetrySideEffects {
+  return {
+    userVisibleOutputSeen: ledger.userVisibleOutputSeen,
+    toolCallSeen: ledger.toolCallSeen,
+    artifactWriteSeen: ledgerArtifactWriteSeen(ledger),
+    liveArtifactSeen: ledger.liveArtifactSeen,
+  };
+}
+
+// Read a run's committed side effects, preferring the truncation-proof ledger
+// and falling back to the batch scan when a run has no ledger (e.g. legacy
+// call sites or tests that build a run object directly).
+export function runSideEffectsForRun(run: {
+  sideEffectLedger?: RunSideEffectLedger;
+  events?: unknown;
+}): RunRetrySideEffects {
+  if (run?.sideEffectLedger) return sideEffectsFromLedger(run.sideEffectLedger);
+  return scanRunEventsForRetrySideEffects(run?.events);
+}
+
+// Distinct-artifact count that survives event-buffer truncation, with the same
+// ledger-preferred / scan-fallback contract as runSideEffectsForRun.
+export function runArtifactCountForRun(run: {
+  sideEffectLedger?: RunSideEffectLedger;
+  events?: unknown;
+}): number {
+  if (run?.sideEffectLedger) return run.sideEffectLedger.artifactPaths.size;
+  return countNewArtifacts(Array.isArray(run?.events) ? run.events : []);
+}
+
+// Truncation-proof `design_system_created`, same ledger-preferred contract.
+export function runDesignSystemCreatedForRun(run: {
+  sideEffectLedger?: RunSideEffectLedger;
+  events?: unknown;
+}): boolean {
+  if (run?.sideEffectLedger) return run.sideEffectLedger.designSystemFileWritten;
+  return didRunCreateDesignSystemFile(Array.isArray(run?.events) ? run.events : []);
+}
+
+// Truncation-proof `preview_module_count`, same ledger-preferred contract.
+export function runPreviewModuleCountForRun(run: {
+  sideEffectLedger?: RunSideEffectLedger;
+  events?: unknown;
+}): number {
+  if (run?.sideEffectLedger) return run.sideEffectLedger.previewModulePaths.size;
+  return countDesignSystemPreviewModules(Array.isArray(run?.events) ? run.events : []);
 }
 
 export function retryFinalResultForRunStatus(status: string, retryAttemptCount?: number | null) {

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -38,6 +38,12 @@ export function createChatRunService({
   // external coding agent can `tail` the file in its own shell during
   // a long OD generation, instead of polling blindly and giving up.
   runsLogDir = null,
+  // Optional observer invoked for every emitted event BEFORE the in-memory
+  // ring buffer is truncated. The daemon uses it to fold committed side
+  // effects (tool calls, artifact writes) into a per-run accumulator that
+  // outlives buffer truncation. Kept generic here: this service does not
+  // interpret event semantics, it just hands each record to the observer.
+  onEventEmitted = null,
 }) {
   const runs = new Map();
 
@@ -155,6 +161,11 @@ export function createChatRunService({
     }
     const id = run.nextEventId++;
     const record = { id, event, data, timestamp: Date.now() };
+    // Fold committed side effects BEFORE the ring buffer can drop this record,
+    // so the finalization-time verdict survives truncation of run.events.
+    if (onEventEmitted) {
+      try { onEventEmitted(run, record); } catch { /* observer must never break emit */ }
+    }
     run.events.push(record);
     if (run.events.length > maxEvents) run.events.splice(0, run.events.length - maxEvents);
     run.updatedAt = Date.now();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -109,9 +109,12 @@ import {
   pinAssistantMessageOnRunCreate,
 } from './runtimes/chat-run-messages.js';
 import {
+  createRunSideEffectLedger,
+  foldEventIntoRunSideEffectLedger,
   resolveRunProjectKindForAnalytics,
   retryFinalResultForRunStatus,
   runRetryEventsForAnalytics,
+  runSideEffectsForRun,
   scanRunEventsForFinishedProps,
   scanRunEventsForRetrySideEffects,
 } from './runtimes/run-lifecycle-analytics.js';
@@ -2401,6 +2404,14 @@ export async function startServer({
       createSseResponse,
       createSseErrorPayload,
       runsLogDir: path.join(RUNTIME_DATA_DIR, 'runs'),
+      // Fold committed side effects into a truncation-proof per-run ledger as
+      // each event is emitted, so the finalization verdict (retry safety gate,
+      // artifact_count, close-status artifactProducedThisRun) does not depend on
+      // early tool_use/artifact events surviving the run.events ring buffer.
+      onEventEmitted: (run, record) => {
+        if (!run.sideEffectLedger) run.sideEffectLedger = createRunSideEffectLedger();
+        foldEventIntoRunSideEffectLedger(run.sideEffectLedger, record);
+      },
     }),
     analytics: analyticsService,
     getAppVersion: () => telemetry.getCachedAppVersion()?.version ?? '0.0.0',
@@ -5056,7 +5067,7 @@ export async function startServer({
         events: run.events,
       });
       const sideEffects = {
-        ...scanRunEventsForRetrySideEffects(run.events),
+        ...runSideEffectsForRun(run),
         cancelRequested: !!run.cancelRequested,
       };
       const decision = decideSafeRunRetry({
@@ -7242,7 +7253,7 @@ export async function startServer({
       const acpCleanCompletion =
         typeof acpSession?.completedSuccessfully === 'function' &&
         acpSession.completedSuccessfully();
-      const runArtifactSideEffects = scanRunEventsForRetrySideEffects(run.events);
+      const runArtifactSideEffects = runSideEffectsForRun(run);
       const status = classifyChatRunCloseStatus({
         cancelRequested: !!run.cancelRequested,
         code,

--- a/apps/daemon/tests/run-event-truncation-artifact-verdict.test.ts
+++ b/apps/daemon/tests/run-event-truncation-artifact-verdict.test.ts
@@ -1,0 +1,242 @@
+// Regression: a run's committed-artifact verdict must survive truncation of
+// the in-memory event ring buffer.
+//
+// run.events is capped at createChatRunService `maxEvents` (2000). On a long
+// run, the earliest events — including an artifact's tool_use / tool_result
+// pair — are spliced out. The finalization consumers (retry safety gate,
+// artifact_count, and the close-status `artifactProducedThisRun` verdict) used
+// to re-scan the truncated run.events, so a run that genuinely produced an
+// artifact early, then streamed >2000 more events, then exited non-zero, was
+// misclassified 'failed' (its non-zero exit no longer rescued by the lost
+// artifact evidence). The fix folds committed side effects into a
+// truncation-proof per-run ledger at emit time.
+//
+// Two layers:
+//   1. HTTP-level: drive a real run over the daemon API with a fake claude CLI
+//      that writes an artifact early, floods past the ring buffer, then exits
+//      non-zero. Expected 'succeeded'; before the fix, 'failed'.
+//   2. Unit: fold the same shape into the ledger and confirm the verdict holds
+//      regardless of how many later events would have truncated run.events.
+
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+import {
+  createRunSideEffectLedger,
+  foldEventIntoRunSideEffectLedger,
+  runArtifactCountForRun,
+  runSideEffectsForRun,
+  sideEffectsFromLedger,
+} from '../src/runtimes/run-lifecycle-analytics.js';
+
+const PROD_DEFAULT_MAX_EVENTS = 2_000;
+
+describe('run event-buffer truncation vs artifact verdict (unit)', () => {
+  it('the ledger keeps the artifact verdict after 2000+ later events', () => {
+    const ledger = createRunSideEffectLedger();
+    // Early artifact write: a Write index.html tool_use paired with a
+    // non-error tool_result.
+    foldEventIntoRunSideEffectLedger(ledger, {
+      event: 'agent',
+      data: { type: 'tool_use', id: 'toolu_1', name: 'Write', input: { file_path: 'index.html' } },
+    });
+    foldEventIntoRunSideEffectLedger(ledger, {
+      event: 'agent',
+      data: { type: 'tool_result', toolUseId: 'toolu_1', isError: false },
+    });
+    // Flood with far more than maxEvents later events — these would splice the
+    // tool_use/tool_result out of an in-memory run.events buffer.
+    for (let i = 0; i < PROD_DEFAULT_MAX_EVENTS + 500; i++) {
+      foldEventIntoRunSideEffectLedger(ledger, {
+        event: 'agent',
+        data: { type: 'text_delta', delta: `tok${i}` },
+      });
+    }
+    const verdict = sideEffectsFromLedger(ledger);
+    expect(verdict.artifactWriteSeen).toBe(true);
+    expect(ledger.artifactPaths.size).toBe(1);
+  });
+
+  it('a failed (isError) tool_result does not count as an artifact', () => {
+    const ledger = createRunSideEffectLedger();
+    foldEventIntoRunSideEffectLedger(ledger, {
+      event: 'agent',
+      data: { type: 'tool_use', id: 'toolu_1', name: 'Write', input: { file_path: 'index.html' } },
+    });
+    foldEventIntoRunSideEffectLedger(ledger, {
+      event: 'agent',
+      data: { type: 'tool_result', toolUseId: 'toolu_1', isError: true },
+    });
+    expect(sideEffectsFromLedger(ledger).artifactWriteSeen).toBe(false);
+    expect(ledger.artifactPaths.size).toBe(0);
+  });
+
+  it('pairs a tool_result that arrives before its tool_use', () => {
+    const ledger = createRunSideEffectLedger();
+    foldEventIntoRunSideEffectLedger(ledger, {
+      event: 'agent',
+      data: { type: 'tool_result', toolUseId: 'toolu_1', isError: false },
+    });
+    foldEventIntoRunSideEffectLedger(ledger, {
+      event: 'agent',
+      data: { type: 'tool_use', id: 'toolu_1', name: 'Write', input: { file_path: 'index.html' } },
+    });
+    expect(sideEffectsFromLedger(ledger).artifactWriteSeen).toBe(true);
+  });
+
+  it('runSideEffectsForRun falls back to scanning run.events when no ledger', () => {
+    const events = [
+      { event: 'agent', data: { type: 'tool_use', id: 'toolu_1', name: 'Write', input: { file_path: 'index.html' } } },
+      { event: 'agent', data: { type: 'tool_result', toolUseId: 'toolu_1', isError: false } },
+    ];
+    expect(runSideEffectsForRun({ events }).artifactWriteSeen).toBe(true);
+    expect(runArtifactCountForRun({ events })).toBe(1);
+  });
+});
+
+type StartedServer = { url: string; server: Server; shutdown?: () => Promise<void> | void };
+type RunStatus = { id: string; status: string; exitCode: number | null };
+
+describe('run event-buffer truncation vs artifact verdict (HTTP)', () => {
+  const originalEnv = {
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+  };
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await rm(binDir, { recursive: true, force: true });
+    binDir = null;
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('a run that wrote an artifact then flooded past the ring buffer, then exited non-zero, is succeeded', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-trunc-artifact-bin-'));
+    // Flood well past maxEvents (2000) so the early tool_use/tool_result pair
+    // is spliced out of the in-memory run.events buffer.
+    const fakeClaude = await writeArtifactThenFloodClaude(binDir, 'claude-trunc', PROD_DEFAULT_MAX_EVENTS + 500);
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const run = await createAndWaitForRun(started.url);
+
+    // The run genuinely produced index.html (its tool_use/tool_result is in the
+    // on-disk log) and then exited non-zero. The non-zero exit must be rescued
+    // by the artifact it produced — the verdict must not depend on that
+    // evidence surviving the run.events ring buffer.
+    expect(run.exitCode).toBe(1);
+    expect(run.status).toBe('succeeded');
+  });
+});
+
+async function writeArtifactThenFloodClaude(dir: string, name: string, flood: number): Promise<string> {
+  const bin = path.join(dir, name);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+if (process.argv.includes('--version')) { console.log('claude-code 1.0.0-trunc'); process.exit(0); }
+if (process.argv.includes('--help')) { console.log('Usage: claude -p [--add-dir DIR]'); process.exit(0); }
+// Synchronous writes so every line is delivered before the process exits.
+const W = (o) => fs.writeSync(1, JSON.stringify(o) + '\\n');
+W({ type: 'system', subtype: 'init', model: 'trunc-test' });
+// Early artifact: Write index.html, stop_reason 'tool_use' so no clean turn_end
+// (a clean turn would independently rescue the run and mask the bug).
+W({ type: 'assistant', message: { id: 'm_tool', content: [
+  { type: 'tool_use', id: 'toolu_1', name: 'Write', input: { file_path: 'index.html', content: '<html>hi</html>' } },
+], stop_reason: 'tool_use' } });
+W({ type: 'user', message: { content: [
+  { type: 'tool_result', tool_use_id: 'toolu_1', content: 'File written', is_error: false },
+] } });
+// Flood: text_delta stream events push the early pair out of the ring buffer.
+for (let i = 0; i < ${flood}; i++) {
+  W({ type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 't' + i + ' ' } } });
+}
+process.exit(1); // non-zero, no clean turn_end
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createAndWaitForRun(url: string): Promise<RunStatus> {
+  const projectId = `trunc_artifact_${randomUUID()}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Truncation artifact repro',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const projectBody = await projectResponse.json() as { conversationId: string };
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'trunc-test',
+      'x-od-analytics-session-id': 'trunc-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId: projectBody.conversationId,
+      assistantMessageId: `assistant_trunc_${randomUUID()}`,
+      clientRequestId: `client_trunc_${randomUUID()}`,
+      agentId: 'claude',
+      message: 'reproduce artifact-verdict truncation',
+      currentPrompt: 'reproduce artifact-verdict truncation',
+    }),
+  });
+  expect(runResponse.status).toBe(202);
+  const body = await runResponse.json() as { runId: string };
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 20_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(body.runId)}`);
+    expect(response.status).toBe(200);
+    const run = await response.json() as RunStatus;
+    if (['failed', 'succeeded', 'canceled'].includes(run.status)) return run;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`run ${body.runId} did not finish`);
+}

--- a/apps/daemon/tests/run-event-truncation-artifact-verdict.test.ts
+++ b/apps/daemon/tests/run-event-truncation-artifact-verdict.test.ts
@@ -76,17 +76,42 @@ describe('run event-buffer truncation vs artifact verdict (unit)', () => {
     expect(ledger.artifactPaths.size).toBe(0);
   });
 
-  it('pairs a tool_result that arrives before its tool_use', () => {
+  it('does not accumulate unbounded state for ordinary non-write tool results', () => {
     const ledger = createRunSideEffectLedger();
-    foldEventIntoRunSideEffectLedger(ledger, {
-      event: 'agent',
-      data: { type: 'tool_result', toolUseId: 'toolu_1', isError: false },
-    });
+    // A long tool-heavy run: thousands of Read/Bash/Grep calls, each a
+    // tool_use + tool_result pair. None are write/edit tools, so none should
+    // leave anything behind in the ledger's pending map — otherwise this fix
+    // would reintroduce unbounded per-run growth on the same long-run path it
+    // is meant to harden.
+    for (let i = 0; i < 5_000; i++) {
+      const id = `toolu_read_${i}`;
+      foldEventIntoRunSideEffectLedger(ledger, {
+        event: 'agent',
+        data: { type: 'tool_use', id, name: 'Read', input: { file_path: `src/file${i}.ts` } },
+      });
+      foldEventIntoRunSideEffectLedger(ledger, {
+        event: 'agent',
+        data: { type: 'tool_result', toolUseId: id, isError: false },
+      });
+    }
+    expect(ledger.pendingWritePathById.size).toBe(0);
+    expect(sideEffectsFromLedger(ledger).artifactWriteSeen).toBe(false);
+    expect(ledger.toolCallSeen).toBe(true);
+  });
+
+  it('an artifact write pairs and clears its pending entry once resolved', () => {
+    const ledger = createRunSideEffectLedger();
     foldEventIntoRunSideEffectLedger(ledger, {
       event: 'agent',
       data: { type: 'tool_use', id: 'toolu_1', name: 'Write', input: { file_path: 'index.html' } },
     });
+    foldEventIntoRunSideEffectLedger(ledger, {
+      event: 'agent',
+      data: { type: 'tool_result', toolUseId: 'toolu_1', isError: false },
+    });
     expect(sideEffectsFromLedger(ledger).artifactWriteSeen).toBe(true);
+    // No lingering pending state after a write pairs with its result.
+    expect(ledger.pendingWritePathById.size).toBe(0);
   });
 
   it('runSideEffectsForRun falls back to scanning run.events when no ledger', () => {


### PR DESCRIPTION
Fixes #5350

## Why

I'm hardening the daemon's run-lifecycle / event-retention path and found this while auditing how the finalization verdict reads run state. `run.events` is a bounded ring buffer (maxEvents = 2000); several finalization consumers re-scan it to decide "did this run produce an artifact?". On a long run the artifact's `tool_use`/`tool_result` pair is spliced out before finalization, so a run that genuinely produced an artifact — then streamed >2000 events, then exited non-zero — is misclassified `failed`. The same truncated scan can open the retry safety gate (re-running non-idempotent work) and under-reports `artifact_count` / `design_system_created` / `preview_module_count`. The full history is on disk (`events.jsonl`); only the in-memory verdict is wrong.

## What users will see

A long generation that wrote a file and then kept working before the CLI exited non-zero now correctly shows as **succeeded** instead of a spurious **failed** (the artifact was there all along). No new surface; behavior correction only.

## Surface area

- [x] **None** — internal daemon fix + regression test only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/run-event-truncation-artifact-verdict.test.ts`.
  - HTTP-level test: drives a real run over the daemon API with a fake `claude` CLI that writes an artifact, floods past the ring buffer (maxEvents + 500), then exits non-zero.
  - Unit tests: cover the ledger's tool_use/tool_result pairing (both arrival orders, isError exclusion) and truncation survival, plus the scan-fallback contract.
- Did the test go red on `main` and green on this branch? **yes** — the HTTP symptom test asserts `succeeded`: red (`failed`) on `main`, green with the fix, deterministic 5/5.
- Live A/B on a real daemon (production HTTP API, same fake CLI): before the fix flood=2500 → `failed` (6/6), after the fix → `succeeded` (2/2 ×2); flood=100 stays `succeeded`. A threshold sweep pins the flip exactly at the 2000-event boundary (total 2004 → succeeded, 2007 → failed).

## Approach

Fold committed side effects into a truncation-proof per-run ledger **at emit time**, before the ring buffer can drop the record. `createChatRunService` gains a generic `onEventEmitted` observer (it does not interpret event semantics); the daemon wires it to the ledger. Finalization consumers read the ledger and fall back to the batch scan when a run has no ledger (legacy/test call sites), so short runs and existing tests are unaffected.

## Validation

- `pnpm guard` (78 pass) + `pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit` (clean)
- Full daemon suite: 5464 passed. The 19 pre-existing failures (proxy/SOCKS, connection-test credentials, MiniMax key, vela AMR) reproduce identically on clean `origin/main` and are unrelated to this change (verified by stashing the change and re-running the affected files on baseline).
- Neighboring suites (artifact / retry / analytics / lifecycle): 328 passed.
