### PR TITLE
fix(web): hide Next Step actions while a question form is unanswered

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -748,6 +748,22 @@ function AssistantMessageImpl({
             : !!onToolboxAction ||
               !!onNextStepCreateDesignSystem ||
               (!!nextStepArtifactName && (!!onArtifactShare || !!onArtifactDownload));
+  // While this message still has a question form the user hasn't submitted
+  // (or skipped) yet, keep the chat pane focused on that form instead of also
+  // surfacing "Next Step" follow-ups — otherwise users can jump into follow-up
+  // actions before the current question stage is resolved.
+  const hasUnansweredQuestionForm = useMemo(() => {
+    for (const block of blocks) {
+      if (block.kind !== "text") continue;
+      for (const seg of splitOnQuestionForms(block.text)) {
+        if (seg.kind !== "form") continue;
+        if (suppressDirectionForms && isDirectionForm(seg.form)) continue;
+        const submitted = nextUserContent ? parseSubmittedAnswers(seg.form, nextUserContent) : null;
+        if (submitted == null) return true;
+      }
+    }
+    return false;
+  }, [blocks, nextUserContent, suppressDirectionForms]);
   // Terminal turns should leave the user with an actionable path, including
   // canceled/failed/no-artifact turns. Artifact-backed cards still wire Share
   // and Download to the chosen file; incomplete cards fall back to composer
@@ -755,6 +771,7 @@ function AssistantMessageImpl({
   const showNextStepActions =
     !streaming &&
     runTerminal &&
+    !hasUnansweredQuestionForm &&
     ((!!isLast && hasNextStepPrimary) || showOpenDesignSubmission);
   // Pre-output vs working: before any real content (text / thinking / tools /
   // files) the footer shimmers "Preparing…"; the moment content lands it

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -755,7 +755,12 @@ function AssistantMessageImpl({
   const hasUnansweredQuestionForm = useMemo(() => {
     for (const block of blocks) {
       if (block.kind !== "text") continue;
-      for (const seg of splitOnQuestionForms(block.text)) {
+      // Strip <artifact>...</artifact> spans first, same as ProseBlock does
+      // before rendering. A `<question-form>` tag can appear inert inside an
+      // artifact payload (e.g. generated HTML that happens to contain that
+      // literal markup) — that never reaches the Questions banner, so it must
+      // not count as a real pending form.
+      for (const seg of splitOnQuestionForms(stripArtifact(block.text))) {
         if (seg.kind !== "form") continue;
         if (suppressDirectionForms && isDirectionForm(seg.form)) continue;
         const submitted = nextUserContent ? parseSubmittedAnswers(seg.form, nextUserContent) : null;

--- a/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
@@ -335,4 +335,42 @@ describe('AssistantMessage next-step affordance', () => {
 
     expect(screen.getByTestId('next-step-actions')).toBeTruthy();
   });
+
+  // Regression for review feedback on #5364: a `<question-form>` tag can
+  // appear inert inside an `<artifact>` payload (e.g. the model generates
+  // HTML that happens to contain that literal markup as sample/demo content)
+  // — that text never reaches the Questions banner, so it must not be
+  // mistaken for a real pending form and suppress Next Step actions.
+  it('does not treat question-form markup embedded inside an artifact as a pending form', () => {
+    // A literal, well-formed <question-form> tag sitting inside the
+    // artifact's own HTML body (e.g. the generated page documents/echoes the
+    // protocol as sample content) — real bytes that would parse as a form
+    // segment if scanned directly, but they're inert once stripArtifact
+    // removes the whole artifact span before rendering.
+    const artifactBody =
+      '<html><body>' +
+      '<question-form id="demo" title="Demo">' +
+      '{"questions":[{"id":"tone","label":"Tone","type":"text"}]}' +
+      '</question-form>' +
+      '</body></html>';
+    const content =
+      'Here is the generated page.\n' +
+      `<artifact type="text/html" identifier="demo.html">${artifactBody}</artifact>`;
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          content,
+          events: [{ kind: 'text', text: content } as NonNullable<ChatMessage['events']>[number]],
+          producedFiles: [producedFile('demo.html')],
+        })}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        {...handlers()}
+      />,
+    );
+
+    expect(screen.queryByTestId('questions-banner')).toBeNull();
+    expect(screen.getByTestId('next-step-actions')).toBeTruthy();
+  });
 });

--- a/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
@@ -290,4 +290,49 @@ describe('AssistantMessage next-step affordance', () => {
     );
     expect(screen.getByTestId('next-step-actions')).toBeTruthy();
   });
+
+  // Regression for: the Next Step card must not appear while this turn's
+  // question form is still unanswered — otherwise users see follow-up
+  // actions before the current Question stage is resolved.
+  it('hides Next Step actions while this turn carries an unanswered question form', () => {
+    const questionFormText =
+      'Before we start, a couple of questions.\n' +
+      '<question-form id="discovery" title="Quick brief">\n' +
+      '{"questions":[{"id":"tone","label":"Tone","type":"text","required":true}]}\n' +
+      '</question-form>';
+    const message = baseMessage({
+      content: questionFormText,
+      events: [{ kind: 'text', text: questionFormText } as NonNullable<ChatMessage['events']>[number]],
+      producedFiles: [],
+    });
+
+    const view = render(
+      <AssistantMessage
+        message={message}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        {...handlers()}
+      />,
+    );
+
+    expect(screen.getByTestId('questions-banner')).toBeTruthy();
+    expect(screen.queryByTestId('next-step-actions')).toBeNull();
+
+    // Once the form is submitted (a "[form answers — …]" reply lands right
+    // after this message), the Question stage is resolved and Next Step
+    // actions can appear.
+    view.rerender(
+      <AssistantMessage
+        message={message}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        nextUserContent={'[form answers — discovery]\n- Tone: Warm'}
+        {...handlers()}
+      />,
+    );
+
+    expect(screen.getByTestId('next-step-actions')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Fixes #5364

## Why

Continuing through the open Community issues on this repo. Reported: while a Question-stage form is still open in the Questions tab, the chat pane's `NEXT STEP` card (Continue working / Generate artifact / More) already shows next to it, letting users jump into follow-up actions before the current question stage is resolved.

## What users will see

No new UI. The Next Step card now stays hidden for a turn whose question form hasn't been submitted or skipped yet, and appears as before once it has.

## Surface area

- [x] **None** — bug fix confined to `showNextStepActions`'s gating condition in `AssistantMessage.tsx`; no new UI surface, endpoint, or default-behavior change.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/AssistantMessage.nextStep.test.tsx` → `hides Next Step actions while this turn carries an unanswered question form` (plus `does not treat question-form markup embedded inside an artifact as a pending form`, added after review).
- Did the test go red on `main` and green on this branch? **Yes**, for both. Reverted `AssistantMessage.tsx` to the `main` version locally with each new test in place: both failed (Next Step rendered while the form was still open; then, after the artifact fix, Next Step was wrongly hidden for a form embedded inside an artifact). Restored the fixes: both pass, full suite green (14/14).

## Root cause

`showNextStepActions` only checked run-terminal/artifact state, never whether the same turn still carried a question form the user hadn't answered. Added `hasUnansweredQuestionForm`: scans the message's text blocks for `<question-form>`/`<ask-question>` segments and checks whether a `"[form answers — …]"` reply already followed — the same check `FormBlock` uses to render the Questions banner as answered/unanswered.

## Validation

- `pnpm exec vitest run tests/components/AssistantMessage.nextStep.test.tsx` (apps/web) — 14/14 pass, including both regression tests (each confirmed red on `main`, green on this branch).
- `pnpm run typecheck` (apps/web) — clean, no errors.
