### PR TITLE
fix web browser-assist guide layering

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -656,6 +656,10 @@ interface Props {
   currentDesignSystemId?: string | null;
   onActiveDesignSystemChange?: (project: Project) => void;
   onShowToast?: (message: string) => void;
+  // Optional transient UI owned by the project shell. Rendering it inside the
+  // scroll-area wrapper keeps it structurally above the variable-height
+  // composer instead of guessing a bottom offset from outside ChatPane.
+  chatLogTray?: ReactNode;
   // Project header slot. The former standalone chrome header row was removed;
   // its back button, project title (editable) and design-system picker moved
   // into the top of the chat pane. ProjectView owns the project record so it
@@ -877,6 +881,7 @@ export function ChatPane({
   currentDesignSystemId,
   onActiveDesignSystemChange,
   onShowToast,
+  chatLogTray,
   onBack,
   backLabel,
   projectHeader,
@@ -2204,7 +2209,7 @@ export function ChatPane({
       </div>
       {tab === 'chat' ? (
         <>
-          <div className="chat-log-wrap">
+          <div className={`chat-log-wrap${chatLogTray ? ' has-chat-log-tray' : ''}`}>
             <div
               className={[
                 'chat-log',
@@ -2624,6 +2629,7 @@ export function ChatPane({
                   the viewport, then shrinks as the reply streams in below. */}
               <div className="chat-log-tail-spacer" ref={tailSpacerRef} aria-hidden />
             </div>
+            {chatLogTray}
             {/* Always mounted so the CSS transition can play in both
                 directions; the `chat-jump-btn-active` class flips the
                 slide + opacity, and `aria-hidden` + `tabIndex={-1}`

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1576,6 +1576,7 @@ export function ProjectView({
     code?: string | null;
     tone?: 'default' | 'success' | 'error' | 'loading';
     ttlMs?: number;
+    scope?: 'chat-pane';
   } | null>(null);
   // Brand extraction has no SSE; this polls the brand's status and, once the
   // backing extraction finalizes a `user:<id>` design system, surfaces a
@@ -3097,6 +3098,7 @@ export function ProjectView({
         details: t('chat.brandBrowserAssistDownloadGuideDetails'),
         tone: 'default',
         ttlMs: 12000,
+        scope: 'chat-pane',
       });
       return { ok: true, action: 'opened' };
     },
@@ -7424,6 +7426,21 @@ export function ProjectView({
     ? COMMENT_INSPECTOR_PANEL_WIDTH
     : chatPanelWidthRef.current;
   const chatPanelAriaMinWidth = Math.min(MIN_CHAT_PANEL_WIDTH, chatPanelMaxWidth);
+  const projectActionsToastInChatPane =
+    projectActionsToast?.scope === 'chat-pane' &&
+    !workspaceFocused &&
+    !commentInspectorActive &&
+    Boolean(activeConversationId || conversationLoadError);
+  const projectActionsToastNode = projectActionsToast ? (
+    <Toast
+      message={projectActionsToast.message}
+      details={projectActionsToast.details}
+      code={projectActionsToast.code}
+      tone={projectActionsToast.tone}
+      ttlMs={projectActionsToast.ttlMs}
+      onDismiss={() => setProjectActionsToast(null)}
+    />
+  ) : null;
 
   const renderPreferredChatPanelWidth = useCallback((
     preferredWidth: number,
@@ -8490,6 +8507,13 @@ export function ProjectView({
               }
               createDesignSystemFromProjectBusy={projectDesignSystemCreateStarting}
               onBrandBrowserAssistConfirm={handleBrandBrowserAssistConfirm}
+              chatLogTray={
+                projectActionsToastInChatPane ? (
+                  <div className="project-actions-toast-anchor">
+                    {projectActionsToastNode}
+                  </div>
+                ) : null
+              }
               composerDraftSignal={composerDraftSignal}
               petConfig={config.pet}
               onAdoptPet={onAdoptPetInline}
@@ -8776,16 +8800,7 @@ export function ProjectView({
         />
       ) : null}
       <AnimatePresence>
-        {projectActionsToast ? (
-          <Toast
-            message={projectActionsToast.message}
-            details={projectActionsToast.details}
-            code={projectActionsToast.code}
-            tone={projectActionsToast.tone}
-            ttlMs={projectActionsToast.ttlMs}
-            onDismiss={() => setProjectActionsToast(null)}
-          />
-        ) : null}
+        {projectActionsToast && !projectActionsToastInChatPane ? projectActionsToastNode : null}
         {brandReadyPrompt ? (
           <BrandReadyPrompt
             key="brand-ready-prompt"

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -134,6 +134,35 @@
   bottom: auto;
   z-index: 1200;
 }
+.project-actions-toast-anchor {
+  position: relative;
+  z-index: 60;
+  flex: 0 0 auto;
+  width: min(420px, calc(100% - 32px));
+  max-width: calc(100% - 32px);
+  margin: 0 auto 12px;
+  pointer-events: none;
+}
+.chat-log-wrap.has-chat-log-tray {
+  flex-direction: column;
+}
+.project-actions-toast-anchor .od-toast {
+  position: static;
+  inset: auto;
+  width: 100%;
+  max-width: 100%;
+  transform: none;
+  animation: none;
+  pointer-events: auto;
+}
+.project-actions-toast-anchor .od-toast.placement-top {
+  top: auto;
+  bottom: auto;
+  z-index: 1000;
+}
+.project-actions-toast-anchor .od-toast.leaving {
+  animation: none;
+}
 .od-toast.tone-success {
   border: 1px solid color-mix(in srgb, var(--success, #2da44e) 42%, var(--border));
   background: color-mix(in srgb, var(--success, #2da44e) 14%, var(--bg));

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { ComponentProps } from 'react';
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ProjectView,
@@ -184,7 +184,13 @@ const chatPaneSpy = vi.fn();
 vi.mock('../../src/components/ChatPane', () => ({
   ChatPane: (props: Record<string, unknown>) => {
     chatPaneSpy(props);
-    return null;
+    return (
+      <div className="pane">
+        <div className={`chat-log-wrap${props.chatLogTray ? ' has-chat-log-tray' : ''}`}>
+          {props.chatLogTray as ComponentProps<'div'>['children']}
+        </div>
+      </div>
+    );
   },
 }));
 
@@ -207,6 +213,12 @@ async function waitForReadyChatPaneProps() {
     expect(chatPaneSpy.mock.calls.at(-1)?.[0]?.sendDisabled).toBe(false);
   });
   return chatPaneSpy.mock.calls.at(-1)?.[0] as {
+    onBrandBrowserAssistConfirm?: (card: {
+      brandId: string;
+      browserTabId?: string;
+      reason?: string;
+      url?: string;
+    }) => Promise<{ ok: boolean; action?: string; message?: string } | void> | { ok: boolean; action?: string; message?: string } | void;
     onSend?: (prompt: string, attachments: unknown[], comments: unknown[]) => Promise<void>;
     initialDraft?: string;
   };
@@ -930,6 +942,90 @@ describe('ProjectView daemon cleanup', () => {
     });
     expect(streamViaDaemon).not.toHaveBeenCalled();
     expect(window.sessionStorage.getItem('od:auto-send-first:brand-project')).toBeNull();
+  });
+
+  it('anchors the brand browser-assist download guide between the transcript and composer', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-brand', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockResolvedValue(undefined);
+
+    chatPaneSpy.mockClear();
+    fileWorkspaceSpy.mockClear();
+
+    render(
+      <ProjectView
+        project={{
+          id: 'brand-project',
+          name: 'Refly Design System',
+          skillId: null,
+          designSystemId: null,
+          metadata: {
+            kind: 'brand',
+            importedFrom: 'brand-extraction',
+            brandId: 'refly-ai',
+            brandSourceUrl: 'https://refly.ai/',
+          },
+          createdAt: 1,
+          updatedAt: 1,
+        } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    const chatProps = await waitForReadyChatPaneProps();
+    expect(chatProps.onBrandBrowserAssistConfirm).toBeTypeOf('function');
+
+    let result: { ok: boolean; action?: string; message?: string } | void = undefined;
+    await act(async () => {
+      result = await chatProps.onBrandBrowserAssistConfirm?.({
+        brandId: 'refly-ai',
+        browserTabId: 'brand-browser-tab',
+        reason: 'Cloudflare',
+        url: 'https://refly.ai/',
+      });
+    });
+
+    expect(result).toMatchObject({ ok: true, action: 'opened' });
+    await waitFor(() => {
+      expect(fileWorkspaceSpy.mock.calls.at(-1)?.[0]?.browserOpenRequest).toMatchObject({
+        tabId: 'brand-browser-tab',
+        url: 'https://refly.ai/',
+        attentionAction: 'download-page',
+      });
+    });
+
+    const toast = await waitFor(() => {
+      const node = document.querySelector('.od-toast');
+      expect(node?.textContent).toContain('chat.brandBrowserAssistDownloadGuideTitle');
+      return node as HTMLElement;
+    });
+    expect(toast.closest('.project-actions-toast-anchor')).toBeTruthy();
+    expect(toast.closest('.split-chat-slot')).toBeTruthy();
+    expect(toast.closest('.chat-log-wrap')?.className).toContain('has-chat-log-tray');
   });
 
   it('waits for pendingPrompt hydration before consuming an auto-send flag', async () => {


### PR DESCRIPTION
Fixes #5345

## Why

I reproduced the website-extraction recovery flow for a Cloudflare-gated page. After Browser assist opened the site, the Download Page guide still used the shared project-level, viewport-fixed toast surface. In split view that let the guide span the center boundary, cover the page the user needed to inspect, and compete with the chat composer.

This keeps the change scoped to the browser-assist guide rather than changing the extraction logic or the placement of unrelated project-action toasts.

## What users will see

After opening Browser assist, the Download Page guide appears in an in-flow tray at the bottom of the left extraction transcript, immediately above the composer. The full instruction remains visible without covering the right Browser pane, the Next Step card, or a variable-height composer.

Other project-action toasts keep their existing global placement.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

### Before

The issue reproduction shows the viewport-level guide spanning the split view and obscuring the Browser page:

![Before: browser-assist guide overlapping the split view](https://github.com/user-attachments/assets/a3ebfeff-9556-43d4-8904-0b5b1ae82575)

### After

The guide is contained in the left chat pane between the transcript and composer:

![After: browser-assist guide contained in the chat tray](https://gist.githubusercontent.com/roian6/9e35228add3dab2e60428f36cf6251c3/raw/d86bb7cfce80bdba74effbf557ecb42f4d807eab/issue-5345-after.png)

At a 1440×960 viewport, the guide ended at x=440, the left pane ended at x=460, and the Browser pane started at x=468 (`intersectsBrowser: false`).

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.run-cleanup.test.tsx` — `anchors the brand browser-assist download guide between the transcript and composer`
- Did the test go red on `main` and green on this branch? **Yes.** With the test-only patch on fresh `origin/main`, it failed because the toast had no `.project-actions-toast-anchor`; it passes on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/ProjectView.run-cleanup.test.tsx tests/components/ChatPane.streaming.test.tsx tests/components/Toast.test.tsx` — 92 passed
- `pnpm --filter @open-design/web build`
- Node 24 live-app Browser-assist click-through with screenshot and DOM geometry readback
- `git diff --check`
