### PR TITLE
Fix Windows-generated artifact previews

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2863,7 +2863,12 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
   }
 
   function encodeProjectPathForUrl(filePath: string): string {
-    return filePath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+    return filePath
+      .replace(/\\/g, '/')
+      .split('/')
+      .filter((segment) => segment.length > 0)
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
   }
 
   async function maybeResolveVitePreviewHtml({
@@ -3335,13 +3340,16 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     }
   });
 
-  app.get('/api/projects/:id/files/:name/preview', async (req, res) => {
+  app.get(/^\/api\/projects\/([^/]+)\/files\/(.+)\/preview$/u, async (req, res) => {
     try {
-      const project = getProject(db, req.params.id);
+      const params = req.params as unknown as { 0?: string; 1?: string };
+      const projectId = String(params[0] ?? '');
+      const relPath = String(params[1] ?? '');
+      const project = getProject(db, projectId);
       const file = await readProjectFile(
         PROJECTS_DIR,
-        req.params.id,
-        req.params.name,
+        projectId,
+        relPath,
         project?.metadata,
       );
       const preview = await buildDocumentPreview(file);

--- a/apps/daemon/tests/project-upload-subdir-path.test.ts
+++ b/apps/daemon/tests/project-upload-subdir-path.test.ts
@@ -11,7 +11,7 @@
 // a subdirectory in the desired name must survive name resolution.
 
 import { describe, expect, it } from 'vitest';
-import { sanitizeName, sanitizePath } from '../src/projects.js';
+import { sanitizeName, sanitizePath, validateProjectPath } from '../src/projects.js';
 
 describe('project upload name resolution preserves subdirectories', () => {
   it('sanitizeName flattens a subdirectory path (the pre-fix behavior)', () => {
@@ -22,6 +22,11 @@ describe('project upload name resolution preserves subdirectories', () => {
   it('sanitizePath keeps the subdirectory the design-kit uploader intends', () => {
     expect(sanitizePath('imagery/hero.png')).toBe('imagery/hero.png');
     expect(sanitizePath('logos/wordmark.svg')).toBe('logos/wordmark.svg');
+  });
+
+  it('normalizes Windows separators to project-relative URL paths', () => {
+    expect(validateProjectPath(String.raw`preview\index.html`)).toBe('preview/index.html');
+    expect(validateProjectPath(String.raw`preview\assets\hero.png`)).toBe('preview/assets/hero.png');
   });
 
   it('sanitizePath rejects traversal and sanitizes each segment', () => {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1660,6 +1660,15 @@ export function projectFileUrl(projectId: string, name: string): string {
   return projectRawUrl(projectId, name);
 }
 
+function encodeProjectPathForUrl(filePath: string): string {
+  return filePath
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
 export interface ProjectFilePreviewSection {
   title: string;
   lines: string[];
@@ -1676,8 +1685,10 @@ export async function fetchProjectFilePreview(
   name: string,
 ): Promise<ProjectFilePreview | null> {
   try {
+    const safePath = encodeProjectPathForUrl(name);
+    if (!safePath) return null;
     const resp = await fetch(
-      `/api/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(name)}/preview`,
+      `/api/projects/${encodeURIComponent(projectId)}/files/${safePath}/preview`,
     );
     if (!resp.ok) return null;
     return (await resp.json()) as ProjectFilePreview;
@@ -1729,17 +1740,13 @@ export async function fetchProjectFileTextPreview(
   name: string,
   options?: { limit?: number; cacheBustKey?: string | number },
 ): Promise<ProjectFileTextPreviewResponse | null> {
-  const segments = name
-    .split('/')
-    .filter((segment) => segment.length > 0)
-    .map(encodeURIComponent)
-    .join('/');
-  if (!segments) return null;
+  const safePath = encodeProjectPathForUrl(name);
+  if (!safePath) return null;
   const params = new URLSearchParams();
   if (options?.limit != null) params.set('limit', String(options.limit));
   if (options?.cacheBustKey != null) params.set('cacheBust', String(options.cacheBustKey));
   const query = params.toString();
-  const url = `/api/projects/${encodeURIComponent(projectId)}/text-preview/${segments}${query ? `?${query}` : ''}`;
+  const url = `/api/projects/${encodeURIComponent(projectId)}/text-preview/${safePath}${query ? `?${query}` : ''}`;
 
   try {
     const resp = await fetch(url, { cache: 'no-store' });
@@ -2139,10 +2146,7 @@ export async function uploadProjectFiles(
 export function projectRawUrl(projectId: string, filePath: string): string {
   // Encode each path segment individually so a slash inside the file
   // path stays a path separator, not %2F.
-  const safePath = filePath
-    .split('/')
-    .map((seg) => encodeURIComponent(seg))
-    .join('/');
+  const safePath = encodeProjectPathForUrl(filePath);
   return `/api/projects/${encodeURIComponent(projectId)}/raw/${safePath}`;
 }
 

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -16,10 +16,13 @@ import {
   fetchPluginExampleHtml,
   fetchPluginPreviewHtml,
   fetchProjectDesignSystemPackageAudit,
+  fetchProjectFilePreview,
   fetchProjectFileText,
+  fetchProjectFileTextPreview,
   fetchSkillExample,
   isDeployProviderId,
   openFolderDialog,
+  projectRawUrl,
   updateDeployConfig,
   uploadProjectFiles,
   writeProjectTextFileDetailed,
@@ -151,6 +154,63 @@ describe('writeProjectTextFileDetailed', () => {
       code: 'ARTIFACT_REGRESSION',
       message: 'new artifact is smaller than the prior version',
     });
+  });
+});
+
+describe('project file preview URLs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('normalizes Windows separators when building raw project file URLs', () => {
+    expect(projectRawUrl('project 1', String.raw`preview\index.html`))
+      .toBe('/api/projects/project%201/raw/preview/index.html');
+    expect(projectRawUrl('project 1', String.raw`preview\assets\hero image.png`))
+      .toBe('/api/projects/project%201/raw/preview/assets/hero%20image.png');
+  });
+
+  it('fetches document previews through normalized project path segments', async () => {
+    const preview = { kind: 'document', title: 'Artifact', sections: [] };
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(preview), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchProjectFilePreview('project 1', String.raw`preview\artifact.docx`))
+      .resolves.toEqual(preview);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/project%201/files/preview/artifact.docx/preview',
+    );
+  });
+
+  it('fetches text previews through normalized project path segments', async () => {
+    const textPreview = {
+      text: '<!doctype html>',
+      truncated: false,
+      size: 15,
+      limit: 1024,
+      mime: 'text/html',
+      kind: 'html',
+      poweredPreview: { required: false, scannedBytes: 15, complete: true },
+    };
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(textPreview), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchProjectFileTextPreview('project 1', String.raw`preview\index.html`, {
+      cacheBustKey: 'mtime',
+      limit: 4096,
+    })).resolves.toEqual(textPreview);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/project%201/text-preview/preview/index.html?limit=4096&cacheBust=mtime',
+      { cache: 'no-store' },
+    );
   });
 });
 


### PR DESCRIPTION
Closes #764

## Why

Windows-generated artifact paths can enter the preview flow with backslash separators. The app already normalizes those paths when resolving project files on disk, but the web preview URL builders encoded the backslashes as literal `%5C` characters instead of path separators. That made generated HTML and supporting preview fetches fail even though the artifact appeared in Design Files.

This fixes the Windows preview feedback loop so generated artifacts can be opened consistently from the file list.

## What users will see

Opening a generated artifact whose path came from Windows now loads the same preview URL shape as other platforms. Nested files such as `preview\\index.html` resolve as `preview/index.html`, including raw HTML loads, text previews, and document preview fetches.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — existing project file preview route now accepts nested path segments consistently with raw/text preview routes
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — Windows-style artifact paths now preview as their POSIX-normalized project paths
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A: no visible UI chrome changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/registry.test.ts` (`project file preview URLs`) and `apps/daemon/tests/project-upload-subdir-path.test.ts`
- Did the test go red on `main` and green on this branch? No. I could not run the test suite locally because this environment has no `node`, `npm`, `corepack`, or `pnpm` on PATH.

## Validation

Attempted but blocked by missing local Node toolchain:

- `pnpm --filter @open-design/web test -- apps/web/tests/providers/registry.test.ts` -> `pnpm: command not found`
- `pnpm --filter @open-design/daemon test -- apps/daemon/tests/project-upload-subdir-path.test.ts` -> `pnpm: command not found`
- `pnpm guard` / `pnpm typecheck` not run for the same reason

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>