### PR TITLE
feat(web): polish coderpet motion and mac packaging

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,7 +9,7 @@ import {
 import { EntryView } from './components/EntryView';
 import type { CreateInput } from './components/NewProjectPanel';
 import { MemoryToast } from './components/MemoryToast';
-import { PetOverlay } from './components/pet/PetOverlay';
+import { PetOverlay, type AgentSessionState } from './components/pet/PetOverlay';
 import { migrateCustomPetAtlas } from './components/pet/pets';
 import { ProjectView } from './components/ProjectView';
 import {
@@ -894,6 +894,8 @@ export function App() {
     [handleSetPetEnabled],
   );
 
+  const [agentSessionState, setAgentSessionState] = useState<AgentSessionState>('idle');
+
   // Toggle wake/tuck — used by the pet rail and the composer button.
   const handleTogglePet = useCallback(() => {
     setConfig((curr) => {
@@ -998,6 +1000,7 @@ export function App() {
           onAdoptPetInline={handleAdoptPet}
           onTogglePet={handleTogglePet}
           onOpenPetSettings={openPetSettings}
+          onAgentSessionChange={setAgentSessionState}
           onBack={handleBack}
           onClearPendingPrompt={handleClearPendingPrompt}
           onTouchProject={handleTouchProject}
@@ -1039,6 +1042,7 @@ export function App() {
         pet={config.pet?.enabled ? config.pet : undefined}
         onTuck={handleTuckPet}
         onOpenSettings={openPetSettings}
+        agentSessionState={agentSessionState}
       />
       {settingsOpen ? (
         <SettingsDialog
@@ -1071,6 +1075,8 @@ export function App() {
           daemonMediaProvidersFetchState={daemonMediaProvidersFetchState}
           mediaProvidersNotice={mediaProvidersNotice}
           onReloadMediaProviders={reloadMediaProvidersFromDaemon}
+          previewAgentSessionState={agentSessionState}
+          onPreviewAgentSessionChange={setAgentSessionState}
         />
       ) : null}
       <MemoryToast onOpenMemory={() => openSettings('memory')} />

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -142,6 +142,8 @@ interface Props {
   onAdoptPetInline?: (petId: string) => void;
   onTogglePet?: () => void;
   onOpenPetSettings?: () => void;
+  /** Notifies App of agent session state changes so PetOverlay can animate. */
+  onAgentSessionChange?: (state: 'idle' | 'thinking' | 'done' | 'error') => void;
   onBack: () => void;
   onClearPendingPrompt: () => void;
   onTouchProject: () => void;
@@ -271,6 +273,7 @@ export function ProjectView({
   onAdoptPetInline,
   onTogglePet,
   onOpenPetSettings,
+  onAgentSessionChange,
   onBack,
   onClearPendingPrompt,
   onTouchProject,
@@ -291,6 +294,28 @@ export function ProjectView({
   const [attachedComments, setAttachedComments] = useState<PreviewComment[]>([]);
   const [streaming, setStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Bubble streaming/error state up to App so PetOverlay can animate.
+  const prevStreamingRef = useRef(false);
+  useEffect(() => {
+    if (!onAgentSessionChange) return;
+    if (streaming) {
+      prevStreamingRef.current = true;
+      onAgentSessionChange('thinking');
+      return;
+    }
+    if (error) {
+      prevStreamingRef.current = false;
+      onAgentSessionChange('error');
+      return;
+    }
+    if (prevStreamingRef.current) {
+      prevStreamingRef.current = false;
+      onAgentSessionChange('done'); // PetOverlay auto-resets to idle after 2s
+      return;
+    }
+    onAgentSessionChange('idle');
+  }, [streaming, error, onAgentSessionChange]);
   const [audioVoiceOptionsError, setAudioVoiceOptionsError] = useState<string | null>(null);
   const [artifact, setArtifact] = useState<Artifact | null>(null);
   const [filesRefresh, setFilesRefresh] = useState(0);

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -95,6 +95,7 @@ import {
   requestNotificationPermission,
   showCompletionNotification,
 } from '../utils/notifications';
+import type { AgentSessionState } from './pet/PetOverlay';
 
 export type SettingsSection =
   | 'execution'
@@ -154,6 +155,8 @@ interface Props {
   daemonMediaProvidersFetchState?: 'idle' | 'ok' | 'error';
   mediaProvidersNotice?: string | null;
   onReloadMediaProviders?: () => Promise<AppConfig['mediaProviders'] | null>;
+  previewAgentSessionState?: AgentSessionState;
+  onPreviewAgentSessionChange?: (state: AgentSessionState) => void;
 }
 
 export interface AgentRefreshOptions {
@@ -639,17 +642,19 @@ export function SettingsDialog({
   agents,
   daemonLive,
   appVersionInfo,
-  welcome,
+  welcome = false,
   initialSection = 'execution',
+  composioConfigLoading = false,
   onPersist,
   onPersistComposioKey,
-  composioConfigLoading = false,
   onClose,
   onRefreshAgents,
   daemonMediaProviders,
   daemonMediaProvidersFetchState = 'idle',
   mediaProvidersNotice,
   onReloadMediaProviders,
+  previewAgentSessionState,
+  onPreviewAgentSessionChange,
 }: Props) {
   const { t, locale, setLocale } = useI18n();
   const analytics = useAnalytics();
@@ -2556,7 +2561,12 @@ export function SettingsDialog({
           ) : null}
 
           {activeSection === 'pet' ? (
-            <PetSettings cfg={cfg} setCfg={setCfg} />
+            <PetSettings
+              cfg={cfg}
+              setCfg={setCfg}
+              previewAgentSessionState={previewAgentSessionState}
+              onPreviewAgentSessionChange={onPreviewAgentSessionChange}
+            />
           ) : null}
 
           {activeSection === 'skills' ? (

--- a/apps/web/src/components/pet/PetOverlay.tsx
+++ b/apps/web/src/components/pet/PetOverlay.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
 import { useT } from '../../i18n';
 import { Icon } from '../Icon';
 import type { PetConfig } from '../../types';
@@ -11,10 +18,14 @@ import {
 } from './pets';
 import { PetSpriteFace } from './PetSpriteFace';
 
+export type AgentSessionState = 'idle' | 'thinking' | 'done' | 'error';
+
 interface Props {
   pet: PetConfig | undefined;
   onTuck: () => void;
   onOpenSettings: () => void;
+  /** Current AI agent session state. Drives pet animation when no user gesture is active. */
+  agentSessionState?: AgentSessionState;
 }
 
 const STORAGE_KEY = 'open-design:pet-position';
@@ -57,6 +68,51 @@ const DRAG_GESTURE_MIN_PX = 14;
 // jumping/waving so diagonal drags don't strobe between rows.
 const DRAG_AXIS_BIAS = 1.18;
 
+// Autonomous horizontal pacing. This is the concrete "movement mode"
+// for the personalized pet MVP: when the user is not hovering,
+// dragging, or reading the bubble, the companion walks left ↔ right
+// inside the viewport bounds instead of staying parked in one corner.
+const AUTO_WALK_EDGE_PADDING_PX = 8;
+const AUTO_WALK_SPRITE_BOX_PX = 96;
+const AUTO_WALK_SPEED_PX_PER_SEC = 40;
+const AUTO_WALK_TURN_PAUSE_MS = 820;
+const AUTO_WALK_RESUME_PAUSE_MS = 560;
+
+type BubbleStatusTone = 'ready' | 'active' | 'paused';
+
+interface BubbleStatusItem {
+  label: string;
+  value: string;
+  tone: BubbleStatusTone;
+}
+
+function atlasRowLabel(
+  t: ReturnType<typeof useT>,
+  rowId: string,
+): string {
+  switch (rowId) {
+    case 'running-left':
+      return t('pet.atlasRow.running-left');
+    case 'running-right':
+      return t('pet.atlasRow.running-right');
+    case 'waving':
+      return t('pet.atlasRow.waving');
+    case 'jumping':
+      return t('pet.atlasRow.jumping');
+    case 'waiting':
+      return t('pet.atlasRow.waiting');
+    case 'running':
+      return t('pet.atlasRow.running');
+    case 'review':
+      return t('pet.atlasRow.review');
+    case 'failed':
+      return t('pet.atlasRow.failed');
+    case 'idle':
+    default:
+      return t('pet.atlasRow.idle');
+  }
+}
+
 function loadPosition(): Position {
   if (typeof window === 'undefined') return DEFAULT_POSITION;
   try {
@@ -83,7 +139,7 @@ function savePosition(p: Position) {
 // Compact floating sprite + speech bubble. Rendered at the document
 // root via App.tsx so it stays put when the user navigates between
 // the entry and project views.
-export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
+export function PetOverlay({ pet, onTuck, onOpenSettings, agentSessionState }: Props) {
   const t = useT();
   const active = useMemo(() => resolveActivePet(pet), [pet]);
   const [bubbleOpen, setBubbleOpen] = useState(false);
@@ -98,6 +154,11 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
   // interaction state wins as soon as a gesture fires.
   const [ambientRowId, setAmbientRowId] = useState<string | null>(null);
   const [hovered, setHovered] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [movementMode, setMovementMode] = useState<'walk-left' | 'walk-right' | null>('walk-left');
+  const movementModeRef = useRef<'walk-left' | 'walk-right' | null>('walk-left');
+  const walkDirectionRef = useRef<'left' | 'right'>('left');
+  const walkPauseUntilRef = useRef<number>(0);
   const dragRef = useRef<{
     startX: number;
     startY: number;
@@ -125,11 +186,142 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
     savePosition(position);
   }, [position]);
 
+  const agentPoseActive =
+    !dragging &&
+    !hovered &&
+    !bubbleOpen &&
+    agentSessionState != null &&
+    agentSessionState !== 'idle';
+
+  // Agent session state drives pet interaction when no user gesture is active.
+  // User drag/hover/bubble takes priority — agent state only applies while calm.
+  useEffect(() => {
+    if (dragging || hovered || bubbleOpen) return;
+    if (!agentSessionState || agentSessionState === 'idle') {
+      setInteraction((prev) => (
+        prev === 'agent-thinking' || prev === 'agent-done' || prev === 'agent-error'
+          ? 'idle'
+          : prev
+      ));
+      return;
+    }
+    const map: Record<Exclude<AgentSessionState, 'idle'>, PetInteraction> = {
+      thinking: 'agent-thinking',
+      done: 'agent-done',
+      error: 'agent-error',
+    };
+    setInteraction(map[agentSessionState]);
+    // For 'done'/'error' flash back to idle after 2s so the pet doesn't
+    // stay frozen in the completed-hop or failed pose indefinitely.
+    if (agentSessionState === 'done' || agentSessionState === 'error') {
+      const id = window.setTimeout(() => {
+        setInteraction((prev) => (prev === map[agentSessionState] ? 'idle' : prev));
+      }, 2000);
+      return () => window.clearTimeout(id);
+    }
+  }, [agentSessionState, bubbleOpen, dragging, hovered]);
+
   const lines = useMemo(
     () => (active ? [active.greeting, ...ambientLines(active.name)] : []),
     [active],
   );
   const visibleLine = lines.length > 0 ? lines[ambientIdx % lines.length] : '';
+
+  const applyMovementMode = useCallback((next: 'walk-left' | 'walk-right' | null) => {
+    if (movementModeRef.current === next) return;
+    movementModeRef.current = next;
+    setMovementMode(next);
+  }, []);
+
+  const resumeAutoWalk = useCallback((pauseMs = AUTO_WALK_RESUME_PAUSE_MS) => {
+    walkPauseUntilRef.current = performance.now() + pauseMs;
+    applyMovementMode(walkDirectionRef.current === 'left' ? 'walk-left' : 'walk-right');
+  }, [applyMovementMode]);
+
+  if (!active) return null;
+
+  const currentRowId = agentPoseActive
+    ? preferredRowId(interaction)
+    : movementMode === 'walk-left'
+      ? 'running-left'
+      : movementMode === 'walk-right'
+        ? 'running-right'
+        : ambientRowId ?? preferredRowId(interaction);
+  const currentRowLabel = active.atlas
+    ? atlasRowLabel(t, currentRowId)
+    : agentPoseActive
+      ? interaction === 'agent-thinking'
+        ? 'Thinking'
+        : interaction === 'agent-done'
+          ? 'Done'
+          : 'Error'
+      : movementMode
+        ? 'Walking'
+        : interaction === 'waiting'
+          ? 'Waiting'
+          : hovered
+            ? 'Watching'
+            : 'Floating';
+  const statusHeadline = dragging
+    ? 'Drag mode'
+    : bubbleOpen
+      ? 'Status open'
+      : hovered
+        ? 'Focused'
+        : agentPoseActive
+          ? interaction === 'agent-thinking'
+            ? 'Agent thinking'
+            : interaction === 'agent-done'
+              ? 'Agent done'
+              : 'Agent error'
+          : movementMode
+            ? 'Patrolling'
+            : interaction === 'waiting'
+              ? 'Waiting'
+              : 'Idle';
+  const statusSummary = dragging
+    ? 'Following your pointer inside the workspace.'
+    : bubbleOpen
+      ? 'Sharing the current state before the next move.'
+      : hovered
+        ? 'Paused here and reacting to your attention.'
+        : agentPoseActive
+          ? interaction === 'agent-thinking'
+            ? 'Watching the current AI run while it works.'
+            : interaction === 'agent-done'
+              ? 'Reacting to a completed AI run before settling down.'
+              : 'Flagging that the latest AI run needs attention.'
+          : movementMode
+            ? 'Walking edge to edge so the companion feels alive.'
+            : interaction === 'waiting'
+              ? 'Holding position until the next nudge.'
+              : 'Resting quietly between ambient beats.';
+  const bubbleStatusItems: BubbleStatusItem[] = [
+    {
+      label: 'Mode',
+      value: statusHeadline,
+      tone: dragging || movementMode || agentPoseActive ? 'active' : bubbleOpen ? 'ready' : 'paused',
+    },
+    {
+      label: 'Motion',
+      value: currentRowLabel,
+      tone: movementMode || hovered || dragging || agentPoseActive ? 'active' : 'ready',
+    },
+    {
+      label: 'Bubble',
+      value: bubbleOpen ? 'Open' : 'Closed',
+      tone: bubbleOpen ? 'ready' : 'paused',
+    },
+  ];
+  const motionState = dragging
+    ? 'dragging'
+    : movementMode
+      ? 'walking'
+      : bubbleOpen
+        ? 'paused'
+        : hovered
+          ? 'focused'
+          : 'idle';
 
   // (Re)arms the long-idle waiting timer. Called every time the user
   // interacts so an active session never falls into "waiting" mid-drag.
@@ -204,12 +396,89 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
     };
   }, [interaction, active?.id, active?.atlas]);
 
-  if (!active) return null;
+  useEffect(() => {
+    if (!active) return;
+    walkDirectionRef.current = 'left';
+    walkPauseUntilRef.current = performance.now() + AUTO_WALK_TURN_PAUSE_MS;
+    setDragging(false);
+    applyMovementMode('walk-left');
+  }, [active?.id, applyMovementMode]);
 
-  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+  useEffect(() => {
+    if (!active) return;
+    if (bubbleOpen || agentPoseActive) {
+      applyMovementMode(null);
+      return;
+    }
+    if (hovered || dragging) return;
+    resumeAutoWalk();
+  }, [active?.id, bubbleOpen, agentPoseActive, hovered, dragging, applyMovementMode, resumeAutoWalk]);
+
+  // Horizontal autonomous walk. This is the first real movement-mode
+  // pass for the pet: when it is not being interacted with, it paces
+  // inside the viewport and flips direction at the edges.
+  useEffect(() => {
+    if (!active || hovered || dragging || bubbleOpen || agentPoseActive) {
+      applyMovementMode(null);
+      return;
+    }
+
+    let frameId = 0;
+    let previousTs: number | null = null;
+
+    const tick = (ts: number) => {
+      if (previousTs == null) {
+        previousTs = ts;
+        frameId = window.requestAnimationFrame(tick);
+        return;
+      }
+      const dt = Math.min(48, ts - previousTs);
+      previousTs = ts;
+
+      if (ts >= walkPauseUntilRef.current) {
+        const direction = walkDirectionRef.current;
+        const delta = (AUTO_WALK_SPEED_PX_PER_SEC * dt) / 1000;
+        setPosition((curr) => {
+          const minRight = AUTO_WALK_EDGE_PADDING_PX;
+          const maxRight = Math.max(
+            AUTO_WALK_EDGE_PADDING_PX,
+            window.innerWidth - AUTO_WALK_SPRITE_BOX_PX - AUTO_WALK_EDGE_PADDING_PX,
+          );
+          let nextRight = curr.right + (direction === 'left' ? delta : -delta);
+
+          if (nextRight >= maxRight) {
+            nextRight = maxRight;
+            walkDirectionRef.current = 'right';
+            walkPauseUntilRef.current = ts + AUTO_WALK_TURN_PAUSE_MS;
+            applyMovementMode('walk-right');
+          } else if (nextRight <= minRight) {
+            nextRight = minRight;
+            walkDirectionRef.current = 'left';
+            walkPauseUntilRef.current = ts + AUTO_WALK_TURN_PAUSE_MS;
+            applyMovementMode('walk-left');
+          } else {
+            applyMovementMode(direction === 'left' ? 'walk-left' : 'walk-right');
+          }
+
+          nextRight = Math.round(nextRight);
+          if (nextRight === curr.right) return curr;
+          return { ...curr, right: nextRight };
+        });
+      }
+
+      frameId = window.requestAnimationFrame(tick);
+    };
+
+    frameId = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frameId);
+  }, [active?.id, active, hovered, dragging, bubbleOpen, agentPoseActive, applyMovementMode]);
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     const target = event.currentTarget;
     target.setPointerCapture(event.pointerId);
+    setDragging(true);
+    applyMovementMode(null);
     dragRef.current = {
       startX: event.clientX,
       startY: event.clientY,
@@ -221,7 +490,7 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
     armWaitingTimer();
   };
 
-  const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
     const drag = dragRef.current;
     if (!drag) return;
     const dx = event.clientX - drag.startX;
@@ -232,8 +501,12 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
     // tracks the cursor while staying anchored to the corner system.
     // The clamp budget (~120px) keeps the 96px sprite plus its drop
     // shadow on-screen even when dragged toward the opposite edge.
-    const nextRight = Math.max(8, Math.min(window.innerWidth - 120, drag.startRight - dx));
-    const nextBottom = Math.max(8, Math.min(window.innerHeight - 120, drag.startBottom - dy));
+    const nextRight = Math.round(
+      Math.max(8, Math.min(window.innerWidth - 120, drag.startRight - dx)),
+    );
+    const nextBottom = Math.round(
+      Math.max(8, Math.min(window.innerHeight - 120, drag.startBottom - dy)),
+    );
     setPosition({ right: nextRight, bottom: nextBottom });
 
     // Classify the gesture direction once it clears the jitter floor
@@ -263,9 +536,10 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
     armWaitingTimer();
   };
 
-  const onPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+  const onPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
     const drag = dragRef.current;
     dragRef.current = null;
+    setDragging(false);
     try {
       event.currentTarget.releasePointerCapture(event.pointerId);
     } catch {
@@ -283,11 +557,15 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
     // pet stops "running" the moment the user lets go. Hovered state
     // wins so a release-into-hover keeps the wave going.
     setInteraction(hovered ? 'hover' : 'idle');
+    if (!hovered && !bubbleOpen && !(drag && !drag.moved)) {
+      resumeAutoWalk();
+    }
     armWaitingTimer();
   };
 
   const onPointerEnter = () => {
     setHovered(true);
+    applyMovementMode(null);
     // Don't override an active drag direction with the hover wave —
     // the user is mid-gesture and they expect the running cycle to
     // keep playing until they let go.
@@ -297,7 +575,12 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
 
   const onPointerLeave = () => {
     setHovered(false);
-    if (!dragRef.current) setInteraction('idle');
+    if (!dragRef.current) {
+      setInteraction('idle');
+      if (!bubbleOpen) {
+        resumeAutoWalk();
+      }
+    }
     armWaitingTimer();
   };
 
@@ -318,6 +601,18 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
         <div className="pet-bubble" role="status">
           <div className="pet-bubble-name">{active.name}</div>
           <div className="pet-bubble-line">{visibleLine}</div>
+          <div className="pet-bubble-summary">
+            <div className="pet-bubble-summary-title">{statusHeadline}</div>
+            <div className="pet-bubble-summary-copy">{statusSummary}</div>
+          </div>
+          <div className="pet-bubble-status-list" aria-label={`${active.name} status summary`}>
+            {bubbleStatusItems.map((item) => (
+              <div key={item.label} className={`pet-bubble-status tone-${item.tone}`}>
+                <span className="pet-bubble-status-label">{item.label}</span>
+                <span className="pet-bubble-status-value">{item.value}</span>
+              </div>
+            ))}
+          </div>
           <div className="pet-bubble-actions">
             <button
               type="button"
@@ -351,6 +646,7 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
         aria-label={t('pet.spriteAria', { name: active.name })}
         data-pet-state={interaction}
         data-pet-ambient={ambientRowId ?? undefined}
+        data-pet-motion={motionState}
         style={{
           // For atlas-backed pets the row swap *is* the animation, so
           // we let the sprite element sit still and animate frames
@@ -364,7 +660,8 @@ export function PetOverlay({ pet, onTuck, onOpenSettings }: Props) {
         <PetSpriteFace
           active={active}
           className="pet-sprite-glyph"
-          rowId={ambientRowId ?? preferredRowId(interaction)}
+          size={AUTO_WALK_SPRITE_BOX_PX}
+          rowId={currentRowId}
         />
         <span className="pet-sprite-shadow" aria-hidden />
       </div>

--- a/apps/web/src/components/pet/PetSettings.tsx
+++ b/apps/web/src/components/pet/PetSettings.tsx
@@ -18,6 +18,7 @@ import {
   FRAMES_MIN,
   resolveActivePet,
 } from './pets';
+import type { AgentSessionState } from './PetOverlay';
 import { PetSpriteFace } from './PetSpriteFace';
 import { loadPetImageFromFile } from './image';
 import {
@@ -33,6 +34,8 @@ import {
 interface Props {
   cfg: AppConfig;
   setCfg: Dispatch<SetStateAction<AppConfig>>;
+  previewAgentSessionState?: AgentSessionState;
+  onPreviewAgentSessionChange?: (state: AgentSessionState) => void;
 }
 
 // Curated palette so the customize swatch row stays compact and on-brand
@@ -48,7 +51,12 @@ const ACCENT_SWATCHES = [
   '#0d0c0a',
 ];
 
-export function PetSettings({ cfg, setCfg }: Props) {
+export function PetSettings({
+  cfg,
+  setCfg,
+  previewAgentSessionState,
+  onPreviewAgentSessionChange,
+}: Props) {
   const t = useT();
   const pet: PetConfig = cfg.pet ?? { ...DEFAULT_PET, custom: defaultCustomPet() };
   const customGlyphId = useId();
@@ -413,6 +421,10 @@ export function PetSettings({ cfg, setCfg }: Props) {
     adopted: true,
     petId: CUSTOM_PET_ID,
   })!;
+  const showDevAgentPreview =
+    typeof process !== 'undefined'
+    && process.env?.NODE_ENV === 'development'
+    && typeof onPreviewAgentSessionChange === 'function';
 
   // Built-in pets are the bundled spritesheets baked into the repo at
   // `assets/community-pets/<id>/`; the daemon flags them with
@@ -600,6 +612,30 @@ export function PetSettings({ cfg, setCfg }: Props) {
             <span>{pet.custom.greeting || t('pet.customGreetingPlaceholder')}</span>
           </div>
         </div>
+        {showDevAgentPreview ? (
+          <div className="field" style={{ gap: 8 }}>
+            <span className="field-label">Agent state preview (dev)</span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              {(['idle', 'thinking', 'done', 'error'] as const).map((state) => {
+                const active = previewAgentSessionState === state;
+                return (
+                  <button
+                    key={state}
+                    type="button"
+                    className={`seg-btn small${active ? ' active' : ' ghost'}`}
+                    onClick={() => onPreviewAgentSessionChange?.(state)}
+                    aria-pressed={active}
+                  >
+                    <span>{state}</span>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="hint">
+              Overlay에서 thinking / done / error pose를 바로 확인하는 개발용 프리뷰.
+            </p>
+          </div>
+        ) : null}
         <div className="pet-image-controls">
           <input
             ref={fileInputRef}

--- a/apps/web/src/components/pet/PetSpriteFace.tsx
+++ b/apps/web/src/components/pet/PetSpriteFace.tsx
@@ -54,6 +54,7 @@ export function PetSpriteFace({ active, className, size, rowId }: Props) {
 
   const frames = Math.max(1, active.frames ?? 1);
   const fps = Math.max(1, active.fps ?? 6);
+  const renderSize = size ? Math.max(1, Math.round(size)) : undefined;
   if (frames === 1) {
     return (
       <span
@@ -61,15 +62,16 @@ export function PetSpriteFace({ active, className, size, rowId }: Props) {
         aria-hidden
         style={{
           backgroundImage: `url(${active.imageUrl})`,
-          width: size,
-          height: size,
+          width: renderSize,
+          height: renderSize,
         }}
       />
     );
   }
-  // Strip mode — N frames laid out horizontally. The image is
-  // (N × container_width) wide, so the visible frame is selected by
-  // sliding background-position-x from 0% to 100% in (N-1) steps.
+  // Strip mode — N frames laid out horizontally. When the parent passes
+  // a concrete pixel `size`, we also pin the background sheet to exact
+  // pixel dimensions so Retina browsers step whole cells instead of
+  // percentage-derived subpixels.
   // `steps(N, jump-none)` is required because the default jump-end
   // would land on 0/N, 1/N, …, (N-1)/N, which slices each frame mid-cell;
   // jump-none lands on the actual cell boundaries 0/(N-1) … 1.
@@ -80,10 +82,16 @@ export function PetSpriteFace({ active, className, size, rowId }: Props) {
       aria-hidden
       style={{
         backgroundImage: `url(${active.imageUrl})`,
-        backgroundSize: `${frames * 100}% 100%`,
+        backgroundPosition: '0px 0px',
+        backgroundSize: renderSize
+          ? `${frames * renderSize}px ${renderSize}px`
+          : `${frames * 100}% 100%`,
+        ['--pet-frames-end-x' as string]: renderSize
+          ? `-${(frames - 1) * renderSize}px`
+          : '100%',
         animation: `pet-frames ${durationMs}ms steps(${frames}, jump-none) infinite`,
-        width: size,
-        height: size,
+        width: renderSize,
+        height: renderSize,
       }}
     />
   );
@@ -118,40 +126,46 @@ function AtlasSprite({
     ?? rowsDef[0]!;
   const rowFrames = Math.max(1, def.frames);
   const fps = Math.max(1, def.fps);
+  const renderSize = size ? Math.max(1, Math.round(size)) : undefined;
 
-  const [frame, setFrame] = useState(0);
-  // Reset to frame 0 on row change so a freshly-triggered animation
-  // (e.g. tap → waving) starts cleanly instead of mid-cycle.
+  const [animationCycle, setAnimationCycle] = useState(0);
+
+  // Reset atlas playback on row change so a freshly-triggered
+  // interaction starts from frame 0, but keep the per-frame stepping in
+  // CSS. That removes a React state update on every frame tick.
   useEffect(() => {
-    setFrame(0);
-    if (rowFrames <= 1) return;
-    const intervalMs = Math.max(16, Math.round(1000 / fps));
-    const id = window.setInterval(() => {
-      setFrame((f) => (f + 1) % rowFrames);
-    }, intervalMs);
-    return () => window.clearInterval(id);
+    setAnimationCycle((value) => value + 1);
   }, [def.id, def.index, rowFrames, fps]);
 
   // Background math:
-  //   - background-size = (cols × 100%) × (rows × 100%)
-  //     → each grid cell renders at exactly the container size.
-  //   - background-position-x = frame / (cols - 1) × 100%
-  //     → 0% slides to the leftmost cell, 100% to the rightmost,
-  //       intermediate cells land at frame/(cols-1) of the offset range.
-  //   - background-position-y = rowIndex / (rows - 1) × 100%
-  const xPct = cols > 1 ? (frame / (cols - 1)) * 100 : 0;
+  //   - when `size` is known, background-size/background-position use
+  //     exact pixels so each atlas cell stays on integer boundaries.
+  //   - fallback percentage math is kept for callers that only inherit
+  //     container dimensions.
+  const endXPct = cols > 1 ? ((rowFrames - 1) / (cols - 1)) * 100 : 0;
   const yPct = rows > 1 ? (def.index / (rows - 1)) * 100 : 0;
+  const endXPx = renderSize ? (rowFrames - 1) * renderSize : null;
+  const rowYPx = renderSize ? def.index * renderSize : null;
+  const durationMs = Math.max(1, Math.round((rowFrames / fps) * 1000));
 
   return (
     <span
+      key={`${def.id}:${def.index}:${animationCycle}`}
       className={`${className ?? ''} pet-image atlas`.trim()}
       aria-hidden
       style={{
         backgroundImage: `url(${imageUrl})`,
-        backgroundSize: `${cols * 100}% ${rows * 100}%`,
-        backgroundPosition: `${xPct}% ${yPct}%`,
-        width: size,
-        height: size,
+        backgroundSize: renderSize
+          ? `${cols * renderSize}px ${rows * renderSize}px`
+          : `${cols * 100}% ${rows * 100}%`,
+        backgroundPosition: renderSize ? `0px -${rowYPx}px` : `0% ${yPct}%`,
+        ['--pet-atlas-end-x' as string]: endXPx != null ? `-${endXPx}px` : `${endXPct}%`,
+        animation:
+          rowFrames > 1
+            ? `pet-atlas-frames ${durationMs}ms steps(${rowFrames}, jump-none) infinite`
+            : 'none',
+        width: renderSize,
+        height: renderSize,
       }}
     />
   );

--- a/apps/web/src/components/pet/codexAtlas.ts
+++ b/apps/web/src/components/pet/codexAtlas.ts
@@ -218,11 +218,11 @@ export async function cropAtlasRow(
 
 // Same idea as `cropAtlasRow` but keeps every row so the overlay can
 // switch animations on the fly. We downscale to a target cell height
-// (default 80 px → 8x9 grid lands at ~528 KB PNG which fits inside the
-// MAX_DATA_URL_BYTES guard from `image.ts` even for busy spritesheets)
-// while preserving the grid layout 1:1 so background-position math in
-// `PetSpriteFace` stays simple.
-const DEFAULT_FULL_ATLAS_MAX_CELL = 80;
+// of 96 px so the 96 px overlay sprite keeps a 1:1 source cell on
+// standard displays instead of upscaling a smaller 80 px cell. That
+// stays within the localStorage budget while noticeably improving edge
+// clarity on desktop and HiDPI panels.
+const DEFAULT_FULL_ATLAS_MAX_CELL = 96;
 
 export interface PreparedAtlas {
   // PNG data URL of the full atlas, ready to drop into

--- a/apps/web/src/components/pet/pets.ts
+++ b/apps/web/src/components/pet/pets.ts
@@ -158,7 +158,11 @@ export type PetInteraction =
   | 'drag-left'
   | 'drag-up'
   | 'drag-down'
-  | 'waiting';
+  | 'waiting'
+  // Agent session states — driven externally via agentSessionState prop
+  | 'agent-thinking'  // AI agent is processing (maps to 'review' atlas row)
+  | 'agent-done'      // Agent just completed a task (maps to 'jumping' for hop)
+  | 'agent-error';    // Agent hit an error (maps to 'failed' atlas row)
 
 // Preferred Codex atlas row id for each interaction state. Hover and
 // drag each map to a dedicated action row so the pet visibly reacts to
@@ -174,6 +178,9 @@ const INTERACTION_ROW_ID: Record<PetInteraction, string> = {
   'drag-up': 'jumping',
   'drag-down': 'waving',
   waiting: 'waiting',
+  'agent-thinking': 'review',
+  'agent-done': 'jumping',
+  'agent-error': 'failed',
 };
 
 const ROW_FALLBACK_ORDER: readonly string[] = [

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14128,10 +14128,24 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   cursor: grab;
   user-select: none;
   touch-action: none;
-  transition: transform 160ms ease;
+  transition: transform 160ms ease, filter 160ms ease;
 }
 .pet-sprite:hover {
   transform: translateY(-2px);
+}
+.pet-sprite[data-pet-motion='walking']:hover {
+  transform: translateY(-1px);
+}
+.pet-sprite[data-pet-motion='paused'] {
+  transform: translateY(0);
+}
+.pet-sprite[data-pet-motion='paused'] .pet-sprite-shadow {
+  animation: none;
+  transform: translateX(-50%) scale(0.96);
+  opacity: 0.2;
+}
+.pet-sprite[data-pet-motion='walking'] .pet-sprite-shadow {
+  animation-duration: 2.8s;
 }
 .pet-sprite:active { cursor: grabbing; }
 .pet-sprite-glyph {
@@ -14216,6 +14230,58 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 }
 .pet-bubble-line {
   color: var(--text);
+}
+.pet-bubble-summary {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid color-mix(in srgb, var(--pet-accent) 22%, transparent);
+}
+.pet-bubble-summary-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+}
+.pet-bubble-summary-copy {
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.pet-bubble-status-list {
+  margin-top: 8px;
+  display: grid;
+  gap: 6px;
+}
+.pet-bubble-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 10px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+}
+.pet-bubble-status.tone-active {
+  border-color: color-mix(in srgb, var(--pet-accent) 45%, var(--border));
+  background: color-mix(in srgb, var(--pet-accent) 10%, var(--bg-subtle));
+}
+.pet-bubble-status.tone-ready {
+  border-color: color-mix(in srgb, var(--pet-accent) 30%, var(--border));
+}
+.pet-bubble-status.tone-paused {
+  opacity: 0.84;
+}
+.pet-bubble-status-label {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.pet-bubble-status-value {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+  text-align: right;
 }
 .pet-bubble-actions {
   margin-top: 8px;
@@ -15228,8 +15294,8 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
    (container_width − background_width). With background-size set to
    `${frames * 100}% 100%` each `steps()` tick lands on a frame edge. */
 @keyframes pet-frames {
-  from { background-position-x: 0%; }
-  to { background-position-x: 100%; }
+  from { background-position-x: 0px; }
+  to { background-position-x: var(--pet-frames-end-x, 100%); }
 }
 
 /* Full-atlas mode: the sprite renders the active row from a Codex
@@ -15240,19 +15306,16 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
    PetSpriteFace based on `frames / (cols - 1) * 100%`. */
 .pet-image.atlas {
   background-repeat: no-repeat;
-  /* The sprite element switches rows on the fly; smooth out the
-     row transitions so direction changes feel less jarring without
-     blurring the per-frame `steps()` cadence. */
-  transition: background-position-y 220ms ease;
+  will-change: background-position;
 }
 @keyframes pet-atlas-frames {
-  from { background-position-x: 0%; }
+  from { background-position-x: 0px; }
   to { background-position-x: var(--pet-atlas-end-x, 100%); }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .pet-image.frames,
-  .pet-image.atlas { animation: none !important; background-position-x: 0% !important; }
+  .pet-image.atlas { animation: none !important; background-position-x: 0px !important; }
 }
 
 /* PetSettings — upload row, frames/fps grid, error caption */

--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -1,5 +1,7 @@
-import { chmod, cp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { chmod, cp, mkdir, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import { promisify } from "node:util";
 
 import type { ToolPackConfig } from "../config.js";
 import {
@@ -21,6 +23,8 @@ import { INTERNAL_PACKAGES, PRODUCT_NAME } from "./constants.js";
 import { readPackagedVersion } from "./manifest.js";
 import type { MacPaths, PackedTarballInfo } from "./types.js";
 
+const execFileAsync = promisify(execFile);
+
 function toPosixPath(value: string): string {
   return value.replaceAll("\\", "/");
 }
@@ -28,6 +32,167 @@ function toPosixPath(value: string): string {
 function toRelativeImportSpecifier(fromDirectory: string, targetPath: string): string {
   const specifier = toPosixPath(relative(fromDirectory, targetPath));
   return specifier.startsWith(".") ? specifier : `./${specifier}`;
+}
+
+function isSystemMacLibraryPath(value: string): boolean {
+  return value.startsWith("/System/") || value.startsWith("/usr/lib/");
+}
+
+function parseOtoolDependencies(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .slice(1)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(" (")[0])
+    .filter((value): value is string => value != null && value.length > 0);
+}
+
+async function listMachODependencies(binaryPath: string): Promise<string[]> {
+  const { stdout } = await execFileAsync("otool", ["-L", binaryPath], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  return parseOtoolDependencies(stdout);
+}
+
+async function rewriteInstallName(targetPath: string, args: string[]): Promise<void> {
+  if (args.length === 0) return;
+  await execFileAsync("install_name_tool", [...args, targetPath], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+}
+
+async function bundleMacNodeRuntime(resourceRoot: string): Promise<void> {
+  const binRoot = join(resourceRoot, "bin");
+  const libRoot = join(resourceRoot, "lib");
+  await mkdir(binRoot, { recursive: true });
+  await mkdir(libRoot, { recursive: true });
+
+  const sourceNodePath = await realpath(process.execPath);
+  const nodeDestinationPath = join(binRoot, "node");
+  await cp(sourceNodePath, nodeDestinationPath);
+  await chmod(nodeDestinationPath, 0o755);
+
+  type ResolvedDependency = {
+    bundledBaseName: string;
+    sourcePath: string;
+  };
+
+  const bundledLibraryPathByKey = new Map<string, string>();
+  const pendingLibraries: ResolvedDependency[] = [];
+  const sourceNodeLibRoot = join(dirname(sourceNodePath), "..", "lib");
+
+  const resolveDependency = async (requestingBinaryPath: string, dependency: string): Promise<ResolvedDependency | null> => {
+    if (dependency.startsWith("@rpath/")) {
+      const bundledBaseName = dependency.slice("@rpath/".length);
+      for (const candidate of [
+        join(dirname(requestingBinaryPath), "..", "lib", bundledBaseName),
+        join(sourceNodeLibRoot, bundledBaseName),
+      ]) {
+        try {
+          return { bundledBaseName, sourcePath: await realpath(candidate) };
+        } catch {
+          // try next candidate
+        }
+      }
+      return null;
+    }
+
+    if (dependency.startsWith("@loader_path/")) {
+      const bundledBaseName = dependency.slice("@loader_path/".length);
+      try {
+        return {
+          bundledBaseName,
+          sourcePath: await realpath(join(dirname(requestingBinaryPath), bundledBaseName)),
+        };
+      } catch {
+        return null;
+      }
+    }
+
+    if (!dependency.startsWith("/") || isSystemMacLibraryPath(dependency)) {
+      return null;
+    }
+
+    return {
+      bundledBaseName: dependency.split("/").at(-1) ?? "library.dylib",
+      sourcePath: await realpath(dependency),
+    };
+  };
+
+  const ensureBundledLibrary = async ({ bundledBaseName, sourcePath }: ResolvedDependency): Promise<string> => {
+    const key = `${sourcePath}::${bundledBaseName}`;
+    const existing = bundledLibraryPathByKey.get(key);
+    if (existing != null) {
+      return existing;
+    }
+
+    const destinationPath = join(libRoot, bundledBaseName);
+    await cp(sourcePath, destinationPath);
+    bundledLibraryPathByKey.set(key, destinationPath);
+    pendingLibraries.push({ bundledBaseName, sourcePath });
+    return destinationPath;
+  };
+
+  for (const dependency of await listMachODependencies(sourceNodePath)) {
+    const resolvedDependency = await resolveDependency(sourceNodePath, dependency);
+    if (resolvedDependency == null) continue;
+    await ensureBundledLibrary(resolvedDependency);
+  }
+
+  for (let index = 0; index < pendingLibraries.length; index += 1) {
+    const pendingLibrary = pendingLibraries[index];
+    if (pendingLibrary == null) continue;
+    for (const dependency of await listMachODependencies(pendingLibrary.sourcePath)) {
+      const resolvedDependency = await resolveDependency(pendingLibrary.sourcePath, dependency);
+      if (resolvedDependency == null) continue;
+      await ensureBundledLibrary(resolvedDependency);
+    }
+  }
+
+  const resolveBundledDependencyPath = async (sourcePath: string, dependency: string): Promise<string | null> => {
+    const resolvedDependency = await resolveDependency(sourcePath, dependency);
+    if (resolvedDependency == null) return null;
+    return bundledLibraryPathByKey.get(`${resolvedDependency.sourcePath}::${resolvedDependency.bundledBaseName}`) ?? null;
+  };
+
+  const rewriteDependencyReference = async (targetPath: string, sourcePath: string): Promise<void> => {
+    const dependencies = await listMachODependencies(sourcePath);
+    const changes: string[] = [];
+    for (const dependency of dependencies) {
+      const bundledDependencyPath = await resolveBundledDependencyPath(sourcePath, dependency);
+      if (bundledDependencyPath == null) continue;
+      const bundledBaseName = bundledDependencyPath.split("/").at(-1);
+      if (bundledBaseName == null) continue;
+      const nextReference = targetPath === nodeDestinationPath
+        ? `@loader_path/../lib/${bundledBaseName}`
+        : `@loader_path/${bundledBaseName}`;
+      changes.push("-change", dependency, nextReference);
+    }
+    await rewriteInstallName(targetPath, changes);
+  };
+
+  await rewriteDependencyReference(nodeDestinationPath, sourceNodePath);
+  for (const [key, bundledLibraryPath] of bundledLibraryPathByKey.entries()) {
+    const [sourcePath] = key.split("::");
+    const bundledBaseName = bundledLibraryPath.split("/").at(-1);
+    if (sourcePath == null || bundledBaseName == null) continue;
+    await rewriteInstallName(bundledLibraryPath, ["-id", `@loader_path/${bundledBaseName}`]);
+    await rewriteDependencyReference(bundledLibraryPath, sourcePath);
+  }
+
+  for (const bundledLibraryPath of bundledLibraryPathByKey.values()) {
+    await execFileAsync("codesign", ["--force", "--sign", "-", bundledLibraryPath], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+  }
+  await execFileAsync("codesign", ["--force", "--sign", "-", nodeDestinationPath], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
 }
 
 async function buildPrebundledStandaloneRuntime(
@@ -128,9 +293,7 @@ export async function copyResourceTree(config: ToolPackConfig, paths: MacPaths):
     workspaceRoot: config.workspaceRoot,
     resourceRoot: paths.resourceRoot,
   });
-  await mkdir(join(paths.resourceRoot, "bin"), { recursive: true });
-  await cp(process.execPath, join(paths.resourceRoot, "bin", "node"));
-  await chmod(join(paths.resourceRoot, "bin", "node"), 0o755);
+  await bundleMacNodeRuntime(paths.resourceRoot);
 }
 
 export async function collectWorkspaceTarballs(


### PR DESCRIPTION
## Summary
- add autonomous coderpet pacing, calmer resume timing, and richer pet status wiring
- refine pet settings / atlas rendering surfaces and related web integration
- update mac packaging flow used for local beta install/start verification

## Validation
- corepack pnpm --filter @open-design/web typecheck
- corepack pnpm --filter @open-design/tools-pack typecheck
- git diff --check -- apps/web/src/App.tsx apps/web/src/components/ProjectView.tsx apps/web/src/components/SettingsDialog.tsx apps/web/src/components/pet/PetOverlay.tsx apps/web/src/components/pet/PetSettings.tsx apps/web/src/components/pet/PetSpriteFace.tsx apps/web/src/components/pet/codexAtlas.ts apps/web/src/components/pet/pets.ts apps/web/src/index.css tools/pack/src/mac/app.ts