### PR TITLE
fix(ci): push the rolling plugin-preview manifest as the release-bot App

### DIFF
--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -41,6 +41,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          # Do NOT persist the default GITHUB_TOKEN as a github.com credential.
+          # The rolling manifest branch is force-pushed below with the release-bot
+          # App token (`x-access-token:${APP_TOKEN}`) precisely so the resulting PR
+          # sync is attributed to app/open-design-release-bot and its CI runs
+          # automatically (a github-actions[bot]-attributed pull_request run is held
+          # as `action_required` — GitHub's bot-recursion gate — which starves
+          # bake-plugin-previews-automerge.yml, since that reactor only approves +
+          # enqueues on `workflow_run.conclusion == 'success'`). When checkout
+          # persists the GITHUB_TOKEN it installs an `http.https://github.com/.extraheader`
+          # Authorization header that overrides the inline App token on push, so the
+          # force-push authenticates as github-actions[bot] and the rolling PR's CI
+          # never runs without a manual "Approve and run". Nothing between here and
+          # the push needs the persisted credential (setup-workspace only touches the
+          # pnpm store; render/upload uses R2 creds; gh + push use the App token), so
+          # dropping it is safe and keeps the App token the sole push credential.
+          persist-credentials: false
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace


### PR DESCRIPTION
## Why

My use case: PR #5312 merged 10 WebGL example templates, the post-merge bake baked them (run 28963067917, `174 baked`) and uploaded the clips to R2 — but the gallery still showed the live `example.html` iframe fallback, not the baked video. Investigating "is the bake workflow broken?" led here.

The pain: the bake is fine, but the **rolling manifest PR that points `main` at the baked clips has not merged since 2026-06-30**. `bake-plugin-previews.yml` force-pushes the `chore/plugin-previews` branch with the **release-bot App token** specifically so the rolling PR's sync is attributed to `app/open-design-release-bot` and its CI runs automatically — then `bake-plugin-previews-automerge.yml` approves + enqueues it. But the Checkout step persists the default `GITHUB_TOKEN` as an `http.https://github.com/.extraheader` Authorization header, and that header **overrides the inline App token on push**. So since ~2026-07-08 the force-push authenticated as `github-actions[bot]`, and a `github-actions[bot]`-attributed `pull_request` run is held as **`action_required`** (GitHub's bot-recursion gate — 0 jobs, and no REST `approve` for a non-fork run). With no green CI, the automerge reactor (gated on `workflow_run.conclusion == 'success'`) stayed `skipped` and the manifest PR sat `BLOCKED` / `REVIEW_REQUIRED` indefinitely. Net effect: `main`'s baked-preview manifest froze at the 06-30 render (0 of the 15 `example-webgl-*` clips present) while the clips sat idle on R2.

Confirmed the mechanism by comparing runs: identical bake code, `05ccccb…d385968` push → CI actor `open-design-release-bot[bot]` → `success`; later `d385968…8ae7aaa` push → CI actor `github-actions[bot]` → `action_required`. The App is installed with full permissions (`actions/contents/pull_requests/workflows: write`), so it is not a permissions regression — it is the persisted-credential override on the push.

(The immediate backlog was drained by hand: re-ran the gated CI as a maintainer to clear the `action_required` gate, then approved + enqueued the rolling PR after verifying `main`'s manifest was untouched in the advance range. This PR removes the recurring cause so it stays hands-free.)

## What users will see

No user-facing change. Behind the scenes, freshly-baked home-gallery preview clips (like the new WebGL example templates) reach `main` on their own again: the post-merge bake's rolling manifest PR is re-attributed to the release-bot App, its CI runs without a manual "Approve and run", and `bake-plugin-previews-automerge.yml` approves + enqueues it as designed — instead of the PR silently stalling and the gallery falling back to the live iframe.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [x] **Extension point** — CI: `.github/workflows/bake-plugin-previews.yml` (post-merge bake / rolling-manifest-PR writer). No change to the discovery protocol, the bake script, or the manifest format.
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

CI-only change; no UI.

## Bug fix verification

The failure is an infra/attribution race that only reproduces against GitHub's live workflow-approval behavior, so there is no cheap red-spec layer for it. Evidence chain instead:
- Before: rolling-branch CI runs since 2026-07-08 all `action_required` with actor `github-actions[bot]` (last real `success` was `d385968…`, actor `open-design-release-bot[bot]`); automerge runs all `skipped`; `#5285` stuck `BLOCKED`.
- After: with `persist-credentials: false`, the force-push carries only the App token, so the next post-merge (or nightly) bake's rolling-branch CI should be attributed to `app/open-design-release-bot` and run without approval. Watch the next run of `bake-plugin-previews.yml` → the `chore/plugin-previews` CI run's `actor` should read `open-design-release-bot[bot]` and conclude `success`, and `bake-plugin-previews-automerge.yml` should approve + enqueue instead of skipping.

## Validation

- `git diff` is a single additive `with: { persist-credentials: false }` block + rationale comment on the Checkout step; no logic changed.
- Audited that nothing between checkout and the push consumes the persisted git credential: `setup-workspace` only manages the pnpm store, the bake composite renders/uploads with R2 creds, and both `gh` and the `git push` use the minted App token explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
