### PR TITLE
fix(ci): push the release-cut baked manifest as a ruleset bypass bot

### DIFF
--- a/.github/workflows/bake-plugin-previews-release.yml
+++ b/.github/workflows/bake-plugin-previews-release.yml
@@ -40,7 +40,16 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
-          token: ${{ secrets.PREVIEW_BAKE_TOKEN || github.token }}
+          # Read-only clone with the default token, but do NOT persist it as a
+          # github.com credential. release/** is guarded by the "Protected
+          # branches (preview/*, release/v*)" ruleset (deletion / non_fast_forward
+          # / pull_request), so a direct push is rejected (GH013) unless the pusher
+          # is a bypass actor. github-actions[bot] is NOT one — so the manifest
+          # writeback below force-authenticates as open-design-bot, which IS a
+          # bypass actor, via an explicit token URL. A persisted github.token
+          # extraheader would override that inline token on push (see #5357), so
+          # drop it; nothing between here and the push needs the persisted cred.
+          persist-credentials: false
 
       - name: Loop guard — skip the bake bot's own manifest commit
         id: guard
@@ -71,8 +80,26 @@ jobs:
           r2-bucket: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_BUCKET }}
           r2-endpoint: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_URL }}
 
+      - name: Mint the open-design-bot token for the release-branch push
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        id: bot
+        # open-design-bot (app id 3640364) is a bypass actor on the
+        # "Protected branches (preview/*, release/v*)" ruleset, so its push clears
+        # the pull_request rule that rejects github-actions[bot] (GH013). The
+        # release bake pushes the manifest directly (it then rides the non-squash
+        # release back-merge to main). Minted here — after the long render, not at
+        # job start — because an App token lives ~1h and the render can run long.
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          owner: nexu-io
+          repositories: open-design
+
       - name: Commit the authoritative manifest onto the release branch
         if: ${{ steps.guard.outputs.skip != 'true' }}
+        env:
+          BOT_TOKEN: ${{ steps.bot.outputs.token }}
         run: |
           OLD=data/plugin-previews/manifest.json
           NEW=.tmp/plugin-previews/manifest.json
@@ -89,4 +116,7 @@ jobs:
           git config user.email "bot@open-design.ai"
           git add "$OLD"
           git commit -m "chore(plugin-previews): refresh baked preview manifest (release cut)"
-          git push origin "HEAD:${GITHUB_REF#refs/heads/}"
+          # Push as open-design-bot (a ruleset bypass actor) via an explicit token
+          # URL. A plain `git push origin` would authenticate as github-actions[bot]
+          # and be rejected by the release/** pull_request rule (GH013).
+          git push "https://x-access-token:${BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF#refs/heads/}"

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -29,6 +29,12 @@ const bakePreviewsAutomergeWorkflowPath = join(
   "bake-plugin-previews-automerge.yml",
 );
 const bakePreviewsWorkflowPath = join(workspaceRoot, ".github", "workflows", "bake-plugin-previews.yml");
+const bakePreviewsReleaseWorkflowPath = join(
+  workspaceRoot,
+  ".github",
+  "workflows",
+  "bake-plugin-previews-release.yml",
+);
 const finalizeReleaseWorkflowPath = join(workspaceRoot, ".github", "workflows", "finalize-release.yml");
 const handoffScriptPath = join(workspaceRoot, ".github", "scripts", "handoff.py");
 const releaseBetaWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-beta.yml");
