### PR TITLE
fix(daemon): honor BYOK defaults in media dispatch hint

### DIFF
--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -285,16 +285,17 @@ The daemon injects these env vars into your shell (**POSIX bash — not PowerShe
 - \`OD_BIN\`        — absolute path to the OD CLI script
 - \`OD_PROJECT_ID\` — the active project id
 
-**Always use the generate→wait loop below.** \`media generate\` always exits 0 — either with \`{"file":{...}}\` if done within ~25s, or with \`{"taskId":"..."}\` as a handoff for slow models (flux-pro-ultra ~60–180s, veo-3-fal longer). Whenever the output contains a \`taskId\`, keep polling with \`media wait\` until exit 0 (done) or exit 5 (failed).
+**Always use the generate→wait loop below.** \`media generate\` always exits 0 — either with \`{"file":{...}}\` if done within ~25s, or with \`{"taskId":"..."}\` as a handoff for slow models. Whenever the output contains a \`taskId\`, keep polling with \`media wait\` until exit 0 (done) or exit 5 (failed).
 
 Use **POSIX \`$VAR\` syntax** — do NOT translate to PowerShell (\`$env:VAR\`, \`&\` operator). Uses \`python3\` for JSON parsing (do NOT use \`jq\`):
 
 \`\`\`bash
 # POSIX bash — do NOT convert to PowerShell
+IMAGE_MODEL=IMAGE_MODEL_VALUE
 out=\$("$OD_NODE_BIN" "$OD_BIN" media generate \\
   --project "$OD_PROJECT_ID" \\
   --surface image \\
-  --model flux-pro-ultra \\
+  --model "$IMAGE_MODEL" \\
   --prompt "..." \\
   --aspect 16:9)
 ec=\$?
@@ -320,7 +321,7 @@ printf '%s\\n' "\$last"
 
 **Never ask the user for an API key.** The daemon reads provider credentials from its config; keys are never passed through the shell. If the provider returns an auth error, tell the user to open Settings → AI Providers and confirm the key is configured there.
 
-For the best fal image model use \`--model flux-pro-ultra\`. For video use \`--model veo-3-fal\` or \`--model wan-2.1-t2v\`. Always pass \`--surface\` explicitly (\`image\`, \`video\`, or \`audio\`). Any \`fal-ai/*\` path (e.g. \`fal-ai/flux/schnell\`, \`fal-ai/wan-i2v\`) is also a valid \`--model\` value for image/video — pass it through as-is without substitution.`;
+MODEL_SELECTION_GUIDANCE`;
 
 function renderByokMediaDefaultsHint(defaults?: ByokMediaDefaults): string {
   const lines: string[] = [];
@@ -343,8 +344,28 @@ a different model or voice.
 ${lines.join('\n')}`;
 }
 
+function shellDoubleQuote(value: string): string {
+  return `"${value.replace(/(["\\$`])/g, '\\$1')}"`;
+}
+
+function renderMediaDispatchModelGuidance(defaults?: ByokMediaDefaults): string {
+  const imageModel = defaults?.imageModel?.trim();
+  const videoModel = defaults?.videoModel?.trim();
+  const imagePart = imageModel
+    ? `For image generation prefer your configured model: \`${imageModel}\`.`
+    : 'For the best fal image model use `--model flux-pro-ultra`.';
+  const videoPart = videoModel
+    ? `For video prefer your configured model: \`${videoModel}\`.`
+    : 'For video use `--model veo-3-fal` or `--model wan-2.1-t2v`.';
+  return `${imagePart} ${videoPart} Always pass \`--surface\` explicitly (\`image\`, \`video\`, or \`audio\`). Any \`fal-ai/*\` path (e.g. \`fal-ai/flux/schnell\`, \`fal-ai/wan-i2v\`) is also a valid \`--model\` value for image/video — pass it through as-is without substitution.`;
+}
+
 function renderMediaDispatchHint(defaults?: ByokMediaDefaults): string {
-  return `${MEDIA_DISPATCH_HINT}${renderByokMediaDefaultsHint(defaults)}`;
+  const imageModel = defaults?.imageModel?.trim() || 'flux-pro-ultra';
+  const hint = MEDIA_DISPATCH_HINT
+    .replace('IMAGE_MODEL_VALUE', shellDoubleQuote(imageModel))
+    .replace('MODEL_SELECTION_GUIDANCE', renderMediaDispatchModelGuidance(defaults));
+  return `${hint}${renderByokMediaDefaultsHint(defaults)}`;
 }
 
 const FILESYSTEM_HANDOFF_OVERRIDE = `

--- a/apps/daemon/tests/system-prompt-template.test.ts
+++ b/apps/daemon/tests/system-prompt-template.test.ts
@@ -450,6 +450,11 @@ describe('composeSystemPrompt — metadata.promptTemplate', () => {
     expect(out).toContain('## Media generation (if asked)');
     expect(out).toContain('### Run-scoped BYOK media defaults');
     expect(out).toContain('- Image model: `senseaudio-image-1.0-260319`');
+    expect(out).toContain('IMAGE_MODEL="senseaudio-image-1.0-260319"');
+    expect(out).toContain('--model "$IMAGE_MODEL"');
+    expect(out).toContain('For image generation prefer your configured model: `senseaudio-image-1.0-260319`.');
+    expect(out).not.toContain('--model flux-pro-ultra');
+    expect(out).not.toContain('For the best fal image model use `--model flux-pro-ultra`');
   });
 
   it('keeps unrestricted enabled media contract unchanged', () => {


### PR DESCRIPTION
Fixes #5117

## Why

I am opening this PR to close the reopened #5117 bug with a focused daemon prompt fix. The repro shows a freeform/non-media project selecting Image later in the flow, while the lightweight media dispatch hint still steers the agent toward `flux-pro-ultra` and Fal even when the chat UI supplied an OpenAI/BYOK image default.

The user-facing pain is that users who already configured an image provider can still get told to configure Fal, because the fallback prompt example and recommendation hard-code a Fal image model. This PR keeps the fallback path, but makes it honor run-scoped BYOK media defaults when present.

## What users will see

When a non-media project later asks for image generation and the run has a configured image default, the agent prompt now points the generate command at that configured model instead of `flux-pro-ultra`. Users should no longer be pushed toward Fal just because the lightweight dispatch hint was used.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — daemon prompt behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/system-prompt-template.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new assertions failed before the source change because the non-media dispatch hint still rendered `--model flux-pro-ultra`; after the fix the same test passes.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/system-prompt-template.test.ts` from `apps/daemon` — 29 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm guard` — passed

Note: local validation emitted the existing Node engine warning because this machine is on Node v22.14.0 while the repo targets Node `~24`.
