### PR TITLE
Add Reasonix MCP installer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Inside a project's Studio, the same design system streams out multiple artifact 
 |---|:---:|---|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Supported | `od mcp install claude` |
 | [Codex CLI](https://github.com/openai/codex) | ✅ Supported | `od mcp install codex` |
+| [DeepSeek Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | ✅ Supported | `od mcp install reasonix` |
 | [Cursor](https://www.cursor.com/cli) | ✅ Supported | `od mcp install cursor` |
 | [VS Code + GitHub Copilot](https://github.com/features/copilot) | ✅ Supported | `od mcp install copilot` |
 | [GitHub Copilot CLI](https://github.com/features/copilot/cli) | ✅ Supported | `od mcp install copilot` |
@@ -303,8 +304,9 @@ You can use Open Design without ever opening the GUI — call it as a skill, plu
 ```bash
 # One-line install into the agent you're using:
 od mcp install <agent>
-# <agent> = claude | codex | cursor | copilot | openclaw | antigravity | gemini
-#         | pi | vibe | hermes | cline | kimi | trae | opencode
+# <agent> = claude | codex | reasonix | cursor | copilot | openclaw
+#         | antigravity | gemini | pi | vibe | hermes | cline | kimi
+#         | trae | opencode
 
 # Hosted equivalent for curl-based setup:
 curl -fsSL https://open-design.ai/install.sh | sh -s <agent>

--- a/apps/daemon/src/mcp-agent-install.ts
+++ b/apps/daemon/src/mcp-agent-install.ts
@@ -11,7 +11,7 @@
 //   - 'cli'    : the agent ships its own `<bin> mcp add/remove/get`. We
 //                shell out to it (like codex-cli.ts) so we inherit the
 //                agent's merge/validation rules instead of editing its
-//                config by hand. Used for claude / codex / kimi.
+//                config by hand. Used for claude / codex / kimi / reasonix.
 //   - 'json'   : the agent reads a JSON config file with a known schema.
 //                We deep-merge one server entry, never clobbering the
 //                rest of the file. Used for cursor / copilot / cline /
@@ -32,6 +32,7 @@ import path from 'node:path';
 export const AGENT_SLUGS = [
   'claude',
   'codex',
+  'reasonix',
   'cursor',
   'copilot',
   'openclaw',
@@ -170,6 +171,19 @@ export function planAgentInstall(
           'mcp', 'add', serverName,
           ...envFlags(spec.env, '--env'),
           '--', spec.command, ...spec.args,
+        ],
+        removeArgv: ['mcp', 'remove', serverName],
+        getArgv: ['mcp', 'get', serverName],
+      };
+    case 'reasonix':
+      return {
+        kind: 'cli',
+        slug,
+        bin: 'reasonix',
+        addArgv: [
+          'mcp', 'add', serverName,
+          ...envFlags(spec.env, '--env'),
+          spec.command, ...spec.args,
         ],
         removeArgv: ['mcp', 'remove', serverName],
         getArgv: ['mcp', 'get', serverName],

--- a/apps/daemon/tests/mcp-agent-install.test.ts
+++ b/apps/daemon/tests/mcp-agent-install.test.ts
@@ -28,8 +28,9 @@ describe('agent slug guard', () => {
   it('accepts every documented slug and rejects others', () => {
     for (const s of AGENT_SLUGS) expect(isAgentSlug(s)).toBe(true);
     expect(isAgentSlug('not-an-agent')).toBe(false);
-    expect(AGENT_SLUGS).toHaveLength(14);
+    expect(AGENT_SLUGS).toHaveLength(15);
     expect(isAgentSlug('kiro')).toBe(true);
+    expect(isAgentSlug('reasonix')).toBe(true);
   });
 });
 
@@ -55,6 +56,19 @@ describe('CLI-driven agents', () => {
     expect(plan.addArgv).toContain('--env');
     expect(plan.addArgv).toContain('OD_DATA_DIR=/home/u/.open-design');
     expect(plan.addArgv.slice(-SPEC.args.length - 2)).toEqual(['--', SPEC.command, ...SPEC.args]);
+  });
+
+  it('reasonix uses its native mcp add/remove/get commands', () => {
+    const plan = planAgentInstall('reasonix', SPEC, ctx());
+    if (plan.kind !== 'cli') throw new Error('expected cli');
+    expect(plan.bin).toBe('reasonix');
+    expect(plan.addArgv).toEqual([
+      'mcp', 'add', 'open-design',
+      '--env', 'OD_DATA_DIR=/home/u/.open-design',
+      SPEC.command, ...SPEC.args,
+    ]);
+    expect(plan.removeArgv).toEqual(['mcp', 'remove', 'open-design']);
+    expect(plan.getArgv).toEqual(['mcp', 'get', 'open-design']);
   });
 
 });


### PR DESCRIPTION
## Why

Reasonix already exists as an Open Design runtime adapter, and Reasonix now exposes the native MCP management commands that the installer expects: `reasonix mcp add`, `reasonix mcp remove`, and `reasonix mcp get`.

This removes the gap where Reasonix could run Open Design work, but `od mcp install <agent>` did not accept `reasonix` as a supported target.

## What users will see

Reasonix users can run:

```bash
od mcp install reasonix
```

The README supported-agent table also lists DeepSeek Reasonix with the matching one-line install command.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a CLI installer and README update.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp-agent-install.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `node apps/daemon/dist/cli.js mcp install reasonix --print --json --daemon-url http://127.0.0.1:7456`