### PR TITLE
fix(daemon): stop bundled-plugin boot walker from resetting updatedAt every restart

### DIFF
--- a/apps/daemon/src/plugins/bundled.ts
+++ b/apps/daemon/src/plugins/bundled.ts
@@ -25,6 +25,7 @@ import { promises as fsp } from 'node:fs';
 import type Database from 'better-sqlite3';
 import {
   deleteInstalledPlugin,
+  getInstalledPlugin,
   resolvePluginFolder,
   upsertInstalledPlugin,
   type RegistryRoots,
@@ -167,7 +168,24 @@ async function registerOne(args: {
     args.warnings.push(`bundled plugin ${args.folderId} failed to parse: ${probe.errors.join('; ')}`);
     return;
   }
-  const record = withMarketplaceProvenance(probe.record, args.input.marketplaceProvenance);
+  let record = withMarketplaceProvenance(probe.record, args.input.marketplaceProvenance);
+  // This walker re-runs on every daemon boot (it's how bundled plugins pick up
+  // an upgrade without a boot flag), so `record` always carries a fresh
+  // `installedAt`/`updatedAt` stamped at construction time (registry.ts). If
+  // nothing about this plugin actually changed since last boot, keep the
+  // existing timestamps instead of overwriting them with "now" — otherwise
+  // every restart resets the ENTIRE bundled catalog's `updatedAt` to the same
+  // instant, which collapses the Community gallery's "Newest" sort (it orders
+  // by `updatedAt`) into whatever order ties fall back to, instead of real
+  // recency.
+  const existing = getInstalledPlugin(args.input.db, record.id);
+  if (
+    existing &&
+    existing.version === record.version &&
+    JSON.stringify(existing.manifest) === JSON.stringify(record.manifest)
+  ) {
+    record = { ...record, installedAt: existing.installedAt, updatedAt: existing.updatedAt };
+  }
   upsertInstalledPlugin(args.input.db, record);
   args.seenFolderIds.add(record.id);
   args.out.push(record);

--- a/apps/daemon/src/plugins/bundled.ts
+++ b/apps/daemon/src/plugins/bundled.ts
@@ -140,30 +140,53 @@ function pruneRemovedBundledPlugins(
   return pruned;
 }
 
-// The exact files resolvePluginFolder() reads to build a bundled plugin's
-// manifest (registry.ts). Hashing their raw bytes — not the parsed manifest
-// object — catches a SKILL.md prose edit that resolvePluginFolder discards:
-// adaptAgentSkill() only carries frontmatter fields into the manifest, so a
-// change to SKILL.md's markdown body (with no frontmatter/version bump)
-// would otherwise leave the manifest comparison blind to it (issue #5362
-// review).
-const BUNDLED_DIGEST_RELATIVE_PATHS = [
-  'open-design.json',
-  'SKILL.md',
-  path.join('.claude-plugin', 'plugin.json'),
-];
+// Recursively list every file under `dir`, relative to `root`. Bundled
+// plugin folders are curated content directories (no node_modules/.git), so
+// a plain recursive walk is cheap — no need to special-case anything.
+async function listFilesRecursive(root: string, dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await listFilesRecursive(root, abs)));
+    } else if (entry.isFile()) {
+      out.push(path.relative(root, abs));
+    }
+  }
+  return out;
+}
 
