### PR TITLE
docs: apply fallback doc touch for missing SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Open Design is what you get when the **agent-native** loop Anthropic shipped wit
 
 It's also the **Figma alternative for the agent era** — instead of pushing pixels on a canvas, it delivers single-page artifacts in real CSS, real fonts, real components, exported straight to HTML / PDF / PPTX / MP4 — already shaped by your design system, already runnable inside the agent you use every day.
 
-
 ---
 
 ## Product tour


### PR DESCRIPTION
Closes #1328

## Why

This branch implements issue `#1328`. I checked the repo root first and confirmed there is no `SECURITY.md`, so the requested primary change was not available. Per the issue's fallback instruction, I made the smallest safe docs-only no-op touch instead of introducing new security-policy content.

## What users will see

No product or policy change. The repo just gets a minimal root-doc cleanup because there is no root `SECURITY.md` to update.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A.

## Bug fix verification

- Not a runtime bug fix; this is a docs-only fallback change because the repo has no root `SECURITY.md`.

## Validation

- `git diff --check -- README.md`
- `pnpm guard` (fails in this environment: Node `v22.22.0` instead of the repo's required Node `~24`, and local dependencies/tooling like `tsx` are not installed)
- `pnpm typecheck` (fails in this environment for the same reasons: Node `v22.22.0` plus missing local tools such as `tsc` / `astro`)

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>