### PR TITLE
fix(web): update composer provider icon after switching to BYOK

### DIFF
--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -333,7 +333,7 @@ export function AvatarMenu({
         title={t('avatar.title')}
         aria-label={t('avatar.title')}
       >
-        {currentAgent ? (
+        {config.mode === 'daemon' && currentAgent ? (
           <AgentIcon id={currentAgent.id} size={20} />
         ) : (
           <RemixIcon name="link" size={20} />

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -116,6 +116,46 @@ describe('AvatarMenu', () => {
     vi.clearAllMocks();
   });
 
+  // Regression for: the composer's compact provider trigger kept showing the
+  // last-used local CLI agent's icon after switching to `Use API · BYOK`,
+  // because the icon was picked purely from `currentAgent` (derived from
+  // `config.agentId`) without checking `config.mode` — the same check every
+  // other mode-aware element in this file (and InlineModelSwitcher's chip)
+  // already makes.
+  it('shows the BYOK glyph, not the stale CLI agent icon, once mode switches to api', () => {
+    const trigger = () => screen.getByRole('button', { name: 'avatar.title' });
+
+    const { rerender } = render(
+      <AvatarMenu
+        config={baseConfig}
+        agents={[codexAgent, claudeAgent]}
+        daemonLive
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onRefreshAgents={vi.fn()}
+      />,
+    );
+    expect(trigger().querySelector('img.agent-icon')).toBeTruthy();
+    expect(trigger().querySelector('.ri-link')).toBeNull();
+
+    rerender(
+      <AvatarMenu
+        config={{ ...baseConfig, mode: 'api' }}
+        agents={[codexAgent, claudeAgent]}
+        daemonLive
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onRefreshAgents={vi.fn()}
+      />,
+    );
+    expect(trigger().querySelector('img.agent-icon')).toBeNull();
+    expect(trigger().querySelector('.ri-link')).toBeTruthy();
+  });
+
   it('opens execution settings when Local CLI is selected while the daemon is offline', () => {
     const onOpenSettings = vi.fn();
     renderMenu({


### PR DESCRIPTION
Fixes #5366

## Why

Continuing through the open Community issues on this repo. Reported: after switching the composer from a local CLI provider to `Use API · BYOK`, the compact provider button still showed the old CLI provider's icon, which is misleading about which execution mode is actually active.

## What users will see

No new UI. The composer footer's provider trigger button now shows the BYOK/link glyph immediately after switching to `Use API · BYOK`, instead of the stale local-CLI agent icon.

## Surface area

- [x] **None** — bug fix confined to `AvatarMenu`'s trigger icon condition; no new UI surface, endpoint, or default-behavior change.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/AvatarMenu.test.tsx` → `shows the BYOK glyph, not the stale CLI agent icon, once mode switches to api`.
- Did the test go red on `main` and green on this branch? **Yes.** Reverted `AvatarMenu.tsx` to the `main` version locally with the new test in place: it failed (rendered `<img class="agent-icon" src="/agent-icons/codex.svg">` instead of the `.ri-link` glyph after switching to `api` mode). Restored the fix: passes, full suite green (12/12).

## Root cause

`AvatarMenu`'s trigger button rendered `currentAgent ? <AgentIcon id={currentAgent.id} .../> : <RemixIcon name="link" .../>` — `currentAgent` is derived purely from `config.agentId` (the last-selected local CLI agent), independent of `config.mode`. Switching to BYOK only flips `config.mode` to `'api'`; `config.agentId` is left untouched, so `currentAgent` stays truthy and the trigger kept resolving to the old CLI icon.

Every other mode-aware branch in this same file (e.g. the `Use Local CLI` / `Use API · BYOK` menu rows) and the equivalent chip icon in `InlineModelSwitcher.tsx` (`config.mode === 'daemon' && currentAgent ? <AgentIcon/> : <link glyph/>`) already gate on `config.mode` — the trigger's icon was the one spot that didn't. Fix: add the same `config.mode === 'daemon'` check.

## Validation

- `pnpm exec vitest run tests/components/AvatarMenu.test.tsx` (apps/web) — 12/12 pass, including the new regression test (confirmed red on `main`, green on this branch).
- `pnpm run typecheck` (apps/web) — clean, no errors.
