### PR TITLE
fix(web): use current logo on home surfaces

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -116,7 +116,7 @@ export function EntryNavRail({
             data-testid="entry-nav-logo"
           >
             <img
-              src="/app-icon.svg"
+              src="/logo.svg"
               alt=""
               className="entry-nav-rail__logo-img"
               draggable={false}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1211,7 +1211,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     <section ref={homeHeroRef} className="home-hero" data-testid="home-hero">
       <div className="home-hero__brand" aria-hidden>
         <span className="home-hero__brand-mark">
-          <img src="/app-icon.svg" alt="" draggable={false} />
+          <img src="/logo.svg" alt="" draggable={false} />
         </span>
         <span className="home-hero__brand-name">Open Design</span>
       </div>

--- a/apps/web/tests/components/home-logo-assets.test.ts
+++ b/apps/web/tests/components/home-logo-assets.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const homeHeroSource = readFileSync(
+  new URL('../../src/components/HomeHero.tsx', import.meta.url),
+  'utf8',
+);
+const entryNavRailSource = readFileSync(
+  new URL('../../src/components/EntryNavRail.tsx', import.meta.url),
+  'utf8',
+);
+
+describe('Home logo assets', () => {
+  it('uses the current Open Design logo glyph on both Home entry surfaces', () => {
+    expect(homeHeroSource).toContain('src="/logo.svg"');
+    expect(homeHeroSource).not.toContain('src="/app-icon.svg"');
+
+    expect(entryNavRailSource).toContain('src="/logo.svg"');
+    expect(entryNavRailSource).not.toContain('src="/app-icon.svg"');
+  });
+});


### PR DESCRIPTION
Fixes #5365

## Why

I picked this up after the issue confirmed that the Home entry surfaces were still using the older `/app-icon.svg` mark. This is a small visual consistency bug on the main Home experience: the hero brand mark and left navigation mark should match the current Open Design logo glyph.

## What users will see

The Home hero brand mark and the left navigation logo now use the current Open Design logo asset instead of the older app icon.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

After — Home hero rendered with the current logo glyph:

![Home page logo uses the current Open Design glyph](https://gist.githubusercontent.com/roian6/d0c08e4c8c6378f41d28d6806a5752cb/raw/287bca2e01c44328e164afda1bc810ee10113098/home-logo-5365-after.png)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/home-logo-assets.test.ts`
- Did the test go red on `main` and green on this branch? yes

## Validation

- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/home-logo-assets.test.ts --reporter=verbose`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
