### PR TITLE
fix(web): label library filter selects for screen readers

### DIFF
--- a/apps/web/src/components/LibrarySection.tsx
+++ b/apps/web/src/components/LibrarySection.tsx
@@ -1131,14 +1131,14 @@ export function LibrarySection({ active, onOpenProject }: Props) {
             onChange={(e) => setSearch(e.target.value)}
           />
         </div>
-        <select className={styles.select} value={kind} onChange={(e) => setKind(e.target.value)}>
+        <select aria-label="Filter by kind" className={styles.select} value={kind} onChange={(e) => setKind(e.target.value)}>
           {KIND_FILTERS.map((f) => (
             <option key={f.value} value={f.value}>
               {f.label}
             </option>
           ))}
         </select>
-        <select className={styles.select} value={source} onChange={(e) => setSource(e.target.value)}>
+        <select aria-label="Filter by source" className={styles.select} value={source} onChange={(e) => setSource(e.target.value)}>
           {SOURCE_FILTERS.map((f) => (
             <option key={f.value} value={f.value}>
               {f.label}

--- a/apps/web/tests/components/LibrarySection.a11y.test.tsx
+++ b/apps/web/tests/components/LibrarySection.a11y.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LibraryAsset } from '@open-design/contracts';
+
+vi.mock('../../src/components/plugins-home/useInView', () => ({
+  useInView: () => ({ ref: { current: null }, inView: false }),
+}));
+
+const fetchLibraryAssets = vi.fn(async (): Promise<LibraryAsset[]> => []);
+const fetchLibraryAsset = vi.fn(async (): Promise<LibraryAsset | null> => null);
+vi.mock('../../src/providers/registry', () => ({
+  fetchLibraryAssets: (...args: unknown[]) => fetchLibraryAssets(...(args as [])),
+  fetchLibraryAsset: (...args: unknown[]) => fetchLibraryAsset(...(args as [])),
+  libraryAssetRawUrl: (id: string) => `/raw/${id}`,
+  applyLibraryAsset: vi.fn(),
+  deleteLibraryAsset: vi.fn(),
+  editLibraryAssetAsPage: vi.fn(),
+  fetchDesignSystem: vi.fn(),
+  fetchDesignSystems: vi.fn(async () => []),
+  fetchLibraryAssetAsFile: vi.fn(),
+}));
+
+import { LibrarySection } from '../../src/components/LibrarySection';
+
+function makeAsset(over: Partial<LibraryAsset> = {}): LibraryAsset {
+  const now = 1_700_000_000_000;
+  return {
+    id: over.id ?? 'asset-1',
+    kind: 'image',
+    storage: 'owned',
+    capturedAt: now,
+    archivedDate: '2024-01-01',
+    contentHash: `hash-${over.id ?? 'asset-1'}`,
+    tags: [],
+    sources: [],
+    createdAt: now,
+    updatedAt: now,
+    sourceTitle: 'A photo',
+    ...over,
+  };
+}
+
+describe('LibrarySection accessibility', () => {
+  beforeEach(() => {
+    fetchLibraryAssets.mockReset().mockResolvedValue([makeAsset()]);
+    fetchLibraryAsset.mockReset().mockResolvedValue(null);
+    (globalThis as { EventSource?: unknown }).EventSource = class {
+      addEventListener() {}
+      close() {}
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('gives the library filter selects accessible names', async () => {
+    render(<LibrarySection active onOpenProject={() => {}} />);
+
+    await screen.findByText('A photo');
+
+    expect(screen.getByRole('combobox', { name: 'Filter by kind' })).toBeTruthy();
+    expect(screen.getByRole('combobox', { name: 'Filter by source' })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #1293

## Why

I picked up issue #1293 because the Library toolbar filters in `LibrarySection` were exposing two unlabeled native selects to assistive tech. Screen readers announced them as unnamed comboboxes, which makes the filter controls ambiguous and harder to use.

## What users will see

In the Library toolbar, screen readers now announce the kind and source filter dropdowns as "Filter by kind" and "Filter by source" instead of unlabeled comboboxes.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual change; this is an accessibility-only fix for native select labels.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/LibrarySection.a11y.test.tsx`
- Did the test go red on `main` and green on this branch? `yes`
- Root cause: the two toolbar `<select>` elements in `apps/web/src/components/LibrarySection.tsx` had no associated label or `aria-label`, so they exposed unnamed `combobox` roles.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/LibrarySection.a11y.test.tsx --reporter=verbose --testTimeout=10000`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>