### PR TITLE
fix(web): observe transform track so keyboard nav updates the deck toolbar

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2573,6 +2573,13 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       for (var i = 0; i < list.length; i++) {
         mo.observe(list[i], { attributes: true, attributeFilter: ['class', 'style', 'hidden', 'aria-hidden'] });
       }
+      // Transform-driven decks leave the slides untouched and translate a
+      // track element instead, so watching only the slides misses navigation
+      // the artifact drives itself (its own keyboard handler). Scroll decks
+      // are covered by the scroll listener and class-toggle decks by the
+      // slide observer above; the track is the remaining path to the host counter.
+      var track = transformTrack(list);
+      if (track) mo.observe(track, { attributes: true, attributeFilter: ['style'] });
     } catch (e) {}
     setTimeout(restoreInitialSlide, 100);
   }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7004,3 +7004,63 @@ describe('LiveArtifactRefreshHistoryPanel', () => {
     expect(markup).not.toContain('>Never<');
   });
 });
+
+describe('FileViewer deck navigation toolbar', () => {
+  function renderDeck() {
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={baseFile({
+          name: 'deck.html',
+          path: 'deck.html',
+          mime: 'text/html',
+          kind: 'html',
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Deck',
+            entry: 'deck.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        isDeck
+        liveHtml={'<html><body><section class="slide">one</section><section class="slide">two</section><section class="slide">three</section></body></html>'}
+      />,
+    );
+    return screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+  }
+
+  function reportSlideState(frame: HTMLIFrameElement, active: number, count: number) {
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active, count },
+    }));
+  }
+
+  const counter = () => document.querySelector('.deck-nav-counter');
+  const prevButton = () => screen.getByLabelText('Previous slide') as HTMLButtonElement;
+  const nextButton = () => screen.getByLabelText('Next slide') as HTMLButtonElement;
+
+  // The bridge reports keyboard-driven navigation as `od:slide-state`; the toolbar
+  // has to follow it, not just toolbar clicks. See srcdoc-deck-bridge-keyboard-sync.
+  it('follows reported slide state for the counter and the prev/next buttons', async () => {
+    const frame = renderDeck();
+
+    reportSlideState(frame, 0, 3);
+    await waitFor(() => expect(counter()?.textContent).toBe('1 / 3'));
+    expect(prevButton().disabled).toBe(true);
+    expect(nextButton().disabled).toBe(false);
+
+    reportSlideState(frame, 1, 3);
+    await waitFor(() => expect(counter()?.textContent).toBe('2 / 3'));
+    expect(prevButton().disabled).toBe(false);
+    expect(nextButton().disabled).toBe(false);
+
+    reportSlideState(frame, 2, 3);
+    await waitFor(() => expect(counter()?.textContent).toBe('3 / 3'));
+    expect(prevButton().disabled).toBe(false);
+    expect(nextButton().disabled).toBe(true);
+  });
+});

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-sync.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { buildSrcdoc } from '../../src/runtime/srcdoc';
+
+// When the artifact's own keyboard handler drives navigation, the host toolbar
+// only learns about it through `od:slide-state`. Class-toggle decks mutate the
+// slides and scroll decks fire scroll events, but transform decks translate a
+// track element that nothing used to observe, so the host counter and the
+// prev/next buttons stayed on the previous slide until a toolbar click.
+
+function extractDeckBridgeScript(srcdoc: string): string {
+  const match = srcdoc.match(/<script data-od-deck-bridge>([\s\S]*?)<\/script>/);
+  if (!match || !match[1]) {
+    throw new Error('deck bridge script not found in srcdoc');
+  }
+  return match[1];
+}
+
+const CLASS_TOGGLE_DECK = `
+  <div class="deck">
+    <section class="slide active">One</section>
+    <section class="slide">Two</section>
+    <section class="slide">Three</section>
+  </div>
+`;
+
+const TRANSFORM_DECK = `
+  <div class="deck-shell">
+    <div class="deck-track" id="deck-track" style="transform: translateX(0%)">
+      <section class="slide active">One</section>
+      <section class="slide">Two</section>
+      <section class="slide">Three</section>
+    </div>
+  </div>
+`;
+
+type DeckWindow = JSDOM['window'];
+
+/** Boots the deck bridge over an artifact that already installed its own keyboard handler. */
+function bootDeck(bodyHtml: string, installArtifactKeyHandler: (win: DeckWindow) => void) {
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  const parentPostMessage = vi.fn();
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: parentPostMessage },
+  });
+  Object.defineProperty(win, 'innerWidth', { configurable: true, value: 1000 });
+
+  installArtifactKeyHandler(win);
+  win.eval(script);
+
+  // The bridge posts an initial state ~100ms after boot (restoreInitialSlide).
+  // Let it land before assertions, otherwise it masks a missing keyboard report.
+  const settleBoot = () => new Promise((resolve) => setTimeout(resolve, 400));
+
+  return { win, parentPostMessage, settleBoot };
+}
+
+function lastSlideState(postMessage: ReturnType<typeof vi.fn>) {
+  const calls = postMessage.mock.calls.filter(
+    (call) => call[0] && call[0].type === 'od:slide-state',
+  );
+  return calls.at(-1)?.[0] ?? null;
+}
+
+function press(win: DeckWindow, key: string) {
+  win.document.dispatchEvent(new win.KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+const flushObserver = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+describe('deck bridge keyboard sync', () => {
+  it('reports slide state when a transform deck moves its own track', async () => {
+    const { win, parentPostMessage, settleBoot } = bootDeck(TRANSFORM_DECK, (w) => {
+      w.document.addEventListener('keydown', (event) => {
+        const track = w.document.getElementById('deck-track');
+        if (!track) return;
+        const match = /translateX\(\s*(-?[0-9.]+)%\s*\)/.exec(track.style.transform || '');
+        const current = match?.[1] ? Math.abs(parseFloat(match[1])) / 100 : 0;
+        if (event.key === 'ArrowRight' && current < 2) {
+          track.style.transform = `translateX(${-(current + 1) * 100}%)`;
+        } else if (event.key === 'ArrowLeft' && current > 0) {
+          track.style.transform = `translateX(${-(current - 1) * 100}%)`;
+        }
+      });
+    });
+
+    await settleBoot();
+    parentPostMessage.mockClear();
+
+    press(win, 'ArrowRight');
+    await flushObserver();
+    expect(lastSlideState(parentPostMessage)).toEqual({
+      type: 'od:slide-state',
+      active: 1,
+      count: 3,
+    });
+
+    press(win, 'ArrowLeft');
+    await flushObserver();
+    expect(lastSlideState(parentPostMessage)).toEqual({
+      type: 'od:slide-state',
+      active: 0,
+      count: 3,
+    });
+  });
+
+  it('reports slide state when a class-toggle deck moves its own slides', async () => {
+    const { win, parentPostMessage, settleBoot } = bootDeck(CLASS_TOGGLE_DECK, (w) => {
+      w.document.addEventListener('keydown', (event) => {
+        if (event.key !== 'ArrowRight') return;
+        const slides = [...w.document.querySelectorAll('.slide')];
+        const index = slides.findIndex((slide) => slide.classList.contains('active'));
+        const current = slides[index];
+        const next = slides[index + 1];
+        if (!current || !next) return;
+        current.classList.remove('active');
+        next.classList.add('active');
+      });
+    });
+
+    await settleBoot();
+    parentPostMessage.mockClear();
+
+    press(win, 'ArrowRight');
+    await flushObserver();
+    expect(lastSlideState(parentPostMessage)).toEqual({
+      type: 'od:slide-state',
+      active: 1,
+      count: 3,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #5369
Fixes #5363

## Why

Scratching an itch surfaced by two community bug reports: with a paged preview open, navigating slides with the keyboard leaves the host toolbar behind — the page indicator keeps showing the old page and the prev/next buttons keep their old enabled/disabled state. Clicking a toolbar button once appears to "fix" it, which makes the controls feel untrustworthy.

Both issues are the same bug. The host reads a single `slideState`, and that one value drives both the `.deck-nav-counter` text (#5363) and the prev/next `disabled` attributes (#5369). Fixing the path that populates it fixes both symptoms; there is no scenario where one is stale and the other is fresh.

## What users will see

In a multi-page preview or deck, pressing the arrow keys now updates the toolbar page indicator and the prev/next button states immediately, without having to click a toolbar button first.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

No new keyboard shortcut: the arrow keys already navigated the deck. What changes is that the host toolbar now learns about it.

## Screenshots

Not a visual change to any surface — no new UI. The change is that existing toolbar controls update when they previously did not. The behavior is covered by the regression test below rather than a screenshot.

## Bug fix verification

Root cause: the deck bridge already translates artifact-driven navigation into `od:slide-state` through the `observeSlides()` MutationObserver in `apps/web/src/runtime/srcdoc.ts`, but it only observed the **slide** elements. Transform-driven decks never touch the slides — they translate a **track** element — so the observer never fired and the host toolbar was never told. Class-toggle decks (covered by the slide observer) and scroll decks (covered by the scroll listener) were already fine; the track was the one uncovered path.

That also explains the "click a toolbar button once and the keyboard starts working" report: a keydown inside the iframe never reaches the host `window`, so before the click only the artifact's own handler runs, silently. After clicking a toolbar button, focus sits on the host document, so arrow keys instead take the `od:slide` → `go()` → `report()` path, which always reported.

The fix observes the transform track's `style` alongside the slides — 7 lines, no behavior change for decks that already worked.

- Test path that reproduces the bug: `apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-sync.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — on `main` the transform-deck case posts zero `od:slide-state` messages after ArrowRight; on this branch it reports `active: 1`, then `active: 0` after ArrowLeft. The class-toggle case passes on both and is included as a guard against regressing the path that already worked.

You asked for coverage that the *toolbar counter/button state* updates, so there is a second test — `apps/web/tests/components/FileViewer.test.tsx` → "FileViewer deck navigation toolbar". To be precise about what it proves: it passes on `main` too, because the host side was never broken. It locks in the contract the bridge test depends on — that `.deck-nav-counter` text and the prev/next `disabled` attributes follow whatever `od:slide-state` reports, regardless of who sent it. The red/green evidence for the bug itself is the bridge test above.

While writing that test I hit a trap worth flagging: the bridge posts an initial state ~100ms after boot (`restoreInitialSlide`). A test that presses a key before that lands sees the boot report and passes *even without the fix*. My first draft was green for exactly that wrong reason. The test now waits for boot to settle before clearing the spy.

**Known limitation, out of scope here:** `activeIndexFromTransform()` parses only `%` and `vw` units. A deck that translates its track in `px` will now fire the observer but `activeIndex()` can't derive the slide from it, so it would still report `active: 0`. Both linked issues describe the `%`/`vw` case, which this fixes. Happy to widen the parser in a follow-up if you've seen `px` tracks in the wild.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/web test tests/runtime/srcdoc-deck-bridge-keyboard-sync.test.ts` — 2 passed
- `pnpm --filter @open-design/web test tests/components/FileViewer.test.tsx -t "deck navigation toolbar"` — 1 passed
- Full `tests/runtime/` suite — 416 passed, 13 failed, all 13 in `tests/runtime/amr-balance-gate.test.ts`. Those 13 also fail on a pristine `upstream/main` tip (`afec21ac4`) with no changes applied, so they are pre-existing and unrelated to this PR.
