### PR TITLE
fix(web): scope saved page snapshot popover to Browser pane (#5414)

### DIFF
--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1704,15 +1704,6 @@ export function DesignBrowserPanel({
         message,
         source: 'page-snapshot',
       });
-      emitPageSnapshotToast({
-        actionFileName: manifestFile,
-        actionLabel: t('designBrowser.status.viewDesignFiles'),
-        actionTarget: 'design-files',
-        elapsedSeconds,
-        message,
-        status: 'success',
-        ttlMs: 8000,
-      });
       return {
         ok: true,
         baseUrl: manifest.baseUrl,
@@ -1732,12 +1723,9 @@ export function DesignBrowserPanel({
         message,
         source: 'page-snapshot',
       });
-      emitPageSnapshotToast({
-        elapsedSeconds,
-        message,
-        status: canceled ? 'canceled' : 'error',
-        ttlMs: canceled ? 3000 : 8000,
-      });
+      // Inline status already shows the error/cancellation scoped to the
+      // Browser pane; the global toast is suppressed on terminal outcomes to
+      // prevent the confirmation from straddling the split-pane boundary.
       return { ok: false, message };
     } finally {
       if (archiveRunRef.current?.id === run.id) {
@@ -2171,7 +2159,11 @@ export function DesignBrowserPanel({
   const statusIsPageSnapshot = Boolean(
     statusMessage && typeof statusMessage === 'object' && statusMessage.source === 'page-snapshot',
   );
-  const showStatusMessage = Boolean(statusMessage) && !(statusIsPageSnapshot && onPageSnapshotToast);
+  // Suppress the inline status message while the page-snapshot is actively saving
+  // (the global toast broadcasts elapsed progress every second). On success or
+  // failure show the inline status so the confirmation stays scoped to the
+  // Browser pane instead of straddling the split-pane boundary as a global toast.
+  const showStatusMessage = Boolean(statusMessage) && !(statusIsPageSnapshot && archiveSaving);
 
   return (
     <section className="design-browser" aria-label={t('designBrowser.aria')}>


### PR DESCRIPTION
Closes #5414

## Problem

The saved page snapshot success/error confirmation appears as a global Toast that straddles the split-pane boundary, covering both the left chat pane and right Browser pane. The popover looks anchored to the wrong surface.

Root cause: `DesignBrowserPanel.savePageSnapshot` called both `setStatusMessage` (inline, scoped to Browser pane) AND `emitPageSnapshotToast` (global fixed Toast) on every terminal outcome. The inline status was also suppressed whenever a page-snapshot toast handler was present (line 2174: `!(statusIsPageSnapshot && onPageSnapshotToast)`), so only the global popover was visible.

## Solution

Three related changes in `apps/web/src/components/DesignBrowserPanel.tsx`:

| Change | Lines | Effect |
|--------|-------|--------|
| `showStatusMessage` condition | 2174 | Suppress inline status only while the snapshot is actively **saving** (`archiveSaving`), not whenever a toast handler exists. On success/failure the inline `db-status` reappears, anchoring the confirmation within the Browser pane. |
| `savePageSnapshot` success path | ~1707 | No longer emits `emitPageSnapshotToast` — the inline `db-status` with action buttons is the single source of truth. |
| `savePageSnapshot` error/cancel path | ~1741 | Same — drops the global toast, relying entirely on the inline `db-status`. |

The loading/progress path still emits the global Toast (the 1s ticker updates elapsed seconds) so the user sees live progress during the download. Once saving completes, the inline status takes over.

## Verification

- `tsc --noEmit` on `apps/web`: 0 new errors in `DesignBrowserPanel.tsx`
- `git diff` shows —16 lines of global toast emission, +8 lines of guard and comment