### PR TITLE
fix(web): portal deploy success toast above deploy modal backdrop (#5326)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -12888,7 +12888,7 @@ function HtmlViewer({
         </div>,
         document.body,
       ) : null}
-      {deploySavedToast ? (
+      {deploySavedToast && typeof document !== 'undefined' ? createPortal(
         <Toast
           message={deploySavedToast.message}
           details={deploySavedToast.details}
@@ -12896,7 +12896,8 @@ function HtmlViewer({
           placement="top"
           ttlMs={3600}
           onDismiss={() => setDeploySavedToast(null)}
-        />
+        />,
+        document.body,
       ) : null}
       {deployActionToast && typeof document !== 'undefined' ? createPortal(
         <Toast

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -132,7 +132,7 @@
 .od-toast.placement-top {
   top: 64px;
   bottom: auto;
-  z-index: 1200;
+  z-index: 1800;
 }
 .project-actions-toast-anchor {
   position: relative;


### PR DESCRIPTION
Closes #5326

## Problem

The deploy success toast (`deploySavedToast` in `FileViewer.tsx`) was rendered **inline in the component tree**, not portaled to `document.body`. Adjacent deploy toasts (`deployErrorToast`, `deployActionToast`) ARE portaled to `document.body`. As a result, after a successful deploy credential save inside the Vercel deploy modal:

- The deploy modal backdrop (`z-index: 1700` via `.viewer-modal-backdrop`) covered the success toast.
- The user saw no visible confirmation — the deployment "appeared to do nothing", exactly as described in #5326.

The deeper root cause is that placement-top toasts have `z-index: 1200` (`routines.css`), which is below the modal backdrop's `1700`. Even if the toast were portaled, it would still be hidden behind the backdrop.

## Solution

Two surgical changes:

1. **FileViewer.tsx** — Portal `deploySavedToast` to `document.body` using `createPortal`, mirroring the existing `deployActionToast` 4 lines below. This guarantees the toast renders above the modal subtree in DOM order.

2. **routines.css** — Raise `.od-toast.placement-top` `z-index` from `1200` → `1800` so the toast sits above modal backdrops (`1700`). The in-anchor override `.project-actions-toast-anchor .od-toast.placement-top` (`z-index: 1000`) is unchanged — that lower value is intentional for the in-flow tray variant.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/components/FileViewer.tsx` | +2 / −1 — wrap `deploySavedToast` in `createPortal(...)` to `document.body` |
| `apps/web/src/styles/viewer/routines.css` | +1 / −1 — raise `.od-toast.placement-top` z-index 1200 → 1800 |

## Test plan

1. Open the Vercel deploy modal for an HTML artifact → save deploy credentials
2. **Success toast now renders visible above the modal backdrop** ✅
3. Copy link / other deploy actions inside the modal → toasts visible above backdrop ✅
4. Other placement-top toasts (e.g. browser-assist) render above modal layers ✅
5. In-anchor placement-top toasts (project-actions tray) keep their in-flow z-index 1000 ✅

/cc @AmyShang-alt — bug originally reproduced during PR #3301 QA.