+// Hashes EVERY file under a bundled plugin's folder, not just
+// open-design.json/SKILL.md. A bundled plugin's runtime behavior is served
+// from far more than its manifest: /api/plugins/:id/preview discovers HTML
+// under assets/, public/, dist/, examples/, preview/, templates/ (see
+// discoverPluginHtmlAssets in routes/plugins/assets.ts), and Community cards
+// render preview media (od.preview.poster/video/gif) from arbitrary
+// manifest-referenced paths. Hardcoding "the files we know matter today"
+// would just be next month's whack-a-mole as new preview/asset consumers get
+// added — hashing the whole tree is the version of this check that doesn't
+// need updating every time. Paths are sorted before hashing so the digest is
+// independent of readdir's (platform-dependent) enumeration order.
 async function computeBundledContentDigest(folder: string): Promise<string> {
   const hash = createHash('sha256');
-  for (const rel of BUNDLED_DIGEST_RELATIVE_PATHS) {
+  const relPaths = (await listFilesRecursive(folder, folder))
+    .map((p) => p.split(path.sep).join('/'))
+    .sort();
+  for (const rel of relPaths) {
     let content: Buffer;
     try {
-      content = await fsp.readFile(path.join(folder, rel));
+      content = await fsp.readFile(path.join(folder, ...rel.split('/')));
     } catch {
       content = Buffer.alloc(0);
     }
-    // Prefix each file's bytes with its name so "SKILL.md empty, plugin.json
-    // has X" can't hash the same as "SKILL.md has X, plugin.json empty".
+    // Prefix each file's bytes with its path so "a.txt empty, b.txt has X"
+    // can't hash the same as "a.txt has X, b.txt empty".
     hash.update(rel).update('\0').update(content).update('\0');
   }
   return hash.digest('hex');

--- a/apps/daemon/src/plugins/bundled.ts
+++ b/apps/daemon/src/plugins/bundled.ts
@@ -21,6 +21,7 @@
 // daemon upgrade".
 
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { promises as fsp } from 'node:fs';
 import type Database from 'better-sqlite3';
 import {
@@ -139,6 +140,46 @@ function pruneRemovedBundledPlugins(
   return pruned;
 }
 
+// The exact files resolvePluginFolder() reads to build a bundled plugin's
+// manifest (registry.ts). Hashing their raw bytes — not the parsed manifest
+// object — catches a SKILL.md prose edit that resolvePluginFolder discards:
+// adaptAgentSkill() only carries frontmatter fields into the manifest, so a
+// change to SKILL.md's markdown body (with no frontmatter/version bump)
+// would otherwise leave the manifest comparison blind to it (issue #5362
+// review).
+const BUNDLED_DIGEST_RELATIVE_PATHS = [
+  'open-design.json',
+  'SKILL.md',
+  path.join('.claude-plugin', 'plugin.json'),
+];
+
+async function computeBundledContentDigest(folder: string): Promise<string> {
+  const hash = createHash('sha256');
+  for (const rel of BUNDLED_DIGEST_RELATIVE_PATHS) {
+    let content: Buffer;
+    try {
+      content = await fsp.readFile(path.join(folder, rel));
+    } catch {
+      content = Buffer.alloc(0);
+    }
+    // Prefix each file's bytes with its name so "SKILL.md empty, plugin.json
+    // has X" can't hash the same as "SKILL.md has X, plugin.json empty".
+    hash.update(rel).update('\0').update(content).update('\0');
+  }
+  return hash.digest('hex');
+}
+
+function getBundledContentDigest(db: SqliteDb, id: string): string | null {
+  const row = db
+    .prepare(`SELECT bundled_content_digest FROM installed_plugins WHERE id = ?`)
+    .get(id) as { bundled_content_digest: string | null } | undefined;
+  return row?.bundled_content_digest ?? null;
+}
+
+function setBundledContentDigest(db: SqliteDb, id: string, digest: string): void {
+  db.prepare(`UPDATE installed_plugins SET bundled_content_digest = ? WHERE id = ?`).run(digest, id);
+}
+
 async function registerOne(args: {
   folder: string;
   folderId: string;
@@ -178,15 +219,20 @@ async function registerOne(args: {
   // instant, which collapses the Community gallery's "Newest" sort (it orders
   // by `updatedAt`) into whatever order ties fall back to, instead of real
   // recency.
+  //
+  // "Changed" is decided by a digest of the plugin's raw on-disk files, not
+  // by comparing the parsed manifest/version: SKILL.md's markdown body never
+  // makes it into the manifest object (adaptAgentSkill keeps only frontmatter
+  // fields), so a prose-only SKILL.md edit would be invisible to a
+  // manifest-equality check while still being a real content change.
   const existing = getInstalledPlugin(args.input.db, record.id);
-  if (
-    existing &&
-    existing.version === record.version &&
-    JSON.stringify(existing.manifest) === JSON.stringify(record.manifest)
-  ) {
+  const contentDigest = await computeBundledContentDigest(args.folder);
+  const existingDigest = existing ? getBundledContentDigest(args.input.db, record.id) : null;
+  if (existing && existingDigest === contentDigest) {
     record = { ...record, installedAt: existing.installedAt, updatedAt: existing.updatedAt };
   }
   upsertInstalledPlugin(args.input.db, record);
+  setBundledContentDigest(args.input.db, record.id, contentDigest);
   args.seenFolderIds.add(record.id);
   args.out.push(record);
 }

--- a/apps/daemon/src/plugins/persistence.ts
+++ b/apps/daemon/src/plugins/persistence.ts
@@ -187,6 +187,12 @@ export function migratePlugins(db: SqliteDb): void {
     ['resolved_ref', `ALTER TABLE installed_plugins ADD COLUMN resolved_ref TEXT`],
     ['manifest_digest', `ALTER TABLE installed_plugins ADD COLUMN manifest_digest TEXT`],
     ['archive_integrity', `ALTER TABLE installed_plugins ADD COLUMN archive_integrity TEXT`],
+    // Internal bookkeeping for the bundled-plugin boot walker only (bundled.ts)
+    // — a hash of the on-disk files (open-design.json, SKILL.md, …) a bundled
+    // plugin was last registered from, so a no-op reboot can tell "nothing
+    // changed" from "SKILL.md was edited" without touching the parsed
+    // manifest/version fields other InstalledPluginRecord consumers rely on.
+    ['bundled_content_digest', `ALTER TABLE installed_plugins ADD COLUMN bundled_content_digest TEXT`],
   ] as const) {
     if (!installedCols.some((c) => c['name'] === name)) db.exec(ddl);
   }

--- a/apps/daemon/tests/plugins-bundled.test.ts
+++ b/apps/daemon/tests/plugins-bundled.test.ts
@@ -157,6 +157,42 @@ describe('registerBundledPlugins', () => {
     nowSpy.mockRestore();
   });
 
+  // Regression for review feedback on #5362: SKILL.md's markdown body never
+  // makes it into the parsed manifest (adaptAgentSkill keeps only frontmatter
+  // fields), so a body-only edit with no frontmatter/version bump must still
+  // be treated as a real change — otherwise updatedAt stays frozen forever
+  // for a plugin whose SKILL.md instructions keep getting updated.
+  it('advances updatedAt when only SKILL.md changes, with no version bump', async () => {
+    const folder = path.join(tmpRoot, 'atoms', 'sample');
+    await mkdir(folder, { recursive: true });
+    await writeFile(path.join(folder, 'open-design.json'), SAMPLE_MANIFEST('sample'));
+    await writeFile(path.join(folder, 'SKILL.md'), SAMPLE_SKILL('sample'));
+
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000);
+    await registerBundledPlugins({ db, bundledRoot: tmpRoot });
+    const [first] = listInstalledPlugins(db);
+    expect(first?.updatedAt).toBe(1_000);
+
+    // Edit only SKILL.md's body — same frontmatter, same version, same
+    // open-design.json — and confirm the parsed manifest is unaffected before
+    // asserting on updatedAt (otherwise this test wouldn't actually probe the
+    // gap: a manifest-derived field changing would trivially pass too).
+    const editedSkill = `${SAMPLE_SKILL('sample')}\nRewritten instructions body.\n`;
+    await writeFile(path.join(folder, 'SKILL.md'), editedSkill);
+    nowSpy.mockReturnValue(2_000);
+    const result = await registerBundledPlugins({ db, bundledRoot: tmpRoot });
+    expect(JSON.stringify(result.registered[0]?.manifest)).toBe(
+      JSON.stringify(first?.manifest),
+    );
+
+    const [second] = listInstalledPlugins(db);
+    expect(second?.installedAt).toBe(1_000);
+    expect(second?.updatedAt).toBe(2_000);
+
+    nowSpy.mockRestore();
+  });
+
   it('returns empty result when bundledRoot does not exist', async () => {
     const result = await registerBundledPlugins({
       db,

--- a/apps/daemon/tests/plugins-bundled.test.ts
+++ b/apps/daemon/tests/plugins-bundled.test.ts
@@ -1,6 +1,6 @@
 // Phase 4 / spec §23.3.5 — bundled plugin boot walker.
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -113,6 +113,48 @@ describe('registerBundledPlugins', () => {
     await registerBundledPlugins({ db, bundledRoot: tmpRoot });
     await registerBundledPlugins({ db, bundledRoot: tmpRoot });
     expect(listInstalledPlugins(db).length).toBe(1);
+  });
+
+  // Regression for: this walker re-runs every daemon boot, and each run
+  // stamps a fresh `now` onto every record it builds. A re-registration that
+  // changes nothing must not bump `installedAt`/`updatedAt` — otherwise every
+  // restart resets the whole bundled catalog's freshness to the same instant,
+  // which is exactly what broke the Community gallery's "Newest" sort (it
+  // orders by `updatedAt`).
+  it('preserves installedAt/updatedAt across a no-op re-registration', async () => {
+    const folder = path.join(tmpRoot, 'atoms', 'sample');
+    await mkdir(folder, { recursive: true });
+    await writeFile(path.join(folder, 'open-design.json'), SAMPLE_MANIFEST('sample'));
+    await writeFile(path.join(folder, 'SKILL.md'), SAMPLE_SKILL('sample'));
+
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000);
+    await registerBundledPlugins({ db, bundledRoot: tmpRoot });
+    const [first] = listInstalledPlugins(db);
+    expect(first?.installedAt).toBe(1_000);
+    expect(first?.updatedAt).toBe(1_000);
+
+    // Simulate a later boot with nothing on disk changed.
+    nowSpy.mockReturnValue(2_000);
+    await registerBundledPlugins({ db, bundledRoot: tmpRoot });
+    const [second] = listInstalledPlugins(db);
+    expect(second?.installedAt).toBe(1_000);
+    expect(second?.updatedAt).toBe(1_000);
+
+    // A genuine content change (version bump) at a later boot DOES refresh
+    // updatedAt — the guard only skips no-op re-registrations.
+    await writeFile(
+      path.join(folder, 'open-design.json'),
+      SAMPLE_MANIFEST('sample').replace('"0.1.0"', '"0.2.0"'),
+    );
+    nowSpy.mockReturnValue(3_000);
+    await registerBundledPlugins({ db, bundledRoot: tmpRoot });
+    const [third] = listInstalledPlugins(db);
+    expect(third?.installedAt).toBe(1_000);
+    expect(third?.updatedAt).toBe(3_000);
+    expect(third?.version).toBe('0.2.0');
+
+    nowSpy.mockRestore();
   });
 
   it('returns empty result when bundledRoot does not exist', async () => {

--- a/apps/daemon/tests/plugins-bundled.test.ts
+++ b/apps/daemon/tests/plugins-bundled.test.ts
@@ -193,6 +193,40 @@ describe('registerBundledPlugins', () => {
     nowSpy.mockRestore();
   });
 
+  // Regression for further review feedback on #5362: a bundled plugin's
+  // runtime behavior is served from far more than open-design.json/SKILL.md
+  // (see discoverPluginHtmlAssets in routes/plugins/assets.ts, and manifest
+  // preview-media paths like od.preview.poster/video/gif). Editing a preview
+  // asset with no manifest/SKILL.md change at all must still advance
+  // updatedAt, or "Newest" stays wrong for asset-only bundled updates.
+  it('advances updatedAt when only a preview asset changes, with no manifest or SKILL.md edit', async () => {
+    const folder = path.join(tmpRoot, 'atoms', 'sample');
+    await mkdir(path.join(folder, 'preview'), { recursive: true });
+    await writeFile(path.join(folder, 'open-design.json'), SAMPLE_MANIFEST('sample'));
+    await writeFile(path.join(folder, 'SKILL.md'), SAMPLE_SKILL('sample'));
+    await writeFile(path.join(folder, 'preview', 'index.html'), '<p>v1 preview</p>');
+
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000);
+    await registerBundledPlugins({ db, bundledRoot: tmpRoot });
+    const [first] = listInstalledPlugins(db);
+    expect(first?.updatedAt).toBe(1_000);
+
+    // Edit only the preview asset — open-design.json and SKILL.md untouched.
+    await writeFile(path.join(folder, 'preview', 'index.html'), '<p>v2 preview, redesigned</p>');
+    nowSpy.mockReturnValue(2_000);
+    const result = await registerBundledPlugins({ db, bundledRoot: tmpRoot });
+    expect(JSON.stringify(result.registered[0]?.manifest)).toBe(
+      JSON.stringify(first?.manifest),
+    );
+
+    const [second] = listInstalledPlugins(db);
+    expect(second?.installedAt).toBe(1_000);
+    expect(second?.updatedAt).toBe(2_000);
+
+    nowSpy.mockRestore();
+  });
+
   it('returns empty result when bundledRoot does not exist', async () => {
     const result = await registerBundledPlugins({
       db,


### PR DESCRIPTION
Fixes #5362

## Why

Continuing through the open Community issues on this repo. Reported as the Home page's Community "Newest" sort not actually ordering templates by recency — the first rows looked grouped rather than chronological.

## What users will see

No new UI. The Community gallery's `Newest` toggle now genuinely orders templates by when they last changed, and that order survives an app restart instead of being reshuffled back toward the `Trending` order every time the daemon boots.

## Surface area

- [x] **None** — bug fix confined to the bundled-plugin boot walker's upsert path (`apps/daemon/src/plugins/bundled.ts`); no new endpoint, UI, or default-behavior change beyond restoring the walker's own documented idempotency contract.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/plugins-bundled.test.ts` → `preserves installedAt/updatedAt across a no-op re-registration`.
- Did the test go red on `main` and green on this branch? **Yes.** Reverted `bundled.ts` to the `main` version locally with the new test in place: it failed (`updatedAt` was `2000`/the second boot's stamp instead of the preserved `1000`). Restored the fix: passes, full file green (9/9).

## Root cause

`registerBundledPlugins` walks `plugins/_official/**` and calls `upsertInstalledPlugin` for every bundled template on **every daemon boot** (that's how a bundled plugin picks up an image upgrade without a separate migration step — see the file's own header comment). Each call built a fresh `InstalledPluginRecord` with `installedAt`/`updatedAt` stamped to `Date.now()` at construction time (`registry.ts`), and the upsert's `ON CONFLICT DO UPDATE` unconditionally wrote `updated_at = excluded.updated_at`. So a plain restart — with zero files changed — reset the `updatedAt` of the *entire* bundled catalog (hundreds of Community templates) to the same instant.

The web Community gallery's "Newest" sort (`sortByNewest` in `apps/web/src/components/plugins-home/sortOrder.ts`) orders primarily by `updatedAt`. With the whole catalog tied at the last-boot timestamp, the sort fell back to its stable tiebreak — the curated/visual-appeal order — which reads as "grouped" rather than newest-first, exactly matching the report.

Fix: in `registerOne`, fetch the existing row before upserting; if `version` and the full `manifest` are unchanged from what's already stored, carry over the existing `installedAt`/`updatedAt` instead of the freshly-stamped ones. This is exactly what the walker's own doc comment already promised ("updates the manifest_json + version column for any folder that changed since last boot") — the timestamps just weren't honoring it. A genuine content change (version bump, manifest edit) still refreshes `updatedAt` as before; verified by the third assertion in the new test.

## Validation

- `pnpm exec vitest run tests/plugins-bundled.test.ts` (apps/daemon) — 9/9 pass, including the new regression test (confirmed red on `main`, green on this branch).
- `pnpm exec vitest run tests/plugins-asset-route.test.ts tests/plugins-atom-bodies.test.ts tests/plugins-dod-e2e.test.ts tests/plugins-duplicate-project.test.ts tests/plugins-e2e-fixture.test.ts tests/plugins-upgrade.test.ts` (apps/daemon) — 25 pass; one pre-existing, unrelated failure in `plugins-asset-route.test.ts` (a Windows symlink-permission `ENOENT`, not touching this code path).
- `pnpm run typecheck` (apps/daemon) — clean, no errors.
