### PR TITLE
docs: add a one-line intro to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Open Design
 
+This guide explains how to contribute to Open Design.
+
 Thanks for thinking about contributing. OD is small on purpose — most of the value lives in **files** (skills, design systems, prompt fragments) rather than framework code. That means the highest-leverage contributions are usually one folder, one Markdown file, or one PR-sized adapter.
 
 This guide tells you exactly where to look for each type of contribution and what bar a PR has to clear before we merge it.


### PR DESCRIPTION
Closes #1276

## Why

`CONTRIBUTING.md` currently jumps from the title straight into detailed guidance. This tiny docs issue asks for a one-sentence introduction so readers immediately understand that the file is the contribution guide for Open Design.

## What users will see

Opening `CONTRIBUTING.md` now shows a concise sentence directly under the title explaining that the document is the guide for contributing to Open Design.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A.

## Bug fix verification

- Not a bug fix; this is a docs-only update.

## Validation

- `git diff --check`
- Reviewed the constrained one-file diff in `CONTRIBUTING.md`
- `pnpm guard` could not run successfully in this environment because the workspace is on Node `v22.22.0` instead of the required Node `~24` and local dependencies such as `tsx` are not installed
- `pnpm typecheck` could not run successfully in this environment for the same reason (`tsc` / `astro` are unavailable without installed workspace dependencies)

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>