### PR TITLE
fix(web): add Open Design sign-in button to project details agent menu (#5244)

### DIFF
--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, useCallback, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { AmrWalletSnapshot } from '@open-design/contracts';
 import { getResolvedDeviceId } from '../analytics/client';
-import { amrHandoffDeviceId, attributedAmrUrl, recordAmrEntry } from '../analytics/amr-attribution';
+import {
+  amrHandoffDeviceId,
+  attributedAmrUrl,
+  recordAmrEntry,
+} from '../analytics/amr-attribution';
+import { beginAmrAuthTracking, resolveAmrAuthTracking } from '../analytics/amr-auth';
 import { useAnalytics } from '../analytics/provider';
 import { useT } from '../i18n';
 import { AgentIcon } from './AgentIcon';
@@ -22,9 +27,11 @@ import { apiProtocolLabel } from '../utils/apiProtocol';
 import { fetchProviderModels } from '../providers/provider-models';
 import {
   canUpgradeVelaPlan,
+  cancelVelaLogin,
   fetchAmrWalletSnapshot,
   fetchVelaLoginStatus,
   formatVelaBalanceUsd,
+  startVelaLogin,
   type VelaLoginStatus,
 } from '../providers/daemon';
 import {
@@ -32,6 +39,14 @@ import {
 } from '../runtime/amr-guidance';
 import { isMacPlatform } from '../utils/platform';
 import { isVisibleLocalCliAgent } from '../utils/visibleAgents';
+import {
+  AMR_LOGIN_POLL_INTERVAL_MS,
+  AMR_LOGIN_STARTUP_SETTLE_MS,
+  AMR_LOGIN_STATUS_EVENT,
+  AMR_LOGIN_TIMEOUT_MS,
+  amrLoginPollOutcome,
+  notifyAmrLoginStatusChanged,
+} from './amrLoginPolling';
 
 interface Props {
   config: AppConfig;
@@ -221,6 +236,144 @@ export function AvatarMenu({
       cancelled = true;
     };
   }, [open, amrAvailable]);
+
+  // AMR sign-in flow. The Home page's InlineModelSwitcher has its own copy of
+  // this; AvatarMenu (project details page) used to only render the row when
+  // the user was already signed in, leaving no way to sign in from the project
+  // details agent menu. The shared polling + auth tracking mirrors the
+  // InlineModelSwitcher implementation so cross-surface event broadcasts
+  // (notifyAmrLoginStatusChanged) keep both menus in sync.
+  const [amrLoginPending, setAmrLoginPending] = useState(false);
+  const [amrLoginError, setAmrLoginError] = useState<string | null>(null);
+  const amrPollRef = useRef<number | null>(null);
+  const amrLoginStartedAtRef = useRef<number | null>(null);
+  const amrLoginPendingRef = useRef(false);
+  const amrStopPolling = useCallback(() => {
+    if (amrPollRef.current !== null) {
+      window.clearInterval(amrPollRef.current);
+      amrPollRef.current = null;
+    }
+  }, []);
+  const amrRefreshLoginStatus = useCallback(async () => {
+    const next = await fetchVelaLoginStatus();
+    if (next) setAmrAccount(next);
+    return next;
+  }, []);
+  const amrStartPolling = useCallback(
+    (startedAt: number) => {
+      amrStopPolling();
+      amrLoginStartedAtRef.current = startedAt;
+      const tick = async () => {
+        const next = await amrRefreshLoginStatus();
+        const outcome = amrLoginPollOutcome(next, startedAt);
+        if (outcome === 'signed-in') {
+          resolveAmrAuthTracking(analytics.track, 'success', undefined, {
+            signedInUserId: next?.user?.id ?? null,
+          });
+          notifyAmrLoginStatusChanged();
+          amrStopPolling();
+          amrLoginStartedAtRef.current = null;
+          amrLoginPendingRef.current = false;
+          setAmrLoginPending(false);
+        } else if (outcome === 'timed-out' || outcome === 'stopped') {
+          amrStopPolling();
+          amrLoginStartedAtRef.current = null;
+          amrLoginPendingRef.current = false;
+          setAmrLoginPending(false);
+          if (outcome === 'timed-out') {
+            setAmrLoginError(t('settings.amrLoginErrorCompact'));
+          }
+        }
+      };
+      amrPollRef.current = window.setInterval(tick, AMR_LOGIN_POLL_INTERVAL_MS);
+    },
+    [amrRefreshLoginStatus, amrStopPolling, analytics.track, t],
+  );
+  // Polling cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      amrStopPolling();
+      amrLoginPendingRef.current = false;
+      amrLoginStartedAtRef.current = null;
+    };
+  }, [amrStopPolling]);
+  // React to login status broadcasts from other surfaces (e.g. the Home page
+  //InlineModelSwitcher starting/cancelling a sign-in). When a sign-in succeeds
+  // elsewhere we refresh local state and stop our own poll if one is running.
+  useEffect(() => {
+    const onStatusChange = () => {
+      void amrRefreshLoginStatus().then((next) => {
+        if (next?.loggedIn) {
+          amrStopPolling();
+          amrLoginStartedAtRef.current = null;
+          amrLoginPendingRef.current = false;
+          setAmrLoginPending(false);
+          setAmrLoginError(null);
+        }
+      });
+    };
+    window.addEventListener(AMR_LOGIN_STATUS_EVENT, onStatusChange);
+    return () => {
+      window.removeEventListener(AMR_LOGIN_STATUS_EVENT, onStatusChange);
+    };
+  }, [amrRefreshLoginStatus, amrStopPolling]);
+  const handleAmrSignIn = useCallback(async () => {
+    if (amrLoginPendingRef.current) return;
+    amrLoginPendingRef.current = true;
+    const startedAt = Date.now();
+    amrLoginStartedAtRef.current = startedAt;
+    setAmrLoginError(null);
+    setAmrLoginPending(true);
+    const attribution = recordAmrEntry(
+      analytics.track,
+      'avatar_amr_agent_card',
+      new Date(),
+      { metricsConsent: config.telemetry?.metrics === true },
+    );
+    beginAmrAuthTracking(attribution, startedAt);
+    const odDeviceId = amrHandoffDeviceId({
+      metricsConsent: config.telemetry?.metrics === true,
+      resolvedDeviceId: getResolvedDeviceId(),
+      installationId: config.installationId,
+    });
+    const result = await startVelaLogin(attribution, odDeviceId);
+    if (!result.ok && !result.alreadyRunning) {
+      resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed');
+      amrLoginStartedAtRef.current = null;
+      amrLoginPendingRef.current = false;
+      setAmrLoginPending(false);
+      setAmrLoginError(result.error || t('settings.amrLoginErrorCompact'));
+      return;
+    }
+    notifyAmrLoginStatusChanged('login-started');
+    amrStartPolling(startedAt);
+  }, [amrStartPolling, analytics.track, config.installationId, config.telemetry?.metrics, t]);
+  const handleAmrCancelLogin = useCallback(async () => {
+    resolveAmrAuthTracking(analytics.track, 'cancelled');
+    amrStopPolling();
+    setAmrLoginError(null);
+    const result = await cancelVelaLogin();
+    amrLoginStartedAtRef.current = null;
+    amrLoginPendingRef.current = false;
+    setAmrLoginPending(false);
+    if (!result.ok) {
+      setAmrLoginError(t('settings.amrLoginErrorCompact'));
+      return;
+    }
+    setAmrAccount((current) =>
+      current
+        ? { ...current, loggedIn: false, loginInFlight: false, user: null }
+        : {
+            loggedIn: false,
+            loginInFlight: false,
+            profile: 'default',
+            user: null,
+            configPath: '',
+          },
+    );
+    notifyAmrLoginStatusChanged('login-canceled');
+  }, [amrStopPolling, analytics.track, t]);
+
   const amrPlanTrimmed = amrAccount?.loggedIn
     ? amrAccount.account?.plan?.trim() || ''
     : '';
