### PR TITLE
fix(web): stop question-form submit from enqueueing duplicate tasks

### DIFF
--- a/apps/web/src/components/QuestionForm.tsx
+++ b/apps/web/src/components/QuestionForm.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { useT } from '../i18n';
 import type { DirectionCard, FormOption, QuestionForm } from '../artifacts/question-form';
 import { formatFormAnswers, formOptionValueForLabel } from '../artifacts/question-form';
@@ -53,7 +53,16 @@ export const QuestionFormView = forwardRef<QuestionFormHandle, Props>(function Q
     [form, submittedAnswers, draftAnswers],
   );
   const [answers, setAnswers] = useState<Record<string, string | string[]>>(initial);
-  const locked = !interactive || !onSubmit || submittedAnswers !== undefined;
+  // Guards against repeated clicks (internal button, external Continue/Skip
+  // ref, or the auto-continue countdown) firing onSubmit more than once for
+  // the same form — submittedAnswers only arrives after a full round trip
+  // through the agent, so without this a burst of clicks queues one task per
+  // click. The ref makes the guard effective immediately (before the re-render
+  // that `submitted` state triggers); the state mirrors it into `locked` so
+  // the form visually locks the instant it's submitted.
+  const submittedRef = useRef(false);
+  const [submitted, setSubmitted] = useState(false);
+  const locked = !interactive || !onSubmit || submittedAnswers !== undefined || submitted;
   const currentAnswers = submittedAnswers ?? answers;
 
   // When the form streams in question-by-question, backfill state for newly
@@ -105,16 +114,20 @@ export const QuestionFormView = forwardRef<QuestionFormHandle, Props>(function Q
   }
 
   function handleSubmit() {
-    if (locked || !onSubmit) return;
+    if (locked || !onSubmit || submittedRef.current) return;
     // Block submit until required fields are answered and selection caps hold.
     // skipAll() is the only path that intentionally bypasses this (the new
     // Questions-tab Skip button / countdown).
     if (!ready) return;
+    submittedRef.current = true;
+    setSubmitted(true);
     onSubmit(formatFormAnswers(form, answers), answers);
   }
 
   function handleSkipAll() {
-    if (locked || !onSubmit) return;
+    if (locked || !onSubmit || submittedRef.current) return;
+    submittedRef.current = true;
+    setSubmitted(true);
     const empty: Record<string, string | string[]> = {};
     onSubmit(formatFormAnswers(form, empty), empty);
   }

--- a/apps/web/tests/components/QuestionForm.test.tsx
+++ b/apps/web/tests/components/QuestionForm.test.tsx
@@ -319,6 +319,39 @@ describe('QuestionFormView', () => {
     expect(onSubmit.mock.calls[0]?.[1]).toEqual({ platform: 'mobile' });
   });
 
+  // Regression for: repeated clicks on the same submit/Continue affordance
+  // enqueued one duplicate task per click, since the form only locks once
+  // `submittedAnswers` round-trips back through the agent. The form must
+  // self-lock on the FIRST submit so a burst of clicks fires onSubmit once.
+  it('ignores repeated submit clicks after the first one fires onSubmit', () => {
+    const onSubmit = vi.fn();
+    render(<QuestionFormView form={checkboxObjectForm} interactive onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByLabelText('Editorial / magazine'));
+    const submit = screen.getByRole('button', { name: 'Send answers' });
+
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    // Once submitted the form locks immediately (the footer button is
+    // replaced by the "already sent" note), so a 4th click has nothing to hit.
+    expect(screen.queryByRole('button', { name: 'Send answers' })).toBeNull();
+  });
+
+  it('ignores a second skipAll call reached via the imperative handle after the first', () => {
+    const onSubmit = vi.fn();
+    const ref = { current: null as import('../../src/components/QuestionForm').QuestionFormHandle | null };
+    render(<QuestionFormView ref={ref} form={checkboxObjectForm} interactive onSubmit={onSubmit} />);
+
+    ref.current?.skipAll();
+    ref.current?.skipAll();
+    ref.current?.submit();
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it('submits native defaults for required color and defaultless range controls', () => {
     const nativeDefaultsForm = {
       id: 'native-defaults',


### PR DESCRIPTION
Fixes #5346

## Why

Hit this while working through the open Community issues on this repo — reported by a user repeatedly clicking Continue/Skip on a question form and ending up with dozens of duplicate queued runs for the same submission.

## What users will see

No new UI. Clicking Continue/Skip/the internal submit button on a question form (or waiting out the auto-continue countdown) now enqueues exactly one task no matter how many times it's clicked — the form's footer locks to an "already sent" note the instant the first click lands, instead of staying clickable until the agent round-trip confirms the answer.

## Surface area

- [x] **None** — bug fix confined to `QuestionFormView`'s submit/skip guard; no new UI surface, endpoint, or default-behavior change beyond the bug fix itself.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/QuestionForm.test.tsx` → `ignores repeated submit clicks after the first one fires onSubmit` and `ignores a second skipAll call reached via the imperative handle after the first`.
- Did the test go red on `main` and green on this branch? **Yes.** Reverted `QuestionForm.tsx` to the `main` version locally with the new tests in place: both failed (`onSubmit` called 3 times / 2 times instead of 1). Restored the fix: both pass, full suite green (13/13).

## Validation

- `pnpm run guard` (root) — 78/78 checks pass.
- `pnpm run typecheck` (apps/web) — clean, no errors.
- `pnpm exec vitest run tests/components/QuestionForm.test.tsx` — 13/13 pass, including the two new regression tests (confirmed red on `main`, green on this branch — see Bug fix verification above).
