### PR TITLE
feat(contracts): agent-ready capability contracts + design RFCs (#5398)

### DIFF
--- a/docs/rfc-drafts/agent-ready-cross-project.md
+++ b/docs/rfc-drafts/agent-ready-cross-project.md
@@ -1,0 +1,145 @@
+# RFC: Agent-ready Open Design — cross-project tasks & spanning-project permissions
+
+**Status:** Draft (companion to agent-ready.md; the maintainer's separate reviewable permissions writeup)
+**Author:** @leonaburime-ucla
+**Related:** #5398 (make Open Design agent-ready); companion: [agent-ready.md](./agent-ready.md) (slice 5)
+
+## Summary
+
+The umbrella RFC ([agent-ready.md](./agent-ready.md)) defers "cross-project task
+ownership + bounded permissions" to slice 5 and, per the maintainer's request,
+keeps spanning-project **permissions** as their own reviewable writeup rather than
+a footnote. This is that writeup. It introduces one minimal pure type — `AgentTask`
+— and presents the permissions model as **options → recommendation**, not a decree.
+
+Key insight: cross-project work and the deferred "long-horizon complex task" are
+the SAME shape. A task that is not bound to one project owns a goal across many
+steps AND across many projects. `AgentTask` answers both. No behavior code ships
+here — types + prose only; actual multi-project runs are slice 4/5 implementation.
+
+## Problem
+
+Today a chat is bound to one project's page, so a real instruction like "drop the
+HeyGen intro into the Apple project's index.html, and pull the Ford project's hero
+images near the footer" (issue #5398, Example 2) has nowhere to live: it spans two
+projects, two integrations, and a file edit. Two things are missing:
+
+1. **A durable owner** for a goal that outlives one step and crosses projects.
+2. **A bounded permission model** — what set of projects may a task touch, and how
+   is that granted — so cross-project autonomy does not become unbounded
+   blast-radius.
+
+## The AgentTask model
+
+`AgentTask` (in `packages/contracts/src/agent-tools/task.ts`) is a durable,
+project-agnostic record: a stable `taskId`, an optional human `goal`, a
+`projectIds` set (the authorized projects — the ownership/blast-radius boundary,
+NOT the enforcement mechanism), and a `status` from the `AGENT_TASK_STATUSES`
+const-union (`active` / `awaiting-consent` / `completed` / `failed` / `cancelled`).
+
+It is deliberately minimal. It carries **no** embedded project state, no roles, no
+UI shape — the guard against re-modeling `ProjectView` as a "task." Steps correlate
+to a task the same way single-project steps already correlate to a run: by id. A
+long-horizon single-project task is just an `AgentTask` whose `projectIds` has one
+entry; a cross-project task has several.
+
+## Project addressing — options → recommendation
+
+How does a tool call say which project it targets?
+
+- **(a) `projectId` inside the tool's `input`.** Works today with zero contract
+  change. *But* it is invisible to the daemon: the daemon cannot route or
+  permission-check a target buried in tool-specific `input` without parsing every
+  tool's schema.
+- **(b) A first-class `targetProjectId?` on the action envelope.** The daemon reads
+  the target directly, so it can route the action and enforce the task's
+  `projectIds` boundary uniformly, regardless of the tool.
+
+**Recommend (b)** for cross-project work, added as an OPTIONAL, non-breaking field
+on `BrowserActionRequest` when slice 5 lands (alongside an optional `taskId?` to
+correlate steps to the `AgentTask`). It is **not** added in slice 1: adding an
+optional field later is non-breaking, so the shipped contract stays minimal. The
+future addition:
+
+    // BrowserActionRequest (slice 5, non-breaking optionals):
+    taskId?: string;          // the AgentTask this step advances
+    targetProjectId?: string; // absent = the run's current project
+
+## Cross-project discovery
+
+No new mechanism is required. The registry and `capability.search` are already
+**workspace-level** for `api`-surface tools (see agent-ready.md "Agent tool
+search — options"). So "pull the Ford project's hero images" is a content-search
+`api` tool invoked with a `targetProjectId` the task is authorized for — discovery
+and retrieval reuse the existing search/registry surface, scoped by the task's
+`projectIds`. Cross-project is a *permission + addressing* problem, not a new
+discovery problem.
+
+## Permissions — options → recommendation (the maintainer's separate reviewable decision)
+
+This is the decision the maintainer asked to keep as its own writeup. How does a
+user grant a task access to projects?
+
+- **Option 1 — Explicit allow-list at task creation.** `projectIds` is fixed when
+  the task is created. *Pros:* simplest, fully bounded blast-radius, trivially
+  reviewable/auditable. *Cons:* rigid — the user must know every project up front;
+  widening scope mid-task means restarting or re-prompting.
+- **Option 2 — Just-in-time consent on first touch.** The task starts with a
+  narrow (or empty) `projectIds`; touching a new project moves it to
+  `awaiting-consent` and prompts the user, appending on approval or denying via the
+  reserved `USER_DENIED` action error. *Pros:* least-privilege, grows the set
+  naturally, no upfront enumeration. *Cons:* interrupts long autonomous runs; needs
+  a consent surface (GenUI / `question-form` can serve it).
+- **Option 3 — Workspace-wide with per-write confirmation.** Reads span the whole
+  workspace; only writes confirm. *Pros:* frictionless discovery/reads. *Cons:*
+  broad read blast-radius; write-confirmation fatigue; weakest audit story.
+
+**Recommended default: Option 1 as the authoritative boundary, extended by Option 2
+to widen it.** The `projectIds` set is the hard blast-radius boundary; a step
+targeting a project outside it does not silently proceed — the task enters
+`awaiting-consent` and the user either appends the project (Option 2) or the step
+is denied (`USER_DENIED`). Reads and writes within the allow-list proceed; any
+touch outside it requires consent. This gives an auditable static boundary plus
+least-privilege growth, and reuses the already-reserved consent primitive rather
+than inventing a new one.
+
+**This recommendation is explicitly a proposal for review, not a decree** — it is
+the reviewable permissions decision the maintainer flagged. Reviewers should weigh
+whether writes *inside* the allow-list also warrant confirmation, and whether
+read-only cross-project discovery is granted more liberally than write access.
+
+## Relationship to slices 4 and 5
+
+- **Slice 4 (global chat mount)** is the prerequisite home: a task not bound to one
+  project's chat needs a workspace-level assistant to live in.
+- **Slice 5 (this design's runtime)** creates/persists `AgentTask` in the daemon's
+  SQLite store under the resolved data root (`RUNTIME_DATA_DIR` — no path literal
+  per the data-directory contract), adds the optional `taskId?`/`targetProjectId?`
+  envelope fields, and enforces `projectIds` per the chosen permission model.
+
+The `AgentTask` **type** lands now (slice 1 companion) so reviewers judge the shape
+and the permission options together; the runtime is slice 5.
+
+## Deferred / Out of scope
+
+- All behavior/runtime: task creation, persistence, scheduling, and permission
+  enforcement (slice 5).
+- Envelope changes to `BrowserActionRequest` (`taskId?`, `targetProjectId?`) — added
+  non-breakingly in slice 5, not this PR.
+- Per-step progress/streaming for long-horizon tasks; task pause/resume UX; task
+  history and audit-log shapes; multi-user / shared-task ownership; role- or
+  capability-scoped grants (beyond project-set scoping).
+
+## Open questions
+
+1. **Permission model** — which of the three options (or the recommended hybrid) do
+   product + maintainers want as the default?
+2. **Read vs write asymmetry** — should cross-project reads be granted more freely
+   than writes within the same `projectIds` boundary?
+3. **Consent surface** — reuse GenUI / `question-form` for `awaiting-consent`, or a
+   dedicated task-permission prompt?
+4. **Task durability** — should `AgentTask` gain an optional `protocolVersion` /
+   timestamps when the runtime lands, or stay envelope-free? (Both are non-breaking
+   additions later.)
+
+See the umbrella design: [agent-ready.md](./agent-ready.md).

--- a/docs/rfc-drafts/agent-ready-cross-project.md
+++ b/docs/rfc-drafts/agent-ready-cross-project.md
@@ -51,19 +51,28 @@ How does a tool call say which project it targets?
   change. *But* it is invisible to the daemon: the daemon cannot route or
   permission-check a target buried in tool-specific `input` without parsing every
   tool's schema.
-- **(b) A first-class `targetProjectId?` on the action envelope.** The daemon reads
-  the target directly, so it can route the action and enforce the task's
-  `projectIds` boundary uniformly, regardless of the tool.
+- **(b) A first-class `targetProjectId?` the daemon reads directly** — carried on
+  each surface's own request path (per agent-ready.md the two surfaces have
+  distinct call paths, so there is no single universal envelope to bolt it onto).
+  The daemon reads the target without parsing tool-specific `input`, so it can
+  route and enforce the task's `projectIds` boundary uniformly on both paths.
 
-**Recommend (b)** for cross-project work, added as an OPTIONAL, non-breaking field
-on `BrowserActionRequest` when slice 5 lands (alongside an optional `taskId?` to
-correlate steps to the `AgentTask`). It is **not** added in slice 1: adding an
-optional field later is non-breaking, so the shipped contract stays minimal. The
-future addition:
+**Recommend (b)** for cross-project work, added as OPTIONAL, non-breaking fields
+when slice 5 lands (alongside an optional `taskId?` to correlate steps to the
+`AgentTask`). Because a `browser` call and an `api` call travel different paths,
+the fields are added on **both**: on `BrowserActionRequest` for the browser
+surface, and on the `api`-call request (query/body the daemon controls) for `api`
+tools — which do not use the browser envelope. They are **not** added in slice 1:
+adding an optional field later is non-breaking, so the shipped contract stays
+minimal. The future browser-envelope addition:
 
     // BrowserActionRequest (slice 5, non-breaking optionals):
     taskId?: string;          // the AgentTask this step advances
     targetProjectId?: string; // absent = the run's current project
+
+    // The api-call path carries the same two as daemon-controlled request
+    // params, so an api capability can be routed and permission-checked
+    // cross-project without ever touching the browser envelope.
 
 ## Cross-project discovery
 
@@ -115,7 +124,8 @@ read-only cross-project discovery is granted more liberally than write access.
 - **Slice 5 (this design's runtime)** creates/persists `AgentTask` in the daemon's
   SQLite store under the resolved data root (`RUNTIME_DATA_DIR` — no path literal
   per the data-directory contract), adds the optional `taskId?`/`targetProjectId?`
-  envelope fields, and enforces `projectIds` per the chosen permission model.
+  routing fields on both call paths (browser envelope + `api`-call request), and
+  enforces `projectIds` per the chosen permission model.
 
 The `AgentTask` **type** lands now (slice 1 companion) so reviewers judge the shape
 and the permission options together; the runtime is slice 5.
@@ -124,7 +134,8 @@ and the permission options together; the runtime is slice 5.
 
 - All behavior/runtime: task creation, persistence, scheduling, and permission
   enforcement (slice 5).
-- Envelope changes to `BrowserActionRequest` (`taskId?`, `targetProjectId?`) — added
+- Cross-project routing fields (`taskId?`, `targetProjectId?`) on both call paths —
+  the `BrowserActionRequest` envelope and the `api`-call request — added
   non-breakingly in slice 5, not this PR.
 - Per-step progress/streaming for long-horizon tasks; task pause/resume UX; task
   history and audit-log shapes; multi-user / shared-task ownership; role- or

--- a/docs/rfc-drafts/agent-ready.md
+++ b/docs/rfc-drafts/agent-ready.md
@@ -44,22 +44,32 @@ MCP/WebMCP-congruent surface:
 |---|---|---|
 | **Declare** | `AgentToolDescriptor` (`browser` \| `api` union) | tool definition |
 | **List** | `AgentToolManifest` (`protocolVersion`, `runId`, `tools[]`) | `tools/list` |
-| **Search** | `AgentToolSearchQuery` → `AgentToolSearchResult` (paged) | discovery over `tools/list` |
-| **Call** | `BrowserActionRequest` (`invocationId`, `runId`, `tool`, `input`) | `tools/call` |
-| **Result** | `BrowserActionResult` (`ok`-discriminated; `result: JsonValue`) | tool result |
+| **Search** | `AgentToolSearchQuery` → `AgentToolSearchResult` (paged, `api` only) | discovery over `tools/list` |
+| **Call — `browser`** | `BrowserActionRequest` (`invocationId`, `runId`, `tool`, `input`) — dispatch toward a live session | `tools/call` (browser surface) |
+| **Result — `browser`** | `BrowserActionResult` (`ok`-discriminated; `result: JsonValue`) | tool result |
+| **Call — `api`** | the tool's own declared `/api/*` route + `od` subcommand (`ApiToolDescriptor.api` / `.cli`) — no round-trip envelope | `tools/call` (api surface) |
 
 `AgentToolDescriptor` carries `name` (stable, dot-namespaced), `description`
 (model- and catalog-facing), `inputSchema` (JSON Schema as `JsonValue`, so it
 crosses the MCP wire verbatim — WebMCP / MCP-UI / A2UI ready), and a `surface`
 discriminant. A `browser` tool asserts `viewStateOnly: true`; an `api` tool
 carries both its `/api/*` route and its `od` subcommand, so the UI/CLI dual-track
-law is **structural**, not a review checkbox. `protocolVersion` on the manifest
-and the action messages is the literal `typeof AGENT_ACTIONS_PROTOCOL_VERSION`, so
-catalog and calls version together. The action identity is a daemon-minted
-`invocationId`; a provider `tool_call_id` or MCP request id maps to it daemon-side
-and never enters the contract, so `result: JsonValue` means a navigation
-acknowledgement and a future data-returning read serialize identically — no
-navigation special case.
+law is **structural**, not a review checkbox.
+
+**The two surfaces are called through two distinct request paths — the envelope is
+not universal.** An `api` capability is a normal `/api/*` action: the daemon
+invokes its declared route directly (and it is reachable as an `od` subcommand),
+so it needs no dispatch-and-await round-trip and does **not** use
+`BrowserActionRequest`. `BrowserActionRequest` / `BrowserActionResult` exist
+**only** for the `browser` surface — the genuinely new inbound seam — because a
+browser tool runs in a remote context (the live session) the daemon must dispatch
+to and await a result from. On that browser path the action identity is a
+daemon-minted `invocationId`; a provider `tool_call_id` or MCP request id maps to
+it daemon-side and never enters the contract, so `result: JsonValue` means a
+navigation acknowledgement and a future data-returning browser read serialize
+identically — no navigation special case. `protocolVersion` on the manifest and
+on the browser-action messages is the literal `typeof AGENT_ACTIONS_PROTOCOL_VERSION`,
+so catalog and browser calls version together.
 
 ## Complex / multi-step workflows
 

--- a/docs/rfc-drafts/agent-ready.md
+++ b/docs/rfc-drafts/agent-ready.md
@@ -1,0 +1,265 @@
+# RFC: Agent-ready Open Design — one assistant that can drive the whole app
+
+**Status:** Draft (umbrella design for review; only slice 1 ships code in the first PR)
+**Author:** @leonaburime-ucla
+**Related:** #5398 (make Open Design agent-ready)
+
+## Summary
+
+Today the chat assistant only helps with the page you are on. This RFC proposes
+turning it into one assistant that can drive the whole app — including taking
+actions in the browser UI on the user's behalf — built product-neutrally so the
+same engine could power other products on this foundation.
+
+This umbrella RFC presents the WHOLE arc so maintainers and product reviewers can
+evaluate it at once (the issue is labeled `needs-product-direction`). Only
+**slice 1** ships code in the first PR: the shared contracts
+(`packages/contracts/src/agent-tools/`) plus this RFC. Everything past slice 1 is
+described here as types + prose, and the genuinely open calls are presented as
+**options considered → recommendation** rather than decrees, so reviewers judge
+the design space.
+
+## Problem
+
+- **The chat is stuck on one page; real work isn't.** A real task touches several
+  places (design system → deck → media), which today means several chats and a
+  lot of clicking.
+- **People can't find what OD can do.** Capabilities are discoverable only by
+  navigating to their page; there is no one catalog of "what can you do?".
+- **The inbound half is missing.** OD already emits its runs in **AG-UI format —
+  the outbound half** (`packages/agui-adapter` → `/api/agui`). There is no
+  inbound path where the assistant *executes* an interface action and gets the
+  result back. That return path is the genuinely new seam.
+
+Two execution models must both be served: (a) the **BYOK daemon-loop**, where the
+daemon runs the model turn and orchestrates tools; and (b) a **local-CLI agent**
+subprocess (Claude/Codex/etc.) that can only reach tools via MCP.
+
+## The capability model (declare / list / search / call / result)
+
+Every capability is one **tool**, declared once and reachable through an
+MCP/WebMCP-congruent surface:
+
+| Concern | Shape (in `contracts`) | MCP analog |
+|---|---|---|
+| **Declare** | `AgentToolDescriptor` (`browser` \| `api` union) | tool definition |
+| **List** | `AgentToolManifest` (`protocolVersion`, `runId`, `tools[]`) | `tools/list` |
+| **Search** | `AgentToolSearchQuery` → `AgentToolSearchResult` (paged) | discovery over `tools/list` |
+| **Call** | `BrowserActionRequest` (`invocationId`, `runId`, `tool`, `input`) | `tools/call` |
+| **Result** | `BrowserActionResult` (`ok`-discriminated; `result: JsonValue`) | tool result |
+
+`AgentToolDescriptor` carries `name` (stable, dot-namespaced), `description`
+(model- and catalog-facing), `inputSchema` (JSON Schema as `JsonValue`, so it
+crosses the MCP wire verbatim — WebMCP / MCP-UI / A2UI ready), and a `surface`
+discriminant. A `browser` tool asserts `viewStateOnly: true`; an `api` tool
+carries both its `/api/*` route and its `od` subcommand, so the UI/CLI dual-track
+law is **structural**, not a review checkbox. `protocolVersion` on the manifest
+and the action messages is the literal `typeof AGENT_ACTIONS_PROTOCOL_VERSION`, so
+catalog and calls version together. The action identity is a daemon-minted
+`invocationId`; a provider `tool_call_id` or MCP request id maps to it daemon-side
+and never enters the contract, so `result: JsonValue` means a navigation
+acknowledgement and a future data-returning read serialize identically — no
+navigation special case.
+
+## Complex / multi-step workflows
+
+The slice-1 shapes support complex work, not just one action:
+
+- **Chaining.** The agent loop drives one step at a time: each step is a
+  `BrowserActionRequest` correlated to its `BrowserActionResult` by
+  `invocationId`; because `result` is `JsonValue`, one step's output feeds the
+  next step's `input`. No workflow object is required for sequential work.
+- **Concurrency.** Each invocation has its own `invocationId`, so independent
+  invocations may be in flight at once; the daemon reconciles each result to its
+  own record. Nothing in the shapes forces serialization.
+
+**Deferred:** streaming/progress for long-running steps (results are terminal in
+slice 1), and a first-class task/workflow object that can span projects — slice 5,
+with its own permissions RFC.
+
+## Agent tool search — options
+
+As OD accumulates tools across design systems, media, connectors, and Composio,
+handing the model the full catalog gets expensive — the daemon's own MCP layer
+notes a `tools/list` response costs on the order of ~150 tokens per call. So the
+model should **find** relevant tools, not receive all of them. Two orthogonal
+axes: how matches are computed (A/B/C), and how much of a tool enters model
+context at all (D).
+
+**Option A — Keyword / substring (SQL `LIKE`/FTS5 over name + description).**
+Query the persisted registry over `name` and `description`.
+*Pros:* zero new infra, deterministic, debuggable, no model dependency, cheap.
+*Cons:* weak on vague intent ("make the images match the brand" won't match
+`imagegen.recolor` by keyword); sensitive to naming discipline.
+
+**Option B — Semantic / embedding search.**
+Embed each descriptor; store vectors; rank the query by cosine similarity.
+*Pros:* best recall on fuzzy intent; robust to vocabulary mismatch.
+*Cons:* needs an embedding model + a vector store, adds cost + latency + a model
+dependency, and non-determinism that complicates review and tests. Overkill until
+tool count and fuzzy-intent misses justify it.
+
+**Option C — Hybrid (keyword prefilter → semantic rank).**
+`LIKE`/FTS narrows to a candidate set; embeddings rank within it.
+*Pros:* bounds embedding cost to a small candidate set while keeping fuzzy recall.
+*Cons:* two subsystems to build and keep consistent; premature before B is even
+warranted.
+
+**Option D — Deferred tools / progressive disclosure (context-budget strategy,
+orthogonal to A/B/C).**
+Only tool **names** (and one-line descriptions) enter model context; the full
+`inputSchema` is fetched on demand via search — exactly how coding-agent harnesses
+expose a "ToolSearch" over deferred tools. This is not a matching algorithm; it is
+what the model *sees*, and it composes with whichever of A/B/C computes the match.
+
+**Advertisement axis — PUSH vs PULL.**
+- *PUSH:* the frontend advertises its live `AgentToolManifest` on mount / on tool
+  registration. **Required for browser-surface tools** — the daemon cannot know
+  which browser tools are live without the session telling it.
+- *PULL:* the agent calls `capability.search` on demand against the persisted
+  registry. Transport-agnostic; works for local-CLI-via-MCP; the natural fit for
+  the large, persistent `api`-surface catalog.
+
+**Recommended slice-3 default: A + D, with hybrid PUSH/PULL.** Ship keyword/FTS5
+matching (A) under deferred/progressive disclosure (D): names-only in context,
+schemas fetched on `capability.search`. Advertise **browser** tool availability by
+PUSH (the session tells the daemon what is live) and discover the **api** catalog
+by PULL (`capability.search`). Defer B/C until we have evidence of fuzzy-intent
+misses at real tool counts — adding embedding ranking later is a
+runtime/`providers` change behind the same `search` port and needs no contract
+change (see "Non-breaking type hooks").
+
+## Options considered → recommendation (key decisions)
+
+**Return path.**
+Options: (1) reuse GenUI `POST /api/runs/:runId/genui/:surfaceId/respond`;
+(2) a NEW run-scoped `POST /api/runs/:runId/actions/:invocationId/result`;
+(3) make `agui-adapter` inbound.
+Tradeoff: (1) is live and proven but its surface/`respondedBy` lifecycle is shaped
+for HITL surfaces, so every future action feature would mutate a table owned by
+another concern; (3) welds the return path to one wire protocol and abandons the
+native non-AG-UI chat path.
+**Recommend (2)** — a dedicated endpoint *patterned on* GenUI's pending→responded
+lifecycle without overloading `genui_surfaces`, keeping action semantics
+(timeouts, consent, correlation) in their own home.
+
+**Registry persistence.**
+Options: in-memory; the daemon's SQLite store under the resolved data root
+(`RUNTIME_DATA_DIR`); a flat file.
+Tradeoff: in-memory loses the catalog on restart and can't scale to "too many
+tools" or support search; a flat file re-implements indexing badly.
+**Recommend SQLite** under the resolved data root — it scales, gives FTS5 for
+Option A for free, and matches how the daemon already persists state. (Per the
+repo's Daemon data directory contract, this RFC names no filesystem path; the
+store derives from the resolved data root.)
+
+**Advertisement scope.**
+Options: per-run; per-session/tab; per-app-shell.
+Tradeoff: browser tools are only live while their tab is mounted, so app-shell
+scope over-claims availability and per-run alone can't see a tab that mounted
+mid-run.
+**Recommend per-session/tab availability advertised into the active run** — the
+manifest granularity stays `manifest(runId)`, but browser-tool availability is
+sourced from the live session, reconciled to the run.
+
+**Action identity.**
+Options: daemon-minted `invocationId`; provider `toolCallId`.
+Tradeoff: `toolCallId` is free in the BYOK loop but absent in the MCP bridge and
+scoped per-provider-turn, so using it as identity binds the contract to one
+execution model.
+**Recommend daemon-minted `invocationId`** as the sole contract identity; a
+`toolCallId`/MCP request id maps to it daemon-side and never enters the contract.
+
+**Result transport.**
+Options: `POST` return; a websocket/SSE push channel for lower latency.
+Tradeoff: `POST` is simplest and the browser already has an authenticated HTTP
+path; a push channel lowers latency but adds a persistent connection and
+reconnection semantics.
+**Recommend `POST` for slices 2–3**; revisit a push channel only if action
+round-trip latency becomes a measured problem. Dispatch (daemon→browser) already
+rides the existing outbound run-event stream, so only the return leg is at issue.
+
+## Registry boundary
+
+The descriptor + manifest + search shapes and the `AgentToolRegistry` **port**
+live in `packages/contracts` (this PR, pure types). The registry **runtime**
+(registration + lookup + SQLite persistence) lands in slice 2 in a NEW standalone
+`packages/agent-tools` package **forbidden from importing `apps/*` or any
+project-specific code** — the guard against re-inventing a `ProjectView`-shaped
+abstraction — enforced by a `scripts/check-cross-app-imports.ts`-style guard wired
+into `pnpm guard`. Design tools register themselves as entries; the list itself
+stays product-neutral.
+
+## Return path
+
+Transport-agnostic across both execution models, converging on a daemon-side
+invocation record keyed by `invocationId`:
+
+- **Dispatch** rides the existing outbound run-event stream as a new event kind
+  carrying a `BrowserActionRequest`.
+- **Return** is a new run-scoped endpoint
+  `POST /api/runs/:runId/actions/:invocationId/result`, patterned on GenUI's
+  pending → responded lifecycle (see the return-path option above).
+- **Local-CLI agents** reach browser tools via a per-run **frontend-bridge MCP
+  server** extending `buildLiveArtifactsMcpServersForAgent`; its handlers await
+  the same invocation record.
+
+## Dual-track exemption
+
+> A tool may be `surface: 'browser'` — and ship without an `od` CLI form — ONLY
+> if its whole effect is an ephemeral browser view movement (navigate, scroll,
+> focus, panel visibility, current selection) and nothing it produces outlives the
+> browser session. If it creates, mutates, or reads anything that persists beyond
+> the session, or could be meaningfully invoked with no browser attached, it is a
+> capability: `surface: 'api'` with both an `/api/*` route and an `od` subcommand.
+
+Litmus: *"could it be meaningfully invoked with no browser attached?"* must FAIL
+for a browser tool. "Go to Media" fails it (exempt); "export the deck" passes it
+(a capability — cannot hide behind the exemption).
+
+## Slice roadmap
+
+| Slice | Deliverable | Ships code? |
+|---|---|---|
+| **Prereq** | `ChatComposer` decomposition — the active vertical-slice canary, **in progress**; prerequisite for a global mount. | in progress |
+| **1 (this PR)** | Contracts (`agent-tools/`: descriptor, actions, manifest, registry port) + this RFC. | ✅ types only |
+| **2** | Guarded `packages/agent-tools` runtime + SQLite persistence + one browser nav tool AND one browser click tool + the return endpoint → prove one action round-trips live. | ✅ |
+| **3** | Search (`capability.search`, default A + D) + PUSH/PULL advertisement handshake + "what can you do?" catalog view + frontend-bridge MCP server for local-CLI agents. | ✅ |
+| **4** | Global chat mount (one assistant, not three page-bound ones). | ✅ |
+| **5** | Cross-project task ownership + bounded permissions — see [companion RFC](./agent-ready-cross-project.md) (`AgentTask` + permissions options). | own RFC |
+
+## Non-breaking type hooks — ruled out for now
+
+Adding an optional field later is itself non-breaking, so slice 1 stays minimal:
+
+- **`AgentToolSearchResult` item `score?`** — ruled OUT. Only Option B needs it;
+  add it (optional) when embedding ranking lands. Non-breaking then.
+- **`AgentToolSearchQuery.tags?: string[]`** — ruled OUT. No taxonomy exists yet;
+  add optionally if a tag facet appears.
+- **`AgentToolManifest` `hasMore?`/cursor** — ruled OUT. The manifest is the
+  *full* small-run catalog; the large-registry path is `search()`, which already
+  pages. Adding paging to the manifest would duplicate that seam.
+
+## Deferred / Out of scope (this PR)
+
+- Any behavior/feature code — slice 1 is contracts + this RFC only.
+- The `packages/agent-tools` runtime, its guard, and SQLite persistence (slice 2).
+- Search execution, the advertisement handshake, the catalog view, and the
+  frontend-bridge MCP server (slice 3).
+- Global chat mount (slice 4); cross-project ownership + permissions (slice 5).
+- Consent UX (`USER_DENIED` is reserved in the contract but unwired).
+- Multi-tab / multi-session arbitration; streaming/progress results;
+  result-size limits; `resultSchema` validation; any `scope`/permission fields.
+- No new chat framework, no changes to `agui-adapter` / `genui_surfaces` / the run
+  engine in this PR.
+
+## Open questions
+
+1. **Product direction** — is the browser-action bridge the right first
+   investment (the `needs-product-direction` question), ahead of global chat?
+2. **Search default** — is A + D sufficient for slice 3, or do reviewers expect
+   semantic search (B/C) from day one?
+3. **Consent** — when does a browser action need explicit confirmation, and should
+   `USER_DENIED` gate destructive `api`-surface tools too?
+4. **Manifest freshness** — does a run re-fetch the manifest as tools register
+   (PUSH), or snapshot it at run start?

--- a/packages/contracts/src/agent-tools/actions.ts
+++ b/packages/contracts/src/agent-tools/actions.ts
@@ -1,0 +1,86 @@
+// Action round-trip shapes — the request the daemon dispatches toward a browser
+// session, and the result the browser sends back. These are transport-agnostic:
+// they name no wire (SSE / AG-UI / MCP) and no execution model (BYOK daemon-loop
+// vs local-CLI-via-MCP). Both models converge on a daemon-side invocation record
+// keyed by `invocationId`. See docs/rfc-drafts/agent-ready.md.
+
+import type { JsonValue } from '../common.js';
+import type { AgentToolName } from './descriptor.js';
+
+/**
+ * Wire-format version for the browser-action request/result pair. Carried on
+ * both messages so the daemon and a browser session can detect skew; bump it
+ * when the envelope shape changes incompatibly.
+ */
+export const AGENT_ACTIONS_PROTOCOL_VERSION = 1;
+
+/**
+ * One invocation of a browser-surface tool, minted by the daemon and dispatched
+ * toward a live browser session over the existing outbound run-event stream.
+ *
+ * The daemon mints `invocationId`; a provider `tool_call_id` (BYOK loop) or an
+ * MCP request id (local-CLI agent) is mapped to it daemon-side and never enters
+ * this contract, so the shape stays neutral across both execution models.
+ */
+export interface BrowserActionRequest {
+  protocolVersion: typeof AGENT_ACTIONS_PROTOCOL_VERSION;
+  /** The stable action identity. Daemon-minted, unique per invocation. */
+  invocationId: string;
+  /** The run this invocation belongs to. */
+  runId: string;
+  /** Which tool to invoke (matches a registered `BrowserToolDescriptor.name`). */
+  tool: AgentToolName;
+  /** Validated against the tool's `inputSchema` before dispatch. */
+  input: JsonValue;
+}
+
+/**
+ * Terminal error codes for a browser action. The `const` array mirrors the
+ * house `API_ERROR_CODES` idiom so the union derives from a single source.
+ */
+export const BROWSER_ACTION_ERROR_CODES = [
+  // No live browser session advertises a handler for this tool.
+  'TOOL_NOT_AVAILABLE',
+  // `input` failed the tool's `inputSchema`.
+  'INVALID_INPUT',
+  // The browser-side handler threw while executing.
+  'EXECUTION_FAILED',
+  // The daemon-side deadline for a result expired.
+  'TIMEOUT',
+  // The handler was torn down (page navigated / component unmounted) before it
+  // could produce a result.
+  'SUPERSEDED',
+  // Reserved for a future consent prompt; no UX wired in slice 1.
+  'USER_DENIED',
+] as const;
+
+export type BrowserActionErrorCode = (typeof BROWSER_ACTION_ERROR_CODES)[number];
+
+/**
+ * The uniform terminal result of a browser action, `ok`-discriminated and
+ * correlated to its request by `invocationId`. `result` is a {@link JsonValue}
+ * so a navigation acknowledgement (`{ view: 'media' }`) and a future
+ * data-returning read serialize through the same shape — never a navigation
+ * special case.
+ */
+export type BrowserActionResult =
+  | {
+      protocolVersion: typeof AGENT_ACTIONS_PROTOCOL_VERSION;
+      /** Echoes `BrowserActionRequest.invocationId` — the join key back to the run. */
+      invocationId: string;
+      /** Echoes the tool name for observability; not an identity. */
+      tool: AgentToolName;
+      ok: true;
+      result: JsonValue;
+    }
+  | {
+      protocolVersion: typeof AGENT_ACTIONS_PROTOCOL_VERSION;
+      invocationId: string;
+      tool: AgentToolName;
+      ok: false;
+      error: {
+        code: BrowserActionErrorCode;
+        message: string;
+        details?: JsonValue;
+      };
+    };

--- a/packages/contracts/src/agent-tools/descriptor.ts
+++ b/packages/contracts/src/agent-tools/descriptor.ts
@@ -1,0 +1,86 @@
+// Agent-tool descriptor — the shared, product-neutral shape that declares one
+// capability the assistant can invoke. Pure transport/capability shape only: no
+// UI-component fields (no button/panel/React props), no runtime logic, and no
+// imports from apps/daemon/browser/React. The registry RUNTIME that stores and
+// looks these up will live in a future standalone `packages/agent-tools`
+// package (see docs/rfc-drafts/agent-ready.md); this file is only the
+// wire shape.
+
+import type { JsonValue } from '../common.js';
+
+/**
+ * Stable tool identity. Lowercase, dot-namespaced and domain-grouped so tools
+ * cluster by owner — for example `navigation.goto` or `imagegen.create`. The
+ * `name` is the only cross-surface identity a caller may rely on; renaming a
+ * tool is a breaking change.
+ *
+ * Documented shape (not enforced at the type level — contracts is shapes-only):
+ * `/^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$/`
+ */
+export type AgentToolName = string;
+
+export type AgentToolHttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * The surfaces a tool can run on — the descriptor union's discriminant, named so
+ * the list/search shapes ({@link AgentToolManifest}, {@link AgentToolSearchQuery})
+ * can reuse it.
+ */
+export type AgentToolSurface = 'browser' | 'api';
+
+/** Fields common to every tool regardless of where it runs. */
+interface AgentToolDescriptorBase {
+  name: AgentToolName;
+  /**
+   * Model- and catalog-facing description: the text the assistant reads to
+   * decide when to call the tool, and the text a future "what can you do?"
+   * discovery view renders. Capability copy, never UI markup.
+   */
+  description: string;
+  /**
+   * JSON Schema (draft 2020-12) for the tool's input object, carried as a plain
+   * {@link JsonValue} so it crosses the MCP wire verbatim and stays
+   * framework-neutral (WebMCP / MCP-UI / A2UI ready). Authors may write Zod and
+   * emit JSON Schema, but the contract carries the emitted schema — never a Zod
+   * value.
+   */
+  inputSchema: JsonValue;
+}
+
+/**
+ * A tool whose whole effect is an ephemeral browser view movement (navigate,
+ * scroll, focus, open a panel). It runs in the browser and has no meaningful
+ * `od` CLI form, so it is exempt from the UI/CLI dual-track law — but only by
+ * asserting that exemption explicitly at the type level.
+ */
+export interface BrowserToolDescriptor extends AgentToolDescriptorBase {
+  surface: 'browser';
+  /**
+   * Literal `true`: this tool's whole effect is ephemeral browser view state
+   * and nothing it does outlives the session. Required so a browser tool cannot
+   * be declared without claiming the dual-track exemption (see RFC §5).
+   */
+  viewStateOnly: true;
+  api?: never;
+  cli?: never;
+}
+
+/**
+ * A real capability that runs as a normal API action. The UI/CLI dual-track law
+ * is encoded structurally: an api tool cannot be declared without both its
+ * `/api/*` route and its `od` subcommand.
+ */
+export interface ApiToolDescriptor extends AgentToolDescriptorBase {
+  surface: 'api';
+  /**
+   * The HTTP endpoint this capability drives. Method + route only; headers,
+   * bodies, and auth are transport concerns resolved at call time, not here.
+   */
+  api: { method: AgentToolHttpMethod; route: string };
+  /** The equivalent `od` CLI form, satisfying the dual-track law. */
+  cli: { subcommand: string };
+  viewStateOnly?: never;
+}
+
+/** The descriptor union, discriminated on `surface`. */
+export type AgentToolDescriptor = BrowserToolDescriptor | ApiToolDescriptor;

--- a/packages/contracts/src/agent-tools/index.ts
+++ b/packages/contracts/src/agent-tools/index.ts
@@ -1,0 +1,5 @@
+export * from './descriptor.js';
+export * from './actions.js';
+export * from './manifest.js';
+export * from './registry.js';
+export * from './task.js';

--- a/packages/contracts/src/agent-tools/manifest.ts
+++ b/packages/contracts/src/agent-tools/manifest.ts
@@ -3,7 +3,7 @@
 // a large registry. Pure types only: no runtime logic, no imports from
 // apps/daemon/browser/React. The MCP-congruent `tools/list` analog.
 
-import type { AgentToolDescriptor } from './descriptor.js';
+import type { AgentToolDescriptor, ApiToolDescriptor } from './descriptor.js';
 import { AGENT_ACTIONS_PROTOCOL_VERSION } from './actions.js';
 
 /**
@@ -52,9 +52,17 @@ export interface AgentToolSearchQuery {
  * Deliberately returns full descriptors and no ranking `score` — keyword search
  * (the slice-3 default) needs none, and a score can be added later without a
  * breaking change (see the RFC "Non-breaking type hooks").
+ *
+ * Items are `ApiToolDescriptor` only, not the full {@link AgentToolDescriptor}
+ * union: search is the PULL path over the persistent `api` catalog, so the
+ * result type enforces the same invariant as {@link AgentToolSearchQuery.surface}
+ * on the response side — a registry implementation cannot type-check while
+ * leaking `browser` descriptors into a session-less search result. Browser tools
+ * are advertised by PUSH per-session and are never a search result (see the RFC
+ * "Advertisement axis — PUSH vs PULL").
  */
 export interface AgentToolSearchResult {
-  tools: AgentToolDescriptor[];
+  tools: ApiToolDescriptor[];
   /** Opaque cursor to fetch the next page; absent on the final page. */
   nextCursor?: string;
   /** Best-effort total match count; optional so a store need not count to page. */

--- a/packages/contracts/src/agent-tools/manifest.ts
+++ b/packages/contracts/src/agent-tools/manifest.ts
@@ -3,7 +3,7 @@
 // a large registry. Pure types only: no runtime logic, no imports from
 // apps/daemon/browser/React. The MCP-congruent `tools/list` analog.
 
-import type { AgentToolDescriptor, AgentToolSurface } from './descriptor.js';
+import type { AgentToolDescriptor } from './descriptor.js';
 import { AGENT_ACTIONS_PROTOCOL_VERSION } from './actions.js';
 
 /**
@@ -30,8 +30,16 @@ export interface AgentToolManifest {
 export interface AgentToolSearchQuery {
   /** Free-text match over tool name/description. Omitted = match all. */
   query?: string;
-  /** Restrict to one surface (only browser view tools, or only api capabilities). */
-  surface?: AgentToolSurface;
+  /**
+   * Restrict to a surface. Search is the PULL path over the persistent registry,
+   * which holds only `api`-surface tools — browser availability is PUSH-advertised
+   * per-session and is never searched (see the RFC "Advertisement axis — PUSH vs
+   * PULL"). So `'api'` is the only searchable surface: the field exists to document
+   * that scope and to stay forward-compatible if a future surface becomes
+   * persistently searchable. Browser-tool discovery needs live session scope this
+   * query deliberately does not carry.
+   */
+  surface?: 'api';
   /** Page size. The registry clamps to its own maximum. */
   limit?: number;
   /** Opaque forward cursor from a previous {@link AgentToolSearchResult.nextCursor}. */

--- a/packages/contracts/src/agent-tools/manifest.ts
+++ b/packages/contracts/src/agent-tools/manifest.ts
@@ -1,0 +1,54 @@
+// Agent-tool list + search vocabulary — the "what can you do?" catalog a run or
+// frontend advertises, plus a paged search shape for progressive discovery over
+// a large registry. Pure types only: no runtime logic, no imports from
+// apps/daemon/browser/React. The MCP-congruent `tools/list` analog.
+
+import type { AgentToolDescriptor, AgentToolSurface } from './descriptor.js';
+import { AGENT_ACTIONS_PROTOCOL_VERSION } from './actions.js';
+
+/**
+ * The capability catalog a run advertises to the model — the `tools/list` analog
+ * ("what can you do?"). Small runs hand the model the whole `tools` array; large
+ * registries hand it an {@link AgentToolSearchQuery} instead (see the RFC
+ * "Agent tool search — options"). `protocolVersion` reuses the browser-action
+ * version so catalog and calls version together.
+ */
+export interface AgentToolManifest {
+  protocolVersion: typeof AGENT_ACTIONS_PROTOCOL_VERSION;
+  /** The run this catalog was assembled for. */
+  runId: string;
+  /** The advertised tools, as product-neutral descriptors. */
+  tools: AgentToolDescriptor[];
+}
+
+/**
+ * A progressive-discovery query over the registry — the answer to "too many
+ * tools." Mirrors the Composio `listToolsPage({ limit, cursor })` paged idiom so
+ * an agent fetches relevant tools just-in-time instead of receiving the full
+ * list. All fields optional: an empty query pages the whole registry.
+ */
+export interface AgentToolSearchQuery {
+  /** Free-text match over tool name/description. Omitted = match all. */
+  query?: string;
+  /** Restrict to one surface (only browser view tools, or only api capabilities). */
+  surface?: AgentToolSurface;
+  /** Page size. The registry clamps to its own maximum. */
+  limit?: number;
+  /** Opaque forward cursor from a previous {@link AgentToolSearchResult.nextCursor}. */
+  cursor?: string;
+}
+
+/**
+ * One page of search results. `nextCursor` is present iff more pages remain;
+ * `total` is a best-effort count the registry MAY omit for cheap paging.
+ * Deliberately returns full descriptors and no ranking `score` — keyword search
+ * (the slice-3 default) needs none, and a score can be added later without a
+ * breaking change (see the RFC "Non-breaking type hooks").
+ */
+export interface AgentToolSearchResult {
+  tools: AgentToolDescriptor[];
+  /** Opaque cursor to fetch the next page; absent on the final page. */
+  nextCursor?: string;
+  /** Best-effort total match count; optional so a store need not count to page. */
+  total?: number;
+}

--- a/packages/contracts/src/agent-tools/registry.ts
+++ b/packages/contracts/src/agent-tools/registry.ts
@@ -1,0 +1,30 @@
+// Agent-tool registry PORT — a pure interface describing the boundary reviewers
+// evaluate now. This is TYPES ONLY. The IMPLEMENTATION is slice 2: it lives in a
+// new standalone `packages/agent-tools` package, is persisted in the daemon's
+// SQLite store under the resolved data root, and MUST NOT import `apps/*` or any
+// project-specific code (enforced by a `check-cross-app-imports.ts`-style guard
+// wired into `pnpm guard`). Contracts stays runtime-free — nothing here has a body.
+
+import type { AgentToolDescriptor, AgentToolName } from './descriptor.js';
+import type {
+  AgentToolManifest,
+  AgentToolSearchQuery,
+  AgentToolSearchResult,
+} from './manifest.js';
+
+/**
+ * The port the rest of the system depends on to declare, look up, list, and
+ * search capability tools. Methods are async because the backing store is
+ * SQLite (see the RFC "Registry persistence"); the port itself carries no
+ * transport, no persistence detail, and no app/project coupling.
+ */
+export interface AgentToolRegistry {
+  /** Declare (or replace by `name`) a tool. Idempotent on the descriptor name. */
+  register(descriptor: AgentToolDescriptor): Promise<void>;
+  /** Look up one tool by its stable name; `undefined` if not registered. */
+  get(name: AgentToolName): Promise<AgentToolDescriptor | undefined>;
+  /** Assemble the full advertised catalog for a run (the `tools/list` analog). */
+  manifest(runId: string): Promise<AgentToolManifest>;
+  /** Progressive/paged discovery over a large registry (the `tools/search` analog). */
+  search(query: AgentToolSearchQuery): Promise<AgentToolSearchResult>;
+}

--- a/packages/contracts/src/agent-tools/task.ts
+++ b/packages/contracts/src/agent-tools/task.ts
@@ -1,0 +1,56 @@
+// Agent task — a project-agnostic, durable unit of work that owns a goal across
+// many steps AND across many projects. The same shape answers two deferred needs
+// at once: cross-project work and long-horizon (multi-step) work — a task simply
+// is not bound to a single project. Pure types only: no runtime logic, no imports
+// from apps/daemon/browser/React, and (deliberately) NO project/app UI state — an
+// AgentTask is a bounded ownership record, not a `ProjectView`. The runtime that
+// creates, persists, and enforces these lands in slice 5 (see
+// docs/rfc-drafts/agent-ready-cross-project.md); this file is only the shape.
+
+/**
+ * Lifecycle states for an {@link AgentTask}. The `const` array mirrors the house
+ * `API_ERROR_CODES` idiom so the union derives from a single source.
+ */
+export const AGENT_TASK_STATUSES = [
+  // Running (or ready to run) its next step.
+  'active',
+  // Paused pending user consent — e.g. the task tried to touch a project outside
+  // its authorized set, or a write requires confirmation (see the companion RFC
+  // "Permissions"). Correlates to the reserved `USER_DENIED` action error.
+  'awaiting-consent',
+  // The goal was reached; the task is terminal.
+  'completed',
+  // The task stopped on an unrecoverable error; terminal.
+  'failed',
+  // The user (or system) cancelled the task before completion; terminal.
+  'cancelled',
+] as const;
+
+export type AgentTaskStatus = (typeof AGENT_TASK_STATUSES)[number];
+
+/**
+ * A durable, project-agnostic unit of work. An AgentTask owns a goal that may
+ * span several steps and several projects; it is NOT tied to the chat of any one
+ * project.
+ *
+ * `projectIds` is the ownership / blast-radius boundary — the SET of projects
+ * this task is authorized to touch — NOT the enforcement mechanism. How that set
+ * is granted and widened (explicit allow-list vs just-in-time consent) is the
+ * maintainer's separate reviewable decision; see the companion RFC "Permissions".
+ * Keeping the boundary as a plain id set (no embedded project state, no roles) is
+ * the deliberate guard against re-modeling `ProjectView` here.
+ */
+export interface AgentTask {
+  /** Stable identity for the task; unique within a workspace. */
+  taskId: string;
+  /** Optional human-readable goal ("Apply our Q3 brand to the pitch deck"). */
+  goal?: string;
+  /**
+   * The projects this task is authorized to act on. Empty means "no project
+   * scope granted yet." A step targeting a project not in this set must obtain
+   * consent (see the RFC) rather than proceed.
+   */
+  projectIds: string[];
+  /** Current lifecycle state. */
+  status: AgentTaskStatus;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -52,5 +52,6 @@ export * from './prompts/plugin-block.js';
 export * from './prompts/atom-block.js';
 export * from './critique.js';
 export * from './plugins/index.js';
+export * from './agent-tools/index.js';
 export * from './analytics/events.js';
 export * from './analytics/public-params.js';


### PR DESCRIPTION
Part of #5398 (issue-first RFC: make Open Design agent-ready). This lands the
contract **foundation** and the **full design (all 5 slices)** for review — only
the contracts are code; behavior follows per the roadmap in
`docs/rfc-drafts/agent-ready.md`. It intentionally does **not** close the proposal.

## Why

- **Use case:** I opened proposal #5398 (turn the page-bound chat into one assistant
  that can drive the whole app) and want to move it from discussion to something
  reviewable. On the implementation side the maintainer greenlit a contracts-first
  cut; this lands those contracts plus the umbrella design so product review (the
  issue is `needs-product-direction`) can evaluate the whole arc at once.
- **Pain:** today the assistant is trapped on one page. There is no shared vocabulary
  for capabilities, no inbound "execute a UI action and return the result" path
  (AG-UI is outbound-only), and no catalog of what the assistant can do. This PR lays
  the pure-type foundation and the design for all of it, without shipping behavior.

## What users will see

**Nothing at runtime yet — this is pure contract *types* + design docs, no behavior.**
It is the reviewable foundation; user-facing changes (driving the UI from chat, a
"what can you do?" catalog, cross-project tasks) arrive in later slices per the
roadmap. Reviewers get:

- `packages/contracts/src/agent-tools/` — the capability vocabulary: `AgentToolDescriptor`
  (declare; discriminated on `surface`, dual-track law encoded structurally),
  `BrowserActionRequest`/`BrowserActionResult` (call/result; identity is a daemon-minted
  `invocationId`), `AgentToolManifest` + paged search (list/find), `AgentToolRegistry`
  (port), and `AgentTask` (the cross-project / long-horizon unit).
- `docs/rfc-drafts/agent-ready.md` — umbrella design: the MCP/WebMCP-congruent capability
  model, slice roadmap, "Agent tool search — options", and "options considered →
  recommendation" on the load-bearing calls (return path, persistence, identity, …).
- `docs/rfc-drafts/agent-ready-cross-project.md` — the maintainer's separate reviewable
  permissions writeup (`AgentTask` + permission options, not decreed).

Cross-project ownership and spanning-project permissions are **out of scope as behavior**
and kept to their own companion RFC per the maintainer's request.

## Surface area

- [x] **API / contract** — new pure-TypeScript shapes in `packages/contracts` (`agent-tools/` domain). No `/api/*` endpoint or SSE event yet.
- [ ] UI · [ ] Keyboard · [ ] CLI / env var · [ ] Extension point · [ ] i18n · [ ] New top-level dependency · [ ] Default behavior change

_Note on the UI/CLI dual-track law: this lands **no invokable capability** — only
contract types and design docs — so there is no surface to mirror yet. The dual-track
requirement (capability tools carry both UI + `od`; view/navigation tools are the
documented exception) is specified in `agent-ready.md` and lands with the runtime in
later slices._

## Screenshots

N/A — no UI in this change.

## Bug fix verification

N/A — not a bug fix.

## Validation

- `pnpm --filter @open-design/contracts typecheck` — pass (exit 0)
- `pnpm guard` — pass (87/87)
- New exports checked for collisions against the existing `contracts` barrel — none.
- No runtime consumers yet (types only), so no downstream build/test is exercised.
