### PR TITLE
fix: hide native caret while composer placeholder carousel runs

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -1244,6 +1244,17 @@
   caret-color: var(--accent);
   -webkit-user-modify: read-write-plaintext-only; /* paste-as-plain-text guard */
 }
+/* While the empty composer runs the placeholder typewriter carousel, the
+   carousel draws its own decorative caret trailing the animated text. Suppress
+   the native caret (which sits at offset 0) so the two don't blink at once
+   (#5373). Keyed off the carousel being a sibling of the editor, so it covers
+   both the chat composer (.composer-input-wrap) and the home hero
+   (.home-hero__prompt-editor) without depending on the wrapper class. The
+   carousel unmounts as soon as the field has text, which restores the native
+   caret automatically. */
+.composer-input-editor:has(~ .home-hero__carousel) [contenteditable='true'] {
+  caret-color: transparent;
+}
 .composer.composer-active-file-mode .composer-input-editor [contenteditable='true'],
 .composer.composer-active-file-mode .composer-input-editor .composer-editable {
   min-height: clamp(150px, 20vh, 210px);


### PR DESCRIPTION
Fixes #5373

## Why

Scratching an itch while poking around OD: focusing the empty composer shows two blinking carets at once, which reads as a rendering glitch. As you noted, the cleaner cut was to first separate shared-composer vs route-specific. It turned out to be the shared composer: the `caret-color` rule on the editable is global, and any empty+idle composer that runs the placeholder carousel hits it. The design-system follow-up composer is just one route that feeds the carousel scenarios; the home hero has the identical flaw.

## What users will see

When the composer is empty and focused and the placeholder typewriter carousel is animating, there's now a single caret (the decorative one trailing the animated text) instead of two. As soon as you type, the carousel goes away and the normal text caret is back exactly as before. Affects both the home hero and the in-chat composer (including the design-system extraction follow-up).

## Surface area

- [x] **UI** — behavior of the composer caret in the empty/placeholder state

## Screenshots

The offending element is a 1px blinking caret, which doesn't capture cleanly in a still. Happy to record a short before/after GIF if useful — see the deterministic verification below, which pins the behavior more reliably than a screenshot can.

## Bug fix verification

Root cause: the native browser caret (`caret-color: var(--accent)` on `.composer-input-editor [contenteditable]`) blinks at offset 0 while `PlaceholderCarousel` separately renders its own decorative 1px caret trailing the animated placeholder text. Two carets. The fix suppresses the native caret only while the carousel is mounted.

- **Test path / red spec:** none added. A jsdom/vitest component test can't reproduce this — jsdom doesn't evaluate `:has()` or paint carets, so a unit assertion couldn't actually go red if the rule broke. That would be test theater. If you'd prefer a Playwright visual guard I'm glad to add one.
- **Verification done instead** (in the running app, `pnpm --filter @open-design/web dev`, on the home hero which shares this exact path): read the editable's computed `caret-color` in each state:
  - empty + focused, carousel active, before fix: `rgb(201, 100, 66)` (the accent) — native caret visible → two carets.
  - same, with fix: `rgba(0, 0, 0, 0)` (transparent) — native caret hidden, only the decorative caret shows.
  - carousel unmounted (what typing triggers, since `PlaceholderCarousel` returns `null` once `draft.trim()` is non-empty): reverts to `rgb(201, 100, 66)` — native caret restored, normal editing unaffected.

The rule is keyed off the carousel being a sibling of the editor, so it self-gates (only applies while the carousel node exists) and covers both `.composer-input-wrap` and the home hero's `.home-hero__prompt-editor` without depending on the wrapper class. Specificity (0,3,0) wins over the base rule and there's no later `caret-color` declaration that re-sets it. `:has(~ …)` is already used across the codebase's CSS (including in `chat.css`), so no build/browser-support concern.
