### PR TITLE
perf(bake): render plugin previews concurrently (bounded worker pool)

### DIFF
--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -35,7 +35,8 @@
 // script only renders + encodes so it stays runnable locally and in CI alike.
 
 import puppeteer from 'puppeteer-core';
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { mkdirSync, rmSync, writeFileSync, readFileSync, statSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
@@ -118,6 +119,22 @@ const STRICT = process.argv.includes('--strict') || process.env.PREVIEW_STRICT =
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// How many plugins to render concurrently. The per-clip cost is dominated by
+// wall-clock waits (HOLD dwell + slide walk / pan + font/image settle) that
+// yield to the event loop, so overlapping N renders scales the sweep near-
+// linearly until the runner's cores saturate. Default 4 matches the standard
+// GitHub-hosted ubuntu runner (4 vCPU / 16GB); dial down via PREVIEW_CONCURRENCY
+// if capture quality degrades under contention, or up on a bigger runner.
+const CONCURRENCY = Math.max(1,
+  Number(process.env.PREVIEW_CONCURRENCY || arg('concurrency', '')) || 4);
+
+// ffmpeg/ffprobe as promises, NOT execFileSync: a synchronous encode/probe
+// blocks the event loop, which stalls the CDP `screencastFrameAck` of every
+// OTHER concurrently-capturing page (Chrome only sends the next screencast
+// frame after the ack), starving their clips of frames. Async keeps every
+// page's capture flowing while one plugin encodes.
+const execFileP = promisify(execFile);
+
 function resolveChrome() {
   if (process.env.CHROME && existsSync(process.env.CHROME)) return process.env.CHROME;
   const candidates = [
@@ -145,9 +162,10 @@ function resolveChrome() {
 // swallowed probe error would silently disable exactly the checks this
 // pipeline exists for. A thrown error becomes an `error …` skip for that
 // plugin, lands in bake-report.json, and fails strict mode.
-function probeClipMs(file) {
-  const out = execFileSync('ffprobe', ['-v', 'error', '-show_entries', 'format=duration',
-    '-of', 'csv=p=0', file], { encoding: 'utf8' }).trim();
+async function probeClipMs(file) {
+  const { stdout } = await execFileP('ffprobe', ['-v', 'error', '-show_entries', 'format=duration',
+    '-of', 'csv=p=0', file], { encoding: 'utf8' });
+  const out = stdout.trim();
   const s = Number(out);
   if (!Number.isFinite(s) || s <= 0) throw new Error(`ffprobe returned no duration for ${file}: "${out}"`);
   return Math.round(s * 1000);
@@ -161,12 +179,12 @@ function probeClipMs(file) {
 // artwork moves YMAX/YMIN far past these bounds.
 const BLANK_MAX_Y = 24;
 const BLANK_MIN_Y = 232;
-function clipLumaRange(file) {
+async function clipLumaRange(file) {
   const esc = file.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/:/g, '\\:');
   // nk=0 keeps the tag names in the output: ffprobe emits the tags in
   // signalstats' own order (YMIN before YMAX), not the -show_entries order,
   // so parse by key instead of by position.
-  const out = execFileSync('ffprobe', ['-v', 'error', '-f', 'lavfi',
+  const { stdout: out } = await execFileP('ffprobe', ['-v', 'error', '-f', 'lavfi',
     '-i', `movie='${esc}',signalstats`,
     '-show_entries', 'frame_tags=lavfi.signalstats.YMAX,lavfi.signalstats.YMIN',
     '-of', 'csv=p=0:nk=0'], { encoding: 'utf8' });
@@ -485,7 +503,15 @@ async function bakeOne(browser, id, hash, motion) {
   for (let i = 0; i < frames.length; i += 1) {
     const fp = path.join(frameDir, `f-${String(i).padStart(4, '0')}.jpg`);
     writeFileSync(fp, Buffer.from(frames[i].data, 'base64'));
-    if (i > 0) lines.push(`duration ${(frames[i].ts - frames[i - 1].ts).toFixed(4)}`);
+    // Clamp to >=0: CDP screencast frame timestamps are occasionally NON-
+    // monotonic (a later frame carries an earlier `metadata.timestamp`),
+    // yielding a negative inter-frame duration that ffmpeg's concat demuxer
+    // rejects outright ("Invalid data found when processing input"), failing
+    // the whole clip — and, in strict pre-merge, the PR. A 0-duration frame is
+    // harmless (the fps filter resamples the timeline anyway). CPU contention
+    // from concurrent renders makes the non-monotonic blips more frequent, so
+    // this guard matters more once the sweep runs in parallel.
+    if (i > 0) lines.push(`duration ${Math.max(0, frames[i].ts - frames[i - 1].ts).toFixed(4)}`);
     lines.push(`file '${fp}'`);
   }
   // A static page repaints nothing after its first paint, so the screencast
@@ -517,16 +543,23 @@ async function bakeOne(browser, id, hash, motion) {
   const video = path.join(OUT, videoKey);
   const poster = path.join(OUT, posterKey);
   mkdirSync(path.dirname(video), { recursive: true });
-  const ff = (a) => execFileSync('ffmpeg', ['-y', ...a], { stdio: 'ignore' });
+  // `-loglevel error -nostats` is the promisified-execFile equivalent of the
+  // old execFileSync `stdio: 'ignore'`: promisified execFile BUFFERS stderr
+  // (there is no `stdio: 'ignore'`), and ffmpeg's default banner + per-frame
+  // progress could otherwise grow past maxBuffer and reject a good encode with
+  // ENOBUFS. Quiet ffmpeg to errors only, and keep a generous buffer as a
+  // backstop. This changes only console chatter, never the encoded output.
+  const ff = (a) => execFileP('ffmpeg', ['-y', '-loglevel', 'error', '-nostats', ...a],
+    { maxBuffer: 64 * 1024 * 1024 });
   // H.264 MP4, constant frame rate (the fps filter resamples the concat's
   // real-time timeline to a constant FPS). H.264 decodes reliably in both
   // browsers and Electron — VP9 encoded from this frame pipeline intermittently
   // tripped Chromium/Electron's decoder (PIPELINE_ERROR_DECODE). `+faststart`
   // moves the moov atom up front so playback can begin before the full download.
-  ff(['-f', 'concat', '-safe', '0', '-i', listPath,
+  await ff(['-f', 'concat', '-safe', '0', '-i', listPath,
     '-vf', `scale=${OUT_W}:-2,fps=${FPS}`, '-c:v', 'libx264', '-crf', String(CRF),
     '-pix_fmt', 'yuv420p', '-movflags', '+faststart', '-r', String(FPS), '-an', video]);
-  ff(['-i', path.join(frameDir, 'f-0000.jpg'), '-vf', `scale=${OUT_W}:-2`,
+  await ff(['-i', path.join(frameDir, 'f-0000.jpg'), '-vf', `scale=${OUT_W}:-2`,
     '-q:v', '5', '-frames:v', '1', poster]);
   rmSync(frameDir, { recursive: true, force: true });
 
@@ -534,7 +567,7 @@ async function bakeOne(browser, id, hash, motion) {
   // blank card until the plugin's next content change. Deleting the outputs
   // keeps the broken clip out of the R2 upload (the CI step copies OUT
   // recursively).
-  const luma = clipLumaRange(video);
+  const luma = await clipLumaRange(video);
   if (luma.maxY < BLANK_MAX_Y || luma.minY > BLANK_MIN_Y) {
     rmSync(path.dirname(video), { recursive: true, force: true });
     return { id, skipped: `blank clip (luma ${luma.minY}..${luma.maxY})` };
@@ -543,7 +576,7 @@ async function bakeOne(browser, id, hash, motion) {
   // Manifest metadata must describe the FILE, not the intent: durationMs is
   // the encoded duration, and holdMs (the span the gallery loops while idle)
   // is clamped to it so the idle loop never points past the end of the clip.
-  const encodedMs = probeClipMs(video);
+  const encodedMs = await probeClipMs(video);
   return { id, durationMs: encodedMs, holdMs: Math.min(HOLD_MS, encodedMs), video: videoKey, poster: posterKey,
     bytes: statSync(video).size, posterBytes: statSync(poster).size };
 }
@@ -552,13 +585,24 @@ async function bakeOne(browser, id, hash, motion) {
 mkdirSync(OUT, { recursive: true });
 const ids = await discoverIds();
 const motionMap = await loadMotionMap();
-console.log(`baking ${ids.length} plugin previews from ${BASE_URL} -> ${OUT}`);
-const browser = await puppeteer.launch({
+console.log(`baking ${ids.length} plugin previews from ${BASE_URL} -> ${OUT} (concurrency ${CONCURRENCY})`);
+// Browser launch options, reused per worker below. NOT a single shared browser:
+// CDP screencast only follows the ACTIVE tab, so capturing a page in a shared
+// browser while another page is foreground starves it of frames (a frames-0
+// skip, or a near-empty clip). Each concurrent worker therefore drives its OWN
+// browser, where its page is always the sole foreground tab.
+const launchOptions = {
   executablePath: resolveChrome(), headless: 'new',
   // Let muted hero background videos (.mp4/CloudFront, common on premium
-  // landing pages) autoplay so the capture isn't a frozen first frame.
-  args: ['--no-sandbox', '--hide-scrollbars', '--autoplay-policy=no-user-gesture-required'],
-});
+  // landing pages) autoplay so the capture isn't a frozen first frame. The
+  // backgrounding flags are belt-and-suspenders: a worker holds one page at a
+  // time so it is already foreground, but these keep painting alive if a page's
+  // window is ever treated as occluded.
+  args: ['--no-sandbox', '--hide-scrollbars', '--autoplay-policy=no-user-gesture-required',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding'],
+};
 
 const manifestPath = path.join(OUT, 'manifest.json');
 const previews = existsSync(manifestPath)
@@ -572,7 +616,7 @@ let ok = 0, skip = 0, reused = 0;
 // crash, …) from the routine skips every sweep has (non-html plugins 404 the
 // preview route); strict mode fails on the former, never on the latter.
 const report = { skipped: [], stale: [], blank: [], errors: [] };
-for (const id of ids) {
+async function processOne(id, getBrowser) {
   const t0 = Date.now();
   // Content-hash skip: a plugin whose preview HTML (and the bake recipe) is
   // unchanged reuses its existing clip — no render, and the CI step re-uploads
@@ -593,7 +637,7 @@ for (const id of ids) {
     console.log(`  ~ ${id}: skip (${reason})`);
     report.skipped.push({ id, reason });
     report.errors.push(id);
-    continue;
+    return;
   }
   const prev = previews[id];
   // In CI the unchanged clips already live on R2 (not on disk), so PREVIEW_REMOTE
@@ -604,10 +648,10 @@ for (const id of ids) {
   if (hash && prev && prev.hash === hash && filesPresent) {
     reused += 1;
     console.log(`  = ${id}: unchanged, reused`);
-    continue;
+    return;
   }
   let r;
-  try { r = await bakeOne(browser, id, hash, motionMap[id]); } catch (e) { r = { id, skipped: `error ${e.message}` }; }
+  try { r = await bakeOne(await getBrowser(), id, hash, motionMap[id]); } catch (e) { r = { id, skipped: `error ${e.message}` }; }
   if (r.skipped) {
     skip += 1;
     console.log(`  ~ ${id}: skip (${r.skipped})`);
@@ -615,14 +659,48 @@ for (const id of ids) {
     if (r.skipped.startsWith('blank clip')) report.blank.push(id);
     if (r.skipped.startsWith('error ')) report.errors.push(id);
     if (prev && hash && prev.hash !== hash) report.stale.push(id);
-    continue;
+    return;
   }
   previews[id] = { video: r.video, poster: r.poster, durationMs: r.durationMs, holdMs: r.holdMs, hash };
   ok += 1;
   console.log(`  + ${id}: ${(r.bytes / 1024).toFixed(0)}KB mp4, ${(r.posterBytes / 1024).toFixed(0)}KB poster (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+  // Shared state (previews, counters, report) is only ever mutated in the
+  // synchronous span between awaits, so the single-threaded event loop
+  // serializes it — no lock needed. Rewriting the FULL manifest after each
+  // success is last-complete-wins under concurrency: whoever writes last
+  // serializes the most complete `previews`, and every earlier write is a
+  // subset it supersedes.
   writeFileSync(manifestPath, JSON.stringify({ generatedAt: null, previews }, null, 2));
 }
-await browser.close();
+
+// Bounded worker pool: CONCURRENCY workers pull ids from a shared cursor so up
+// to CONCURRENCY plugins render at once. The per-clip cost is mostly wall-clock
+// waits that yield to the event loop, so overlapping them scales the sweep
+// near-linearly until the runner's cores saturate (see CONCURRENCY above). An
+// all-cached sweep just races the cheap hash fetches through the same pool.
+let cursor = 0;
+async function worker() {
+  // Each worker owns its browser (see launchOptions) and processes its ids
+  // sequentially, reusing that browser across them — launching it inside the
+  // worker is what keeps every captured page foreground. Lazy: a worker that
+  // only hits the reuse fast-path (an all-cached sweep, the common post-merge
+  // case) never pays a browser launch.
+  let browser = null;
+  const getBrowser = async () => (browser ??= await puppeteer.launch(launchOptions));
+  try {
+    for (;;) {
+      const i = cursor;
+      cursor += 1;
+      if (i >= ids.length) break;
+      await processOne(ids[i], getBrowser);
+    }
+  } finally {
+    if (browser) await browser.close();
+  }
+}
+await Promise.all(
+  Array.from({ length: Math.min(CONCURRENCY, ids.length) }, () => worker()),
+);
 // Written next to the manifest (the R2 upload step excludes it, same as
 // manifest.json) so both the strict pre-merge job and a human reading a
 // nightly run can see exactly which entries are broken or lagging.
@@ -638,7 +716,19 @@ if (report.stale.length) {
 if (report.errors.length) {
   console.error(`ERRORED bakes (unexpected exception — validation infrastructure problem or renderer crash, see the skip reasons above): ${report.errors.join(', ')}`);
 }
-if (STRICT && (report.blank.length || report.stale.length || report.errors.length)) {
+const strictFail = STRICT && (report.blank.length || report.stale.length || report.errors.length);
+if (strictFail) {
   console.error('strict mode: failing on blank/stale/errored previews');
-  process.exit(1);
 }
+// Exit explicitly. Puppeteer can leave the event loop non-empty after
+// browser.close() (a lingering child-process/transport handle), and with one
+// browser PER worker that reliably keeps this CLI alive after all work is done
+// — on CI that means the step hangs until the 90-min job timeout instead of
+// finishing in minutes. Everything above is persisted synchronously
+// (writeFileSync), so the only thing left to protect is the piped stdout/stderr
+// on CI: drain both so the final summary / strict message is never truncated,
+// then hard-exit with the strict-aware code.
+await Promise.all([process.stdout, process.stderr].map(
+  (stream) => new Promise((resolve) => stream.write('', resolve)),
+));
+process.exit(strictFail ? 1 : 0);


### PR DESCRIPTION
## Why

While looking at why #5083's checks sat at 24+ minutes, the culprit was one long pole: **Bake plugin previews (pre-merge)** at 24m32s while every other check finished in ~5 min. That PR touches the deck renderer, so every deck example's *served* preview HTML changes and the content-hash skip re-bakes them all — the run rendered **80 clips, one at a time, ~16s each ≈ 19 min of pure serial render** (setup was only ~3 min). Any PR that changes shared deck/renderer inputs pays this. This is a maintainer itch — the bake pipeline is mine — and it's slowing down every contributor whose PR trips the bake trigger.

The render was fully serial (`for (const id of ids) { await bakeOne(...) }`), yet each clip's cost is almost all wall-clock *waiting* (HOLD dwell + slide-walk / pan + font/image settle) that yields to the event loop — ideal for overlapping.

## What users will see

Nothing in the product. This is CI/infra: the plugin-preview bake finishes materially faster. Local A/B on 6 forced re-bakes: **83s serial → 32s at concurrency 3 (~2.6×)**; the 80-item CI sweep amortizes browser launch across ~20 clips/worker, so it should land closer to **~4×**, dropping the render from ~19 min to ~5 min. The same script backs the pre-merge, post-merge, and release-cut bake workflows, so all three speed up.

New internal knob: `PREVIEW_CONCURRENCY` (default 4 = the standard GitHub runner's vCPUs; matches the existing `PREVIEW_*` env family in this script). Not a product surface.

## Surface area

- [x] **None** — internal CI/build tooling only (bake render script). Adds one internal env var `PREVIEW_CONCURRENCY`; not `OD_*`, not user-facing.

## Screenshots

n/a (no UI)

## Bug fix verification

Primarily a perf change, but it also fixes two latent robustness bugs that concurrency surfaced/aggravates — both reproduced locally against a real daemon:

- **Negative concat duration → whole clip rejected.** CDP screencast frame timestamps are occasionally non-monotonic, producing a negative `duration` line that ffmpeg's concat demuxer rejects (`Invalid data found when processing input`), failing the plugin — and in strict pre-merge, the PR. Reproduced **serially** on `example-deck-swiss-international` (`duration -0.0446`); clamping inter-frame durations to `>=0` turns it green. CPU contention from concurrent renders makes the blips more frequent, so it matters more once parallel.
- **frames-0 / near-empty clips under a shared browser.** CDP screencast only follows the active tab, so capturing a background page starves it of frames. Reproduced both a `frames 0` skip and a 5KB near-empty clip with a shared browser + N pages. Fixed by giving each worker its **own** browser (its page is always foreground); clip sizes then match the serial baseline byte-for-byte.

A red unit spec isn't cheap here (the render path needs a live daemon + headless Chrome + ffmpeg), so verification is the real-daemon A/B below. The pre-merge bake job itself is the end-to-end gate — it runs on this PR because the change touches `scripts/bake-plugin-previews.mjs`.

## Validation

Ran the real script against a live daemon (`127.0.0.1/api/plugins`, my own Chrome + ffmpeg), same 6 forced re-bakes, final code:

- `concurrency=1`: **83s**, 6 baked / 0 skipped, exit 0
- `concurrency=3`: **32s**, 6 baked / 0 skipped, exit 0
- Clip sizes at c=3 match the serial baseline (e.g. `frontend-slides` 145KB vs 144KB; `fs-electric-studio` 141KB vs 144KB) — parallel capture quality is identical.
- **Clean exit**: 0 lingering `node`/Chrome processes afterward. (An earlier revision hung after `done:` — puppeteer leaves a handle after `browser.close()`, which with a browser-per-worker keeps the CLI alive to the 90-min job timeout. Fixed by draining stdout/stderr then `process.exit`.)
- `node --check` clean.

CI's pre-merge bake (triggered by the `scripts/bake-plugin-previews.mjs` path) is the on-runner end-to-end validation; I'll confirm the wall-clock drop and eyeball a clip there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)