### PR TITLE
fix(daemon): add missing imports for scanRunEventsForUsageAnalytics and detectSkillPluginCandidate

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -120,6 +120,8 @@ import {
   scanRunEventsForFinishedProps,
   scanRunEventsForRetrySideEffects,
 } from './runtimes/run-lifecycle-analytics.js';
+import { scanRunEventsForUsageAnalytics } from './run-analytics-observability.js';
+import { detectSkillPluginCandidate } from './plugins/skill-candidates.js';
 export {
   composeLiveInstructionPrompt,
   formatDesignFilesWorkspaceHint,


### PR DESCRIPTION
Two standalone functions referenced in server.ts were never imported, causing silent ReferenceErrors caught and swallowed by .catch handlers:

- **scanRunEventsForUsageAnalytics** (from `run-analytics-observability.ts`) — devloop tokens_used reconciliation silently threw on every run. Partial fix for #5433 (import side).
- **detectSkillPluginCandidate** (from `plugins/skill-candidates.ts`) — skill candidate detection silently threw on every run completion. No issue filed yet.

Both errors have been silently failing since the functions were introduced in their respective refactors. The .catch wrappers prevented crashes but meant the features were permanently disabled.

## Changes
```
apps/daemon/src/server.ts | 2 ++
```
