### PR TITLE
fix(web): stop AMR request loop in settings

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -628,6 +628,28 @@ function AppInner() {
   // globals effect below reads it; the sync effects live next to the
   // other AMR plumbing further down.
   const [amrLoginStatus, setAmrLoginStatus] = useState<VelaLoginStatus | null>(null);
+  // Child surfaces report status snapshots, not login events. Deduplicate the
+  // signed-in transition here: restarting the model poll for every Settings
+  // snapshot updates `agents`, which makes Settings fetch status again and
+  // creates a status -> models -> agents request loop.
+  const amrLoginStatusRef = useRef<VelaLoginStatus | null>(null);
+  const applyAmrLoginStatus = useCallback((
+    status: VelaLoginStatus,
+    options: { forceModelRefresh?: boolean; restartOnSignIn?: boolean } = {},
+  ) => {
+    const wasLoggedIn = amrLoginStatusRef.current?.loggedIn === true;
+    amrLoginStatusRef.current = status;
+    setAmrLoginStatus(status);
+    if (
+      status.loggedIn === true
+      && (
+        options.forceModelRefresh === true
+        || (options.restartOnSignIn === true && !wasLoggedIn)
+      )
+    ) {
+      restartAmrPolling();
+    }
+  }, [restartAmrPolling]);
 
   // v2 analytics requires every event to carry the configure-state
   // triplet (has_available_configure_cli / configure_type /
@@ -769,16 +791,21 @@ function AppInner() {
   // unmounted before their poll settled.
   useEffect(() => {
     let cancelled = false;
-    const sync = async (options: { refresh?: boolean } = {}) => {
+    const sync = async (
+      options: { refresh?: boolean } = {},
+      restartOnSignIn = false,
+    ) => {
       const status = await fetchVelaLoginStatus(options);
-      if (!cancelled && status) setAmrLoginStatus(status);
-      if (!cancelled && status?.loggedIn === true && options.refresh) {
-        restartAmrPolling();
+      if (!cancelled && status) {
+        applyAmrLoginStatus(status, {
+          forceModelRefresh: options.refresh === true,
+          restartOnSignIn,
+        });
       }
     };
     void sync();
     const onStatusEvent = () => {
-      void sync();
+      void sync({}, true);
     };
     const onReturnToApp = () => {
       if (document.visibilityState === 'hidden') return;
@@ -793,7 +820,7 @@ function AppInner() {
       window.removeEventListener('focus', onReturnToApp);
       document.removeEventListener('visibilitychange', onReturnToApp);
     };
-  }, [daemonLive, restartAmrPolling]);
+  }, [applyAmrLoginStatus, daemonLive]);
 
   useEffect(() => {
     analytics.setUserId(
@@ -802,10 +829,8 @@ function AppInner() {
   }, [analytics.setUserId, amrLoginStatus]);
 
   const handleAmrLoginStatusChange = useCallback((status: VelaLoginStatus | null) => {
-    if (status) setAmrLoginStatus(status);
-    if (status?.loggedIn !== true) return;
-    restartAmrPolling();
-  }, [restartAmrPolling]);
+    if (status) applyAmrLoginStatus(status, { restartOnSignIn: true });
+  }, [applyAmrLoginStatus]);
 
   // Bootstrap — detect daemon, then fan out independent fetches so each
   // entry-view tab can render the moment its own data lands. Earlier this

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -466,6 +466,37 @@ describe('App AMR polling', () => {
     }, { timeout: 4_000 });
   });
 
+  it('does not restart AMR model polling for repeated signed-in status snapshots', async () => {
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'remote-a', label: 'remote-a' }],
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByText('open settings'));
+    await waitFor(() => {
+      expect(screen.getByText('mark amr signed in')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('mark amr signed in'));
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.click(screen.getByText('mark amr signed in'));
+    fireEvent.click(screen.getByText('mark amr signed in'));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+  });
+
   it('stops polling after the preset retry budget is exhausted when remote never arrives', {
     timeout: 20_000,
   }, async () => {


### PR DESCRIPTION
## Why

Opening Settings while Open Design Cloud was signed in could create an unbounded request cycle across the AMR status, wallet, and model endpoints. Settings reported each status snapshot to App, App treated every signed-in snapshot as a fresh login and restarted model polling, and the resulting agent update caused Settings to fetch the same account data again.

This was found while investigating high-frequency requests from the packaged `od://app` Settings surface. The loop wastes local daemon resources, makes Settings noisy and sluggish, and risks amplifying traffic if cache behavior changes or expires.

## What users will see

Settings opens normally without continuously requesting Open Design Cloud status, wallet, and model data. Genuine sign-in transitions still refresh the model catalog, and returning to the app still performs the existing forced account refresh.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This fixes background request behavior without changing the visible Settings UI.

## Bug fix verification

- Test path: `apps/web/tests/components/App.amr-polling.test.tsx`
- The regression test went red before the source change (four model fetches instead of two) and green after the fix.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/App.amr-polling.test.tsx --reporter=verbose --maxWorkers=1` (10 passed)
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/contracts build && pnpm --filter @open-design/web typecheck`