@@ -483,6 +636,28 @@ export function AvatarMenu({
                         >
                           {t('settings.amrUpgrade')}
                         </a>
+                      ) : null}
+                      {amrAccount && !amrAccount.loggedIn ? (
+                        <button
+                          type="button"
+                          className="avatar-amr-row__sign-in"
+                          data-testid="avatar-amr-signin"
+                          disabled={amrLoginPending}
+                          title={amrLoginPending ? t('settings.amrCancelSignIn') : undefined}
+                          onClick={() => {
+                            if (amrLoginPending) {
+                              void handleAmrCancelLogin();
+                              return;
+                            }
+                            void handleAmrSignIn();
+                          }}
+                        >
+                          {amrLoginPending
+                            ? t('settings.amrSigningIn')
+                            : amrLoginError
+                              ? t('settings.amrAuthorize')
+                              : t('settings.amrSignIn')}
+                        </button>
                       ) : null}
                     </div>
                   );

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -45,6 +45,7 @@ import {
   AMR_LOGIN_STATUS_EVENT,
   AMR_LOGIN_TIMEOUT_MS,
   amrLoginPollOutcome,
+  amrLoginStatusEventReason,
   notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
 
@@ -301,7 +302,19 @@ export function AvatarMenu({
   //InlineModelSwitcher starting/cancelling a sign-in). When a sign-in succeeds
   // elsewhere we refresh local state and stop our own poll if one is running.
   useEffect(() => {
-    const onStatusChange = () => {
+    const onStatusChange = (event: Event) => {
+      const reason = amrLoginStatusEventReason(event);
+      if (reason === 'login-started') {
+        const startedAt = Date.now();
+        amrLoginStartedAtRef.current = startedAt;
+        setAmrLoginError(null);
+        setAmrLoginPending(true);
+        void startAmrPolling(startedAt);
+      } else if (reason === 'login-canceled') {
+        amrLoginStartedAtRef.current = null;
+        setAmrLoginPending(false);
+        setAmrLoginError(null);
+      }
       void amrRefreshLoginStatus().then((next) => {
         if (next?.loggedIn) {
           amrStopPolling();
@@ -316,7 +329,7 @@ export function AvatarMenu({
     return () => {
       window.removeEventListener(AMR_LOGIN_STATUS_EVENT, onStatusChange);
     };
-  }, [amrRefreshLoginStatus, amrStopPolling]);
+  }, [amrRefreshLoginStatus, amrStopPolling, startAmrPolling]);
   const handleAmrSignIn = useCallback(async () => {
     if (amrLoginPendingRef.current) return;
     amrLoginPendingRef.current = true;
@@ -642,7 +655,6 @@ export function AvatarMenu({
                           type="button"
                           className="avatar-amr-row__sign-in"
                           data-testid="avatar-amr-signin"
-                          disabled={amrLoginPending}
                           title={amrLoginPending ? t('settings.amrCancelSignIn') : undefined}
                           onClick={() => {
                             if (amrLoginPending) {

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1240,6 +1240,43 @@
     background-color 150ms ease,
     box-shadow 150ms ease;
 }
+.avatar-amr-row__sign-in {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+}
+.avatar-amr-row__sign-in:disabled {
+  cursor: default;
+  opacity: 0.8;
+}
+@media (hover: hover) and (pointer: fine) {
+  .avatar-amr-row__sign-in:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  }
+}
+.avatar-amr-row__sign-in:active:not(:disabled) {
+  transform: scale(0.96);
+}
+.avatar-amr-row__sign-in:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+}
 @media (hover: hover) and (pointer: fine) {
   .avatar-amr-row__upgrade:hover {
     background: var(--accent-hover);
@@ -1260,6 +1297,12 @@
     transition: background-color 150ms ease;
   }
   .avatar-amr-row__upgrade:active {
+    transform: none;
+  }
+  .avatar-amr-row__sign-in {
+    transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+  }
+  .avatar-amr-row__sign-in:active:not(:disabled) {
     transform: none;
   }
 }


### PR DESCRIPTION
Closes #5244

## Problem

The **Home page** agent/provider menu (InlineModelSwitcher) already shows a login button on the Open Design row when the user is signed out. The **project details page** agent menu (AvatarMenu) only rendered the AMR row with Upgrade and balance info for logged-in users — there was no way to sign in from the project details context, creating a dead-end UX.

## Solution

Add the full AMR sign-in flow to AvatarMenu, mirroring the Home page implementation:

- Login state: `startVelaLogin`, `cancelVelaLogin`, `amrLoginPollOutcome` polling with timeout
- Auth tracking: `beginAmrAuthTracking` / `resolveAmrAuthTracking`
- Cross-surface sync: `AMR_LOGIN_STATUS_EVENT` listener so sign-in state updates from either menu

When `amrAccount?.loggedIn === false`, the AMR row shows a **Sign In** button. When in-flight it shows **Signing in…** (click to cancel). On timeout/error it shows **Authorize** for re-try.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/components/AvatarMenu.tsx` | +177 / −2 — add sign-in state, handlers, polling, event listener, and Login button JSX |
| `apps/web/src/styles/shell.css` | +43 — add `.avatar-amr-row__sign-in` styles matching the existing `__upgrade` button size (22px pill, same row layout) |

## Test plan

1. Open a project detail page while logged out of Open Design → agent menu shows the AMR row with **Sign In** button ✅
2. Click Sign In → button shows **Signing in…** → opens Vela login page in browser ✅
3. Click while signing in → cancels the login flow ✅
4. Complete login in browser → poll detects it → row updates to show plan/balance/Upgrade ✅
5. Home page menu also updates via `AMR_LOGIN_STATUS_EVENT` broadcast ✅
