### PR TITLE
refactor(web): decompose ChatPane.tsx into a features/chat-pane vertical slice

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1,10 +1,4 @@
 import {
-  Fragment,
-  memo,
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -14,39 +8,17 @@ import {
   type ReactNode,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { hasOdCard } from '@open-design/contracts';
 import { useAnalytics } from '../analytics/provider';
-import { getResolvedDeviceId } from '../analytics/client';
-import { trackChatPanelClick, trackMessageQueueClick, trackRunFailedToastSurfaceView } from '../analytics/events';
-import { amrHandoffDeviceId, attributedAmrUrl, recordAmrEntry } from '../analytics/amr-attribution';
 import { useT } from '../i18n';
-import { startersForProduct, type ProductType } from '../onboarding/recommendation';
-import { starterCopyFor } from '../onboarding/starter-copy';
-import {
-  FEATURED_DESIGN_TOOLBOX_ACTION_IDS,
-  findDesignToolboxSkill,
-  getDesignToolboxAction,
-  type DesignToolboxActionId,
-} from '../runtime/design-toolbox';
+import type { ProductType } from '../onboarding/recommendation';
 import type { Dict } from '../i18n/types';
-import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { projectRawUrl } from '../providers/registry';
-import { takeComposerSeedFor } from '../state/libraryHandoff';
-import { splitOnQuestionForms } from '../artifacts/question-form';
-import { stripArtifact } from '../artifacts/strip';
 import type { TodoItem } from '../runtime/todos';
 import type { AppliedPluginSnapshot, ChatSessionMode, WorkspaceContextItem } from '@open-design/contracts';
 import type { TrackingProjectKind } from '@open-design/contracts/analytics';
-import {
-  DESIGN_SYSTEM_WORKSPACE_DISPLAY_DESCRIPTION,
-  DESIGN_SYSTEM_WORKSPACE_DISPLAY_TITLE,
-  isDesignSystemWorkspacePrompt,
-} from '../design-system-auto-prompt';
-import { isTodoWriteToolName, latestTodoWriteInputForPinnedCard } from '../runtime/todos';
 import type { AppConfig, ChatAttachment, ChatCommentAttachment, ChatMessage, ChatMessageFeedbackChange, Conversation, DesignSystemSummary, PreviewComment, Project, ProjectFile, ProjectMetadata, SkillSummary } from '../types';
-import { agentDisplayName } from '../utils/agentLabels';
-import { commentTargetDisplayName, commentsToAttachments, simplePositionLabel } from '../comments';
-import { AssistantMessage, type QuestionFormOpenRequest } from './AssistantMessage';
+import { commentsToAttachments } from '../comments';
+import type { QuestionFormOpenRequest } from './AssistantMessage';
 import type { BrandBrowserAssistConfirm } from './OdCard';
 import {
   DESIGN_SYSTEM_NEXT_STEP_ACTIONS,
@@ -54,19 +26,6 @@ import {
 } from './NextStepActions';
 import { AmrGuidance } from './AmrGuidance';
 import { AmrLoginPill } from './AmrLoginPill';
-import {
-  AMR_LOGIN_STATUS_EVENT,
-  amrLoginStatusEventReason,
-} from './amrLoginPolling';
-import {
-  amrPlansUrlForProfile,
-  amrRechargeUrlForProfile,
-  resolveRunFailureUi,
-} from '../runtime/amr-guidance';
-import {
-  fetchVelaLoginStatus,
-  type VelaLoginStatus,
-} from '../providers/daemon';
 import { RESUME_CONTINUE_PROMPT } from '../runtime/resume';
 import {
   ChatComposer,
@@ -74,381 +33,49 @@ import {
   type ChatSendMeta,
 } from './ChatComposer';
 import type { PlaceholderScenario } from './home-hero/placeholderScenarios';
-import { listDesignArtifactCandidates } from './design-files/designArtifacts';
 import type { PluginFolderAgentAction } from './design-files/pluginFolderActions';
-import { Icon, type IconName } from './Icon';
+import { Icon } from './Icon';
 import { repoConnectCopy } from './design-system-github-evidence';
-import { isRenderableSketchJson, SketchPreview } from './SketchPreview';
 import type { SettingsSection } from './SettingsDialog';
+import {
+  buildRunErrorDiagnosticText,
+  ChatConversationLoading,
+  ChatRows,
+  compactCount,
+  ConversationRow,
+  conversationMessageCount,
+  conversationMetaLabel,
+  ImportedFolderArtifacts,
+  isAssistantMessageStreaming,
+  isBrandExtractionNextStepProject,
+  isDesignSystemNextStepProject,
+  isProgrammaticBrandAssistantMessage,
+  importedFolderArtifactsFor,
+  nextUserContentByAssistantIdFor,
+  pickStarters,
+  QueuedSendStrip,
+  retryableAssistantMessage,
+  shouldHideEmptyBrandAssistantMessage,
+  sortArtifactsByModified,
+  useChatLogScrollAnchor,
+  useComposerDraftSync,
+  useComposerPortalLayout,
+  useComposerStarterScenarios,
+  useConversationHistory,
+  useQueuedSendEditing,
+  useRunErrorState,
+  type AssistantCallbacks,
+  type QueuedSendItem,
+  type QueuedSendUpdate,
+  type StarterPrompt,
+} from '../features/chat-pane';
+
+// Re-exported for external consumers that imported these as named helpers
+// off `ChatPane.tsx` directly (e.g. `ConversationsMenu.tsx` imports
+// `conversationMetaLabel`) — now sourced from the chat-pane slice.
+export { buildRunErrorDiagnosticText, conversationMetaLabel, isAssistantMessageStreaming, retryableAssistantMessage };
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
-
-// Featured starter prompts shown on the empty chat. Clicking one fills
-// the composer (does not auto-send) so users can tweak before sending.
-// Each prompt is intentionally dense — it should showcase ambitious
-// layout, typographic, and information-design moves rather than a
-// generic landing page.
-//
-// Starter sets are picked per project kind (and per video model) so a
-// fresh seedance video, a hyperframes html-in-canvas video, an image
-// project and an audio project each see relevant prompts instead of the
-// generic starter set. The default (prototype/deck/template/other/
-// live-artifact) set stays i18n-translated via existing chat.example*
-// keys so the user-facing copy keeps its localizations. The new media
-// sets are inline English literals — they are technical agent prompts
-// that work well across locales without translation, and going through
-// i18n for each of them would balloon every Dict entry by 12+ keys.
-type StarterPrompt = {
-  icon: string;
-  title: string;
-  // Empty for path-scoped onboarding starters, which have no category tag.
-  tag: string;
-  prompt: string;
-};
-
-const DEFAULT_STARTER_KEYS: Array<{
-  icon: string;
-  titleKey: keyof Dict;
-  tagKey: keyof Dict;
-  promptKey: keyof Dict;
-}> = [
-  {
-    icon: '▤',
-    titleKey: 'chat.example1Title',
-    tagKey: 'chat.example1Tag',
-    promptKey: 'chat.example1Prompt',
-  },
-  {
-    icon: '▦',
-    titleKey: 'chat.example2Title',
-    tagKey: 'chat.example2Tag',
-    promptKey: 'chat.example2Prompt',
-  },
-  {
-    icon: '◈',
-    titleKey: 'chat.example3Title',
-    tagKey: 'chat.example3Tag',
-    promptKey: 'chat.example3Prompt',
-  },
-  {
-    icon: '▶',
-    titleKey: 'chat.example4Title',
-    tagKey: 'chat.example4Tag',
-    promptKey: 'chat.example4Prompt',
-  },
-];
-
-const IMPORTED_ARTIFACTS_INITIAL_VISIBLE_COUNT = 5;
-const IMPORTED_ARTIFACTS_REVEAL_COUNT = 5;
-
-const IMAGE_STARTERS: StarterPrompt[] = [
-  {
-    icon: '◯',
-    title: 'Editorial portrait',
-    tag: 'Portrait',
-    prompt:
-      'A close-up editorial portrait of a young creative director in their late 20s, soft natural light through tall studio windows, warm neutral palette (cream, taupe, soft black), shot at 85mm f/1.8 with shallow depth of field, sharp gaze straight to camera, subtle film grain, no makeup look.',
-  },
-  {
-    icon: '▭',
-    title: 'Product hero',
-    tag: 'E-commerce',
-    prompt:
-      'A premium product hero shot of a single matte ceramic coffee mug on a warm cream paper backdrop. Hard rim light from the upper-left, gentle elongated shadow stretching to the lower-right, faint steam rising from the cup. Square crop, centered composition, room above for headline copy, no props or hands in frame.',
-  },
-  {
-    icon: '◐',
-    title: 'Flat illustration',
-    tag: 'Illustration',
-    prompt:
-      'A flat vector illustration of a cozy reading nook by a rainy window — geometric shapes, restrained 5-color palette (cream, terracotta, deep teal, burnt sienna, soft black), thin 1.5px line accents, no gradients, no textures, soft drop shadows only on the foreground armchair.',
-  },
-];
-
-// Pure-video / cinematic-shot starters for seedance, sora, kling, veo,
-// grok-imagine and similar text-to-video models. Each prompt is one
-// shot, restrained motion, and a clear visual concept the model can
-// nail in 5-10 seconds.
-const VIDEO_SEEDANCE_STARTERS: StarterPrompt[] = [
-  {
-    icon: '◉',
-    title: 'Product reveal',
-    tag: 'Cinematic',
-    prompt:
-      'A 5-second product reveal: a minimal high-end skincare bottle on a clean cream stone surface, soft side light from camera-left, slow camera push-in, subtle depth-of-field shift from the cap to the label, restrained motion, no text overlays, no people in frame.',
-  },
-  {
-    icon: '▣',
-    title: 'Lantern close-up',
-    tag: 'Mood',
-    prompt:
-      'A 6-second cinematic close-up of a young woman holding a glowing paper lantern in a misty pine forest at golden hour. Shallow depth of field on her eyes, gentle dolly-in, ambient particles drifting through the warm shaft of light, no dialogue, ambient forest sound only.',
-  },
-  {
-    icon: '⌘',
-    title: 'Neon street drift',
-    tag: 'Action',
-    prompt:
-      'A 5-second street-racing tracking shot at night in a neon-lit cyberpunk Hong Kong alley. Low-angle camera following a matte-black sports car drifting around a tight corner, motion blur on the wheels, lens flares from oncoming neon signs, rain-slick asphalt reflecting the lights, no on-screen text.',
-  },
-];
-
-// HyperFrames HTML-in-canvas starters — these target the
-// hyperframes-html video model where the renderer captures live DOM
-// into a WebGL texture and runs shader effects on top. References:
-// https://www.remotion.dev/docs/html-in-canvas (concept), the seven
-// vfx-* catalog blocks shipped via `npx hyperframes add vfx-*`, and
-// skills/hyperframes/references/html-in-canvas.md.
-const VIDEO_HYPERFRAMES_STARTERS: StarterPrompt[] = [
-  {
-    icon: '◉',
-    title: 'Magnifying glass reveal',
-    tag: 'HTML-in-canvas',
-    prompt:
-      'Make a 5-second composition with a single line of bold display text on a clean canvas. Animate a round magnifying glass that travels left to right across the line, with subtle glass refraction warping the letters underneath as it passes. Use HyperFrames html-in-canvas — capture the text DOM and run the lens shader on top via a vfx-liquid-glass-style pass. Pure CSS for the text; the glass is a WebGL layer.',
-  },
-  {
-    icon: '▦',
-    title: 'CRT terminal scene',
-    tag: 'Vintage VFX',
-    prompt:
-      "Make a CRT-screen composition: dark canvas, monospace terminal text typing `npx hyperframes init my-video`, then `claude` invoked with the prompt 'Add a CRT effect using HTML-in-canvas'. Apply a subtle convex-curvature shader, scanlines, slight chromatic aberration, and a soft phosphor glow on top of the live DOM via html-in-canvas. The terminal text stays as real CSS so it's pixel-sharp before the shader pass.",
-  },
-  {
-    icon: '◈',
-    title: 'Glitch breakdown',
-    tag: 'Glitch',
-    prompt:
-      'Build a 6-second composition that displays a hero headline and a one-line subhead on a dark canvas, then breaks into a hard digital glitch — RGB channel split, horizontal displacement bands, brief frame-stutter, and a final clean reset. Capture the live DOM via html-in-canvas and run the glitch pass on top, so the type is real CSS underneath the shader.',
-  },
-];
-
-// Speech-focused audio starters — the New Project audio panel only
-// surfaces the `speech` kind today (see MediaProjectOptions), so we
-// match that. If/when the music + sfx tabs come back, broaden this set.
-const AUDIO_STARTERS: StarterPrompt[] = [
-  {
-    icon: '♪',
-    title: 'Brand voiceover',
-    tag: 'Speech',
-    prompt:
-      "A 30-second warm-toned narrative voiceover for a product launch video — confident but conversational, mid-tempo, with a beat of pause after the brand name. Script: 'Three years in the making. One simple promise. Meet [product name] — the way work was supposed to feel.' English, neutral North American accent.",
-  },
-  {
-    icon: '♫',
-    title: 'Onboarding narration',
-    tag: 'Speech',
-    prompt:
-      "A 20-second friendly onboarding narration for a mobile app's first-launch screen. Reassuring, smiling tone, slow enough to feel attentive without sounding scripted. Script: 'Welcome to Loop. Let's set up your space — three quick questions and you're in. You can change any of this later.'",
-  },
-  {
-    icon: '♬',
-    title: 'Story passage read',
-    tag: 'Speech',
-    prompt:
-      "A 45-second cinematic read of an opening passage. Low, measured delivery with breath between sentences, slightly intimate close-mic'd quality. Script: 'The city sleeps in pieces. A neon sign flickers above the ramen counter. Across the avenue, a window glows — the only one still on this side of midnight.'",
-  },
-];
-
-function pickStarters(
-  metadata: ProjectMetadata | undefined,
-  t: TranslateFn,
-): StarterPrompt[] {
-  const kind = metadata?.kind;
-  if (kind === 'image') return IMAGE_STARTERS;
-  if (kind === 'video') {
-    return metadata?.videoModel === 'hyperframes-html'
-      ? VIDEO_HYPERFRAMES_STARTERS
-      : VIDEO_SEEDANCE_STARTERS;
-  }
-  if (kind === 'audio') return AUDIO_STARTERS;
-  return DEFAULT_STARTER_KEYS.map((entry) => ({
-    icon: entry.icon,
-    title: t(entry.titleKey),
-    tag: t(entry.tagKey),
-    prompt: t(entry.promptKey),
-  }));
-}
-
-function sortArtifactsByModified(files: ProjectFile[]): ProjectFile[] {
-  return [...files].sort(
-    (a, b) => b.mtime - a.mtime || a.name.localeCompare(b.name),
-  );
-}
-
-function ImportedFolderArtifacts({
-  projectId,
-  files,
-  onOpenFile,
-  t,
-}: {
-  projectId: string | null;
-  files: ProjectFile[];
-  onOpenFile?: (name: string) => void;
-  t: TranslateFn;
-}) {
-  const [visibleCount, setVisibleCount] = useState(IMPORTED_ARTIFACTS_INITIAL_VISIBLE_COUNT);
-
-  useEffect(() => {
-    setVisibleCount(IMPORTED_ARTIFACTS_INITIAL_VISIBLE_COUNT);
-  }, [files]);
-
-  if (files.length === 0) {
-    return (
-      <div className="chat-design-artifacts-empty" data-testid="chat-design-artifacts-empty">
-        {t('designFiles.empty')}
-      </div>
-    );
-  }
-
-  const visibleFiles = files.slice(0, visibleCount);
-  const hiddenCount = Math.max(0, files.length - visibleFiles.length);
-  const revealCount = Math.min(IMPORTED_ARTIFACTS_REVEAL_COUNT, hiddenCount);
-  const revealLabel = t('chat.designArtifactsShowMore', { count: revealCount });
-
-  return (
-    <div className="chat-design-artifacts" data-testid="chat-design-artifacts">
-      {visibleFiles.map((file, index) => {
-        const openable = Boolean(onOpenFile);
-        const openLabel = `${t('designFiles.previewOpen')} ${file.name}`;
-        const openFile = () => {
-          onOpenFile?.(file.name);
-        };
-        return (
-          <div
-            key={file.name}
-            className="chat-design-artifact"
-            data-kind={file.kind}
-            data-file-name={file.name}
-            data-testid={`chat-design-artifact-${index}`}
-            role={openable ? 'button' : 'listitem'}
-            tabIndex={openable ? 0 : undefined}
-            title={openLabel}
-            aria-label={openLabel}
-            onDoubleClick={openable ? openFile : undefined}
-            onKeyDown={
-              openable
-                ? (event) => {
-                    if (event.key !== 'Enter' && event.key !== ' ') return;
-                    event.preventDefault();
-                    openFile();
-                  }
-                : undefined
-            }
-          >
-            <div className="chat-design-artifact-preview" aria-hidden>
-              <ChatArtifactPreview projectId={projectId} file={file} />
-            </div>
-            <div className="chat-design-artifact-meta">
-              <span className="chat-design-artifact-name" title={file.name}>
-                {file.name}
-              </span>
-              <span className="chat-design-artifact-kind">
-                {chatArtifactKindLabel(file.kind, t)}
-              </span>
-            </div>
-          </div>
-        );
-      })}
-      {hiddenCount > 0 ? (
-        <button
-          type="button"
-          className="chat-design-artifact chat-design-artifact-more"
-          data-testid="chat-design-artifacts-more"
-          aria-label={revealLabel}
-          title={revealLabel}
-          onClick={() => {
-            setVisibleCount((current) =>
-              Math.min(files.length, current + IMPORTED_ARTIFACTS_REVEAL_COUNT),
-            );
-          }}
-        >
-          <span className="chat-design-artifact-more-icon" aria-hidden>
-            +
-          </span>
-          <span className="chat-design-artifact-more-count">
-            {revealLabel}
-          </span>
-        </button>
-      ) : null}
-    </div>
-  );
-}
-
-function ChatArtifactPreview({
-  projectId,
-  file,
-}: {
-  projectId: string | null;
-  file: ProjectFile;
-}) {
-  if (!projectId) {
-    return <ChatArtifactFallback kind={file.kind} />;
-  }
-
-  const url = `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}`;
-  if (isRenderableSketchJson(file)) {
-    return <SketchPreview projectId={projectId} file={file} />;
-  }
-  if (file.kind === 'image' || file.kind === 'sketch') {
-    return <img src={url} alt="" loading="lazy" />;
-  }
-  if (file.kind === 'html') {
-    return (
-      <iframe
-        title={file.name}
-        src={url}
-        sandbox="allow-scripts allow-downloads"
-        loading="lazy"
-      />
-    );
-  }
-  if (file.kind === 'video') {
-    return <video src={url} muted playsInline preload="metadata" />;
-  }
-  return <ChatArtifactFallback kind={file.kind} />;
-}
-
-function ChatArtifactFallback({ kind }: { kind: ProjectFile['kind'] }) {
-  return (
-    <span className="chat-design-artifact-fallback">
-      <Icon name={chatArtifactIcon(kind)} size={28} />
-      <span>{chatArtifactShortKind(kind)}</span>
-    </span>
-  );
-}
-
-function chatArtifactIcon(kind: ProjectFile['kind']): IconName {
-  if (kind === 'html' || kind === 'code') return 'file-code';
-  if (kind === 'image' || kind === 'sketch') return 'image';
-  if (kind === 'video' || kind === 'audio') return 'play';
-  if (kind === 'presentation') return 'present';
-  return 'file';
-}
-
-function chatArtifactShortKind(kind: ProjectFile['kind']): string {
-  if (kind === 'html') return 'HTML';
-  if (kind === 'image') return 'IMG';
-  if (kind === 'sketch') return 'SKETCH';
-  if (kind === 'video') return 'VIDEO';
-  if (kind === 'pdf') return 'PDF';
-  if (kind === 'presentation') return 'PPT';
-  if (kind === 'document') return 'DOC';
-  return 'FILE';
-}
-
-function chatArtifactKindLabel(kind: ProjectFile['kind'], t: TranslateFn): string {
-  if (kind === 'html') return t('designFiles.kindHtml');
-  if (kind === 'image') return t('designFiles.kindImage');
-  if (kind === 'sketch') return t('designFiles.kindSketch');
-  if (kind === 'video') return 'Video';
-  if (kind === 'audio') return 'Audio';
-  if (kind === 'pdf') return t('designFiles.kindPdf');
-  if (kind === 'document') return t('designFiles.kindDocument');
-  if (kind === 'presentation') return t('designFiles.kindPresentation');
-  if (kind === 'spreadsheet') return t('designFiles.kindSpreadsheet');
-  return t('designFiles.kindBinary');
-}
 
 interface Props {
   messages: ChatMessage[];
@@ -671,103 +298,28 @@ interface Props {
   config?: AppConfig;
 }
 
-const AMR_PROFILE_ENV_KEY = 'OPEN_DESIGN_AMR_PROFILE';
-
 type Tab = 'chat' | 'comments';
 
-const CHAT_MESSAGE_VIRTUALIZE_THRESHOLD = 80;
-const CHAT_MESSAGE_OVERSCAN_PX = 900;
-const CHAT_VIRTUAL_ROW_GAP_PX = 14;
-const CHAT_VIRTUAL_MIN_ROW_HEIGHT = 36;
-const CHAT_VIRTUAL_DEFAULT_VIEWPORT_PX = 640;
-const CHAT_VIRTUAL_INITIAL_TAIL_ROWS = 16;
 const CONVERSATION_ROW_HEIGHT_PX = 34;
 const CONVERSATION_VIRTUALIZE_THRESHOLD = 36;
 const CONVERSATION_OVERSCAN_ROWS = 8;
 
-interface RunErrorDiagnosticInput {
-  message: string;
-  rawMessage?: string | null;
-  errorCode?: string;
-  traceId?: string;
-  projectId?: string | null;
-  conversationId?: string | null;
-  assistantMessageId?: string;
-  agentId?: string;
-}
-
-interface QueuedSendItem {
-  id: string;
-  prompt: string;
-  attachments?: ChatAttachment[];
-  commentAttachments?: ChatCommentAttachment[];
-  meta?: ChatSendMeta;
-}
-
-interface QueuedSendUpdate {
-  prompt: string;
-  attachments: ChatAttachment[];
-  commentAttachments: ChatCommentAttachment[];
-  meta?: ChatSendMeta;
-}
-
-// Gap left above the anchored user message when it is pinned to the top.
-const ANCHOR_TOP_PADDING = 12;
-
-function shouldHideEmptyBrandAssistantMessage(message: ChatMessage, metadata?: ProjectMetadata): boolean {
-  if (metadata?.importedFrom !== 'brand-extraction' && metadata?.kind !== 'brand') return false;
-  if (message.role !== 'assistant') return false;
-  if (brandAssistantTextHasVisibleContent(message.content)) return false;
-  if ((message.events ?? []).some(hasVisibleBrandAssistantEvent)) return false;
-  if ((message.producedFiles?.length ?? 0) > 0) return false;
-  return Boolean(message.runStatus || message.endedAt);
-}
-
-function brandAssistantTextHasVisibleContent(content: string): boolean {
-  const trimmed = content.trim();
-  if (!trimmed) return false;
-  if (hasOdCard(trimmed)) return true;
-  const withoutArtifacts = stripArtifact(trimmed).trim();
-  if (!withoutArtifacts) return false;
-  return splitOnQuestionForms(withoutArtifacts).some((segment) => {
-    if (segment.kind === 'form') return true;
-    return segment.text.trim().length > 0;
-  });
-}
-
-const HIDDEN_BRAND_ASSISTANT_STATUS_LABELS = new Set([
-  'streaming',
-  'starting',
-  'running',
-  'requesting',
-  'thinking',
-  'empty_response',
-  'done',
-  'completed',
-]);
-
-function hasVisibleBrandAssistantEvent(event: NonNullable<ChatMessage['events']>[number]): boolean {
-  switch (event.kind) {
-    case 'text':
-      return brandAssistantTextHasVisibleContent(event.text);
-    case 'thinking':
-      return event.text.trim().length > 0;
-    case 'tool_use':
-    case 'live_artifact':
-    case 'live_artifact_refresh':
-    case 'plugin_candidate':
-      return true;
-    case 'tool_result':
-      return false;
-    case 'raw':
-      return false;
-    case 'status':
-      return !HIDDEN_BRAND_ASSISTANT_STATUS_LABELS.has(event.label);
-    case 'usage':
-    case 'diagnostic':
-    case 'conversation_title':
-      return false;
-  }
+// Injectable hooks for the orchestrator. Each defaults to its wired hook, so
+// production callers pass nothing while tests swap a hook for a fake and
+// render the orchestrator directly instead of mocking modules. Per-hook
+// injection (not one bag) keeps each seam independently overridable,
+// matching `MemorySection.tsx`'s `MemorySectionHooks` pattern. Prop names
+// are deliberately distinct from the hook identifiers they default to — a
+// destructuring parameter default that references its own binding name
+// throws a TDZ error.
+interface ChatPaneHooks {
+  useStarterScenarios?: typeof useComposerStarterScenarios;
+  useHistory?: typeof useConversationHistory;
+  usePortalLayout?: typeof useComposerPortalLayout;
+  useQueuedSend?: typeof useQueuedSendEditing;
+  useRunError?: typeof useRunErrorState;
+  useDraftSync?: typeof useComposerDraftSync;
+  useScrollAnchor?: typeof useChatLogScrollAnchor;
 }
 
 export function ChatPane({
@@ -887,89 +439,26 @@ export function ChatPane({
   projectHeader,
   designSystemPicker,
   config,
-}: Props) {
+  useStarterScenarios = useComposerStarterScenarios,
+  useHistory = useConversationHistory,
+  usePortalLayout = useComposerPortalLayout,
+  useQueuedSend = useQueuedSendEditing,
+  useRunError = useRunErrorState,
+  useDraftSync = useComposerDraftSync,
+  useScrollAnchor = useChatLogScrollAnchor,
+}: Props & ChatPaneHooks) {
   const t = useT();
   const analytics = useAnalytics();
   const displayMessages = useMemo(
     () => messages.filter((message) => !shouldHideEmptyBrandAssistantMessage(message, projectMetadata)),
     [messages, projectMetadata],
   );
-  const amrProfile = config?.agentCliEnv?.amr?.[AMR_PROFILE_ENV_KEY] ?? null;
-  const [inlineAmrLoginStatus, setInlineAmrLoginStatus] =
-    useState<VelaLoginStatus | null>(null);
   const logRef = useRef<HTMLDivElement | null>(null);
-  // Guards the inline AMR sign-in card so a successful login auto-retries the
-  // failed run exactly once (the pill's onStatusChange fires loggedIn on every
-  // poll). Keyed by the failed assistant's id.
-  const amrAuthRetriedRef = useRef<string | null>(null);
-  // Tracks the last observed AMR login state so we retry only on a real
-  // signed-out -> signed-in transition. Without this, a run that keeps failing
-  // AMR_AUTH_REQUIRED while /status already reports signed-in would auto-retry
-  // forever (each retry is a new assistant id, so the id guard alone never
-  // converges).
-  const amrAuthPrevLoggedInRef = useRef<boolean | undefined>(undefined);
-  const chatLogScrollIdleTimerRef = useRef<number | null>(null);
-  const historyWrapRef = useRef<HTMLDivElement | null>(null);
   const composerRef = useRef<ChatComposerHandle | null>(null);
   const composerSlotRef = useRef<HTMLDivElement | null>(null);
   const composerLayerRef = useRef<HTMLDivElement | null>(null);
   const queuedSendStripRef = useRef<HTMLDivElement | null>(null);
-  const didInitialScrollRef = useRef(false);
-  const runFailedToastSurfaceKeysRef = useRef<Set<string>>(new Set());
-  // Tracks whether the user is glued close enough to the bottom that
-  // streamed content should auto-follow. Distinct from the jump-button
-  // state below, which uses a wider threshold (120px) so the affordance
-  // stays visible for short scroll-ups. Auto-follow needs the tighter
-  // 80px cutoff: scrolling ~90px up is an intentional pause that
-  // shouldn't be yanked back the moment the next chunk streams in.
-  const pinnedToBottomRef = useRef(true);
-  const scrolledToFormRef = useRef<Set<string>>(new Set());
-  const refreshInlineAmrLoginStatus = useCallback(async (options: { refresh?: boolean } = {}) => {
-    const next = await fetchVelaLoginStatus(options).catch(() => null);
-    if (next) setInlineAmrLoginStatus(next);
-    return next;
-  }, []);
-
-  useEffect(() => {
-    void refreshInlineAmrLoginStatus();
-    const onAmrLoginStatusChange = (event: Event) => {
-      const reason = amrLoginStatusEventReason(event);
-      if (reason === 'login-canceled') return;
-      void refreshInlineAmrLoginStatus();
-    };
-    window.addEventListener(AMR_LOGIN_STATUS_EVENT, onAmrLoginStatusChange);
-    return () => {
-      window.removeEventListener(AMR_LOGIN_STATUS_EVENT, onAmrLoginStatusChange);
-    };
-  }, [refreshInlineAmrLoginStatus]);
-
-  useEffect(() => {
-    const refreshAfterExternalAmrReturn = () => {
-      if (document.visibilityState === 'hidden') return;
-      void refreshInlineAmrLoginStatus({ refresh: true });
-    };
-    window.addEventListener('focus', refreshAfterExternalAmrReturn);
-    document.addEventListener('visibilitychange', refreshAfterExternalAmrReturn);
-    return () => {
-      window.removeEventListener('focus', refreshAfterExternalAmrReturn);
-      document.removeEventListener('visibilitychange', refreshAfterExternalAmrReturn);
-    };
-  }, [refreshInlineAmrLoginStatus]);
-
-  // "Anchor the just-sent turn to the top" (ChatGPT-style). On send we pin
-  // the user's message to the top of the viewport and let the reply stream
-  // below it instead of following the bottom. `pending` is armed by the
-  // composer's onSend; the messages effect promotes it to `active` once the
-  // new user turn actually renders. A dynamic tail spacer reserves just
-  // enough real, scrollable blank space below the turn so the message can
-  // reach the top even when the reply is short. The spacer is only resized
-  // while the message sits at its pinned position — once the user scrolls
-  // below it, the reserved blank stays put (no collapse, no jump).
-  const anchorPendingRef = useRef(false);
-  const anchorActiveRef = useRef(false);
   const tailSpacerRef = useRef<HTMLDivElement | null>(null);
-  const prevStreamingRef = useRef(streaming);
-  const prevLastUserIdRef = useRef<string | undefined>(undefined);
   // AssistantMessage's interaction callbacks are re-created per render and
   // excluded from its memo comparison (so streaming doesn't re-render every
   // message). Route them through this ref so a memoized message still calls the
@@ -1000,380 +489,124 @@ export function ChatPane({
     onNextStepCreateDesign: onCreateDesignFromActiveDesignSystem,
     onNextStepCreateDesignSystem: onCreateDesignSystemFromProject,
   };
-  // Featured design-toolbox follow-up rows on the assistant "next step" card.
-  // The toolbox left the "+" menu, so these route straight into the composer
-  // we own here: seeding an action's prompt+skill, or opening the full panel.
-  // Both stay stable (composer ref + no deps) so AssistantMessage stays memoized.
-  const handleToolboxAction = useCallback((id: DesignToolboxActionId) => {
-    composerRef.current?.applyDesignToolboxAction(id);
-  }, []);
-  const handleNextStepPromptAction = useCallback((
-    prompt: string,
-    options?: { sessionMode?: ChatSessionMode },
-  ) => {
-    if (options?.sessionMode && options.sessionMode !== sessionMode) {
-      onSessionModeChange?.(options.sessionMode);
-    }
-    composerRef.current?.setDraft(prompt, {
-      entryFrom: 'next_step',
-      sessionMode: options?.sessionMode,
-    });
-  }, [onSessionModeChange, sessionMode]);
-  const handlePickSkill = useCallback((skillId: string) => {
-    composerRef.current?.applyDesignToolboxSkill(skillId);
-  }, []);
-  const latestAssistantForBrandState = useMemo(() => {
-    for (let i = displayMessages.length - 1; i >= 0; i -= 1) {
-      const message = displayMessages[i]!;
-      if (message.role === 'assistant') return message;
-    }
-    return null;
-  }, [displayMessages]);
-  const nextStepVariant: NextStepActionsVariant = sessionMode === 'plan'
-    ? 'plan'
-    : isDesignSystemNextStepProject(projectMetadata)
-      ? isBrandExtractionNextStepProject(projectMetadata)
-        ? brandExtractionComplete
-          ? 'brand-extraction'
-          : !latestAssistantForBrandState || isProgrammaticBrandAssistantMessage(latestAssistantForBrandState)
-            ? 'brand-programmatic-incomplete'
-            : 'brand-ai-incomplete'
-        : 'design-system'
-      : 'default';
-  // The `@skill` shown in each featured row's hover detail — matched the same
-  // way the composer matches it, using the raw skill name (what gets inlined
-  // into the draft). Recomputed only when the skill list changes.
-  const featuredToolboxSkillNames = useMemo<Partial<Record<DesignToolboxActionId, string | null>>>(() => {
-    const map: Partial<Record<DesignToolboxActionId, string | null>> = {};
-    for (const id of FEATURED_DESIGN_TOOLBOX_ACTION_IDS) {
-      const action = getDesignToolboxAction(id);
-      map[id] = action ? (findDesignToolboxSkill(action, skills)?.name ?? null) : null;
-    }
-    return map;
-  }, [skills]);
-  const blankProjectComposerScenarios = useMemo<PlaceholderScenario[]>(
-    () => pickStarters(projectMetadata, t).map((starter, index) => ({
-      id: `blank-${projectMetadata?.kind ?? 'prototype'}-${index}`,
-      text: starter.prompt,
-      chipId: 'project',
-    })),
-    [projectMetadata, t],
-  );
-  // Empty-conversation starter cards. A recommendation-started project shows
-  // its OWN product path's starters — clicking replaces the composer draft, so
-  // the pre-filled first request and the cards complement rather than compete.
-  // The general fallback path and every other project keep the generic set.
-  const starterTemplateCards = useMemo<StarterPrompt[]>(() => {
-    if (onboardingStarterPath && onboardingStarterPath !== 'general') {
-      return startersForProduct(onboardingStarterPath).map((starter) => {
-        const copy = starterCopyFor(starter.id);
-        return { icon: '✦', title: t(copy.title), tag: '', prompt: t(copy.firstPrompt) };
-      });
-    }
-    return pickStarters(projectMetadata, t);
-  }, [onboardingStarterPath, projectMetadata, t]);
-  const followUpComposerScenarios = useMemo<PlaceholderScenario[]>(() => {
-    if (nextStepVariant === 'design-system') {
-      return DESIGN_SYSTEM_NEXT_STEP_ACTIONS.map((action) => ({
-        id: action.id,
-        text: action.prompt,
-        chipId: 'design-system',
-      }));
-    }
-    if (nextStepVariant === 'plan') {
-      return [
-        {
-          id: 'plan-generate-from-doc',
-          text: t('nextStep.planGeneratePrompt'),
-          chipId: 'plan',
-          sessionMode: 'design',
-        },
-        {
-          id: 'plan-improve-doc',
-          text: t('nextStep.planImprovePrompt'),
-          chipId: 'plan',
-          sessionMode: 'plan',
-        },
-      ];
-    }
-    const promptPairs: Array<[string, string]> = [
-      ['auto-match', t('chat.designToolbox.prompt.autoMatchIntro')],
-      ['visual-polish', t('chat.designToolbox.prompt.visualPolish')],
-      ['asset-search', t('chat.designToolbox.prompt.assetSearch')],
-      ['icon-workflow', t('chat.designToolbox.prompt.iconWorkflow')],
-      ['anti-ai-polish', t('chat.designToolbox.prompt.antiAiPolish')],
-      ['motion-polish', t('chat.designToolbox.prompt.motionPolish')],
-      ['chart-gen', t('chat.designToolbox.prompt.chartGen')],
-    ];
-    return promptPairs.map(([id, text]) => ({
-      id: `follow-up-${id}`,
-      text,
-      chipId: 'design-toolbox',
-    }));
-  }, [nextStepVariant, t]);
-  const composerPlaceholderScenarios = useMemo<PlaceholderScenario[]>(() => {
-    if (loading || initialDraft?.trim()) return [];
-    if (displayMessages.length === 0 && queuedItems.length === 0) return blankProjectComposerScenarios;
-    if (displayMessages.length > 0) return followUpComposerScenarios;
-    return [];
-  }, [
-    blankProjectComposerScenarios,
-    displayMessages.length,
-    followUpComposerScenarios,
-    initialDraft,
+  const {
+    handleToolboxAction,
+    handleNextStepPromptAction,
+    handlePickSkill,
+    handleStarterCardClick,
+    nextStepVariant,
+    featuredToolboxSkillNames,
+    starterTemplateCards,
+    composerPlaceholderScenarios,
+  } = useStarterScenarios(composerRef, {
+    displayMessages,
+    projectMetadata,
+    sessionMode,
+    onSessionModeChange,
+    skills,
+    onboardingStarterPath,
+    t,
     loading,
-    queuedItems.length,
-  ]);
+    initialDraft,
+    queuedItemsLength: queuedItems.length,
+    brandExtractionComplete,
+    analyticsTrack: analytics.track,
+  });
   const [tab, setTab] = useState<Tab>('chat');
-  const [showConvList, setShowConvList] = useState(false);
-  const [conversationSearch, setConversationSearch] = useState('');
-  const deferredConversationSearch = useDeferredValue(conversationSearch);
-  const [scrolledFromBottom, setScrolledFromBottom] = useState(false);
-  const [chatLogScrollable, setChatLogScrollable] = useState(false);
-  const [chatLogScrolling, setChatLogScrolling] = useState(false);
-  const [composerPortalTarget, setComposerPortalTarget] = useState<HTMLElement | null>(null);
-  const [composerPortalRect, setComposerPortalRect] = useState<{
-    left: number;
-    width: number;
-    bottom: number;
-  } | null>(null);
-  const [composerSlotHeight, setComposerSlotHeight] = useState(0);
-  const [editingQueuedSendId, setEditingQueuedSendId] = useState<string | null>(null);
-  // Reverse scan (no array copy) + memo so this and the maps below don't
-  // recompute on every non-`messages` render (scroll, hover, toggles).
-  const lastAssistantId = useMemo(() => {
-    for (let i = displayMessages.length - 1; i >= 0; i--) {
-      if (displayMessages[i]!.role === 'assistant') return displayMessages[i]!.id;
-    }
-    return undefined;
-  }, [displayMessages]);
-  const hasActiveRunMessage = displayMessages.some(
-    (m) => m.role === 'assistant' && isActiveRunStatus(m.runStatus),
-  );
-  const retryAssistant = retryableAssistantMessage(displayMessages, lastAssistantId, streaming);
-  // The failed run's error event lives on the (persisted) assistant message, so
-  // the error card + AMR card survive a reload — unlike the ephemeral global
-  // `error` state. Drive both off this event.
-  const failedRunErrorEvent = (() => {
-    const evs = retryAssistant?.events ?? [];
-    for (let i = evs.length - 1; i >= 0; i--) {
-      const ev = evs[i];
-      if (ev?.kind === 'status' && ev.label === 'error') return ev;
-    }
-    return null;
-  })();
-  // Per-case failure UI (button + copy + whether to promote AMR). Only
-  // meaningful for a failed run (retryAssistant present).
-  const runFailureUi = retryAssistant
-    ? resolveRunFailureUi(
-        failedRunErrorEvent?.code,
-        failedRunErrorEvent?.failureDetail,
-        retryAssistant.agentId,
-      )
-    : null;
-  const hasInlineAmrAuthorizeFailure = Boolean(
-    retryAssistant && onRetry && runFailureUi?.primaryAction === 'authorize',
-  );
-  useEffect(() => {
-    if (!hasInlineAmrAuthorizeFailure || !retryAssistant || !onRetry) return;
-    let stopped = false;
-    const retryIfSignedIn = async () => {
-      const next = await refreshInlineAmrLoginStatus();
-      if (stopped) return;
-      // Retry only on a real signed-out -> signed-in transition. A null/unknown
-      // status is NOT treated as signed-out, so it can't fabricate a transition;
-      // and once signed-in we never retry again until an explicit signed-out is
-      // seen. Otherwise a run that keeps failing auth while /status reports
-      // signed-in would retry forever (each retry is a new assistant id).
-      if (next?.loggedIn === true) {
-        const wasSignedOut = amrAuthPrevLoggedInRef.current === false;
-        amrAuthPrevLoggedInRef.current = true;
-        if (wasSignedOut && amrAuthRetriedRef.current !== retryAssistant.id) {
-          amrAuthRetriedRef.current = retryAssistant.id;
-          onRetry(retryAssistant);
-        }
-      } else if (next && next.loggedIn === false) {
-        amrAuthPrevLoggedInRef.current = false;
-      }
-    };
-    void retryIfSignedIn();
-    const interval = window.setInterval(() => {
-      void retryIfSignedIn();
-    }, 500);
-    return () => {
-      stopped = true;
-      window.clearInterval(interval);
-    };
-  }, [
-    hasInlineAmrAuthorizeFailure,
-    onRetry,
-    refreshInlineAmrLoginStatus,
-    retryAssistant,
-  ]);
-  // Offer Continue (resume) when the failed run is resumable AND the active
-  // agent still matches the agent that produced it. The daemon stores a
-  // resumable session per (conversation, agent); after an agent switch the new
-  // agent has no id for that session, so a resume would silently start fresh —
-  // fall back to the from-scratch Retry instead. We do NOT require `onResumeRun`
-  // here: because the daemon persists the resumable session, the plain Retry
-  // path (which re-sends the original prompt) would itself silently resume that
-  // session and double the work. So every ChatPane surface must offer Continue
-  // for a resumable failure — `onResumeRun` when wired (primary chat, carries
-  // the resume_continue analytics), otherwise a plain `onSend` of the canonical
-  // continue prompt (resumes the session without re-sending the original turn).
-  const canResumeFailedRun =
-    !!retryAssistant?.resumable &&
-    !!retryAssistant?.agentId &&
-    retryAssistant.agentId === config?.agentId;
-  // Prefer a case-specific message (AMR auth / balance) over the raw upstream
-  // string; fall back to the live global error (also covers conversation-load
-  // / audio errors) then the persisted run error so a reload still shows it.
-  const rawError = error ?? failedRunErrorEvent?.detail ?? null;
-  // Friendly agent name for {agent} interpolation in failure copy (e.g. the
-  // sign-in messages). Falls back to a neutral word when unreadable, never null.
-  const failedAgentLabel =
-    agentDisplayName(retryAssistant?.agentId, retryAssistant?.agentName) ??
-    t('chat.runError.agentFallback');
-  const displayError = runFailureUi?.messageKey
-    ? t(runFailureUi.messageKey, { agent: failedAgentLabel })
-    : rawError;
-  const errorDiagnosticText = displayError
-    ? buildRunErrorDiagnosticText({
-        message: displayError,
-        rawMessage: rawError,
-        errorCode: failedRunErrorEvent?.code,
-        traceId: retryAssistant?.runId,
-        projectId,
-        conversationId: activeConversationId,
-        assistantMessageId: retryAssistant?.id,
-        agentId: retryAssistant?.agentId,
-      })
-    : null;
-  // First non-empty line of the diagnostics — shown as the one-line peek when
-  // the error-source area is collapsed.
-  const errorSourcePeek =
-    errorDiagnosticText?.split('\n').find((line) => line.trim().length > 0)?.trim() ?? null;
-  // Status-dot tone for the unified card. Brand (accent) for AMR sign-in/top-up
-  // — the commercial recovery path; warn (amber) for the self-healing
-  // connection drop; error (red) for everything else. Purely visual.
-  const runErrorTone: 'error' | 'warn' | 'brand' =
-    runFailureUi?.primaryAction === 'authorize' ||
-    runFailureUi?.primaryAction === 'recharge' ||
-    runFailureUi?.primaryAction === 'upgrade'
-      ? 'brand'
-      : failedRunErrorEvent?.code === 'AGENT_CONNECTION_DROPPED'
-        ? 'warn'
-        : 'error';
-  const [copiedErrorDiagnostic, setCopiedErrorDiagnostic] = useState(false);
-  // Collapsed by default: the error source area shows one line until expanded.
-  const [errorSourceOpen, setErrorSourceOpen] = useState(false);
-  const errorDiagnosticCopyTimerRef = useRef<number | null>(null);
-  const copyErrorDiagnostic = useCallback(async () => {
-    if (!errorDiagnosticText) return;
-    const ok = await copyToClipboard(errorDiagnosticText);
-    if (!ok) return;
-    if (errorDiagnosticCopyTimerRef.current != null) {
-      window.clearTimeout(errorDiagnosticCopyTimerRef.current);
-    }
-    setCopiedErrorDiagnostic(true);
-    errorDiagnosticCopyTimerRef.current = window.setTimeout(() => {
-      errorDiagnosticCopyTimerRef.current = null;
-      setCopiedErrorDiagnostic(false);
-    }, 1600);
-  }, [errorDiagnosticText]);
-  useEffect(() => () => {
-    if (errorDiagnosticCopyTimerRef.current != null) {
-      window.clearTimeout(errorDiagnosticCopyTimerRef.current);
-      errorDiagnosticCopyTimerRef.current = null;
-    }
-  }, []);
-  // The failed run whose error this top-level card represents. AssistantMessage
-  // suppresses only THIS message's per-message error pill (to avoid the
-  // duplicate); other failed turns — older history, or once a follow-up makes
-  // this no longer the last assistant — keep their pill so the error survives.
-  const errorCardOwnerId =
-    retryAssistant && failedRunErrorEvent ? retryAssistant.id : null;
-  // AMR promotion card payload (only the non-AMR model/auth/quota case).
-  const amrSwitchPayload =
-    runFailureUi?.showSwitchCard
-    && failedRunErrorEvent?.code !== 'UPSTREAM_UNAVAILABLE'
-    && retryAssistant
-    && failedRunErrorEvent?.code
-      ? {
-          errorCode: failedRunErrorEvent.code,
-          projectId: projectId ?? '',
-          projectKind: projectKindForTracking,
-          conversationId: activeConversationId,
-          assistantMessageId: retryAssistant.id,
-          runId: retryAssistant.runId ?? null,
-        }
-      : null;
-  const showByokRecoveryCta = showByokRecoveryAction && Boolean(onSwitchToLocalCli);
-  // A `primaryAction: 'none'` failure (e.g. a hard quota where retrying is
-  // futile) contributes no button of its own — it relies on the AMR switch card
-  // below. Only claim the actions row when a real control will render, so a
-  // no-action card doesn't leave an empty flex row (and a dangling column gap).
-  const runFailureHasAction = Boolean(
-    retryAssistant &&
-      onRetry &&
-      runFailureUi &&
-      (runFailureUi.primaryAction !== 'none' ||
-        runFailureUi.secondaryRetry ||
-        canResumeFailedRun),
-  );
-  const showErrorActions = showByokRecoveryCta || runFailureHasAction;
-  useEffect(() => {
-    if (!displayError || !failedRunErrorEvent?.code || !retryAssistant) return;
-    // The hosted-AMR nudge owns this same surface_view when it renders below
-    // the error card. For all other failed-run guidance (AMR auth/balance,
-    // Antigravity auth/quota, upstream outage, generic retry), the chat error
-    // card itself is the visible run_failed_toast surface.
-    if (amrSwitchPayload) return;
-
-    const key = [
-      projectId ?? '',
-      activeConversationId ?? '',
-      retryAssistant.id,
-      retryAssistant.runId ?? '',
-      failedRunErrorEvent.code,
-    ].join(':');
-    if (runFailedToastSurfaceKeysRef.current.has(key)) return;
-    runFailedToastSurfaceKeysRef.current.add(key);
-
-    trackRunFailedToastSurfaceView(analytics.track, {
-      page_name: 'chat_panel',
-      area: 'chat_panel',
-      element: 'run_failed_toast',
-      error_code: failedRunErrorEvent.code,
-      project_id: projectId ?? '',
-      project_kind: projectKindForTracking,
-      conversation_id: activeConversationId,
-      assistant_message_id: retryAssistant.id,
-      run_id: retryAssistant.runId ?? null,
-    });
-  }, [
-    activeConversationId,
-    analytics.track,
-    amrSwitchPayload,
-    displayError,
-    failedRunErrorEvent?.code,
+  const {
+    historyWrapRef,
+    showConvList,
+    setShowConvList,
+    conversationSearch,
+    setConversationSearch,
+    activeConversation,
+    filteredConversations,
+    handleToggleHistoryList,
+    handleStartNewConversation,
+    handleSelectConversation,
+  } = useHistory(conversations, activeConversationId, t, {
+    analyticsTrack: analytics.track,
+    onNewConversation,
+    newConversationDisabled,
+    onSelectConversation,
+  });
+  const { composerPortalTarget, composerPortalRect, composerSlotHeight } =
+    usePortalLayout(composerSlotRef, composerLayerRef, tab);
+  const {
+    editingQueuedSendId,
+    setEditingQueuedSendId,
+    handleEditQueuedSend,
+    handleRemoveQueuedSend,
+    handleSendQueuedNow,
+  } = useQueuedSend(composerRef, queuedItems, {
+    analyticsTrack: analytics.track,
     projectId,
-    projectKindForTracking,
+    onRemoveQueuedSend,
+    onSendQueuedNow,
+  });
+  const {
+    lastAssistantId,
+    hasActiveRunMessage,
     retryAssistant,
-  ]);
+    runFailureUi,
+    canResumeFailedRun,
+    displayError,
+    errorDiagnosticText,
+    errorSourcePeek,
+    runErrorTone,
+    errorCardOwnerId,
+    amrSwitchPayload,
+    showByokRecoveryCta,
+    showErrorActions,
+    copiedErrorDiagnostic,
+    errorSourceOpen,
+    setErrorSourceOpen,
+    copyErrorDiagnostic,
+    inlineAmrLoginStatus,
+    handleAmrLoginStatusChange,
+    handleAmrRecharge,
+    handleAmrUpgrade,
+    handleAmrSignInStarted,
+    handleAmrSwitchActivate,
+  } = useRunError(displayMessages, streaming, error, {
+    projectId,
+    activeConversationId,
+    projectKindForTracking,
+    config,
+    analyticsTrack: analytics.track,
+    onRetry,
+    showByokRecoveryAction,
+    onSwitchToLocalCli,
+    onSwitchToAmrAndRetry,
+    onOpenAmrSettings,
+    t,
+  });
+  const {
+    scrolledFromBottom,
+    chatLogScrollable,
+    chatLogScrolling,
+    jumpToBottom,
+    armAnchorForSend,
+    resetScrollTrackingForSend,
+    unpinFromBottom,
+  } = useScrollAnchor(logRef, tailSpacerRef, queuedSendStripRef, {
+    activeConversationId,
+    displayMessages,
+    streaming,
+    tab,
+    error,
+  });
   const importedFolderArtifacts = useMemo(
-    () =>
-      projectMetadata?.importedFrom === 'folder'
-        ? sortArtifactsByModified(
-            listDesignArtifactCandidates(projectFiles, projectMetadata.entryFile),
-          )
-        : [],
-    [projectFiles, projectMetadata?.entryFile, projectMetadata?.importedFrom],
+    () => importedFolderArtifactsFor(projectFiles, projectMetadata),
+    [projectFiles, projectMetadata],
   );
   const showImportedFolderArtifacts = projectMetadata?.importedFrom === 'folder';
-  const composerDraftStorageKey = projectId && activeConversationId
-    ? `od:chat-composer:draft:${projectId}:${activeConversationId}`
-    : undefined;
+  const { composerDraftStorageKey } = useDraftSync(composerRef, {
+    initialDraft,
+    composerDraftSignal,
+    projectId,
+    activeConversationId,
+  });
   // Only the first user message gets the active-plugin chip — the
   // plugin is project-scoped so re-stamping it on every reply would be
   // noise. Subsequent messages still run under the same snapshot.
@@ -1390,616 +623,10 @@ export function ChatPane({
   // Map each assistant message id to the user message that follows it (if any)
   // so the chat-side Questions banner can reopen that exact answered form in
   // the right-hand panel later.
-  const nextUserContentByAssistantId = useMemo(() => {
-    const map = new Map<string, string>();
-    for (let i = 0; i < displayMessages.length - 1; i++) {
-      const m = displayMessages[i]!;
-      const next = displayMessages[i + 1]!;
-      if (m.role === 'assistant' && next.role === 'user') {
-        map.set(m.id, next.content);
-      }
-    }
-    return map;
-  }, [displayMessages]);
-
-  useEffect(() => {
-    didInitialScrollRef.current = false;
-    anchorPendingRef.current = false;
-    anchorActiveRef.current = false;
-    prevLastUserIdRef.current = undefined;
-    resetTailSpacer();
-    // A new conversation should land at the bottom (its own initial
-    // scroll), not inherit the previous conversation's saved position —
-    // including any anchor-to-top reserve still held by the tail spacer, which
-    // would otherwise strand the freshly opened conversation below a dead gap.
-    savedChatScrollRef.current = null;
-    scrolledToFormRef.current = new Set();
-    anchorActiveRef.current = false;
-    anchorPendingRef.current = false;
-    resetTailSpacer();
-  }, [activeConversationId]);
-
-  // ChatComposer's internal `seededRef` latches after the first
-  // non-empty `initialDraft`, so a parent setting `initialDraft` back
-  // to `undefined` will not flow into the composer's draft state. When
-  // the parent does that transition (because the seed is now stale —
-  // e.g. ProjectView discovered the conversation already has a sent
-  // user message after a reload), reach into the composer and clear
-  // the textarea so the user does not see the prompt they already
-  // submitted.
-  const lastSeenInitialDraftRef = useRef<string | undefined>(initialDraft);
-  useEffect(() => {
-    const previous = lastSeenInitialDraftRef.current;
-    lastSeenInitialDraftRef.current = initialDraft;
-    if (previous && initialDraft === undefined) {
-      composerRef.current?.setDraft('');
-    }
-  }, [initialDraft]);
-
-  // Parent-driven composer prefill (the "Import repo" CTA). Reuse the same
-  // imperative setDraft the starter cards use; the nonce guards against
-  // re-applying the same signal on unrelated re-renders.
-  const lastDraftSignalNonceRef = useRef<number | null>(null);
-  useEffect(() => {
-    if (!composerDraftSignal) return;
-    if (lastDraftSignalNonceRef.current === composerDraftSignal.nonce) return;
-    lastDraftSignalNonceRef.current = composerDraftSignal.nonce;
-    composerRef.current?.setDraft(composerDraftSignal.text);
-  }, [composerDraftSignal]);
-
-  // Library "optimize design system" hand-off: when the user pushed selected
-  // assets into this project's design system from the Library, pre-fill the
-  // composer with the query + those assets (as attachment chips) so they only
-  // need to review and Send. Fires once, after the composer mounts for the
-  // routed conversation; re-checks on conversation change so an async-loaded
-  // composer still gets seeded. The seed is consumed (cleared) on apply.
-  const seededComposerSeedRef = useRef(false);
-  useEffect(() => {
-    if (seededComposerSeedRef.current) return;
-    if (!projectId || !composerRef.current) return;
-    const seed = takeComposerSeedFor(projectId);
-    if (!seed) return;
-    seededComposerSeedRef.current = true;
-    composerRef.current.restoreDraft({ text: seed.text, attachments: seed.attachments });
-  }, [projectId, activeConversationId]);
-
-  useEffect(() => {
-    if (!editingQueuedSendId) return;
-    if (queuedItems.some((item) => item.id === editingQueuedSendId)) return;
-    setEditingQueuedSendId(null);
-  }, [editingQueuedSendId, queuedItems]);
-
-  const restoreQueuedSendToComposer = (item: QueuedSendItem) => {
-    setEditingQueuedSendId(item.id);
-    composerRef.current?.restoreDraft({
-      text: item.prompt,
-      attachments: item.attachments ?? [],
-      commentAttachments: item.commentAttachments ?? [],
-      meta: item.meta,
-    });
-  };
-
-  useEffect(() => {
-    const el = logRef.current;
-    if (!el || didInitialScrollRef.current || displayMessages.length === 0) return;
-    didInitialScrollRef.current = true;
-    requestAnimationFrame(() => {
-      // If the last assistant message contains a question form, scroll to
-      // the form instead of the bottom, so the user sees the form first.
-      const lastAssistantMsg = [...displayMessages].reverse().find((m) => m.role === 'assistant');
-      if (lastAssistantMsg?.content.includes('<question-form')) {
-        const assistantEls = el.querySelectorAll('.msg.assistant');
-        const lastAssistantEl = assistantEls[assistantEls.length - 1];
-        const formEl = lastAssistantEl?.querySelector<HTMLElement>('[data-form-id]');
-        if (formEl && !scrolledToFormRef.current.has(formEl.dataset.formId!)) {
-          scrolledToFormRef.current.add(formEl.dataset.formId!);
-          formEl.scrollIntoView({ block: 'start', behavior: 'smooth' });
-          pinnedToBottomRef.current = false;
-          setScrolledFromBottom(true);
-          return;
-        }
-        // Already handled by the auto-scroll effect — don't bottom-scroll.
-        if (formEl) return;
-      }
-      // Initial-load bottom-pin must be instant — smooth scrollTo emits
-      // intermediate scroll events that flip pinnedToBottomRef to false.
-      el.scrollTop = el.scrollHeight;
-      setScrolledFromBottom(false);
-      pinnedToBottomRef.current = true;
-    });
-    // `tab` is in the deps so that switching conversations while
-    // Comments is open doesn't strand the new conversation at scrollTop:
-    // 0. The activeConversationId-reset effect above clears
-    // didInitialScrollRef while the chat-log is unmounted; this effect
-    // then re-runs when the user returns to Chat and the element is
-    // available, scrolling the new conversation to its initial bottom.
-  }, [activeConversationId, displayMessages, tab]);
-
-  // When a turn finishes streaming, release the anchor-to-top reserve. The
-  // tail spacer only exists to give a streaming reply room to grow while the
-  // user message stays pinned at the top; once the reply is final it must not
-  // linger, or a short turn (typical of a fresh fork) is left with a large
-  // dead gap below it. Collapsing the spacer lets the bottom-anchored layout
-  // settle the finished transcript against the composer.
-  useEffect(() => {
-    const was = prevStreamingRef.current;
-    prevStreamingRef.current = streaming;
-    // The tail spacer only ever holds the anchor-to-top reserve for an actively
-    // streaming reply, so once the turn ends it must collapse unconditionally —
-    // even if a mid-turn scroll already cleared `anchorActiveRef` (which leaves
-    // the spacer sized). Collapsing it lets the bottom-anchored layout settle a
-    // finished short turn against the composer instead of below a dead gap.
-    if (was && !streaming) {
-      anchorActiveRef.current = false;
-      resetTailSpacer();
-    }
-  }, [streaming]);
-
-  useEffect(() => {
-    const el = logRef.current;
-    if (!el) return;
-    // Auto-scroll only when the user was already pinned near the bottom,
-    // so a scrollback session reading earlier output isn't yanked to the
-    // latest message. We key off the pre-content `pinnedToBottomRef`
-    // (a ref so it doesn't itself re-fire this effect on scroll) instead
-    // of recomputing distance from the just-grown scrollHeight: a single
-    // streamed chunk can add 100+ px in one render, which made the
-    // post-content distance check skip auto-scroll even when the user
-    // was glued to the bottom. We deliberately use the tighter 80px
-    // cutoff tracked by the ref (not the wider 120px jump-button
-    // threshold) so a deliberate ~90px scroll-up isn't snapped back the
-    // next time content streams in. Issue #983.
-
-    // A brand-new user turn from a local send: switch to "anchor to top"
-    // mode and smooth-scroll their message to the top of the viewport.
-    const lastUser = [...displayMessages].reverse().find((m) => m.role === 'user');
-    const prevUserId = prevLastUserIdRef.current;
-    prevLastUserIdRef.current = lastUser?.id;
-    if (anchorPendingRef.current && lastUser && lastUser.id !== prevUserId) {
-      anchorPendingRef.current = false;
-      resetTailSpacer();
-      anchorActiveRef.current = true;
-      pinnedToBottomRef.current = false;
-      setScrolledFromBottom(true);
-      requestAnimationFrame(() => {
-        sizeAnchorSpacer();
-        scrollAnchorToTop();
-      });
-      return;
-    }
-    // While anchored, the message stays at the top on its own (nothing above
-    // it changes), so we only shrink the spacer as the reply grows — never
-    // re-scroll. This is what keeps scrolling down and the final settle smooth.
-    if (anchorActiveRef.current) {
-      requestAnimationFrame(sizeAnchorSpacer);
-      return;
-    }
-
-    if (pinnedToBottomRef.current) {
-      // If the last assistant message contains a question form, scroll to
-      // the form instead of the bottom, so the user lands on the form.
-      const lastAssistantMsg = [...displayMessages].reverse().find((m) => m.role === 'assistant');
-      if (lastAssistantMsg?.content.includes('<question-form')) {
-        const assistantEls = el.querySelectorAll('.msg.assistant');
-        const lastAssistantEl = assistantEls[assistantEls.length - 1];
-        const formEl = lastAssistantEl?.querySelector<HTMLElement>('[data-form-id]');
-        if (formEl && !scrolledToFormRef.current.has(formEl.dataset.formId!)) {
-          scrolledToFormRef.current.add(formEl.dataset.formId!);
-          formEl.scrollIntoView({ block: 'start', behavior: 'smooth' });
-          pinnedToBottomRef.current = false;
-          setScrolledFromBottom(true);
-          return;
-        }
-        // Form tag in content but the DOM element isn't ready yet (partial
-        // stream) — skip bottom-scroll to avoid a jarring jump that gets
-        // undone when the form finishes rendering.
-        if (streaming) return;
-      }
-      // Streaming bottom-pin must be instant — smooth scrollTo emits
-      // intermediate scroll events that flip pinnedToBottomRef to false,
-      // breaking auto-follow for subsequent chunks.
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [displayMessages, error, streaming]);
-
-  // Saved chat-log scroll state, preserved across tab switches. The
-  // chat-log <div> is conditionally rendered so it unmounts when the
-  // user switches to Comments. On remount it would default to
-  // scrollTop: 0 and the initial-bottom-scroll effect skips because
-  // didInitialScrollRef is already true. We capture either the absolute
-  // scrollTop or a "pinned to bottom" flag while Chat is visible, so
-  // bottom-followers stay pinned even when new messages stream in
-  // off-tab. Issue #790.
-  const savedChatScrollRef = useRef<
-    { pinnedToBottom: true } | { pinnedToBottom: false; scrollTop: number } | null
-  >(null);
-  useEffect(() => {
-    if (tab !== 'chat') return;
-    const el = logRef.current;
-    if (!el) return;
-
-    function syncScrollable(target: HTMLDivElement) {
-      const next = target.scrollHeight - target.clientHeight > 1;
-      setChatLogScrollable((prev) => (prev === next ? prev : next));
-      if (!next) setChatLogScrolling(false);
-    }
-
-    function markScrolling() {
-      setChatLogScrolling(true);
-      if (chatLogScrollIdleTimerRef.current !== null) {
-        window.clearTimeout(chatLogScrollIdleTimerRef.current);
-      }
-      chatLogScrollIdleTimerRef.current = window.setTimeout(() => {
-        chatLogScrollIdleTimerRef.current = null;
-        setChatLogScrolling(false);
-      }, 650);
-    }
-
-    // Restore previously-saved position on remount. Defer to the next
-    // frame so the conditional <> contents finish layout before the
-    // scrollTop write lands.
-    const saved = savedChatScrollRef.current;
-    if (saved !== null) {
-      requestAnimationFrame(() => {
-        const target = logRef.current;
-        if (!target) return;
-        if (saved.pinnedToBottom) {
-          target.scrollTop = target.scrollHeight;
-        } else {
-          target.scrollTop = saved.scrollTop;
-        }
-        syncScrollable(target);
-        // Resync the jump-to-latest affordance with the restored
-        // position. Without this, a user who left Chat ~60px from the
-        // bottom and returns to find new messages stacked underneath
-        // would land hundreds of pixels above the latest turn while
-        // scrolledFromBottom remained false until they scrolled.
-        const distance =
-          target.scrollHeight - target.scrollTop - target.clientHeight;
-        setScrolledFromBottom(distance > 120);
-        pinnedToBottomRef.current = distance < 80;
-      });
-    }
-
-    function snapshot(target: HTMLDivElement) {
-      const distance =
-        target.scrollHeight - target.scrollTop - target.clientHeight;
-      savedChatScrollRef.current =
-        distance < 50
-          ? { pinnedToBottom: true }
-          : { pinnedToBottom: false, scrollTop: target.scrollTop };
-    }
-
-    function onScroll() {
-      const target = logRef.current;
-      if (!target) return;
-      // A genuine user scroll (one that moves away from where the anchored
-      // message currently sits) releases the auto-resize behavior. We do NOT
-      // collapse the tail spacer: the reserved blank below stays as real,
-      // scrollable space so scrolling down feels natural instead of snapping.
-      if (anchorActiveRef.current) {
-        const pinnedTop = lastUserMsgTopInContent(target);
-        if (
-          pinnedTop !== null &&
-          Math.abs(target.scrollTop - (pinnedTop - ANCHOR_TOP_PADDING)) > 40
-        ) {
-          anchorActiveRef.current = false;
-        }
-      }
-      syncScrollable(target);
-      markScrolling();
-      snapshot(target);
-      const distance =
-        target.scrollHeight - target.scrollTop - target.clientHeight;
-      // Functional updater bails out when the value is unchanged so a flood
-      // of scroll events (e.g. programmatic scrollTop + ResizeObserver
-      // follow-up during streaming) does not schedule a re-render per tick
-      // and trip React's "Maximum update depth exceeded" guard.
-      const next = distance > 120;
-      setScrolledFromBottom((prev) => (prev === next ? prev : next));
-      pinnedToBottomRef.current = distance < 80;
-    }
-    syncScrollable(el);
-    el.addEventListener('scroll', onScroll);
-    return () => {
-      // Capture final scroll state before unmount; the ref normally
-      // tracks via onScroll, but programmatic scrolls or layout shifts
-      // right before unmount can leave it stale.
-      snapshot(el);
-      el.removeEventListener('scroll', onScroll);
-      if (chatLogScrollIdleTimerRef.current !== null) {
-        window.clearTimeout(chatLogScrollIdleTimerRef.current);
-        chatLogScrollIdleTimerRef.current = null;
-      }
-      setChatLogScrolling(false);
-    };
-  }, [tab]);
-
-  useEffect(() => {
-    if (tab !== 'chat') return;
-    const el = logRef.current;
-    if (!el) return;
-
-    let followFrame: number | null = null;
-    const followLatestIfPinned = () => {
-      // While anchored, only shrink the tail spacer as the reply grows
-      // (resize-only, never scroll) so the user message stays put without
-      // fighting a manual scroll-down.
-      if (anchorActiveRef.current) {
-        if (followFrame !== null) return;
-        followFrame = requestAnimationFrame(() => {
-          followFrame = null;
-          if (!anchorActiveRef.current) return;
-          sizeAnchorSpacer();
-        });
-        return;
-      }
-      if (!pinnedToBottomRef.current || followFrame !== null) return;
-      followFrame = requestAnimationFrame(() => {
-        followFrame = null;
-        const target = logRef.current;
-        if (!target || !pinnedToBottomRef.current) return;
-        target.scrollTop = target.scrollHeight;
-        setScrolledFromBottom(false);
-      });
-    };
-
-    const resizeObserver =
-      typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(() => {
-            const target = logRef.current;
-            if (target) {
-              const next = target.scrollHeight - target.clientHeight > 1;
-              setChatLogScrollable((prev) => (prev === next ? prev : next));
-              if (!next) setChatLogScrolling(false);
-            }
-            followLatestIfPinned();
-          })
-        : null;
-    const observedChildren = new Set<Element>();
-    const syncObservedChildren = () => {
-      if (!resizeObserver) return;
-      const currentChildren = new Set(Array.from(el.children));
-      // The tail spacer's height is driven by the anchor logic; observing it
-      // would feed its own resize back into followLatestIfPinned.
-      if (tailSpacerRef.current) currentChildren.delete(tailSpacerRef.current);
-      for (const child of currentChildren) {
-        if (observedChildren.has(child)) continue;
-        resizeObserver.observe(child);
-        observedChildren.add(child);
-      }
-      for (const child of observedChildren) {
-        if (currentChildren.has(child)) continue;
-        resizeObserver.unobserve(child);
-        observedChildren.delete(child);
-      }
-    };
-
-    let observedQueuedSendStrip: Element | null = null;
-    const syncQueuedSendStrip = () => {
-      if (!resizeObserver) return;
-      const queuedEl = queuedSendStripRef.current;
-      if (queuedEl && observedQueuedSendStrip !== queuedEl) {
-        if (observedQueuedSendStrip) {
-          resizeObserver.unobserve(observedQueuedSendStrip);
-        }
-        resizeObserver.observe(queuedEl);
-        observedQueuedSendStrip = queuedEl;
-      } else if (!queuedEl && observedQueuedSendStrip) {
-        resizeObserver.unobserve(observedQueuedSendStrip);
-        observedQueuedSendStrip = null;
-      }
-    };
-
-    syncObservedChildren();
-    syncQueuedSendStrip();
-
-    const mutationObserver =
-      typeof MutationObserver !== 'undefined'
-        ? new MutationObserver(() => {
-            syncObservedChildren();
-            syncQueuedSendStrip();
-            followLatestIfPinned();
-          })
-        : null;
-    // childList + subtree only — NOT characterData. Auto-follow during
-    // streaming is driven by the ResizeObserver on each message child (text
-    // growth changes height), so observing per-character text mutations would
-    // re-run the full sync sweep on every streamed frame for no extra benefit.
-    mutationObserver?.observe(el, {
-      childList: true,
-      subtree: true,
-    });
-    // QueuedSendStrip lives outside the chat-log subtree (it is a sibling of
-    // .chat-log-wrap inside .pane). The MutationObserver above only fires for
-    // changes inside el, so it cannot detect that surface mounting or
-    // unmounting. Watch the nearest common ancestor (.pane) with childList-only
-    // to keep its observer current.
-    const paneEl = el.parentElement?.parentElement ?? null;
-    if (paneEl && mutationObserver) {
-      mutationObserver.observe(paneEl, { childList: true });
-    }
-
-    return () => {
-      if (followFrame !== null) cancelAnimationFrame(followFrame);
-      mutationObserver?.disconnect();
-      resizeObserver?.disconnect();
-    };
-  }, [tab]);
-
-  // Close the conversation history dropdown on outside click / Escape.
-  useEffect(() => {
-    if (!showConvList) return;
-    function onPointer(e: MouseEvent) {
-      const target = e.target as Node;
-      if (historyWrapRef.current?.contains(target)) return;
-      setShowConvList(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setShowConvList(false);
-    }
-    document.addEventListener('mousedown', onPointer);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [showConvList]);
-
-  useEffect(() => {
-    if (showConvList) return;
-    setConversationSearch('');
-  }, [showConvList]);
-
-  const activeConversation =
-    conversations.find((c) => c.id === activeConversationId) ?? null;
-  const filteredConversations = useMemo(
-    () => filterConversations(conversations, deferredConversationSearch, t),
-    [conversations, deferredConversationSearch, t],
+  const nextUserContentByAssistantId = useMemo(
+    () => nextUserContentByAssistantIdFor(displayMessages),
+    [displayMessages],
   );
-
-  function resetTailSpacer() {
-    const s = tailSpacerRef.current;
-    if (s) s.style.height = '0px';
-  }
-
-  // Content offset (distance from the top of the scroll content) of the most
-  // recent user message. Invariant to the current scrollTop, so it's safe to
-  // call regardless of where the user has scrolled.
-  function lastUserMsgTopInContent(el: HTMLDivElement): number | null {
-    const userEls = el.querySelectorAll<HTMLElement>('.msg.user');
-    const msgEl = userEls[userEls.length - 1];
-    if (!msgEl) return null;
-    const elRect = el.getBoundingClientRect();
-    const msgRect = msgEl.getBoundingClientRect();
-    return el.scrollTop + (msgRect.top - elRect.top);
-  }
-
-  // Resize the tail spacer so the anchored message can sit at the top with
-  // just enough room below it — no more. This is a resize ONLY (never a
-  // scroll): shrinking empty space below the fold can't shift what's visible
-  // while the user is pinned near the top, so it never causes jitter. As the
-  // reply streams in, `needed` shrinks monotonically toward 0.
-  function sizeAnchorSpacer() {
-    const el = logRef.current;
-    const spacer = tailSpacerRef.current;
-    if (!el || !spacer) return;
-    const msgTopInContent = lastUserMsgTopInContent(el);
-    if (msgTopInContent === null) return;
-    const spacerH = spacer.offsetHeight;
-    const contentBelow = el.scrollHeight - spacerH - msgTopInContent;
-    const needed = Math.max(0, el.clientHeight - contentBelow - ANCHOR_TOP_PADDING);
-    spacer.style.height = `${needed}px`;
-  }
-
-  // Smooth-scroll the anchored message to the top. Called ONCE per turn (on
-  // send). The message then stays at the top on its own as the reply streams
-  // below it, so we never re-scroll — re-scrolling each chunk is what caused
-  // the scroll-down fight and the settle jitter.
-  function scrollAnchorToTop() {
-    const el = logRef.current;
-    if (!el) return;
-    const msgTopInContent = lastUserMsgTopInContent(el);
-    if (msgTopInContent === null) return;
-    const target = Math.max(0, msgTopInContent - ANCHOR_TOP_PADDING);
-    el.scrollTo({ top: target, behavior: 'smooth' });
-  }
-
-  function jumpToBottom() {
-    const el = logRef.current;
-    if (!el) return;
-    anchorActiveRef.current = false;
-    pinnedToBottomRef.current = true;
-    resetTailSpacer();
-    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-  }
-
-  useEffect(() => {
-    if (typeof document === 'undefined') return;
-    setComposerPortalTarget(document.body);
-  }, []);
-
-  useLayoutEffect(() => {
-    if (tab !== 'chat') {
-      setComposerPortalRect(null);
-      return;
-    }
-    const slot = composerSlotRef.current;
-    if (!slot || typeof window === 'undefined') return;
-
-    let frame: number | null = null;
-    const updateRect = () => {
-      frame = null;
-      const rect = slot.getBoundingClientRect();
-      setComposerPortalRect((prev) => {
-        const next = {
-          left: Math.round(rect.left),
-          width: Math.round(rect.width),
-          bottom: Math.max(0, Math.round(window.innerHeight - rect.bottom)),
-        };
-        if (
-          prev
-          && prev.left === next.left
-          && prev.width === next.width
-          && prev.bottom === next.bottom
-        ) {
-          return prev;
-        }
-        return next;
-      });
-    };
-    const scheduleUpdate = () => {
-      if (frame !== null) return;
-      frame = window.requestAnimationFrame(updateRect);
-    };
-
-    updateRect();
-    const resizeObserver =
-      typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(scheduleUpdate)
-        : null;
-    resizeObserver?.observe(slot);
-    const pane = slot.closest('.pane');
-    if (pane) resizeObserver?.observe(pane);
-    window.addEventListener('resize', scheduleUpdate);
-    window.visualViewport?.addEventListener('resize', scheduleUpdate);
-
-    return () => {
-      if (frame !== null) window.cancelAnimationFrame(frame);
-      resizeObserver?.disconnect();
-      window.removeEventListener('resize', scheduleUpdate);
-      window.visualViewport?.removeEventListener('resize', scheduleUpdate);
-    };
-  }, [tab]);
-
-  useLayoutEffect(() => {
-    if (tab !== 'chat' || !composerPortalTarget || !composerPortalRect) return;
-    const layer = composerLayerRef.current;
-    if (!layer || typeof window === 'undefined') return;
-
-    let frame: number | null = null;
-    const updateHeight = () => {
-      frame = null;
-      const nextHeight = Math.ceil(layer.getBoundingClientRect().height);
-      setComposerSlotHeight((prev) => (prev === nextHeight ? prev : nextHeight));
-    };
-    const scheduleUpdate = () => {
-      if (frame !== null) return;
-      frame = window.requestAnimationFrame(updateHeight);
-    };
-
-    updateHeight();
-    const resizeObserver =
-      typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(scheduleUpdate)
-        : null;
-    resizeObserver?.observe(layer);
-
-    return () => {
-      if (frame !== null) window.cancelAnimationFrame(frame);
-      resizeObserver?.disconnect();
-    };
-  }, [composerPortalRect, composerPortalTarget, tab]);
 
   const composerNode = (
     <ChatComposer
@@ -2021,8 +648,7 @@ export function ChatPane({
       commentAttachments={commentsToAttachments(attachedComments)}
       onRemoveCommentAttachment={onDetachComment}
       onSend={(prompt, attachments, commentAttachments, meta) => {
-        pinnedToBottomRef.current = true;
-        scrolledToFormRef.current = new Set();
+        resetScrollTrackingForSend();
         if (editingQueuedSendId && onUpdateQueuedSend) {
           const original = queuedItems.find((item) => item.id === editingQueuedSendId);
           const update: QueuedSendUpdate = {
@@ -2040,9 +666,7 @@ export function ChatPane({
         // the new user turn renders, pinning it to the top of the view.
         // Clear any stale reserve from the previous turn first so a resend
         // doesn't strand the new turn below a leftover gap (release #3653).
-        anchorActiveRef.current = false;
-        resetTailSpacer();
-        anchorPendingRef.current = true;
+        armAnchorForSend();
         onSend(prompt, attachments, commentAttachments, meta);
       }}
       onStop={onStop}
@@ -2121,19 +745,7 @@ export function ChatPane({
             aria-label={t('chat.conversationsAria')}
             aria-haspopup="menu"
             aria-expanded={showConvList}
-            onClick={() => {
-              setShowConvList((v) => {
-                const next = !v;
-                if (next) {
-                  trackChatPanelClick(analytics.track, {
-                    page_name: 'chat_panel',
-                    area: 'chat_panel',
-                    element: 'history',
-                  });
-                }
-                return next;
-              });
-            }}
+            onClick={handleToggleHistoryList}
           >
             <Icon name="comment" size={16} />
           </button>
@@ -2156,16 +768,7 @@ export function ChatPane({
                     className="chat-history-new"
                     data-testid="conversation-history-new"
                     disabled={newConversationDisabled}
-                    onClick={() => {
-                      if (newConversationDisabled) return;
-                      trackChatPanelClick(analytics.track, {
-                        page_name: 'chat_panel',
-                        area: 'chat_panel',
-                        element: 'new_chat',
-                      });
-                      onNewConversation();
-                      setShowConvList(false);
-                    }}
+                    onClick={handleStartNewConversation}
                   >
                     <Icon name="plus" size={11} />
                     <span>{t('chat.new')}</span>
@@ -2208,10 +811,7 @@ export function ChatPane({
                       conversation={c}
                       active={c.id === activeConversationId}
                       messageCount={conversationMessageCount(c, activeConversationId, messagesConversationId, messages.length)}
-                      onSelect={() => {
-                        onSelectConversation(c.id);
-                        setShowConvList(false);
-                      }}
+                      onSelect={() => handleSelectConversation(c.id)}
                       onDelete={() => onDeleteConversation(c.id)}
                       t={t}
                     />
@@ -2245,9 +845,7 @@ export function ChatPane({
                   '.thinking-toggle, .action-card-toggle, button.op-card-head, [aria-expanded]',
                 );
                 if (toggle && logRef.current?.contains(toggle)) {
-                  pinnedToBottomRef.current = false;
-                  anchorActiveRef.current = false;
-                  setScrolledFromBottom(true);
+                  unpinFromBottom();
                 }
               }}
             >
@@ -2260,6 +858,7 @@ export function ChatPane({
                       files={importedFolderArtifacts}
                       onOpenFile={onRequestOpenFile}
                       t={t}
+                      projectRawUrl={projectRawUrl}
                     />
                   ) : (
                     <>
@@ -2276,14 +875,7 @@ export function ChatPane({
                             role="listitem"
                             className="chat-example"
                             style={{ animationDelay: `${i * 70}ms` }}
-                            onClick={() => {
-                              trackChatPanelClick(analytics.track, {
-                                page_name: 'chat_panel',
-                                area: 'chat_panel',
-                                element: 'template_card',
-                              });
-                              composerRef.current?.setDraft(ex.prompt);
-                            }}
+                            onClick={() => handleStarterCardClick(ex.prompt)}
                             title={t('chat.fillInputTitle')}
                           >
                             <span className="chat-example-icon" aria-hidden>
@@ -2386,6 +978,7 @@ export function ChatPane({
                 t={t}
                 onOpenQuestions={onOpenQuestions}
                 scrollContainerRef={logRef}
+                projectRawUrl={projectRawUrl}
               />
               {displayError ? (
                 <div className="run-error" data-tone={runErrorTone}>
@@ -2472,30 +1065,8 @@ export function ChatPane({
                               showActivationDetails
                               hideSignedOutStatus
                               revealPendingCancelAction
-                              onSignInStarted={() => {
-                                amrAuthPrevLoggedInRef.current = false;
-                              }}
-                              onStatusChange={(loginStatus) => {
-                                // Retry only on a real signed-out -> signed-in
-                                // transition (see amrAuthPrevLoggedInRef).
-                                if (loginStatus?.loggedIn === true) {
-                                  const wasSignedOut =
-                                    amrAuthPrevLoggedInRef.current === false;
-                                  amrAuthPrevLoggedInRef.current = true;
-                                  if (
-                                    wasSignedOut &&
-                                    amrAuthRetriedRef.current !== retryAssistant.id
-                                  ) {
-                                    amrAuthRetriedRef.current = retryAssistant.id;
-                                    onRetry(retryAssistant);
-                                  }
-                                } else if (
-                                  loginStatus &&
-                                  loginStatus.loggedIn === false
-                                ) {
-                                  amrAuthPrevLoggedInRef.current = false;
-                                }
-                              }}
+                              onSignInStarted={handleAmrSignInStarted}
+                              onStatusChange={handleAmrLoginStatusChange}
                             />
                           ) : runFailureUi.primaryAction === 'launch-terminal-auth' ? (
                             <button
@@ -2521,39 +1092,7 @@ export function ChatPane({
                             <button
                               type="button"
                               className="chat-error-action"
-                              onClick={() => {
-                                const attribution = recordAmrEntry(
-                                  analytics.track,
-                                  'chat_error_recharge',
-                                  new Date(),
-                                  {
-                                    metricsConsent:
-                                      config?.telemetry?.metrics === true,
-                                  },
-                                );
-                                // Forward the canonical telemetry device id to
-                                // AMR only on metrics opt-in (see
-                                // amrHandoffDeviceId). Sourced from the current
-                                // config.installationId / resolved device id,
-                                // not the mount-time bootstrap UUID, so the join
-                                // key matches the telemetry identity even across
-                                // a Delete-my-data rotation.
-                                const deviceId = amrHandoffDeviceId({
-                                  metricsConsent:
-                                    config?.telemetry?.metrics === true,
-                                  resolvedDeviceId: getResolvedDeviceId(),
-                                  installationId: config?.installationId,
-                                });
-                                window.open(
-                                  attributedAmrUrl(
-                                    amrRechargeUrlForProfile(amrProfile),
-                                    attribution,
-                                    deviceId,
-                                  ),
-                                  '_blank',
-                                  'noopener,noreferrer',
-                                );
-                              }}
+                              onClick={handleAmrRecharge}
                             >
                               {t('chat.amrError.rechargeCta')}
                             </button>
@@ -2561,32 +1100,7 @@ export function ChatPane({
                             <button
                               type="button"
                               className="chat-error-action"
-                              onClick={() => {
-                                const attribution = recordAmrEntry(
-                                  analytics.track,
-                                  'chat_error_upgrade',
-                                  new Date(),
-                                  {
-                                    metricsConsent:
-                                      config?.telemetry?.metrics === true,
-                                  },
-                                );
-                                const deviceId = amrHandoffDeviceId({
-                                  metricsConsent:
-                                    config?.telemetry?.metrics === true,
-                                  resolvedDeviceId: getResolvedDeviceId(),
-                                  installationId: config?.installationId,
-                                });
-                                window.open(
-                                  attributedAmrUrl(
-                                    amrPlansUrlForProfile(amrProfile),
-                                    attribution,
-                                    deviceId,
-                                  ),
-                                  '_blank',
-                                  'noopener,noreferrer',
-                                );
-                              }}
+                              onClick={handleAmrUpgrade}
                             >
                               {t('chat.amrBalanceGate.plansCta')}
                             </button>
@@ -2630,13 +1144,7 @@ export function ChatPane({
                   {...amrSwitchPayload}
                   sourceDetail="chat_error_switch_retry_card"
                   metricsConsent={config?.telemetry?.metrics === true}
-                  onActivate={() => {
-                    if (retryAssistant && onSwitchToAmrAndRetry) {
-                      onSwitchToAmrAndRetry(retryAssistant);
-                    } else {
-                      onOpenAmrSettings?.();
-                    }
-                  }}
+                  onActivate={handleAmrSwitchActivate}
                 />
               ) : null}
               {/* Dynamic spacer: when a turn is anchored to the top, this
@@ -2668,41 +1176,10 @@ export function ChatPane({
             containerRef={queuedSendStripRef}
             items={queuedItems}
             editingId={editingQueuedSendId}
-            onEdit={(item) => {
-              trackMessageQueueClick(analytics.track, {
-                page_name: 'chat_panel',
-                area: 'message_queue',
-                element: 'edit',
-                project_id: projectId ?? '',
-                queue_length: queuedItems.length,
-              });
-              restoreQueuedSendToComposer(item);
-            }}
-            onRemove={onRemoveQueuedSend
-              ? (id) => {
-                  trackMessageQueueClick(analytics.track, {
-                    page_name: 'chat_panel',
-                    area: 'message_queue',
-                    element: 'delete',
-                    project_id: projectId ?? '',
-                    queue_length: queuedItems.length,
-                  });
-                  onRemoveQueuedSend(id);
-                }
-              : undefined}
+            onEdit={handleEditQueuedSend}
+            onRemove={handleRemoveQueuedSend}
             onReorder={onReorderQueuedSends}
-            onSendNow={onSendQueuedNow
-              ? (id) => {
-                  trackMessageQueueClick(analytics.track, {
-                    page_name: 'chat_panel',
-                    area: 'message_queue',
-                    element: 'send_now',
-                    project_id: projectId ?? '',
-                    queue_length: queuedItems.length,
-                  });
-                  onSendQueuedNow(id);
-                }
-              : undefined}
+            onSendNow={handleSendQueuedNow}
           />
           <div
             className="chat-composer-slot"
@@ -2732,1601 +1209,4 @@ export function ChatPane({
       ) : null}
     </div>
   );
-}
-
-interface AssistantCallbacks {
-  onContinueRemainingTasks:
-    | ((assistantMessage: ChatMessage, todos: TodoItem[]) => void)
-    | undefined;
-  onAssistantFeedback:
-    | ((message: ChatMessage, change: ChatMessageFeedbackChange) => void)
-    | undefined;
-  onBrandBrowserAssistConfirm: BrandBrowserAssistConfirm | undefined;
-  onArtifactShare: ((fileName: string) => void) | undefined;
-  onForkFromMessage: ((message: ChatMessage) => void) | undefined;
-  onShareToOpenDesign: ((assistantMessageId: string) => void) | undefined;
-  onNextStepAiOptimize: (() => void) | undefined;
-  onNextStepContinueExtraction: (() => void) | undefined;
-  onNextStepContinueAiExtraction: (() => void) | undefined;
-  onNextStepCreateDesign: (() => void) | undefined;
-  onNextStepCreateDesignSystem: (() => void) | undefined;
-}
-
-type ChatRenderItem = {
-  kind: 'message';
-  key: string;
-  message: ChatMessage;
-};
-
-function ChatConversationLoading({ t }: { t: TranslateFn }) {
-  return (
-    <div className="chat-loading-state" role="status" aria-live="polite">
-      <span className="chat-loading-mark" aria-hidden>
-        <span />
-        <span />
-        <span />
-      </span>
-      <span className="chat-loading-copy">{t('common.loading')}</span>
-      <span className="chat-loading-lines" aria-hidden>
-        <span />
-        <span />
-        <span />
-      </span>
-    </div>
-  );
-}
-
-function ChatRows({
-  messages,
-  streaming,
-  liveToolInput,
-  projectId,
-  projectKindForTracking,
-  activeConversationId,
-  activeConversationKey,
-  projectFiles,
-  projectMetadata,
-  projectFileNames,
-  onRequestOpenFile,
-  onRequestPluginDetails,
-  onRequestDesignSystemDetails,
-  onRequestPluginFolderAgentAction,
-  activePluginActionPaths,
-  hiddenPluginActionPaths,
-  onShareToOpenDesign,
-  shareToOpenDesignBusyMessageId,
-  forceStreamingMessageIds,
-  lastAssistantId,
-  firstUserMessageId,
-  activePluginSnapshot,
-  activeDesignSystem,
-  hasActiveDesignSystem,
-  errorCardOwnerId,
-  nextUserContentByAssistantId,
-  assistantCallbacksRef,
-  onContinueRemainingTasks,
-  onBrandBrowserAssistConfirm,
-  onArtifactShare,
-  onToolboxAction,
-  onNextStepPromptAction,
-  onNextStepAiOptimize,
-  nextStepAiOptimizeBusy,
-  onNextStepContinueExtraction,
-  nextStepContinueExtractionBusy,
-  onNextStepContinueAiExtraction,
-  nextStepContinueAiExtractionBusy,
-  onNextStepCreateDesign,
-  nextStepCreateDesignBusy,
-  onNextStepCreateDesignSystem,
-  nextStepCreateDesignSystemBusy,
-  onPickSkill,
-  onArtifactDownload,
-  nextStepSkills,
-  toolboxSkillNames,
-  nextStepVariant,
-  onForkFromMessage,
-  onAssistantFeedback,
-  forkingMessageId,
-  t,
-  onOpenQuestions,
-  scrollContainerRef,
-}: {
-  messages: ChatMessage[];
-  streaming: boolean;
-  liveToolInput?: Record<string, { name: string; text: string; seq?: number }>;
-  projectId: string | null;
-  projectKindForTracking: TrackingProjectKind | null;
-  activeConversationId: string | null;
-  activeConversationKey: string;
-  projectFiles: ProjectFile[];
-  projectMetadata?: ProjectMetadata;
-  projectFileNames?: Set<string>;
-  onRequestOpenFile?: (name: string) => void;
-  onRequestPluginDetails?: (pluginId: string) => void;
-  onRequestDesignSystemDetails?: (system: DesignSystemSummary) => void;
-  onRequestPluginFolderAgentAction?: (relativePath: string, action: PluginFolderAgentAction) => void;
-  activePluginActionPaths?: Set<string>;
-  hiddenPluginActionPaths?: Set<string>;
-  onShareToOpenDesign?: (assistantMessageId: string) => void;
-  shareToOpenDesignBusyMessageId?: string | null;
-  forceStreamingMessageIds?: Set<string>;
-  lastAssistantId: string | undefined;
-  firstUserMessageId: string | undefined;
-  activePluginSnapshot?: AppliedPluginSnapshot | null;
-  activeDesignSystem?: DesignSystemSummary | null;
-  hasActiveDesignSystem: boolean;
-  errorCardOwnerId: string | null;
-  nextUserContentByAssistantId: Map<string, string>;
-  assistantCallbacksRef: MutableRefObject<AssistantCallbacks>;
-  onContinueRemainingTasks?: (assistantMessage: ChatMessage, todos: TodoItem[]) => void;
-  onBrandBrowserAssistConfirm?: BrandBrowserAssistConfirm;
-  onArtifactShare?: (fileName: string) => void;
-  onToolboxAction?: (id: DesignToolboxActionId) => void;
-  onNextStepPromptAction?: (
-    prompt: string,
-    options?: { sessionMode?: ChatSessionMode },
-  ) => void;
-  onNextStepAiOptimize?: () => void;
-  nextStepAiOptimizeBusy?: boolean;
-  onNextStepContinueExtraction?: () => void;
-  nextStepContinueExtractionBusy?: boolean;
-  onNextStepContinueAiExtraction?: () => void;
-  nextStepContinueAiExtractionBusy?: boolean;
-  onNextStepCreateDesign?: () => void;
-  nextStepCreateDesignBusy?: boolean;
-  onNextStepCreateDesignSystem?: () => void;
-  nextStepCreateDesignSystemBusy?: boolean;
-  onPickSkill?: (skillId: string) => void;
-  onArtifactDownload?: (fileName: string) => void;
-  nextStepSkills?: SkillSummary[];
-  toolboxSkillNames?: Partial<Record<DesignToolboxActionId, string | null>>;
-  nextStepVariant?: NextStepActionsVariant;
-  onForkFromMessage?: (message: ChatMessage) => void;
-  onAssistantFeedback?: (message: ChatMessage, change: ChatMessageFeedbackChange) => void;
-  forkingMessageId?: string | null;
-  t: TranslateFn;
-  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
-  scrollContainerRef: MutableRefObject<HTMLDivElement | null>;
-}) {
-  const conversationTodoInput = useMemo(
-    () => latestTodoWriteInputForPinnedCard(messages),
-    [messages],
-  );
-  const conversationTodoAnchorMessageId = useMemo(
-    () => firstTodoWriteAssistantMessageId(messages),
-    [messages],
-  );
-  const items = useMemo(
-    () => buildChatRenderItems(messages),
-    [messages],
-  );
-  const virtualized = items.length > CHAT_MESSAGE_VIRTUALIZE_THRESHOLD;
-  const virtualWindow = useMeasuredVirtualWindow(items, {
-    enabled: virtualized,
-    containerRef: scrollContainerRef,
-    estimateSize: estimateChatRenderItemHeight,
-    overscanPx: CHAT_MESSAGE_OVERSCAN_PX,
-    resetKey: activeConversationKey,
-    initialTailRows: CHAT_VIRTUAL_INITIAL_TAIL_ROWS,
-    alwaysIncludeKey:
-      conversationTodoInput != null && conversationTodoAnchorMessageId
-        ? `message:${conversationTodoAnchorMessageId}`
-        : undefined,
-  });
-
-  const renderItem = (item: ChatRenderItem) => {
-    const m = item.message;
-    const messageStreaming = isAssistantMessageStreaming(
-      m,
-      streaming,
-      lastAssistantId,
-      forceStreamingMessageIds,
-    );
-    if (m.role === 'user') {
-      return (
-        <UserMessage
-          message={m}
-          projectId={projectId}
-          projectFileNames={projectFileNames}
-          onRequestOpenFile={onRequestOpenFile}
-          onRequestPluginDetails={onRequestPluginDetails}
-          onRequestDesignSystemDetails={onRequestDesignSystemDetails}
-          t={t}
-          activePluginSnapshot={
-            m.id === firstUserMessageId
-              ? activePluginSnapshot ?? null
-              : null
-          }
-          activeDesignSystem={
-            m.id === firstUserMessageId
-              ? activeDesignSystem ?? null
-              : null
-          }
-        />
-      );
-    }
-    return (
-      <AssistantMessage
-        message={m}
-        streaming={messageStreaming}
-        // Only the streaming row consumes live tool input. Non-streaming rows
-        // get a stable `undefined`, so adding `liveToolInput` to the memo
-        // comparator re-renders just this row per `tool_input_delta`, not all N.
-        liveToolInput={messageStreaming ? liveToolInput : undefined}
-        showConversationTodoCard={m.id === conversationTodoAnchorMessageId}
-        conversationTodoInput={conversationTodoInput}
-        projectId={projectId}
-        projectKind={projectKindForTracking}
-        conversationId={activeConversationId}
-        projectFiles={projectFiles}
-        projectMetadata={projectMetadata}
-        projectFileNames={projectFileNames}
-        onRequestOpenFile={onRequestOpenFile}
-        onRequestPluginFolderAgentAction={onRequestPluginFolderAgentAction}
-        activePluginActionPaths={activePluginActionPaths}
-        hiddenPluginActionPaths={hiddenPluginActionPaths}
-        onShareToOpenDesign={
-          onShareToOpenDesign
-            ? () => assistantCallbacksRef.current.onShareToOpenDesign?.(m.id)
-            : undefined
-        }
-        shareToOpenDesignBusy={shareToOpenDesignBusyMessageId === m.id}
-        isLast={m.id === lastAssistantId}
-        errorCardOwnerId={errorCardOwnerId}
-        nextUserContent={nextUserContentByAssistantId.get(m.id)}
-        suppressDirectionForms={hasActiveDesignSystem}
-        hasDesignSystemContext={hasActiveDesignSystem || !!activeDesignSystem}
-        onOpenQuestions={onOpenQuestions}
-        onBrandBrowserAssistConfirm={
-          onBrandBrowserAssistConfirm
-            ? (card) => assistantCallbacksRef.current.onBrandBrowserAssistConfirm?.(card)
-            : undefined
-        }
-        onContinueRemainingTasks={
-          m.id === lastAssistantId && onContinueRemainingTasks
-            ? (todos) => assistantCallbacksRef.current.onContinueRemainingTasks?.(m, todos)
-            : undefined
-        }
-        onForkFromMessage={
-          onForkFromMessage
-            ? () => assistantCallbacksRef.current.onForkFromMessage?.(m)
-            : undefined
-        }
-        forking={forkingMessageId === m.id}
-        onFeedback={
-          onAssistantFeedback
-            ? (rating) => assistantCallbacksRef.current.onAssistantFeedback?.(m, rating)
-            : undefined
-        }
-        onArtifactShare={
-          onArtifactShare
-            ? (fileName) => assistantCallbacksRef.current.onArtifactShare?.(fileName)
-            : undefined
-        }
-        onToolboxAction={onToolboxAction}
-        onNextStepPromptAction={onNextStepPromptAction}
-        onNextStepAiOptimize={
-          onNextStepAiOptimize
-            ? () => assistantCallbacksRef.current.onNextStepAiOptimize?.()
-            : undefined
-        }
-        nextStepAiOptimizeBusy={nextStepAiOptimizeBusy}
-        onNextStepContinueExtraction={
-          onNextStepContinueExtraction
-            ? () => assistantCallbacksRef.current.onNextStepContinueExtraction?.()
-            : undefined
-        }
-        nextStepContinueExtractionBusy={nextStepContinueExtractionBusy}
-        onNextStepContinueAiExtraction={
-          onNextStepContinueAiExtraction
-            ? () => assistantCallbacksRef.current.onNextStepContinueAiExtraction?.()
-            : undefined
-        }
-        nextStepContinueAiExtractionBusy={nextStepContinueAiExtractionBusy}
-        onNextStepCreateDesign={
-          onNextStepCreateDesign
-            ? () => assistantCallbacksRef.current.onNextStepCreateDesign?.()
-            : undefined
-        }
-        nextStepCreateDesignBusy={nextStepCreateDesignBusy}
-        onNextStepCreateDesignSystem={
-          onNextStepCreateDesignSystem
-            ? () => assistantCallbacksRef.current.onNextStepCreateDesignSystem?.()
-            : undefined
-        }
-        nextStepCreateDesignSystemBusy={nextStepCreateDesignSystemBusy}
-        onPickSkill={onPickSkill}
-        onArtifactDownload={onArtifactDownload}
-        nextStepSkills={nextStepSkills}
-        toolboxSkillNames={toolboxSkillNames}
-        nextStepVariant={nextStepVariant}
-      />
-    );
-  };
-
-  if (items.length === 0) return null;
-
-  if (!virtualized) {
-    return (
-      <>
-        {items.map((item) => (
-          <Fragment key={item.key}>{renderItem(item)}</Fragment>
-        ))}
-      </>
-    );
-  }
-
-  return (
-    <div
-      className="chat-virtual-spacer"
-      data-testid="chat-virtual-spacer"
-      style={{ height: virtualWindow.totalHeight }}
-    >
-      {virtualWindow.rows.map((row) => (
-        <VirtualChatRow
-          key={row.item.key}
-          itemKey={row.item.key}
-          top={row.top}
-          onMeasure={virtualWindow.onMeasure}
-        >
-          {renderItem(row.item)}
-        </VirtualChatRow>
-      ))}
-    </div>
-  );
-}
-
-function VirtualChatRow({
-  itemKey,
-  top,
-  onMeasure,
-  children,
-}: {
-  itemKey: string;
-  top: number;
-  onMeasure: (key: string, height: number) => void;
-  children: ReactNode;
-}) {
-  const rowRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const node = rowRef.current;
-    if (!node) return;
-    const measure = () => {
-      const height = node.getBoundingClientRect().height;
-      onMeasure(itemKey, height);
-    };
-    measure();
-    if (typeof ResizeObserver === 'undefined') return undefined;
-    const observer = new ResizeObserver(measure);
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [itemKey, onMeasure]);
-
-  return (
-    <div
-      ref={rowRef}
-      className="chat-virtual-row"
-      style={{ transform: `translateY(${top}px)` }}
-    >
-      {children}
-    </div>
-  );
-}
-
-function buildChatRenderItems(messages: ChatMessage[]): ChatRenderItem[] {
-  const items: ChatRenderItem[] = [];
-  for (let i = 0; i < messages.length; i += 1) {
-    const message = messages[i]!;
-    items.push({
-      kind: 'message',
-      key: `message:${message.id}`,
-      message,
-    });
-  }
-  return items;
-}
-
-function firstTodoWriteAssistantMessageId(messages: ChatMessage[]): string | null {
-  const message = messages.find(
-    (candidate) =>
-      candidate.role === 'assistant' &&
-      candidate.events?.some(
-        (event) => event.kind === 'tool_use' && isTodoWriteToolName(event.name),
-      ),
-  );
-  return message?.id ?? null;
-}
-
-function estimateChatRenderItemHeight(item: ChatRenderItem): number {
-  const message = item.message;
-  const contentLength = message.content?.length ?? 0;
-  const attachmentCount = (message.attachments?.length ?? 0) + (message.commentAttachments?.length ?? 0);
-  const eventCount = message.events?.length ?? 0;
-  const fileCount = message.producedFiles?.length ?? 0;
-  const base = message.role === 'user' ? 82 : 118;
-  const contentRows = Math.min(18, Math.ceil(contentLength / 120));
-  return (
-    base
-    + contentRows * 18
-    + attachmentCount * 34
-    + eventCount * 28
-    + fileCount * 32
-    + CHAT_VIRTUAL_ROW_GAP_PX
-  );
-}
-
-function useMeasuredVirtualWindow<T extends { key: string }>(
-  items: T[],
-  {
-    enabled,
-    containerRef,
-    estimateSize,
-    overscanPx,
-    resetKey,
-    initialTailRows,
-    alwaysIncludeKey,
-  }: {
-    enabled: boolean;
-    containerRef: MutableRefObject<HTMLDivElement | null>;
-    estimateSize: (item: T) => number;
-    overscanPx: number;
-    resetKey: string;
-    initialTailRows: number;
-    alwaysIncludeKey?: string;
-  },
-) {
-  const measuredHeightsRef = useRef<Map<string, number>>(new Map());
-  const [measureVersion, setMeasureVersion] = useState(0);
-  const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 });
-
-  useEffect(() => {
-    measuredHeightsRef.current.clear();
-    setMeasureVersion((version) => version + 1);
-    setViewport({ scrollTop: 0, height: 0 });
-  }, [resetKey]);
-
-  useEffect(() => {
-    if (!enabled) return undefined;
-    const el = containerRef.current;
-    if (!el) return undefined;
-    let frame: number | null = null;
-    const readViewport = () => {
-      frame = null;
-      setViewport((current) => {
-        const next = {
-          scrollTop: el.scrollTop,
-          height: el.clientHeight || CHAT_VIRTUAL_DEFAULT_VIEWPORT_PX,
-        };
-        return current.scrollTop === next.scrollTop && current.height === next.height
-          ? current
-          : next;
-      });
-    };
-    const scheduleRead = () => {
-      if (frame !== null) return;
-      frame = requestAnimationFrame(readViewport);
-    };
-    scheduleRead();
-    el.addEventListener('scroll', scheduleRead, { passive: true });
-    const observer =
-      typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(scheduleRead)
-        : null;
-    observer?.observe(el);
-    return () => {
-      if (frame !== null) cancelAnimationFrame(frame);
-      el.removeEventListener('scroll', scheduleRead);
-      observer?.disconnect();
-    };
-  }, [containerRef, enabled]);
-
-  const layout = useMemo(() => {
-    const offsets: number[] = [];
-    const sizes: number[] = [];
-    let cursor = 0;
-    for (const item of items) {
-      offsets.push(cursor);
-      const measured = measuredHeightsRef.current.get(item.key);
-      const size = Math.max(
-        CHAT_VIRTUAL_MIN_ROW_HEIGHT,
-        measured ?? estimateSize(item),
-      );
-      sizes.push(size);
-      cursor += size;
-    }
-    return { offsets, sizes, totalHeight: cursor };
-  }, [estimateSize, items, measureVersion]);
-
-  const rows = useMemo(() => {
-    if (!enabled || items.length === 0) return [];
-    const height = viewport.height || CHAT_VIRTUAL_DEFAULT_VIEWPORT_PX;
-    if (viewport.scrollTop === 0 && viewport.height === 0) {
-      const start = Math.max(0, items.length - initialTailRows);
-      const rows = items.slice(start).map((item, offset) => {
-        const index = start + offset;
-        return { item, index, top: layout.offsets[index] ?? 0 };
-      });
-      return includeVirtualRowByKey(rows, items, layout.offsets, alwaysIncludeKey);
-    }
-    const startTarget = Math.max(0, viewport.scrollTop - overscanPx);
-    const endTarget = viewport.scrollTop + height + overscanPx;
-    let start = 0;
-    while (
-      start < items.length - 1
-      && (layout.offsets[start] ?? 0) + (layout.sizes[start] ?? 0) < startTarget
-    ) {
-      start += 1;
-    }
-    let end = start;
-    while (end < items.length && (layout.offsets[end] ?? 0) <= endTarget) {
-      end += 1;
-    }
-    const rows = items.slice(start, end).map((item, offset) => {
-      const index = start + offset;
-      return { item, index, top: layout.offsets[index] ?? 0 };
-    });
-    return includeVirtualRowByKey(rows, items, layout.offsets, alwaysIncludeKey);
-  }, [
-    alwaysIncludeKey,
-    enabled,
-    initialTailRows,
-    items,
-    layout.offsets,
-    layout.sizes,
-    overscanPx,
-    viewport.height,
-    viewport.scrollTop,
-  ]);
-
-  const onMeasure = useCallback((key: string, height: number) => {
-    if (!Number.isFinite(height) || height <= 0) return;
-    const next = Math.max(CHAT_VIRTUAL_MIN_ROW_HEIGHT, Math.ceil(height));
-    const previous = measuredHeightsRef.current.get(key);
-    if (previous !== undefined && Math.abs(previous - next) < 2) return;
-    measuredHeightsRef.current.set(key, next);
-    setMeasureVersion((version) => version + 1);
-  }, []);
-
-  return {
-    rows,
-    totalHeight: layout.totalHeight,
-    onMeasure,
-  };
-}
-
-function includeVirtualRowByKey<T extends { key: string }>(
-  rows: Array<{ item: T; index: number; top: number }>,
-  items: T[],
-  offsets: number[],
-  key: string | undefined,
-): Array<{ item: T; index: number; top: number }> {
-  if (!key || rows.some((row) => row.item.key === key)) return rows;
-  const index = items.findIndex((item) => item.key === key);
-  if (index === -1) return rows;
-  return [
-    ...rows,
-    {
-      item: items[index]!,
-      index,
-      top: offsets[index] ?? 0,
-    },
-  ].sort((a, b) => a.index - b.index);
-}
-
-function QueuedSendStrip({
-  containerRef,
-  editingId,
-  items,
-  onEdit,
-  onRemove,
-  onReorder,
-  onSendNow,
-}: {
-  containerRef?: MutableRefObject<HTMLDivElement | null>;
-  editingId?: string | null;
-  items: QueuedSendItem[];
-  onEdit?: (item: QueuedSendItem) => void;
-  onRemove?: (id: string) => void;
-  onReorder?: (orderedIds: string[]) => void;
-  onSendNow?: (id: string) => void;
-}) {
-  const t = useT();
-  const [dragState, setDragState] = useState<QueuedSendDragState | null>(null);
-  if (items.length === 0) return null;
-  const canReorder = Boolean(onReorder && items.length > 1);
-  const overflowCount = Math.max(0, items.length - QUEUED_SEND_VISIBLE_ROW_COUNT);
-
-  const handleDragStart = (
-    event: ReactDragEvent<HTMLButtonElement>,
-    item: QueuedSendItem,
-  ) => {
-    if (!canReorder) return;
-    event.dataTransfer.effectAllowed = 'move';
-    event.dataTransfer.setData(QUEUED_SEND_DRAG_MIME, item.id);
-    event.dataTransfer.setData('text/plain', item.id);
-    setDragState({ draggingId: item.id, overId: item.id, edge: null });
-  };
-
-  const handleDragOver = (
-    event: ReactDragEvent<HTMLDivElement>,
-    targetId: string,
-  ) => {
-    if (!canReorder) return;
-    const draggingId = dragState?.draggingId || event.dataTransfer.getData(QUEUED_SEND_DRAG_MIME);
-    if (!draggingId) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-    if (draggingId === targetId) {
-      if (dragState?.overId !== targetId || dragState.edge !== null) {
-        setDragState({ draggingId, overId: targetId, edge: null });
-      }
-      return;
-    }
-    const edge = queuedDropEdgeForEvent(event);
-    if (
-      dragState?.draggingId !== draggingId
-      || dragState.overId !== targetId
-      || dragState.edge !== edge
-    ) {
-      setDragState({ draggingId, overId: targetId, edge });
-    }
-  };
-
-  const handleDrop = (
-    event: ReactDragEvent<HTMLDivElement>,
-    targetId: string,
-  ) => {
-    if (!canReorder) return;
-    event.preventDefault();
-    const draggingId =
-      dragState?.draggingId
-      || event.dataTransfer.getData(QUEUED_SEND_DRAG_MIME)
-      || event.dataTransfer.getData('text/plain');
-    if (!draggingId || draggingId === targetId) {
-      setDragState(null);
-      return;
-    }
-    const edge = dragState?.overId === targetId && dragState.edge
-      ? dragState.edge
-      : queuedDropEdgeForEvent(event);
-    const nextIds = reorderQueuedSendIds(items, draggingId, targetId, edge);
-    if (nextIds.join('\0') !== items.map((item) => item.id).join('\0')) {
-      onReorder?.(nextIds);
-    }
-    setDragState(null);
-  };
-
-  return (
-    <div
-      ref={containerRef}
-      className="chat-queued-send-strip"
-      data-testid="chat-queued-send-strip"
-      onDragLeave={(event) => {
-        const related = event.relatedTarget;
-        if (related instanceof Node && event.currentTarget.contains(related)) return;
-        setDragState(null);
-      }}
-    >
-      <div className="chat-queued-send-header">
-        <div className="chat-queued-send-heading">
-          <strong>
-            {items.length} {t('chat.queuedHeader')}
-          </strong>
-          <span aria-hidden>↩</span>
-          <span>{t('chat.queuedToSend')}</span>
-        </div>
-      </div>
-      <div className={`chat-queued-send-list${overflowCount > 0 ? ' is-scrollable' : ''}`}>
-        {items.map((item, index) => {
-          const isDragging = dragState?.draggingId === item.id;
-          const dropClass = dragState?.overId === item.id
-            && dragState.draggingId !== item.id
-            && dragState.edge
-            ? ` chat-queued-send-row-drop-${dragState.edge}`
-            : '';
-          return (
-            <div
-              className={`chat-queued-send-row${index === 0 ? ' chat-queued-send-row-active' : ''}${
-                editingId === item.id ? ' chat-queued-send-row-editing' : ''
-              }${isDragging ? ' chat-queued-send-row-dragging' : ''}${dropClass}`}
-              key={item.id}
-              onDragOver={(event) => handleDragOver(event, item.id)}
-              onDrop={(event) => handleDrop(event, item.id)}
-            >
-              <button
-                type="button"
-                className="chat-queued-send-drag-handle chat-queued-send-tooltip od-tooltip"
-                title={t('chat.queuedReorder')}
-                data-tooltip={t('chat.queuedReorder')}
-                data-tooltip-placement="right"
-                aria-label={t('chat.queuedReorder')}
-                draggable={canReorder}
-                disabled={!canReorder}
-                onDragStart={(event) => handleDragStart(event, item)}
-                onDragEnd={() => setDragState(null)}
-              >
-                <Icon name="grip-vertical" size={14} />
-              </button>
-              <div className="chat-queued-send-main">
-                <span className="chat-queued-send-title">{summarizeQueuedPrompt(item, t)}</span>
-                <QueuedSendMetaChips item={item} />
-              </div>
-              <div className="chat-queued-send-actions">
-                {onEdit ? (
-                  <button
-                    type="button"
-                    className="chat-queued-send-action chat-queued-send-tooltip od-tooltip"
-                    title={t('chat.queuedEdit')}
-                    data-tooltip={t('chat.queuedEdit')}
-                    data-tooltip-placement="top"
-                    aria-label={t('chat.queuedEdit')}
-                    onClick={() => onEdit(item)}
-                  >
-                    <Icon name="pencil" size={13} />
-                  </button>
-                ) : null}
-                <button
-                  type="button"
-                  className="chat-queued-send-action chat-queued-send-tooltip od-tooltip"
-                  title={t('chat.send')}
-                  data-tooltip={t('chat.send')}
-                  data-tooltip-placement="top"
-                  aria-label={t('chat.send')}
-                  data-testid="chat-queued-send-now"
-                  onClick={() => onSendNow?.(item.id)}
-                  disabled={!onSendNow}
-                >
-                  <Icon name="arrow-up" size={13} />
-                </button>
-                {onRemove ? (
-                  <button
-                    type="button"
-                    className="chat-queued-send-action chat-queued-send-tooltip od-tooltip"
-                    onClick={() => onRemove(item.id)}
-                    title={t('chat.comments.remove')}
-                    data-tooltip={t('chat.comments.remove')}
-                    data-tooltip-placement="top"
-                    aria-label={t('chat.comments.remove')}
-                  >
-                    <Icon name="trash" size={13} />
-                  </button>
-                ) : null}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      {overflowCount > 0 ? (
-        <div className="chat-queued-send-overflow">
-          +{overflowCount} {t('chat.queuedMore')}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-const QUEUED_SEND_DRAG_MIME = 'application/x-open-design-queued-send';
-const QUEUED_SEND_VISIBLE_ROW_COUNT = 4;
-
-type QueuedSendDropEdge = 'before' | 'after';
-
-interface QueuedSendDragState {
-  draggingId: string;
-  overId: string | null;
-  edge: QueuedSendDropEdge | null;
-}
-
-function queuedDropEdgeForEvent(event: ReactDragEvent<HTMLElement>): QueuedSendDropEdge {
-  const rect = event.currentTarget.getBoundingClientRect();
-  return event.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
-}
-
-function reorderQueuedSendIds(
-  items: QueuedSendItem[],
-  draggingId: string,
-  targetId: string,
-  edge: QueuedSendDropEdge,
-): string[] {
-  const ids = items.map((item) => item.id);
-  const from = ids.indexOf(draggingId);
-  if (from < 0) return ids;
-  const [draggedId] = ids.splice(from, 1);
-  const targetIndex = ids.indexOf(targetId);
-  if (targetIndex < 0 || !draggedId) return items.map((item) => item.id);
-  ids.splice(edge === 'after' ? targetIndex + 1 : targetIndex, 0, draggedId);
-  return ids;
-}
-
-function summarizeQueuedPrompt(item: QueuedSendItem, t: TranslateFn): string {
-  const normalized = item.prompt.replace(/\s+/g, ' ').trim();
-  const text = normalized || t('chat.queuedFollowUpFallback');
-  return text.length > 58 ? `${text.slice(0, 57)}...` : text;
-}
-
-// Surfaces what a queued turn carries — attachments, visual marks, and the
-// staged plugin / skill / MCP / connector context from its meta — as compact
-// chips so the user can see (and trust) what will be sent without expanding it.
-// Counts use the same plain-English style as the rest of this strip.
-function QueuedSendMetaChips({ item }: { item: QueuedSendItem }) {
-  const ctx = item.meta?.context;
-  const files = item.attachments?.length ?? 0;
-  const marks = item.commentAttachments?.length ?? 0;
-  const plugins = item.meta?.appliedPluginSnapshot ? 1 : ctx?.pluginIds?.length ?? 0;
-  const skills = ctx?.skillIds?.length ?? 0;
-  const mcp = ctx?.mcpServerIds?.length ?? 0;
-  const connectors = ctx?.connectorIds?.length ?? 0;
-  const workspace = ctx?.workspaceItems?.length ?? 0;
-  const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`;
-  const chips: Array<{ key: string; label: string }> = [];
-  if (files > 0) chips.push({ key: 'files', label: plural(files, 'file') });
-  if (marks > 0) chips.push({ key: 'marks', label: plural(marks, 'mark') });
-  if (plugins > 0) chips.push({ key: 'plugins', label: plural(plugins, 'plugin') });
-  if (skills > 0) chips.push({ key: 'skills', label: plural(skills, 'skill') });
-  if (mcp > 0) chips.push({ key: 'mcp', label: `${mcp} MCP` });
-  if (connectors > 0) chips.push({ key: 'connectors', label: plural(connectors, 'connector') });
-  if (workspace > 0) chips.push({ key: 'workspace', label: plural(workspace, 'workspace context') });
-  if (chips.length === 0) return null;
-  return (
-    <div className="chat-queued-send-chips">
-      {chips.map((chip) => (
-        <span key={chip.key} className="chat-queued-send-chip">
-          {chip.label}
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function CommentsPanel({
-  comments,
-  attachedComments,
-  onAttach,
-  onDetach,
-  onDelete,
-  t,
-}: {
-  comments: PreviewComment[];
-  attachedComments: PreviewComment[];
-  onAttach?: (comment: PreviewComment) => void;
-  onDetach?: (commentId: string) => void;
-  onDelete?: (commentId: string) => void;
-  t: TranslateFn;
-}) {
-  const attachedIds = new Set(attachedComments.map((comment) => comment.id));
-  const saved = comments.filter((comment) => !attachedIds.has(comment.id));
-  return (
-    <div className="comments-panel" data-testid="comments-panel">
-      <CommentSection
-        title={t('chat.comments.attached')}
-        empty={t('chat.comments.emptyAttached')}
-        comments={attachedComments}
-        actionLabel={t('chat.comments.remove')}
-        onAction={(comment) => onDetach?.(comment.id)}
-        attached
-      />
-      <CommentSection
-        title={t('chat.comments.saved')}
-        empty={t('chat.comments.emptySaved')}
-        comments={saved}
-        actionLabel={t('chat.comments.add')}
-        onAction={(comment) => onAttach?.(comment)}
-        secondaryActionLabel={t('chat.comments.remove')}
-        onSecondaryAction={(comment) => onDelete?.(comment.id)}
-      />
-      {saved.length > 0 ? (
-        <div className="comments-footer">
-          <button
-            type="button"
-            className="primary"
-            onClick={() => saved.forEach((comment) => onAttach?.(comment))}
-          >
-            {t('chat.comments.addAll')}
-          </button>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function CommentSection({
-  title,
-  empty,
-  comments,
-  actionLabel,
-  onAction,
-  secondaryActionLabel,
-  onSecondaryAction,
-  attached,
-}: {
-  title: string;
-  empty: string;
-  comments: PreviewComment[];
-  actionLabel: string;
-  onAction: (comment: PreviewComment) => void;
-  secondaryActionLabel?: string;
-  onSecondaryAction?: (comment: PreviewComment) => void;
-  attached?: boolean;
-}) {
-  return (
-    <section className="comments-section">
-      <h3>{title}</h3>
-      {comments.length === 0 ? (
-        <p className="comments-empty">{empty}</p>
-      ) : (
-        comments.map((comment) => (
-          <article
-            key={comment.id}
-            className={`comment-card${attached ? ' attached' : ''}`}
-            data-testid={`comment-card-${comment.elementId}`}
-          >
-            <div className="comment-card-top">
-              <strong>{commentTargetDisplayName(comment)}</strong>
-              <div className="comment-card-actions">
-                {secondaryActionLabel && onSecondaryAction ? (
-                  <button
-                    type="button"
-                    className="comment-card-action danger"
-                    onClick={() => onSecondaryAction(comment)}
-                  >
-                    {secondaryActionLabel}
-                  </button>
-                ) : null}
-                <button type="button" className="comment-card-action" onClick={() => onAction(comment)}>
-                  {actionLabel}
-                </button>
-              </div>
-            </div>
-            <p>{comment.note}</p>
-            <div className="comment-card-meta">
-              <span>{comment.id}</span>
-              <span>{comment.filePath}</span>
-              <span>{commentTargetDisplayName(comment)}</span>
-              <span>{simplePositionLabel(comment.position)}</span>
-            </div>
-          </article>
-        ))
-      )}
-    </section>
-  );
-}
-
-function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {
-  return status === 'queued' || status === 'running';
-}
-
-function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
-  return status === 'succeeded' || status === 'failed' || status === 'canceled';
-}
-
-export function retryableAssistantMessage(
-  messages: ChatMessage[],
-  lastAssistantId: string | null | undefined,
-  paneStreaming: boolean,
-): ChatMessage | null {
-  if (paneStreaming) return null;
-  const last = messages[messages.length - 1];
-  if (!last || last.role !== 'assistant') return null;
-  if (last.id !== lastAssistantId) return null;
-  return last.runStatus === 'failed' ? last : null;
-}
-
-export function isAssistantMessageStreaming(
-  message: ChatMessage,
-  paneStreaming: boolean,
-  lastAssistantId: string | null | undefined,
-  forceStreamingMessageIds?: Set<string>,
-): boolean {
-  if (message.role !== 'assistant') return false;
-  if (forceStreamingMessageIds?.has(message.id)) return true;
-  if (isActiveRunStatus(message.runStatus)) return true;
-  if (message.id !== lastAssistantId) return false;
-  if (!paneStreaming) return false;
-  if (message.endedAt !== undefined) return false;
-  if (isTerminalRunStatus(message.runStatus)) return false;
-  return true;
-}
-
-export function buildRunErrorDiagnosticText(input: RunErrorDiagnosticInput): string {
-  const lines: string[] = [];
-  const sourceText = input.rawMessage?.trim() || input.message.trim();
-  if (sourceText) {
-    lines.push(sourceText, '');
-  }
-
-  lines.push(
-    'Open Design run error diagnostics',
-    `trace_id: ${input.traceId ?? 'n/a'}`,
-    `run_id: ${input.traceId ?? 'n/a'}`,
-    `error_code: ${input.errorCode ?? 'n/a'}`,
-    `project_id: ${input.projectId ?? 'n/a'}`,
-    `conversation_id: ${input.conversationId ?? 'n/a'}`,
-    `assistant_message_id: ${input.assistantMessageId ?? 'n/a'}`,
-    `agent_id: ${input.agentId ?? 'n/a'}`,
-  );
-
-  return lines.join('\n');
-}
-
-function filterConversations(
-  conversations: Conversation[],
-  query: string,
-  t: TranslateFn,
-): Conversation[] {
-  const normalized = query.trim().toLocaleLowerCase();
-  if (!normalized) return conversations;
-  return conversations.filter((conversation) => {
-    const title = conversation.title || t('chat.untitledConversation');
-    const meta = conversationMetaLabel(conversation, t);
-    return `${title} ${conversation.id} ${meta}`.toLocaleLowerCase().includes(normalized);
-  });
-}
-
-function conversationMessageCount(
-  conversation: Conversation,
-  activeConversationId: string | null,
-  messagesConversationId: string | null,
-  activeMessageCount: number,
-): number | null {
-  // The live `messages` array is authoritative for the active conversation —
-  // it stays fresh as a run streams new turns in — but ONLY once it has
-  // actually loaded for that conversation. While a switch is mid-flight (or a
-  // load failed) `messages` is reset to [] and `messagesConversationId` no
-  // longer matches the active id; trusting `messages.length` there renders a
-  // phantom "0 msg". Fall back to the persisted server count until the live
-  // array catches up.
-  if (
-    conversation.id === activeConversationId &&
-    messagesConversationId === activeConversationId
-  ) {
-    return activeMessageCount;
-  }
-  return typeof conversation.messageCount === 'number' ? conversation.messageCount : null;
-}
-
-function compactCount(value: number): string {
-  if (value < 1000) return String(value);
-  const compact = Math.floor(value / 100) / 10;
-  return `${compact}k`;
-}
-
-function ConversationRow({
-  conversation,
-  active,
-  messageCount,
-  onSelect,
-  onDelete,
-  t,
-}: {
-  conversation: Conversation;
-  active: boolean;
-  messageCount: number | null;
-  onSelect: () => void;
-  onDelete: () => void;
-  t: TranslateFn;
-}) {
-  const displayTitle =
-    conversation.title || t('chat.untitledConversation');
-
-  return (
-    <div
-      className={`chat-conv-item${active ? ' active' : ''}`}
-      data-testid={`conversation-item-${conversation.id}`}
-    >
-      <button
-        type="button"
-        className="chat-conv-item-name"
-        data-testid={`conversation-select-${conversation.id}`}
-        style={{ background: 'transparent', border: 'none', padding: 0, textAlign: 'left' }}
-        onClick={onSelect}
-      >
-        {displayTitle}
-      </button>
-      <span
-        className="chat-conv-item-meta"
-        data-testid={`conversation-meta-${conversation.id}`}
-      >
-        {messageCount !== null ? `${compactCount(messageCount)} msg · ` : ''}
-        {conversationMetaLabel(conversation, t)}
-      </span>
-      <button
-        type="button"
-        className="chat-conv-item-del"
-        data-testid={`conversation-delete-${conversation.id}`}
-        title={t('chat.deleteConversation')}
-        onClick={(e) => {
-          e.stopPropagation();
-          if (
-            confirm(t('chat.deleteConversationConfirm', { title: displayTitle }))
-          ) {
-            onDelete();
-          }
-        }}
-      >
-        <Icon name="close" size={12} />
-      </button>
-    </div>
-  );
-}
-
-// Memoized (hoisted impl referenced below): a static user message has stable
-// props, so it skips re-render while a later turn streams.
-const UserMessage = memo(UserMessageImpl);
-
-function UserMessageImpl({
-  message,
-  projectId,
-  projectFileNames,
-  onRequestOpenFile,
-  onRequestPluginDetails,
-  onRequestDesignSystemDetails,
-  t,
-  activePluginSnapshot,
-  activeDesignSystem,
-}: {
-  message: ChatMessage;
-  projectId: string | null;
-  projectFileNames?: Set<string>;
-  onRequestOpenFile?: (name: string) => void;
-  onRequestPluginDetails?: (pluginId: string) => void;
-  onRequestDesignSystemDetails?: (system: DesignSystemSummary) => void;
-  t: TranslateFn;
-  activePluginSnapshot?: AppliedPluginSnapshot | null;
-  activeDesignSystem?: DesignSystemSummary | null;
-}) {
-  const attachments = sortChatAttachmentsForDisplay(message.attachments ?? []);
-  const commentAttachments = message.commentAttachments ?? [];
-  const workspaceItems = message.runContext?.workspaceItems ?? [];
-  const messagePluginSnapshot = message.appliedPluginSnapshot ?? activePluginSnapshot ?? null;
-  const hasRunContext = Boolean(
-    message.sessionMode ||
-      workspaceItems.length > 0 ||
-      messagePluginSnapshot ||
-      activeDesignSystem,
-  );
-  const [copied, setCopied] = useState(false);
-  const copyTimerRef = useRef<ReturnType<typeof setTimeout>>();
-
-  useEffect(() => {
-    return () => {
-      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
-    };
-  }, []);
-
-  async function handleCopy() {
-    if (!message.content) return;
-    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
-    const ok = await copyToClipboard(message.content);
-    if (!ok) return;
-    setCopied(true);
-    copyTimerRef.current = setTimeout(() => {
-      setCopied(false);
-      copyTimerRef.current = undefined;
-    }, 2000);
-  }
-
-  const isDesignSystemWorkspaceRequest = isDesignSystemWorkspacePrompt(message.content);
-
-  return (
-    <div className="msg user">
-      <span className="sr-only">{t('chat.you')}</span>
-      {hasRunContext ? (
-        <div className="msg-run-context-row" data-testid="msg-run-context-row">
-          {message.sessionMode ? (
-            <MessageSessionModeChip mode={message.sessionMode} t={t} />
-          ) : null}
-          {workspaceItems.map((item) => (
-            <ActiveWorkspaceContextChip
-              key={`${item.kind}:${item.id}`}
-              item={item}
-              onOpen={onRequestOpenFile}
-            />
-          ))}
-          {messagePluginSnapshot ? (
-            <ActivePluginChip
-              snapshot={messagePluginSnapshot}
-              t={t}
-              onOpenDetails={onRequestPluginDetails}
-            />
-          ) : null}
-          {activeDesignSystem ? (
-            <ActiveDesignSystemChip
-              system={activeDesignSystem}
-              onOpenDetails={onRequestDesignSystemDetails}
-            />
-          ) : null}
-        </div>
-      ) : null}
-      {attachments.length > 0 ? (
-        <div className="user-attachments">
-          {attachments.map((a, index) => {
-            const baseName = a.path.split('/').pop() || a.path;
-            const openable =
-              !!onRequestOpenFile &&
-              (projectFileNames ? projectFileNames.has(baseName) : true);
-            const handleOpen = openable
-              ? () => onRequestOpenFile?.(baseName)
-              : undefined;
-            return (
-              <button
-                type="button"
-                key={a.path}
-                className={`user-attachment staged-${a.kind}${openable ? ' openable' : ''}`}
-                onClick={handleOpen}
-                disabled={!openable}
-                title={openable ? t('chat.openFile', { name: baseName }) : a.path}
-              >
-                <span className="staged-order" aria-label={`Attachment ${index + 1}`}>
-                  {index + 1}
-                </span>
-                {a.kind === 'image' && projectId ? (
-                  <img src={projectRawUrl(projectId, a.path)} alt={a.name} />
-                ) : (
-                  <Icon name="file" size={14} />
-                )}
-                <span className="staged-name">{a.name}</span>
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-      {commentAttachments.some((attachment) => attachment.selectionKind !== 'visual') ? (
-        <div className="user-attachments comment-history-attachments">
-          {commentAttachments.filter((attachment) => attachment.selectionKind !== 'visual').map((a) => (
-            <span key={a.id} className="user-attachment staged-comment">
-              <span className="staged-name" title={a.comment ? `${commentTargetDisplayName(a)}: ${a.comment}` : commentTargetDisplayName(a)}>
-                <strong>{commentTargetDisplayName(a)}</strong>
-                {a.comment ? <span>{a.comment}</span> : null}
-              </span>
-            </span>
-          ))}
-        </div>
-      ) : null}
-      {message.content && isDesignSystemWorkspaceRequest ? (
-        <div className="user-text-wrap user-status-wrap">
-          <div className="user-status-card design-system-generation-status">
-            <span className="user-status-card__icon">
-              <Icon name="blocks" size={15} />
-            </span>
-            <span className="user-status-card__copy">
-              <strong>{DESIGN_SYSTEM_WORKSPACE_DISPLAY_TITLE}</strong>
-              <span>{DESIGN_SYSTEM_WORKSPACE_DISPLAY_DESCRIPTION}</span>
-            </span>
-          </div>
-        </div>
-      ) : message.content ? (
-        <div className="user-text-wrap">
-          <div className="user-text user-bubble">{message.content}</div>
-          <div className="user-actions">
-            <button
-              type="button"
-              className="ghost user-copy-btn"
-              onClick={handleCopy}
-              aria-label={copied ? t('chat.copyDone') : t('chat.copyPrompt')}
-              title={copied ? t('chat.copyDone') : t('chat.copyPrompt')}
-            >
-              <Icon name={copied ? 'check' : 'copy'} size={13} />
-            </button>
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-// Context chip rendered above a user message when the project pinned a
-// plugin at create time (PluginLoopHome on Home). Replaces the noisy
-// in-composer plugin rail so the user is not re-prompted to pick
-// something they already chose; instead the active plugin lives inside
-// the run message it kicked off.
-function ActivePluginChip({
-  snapshot,
-  t: _t,
-  onOpenDetails,
-}: {
-  snapshot: AppliedPluginSnapshot;
-  t: TranslateFn;
-  onOpenDetails?: (pluginId: string) => void;
-}) {
-  const title = snapshot.pluginTitle ?? snapshot.pluginId;
-  const version = snapshot.pluginVersion;
-  const taskKind = snapshot.taskKind;
-  const content = (
-    <>
-      <span className="msg-plugin-chip__dot" aria-hidden />
-      <span className="msg-plugin-chip__label">
-        <span className="msg-plugin-chip__kind">Plugin</span>
-        <span className="msg-plugin-chip__title">{title}</span>
-        {version ? (
-          <span className="msg-plugin-chip__version">@{version}</span>
-        ) : null}
-      </span>
-      {taskKind ? (
-        <span className="msg-plugin-chip__task">{taskKind}</span>
-      ) : null}
-    </>
-  );
-  // One clean chip per message — the plugin's full resolved context still
-  // rides the run via the persisted snapshot; we no longer fan it out into
-  // per-category (design-system / asset / skill) chips here.
-  return (
-    <div className="msg-plugin-context" data-testid="msg-plugin-context">
-      {onOpenDetails ? (
-        <button
-          type="button"
-          className="msg-plugin-chip msg-plugin-chip--action"
-          data-testid="msg-plugin-chip"
-          title={title}
-          onClick={() => onOpenDetails(snapshot.pluginId)}
-        >
-          {content}
-        </button>
-      ) : (
-        <div className="msg-plugin-chip" data-testid="msg-plugin-chip">
-          {content}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function MessageSessionModeChip({
-  mode,
-  t,
-}: {
-  mode: ChatSessionMode;
-  t: TranslateFn;
-}) {
-  const label = mode === 'chat'
-    ? t('chat.mode.chat.label')
-    : mode === 'plan'
-      ? t('chat.mode.plan.label')
-      : t('chat.mode.design.label');
-  const icon = mode === 'chat' ? 'comment' : mode === 'plan' ? 'file' : 'sparkles';
-  return (
-    <div
-      className={`msg-mode-chip msg-mode-chip--${mode}`}
-      data-testid="msg-session-mode-chip"
-      title={label}
-    >
-      <Icon name={icon} size={12} />
-      <span>{label}</span>
-    </div>
-  );
-}
-
-function ActiveDesignSystemChip({
-  system,
-  onOpenDetails,
-}: {
-  system: DesignSystemSummary;
-  onOpenDetails?: (system: DesignSystemSummary) => void;
-}) {
-  const content = (
-    <>
-      <span className="msg-plugin-chip__dot" aria-hidden />
-      <span className="msg-plugin-chip__label">
-        <span className="msg-plugin-chip__kind">Design System</span>
-        <span className="msg-plugin-chip__title">{system.title}</span>
-      </span>
-      {system.category ? (
-        <span className="msg-plugin-chip__task">{system.category}</span>
-      ) : null}
-    </>
-  );
-  if (!onOpenDetails) {
-    return (
-      <div className="msg-plugin-chip msg-plugin-chip--design-system" data-testid="msg-design-system-chip">
-        {content}
-      </div>
-    );
-  }
-  return (
-    <button
-      type="button"
-      className="msg-plugin-chip msg-plugin-chip--design-system msg-plugin-chip--action"
-      data-testid="msg-design-system-chip"
-      title={system.title}
-      onClick={() => onOpenDetails(system)}
-    >
-      {content}
-    </button>
-  );
-}
-
-const WORKSPACE_DESIGN_FILES_TAB = '__design_files__';
-const WORKSPACE_DESIGN_SYSTEM_TAB = '__design_system__';
-
-function ActiveWorkspaceContextChip({
-  item,
-  onOpen,
-}: {
-  item: WorkspaceContextItem;
-  onOpen?: (name: string) => void;
-}) {
-  const target = workspaceContextOpenTarget(item);
-  const content = (
-    <>
-      <span className="msg-plugin-chip__icon" aria-hidden>
-        <Icon name={workspaceContextIcon(item)} size={12} />
-      </span>
-      <span className="msg-plugin-chip__label">
-        <span className="msg-plugin-chip__kind">Current</span>
-        <span className="msg-plugin-chip__title">{item.label}</span>
-      </span>
-    </>
-  );
-  if (!target || !onOpen) {
-    return (
-      <div
-        className={`msg-plugin-chip msg-plugin-chip--workspace msg-plugin-chip--workspace-${item.kind}`}
-        data-testid="msg-workspace-context-chip"
-        title={workspaceContextTitle(item)}
-      >
-        {content}
-      </div>
-    );
-  }
-  return (
-    <button
-      type="button"
-      className={`msg-plugin-chip msg-plugin-chip--workspace msg-plugin-chip--workspace-${item.kind} msg-plugin-chip--action`}
-      data-testid="msg-workspace-context-chip"
-      title={workspaceContextTitle(item)}
-      onClick={() => onOpen(target)}
-    >
-      {content}
-    </button>
-  );
-}
-
-function workspaceContextOpenTarget(item: WorkspaceContextItem): string | null {
-  if (item.tabId) return item.tabId;
-  if (item.kind === 'design-files') return WORKSPACE_DESIGN_FILES_TAB;
-  if (item.kind === 'design-system') return WORKSPACE_DESIGN_SYSTEM_TAB;
-  if (item.kind === 'file' || item.kind === 'live-artifact') {
-    return item.path ?? item.label;
-  }
-  return null;
-}
-
-function workspaceContextIcon(item: WorkspaceContextItem): IconName {
-  if (item.kind === 'browser') return 'globe';
-  if (item.kind === 'folder' || item.kind === 'design-files') return 'folder';
-  if (item.kind === 'project') return 'folder';
-  if (item.kind === 'local-code') return 'terminal';
-  if (item.kind === 'terminal') return 'terminal';
-  if (item.kind === 'side-chat') return 'comment';
-  if (item.kind === 'design-system') return 'blocks';
-  return 'file';
-}
-
-function workspaceContextTitle(item: WorkspaceContextItem): string {
-  return [
-    workspaceContextKindLabel(item.kind),
-    item.path ? `path: ${item.path}` : null,
-    item.absolutePath ? `absolute: ${item.absolutePath}` : null,
-    item.url ? `url: ${item.url}` : null,
-    item.title ? `title: ${item.title}` : null,
-  ].filter(Boolean).join(' | ');
-}
-
-function workspaceContextKindLabel(kind: WorkspaceContextItem['kind']): string {
-  switch (kind) {
-    case 'browser':
-      return 'Browser';
-    case 'design-files':
-      return 'Design files';
-    case 'design-system':
-      return 'Design system';
-    case 'folder':
-      return 'Folder';
-    case 'project':
-      return 'Project';
-    case 'local-code':
-      return 'Local code';
-    case 'terminal':
-      return 'Terminal';
-    case 'side-chat':
-      return 'Side chat';
-    case 'live-artifact':
-      return 'Live artifact';
-    case 'file':
-    default:
-      return 'File';
-  }
-}
-
-function sortChatAttachmentsForDisplay(attachments: ChatAttachment[]): ChatAttachment[] {
-  return attachments
-    .map((attachment, index) => ({ attachment, index }))
-    .sort((a, b) => {
-      const aOrder = typeof a.attachment.order === 'number' && Number.isFinite(a.attachment.order)
-        ? a.attachment.order
-        : a.index;
-      const bOrder = typeof b.attachment.order === 'number' && Number.isFinite(b.attachment.order)
-        ? b.attachment.order
-        : b.index;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-      return a.index - b.index;
-    })
-    .map((entry) => entry.attachment);
-}
-
-function isDesignSystemNextStepProject(metadata: ProjectMetadata | undefined): boolean {
-  if (!metadata) return false;
-  return (
-    metadata.kind === 'brand' ||
-    metadata.importedFrom === 'design-system' ||
-    metadata.importedFrom === 'brand-extraction' ||
-    Boolean(metadata.brandDesignSystemId)
-  );
-}
-
-function isBrandExtractionNextStepProject(metadata: ProjectMetadata | undefined): boolean {
-  if (!metadata) return false;
-  return (
-    metadata.kind === 'brand' ||
-    metadata.importedFrom === 'brand-extraction' ||
-    Boolean(metadata.brandId) ||
-    Boolean(metadata.brandDesignSystemId)
-  );
-}
-
-function isProgrammaticBrandAssistantMessage(message: ChatMessage | null | undefined): boolean {
-  if (!message || message.role !== 'assistant') return false;
-  const content = message.content || '';
-  return (
-    content.includes('<od-card type="brand-browser-assist"') ||
-    /programmatic (design-system )?extraction|automatic pass needs a hand|extraction stopped/i.test(content) ||
-    /程序化.*抽取|程式化.*抽取|抽取已停止/.test(content)
-  );
-}
-
-function relTime(ts: number, t: TranslateFn): string {
-  const diff = Date.now() - ts;
-  const min = 60_000;
-  const hr = 60 * min;
-  const day = 24 * hr;
-  if (diff < min) return t('common.now');
-  if (diff < hr) return t('common.minutesShort', { n: Math.floor(diff / min) });
-  if (diff < day) return t('common.hoursShort', { n: Math.floor(diff / hr) });
-  if (diff < 7 * day) return t('common.daysShort', { n: Math.floor(diff / day) });
-  return new Date(ts).toLocaleDateString();
-}
-
-export function conversationMetaLabel(
-  conversation: Conversation,
-  t: TranslateFn,
-): string {
-  const latestRun = conversation.latestRun;
-  if (
-    latestRun &&
-    (latestRun.status === 'succeeded' ||
-      latestRun.status === 'failed' ||
-      latestRun.status === 'canceled') &&
-    typeof conversation.totalDurationMs === 'number' &&
-    Number.isFinite(conversation.totalDurationMs)
-  ) {
-    return formatDurationShort(conversation.totalDurationMs);
-  }
-  if (
-    latestRun &&
-    (latestRun.status === 'succeeded' ||
-      latestRun.status === 'failed' ||
-      latestRun.status === 'canceled') &&
-    typeof latestRun.durationMs === 'number' &&
-    Number.isFinite(latestRun.durationMs)
-  ) {
-    return formatDurationShort(latestRun.durationMs);
-  }
-  return relTime(conversation.updatedAt, t);
-}
-
-function formatDurationShort(ms: number): string {
-  const s = Math.max(0, ms) / 1000;
-  if (s < 60) return `${s.toFixed(s < 10 ? 1 : 0)}s`;
-  const m = Math.floor(s / 60);
-  const rem = Math.floor(s - m * 60);
-  return `${m}m ${rem.toString().padStart(2, '0')}s`;
 }

--- a/apps/web/src/features/chat-pane/components/ActiveDesignSystemChip.tsx
+++ b/apps/web/src/features/chat-pane/components/ActiveDesignSystemChip.tsx
@@ -1,0 +1,40 @@
+import type { DesignSystemSummary } from '../../../types';
+
+export function ActiveDesignSystemChip({
+  system,
+  onOpenDetails,
+}: {
+  system: DesignSystemSummary;
+  onOpenDetails?: (system: DesignSystemSummary) => void;
+}) {
+  const content = (
+    <>
+      <span className="msg-plugin-chip__dot" aria-hidden />
+      <span className="msg-plugin-chip__label">
+        <span className="msg-plugin-chip__kind">Design System</span>
+        <span className="msg-plugin-chip__title">{system.title}</span>
+      </span>
+      {system.category ? (
+        <span className="msg-plugin-chip__task">{system.category}</span>
+      ) : null}
+    </>
+  );
+  if (!onOpenDetails) {
+    return (
+      <div className="msg-plugin-chip msg-plugin-chip--design-system" data-testid="msg-design-system-chip">
+        {content}
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="msg-plugin-chip msg-plugin-chip--design-system msg-plugin-chip--action"
+      data-testid="msg-design-system-chip"
+      title={system.title}
+      onClick={() => onOpenDetails(system)}
+    >
+      {content}
+    </button>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/ActivePluginChip.tsx
+++ b/apps/web/src/features/chat-pane/components/ActivePluginChip.tsx
@@ -1,0 +1,60 @@
+import type { AppliedPluginSnapshot } from '@open-design/contracts';
+import type { Dict } from '../../../i18n/types';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+// Context chip rendered above a user message when the project pinned a
+// plugin at create time (PluginLoopHome on Home). Replaces the noisy
+// in-composer plugin rail so the user is not re-prompted to pick
+// something they already chose; instead the active plugin lives inside
+// the run message it kicked off.
+export function ActivePluginChip({
+  snapshot,
+  t: _t,
+  onOpenDetails,
+}: {
+  snapshot: AppliedPluginSnapshot;
+  t: TranslateFn;
+  onOpenDetails?: (pluginId: string) => void;
+}) {
+  const title = snapshot.pluginTitle ?? snapshot.pluginId;
+  const version = snapshot.pluginVersion;
+  const taskKind = snapshot.taskKind;
+  const content = (
+    <>
+      <span className="msg-plugin-chip__dot" aria-hidden />
+      <span className="msg-plugin-chip__label">
+        <span className="msg-plugin-chip__kind">Plugin</span>
+        <span className="msg-plugin-chip__title">{title}</span>
+        {version ? (
+          <span className="msg-plugin-chip__version">@{version}</span>
+        ) : null}
+      </span>
+      {taskKind ? (
+        <span className="msg-plugin-chip__task">{taskKind}</span>
+      ) : null}
+    </>
+  );
+  // One clean chip per message — the plugin's full resolved context still
+  // rides the run via the persisted snapshot; we no longer fan it out into
+  // per-category (design-system / asset / skill) chips here.
+  return (
+    <div className="msg-plugin-context" data-testid="msg-plugin-context">
+      {onOpenDetails ? (
+        <button
+          type="button"
+          className="msg-plugin-chip msg-plugin-chip--action"
+          data-testid="msg-plugin-chip"
+          title={title}
+          onClick={() => onOpenDetails(snapshot.pluginId)}
+        >
+          {content}
+        </button>
+      ) : (
+        <div className="msg-plugin-chip" data-testid="msg-plugin-chip">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/ActiveWorkspaceContextChip.tsx
+++ b/apps/web/src/features/chat-pane/components/ActiveWorkspaceContextChip.tsx
@@ -1,0 +1,46 @@
+import type { WorkspaceContextItem } from '@open-design/contracts';
+import { Icon } from '../../../components/Icon';
+import { workspaceContextIcon, workspaceContextOpenTarget, workspaceContextTitle } from '../rules';
+
+export function ActiveWorkspaceContextChip({
+  item,
+  onOpen,
+}: {
+  item: WorkspaceContextItem;
+  onOpen?: (name: string) => void;
+}) {
+  const target = workspaceContextOpenTarget(item);
+  const content = (
+    <>
+      <span className="msg-plugin-chip__icon" aria-hidden>
+        <Icon name={workspaceContextIcon(item)} size={12} />
+      </span>
+      <span className="msg-plugin-chip__label">
+        <span className="msg-plugin-chip__kind">Current</span>
+        <span className="msg-plugin-chip__title">{item.label}</span>
+      </span>
+    </>
+  );
+  if (!target || !onOpen) {
+    return (
+      <div
+        className={`msg-plugin-chip msg-plugin-chip--workspace msg-plugin-chip--workspace-${item.kind}`}
+        data-testid="msg-workspace-context-chip"
+        title={workspaceContextTitle(item)}
+      >
+        {content}
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className={`msg-plugin-chip msg-plugin-chip--workspace msg-plugin-chip--workspace-${item.kind} msg-plugin-chip--action`}
+      data-testid="msg-workspace-context-chip"
+      title={workspaceContextTitle(item)}
+      onClick={() => onOpen(target)}
+    >
+      {content}
+    </button>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/ChatArtifactPreview.tsx
+++ b/apps/web/src/features/chat-pane/components/ChatArtifactPreview.tsx
@@ -1,0 +1,51 @@
+import { Icon } from '../../../components/Icon';
+import { isRenderableSketchJson, SketchPreview } from '../../../components/SketchPreview';
+import type { ProjectFile } from '../../../types';
+import { chatArtifactIcon, chatArtifactShortKind } from '../rules';
+
+export function ChatArtifactFallback({ kind }: { kind: ProjectFile['kind'] }) {
+  return (
+    <span className="chat-design-artifact-fallback">
+      <Icon name={chatArtifactIcon(kind)} size={28} />
+      <span>{chatArtifactShortKind(kind)}</span>
+    </span>
+  );
+}
+
+export function ChatArtifactPreview({
+  projectId,
+  file,
+  projectRawUrl,
+}: {
+  projectId: string | null;
+  file: ProjectFile;
+  // Threaded in rather than imported directly — see `UserMessage.tsx` for
+  // why this dumb component doesn't reach into `providers/` itself.
+  projectRawUrl: (projectId: string, filePath: string) => string;
+}) {
+  if (!projectId) {
+    return <ChatArtifactFallback kind={file.kind} />;
+  }
+
+  const url = `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}`;
+  if (isRenderableSketchJson(file)) {
+    return <SketchPreview projectId={projectId} file={file} />;
+  }
+  if (file.kind === 'image' || file.kind === 'sketch') {
+    return <img src={url} alt="" loading="lazy" />;
+  }
+  if (file.kind === 'html') {
+    return (
+      <iframe
+        title={file.name}
+        src={url}
+        sandbox="allow-scripts allow-downloads"
+        loading="lazy"
+      />
+    );
+  }
+  if (file.kind === 'video') {
+    return <video src={url} muted playsInline preload="metadata" />;
+  }
+  return <ChatArtifactFallback kind={file.kind} />;
+}

--- a/apps/web/src/features/chat-pane/components/ChatConversationLoading.tsx
+++ b/apps/web/src/features/chat-pane/components/ChatConversationLoading.tsx
@@ -1,0 +1,21 @@
+import type { Dict } from '../../../i18n/types';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+export function ChatConversationLoading({ t }: { t: TranslateFn }) {
+  return (
+    <div className="chat-loading-state" role="status" aria-live="polite">
+      <span className="chat-loading-mark" aria-hidden>
+        <span />
+        <span />
+        <span />
+      </span>
+      <span className="chat-loading-copy">{t('common.loading')}</span>
+      <span className="chat-loading-lines" aria-hidden>
+        <span />
+        <span />
+        <span />
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/ChatRows.tsx
+++ b/apps/web/src/features/chat-pane/components/ChatRows.tsx
@@ -1,0 +1,347 @@
+import { Fragment, useMemo, type MutableRefObject } from 'react';
+import type {
+  AppliedPluginSnapshot,
+  ChatSessionMode,
+  WorkspaceContextItem,
+} from '@open-design/contracts';
+import type { TrackingProjectKind } from '@open-design/contracts/analytics';
+import { AssistantMessage, type QuestionFormOpenRequest } from '../../../components/AssistantMessage';
+import type { BrandBrowserAssistConfirm } from '../../../components/OdCard';
+import type { NextStepActionsVariant } from '../../../components/NextStepActions';
+import type { DesignToolboxActionId } from '../../../runtime/design-toolbox';
+import type { TodoItem } from '../../../runtime/todos';
+import { latestTodoWriteInputForPinnedCard } from '../../../runtime/todos';
+import type { Dict } from '../../../i18n/types';
+import type {
+  ChatAttachment,
+  ChatCommentAttachment,
+  ChatMessage,
+  ChatMessageFeedbackChange,
+  DesignSystemSummary,
+  ProjectFile,
+  ProjectMetadata,
+  SkillSummary,
+} from '../../../types';
+import type { PluginFolderAgentAction } from '../../../components/design-files/pluginFolderActions';
+import {
+  CHAT_MESSAGE_OVERSCAN_PX,
+  CHAT_MESSAGE_VIRTUALIZE_THRESHOLD,
+  CHAT_VIRTUAL_INITIAL_TAIL_ROWS,
+} from '../constants';
+import { useMeasuredVirtualWindow } from '../hooks/useMeasuredVirtualWindow.hooks';
+import {
+  buildChatRenderItems,
+  estimateChatRenderItemHeight,
+  firstTodoWriteAssistantMessageId,
+  isAssistantMessageStreaming,
+} from '../rules';
+import type { AssistantCallbacks, ChatRenderItem } from '../types';
+import { UserMessage } from './UserMessage';
+import { VirtualChatRow } from './VirtualChatRow';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+export function ChatRows({
+  messages,
+  streaming,
+  liveToolInput,
+  projectId,
+  projectKindForTracking,
+  activeConversationId,
+  activeConversationKey,
+  projectFiles,
+  projectMetadata,
+  projectFileNames,
+  onRequestOpenFile,
+  onRequestPluginDetails,
+  onRequestDesignSystemDetails,
+  onRequestPluginFolderAgentAction,
+  activePluginActionPaths,
+  hiddenPluginActionPaths,
+  onShareToOpenDesign,
+  shareToOpenDesignBusyMessageId,
+  forceStreamingMessageIds,
+  lastAssistantId,
+  firstUserMessageId,
+  activePluginSnapshot,
+  activeDesignSystem,
+  hasActiveDesignSystem,
+  errorCardOwnerId,
+  nextUserContentByAssistantId,
+  assistantCallbacksRef,
+  onContinueRemainingTasks,
+  onBrandBrowserAssistConfirm,
+  onArtifactShare,
+  onToolboxAction,
+  onNextStepPromptAction,
+  onNextStepAiOptimize,
+  nextStepAiOptimizeBusy,
+  onNextStepContinueExtraction,
+  nextStepContinueExtractionBusy,
+  onNextStepContinueAiExtraction,
+  nextStepContinueAiExtractionBusy,
+  onNextStepCreateDesign,
+  nextStepCreateDesignBusy,
+  onNextStepCreateDesignSystem,
+  nextStepCreateDesignSystemBusy,
+  onPickSkill,
+  onArtifactDownload,
+  nextStepSkills,
+  toolboxSkillNames,
+  nextStepVariant,
+  onForkFromMessage,
+  onAssistantFeedback,
+  forkingMessageId,
+  t,
+  onOpenQuestions,
+  scrollContainerRef,
+  projectRawUrl,
+}: {
+  messages: ChatMessage[];
+  streaming: boolean;
+  liveToolInput?: Record<string, { name: string; text: string; seq?: number }>;
+  projectId: string | null;
+  projectKindForTracking: TrackingProjectKind | null;
+  activeConversationId: string | null;
+  activeConversationKey: string;
+  projectFiles: ProjectFile[];
+  projectMetadata?: ProjectMetadata;
+  projectFileNames?: Set<string>;
+  onRequestOpenFile?: (name: string) => void;
+  onRequestPluginDetails?: (pluginId: string) => void;
+  onRequestDesignSystemDetails?: (system: DesignSystemSummary) => void;
+  onRequestPluginFolderAgentAction?: (relativePath: string, action: PluginFolderAgentAction) => void;
+  activePluginActionPaths?: Set<string>;
+  hiddenPluginActionPaths?: Set<string>;
+  onShareToOpenDesign?: (assistantMessageId: string) => void;
+  shareToOpenDesignBusyMessageId?: string | null;
+  forceStreamingMessageIds?: Set<string>;
+  lastAssistantId: string | undefined;
+  firstUserMessageId: string | undefined;
+  activePluginSnapshot?: AppliedPluginSnapshot | null;
+  activeDesignSystem?: DesignSystemSummary | null;
+  hasActiveDesignSystem: boolean;
+  errorCardOwnerId: string | null;
+  nextUserContentByAssistantId: Map<string, string>;
+  assistantCallbacksRef: MutableRefObject<AssistantCallbacks>;
+  onContinueRemainingTasks?: (assistantMessage: ChatMessage, todos: TodoItem[]) => void;
+  onBrandBrowserAssistConfirm?: BrandBrowserAssistConfirm;
+  onArtifactShare?: (fileName: string) => void;
+  onToolboxAction?: (id: DesignToolboxActionId) => void;
+  onNextStepPromptAction?: (
+    prompt: string,
+    options?: { sessionMode?: ChatSessionMode },
+  ) => void;
+  onNextStepAiOptimize?: () => void;
+  nextStepAiOptimizeBusy?: boolean;
+  onNextStepContinueExtraction?: () => void;
+  nextStepContinueExtractionBusy?: boolean;
+  onNextStepContinueAiExtraction?: () => void;
+  nextStepContinueAiExtractionBusy?: boolean;
+  onNextStepCreateDesign?: () => void;
+  nextStepCreateDesignBusy?: boolean;
+  onNextStepCreateDesignSystem?: () => void;
+  nextStepCreateDesignSystemBusy?: boolean;
+  onPickSkill?: (skillId: string) => void;
+  onArtifactDownload?: (fileName: string) => void;
+  nextStepSkills?: SkillSummary[];
+  toolboxSkillNames?: Partial<Record<DesignToolboxActionId, string | null>>;
+  nextStepVariant?: NextStepActionsVariant;
+  onForkFromMessage?: (message: ChatMessage) => void;
+  onAssistantFeedback?: (message: ChatMessage, change: ChatMessageFeedbackChange) => void;
+  forkingMessageId?: string | null;
+  t: TranslateFn;
+  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
+  scrollContainerRef: MutableRefObject<HTMLDivElement | null>;
+  // Threaded in rather than imported directly — see `UserMessage.tsx` for
+  // why this dumb component doesn't reach into `providers/` itself.
+  projectRawUrl: (projectId: string, filePath: string) => string;
+}) {
+  const conversationTodoInput = useMemo(
+    () => latestTodoWriteInputForPinnedCard(messages),
+    [messages],
+  );
+  const conversationTodoAnchorMessageId = useMemo(
+    () => firstTodoWriteAssistantMessageId(messages),
+    [messages],
+  );
+  const items = useMemo(
+    () => buildChatRenderItems(messages),
+    [messages],
+  );
+  const virtualized = items.length > CHAT_MESSAGE_VIRTUALIZE_THRESHOLD;
+  const virtualWindow = useMeasuredVirtualWindow(items, {
+    enabled: virtualized,
+    containerRef: scrollContainerRef,
+    estimateSize: estimateChatRenderItemHeight,
+    overscanPx: CHAT_MESSAGE_OVERSCAN_PX,
+    resetKey: activeConversationKey,
+    initialTailRows: CHAT_VIRTUAL_INITIAL_TAIL_ROWS,
+    alwaysIncludeKey:
+      conversationTodoInput != null && conversationTodoAnchorMessageId
+        ? `message:${conversationTodoAnchorMessageId}`
+        : undefined,
+  });
+
+  const renderItem = (item: ChatRenderItem) => {
+    const m = item.message;
+    const messageStreaming = isAssistantMessageStreaming(
+      m,
+      streaming,
+      lastAssistantId,
+      forceStreamingMessageIds,
+    );
+    if (m.role === 'user') {
+      return (
+        <UserMessage
+          message={m}
+          projectId={projectId}
+          projectFileNames={projectFileNames}
+          onRequestOpenFile={onRequestOpenFile}
+          onRequestPluginDetails={onRequestPluginDetails}
+          onRequestDesignSystemDetails={onRequestDesignSystemDetails}
+          t={t}
+          activePluginSnapshot={
+            m.id === firstUserMessageId
+              ? activePluginSnapshot ?? null
+              : null
+          }
+          activeDesignSystem={
+            m.id === firstUserMessageId
+              ? activeDesignSystem ?? null
+              : null
+          }
+          projectRawUrl={projectRawUrl}
+        />
+      );
+    }
+    return (
+      <AssistantMessage
+        message={m}
+        streaming={messageStreaming}
+        // Only the streaming row consumes live tool input. Non-streaming rows
+        // get a stable `undefined`, so adding `liveToolInput` to the memo
+        // comparator re-renders just this row per `tool_input_delta`, not all N.
+        liveToolInput={messageStreaming ? liveToolInput : undefined}
+        showConversationTodoCard={m.id === conversationTodoAnchorMessageId}
+        conversationTodoInput={conversationTodoInput}
+        projectId={projectId}
+        projectKind={projectKindForTracking}
+        conversationId={activeConversationId}
+        projectFiles={projectFiles}
+        projectMetadata={projectMetadata}
+        projectFileNames={projectFileNames}
+        onRequestOpenFile={onRequestOpenFile}
+        onRequestPluginFolderAgentAction={onRequestPluginFolderAgentAction}
+        activePluginActionPaths={activePluginActionPaths}
+        hiddenPluginActionPaths={hiddenPluginActionPaths}
+        onShareToOpenDesign={
+          onShareToOpenDesign
+            ? () => assistantCallbacksRef.current.onShareToOpenDesign?.(m.id)
+            : undefined
+        }
+        shareToOpenDesignBusy={shareToOpenDesignBusyMessageId === m.id}
+        isLast={m.id === lastAssistantId}
+        errorCardOwnerId={errorCardOwnerId}
+        nextUserContent={nextUserContentByAssistantId.get(m.id)}
+        suppressDirectionForms={hasActiveDesignSystem}
+        hasDesignSystemContext={hasActiveDesignSystem || !!activeDesignSystem}
+        onOpenQuestions={onOpenQuestions}
+        onBrandBrowserAssistConfirm={
+          onBrandBrowserAssistConfirm
+            ? (card) => assistantCallbacksRef.current.onBrandBrowserAssistConfirm?.(card)
+            : undefined
+        }
+        onContinueRemainingTasks={
+          m.id === lastAssistantId && onContinueRemainingTasks
+            ? (todos) => assistantCallbacksRef.current.onContinueRemainingTasks?.(m, todos)
+            : undefined
+        }
+        onForkFromMessage={
+          onForkFromMessage
+            ? () => assistantCallbacksRef.current.onForkFromMessage?.(m)
+            : undefined
+        }
+        forking={forkingMessageId === m.id}
+        onFeedback={
+          onAssistantFeedback
+            ? (rating) => assistantCallbacksRef.current.onAssistantFeedback?.(m, rating)
+            : undefined
+        }
+        onArtifactShare={
+          onArtifactShare
+            ? (fileName) => assistantCallbacksRef.current.onArtifactShare?.(fileName)
+            : undefined
+        }
+        onToolboxAction={onToolboxAction}
+        onNextStepPromptAction={onNextStepPromptAction}
+        onNextStepAiOptimize={
+          onNextStepAiOptimize
+            ? () => assistantCallbacksRef.current.onNextStepAiOptimize?.()
+            : undefined
+        }
+        nextStepAiOptimizeBusy={nextStepAiOptimizeBusy}
+        onNextStepContinueExtraction={
+          onNextStepContinueExtraction
+            ? () => assistantCallbacksRef.current.onNextStepContinueExtraction?.()
+            : undefined
+        }
+        nextStepContinueExtractionBusy={nextStepContinueExtractionBusy}
+        onNextStepContinueAiExtraction={
+          onNextStepContinueAiExtraction
+            ? () => assistantCallbacksRef.current.onNextStepContinueAiExtraction?.()
+            : undefined
+        }
+        nextStepContinueAiExtractionBusy={nextStepContinueAiExtractionBusy}
+        onNextStepCreateDesign={
+          onNextStepCreateDesign
+            ? () => assistantCallbacksRef.current.onNextStepCreateDesign?.()
+            : undefined
+        }
+        nextStepCreateDesignBusy={nextStepCreateDesignBusy}
+        onNextStepCreateDesignSystem={
+          onNextStepCreateDesignSystem
+            ? () => assistantCallbacksRef.current.onNextStepCreateDesignSystem?.()
+            : undefined
+        }
+        nextStepCreateDesignSystemBusy={nextStepCreateDesignSystemBusy}
+        onPickSkill={onPickSkill}
+        onArtifactDownload={onArtifactDownload}
+        nextStepSkills={nextStepSkills}
+        toolboxSkillNames={toolboxSkillNames}
+        nextStepVariant={nextStepVariant}
+      />
+    );
+  };
+
+  if (items.length === 0) return null;
+
+  if (!virtualized) {
+    return (
+      <>
+        {items.map((item) => (
+          <Fragment key={item.key}>{renderItem(item)}</Fragment>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <div
+      className="chat-virtual-spacer"
+      data-testid="chat-virtual-spacer"
+      style={{ height: virtualWindow.totalHeight }}
+    >
+      {virtualWindow.rows.map((row) => (
+        <VirtualChatRow
+          key={row.item.key}
+          itemKey={row.item.key}
+          top={row.top}
+          onMeasure={virtualWindow.onMeasure}
+        >
+          {renderItem(row.item)}
+        </VirtualChatRow>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/CommentSection.tsx
+++ b/apps/web/src/features/chat-pane/components/CommentSection.tsx
@@ -1,0 +1,64 @@
+import { commentTargetDisplayName, simplePositionLabel } from '../../../comments';
+import type { PreviewComment } from '../../../types';
+
+export function CommentSection({
+  title,
+  empty,
+  comments,
+  actionLabel,
+  onAction,
+  secondaryActionLabel,
+  onSecondaryAction,
+  attached,
+}: {
+  title: string;
+  empty: string;
+  comments: PreviewComment[];
+  actionLabel: string;
+  onAction: (comment: PreviewComment) => void;
+  secondaryActionLabel?: string;
+  onSecondaryAction?: (comment: PreviewComment) => void;
+  attached?: boolean;
+}) {
+  return (
+    <section className="comments-section">
+      <h3>{title}</h3>
+      {comments.length === 0 ? (
+        <p className="comments-empty">{empty}</p>
+      ) : (
+        comments.map((comment) => (
+          <article
+            key={comment.id}
+            className={`comment-card${attached ? ' attached' : ''}`}
+            data-testid={`comment-card-${comment.elementId}`}
+          >
+            <div className="comment-card-top">
+              <strong>{commentTargetDisplayName(comment)}</strong>
+              <div className="comment-card-actions">
+                {secondaryActionLabel && onSecondaryAction ? (
+                  <button
+                    type="button"
+                    className="comment-card-action danger"
+                    onClick={() => onSecondaryAction(comment)}
+                  >
+                    {secondaryActionLabel}
+                  </button>
+                ) : null}
+                <button type="button" className="comment-card-action" onClick={() => onAction(comment)}>
+                  {actionLabel}
+                </button>
+              </div>
+            </div>
+            <p>{comment.note}</p>
+            <div className="comment-card-meta">
+              <span>{comment.id}</span>
+              <span>{comment.filePath}</span>
+              <span>{commentTargetDisplayName(comment)}</span>
+              <span>{simplePositionLabel(comment.position)}</span>
+            </div>
+          </article>
+        ))
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/CommentsPanel.tsx
+++ b/apps/web/src/features/chat-pane/components/CommentsPanel.tsx
@@ -1,0 +1,56 @@
+import type { Dict } from '../../../i18n/types';
+import type { PreviewComment } from '../../../types';
+import { CommentSection } from './CommentSection';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+export function CommentsPanel({
+  comments,
+  attachedComments,
+  onAttach,
+  onDetach,
+  onDelete,
+  t,
+}: {
+  comments: PreviewComment[];
+  attachedComments: PreviewComment[];
+  onAttach?: (comment: PreviewComment) => void;
+  onDetach?: (commentId: string) => void;
+  onDelete?: (commentId: string) => void;
+  t: TranslateFn;
+}) {
+  const attachedIds = new Set(attachedComments.map((comment) => comment.id));
+  const saved = comments.filter((comment) => !attachedIds.has(comment.id));
+  return (
+    <div className="comments-panel" data-testid="comments-panel">
+      <CommentSection
+        title={t('chat.comments.attached')}
+        empty={t('chat.comments.emptyAttached')}
+        comments={attachedComments}
+        actionLabel={t('chat.comments.remove')}
+        onAction={(comment) => onDetach?.(comment.id)}
+        attached
+      />
+      <CommentSection
+        title={t('chat.comments.saved')}
+        empty={t('chat.comments.emptySaved')}
+        comments={saved}
+        actionLabel={t('chat.comments.add')}
+        onAction={(comment) => onAttach?.(comment)}
+        secondaryActionLabel={t('chat.comments.remove')}
+        onSecondaryAction={(comment) => onDelete?.(comment.id)}
+      />
+      {saved.length > 0 ? (
+        <div className="comments-footer">
+          <button
+            type="button"
+            className="primary"
+            onClick={() => saved.forEach((comment) => onAttach?.(comment))}
+          >
+            {t('chat.comments.addAll')}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/ConversationRow.tsx
+++ b/apps/web/src/features/chat-pane/components/ConversationRow.tsx
@@ -1,0 +1,65 @@
+import { Icon } from '../../../components/Icon';
+import type { Dict } from '../../../i18n/types';
+import type { Conversation } from '../../../types';
+import { compactCount, conversationMetaLabel } from '../rules';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+export function ConversationRow({
+  conversation,
+  active,
+  messageCount,
+  onSelect,
+  onDelete,
+  t,
+}: {
+  conversation: Conversation;
+  active: boolean;
+  messageCount: number | null;
+  onSelect: () => void;
+  onDelete: () => void;
+  t: TranslateFn;
+}) {
+  const displayTitle =
+    conversation.title || t('chat.untitledConversation');
+
+  return (
+    <div
+      className={`chat-conv-item${active ? ' active' : ''}`}
+      data-testid={`conversation-item-${conversation.id}`}
+    >
+      <button
+        type="button"
+        className="chat-conv-item-name"
+        data-testid={`conversation-select-${conversation.id}`}
+        style={{ background: 'transparent', border: 'none', padding: 0, textAlign: 'left' }}
+        onClick={onSelect}
+      >
+        {displayTitle}
+      </button>
+      <span
+        className="chat-conv-item-meta"
+        data-testid={`conversation-meta-${conversation.id}`}
+      >
+        {messageCount !== null ? `${compactCount(messageCount)} msg · ` : ''}
+        {conversationMetaLabel(conversation, t)}
+      </span>
+      <button
+        type="button"
+        className="chat-conv-item-del"
+        data-testid={`conversation-delete-${conversation.id}`}
+        title={t('chat.deleteConversation')}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (
+            confirm(t('chat.deleteConversationConfirm', { title: displayTitle }))
+          ) {
+            onDelete();
+          }
+        }}
+      >
+        <Icon name="close" size={12} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/ImportedFolderArtifacts.tsx
+++ b/apps/web/src/features/chat-pane/components/ImportedFolderArtifacts.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import type { Dict } from '../../../i18n/types';
+import type { ProjectFile } from '../../../types';
+import {
+  IMPORTED_ARTIFACTS_INITIAL_VISIBLE_COUNT,
+  IMPORTED_ARTIFACTS_REVEAL_COUNT,
+} from '../constants';
+import { chatArtifactKindLabel } from '../rules';
+import { ChatArtifactPreview } from './ChatArtifactPreview';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+export function ImportedFolderArtifacts({
+  projectId,
+  files,
+  onOpenFile,
+  t,
+  projectRawUrl,
+}: {
+  projectId: string | null;
+  files: ProjectFile[];
+  onOpenFile?: (name: string) => void;
+  t: TranslateFn;
+  // Threaded in rather than imported directly — see `UserMessage.tsx` for
+  // why this dumb component doesn't reach into `providers/` itself.
+  projectRawUrl: (projectId: string, filePath: string) => string;
+}) {
+  const [visibleCount, setVisibleCount] = useState(IMPORTED_ARTIFACTS_INITIAL_VISIBLE_COUNT);
+
+  useEffect(() => {
+    setVisibleCount(IMPORTED_ARTIFACTS_INITIAL_VISIBLE_COUNT);
+  }, [files]);
+
+  if (files.length === 0) {
+    return (
+      <div className="chat-design-artifacts-empty" data-testid="chat-design-artifacts-empty">
+        {t('designFiles.empty')}
+      </div>
+    );
+  }
+
+  const visibleFiles = files.slice(0, visibleCount);
+  const hiddenCount = Math.max(0, files.length - visibleFiles.length);
+  const revealCount = Math.min(IMPORTED_ARTIFACTS_REVEAL_COUNT, hiddenCount);
+  const revealLabel = t('chat.designArtifactsShowMore', { count: revealCount });
+
+  return (
+    <div className="chat-design-artifacts" data-testid="chat-design-artifacts">
+      {visibleFiles.map((file, index) => {
+        const openable = Boolean(onOpenFile);
+        const openLabel = `${t('designFiles.previewOpen')} ${file.name}`;
+        const openFile = () => {
+          onOpenFile?.(file.name);
+        };
+        return (
+          <div
+            key={file.name}
+            className="chat-design-artifact"
+            data-kind={file.kind}
+            data-file-name={file.name}
+            data-testid={`chat-design-artifact-${index}`}
+            role={openable ? 'button' : 'listitem'}
+            tabIndex={openable ? 0 : undefined}
+            title={openLabel}
+            aria-label={openLabel}
+            onDoubleClick={openable ? openFile : undefined}
+            onKeyDown={
+              openable
+                ? (event) => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+                    event.preventDefault();
+                    openFile();
+                  }
+                : undefined
+            }
+          >
+            <div className="chat-design-artifact-preview" aria-hidden>
+              <ChatArtifactPreview projectId={projectId} file={file} projectRawUrl={projectRawUrl} />
+            </div>
+            <div className="chat-design-artifact-meta">
+              <span className="chat-design-artifact-name" title={file.name}>
+                {file.name}
+              </span>
+              <span className="chat-design-artifact-kind">
+                {chatArtifactKindLabel(file.kind, t)}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+      {hiddenCount > 0 ? (
+        <button
+          type="button"
+          className="chat-design-artifact chat-design-artifact-more"
+          data-testid="chat-design-artifacts-more"
+          aria-label={revealLabel}
+          title={revealLabel}
+          onClick={() => {
+            setVisibleCount((current) =>
+              Math.min(files.length, current + IMPORTED_ARTIFACTS_REVEAL_COUNT),
+            );
+          }}
+        >
+          <span className="chat-design-artifact-more-icon" aria-hidden>
+            +
+          </span>
+          <span className="chat-design-artifact-more-count">
+            {revealLabel}
+          </span>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/MessageSessionModeChip.tsx
+++ b/apps/web/src/features/chat-pane/components/MessageSessionModeChip.tsx
@@ -1,0 +1,30 @@
+import type { ChatSessionMode } from '@open-design/contracts';
+import { Icon } from '../../../components/Icon';
+import type { Dict } from '../../../i18n/types';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+export function MessageSessionModeChip({
+  mode,
+  t,
+}: {
+  mode: ChatSessionMode;
+  t: TranslateFn;
+}) {
+  const label = mode === 'chat'
+    ? t('chat.mode.chat.label')
+    : mode === 'plan'
+      ? t('chat.mode.plan.label')
+      : t('chat.mode.design.label');
+  const icon = mode === 'chat' ? 'comment' : mode === 'plan' ? 'file' : 'sparkles';
+  return (
+    <div
+      className={`msg-mode-chip msg-mode-chip--${mode}`}
+      data-testid="msg-session-mode-chip"
+      title={label}
+    >
+      <Icon name={icon} size={12} />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/QueuedSendMetaChips.tsx
+++ b/apps/web/src/features/chat-pane/components/QueuedSendMetaChips.tsx
@@ -1,0 +1,35 @@
+import type { QueuedSendItem } from '../types';
+
+// Surfaces what a queued turn carries — attachments, visual marks, and the
+// staged plugin / skill / MCP / connector context from its meta — as compact
+// chips so the user can see (and trust) what will be sent without expanding it.
+// Counts use the same plain-English style as the rest of this strip.
+export function QueuedSendMetaChips({ item }: { item: QueuedSendItem }) {
+  const ctx = item.meta?.context;
+  const files = item.attachments?.length ?? 0;
+  const marks = item.commentAttachments?.length ?? 0;
+  const plugins = item.meta?.appliedPluginSnapshot ? 1 : ctx?.pluginIds?.length ?? 0;
+  const skills = ctx?.skillIds?.length ?? 0;
+  const mcp = ctx?.mcpServerIds?.length ?? 0;
+  const connectors = ctx?.connectorIds?.length ?? 0;
+  const workspace = ctx?.workspaceItems?.length ?? 0;
+  const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`;
+  const chips: Array<{ key: string; label: string }> = [];
+  if (files > 0) chips.push({ key: 'files', label: plural(files, 'file') });
+  if (marks > 0) chips.push({ key: 'marks', label: plural(marks, 'mark') });
+  if (plugins > 0) chips.push({ key: 'plugins', label: plural(plugins, 'plugin') });
+  if (skills > 0) chips.push({ key: 'skills', label: plural(skills, 'skill') });
+  if (mcp > 0) chips.push({ key: 'mcp', label: `${mcp} MCP` });
+  if (connectors > 0) chips.push({ key: 'connectors', label: plural(connectors, 'connector') });
+  if (workspace > 0) chips.push({ key: 'workspace', label: plural(workspace, 'workspace context') });
+  if (chips.length === 0) return null;
+  return (
+    <div className="chat-queued-send-chips">
+      {chips.map((chip) => (
+        <span key={chip.key} className="chat-queued-send-chip">
+          {chip.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/QueuedSendStrip.tsx
+++ b/apps/web/src/features/chat-pane/components/QueuedSendStrip.tsx
@@ -1,0 +1,204 @@
+import { useState, type DragEvent as ReactDragEvent, type MutableRefObject } from 'react';
+import { Icon } from '../../../components/Icon';
+import { useT } from '../../../i18n';
+import { QUEUED_SEND_DRAG_MIME, QUEUED_SEND_VISIBLE_ROW_COUNT } from '../constants';
+import { queuedDropEdgeForPosition, reorderQueuedSendIds, summarizeQueuedPrompt } from '../rules';
+import type { QueuedSendDragState, QueuedSendItem } from '../types';
+import { QueuedSendMetaChips } from './QueuedSendMetaChips';
+
+function dropEdgeForEvent(event: ReactDragEvent<HTMLElement>) {
+  const rect = event.currentTarget.getBoundingClientRect();
+  return queuedDropEdgeForPosition(event.clientY, rect.top, rect.height);
+}
+
+export function QueuedSendStrip({
+  containerRef,
+  editingId,
+  items,
+  onEdit,
+  onRemove,
+  onReorder,
+  onSendNow,
+}: {
+  containerRef?: MutableRefObject<HTMLDivElement | null>;
+  editingId?: string | null;
+  items: QueuedSendItem[];
+  onEdit?: (item: QueuedSendItem) => void;
+  onRemove?: (id: string) => void;
+  onReorder?: (orderedIds: string[]) => void;
+  onSendNow?: (id: string) => void;
+}) {
+  const t = useT();
+  const [dragState, setDragState] = useState<QueuedSendDragState | null>(null);
+  if (items.length === 0) return null;
+  const canReorder = Boolean(onReorder && items.length > 1);
+  const overflowCount = Math.max(0, items.length - QUEUED_SEND_VISIBLE_ROW_COUNT);
+
+  const handleDragStart = (
+    event: ReactDragEvent<HTMLButtonElement>,
+    item: QueuedSendItem,
+  ) => {
+    if (!canReorder) return;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData(QUEUED_SEND_DRAG_MIME, item.id);
+    event.dataTransfer.setData('text/plain', item.id);
+    setDragState({ draggingId: item.id, overId: item.id, edge: null });
+  };
+
+  const handleDragOver = (
+    event: ReactDragEvent<HTMLDivElement>,
+    targetId: string,
+  ) => {
+    if (!canReorder) return;
+    const draggingId = dragState?.draggingId || event.dataTransfer.getData(QUEUED_SEND_DRAG_MIME);
+    if (!draggingId) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    if (draggingId === targetId) {
+      if (dragState?.overId !== targetId || dragState.edge !== null) {
+        setDragState({ draggingId, overId: targetId, edge: null });
+      }
+      return;
+    }
+    const edge = dropEdgeForEvent(event);
+    if (
+      dragState?.draggingId !== draggingId
+      || dragState.overId !== targetId
+      || dragState.edge !== edge
+    ) {
+      setDragState({ draggingId, overId: targetId, edge });
+    }
+  };
+
+  const handleDrop = (
+    event: ReactDragEvent<HTMLDivElement>,
+    targetId: string,
+  ) => {
+    if (!canReorder) return;
+    event.preventDefault();
+    const draggingId =
+      dragState?.draggingId
+      || event.dataTransfer.getData(QUEUED_SEND_DRAG_MIME)
+      || event.dataTransfer.getData('text/plain');
+    if (!draggingId || draggingId === targetId) {
+      setDragState(null);
+      return;
+    }
+    const edge = dragState?.overId === targetId && dragState.edge
+      ? dragState.edge
+      : dropEdgeForEvent(event);
+    const nextIds = reorderQueuedSendIds(items, draggingId, targetId, edge);
+    if (nextIds.join('\0') !== items.map((item) => item.id).join('\0')) {
+      onReorder?.(nextIds);
+    }
+    setDragState(null);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="chat-queued-send-strip"
+      data-testid="chat-queued-send-strip"
+      onDragLeave={(event) => {
+        const related = event.relatedTarget;
+        if (related instanceof Node && event.currentTarget.contains(related)) return;
+        setDragState(null);
+      }}
+    >
+      <div className="chat-queued-send-header">
+        <div className="chat-queued-send-heading">
+          <strong>
+            {items.length} {t('chat.queuedHeader')}
+          </strong>
+          <span aria-hidden>↩</span>
+          <span>{t('chat.queuedToSend')}</span>
+        </div>
+      </div>
+      <div className={`chat-queued-send-list${overflowCount > 0 ? ' is-scrollable' : ''}`}>
+        {items.map((item, index) => {
+          const isDragging = dragState?.draggingId === item.id;
+          const dropClass = dragState?.overId === item.id
+            && dragState.draggingId !== item.id
+            && dragState.edge
+            ? ` chat-queued-send-row-drop-${dragState.edge}`
+            : '';
+          return (
+            <div
+              className={`chat-queued-send-row${index === 0 ? ' chat-queued-send-row-active' : ''}${
+                editingId === item.id ? ' chat-queued-send-row-editing' : ''
+              }${isDragging ? ' chat-queued-send-row-dragging' : ''}${dropClass}`}
+              key={item.id}
+              onDragOver={(event) => handleDragOver(event, item.id)}
+              onDrop={(event) => handleDrop(event, item.id)}
+            >
+              <button
+                type="button"
+                className="chat-queued-send-drag-handle chat-queued-send-tooltip od-tooltip"
+                title={t('chat.queuedReorder')}
+                data-tooltip={t('chat.queuedReorder')}
+                data-tooltip-placement="right"
+                aria-label={t('chat.queuedReorder')}
+                draggable={canReorder}
+                disabled={!canReorder}
+                onDragStart={(event) => handleDragStart(event, item)}
+                onDragEnd={() => setDragState(null)}
+              >
+                <Icon name="grip-vertical" size={14} />
+              </button>
+              <div className="chat-queued-send-main">
+                <span className="chat-queued-send-title">{summarizeQueuedPrompt(item, t)}</span>
+                <QueuedSendMetaChips item={item} />
+              </div>
+              <div className="chat-queued-send-actions">
+                {onEdit ? (
+                  <button
+                    type="button"
+                    className="chat-queued-send-action chat-queued-send-tooltip od-tooltip"
+                    title={t('chat.queuedEdit')}
+                    data-tooltip={t('chat.queuedEdit')}
+                    data-tooltip-placement="top"
+                    aria-label={t('chat.queuedEdit')}
+                    onClick={() => onEdit(item)}
+                  >
+                    <Icon name="pencil" size={13} />
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="chat-queued-send-action chat-queued-send-tooltip od-tooltip"
+                  title={t('chat.send')}
+                  data-tooltip={t('chat.send')}
+                  data-tooltip-placement="top"
+                  aria-label={t('chat.send')}
+                  data-testid="chat-queued-send-now"
+                  onClick={() => onSendNow?.(item.id)}
+                  disabled={!onSendNow}
+                >
+                  <Icon name="arrow-up" size={13} />
+                </button>
+                {onRemove ? (
+                  <button
+                    type="button"
+                    className="chat-queued-send-action chat-queued-send-tooltip od-tooltip"
+                    onClick={() => onRemove(item.id)}
+                    title={t('chat.comments.remove')}
+                    data-tooltip={t('chat.comments.remove')}
+                    data-tooltip-placement="top"
+                    aria-label={t('chat.comments.remove')}
+                  >
+                    <Icon name="trash" size={13} />
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {overflowCount > 0 ? (
+        <div className="chat-queued-send-overflow">
+          +{overflowCount} {t('chat.queuedMore')}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/components/UserMessage.tsx
+++ b/apps/web/src/features/chat-pane/components/UserMessage.tsx
@@ -1,0 +1,190 @@
+import { memo, useEffect, useRef, useState } from 'react';
+import type { AppliedPluginSnapshot } from '@open-design/contracts';
+import { commentTargetDisplayName } from '../../../comments';
+import { Icon } from '../../../components/Icon';
+import {
+  DESIGN_SYSTEM_WORKSPACE_DISPLAY_DESCRIPTION,
+  DESIGN_SYSTEM_WORKSPACE_DISPLAY_TITLE,
+  isDesignSystemWorkspacePrompt,
+} from '../../../design-system-auto-prompt';
+import type { Dict } from '../../../i18n/types';
+import { copyToClipboard } from '../../../lib/copy-to-clipboard';
+import type { ChatMessage, DesignSystemSummary } from '../../../types';
+import { sortChatAttachmentsForDisplay } from '../rules';
+import { ActiveDesignSystemChip } from './ActiveDesignSystemChip';
+import { ActivePluginChip } from './ActivePluginChip';
+import { ActiveWorkspaceContextChip } from './ActiveWorkspaceContextChip';
+import { MessageSessionModeChip } from './MessageSessionModeChip';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+function UserMessageImpl({
+  message,
+  projectId,
+  projectFileNames,
+  onRequestOpenFile,
+  onRequestPluginDetails,
+  onRequestDesignSystemDetails,
+  t,
+  activePluginSnapshot,
+  activeDesignSystem,
+  projectRawUrl,
+}: {
+  message: ChatMessage;
+  projectId: string | null;
+  projectFileNames?: Set<string>;
+  onRequestOpenFile?: (name: string) => void;
+  onRequestPluginDetails?: (pluginId: string) => void;
+  onRequestDesignSystemDetails?: (system: DesignSystemSummary) => void;
+  t: TranslateFn;
+  activePluginSnapshot?: AppliedPluginSnapshot | null;
+  activeDesignSystem?: DesignSystemSummary | null;
+  // Threaded in rather than imported directly — `providers/registry` may
+  // only be imported from `dependencies.ts` inside a `features/**` file
+  // (see `scripts/check-web-slice-boundaries.ts`), and this is a dumb
+  // presentational component, not a port-consuming hook.
+  projectRawUrl: (projectId: string, filePath: string) => string;
+}) {
+  const attachments = sortChatAttachmentsForDisplay(message.attachments ?? []);
+  const commentAttachments = message.commentAttachments ?? [];
+  const workspaceItems = message.runContext?.workspaceItems ?? [];
+  const messagePluginSnapshot = message.appliedPluginSnapshot ?? activePluginSnapshot ?? null;
+  const hasRunContext = Boolean(
+    message.sessionMode ||
+      workspaceItems.length > 0 ||
+      messagePluginSnapshot ||
+      activeDesignSystem,
+  );
+  const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  async function handleCopy() {
+    if (!message.content) return;
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    const ok = await copyToClipboard(message.content);
+    if (!ok) return;
+    setCopied(true);
+    copyTimerRef.current = setTimeout(() => {
+      setCopied(false);
+      copyTimerRef.current = undefined;
+    }, 2000);
+  }
+
+  const isDesignSystemWorkspaceRequest = isDesignSystemWorkspacePrompt(message.content);
+
+  return (
+    <div className="msg user">
+      <span className="sr-only">{t('chat.you')}</span>
+      {hasRunContext ? (
+        <div className="msg-run-context-row" data-testid="msg-run-context-row">
+          {message.sessionMode ? (
+            <MessageSessionModeChip mode={message.sessionMode} t={t} />
+          ) : null}
+          {workspaceItems.map((item) => (
+            <ActiveWorkspaceContextChip
+              key={`${item.kind}:${item.id}`}
+              item={item}
+              onOpen={onRequestOpenFile}
+            />
+          ))}
+          {messagePluginSnapshot ? (
+            <ActivePluginChip
+              snapshot={messagePluginSnapshot}
+              t={t}
+              onOpenDetails={onRequestPluginDetails}
+            />
+          ) : null}
+          {activeDesignSystem ? (
+            <ActiveDesignSystemChip
+              system={activeDesignSystem}
+              onOpenDetails={onRequestDesignSystemDetails}
+            />
+          ) : null}
+        </div>
+      ) : null}
+      {attachments.length > 0 ? (
+        <div className="user-attachments">
+          {attachments.map((a, index) => {
+            const baseName = a.path.split('/').pop() || a.path;
+            const openable =
+              !!onRequestOpenFile &&
+              (projectFileNames ? projectFileNames.has(baseName) : true);
+            const handleOpen = openable
+              ? () => onRequestOpenFile?.(baseName)
+              : undefined;
+            return (
+              <button
+                type="button"
+                key={a.path}
+                className={`user-attachment staged-${a.kind}${openable ? ' openable' : ''}`}
+                onClick={handleOpen}
+                disabled={!openable}
+                title={openable ? t('chat.openFile', { name: baseName }) : a.path}
+              >
+                <span className="staged-order" aria-label={`Attachment ${index + 1}`}>
+                  {index + 1}
+                </span>
+                {a.kind === 'image' && projectId ? (
+                  <img src={projectRawUrl(projectId, a.path)} alt={a.name} />
+                ) : (
+                  <Icon name="file" size={14} />
+                )}
+                <span className="staged-name">{a.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+      {commentAttachments.some((attachment) => attachment.selectionKind !== 'visual') ? (
+        <div className="user-attachments comment-history-attachments">
+          {commentAttachments.filter((attachment) => attachment.selectionKind !== 'visual').map((a) => (
+            <span key={a.id} className="user-attachment staged-comment">
+              <span className="staged-name" title={a.comment ? `${commentTargetDisplayName(a)}: ${a.comment}` : commentTargetDisplayName(a)}>
+                <strong>{commentTargetDisplayName(a)}</strong>
+                {a.comment ? <span>{a.comment}</span> : null}
+              </span>
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {message.content && isDesignSystemWorkspaceRequest ? (
+        <div className="user-text-wrap user-status-wrap">
+          <div className="user-status-card design-system-generation-status">
+            <span className="user-status-card__icon">
+              <Icon name="blocks" size={15} />
+            </span>
+            <span className="user-status-card__copy">
+              <strong>{DESIGN_SYSTEM_WORKSPACE_DISPLAY_TITLE}</strong>
+              <span>{DESIGN_SYSTEM_WORKSPACE_DISPLAY_DESCRIPTION}</span>
+            </span>
+          </div>
+        </div>
+      ) : message.content ? (
+        <div className="user-text-wrap">
+          <div className="user-text user-bubble">{message.content}</div>
+          <div className="user-actions">
+            <button
+              type="button"
+              className="ghost user-copy-btn"
+              onClick={handleCopy}
+              aria-label={copied ? t('chat.copyDone') : t('chat.copyPrompt')}
+              title={copied ? t('chat.copyDone') : t('chat.copyPrompt')}
+            >
+              <Icon name={copied ? 'check' : 'copy'} size={13} />
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// Memoized: a static user message has stable props, so it skips re-render
+// while a later turn streams.
+export const UserMessage = memo(UserMessageImpl);

--- a/apps/web/src/features/chat-pane/components/VirtualChatRow.tsx
+++ b/apps/web/src/features/chat-pane/components/VirtualChatRow.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+
+export function VirtualChatRow({
+  itemKey,
+  top,
+  onMeasure,
+  children,
+}: {
+  itemKey: string;
+  top: number;
+  onMeasure: (key: string, height: number) => void;
+  children: ReactNode;
+}) {
+  const rowRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const node = rowRef.current;
+    if (!node) return;
+    const measure = () => {
+      const height = node.getBoundingClientRect().height;
+      onMeasure(itemKey, height);
+    };
+    measure();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [itemKey, onMeasure]);
+
+  return (
+    <div
+      ref={rowRef}
+      className="chat-virtual-row"
+      style={{ transform: `translateY(${top}px)` }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-pane/constants.ts
+++ b/apps/web/src/features/chat-pane/constants.ts
@@ -1,0 +1,174 @@
+import type { Dict } from '../../i18n/types';
+import type { StarterPrompt } from './types';
+
+export const CHAT_MESSAGE_VIRTUALIZE_THRESHOLD = 80;
+export const CHAT_MESSAGE_OVERSCAN_PX = 900;
+export const CHAT_VIRTUAL_ROW_GAP_PX = 14;
+export const CHAT_VIRTUAL_MIN_ROW_HEIGHT = 36;
+export const CHAT_VIRTUAL_DEFAULT_VIEWPORT_PX = 640;
+export const CHAT_VIRTUAL_INITIAL_TAIL_ROWS = 16;
+
+export const WORKSPACE_DESIGN_FILES_TAB = '__design_files__';
+export const WORKSPACE_DESIGN_SYSTEM_TAB = '__design_system__';
+
+export const IMPORTED_ARTIFACTS_INITIAL_VISIBLE_COUNT = 5;
+export const IMPORTED_ARTIFACTS_REVEAL_COUNT = 5;
+
+export const QUEUED_SEND_DRAG_MIME = 'application/x-open-design-queued-send';
+export const QUEUED_SEND_VISIBLE_ROW_COUNT = 4;
+
+// Featured starter prompts shown on the empty chat. Clicking one fills
+// the composer (does not auto-send) so users can tweak before sending.
+// Each prompt is intentionally dense — it should showcase ambitious
+// layout, typographic, and information-design moves rather than a
+// generic landing page.
+//
+// Starter sets are picked per project kind (and per video model) so a
+// fresh seedance video, a hyperframes html-in-canvas video, an image
+// project and an audio project each see relevant prompts instead of the
+// generic starter set. The default (prototype/deck/template/other/
+// live-artifact) set stays i18n-translated via existing chat.example*
+// keys so the user-facing copy keeps its localizations. The new media
+// sets are inline English literals — they are technical agent prompts
+// that work well across locales without translation, and going through
+// i18n for each of them would balloon every Dict entry by 12+ keys.
+export const DEFAULT_STARTER_KEYS: Array<{
+  icon: string;
+  titleKey: keyof Dict;
+  tagKey: keyof Dict;
+  promptKey: keyof Dict;
+}> = [
+  {
+    icon: '▤',
+    titleKey: 'chat.example1Title',
+    tagKey: 'chat.example1Tag',
+    promptKey: 'chat.example1Prompt',
+  },
+  {
+    icon: '▦',
+    titleKey: 'chat.example2Title',
+    tagKey: 'chat.example2Tag',
+    promptKey: 'chat.example2Prompt',
+  },
+  {
+    icon: '◈',
+    titleKey: 'chat.example3Title',
+    tagKey: 'chat.example3Tag',
+    promptKey: 'chat.example3Prompt',
+  },
+  {
+    icon: '▶',
+    titleKey: 'chat.example4Title',
+    tagKey: 'chat.example4Tag',
+    promptKey: 'chat.example4Prompt',
+  },
+];
+
+export const IMAGE_STARTERS: StarterPrompt[] = [
+  {
+    icon: '◯',
+    title: 'Editorial portrait',
+    tag: 'Portrait',
+    prompt:
+      'A close-up editorial portrait of a young creative director in their late 20s, soft natural light through tall studio windows, warm neutral palette (cream, taupe, soft black), shot at 85mm f/1.8 with shallow depth of field, sharp gaze straight to camera, subtle film grain, no makeup look.',
+  },
+  {
+    icon: '▭',
+    title: 'Product hero',
+    tag: 'E-commerce',
+    prompt:
+      'A premium product hero shot of a single matte ceramic coffee mug on a warm cream paper backdrop. Hard rim light from the upper-left, gentle elongated shadow stretching to the lower-right, faint steam rising from the cup. Square crop, centered composition, room above for headline copy, no props or hands in frame.',
+  },
+  {
+    icon: '◐',
+    title: 'Flat illustration',
+    tag: 'Illustration',
+    prompt:
+      'A flat vector illustration of a cozy reading nook by a rainy window — geometric shapes, restrained 5-color palette (cream, terracotta, deep teal, burnt sienna, soft black), thin 1.5px line accents, no gradients, no textures, soft drop shadows only on the foreground armchair.',
+  },
+];
+
+// Pure-video / cinematic-shot starters for seedance, sora, kling, veo,
+// grok-imagine and similar text-to-video models. Each prompt is one
+// shot, restrained motion, and a clear visual concept the model can
+// nail in 5-10 seconds.
+export const VIDEO_SEEDANCE_STARTERS: StarterPrompt[] = [
+  {
+    icon: '◉',
+    title: 'Product reveal',
+    tag: 'Cinematic',
+    prompt:
+      'A 5-second product reveal: a minimal high-end skincare bottle on a clean cream stone surface, soft side light from camera-left, slow camera push-in, subtle depth-of-field shift from the cap to the label, restrained motion, no text overlays, no people in frame.',
+  },
+  {
+    icon: '▣',
+    title: 'Lantern close-up',
+    tag: 'Mood',
+    prompt:
+      'A 6-second cinematic close-up of a young woman holding a glowing paper lantern in a misty pine forest at golden hour. Shallow depth of field on her eyes, gentle dolly-in, ambient particles drifting through the warm shaft of light, no dialogue, ambient forest sound only.',
+  },
+  {
+    icon: '⌘',
+    title: 'Neon street drift',
+    tag: 'Action',
+    prompt:
+      'A 5-second street-racing tracking shot at night in a neon-lit cyberpunk Hong Kong alley. Low-angle camera following a matte-black sports car drifting around a tight corner, motion blur on the wheels, lens flares from oncoming neon signs, rain-slick asphalt reflecting the lights, no on-screen text.',
+  },
+];
+
+// HyperFrames HTML-in-canvas starters — these target the
+// hyperframes-html video model where the renderer captures live DOM
+// into a WebGL texture and runs shader effects on top. References:
+// https://www.remotion.dev/docs/html-in-canvas (concept), the seven
+// vfx-* catalog blocks shipped via `npx hyperframes add vfx-*`, and
+// skills/hyperframes/references/html-in-canvas.md.
+export const VIDEO_HYPERFRAMES_STARTERS: StarterPrompt[] = [
+  {
+    icon: '◉',
+    title: 'Magnifying glass reveal',
+    tag: 'HTML-in-canvas',
+    prompt:
+      'Make a 5-second composition with a single line of bold display text on a clean canvas. Animate a round magnifying glass that travels left to right across the line, with subtle glass refraction warping the letters underneath as it passes. Use HyperFrames html-in-canvas — capture the text DOM and run the lens shader on top via a vfx-liquid-glass-style pass. Pure CSS for the text; the glass is a WebGL layer.',
+  },
+  {
+    icon: '▦',
+    title: 'CRT terminal scene',
+    tag: 'Vintage VFX',
+    prompt:
+      "Make a CRT-screen composition: dark canvas, monospace terminal text typing `npx hyperframes init my-video`, then `claude` invoked with the prompt 'Add a CRT effect using HTML-in-canvas'. Apply a subtle convex-curvature shader, scanlines, slight chromatic aberration, and a soft phosphor glow on top of the live DOM via html-in-canvas. The terminal text stays as real CSS so it's pixel-sharp before the shader pass.",
+  },
+  {
+    icon: '◈',
+    title: 'Glitch breakdown',
+    tag: 'Glitch',
+    prompt:
+      'Build a 6-second composition that displays a hero headline and a one-line subhead on a dark canvas, then breaks into a hard digital glitch — RGB channel split, horizontal displacement bands, brief frame-stutter, and a final clean reset. Capture the live DOM via html-in-canvas and run the glitch pass on top, so the type is real CSS underneath the shader.',
+  },
+];
+
+// Speech-focused audio starters — the New Project audio panel only
+// surfaces the `speech` kind today (see MediaProjectOptions), so we
+// match that. If/when the music + sfx tabs come back, broaden this set.
+export const AUDIO_STARTERS: StarterPrompt[] = [
+  {
+    icon: '♪',
+    title: 'Brand voiceover',
+    tag: 'Speech',
+    prompt:
+      "A 30-second warm-toned narrative voiceover for a product launch video — confident but conversational, mid-tempo, with a beat of pause after the brand name. Script: 'Three years in the making. One simple promise. Meet [product name] — the way work was supposed to feel.' English, neutral North American accent.",
+  },
+  {
+    icon: '♫',
+    title: 'Onboarding narration',
+    tag: 'Speech',
+    prompt:
+      "A 20-second friendly onboarding narration for a mobile app's first-launch screen. Reassuring, smiling tone, slow enough to feel attentive without sounding scripted. Script: 'Welcome to Loop. Let's set up your space — three quick questions and you're in. You can change any of this later.'",
+  },
+  {
+    icon: '♬',
+    title: 'Story passage read',
+    tag: 'Speech',
+    prompt:
+      "A 45-second cinematic read of an opening passage. Low, measured delivery with breath between sentences, slightly intimate close-mic'd quality. Script: 'The city sleeps in pieces. A neon sign flickers above the ramen counter. Across the avenue, a window glows — the only one still on this side of midnight.'",
+  },
+];

--- a/apps/web/src/features/chat-pane/dependencies.ts
+++ b/apps/web/src/features/chat-pane/dependencies.ts
@@ -1,0 +1,34 @@
+// The one file in this slice allowed to import `providers/` — everything
+// else in the slice depends on the port, so swapping the adapter (or a fake
+// in tests) touches only this file.
+import {
+  getDocumentBody,
+  openExternalUrl,
+  scheduleInterval,
+  scheduleTimeout,
+  subscribeComposerLayerHeight,
+  subscribeComposerPortalRect,
+  subscribeOutsideClickOrEscape,
+  subscribeVisibleFocusOrVisibilityChange,
+  subscribeWindowEvent,
+} from '../../providers/dom';
+import { fetchVelaLoginStatus } from '../../providers/daemon';
+import type { AmrLoginPort, ChatPaneDomPort } from './ports';
+
+/** Default binding: the real browser DOM. */
+export const chatPaneDomPort: ChatPaneDomPort = {
+  getDocumentBody,
+  subscribeComposerPortalRect,
+  subscribeComposerLayerHeight,
+  subscribeOutsideClickOrEscape,
+  subscribeWindowEvent,
+  subscribeVisibleFocusOrVisibilityChange,
+  scheduleInterval,
+  scheduleTimeout,
+  openExternalUrl,
+};
+
+/** Default binding: the real vela-login-status endpoint. */
+export const amrLoginPort: AmrLoginPort = {
+  fetchVelaLoginStatus,
+};

--- a/apps/web/src/features/chat-pane/hooks/useChatLogScrollAnchor.hooks.ts
+++ b/apps/web/src/features/chat-pane/hooks/useChatLogScrollAnchor.hooks.ts
@@ -1,0 +1,521 @@
+import { useEffect, useRef, useState, type MutableRefObject } from 'react';
+import type { ChatMessage } from '../../../types';
+import { chatPaneDomPort } from '../dependencies';
+import type { ChatPaneDomPort } from '../ports';
+
+// Gap left above the anchored user message when it is pinned to the top.
+const ANCHOR_TOP_PADDING = 12;
+
+/**
+ * Owns the chat-log's scroll-anchoring subsystem: "anchor the just-sent turn
+ * to the top" (ChatGPT-style), the initial-scroll-to-bottom-or-question-form
+ * behavior, the jump-to-latest affordance, and the ResizeObserver/
+ * MutationObserver-driven auto-follow while streaming. This is the single
+ * most entangled cluster in the orchestrator (matches the equivalent "big
+ * one" cluster in the ChatComposer decomposition) — see the extraction plan
+ * handoff for why it lands last.
+ */
+export function useChatLogScrollAnchor(
+  logRef: MutableRefObject<HTMLDivElement | null>,
+  tailSpacerRef: MutableRefObject<HTMLDivElement | null>,
+  queuedSendStripRef: MutableRefObject<HTMLDivElement | null>,
+  {
+    activeConversationId,
+    displayMessages,
+    streaming,
+    tab,
+    error,
+  }: {
+    activeConversationId: string | null;
+    displayMessages: ChatMessage[];
+    streaming: boolean;
+    tab: string;
+    error: string | null;
+  },
+  domPort: ChatPaneDomPort = chatPaneDomPort,
+) {
+  const [scrolledFromBottom, setScrolledFromBottom] = useState(false);
+  const [chatLogScrollable, setChatLogScrollable] = useState(false);
+  const [chatLogScrolling, setChatLogScrolling] = useState(false);
+  const chatLogScrollIdleTimerRef = useRef<(() => void) | null>(null);
+  const didInitialScrollRef = useRef(false);
+  // Tracks whether the user is glued close enough to the bottom that
+  // streamed content should auto-follow. Distinct from the jump-button
+  // state below, which uses a wider threshold (120px) so the affordance
+  // stays visible for short scroll-ups. Auto-follow needs the tighter
+  // 80px cutoff: scrolling ~90px up is an intentional pause that
+  // shouldn't be yanked back the moment the next chunk streams in.
+  const pinnedToBottomRef = useRef(true);
+  const scrolledToFormRef = useRef<Set<string>>(new Set());
+  // "Anchor the just-sent turn to the top" (ChatGPT-style). On send we pin
+  // the user's message to the top of the viewport and let the reply stream
+  // below it instead of following the bottom. `pending` is armed by the
+  // composer's onSend; the messages effect promotes it to `active` once the
+  // new user turn actually renders. A dynamic tail spacer reserves just
+  // enough real, scrollable blank space below the turn so the message can
+  // reach the top even when the reply is short. The spacer is only resized
+  // while the message sits at its pinned position — once the user scrolls
+  // below it, the reserved blank stays put (no collapse, no jump).
+  const anchorPendingRef = useRef(false);
+  const anchorActiveRef = useRef(false);
+  const prevStreamingRef = useRef(streaming);
+  const prevLastUserIdRef = useRef<string | undefined>(undefined);
+  // Saved chat-log scroll state, preserved across tab switches. The
+  // chat-log <div> is conditionally rendered so it unmounts when the
+  // user switches to Comments. On remount it would default to
+  // scrollTop: 0 and the initial-bottom-scroll effect skips because
+  // didInitialScrollRef is already true. We capture either the absolute
+  // scrollTop or a "pinned to bottom" flag while Chat is visible, so
+  // bottom-followers stay pinned even when new messages stream in
+  // off-tab. Issue #790.
+  const savedChatScrollRef = useRef<
+    { pinnedToBottom: true } | { pinnedToBottom: false; scrollTop: number } | null
+  >(null);
+
+  function resetTailSpacer() {
+    const s = tailSpacerRef.current;
+    if (s) s.style.height = '0px';
+  }
+
+  // Content offset (distance from the top of the scroll content) of the most
+  // recent user message. Invariant to the current scrollTop, so it's safe to
+  // call regardless of where the user has scrolled.
+  function lastUserMsgTopInContent(el: HTMLDivElement): number | null {
+    const userEls = el.querySelectorAll<HTMLElement>('.msg.user');
+    const msgEl = userEls[userEls.length - 1];
+    if (!msgEl) return null;
+    const elRect = el.getBoundingClientRect();
+    const msgRect = msgEl.getBoundingClientRect();
+    return el.scrollTop + (msgRect.top - elRect.top);
+  }
+
+  // Resize the tail spacer so the anchored message can sit at the top with
+  // just enough room below it — no more. This is a resize ONLY (never a
+  // scroll): shrinking empty space below the fold can't shift what's visible
+  // while the user is pinned near the top, so it never causes jitter. As the
+  // reply streams in, `needed` shrinks monotonically toward 0.
+  function sizeAnchorSpacer() {
+    const el = logRef.current;
+    const spacer = tailSpacerRef.current;
+    if (!el || !spacer) return;
+    const msgTopInContent = lastUserMsgTopInContent(el);
+    if (msgTopInContent === null) return;
+    const spacerH = spacer.offsetHeight;
+    const contentBelow = el.scrollHeight - spacerH - msgTopInContent;
+    const needed = Math.max(0, el.clientHeight - contentBelow - ANCHOR_TOP_PADDING);
+    spacer.style.height = `${needed}px`;
+  }
+
+  // Smooth-scroll the anchored message to the top. Called ONCE per turn (on
+  // send). The message then stays at the top on its own as the reply streams
+  // below it, so we never re-scroll — re-scrolling each chunk is what caused
+  // the scroll-down fight and the settle jitter.
+  function scrollAnchorToTop() {
+    const el = logRef.current;
+    if (!el) return;
+    const msgTopInContent = lastUserMsgTopInContent(el);
+    if (msgTopInContent === null) return;
+    const target = Math.max(0, msgTopInContent - ANCHOR_TOP_PADDING);
+    el.scrollTo({ top: target, behavior: 'smooth' });
+  }
+
+  function jumpToBottom() {
+    const el = logRef.current;
+    if (!el) return;
+    anchorActiveRef.current = false;
+    pinnedToBottomRef.current = true;
+    resetTailSpacer();
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+  }
+
+  // Called by the composer's onSend, before the send-branch decides whether
+  // this is a new turn or a queued-send edit — both paths reset the "glued
+  // to bottom" tracking.
+  function resetScrollTrackingForSend() {
+    pinnedToBottomRef.current = true;
+    scrolledToFormRef.current = new Set();
+  }
+
+  // Called by the composer's onSend for a genuine new turn (not a queued-send
+  // edit) — arms the anchor-to-top behavior; the messages effect below
+  // promotes it to `active` once the new user turn actually renders.
+  function armAnchorForSend() {
+    anchorActiveRef.current = false;
+    resetTailSpacer();
+    anchorPendingRef.current = true;
+  }
+
+  // Expanding an accordion (tool card / thinking block) should grow
+  // downward with the clicked header staying put. While a run is glued to
+  // the bottom, the ResizeObserver would re-pin to the bottom on the height
+  // change and push the header up, so the chat-log's click-capture handler
+  // calls this the moment the user toggles one open.
+  function unpinFromBottom() {
+    pinnedToBottomRef.current = false;
+    anchorActiveRef.current = false;
+    setScrolledFromBottom(true);
+  }
+
+  useEffect(() => {
+    didInitialScrollRef.current = false;
+    anchorPendingRef.current = false;
+    anchorActiveRef.current = false;
+    prevLastUserIdRef.current = undefined;
+    resetTailSpacer();
+    // A new conversation should land at the bottom (its own initial
+    // scroll), not inherit the previous conversation's saved position —
+    // including any anchor-to-top reserve still held by the tail spacer, which
+    // would otherwise strand the freshly opened conversation below a dead gap.
+    savedChatScrollRef.current = null;
+    scrolledToFormRef.current = new Set();
+    anchorActiveRef.current = false;
+    anchorPendingRef.current = false;
+    resetTailSpacer();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeConversationId]);
+
+  useEffect(() => {
+    const el = logRef.current;
+    if (!el || didInitialScrollRef.current || displayMessages.length === 0) return;
+    didInitialScrollRef.current = true;
+    requestAnimationFrame(() => {
+      // If the last assistant message contains a question form, scroll to
+      // the form instead of the bottom, so the user sees the form first.
+      const lastAssistantMsg = [...displayMessages].reverse().find((m) => m.role === 'assistant');
+      if (lastAssistantMsg?.content.includes('<question-form')) {
+        const assistantEls = el.querySelectorAll('.msg.assistant');
+        const lastAssistantEl = assistantEls[assistantEls.length - 1];
+        const formEl = lastAssistantEl?.querySelector<HTMLElement>('[data-form-id]');
+        if (formEl && !scrolledToFormRef.current.has(formEl.dataset.formId!)) {
+          scrolledToFormRef.current.add(formEl.dataset.formId!);
+          formEl.scrollIntoView({ block: 'start', behavior: 'smooth' });
+          pinnedToBottomRef.current = false;
+          setScrolledFromBottom(true);
+          return;
+        }
+        // Already handled by the auto-scroll effect — don't bottom-scroll.
+        if (formEl) return;
+      }
+      // Initial-load bottom-pin must be instant — smooth scrollTo emits
+      // intermediate scroll events that flip pinnedToBottomRef to false.
+      el.scrollTop = el.scrollHeight;
+      setScrolledFromBottom(false);
+      pinnedToBottomRef.current = true;
+    });
+    // `tab` is in the deps so that switching conversations while
+    // Comments is open doesn't strand the new conversation at scrollTop:
+    // 0. The activeConversationId-reset effect above clears
+    // didInitialScrollRef while the chat-log is unmounted; this effect
+    // then re-runs when the user returns to Chat and the element is
+    // available, scrolling the new conversation to its initial bottom.
+  }, [activeConversationId, displayMessages, tab]);
+
+  // When a turn finishes streaming, release the anchor-to-top reserve. The
+  // tail spacer only exists to give a streaming reply room to grow while the
+  // user message stays pinned at the top; once the reply is final it must not
+  // linger, or a short turn (typical of a fresh fork) is left with a large
+  // dead gap below it. Collapsing the spacer lets the bottom-anchored layout
+  // settle the finished transcript against the composer.
+  useEffect(() => {
+    const was = prevStreamingRef.current;
+    prevStreamingRef.current = streaming;
+    // The tail spacer only ever holds the anchor-to-top reserve for an actively
+    // streaming reply, so once the turn ends it must collapse unconditionally —
+    // even if a mid-turn scroll already cleared `anchorActiveRef` (which leaves
+    // the spacer sized). Collapsing it lets the bottom-anchored layout settle a
+    // finished short turn against the composer instead of below a dead gap.
+    if (was && !streaming) {
+      anchorActiveRef.current = false;
+      resetTailSpacer();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [streaming]);
+
+  useEffect(() => {
+    const el = logRef.current;
+    if (!el) return;
+    // Auto-scroll only when the user was already pinned near the bottom,
+    // so a scrollback session reading earlier output isn't yanked to the
+    // latest message. We key off the pre-content `pinnedToBottomRef`
+    // (a ref so it doesn't itself re-fire this effect on scroll) instead
+    // of recomputing distance from the just-grown scrollHeight: a single
+    // streamed chunk can add 100+ px in one render, which made the
+    // post-content distance check skip auto-scroll even when the user
+    // was glued to the bottom. We deliberately use the tighter 80px
+    // cutoff tracked by the ref (not the wider 120px jump-button
+    // threshold) so a deliberate ~90px scroll-up isn't snapped back the
+    // next time content streams in. Issue #983.
+
+    // A brand-new user turn from a local send: switch to "anchor to top"
+    // mode and smooth-scroll their message to the top of the viewport.
+    const lastUser = [...displayMessages].reverse().find((m) => m.role === 'user');
+    const prevUserId = prevLastUserIdRef.current;
+    prevLastUserIdRef.current = lastUser?.id;
+    if (anchorPendingRef.current && lastUser && lastUser.id !== prevUserId) {
+      anchorPendingRef.current = false;
+      resetTailSpacer();
+      anchorActiveRef.current = true;
+      pinnedToBottomRef.current = false;
+      setScrolledFromBottom(true);
+      requestAnimationFrame(() => {
+        sizeAnchorSpacer();
+        scrollAnchorToTop();
+      });
+      return;
+    }
+    // While anchored, the message stays at the top on its own (nothing above
+    // it changes), so we only shrink the spacer as the reply grows — never
+    // re-scroll. This is what keeps scrolling down and the final settle smooth.
+    if (anchorActiveRef.current) {
+      requestAnimationFrame(sizeAnchorSpacer);
+      return;
+    }
+
+    if (pinnedToBottomRef.current) {
+      // If the last assistant message contains a question form, scroll to
+      // the form instead of the bottom, so the user lands on the form.
+      const lastAssistantMsg = [...displayMessages].reverse().find((m) => m.role === 'assistant');
+      if (lastAssistantMsg?.content.includes('<question-form')) {
+        const assistantEls = el.querySelectorAll('.msg.assistant');
+        const lastAssistantEl = assistantEls[assistantEls.length - 1];
+        const formEl = lastAssistantEl?.querySelector<HTMLElement>('[data-form-id]');
+        if (formEl && !scrolledToFormRef.current.has(formEl.dataset.formId!)) {
+          scrolledToFormRef.current.add(formEl.dataset.formId!);
+          formEl.scrollIntoView({ block: 'start', behavior: 'smooth' });
+          pinnedToBottomRef.current = false;
+          setScrolledFromBottom(true);
+          return;
+        }
+        // Form tag in content but the DOM element isn't ready yet (partial
+        // stream) — skip bottom-scroll to avoid a jarring jump that gets
+        // undone when the form finishes rendering.
+        if (streaming) return;
+      }
+      // Streaming bottom-pin must be instant — smooth scrollTo emits
+      // intermediate scroll events that flip pinnedToBottomRef to false,
+      // breaking auto-follow for subsequent chunks.
+      el.scrollTop = el.scrollHeight;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayMessages, error, streaming]);
+
+  useEffect(() => {
+    if (tab !== 'chat') return;
+    const el = logRef.current;
+    if (!el) return;
+
+    function syncScrollable(target: HTMLDivElement) {
+      const next = target.scrollHeight - target.clientHeight > 1;
+      setChatLogScrollable((prev) => (prev === next ? prev : next));
+      if (!next) setChatLogScrolling(false);
+    }
+
+    function markScrolling() {
+      setChatLogScrolling(true);
+      chatLogScrollIdleTimerRef.current?.();
+      chatLogScrollIdleTimerRef.current = domPort.scheduleTimeout(() => {
+        chatLogScrollIdleTimerRef.current = null;
+        setChatLogScrolling(false);
+      }, 650);
+    }
+
+    // Restore previously-saved position on remount. Defer to the next
+    // frame so the conditional <> contents finish layout before the
+    // scrollTop write lands.
+    const saved = savedChatScrollRef.current;
+    if (saved !== null) {
+      requestAnimationFrame(() => {
+        const target = logRef.current;
+        if (!target) return;
+        if (saved.pinnedToBottom) {
+          target.scrollTop = target.scrollHeight;
+        } else {
+          target.scrollTop = saved.scrollTop;
+        }
+        syncScrollable(target);
+        // Resync the jump-to-latest affordance with the restored
+        // position. Without this, a user who left Chat ~60px from the
+        // bottom and returns to find new messages stacked underneath
+        // would land hundreds of pixels above the latest turn while
+        // scrolledFromBottom remained false until they scrolled.
+        const distance =
+          target.scrollHeight - target.scrollTop - target.clientHeight;
+        setScrolledFromBottom(distance > 120);
+        pinnedToBottomRef.current = distance < 80;
+      });
+    }
+
+    function snapshot(target: HTMLDivElement) {
+      const distance =
+        target.scrollHeight - target.scrollTop - target.clientHeight;
+      savedChatScrollRef.current =
+        distance < 50
+          ? { pinnedToBottom: true }
+          : { pinnedToBottom: false, scrollTop: target.scrollTop };
+    }
+
+    function onScroll() {
+      const target = logRef.current;
+      if (!target) return;
+      // A genuine user scroll (one that moves away from where the anchored
+      // message currently sits) releases the auto-resize behavior. We do NOT
+      // collapse the tail spacer: the reserved blank below stays as real,
+      // scrollable space so scrolling down feels natural instead of snapping.
+      if (anchorActiveRef.current) {
+        const pinnedTop = lastUserMsgTopInContent(target);
+        if (
+          pinnedTop !== null &&
+          Math.abs(target.scrollTop - (pinnedTop - ANCHOR_TOP_PADDING)) > 40
+        ) {
+          anchorActiveRef.current = false;
+        }
+      }
+      syncScrollable(target);
+      markScrolling();
+      snapshot(target);
+      const distance =
+        target.scrollHeight - target.scrollTop - target.clientHeight;
+      // Functional updater bails out when the value is unchanged so a flood
+      // of scroll events (e.g. programmatic scrollTop + ResizeObserver
+      // follow-up during streaming) does not schedule a re-render per tick
+      // and trip React's "Maximum update depth exceeded" guard.
+      const next = distance > 120;
+      setScrolledFromBottom((prev) => (prev === next ? prev : next));
+      pinnedToBottomRef.current = distance < 80;
+    }
+    syncScrollable(el);
+    el.addEventListener('scroll', onScroll);
+    return () => {
+      // Capture final scroll state before unmount; the ref normally
+      // tracks via onScroll, but programmatic scrolls or layout shifts
+      // right before unmount can leave it stale.
+      snapshot(el);
+      el.removeEventListener('scroll', onScroll);
+      chatLogScrollIdleTimerRef.current?.();
+      chatLogScrollIdleTimerRef.current = null;
+      setChatLogScrolling(false);
+    };
+  }, [domPort, tab]);
+
+  useEffect(() => {
+    if (tab !== 'chat') return;
+    const el = logRef.current;
+    if (!el) return;
+
+    let followFrame: number | null = null;
+    const followLatestIfPinned = () => {
+      // While anchored, only shrink the tail spacer as the reply grows
+      // (resize-only, never scroll) so the user message stays put without
+      // fighting a manual scroll-down.
+      if (anchorActiveRef.current) {
+        if (followFrame !== null) return;
+        followFrame = requestAnimationFrame(() => {
+          followFrame = null;
+          if (!anchorActiveRef.current) return;
+          sizeAnchorSpacer();
+        });
+        return;
+      }
+      if (!pinnedToBottomRef.current || followFrame !== null) return;
+      followFrame = requestAnimationFrame(() => {
+        followFrame = null;
+        const target = logRef.current;
+        if (!target || !pinnedToBottomRef.current) return;
+        target.scrollTop = target.scrollHeight;
+        setScrolledFromBottom(false);
+      });
+    };
+
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => {
+            const target = logRef.current;
+            if (target) {
+              const next = target.scrollHeight - target.clientHeight > 1;
+              setChatLogScrollable((prev) => (prev === next ? prev : next));
+              if (!next) setChatLogScrolling(false);
+            }
+            followLatestIfPinned();
+          })
+        : null;
+    const observedChildren = new Set<Element>();
+    const syncObservedChildren = () => {
+      if (!resizeObserver) return;
+      const currentChildren = new Set(Array.from(el.children));
+      // The tail spacer's height is driven by the anchor logic; observing it
+      // would feed its own resize back into followLatestIfPinned.
+      if (tailSpacerRef.current) currentChildren.delete(tailSpacerRef.current);
+      for (const child of currentChildren) {
+        if (observedChildren.has(child)) continue;
+        resizeObserver.observe(child);
+        observedChildren.add(child);
+      }
+      for (const child of observedChildren) {
+        if (currentChildren.has(child)) continue;
+        resizeObserver.unobserve(child);
+        observedChildren.delete(child);
+      }
+    };
+
+    let observedQueuedSendStrip: Element | null = null;
+    const syncQueuedSendStrip = () => {
+      if (!resizeObserver) return;
+      const queuedEl = queuedSendStripRef.current;
+      if (queuedEl && observedQueuedSendStrip !== queuedEl) {
+        if (observedQueuedSendStrip) {
+          resizeObserver.unobserve(observedQueuedSendStrip);
+        }
+        resizeObserver.observe(queuedEl);
+        observedQueuedSendStrip = queuedEl;
+      } else if (!queuedEl && observedQueuedSendStrip) {
+        resizeObserver.unobserve(observedQueuedSendStrip);
+        observedQueuedSendStrip = null;
+      }
+    };
+
+    syncObservedChildren();
+    syncQueuedSendStrip();
+
+    const mutationObserver =
+      typeof MutationObserver !== 'undefined'
+        ? new MutationObserver(() => {
+            syncObservedChildren();
+            syncQueuedSendStrip();
+            followLatestIfPinned();
+          })
+        : null;
+    // childList + subtree only — NOT characterData. Auto-follow during
+    // streaming is driven by the ResizeObserver on each message child (text
+    // growth changes height), so observing per-character text mutations would
+    // re-run the full sync sweep on every streamed frame for no extra benefit.
+    mutationObserver?.observe(el, {
+      childList: true,
+      subtree: true,
+    });
+    // QueuedSendStrip lives outside the chat-log subtree (it is a sibling of
+    // .chat-log-wrap inside .pane). The MutationObserver above only fires for
+    // changes inside el, so it cannot detect that surface mounting or
+    // unmounting. Watch the nearest common ancestor (.pane) with childList-only
+    // to keep its observer current.
+    const paneEl = el.parentElement?.parentElement ?? null;
+    if (paneEl && mutationObserver) {
+      mutationObserver.observe(paneEl, { childList: true });
+    }
+
+    return () => {
+      if (followFrame !== null) cancelAnimationFrame(followFrame);
+      mutationObserver?.disconnect();
+      resizeObserver?.disconnect();
+    };
+  }, [queuedSendStripRef, tab, tailSpacerRef]);
+
+  return {
+    scrolledFromBottom,
+    chatLogScrollable,
+    chatLogScrolling,
+    jumpToBottom,
+    armAnchorForSend,
+    resetScrollTrackingForSend,
+    unpinFromBottom,
+  };
+}

--- a/apps/web/src/features/chat-pane/hooks/useComposerDraftSync.hooks.ts
+++ b/apps/web/src/features/chat-pane/hooks/useComposerDraftSync.hooks.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, type MutableRefObject } from 'react';
+import type { ChatComposerHandle } from '../../../components/ChatComposer';
+import { takeComposerSeedFor } from '../../../state/libraryHandoff';
+
+export function useComposerDraftSync(
+  composerRef: MutableRefObject<ChatComposerHandle | null>,
+  {
+    initialDraft,
+    composerDraftSignal,
+    projectId,
+    activeConversationId,
+  }: {
+    initialDraft: string | undefined;
+    composerDraftSignal: { text: string; nonce: number } | undefined;
+    projectId: string | null;
+    activeConversationId: string | null;
+  },
+) {
+  const composerDraftStorageKey = projectId && activeConversationId
+    ? `od:chat-composer:draft:${projectId}:${activeConversationId}`
+    : undefined;
+
+  // ChatComposer's internal `seededRef` latches after the first
+  // non-empty `initialDraft`, so a parent setting `initialDraft` back
+  // to `undefined` will not flow into the composer's draft state. When
+  // the parent does that transition (because the seed is now stale —
+  // e.g. ProjectView discovered the conversation already has a sent
+  // user message after a reload), reach into the composer and clear
+  // the textarea so the user does not see the prompt they already
+  // submitted.
+  const lastSeenInitialDraftRef = useRef<string | undefined>(initialDraft);
+  useEffect(() => {
+    const previous = lastSeenInitialDraftRef.current;
+    lastSeenInitialDraftRef.current = initialDraft;
+    if (previous && initialDraft === undefined) {
+      composerRef.current?.setDraft('');
+    }
+  }, [composerRef, initialDraft]);
+
+  // Parent-driven composer prefill (the "Import repo" CTA). Reuse the same
+  // imperative setDraft the starter cards use; the nonce guards against
+  // re-applying the same signal on unrelated re-renders.
+  const lastDraftSignalNonceRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!composerDraftSignal) return;
+    if (lastDraftSignalNonceRef.current === composerDraftSignal.nonce) return;
+    lastDraftSignalNonceRef.current = composerDraftSignal.nonce;
+    composerRef.current?.setDraft(composerDraftSignal.text);
+  }, [composerDraftSignal, composerRef]);
+
+  // Library "optimize design system" hand-off: when the user pushed selected
+  // assets into this project's design system from the Library, pre-fill the
+  // composer with the query + those assets (as attachment chips) so they only
+  // need to review and Send. Fires once, after the composer mounts for the
+  // routed conversation; re-checks on conversation change so an async-loaded
+  // composer still gets seeded. The seed is consumed (cleared) on apply.
+  const seededComposerSeedRef = useRef(false);
+  useEffect(() => {
+    if (seededComposerSeedRef.current) return;
+    if (!projectId || !composerRef.current) return;
+    const seed = takeComposerSeedFor(projectId);
+    if (!seed) return;
+    seededComposerSeedRef.current = true;
+    composerRef.current.restoreDraft({ text: seed.text, attachments: seed.attachments });
+  }, [activeConversationId, composerRef, projectId]);
+
+  return { composerDraftStorageKey };
+}

--- a/apps/web/src/features/chat-pane/hooks/useComposerPortalLayout.hooks.ts
+++ b/apps/web/src/features/chat-pane/hooks/useComposerPortalLayout.hooks.ts
@@ -1,0 +1,55 @@
+import { useEffect, useLayoutEffect, useState, type MutableRefObject } from 'react';
+import { chatPaneDomPort } from '../dependencies';
+import type { ChatPaneDomPort } from '../ports';
+
+export function useComposerPortalLayout(
+  composerSlotRef: MutableRefObject<HTMLDivElement | null>,
+  composerLayerRef: MutableRefObject<HTMLDivElement | null>,
+  tab: string,
+  port: ChatPaneDomPort = chatPaneDomPort,
+) {
+  const [composerPortalTarget, setComposerPortalTarget] = useState<HTMLElement | null>(null);
+  const [composerPortalRect, setComposerPortalRect] = useState<{
+    left: number;
+    width: number;
+    bottom: number;
+  } | null>(null);
+  const [composerSlotHeight, setComposerSlotHeight] = useState(0);
+
+  useEffect(() => {
+    setComposerPortalTarget(port.getDocumentBody());
+  }, [port]);
+
+  useLayoutEffect(() => {
+    if (tab !== 'chat') {
+      setComposerPortalRect(null);
+      return;
+    }
+    const slot = composerSlotRef.current;
+    if (!slot) return;
+    return port.subscribeComposerPortalRect(slot, (next) => {
+      setComposerPortalRect((prev) => {
+        if (
+          prev
+          && prev.left === next.left
+          && prev.width === next.width
+          && prev.bottom === next.bottom
+        ) {
+          return prev;
+        }
+        return next;
+      });
+    });
+  }, [composerSlotRef, port, tab]);
+
+  useLayoutEffect(() => {
+    if (tab !== 'chat' || !composerPortalTarget || !composerPortalRect) return;
+    const layer = composerLayerRef.current;
+    if (!layer) return;
+    return port.subscribeComposerLayerHeight(layer, (nextHeight) => {
+      setComposerSlotHeight((prev) => (prev === nextHeight ? prev : nextHeight));
+    });
+  }, [composerLayerRef, composerPortalRect, composerPortalTarget, port, tab]);
+
+  return { composerPortalTarget, composerPortalRect, composerSlotHeight };
+}

--- a/apps/web/src/features/chat-pane/hooks/useComposerStarterScenarios.hooks.ts
+++ b/apps/web/src/features/chat-pane/hooks/useComposerStarterScenarios.hooks.ts
@@ -1,0 +1,201 @@
+import { useCallback, useMemo, type MutableRefObject } from 'react';
+import type { ChatSessionMode } from '@open-design/contracts';
+import { trackChatPanelClick } from '../../../analytics/events';
+import type { ChatComposerHandle } from '../../../components/ChatComposer';
+import type { PlaceholderScenario } from '../../../components/home-hero/placeholderScenarios';
+import { DESIGN_SYSTEM_NEXT_STEP_ACTIONS, type NextStepActionsVariant } from '../../../components/NextStepActions';
+import type { Dict } from '../../../i18n/types';
+import type { ProductType } from '../../../onboarding/recommendation';
+import { startersForProduct } from '../../../onboarding/recommendation';
+import { starterCopyFor } from '../../../onboarding/starter-copy';
+import {
+  FEATURED_DESIGN_TOOLBOX_ACTION_IDS,
+  findDesignToolboxSkill,
+  getDesignToolboxAction,
+  type DesignToolboxActionId,
+} from '../../../runtime/design-toolbox';
+import type { ChatMessage, ProjectMetadata, SkillSummary } from '../../../types';
+import {
+  isBrandExtractionNextStepProject,
+  isDesignSystemNextStepProject,
+  isProgrammaticBrandAssistantMessage,
+  latestAssistantForBrandStateFor,
+  pickStarters,
+} from '../rules';
+import type { StarterPrompt } from '../types';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+type Track = (
+  event: string,
+  properties: Record<string, unknown>,
+  options?: { requestId?: string; insertId?: string },
+) => void;
+
+export function useComposerStarterScenarios(
+  composerRef: MutableRefObject<ChatComposerHandle | null>,
+  {
+    displayMessages,
+    projectMetadata,
+    sessionMode,
+    onSessionModeChange,
+    skills,
+    onboardingStarterPath,
+    t,
+    loading,
+    initialDraft,
+    queuedItemsLength,
+    brandExtractionComplete,
+    analyticsTrack,
+  }: {
+    displayMessages: ChatMessage[];
+    projectMetadata: ProjectMetadata | undefined;
+    sessionMode: ChatSessionMode;
+    onSessionModeChange?: (mode: ChatSessionMode) => void;
+    skills: SkillSummary[];
+    onboardingStarterPath: ProductType | null;
+    t: TranslateFn;
+    loading: boolean;
+    initialDraft: string | undefined;
+    queuedItemsLength: number;
+    brandExtractionComplete: boolean;
+    analyticsTrack: Track;
+  },
+) {
+  const handleToolboxAction = useCallback((id: DesignToolboxActionId) => {
+    composerRef.current?.applyDesignToolboxAction(id);
+  }, [composerRef]);
+  const handleStarterCardClick = useCallback((prompt: string) => {
+    trackChatPanelClick(analyticsTrack, {
+      page_name: 'chat_panel',
+      area: 'chat_panel',
+      element: 'template_card',
+    });
+    composerRef.current?.setDraft(prompt);
+  }, [analyticsTrack, composerRef]);
+  const handleNextStepPromptAction = useCallback((
+    prompt: string,
+    options?: { sessionMode?: ChatSessionMode },
+  ) => {
+    if (options?.sessionMode && options.sessionMode !== sessionMode) {
+      onSessionModeChange?.(options.sessionMode);
+    }
+    composerRef.current?.setDraft(prompt, {
+      entryFrom: 'next_step',
+      sessionMode: options?.sessionMode,
+    });
+  }, [composerRef, onSessionModeChange, sessionMode]);
+  const handlePickSkill = useCallback((skillId: string) => {
+    composerRef.current?.applyDesignToolboxSkill(skillId);
+  }, [composerRef]);
+
+  const latestAssistantForBrandState = useMemo(
+    () => latestAssistantForBrandStateFor(displayMessages),
+    [displayMessages],
+  );
+  const nextStepVariant: NextStepActionsVariant = sessionMode === 'plan'
+    ? 'plan'
+    : isDesignSystemNextStepProject(projectMetadata)
+      ? isBrandExtractionNextStepProject(projectMetadata)
+        ? brandExtractionComplete
+          ? 'brand-extraction'
+          : !latestAssistantForBrandState || isProgrammaticBrandAssistantMessage(latestAssistantForBrandState)
+            ? 'brand-programmatic-incomplete'
+            : 'brand-ai-incomplete'
+        : 'design-system'
+      : 'default';
+  // The `@skill` shown in each featured row's hover detail — matched the same
+  // way the composer matches it, using the raw skill name (what gets inlined
+  // into the draft). Recomputed only when the skill list changes.
+  const featuredToolboxSkillNames = useMemo<Partial<Record<DesignToolboxActionId, string | null>>>(() => {
+    const map: Partial<Record<DesignToolboxActionId, string | null>> = {};
+    for (const id of FEATURED_DESIGN_TOOLBOX_ACTION_IDS) {
+      const action = getDesignToolboxAction(id);
+      map[id] = action ? (findDesignToolboxSkill(action, skills)?.name ?? null) : null;
+    }
+    return map;
+  }, [skills]);
+  const blankProjectComposerScenarios = useMemo<PlaceholderScenario[]>(
+    () => pickStarters(projectMetadata, t).map((starter, index) => ({
+      id: `blank-${projectMetadata?.kind ?? 'prototype'}-${index}`,
+      text: starter.prompt,
+      chipId: 'project',
+    })),
+    [projectMetadata, t],
+  );
+  // Empty-conversation starter cards. A recommendation-started project shows
+  // its OWN product path's starters — clicking replaces the composer draft, so
+  // the pre-filled first request and the cards complement rather than compete.
+  // The general fallback path and every other project keep the generic set.
+  const starterTemplateCards = useMemo<StarterPrompt[]>(() => {
+    if (onboardingStarterPath && onboardingStarterPath !== 'general') {
+      return startersForProduct(onboardingStarterPath).map((starter) => {
+        const copy = starterCopyFor(starter.id);
+        return { icon: '✦', title: t(copy.title), tag: '', prompt: t(copy.firstPrompt) };
+      });
+    }
+    return pickStarters(projectMetadata, t);
+  }, [onboardingStarterPath, projectMetadata, t]);
+  const followUpComposerScenarios = useMemo<PlaceholderScenario[]>(() => {
+    if (nextStepVariant === 'design-system') {
+      return DESIGN_SYSTEM_NEXT_STEP_ACTIONS.map((action) => ({
+        id: action.id,
+        text: action.prompt,
+        chipId: 'design-system',
+      }));
+    }
+    if (nextStepVariant === 'plan') {
+      return [
+        {
+          id: 'plan-generate-from-doc',
+          text: t('nextStep.planGeneratePrompt'),
+          chipId: 'plan',
+          sessionMode: 'design',
+        },
+        {
+          id: 'plan-improve-doc',
+          text: t('nextStep.planImprovePrompt'),
+          chipId: 'plan',
+          sessionMode: 'plan',
+        },
+      ];
+    }
+    const promptPairs: Array<[string, string]> = [
+      ['auto-match', t('chat.designToolbox.prompt.autoMatchIntro')],
+      ['visual-polish', t('chat.designToolbox.prompt.visualPolish')],
+      ['asset-search', t('chat.designToolbox.prompt.assetSearch')],
+      ['icon-workflow', t('chat.designToolbox.prompt.iconWorkflow')],
+      ['anti-ai-polish', t('chat.designToolbox.prompt.antiAiPolish')],
+      ['motion-polish', t('chat.designToolbox.prompt.motionPolish')],
+      ['chart-gen', t('chat.designToolbox.prompt.chartGen')],
+    ];
+    return promptPairs.map(([id, text]) => ({
+      id: `follow-up-${id}`,
+      text,
+      chipId: 'design-toolbox',
+    }));
+  }, [nextStepVariant, t]);
+  const composerPlaceholderScenarios = useMemo<PlaceholderScenario[]>(() => {
+    if (loading || initialDraft?.trim()) return [];
+    if (displayMessages.length === 0 && queuedItemsLength === 0) return blankProjectComposerScenarios;
+    if (displayMessages.length > 0) return followUpComposerScenarios;
+    return [];
+  }, [
+    blankProjectComposerScenarios,
+    displayMessages.length,
+    followUpComposerScenarios,
+    initialDraft,
+    loading,
+    queuedItemsLength,
+  ]);
+
+  return {
+    handleToolboxAction,
+    handleNextStepPromptAction,
+    handlePickSkill,
+    handleStarterCardClick,
+    nextStepVariant,
+    featuredToolboxSkillNames,
+    starterTemplateCards,
+    composerPlaceholderScenarios,
+  };
+}

--- a/apps/web/src/features/chat-pane/hooks/useConversationHistory.hooks.ts
+++ b/apps/web/src/features/chat-pane/hooks/useConversationHistory.hooks.ts
@@ -1,0 +1,98 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { trackChatPanelClick } from '../../../analytics/events';
+import type { Dict } from '../../../i18n/types';
+import type { Conversation } from '../../../types';
+import { chatPaneDomPort } from '../dependencies';
+import type { ChatPaneDomPort } from '../ports';
+import { filterConversations } from '../rules';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+type Track = (
+  event: string,
+  properties: Record<string, unknown>,
+  options?: { requestId?: string; insertId?: string },
+) => void;
+
+export function useConversationHistory(
+  conversations: Conversation[],
+  activeConversationId: string | null,
+  t: TranslateFn,
+  {
+    analyticsTrack,
+    onNewConversation,
+    newConversationDisabled,
+    onSelectConversation,
+  }: {
+    analyticsTrack: Track;
+    onNewConversation: (() => void) | undefined;
+    newConversationDisabled: boolean;
+    onSelectConversation: (id: string) => void;
+  },
+  port: ChatPaneDomPort = chatPaneDomPort,
+) {
+  const historyWrapRef = useRef<HTMLDivElement | null>(null);
+  const [showConvList, setShowConvList] = useState(false);
+  const [conversationSearch, setConversationSearch] = useState('');
+  const deferredConversationSearch = useDeferredValue(conversationSearch);
+
+  // Close the conversation history dropdown on outside click / Escape.
+  useEffect(() => {
+    if (!showConvList) return;
+    return port.subscribeOutsideClickOrEscape(historyWrapRef, () => setShowConvList(false));
+  }, [port, showConvList]);
+
+  useEffect(() => {
+    if (showConvList) return;
+    setConversationSearch('');
+  }, [showConvList]);
+
+  const activeConversation =
+    conversations.find((c) => c.id === activeConversationId) ?? null;
+  const filteredConversations = useMemo(
+    () => filterConversations(conversations, deferredConversationSearch, t),
+    [conversations, deferredConversationSearch, t],
+  );
+
+  const handleToggleHistoryList = useCallback(() => {
+    setShowConvList((v) => {
+      const next = !v;
+      if (next) {
+        trackChatPanelClick(analyticsTrack, {
+          page_name: 'chat_panel',
+          area: 'chat_panel',
+          element: 'history',
+        });
+      }
+      return next;
+    });
+  }, [analyticsTrack]);
+
+  const handleStartNewConversation = useCallback(() => {
+    if (newConversationDisabled || !onNewConversation) return;
+    trackChatPanelClick(analyticsTrack, {
+      page_name: 'chat_panel',
+      area: 'chat_panel',
+      element: 'new_chat',
+    });
+    onNewConversation();
+    setShowConvList(false);
+  }, [analyticsTrack, newConversationDisabled, onNewConversation]);
+
+  const handleSelectConversation = useCallback((id: string) => {
+    onSelectConversation(id);
+    setShowConvList(false);
+  }, [onSelectConversation]);
+
+  return {
+    historyWrapRef,
+    showConvList,
+    setShowConvList,
+    conversationSearch,
+    setConversationSearch,
+    activeConversation,
+    filteredConversations,
+    handleToggleHistoryList,
+    handleStartNewConversation,
+    handleSelectConversation,
+  };
+}

--- a/apps/web/src/features/chat-pane/hooks/useMeasuredVirtualWindow.hooks.ts
+++ b/apps/web/src/features/chat-pane/hooks/useMeasuredVirtualWindow.hooks.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
+import {
+  CHAT_VIRTUAL_DEFAULT_VIEWPORT_PX,
+  CHAT_VIRTUAL_MIN_ROW_HEIGHT,
+} from '../constants';
+import { includeVirtualRowByKey } from '../rules';
+
+export function useMeasuredVirtualWindow<T extends { key: string }>(
+  items: T[],
+  {
+    enabled,
+    containerRef,
+    estimateSize,
+    overscanPx,
+    resetKey,
+    initialTailRows,
+    alwaysIncludeKey,
+  }: {
+    enabled: boolean;
+    containerRef: MutableRefObject<HTMLDivElement | null>;
+    estimateSize: (item: T) => number;
+    overscanPx: number;
+    resetKey: string;
+    initialTailRows: number;
+    alwaysIncludeKey?: string;
+  },
+) {
+  const measuredHeightsRef = useRef<Map<string, number>>(new Map());
+  const [measureVersion, setMeasureVersion] = useState(0);
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 });
+
+  useEffect(() => {
+    measuredHeightsRef.current.clear();
+    setMeasureVersion((version) => version + 1);
+    setViewport({ scrollTop: 0, height: 0 });
+  }, [resetKey]);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const el = containerRef.current;
+    if (!el) return undefined;
+    let frame: number | null = null;
+    const readViewport = () => {
+      frame = null;
+      setViewport((current) => {
+        const next = {
+          scrollTop: el.scrollTop,
+          height: el.clientHeight || CHAT_VIRTUAL_DEFAULT_VIEWPORT_PX,
+        };
+        return current.scrollTop === next.scrollTop && current.height === next.height
+          ? current
+          : next;
+      });
+    };
+    const scheduleRead = () => {
+      if (frame !== null) return;
+      frame = requestAnimationFrame(readViewport);
+    };
+    scheduleRead();
+    el.addEventListener('scroll', scheduleRead, { passive: true });
+    const observer =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(scheduleRead)
+        : null;
+    observer?.observe(el);
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+      el.removeEventListener('scroll', scheduleRead);
+      observer?.disconnect();
+    };
+  }, [containerRef, enabled]);
+
+  const layout = useMemo(() => {
+    const offsets: number[] = [];
+    const sizes: number[] = [];
+    let cursor = 0;
+    for (const item of items) {
+      offsets.push(cursor);
+      const measured = measuredHeightsRef.current.get(item.key);
+      const size = Math.max(
+        CHAT_VIRTUAL_MIN_ROW_HEIGHT,
+        measured ?? estimateSize(item),
+      );
+      sizes.push(size);
+      cursor += size;
+    }
+    return { offsets, sizes, totalHeight: cursor };
+  }, [estimateSize, items, measureVersion]);
+
+  const rows = useMemo(() => {
+    if (!enabled || items.length === 0) return [];
+    const height = viewport.height || CHAT_VIRTUAL_DEFAULT_VIEWPORT_PX;
+    if (viewport.scrollTop === 0 && viewport.height === 0) {
+      const start = Math.max(0, items.length - initialTailRows);
+      const rows = items.slice(start).map((item, offset) => {
+        const index = start + offset;
+        return { item, index, top: layout.offsets[index] ?? 0 };
+      });
+      return includeVirtualRowByKey(rows, items, layout.offsets, alwaysIncludeKey);
+    }
+    const startTarget = Math.max(0, viewport.scrollTop - overscanPx);
+    const endTarget = viewport.scrollTop + height + overscanPx;
+    let start = 0;
+    while (
+      start < items.length - 1
+      && (layout.offsets[start] ?? 0) + (layout.sizes[start] ?? 0) < startTarget
+    ) {
+      start += 1;
+    }
+    let end = start;
+    while (end < items.length && (layout.offsets[end] ?? 0) <= endTarget) {
+      end += 1;
+    }
+    const rows = items.slice(start, end).map((item, offset) => {
+      const index = start + offset;
+      return { item, index, top: layout.offsets[index] ?? 0 };
+    });
+    return includeVirtualRowByKey(rows, items, layout.offsets, alwaysIncludeKey);
+  }, [
+    alwaysIncludeKey,
+    enabled,
+    initialTailRows,
+    items,
+    layout.offsets,
+    layout.sizes,
+    overscanPx,
+    viewport.height,
+    viewport.scrollTop,
+  ]);
+
+  const onMeasure = useCallback((key: string, height: number) => {
+    if (!Number.isFinite(height) || height <= 0) return;
+    const next = Math.max(CHAT_VIRTUAL_MIN_ROW_HEIGHT, Math.ceil(height));
+    const previous = measuredHeightsRef.current.get(key);
+    if (previous !== undefined && Math.abs(previous - next) < 2) return;
+    measuredHeightsRef.current.set(key, next);
+    setMeasureVersion((version) => version + 1);
+  }, []);
+
+  return {
+    rows,
+    totalHeight: layout.totalHeight,
+    onMeasure,
+  };
+}

--- a/apps/web/src/features/chat-pane/hooks/useQueuedSendEditing.hooks.ts
+++ b/apps/web/src/features/chat-pane/hooks/useQueuedSendEditing.hooks.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useState, type MutableRefObject } from 'react';
+import { trackMessageQueueClick } from '../../../analytics/events';
+import type { ChatComposerHandle } from '../../../components/ChatComposer';
+import type { QueuedSendItem } from '../types';
+
+type Track = (
+  event: string,
+  properties: Record<string, unknown>,
+  options?: { requestId?: string; insertId?: string },
+) => void;
+
+export function useQueuedSendEditing(
+  composerRef: MutableRefObject<ChatComposerHandle | null>,
+  queuedItems: QueuedSendItem[],
+  {
+    analyticsTrack,
+    projectId,
+    onRemoveQueuedSend,
+    onSendQueuedNow,
+  }: {
+    analyticsTrack: Track;
+    projectId: string | null;
+    onRemoveQueuedSend: ((id: string) => void) | undefined;
+    onSendQueuedNow: ((id: string) => void) | undefined;
+  },
+) {
+  const [editingQueuedSendId, setEditingQueuedSendId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!editingQueuedSendId) return;
+    if (queuedItems.some((item) => item.id === editingQueuedSendId)) return;
+    setEditingQueuedSendId(null);
+  }, [editingQueuedSendId, queuedItems]);
+
+  const restoreQueuedSendToComposer = (item: QueuedSendItem) => {
+    setEditingQueuedSendId(item.id);
+    composerRef.current?.restoreDraft({
+      text: item.prompt,
+      attachments: item.attachments ?? [],
+      commentAttachments: item.commentAttachments ?? [],
+      meta: item.meta,
+    });
+  };
+
+  const handleEditQueuedSend = useCallback((item: QueuedSendItem) => {
+    trackMessageQueueClick(analyticsTrack, {
+      page_name: 'chat_panel',
+      area: 'message_queue',
+      element: 'edit',
+      project_id: projectId ?? '',
+      queue_length: queuedItems.length,
+    });
+    restoreQueuedSendToComposer(item);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [analyticsTrack, projectId, queuedItems.length]);
+
+  const handleRemoveQueuedSend = onRemoveQueuedSend
+    ? (id: string) => {
+        trackMessageQueueClick(analyticsTrack, {
+          page_name: 'chat_panel',
+          area: 'message_queue',
+          element: 'delete',
+          project_id: projectId ?? '',
+          queue_length: queuedItems.length,
+        });
+        onRemoveQueuedSend(id);
+      }
+    : undefined;
+
+  const handleSendQueuedNow = onSendQueuedNow
+    ? (id: string) => {
+        trackMessageQueueClick(analyticsTrack, {
+          page_name: 'chat_panel',
+          area: 'message_queue',
+          element: 'send_now',
+          project_id: projectId ?? '',
+          queue_length: queuedItems.length,
+        });
+        onSendQueuedNow(id);
+      }
+    : undefined;
+
+  return {
+    editingQueuedSendId,
+    setEditingQueuedSendId,
+    restoreQueuedSendToComposer,
+    handleEditQueuedSend,
+    handleRemoveQueuedSend,
+    handleSendQueuedNow,
+  };
+}

--- a/apps/web/src/features/chat-pane/hooks/useRunErrorState.hooks.ts
+++ b/apps/web/src/features/chat-pane/hooks/useRunErrorState.hooks.ts
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { TrackingProjectKind } from '@open-design/contracts/analytics';
+import { amrHandoffDeviceId, attributedAmrUrl, recordAmrEntry } from '../../../analytics/amr-attribution';
+import { getResolvedDeviceId } from '../../../analytics/client';
+import { trackRunFailedToastSurfaceView } from '../../../analytics/events';
+import {
+  AMR_LOGIN_STATUS_EVENT,
+  amrLoginStatusEventReason,
+} from '../../../components/amrLoginPolling';
+import { copyToClipboard } from '../../../lib/copy-to-clipboard';
+import {
+  amrPlansUrlForProfile,
+  amrRechargeUrlForProfile,
+  resolveRunFailureUi,
+} from '../../../runtime/amr-guidance';
+import { agentDisplayName } from '../../../utils/agentLabels';
+import type { Dict } from '../../../i18n/types';
+import type { AppConfig, ChatMessage } from '../../../types';
+import { amrLoginPort, chatPaneDomPort } from '../dependencies';
+import type { AmrLoginPort, ChatPaneDomPort } from '../ports';
+import { buildRunErrorDiagnosticText, isActiveRunStatus, retryableAssistantMessage } from '../rules';
+import type { VelaLoginStatus } from '../types';
+
+const AMR_PROFILE_ENV_KEY = 'OPEN_DESIGN_AMR_PROFILE';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+type Track = (
+  event: string,
+  properties: Record<string, unknown>,
+  options?: { requestId?: string; insertId?: string },
+) => void;
+
+export function useRunErrorState(
+  displayMessages: ChatMessage[],
+  streaming: boolean,
+  error: string | null,
+  {
+    projectId,
+    activeConversationId,
+    projectKindForTracking,
+    config,
+    analyticsTrack,
+    onRetry,
+    showByokRecoveryAction,
+    onSwitchToLocalCli,
+    onSwitchToAmrAndRetry,
+    onOpenAmrSettings,
+    t,
+  }: {
+    projectId: string | null;
+    activeConversationId: string | null;
+    projectKindForTracking: TrackingProjectKind | null;
+    config: AppConfig | undefined;
+    analyticsTrack: Track;
+    onRetry: ((assistantMessage: ChatMessage) => void) | undefined;
+    showByokRecoveryAction: boolean;
+    onSwitchToLocalCli: (() => void) | undefined;
+    onSwitchToAmrAndRetry: ((failedAssistant: ChatMessage) => void) | undefined;
+    onOpenAmrSettings: (() => void) | undefined;
+    t: TranslateFn;
+  },
+  domPort: ChatPaneDomPort = chatPaneDomPort,
+  loginPort: AmrLoginPort = amrLoginPort,
+) {
+  const amrProfile = config?.agentCliEnv?.amr?.[AMR_PROFILE_ENV_KEY] ?? null;
+  const [inlineAmrLoginStatus, setInlineAmrLoginStatus] =
+    useState<VelaLoginStatus | null>(null);
+  // Guards the inline AMR sign-in card so a successful login auto-retries the
+  // failed run exactly once (the pill's onStatusChange fires loggedIn on every
+  // poll). Keyed by the failed assistant's id.
+  const amrAuthRetriedRef = useRef<string | null>(null);
+  // Tracks the last observed AMR login state so we retry only on a real
+  // signed-out -> signed-in transition. Without this, a run that keeps failing
+  // AMR_AUTH_REQUIRED while /status already reports signed-in would auto-retry
+  // forever (each retry is a new assistant id, so the id guard alone never
+  // converges).
+  const amrAuthPrevLoggedInRef = useRef<boolean | undefined>(undefined);
+  const runFailedToastSurfaceKeysRef = useRef<Set<string>>(new Set());
+
+  const refreshInlineAmrLoginStatus = useCallback(async (options: { refresh?: boolean } = {}) => {
+    const next = await loginPort.fetchVelaLoginStatus(options).catch(() => null);
+    if (next) setInlineAmrLoginStatus(next);
+    return next;
+  }, [loginPort]);
+
+  useEffect(() => {
+    void refreshInlineAmrLoginStatus();
+    return domPort.subscribeWindowEvent(AMR_LOGIN_STATUS_EVENT, (event) => {
+      const reason = amrLoginStatusEventReason(event);
+      if (reason === 'login-canceled') return;
+      void refreshInlineAmrLoginStatus();
+    });
+  }, [domPort, refreshInlineAmrLoginStatus]);
+
+  // Re-check login status when the user returns to this tab (e.g. after
+  // completing sign-in in an external AMR tab) — focus/visibilitychange don't
+  // otherwise trigger a refresh, so a completed external sign-in would
+  // silently sit stale until the next poll tick.
+  useEffect(
+    () =>
+      domPort.subscribeVisibleFocusOrVisibilityChange(() => {
+        void refreshInlineAmrLoginStatus({ refresh: true });
+      }),
+    [domPort, refreshInlineAmrLoginStatus],
+  );
+
+  const lastAssistantId = (() => {
+    for (let i = displayMessages.length - 1; i >= 0; i--) {
+      if (displayMessages[i]!.role === 'assistant') return displayMessages[i]!.id;
+    }
+    return undefined;
+  })();
+  const hasActiveRunMessage = displayMessages.some(
+    (m) => m.role === 'assistant' && isActiveRunStatus(m.runStatus),
+  );
+  const retryAssistant = retryableAssistantMessage(displayMessages, lastAssistantId, streaming);
+  // The failed run's error event lives on the (persisted) assistant message, so
+  // the error card + AMR card survive a reload — unlike the ephemeral global
+  // `error` state. Drive both off this event.
+  const failedRunErrorEvent = (() => {
+    const evs = retryAssistant?.events ?? [];
+    for (let i = evs.length - 1; i >= 0; i--) {
+      const ev = evs[i];
+      if (ev?.kind === 'status' && ev.label === 'error') return ev;
+    }
+    return null;
+  })();
+  // Per-case failure UI (button + copy + whether to promote AMR). Only
+  // meaningful for a failed run (retryAssistant present).
+  const runFailureUi = retryAssistant
+    ? resolveRunFailureUi(
+        failedRunErrorEvent?.code,
+        failedRunErrorEvent?.failureDetail,
+        retryAssistant.agentId,
+      )
+    : null;
+  const hasInlineAmrAuthorizeFailure = Boolean(
+    retryAssistant && onRetry && runFailureUi?.primaryAction === 'authorize',
+  );
+
+  // Shared signed-out -> signed-in transition detector, driven either by the
+  // 500ms poll below or by the inline AmrLoginPill's own onStatusChange event.
+  const attemptAmrRetryOnSignIn = useCallback((next: VelaLoginStatus | null) => {
+    if (!retryAssistant || !onRetry) return;
+    if (next?.loggedIn === true) {
+      const wasSignedOut = amrAuthPrevLoggedInRef.current === false;
+      amrAuthPrevLoggedInRef.current = true;
+      if (wasSignedOut && amrAuthRetriedRef.current !== retryAssistant.id) {
+        amrAuthRetriedRef.current = retryAssistant.id;
+        onRetry(retryAssistant);
+      }
+    } else if (next && next.loggedIn === false) {
+      amrAuthPrevLoggedInRef.current = false;
+    }
+  }, [onRetry, retryAssistant]);
+
+  useEffect(() => {
+    if (!hasInlineAmrAuthorizeFailure || !retryAssistant || !onRetry) return;
+    let stopped = false;
+    const retryIfSignedIn = async () => {
+      const next = await refreshInlineAmrLoginStatus();
+      if (stopped) return;
+      attemptAmrRetryOnSignIn(next);
+    };
+    void retryIfSignedIn();
+    return domPort.scheduleInterval(() => {
+      void retryIfSignedIn();
+    }, 500);
+  }, [
+    attemptAmrRetryOnSignIn,
+    domPort,
+    hasInlineAmrAuthorizeFailure,
+    onRetry,
+    refreshInlineAmrLoginStatus,
+    retryAssistant,
+  ]);
+
+  // The inline AmrLoginPill's own status-change event (fires on every poll it
+  // runs itself) — reuses the same transition detector as the effect above.
+  const handleAmrLoginStatusChange = useCallback((next: VelaLoginStatus | null) => {
+    attemptAmrRetryOnSignIn(next);
+  }, [attemptAmrRetryOnSignIn]);
+
+  // Offer Continue (resume) when the failed run is resumable AND the active
+  // agent still matches the agent that produced it. The daemon stores a
+  // resumable session per (conversation, agent); after an agent switch the new
+  // agent has no id for that session, so a resume would silently start fresh —
+  // fall back to the from-scratch Retry instead. We do NOT require `onResumeRun`
+  // here: because the daemon persists the resumable session, the plain Retry
+  // path (which re-sends the original prompt) would itself silently resume that
+  // session and double the work. So every ChatPane surface must offer Continue
+  // for a resumable failure — `onResumeRun` when wired (primary chat, carries
+  // the resume_continue analytics), otherwise a plain `onSend` of the canonical
+  // continue prompt (resumes the session without re-sending the original turn).
+  const canResumeFailedRun =
+    !!retryAssistant?.resumable &&
+    !!retryAssistant?.agentId &&
+    retryAssistant.agentId === config?.agentId;
+  // Prefer a case-specific message (AMR auth / balance) over the raw upstream
+  // string; fall back to the live global error (also covers conversation-load
+  // / audio errors) then the persisted run error so a reload still shows it.
+  const rawError = error ?? failedRunErrorEvent?.detail ?? null;
+  // Friendly agent name for {agent} interpolation in failure copy (e.g. the
+  // sign-in messages). Falls back to a neutral word when unreadable, never null.
+  const failedAgentLabel =
+    agentDisplayName(retryAssistant?.agentId, retryAssistant?.agentName) ??
+    t('chat.runError.agentFallback');
+  const displayError = runFailureUi?.messageKey
+    ? t(runFailureUi.messageKey, { agent: failedAgentLabel })
+    : rawError;
+  const errorDiagnosticText = displayError
+    ? buildRunErrorDiagnosticText({
+        message: displayError,
+        rawMessage: rawError,
+        errorCode: failedRunErrorEvent?.code,
+        traceId: retryAssistant?.runId,
+        projectId,
+        conversationId: activeConversationId,
+        assistantMessageId: retryAssistant?.id,
+        agentId: retryAssistant?.agentId,
+      })
+    : null;
+  // First non-empty line of the diagnostics — shown as the one-line peek when
+  // the error-source area is collapsed.
+  const errorSourcePeek =
+    errorDiagnosticText?.split('\n').find((line) => line.trim().length > 0)?.trim() ?? null;
+  // Status-dot tone for the unified card. Brand (accent) for AMR sign-in/top-up
+  // — the commercial recovery path; warn (amber) for the self-healing
+  // connection drop; error (red) for everything else. Purely visual.
+  const runErrorTone: 'error' | 'warn' | 'brand' =
+    runFailureUi?.primaryAction === 'authorize' ||
+    runFailureUi?.primaryAction === 'recharge' ||
+    runFailureUi?.primaryAction === 'upgrade'
+      ? 'brand'
+      : failedRunErrorEvent?.code === 'AGENT_CONNECTION_DROPPED'
+        ? 'warn'
+        : 'error';
+  const [copiedErrorDiagnostic, setCopiedErrorDiagnostic] = useState(false);
+  // Collapsed by default: the error source area shows one line until expanded.
+  const [errorSourceOpen, setErrorSourceOpen] = useState(false);
+  const errorDiagnosticCopyTimerRef = useRef<(() => void) | null>(null);
+  const copyErrorDiagnostic = useCallback(async () => {
+    if (!errorDiagnosticText) return;
+    const ok = await copyToClipboard(errorDiagnosticText);
+    if (!ok) return;
+    errorDiagnosticCopyTimerRef.current?.();
+    setCopiedErrorDiagnostic(true);
+    errorDiagnosticCopyTimerRef.current = domPort.scheduleTimeout(() => {
+      errorDiagnosticCopyTimerRef.current = null;
+      setCopiedErrorDiagnostic(false);
+    }, 1600);
+  }, [domPort, errorDiagnosticText]);
+  useEffect(() => () => {
+    errorDiagnosticCopyTimerRef.current?.();
+    errorDiagnosticCopyTimerRef.current = null;
+  }, []);
+  // The "recharge" run-error action: records AMR entry attribution, forwards
+  // the telemetry device id on opt-in, and opens the recharge URL.
+  const handleAmrRecharge = useCallback(() => {
+    const attribution = recordAmrEntry(
+      analyticsTrack,
+      'chat_error_recharge',
+      new Date(),
+      { metricsConsent: config?.telemetry?.metrics === true },
+    );
+    // Forward the canonical telemetry device id to AMR only on metrics
+    // opt-in (see amrHandoffDeviceId). Sourced from the current
+    // config.installationId / resolved device id, not the mount-time
+    // bootstrap UUID, so the join key matches the telemetry identity even
+    // across a Delete-my-data rotation.
+    const deviceId = amrHandoffDeviceId({
+      metricsConsent: config?.telemetry?.metrics === true,
+      resolvedDeviceId: getResolvedDeviceId(),
+      installationId: config?.installationId,
+    });
+    domPort.openExternalUrl(
+      attributedAmrUrl(amrRechargeUrlForProfile(amrProfile), attribution, deviceId),
+    );
+  }, [amrProfile, analyticsTrack, config?.installationId, config?.telemetry?.metrics, domPort]);
+  // The "upgrade" run-error action: same attribution/device-id handoff as
+  // recharge, but points at the plans page (tier entitlement, not balance).
+  const handleAmrUpgrade = useCallback(() => {
+    const attribution = recordAmrEntry(
+      analyticsTrack,
+      'chat_error_upgrade',
+      new Date(),
+      { metricsConsent: config?.telemetry?.metrics === true },
+    );
+    const deviceId = amrHandoffDeviceId({
+      metricsConsent: config?.telemetry?.metrics === true,
+      resolvedDeviceId: getResolvedDeviceId(),
+      installationId: config?.installationId,
+    });
+    domPort.openExternalUrl(
+      attributedAmrUrl(amrPlansUrlForProfile(amrProfile), attribution, deviceId),
+    );
+  }, [amrProfile, analyticsTrack, config?.installationId, config?.telemetry?.metrics, domPort]);
+  // Guards the inline AMR sign-in pill's re-poll: once the user clicks through
+  // to start an external sign-in, force the transition detector back to
+  // "was signed out" so the eventual signed-in poll result is treated as a
+  // real transition (and retries), even if the pill's last observed status
+  // before the click happened to already read signed-in from a stale poll.
+  const handleAmrSignInStarted = useCallback(() => {
+    amrAuthPrevLoggedInRef.current = false;
+  }, []);
+  // The hosted-AMR promotion card's activate action: switch-and-retry when
+  // wired, otherwise fall back to opening AMR settings.
+  const handleAmrSwitchActivate = useCallback(() => {
+    if (retryAssistant && onSwitchToAmrAndRetry) {
+      onSwitchToAmrAndRetry(retryAssistant);
+    } else {
+      onOpenAmrSettings?.();
+    }
+  }, [onOpenAmrSettings, onSwitchToAmrAndRetry, retryAssistant]);
+  // The failed run whose error this top-level card represents. AssistantMessage
+  // suppresses only THIS message's per-message error pill (to avoid the
+  // duplicate); other failed turns — older history, or once a follow-up makes
+  // this no longer the last assistant — keep their pill so the error survives.
+  const errorCardOwnerId =
+    retryAssistant && failedRunErrorEvent ? retryAssistant.id : null;
+  // AMR promotion card payload (only the non-AMR model/auth/quota case).
+  const amrSwitchPayload =
+    runFailureUi?.showSwitchCard
+    && failedRunErrorEvent?.code !== 'UPSTREAM_UNAVAILABLE'
+    && retryAssistant
+    && failedRunErrorEvent?.code
+      ? {
+          errorCode: failedRunErrorEvent.code,
+          projectId: projectId ?? '',
+          projectKind: projectKindForTracking,
+          conversationId: activeConversationId,
+          assistantMessageId: retryAssistant.id,
+          runId: retryAssistant.runId ?? null,
+        }
+      : null;
+  const showByokRecoveryCta = showByokRecoveryAction && Boolean(onSwitchToLocalCli);
+  // A `primaryAction: 'none'` failure (e.g. a hard quota where retrying is
+  // futile) contributes no button of its own — it relies on the AMR switch card
+  // below. Only claim the actions row when a real control will render, so a
+  // no-action card doesn't leave an empty flex row (and a dangling column gap).
+  const runFailureHasAction = Boolean(
+    retryAssistant &&
+      onRetry &&
+      runFailureUi &&
+      (runFailureUi.primaryAction !== 'none' ||
+        runFailureUi.secondaryRetry ||
+        canResumeFailedRun),
+  );
+  const showErrorActions = showByokRecoveryCta || runFailureHasAction;
+  useEffect(() => {
+    if (!displayError || !failedRunErrorEvent?.code || !retryAssistant) return;
+    // The hosted-AMR nudge owns this same surface_view when it renders below
+    // the error card. For all other failed-run guidance (AMR auth/balance,
+    // Antigravity auth/quota, upstream outage, generic retry), the chat error
+    // card itself is the visible run_failed_toast surface.
+    if (amrSwitchPayload) return;
+
+    const key = [
+      projectId ?? '',
+      activeConversationId ?? '',
+      retryAssistant.id,
+      retryAssistant.runId ?? '',
+      failedRunErrorEvent.code,
+    ].join(':');
+    if (runFailedToastSurfaceKeysRef.current.has(key)) return;
+    runFailedToastSurfaceKeysRef.current.add(key);
+
+    trackRunFailedToastSurfaceView(analyticsTrack, {
+      page_name: 'chat_panel',
+      area: 'chat_panel',
+      element: 'run_failed_toast',
+      error_code: failedRunErrorEvent.code,
+      project_id: projectId ?? '',
+      project_kind: projectKindForTracking,
+      conversation_id: activeConversationId,
+      assistant_message_id: retryAssistant.id,
+      run_id: retryAssistant.runId ?? null,
+    });
+  }, [
+    activeConversationId,
+    analyticsTrack,
+    amrSwitchPayload,
+    displayError,
+    failedRunErrorEvent?.code,
+    projectId,
+    projectKindForTracking,
+    retryAssistant,
+  ]);
+
+  return {
+    lastAssistantId,
+    hasActiveRunMessage,
+    retryAssistant,
+    runFailureUi,
+    canResumeFailedRun,
+    displayError,
+    errorDiagnosticText,
+    errorSourcePeek,
+    runErrorTone,
+    errorCardOwnerId,
+    amrSwitchPayload,
+    showByokRecoveryCta,
+    showErrorActions,
+    copiedErrorDiagnostic,
+    errorSourceOpen,
+    setErrorSourceOpen,
+    copyErrorDiagnostic,
+    inlineAmrLoginStatus,
+    handleAmrLoginStatusChange,
+    handleAmrRecharge,
+    handleAmrUpgrade,
+    handleAmrSignInStarted,
+    handleAmrSwitchActivate,
+  };
+}

--- a/apps/web/src/features/chat-pane/index.ts
+++ b/apps/web/src/features/chat-pane/index.ts
@@ -1,0 +1,46 @@
+// Public API of the chat-pane slice. Consumers (the ChatPane orchestrator,
+// which lives outside the slice at components/ChatPane.tsx, and any other
+// app code) import ONLY from here — never from the slice's internal files.
+// `scripts/check-web-slice-boundaries.ts` fails any outside-in deep import
+// that reaches past this barrel (ADR 0002).
+
+// Pure rules the orchestrator reads directly.
+export {
+  buildRunErrorDiagnosticText,
+  compactCount,
+  conversationMessageCount,
+  conversationMetaLabel,
+  filterConversations,
+  importedFolderArtifactsFor,
+  isActiveRunStatus,
+  isAssistantMessageStreaming,
+  isBrandExtractionNextStepProject,
+  isDesignSystemNextStepProject,
+  isProgrammaticBrandAssistantMessage,
+  isTerminalRunStatus,
+  nextUserContentByAssistantIdFor,
+  pickStarters,
+  queuedDropEdgeForPosition,
+  reorderQueuedSendIds,
+  retryableAssistantMessage,
+  shouldHideEmptyBrandAssistantMessage,
+  sortArtifactsByModified,
+  summarizeQueuedPrompt,
+} from './rules';
+
+export type { AssistantCallbacks, QueuedSendDragState, QueuedSendDropEdge, QueuedSendItem, QueuedSendUpdate, RunErrorDiagnosticInput, StarterPrompt } from './types';
+
+export { ChatConversationLoading } from './components/ChatConversationLoading';
+export { ChatRows } from './components/ChatRows';
+export { CommentsPanel } from './components/CommentsPanel';
+export { ConversationRow } from './components/ConversationRow';
+export { ImportedFolderArtifacts } from './components/ImportedFolderArtifacts';
+export { QueuedSendStrip } from './components/QueuedSendStrip';
+
+export { useChatLogScrollAnchor } from './hooks/useChatLogScrollAnchor.hooks';
+export { useComposerDraftSync } from './hooks/useComposerDraftSync.hooks';
+export { useComposerPortalLayout } from './hooks/useComposerPortalLayout.hooks';
+export { useComposerStarterScenarios } from './hooks/useComposerStarterScenarios.hooks';
+export { useConversationHistory } from './hooks/useConversationHistory.hooks';
+export { useQueuedSendEditing } from './hooks/useQueuedSendEditing.hooks';
+export { useRunErrorState } from './hooks/useRunErrorState.hooks';

--- a/apps/web/src/features/chat-pane/ports.ts
+++ b/apps/web/src/features/chat-pane/ports.ts
@@ -1,0 +1,31 @@
+// The chat-pane slice's dependency on transport/DOM globals, expressed as an
+// interface it owns. The slice depends on this port, never on `providers/`
+// directly; a provider is bound to it in `dependencies.ts`.
+import type { ComposerPortalRect, VelaLoginStatus } from './types';
+
+/** Transport the AMR inline-login-status hook needs. */
+export interface AmrLoginPort {
+  fetchVelaLoginStatus(options?: { refresh?: boolean }): Promise<VelaLoginStatus | null>;
+}
+
+/** DOM reads/subscriptions this slice's hooks need. */
+export interface ChatPaneDomPort {
+  getDocumentBody(): HTMLElement | null;
+  subscribeComposerPortalRect(
+    slot: HTMLElement,
+    onRect: (rect: ComposerPortalRect) => void,
+  ): () => void;
+  subscribeComposerLayerHeight(
+    layer: HTMLElement,
+    onHeight: (height: number) => void,
+  ): () => void;
+  subscribeOutsideClickOrEscape(
+    container: { current: HTMLElement | null },
+    onClose: () => void,
+  ): () => void;
+  subscribeWindowEvent(eventName: string, onEvent: (event: Event) => void): () => void;
+  subscribeVisibleFocusOrVisibilityChange(onVisible: () => void): () => void;
+  scheduleInterval(callback: () => void, ms: number): () => void;
+  scheduleTimeout(callback: () => void, ms: number): () => void;
+  openExternalUrl(url: string): void;
+}

--- a/apps/web/src/features/chat-pane/rules.ts
+++ b/apps/web/src/features/chat-pane/rules.ts
@@ -1,0 +1,522 @@
+import type {
+  ChatAttachment,
+  ChatMessage,
+  Conversation,
+  ProjectFile,
+  ProjectMetadata,
+} from '../../types';
+import type { WorkspaceContextItem } from '@open-design/contracts';
+import { hasOdCard } from '@open-design/contracts';
+import type { IconName } from '../../components/Icon';
+import { listDesignArtifactCandidates } from '../../components/design-files/designArtifacts';
+import { splitOnQuestionForms } from '../../artifacts/question-form';
+import { stripArtifact } from '../../artifacts/strip';
+import type { Dict } from '../../i18n/types';
+import {
+  AUDIO_STARTERS,
+  CHAT_VIRTUAL_ROW_GAP_PX,
+  DEFAULT_STARTER_KEYS,
+  IMAGE_STARTERS,
+  VIDEO_HYPERFRAMES_STARTERS,
+  VIDEO_SEEDANCE_STARTERS,
+  WORKSPACE_DESIGN_FILES_TAB,
+  WORKSPACE_DESIGN_SYSTEM_TAB,
+} from './constants';
+import type {
+  ChatRenderItem,
+  QueuedSendDropEdge,
+  QueuedSendItem,
+  RunErrorDiagnosticInput,
+  StarterPrompt,
+} from './types';
+import { isTodoWriteToolName } from '../../runtime/todos';
+
+type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+export function shouldHideEmptyBrandAssistantMessage(message: ChatMessage, metadata?: ProjectMetadata): boolean {
+  if (metadata?.importedFrom !== 'brand-extraction' && metadata?.kind !== 'brand') return false;
+  if (message.role !== 'assistant') return false;
+  if (brandAssistantTextHasVisibleContent(message.content)) return false;
+  if ((message.events ?? []).some(hasVisibleBrandAssistantEvent)) return false;
+  if ((message.producedFiles?.length ?? 0) > 0) return false;
+  return Boolean(message.runStatus || message.endedAt);
+}
+
+export function brandAssistantTextHasVisibleContent(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+  if (hasOdCard(trimmed)) return true;
+  const withoutArtifacts = stripArtifact(trimmed).trim();
+  if (!withoutArtifacts) return false;
+  return splitOnQuestionForms(withoutArtifacts).some((segment) => {
+    if (segment.kind === 'form') return true;
+    return segment.text.trim().length > 0;
+  });
+}
+
+const HIDDEN_BRAND_ASSISTANT_STATUS_LABELS = new Set([
+  'streaming',
+  'starting',
+  'running',
+  'requesting',
+  'thinking',
+  'empty_response',
+  'done',
+  'completed',
+]);
+
+export function hasVisibleBrandAssistantEvent(event: NonNullable<ChatMessage['events']>[number]): boolean {
+  switch (event.kind) {
+    case 'text':
+      return brandAssistantTextHasVisibleContent(event.text);
+    case 'thinking':
+      return event.text.trim().length > 0;
+    case 'tool_use':
+    case 'live_artifact':
+    case 'live_artifact_refresh':
+    case 'plugin_candidate':
+      return true;
+    case 'tool_result':
+      return false;
+    case 'raw':
+      return false;
+    case 'status':
+      return !HIDDEN_BRAND_ASSISTANT_STATUS_LABELS.has(event.label);
+    case 'usage':
+    case 'diagnostic':
+    case 'conversation_title':
+      return false;
+  }
+}
+
+export function pickStarters(
+  metadata: ProjectMetadata | undefined,
+  t: TranslateFn,
+): StarterPrompt[] {
+  const kind = metadata?.kind;
+  if (kind === 'image') return IMAGE_STARTERS;
+  if (kind === 'video') {
+    return metadata?.videoModel === 'hyperframes-html'
+      ? VIDEO_HYPERFRAMES_STARTERS
+      : VIDEO_SEEDANCE_STARTERS;
+  }
+  if (kind === 'audio') return AUDIO_STARTERS;
+  return DEFAULT_STARTER_KEYS.map((entry) => ({
+    icon: entry.icon,
+    title: t(entry.titleKey),
+    tag: t(entry.tagKey),
+    prompt: t(entry.promptKey),
+  }));
+}
+
+export function sortArtifactsByModified(files: ProjectFile[]): ProjectFile[] {
+  return [...files].sort(
+    (a, b) => b.mtime - a.mtime || a.name.localeCompare(b.name),
+  );
+}
+
+export function importedFolderArtifactsFor(
+  projectFiles: ProjectFile[],
+  projectMetadata: ProjectMetadata | undefined,
+): ProjectFile[] {
+  return projectMetadata?.importedFrom === 'folder'
+    ? sortArtifactsByModified(
+        listDesignArtifactCandidates(projectFiles, projectMetadata.entryFile),
+      )
+    : [];
+}
+
+export function chatArtifactIcon(kind: ProjectFile['kind']): IconName {
+  if (kind === 'html' || kind === 'code') return 'file-code';
+  if (kind === 'image' || kind === 'sketch') return 'image';
+  if (kind === 'video' || kind === 'audio') return 'play';
+  if (kind === 'presentation') return 'present';
+  return 'file';
+}
+
+export function chatArtifactShortKind(kind: ProjectFile['kind']): string {
+  if (kind === 'html') return 'HTML';
+  if (kind === 'image') return 'IMG';
+  if (kind === 'sketch') return 'SKETCH';
+  if (kind === 'video') return 'VIDEO';
+  if (kind === 'pdf') return 'PDF';
+  if (kind === 'presentation') return 'PPT';
+  if (kind === 'document') return 'DOC';
+  return 'FILE';
+}
+
+export function chatArtifactKindLabel(kind: ProjectFile['kind'], t: TranslateFn): string {
+  if (kind === 'html') return t('designFiles.kindHtml');
+  if (kind === 'image') return t('designFiles.kindImage');
+  if (kind === 'sketch') return t('designFiles.kindSketch');
+  if (kind === 'video') return 'Video';
+  if (kind === 'audio') return 'Audio';
+  if (kind === 'pdf') return t('designFiles.kindPdf');
+  if (kind === 'document') return t('designFiles.kindDocument');
+  if (kind === 'presentation') return t('designFiles.kindPresentation');
+  if (kind === 'spreadsheet') return t('designFiles.kindSpreadsheet');
+  return t('designFiles.kindBinary');
+}
+
+export function buildChatRenderItems(messages: ChatMessage[]): ChatRenderItem[] {
+  const items: ChatRenderItem[] = [];
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i]!;
+    items.push({
+      kind: 'message',
+      key: `message:${message.id}`,
+      message,
+    });
+  }
+  return items;
+}
+
+export function firstTodoWriteAssistantMessageId(messages: ChatMessage[]): string | null {
+  const message = messages.find(
+    (candidate) =>
+      candidate.role === 'assistant' &&
+      candidate.events?.some(
+        (event) => event.kind === 'tool_use' && isTodoWriteToolName(event.name),
+      ),
+  );
+  return message?.id ?? null;
+}
+
+export function estimateChatRenderItemHeight(item: ChatRenderItem): number {
+  const message = item.message;
+  const contentLength = message.content?.length ?? 0;
+  const attachmentCount = (message.attachments?.length ?? 0) + (message.commentAttachments?.length ?? 0);
+  const eventCount = message.events?.length ?? 0;
+  const fileCount = message.producedFiles?.length ?? 0;
+  const base = message.role === 'user' ? 82 : 118;
+  const contentRows = Math.min(18, Math.ceil(contentLength / 120));
+  return (
+    base
+    + contentRows * 18
+    + attachmentCount * 34
+    + eventCount * 28
+    + fileCount * 32
+    + CHAT_VIRTUAL_ROW_GAP_PX
+  );
+}
+
+export function includeVirtualRowByKey<T extends { key: string }>(
+  rows: Array<{ item: T; index: number; top: number }>,
+  items: T[],
+  offsets: number[],
+  key: string | undefined,
+): Array<{ item: T; index: number; top: number }> {
+  if (!key || rows.some((row) => row.item.key === key)) return rows;
+  const index = items.findIndex((item) => item.key === key);
+  if (index === -1) return rows;
+  return [
+    ...rows,
+    {
+      item: items[index]!,
+      index,
+      top: offsets[index] ?? 0,
+    },
+  ].sort((a, b) => a.index - b.index);
+}
+
+export function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {
+  return status === 'queued' || status === 'running';
+}
+
+export function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
+  return status === 'succeeded' || status === 'failed' || status === 'canceled';
+}
+
+export function retryableAssistantMessage(
+  messages: ChatMessage[],
+  lastAssistantId: string | null | undefined,
+  paneStreaming: boolean,
+): ChatMessage | null {
+  if (paneStreaming) return null;
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'assistant') return null;
+  if (last.id !== lastAssistantId) return null;
+  return last.runStatus === 'failed' ? last : null;
+}
+
+export function isAssistantMessageStreaming(
+  message: ChatMessage,
+  paneStreaming: boolean,
+  lastAssistantId: string | null | undefined,
+  forceStreamingMessageIds?: Set<string>,
+): boolean {
+  if (message.role !== 'assistant') return false;
+  if (forceStreamingMessageIds?.has(message.id)) return true;
+  if (isActiveRunStatus(message.runStatus)) return true;
+  if (message.id !== lastAssistantId) return false;
+  if (!paneStreaming) return false;
+  if (message.endedAt !== undefined) return false;
+  if (isTerminalRunStatus(message.runStatus)) return false;
+  return true;
+}
+
+export function buildRunErrorDiagnosticText(input: RunErrorDiagnosticInput): string {
+  const lines: string[] = [];
+  const sourceText = input.rawMessage?.trim() || input.message.trim();
+  if (sourceText) {
+    lines.push(sourceText, '');
+  }
+
+  lines.push(
+    'Open Design run error diagnostics',
+    `trace_id: ${input.traceId ?? 'n/a'}`,
+    `run_id: ${input.traceId ?? 'n/a'}`,
+    `error_code: ${input.errorCode ?? 'n/a'}`,
+    `project_id: ${input.projectId ?? 'n/a'}`,
+    `conversation_id: ${input.conversationId ?? 'n/a'}`,
+    `assistant_message_id: ${input.assistantMessageId ?? 'n/a'}`,
+    `agent_id: ${input.agentId ?? 'n/a'}`,
+  );
+
+  return lines.join('\n');
+}
+
+export function filterConversations(
+  conversations: Conversation[],
+  query: string,
+  t: TranslateFn,
+): Conversation[] {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (!normalized) return conversations;
+  return conversations.filter((conversation) => {
+    const title = conversation.title || t('chat.untitledConversation');
+    const meta = conversationMetaLabel(conversation, t);
+    return `${title} ${conversation.id} ${meta}`.toLocaleLowerCase().includes(normalized);
+  });
+}
+
+export function conversationMessageCount(
+  conversation: Conversation,
+  activeConversationId: string | null,
+  messagesConversationId: string | null,
+  activeMessageCount: number,
+): number | null {
+  // The live `messages` array is authoritative for the active conversation —
+  // it stays fresh as a run streams new turns in — but ONLY once it has
+  // actually loaded for that conversation. While a switch is mid-flight (or a
+  // load failed) `messages` is reset to [] and `messagesConversationId` no
+  // longer matches the active id; trusting `messages.length` there renders a
+  // phantom "0 msg". Fall back to the persisted server count until the live
+  // array catches up.
+  if (
+    conversation.id === activeConversationId &&
+    messagesConversationId === activeConversationId
+  ) {
+    return activeMessageCount;
+  }
+  return typeof conversation.messageCount === 'number' ? conversation.messageCount : null;
+}
+
+export function compactCount(value: number): string {
+  if (value < 1000) return String(value);
+  const compact = Math.floor(value / 100) / 10;
+  return `${compact}k`;
+}
+
+export function workspaceContextOpenTarget(item: WorkspaceContextItem): string | null {
+  if (item.tabId) return item.tabId;
+  if (item.kind === 'design-files') return WORKSPACE_DESIGN_FILES_TAB;
+  if (item.kind === 'design-system') return WORKSPACE_DESIGN_SYSTEM_TAB;
+  if (item.kind === 'file' || item.kind === 'live-artifact') {
+    return item.path ?? item.label;
+  }
+  return null;
+}
+
+export function workspaceContextIcon(item: WorkspaceContextItem): IconName {
+  if (item.kind === 'browser') return 'globe';
+  if (item.kind === 'folder' || item.kind === 'design-files') return 'folder';
+  if (item.kind === 'project') return 'folder';
+  if (item.kind === 'local-code') return 'terminal';
+  if (item.kind === 'terminal') return 'terminal';
+  if (item.kind === 'side-chat') return 'comment';
+  if (item.kind === 'design-system') return 'blocks';
+  return 'file';
+}
+
+export function workspaceContextTitle(item: WorkspaceContextItem): string {
+  return [
+    workspaceContextKindLabel(item.kind),
+    item.path ? `path: ${item.path}` : null,
+    item.absolutePath ? `absolute: ${item.absolutePath}` : null,
+    item.url ? `url: ${item.url}` : null,
+    item.title ? `title: ${item.title}` : null,
+  ].filter(Boolean).join(' | ');
+}
+
+export function workspaceContextKindLabel(kind: WorkspaceContextItem['kind']): string {
+  switch (kind) {
+    case 'browser':
+      return 'Browser';
+    case 'design-files':
+      return 'Design files';
+    case 'design-system':
+      return 'Design system';
+    case 'folder':
+      return 'Folder';
+    case 'project':
+      return 'Project';
+    case 'local-code':
+      return 'Local code';
+    case 'terminal':
+      return 'Terminal';
+    case 'side-chat':
+      return 'Side chat';
+    case 'live-artifact':
+      return 'Live artifact';
+    case 'file':
+    default:
+      return 'File';
+  }
+}
+
+export function sortChatAttachmentsForDisplay(attachments: ChatAttachment[]): ChatAttachment[] {
+  return attachments
+    .map((attachment, index) => ({ attachment, index }))
+    .sort((a, b) => {
+      const aOrder = typeof a.attachment.order === 'number' && Number.isFinite(a.attachment.order)
+        ? a.attachment.order
+        : a.index;
+      const bOrder = typeof b.attachment.order === 'number' && Number.isFinite(b.attachment.order)
+        ? b.attachment.order
+        : b.index;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.attachment);
+}
+
+export function isDesignSystemNextStepProject(metadata: ProjectMetadata | undefined): boolean {
+  if (!metadata) return false;
+  return (
+    metadata.kind === 'brand' ||
+    metadata.importedFrom === 'design-system' ||
+    metadata.importedFrom === 'brand-extraction' ||
+    Boolean(metadata.brandDesignSystemId)
+  );
+}
+
+export function isBrandExtractionNextStepProject(metadata: ProjectMetadata | undefined): boolean {
+  if (!metadata) return false;
+  return (
+    metadata.kind === 'brand' ||
+    metadata.importedFrom === 'brand-extraction' ||
+    Boolean(metadata.brandId) ||
+    Boolean(metadata.brandDesignSystemId)
+  );
+}
+
+export function isProgrammaticBrandAssistantMessage(message: ChatMessage | null | undefined): boolean {
+  if (!message || message.role !== 'assistant') return false;
+  const content = message.content || '';
+  return (
+    content.includes('<od-card type="brand-browser-assist"') ||
+    /programmatic (design-system )?extraction|automatic pass needs a hand|extraction stopped/i.test(content) ||
+    /程序化.*抽取|程式化.*抽取|抽取已停止/.test(content)
+  );
+}
+
+export function relTime(ts: number, t: TranslateFn): string {
+  const diff = Date.now() - ts;
+  const min = 60_000;
+  const hr = 60 * min;
+  const day = 24 * hr;
+  if (diff < min) return t('common.now');
+  if (diff < hr) return t('common.minutesShort', { n: Math.floor(diff / min) });
+  if (diff < day) return t('common.hoursShort', { n: Math.floor(diff / hr) });
+  if (diff < 7 * day) return t('common.daysShort', { n: Math.floor(diff / day) });
+  return new Date(ts).toLocaleDateString();
+}
+
+export function conversationMetaLabel(
+  conversation: Conversation,
+  t: TranslateFn,
+): string {
+  const latestRun = conversation.latestRun;
+  if (
+    latestRun &&
+    (latestRun.status === 'succeeded' ||
+      latestRun.status === 'failed' ||
+      latestRun.status === 'canceled') &&
+    typeof conversation.totalDurationMs === 'number' &&
+    Number.isFinite(conversation.totalDurationMs)
+  ) {
+    return formatDurationShort(conversation.totalDurationMs);
+  }
+  if (
+    latestRun &&
+    (latestRun.status === 'succeeded' ||
+      latestRun.status === 'failed' ||
+      latestRun.status === 'canceled') &&
+    typeof latestRun.durationMs === 'number' &&
+    Number.isFinite(latestRun.durationMs)
+  ) {
+    return formatDurationShort(latestRun.durationMs);
+  }
+  return relTime(conversation.updatedAt, t);
+}
+
+// Maps each assistant message id to the user message that follows it (if
+// any) so the chat-side Questions banner can reopen that exact answered form
+// in the right-hand panel later.
+export function nextUserContentByAssistantIdFor(displayMessages: ChatMessage[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (let i = 0; i < displayMessages.length - 1; i++) {
+    const m = displayMessages[i]!;
+    const next = displayMessages[i + 1]!;
+    if (m.role === 'assistant' && next.role === 'user') {
+      map.set(m.id, next.content);
+    }
+  }
+  return map;
+}
+
+export function latestAssistantForBrandStateFor(displayMessages: ChatMessage[]): ChatMessage | null {
+  for (let i = displayMessages.length - 1; i >= 0; i -= 1) {
+    const message = displayMessages[i]!;
+    if (message.role === 'assistant') return message;
+  }
+  return null;
+}
+
+// Takes plain numbers (not a DOM/React drag event) so this stays testable
+// with zero doubles — the caller reads `event.clientY` and
+// `event.currentTarget.getBoundingClientRect()` before calling in.
+export function queuedDropEdgeForPosition(clientY: number, rectTop: number, rectHeight: number): QueuedSendDropEdge {
+  return clientY < rectTop + rectHeight / 2 ? 'before' : 'after';
+}
+
+export function reorderQueuedSendIds(
+  items: QueuedSendItem[],
+  draggingId: string,
+  targetId: string,
+  edge: QueuedSendDropEdge,
+): string[] {
+  const ids = items.map((item) => item.id);
+  const from = ids.indexOf(draggingId);
+  if (from < 0) return ids;
+  const [draggedId] = ids.splice(from, 1);
+  const targetIndex = ids.indexOf(targetId);
+  if (targetIndex < 0 || !draggedId) return items.map((item) => item.id);
+  ids.splice(edge === 'after' ? targetIndex + 1 : targetIndex, 0, draggedId);
+  return ids;
+}
+
+export function summarizeQueuedPrompt(item: QueuedSendItem, t: TranslateFn): string {
+  const normalized = item.prompt.replace(/\s+/g, ' ').trim();
+  const text = normalized || t('chat.queuedFollowUpFallback');
+  return text.length > 58 ? `${text.slice(0, 57)}...` : text;
+}
+
+export function formatDurationShort(ms: number): string {
+  const s = Math.max(0, ms) / 1000;
+  if (s < 60) return `${s.toFixed(s < 10 ? 1 : 0)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.floor(s - m * 60);
+  return `${m}m ${rem.toString().padStart(2, '0')}s`;
+}

--- a/apps/web/src/features/chat-pane/types.ts
+++ b/apps/web/src/features/chat-pane/types.ts
@@ -1,0 +1,117 @@
+import type { ChatAttachment, ChatCommentAttachment, ChatMessage, ChatMessageFeedbackChange } from '../../types';
+import type { BrandBrowserAssistConfirm } from '../../components/OdCard';
+import type { ChatSendMeta } from '../../components/ChatComposer';
+import type { TodoItem } from '../../runtime/todos';
+
+export interface QueuedSendItem {
+  id: string;
+  prompt: string;
+  attachments?: ChatAttachment[];
+  commentAttachments?: ChatCommentAttachment[];
+  meta?: ChatSendMeta;
+}
+
+export interface QueuedSendUpdate {
+  prompt: string;
+  attachments: ChatAttachment[];
+  commentAttachments: ChatCommentAttachment[];
+  meta?: ChatSendMeta;
+}
+
+export type ChatRenderItem = {
+  kind: 'message';
+  key: string;
+  message: ChatMessage;
+};
+
+// Stable-ref bundle for AssistantMessage's interaction callbacks. The
+// orchestrator keeps a ref of this shape so a memoized message row still
+// calls the latest handler without busting AssistantMessage's memo
+// comparison (which excludes these callbacks — see areAssistantMessagePropsEqual
+// in AssistantMessage.tsx).
+export interface AssistantCallbacks {
+  onContinueRemainingTasks:
+    | ((assistantMessage: ChatMessage, todos: TodoItem[]) => void)
+    | undefined;
+  onAssistantFeedback:
+    | ((message: ChatMessage, change: ChatMessageFeedbackChange) => void)
+    | undefined;
+  onBrandBrowserAssistConfirm: BrandBrowserAssistConfirm | undefined;
+  onArtifactShare: ((fileName: string) => void) | undefined;
+  onForkFromMessage: ((message: ChatMessage) => void) | undefined;
+  onShareToOpenDesign: ((assistantMessageId: string) => void) | undefined;
+  onNextStepAiOptimize: (() => void) | undefined;
+  onNextStepContinueExtraction: (() => void) | undefined;
+  onNextStepContinueAiExtraction: (() => void) | undefined;
+  onNextStepCreateDesign: (() => void) | undefined;
+  onNextStepCreateDesignSystem: (() => void) | undefined;
+}
+
+export interface RunErrorDiagnosticInput {
+  message: string;
+  rawMessage?: string | null;
+  errorCode?: string;
+  traceId?: string;
+  projectId?: string | null;
+  conversationId?: string | null;
+  assistantMessageId?: string;
+  agentId?: string;
+}
+
+// Port result types — defined in-slice (not imported from `providers/daemon`)
+// per the same AST-level import-type restriction as `ComposerPortalRect`
+// below. Mirror `providers/daemon.ts`'s `VelaLoginStatus`/`VelaUser`/
+// `VelaLiveAccount` field-for-field so a value returned by the real
+// `fetchVelaLoginStatus()` (bound in `dependencies.ts`) stays structurally
+// assignable everywhere this type is threaded (e.g. `AmrLoginPill`'s
+// `initialStatus` prop, which imports the real type directly).
+export interface VelaUser {
+  id: string;
+  email: string;
+  name?: string;
+  image?: string | null;
+  plan?: string;
+  balanceUsd?: string | null;
+}
+
+export interface VelaLiveAccount {
+  plan?: string;
+  balanceUsd?: string | null;
+}
+
+export interface VelaLoginStatus {
+  loggedIn: boolean;
+  loginInFlight?: boolean;
+  profile: string;
+  user: VelaUser | null;
+  account?: VelaLiveAccount;
+  configPath: string;
+  activationUrl?: string;
+  userCode?: string;
+  browserOpenFailed?: boolean;
+}
+
+// Port result type — defined in-slice (not imported from `providers/dom`)
+// because the guard's no-`providers/`-import-outside-`dependencies.ts` rule
+// is AST-level and catches `import type` too.
+export interface ComposerPortalRect {
+  left: number;
+  width: number;
+  bottom: number;
+}
+
+export type QueuedSendDropEdge = 'before' | 'after';
+
+export interface QueuedSendDragState {
+  draggingId: string;
+  overId: string | null;
+  edge: QueuedSendDropEdge | null;
+}
+
+export type StarterPrompt = {
+  icon: string;
+  title: string;
+  // Empty for path-scoped onboarding starters, which have no category tag.
+  tag: string;
+  prompt: string;
+};

--- a/apps/web/src/providers/dom.ts
+++ b/apps/web/src/providers/dom.ts
@@ -1,0 +1,171 @@
+// Thin browser-global reads/subscriptions for the chat-pane slice. Kept as a
+// provider (not inlined in a feature) so `features/**` stays DOM-free per the
+// `check-web-slice-boundaries` guard — the slice reaches this only through its
+// own port + `dependencies.ts`.
+
+/** The document body, or `null` outside the browser (SSR). */
+export function getDocumentBody(): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  return document.body;
+}
+
+/** Rect the composer's portal layer should be positioned at, relative to
+ *  `slot`'s box and the viewport's bottom edge. */
+export interface ComposerPortalRect {
+  left: number;
+  width: number;
+  bottom: number;
+}
+
+/**
+ * Watches `slot`'s box (and its `.pane` ancestor, and viewport resize) and
+ * reports the composer portal's target rect on every change. A no-op
+ * subscription outside the browser (SSR).
+ */
+export function subscribeComposerPortalRect(
+  slot: HTMLElement,
+  onRect: (rect: ComposerPortalRect) => void,
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+  let frame: number | null = null;
+  const updateRect = () => {
+    frame = null;
+    const rect = slot.getBoundingClientRect();
+    onRect({
+      left: Math.round(rect.left),
+      width: Math.round(rect.width),
+      bottom: Math.max(0, Math.round(window.innerHeight - rect.bottom)),
+    });
+  };
+  const scheduleUpdate = () => {
+    if (frame !== null) return;
+    frame = window.requestAnimationFrame(updateRect);
+  };
+  updateRect();
+  const resizeObserver =
+    typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(scheduleUpdate)
+      : null;
+  resizeObserver?.observe(slot);
+  const pane = slot.closest('.pane');
+  if (pane) resizeObserver?.observe(pane);
+  window.addEventListener('resize', scheduleUpdate);
+  window.visualViewport?.addEventListener('resize', scheduleUpdate);
+  return () => {
+    if (frame !== null) window.cancelAnimationFrame(frame);
+    resizeObserver?.disconnect();
+    window.removeEventListener('resize', scheduleUpdate);
+    window.visualViewport?.removeEventListener('resize', scheduleUpdate);
+  };
+}
+
+/**
+ * Watches `layer`'s box height and reports it on every change. A no-op
+ * subscription outside the browser (SSR).
+ */
+export function subscribeComposerLayerHeight(
+  layer: HTMLElement,
+  onHeight: (height: number) => void,
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+  let frame: number | null = null;
+  const updateHeight = () => {
+    frame = null;
+    onHeight(Math.ceil(layer.getBoundingClientRect().height));
+  };
+  const scheduleUpdate = () => {
+    if (frame !== null) return;
+    frame = window.requestAnimationFrame(updateHeight);
+  };
+  updateHeight();
+  const resizeObserver =
+    typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(scheduleUpdate)
+      : null;
+  resizeObserver?.observe(layer);
+  return () => {
+    if (frame !== null) window.cancelAnimationFrame(frame);
+    resizeObserver?.disconnect();
+  };
+}
+
+/**
+ * Fires `onClose` on a `mousedown` outside `container.current`, or on
+ * Escape anywhere. A no-op subscription outside the browser (SSR).
+ */
+export function subscribeOutsideClickOrEscape(
+  container: { current: HTMLElement | null },
+  onClose: () => void,
+): () => void {
+  if (typeof document === 'undefined') return () => {};
+  function onPointer(e: MouseEvent) {
+    const target = e.target as Node;
+    if (container.current?.contains(target)) return;
+    onClose();
+  }
+  function onKey(e: KeyboardEvent) {
+    if (e.key === 'Escape') onClose();
+  }
+  document.addEventListener('mousedown', onPointer);
+  document.addEventListener('keydown', onKey);
+  return () => {
+    document.removeEventListener('mousedown', onPointer);
+    document.removeEventListener('keydown', onKey);
+  };
+}
+
+/**
+ * Adds a `window` event listener for `eventName` and returns the matching
+ * removal function. A no-op subscription outside the browser (SSR).
+ */
+export function subscribeWindowEvent(
+  eventName: string,
+  onEvent: (event: Event) => void,
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener(eventName, onEvent);
+  return () => window.removeEventListener(eventName, onEvent);
+}
+
+/**
+ * Fires `onVisible` when the tab regains focus or becomes visible again
+ * (e.g. returning from an external AMR sign-in tab) — skipped while the tab
+ * itself is hidden, since `visibilitychange` also fires on the way out.
+ * A no-op subscription outside the browser (SSR).
+ */
+export function subscribeVisibleFocusOrVisibilityChange(onVisible: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const handler = () => {
+    if (document.visibilityState === 'hidden') return;
+    onVisible();
+  };
+  window.addEventListener('focus', handler);
+  document.addEventListener('visibilitychange', handler);
+  return () => {
+    window.removeEventListener('focus', handler);
+    document.removeEventListener('visibilitychange', handler);
+  };
+}
+
+/** Runs `callback` every `ms` via `window.setInterval`; the returned
+ *  function clears it. A no-op outside the browser (SSR). */
+export function scheduleInterval(callback: () => void, ms: number): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const id = window.setInterval(callback, ms);
+  return () => window.clearInterval(id);
+}
+
+/** Runs `callback` once after `ms` via `window.setTimeout`; the returned
+ *  function cancels it. A no-op outside the browser (SSR). */
+export function scheduleTimeout(callback: () => void, ms: number): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const id = window.setTimeout(callback, ms);
+  return () => window.clearTimeout(id);
+}
+
+/** Opens `url` in a new tab (`noopener,noreferrer`); a no-op outside the
+ *  browser (SSR). */
+export function openExternalUrl(url: string): void {
+  if (typeof window === 'undefined') return;
+  window.open(url, '_blank', 'noopener,noreferrer');
+}


### PR DESCRIPTION
## Why

Decomposing the `ChatPane.tsx` god-component into a `features/chat-pane/` vertical slice (ports, pure rules, feature-local hooks, dumb components), following the same shape as the `MemorySection.tsx`/`McpClientSection.tsx` canaries on an unmerged branch lineage. `ChatPane.tsx` had grown to 4,332 lines with no unit-testable seams.

This branch is rebuilt directly against current `main` (not carried over from the prior unmerged canary lineage), so it is deliberately **standalone**: it does not depend on `docs/adr/0002-frontend-vertical-slice-decomposition.md`, `dev-skills/fixing-open-design-web/SKILL.md`, or the `check-web-slice-boundaries` guard script, none of which exist on `main` yet. Those land separately once the prerequisite canary work merges; this PR only adds `features/chat-pane/` and `providers/dom.ts`.

This is a **draft PR opened to run CI against the real GitHub Actions pipeline** (Playwright visual diffs, the full validation matrix, etc.) — not requesting review or merge yet.

## What users will see

Nothing. Pure internal refactor — same component, same props, same rendered markup.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] **None** — internal refactor only

## What this does

`ChatPane.tsx`: 4,332 → 1,194 lines. Structurally this file was closer to `FileViewer`/`ProjectView`'s shape than a single-component god-file: one large orchestrator plus ~15 already-inline subcomponents and ~30 pure helpers, all in one file, with zero direct transport (all data arrives via props from `ProjectView`).

- **Mechanical moves**: message-list rendering (`ChatRows`/`VirtualChatRow`/`useMeasuredVirtualWindow`), comments panel, message-row rendering (`ConversationRow`/`UserMessage`/chip components), artifact previews, the queued-send strip, and ~20 pure helper functions — all moved into `features/chat-pane/components/` and `rules.ts` unchanged.
- **Independent orchestrator clusters**, each its own feature-local hook: `useConversationHistory`, `useComposerPortalLayout`, `useComposerDraftSync`, `useQueuedSendEditing`, `useComposerStarterScenarios`.
- **`useRunErrorState`**: the AMR inline-login + run-error diagnostics subsystem, including a shared signed-out→signed-in retry-transition detector used by both a 500ms poll and `AmrLoginPill`'s own `onStatusChange` event, the `chatLogTray` pass-through, the focus/visibilitychange-driven login refresh, and the `upgrade` run-failure action (tier-entitlement case, `amrPlansUrlForProfile`) alongside the existing `authorize`/`recharge` cases.
- **`useChatLogScrollAnchor`**: the chat-log's scroll-anchoring subsystem in full — anchor-just-sent-turn-to-top, initial-scroll, jump-to-latest, tab-switch scroll save/restore, and the `ResizeObserver`/`MutationObserver`-driven auto-follow while streaming. Exposes three imperative callbacks so the composer's `onSend` and an accordion-toggle handler stop reaching into this cluster's refs directly.

New `providers/dom.ts` (the slice's only file allowed to import `providers/`) adds 9 SSR-guarded browser bridges (`getDocumentBody`, `subscribeComposerPortalRect`, `subscribeComposerLayerHeight`, `subscribeOutsideClickOrEscape`, `subscribeWindowEvent`, `subscribeVisibleFocusOrVisibilityChange`, `scheduleInterval`, `scheduleTimeout`, `openExternalUrl`) replacing every bare `window`/`document` access this logic needed once it moved into `features/**`.

The orchestrator has zero standalone function/const-arrow declarations outside hook calls, derived `useMemo`/`useCallback` values, and JSX, and an injectable-hooks seam (`ChatPaneHooks`, optional hook props defaulting to the real wired hooks) so a test can render the orchestrator directly with a fake hook instead of mocking modules.

Two pre-existing dead-code findings left untouched, noted not fixed (no scope creep): `CommentsPanel`/`CommentSection` are defined but never rendered anywhere in `ChatPane.tsx`; 3 conversation-list virtualization constants are declared but unused.

## Validation

- `pnpm --filter @open-design/web typecheck` — clean
- Full `@open-design/web` suite — green (410 files / 4,290 tests, 7 pre-existing skips), including `ChatPane.tsx`'s own `tests/components/ChatPane.*.test.tsx` suite
- `pnpm guard` — clean (78/78 checks)
