### PR TITLE
🌻 fix: show "Ready to save" instead of premature export success 

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5557,7 +5557,7 @@ function HtmlViewer({
               return;
             }
             finish('success');
-            if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
+            if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportReady'), tone: 'default' });
           },
           (err) => {
             finish('failed', exportErrorCode(err));
@@ -5572,7 +5572,7 @@ function HtmlViewer({
           return;
         }
         finish('success');
-        if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
+        if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportReady'), tone: 'default' });
       }
     } catch (err) {
       finish('failed', exportErrorCode(err));

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -2582,6 +2582,7 @@ export const ar: Dict = {
   'sketch.tooltipClean': 'تم الحفظ',
   'fileViewer.empty': 'اختر ملفاً لعرضه.',
   'fileViewer.loading': 'جاري التحميل...',
+  'fileViewer.exportReady': 'جاهز للحفظ.',
   'fileViewer.exportPptx': 'تصدير كـ PPTX',
   'fileViewer.openInNewTab': 'فتح في علامة تبويب جديدة',
   'fileViewer.copyPath': 'نسخ المسار',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -2582,6 +2582,7 @@ export const de: Dict = {
   'sketch.tooltipClean': 'Gespeichert',
   'fileViewer.empty': 'Wählen Sie eine Datei zur Ansicht aus.',
   'fileViewer.loading': 'Wird geladen…',
+  'fileViewer.exportReady': 'Zum Speichern bereit',
   'fileViewer.exportPptx': 'Als PPTX exportieren',
   'fileViewer.openInNewTab': 'In neuem Tab öffnen',
   'fileViewer.copyPath': 'Pfad kopieren',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -2596,6 +2596,7 @@ export const en: Dict = {
   'sketch.tooltipClean': 'Saved',
   'fileViewer.empty': 'Select a file to view.',
   'fileViewer.loading': 'Loading…',
+  'fileViewer.exportReady': 'Ready to save',
   'fileViewer.exportPptx': 'Export as PPTX',
   'fileViewer.openInNewTab': 'Open in new tab',
   'fileViewer.copyPath': 'Copy path',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -2583,6 +2583,7 @@ export const esES: Dict = {
   'fileViewer.empty': 'Selecciona un archivo para verlo.',
   'fileViewer.loading': 'Cargando…',
   'fileViewer.exportPptx': 'Exportar como PPTX',
+  'fileViewer.exportReady': 'Listo para guardar',
   'fileViewer.openInNewTab': 'Abrir en pestaña nueva',
   'fileViewer.copyPath': 'Copiar ruta',
   'fileViewer.copied': '¡Copiado!',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -2582,6 +2582,7 @@ export const fa: Dict = {
   'sketch.tooltipClean': 'ذخیره شد',
   'fileViewer.empty': 'یک فایل را برای مشاهده انتخاب کنید.',
   'fileViewer.loading': 'در حال بارگذاری…',
+  'fileViewer.exportReady': 'آماده ذخیره',
   'fileViewer.exportPptx': 'صادرکردن به PPTX',
   'fileViewer.openInNewTab': 'باز کردن در تب جدید',
   'fileViewer.copyPath': 'کپی مسیر',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -2581,6 +2581,7 @@ export const fr: Dict = {
   'sketch.tooltipDirty': 'Modifications non enregistrées',
   'sketch.tooltipClean': 'Enregistré',
   'fileViewer.empty': 'Sélectionnez un fichier à afficher.',
+  'fileViewer.exportReady': 'Prêt à enregistrer',
   'fileViewer.loading': 'Chargement…',
   'fileViewer.exportPptx': 'Exporter en PPTX',
   'fileViewer.openInNewTab': 'Ouvrir dans un nouvel onglet',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -2582,6 +2582,7 @@ export const hu: Dict = {
   'sketch.tooltipClean': 'Mentve',
   'fileViewer.empty': 'Válassz fájlt a megtekintéshez.',
   'fileViewer.loading': 'Betöltés…',
+  'fileViewer.exportReady': 'mentésre kész',
   'fileViewer.exportPptx': 'Exportálás PPTX-ként',
   'fileViewer.openInNewTab': 'Megnyitás új lapon',
   'fileViewer.copyPath': 'Útvonal másolása',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -2581,6 +2581,7 @@ export const id: Dict = {
   'sketch.tooltipDirty': 'Ada perubahan belum disimpan',
   'sketch.tooltipClean': 'Tersimpan',
   'fileViewer.empty': 'Pilih file untuk dilihat.',
+  'fileViewer.exportReady': 'Siap untuk menyimpan',
   'fileViewer.loading': 'Memuat file...',
   'fileViewer.exportPptx': 'Ekspor PPTX',
   'fileViewer.openInNewTab': 'Buka di tab baru',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -2583,6 +2583,7 @@ export const it: Dict = {
   'fileViewer.empty': 'Seleziona un file da visualizzare.',
   'fileViewer.loading': 'Caricamento…',
   'fileViewer.exportPptx': 'Esporta in PPTX',
+  'fileViewer.exportReady': 'Pronto per il salvataggio',
   'fileViewer.openInNewTab': 'Apri in una nuova scheda',
   'fileViewer.copyPath': 'Copia percorso',
   'fileViewer.copied': 'Copiato!',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -2583,6 +2583,7 @@ export const ja: Dict = {
   'fileViewer.empty': 'ファイルを選択して表示します。',
   'fileViewer.loading': '読み込み中…',
   'fileViewer.exportPptx': 'PPTX としてエクスポート',
+  'fileViewer.exportReady': 'ダウンロードの準備ができました',
   'fileViewer.openInNewTab': '新しいタブで開く',
   'fileViewer.copyPath': 'パスをコピー',
   'fileViewer.copied': 'コピーしました！',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -2582,6 +2582,7 @@ export const ko: Dict = {
   'sketch.tooltipClean': '저장됨',
   'fileViewer.empty': '보려는 파일을 선택하세요.',
   'fileViewer.loading': '불러오는 중…',
+  'fileViewer.exportReady': '저장할 준비 완료..',
   'fileViewer.exportPptx': 'PPTX로 내보내기',
   'fileViewer.openInNewTab': '새 탭에서 열기',
   'fileViewer.copyPath': '경로 복사',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -2586,6 +2586,7 @@ export const pl: Dict = {
   'fileViewer.openInNewTab': 'Otwórz w nowej karcie',
   'fileViewer.copyPath': 'Kopiuj ścieżkę',
   'fileViewer.copied': 'Skopiowano!',
+  'fileViewer.exportReady': 'Gotowy do zapisania',
   'fileViewer.share': 'Udostępnij',
   'fileViewer.binaryMeta': 'Binarny · {size}',
   'fileViewer.binaryNote': 'Plik binarny ({size} bajtów). Pobierz go lub otwórz z dysku, aby sprawdzić zawartość.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -2584,6 +2584,7 @@ export const ptBR: Dict = {
   'fileViewer.loading': 'Carregando…',
   'fileViewer.exportPptx': 'Exportar como PPTX',
   'fileViewer.openInNewTab': 'Abrir em nova aba',
+  'fileViewer.exportReady': 'Pronto para salvar',
   'fileViewer.copyPath': 'Copiar caminho',
   'fileViewer.copied': 'Copiado!',
   'fileViewer.share': 'Compartilhar',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -2581,6 +2581,7 @@ export const ru: Dict = {
   'sketch.tooltipDirty': 'Несохраненные изменения',
   'sketch.tooltipClean': 'Сохранено',
   'fileViewer.empty': 'Выберите файл для просмотра.',
+  'fileViewer.exportReady': 'готово к сохранению.',
   'fileViewer.loading': 'Загрузка…',
   'fileViewer.exportPptx': 'Экспорт в PPTX',
   'fileViewer.openInNewTab': 'Открыть в новой вкладке',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -2582,6 +2582,7 @@ export const th: Dict = {
   'sketch.tooltipClean': 'บันทึกสมบูรณ์',
   'fileViewer.empty': 'คลิกที่ไฟล์เพื่อแสดงดู',
   'fileViewer.loading': 'กำลังเรียกโหลด…',
+  'fileViewer.exportReady': 'พร้อมบันทึก.',
   'fileViewer.exportPptx': 'ส่งข้อมูลเป็น PPTX',
   'fileViewer.openInNewTab': 'เข้าจากหน้าต่างใหม่',
   'fileViewer.copyPath': 'ก็อปปี้ลิ้งก์',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -2582,6 +2582,7 @@ export const tr: Dict = {
   'sketch.tooltipClean': 'Kaydedildi',
   'fileViewer.empty': 'Görüntülemek için bir dosya seçin.',
   'fileViewer.loading': 'Yükleniyor…',
+  'fileViewer.exportReady': 'Kaydetmeye Hazır',
   'fileViewer.exportPptx': 'PPTX olarak dışa aktar',
   'fileViewer.openInNewTab': 'Yeni sekmede aç',
   'fileViewer.copyPath': 'Yolu kopyala',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -2583,6 +2583,7 @@ export const uk: Dict = {
   'fileViewer.empty': 'Виберіть файл для перегляду.',
   'fileViewer.loading': 'Завантаження…',
   'fileViewer.exportPptx': 'Експортувати як PPTX',
+  'fileViewer.exportReady': 'готовий рятувати.',
   'fileViewer.openInNewTab': 'Відкрити в новій вкладці',
   'fileViewer.copyPath': 'Копіювати шлях',
   'fileViewer.copied': 'Скопійовано!',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -2825,6 +2825,7 @@ export const zhCN: Dict = {
   "sketch.tooltipClean": "已保存",
   "fileViewer.empty": "请选择一个文件查看。",
   "fileViewer.loading": "加载中…",
+  "fileViewer.exportReady": "加载完成",
   "fileViewer.exportPptx": "导出为 PPTX",
   "fileViewer.openInNewTab": "在新标签页中打开",
   "fileViewer.copyPath": "复制路径",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -2834,6 +2834,7 @@ export const zhTW: Dict = {
   "sketch.tooltipClean": "已儲存",
   "fileViewer.empty": "請選擇一個檔案檢視。",
   "fileViewer.loading": "載入中…",
+  "fileViewer.exportReady": "加載完成",
   "fileViewer.exportPptx": "匯出為 PPTX",
   "fileViewer.openInNewTab": "在新分頁中開啟",
   "fileViewer.copyPath": "複製路徑",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -3433,6 +3433,7 @@ export interface Dict {
   'fileViewer.versions.restoring': string;
   'fileViewer.versions.restoreFailed': string;
   'fileViewer.versions.restoreSuccess': string;
+  'fileViewer.exportReady': string;
   'manualEdit.layers': string;
   'manualEdit.editableCount': string;
   'manualEdit.hiddenBadge': string;


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #5368 🌻 

## changes i did: 

https://github.com/nexu-io/open-design/blob/b0316e94347da1f34e76b22b45d18b0e69882e1f/apps/web/src/components/FileViewer.tsx#L5560 

https://github.com/nexu-io/open-design/blob/b0316e94347da1f34e76b22b45d18b0e69882e1f/apps/web/src/components/FileViewer.tsx#L5575

 changed to 
`setExportToast({ 
          message: t('fileViewer.exportReady'), 
          tone: 'default'`


## What users will see

Before:
During the export flow, the toast displayed "Export successful" before the user had chosen a save location. This could be misleading, as the export process was not yet fully complete.

After:
During the export flow, once the file has been prepared, the toast now displays "Ready to save" instead of indicating that the export has already succeeded. This more accurately reflects the current state and avoids giving premature confirmation before the user completes the save step.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only



## Validation

- Typecheck passes
- Locale integrity test passes
- Toast component tests pass
- FileViewer tests pass


closes #5368  Thank you 🌻 