### PR TITLE
fix(web): show plugin import errors inside the import modal (#5418)

### DIFF
--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -184,19 +184,22 @@ export function PluginsView({
   async function finishImport(
     work: () => Promise<PluginInstallOutcome>,
     targetTab: PluginsTab = 'installed',
+    options?: { suppressFailureNotice?: boolean },
   ) {
     setNotice(null);
     const outcome = await work();
     if (outcome.ok) {
-      // Only the success path publishes to the page-level Notice. Failure
-      // outcomes are now surfaced inline inside the import modal (see
-      // PluginImportModal), so we no longer push failure notices to the
-      // page banner — that banner sits behind the modal backdrop and was
-      // effectively invisible while the modal stayed open on failure.
       setNotice(outcome);
       setImportOpen(false);
       await refresh();
       setActiveTab(targetTab);
+    } else if (!options?.suppressFailureNotice) {
+      // Failure on the page-level (non-modal) path: surface it via the
+      // page Notice banner. The modal path skips this because the banner
+      // sits behind the modal backdrop and is invisible while the modal
+      // stays open on failure — the modal renders its own inline Notice
+      // (see `importError` state in PluginImportModal).
+      setNotice(outcome);
     }
     return outcome;
   }
@@ -621,9 +624,21 @@ export function PluginsView({
       {importOpen ? (
         <PluginImportModal
           onClose={() => setImportOpen(false)}
-          onInstallSource={(source) => finishImport(() => installPluginSource(source))}
-          onUploadZip={(file) => finishImport(() => uploadPluginZip(file))}
-          onUploadFolder={(files) => finishImport(() => uploadPluginFolder(files))}
+          onInstallSource={(source) =>
+            finishImport(() => installPluginSource(source), 'installed', {
+              suppressFailureNotice: true,
+            })
+          }
+          onUploadZip={(file) =>
+            finishImport(() => uploadPluginZip(file), 'installed', {
+              suppressFailureNotice: true,
+            })
+          }
+          onUploadFolder={(files) =>
+            finishImport(() => uploadPluginFolder(files), 'installed', {
+              suppressFailureNotice: true,
+            })
+          }
         />
       ) : null}
     </section>

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -187,8 +187,13 @@ export function PluginsView({
   ) {
     setNotice(null);
     const outcome = await work();
-    setNotice(outcome);
     if (outcome.ok) {
+      // Only the success path publishes to the page-level Notice. Failure
+      // outcomes are now surfaced inline inside the import modal (see
+      // PluginImportModal), so we no longer push failure notices to the
+      // page banner — that banner sits behind the modal backdrop and was
+      // effectively invisible while the modal stayed open on failure.
+      setNotice(outcome);
       setImportOpen(false);
       await refresh();
       setActiveTab(targetTab);
@@ -1560,6 +1565,7 @@ function PluginImportModal({
   const [zipFile, setZipFile] = useState<File | null>(null);
   const [folderFiles, setFolderFiles] = useState<File[]>([]);
   const [working, setWorking] = useState(false);
+  const [importError, setImportError] = useState<PluginInstallOutcome | null>(null);
 
   function selectKind(next: ImportKind) {
     trackPluginImportModalClick(analytics.track, {
@@ -1569,6 +1575,12 @@ function PluginImportModal({
       import_source: next,
     });
     setKind(next);
+    setImportError(null);
+  }
+
+  function handleClose() {
+    setImportError(null);
+    onClose();
   }
 
   async function runImport() {
@@ -1579,6 +1591,7 @@ function PluginImportModal({
       import_source: kind,
     });
     setWorking(true);
+    setImportError(null);
     try {
       let outcome: PluginInstallOutcome | null = null;
       if (kind === 'github') {
@@ -1597,6 +1610,12 @@ function PluginImportModal({
           result: outcome.ok ? 'success' : 'failed',
           ...(outcome.ok ? {} : { error_code: outcome.message ?? 'unknown' }),
         });
+        if (!outcome.ok) {
+          // Surface the failure inside the modal instead of relying on the
+          // page-level Notice banner (which sits behind the modal backdrop
+          // and is invisible while the modal stays open on failure).
+          setImportError(outcome);
+        }
       }
     } finally {
       setWorking(false);
@@ -1609,7 +1628,7 @@ function PluginImportModal({
     (kind === 'folder' && folderFiles.length > 0);
 
   return (
-    <div className="plugins-import-modal__backdrop" role="presentation" onMouseDown={onClose}>
+    <div className="plugins-import-modal__backdrop" role="presentation" onMouseDown={handleClose}>
       <section
         className="plugins-import-modal"
         role="dialog"
@@ -1625,7 +1644,7 @@ function PluginImportModal({
           <button
             type="button"
             className="plugins-import-modal__close"
-            onClick={onClose}
+            onClick={handleClose}
             aria-label="Close import dialog"
           >
             <Icon name="close" size={16} />
@@ -1714,6 +1733,7 @@ function PluginImportModal({
             />
           ) : null}
 
+          {importError ? <Notice outcome={importError} /> : null}
         </div>
 
         <footer className="plugins-import-modal__foot">
@@ -1730,7 +1750,7 @@ function PluginImportModal({
                 area: 'import_modal',
                 element: 'cancel',
               });
-              onClose();
+              handleClose();
             }}
           >
             Cancel


### PR DESCRIPTION
Closes #5418

## Problem

Plugin import failures were only surfaced at the page-level `Notice` banner (line 401), which sits behind the modal backdrop and is invisible while the import modal stays open on failure. The user looking at the modal saw nothing — the error appeared "hidden at the bottom of the underlying page" as described in the issue.

## Solution

Route the failure outcome through `PluginImportModal` via a new `importError` state and render the existing `Notice` component inline inside the modal body, matching the `FigmaImportModal` inline-error pattern. Clear the error on tab switch, modal close, and new import attempts.

`finishImport` no longer pushes failure outcomes to the page-level `Notice` — only the success path does. The page banner still confirms a successful import as before (and the modal auto-closes on success, so the banner is visible). Failure messaging now lives entirely inside the modal where the user took the action.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/components/PluginsView.tsx` | +24 / −4 — add `importError` state to `PluginImportModal`, route failure outcomes inline, add `handleClose` wrapper, gate success-only `setNotice` in `finishImport` |

## Test plan

1. Open Plugins → Import a plugin → try importing an invalid folder (no SKILL.md / plugin.json / open-design.json) → **error appears inside the modal, not behind it** ✅
2. Switch import tab → error clears ✅
3. Close and reopen modal → error cleared ✅
4. Successful import → modal closes, page banner shows success as before ✅