@@ -812,6 +818,32 @@ process.stdin.on("end", () => {
     //    to a live-main base (fetching refs/heads/main as the parent) fails here.
     expect(workflow).toContain('git checkout -B "$BRANCH"');
     expect(workflow).not.toContain("git/ref/heads/main");
+  });
+
+  it("[P2] keeps the release-cut bake pushing its manifest as a ruleset bypass bot", async () => {
+    // release/** is guarded by the "Protected branches (preview/*, release/v*)" ruleset whose
+    // pull_request rule rejects a direct push (GH013) unless the pusher is a bypass actor. The
+    // release-cut bake writes the authoritative manifest straight onto the release branch, so it
+    // must push as open-design-bot — a bypass actor on that ruleset — not github-actions[bot],
+    // which is NOT and gets rejected (this stranded release/v0.14.2's manifest). These three auth
+    // invariants only work together; a refactor that drops any one silently reintroduces the
+    // GH013 regression, so lock them here rather than rely on YAML review.
+    const workflow = await readFile(bakePreviewsReleaseWorkflowPath, "utf8");
+
+    // 1. Checkout must NOT persist GITHUB_TOKEN: its http.extraheader would override the inline bot
+    //    token on push and re-authenticate as github-actions[bot] (the same override fixed in the
+    //    post-merge bake — #5357).
+    expect(workflow).toContain("persist-credentials: false");
+    // 2. The run mints an open-design-bot token via the BOT_APP_* creds — the App that IS a bypass
+    //    actor on the release ruleset. RELEASE_BOT_APP_ID (used by the post-merge bake) is a
+    //    different App and is NOT a bypass actor, so pin the correct credentials, not just the
+    //    generic token action.
+    expect(workflow).toContain("actions/create-github-app-token");
+    expect(workflow).toContain("secrets.BOT_APP_CLIENT_ID");
+    expect(workflow).toContain("secrets.BOT_APP_PRIVATE_KEY");
+    // 3. The manifest push goes through the explicit tokenized URL with that bot token, so it
+    //    authenticates as the bypass actor rather than the checkout's default credential.
+    expect(workflow).toContain("x-access-token:${BOT_TOKEN}");
   });
 
   it("[P2] keeps PR and merge queue CI separated by hot/full validation mode", async () => {


### PR DESCRIPTION
## Why

My use case: chasing why v0.14.1 shipped the 10 WebGL example templates but with **no baked previews** (the home gallery fell back to live `example.html` iframes — pathological lag for a grid of real-time WebGL shaders). One cause was the stuck rolling-manifest PR on main (fixed in #5357). The other is here: the **release-cut full bake never populated the release branch's manifest**.

The pain: `bake-plugin-previews-release.yml` renders every preview on a `release/**` push, uploads the immutable clips to R2, and pushes the authoritative `data/plugin-previews/manifest.json` straight onto the release branch (it then rides the non-squash back-merge to main). But `release/**` is guarded by the **"Protected branches (preview/*, release/v*)"** ruleset whose `pull_request` rule rejects direct pushes — and the workflow pushed with `PREVIEW_BAKE_TOKEN || github.token`, i.e. **github-actions[bot], which is not a bypass actor**. So the writeback died with:

```
remote: error: GH013: Repository rule violations found for refs/heads/release/v0.14.2.
```

(observed on the `release/v0.14.2` run; `release/v0.14.1` didn't even trigger — a separate new-branch `paths-ignore` quirk). Result: the release branch's bundled manifest is never refreshed, so the packaged app has no baked entry for freshly-added templates and renders them live.

The bypass actor already exists on that ruleset — **open-design-bot (app id 3640364)**, the same App the `metrics` / `blog-indexing` / `refresh-contributors-wall` workflows already mint and push with. The release bake just wasn't using it.

## What users will see

No direct UI change. Downstream: a release cut's baked preview manifest actually lands on the release branch again, so the packaged app plays cheap H.264 clips in the home gallery instead of spinning up live WebGL/iframe previews for newly-added templates.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [x] **Extension point** — CI: `.github/workflows/bake-plugin-previews-release.yml` (release-cut bake / manifest writeback). No change to the bake script, manifest format, or the ruleset itself.
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

CI-only change; no UI.

## Bug fix verification

Reproduces only against GitHub's live ruleset enforcement, so no cheap red-spec layer. Evidence + verification path:
- Before: `bake-plugin-previews-release` run on `release/v0.14.2` failed at "Commit the authoritative manifest onto the release branch" with `GH013: Repository rule violations`. The pushing identity was github-actions[bot] (not a bypass actor).
- After: the writeback mints an open-design-bot token (app id 3640364 — a bypass actor on the ruleset) and pushes with it via an explicit token URL. Verify by dispatching this workflow on a release branch (`workflow_dispatch`) once merged — the "Commit … onto the release branch" step should push cleanly (no GH013).

## Validation

- `git diff` is scoped to the release-bake workflow: `persist-credentials: false` on checkout, a new open-design-bot token-mint step after the render, and an explicit-token-URL push. YAML validated.
- Confirmed the App identity: `BOT_APP_CLIENT_ID` / `BOT_APP_PRIVATE_KEY` mint **open-design-bot** (app id 3640364), which is present in ruleset 16390748's `bypass_actors`. github-actions[bot] is not.
- Nothing between checkout and the push consumes the persisted git credential (loop-guard `git log` is local; setup-workspace only touches the pnpm store; render/upload uses R2 creds), so `persist-credentials: false` is safe and keeps the bot token the sole push credential.

## Deferred (follow-up)

- The currently-open release branches carry the old workflow; this fix reaches releases **cut after it merges**. `release/v0.14.1`'s manifest was already backported by hand; if `release/v0.14.2` (or any live branch) needs a re-bake, backport this workflow change there too.
- The `paths-ignore`-on-a-freshly-created-branch quirk (why `release/v0.14.1`'s cut didn't trigger the bake at all) is a separate reliability gap, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
