### PR TITLE
fix(web): lock the discovery Continue button after submit

### DIFF
--- a/apps/web/src/components/QuestionsPanel.tsx
+++ b/apps/web/src/components/QuestionsPanel.tsx
@@ -88,6 +88,19 @@ export function QuestionsPanel({
   const [ready, setReady] = useState(false);
   const [uploadingFiles, setUploadingFiles] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  // Once the user commits an answer we optimistically lock the panel — disabling
+  // Continue/Skip and showing a busy spinner — for the window before the
+  // parent's busy/answered signals catch up (and across the async file upload).
+  // Without it, a form-answer send that is still being dispatched leaves the CTA
+  // enabled, so an impatient user (or the countdown) can re-fire it and pile
+  // duplicate sends into the queue. The ref is the synchronous chokepoint guard;
+  // the state drives rendering.
+  const submittingRef = useRef(false);
+  const [submitting, setSubmitting] = useState(false);
+  const releaseSubmitLock = useCallback(() => {
+    submittingRef.current = false;
+    setSubmitting(false);
+  }, []);
   const [draftAnswers, setDraftAnswers] = useState<QuestionFormAnswers | undefined>(() =>
     readQuestionFormDraft(formKey),
   );
@@ -159,6 +172,13 @@ export function QuestionsPanel({
       answers: QuestionFormAnswers,
       fileSubmissions: QuestionFormFileSubmission[] = [],
     ) => {
+      // Single-submit invariant: a form occurrence commits exactly one answer.
+      // A repeat click, or the countdown racing a click, must not enqueue a
+      // second send (see the "76 queued" repro). Released below if an upload
+      // fails so the user can retry.
+      if (submittingRef.current) return;
+      submittingRef.current = true;
+      setSubmitting(true);
       let attachments: ChatAttachment[] = [];
       let context: RunContextSelection | undefined;
       let submittedText = text;
@@ -166,6 +186,7 @@ export function QuestionsPanel({
         if (!projectId) {
           submitSourceRef.current = 'continue';
           setUploadError(t('questions.uploadNeedsProject'));
+          releaseSubmitLock();
           return;
         }
         setUploadingFiles(true);
@@ -197,6 +218,7 @@ export function QuestionsPanel({
               ? t('questions.uploadPartialFailed', { uploaded, failed })
               : t('questions.uploadFailed', { failed })) + detail,
           );
+          releaseSubmitLock();
           return;
         }
         attachments = result.uploaded.map((attachment, index) => ({
@@ -243,7 +265,7 @@ export function QuestionsPanel({
         onSubmit(submittedText);
       }
     },
-    [analytics.track, form, formKey, onSubmit, projectId, t],
+    [analytics.track, form, formKey, onSubmit, projectId, releaseSubmitLock, t],
   );
   // If this occurrence already finished its reveal in a prior mount, show it in
   // full immediately rather than replaying the animation on remount.
@@ -284,9 +306,18 @@ export function QuestionsPanel({
   // Submission needs the form present, active, fully revealed, and not blocked
   // by a busy/streaming turn. Required-field readiness is tracked separately by
   // `ready` (from QuestionForm) and gates Continue via `canContinue`.
-  const canSubmit = !!form && interactive && !building && !submitDisabled && !uploadingFiles;
+  const canSubmit =
+    !!form && interactive && !building && !submitDisabled && !uploadingFiles && !submitting;
   const canContinue = canSubmit && ready;
   const canSkip = canSubmit;
+
+  // Release the optimistic lock once the world catches up: either the turn is
+  // now busy (`submitDisabled` takes over the disable) or the answer has landed
+  // (`answered`). This also recovers a form that never actually started a turn,
+  // so it stays actionable instead of latching disabled forever.
+  useEffect(() => {
+    if (submitting && (submitDisabled || answered)) releaseSubmitLock();
+  }, [submitting, submitDisabled, answered, releaseSubmitLock]);
 
   // Auto-skip countdown. It only runs while the form is actionable; pausing
   // (busy turn, re-stream) resets it so we never auto-submit a half-ready form.
@@ -359,9 +390,11 @@ export function QuestionsPanel({
               ? t('questions.uploadingFiles')
               : uploadError
                 ? uploadError
-                : canSkip
-                  ? t('questions.autoSkipHint')
-                  : null}
+                : submitting
+                  ? t('questions.submitting')
+                  : canSkip
+                    ? t('questions.autoSkipHint')
+                    : null}
         </span>
         <button
           type="button"
@@ -379,12 +412,20 @@ export function QuestionsPanel({
           type="button"
           className="questions-continue"
           disabled={!canContinue}
+          aria-busy={submitting ? 'true' : undefined}
           onClick={() => {
             submitSourceRef.current = 'continue';
             formRef.current?.submit();
           }}
         >
-          {t('questions.continue')}
+          {submitting ? (
+            <>
+              <span className="questions-continue-spinner" aria-hidden />
+              {t('questions.submitting')}
+            </>
+          ) : (
+            t('questions.continue')
+          )}
         </button>
       </div>
     </div>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3121,6 +3121,7 @@ export const ar: Dict = {
   'questions.generating': 'جارٍ إنشاء الأسئلة…',
   'questions.skipAll': 'تخطّي الكل',
   'questions.autoSkipHint': 'يتابع تلقائيًا عند انتهاء المؤقّت',
+  'questions.submitting': 'جارٍ الإرسال…',
   'sketch.toolSelect': 'تحديد (لا إجراء)',
   'sketch.toolPen': 'قلم',
   'sketch.toolText': 'نص',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3121,6 +3121,7 @@ export const de: Dict = {
   'questions.generating': 'Fragen werden generiert…',
   'questions.skipAll': 'Alle überspringen',
   'questions.autoSkipHint': 'Wird automatisch fortgesetzt, wenn der Timer abläuft',
+  'questions.submitting': 'Wird gesendet…',
   'sketch.toolSelect': 'Auswählen (no-op)',
   'sketch.toolPen': 'Stift',
   'sketch.toolText': 'Text',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3135,6 +3135,7 @@ export const en: Dict = {
   'questions.generating': 'Generating questions…',
   'questions.skipAll': 'Skip all',
   'questions.autoSkipHint': 'Auto-continues when the timer ends',
+  'questions.submitting': 'Submitting…',
   'artifact.odCardTaskBriefChip': 'Memory applied · view brief',
   'artifact.odCardScorecardTitle': 'Self-check',
   'artifact.odCardScorecardStatusPass': 'Passed',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3121,6 +3121,7 @@ export const esES: Dict = {
   'questions.generating': 'Generando preguntas…',
   'questions.skipAll': 'Omitir todo',
   'questions.autoSkipHint': 'Continúa automáticamente cuando termina el temporizador',
+  'questions.submitting': 'Enviando…',
   'sketch.toolSelect': 'Seleccionar (sin acción)',
   'sketch.toolPen': 'Lápiz',
   'sketch.toolText': 'Texto',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3121,6 +3121,7 @@ export const fa: Dict = {
   'questions.generating': 'در حال تولید سؤالات…',
   'questions.skipAll': 'رد کردن همه',
   'questions.autoSkipHint': 'با پایان تایمر به‌طور خودکار ادامه می‌یابد',
+  'questions.submitting': 'در حال ارسال…',
   'sketch.toolSelect': 'انتخاب (غیرفعال)',
   'sketch.toolPen': 'قلم',
   'sketch.toolText': 'متن',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3121,6 +3121,7 @@ export const fr: Dict = {
   'questions.generating': 'Génération des questions…',
   'questions.skipAll': 'Tout ignorer',
   'questions.autoSkipHint': 'Continue automatiquement quand le minuteur se termine',
+  'questions.submitting': 'Envoi en cours…',
   'sketch.toolSelect': 'Sélection (sans effet)',
   'sketch.toolPen': 'Stylo',
   'sketch.toolText': 'Texte',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3121,6 +3121,7 @@ export const hu: Dict = {
   'questions.generating': 'Kérdések generálása…',
   'questions.skipAll': 'Összes kihagyása',
   'questions.autoSkipHint': 'Automatikusan folytatódik az időzítő lejártakor',
+  'questions.submitting': 'Küldés…',
   'sketch.toolSelect': 'Kijelölés (nem aktív)',
   'sketch.toolPen': 'Toll',
   'sketch.toolText': 'Szöveg',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3121,6 +3121,7 @@ export const id: Dict = {
   'questions.generating': 'Generating questions…',
   'questions.skipAll': 'Skip all',
   'questions.autoSkipHint': 'Auto-continues when the timer ends',
+  'questions.submitting': 'Mengirim…',
   'sketch.toolSelect': 'Pilih',
   'sketch.toolPen': 'Pena',
   'sketch.toolText': 'Teks',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3121,6 +3121,7 @@ export const it: Dict = {
   'questions.generating': 'Generazione domande…',
   'questions.skipAll': 'Salta tutto',
   'questions.autoSkipHint': 'Continua automaticamente allo scadere del timer',
+  'questions.submitting': 'Invio in corso…',
   'sketch.toolSelect': 'Selezione (senza effetto)',
   'sketch.toolPen': 'Penna',
   'sketch.toolText': 'Testo',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3121,6 +3121,7 @@ export const ja: Dict = {
   'questions.generating': '質問を生成中…',
   'questions.skipAll': 'すべてスキップ',
   'questions.autoSkipHint': 'タイマー終了時に自動で続行します',
+  'questions.submitting': '送信中…',
   'sketch.toolSelect': '選択（操作なし）',
   'sketch.toolPen': 'ペン',
   'sketch.toolText': 'テキスト',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3121,6 +3121,7 @@ export const ko: Dict = {
   'questions.generating': '질문 생성 중…',
   'questions.skipAll': '모두 건너뛰기',
   'questions.autoSkipHint': '타이머가 종료되면 자동으로 계속됩니다',
+  'questions.submitting': '제출 중…',
   'sketch.toolSelect': '선택',
   'sketch.toolPen': '펜',
   'sketch.toolText': '텍스트',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3121,6 +3121,7 @@ export const pl: Dict = {
   'questions.generating': 'Generowanie pytań…',
   'questions.skipAll': 'Pomiń wszystkie',
   'questions.autoSkipHint': 'Automatycznie kontynuuje po upływie czasu',
+  'questions.submitting': 'Wysyłanie…',
   'sketch.toolSelect': 'Wybierz (brak akcji)',
   'sketch.toolPen': 'Pióro',
   'sketch.toolText': 'Tekst',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3121,6 +3121,7 @@ export const ptBR: Dict = {
   'questions.generating': 'Gerando perguntas…',
   'questions.skipAll': 'Pular tudo',
   'questions.autoSkipHint': 'Continua automaticamente quando o cronômetro termina',
+  'questions.submitting': 'Enviando…',
   'sketch.toolSelect': 'Selecionar (sem ação)',
   'sketch.toolPen': 'Caneta',
   'sketch.toolText': 'Texto',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3121,6 +3121,7 @@ export const ru: Dict = {
   'questions.generating': 'Генерация вопросов…',
   'questions.skipAll': 'Пропустить всё',
   'questions.autoSkipHint': 'Автоматически продолжается по истечении таймера',
+  'questions.submitting': 'Отправка…',
   'sketch.toolSelect': 'Выбор (без действий)',
   'sketch.toolPen': 'Ручка',
   'sketch.toolText': 'Текст',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3121,6 +3121,7 @@ export const th: Dict = {
   'questions.generating': 'กำลังสร้างคำถาม…',
   'questions.skipAll': 'ข้ามทั้งหมด',
   'questions.autoSkipHint': 'ดำเนินการต่อโดยอัตโนมัติเมื่อหมดเวลา',
+  'questions.submitting': 'กำลังส่ง…',
   'sketch.toolSelect': 'จิ้มเลือกตัวสิ่งของ',
   'sketch.toolPen': 'ปากกาวาดลาย',
   'sketch.toolText': 'ข้อความอักษร',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3121,6 +3121,7 @@ export const tr: Dict = {
   'questions.generating': 'Sorular oluşturuluyor…',
   'questions.skipAll': 'Tümünü atla',
   'questions.autoSkipHint': 'Zamanlayıcı bittiğinde otomatik olarak devam eder',
+  'questions.submitting': 'Gönderiliyor…',
   'sketch.toolSelect': 'Seç (işlem yok)',
   'sketch.toolPen': 'Kalem',
   'sketch.toolText': 'Metin',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3121,6 +3121,7 @@ export const uk: Dict = {
   'questions.generating': 'Генерація запитань…',
   'questions.skipAll': 'Пропустити все',
   'questions.autoSkipHint': 'Автоматично продовжується після завершення таймера',
+  'questions.submitting': 'Надсилання…',
   'sketch.toolSelect': 'Виділення (без ефекту)',
   'sketch.toolPen': 'Ручка',
   'sketch.toolText': 'Текст',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -3349,6 +3349,7 @@ export const zhCN: Dict = {
   "questions.generating": "正在生成问题…",
   "questions.skipAll": "一键跳过",
   "questions.autoSkipHint": "倒计时结束后将自动继续",
+  "questions.submitting": "正在提交…",
   "sketch.toolSelect": "选择（占位）",
   "sketch.toolPen": "钢笔",
   "sketch.toolText": "文本",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -3360,6 +3360,7 @@ export const zhTW: Dict = {
   "questions.generating": "正在產生問題…",
   "questions.skipAll": "全部略過",
   "questions.autoSkipHint": "計時器結束時自動繼續",
+  "questions.submitting": "正在提交…",
   "sketch.toolSelect": "選擇（佔位）",
   "sketch.toolPen": "鋼筆",
   "sketch.toolText": "文字",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -3907,6 +3907,7 @@ export interface Dict {
   'questions.generating': string;
   'questions.skipAll': string;
   'questions.autoSkipHint': string;
+  'questions.submitting': string;
 
   // Inline <od-card> memory cards (display-only siblings of question-form)
   'artifact.odCardTaskBriefChip': string;

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -1432,10 +1432,25 @@
   cursor: default;
 }
 .questions-continue {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   border: 1px solid transparent;
   color: #fff;
   background: var(--accent);
   box-shadow: 0 2px 10px color-mix(in srgb, var(--accent) 34%, transparent);
+}
+.questions-continue-spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, #fff 45%, transparent);
+  border-top-color: #fff;
+  animation: icon-spin 0.7s linear infinite;
+}
+.questions-continue[aria-busy='true'] {
+  cursor: progress;
 }
 .questions-continue:hover:not(:disabled) {
   transform: translateY(-1px);

--- a/apps/web/tests/components/QuestionsPanel.submit-lock.test.tsx
+++ b/apps/web/tests/components/QuestionsPanel.submit-lock.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { QuestionsPanel } from '../../src/components/QuestionsPanel';
+import type { QuestionForm } from '../../src/artifacts/question-form';
+
+// A form with no required fields so `ready` is true immediately and Continue is
+// actionable without any input — the minimal fixture that lets us drive the
+// submit chokepoint.
+const form: QuestionForm = {
+  id: 'discovery',
+  title: 'A few quick questions',
+  questions: [
+    { id: 'q1', label: 'What is it about?', type: 'text' },
+    { id: 'q2', label: 'Who is the audience?', type: 'text' },
+  ],
+};
+
+function revealAll() {
+  for (let i = 0; i < form.questions.length; i++) {
+    act(() => {
+      vi.advanceTimersByTime(280);
+    });
+  }
+}
+
+function continueButton(): HTMLButtonElement {
+  const btn = document.querySelector<HTMLButtonElement>('.questions-continue');
+  if (!btn) throw new Error('expected a Continue button');
+  return btn;
+}
+
+afterEach(() => {
+  cleanup();
+  window.sessionStorage.clear();
+  vi.useRealTimers();
+});
+
+describe('QuestionsPanel submit lock', () => {
+  // Repro for the "one Continue click queued 76 sends" bug: while the parent's
+  // busy/answered signals lag (the form-answer send is only just being
+  // dispatched), the Continue button stayed enabled, so a colleague who thought
+  // it was stuck could click again and again — each click firing another send
+  // that piled up in the queue. The panel must lock itself on the first submit.
+  it('fires onSubmit once even when Continue is clicked repeatedly', () => {
+    vi.useFakeTimers();
+    const onSubmit = vi.fn();
+    act(() => {
+      render(
+        <QuestionsPanel
+          form={form}
+          formKey="conv-1:msg-a:discovery"
+          interactive
+          generating={false}
+          onSubmit={onSubmit}
+        />,
+      );
+    });
+    revealAll();
+
+    const button = continueButton();
+    // Three rapid clicks, as an impatient user would while it "looks stuck".
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a disabled loading state on the Continue button after it is clicked', () => {
+    vi.useFakeTimers();
+    act(() => {
+      render(
+        <QuestionsPanel
+          form={form}
+          formKey="conv-1:msg-b:discovery"
+          interactive
+          generating={false}
+          onSubmit={() => {}}
+        />,
+      );
+    });
+    revealAll();
+
+    const button = continueButton();
+    expect(button.disabled).toBe(false);
+
+    act(() => {
+      fireEvent.click(button);
+    });
+
+    // Immediately after the click the button must read as busy and be disabled,
+    // so the click can't be repeated while the turn spins up.
+    expect(continueButton().disabled).toBe(true);
+    expect(continueButton().getAttribute('aria-busy')).toBe('true');
+  });
+
+  // Guard against the panel latching locked forever: once the turn actually
+  // starts (submitDisabled flips true) the busy-disable takes over and the
+  // optimistic lock is released, so a later idle form is still actionable.
+  it('hands the lock off to submitDisabled once the turn is busy', () => {
+    vi.useFakeTimers();
+    const onSubmit = vi.fn();
+    const props = {
+      form,
+      formKey: 'conv-1:msg-c:discovery',
+      interactive: true,
+      generating: false,
+      onSubmit,
+    } as const;
+    const { rerender } = render(<QuestionsPanel {...props} />);
+    revealAll();
+
+    act(() => {
+      fireEvent.click(continueButton());
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(continueButton().disabled).toBe(true);
+
+    // The parent turn starts: submitDisabled becomes true. The button stays
+    // disabled, now because the turn is busy rather than the optimistic lock.
+    act(() => {
+      rerender(<QuestionsPanel {...props} submitDisabled />);
+    });
+    expect(continueButton().disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- This PR is a UX/robustness fix; it doesn't close a tracked issue. -->

## Why

Answering the discovery question form and clicking **Continue** once could
spin up **dozens of identical `[form answers — discovery]` sends** in the
queue (observed live: "76 已排队 / 待发送").

Root cause is a missing-feedback race. Clicking Continue only *queues* the
answer send; the parent's busy/answered signals (`submitDisabled`,
`submittedAnswers`) land a beat later. During that window the Continue CTA
stayed fully enabled with no visual change, so the flow *looks stuck*. A
user's natural reaction — click again, and again — plus the auto-continue
countdown racing the same click, each re-fires the submit, and because the
turn is now busy every re-fire lands in the queue. They pile up fast.

Today the panel only shows a busy state for the file-upload path
(`uploadingFiles`); the common no-file discovery form has no such guard.

## What users will see

On the discovery **Questions** panel, the moment you click **Continue**
(or **Skip all**):

- Both buttons disable instantly.
- Continue shows a spinner and reads **"Submitting…"** (localized) instead
  of staying on "Continue".
- The footer status line reads **"Submitting…"**.

So it's obvious the answer was accepted and the turn is starting — no more
"is it stuck?" repeat-clicking, and no runaway queue. Once the turn is
actually running the normal busy-disable takes over; an idle/unanswered
form stays fully actionable (the lock never latches). If a file upload in
the form fails, the lock releases so the user can retry.

No behavior change for a single, patient click — that path is unchanged.

## Surface area

- [x] **UI** — discovery Questions panel Continue/Skip buttons gain a
      submit/loading state (`apps/web`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — N/A: this guards an in-chat UI affordance
      (the `<question-form>` Continue button); there is no CLI surface for
      answering a question form, so there's nothing to mirror.
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** — added `questions.submitting` to all 19 locale files
      (real translations, no EN fallback)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Before: after clicking Continue the button still reads "Continue" and is
clickable → repeat clicks / countdown re-fire the same send → dozens queue.

After: Continue immediately becomes a disabled `⟳ Submitting…` spinner and
Skip disables too, so the send fires exactly once.

## Bug fix verification

- Test path: `apps/web/tests/components/QuestionsPanel.submit-lock.test.tsx`
- Red before the fix, green after? **yes** — verified by checking out the
  baseline `QuestionsPanel.tsx` (`git show HEAD:…`) and running the new
  spec: all 3 cases fail (three rapid clicks → 3 `onSubmit` calls; button
  not disabled/`aria-busy` after click). With the fix they pass (1 call,
  disabled + `aria-busy`, and the lock hands off to `submitDisabled`).
- `pnpm --filter @open-design/web typecheck`, `pnpm guard`, and the
  `QuestionsPanel` / `QuestionForm` suites all pass.
