### PR TITLE
fix(daemon): import scanRunEventsForUsageAnalytics for devloop token reconciliation

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -369,6 +369,7 @@ import { classifyRunFailure, isResumableFailure } from './run-failure-classifica
 import { decideSafeRunRetry } from './run-retry-policy.js';
 import {
   amrUserIdForRunAnalytics,
+  scanRunEventsForUsageAnalytics,
 } from './run-analytics-observability.js';
 import {
   createRunArtifactBaselines,


### PR DESCRIPTION
Fixes #5433

## Why

While auditing the daemon run/analytics path I found the plugin devloop `tokens_used` reconciliation has been throwing a `ReferenceError` on every run since it was added. `firePipelineForRun` (server.ts, reached from `routes/runs.ts` when a run resolves a plugin snapshot with a pipeline) calls `scanRunEventsForUsageAnalytics(run.events, ...)`, but `server.ts` never imports that function. The reconciliation `.then()` throws `ReferenceError: scanRunEventsForUsageAnalytics is not defined`, the surrounding `.catch` swallows it into a `[plugins] devloop tokens_used reconciliation failed` warning, and the `UPDATE run_devloop_iterations SET tokens_used` never runs — silent analytics data loss.

Regression source: PR #4644 (`24298737c`) added the call and the `UPDATE` but not the `import`.

## What users will see

No user-visible behavior change. The `run_devloop_iterations.tokens_used` analytics column, which has silently been `NULL` for every plugin-devloop run since #4644, now gets backfilled.

## Surface area

- [x] **None** — internal daemon fix.

## Bug fix verification

This is a missing-import `ReferenceError`, certain by static analysis (the symbol is referenced at the call site but absent from `server.ts` imports, so the line throws whenever it runs) and pinned by `git blame` to #4644. The call site is a private closure inside `startServer`, reachable only by a completed plugin-devloop pipeline run, so a faithful end-to-end red spec would require a bespoke pipeline-plugin fixture + fake agent + full HTTP devloop run — disproportionate for a fix of this certainty. Verified instead by:

- The absent import (`grep` shows `scanRunEventsForUsageAnalytics` appears only at the call site, not in any import).
- `git blame` of the call site → #4644.
- `pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit` and `-p tsconfig.tests.json --noEmit` clean (after rebuilding `@open-design/contracts`).
- `pnpm guard` (78 pass).
- Existing `plugins-pipeline-runner` + `plugins-headless-run` suites stay green (14 tests).

Happy to add a full HTTP devloop repro test if reviewers prefer it despite the setup cost.

## Validation

- `pnpm guard`; daemon `tsc` (both tsconfigs); `plugins-pipeline-runner` + `plugins-headless-run` suites.
