### PR TITLE
fix(web): anchor browser-assist extraction error toasts in the chat pane

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -7824,6 +7824,7 @@ export function ProjectView({
             details: null,
             tone: 'error',
             ttlMs: 7000,
+            scope: 'chat-pane',
           });
           return { status: 'handled' };
         }
@@ -7846,6 +7847,7 @@ export function ProjectView({
             details: null,
             tone: 'error',
             ttlMs: 6000,
+            scope: 'chat-pane',
           });
           return { status: 'handled' };
         }
@@ -7875,6 +7877,7 @@ export function ProjectView({
             details: null,
             tone: 'error',
             ttlMs: 5000,
+            scope: 'chat-pane',
           });
           return;
         }
@@ -7923,6 +7926,7 @@ export function ProjectView({
         details: t('chat.brandBrowserAssistDownloadGuideDetails'),
         tone: 'error',
         ttlMs: 7000,
+        scope: 'chat-pane',
       });
     })()
       .catch((err) => {
@@ -7932,6 +7936,7 @@ export function ProjectView({
           details: null,
           tone: 'error',
           ttlMs: 5000,
+          scope: 'chat-pane',
         });
       })
       .finally(() => {

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -40,6 +40,7 @@ const patchProject = vi.fn();
 const patchPreviewCommentStatus = vi.fn();
 const saveTabs = vi.fn();
 const writeProjectTextFile = vi.fn();
+const fetchProjectFileText = vi.fn();
 const cancelBrandExtraction = vi.fn();
 const originalFetch = globalThis.fetch;
 
@@ -135,6 +136,7 @@ vi.mock('../../src/providers/registry', () => ({
   fetchProjectDesignSystemPackageAudit: (...args: unknown[]) => fetchProjectDesignSystemPackageAudit(...args),
   fetchLiveArtifacts: (...args: unknown[]) => fetchLiveArtifacts(...args),
   fetchProjectFiles: (...args: unknown[]) => fetchProjectFiles(...args),
+  fetchProjectFileText: (...args: unknown[]) => fetchProjectFileText(...args),
   fetchSkill: (...args: unknown[]) => fetchSkill(...args),
   patchPreviewCommentStatus: (...args: unknown[]) => patchPreviewCommentStatus(...args),
   upsertPreviewComment: vi.fn(),
@@ -220,6 +222,7 @@ async function waitForReadyChatPaneProps() {
       url?: string;
     }) => Promise<{ ok: boolean; action?: string; message?: string } | void> | { ok: boolean; action?: string; message?: string } | void;
     onSend?: (prompt: string, attachments: unknown[], comments: unknown[]) => Promise<void>;
+    onContinueBrandExtraction?: () => void;
     initialDraft?: string;
   };
 }
@@ -1025,6 +1028,89 @@ describe('ProjectView daemon cleanup', () => {
     });
     expect(toast.closest('.project-actions-toast-anchor')).toBeTruthy();
     expect(toast.closest('.split-chat-slot')).toBeTruthy();
+    expect(toast.closest('.chat-log-wrap')?.className).toContain('has-chat-log-tray');
+  });
+
+  it('anchors the brand browser-assist extraction error toast in the chat pane instead of the global toast surface', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-brand', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockResolvedValue(undefined);
+    // No saved page-snapshot archive → the local read reports a miss, so the
+    // recovery flow falls through to the daemon retry.
+    fetchProjectFileText.mockResolvedValue(null);
+
+    chatPaneSpy.mockClear();
+    fileWorkspaceSpy.mockClear();
+
+    render(
+      <ProjectView
+        project={{
+          id: 'brand-project',
+          name: 'Refly Design System',
+          skillId: null,
+          designSystemId: null,
+          metadata: {
+            kind: 'brand',
+            importedFrom: 'brand-extraction',
+            brandId: 'refly-ai',
+            brandSourceUrl: 'https://refly.ai/',
+          },
+          createdAt: 1,
+          updatedAt: 1,
+        } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    const chatProps = await waitForReadyChatPaneProps();
+    expect(chatProps.onContinueBrandExtraction).toBeTypeOf('function');
+    const continueBrandExtraction = chatProps.onContinueBrandExtraction as () => void;
+
+    // The daemon continue-extraction call fails and there is no desktop host /
+    // browser fallback in jsdom, so the recovery flow surfaces the read-failed
+    // error toast — the surface this test pins to the chat pane. Stubbed only
+    // for the retry so the initial mount keeps the default fetch.
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('offline');
+    }) as never;
+
+    await act(async () => {
+      continueBrandExtraction();
+    });
+
+    const toast = await waitFor(() => {
+      const node = document.querySelector('.od-toast.tone-error');
+      expect(node).toBeTruthy();
+      return node as HTMLElement;
+    });
+    // Regression guard for #5413: browser-assist recovery errors must render in
+    // the in-flow chat-pane tray, not the viewport-fixed global toast surface
+    // that straddled the split boundary and floated over the Browser pane.
+    expect(toast.closest('.project-actions-toast-anchor')).toBeTruthy();
     expect(toast.closest('.chat-log-wrap')?.className).toContain('has-chat-log-tray');
   });
 


