### PR TITLE
fix(web): confirm successful manual edits

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6554,6 +6554,8 @@ function HtmlViewer({
   }, [boardImages]);
   const [commentSavedToast, setCommentSavedToast] = useState<string | null>(null);
   const [templateSavedToast, setTemplateSavedToast] = useState<string | null>(null);
+  const [manualEditSavedToast, setManualEditSavedToast] = useState<{ id: number; message: string } | null>(null);
+  const manualEditSavedToastIdRef = useRef(0);
   const [deploySavedToast, setDeploySavedToast] = useState<{ message: string; details: string } | null>(null);
   const [deployActionToast, setDeployActionToast] = useState<string | null>(null);
   const [versionRestoredToast, setVersionRestoredToast] = useState<{ id: number; message: string } | null>(null);
@@ -8423,6 +8425,9 @@ function HtmlViewer({
   }
 
   async function saveManualEditPanelDraft() {
+    // A new save attempt must not leave a previous success visible while the
+    // next persistence result is still pending.
+    setManualEditSavedToast(null);
     const selectedTarget = selectedManualEditTarget;
     const contentPatchBeforeText = selectedTarget
       ? manualEditContentPatchForDraft(selectedTarget, manualEditDraft, sourceRef.current ?? '')
@@ -8434,13 +8439,25 @@ function HtmlViewer({
     const inlineTextCommitted =
       hadTextCommitInFlight ||
       manualEditTextCommitSequenceRef.current !== textCommitSequenceBeforeSave;
+    let didPersist = inlineTextCommitted;
     if (selectedTarget && (panelContentChanged || !inlineTextCommitted)) {
       const base = sourceRef.current ?? '';
       const contentPatch = manualEditContentPatchForDraft(selectedTarget, manualEditDraft, base);
-      if (contentPatch && !(await applyManualEdit(contentPatch.patch, contentPatch.label))) return;
+      if (contentPatch) {
+        if (!(await applyManualEdit(contentPatch.patch, contentPatch.label))) return;
+        didPersist = true;
+      }
     }
+    const hadPendingStyleSave = Boolean(manualEditPendingStyleRef.current);
     const ok = await flushManualEditStyleSave();
     if (!ok) return;
+    if (didPersist || hadPendingStyleSave) {
+      manualEditSavedToastIdRef.current += 1;
+      setManualEditSavedToast({
+        id: manualEditSavedToastIdRef.current,
+        message: t('manualEdit.saved'),
+      });
+    }
     if (selectedManualEditTarget) void clearManualEditTargetSelection();
     else setManualEditPageStylesOpen(false);
   }
@@ -12106,6 +12123,23 @@ function HtmlViewer({
                   />
                 </div>
               ) : null}
+              {manualEditSavedToast
+                ? createPortal(
+                    <Toast
+                      key={manualEditSavedToast.id}
+                      message={manualEditSavedToast.message}
+                      tone="success"
+                      ttlMs={2200}
+                      placement="top"
+                      onDismiss={() => {
+                        setManualEditSavedToast((current) => (
+                          current?.id === manualEditSavedToast.id ? null : current
+                        ));
+                      }}
+                    />,
+                    document.body,
+                  )
+                : null}
               {templateSavedToast ? (
                 <div className="comment-toast-anchor">
                   <Toast

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -2711,6 +2711,7 @@ export const ar: Dict = {
   'manualEdit.applyAttributes': 'تطبيق السمات',
   'manualEdit.applyHtml': 'تطبيق HTML',
   'manualEdit.applySource': 'تطبيق المصدر',
+  'manualEdit.saved': 'تم الحفظ',
   'manualEdit.invalidAttributes': 'السمات بصيغة JSON غير صالحة.',
   'manualEdit.changes': 'التغييرات',
   'manualEdit.undo': 'تراجع',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -2711,6 +2711,7 @@ export const de: Dict = {
   'manualEdit.applyAttributes': 'Attribute übernehmen',
   'manualEdit.applyHtml': 'HTML übernehmen',
   'manualEdit.applySource': 'Quelle übernehmen',
+  'manualEdit.saved': 'Gespeichert',
   'manualEdit.invalidAttributes': 'Ungültiges Attribute-JSON.',
   'manualEdit.changes': 'Änderungen',
   'manualEdit.undo': 'Rückgängig',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -2725,6 +2725,7 @@ export const en: Dict = {
   'manualEdit.applyAttributes': 'Apply Attributes',
   'manualEdit.applyHtml': 'Apply HTML',
   'manualEdit.applySource': 'Apply Source',
+  'manualEdit.saved': 'Saved',
   'manualEdit.invalidAttributes': 'Invalid attributes JSON.',
   'manualEdit.changes': 'Changes',
   'manualEdit.undo': 'Undo',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -2711,6 +2711,7 @@ export const esES: Dict = {
   'manualEdit.applyAttributes': 'Aplicar atributos',
   'manualEdit.applyHtml': 'Aplicar HTML',
   'manualEdit.applySource': 'Aplicar código fuente',
+  'manualEdit.saved': 'Guardado',
   'manualEdit.invalidAttributes': 'JSON de atributos no válido.',
   'manualEdit.changes': 'Cambios',
   'manualEdit.undo': 'Deshacer',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -2711,6 +2711,7 @@ export const fa: Dict = {
   'manualEdit.applyAttributes': 'اعمال ویژگی‌ها',
   'manualEdit.applyHtml': 'اعمال HTML',
   'manualEdit.applySource': 'اعمال منبع',
+  'manualEdit.saved': 'ذخیره شد',
   'manualEdit.invalidAttributes': 'JSON ویژگی‌ها نامعتبر است.',
   'manualEdit.changes': 'تغییرات',
   'manualEdit.undo': 'واگرد',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -2711,6 +2711,7 @@ export const fr: Dict = {
   'manualEdit.applyAttributes': 'Appliquer les attributs',
   'manualEdit.applyHtml': 'Appliquer le HTML',
   'manualEdit.applySource': 'Appliquer la source',
+  'manualEdit.saved': 'Enregistré',
   'manualEdit.invalidAttributes': 'JSON d’attributs invalide.',
   'manualEdit.changes': 'Modifications',
   'manualEdit.undo': 'Annuler',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -2711,6 +2711,7 @@ export const hu: Dict = {
   'manualEdit.applyAttributes': 'Attribútumok alkalmazása',
   'manualEdit.applyHtml': 'HTML alkalmazása',
   'manualEdit.applySource': 'Forrás alkalmazása',
+  'manualEdit.saved': 'Mentve',
   'manualEdit.invalidAttributes': 'Érvénytelen attribútumok JSON.',
   'manualEdit.changes': 'Módosítások',
   'manualEdit.undo': 'Visszavonás',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -2711,6 +2711,7 @@ export const id: Dict = {
   'manualEdit.applyAttributes': 'Terapkan atribut',
   'manualEdit.applyHtml': 'Terapkan HTML',
   'manualEdit.applySource': 'Terapkan sumber',
+  'manualEdit.saved': 'Tersimpan',
   'manualEdit.invalidAttributes': 'JSON atribut tidak valid.',
   'manualEdit.changes': 'Perubahan',
   'manualEdit.undo': 'Undo',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -2711,6 +2711,7 @@ export const it: Dict = {
   'manualEdit.applyAttributes': 'Applica attributi',
   'manualEdit.applyHtml': 'Applica HTML',
   'manualEdit.applySource': 'Applica sorgente',
+  'manualEdit.saved': 'Salvato',
   'manualEdit.invalidAttributes': 'JSON degli attributi non valido.',
   'manualEdit.changes': 'Modifiche',
   'manualEdit.undo': 'Annulla',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -2711,6 +2711,7 @@ export const ja: Dict = {
   'manualEdit.applyAttributes': '属性を適用',
   'manualEdit.applyHtml': 'HTML を適用',
   'manualEdit.applySource': 'ソースを適用',
+  'manualEdit.saved': '保存済み',
   'manualEdit.invalidAttributes': '属性 JSON が無効です。',
   'manualEdit.changes': '変更',
   'manualEdit.undo': '元に戻す',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -2711,6 +2711,7 @@ export const ko: Dict = {
   'manualEdit.applyAttributes': '속성 적용',
   'manualEdit.applyHtml': 'HTML 적용',
   'manualEdit.applySource': '소스 적용',
+  'manualEdit.saved': '저장됨',
   'manualEdit.invalidAttributes': '유효하지 않은 속성 JSON입니다.',
   'manualEdit.changes': '변경 사항',
   'manualEdit.undo': '실행 취소',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -2711,6 +2711,7 @@ export const pl: Dict = {
   'manualEdit.applyAttributes': 'Zastosuj atrybuty',
   'manualEdit.applyHtml': 'Zastosuj HTML',
   'manualEdit.applySource': 'Zastosuj źródło',
+  'manualEdit.saved': 'Zapisano',
   'manualEdit.invalidAttributes': 'Nieprawidłowe atrybuty JSON.',
   'manualEdit.changes': 'Zmiany',
   'manualEdit.undo': 'Cofnij',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -2711,6 +2711,7 @@ export const ptBR: Dict = {
   'manualEdit.applyAttributes': 'Aplicar atributos',
   'manualEdit.applyHtml': 'Aplicar HTML',
   'manualEdit.applySource': 'Aplicar código-fonte',
+  'manualEdit.saved': 'Salvo',
   'manualEdit.invalidAttributes': 'JSON de atributos inválido.',
   'manualEdit.changes': 'Alterações',
   'manualEdit.undo': 'Desfazer',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -2711,6 +2711,7 @@ export const ru: Dict = {
   'manualEdit.applyAttributes': 'Применить атрибуты',
   'manualEdit.applyHtml': 'Применить HTML',
   'manualEdit.applySource': 'Применить исходный код',
+  'manualEdit.saved': 'Сохранено',
   'manualEdit.invalidAttributes': 'Некорректный JSON атрибутов.',
   'manualEdit.changes': 'Изменения',
   'manualEdit.undo': 'Отменить',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -2711,6 +2711,7 @@ export const th: Dict = {
   'manualEdit.applyAttributes': 'รับพิกัดเข้า',
   'manualEdit.applyHtml': 'ตั้งต้น HTML',
   'manualEdit.applySource': 'รับโค้ดรันระบบ',
+  'manualEdit.saved': 'บันทึกแล้ว',
   'manualEdit.invalidAttributes': 'JSON แอททริบิวต์ใช้งานจริงไม่ได้',
   'manualEdit.changes': 'จุดถูกแก้แล้ว',
   'manualEdit.undo': 'กลับไปเก่า',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -2711,6 +2711,7 @@ export const tr: Dict = {
   'manualEdit.applyAttributes': 'Öznitelikleri Uygula',
   'manualEdit.applyHtml': 'HTML Uygula',
   'manualEdit.applySource': 'Kaynağı Uygula',
+  'manualEdit.saved': 'Kaydedildi',
   'manualEdit.invalidAttributes': 'Geçersiz öznitelikler JSON\'u.',
   'manualEdit.changes': 'Değişiklikler',
   'manualEdit.undo': 'Geri al',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -2711,6 +2711,7 @@ export const uk: Dict = {
   'manualEdit.applyAttributes': 'Застосувати атрибути',
   'manualEdit.applyHtml': 'Застосувати HTML',
   'manualEdit.applySource': 'Застосувати джерело',
+  'manualEdit.saved': 'Збережено',
   'manualEdit.invalidAttributes': 'Некоректний JSON атрибутів.',
   'manualEdit.changes': 'Зміни',
   'manualEdit.undo': 'Скасувати',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -2925,6 +2925,7 @@ export const zhCN: Dict = {
   "manualEdit.applyAttributes": "应用属性",
   "manualEdit.applyHtml": "应用 HTML",
   "manualEdit.applySource": "应用源码",
+  "manualEdit.saved": "已保存",
   "manualEdit.invalidAttributes": "属性 JSON 格式无效。",
   "manualEdit.changes": "修改记录",
   "manualEdit.undo": "撤销",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -2934,6 +2934,7 @@ export const zhTW: Dict = {
   "manualEdit.applyAttributes": "套用屬性",
   "manualEdit.applyHtml": "套用 HTML",
   "manualEdit.applySource": "套用原始碼",
+  "manualEdit.saved": "已儲存",
   "manualEdit.invalidAttributes": "屬性 JSON 無效。",
   "manualEdit.changes": "變更",
   "manualEdit.undo": "復原",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -3489,6 +3489,7 @@ export interface Dict {
   'manualEdit.applyAttributes': string;
   'manualEdit.applyHtml': string;
   'manualEdit.applySource': string;
+  'manualEdit.saved': string;
   'manualEdit.invalidAttributes': string;
   'manualEdit.changes': string;
   'manualEdit.undo': string;

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -62,6 +62,126 @@ afterEach(() => {
 });
 
 describe('FileViewer manual edit history regressions', () => {
+  it('shows success feedback only after a manual edit save is persisted', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero">Hero</h1></body></html>';
+    let saveResolve!: (value: Response) => void;
+    const saveResponse = new Promise<Response>((resolve) => {
+      saveResolve = resolve;
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/projects/project-1/deployments')) {
+        return new Response(JSON.stringify({ deployments: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+        return saveResponse;
+      }
+      if (url.includes('/api/projects/project-1/raw/preview.html')) {
+        return new Response(initialSource, { status: 200 });
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    await selectManualEditTarget();
+
+    act(() => {
+      panelState.props?.onSaveDraft();
+    });
+    await waitFor(() => expect(screen.queryByTestId('mock-manual-edit-panel')).toBeNull());
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(fetchMock.mock.calls.filter(([input, init]) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      return url.includes('/api/projects/project-1/files') && init?.method === 'POST';
+    })).toHaveLength(0);
+
+    await selectManualEditTarget();
+    act(() => {
+      const draft = panelState.props?.draft;
+      if (!draft) throw new Error('Manual edit draft not found');
+      panelState.props?.onDraftChange({ ...draft, text: 'Updated hero' });
+    });
+    await waitFor(() => expect(panelState.props?.draft.text).toBe('Updated hero'));
+
+    act(() => {
+      panelState.props?.onSaveDraft();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/projects/project-1/files'),
+      expect.objectContaining({ method: 'POST' }),
+    ));
+    expect(screen.queryByRole('status')).toBeNull();
+
+    await act(async () => {
+      saveResolve(new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      await saveResponse;
+    });
+
+    const status = await screen.findByRole('status');
+    expect(status.textContent).toContain('Saved');
+    expect(status.classList.contains('placement-top')).toBe(true);
+    expect(status.parentElement).toBe(document.body);
+  });
+
+  it('does not show success feedback when a manual edit save fails', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero">Hero</h1></body></html>';
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/projects/project-1/deployments')) {
+        return new Response(JSON.stringify({ deployments: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ error: 'Write failed' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/raw/preview.html')) {
+        return new Response(initialSource, { status: 200 });
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    await selectManualEditTarget();
+    act(() => {
+      const draft = panelState.props?.draft;
+      if (!draft) throw new Error('Manual edit draft not found');
+      panelState.props?.onDraftChange({ ...draft, text: 'Updated hero' });
+    });
+    await waitFor(() => expect(panelState.props?.draft.text).toBe('Updated hero'));
+
+    act(() => {
+      panelState.props?.onSaveDraft();
+    });
+
+    await waitFor(() => expect(panelState.props?.error).toBeTruthy());
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
   it('flushes pending style edits before activating draw mode from manual edit', async () => {
     const initialSource = '<!doctype html><html><body><h1 data-od-id="hero" style="color: #111111">Hero</h1></body></html>';
     let saveResolve!: (value: Response) => void;


### PR DESCRIPTION
Fixes #2905

## Why

While editing an HTML artifact through the Manual editor, Save closed the inspector without any positive confirmation. That made a successful write look indistinguishable from a no-op or a failed request.

This is a focused fix for the assigned issue: confirm a real successful manual-edit persistence without weakening the existing error path or changing other editor actions.

## What users will see

After a Manual editor Save actually persists a content, inline-text, or pending style change, Open Design shows a localized green `Saved` toast with a check icon. The confirmation appears only after persistence resolves, is announced through a polite status live region, can be dismissed, and expires after 2.2 seconds.

No-op Saves and failed writes do not show the success message. Starting another Save clears any prior confirmation while the next request is pending.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: Manual editor with the changed heading and Save action visible.

![Before — Manual editor before persistence](https://gist.githubusercontent.com/roian6/5bb24321d47f59c0fd9a894f17b677a9/raw/fd4ffb78fa6c970c2f18307467ba9814e63cb09b/before-save.png)

After: persisted heading plus the localized success toast.

![After — persisted edit with Saved confirmation](https://gist.githubusercontent.com/roian6/5bb24321d47f59c0fd9a894f17b677a9/raw/d74d810e40e7446fe1bc7aa6bbb388b7448aa211/after-save.png)

## Bug fix verification

- Test path: `apps/web/tests/components/FileViewer.manual-edit-history.test.tsx`
- Yes. The success-ordering test went red on `main` because no status appeared, the portal placement assertion caught the preview stacking-context clipping, and the no-op assertion caught an incorrect success. It is green on this branch.
- Coverage verifies no success before persistence, success after a confirmed write, no success for a no-op, no success on write failure, body-portal/top placement, and preservation of the existing error path.

## Validation

- `pnpm guard` — passed (78/78 guard tests)
- `pnpm typecheck` — passed across the workspace
- `pnpm --filter @open-design/web exec vitest run tests/components/FileViewer.manual-edit-history.test.tsx tests/components/Toast.test.tsx tests/i18n/locales.test.ts` — passed (30/30)
- Isolated real daemon/web Playwright check — passed: edited `Before save` to `After save`, confirmed persisted source, `role="status"`, `aria-live="polite"`, visible success/check treatment, body portal at z-index 1200, automatic dismissal after 2.2 seconds, and zero console/HTTP errors
- `git diff --check` and targeted secret scan — passed
- Full `pnpm --filter @open-design/web test` did not complete green: 4 failures were confined to `tests/components/App.connectors.test.tsx` (4 failed, 4,288 passed, 7 skipped). The primary privacy-consent assertion reproduced on a clean worktree at unchanged base `fb9ae974`, so it is recorded as a baseline failure rather than hidden.
