### PR TITLE
Expose requestTeamShare as a project-route seam for team moves

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -54,7 +54,7 @@ import { auditDesignSystemPackage } from '../../tools-connectors-cli.js';
 import { parseOrchestratorWorkspace } from '../../workspace-contract.js';
 import { registerProjectConversationRoutes } from './conversations.js';
 
-export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'appConfig' | 'agents' | 'validation'> {}
+export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'appConfig' | 'agents' | 'validation' | 'collabSync'> {}
 
 function projectDetailResolvedDir(
   projectsRoot: string,

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -138,6 +138,21 @@ export interface ServerContext {
   agents: any;
   critique: any;
   openDesignPublicMetadata: OpenDesignPublicMetadataService;
+  /**
+   * C-lane collaboration seam for D's project-visibility routes. After a
+   * successful personal→team move (D's move API), D's handler calls
+   * `collabSync.requestTeamShare(projectId, ownerMemberId)` in-process to trigger
+   * the team sync: the project is marked pending and published to the resource
+   * hub so every teammate can discover + read it. Idempotent (safe to call again
+   * on a re-move). `ownerMemberId` is the member who performed the move — recorded
+   * as the project's single writer so members can tell their own project from a
+   * shared one. D gates the move itself on `canShareProjects`, so this seam does
+   * NOT re-check permission. See routes/collab-sync.ts for the equivalent HTTP
+   * seam (POST /collab/sync-intent) used by the demo surface.
+   */
+  collabSync: {
+    requestTeamShare(projectId: string, ownerMemberId?: string): void;
+  };
   lifecycle: {
     isDaemonShuttingDown: () => boolean;
   };

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4341,6 +4341,9 @@ export async function startServer({
     appConfig: appConfigDeps,
     agents: agentDeps,
     validation: validationDeps,
+    // C-lane sync seam for D's project-visibility routes: a personal→team move
+    // calls requestTeamShare on success to publish the project for the team.
+    collabSync: { requestTeamShare: (projectId, ownerMemberId) => collab.requestTeamShare(projectId, ownerMemberId) },
   });
   registerTerminalRoutes(app, {
     db,


### PR DESCRIPTION
Give the project-visibility move surface a clean in-process seam to trigger team sharing when a project is moved from personal to a team space.

## Why
Project visibility (personal ↔ team) and the collaboration sync mechanism are owned by different route surfaces. When a project is moved into the team space, the move handler needs a way to hand the project off to the sync mechanism so teammates can discover and read it. Until now the only trigger was the HTTP `POST /collab/sync-intent` endpoint (used by the demo surface), which forces a move handler to either make an internal HTTP round-trip or reach into collab internals. This adds a first-class, documented dependency instead.

## What users will see
No direct UI change. This is the wiring that lets "move this project into the team space" actually publish the project to the team: after this + the move handler, a teammate sees the moved project appear in their 全部项目 (team) list and can open it read-only.

## What it does
- Adds a `collabSync` dependency to `ServerContext` (documented) exposing `requestTeamShare(projectId, ownerMemberId?)`.
- Threads it into the project routes (`RegisterProjectRoutesDeps`) and wires it in `server.ts` to the collab runtime.
- A move handler calls `ctx.collabSync.requestTeamShare(projectId, ownerMemberId)` on a successful personal→team move. `ownerMemberId` is the member who performed the move (recorded as the project’s single writer). The call is **idempotent** (safe on a re-move) and does **not** re-check permission — the move handler is expected to gate on `canShareProjects`.

## Testing
- `apps/daemon` typecheck — green.
- The `requestTeamShare` behavior (mark pending → publish → synced) is covered by `apps/daemon/tests/collab-sync-routes.test.ts`.
- Verified end-to-end against a live two-account run: one account shares a project → the other discovers it via `GET /api/workspace/projects/team` and opens it read-only.

## Surface area
- Daemon only: `server-context.ts`, `routes/project/index.ts`, `server.ts`. No contract or web change. The existing `POST /collab/sync-intent` HTTP seam is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)