### PR DESCRIPTION
Fixes #5413

## Why

I picked up #5413 from the community queue. In the browser-assisted website-extraction recovery flow, when Open Design can't read the browser page, the error toast (e.g. "Cannot read the browser page…") rendered on the shared global, viewport-fixed `.od-toast` surface. In split view that centered it on the whole window, so it straddled the pane boundary, floated over the right Browser pane near the composer, and read as a low-contrast / wrongly layered popover (the reporter perceived it as "content bleeding through").

The sibling **Download Page** guide toast in the *same* flow was already migrated off the global surface into an in-flow chat-pane tray in #5403 (`Fixes #5345`) via `scope: 'chat-pane'`. The recovery-path **error** toasts were simply left behind on the global surface this PR brings them in line.

## What users will see

During browser-assisted extraction, the recovery error confirmations ("Cannot read the browser page…", the retry/daemon-failure messages) now appear in the in-flow tray at the bottom of the left extraction transcript, immediately above the composer — the same place the Download Page guide already shows. They no longer straddle the split boundary or float over the right Browser pane. Other project-action toasts (create design system, duplicate project, finalize, etc.) keep their existing global placement.

## Surface area

- [x] **UI**: browser-assist recovery error toast placement in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**: none added (reuses existing `chat.brandBrowserAssist*` strings)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Before (from #5413): the red error toast is viewport-centered, straddling the split boundary and overlapping the Browser pane near the composer.

<img width="715" height="396" alt="image" src="https://github.com/user-attachments/assets/0558c338-26a0-4558-9827-9411d7988074" />

After: the error toast renders in the in-flow chat-pane tray above the composer (same surface as the already-migrated Download Page guide toast in #5403). Consistent with the existing `.project-actions-toast-anchor` presentation.

<img width="451" height="313" alt="image" src="https://github.com/user-attachments/assets/ced941da-3406-4f48-b42f-b79125d0f915" />


## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.run-cleanup.test.tsx` → `anchors the brand browser-assist extraction error toast in the chat pane instead of the global toast surface`
- Did the test go red on `main` and green on this branch? **yes**: the spec drives `onContinueBrandExtraction` into the daemon-failure branch and asserts the `tone-error` toast is inside `.project-actions-toast-anchor`. It fails on the unmodified source (toast renders on the global surface) and passes with the `scope: 'chat-pane'` change.

## Validation

- `pnpm --filter @open-design/web test -- --run ProjectView.run-cleanup` → 64 passed
- `pnpm --filter @open-design/web typecheck` → clean
- `pnpm guard` → 78 passed
- `pnpm typecheck` (root) → clean