### PR TITLE
fix(daemon): filter BAAI BGE embedding models out of the BYOK chat-model picker

### DIFF
--- a/apps/daemon/src/integrations/provider-models.ts
+++ b/apps/daemon/src/integrations/provider-models.ts
@@ -108,6 +108,12 @@ function isOpenAiChatModelId(id: string): boolean {
     normalized.includes('dall-e') ||
     normalized.includes('stable-diffusion') ||
     normalized.includes('flux') ||
+    // BAAI's BGE embedding family (e.g. `BAAI/bge-large-en-v1.5`, served by
+    // gateways like SiliconFlow) doesn't match any of the substrings above —
+    // `bge-reranker-*` variants are already caught by the `rerank` check, but
+    // the plain embedding models slip through and 404 when a chat-completion
+    // test is run against them (issue #5367).
+    /(?:^|[/_-])bge(?:[-_]|$)/u.test(normalized) ||
     (
       normalized.includes('wan') &&
       /(?:^|[-_.:])(?:t2v|i2v|v2v)(?:[-_.:]|$)/u.test(normalized)

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -244,6 +244,41 @@ describe('POST /api/provider/models', () => {
     });
   });
 
+  // Regression for #5367: a gateway's /models catalogue can list embedding
+  // models alongside real chat models. `BAAI/bge-large-en-v1.5` (reported via
+  // SiliconFlow) doesn't contain any of the existing exclusion substrings
+  // (`embedding`, `rerank`, ...), so it was surfacing as a "loaded" chat model
+  // in the picker and then 404ing the moment a user actually tested it.
+  it('excludes the BGE embedding family from an OpenAI-compatible /models catalogue', async () => {
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({
+        data: [
+          { id: 'deepseek-ai/DeepSeek-V3', object: 'model' },
+          { id: 'BAAI/bge-large-en-v1.5', object: 'model' },
+          { id: 'BAAI/bge-reranker-v2-m3', object: 'model' },
+        ],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/provider/models`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        protocol: 'openai',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        apiKey: 'sk-siliconflow',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      kind: 'success',
+      models: [{ id: 'deepseek-ai/DeepSeek-V3', label: 'deepseek-ai/DeepSeek-V3' }],
+    });
+  });
+
   it('routes provider model discovery through the live proxy dispatcher', async () => {
     const proxySpy = vi.spyOn(platform, 'resolveSystemProxyEnv').mockReturnValue({
       HTTP_PROXY: 'http://proxy.example.test:8080',


### PR DESCRIPTION
Fixes #5367

## Why

Continuing through the open Community issues on this repo. Reported: BYOK provider settings can fetch and list a provider's models (e.g. "70 models" from SiliconFlow), but testing a listed model can fail with `model not found` / `404`, because the fetched list includes models that were never usable for chat in the first place.

## What users will see

No new UI. The BYOK model picker for OpenAI-compatible gateways (SiliconFlow, Volcengine Ark, and similar) no longer lists BAAI's BGE embedding models (e.g. `BAAI/bge-large-en-v1.5`) as selectable chat models — they were never valid chat-completion targets and always failed the "test" action with a not-found error.

## Surface area

- [x] **None** — bug fix confined to the existing chat-model classification heuristic (`isOpenAiChatModelId` in `apps/daemon/src/integrations/provider-models.ts`); no new endpoint, UI, or default-behavior change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts` → `excludes the BGE embedding family from an OpenAI-compatible /models catalogue` (under `POST /api/provider/models`).
- Did the test go red on `main` and green on this branch? **Yes.** Reverted `provider-models.ts` to the `main` version locally with the new test in place: it failed (`BAAI/bge-large-en-v1.5` appeared in the returned model list ahead of the real chat model). Restored the fix: passes; full `POST /api/provider/models` block green (12/12).

## Root cause

`listProviderModels` classifies which fetched models are chat-selectable via `isOpenAiChatModelId`, which excludes ids containing substrings like `embedding`, `rerank`, `tts`, `whisper`, etc. BAAI's BGE embedding family (`bge-large-en-v1.5`, `bge-base-zh`, `bge-m3`, …) doesn't contain any of those substrings, so it passed straight through as a normal chat model — while its sibling `bge-reranker-*` variants were already correctly excluded via the `rerank` substring check. The picker then showed it as "loaded from the account," and testing it 404'd, exactly matching the screenshot in the issue (SiliconFlow's `BAAI/bge-large-en-v1.5`).

Scope note: the issue also cites a Volcengine Ark example (`doubao-1-5-thinking-pro-250415 -> 404`) that looks like a genuine chat model name — that failure mode is different (likely an endpoint/deployment-id requirement specific to Ark's API, not a model-classification gap) and isn't addressed by this change; I didn't want to guess at un-verified, vendor-specific API behavior. This PR fixes the concretely-reproducible embedding-model leak (the issue's "Filter fetched provider models down to chat-completion-compatible models" remedy).

## Validation

- `pnpm exec vitest run tests/connection-test.test.ts -t "provider/models"` (apps/daemon) — 12/12 pass, including the new regression test (confirmed red on `main`, green on this branch).
- `pnpm run typecheck` (apps/daemon) — clean, no errors.
