### PR TITLE
refactor(web): decompose ChatComposer.tsx into a features/chat-composer vertical slice

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -13,7 +13,7 @@ import {
 import { createPortal } from 'react-dom';
 import { Button } from '@open-design/components';
 import { useI18n } from '../i18n';
-import { localizePluginDescription, localizePluginTitle } from './plugins-home/localization';
+import { localizePluginDescription } from './plugins-home/localization';
 import type { Dict, Locale } from '../i18n/types';
 import {
   localizeSkillDescription,
@@ -22,12 +22,9 @@ import {
 import { useAnalytics } from '../analytics/provider';
 import {
   trackChatPanelClick,
-  trackComposerBarClick,
   trackComposerSessionModeClick,
   trackContextLinkResult,
-  trackDesignToolboxClick,
   trackFigmaHelpModalSurfaceView,
-  trackFileUploadResult,
   trackProjectReferenceModalSurfaceView,
 } from '../analytics/events';
 import type {
@@ -35,64 +32,44 @@ import type {
   DesignToolboxClickProps,
 } from '@open-design/contracts/analytics';
 import { sessionModeToTracking } from '@open-design/contracts/analytics';
-import { deriveUploadCohort } from '../analytics/upload-tracking';
-import { projectRawUrl, uploadProjectFiles, openFolderDialog, fetchRecentLinkedDirs, pushRecentLinkedDir, dirExists, applyLibraryAsset, fetchLibraryAssetElementHtml } from "../providers/registry";
+import { projectRawUrl, uploadProjectFiles, openFolderDialog, applyLibraryAsset, fetchLibraryAssetElementHtml } from "../providers/registry";
+import { openDesignSystemPickerTrigger } from '../providers/dom';
 import { WorkingDirPicker } from './WorkingDirPicker';
 import { duplicatePluginAsProject, patchProject } from "../state/projects";
 import { navigate } from '../router';
-import { fetchMcpServers } from "../state/mcp";
-import type { McpServerConfig, McpTemplate } from "../state/mcp";
-import { listPlugins } from "../state/projects";
+import type { McpServerConfig } from "@open-design/contracts";
 import type { AppConfig, ChatAttachment, ChatCommentAttachment, Project, ProjectFile, ProjectMetadata, SkillSummary } from "../types";
 import type {
   ContextItem,
-  AppliedPluginSnapshot,
   ChatAnalyticsEntryFrom,
   ChatSessionMode,
   ConnectorDetail,
   InstalledPluginRecord,
   PluginSourceKind,
-  ResearchOptions,
-  RunContextSelection,
   WorkspaceContextItem,
 } from '@open-design/contracts';
-import { buildVisualAnnotationAttachment, commentTargetDisplayName } from '../comments';
 import { Icon, type IconName } from "./Icon";
 import { ComposerPlusMenu, PLUS_SUBMENU_RESOURCE_KIND } from './ComposerPlusMenu';
 import { LibraryPicker } from './LibraryPicker';
 import { FigmaImportModal } from './FigmaImportModal';
 import { FigmaHelpModal } from './FigmaHelpModal';
-import {
-  ProjectReferenceModal,
-  type ProjectReferenceSelection,
-} from './ProjectReferenceModal';
-import { assetTitle, elementMetaOf } from './LibraryAssetMeta';
+import { ProjectReferenceModal } from './ProjectReferenceModal';
 import { SessionModeToggle } from './SessionModeToggle';
-import type { LibraryAsset, LibraryElementMeta } from '@open-design/contracts';
+import type { LibraryElementMeta } from '@open-design/contracts';
 import {
   DESIGN_TOOLBOX_ACTIONS,
-  designToolboxActionBadge,
-  designToolboxActionDescription,
-  designToolboxActionMatchesQuery,
-  designToolboxActionTitle,
-  findDesignToolboxSkill,
   getDesignToolboxAction,
-  skillMatchesQuery,
   type DesignToolboxAction,
   type DesignToolboxActionId,
 } from '../runtime/design-toolbox';
 import { ComposerPluginPreview } from './ComposerPluginPreview';
-import { computeToolboxDetailPosition } from './composer-detail-position';
 import { PluginDetailsModal } from "./PluginDetailsModal";
 import { SkillDetailsModal } from './SkillDetailsModal';
 import { PluginsSection, type PluginsSectionHandle } from "./PluginsSection";
-import { BUILT_IN_PETS, CUSTOM_PET_ID } from "./pet/pets";
 import {
   inlineMentionToken,
-  mentionTokenPresent,
   type InlineMentionEntity,
 } from '../utils/inlineMentions';
-import { workspaceContextLinkedDir, workspaceContextLinkedDirs } from './workspace-context';
 import {
   LexicalComposerInput,
   type LexicalComposerInputHandle,
@@ -102,110 +79,127 @@ import { CaretFloatingLayer } from './composer/CaretFloatingLayer';
 import { ANNOTATION_EVENT, type AnnotationEventDetail } from "./PreviewDrawOverlay";
 import { DesignSystemSwitchPicker } from "./DesignSystemSwitchPicker";
 import { listenForConnectorsChanged } from './connectors-events';
-import { fetchConnectorCatalogSnapshot } from './connectors-state';
 import { PlaceholderCarousel } from './home-hero/PlaceholderCarousel';
 import type { PlaceholderScenario } from './home-hero/placeholderScenarios';
-
-type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
-
-interface TrackedWorkspaceLinkedDir {
-  dir: string;
-  previousLinkedDirs: string[];
-}
-
-function dedupeWorkspaceContextItems(items: WorkspaceContextItem[]): WorkspaceContextItem[] {
-  const out: WorkspaceContextItem[] = [];
-  const seen = new Set<string>();
-  for (const item of items) {
-    const key = `${item.kind}:${item.id}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push(item);
-  }
-  return out;
-}
-
-function trackedWorkspaceLinkedDirsForContexts(
-  items: WorkspaceContextItem[],
-  linkedDirs: string[],
-): Record<string, TrackedWorkspaceLinkedDir> {
-  const out: Record<string, TrackedWorkspaceLinkedDir> = {};
-  for (const item of items) {
-    const dir = workspaceContextLinkedDir(item) ?? '';
-    if (!dir || !linkedDirs.includes(dir)) continue;
-    out[item.id] = {
-      dir,
-      previousLinkedDirs: linkedDirs.filter((linkedDir) => linkedDir !== dir),
-    };
-  }
-  return out;
-}
+import {
+  normalizeChatAttachmentOrders,
+  nextChatAttachmentOrder,
+  workspaceContextIcon,
+  workspaceContextTitle,
+  workspaceContextDescription,
+  lastPathSegment,
+  projectFileMentionTitle,
+  projectFileMentionDescription,
+  workspaceContextKindLabel,
+  prettySize,
+  pluginMatchesQuery,
+  buildDesignToolboxResources,
+  designToolboxResourceMatchesQuery,
+  designToolboxDefaultResources,
+  designToolboxResourceKindLabel,
+  designToolboxResourceIsActive,
+  designToolboxSkillBadge,
+  designToolboxSkillIcon,
+  designToolboxContextLine,
+  designToolboxDraftLine,
+  designToolboxWorkspaceKindLabel,
+  designToolboxResourceIndexLines,
+  designToolboxCompactLine,
+  mcpServerMatchesQuery,
+  mcpTemplateMatchesQuery,
+  pluginSourceLabel,
+  pluginsAllowedForComposer,
+  computeToolboxDetailPosition,
+  type TranslateFn,
+  type DesignToolboxResourceKind,
+  type DesignToolboxResourceIndex,
+  type DesignToolboxResourceBase,
+  type DesignToolboxResource,
+  StagedCommentAttachments,
+  ToolsPluginsPanel,
+  ToolsMcpPanel,
+  ToolboxItemRow,
+  ToolsSkillsPanel,
+  ToolsImportPanel,
+  SlashPopover,
+  MentionPopover,
+  DesignToolboxPanel,
+  StagedRunContexts,
+  useComposerModals,
+  type ComposerModalsController,
+  useComposerUpload,
+  type ComposerUploadController,
+  useWiredWorkingDirStatus,
+  type WorkingDirStatusController,
+  useSlashPopover,
+  type SlashPopoverParams,
+  type SlashPopoverController,
+  useCommentAttachments,
+  type CommentAttachmentsParams,
+  type CommentAttachmentsController,
+  useWiredComposerCatalogue,
+  type ComposerCatalogueParams,
+  type ComposerCatalogueController,
+  useWorkspaceContextLinking,
+  type WorkspaceContextLinkingParams,
+  type WorkspaceContextLinkingController,
+  useMentionPopover,
+  type MentionPopoverParams,
+  type MentionPopoverController,
+  useStagedRunContext,
+  type StagedRunContextParams,
+  type StagedRunContextController,
+  useAppliedPlugin,
+  type AppliedPluginParams,
+  type AppliedPluginController,
+  useWiredComposerDraft,
+  type ComposerDraftParams,
+  type ComposerDraftController,
+  designToolboxResourceTracking,
+  inlineBackedPluginFromRestoredDraft,
+  composerSendGate,
+  expandHatchCommand,
+  expandSearchCommand,
+  trackComposerBar as trackComposerBarImpl,
+  trackDesignToolbox as trackDesignToolboxImpl,
+  duplicatePluginRecordAsProject as duplicatePluginRecordAsProjectImpl,
+  handleEditorChange as handleEditorChangeImpl,
+  applyDesignToolboxAction as applyDesignToolboxActionImpl,
+  applyDesignToolboxSkill as applyDesignToolboxSkillImpl,
+  applyDesignToolboxResource as applyDesignToolboxResourceImpl,
+  setWorkingDirFolder as setWorkingDirFolderImpl,
+  handlePickWorkingDir as handlePickWorkingDirImpl,
+  clearWorkingDir as clearWorkingDirImpl,
+  pickSlash as pickSlashAction,
+  tryHandleMcpSlash as tryHandleMcpSlashAction,
+  tryHandlePetSlash as tryHandlePetSlashAction,
+  appendContextAttachment as appendContextAttachmentImpl,
+  uploadFiles as uploadFilesImpl,
+  addAssetsFromLibrary as addAssetsFromLibraryImpl,
+  handlePasteFiles as handlePasteFilesImpl,
+  handleDrop as handleDropImpl,
+  removeStaged as removeStagedImpl,
+  handleAnnotationEvent as handleAnnotationEventImpl,
+  flushDeferredAnnotationSend as flushDeferredAnnotationSendImpl,
+  handleReferenceProjects as handleReferenceProjectsImpl,
+  handleLinkLocalCodeContext as handleLinkLocalCodeContextImpl,
+  removeWorkspaceContext as removeWorkspaceContextImpl,
+  submit as submitImpl,
+  type DesignToolboxApplyDeps,
+  type WorkingDirActionDeps,
+  type PickSlashDeps,
+  type UploadActionDeps,
+  type AnnotationActionDeps,
+  type DeferredAnnotationSendDeps,
+  type ReferenceProjectsDeps,
+  type LinkLocalCodeContextDeps,
+  type RemoveWorkspaceContextDeps,
+  type EditorChangeDeps,
+  type SendActionDeps,
+  type ChatSendMeta,
+} from '../features/chat-composer';
 
 type ToolsTab = 'plugins' | 'skills' | 'mcp' | 'import';
-
-type MentionTab = 'all' | 'tabs' | 'files' | 'plugins' | 'skills' | 'mcp' | 'connectors';
-
-const USER_PLUGIN_SOURCE_KINDS = new Set<PluginSourceKind>([
-  'user',
-  'project',
-  'marketplace',
-  'github',
-  'url',
-  'local',
-]);
-
-interface SlashCommand {
-  id: string;
-  // Visible label, e.g. `/hatch`. Shown in the popover row.
-  label: string;
-  // Text inserted into the draft when the user picks the entry. The
-  // cursor is positioned at the end of `insert`, so a trailing space
-  // is the difference between a "ready for argument" command and a
-  // "submit immediately" one.
-  insert: string;
-  // i18n key of the short description shown next to the label.
-  descKey: keyof Dict;
-  // Optional argument hint shown after the description.
-  argHint?: string;
-  // Icon glyph from the project Icon set.
-  icon: 'sparkles' | 'eye' | 'sliders';
-}
-
-type DesignToolboxResourceKind =
-  | 'skill'
-  | 'plugin'
-  | 'mcp'
-  | 'mcp-template'
-  | 'connector'
-  | 'file';
-
-interface DesignToolboxResourceIndex {
-  skills: SkillSummary[];
-  plugins: InstalledPluginRecord[];
-  mcpServers: McpServerConfig[];
-  mcpTemplates: McpTemplate[];
-  connectors: ConnectorDetail[];
-  projectFiles: ProjectFile[];
-}
-
-type DesignToolboxResourceBase = {
-  key: string;
-  kind: DesignToolboxResourceKind;
-  id: string;
-  title: string;
-  subtitle: string;
-  badge: string;
-  icon: IconName;
-  searchText: string;
-};
-
-type DesignToolboxResource =
-  | (DesignToolboxResourceBase & { kind: 'skill'; skill: SkillSummary })
-  | (DesignToolboxResourceBase & { kind: 'plugin'; plugin: InstalledPluginRecord })
-  | (DesignToolboxResourceBase & { kind: 'mcp'; server: McpServerConfig })
-  | (DesignToolboxResourceBase & { kind: 'mcp-template'; template: McpTemplate })
-  | (DesignToolboxResourceBase & { kind: 'connector'; connector: ConnectorDetail })
-  | (DesignToolboxResourceBase & { kind: 'file'; file: ProjectFile });
 
 interface Props {
   projectId: string | null;
@@ -352,28 +346,11 @@ export interface ChatComposerHandle {
   openDesignToolbox: () => void;
 }
 
-export interface ChatSendMeta {
-  queueOnly?: boolean;
-  research?: ResearchOptions;
-  context?: RunContextSelection;
-  appliedPluginSnapshot?: AppliedPluginSnapshot;
-  appliedPluginSnapshotId?: string;
-  inlineAppliedPlugin?: {
-    pluginId: string;
-    label: string;
-  };
-  // Per-turn skill ids picked via the @-mention popover. The chat layer
-  // forwards these to the daemon's `skillIds` field so the system prompt
-  // for this run only is composed with the extra skill bodies, without
-  // touching the project's persistent `skillId`.
-  skillIds?: string[];
-  /** Overrides the run_created / run_finished `entry_from` analytics prop for
-   *  this send (e.g. 'mark' when the turn is sent from the Mark draw overlay).
-   *  Behavior never depends on it; it only shapes PostHog props. */
-  entryFrom?: ChatAnalyticsEntryFrom;
-  /** One-shot run mode override for seeded follow-ups before parent state catches up. */
-  sessionMode?: ChatSessionMode;
-}
+// Defined in the slice (features/chat-composer/types.ts) so rules.ts/
+// actions.ts can reference it too; re-exported here so ChatComposer.tsx
+// stays the public import path (ProjectView, SideChatTab import it from
+// './ChatComposer').
+export type { ChatSendMeta };
 
 /**
  * The chat composer: textarea + paste/drop/attach buttons + @-mention
@@ -384,7 +361,27 @@ export interface ChatSendMeta {
  * Selecting one inserts `@<path>` into the prompt and stages it as an
  * attachment so the daemon also includes it explicitly.
  */
-export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
+// Injectable hooks for the orchestrator. Each defaults to its wired hook (or,
+// for the no-port pure-state hooks, the hook itself), so production callers
+// pass nothing while tests swap a hook for a fake and render the orchestrator
+// directly instead of mocking modules. Per-hook injection (not one bag) keeps
+// each seam independently overridable, matching `MemorySection.tsx`'s
+// `MemorySectionHooks` pattern.
+interface ChatComposerHooks {
+  useModals?: () => ComposerModalsController;
+  useUpload?: () => ComposerUploadController;
+  useWorkingDir?: () => WorkingDirStatusController;
+  useSlash?: (params: SlashPopoverParams) => SlashPopoverController;
+  useComments?: (params: CommentAttachmentsParams) => CommentAttachmentsController;
+  useCatalogue?: (params: ComposerCatalogueParams) => ComposerCatalogueController;
+  useWorkspaceContext?: (params: WorkspaceContextLinkingParams) => WorkspaceContextLinkingController;
+  useMention?: (params: MentionPopoverParams) => MentionPopoverController;
+  useStagedRunContext?: (params: StagedRunContextParams) => StagedRunContextController;
+  useAppliedPlugin?: (params: AppliedPluginParams) => AppliedPluginController;
+  useDraft?: (params: ComposerDraftParams) => ComposerDraftController;
+}
+
+export const ChatComposer = forwardRef<ChatComposerHandle, Props & ChatComposerHooks>(
   function ChatComposer(
     {
       projectId,
@@ -433,27 +430,70 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       leadingAccessory,
       designSystemPicker,
       onShowToast,
+      useModals = useComposerModals,
+      useUpload = useComposerUpload,
+      useWorkingDir = useWiredWorkingDirStatus,
+      useSlash = useSlashPopover,
+      useComments = useCommentAttachments,
+      useCatalogue = useWiredComposerCatalogue,
+      useWorkspaceContext = useWorkspaceContextLinking,
+      useMention = useMentionPopover,
+      useStagedRunContext: useStagedRunContextHook = useStagedRunContext,
+      useAppliedPlugin: useAppliedPluginHook = useAppliedPlugin,
+      useDraft = useWiredComposerDraft,
     },
     ref
   ) {
     const { locale, t } = useI18n();
     const analytics = useAnalytics();
+    // Portal target for the slice's dumb components (DesignToolboxPanel's
+    // hover-detail, StagedRunContexts' attachment preview) — resolved once
+    // here so those components stay DOM-free, matching the
+    // `MemoryAdvancedModal` canary's `modalHost` pattern.
+    const modalHost = typeof document === 'undefined' ? null : document.body;
+    // Attachment thumbnails preview in a portal modal. State lives here (not a
+    // feature hook) because the Escape-to-close `keydown` listener is an
+    // accumulating browser subscription — it belongs to this single-instance
+    // orchestrator, not to a per-mount feature hook.
+    const [stagedPreview, setStagedPreview] = useState<ChatAttachment | null>(null);
+    const stagedPreviewUrl = stagedPreview && projectId ? projectRawUrl(projectId, stagedPreview.path) : null;
+    useEffect(() => {
+      if (!stagedPreview) return;
+      function onKey(e: KeyboardEvent) {
+        if (e.key === 'Escape') setStagedPreview(null);
+      }
+      window.addEventListener('keydown', onKey);
+      return () => window.removeEventListener('keydown', onKey);
+    }, [stagedPreview]);
+    const resolveStagedImageUrl = useCallback(
+      (path: string) => (projectId ? projectRawUrl(projectId, path) : null),
+      [projectId],
+    );
     const activeFileContext =
       projectMetadata?.importedFrom === 'folder' && activeProjectFileName
         ? activeProjectFileName
         : null;
     const activeFileDisplayName = activeFileContext ? lastPathSegment(activeFileContext) : null;
-    const [draft, setDraft] = useState(() => initialDraft ?? loadComposerDraft(draftStorageKey) ?? "");
-    const [placeholderScenario, setPlaceholderScenario] = useState<PlaceholderScenario | null>(null);
+    // The Lexical editor handle — drives text/mention/clear/focus from the
+    // host. Replaces the old textareaRef + manual selection plumbing. IME
+    // composition guarding now lives inside the editor's command handlers.
+    // Declared here (rather than alongside the other composer refs below) so
+    // it's available for the draft hook call right after, which needs it for
+    // `replaceEditorDraft`/`insertInlineMentionSeparator`.
+    const editorRef = useRef<LexicalComposerInputHandle | null>(null);
+    const {
+      draft,
+      setDraft,
+      draftRef,
+      seededRef,
+      placeholderScenario,
+      setPlaceholderScenario,
+      replaceEditorDraft,
+      insertInlineMentionSeparator,
+      clearDraft,
+    } = useDraft({ initialDraft, draftStorageKey, editorRef });
     const composerRootRef = useRef<HTMLDivElement | null>(null);
     const pendingSessionModeRef = useRef<ChatSessionMode | null>(null);
-    // Synchronous mirror of `draft`. Event handlers that mutate the draft off
-    // a captured render closure (notably the annotation listener, where two
-    // uploads can resolve concurrently) read/write this ref so their edits
-    // compose instead of clobbering one another. Kept in lockstep with `draft`
-    // by handleEditorChange (the editor is the single source for typing) and by
-    // the programmatic-set paths below.
-    const draftRef = useRef(draft);
     const previousSessionModeRef = useRef(sessionMode);
 
     useEffect(() => {
@@ -468,115 +508,90 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     // conversation switches) so the event measures real chat-panel
     // entries rather than ChatComposer remounts. See PR #2285 review
     // 2026-05-20 04:08 for the rationale.
-    const [staged, setStaged] = useState<ChatAttachment[]>([]);
-    const nextAttachmentOrderRef = useRef(0);
-    const [libraryPickerOpen, setLibraryPickerOpen] = useState(false);
-    const [figmaModalOpen, setFigmaModalOpen] = useState(false);
-    const [figmaHelpOpen, setFigmaHelpOpen] = useState(false);
-    const [projectReferenceOpen, setProjectReferenceOpen] = useState(false);
-    const [stagedVisualComments, setStagedVisualComments] = useState<ChatCommentAttachment[]>([]);
-    const streamingAnnotationSendPendingRef = useRef(false);
-    // Remembers the entry_from that the deferred streaming send must carry once
-    // it flushes. The Mark draw-overlay tags 'mark' synchronously; without this
-    // the flush effect would report the run as the default composer entry.
-    const streamingAnnotationSendEntryFromRef = useRef<ChatSendMeta['entryFrom']>(undefined);
-    const [streamingAnnotationSendPending, setStreamingAnnotationSendPendingState] = useState(false);
-    // Skills the user has @-mentioned for this turn. We dedupe on id and
-    // strip the chip when the user removes the corresponding `@<skill>`
-    // token from the draft, keeping draft and chips in sync.
-    const [stagedSkills, setStagedSkills] = useState<SkillSummary[]>([]);
+    const modals = useModals();
+    const {
+      stagedVisualComments,
+      setStagedVisualComments,
+      streamingAnnotationSendPending,
+      streamingAnnotationSendPendingRef,
+      setStreamingAnnotationSendPending,
+      streamingAnnotationSendEntryFromRef,
+      currentCommentAttachments,
+      removeCommentAttachment,
+    } = useComments({ commentAttachments, onRemoveCommentAttachment });
     // Legacy standalone design-toolbox popover. The next-step card now renders
     // its own cascading skill menu, so nothing opens this anymore; kept compiling
     // behind `openDesignToolbox` until the panel subsystem is removed wholesale.
     const [designToolboxOpen, setDesignToolboxOpen] = useState(false);
-    const [stagedMcpServers, setStagedMcpServers] = useState<McpServerConfig[]>([]);
-    const [stagedConnectors, setStagedConnectors] = useState<ConnectorDetail[]>([]);
+    // stagedSkills/stagedMcpServers/stagedConnectors — the skills/MCP-servers/
+    // connectors the user has @-mentioned or applied for this turn — now come
+    // from useStagedRunContext (called below, once trackComposerBar exists).
     const linkedDirs = projectMetadata?.linkedDirs ?? [];
-    const [stagedWorkspaceContexts, setStagedWorkspaceContexts] = useState<WorkspaceContextItem[]>(
-      () => dedupeWorkspaceContextItems(initialWorkspaceContexts),
-    );
-    const [workspaceLinkedDirAdds, setWorkspaceLinkedDirAdds] = useState<Record<string, TrackedWorkspaceLinkedDir>>(
-      () => trackedWorkspaceLinkedDirsForContexts(initialWorkspaceContexts, linkedDirs),
-    );
-    const [promotedWorkspaceContextDir, setPromotedWorkspaceContextDir] = useState<string | null>(null);
-    const [dismissedWorkspaceContextId, setDismissedWorkspaceContextId] = useState<string | null>(null);
-    const activeWorkspaceContextId = activeWorkspaceContext?.id ?? null;
-    const previousWorkspaceContextIdRef = useRef<string | null>(activeWorkspaceContextId);
-    const [dragActive, setDragActive] = useState(false);
-    // Lexical owns the caret, so the mention/slash trigger state only carries
-    // the typed query — no cursor offset.
-    const [mention, setMention] = useState<{ q: string } | null>(null);
-    // Active-row index for the @-popover's visible union (files → tabs →
-    // plugins → skills → mcp → connectors). Resets to 0 whenever the query
-    // identity or tab changes; drives the visual highlight + Enter/Tab target.
-    const [mentionIndex, setMentionIndex] = useState(0);
-    const [mentionTab, setMentionTab] = useState<MentionTab>('all');
-    // Viewport caret box the floating popover anchors against. Sampled by the
-    // editor at trigger-detection time; null when no trigger is live.
-    const [caretRect, setCaretRect] = useState<CaretRect | null>(null);
-    // Slash-command popover state — when the draft starts with `/` and the
-    // cursor is still inside that token (no space committed yet), we show a
-    // small palette of supported commands. The query is the text after `/`
-    // so the user can type-to-filter.
-    const [slash, setSlash] = useState<{ q: string } | null>(null);
-    const [slashIndex, setSlashIndex] = useState(0);
-    const [uploading, setUploading] = useState(false);
-    const [uploadError, setUploadError] = useState<string | null>(null);
-    // External MCP servers configured by the user. Fetched lazily on mount;
-    // shown in the slash-command palette so `/mcp <id>` inserts a hint into
-    // the prompt that nudges the model to use that server's tools.
-    const [mcpServers, setMcpServers] = useState<McpServerConfig[]>([]);
-    const [mcpTemplates, setMcpTemplates] = useState<McpTemplate[]>([]);
-    const [connectors, setConnectors] = useState<ConnectorDetail[]>([]);
-    // Installed plugins, fetched lazily for the tools-menu Plugins tab and
-    // the @-mention picker. Both surfaces share the same list so applying
-    // a plugin from either path lands on the same project context.
-    const [installedPlugins, setInstalledPlugins] = useState<InstalledPluginRecord[]>([]);
-    // Detail modal — opened from a context chip click (kind === 'plugin')
-    // or from the tools-menu "Details" affordance.
-    const [detailsRecord, setDetailsRecord] = useState<InstalledPluginRecord | null>(null);
-    const [detailsSkill, setDetailsSkill] = useState<{
-      id: string;
-      summary?: SkillSummary | null;
-    } | null>(null);
-    const [activeAppliedPlugin, setActiveAppliedPlugin] =
-      useState<AppliedPluginSnapshot | null>(null);
+    const {
+      stagedWorkspaceContexts,
+      setStagedWorkspaceContexts,
+      workspaceLinkedDirAdds,
+      setWorkspaceLinkedDirAdds,
+      promotedWorkspaceContextDir,
+      setPromotedWorkspaceContextDir,
+      dismissedWorkspaceContextId,
+      setDismissedWorkspaceContextId,
+      visibleWorkspaceContext,
+      selectedWorkspaceContexts,
+      selectedWorkspaceContextDirs,
+      workspaceContextMetadataLinkedDirList,
+      workingDir,
+    } = useWorkspaceContext({ activeWorkspaceContext, initialWorkspaceContexts, linkedDirs });
+    const upload = useUpload();
+    const { staged, setStaged, nextAttachmentOrderRef } = upload;
+    // MCP servers/templates, connectors, installed plugins, and the
+    // `composerEngaged` fetch latch — all fetched lazily once the composer is
+    // actually used (first focus, the tools popover opening, an @/slash
+    // trigger, or a pre-seeded draft). Called here (rather than lower,
+    // alongside the other design-toolbox catalogue memos) so `mcpServers` is
+    // already defined for the `useSlashPopover` call right below, which needs
+    // the raw (unfiltered) list.
+    const catalogue = useCatalogue({
+      projectId,
+      initialEngaged: (draft ?? '').trim().length > 0,
+    });
+    const {
+      mcpServers,
+      mcpTemplates,
+      connectors,
+      installedPlugins,
+      composerEngaged,
+      markComposerEngaged,
+      refreshConnectors,
+    } = catalogue;
+    const slashPopover = useSlash({
+      researchAvailable,
+      t,
+      mcpServers,
+      onOpenMcpSettings,
+    });
+    const { slash, setSlash, slashIndex, setSlashIndex, filteredSlash } = slashPopover;
     const pluginsSectionRef = useRef<PluginsSectionHandle | null>(null);
-    const inlineBackedPluginRef = useRef<{ id: string; label: string } | null>(null);
-    async function duplicateDetailsPlugin(record: InstalledPluginRecord) {
-      try {
-        const result = await duplicatePluginAsProject(record.id, {
-          name: localizePluginTitle(locale, record),
-        });
-        setDetailsRecord(null);
-        navigate({
-          kind: 'project',
-          projectId: result.projectId,
-          conversationId: result.conversationId,
-          fileName: result.relPath,
-        });
-      } catch {
-        onShowToast?.(t('pluginCard.duplicateFailed'));
-      }
-    }
+    const clearPluginsSection = useCallback(() => pluginsSectionRef.current?.clear(), []);
+    const {
+      activeAppliedPlugin,
+      setActiveAppliedPlugin,
+      inlineBackedPluginRef,
+      setInlineBackedPlugin,
+      handlePluginApplied,
+      handlePluginCleared,
+      removeAppliedPlugin,
+    } = useAppliedPluginHook({ draft, setDraft, clearPluginsSection });
     // Consolidated "tools" popover — a single dropdown anchored to the
     // leading sliders icon that hosts project context, MCP, Import actions,
     // and a shortcut to open the full Settings dialog. Replaces the previous
     // row of three standalone buttons (which overflowed in narrow chats).
     // The "+" menu (ComposerPlusMenu) owns its own open / submenu state.
-    // Defer the (large) plugin / MCP / connector fetches until the composer is
-    // actually used — first focus, the tools popover opening, an @/slash
-    // trigger, or a pre-seeded draft. An untouched empty composer (e.g. a home
-    // surface the user bounces off, or a background chat) never pays for the
-    // full plugin-manifest list. Latches once true and never resets.
-    const [composerEngaged, setComposerEngaged] = useState(
-      () => (draft ?? '').trim().length > 0,
-    );
+    // The `composerEngaged` fetch latch itself (deferring the plugin/MCP/
+    // connector fetches until first focus, the tools popover opening, an
+    // @/slash trigger, or a pre-seeded draft) now lives in the catalogue
+    // hook above; see `markComposerEngaged`.
     const fileInputRef = useRef<HTMLInputElement | null>(null);
-    // The Lexical editor handle — drives text/mention/clear/focus from the
-    // host. Replaces the old textareaRef + manual selection plumbing. IME
-    // composition guarding now lives inside the editor's command handlers.
-    const editorRef = useRef<LexicalComposerInputHandle | null>(null);
     // Always points at the latest `applyDesignToolboxAction` closure so the
     // imperative handle (whose deps array doesn't track `draft`/`t`) never seeds
     // the composer from a stale draft when the next-step card fires an action.
@@ -589,83 +604,17 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     // wins over this pending value.
     const pendingEntryFromRef = useRef<ChatAnalyticsEntryFrom | null>(null);
     const petEnabled = Boolean(onAdoptPet && onTogglePet);
-    const [recentDirs, setRecentDirs] = useState<string[]>([]);
-    useEffect(() => {
-      let cancelled = false;
-      void fetchRecentLinkedDirs().then((dirs) => {
-        if (!cancelled) setRecentDirs(dirs);
-      });
-      return () => {
-        cancelled = true;
-      };
-    }, []);
-    const rememberRecentDir = useCallback(async (dir: string) => {
-      setRecentDirs((prev) => [dir, ...prev.filter((d) => d !== dir)].slice(0, 5));
-      const persisted = await pushRecentLinkedDir(dir);
-      setRecentDirs(persisted);
-    }, []);
-    const visibleWorkspaceContext =
-      activeWorkspaceContext && activeWorkspaceContext.id !== dismissedWorkspaceContextId
-        ? activeWorkspaceContext
-        : null;
-    const selectedWorkspaceContexts = useMemo(() => {
-      const out: WorkspaceContextItem[] = [];
-      const seen = new Set<string>();
-      const push = (item: WorkspaceContextItem | null | undefined) => {
-        if (!item) return;
-        const key = `${item.kind}:${item.id}`;
-        if (seen.has(key)) return;
-        seen.add(key);
-        out.push(item);
-      };
-      push(visibleWorkspaceContext);
-      for (const item of stagedWorkspaceContexts) push(item);
-      return out;
-    }, [stagedWorkspaceContexts, visibleWorkspaceContext]);
-    const selectedWorkspaceContextDirs = useMemo<string[]>(
-      () => workspaceContextLinkedDirs(selectedWorkspaceContexts),
-      [selectedWorkspaceContexts],
-    );
-    const workspaceContextMetadataLinkedDirList = useMemo<string[]>(
-      () =>
-        Array.from(new Set([
-          ...Object.values(workspaceLinkedDirAdds).map((tracked) => tracked.dir),
-          ...selectedWorkspaceContextDirs,
-        ])),
-      [selectedWorkspaceContextDirs, workspaceLinkedDirAdds],
-    );
-    const workspaceContextLinkedDirList = useMemo<string[]>(
-      () =>
-        workspaceContextMetadataLinkedDirList.filter((dir) => dir !== promotedWorkspaceContextDir),
-      [promotedWorkspaceContextDir, workspaceContextMetadataLinkedDirList],
-    );
-    const workspaceContextLinkedDirSet = useMemo<Set<string>>(
-      () => new Set(workspaceContextLinkedDirList),
-      [workspaceContextLinkedDirList],
-    );
-    // The project's working directory: the local folder the agent can read
-    // (via `linkedDirs` → `--add-dir`). Shown in the WorkingDirPicker below
-    // the input, mirroring Home. Context-only folders are still linked for
-    // agent read access, but they should not become the displayed primary dir.
-    const workingDir = linkedDirs.find((dir) => !workspaceContextLinkedDirSet.has(dir)) ?? null;
+    const workingDirStatus = useWorkingDir();
     // Live-check whether the selected working directory still exists, so a
     // folder deleted from disk turns the picker red without a page reload.
     // Re-checked when the dir changes, when the window/tab regains focus
     // (e.g. after deleting it in Finder), and when the picker is opened.
-    const [workingDirMissing, setWorkingDirMissing] = useState(false);
-    const checkWorkingDir = useCallback(async () => {
-      if (!workingDir) {
-        setWorkingDirMissing(false);
-        return;
-      }
-      const ok = await dirExists(workingDir);
-      setWorkingDirMissing(!ok);
-    }, [workingDir]);
+    const { checkWorkingDir } = workingDirStatus;
     useEffect(() => {
-      void checkWorkingDir();
-      const onFocus = () => void checkWorkingDir();
+      void checkWorkingDir(workingDir);
+      const onFocus = () => void checkWorkingDir(workingDir);
       const onVisible = () => {
-        if (document.visibilityState === 'visible') void checkWorkingDir();
+        if (document.visibilityState === 'visible') void checkWorkingDir(workingDir);
       };
       window.addEventListener('focus', onFocus);
       document.addEventListener('visibilitychange', onVisible);
@@ -673,149 +622,33 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         window.removeEventListener('focus', onFocus);
         document.removeEventListener('visibilitychange', onVisible);
       };
-    }, [checkWorkingDir]);
-    // initialDraft is only honored on the first non-empty value the parent
-    // hands us. After we seed once, the composer is fully under user control
-    // — re-renders that pass the same prompt back must not reseed. If the
-    // initial useState above already consumed a non-empty initialDraft we
-    // mark it seeded immediately, so an early clear by the user (typing or
-    // backspace before the parent stops passing initialDraft) does not get
-    // overwritten by the effect.
-    const seededRef = useRef(Boolean(initialDraft));
-
-    useEffect(() => {
-      if (seededRef.current) return;
-      if (initialDraft && initialDraft !== draft) {
-        setDraft(initialDraft);
-        seededRef.current = true;
-      } else if (initialDraft === undefined) {
-        seededRef.current = true;
-      }
-    }, [initialDraft, draft]);
-
-    useEffect(() => {
-      saveComposerDraft(draftStorageKey, draft);
-    }, [draftStorageKey, draft]);
-
-    useEffect(() => {
-      if (previousWorkspaceContextIdRef.current === activeWorkspaceContextId) return;
-      previousWorkspaceContextIdRef.current = activeWorkspaceContextId;
-      setDismissedWorkspaceContextId(null);
-      setPromotedWorkspaceContextDir(null);
-    }, [activeWorkspaceContextId]);
-
-    // Latch `composerEngaged` true on the first real interaction so the
-    // deferred fetches below run exactly once, when they are actually needed.
-    useEffect(() => {
-      if (composerEngaged) return;
-      if (draft.trim().length > 0 || mention || slash) {
-        setComposerEngaged(true);
-      }
-    }, [composerEngaged, draft, mention, slash]);
-
-    // Lazy-fetch the user's external MCP servers list (once engaged) so the
-    // `/mcp …` slash palette and the composer's MCP button popover have
-    // something to render. We deliberately do not reactively re-fetch when
-    // the user toggles servers from Settings — the dialog refreshes itself,
-    // and the chat composer rehydrates next time the user re-opens it. A
-    // background poll would be cheap but unnecessary for the typical
-    // edit-once-then-chat workflow.
-    useEffect(() => {
-      if (!composerEngaged) return;
-      let cancelled = false;
-      void (async () => {
-        const data = await fetchMcpServers();
-        if (cancelled || !data) return;
-        setMcpServers(data.servers);
-        setMcpTemplates(data.templates);
-      })();
-      return () => {
-        cancelled = true;
-      };
-    }, [composerEngaged]);
-
+    }, [checkWorkingDir, workingDir]);
     // Skills now come from the parent (App.tsx → ProjectView → ChatPane → ChatComposer)
     // pre-filtered by enabled/disabled state. We no longer fetch a fresh list
     // here to avoid showing skills the user has disabled via Settings.
 
-    // Lazy-fetch installed plugins once on mount; the tools-menu Plugins
-    // tab and the @-mention picker both consume this list.
-    useEffect(() => {
-      if (!projectId || !composerEngaged) return;
-      let cancelled = false;
-      void listPlugins().then((rows) => {
-        if (cancelled) return;
-        setInstalledPlugins(rows);
-      });
-      return () => {
-        cancelled = true;
-      };
-    }, [projectId, composerEngaged]);
-
+    // The MCP servers/templates, installed-plugins, and connector-catalogue
+    // fetches (each gated on `composerEngaged`) now live in the catalogue
+    // hook above. This effect keeps only the connectors-changed
+    // subscription: `listenForConnectorsChanged` is an ACCUMULATING
+    // `window`/event listener, so per the slice's effect-placement rule it
+    // stays here (a guaranteed single instance) rather than inside the hook,
+    // which just exposes `refreshConnectors` for it to call.
     useEffect(() => {
       if (!composerEngaged) return;
-      let cancelled = false;
-      void fetchConnectorCatalogSnapshot().then((rows) => {
-        if (cancelled) return;
-        setConnectors(rows.filter((connector) => connector.status === 'connected'));
-      });
-      return () => {
-        cancelled = true;
-      };
-    }, [composerEngaged]);
+      return listenForConnectorsChanged(() => void refreshConnectors());
+    }, [composerEngaged, refreshConnectors]);
 
-    useEffect(() => {
-      if (!composerEngaged) return;
-      let cancelled = false;
-      async function refreshConnectors() {
-        const rows = await fetchConnectorCatalogSnapshot({ refreshDiscovery: true });
-        if (cancelled) return;
-        setConnectors(rows.filter((connector) => connector.status === 'connected'));
-      }
-      const stopListening = listenForConnectorsChanged(() => void refreshConnectors());
-      return () => {
-        cancelled = true;
-        stopListening();
-      };
-    }, [composerEngaged]);
-
-    useEffect(() => {
-      const inlinePlugin = inlineBackedPluginRef.current;
-      if (!activeAppliedPlugin || inlinePlugin?.id !== activeAppliedPlugin.pluginId) return;
-      if (mentionTokenPresent(draft, inlinePlugin.label)) return;
-      inlineBackedPluginRef.current = null;
-      pluginsSectionRef.current?.clear();
-    }, [activeAppliedPlugin, draft]);
-
-    // Composer-side plugin list: hide bundled atoms (pipeline-only). Keep
-    // the full installed list available even when the project was created
-    // from a pinned plugin, so users can switch or layer different plugin
-    // context from the tools menu and @ picker.
-    const pluginsForComposer = useMemo<InstalledPluginRecord[]>(() => {
-      const allowedKinds = new Set(['skill', 'scenario', 'bundle']);
-      return installedPlugins.filter((p) => {
-        const k = p.manifest?.od?.kind;
-        return !k || allowedKinds.has(k);
-      });
-    }, [installedPlugins]);
+    const pluginsForComposer = useMemo(
+      () => pluginsAllowedForComposer(installedPlugins),
+      [installedPlugins],
+    );
 
     const enabledMcpServers = useMemo(
       () => mcpServers.filter((s) => s.enabled),
       [mcpServers],
     );
 
-    function inlineBackedPluginFromRestoredDraft(
-      text: string,
-      appliedPlugin: AppliedPluginSnapshot | null | undefined,
-      meta: ChatSendMeta | undefined,
-    ): { id: string; label: string } | null {
-      if (!appliedPlugin) return null;
-      const restoredInline = meta?.inlineAppliedPlugin;
-      if (restoredInline?.pluginId !== appliedPlugin.pluginId) return null;
-      return mentionTokenPresent(text, restoredInline.label)
-        ? { id: appliedPlugin.pluginId, label: restoredInline.label }
-        : null;
-    }
 
     const designToolboxResourceIndex = useMemo<DesignToolboxResourceIndex>(
       () => ({
@@ -828,188 +661,18 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       }),
       [connectors, enabledMcpServers, mcpTemplates, pluginsForComposer, projectFiles, skills],
     );
-    const composerMentionEntities = useMemo(
-      () =>
-        buildComposerMentionEntities({
-          connectors,
-          files: projectFiles,
-          mcpServers: enabledMcpServers,
-          plugins: pluginsForComposer,
-          skills,
-          staged,
-          workspaceContexts: selectedWorkspaceContexts,
-        }),
-      [connectors, enabledMcpServers, pluginsForComposer, projectFiles, selectedWorkspaceContexts, skills, staged],
-    );
     // Resolve which tabs to surface in the consolidated tools popover.
     // Plugins is always visible while a project is active so users can
     // apply context without leaving the composer. MCP shows when wired by
-    // Catalog of supported slash commands. Each entry shows up in the
-    // popover when the user types `/` in the composer. The `insert`
-    // value is what we drop into the draft when the user picks the
-    // entry — usually the canonical command form with a trailing space
-    // ready for an argument.
-    const slashCommands = useMemo<SlashCommand[]>(() => {
-      const list: SlashCommand[] = [];
-      // External MCP servers — `/mcp` opens settings, `/mcp <id>` inserts a
-      // prompt-side hint nudging the model to use that server's tools. The
-      // hint flows through to the agent verbatim; the daemon already wired
-      // the MCP config into the agent's launch so the tools are callable.
-      if (onOpenMcpSettings) {
-        list.push({
-          id: 'mcp',
-          label: '/mcp',
-          insert: '/mcp ',
-          descKey: 'pet.slashPet',
-          icon: 'sliders',
-          argHint: 'open settings · <server-id> to insert hint',
-        });
-      }
-      for (const s of enabledMcpServers) {
-        list.push({
-          id: `mcp-${s.id}`,
-          label: `/mcp ${s.id}`,
-          insert: `Use the \`${s.id}\` MCP server tools. `,
-          descKey: 'pet.slashPet',
-          icon: 'sparkles',
-          argHint: s.label || s.transport,
-        });
-      }
-      if (researchAvailable) {
-        list.push({
-          id: 'search',
-          label: '/search',
-          insert: '/search ',
-          descKey: 'pet.slashSearch',
-          icon: 'sparkles',
-          argHint: t('pet.slashSearchArg'),
-        });
-      }
-      return list;
-    }, [researchAvailable, t, enabledMcpServers, onOpenMcpSettings]);
+    // onOpenMcpSettings; see useSlashPopover (called earlier, alongside
+    // mcpServers) for the slash-command catalog.
 
-    const filteredSlash = useMemo(() => {
-      if (!slash) return [] as SlashCommand[];
-      const q = slash.q.toLowerCase();
-      if (!q) return slashCommands;
-      return slashCommands.filter((c) => c.label.toLowerCase().includes(q));
-    }, [slash, slashCommands]);
-
-    function pickSlash(cmd: SlashCommand) {
-      if (!slash) return;
-      // Replace the in-flight `/<query>` trigger with the picked command's
-      // canonical insertion text. Lexical owns the caret afterwards.
-      editorRef.current?.replaceActiveTrigger(cmd.insert);
-      editorRef.current?.focus();
-      setSlash(null);
-    }
-
-    // Expand a `/hatch <concept>` draft into the canonical hatch-pet
-    // skill prompt before sending. Returns null when the draft is not a
-    // hatch command so the caller can fall through to the regular
-    // submit path.
-    function expandHatchCommand(input: string): string | null {
-      const m = /^\/hatch(?:\s+([\s\S]*))?$/i.exec(input.trim());
-      if (!m) return null;
-      const concept = m[1]?.trim() ?? '';
-      const intro = concept
-        ? `Hatch a Codex-compatible animated pet for me. Concept: ${concept}.`
-        : 'Hatch a Codex-compatible animated pet for me.';
-      return [
-        intro,
-        '',
-        'Use the @hatch-pet skill end-to-end:',
-        '1. Generate the base look with $imagegen.',
-        '2. Generate every row strip (idle, running-right, waving, jumping, failed, waiting, running, review).',
-        '3. Mirror running-left from running-right only when the design is symmetric.',
-        '4. Run the deterministic scripts (extract / compose / validate / contact-sheet / videos).',
-        '5. Package the result into ${CODEX_HOME:-$HOME/.codex}/pets/<pet-name>/ with pet.json + spritesheet.webp.',
-        '',
-        'When the spritesheet is saved, tell me the absolute path and the pet folder name. I will adopt it from Settings → Pets → Recently hatched.',
-      ].join('\n');
-    }
-
-    // `/mcp` (no arg) opens settings on the External MCP tab — pure UX hook,
-    // never sent to the agent. `/mcp <id>` is intentionally NOT intercepted
-    // here: the slash palette already replaces it with a natural-language
-    // hint sentence ("Use the `<id>` MCP server tools."), and the user is
-    // expected to keep typing the rest of the prompt before sending.
-    function tryHandleMcpSlash(): boolean {
-      if (!onOpenMcpSettings) return false;
-      const trimmed = draft.trim();
-      if (!/^\/mcp\s*$/i.test(trimmed)) return false;
-      onOpenMcpSettings();
-      setDraft('');
-      editorRef.current?.clear();
-      return true;
-    }
-
-    function expandSearchCommand(input: string): { prompt: string; query: string } | null {
-      const m = /^\/search(?:\s+([\s\S]*))?$/i.exec(input.trim());
-      if (!m) return null;
-      const query = m[1]?.trim() ?? '';
-      if (!query) return null;
-      return {
-        query,
-        prompt: [
-          `Search for: ${query}`,
-          '',
-          'Before answering, your first tool action must be the OD research command for your shell.',
-          'POSIX: "$OD_NODE_BIN" "$OD_BIN" research search --query "<search query>" --max-sources 5',
-          'PowerShell: & $env:OD_NODE_BIN $env:OD_BIN research search --query "<search query>" --max-sources 5',
-          'cmd.exe: "%OD_NODE_BIN%" "%OD_BIN%" research search --query "<search query>" --max-sources 5',
-          'Use the canonical query below as the exact search query, with safe quoting for your shell.',
-          '',
-          'Canonical query:',
-          '',
-          '```text',
-          query.replace(/```/g, '`\u200b`\u200b`'),
-          '```',
-          'If the OD command fails because Tavily is not configured or unavailable, report that error, then use your own search capability as fallback and label the fallback clearly.',
-          'After the command returns JSON or fallback search results, write a reusable Markdown report into Design Files at `research/<safe-query-slug>.md` or another fresh project-relative path.',
-          'The report must include the query, fetched time, short summary, key findings, source list with [1], [2] citations, and a note that source content is external untrusted evidence.',
-          'Then summarize the findings with citations by source index and mention the Markdown report path.',
-        ].join('\n'),
-      };
-    }
-
-    // Parse a `/pet [arg]` slash command out of the draft. Recognized
-    // forms: `/pet` (toggle wake/tuck), `/pet wake`, `/pet tuck`,
-    // `/pet adopt` (open settings), or `/pet <id>` to adopt a built-in
-    // by id. The slash is stripped from the draft on a successful match
-    // so the user does not accidentally send the command to the agent.
-    function tryHandlePetSlash(): boolean {
-      if (!petEnabled) return false;
-      const trimmed = draft.trim();
-      const match = /^\/pet(?:\s+(\S+))?$/i.exec(trimmed);
-      if (!match) return false;
-      const arg = match[1]?.toLowerCase();
-      if (!arg || arg === 'toggle') {
-        onTogglePet?.();
-      } else if (arg === 'wake' || arg === 'show') {
-        if (petConfig?.adopted) {
-          if (!petConfig.enabled) onTogglePet?.();
-        } else {
-          onOpenPetSettings?.();
-        }
-      } else if (arg === 'tuck' || arg === 'hide') {
-        if (petConfig?.enabled) onTogglePet?.();
-      } else if (arg === 'adopt' || arg === 'settings' || arg === 'change') {
-        onOpenPetSettings?.();
-      } else if (arg === CUSTOM_PET_ID) {
-        onAdoptPet?.(CUSTOM_PET_ID);
-      } else {
-        const pet = BUILT_IN_PETS.find((p) => p.id === arg);
-        if (pet) {
-          onAdoptPet?.(pet.id);
-        } else {
-          return false;
-        }
-      }
-      setDraft('');
-      editorRef.current?.clear();
-      return true;
-    }
+    const pickSlashDeps: PickSlashDeps = {
+      slash,
+      setSlash,
+      replaceActiveTrigger: (text) => editorRef.current?.replaceActiveTrigger(text),
+      focusEditor: () => editorRef.current?.focus(),
+    };
 
     useImperativeHandle(
       ref,
@@ -1064,7 +727,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
             restoredAppliedPlugin,
             meta,
           );
-          setUploadError(null);
+          upload.setUploadError(null);
           setMention(null);
           setSlash(null);
           editorRef.current?.setText(text);
@@ -1085,888 +748,132 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           applyDesignToolboxSkillByIdRef.current(skillId);
         },
         openDesignToolbox: () => {
-          setComposerEngaged(true);
+          markComposerEngaged();
           setDesignToolboxOpen(true);
         },
       }),
-      [connectors, mcpServers, pluginsForComposer, skills]
+      [connectors, mcpServers, pluginsForComposer, skills, markComposerEngaged]
     );
-
-    function reset() {
-      pendingEntryFromRef.current = null;
-      pendingSessionModeRef.current = null;
-      const linkedWorkspaceContexts = stagedWorkspaceContexts.filter((item) => (
-        Boolean(item.absolutePath?.trim()) && Boolean(workspaceLinkedDirAdds[item.id])
-      ));
-      const linkedWorkspaceContextIds = new Set(linkedWorkspaceContexts.map((item) => item.id));
-      const nextWorkspaceLinkedDirAdds = Object.fromEntries(
-        Object.entries(workspaceLinkedDirAdds).filter(([id]) => linkedWorkspaceContextIds.has(id)),
-      );
-      setDraft("");
-      setStaged([]);
-      nextAttachmentOrderRef.current = 0;
-      setStagedVisualComments([]);
-      setStagedSkills([]);
-      setStagedMcpServers([]);
-      setStagedConnectors([]);
-      setStagedWorkspaceContexts(linkedWorkspaceContexts);
-      setWorkspaceLinkedDirAdds(nextWorkspaceLinkedDirAdds);
-      if (
-        promotedWorkspaceContextDir &&
-        !linkedWorkspaceContexts.some((item) => item.absolutePath?.trim() === promotedWorkspaceContextDir)
-      ) {
-        setPromotedWorkspaceContextDir(null);
-      }
-      pluginsSectionRef.current?.clear();
-      inlineBackedPluginRef.current = null;
-      setActiveAppliedPlugin(null);
-      setUploadError(null);
-      setMention(null);
-      setMentionTab('all');
-      setSlash(null);
-      editorRef.current?.clear();
-    }
-
-    function currentCommentAttachments(extra: ChatCommentAttachment[] = []): ChatCommentAttachment[] {
-      return sortChatCommentAttachmentsByOrder([...commentAttachments, ...stagedVisualComments, ...extra]);
-    }
-
-    function setStreamingAnnotationSendPending(value: boolean) {
-      streamingAnnotationSendPendingRef.current = value;
-      setStreamingAnnotationSendPendingState(value);
-    }
-
-    function currentRunContextMeta(): ChatSendMeta | undefined {
-      const skillIds = stagedSkills.map((s) => s.id);
-      const pluginIds = activeAppliedPlugin ? [activeAppliedPlugin.pluginId] : [];
-      const mcpServerIds = stagedMcpServers.map((s) => s.id);
-      const connectorIds = stagedConnectors.map((c) => c.id);
-      const workspaceItems = selectedWorkspaceContexts;
-      const context: RunContextSelection = {
-        ...(skillIds.length > 0 ? { skillIds } : {}),
-        ...(pluginIds.length > 0 ? { pluginIds } : {}),
-        ...(mcpServerIds.length > 0 ? { mcpServerIds } : {}),
-        ...(connectorIds.length > 0 ? { connectorIds } : {}),
-        ...(workspaceItems.length > 0 ? { workspaceItems } : {}),
-      };
-      const meta: ChatSendMeta = {
-        ...(skillIds.length > 0 ? { skillIds } : {}),
-        ...(activeAppliedPlugin
-          ? {
-              appliedPluginSnapshot: activeAppliedPlugin,
-              appliedPluginSnapshotId: activeAppliedPlugin.snapshotId,
-              ...(inlineBackedPluginRef.current?.id === activeAppliedPlugin.pluginId
-                ? {
-                    inlineAppliedPlugin: {
-                      pluginId: activeAppliedPlugin.pluginId,
-                      label: inlineBackedPluginRef.current.label,
-                    },
-                  }
-                : {}),
-            }
-          : {}),
-        ...(Object.keys(context).length > 0 ? { context } : {}),
-      };
-      return Object.keys(meta).length > 0 ? meta : undefined;
-    }
-
-    function sendComposedTurn(
-      prompt: string,
-      attachments: ChatAttachment[],
-      nextCommentAttachments: ChatCommentAttachment[],
-      meta?: ChatSendMeta,
-    ): boolean {
-      setStreamingAnnotationSendPending(false);
-      if (!prompt && attachments.length === 0 && nextCommentAttachments.length === 0) return false;
-      const nextAttachments =
-        activeFileContext && !attachments.some((attachment) => attachment.path === activeFileContext)
-          ? [
-              {
-                path: activeFileContext,
-                name: activeFileDisplayName ?? activeFileContext,
-                kind: 'file' as const,
-              },
-              ...attachments,
-            ]
-          : attachments;
-      // Apply pending Next-step metadata if the caller didn't set its own
-      // fields, then clear it so it only colors the immediate next send.
-      const pendingEntryFrom = pendingEntryFromRef.current;
-      const pendingSessionMode = pendingSessionModeRef.current;
-      pendingEntryFromRef.current = null;
-      pendingSessionModeRef.current = null;
-      const effectiveMetaShape: ChatSendMeta = {
-        ...(meta ?? {}),
-        ...(pendingEntryFrom && !meta?.entryFrom ? { entryFrom: pendingEntryFrom } : {}),
-        ...(pendingSessionMode && !meta?.sessionMode ? { sessionMode: pendingSessionMode } : {}),
-      };
-      const effectiveMeta =
-        Object.keys(effectiveMetaShape).length > 0 ? effectiveMetaShape : undefined;
-      onSend(prompt, nextAttachments, nextCommentAttachments, effectiveMeta);
-      reset();
-      return true;
-    }
-
-    function queueMeta(meta?: ChatSendMeta): ChatSendMeta {
-      return { ...(meta ?? {}), queueOnly: true };
-    }
-
-    function reserveAttachmentOrders(count: number): number {
-      const orderStart = Math.max(nextAttachmentOrderRef.current, nextChatAttachmentOrder(staged));
-      nextAttachmentOrderRef.current = orderStart + count;
-      return orderStart;
-    }
-
-    function appendOrderedStagedAttachments(attachments: ChatAttachment[]) {
-      if (attachments.length === 0) return;
-      setStaged((current) => {
-        const knownPaths = new Set(current.map((attachment) => attachment.path));
-        const nextAttachments = attachments.filter((attachment) => !knownPaths.has(attachment.path));
-        if (nextAttachments.length === 0) return current;
-        const next = sortChatAttachmentsByOrder([...current, ...nextAttachments]);
-        nextAttachmentOrderRef.current = Math.max(
-          nextAttachmentOrderRef.current,
-          nextChatAttachmentOrder(next),
-        );
-        return next;
-      });
-    }
-
-    function appendContextAttachment(filePath: string) {
-      setStaged((current) => {
-        if (current.some((item) => item.path === filePath)) return current;
-        const order = Math.max(nextAttachmentOrderRef.current, nextChatAttachmentOrder(current));
-        nextAttachmentOrderRef.current = order + 1;
-        return sortChatAttachmentsByOrder([
-          ...current,
-          {
-            path: filePath,
-            name: filePath.split("/").pop() || filePath,
-            kind: looksLikeImage(filePath) ? "image" : "file",
-            order,
-          },
-        ]);
-      });
-    }
-
-    function replaceEditorDraft(text: string) {
-      draftRef.current = text;
-      setDraft(text);
-      editorRef.current?.setText(text);
-    }
-
-    function insertInlineMentionSeparator() {
-      const current = editorRef.current?.getText() ?? draftRef.current;
-      if (current.trim() && !/\s$/.test(current)) {
-        editorRef.current?.insertText(' ');
-      }
-    }
-
-    function appendWorkspacePrompt(item: WorkspaceContextItem) {
-      setStagedWorkspaceContexts((current) =>
-        current.some((candidate) => candidate.id === item.id)
-          ? current
-          : [...current, item],
-      );
-      insertInlineMentionSeparator();
-      editorRef.current?.insertMention({
-        token: inlineMentionToken(item.label),
-        entity: { id: item.id, kind: 'workspace', label: item.label },
-      });
-      setMention(null);
-      setSlash(null);
-      setComposerEngaged(true);
-    }
-
-    async function addLinkedDirs(dirs: string[]): Promise<Map<string, TrackedWorkspaceLinkedDir | null> | false> {
-      if (!projectId) return false;
-      const trimmedDirs = Array.from(new Set(dirs.map((dir) => dir.trim()).filter(Boolean)));
-      if (trimmedDirs.length === 0) return new Map();
-      const base = projectMetadata ?? { kind: 'prototype' as const };
-      const existing = base.linkedDirs ?? [];
-      const nextLinkedDirs = [...existing];
-      const trackedByDir = new Map<string, TrackedWorkspaceLinkedDir | null>();
-      let changed = false;
-      for (const trimmed of trimmedDirs) {
-        if (nextLinkedDirs.includes(trimmed)) {
-          const ownedByWorkspaceContext = Object.values(workspaceLinkedDirAdds).some(
-            (tracked) => tracked.dir === trimmed,
-          );
-          trackedByDir.set(trimmed, ownedByWorkspaceContext ? { dir: trimmed, previousLinkedDirs: existing } : null);
-          continue;
-        }
-        nextLinkedDirs.push(trimmed);
-        trackedByDir.set(trimmed, { dir: trimmed, previousLinkedDirs: existing });
-        changed = true;
-      }
-      if (changed) {
-        const metadata: ProjectMetadata = { ...base, linkedDirs: nextLinkedDirs };
-        const result = await patchProject(projectId, { metadata });
-        if (!result?.metadata) {
-          onShowToast?.(t('homeWorkingDir.applyFailed'));
-          return false;
-        }
-        onProjectMetadataChange?.(result.metadata);
-        for (const trimmed of trimmedDirs) void rememberRecentDir(trimmed);
-      }
-      return trackedByDir;
-    }
-
-    async function addLinkedDir(dir: string): Promise<TrackedWorkspaceLinkedDir | null | false> {
-      const trackedByDir = await addLinkedDirs([dir]);
-      if (trackedByDir === false) return false;
-      return trackedByDir.get(dir.trim()) ?? null;
-    }
-
-    async function handleReferenceProjects(selections: ProjectReferenceSelection[]) {
-      const items = selections.map(({ project, resolvedDir }) => {
-        const path = resolvedDir.trim();
-        return {
-          id: `project:${project.id}`,
-          kind: 'project',
-          label: project.name || project.id,
-          title: project.name || project.id,
-          path: project.id,
-          ...(path ? { absolutePath: path } : {}),
-        } satisfies WorkspaceContextItem;
-      });
-      const trackedByDir = await addLinkedDirs(items.map((item) => workspaceContextLinkedDir(item) ?? ''));
-      if (trackedByDir === false) {
-        trackContextLinkResult(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          context_kind: 'project',
-          result: 'failed',
-          count: items.length,
-          ...(projectId ? { project_id: projectId } : {}),
-        });
-        return;
-      }
-      for (const item of items) {
-        appendWorkspacePrompt(item);
-      }
-      setProjectReferenceOpen(false);
-      trackContextLinkResult(analytics.track, {
-        page_name: 'chat_panel',
-        area: 'chat_composer',
-        context_kind: 'project',
-        result: 'success',
-        count: items.length,
-        ...(projectId ? { project_id: projectId } : {}),
-      });
-      const trackedAdds: Record<string, TrackedWorkspaceLinkedDir> = {};
-      for (const item of items) {
-        const path = workspaceContextLinkedDir(item);
-        const trackedLinkedDir = path ? trackedByDir.get(path) ?? null : null;
-        if (trackedLinkedDir) trackedAdds[item.id] = trackedLinkedDir;
-      }
-      if (Object.keys(trackedAdds).length > 0) {
-        setWorkspaceLinkedDirAdds((current) => ({ ...current, ...trackedAdds }));
-      }
-    }
-
-    async function handleLinkLocalCodeContext() {
-      const selected = await openFolderDialog();
-      if (!selected) {
-        trackContextLinkResult(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          context_kind: 'local_code',
-          result: 'cancelled',
-          ...(projectId ? { project_id: projectId } : {}),
-        });
-        return;
-      }
-      const trackedLinkedDir = await addLinkedDir(selected);
-      if (trackedLinkedDir === false) {
-        trackContextLinkResult(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          context_kind: 'local_code',
-          result: 'failed',
-          ...(projectId ? { project_id: projectId } : {}),
-        });
-        return;
-      }
-      const label = selected.split(/[/\\]/).filter(Boolean).pop() || selected;
-      const item: WorkspaceContextItem = {
-        id: `local-code:${selected}`,
-        kind: 'local-code',
-        label,
-        title: label,
-        absolutePath: selected,
-      };
-      appendWorkspacePrompt(item);
-      if (trackedLinkedDir) {
-        setWorkspaceLinkedDirAdds((current) => ({ ...current, [item.id]: trackedLinkedDir }));
-      }
-      trackContextLinkResult(analytics.track, {
-        page_name: 'chat_panel',
-        area: 'chat_composer',
-        context_kind: 'local_code',
-        result: 'success',
-        count: 1,
-        ...(projectId ? { project_id: projectId } : {}),
-      });
-    }
-
-    async function insertSkillMention(skill: SkillSummary) {
-      const applied = await applyProjectSkill(skill);
-      if (!applied) return;
-      // Stage the skill so it rides this turn's skillIds, then insert an
-      // atomic `@<name>` pill carrying the skill's real id. The onChange
-      // prune keys on `skill:<id>` being present in the editor text, so the
-      // chip survives until the user deletes the pill.
-      setStagedSkills((prev) =>
-        prev.some((s) => s.id === skill.id) ? prev : [...prev, skill],
-      );
-      editorRef.current?.insertMention({
-        token: inlineMentionToken(skill.name),
-        entity: { id: skill.id, kind: 'skill', label: skill.name },
-      });
-      setMention(null);
-    }
-
-    function stageSkillForCurrentTurn(skill: SkillSummary) {
-      setStagedSkills((prev) =>
-        prev.some((s) => s.id === skill.id) ? prev : [...prev, skill],
-      );
-    }
-
-    function applyDesignToolboxPrompt(
-      prompt: string,
-      skill: SkillSummary | null,
-    ) {
-      const nextPrompt = skill
-        ? `${inlineMentionToken(skill.name)}\n${prompt}`
-        : prompt;
-      if (skill) stageSkillForCurrentTurn(skill);
-      applyDesignToolboxDraft(nextPrompt);
-    }
-
-    function applyDesignToolboxDraft(prompt: string) {
-      replaceEditorDraft(prompt);
-      editorRef.current?.focus();
-    }
 
     // Fills the fixed page/area/project context for the rest of the composer
     // bottom bar (plus menu, design-system / working-dir switch, agent
     // selector, context-chip removal).
-    const trackComposerBar = (
+    const trackComposerBar = useCallback((
       fields: Omit<ComposerBarClickProps, 'page_name' | 'area' | 'project_id'>,
     ) => {
-      trackComposerBarClick(analytics.track, {
-        page_name: 'chat_panel',
-        area: 'chat_composer',
-        ...(projectId ? { project_id: projectId } : {}),
-        ...fields,
-      });
-    };
+      trackComposerBarImpl(fields, { track: analytics.track, projectId });
+    }, [analytics.track, projectId]);
 
     // Fills the fixed page/area/project context so toolbox call sites only
     // pass the event-specific fields (element + ids).
-    const trackDesignToolbox = (
+    const trackDesignToolbox = useCallback((
       fields: Omit<DesignToolboxClickProps, 'page_name' | 'area' | 'project_id'>,
     ) => {
-      trackDesignToolboxClick(analytics.track, {
-        page_name: 'chat_panel',
-        area: 'chat_composer',
-        ...(projectId ? { project_id: projectId } : {}),
-        ...fields,
-      });
+      trackDesignToolboxImpl(fields, { track: analytics.track, projectId });
+    }, [analytics.track, projectId]);
+
+    // Called here (rather than alongside the other cluster hooks above)
+    // because its bound remove callbacks need `trackComposerBar`, which
+    // isn't defined until just above this point.
+    const {
+      stagedSkills,
+      setStagedSkills,
+      stagedMcpServers,
+      setStagedMcpServers,
+      stagedConnectors,
+      setStagedConnectors,
+      removeStagedSkill,
+      removeStagedMcpServer,
+      removeStagedConnector,
+    } = useStagedRunContextHook({ draft, replaceEditorDraft, trackComposerBar });
+
+    // Bundles everything the extracted design-toolbox-apply functions
+    // (features/chat-composer/actions.ts) need from this component's scope,
+    // since they're too entangled with draft/editor-ref/staging state to be
+    // pure rules. Recreated each render so it always closes over the latest
+    // draft/context (mirrors the old inline closures' behavior exactly).
+    const designToolboxApplyDeps: DesignToolboxApplyDeps = {
+      skills,
+      visibleWorkspaceContext,
+      draft,
+      resourceIndex: designToolboxResourceIndex,
+      t,
+      setStagedSkills,
+      setStagedMcpServers,
+      setStagedConnectors,
+      replaceEditorDraft,
+      focusEditor: () => editorRef.current?.focus(),
+      appendContextAttachment: (filePath) => appendContextAttachmentImpl(filePath, uploadActionDeps),
+      setInlineBackedPlugin,
+      applyPluginById: async (id, record) => {
+        await pluginsSectionRef.current?.applyById(id, record);
+      },
     };
 
-    // Every toolbox resource carries a common `kind` + `id`, and the tracking
-    // enum mirrors `DesignToolboxResourceKind` exactly, so this is a direct
-    // projection.
-    function designToolboxResourceTracking(resource: DesignToolboxResource): {
-      resource_kind: NonNullable<DesignToolboxClickProps['resource_kind']>;
-      resource_id: string;
-    } {
-      return { resource_kind: resource.kind, resource_id: resource.id };
-    }
-
-    function applyDesignToolboxAction(action: DesignToolboxAction) {
-      const skill = findDesignToolboxSkill(action, skills);
-      applyDesignToolboxPrompt(
-        designToolboxActionPrompt({
-          action,
-          skill,
-          workspaceItem: visibleWorkspaceContext,
-          activeDraft: draft,
-          resourceIndex: designToolboxResourceIndex,
-          t,
-        }),
-        skill,
-      );
-    }
-    // Recreated each render, so this captures the latest draft/context closure
+    // Recreated each render (designToolboxApplyDeps is a fresh object every
+    // render too), so this always captures the latest draft/context closure
     // for the imperative handle (see applyDesignToolboxActionRef).
+    const applyDesignToolboxAction = useCallback((action: DesignToolboxAction) => {
+      applyDesignToolboxActionImpl(action, designToolboxApplyDeps);
+    }, [designToolboxApplyDeps]);
     applyDesignToolboxActionRef.current = applyDesignToolboxAction;
 
-    function applyDesignToolboxSkill(skill: SkillSummary) {
-      applyDesignToolboxPrompt(
-        designToolboxSkillPrompt({
-          skill,
-          workspaceItem: visibleWorkspaceContext,
-          activeDraft: draft,
-          resourceIndex: designToolboxResourceIndex,
-          t,
-        }),
-        skill,
-      );
-    }
+    const applyDesignToolboxSkill = useCallback((skill: SkillSummary) => {
+      applyDesignToolboxSkillImpl(skill, designToolboxApplyDeps);
+    }, [designToolboxApplyDeps]);
     // Latest-closure bridge for the imperative handle (see the ref declaration).
     applyDesignToolboxSkillByIdRef.current = (skillId: string) => {
       const skill = skills.find((s) => s.id === skillId);
       if (skill) applyDesignToolboxSkill(skill);
     };
 
-    function applyDesignToolboxResource(resource: DesignToolboxResource) {
-      if (resource.kind === 'skill') {
-        applyDesignToolboxSkill(resource.skill);
-        return;
-      }
+    const applyDesignToolboxResource = useCallback((resource: DesignToolboxResource) => {
+      applyDesignToolboxResourceImpl(resource, designToolboxApplyDeps);
+    }, [designToolboxApplyDeps]);
 
-      const prompt = designToolboxResourcePrompt({
-        resource,
-        workspaceItem: visibleWorkspaceContext,
-        activeDraft: draft,
-        resourceIndex: designToolboxResourceIndex,
-        t,
-      });
+    // Deps bag for the attachment/upload cluster's extracted functions (see
+    // features/chat-composer/attachment-actions.ts): the staged-attachment
+    // state + order ref, the already-landed upload UI-feedback hook's
+    // setters, project lifecycle + transport (straight through from this
+    // component's existing providers/registry imports, matching the
+    // WorkingDirActionDeps precedent), analytics, the Lexical editor
+    // primitives these functions drive, and the cross-cluster visual-comment
+    // state `removeStaged` also clears. Recreated each render so it always
+    // closes over the latest staged/draft/upload state.
+    const uploadActionDeps: UploadActionDeps = {
+      staged,
+      setStaged,
+      nextAttachmentOrderRef,
+      setUploading: upload.setUploading,
+      setUploadError: upload.setUploadError,
+      setDragActive: upload.setDragActive,
+      projectId,
+      onEnsureProject,
+      uploadProjectFiles,
+      applyLibraryAsset,
+      fetchLibraryAssetElementHtml,
+      track: analytics.track,
+      getEditorText: () => editorRef.current?.getText() ?? '',
+      insertEditorText: (text) => editorRef.current?.insertText(text),
+      focusEditor: () => editorRef.current?.focus(),
+      replaceEditorDraft,
+      draft,
+      setStagedVisualComments,
+      trackComposerBar,
+    };
 
-      if (resource.kind === 'plugin') {
-        void (async () => {
-          inlineBackedPluginRef.current = {
-            id: resource.plugin.id,
-            label: resource.plugin.title,
-          };
-          await pluginsSectionRef.current?.applyById(resource.plugin.id, resource.plugin);
-          applyDesignToolboxDraft(`${inlineMentionToken(resource.plugin.title)}\n${prompt}`);
-        })();
-        return;
-      }
-
-      if (resource.kind === 'mcp') {
-        const label = resource.server.label || resource.server.id;
-        setStagedMcpServers((current) =>
-          current.some((item) => item.id === resource.server.id)
-            ? current
-            : [...current, resource.server],
-        );
-        applyDesignToolboxDraft(`${inlineMentionToken(label)}\n${prompt}`);
-        return;
-      }
-
-      if (resource.kind === 'connector') {
-        setStagedConnectors((current) =>
-          current.some((item) => item.id === resource.connector.id)
-            ? current
-            : [...current, resource.connector],
-        );
-        applyDesignToolboxDraft(`${inlineMentionToken(resource.connector.name)}\n${prompt}`);
-        return;
-      }
-
-      if (resource.kind === 'file') {
-        const path = resource.file.path ?? resource.file.name;
-        appendContextAttachment(path);
-        applyDesignToolboxDraft(`${inlineMentionToken(path)}\n${prompt}`);
-        return;
-      }
-
-      applyDesignToolboxDraft(prompt);
-    }
-
-    function removeStagedSkill(id: string) {
-      trackComposerBar({ element: 'context_remove', resource_kind: 'skill', resource_id: id });
-      const skill = stagedSkills.find((s) => s.id === id) ?? null;
-      setStagedSkills((prev) => prev.filter((s) => s.id !== id));
-      const labels = [id, skill?.name ?? ''];
-      replaceEditorDraft(stripInlineMentionLabels(draft, labels));
-    }
-
-    function removeStagedMcpServer(id: string) {
-      trackComposerBar({ element: 'context_remove', resource_kind: 'mcp', resource_id: id });
-      const server = stagedMcpServers.find((item) => item.id === id) ?? null;
-      setStagedMcpServers((prev) => prev.filter((item) => item.id !== id));
-      replaceEditorDraft(stripInlineMentionLabels(draft, [
-        id,
-        server?.label ?? '',
-      ]));
-    }
-
-    function removeStagedConnector(id: string) {
-      trackComposerBar({ element: 'context_remove', resource_kind: 'connector', resource_id: id });
-      const connector = stagedConnectors.find((item) => item.id === id) ?? null;
-      setStagedConnectors((prev) => prev.filter((item) => item.id !== id));
-      replaceEditorDraft(stripInlineMentionLabels(draft, [
-        id,
-        connector?.name ?? '',
-      ]));
-    }
-
-    function workspaceContextDirStillReferenced(id: string, dir: string): boolean {
-      return Object.entries(workspaceLinkedDirAdds).some(
-        ([candidateId, candidate]) => candidateId !== id && candidate.dir === dir,
-      ) || selectedWorkspaceContexts.some((item) => (
-        item.id !== id && workspaceContextLinkedDir(item) === dir
-      )) || workingDir === dir;
-    }
-
-    async function removeTrackedWorkspaceLinkedDir(
-      id: string,
-      tracked: TrackedWorkspaceLinkedDir,
-    ): Promise<boolean> {
-      if (!projectId) return true;
-      if (workspaceContextDirStillReferenced(id, tracked.dir)) {
-        setWorkspaceLinkedDirAdds((current) => {
-          const { [id]: _removed, ...rest } = current;
-          return rest;
-        });
-        return true;
-      }
-      const base = projectMetadata ?? { kind: 'prototype' as const };
-      const currentLinkedDirs = base.linkedDirs ?? [...tracked.previousLinkedDirs, tracked.dir];
-      const nextLinkedDirs = currentLinkedDirs.filter((dir) => dir !== tracked.dir);
-      const metadata: ProjectMetadata = { ...base, linkedDirs: nextLinkedDirs };
-      const result = await patchProject(projectId, { metadata });
-      if (!result?.metadata) {
-        onShowToast?.(t('homeWorkingDir.applyFailed'));
-        return false;
-      }
-      onProjectMetadataChange?.(result.metadata);
-      setWorkspaceLinkedDirAdds((current) => {
-        const { [id]: _removed, ...rest } = current;
-        return rest;
-      });
-      return true;
-    }
-
-    async function removeWorkspaceContext(id: string) {
-      trackComposerBar({ element: 'context_remove', resource_kind: 'workspace', resource_id: id });
-      const workspaceItem = selectedWorkspaceContexts.find((item) => item.id === id) ?? null;
-      const trackedLinkedDir = workspaceLinkedDirAdds[id] ?? null;
-      if (trackedLinkedDir && !(await removeTrackedWorkspaceLinkedDir(id, trackedLinkedDir))) {
-        return;
-      }
-      if (visibleWorkspaceContext?.id === id) setDismissedWorkspaceContextId(id);
-      setStagedWorkspaceContexts((prev) => prev.filter((item) => item.id !== id));
-      if (!trackedLinkedDir) {
-        setWorkspaceLinkedDirAdds((current) => {
-          const { [id]: _removed, ...rest } = current;
-          return rest;
-        });
-      }
-      if (workspaceItem) {
-        replaceEditorDraft(stripInlineMentionLabels(draftRef.current, [
-          workspaceItem.label,
-          workspaceItem.id,
-          workspaceItem.title ?? '',
-          workspaceItem.path ?? '',
-          workspaceItem.absolutePath ?? '',
-          workspaceItem.url ?? '',
-        ]));
-      }
-    }
-
-    async function ensureProject(): Promise<string | null> {
-      if (projectId) return projectId;
-      return onEnsureProject();
-    }
-
-    async function uploadFiles(files: File[]) {
-      if (files.length === 0) return;
-      const id = await ensureProject();
-      if (!id) return;
-      setUploading(true);
-      setUploadError(null);
-      // Cohort math is identical to the Design Files Upload button; see
-      // `analytics/upload-tracking.ts`. v2 doc fires one
-      // file_upload_result per surface so this path reports
-      // `page_name='chat_panel'` / `area='chat_composer'`.
-      const cohort = deriveUploadCohort(files);
-      const orderStart = reserveAttachmentOrders(files.length);
-      try {
-        const result = await uploadProjectFiles(id, files);
-        if (result.uploaded.length > 0) {
-          const orderedUploaded = assignChatAttachmentOrders(result.uploaded, orderStart);
-          appendOrderedStagedAttachments(orderedUploaded);
-        }
-        const partial = result.failed.length > 0;
-        if (partial) {
-          const failedCount = result.failed.length;
-          const uploadedCount = result.uploaded.length;
-          const detail = result.error ? ` (${result.error})` : '';
-          setUploadError(
-            uploadedCount > 0
-              ? `Attached ${uploadedCount} file(s), but ${failedCount} failed${detail}.`
-              : `Attachment upload failed for ${failedCount} file(s)${detail}.`,
-          );
-          console.warn('Some attachments failed to upload', result.failed);
-        }
-        trackFileUploadResult(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          project_id: id,
-          ...cohort,
-          result: partial ? 'failed' : 'success',
-          ...(partial && result.error ? { error_code: result.error } : {}),
-        });
-      } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
-        setUploadError(`Attachment upload failed (${detail}).`);
-        trackFileUploadResult(analytics.track, {
-          page_name: 'chat_panel',
-          area: 'chat_composer',
-          project_id: id,
-          ...cohort,
-          result: 'failed',
-          error_code: detail,
-        });
-      } finally {
-        setUploading(false);
-      }
-    }
-
-    // "Select from library" (资源库): copy each chosen asset into the project's
-    // design files and stage it as an attachment chip, mirroring how the native
-    // file picker materializes uploads into the project on attach. The apply
-    // call records a provenance back-link so the registry knows the asset was
-    // consumed.
-    async function addAssetsFromLibrary(assets: LibraryAsset[]) {
-      if (assets.length === 0) return;
-      const id = await ensureProject();
-      if (!id) return;
-      setUploading(true);
-      setUploadError(null);
-      const orderStart = reserveAttachmentOrders(assets.length);
-      try {
-        const applied: ChatAttachment[] = [];
-        // Element-pick captures carry their picked node's markup; collect it so
-        // we can drop the HTML straight into the composer input (the image still
-        // attaches as a normal reference).
-        const elementBlocks: string[] = [];
-        let failed = 0;
-        for (const asset of assets) {
-          const res = await applyLibraryAsset(asset.id, id);
-          if (!res?.relPath) {
-            failed += 1;
-            continue;
-          }
-          applied.push({
-            path: res.relPath,
-            name: assetTitle(asset),
-            kind: asset.kind === 'image' ? 'image' : 'file',
-          });
-          const element = elementMetaOf(asset);
-          if (element?.hasHtml) {
-            const html = await fetchLibraryAssetElementHtml(asset.id);
-            if (html) elementBlocks.push(formatElementHtmlBlock(asset, element, html));
-          }
-        }
-        if (applied.length > 0) {
-          appendOrderedStagedAttachments(assignChatAttachmentOrders(applied, orderStart));
-        }
-        if (elementBlocks.length > 0) {
-          const existing = editorRef.current?.getText() ?? '';
-          editorRef.current?.insertText((existing.trim() ? '\n\n' : '') + elementBlocks.join('\n\n'));
-          editorRef.current?.focus();
-        }
-        if (failed > 0) {
-          setUploadError(
-            applied.length > 0
-              ? `Added ${applied.length} item(s), but ${failed} failed.`
-              : `Could not add ${failed} item(s) from the library.`,
-          );
-        }
-      } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
-        setUploadError(`Could not add from library (${detail}).`);
-      } finally {
-        setUploading(false);
-      }
-    }
-
-    async function uploadClipboardImagesFromAsyncClipboard() {
-      if (!navigator.clipboard?.read) return false;
-      try {
-        const items = await navigator.clipboard.read();
-        const files: File[] = [];
-        const stamp = Date.now();
-        for (const item of items) {
-          const imageType = item.types.find((type) => type.startsWith('image/'));
-          if (!imageType) continue;
-          const blob = await item.getType(imageType);
-          const extension = imageType.split('/')[1]?.replace('jpeg', 'jpg') || 'png';
-          files.push(new File([blob], `clipboard-screenshot-${stamp}.${extension}`, { type: imageType }));
-        }
-        if (files.length === 0) return false;
-        await uploadFiles(files);
-        return true;
-      } catch (err) {
-        console.warn('Could not read image from clipboard', err);
-        return false;
-      }
-    }
-
+    // Registers the ANNOTATION_EVENT window listener (accumulating
+    // subscription, must stay in the orchestrator per the effect-placement
+    // rule) — the actual queue/send/draft handling lives in
+    // `handleAnnotationEventImpl` (attachment-actions.ts), called with
+    // `annotationActionDeps` (built further below, once `sendActionDeps` is
+    // available). The listener callback only runs on a later event, by which
+    // point this render's `annotationActionDeps` is assigned.
     useEffect(() => {
       function onAnnotation(e: Event) {
         const detail = (e as CustomEvent<AnnotationEventDetail>).detail;
         if (!detail) return;
-        void (async () => {
-          let acked = false;
-          const ack = (result: { ok: boolean; message?: string }) => {
-            if (acked) return;
-            acked = true;
-            detail.ack?.(result);
-          };
-          let uploaded: ChatAttachment[] = [];
-          let visualAttachmentInput: Parameters<typeof buildVisualAnnotationAttachment>[0] | null = null;
-          let visualAttachment: ChatCommentAttachment | null = null;
-          try {
-            // Upload the annotation screenshot together with any images the
-            // user attached in the markup composer. The screenshot (when
-            // present) is first so it keeps backing the structured visual
-            // comment; the rest ride along as ordinary chat attachments.
-            const annotationFiles = [detail.file, ...(detail.extraFiles ?? [])].filter(
-              (f): f is File => Boolean(f),
-            );
-            if (annotationFiles.length > 0) {
-              const orderStart = reserveAttachmentOrders(annotationFiles.length);
-              const id = await ensureProject();
-              if (!id) {
-                ack({ ok: false, message: t('chat.annotationProjectCreateFailed') });
-                return;
-              }
-              setUploading(true);
-              const result = await uploadProjectFiles(id, annotationFiles);
-              if (result.uploaded.length > 0) {
-                uploaded = assignChatAttachmentOrders(result.uploaded, orderStart);
-                const screenshot = detail.file ? uploaded[0] : null;
-                if (screenshot && detail.markKind && detail.bounds) {
-                  visualAttachmentInput = {
-                    order: isFiniteAttachmentOrder(screenshot.order) ? screenshot.order : orderStart,
-                    idSeed: screenshot.path,
-                    screenshotPath: screenshot.path,
-                    markKind: detail.markKind,
-                    note: detail.note,
-                    bounds: detail.bounds,
-                    target: detail.target
-                      ? {
-                          filePath: detail.target.filePath || detail.filePath || screenshot.path,
-                          elementId: detail.target.elementId,
-                          selector: detail.target.selector,
-                          label: detail.target.label,
-                          text: detail.target.text,
-                          position: detail.target.position,
-                          htmlHint: detail.target.htmlHint,
-                        }
-                      : {
-                          filePath: detail.filePath || screenshot.path,
-                          position: detail.bounds,
-                        },
-                  };
-                }
-              }
-              if (result.failed.length > 0) {
-                const detailText = result.error ? ` (${result.error})` : '';
-                setUploadError(`Attachment upload failed for ${result.failed.length} file(s)${detailText}.`);
-                if (uploaded.length === 0) {
-                  ack({ ok: false, message: t('chat.annotationUploadFailed') });
-                  return;
-                }
-              }
-            }
-            setUploading(false);
-
-            const appendAnnotationToComposer = () => {
-              if (uploaded.length > 0) {
-                appendOrderedStagedAttachments(uploaded);
-              }
-              if (visualAttachmentInput) {
-                setStagedVisualComments((current) => [
-                  ...current,
-                  buildVisualAnnotationAttachment({
-                    ...visualAttachmentInput!,
-                  }),
-                ]);
-              }
-              if (detail.note) {
-                // Accumulate through draftRef so two annotations resolving
-                // concurrently compose (each reads the other's write) instead
-                // of both starting from the same stale closure. Mirror the
-                // result into the editor with setText so the now-non-empty
-                // editor does not fire an onChange('') that would clobber the
-                // accumulated draft back to empty.
-                const nextDraft = draftRef.current
-                  ? `${draftRef.current}\n${detail.note}`
-                  : detail.note;
-                draftRef.current = nextDraft;
-                setDraft(nextDraft);
-                editorRef.current?.setText(nextDraft);
-              }
-              editorRef.current?.focus();
-            };
-
-            if (detail.action === 'queue') {
-              if (visualAttachmentInput) {
-                visualAttachment = buildVisualAnnotationAttachment({
-                  ...visualAttachmentInput,
-                });
-              }
-              const prompt = [draft.trim(), detail.note].filter(Boolean).join('\n');
-              const attachments = sortChatAttachmentsByOrder([...staged, ...uploaded]);
-              const nextCommentAttachments = currentCommentAttachments(visualAttachment ? [visualAttachment] : []);
-              // Mark draw-overlay → run: tag entry_from='mark' so the dashboard
-              // separates annotation-driven runs from plain composer sends.
-              sendComposedTurn(prompt, attachments, nextCommentAttachments, { ...queueMeta(currentRunContextMeta()), entryFrom: 'mark' });
-              ack({ ok: true });
-              return;
-            }
-
-            if (detail.action === 'send') {
-              if (streaming) {
-                appendAnnotationToComposer();
-                // Carry entry_from='mark' through the deferred send so the
-                // flush effect below reports the run as a Mark annotation
-                // rather than the default composer entry.
-                streamingAnnotationSendEntryFromRef.current = 'mark';
-                setStreamingAnnotationSendPending(true);
-                ack({ ok: true });
-                return;
-              }
-              if (visualAttachmentInput) {
-                visualAttachment = buildVisualAnnotationAttachment({
-                  ...visualAttachmentInput,
-                });
-              }
-              const prompt = [draft.trim(), detail.note].filter(Boolean).join('\n');
-              const attachments = sortChatAttachmentsByOrder([...staged, ...uploaded]);
-              const nextCommentAttachments = currentCommentAttachments(visualAttachment ? [visualAttachment] : []);
-              // Mark draw-overlay → run: tag entry_from='mark' so the dashboard
-              // separates annotation-driven runs from plain composer sends.
-              sendComposedTurn(prompt, attachments, nextCommentAttachments, { ...currentRunContextMeta(), entryFrom: 'mark' });
-              ack({ ok: true });
-              return;
-            }
-
-            if (detail.action === 'draft') {
-              appendAnnotationToComposer();
-              ack({ ok: true });
-              return;
-            }
-
-            ack({ ok: false, message: t('chat.annotationFailed') });
-          } catch (err) {
-            console.warn('Could not send annotation', err);
-            setUploadError(err instanceof Error ? err.message : t('chat.annotationFailed'));
-            ack({ ok: false, message: t('chat.annotationFailed') });
-          } finally {
-            setUploading(false);
-          }
-        })();
+        void handleAnnotationEventImpl(detail, annotationActionDeps);
       }
       window.addEventListener(ANNOTATION_EVENT, onAnnotation);
       return () => window.removeEventListener(ANNOTATION_EVENT, onAnnotation);
@@ -1985,20 +892,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       t,
     ]);
 
+    // Flushes a Mark send deferred while a run was streaming (see
+    // `flushDeferredAnnotationSend` in attachment-actions.ts). Runs on every
+    // dep change (cheap early-return inside), so it stays a plain effect
+    // rather than an event listener; `deferredAnnotationSendDeps` (built
+    // further below) is picked up fresh each time this effect re-fires,
+    // since effects always run after the render that declared them.
     useEffect(() => {
-      if (!streamingAnnotationSendPending || !streamingAnnotationSendPendingRef.current) return;
-      if (streaming || sendDisabled) return;
-      // Read the ref, not the closed-over `draft`: the accumulating annotation
-      // handler writes draftRef synchronously, so the ref is authoritative even
-      // if this effect's render closure predates the last accumulation.
-      const prompt = draftRef.current.trim();
-      // Consume the entry_from captured when the send was deferred (Mark
-      // draw-overlay sets 'mark'); clear it so a later plain send is unaffected.
-      const pendingEntryFrom = streamingAnnotationSendEntryFromRef.current;
-      streamingAnnotationSendEntryFromRef.current = undefined;
-      const baseMeta = currentRunContextMeta();
-      const meta = pendingEntryFrom ? { ...baseMeta, entryFrom: pendingEntryFrom } : baseMeta;
-      sendComposedTurn(prompt, staged, currentCommentAttachments(), meta);
+      flushDeferredAnnotationSendImpl(deferredAnnotationSendDeps);
     }, [
       commentAttachments,
       draft,
@@ -2014,566 +915,283 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       streamingAnnotationSendPending,
     ]);
 
-    // Paste handler invoked by the editor's PastePlugin. `files` are the items
-    // the clipboard exposed synchronously; when empty we fall back to the
-    // async Clipboard API to recover pasted screenshots that some browsers
-    // only surface through `navigator.clipboard.read()`.
-    function handlePasteFiles(files: File[]) {
-      if (files.length > 0) {
-        void uploadFiles(files);
-        return;
-      }
-      void uploadClipboardImagesFromAsyncClipboard();
-    }
-
-    function handleDrop(e: React.DragEvent<HTMLDivElement>) {
-      e.preventDefault();
-      setDragActive(false);
-      const files = Array.from(e.dataTransfer.files ?? []);
-      if (files.length > 0) void uploadFiles(files);
-    }
-
-    async function handleLinkFolder() {
-      if (!projectId) return;
-      const selected = await openFolderDialog();
-      if (!selected) return;
-      await addLinkedDir(selected);
-    }
-
-    function linkedDirsWithWorkspaceContext(primaryDir: string | null): string[] {
-      const primary = primaryDir?.trim();
-      const contextDirs = primary
-        ? workspaceContextMetadataLinkedDirList.filter((dir) => dir !== primary)
-        : workspaceContextMetadataLinkedDirList;
-      return Array.from(new Set([
-        ...(primary ? [primary] : []),
-        ...contextDirs,
-      ]));
-    }
-
-    // The WorkingDirPicker treats the project's working directory as a single
-    // primary folder, so selecting one replaces the primary `linkedDirs` entry
-    // while preserving staged workspace-context dirs. The folder is read-only
-    // awareness for the agent (→ `--add-dir`), not a Design Files import, and
-    // `baseDir` is never touched.
-    async function setWorkingDirFolder(dir: string) {
-      if (!projectId) return;
-      const base = projectMetadata ?? { kind: 'prototype' as const };
-      const metadata: ProjectMetadata = {
-        ...base,
-        linkedDirs: linkedDirsWithWorkspaceContext(dir),
-      };
-      const result = await patchProject(projectId, { metadata });
-      // The daemon rejects stale/inaccessible/system dirs with
-      // INVALID_LINKED_DIR (patchProject → null). Only commit the selection
-      // and promote it in recents when the project accepted it; otherwise
-      // surface the failure and leave recents untouched so a rejected path
-      // isn't re-promoted to the top of the menu.
-      if (!result?.metadata) {
-        onShowToast?.(t('homeWorkingDir.applyFailed'));
-        return;
-      }
-      onProjectMetadataChange?.(result.metadata);
-      const promotedDir = dir.trim();
-      setPromotedWorkspaceContextDir(
-        selectedWorkspaceContextDirs.includes(promotedDir) ? promotedDir : null,
-      );
-      setWorkspaceLinkedDirAdds((current) => {
-        const nextEntries = Object.entries(current).filter(([, tracked]) => (
-          tracked.dir !== promotedDir
-        ));
-        return nextEntries.length === Object.keys(current).length
-          ? current
-          : Object.fromEntries(nextEntries);
-      });
-      void rememberRecentDir(dir);
-    }
-    async function handlePickWorkingDir() {
-      const selected = await openFolderDialog();
-      if (selected) await setWorkingDirFolder(selected);
-    }
-    async function clearWorkingDir() {
-      if (!projectId) return;
-      const base = projectMetadata ?? { kind: 'prototype' as const };
-      const metadata: ProjectMetadata = {
-        ...base,
-        linkedDirs: linkedDirsWithWorkspaceContext(null),
-      };
-      const result = await patchProject(projectId, { metadata });
-      if (result?.metadata) {
-        setPromotedWorkspaceContextDir(null);
-        onProjectMetadataChange?.(result.metadata);
-      }
-    }
-
-    // Lexical drives every text change through this callback. `present` is the
-    // entity list the editor's text currently references (MentionNodes plus
-    // plain `@token`s matched against composerMentionEntities, deduped by
-    // kind:id). We prune the staged skill/mcp/connector chips to whatever the
-    // text still references — generalizing the old skill-only regex prune so a
-    // hand-deleted token also drops its chip and never leaks into the run
-    // context. Workspace contexts that added linked dirs are kept visible until
-    // the chip remove button clears the matching metadata access. `staged`
-    // (files) is intentionally NOT pruned: users attach files via the upload
-    // button without leaving an `@<path>` token.
-    function handleEditorChange(text: string, present: InlineMentionEntity[]) {
-      draftRef.current = text;
-      setDraft(text);
-      const set = new Set(present.map((e) => `${e.kind}:${e.id}`));
-      if (
-        activeAppliedPlugin
-        && inlineBackedPluginRef.current?.id === activeAppliedPlugin.pluginId
-        && !set.has(`plugin:${activeAppliedPlugin.pluginId}`)
-        && !mentionTokenPresent(text, inlineBackedPluginRef.current.label)
-      ) {
-        inlineBackedPluginRef.current = null;
-        pluginsSectionRef.current?.clear();
-      }
-      setStagedSkills((prev) => prev.filter((s) => set.has(`skill:${s.id}`)));
-      setStagedMcpServers((prev) => prev.filter((m) => set.has(`mcp:${m.id}`)));
-      setStagedConnectors((prev) =>
-        prev.filter((c) => set.has(`connector:${c.id}`)),
-      );
-      setStagedWorkspaceContexts((prev) =>
-        prev.filter((item) => set.has(`workspace:${item.id}`) || Boolean(workspaceLinkedDirAdds[item.id])),
-      );
-    }
-
-    // Lexical reports the active @/slash trigger derived from the caret. The
-    // mention popover state collapses to `{ q }`; the slash state replicates
-    // the old detection effect (reset the keyboard index on open). IME
-    // suppression already happened in the editor (it bails while composing).
-    function handleEditorTrigger({
-      mention: nextMention,
-      slash: nextSlash,
-      anchorRect,
-    }: {
-      mention: { q: string } | null;
-      slash: { q: string } | null;
-      anchorRect: CaretRect | null;
-    }) {
-      setCaretRect(anchorRect);
-      if (nextMention && !mention) {
-        setMentionTab('all');
-      } else if (!nextMention) {
-        setMentionTab('all');
-      }
-      setMention((prev) => {
-        // Reset the active row only when the query identity changes (mirror of
-        // the slash reset) so re-renders from unrelated state don't snap it.
-        if (nextMention && (!prev || prev.q !== nextMention.q)) setMentionIndex(0);
-        return nextMention;
-      });
-      if (nextSlash) {
-        setSlash(nextSlash);
-        setSlashIndex(0);
-      } else {
-        setSlash(null);
-      }
-    }
-
-    // Routes popover navigation keys lifted verbatim from the old textarea
-    // onKeyDown. Returns true when the key was consumed so the editor can
-    // preventDefault; false lets the editor handle it normally (e.g. plain
-    // arrow keys when no popover is open).
-    function handlePopoverKey(
-      key: 'ArrowDown' | 'ArrowUp' | 'Tab' | 'Enter' | 'Escape',
-    ): boolean {
-      if (slash && filteredSlash.length > 0) {
-        if (key === 'ArrowDown') {
-          setSlashIndex((i) => (i + 1) % filteredSlash.length);
-          return true;
-        }
-        if (key === 'ArrowUp') {
-          setSlashIndex(
-            (i) => (i - 1 + filteredSlash.length) % filteredSlash.length,
-          );
-          return true;
-        }
-        if (key === 'Tab' || key === 'Enter') {
-          const safe = Math.min(slashIndex, filteredSlash.length - 1);
-          pickSlash(filteredSlash[safe]!);
-          return true;
-        }
-        if (key === 'Escape') {
-          setSlash(null);
-          return true;
-        }
-      }
-      if (mention && key === 'Escape') {
-        setMention(null);
-        return true;
-      }
-      if (mention) {
-        // Drive a single index over the visible section union. MentionPopover
-        // renders the same files-first section order and highlights the
-        // matching row from activeIndex.
-        const showFiles = mentionTab === 'all' || mentionTab === 'files';
-        const showTabs = mentionTab === 'all' || mentionTab === 'tabs';
-        const showPlugins = mentionTab === 'all' || mentionTab === 'plugins';
-        const showSkills = mentionTab === 'all' || mentionTab === 'skills';
-        const showMcp = mentionTab === 'all' || mentionTab === 'mcp';
-        const showConnectors = mentionTab === 'all' || mentionTab === 'connectors';
-        const total =
-          (showFiles ? filteredFiles.length : 0) +
-          (showTabs ? filteredWorkspaceContexts.length : 0) +
-          (showPlugins ? filteredPlugins.length : 0) +
-          (showSkills ? filteredSkills.length : 0) +
-          (showMcp ? filteredMcpServers.length : 0) +
-          (showConnectors ? filteredConnectors.length : 0);
-        if (total > 0) {
-          if (key === 'ArrowDown') {
-            setMentionIndex((i) => (i + 1) % total);
-            return true;
-          }
-          if (key === 'ArrowUp') {
-            setMentionIndex((i) => (i - 1 + total) % total);
-            return true;
-          }
-          if (key === 'Tab' || key === 'Enter') {
-            pickMentionByFlatIndex(Math.min(mentionIndex, total - 1));
-            return true;
-          }
-        }
-      }
-      return false;
-    }
-
-    // Resolve a flat visible-section index to the right insert call. Section
-    // order MUST match MentionPopover's render order (files→tabs→plugins
-    // →skills→mcp→connectors); the activeIndex highlight and Enter target stay in
-    // lockstep across "All" and individual tabs.
-    function pickMentionByFlatIndex(flat: number) {
-      let i = flat;
-      if (mentionTab === 'all' || mentionTab === 'files') {
-        if (i < filteredFiles.length) {
-          insertMention(filteredFiles[i]!.path ?? filteredFiles[i]!.name);
-          return;
-        }
-        i -= filteredFiles.length;
-      }
-      if (mentionTab === 'all' || mentionTab === 'tabs') {
-        if (i < filteredWorkspaceContexts.length) {
-          insertWorkspaceMention(filteredWorkspaceContexts[i]!);
-          return;
-        }
-        i -= filteredWorkspaceContexts.length;
-      }
-      if (mentionTab === 'all' || mentionTab === 'plugins') {
-        if (i < filteredPlugins.length) {
-          void insertPluginMention(filteredPlugins[i]!);
-          return;
-        }
-        i -= filteredPlugins.length;
-      }
-      if (mentionTab === 'all' || mentionTab === 'skills') {
-        if (i < filteredSkills.length) {
-          void insertSkillMention(filteredSkills[i]!);
-          return;
-        }
-        i -= filteredSkills.length;
-      }
-      if (mentionTab === 'all' || mentionTab === 'mcp') {
-        if (i < filteredMcpServers.length) {
-          insertMcpMention(filteredMcpServers[i]!);
-          return;
-        }
-        i -= filteredMcpServers.length;
-      }
-      if (mentionTab === 'all' || mentionTab === 'connectors') {
-        if (i < filteredConnectors.length) {
-          insertConnectorMention(filteredConnectors[i]!);
-          return;
-        }
-      }
-    }
-
-    function insertMention(filePath: string) {
-      editorRef.current?.insertMention({
-        token: inlineMentionToken(filePath),
-        entity: { id: filePath, kind: 'file', label: filePath },
-      });
-      if (!staged.some((s) => s.path === filePath)) {
-        appendContextAttachment(filePath);
-      }
-      setMention(null);
-    }
-
-    async function insertPluginMention(record: InstalledPluginRecord) {
-      editorRef.current?.insertMention({
-        token: inlineMentionToken(record.title),
-        entity: { id: record.id, kind: 'plugin', label: record.title },
-      });
-      setMention(null);
-      inlineBackedPluginRef.current = { id: record.id, label: record.title };
-      await pluginsSectionRef.current?.applyById(record.id, record);
-    }
-
-    function insertMcpMention(server: McpServerConfig) {
-      setStagedMcpServers((current) => (
-        current.some((item) => item.id === server.id) ? current : [...current, server]
-      ));
-      editorRef.current?.insertMention({
-        token: inlineMentionToken(server.label || server.id),
-        entity: { id: server.id, kind: 'mcp', label: server.label || server.id },
-      });
-      setMention(null);
-    }
-
-    function insertConnectorMention(connector: ConnectorDetail) {
-      setStagedConnectors((current) => (
-        current.some((item) => item.id === connector.id) ? current : [...current, connector]
-      ));
-      editorRef.current?.insertMention({
-        token: inlineMentionToken(connector.name),
-        entity: { id: connector.id, kind: 'connector', label: connector.name },
-      });
-      setMention(null);
-    }
-
-    function insertWorkspaceMention(item: WorkspaceContextItem) {
-      setStagedWorkspaceContexts((current) =>
-        current.some((candidate) => candidate.id === item.id)
-          ? current
-          : [...current, item],
-      );
-      editorRef.current?.insertMention({
-        token: inlineMentionToken(item.label),
-        entity: { id: item.id, kind: 'workspace', label: item.label },
-      });
-      setMention(null);
-    }
-
-    async function applyProjectSkill(skill: SkillSummary): Promise<boolean> {
-      if (!projectId) return false;
-      const result = await patchProject(projectId, { skillId: skill.id });
-      if (!result) return false;
-      onProjectSkillChange?.(result.skillId ?? skill.id);
-      return true;
-    }
-
-    function removeStaged(p: string) {
-      trackComposerBar({ element: 'context_remove', resource_kind: 'attachment', resource_id: p });
-      setStaged((s) => s.filter((a) => a.path !== p));
-      setStagedVisualComments((current) => current.filter((attachment) => attachment.screenshotPath !== p));
-      // Strip the `@<path>` token from the draft and push the result back into
-      // the editor so the pill disappears in lockstep with the chip.
-      replaceEditorDraft(stripInlineMentionToken(draft, p));
-    }
-
-    function removeCommentAttachment(id: string) {
-      setStagedVisualComments((current) => current.filter((attachment) => attachment.id !== id));
-      if (!stagedVisualComments.some((attachment) => attachment.id === id)) {
-        onRemoveCommentAttachment?.(id);
-      }
-    }
-
-    async function submit() {
-      const prompt = draft.trim();
-      if (sendDisabled) return;
-      // Intercept `/pet …` and `/mcp` before sending so the slash command
-      // never hits the agent — these are local UX hooks, not model prompts.
-      if (tryHandlePetSlash()) return;
-      if (tryHandleMcpSlash()) return;
-      // `/hatch <concept>` expands into the canonical hatch-pet skill
-      // prompt and *is* sent to the agent — the agent runs the skill,
-      // packages a Codex pet under `~/.codex/pets/`, and the user
-      // adopts it from "Recently hatched" in pet settings afterwards.
-      const contextMeta = currentRunContextMeta();
-      const hatched = expandHatchCommand(prompt);
-      const nextCommentAttachments = currentCommentAttachments();
-      if (hatched) {
-        if (streaming) return;
-        setStreamingAnnotationSendPending(false);
-        onSend(hatched, staged, nextCommentAttachments, contextMeta);
-        reset();
-        return;
-      }
-      const search = researchAvailable ? expandSearchCommand(prompt) : null;
-      if (search) {
-        if (streaming) return;
-        setStreamingAnnotationSendPending(false);
-        onSend(search.prompt, staged, nextCommentAttachments, {
-          ...contextMeta,
-          research: { enabled: true, query: search.query },
-        });
-        reset();
-        return;
-      }
-      if (!prompt && staged.length === 0 && nextCommentAttachments.length === 0) {
-        const placeholderPrompt = placeholderSubmittable && placeholderScenario
-          ? placeholderScenario.text.trim()
-          : '';
-        if (!placeholderPrompt) return;
-        const placeholderMeta: ChatSendMeta | undefined = placeholderScenario?.sessionMode
-          ? {
-              ...(contextMeta ?? {}),
-              sessionMode: placeholderScenario.sessionMode,
-              entryFrom: contextMeta?.entryFrom ?? 'next_step',
-            }
-          : contextMeta;
-        sendComposedTurn(placeholderPrompt, [], [], placeholderMeta);
-        return;
-      }
-      sendComposedTurn(prompt, staged, nextCommentAttachments, contextMeta);
-    }
-
-    // The @-picker offers a unified search across context surfaces:
-    // workspace tabs first, then project files, plugins, skills, active MCP
-    // servers, and connectors. Picked
-    // entities keep an inline @ token for orientation while richer
-    // context is still applied behind the scenes when available.
-    const mentionQuery = mention ? mention.q.toLowerCase() : '';
-    // The suggestion lists below only matter while the @-popover is open
-    // (each is `[]` otherwise). Memoize them on `[mention, mentionQuery,
-    // <source>]` so the filter/sort passes run only when the query or the
-    // backing list actually changes — not on every unrelated composer render
-    // (streaming flips, draft typing routed through Lexical, staged-chip churn).
-    // `mention` is in the deps (not just `mentionQuery`) so the open/close gate
-    // re-evaluates: a null→{q:''} transition keeps the query '' but must flip
-    // the list from `[]` to live results.
-    const filteredWorkspaceContexts = useMemo(
-      () =>
-        mention
-          ? workspaceContexts
-              .filter((item) => {
-                if (!mentionQuery) return true;
-                return workspaceContextSearchText(item).toLowerCase().includes(mentionQuery);
-              })
-              .slice(0, 12)
-          : [],
-      [mention, mentionQuery, workspaceContexts],
-    );
-    const filteredFiles = useMemo(
-      () =>
-        mention
-          ? projectFiles
-              .filter((f) => f.type === undefined || f.type === "file")
-              .filter((f) => {
-                const key = f.path ?? f.name;
-                return key.toLowerCase().includes(mentionQuery);
-              })
-              .slice(0, 12)
-          : [],
-      [mention, mentionQuery, projectFiles],
-    );
-    const filteredPlugins = useMemo(
-      () =>
-        mention
-          ? pluginsForComposer
-              .filter((p) => {
-                if (!mentionQuery) return true;
-                return (
-                  p.title.toLowerCase().includes(mentionQuery) ||
-                  p.id.toLowerCase().includes(mentionQuery) ||
-                  (p.manifest?.description ?? '').toLowerCase().includes(mentionQuery) ||
-                  (p.manifest?.tags ?? []).join(' ').toLowerCase().includes(mentionQuery)
-                );
-              })
-              .slice(0, 8)
-          : [],
-      [mention, mentionQuery, pluginsForComposer],
-    );
-    const filteredMcpServers = useMemo(
-      () =>
-        mention
-          ? enabledMcpServers
-              .filter((s) => {
-                if (!mentionQuery) return true;
-                return [
-                  s.id,
-                  s.label ?? '',
-                  s.transport,
-                  s.url ?? '',
-                  s.command ?? '',
-                ]
-                  .join(' ')
-                  .toLowerCase()
-                  .includes(mentionQuery);
-              })
-              .slice(0, 8)
-          : [],
-      [mention, mentionQuery, enabledMcpServers],
-    );
-    const filteredConnectors = useMemo(
-      () =>
-        mention
-          ? connectors
-              .filter((connector) => {
-                if (!mentionQuery) return true;
-                return [
-                  connector.id,
-                  connector.name,
-                  connector.provider,
-                  connector.category,
-                  connector.description ?? '',
-                  connector.accountLabel ?? '',
-                ]
-                  .join(' ')
-                  .toLowerCase()
-                  .includes(mentionQuery);
-              })
-              .slice(0, 8)
-          : [],
-      [mention, mentionQuery, connectors],
-    );
-    // Already-staged skills drop out of the suggestion list (carried over
-    // from main) so the @-popover keeps moving forward as the user picks.
-    const filteredSkills = useMemo(() => {
-      if (!mention) return [];
-      const stagedSkillIds = new Set(stagedSkills.map((s) => s.id));
-      return skills
-        .filter((s) => !stagedSkillIds.has(s.id))
-        .filter((s) => skillMatchesQuery(s, mentionQuery))
-        .sort((a, b) => skillMentionRank(a, mentionQuery) - skillMentionRank(b, mentionQuery));
-    }, [mention, mentionQuery, skills, stagedSkills]);
-    const liveCommentAttachments = currentCommentAttachments();
-    const placeholderCarouselActive =
-      !streaming
-      && !sendDisabled
-      && !activeFileContext
-      && placeholderScenarios.length > 0
-      && draft.trim().length === 0
-      && staged.length === 0
-      && liveCommentAttachments.length === 0
-      && !mention
-      && !slash;
-    const placeholderSubmittable =
-      placeholderCarouselActive && Boolean(placeholderScenario?.text.trim());
-    const hasComposerPayload =
-      draft.trim().length > 0
-      || staged.length > 0
-      || liveCommentAttachments.length > 0
-      || placeholderSubmittable;
-    const showStopButton = streaming && !hasComposerPayload;
-    const showSendButton = !streaming || hasComposerPayload;
-
-    const openDesignSystemPicker = () => {
-      const trigger = composerRootRef.current?.querySelector<HTMLButtonElement>(
-        '[data-testid="project-ds-picker-trigger"]',
-      );
-      if (!trigger || trigger.disabled) return;
-      window.requestAnimationFrame(() => {
-        if (trigger.getAttribute('aria-expanded') !== 'true') trigger.click();
-        trigger.focus({ preventScroll: true });
-      });
+    // Deps bag for the working-dir set/clear/pick action functions (see
+    // features/chat-composer/actions.ts): transport + the cross-cluster
+    // workspace-context state a promoted dir must reconcile against + the
+    // working-dir-status hook's own recent-dirs writer.
+    const workingDirActionDeps: WorkingDirActionDeps = {
+      projectId,
+      projectMetadata,
+      workspaceContextMetadataLinkedDirList,
+      selectedWorkspaceContextDirs,
+      patchProject,
+      openFolderDialog,
+      onShowToast,
+      onProjectMetadataChange,
+      setPromotedWorkspaceContextDir,
+      setWorkspaceLinkedDirAdds,
+      rememberRecentDir: workingDirStatus.rememberRecentDir,
+      t,
     };
+
+    // Lexical drives every text change through this callback. Spans four
+    // clusters (draft, applied-plugin, staged run-context, workspace-context)
+    // with no single owning hook — see handleEditorChange in actions.ts.
+    const editorChangeDeps: EditorChangeDeps = {
+      draftRef,
+      setDraft,
+      activeAppliedPlugin,
+      inlineBackedPluginRef,
+      clearPluginsSection,
+      setStagedSkills,
+      setStagedMcpServers,
+      setStagedConnectors,
+      stagedWorkspaceContexts,
+      setStagedWorkspaceContexts,
+      workspaceLinkedDirAdds,
+    };
+    const handleEditorChange = useCallback((text: string, present: InlineMentionEntity[]) => {
+      handleEditorChangeImpl(text, present, editorChangeDeps);
+    }, [editorChangeDeps]);
+
+    // `useMentionPopover` needs `pickSlash`/`appendContextAttachment` (bound
+    // via `pickSlashDeps`/`uploadActionDeps`, both above this point) plus the
+    // editor/plugin-ref primitives, so it's called here rather than earlier
+    // alongside the other catalogue-derived hooks.
+    const {
+      mention,
+      setMention,
+      mentionIndex,
+      mentionTab,
+      setMentionTab,
+      caretRect,
+      setCaretRect,
+      composerMentionEntities,
+      filteredFiles,
+      filteredWorkspaceContexts,
+      filteredPlugins,
+      filteredMcpServers,
+      filteredConnectors,
+      filteredSkills,
+      handleEditorTrigger,
+      handlePopoverKey,
+      insertMention,
+      insertPluginMention,
+      insertMcpMention,
+      insertConnectorMention,
+      insertWorkspaceMention,
+      insertSkillMention,
+      handleMentionTabChange,
+    } = useMention({
+      projectFiles,
+      workspaceContexts,
+      pluginsForComposer,
+      enabledMcpServers,
+      connectors,
+      skills,
+      stagedSkills,
+      staged,
+      selectedWorkspaceContexts,
+      slash,
+      setSlash,
+      slashIndex,
+      setSlashIndex,
+      filteredSlash,
+      pickSlash: (cmd) => pickSlashAction(cmd, pickSlashDeps),
+      insertEditorMention: (insert) => editorRef.current?.insertMention(insert),
+      appendContextAttachment: (path) => appendContextAttachmentImpl(path, uploadActionDeps),
+      setStagedSkills,
+      setStagedMcpServers,
+      setStagedConnectors,
+      setStagedWorkspaceContexts,
+      setInlineBackedPlugin,
+      applyPluginById: async (id, record) => {
+        await pluginsSectionRef.current?.applyById(id, record);
+      },
+      projectId,
+      patchProject,
+      onProjectSkillChange,
+    });
+
+    // Latch `composerEngaged` true on the first real interaction so the
+    // catalogue hook's deferred fetches run exactly once, when they are
+    // actually needed. `draft`/`mention`/`slash` are other clusters' state,
+    // so this effect stays in the orchestrator; it only forwards to the
+    // hook's own setter.
+    useEffect(() => {
+      if (composerEngaged) return;
+      if (draft.trim().length > 0 || mention || slash) {
+        markComposerEngaged();
+      }
+    }, [composerEngaged, draft, mention, slash, markComposerEngaged]);
+
+    // Deps bag for the staged workspace-context linking cluster's extracted
+    // functions (see features/chat-composer/actions.ts): project/link
+    // transport, the staged/dismissed/promoted state from
+    // useWorkspaceContextLinking, the mention-insertion + popover-clearing
+    // editor primitives, and analytics. Covers appendWorkspacePrompt,
+    // addLinkedDirs/addLinkedDir, handleReferenceProjects,
+    // handleLinkLocalCodeContext, and removeWorkspaceContext — called
+    // directly from their JSX call sites below rather than through a thin
+    // per-function orchestrator wrapper.
+    const workspaceContextActionDeps: ReferenceProjectsDeps & LinkLocalCodeContextDeps & RemoveWorkspaceContextDeps = {
+      projectId,
+      projectMetadata,
+      workspaceLinkedDirAdds,
+      setWorkspaceLinkedDirAdds,
+      patchProject,
+      onShowToast,
+      onProjectMetadataChange,
+      rememberRecentDir: workingDirStatus.rememberRecentDir,
+      t,
+      track: analytics.track,
+      setProjectReferenceOpen: modals.setProjectReferenceOpen,
+      openFolderDialog,
+      setStagedWorkspaceContexts,
+      insertInlineMentionSeparator,
+      insertMention: (insert) => editorRef.current?.insertMention(insert),
+      setMention,
+      setSlash,
+      markComposerEngaged,
+      selectedWorkspaceContexts,
+      workingDir,
+      visibleWorkspaceContext,
+      setDismissedWorkspaceContextId,
+      draftRef,
+      replaceEditorDraft,
+      trackComposerBar,
+    };
+
+    const liveCommentAttachments = currentCommentAttachments();
+    const { placeholderCarouselActive, placeholderSubmittable, hasComposerPayload, showStopButton, showSendButton } =
+      composerSendGate({
+        streaming,
+        sendDisabled,
+        activeFileContext,
+        placeholderScenarios,
+        draft,
+        staged,
+        commentAttachmentCount: liveCommentAttachments.length,
+        mention,
+        slash,
+        placeholderScenario,
+      });
+
+    // Deps bag for `reset`/`sendComposedTurn`/`submit`/`currentRunContextMeta`
+    // (see features/chat-composer/actions.ts): every staging setter a reset
+    // clears, the Next-step pending refs, the Lexical editor/plugins-section
+    // primitives, `onSend` itself, and everything a submit needs to resolve
+    // pet/mcp slash interception, hatch/search expansion, and the
+    // placeholder-carousel fallback prompt. Built here (once
+    // `placeholderSubmittable` is available). The ANNOTATION_EVENT and
+    // deferred-send-flush effects above reference `annotationActionDeps`/
+    // `deferredAnnotationSendDeps` (both nest this object, built further
+    // below) rather than a named wrapper — their closures only run after
+    // this render completes, by which point those are assigned.
+    const sendActionDeps: SendActionDeps = {
+      pendingEntryFromRef,
+      pendingSessionModeRef,
+      nextAttachmentOrderRef,
+      stagedWorkspaceContexts,
+      workspaceLinkedDirAdds,
+      setWorkspaceLinkedDirAdds,
+      setStagedWorkspaceContexts,
+      promotedWorkspaceContextDir,
+      setPromotedWorkspaceContextDir,
+      setDraft,
+      setStaged,
+      setStagedVisualComments,
+      setStagedSkills,
+      setStagedMcpServers,
+      setStagedConnectors,
+      clearPluginsSection,
+      setInlineBackedPlugin,
+      inlineBackedPluginRef,
+      setActiveAppliedPlugin,
+      activeAppliedPlugin,
+      setUploadError: upload.setUploadError,
+      setMention,
+      setMentionTab,
+      setSlash,
+      clearEditor: () => editorRef.current?.clear(),
+      setStreamingAnnotationSendPending,
+      activeFileContext,
+      activeFileDisplayName,
+      onSend,
+      draft,
+      sendDisabled,
+      petEnabled,
+      petConfig,
+      onTogglePet,
+      onOpenPetSettings,
+      onAdoptPet,
+      onOpenMcpSettings,
+      clearDraft,
+      streaming,
+      staged,
+      currentCommentAttachments,
+      researchAvailable,
+      placeholderSubmittable,
+      placeholderScenario,
+      stagedSkills,
+      stagedMcpServers,
+      stagedConnectors,
+      selectedWorkspaceContexts,
+    };
+
+    // Deps bag for the Mark draw-overlay's ANNOTATION_EVENT handler (see
+    // features/chat-composer/attachment-actions.ts): nests the already-built
+    // upload + send deps bags (every field either is already reachable
+    // through one of them) rather than re-flattening 30+ fields.
+    const annotationActionDeps: AnnotationActionDeps = {
+      t,
+      uploadActionDeps,
+      sendActionDeps,
+      draftRef,
+      setDraft,
+      setEditorText: (text) => editorRef.current?.setText(text),
+      focusEditor: () => editorRef.current?.focus(),
+      draft,
+      staged,
+      currentCommentAttachments,
+      streaming,
+      streamingAnnotationSendEntryFromRef,
+      setStreamingAnnotationSendPending,
+    };
+
+    const deferredAnnotationSendDeps: DeferredAnnotationSendDeps = {
+      streamingAnnotationSendPending,
+      streamingAnnotationSendPendingRef,
+      streaming,
+      sendDisabled,
+      draftRef,
+      streamingAnnotationSendEntryFromRef,
+      staged,
+      currentCommentAttachments,
+      sendActionDeps,
+    };
+
+    const submit = useCallback(() => submitImpl(sendActionDeps), [sendActionDeps]);
+
+    const openDesignSystemPicker = useCallback(() => {
+      openDesignSystemPickerTrigger(composerRootRef.current);
+    }, []);
 
     return (
       <div
         className={[
           'composer',
-          dragActive ? 'drag-active' : '',
+          upload.dragActive ? 'drag-active' : '',
           activeFileContext ? 'composer-active-file-mode' : '',
         ].filter(Boolean).join(' ')}
         data-testid="chat-composer"
         ref={composerRootRef}
         onDragOver={(e) => {
           e.preventDefault();
-          setDragActive(true);
+          upload.setDragActive(true);
         }}
-        onDragLeave={() => setDragActive(false)}
-        onDrop={handleDrop}
+        onDragLeave={() => upload.setDragActive(false)}
+        onDrop={(e) => handleDropImpl(e, uploadActionDeps)}
       >
         <div className="composer-shell">
           {/*
@@ -2591,27 +1209,16 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               projectId={projectId}
               showRail={false}
               renderActiveChip={false}
-              onApplied={(brief, applied) => {
-                setActiveAppliedPlugin(applied.appliedPlugin);
-                // Use functional setState so stale closures from the @-mention
-                // flow (which awaits applyById after setDraft) still see the
-                // latest draft value before deciding whether to seed.
-                if (typeof brief === 'string' && brief.length > 0) {
-                  setDraft((cur) => (cur.trim().length === 0 ? brief : cur));
-                }
-              }}
-              onCleared={() => {
-                inlineBackedPluginRef.current = null;
-                setActiveAppliedPlugin(null);
-              }}
+              onApplied={handlePluginApplied}
+              onCleared={handlePluginCleared}
               onChipDetails={(item: ContextItem) => {
                 if (item.kind === 'plugin') {
                   const record = installedPlugins.find((p) => p.id === item.id);
-                  if (record) setDetailsRecord(record);
+                  if (record) modals.setDetailsRecord(record);
                   return;
                 }
                 if (item.kind === 'skill') {
-                  setDetailsSkill({
+                  modals.setDetailsSkill({
                     id: item.id,
                     summary: skills.find((skill) => skill.id === item.id) ?? null,
                   });
@@ -2637,21 +1244,24 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   : null
               }
               projectId={projectId}
-              onRemoveWorkspace={removeWorkspaceContext}
+              preview={stagedPreview}
+              previewUrl={stagedPreviewUrl}
+              modalHost={modalHost}
+              onPreviewAttachment={setStagedPreview}
+              onClosePreview={() => setStagedPreview(null)}
+              resolveImageUrl={resolveStagedImageUrl}
+              onRemoveWorkspace={(id) => void removeWorkspaceContextImpl(id, workspaceContextActionDeps)}
               onRemoveSkill={removeStagedSkill}
               onRemoveMcp={removeStagedMcpServer}
               onRemoveConnector={removeStagedConnector}
-              onRemoveAttachment={removeStaged}
-              onRemovePlugin={() => {
-                pluginsSectionRef.current?.clear();
-                setActiveAppliedPlugin(null);
-              }}
+              onRemoveAttachment={(p) => removeStagedImpl(p, uploadActionDeps)}
+              onRemovePlugin={removeAppliedPlugin}
               onPluginDetails={(id) => {
                 const record = installedPlugins.find((plugin) => plugin.id === id);
-                if (record) setDetailsRecord(record);
+                if (record) modals.setDetailsRecord(record);
               }}
               onSkillDetails={(id) => {
-                setDetailsSkill({
+                modals.setDetailsSkill({
                   id,
                   summary: stagedSkills.find((skill) => skill.id === id)
                     ?? skills.find((skill) => skill.id === id)
@@ -2687,7 +1297,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               picker will reuse. */}
           <div
             className="composer-input-wrap"
-            onFocus={() => setComposerEngaged(true)}
+            onFocus={() => markComposerEngaged()}
           >
             <LexicalComposerInput
               ref={editorRef}
@@ -2704,7 +1314,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               onChange={handleEditorChange}
               onTrigger={handleEditorTrigger}
               onEnterSend={() => void submit()}
-              onPasteFiles={handlePasteFiles}
+              onPasteFiles={(files) => handlePasteFilesImpl(files, uploadActionDeps)}
               popoverOpen={Boolean(mention) || Boolean(slash && filteredSlash.length > 0)}
               onPopoverKey={handlePopoverKey}
               comboboxAria={{
@@ -2734,10 +1344,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               connectors={filteredConnectors}
               query={mention?.q ?? ''}
               tab={mentionTab}
-              onTabChange={(nextTab) => {
-                setMentionTab(nextTab);
-                setMentionIndex(0);
-              }}
+              onTabChange={handleMentionTabChange}
               activeIndex={mentionIndex}
               currentSkillId={currentSkillId}
               onPickFile={insertMention}
@@ -2756,7 +1363,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
             <SlashPopover
               commands={filteredSlash}
               activeIndex={Math.min(slashIndex, filteredSlash.length - 1)}
-              onPick={pickSlash}
+              onPick={(cmd) => pickSlashAction(cmd, pickSlashDeps)}
               onHover={(i) => setSlashIndex(i)}
               t={t}
             />
@@ -2770,7 +1377,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               style={{ display: 'none' }}
               onChange={(e) => {
                 const files = Array.from(e.target.files ?? []);
-                void uploadFiles(files);
+                void uploadFilesImpl(files, uploadActionDeps);
                 e.target.value = '';
               }}
             />
@@ -2779,7 +1386,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               placementPreference="up"
               onOpen={() => {
                 trackComposerBar({ element: 'plus_menu_open' });
-                setComposerEngaged(true);
+                markComposerEngaged();
               }}
               onSubmenuOpen={(submenu) => {
                 // The toolbox flyout tracks its own open (design_toolbox_open).
@@ -2858,20 +1465,20 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   area: 'project_reference_modal',
                   ...(projectId ? { project_id: projectId } : {}),
                 });
-                setProjectReferenceOpen(true);
+                modals.setProjectReferenceOpen(true);
               }}
               onLinkLocalCode={() => {
                 trackComposerBar({ element: 'plus_pick', resource_kind: 'workspace', resource_id: 'local-code' });
-                void handleLinkLocalCodeContext();
+                void handleLinkLocalCodeContextImpl(workspaceContextActionDeps);
               }}
-              attachLoading={uploading}
+              attachLoading={upload.uploading}
               onSelectFromLibrary={() => {
                 trackChatPanelClick(analytics.track, {
                   page_name: 'chat_panel',
                   area: 'chat_panel',
                   element: 'library',
                 });
-                setLibraryPickerOpen(true);
+                modals.setLibraryPickerOpen(true);
               }}
               onImportFigma={projectId ? () => {
                 trackChatPanelClick(analytics.track, {
@@ -2879,7 +1486,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   area: 'chat_panel',
                   element: 'figma_import',
                 });
-                setFigmaModalOpen(true);
+                modals.setFigmaModalOpen(true);
               } : undefined}
               onShowFigmaHelp={() => {
                 trackChatPanelClick(analytics.track, {
@@ -2892,7 +1499,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   area: 'figma_help_modal',
                   ...(projectId ? { project_id: projectId } : {}),
                 });
-                setFigmaHelpOpen(true);
+                modals.setFigmaHelpOpen(true);
               }}
               onOpenDesignSystems={projectId && designSystemPicker ? () => {
                 trackComposerBar({ element: 'design_system_open' });
@@ -2913,6 +1520,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   activeMcpServerIds={stagedMcpServers.map((server) => server.id)}
                   activeConnectorIds={stagedConnectors.map((connector) => connector.id)}
                   activeFilePaths={staged.map((item) => item.path)}
+                  modalHost={modalHost}
                   onOpened={() => trackDesignToolbox({ element: 'design_toolbox_open' })}
                   onPickAction={(action) => {
                     trackDesignToolbox({
@@ -2969,6 +1577,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                     activeMcpServerIds={stagedMcpServers.map((server) => server.id)}
                     activeConnectorIds={stagedConnectors.map((connector) => connector.id)}
                     activeFilePaths={staged.map((item) => item.path)}
+                    modalHost={modalHost}
                     onOpened={() => trackDesignToolbox({ element: 'design_toolbox_open' })}
                     onPickAction={(action) => {
                       trackDesignToolbox({
@@ -3060,57 +1669,66 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
             <WorkingDirPicker
               placement="up"
               workingDir={workingDir}
-              invalid={workingDirMissing}
-              recentDirs={recentDirs}
-              onOpen={() => void checkWorkingDir()}
+              invalid={workingDirStatus.workingDirMissing}
+              recentDirs={workingDirStatus.recentDirs}
+              onOpen={() => void checkWorkingDir(workingDir)}
               onPickDirectory={() => {
                 // Fire on the click itself (intent), matching the home
                 // composer's working_dir* elements so one dashboard counts the
                 // action across both surfaces.
                 trackComposerBar({ element: 'working_dir' });
-                void handlePickWorkingDir();
+                void handlePickWorkingDirImpl(workingDirActionDeps);
               }}
               onSelectRecent={(dir) => {
                 trackComposerBar({ element: 'working_dir_recent' });
-                void setWorkingDirFolder(dir);
+                void setWorkingDirFolderImpl(dir, workingDirActionDeps);
               }}
               onClear={() => {
                 trackComposerBar({ element: 'working_dir_clear' });
-                void clearWorkingDir();
+                void clearWorkingDirImpl(workingDirActionDeps);
               }}
             />
           </div>
         ) : null}
-        {uploadError ? <span className="composer-hint">{uploadError}</span> : null}
-        {detailsRecord ? (
+        {upload.uploadError ? <span className="composer-hint">{upload.uploadError}</span> : null}
+        {modals.detailsRecord ? (
           <PluginDetailsModal
-            record={detailsRecord}
-            onClose={() => setDetailsRecord(null)}
+            record={modals.detailsRecord}
+            onClose={() => modals.setDetailsRecord(null)}
             onUse={async (record) => {
-              inlineBackedPluginRef.current = null;
+              setInlineBackedPlugin(null);
               await pluginsSectionRef.current?.applyById(record.id, record);
-              setDetailsRecord(null);
+              modals.setDetailsRecord(null);
             }}
-            onDuplicate={(record) => void duplicateDetailsPlugin(record)}
+            onDuplicate={(record) => {
+              void duplicatePluginRecordAsProjectImpl(record, {
+                locale,
+                t,
+                duplicatePluginAsProject,
+                navigate,
+                setDetailsRecord: modals.setDetailsRecord,
+                onShowToast,
+              });
+            }}
             hideUseAction
           />
         ) : null}
-        {detailsSkill ? (
+        {modals.detailsSkill ? (
           <SkillDetailsModal
-            skillId={detailsSkill.id}
-            summary={detailsSkill.summary}
-            onClose={() => setDetailsSkill(null)}
+            skillId={modals.detailsSkill.id}
+            summary={modals.detailsSkill.summary}
+            onClose={() => modals.setDetailsSkill(null)}
           />
         ) : null}
-        {libraryPickerOpen ? (
+        {modals.libraryPickerOpen ? (
           <LibraryPicker
-            onClose={() => setLibraryPickerOpen(false)}
-            onConfirm={(assets) => addAssetsFromLibrary(assets)}
+            onClose={() => modals.setLibraryPickerOpen(false)}
+            onConfirm={(assets) => addAssetsFromLibraryImpl(assets, uploadActionDeps)}
           />
         ) : null}
-        {figmaModalOpen && projectId ? (
+        {modals.figmaModalOpen && projectId ? (
           <FigmaImportModal
-            onClose={() => setFigmaModalOpen(false)}
+            onClose={() => modals.setFigmaModalOpen(false)}
             resolveProjectId={async () => projectId}
             onImported={(result) => {
               // Prefill the composer with the reshape prompt; the user reviews
@@ -3124,14 +1742,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               setDraft(prompt);
               editorRef.current?.setText(prompt);
               editorRef.current?.focus();
-              setFigmaModalOpen(false);
+              modals.setFigmaModalOpen(false);
             }}
           />
         ) : null}
-        {figmaHelpOpen ? (
-          <FigmaHelpModal onClose={() => setFigmaHelpOpen(false)} />
+        {modals.figmaHelpOpen ? (
+          <FigmaHelpModal onClose={() => modals.setFigmaHelpOpen(false)} />
         ) : null}
-        {projectReferenceOpen ? (
+        {modals.projectReferenceOpen ? (
           <ProjectReferenceModal
             currentProjectId={projectId}
             onClose={() => {
@@ -3145,2425 +1763,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 result: 'cancelled',
                 ...(projectId ? { project_id: projectId } : {}),
               });
-              setProjectReferenceOpen(false);
+              modals.setProjectReferenceOpen(false);
             }}
-            onSelect={(items) => void handleReferenceProjects(items)}
+            onSelect={(items) => void handleReferenceProjectsImpl(items, workspaceContextActionDeps)}
           />
         ) : null}
       </div>
     );
   }
 );
-
-function buildComposerMentionEntities({
-  connectors,
-  files,
-  mcpServers,
-  plugins,
-  skills,
-  staged,
-  workspaceContexts,
-}: {
-  connectors: ConnectorDetail[];
-  files: ProjectFile[];
-  mcpServers: McpServerConfig[];
-  plugins: InstalledPluginRecord[];
-  skills: SkillSummary[];
-  staged: ChatAttachment[];
-  workspaceContexts: WorkspaceContextItem[];
-}): InlineMentionEntity[] {
-  const entities: InlineMentionEntity[] = [];
-  const workspaceSeen = new Set<string>();
-  for (const item of workspaceContexts) {
-    if (!item.id || !item.label) continue;
-    const key = `workspace:${item.id}`;
-    if (workspaceSeen.has(key)) continue;
-    workspaceSeen.add(key);
-    entities.push({
-      id: item.id,
-      kind: 'workspace',
-      label: item.label,
-      token: inlineMentionToken(item.label),
-      title: `Workspace: ${item.label}`,
-    });
-  }
-  for (const plugin of plugins) {
-    entities.push({
-      id: plugin.id,
-      kind: 'plugin',
-      label: plugin.title,
-      token: inlineMentionToken(plugin.title),
-      title: `Plugin: ${plugin.title}`,
-    });
-  }
-  for (const skill of skills) {
-    entities.push({
-      id: skill.id,
-      kind: 'skill',
-      label: skill.name,
-      token: inlineMentionToken(skill.name),
-      title: `Skill: ${skill.name}`,
-    });
-    if (skill.id !== skill.name) {
-      entities.push({
-        id: skill.id,
-        kind: 'skill',
-        label: skill.id,
-        token: inlineMentionToken(skill.id),
-        title: `Skill: ${skill.name}`,
-      });
-    }
-  }
-  for (const server of mcpServers) {
-    const label = server.label || server.id;
-    entities.push({
-      id: server.id,
-      kind: 'mcp',
-      label,
-      token: inlineMentionToken(label),
-      title: `MCP: ${label}`,
-    });
-    if (server.id !== label) {
-      entities.push({
-        id: server.id,
-        kind: 'mcp',
-        label: server.id,
-        token: inlineMentionToken(server.id),
-        title: `MCP: ${label}`,
-      });
-    }
-  }
-  for (const connector of connectors) {
-    entities.push({
-      id: connector.id,
-      kind: 'connector',
-      label: connector.name,
-      token: inlineMentionToken(connector.name),
-      title: `Connector: ${connector.name}`,
-    });
-    if (connector.id !== connector.name) {
-      entities.push({
-        id: connector.id,
-        kind: 'connector',
-        label: connector.id,
-        token: inlineMentionToken(connector.id),
-        title: `Connector: ${connector.name}`,
-      });
-    }
-  }
-  const filePaths = new Set<string>();
-  for (const file of files) {
-    const path = file.path ?? file.name;
-    if (!path || filePaths.has(path)) continue;
-    filePaths.add(path);
-    entities.push({
-      id: path,
-      kind: 'file',
-      label: path,
-      token: inlineMentionToken(path),
-      title: `File: ${path}`,
-    });
-  }
-  for (const attachment of staged) {
-    if (!attachment.path || filePaths.has(attachment.path)) continue;
-    filePaths.add(attachment.path);
-    entities.push({
-      id: attachment.path,
-      kind: 'file',
-      label: attachment.path,
-      token: inlineMentionToken(attachment.path),
-      title: `File: ${attachment.path}`,
-    });
-  }
-  return entities;
-}
-
-function isFiniteAttachmentOrder(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
-}
-
-// Upper bound on element markup folded into the composer input so a huge node's
-// outerHTML can't swamp the prompt; the screenshot still attaches in full.
-const MAX_ELEMENT_HTML_CHARS = 8000;
-
-/**
- * Render a captured element's markup as a composer-input block: a one-line
- * descriptor (selector + rendered size) followed by a fenced HTML code block.
- * Used when an element-pick library asset is pulled into the chat so the user
- * sees — and can edit — the element's HTML inline before sending.
- */
-function formatElementHtmlBlock(
-  asset: LibraryAsset,
-  element: LibraryElementMeta,
-  html: string,
-): string {
-  const descriptor = element.selector || element.tag || assetTitle(asset);
-  const size = element.width && element.height ? ` · ${element.width}×${element.height}` : '';
-  const trimmed = html.trim();
-  const body =
-    trimmed.length > MAX_ELEMENT_HTML_CHARS
-      ? `${trimmed.slice(0, MAX_ELEMENT_HTML_CHARS)}\n<!-- …truncated -->`
-      : trimmed;
-  return `Captured element ${descriptor}${size}\n\n\`\`\`html\n${body}\n\`\`\``;
-}
-
-function normalizeChatAttachmentOrders(attachments: ChatAttachment[]): ChatAttachment[] {
-  let fallbackOrder = 0;
-  return attachments.map((attachment) => {
-    if (isFiniteAttachmentOrder(attachment.order)) {
-      fallbackOrder = Math.max(fallbackOrder, Math.floor(attachment.order) + 1);
-      return { ...attachment, order: Math.floor(attachment.order) };
-    }
-    const order = fallbackOrder;
-    fallbackOrder += 1;
-    return { ...attachment, order };
-  });
-}
-
-function assignChatAttachmentOrders(
-  attachments: ChatAttachment[],
-  orderStart: number,
-): ChatAttachment[] {
-  return attachments.map((attachment, index) => ({
-    ...attachment,
-    order: orderStart + index,
-  }));
-}
-
-function nextChatAttachmentOrder(attachments: ChatAttachment[]): number {
-  return attachments.reduce(
-    (max, attachment, index) =>
-      Math.max(max, isFiniteAttachmentOrder(attachment.order) ? Math.floor(attachment.order) + 1 : index + 1),
-    0,
-  );
-}
-
-function sortChatAttachmentsByOrder(attachments: ChatAttachment[]): ChatAttachment[] {
-  return attachments
-    .map((attachment, index) => ({ attachment, index }))
-    .sort((a, b) => {
-      const aOrder = isFiniteAttachmentOrder(a.attachment.order) ? a.attachment.order : a.index;
-      const bOrder = isFiniteAttachmentOrder(b.attachment.order) ? b.attachment.order : b.index;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-      return a.index - b.index;
-    })
-    .map((entry) => entry.attachment);
-}
-
-function sortChatCommentAttachmentsByOrder(attachments: ChatCommentAttachment[]): ChatCommentAttachment[] {
-  return attachments
-    .map((attachment, index) => ({ attachment, index }))
-    .sort((a, b) => {
-      const aOrder = isFiniteAttachmentOrder(a.attachment.order) ? a.attachment.order : a.index;
-      const bOrder = isFiniteAttachmentOrder(b.attachment.order) ? b.attachment.order : b.index;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-      return a.index - b.index;
-    })
-    .map((entry) => entry.attachment);
-}
-
-function workspaceContextIcon(item: WorkspaceContextItem): IconName {
-  if (item.kind === 'browser') return 'globe';
-  if (item.kind === 'folder' || item.kind === 'design-files') return 'folder';
-  if (item.kind === 'project') return 'folder';
-  if (item.kind === 'local-code') return 'terminal';
-  if (item.kind === 'terminal') return 'terminal';
-  if (item.kind === 'side-chat') return 'comment';
-  if (item.kind === 'design-system') return 'blocks';
-  return 'file';
-}
-
-function workspaceContextTitle(item: WorkspaceContextItem): string {
-  return [
-    workspaceContextKindLabel(item.kind),
-    item.path ? `path: ${item.path}` : null,
-    item.absolutePath ? `absolute: ${item.absolutePath}` : null,
-    item.url ? `url: ${item.url}` : null,
-    item.title ? `title: ${item.title}` : null,
-  ].filter(Boolean).join(' | ');
-}
-
-function workspaceContextDescription(item: WorkspaceContextItem): string {
-  if (item.kind === 'design-files') return item.path || 'Project files';
-  if (item.kind === 'project') return item.absolutePath || item.path || item.title || item.id;
-  if (item.kind === 'local-code') return item.absolutePath || item.path || item.title || item.id;
-  if (item.kind === 'terminal') return item.title || 'Terminal session';
-  return item.url || item.path || item.absolutePath || item.title || item.tabId || item.id;
-}
-
-function lastPathSegment(path: string): string {
-  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
-  return normalized.split('/').filter(Boolean).pop() || path;
-}
-
-function projectFileMentionTitle(file: ProjectFile, fallback: string): string {
-  return file.name || lastPathSegment(fallback);
-}
-
-function projectFileMentionDescription(file: ProjectFile, fallback: string): string {
-  const label = projectFileMentionTitle(file, fallback);
-  if (fallback && fallback !== label) return fallback;
-  return [file.kind, file.mime].filter(Boolean).join(' · ');
-}
-
-function workspaceContextSearchText(item: WorkspaceContextItem): string {
-  return [
-    item.id,
-    item.kind,
-    item.label,
-    item.tabId ?? '',
-    item.path ?? '',
-    item.absolutePath ?? '',
-    item.url ?? '',
-    item.title ?? '',
-  ].join(' ');
-}
-
-function workspaceContextKindLabel(kind: WorkspaceContextItem['kind']): string {
-  switch (kind) {
-    case 'browser':
-      return 'Browser';
-    case 'design-files':
-      return 'Design files';
-    case 'design-system':
-      return 'Design system';
-    case 'folder':
-      return 'Folder';
-    case 'project':
-      return 'Project';
-    case 'local-code':
-      return 'Local code';
-    case 'terminal':
-      return 'Terminal';
-    case 'side-chat':
-      return 'Side chat';
-    case 'live-artifact':
-      return 'Live artifact';
-    case 'file':
-    default:
-      return 'File';
-  }
-}
-
-function StagedRunContexts({
-  designSystemPicker,
-  workspaceItems,
-  currentWorkspaceContextId,
-  skills,
-  mcpServers,
-  connectors,
-  attachments,
-  pluginChip,
-  projectId,
-  onRemoveWorkspace,
-  onRemoveSkill,
-  onRemoveMcp,
-  onRemoveConnector,
-  onRemoveAttachment,
-  onRemovePlugin,
-  onPluginDetails,
-  onSkillDetails,
-  t,
-}: {
-  designSystemPicker?: ReactNode;
-  workspaceItems: WorkspaceContextItem[];
-  currentWorkspaceContextId: string | null;
-  skills: SkillSummary[];
-  mcpServers: McpServerConfig[];
-  connectors: ConnectorDetail[];
-  attachments: ChatAttachment[];
-  pluginChip?: { id: string; title: string } | null;
-  projectId: string | null;
-  onRemoveWorkspace: (id: string) => void;
-  onRemoveSkill: (id: string) => void;
-  onRemoveMcp: (id: string) => void;
-  onRemoveConnector: (id: string) => void;
-  onRemoveAttachment: (path: string) => void;
-  onRemovePlugin?: () => void;
-  onPluginDetails?: (id: string) => void;
-  onSkillDetails?: (id: string) => void;
-  t: TranslateFn;
-}) {
-  // Attachment thumbnails preview in a portal modal; keep that state here so the
-  // file chips can live in the same wrap row as the design-system picker and
-  // other run-context chips (so files flow to the picker's right, wrapping to a
-  // new line only when the row fills) instead of forcing a separate row below.
-  const [preview, setPreview] = useState<ChatAttachment | null>(null);
-  const previewUrl = preview && projectId ? projectRawUrl(projectId, preview.path) : null;
-  useEffect(() => {
-    if (!preview) return;
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setPreview(null);
-    }
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [preview]);
-  return (
-    <>
-    <div
-      className="staged-row staged-context-row"
-      data-testid="staged-contexts"
-    >
-      {designSystemPicker ? (
-        <div className="staged-context-picker staged-context-picker--design-system">
-          {designSystemPicker}
-        </div>
-      ) : null}
-      {pluginChip ? (
-        <div className="staged-chip staged-context staged-context--plugin">
-          {/* Two sibling controls — a details button (icon + name) and the
-              remove button — rather than a role=button wrapper containing the
-              remove button. Nested interactive controls break focus order and
-              assistive-tech announcements. */}
-          <button
-            type="button"
-            className="staged-context-open"
-            onClick={() => onPluginDetails?.(pluginChip.id)}
-            title={pluginChip.title}
-            aria-label={pluginChip.title}
-          >
-            <span className="staged-icon" aria-hidden>
-              <Icon name="sparkles" size={12} />
-            </span>
-            <span className="staged-name">{pluginChip.title}</span>
-          </button>
-          <button
-            type="button"
-            className="staged-remove od-tooltip"
-            onClick={() => onRemovePlugin?.()}
-            title={t('common.delete')}
-            data-tooltip={t('common.delete')}
-            aria-label={t('chat.removeAria', { name: pluginChip.title })}
-          >
-            <Icon name="close" size={11} />
-          </button>
-        </div>
-      ) : null}
-      {workspaceItems.map((workspaceItem) => {
-        const kindLabel =
-          workspaceItem.id === currentWorkspaceContextId
-            ? 'Current'
-            : workspaceContextKindLabel(workspaceItem.kind);
-        return (
-          <div
-            key={workspaceItem.id}
-            className={`staged-chip staged-context staged-context--workspace staged-context--workspace-${workspaceItem.kind}`}
-          >
-            <span className="staged-icon" aria-hidden>
-              <Icon name={workspaceContextIcon(workspaceItem)} size={12} />
-            </span>
-            <span className="staged-name" title={workspaceContextTitle(workspaceItem)}>
-              <span className="staged-context-kind">{kindLabel}</span>
-              {workspaceItem.label}
-            </span>
-            <button
-              type="button"
-              className="staged-remove od-tooltip"
-              onClick={() => onRemoveWorkspace(workspaceItem.id)}
-              title={t('common.delete')}
-              data-tooltip={t('common.delete')}
-              aria-label={t('chat.removeAria', { name: workspaceItem.label })}
-            >
-              <Icon name="close" size={11} />
-            </button>
-          </div>
-        );
-      })}
-      {skills.map((s) => (
-        <div
-          key={s.id}
-          className={`staged-chip staged-context staged-context--skill staged-skill-${s.source ?? 'built-in'}`}
-        >
-          <button
-            type="button"
-            className="staged-context-open"
-            onClick={() => onSkillDetails?.(s.id)}
-            title={s.description || s.name}
-            aria-label={s.name}
-          >
-            <span className="staged-icon" aria-hidden>
-              <Icon name="sparkles" size={12} />
-            </span>
-            <span className="staged-name">@{s.name}</span>
-          </button>
-          <button
-            type="button"
-            className="staged-remove od-tooltip"
-            onClick={() => onRemoveSkill(s.id)}
-            title={t('common.delete')}
-            data-tooltip={t('common.delete')}
-            aria-label={t('chat.removeAria', { name: s.name })}
-          >
-            <Icon name="close" size={11} />
-          </button>
-        </div>
-      ))}
-      {mcpServers.map((server) => {
-        const label = server.label || server.id;
-        return (
-          <div
-            key={server.id}
-            className="staged-chip staged-context staged-context--mcp"
-          >
-            <span className="staged-icon" aria-hidden>
-              <Icon name="link" size={12} />
-            </span>
-            <span className="staged-name" title={server.command || server.url || server.id}>
-              @{label}
-            </span>
-            <button
-              type="button"
-              className="staged-remove od-tooltip"
-              onClick={() => onRemoveMcp(server.id)}
-              title={t('common.delete')}
-              data-tooltip={t('common.delete')}
-              aria-label={t('chat.removeAria', { name: label })}
-            >
-              <Icon name="close" size={11} />
-            </button>
-          </div>
-        );
-      })}
-      {connectors.map((connector) => (
-        <div
-          key={connector.id}
-          className="staged-chip staged-context staged-context--connector"
-        >
-          <span className="staged-icon" aria-hidden>
-            <Icon name="link" size={12} />
-          </span>
-          <span className="staged-name" title={connector.accountLabel ?? connector.provider}>
-            @{connector.name}
-          </span>
-          <button
-            type="button"
-            className="staged-remove od-tooltip"
-            onClick={() => onRemoveConnector(connector.id)}
-            title={t('common.delete')}
-            data-tooltip={t('common.delete')}
-            aria-label={t('chat.removeAria', { name: connector.name })}
-          >
-            <Icon name="close" size={11} />
-          </button>
-        </div>
-      ))}
-      {attachments.map((a, index) => {
-        const canPreview = a.kind === 'image' && Boolean(projectId);
-        const imageUrl = canPreview ? projectRawUrl(projectId!, a.path) : null;
-        return (
-          <div key={a.path} className={`staged-chip staged-${a.kind}`}>
-            <span className="staged-order" aria-label={`Attachment ${index + 1}`}>
-              {index + 1}
-            </span>
-            {canPreview && imageUrl ? (
-              <button
-                type="button"
-                className="staged-preview-trigger"
-                onClick={() => setPreview(a)}
-                title={a.path}
-                aria-label={`Preview ${a.name}`}
-              >
-                <img src={imageUrl} alt="" aria-hidden />
-                <span className="staged-name">{a.name}</span>
-              </button>
-            ) : (
-              <>
-                <span className="staged-icon" aria-hidden>
-                  <Icon name="file" size={13} />
-                </span>
-                <span className="staged-name" title={a.path}>
-                  {a.name}
-                </span>
-              </>
-            )}
-            <button
-              type="button"
-              className="staged-remove od-tooltip"
-              onClick={() => onRemoveAttachment(a.path)}
-              title={t('common.delete')}
-              data-tooltip={t('common.delete')}
-              aria-label={t('chat.removeAria', { name: a.name })}
-            >
-              <Icon name="close" size={11} />
-            </button>
-          </div>
-        );
-      })}
-    </div>
-    {preview && previewUrl ? createPortal(
-      <div
-        className="staged-preview-modal"
-        role="dialog"
-        aria-modal="true"
-        aria-label={preview.name}
-        onMouseDown={(e) => {
-          if (e.target === e.currentTarget) setPreview(null);
-        }}
-      >
-        <div className="staged-preview-card">
-          <div className="staged-preview-head">
-            <span title={preview.path}>{preview.name}</span>
-            <button
-              type="button"
-              className="icon-only od-tooltip"
-              onClick={() => setPreview(null)}
-              aria-label={t('common.close')}
-              title={t('common.close')}
-              data-tooltip={t('common.close')}
-            >
-              <Icon name="close" size={14} />
-            </button>
-          </div>
-          <img src={previewUrl} alt={preview.name} />
-        </div>
-      </div>,
-      document.body
-    ) : null}
-    </>
-  );
-}
-
-function StagedCommentAttachments({
-  attachments,
-  onRemove,
-  t,
-}: {
-  attachments: ChatCommentAttachment[];
-  onRemove: (id: string) => void;
-  t: TranslateFn;
-}) {
-  const visibleAttachments = attachments.filter((attachment) => attachment.selectionKind !== 'visual');
-  if (visibleAttachments.length === 0) return null;
-  return (
-    <div className="staged-row comment-staged-row" data-testid="staged-comment-attachments">
-      {visibleAttachments.map((a) => (
-        <div key={a.id} className="staged-chip staged-comment">
-          <span
-            className="staged-name"
-            title={`${a.screenshotPath ? `${a.screenshotPath}: ` : ''}${commentTargetDisplayName(a)}${a.comment ? `: ${a.comment}` : ''}`}
-          >
-            <strong>{commentTargetDisplayName(a)}</strong>
-            {a.comment ? <span>{a.comment}</span> : null}
-          </span>
-          <button
-            type="button"
-            className="staged-remove od-tooltip"
-            onClick={() => onRemove(a.id)}
-            title={t('chat.comments.removeAttachment')}
-            data-tooltip={t('chat.comments.removeAttachment')}
-            aria-label={t('chat.comments.removeAttachmentAria', { name: a.elementId })}
-          >
-            <Icon name="close" size={11} />
-          </button>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function ToolsPluginsPanel({
-  plugins,
-  activePluginId,
-  onApply,
-  onShowDetails,
-}: {
-  plugins: InstalledPluginRecord[];
-  activePluginId: string | null;
-  onApply: (record: InstalledPluginRecord) => void | Promise<void>;
-  onShowDetails: (record: InstalledPluginRecord) => void;
-}) {
-  const { locale } = useI18n();
-  const [pendingId, setPendingId] = useState<string | null>(null);
-  const [source, setSource] = useState<'community' | 'mine'>('community');
-  const [query, setQuery] = useState('');
-  const communityPlugins = useMemo(
-    () => plugins.filter((p) => p.sourceKind === 'bundled'),
-    [plugins],
-  );
-  const userPlugins = useMemo(
-    () => plugins.filter((p) => USER_PLUGIN_SOURCE_KINDS.has(p.sourceKind)),
-    [plugins],
-  );
-  const scopedPlugins = source === 'community' ? communityPlugins : userPlugins;
-  const visiblePlugins = useMemo(
-    () => scopedPlugins.filter((p) => pluginMatchesQuery(p, query)),
-    [scopedPlugins, query],
-  );
-
-  return (
-    <>
-      <div className="composer-tools-filter">
-        <div className="composer-tools-segments" role="tablist" aria-label="Plugin source">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={source === 'community'}
-            className={`composer-tools-segment${source === 'community' ? ' active' : ''}`}
-            onClick={() => setSource('community')}
-            title={`${communityPlugins.length} installed official plugins`}
-          >
-            Official
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={source === 'mine'}
-            className={`composer-tools-segment${source === 'mine' ? ' active' : ''}`}
-            onClick={() => setSource('mine')}
-            title={`${userPlugins.length} installed user plugins`}
-          >
-            My plugins
-          </button>
-        </div>
-        <input
-          className="composer-tools-search"
-          value={query}
-          onChange={(e) => setQuery(e.currentTarget.value)}
-          placeholder="Search plugins…"
-          aria-label="Search plugins"
-        />
-      </div>
-      {visiblePlugins.length === 0 ? (
-        <div className="composer-tools-empty">
-          {plugins.length === 0 ? (
-            <>
-              No plugins installed yet. Browse Official or add your own with{' '}
-              <code>od plugin install &lt;source&gt;</code>.
-            </>
-          ) : query ? (
-            <>No {source === 'community' ? 'Official' : 'My plugins'} results for “{query}”.</>
-          ) : (
-            <>No {source === 'community' ? 'Official' : 'My plugins'} plugins available.</>
-          )}
-        </div>
-      ) : (
-        <div className="composer-tools-list">
-          {visiblePlugins.map((p) => {
-            const pluginTitle = localizePluginTitle(locale, p);
-            const pluginDescription = localizePluginDescription(locale, p);
-            return (
-            <div
-              key={p.id}
-              className={`composer-tools-row composer-tools-row--plugin${
-                p.id === activePluginId ? ' active' : ''
-              }`}
-            >
-              <button
-                type="button"
-                className="composer-tools-row-main"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={async () => {
-                  setPendingId(p.id);
-                  try {
-                    await onApply(p);
-                  } finally {
-                    setPendingId(null);
-                  }
-                }}
-                disabled={pendingId !== null}
-                aria-busy={pendingId === p.id ? 'true' : undefined}
-                title={pluginDescription || pluginTitle}
-              >
-                <Icon name="sparkles" size={12} />
-                <span className="composer-tools-row-body">
-                  <strong>{pluginTitle}</strong>
-                  {pluginDescription ? (
-                    <span className="composer-tools-row-meta">
-                      {pluginDescription}
-                    </span>
-                  ) : (
-                    <span className="composer-tools-row-meta">{p.id}</span>
-                  )}
-                </span>
-                {pendingId === p.id ? (
-                  <span className="composer-tools-row-pending">Applying…</span>
-                ) : null}
-              </button>
-              <button
-                type="button"
-                className="composer-tools-row-side"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => onShowDetails(p)}
-                title={`View details for ${pluginTitle}`}
-                aria-label={`View details for ${pluginTitle}`}
-              >
-                <Icon name="eye" size={12} />
-              </button>
-            </div>
-            );
-          })}
-        </div>
-      )}
-    </>
-  );
-}
-
-function ToolsMcpPanel({
-  servers,
-  templates,
-  onInsert,
-  onManage,
-}: {
-  servers: McpServerConfig[];
-  templates: McpTemplate[];
-  onInsert: (serverId: string) => void;
-  onManage: () => void;
-}) {
-  const [query, setQuery] = useState('');
-  const visibleServers = useMemo(
-    () => servers.filter((s) => mcpServerMatchesQuery(s, query)),
-    [servers, query],
-  );
-  const visibleTemplates = useMemo(
-    () => templates.filter((tpl) => mcpTemplateMatchesQuery(tpl, query)).slice(0, 8),
-    [templates, query],
-  );
-
-  return (
-    <>
-      <div className="composer-tools-filter">
-        <input
-          className="composer-tools-search"
-          value={query}
-          onChange={(e) => setQuery(e.currentTarget.value)}
-          placeholder="Search MCP…"
-          aria-label="Search MCP servers and templates"
-        />
-      </div>
-      {visibleServers.length === 0 ? (
-        <div className="composer-tools-empty">
-          {servers.length === 0
-            ? 'No enabled MCP servers configured yet.'
-            : `No configured MCP results for “${query}”.`}
-        </div>
-      ) : (
-        <div className="composer-tools-list">
-          <div className="composer-tools-section-label">Configured</div>
-          {visibleServers.map((s) => (
-            <button
-              key={s.id}
-              type="button"
-              role="menuitem"
-              className="composer-tools-row"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => onInsert(s.id)}
-              title={`Insert a hint that nudges the model to use ${s.label || s.id}`}
-            >
-              <Icon name="link" size={12} />
-              <span className="composer-tools-row-body">
-                <strong>{s.label || s.id}</strong>
-                <span className="composer-tools-row-meta">{s.transport}</span>
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
-      {visibleTemplates.length > 0 ? (
-        <div className="composer-tools-list">
-          <div className="composer-tools-section-label">Templates</div>
-          {visibleTemplates.map((tpl) => (
-            <button
-              key={tpl.id}
-              type="button"
-              role="menuitem"
-              className="composer-tools-row"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={onManage}
-              title={`Add ${tpl.label} from Settings`}
-            >
-              <Icon name="plus" size={12} />
-              <span className="composer-tools-row-body">
-                <strong>{tpl.label}</strong>
-                <span className="composer-tools-row-meta">
-                  {tpl.transport}
-                  {tpl.category ? ` · ${tpl.category}` : ''}
-                </span>
-              </span>
-            </button>
-          ))}
-        </div>
-      ) : null}
-      <button
-        type="button"
-        role="menuitem"
-        className="composer-tools-row composer-tools-row-action"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={onManage}
-      >
-        <Icon name="settings" size={12} />
-        <span>Manage MCP servers…</span>
-      </button>
-    </>
-  );
-}
-
-function DesignToolboxPanel({
-  actions,
-  skills,
-  plugins,
-  mcpServers,
-  mcpTemplates,
-  connectors,
-  projectFiles,
-  activeSkillIds,
-  activePluginId,
-  activeMcpServerIds,
-  activeConnectorIds,
-  activeFilePaths,
-  onPickAction,
-  onPickSkill,
-  onPickResource,
-  onOpened,
-}: {
-  actions: DesignToolboxAction[];
-  skills: SkillSummary[];
-  plugins: InstalledPluginRecord[];
-  mcpServers: McpServerConfig[];
-  mcpTemplates: McpTemplate[];
-  connectors: ConnectorDetail[];
-  projectFiles: ProjectFile[];
-  activeSkillIds: string[];
-  activePluginId: string | null;
-  activeMcpServerIds: string[];
-  activeConnectorIds: string[];
-  activeFilePaths: string[];
-  onPickAction: (action: DesignToolboxAction) => void;
-  onPickSkill: (skill: SkillSummary) => void;
-  onPickResource: (resource: DesignToolboxResource) => void;
-  onOpened?: () => void;
-}) {
-  const { locale, t } = useI18n();
-  const [query, setQuery] = useState('');
-  // Fire once when the toolbox panel mounts (i.e. the user opened it).
-  useEffect(() => {
-    onOpened?.();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  const activeSkillSet = useMemo(() => new Set(activeSkillIds), [activeSkillIds]);
-  const activeMcpServerSet = useMemo(() => new Set(activeMcpServerIds), [activeMcpServerIds]);
-  const activeConnectorSet = useMemo(() => new Set(activeConnectorIds), [activeConnectorIds]);
-  const activeFileSet = useMemo(() => new Set(activeFilePaths), [activeFilePaths]);
-  const resources = useMemo(
-    () =>
-      buildDesignToolboxResources({
-        skills,
-        plugins,
-        mcpServers,
-        mcpTemplates,
-        connectors,
-        projectFiles,
-        locale,
-        t,
-      }),
-    [connectors, locale, mcpServers, mcpTemplates, plugins, projectFiles, skills, t],
-  );
-  const visibleActions = useMemo(
-    () =>
-      actions.filter((action) => {
-        const skill = findDesignToolboxSkill(action, skills);
-        return designToolboxActionMatchesQuery(
-          action,
-          query,
-          skill,
-          t,
-          skill ? [localizeSkillName(locale, skill), localizeSkillDescription(locale, skill)] : [],
-        );
-      }),
-    [actions, query, skills, locale, t],
-  );
-  const visibleResources = useMemo(
-    () => {
-      const source = query
-        ? resources.filter((resource) => designToolboxResourceMatchesQuery(resource, query))
-        : designToolboxDefaultResources(actions, resources);
-      return source.slice(0, query ? 14 : 8);
-    },
-    [actions, query, resources],
-  );
-
-  // One shared hover-detail panel for the whole list — swapping a single
-  // portaled panel as the cursor sweeps rows, instead of one panel per row
-  // (which ghosted: the close delay left several stacked on screen at once).
-  const [toolboxDetail, setToolboxDetail] = useState<{
-    key: string;
-    left: number;
-    top: number;
-    node: ReactNode;
-  } | null>(null);
-  const detailCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  function cancelDetailClose() {
-    if (detailCloseTimer.current) {
-      clearTimeout(detailCloseTimer.current);
-      detailCloseTimer.current = null;
-    }
-  }
-  function showToolboxDetail(key: string, rect: DOMRect, node: ReactNode) {
-    cancelDetailClose();
-    // Plugin rows render a tall visual preview; the helper clamps both axes
-    // into the viewport so the fixed panel never lands off-screen on a
-    // narrow pane (see computeToolboxDetailPosition).
-    const { left, top } = computeToolboxDetailPosition(
-      rect,
-      { width: window.innerWidth, height: window.innerHeight },
-      { detailWidth: 264, gap: 8, margin: 8, estimatedHeight: 340 },
-    );
-    setToolboxDetail({ key, left, top, node });
-  }
-  function scheduleToolboxDetailClose(key: string) {
-    cancelDetailClose();
-    detailCloseTimer.current = setTimeout(() => {
-      setToolboxDetail((cur) => (cur?.key === key ? null : cur));
-      detailCloseTimer.current = null;
-    }, 160);
-  }
-  useEffect(() => () => cancelDetailClose(), []);
-
-  return (
-    <>
-      <div className="composer-design-toolbox-head">
-        <div className="composer-design-toolbox-title">
-          <Icon name="lightbulb" size={14} />
-          <span>{t('chat.designToolbox.title')}</span>
-        </div>
-      </div>
-      <div className="plus-menu__search">
-        <Icon name="search" size={13} />
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.currentTarget.value)}
-          placeholder={t('chat.designToolbox.searchPlaceholder')}
-          aria-label={t('chat.designToolbox.searchAria')}
-        />
-      </div>
-      {visibleActions.length > 0 || visibleResources.length > 0 ? (
-        <div className="plus-menu__list">
-          {visibleActions.length > 0 ? (
-            <div className="plus-menu__section-label">
-              {t('chat.designToolbox.followupSection')}
-            </div>
-          ) : null}
-          {visibleActions.map((action) => {
-            const skill = findDesignToolboxSkill(action, skills);
-            const actionTitle = designToolboxActionTitle(action, t);
-            const actionDescription = designToolboxActionDescription(action, t);
-            const skillName = skill ? localizeSkillName(locale, skill) : null;
-            return (
-              <ToolboxItemRow
-                key={action.id}
-                detailKey={action.id}
-                icon={action.icon}
-                name={actionTitle}
-                onHover={showToolboxDetail}
-                onLeave={scheduleToolboxDetailClose}
-                onPick={() => onPickAction(action)}
-                detail={
-                  <>
-                    <div className="plus-menu__detail-title">{actionTitle}</div>
-                    {actionDescription ? (
-                      <div className="plus-menu__detail-desc">{actionDescription}</div>
-                    ) : null}
-                    {skillName ? (
-                      <div className="plus-menu__detail-skill">@{skillName}</div>
-                    ) : null}
-                    <div className="plus-menu__detail-badge">
-                      {designToolboxActionBadge(action, t)}
-                    </div>
-                  </>
-                }
-              />
-            );
-          })}
-          {visibleResources.length > 0 ? (
-            <div className="plus-menu__section-label">
-              {t('chat.designToolbox.resourcesSection')}
-            </div>
-          ) : null}
-          {visibleResources.map((resource) => {
-            const active = designToolboxResourceIsActive(resource, {
-              skillIds: activeSkillSet,
-              pluginId: activePluginId,
-              mcpServerIds: activeMcpServerSet,
-              connectorIds: activeConnectorSet,
-              filePaths: activeFileSet,
-            });
-            return (
-              <ToolboxItemRow
-                key={resource.key}
-                detailKey={resource.key}
-                icon={resource.icon}
-                name={resource.title}
-                active={active}
-                onHover={showToolboxDetail}
-                onLeave={scheduleToolboxDetailClose}
-                onPick={() => {
-                  if (resource.kind === 'skill') {
-                    onPickSkill(resource.skill);
-                  } else {
-                    onPickResource(resource);
-                  }
-                }}
-                detail={
-                  // Plugin rows reuse the rich visual preview (poster /
-                  // sandboxed example iframe + meta); every other kind keeps
-                  // the compact text detail since it has no preview asset.
-                  resource.kind === 'plugin' ? (
-                    <ComposerPluginPreview record={resource.plugin} locale={locale} />
-                  ) : (
-                    <>
-                      <div className="plus-menu__detail-title">{resource.title}</div>
-                      {resource.subtitle ? (
-                        <div className="plus-menu__detail-desc">{resource.subtitle}</div>
-                      ) : null}
-                      <div className="plus-menu__detail-skill">
-                        {designToolboxResourceKindLabel(resource.kind, t)}
-                      </div>
-                      <div className="plus-menu__detail-badge">
-                        {active ? t('chat.designToolbox.selected') : resource.badge}
-                      </div>
-                    </>
-                  )
-                }
-              />
-            );
-          })}
-        </div>
-      ) : (
-        <div className="plus-menu__empty">
-          {t('chat.designToolbox.noResources', { query })}
-        </div>
-      )}
-      {toolboxDetail
-        ? createPortal(
-            <div
-              className="plus-menu__detail"
-              style={{ left: toolboxDetail.left, top: toolboxDetail.top }}
-              onMouseEnter={cancelDetailClose}
-              onMouseLeave={() => scheduleToolboxDetailClose(toolboxDetail.key)}
-            >
-              {toolboxDetail.node}
-            </div>,
-            document.body,
-          )
-        : null}
-    </>
-  );
-}
-
-// A single toolbox row, styled like the Connectors/Plugins submenu rows
-// (single line: icon + name). Clicking applies the entry; hovering shows a
-// third-level detail panel (title / description / @skill / badge). The detail
-// panel is PORTALED to <body> because the parent flyout uses `overflow-y: auto`
-// (height-capped scroll) which would otherwise clip a nested panel.
-// The hover detail panel is owned by the PARENT
-// (DesignToolboxPanel) as ONE shared panel — not per-row — so sweeping across
-// rows swaps the single panel in place instead of stacking several portaled
-// panels that briefly coexist (the close delay would otherwise leave 2-4 of
-// them on screen at once, reading as ghosting). The row just reports hover
-// enter/leave with its rect + detail node.
-function ToolboxItemRow({
-  icon,
-  name,
-  active,
-  detailKey,
-  detail,
-  onHover,
-  onLeave,
-  onPick,
-}: {
-  icon: IconName;
-  name: string;
-  active?: boolean;
-  detailKey: string;
-  detail: ReactNode;
-  onHover: (key: string, rect: DOMRect, detail: ReactNode) => void;
-  onLeave: (key: string) => void;
-  onPick: () => void;
-}) {
-  const rowRef = useRef<HTMLDivElement | null>(null);
-  return (
-    <div
-      ref={rowRef}
-      className="plus-menu__subitem"
-      onMouseEnter={() => {
-        const r = rowRef.current?.getBoundingClientRect();
-        if (r) onHover(detailKey, r, detail);
-      }}
-      onMouseLeave={() => onLeave(detailKey)}
-    >
-      <button
-        type="button"
-        role="menuitem"
-        className={`plus-menu__item${active ? ' is-active' : ''}`}
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={onPick}
-      >
-        <Icon name={icon} size={14} className="plus-menu__item-icon" />
-        <span>{name}</span>
-      </button>
-    </div>
-  );
-}
-
-function ToolsSkillsPanel({
-  skills,
-  currentSkillId,
-  onPick,
-}: {
-  skills: SkillSummary[];
-  currentSkillId: string | null;
-  onPick: (skill: SkillSummary) => void | Promise<void>;
-}) {
-  const { locale } = useI18n();
-  const [query, setQuery] = useState('');
-  const [pendingId, setPendingId] = useState<string | null>(null);
-  const visibleSkills = useMemo(
-    () => skills.filter((s) => skillMatchesQuery(s, query)).slice(0, 24),
-    [skills, query],
-  );
-  return (
-    <>
-      <div className="composer-tools-filter">
-        <input
-          className="composer-tools-search"
-          value={query}
-          onChange={(e) => setQuery(e.currentTarget.value)}
-          placeholder="Search skills…"
-          aria-label="Search skills"
-        />
-      </div>
-      {visibleSkills.length === 0 ? (
-        <div className="composer-tools-empty">
-          {skills.length === 0 ? 'No skills available yet.' : `No skills found for “${query}”.`}
-        </div>
-      ) : (
-        <div className="composer-tools-list">
-          {visibleSkills.map((skill) => {
-            const active = skill.id === currentSkillId;
-            return (
-              <button
-                key={skill.id}
-                type="button"
-                role="menuitem"
-                className={`composer-tools-row${active ? ' active' : ''}`}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={async () => {
-                  setPendingId(skill.id);
-                  try {
-                    await onPick(skill);
-                  } finally {
-                    setPendingId(null);
-                  }
-                }}
-                disabled={pendingId !== null}
-                title={localizeSkillDescription(locale, skill)}
-              >
-                <Icon name={active ? 'check' : 'file'} size={12} />
-                <span className="composer-tools-row-body">
-                  <strong>{localizeSkillName(locale, skill)}</strong>
-                  <span className="composer-tools-row-meta">
-                    {skill.mode}
-                    {skill.surface ? ` · ${skill.surface}` : ''}
-                  </span>
-                </span>
-                {pendingId === skill.id ? (
-                  <span className="composer-tools-row-pending">Applying…</span>
-                ) : null}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </>
-  );
-}
-
-function pluginMatchesQuery(plugin: InstalledPluginRecord, query: string): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  return [
-    plugin.title,
-    plugin.id,
-    plugin.sourceKind,
-    plugin.source,
-    plugin.manifest?.description ?? '',
-    ...(plugin.manifest?.tags ?? []),
-  ]
-    .join(' ')
-    .toLowerCase()
-    .includes(q);
-}
-
-
-function buildDesignToolboxResources({
-  skills,
-  plugins,
-  mcpServers,
-  mcpTemplates,
-  connectors,
-  projectFiles,
-  locale,
-  t,
-}: DesignToolboxResourceIndex & { locale: Locale; t: TranslateFn }): DesignToolboxResource[] {
-  const resources: DesignToolboxResource[] = [];
-
-  for (const skill of skills) {
-    const title = localizeSkillName(locale, skill);
-    const subtitle = localizeSkillDescription(locale, skill);
-    resources.push({
-      key: `skill:${skill.id}`,
-      kind: 'skill',
-      id: skill.id,
-      title,
-      subtitle,
-      badge: designToolboxSkillBadge(skill, t),
-      icon: designToolboxSkillIcon(skill),
-      searchText: [
-        'skill',
-        skill.id,
-        skill.name,
-        title,
-        subtitle,
-        skill.mode,
-        skill.surface ?? '',
-        skill.category ?? '',
-        ...skill.triggers,
-      ].join(' '),
-      skill,
-    });
-  }
-
-  for (const plugin of plugins) {
-    const subtitle = localizePluginDescription(locale, plugin) || plugin.id;
-    resources.push({
-      key: `plugin:${plugin.id}`,
-      kind: 'plugin',
-      id: plugin.id,
-      title: localizePluginTitle(locale, plugin),
-      subtitle,
-      badge: plugin.manifest?.od?.kind ?? 'plugin',
-      icon: 'sparkles',
-      searchText: [
-        'plugin',
-        plugin.id,
-        plugin.title,
-        plugin.sourceKind,
-        plugin.source,
-        subtitle,
-        ...(plugin.manifest?.tags ?? []),
-        plugin.manifest?.od?.kind ?? '',
-        plugin.manifest?.od?.scenario ?? '',
-        plugin.manifest?.od?.mode ?? '',
-      ].join(' '),
-      plugin,
-    });
-  }
-
-  for (const server of mcpServers) {
-    const title = server.label || server.id;
-    const subtitle = server.command || server.url || server.transport;
-    resources.push({
-      key: `mcp:${server.id}`,
-      kind: 'mcp',
-      id: server.id,
-      title,
-      subtitle,
-      badge: 'MCP',
-      icon: 'link',
-      searchText: [
-        'mcp',
-        server.id,
-        title,
-        subtitle,
-        server.transport,
-        server.templateId ?? '',
-      ].join(' '),
-      server,
-    });
-  }
-
-  for (const template of mcpTemplates) {
-    resources.push({
-      key: `mcp-template:${template.id}`,
-      kind: 'mcp-template',
-      id: template.id,
-      title: template.label,
-      subtitle: template.description,
-      badge: template.category,
-      icon: 'plus',
-      searchText: [
-        'mcp template',
-        template.id,
-        template.label,
-        template.description,
-        template.transport,
-        template.category,
-        template.homepage ?? '',
-        template.example ?? '',
-      ].join(' '),
-      template,
-    });
-  }
-
-  for (const connector of connectors) {
-    const toolCount = connector.toolCount ?? connector.tools.length;
-    resources.push({
-      key: `connector:${connector.id}`,
-      kind: 'connector',
-      id: connector.id,
-      title: connector.name,
-      subtitle: [
-        connector.description ?? connector.provider,
-        toolCount > 0 ? `${toolCount} tools` : null,
-        connector.accountLabel ?? null,
-      ].filter(Boolean).join(' · '),
-      badge: connector.category || 'connector',
-      icon: 'link',
-      searchText: [
-        'connector',
-        connector.id,
-        connector.name,
-        connector.provider,
-        connector.category,
-        connector.description ?? '',
-        connector.accountLabel ?? '',
-        ...(connector.featuredToolNames ?? []),
-        ...(connector.allowedToolNames ?? []),
-        ...connector.tools.slice(0, 20).flatMap((tool) => [tool.name, tool.title, tool.description ?? '']),
-      ].join(' '),
-      connector,
-    });
-  }
-
-  const seenFiles = new Set<string>();
-  for (const file of projectFiles) {
-    if (file.type === 'dir') continue;
-    const path = file.path ?? file.name;
-    if (!path || seenFiles.has(path)) continue;
-    seenFiles.add(path);
-    resources.push({
-      key: `file:${path}`,
-      kind: 'file',
-      id: path,
-      title: path,
-      subtitle: [file.kind, file.mime, file.artifactKind ?? ''].filter(Boolean).join(' · '),
-      badge: file.artifactKind ?? file.kind,
-      icon: looksLikeImage(path) ? 'image' : 'file',
-      searchText: [
-        'file',
-        'design file',
-        path,
-        file.name,
-        file.kind,
-        file.mime,
-        file.artifactKind ?? '',
-      ].join(' '),
-      file,
-    });
-  }
-
-  return resources;
-}
-
-function designToolboxResourceMatchesQuery(
-  resource: DesignToolboxResource,
-  query: string,
-): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  return resource.searchText.toLowerCase().includes(q);
-}
-
-function designToolboxDefaultResources(
-  actions: DesignToolboxAction[],
-  resources: DesignToolboxResource[],
-): DesignToolboxResource[] {
-  const out: DesignToolboxResource[] = [];
-  const seen = new Set<string>();
-  function add(resource: DesignToolboxResource | null | undefined) {
-    if (!resource || seen.has(resource.key)) return;
-    seen.add(resource.key);
-    out.push(resource);
-  }
-  function addByKindId(kind: DesignToolboxResourceKind, id: string) {
-    add(resources.find((resource) => resource.kind === kind && resource.id === id));
-  }
-
-  addByKindId('skill', 'creative-director');
-  for (const action of actions) {
-    const skill = resources.find((resource) =>
-      resource.kind === 'skill'
-      && action.preferredSkillIds.some((id) => resource.skill.id === id || resource.skill.name === id),
-    );
-    add(skill);
-  }
-  for (const term of ['design', 'image', 'video', 'motion', 'figma']) {
-    for (const resource of resources) {
-      if (out.length >= 8) return out;
-      if (resource.kind !== 'skill' && designToolboxResourceMatchesQuery(resource, term)) {
-        add(resource);
-      }
-    }
-  }
-  return out;
-}
-
-function designToolboxResourceKindLabel(
-  kind: DesignToolboxResourceKind,
-  t: TranslateFn,
-): string {
-  switch (kind) {
-    case 'skill':
-      return t('chat.designToolbox.kind.skill');
-    case 'plugin':
-      return t('chat.designToolbox.kind.plugin');
-    case 'mcp':
-      return t('chat.designToolbox.kind.mcp');
-    case 'mcp-template':
-      return t('chat.designToolbox.kind.mcpTemplate');
-    case 'connector':
-      return t('chat.designToolbox.kind.connector');
-    case 'file':
-      return t('chat.designToolbox.kind.designFile');
-  }
-}
-
-function designToolboxResourceIsActive(
-  resource: DesignToolboxResource,
-  active: {
-    skillIds: Set<string>;
-    pluginId: string | null;
-    mcpServerIds: Set<string>;
-    connectorIds: Set<string>;
-    filePaths: Set<string>;
-  },
-): boolean {
-  switch (resource.kind) {
-    case 'skill':
-      return active.skillIds.has(resource.skill.id);
-    case 'plugin':
-      return active.pluginId === resource.plugin.id;
-    case 'mcp':
-      return active.mcpServerIds.has(resource.server.id);
-    case 'connector':
-      return active.connectorIds.has(resource.connector.id);
-    case 'file':
-      return active.filePaths.has(resource.file.path ?? resource.file.name);
-    case 'mcp-template':
-      return false;
-  }
-}
-
-
-function isDesignToolboxSkill(skill: SkillSummary): boolean {
-  const category = skill.category ?? '';
-  if (
-    [
-      'animation-motion',
-      'creative-direction',
-      'image-generation',
-      'video-generation',
-      'web-artifacts',
-    ].includes(category)
-  ) {
-    return true;
-  }
-  return [
-    'animation',
-    'motion',
-    'gsap',
-    'polish',
-    'critique',
-    'taste',
-    'anti slop',
-    'anti ai',
-    'image',
-    'asset',
-    'reference',
-    'icon',
-    'logo',
-    'chart',
-    'diagram',
-    'echarts',
-    'three',
-    'spline',
-    'rive',
-    'lottie',
-    'mapbox',
-    'deck.gl',
-    'video',
-    'frontend',
-    'beautify',
-  ].some((term) => skillMatchesQuery(skill, term));
-}
-
-function designToolboxDefaultSkills(
-  actions: DesignToolboxAction[],
-  skills: SkillSummary[],
-): SkillSummary[] {
-  const out: SkillSummary[] = [];
-  const seen = new Set<string>();
-  function add(skill: SkillSummary | null | undefined) {
-    if (!skill || seen.has(skill.id)) return;
-    seen.add(skill.id);
-    out.push(skill);
-  }
-  for (const action of actions) {
-    add(findDesignToolboxSkill(action, skills));
-  }
-  for (const action of actions) {
-    for (const id of action.preferredSkillIds) {
-      add(skills.find((skill) => skill.id === id || skill.name === id));
-    }
-  }
-  return out;
-}
-
-function designToolboxSkillBadge(skill: SkillSummary, t: TranslateFn): string {
-  if (skill.mode === 'video' || skill.category === 'video-generation') return t('chat.designToolbox.badge.video');
-  if (skill.mode === 'image' || skill.category === 'image-generation') return t('chat.designToolbox.badge.image');
-  if (skill.category === 'animation-motion') return t('chat.designToolbox.badge.motion');
-  if (skill.category === 'creative-direction') return t('chat.designToolbox.badge.polish');
-  return skill.mode;
-}
-
-function designToolboxSkillIcon(skill: SkillSummary): IconName {
-  if (skill.mode === 'video' || skill.category === 'video-generation') return 'play';
-  if (skill.mode === 'image' || skill.category === 'image-generation') return 'image';
-  if (skill.category === 'animation-motion') return 'sliders';
-  if (skill.category === 'creative-direction') return 'sparkles';
-  return 'file';
-}
-
-function designToolboxContextLine(
-  workspaceItem: WorkspaceContextItem | null,
-  t: TranslateFn,
-): string {
-  if (!workspaceItem) {
-    return t('chat.designToolbox.prompt.contextGeneric');
-  }
-  const label = workspaceItem.label || workspaceItem.path || workspaceItem.title || workspaceItem.id;
-  return t('chat.designToolbox.prompt.contextSpecific', {
-    kind: designToolboxWorkspaceKindLabel(workspaceItem.kind, t),
-    label,
-  });
-}
-
-function designToolboxDraftLine(activeDraft: string, t: TranslateFn): string {
-  const trimmed = activeDraft.trim();
-  if (!trimmed) return '';
-  return t('chat.designToolbox.prompt.preserveDraft', { draft: trimmed });
-}
-
-function designToolboxWorkspaceKindLabel(
-  kind: WorkspaceContextItem['kind'],
-  t: TranslateFn,
-): string {
-  switch (kind) {
-    case 'browser':
-      return t('chat.designToolbox.context.browser');
-    case 'design-files':
-      return t('chat.designToolbox.context.designFiles');
-    case 'design-system':
-      return t('chat.designToolbox.context.designSystem');
-    case 'folder':
-    case 'project':
-    case 'local-code':
-      return t('chat.designToolbox.context.folder');
-    case 'terminal':
-      return t('chat.designToolbox.context.terminal');
-    case 'side-chat':
-      return t('chat.designToolbox.context.sideChat');
-    case 'live-artifact':
-      return t('chat.designToolbox.context.liveArtifact');
-    case 'file':
-    default:
-      return t('chat.designToolbox.context.file');
-  }
-}
-
-function designToolboxActionPrompt({
-  action,
-  skill,
-  workspaceItem,
-  activeDraft,
-  resourceIndex,
-  t,
-}: {
-  action: DesignToolboxAction;
-  skill: SkillSummary | null;
-  workspaceItem: WorkspaceContextItem | null;
-  activeDraft: string;
-  resourceIndex: DesignToolboxResourceIndex;
-  t: TranslateFn;
-}): string {
-  const skillLine = skill
-    ? t('chat.designToolbox.prompt.selectedSkill', { skill: skill.name })
-    : t('chat.designToolbox.prompt.noSkill');
-  const resourceLines = designToolboxResourceIndexLines(resourceIndex, t);
-  const draftLine = designToolboxDraftLine(activeDraft, t);
-  const base = [
-    designToolboxContextLine(workspaceItem, t),
-    skillLine,
-    ...resourceLines,
-    draftLine,
-  ].filter(Boolean);
-
-  switch (action.id) {
-    case 'auto-match':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.autoMatchIntro'),
-        t('chat.designToolbox.prompt.autoMatchStep1'),
-        t('chat.designToolbox.prompt.autoMatchStep2'),
-        t('chat.designToolbox.prompt.autoMatchStep3'),
-        t('chat.designToolbox.prompt.autoMatchStep4'),
-      ].join('\n');
-    case 'asset-search':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.assetSearch'),
-      ].join('\n');
-    case 'icon-workflow':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.iconWorkflow'),
-      ].join('\n');
-    case 'image-replace':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.imageReplace'),
-      ].join('\n');
-    case 'reference-extract':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.referenceExtract'),
-      ].join('\n');
-    case 'motion':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.motion'),
-      ].join('\n');
-    case 'motion-polish':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.motionPolish'),
-      ].join('\n');
-    case 'transition-motion':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.transitionMotion'),
-      ].join('\n');
-    case 'plan-outline':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.planOutline'),
-      ].join('\n');
-    case 'threejs-scene':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.threejsScene'),
-      ].join('\n');
-    case 'anti-ai-polish':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.antiAiPolish'),
-      ].join('\n');
-    case 'visual-polish':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.visualPolish'),
-      ].join('\n');
-    case 'image-gen':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.imageGen'),
-      ].join('\n');
-    case 'chart-gen':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.chartGen'),
-      ].join('\n');
-    case 'logo-gen':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.logoGen'),
-      ].join('\n');
-    case 'video-gen':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.videoGen'),
-      ].join('\n');
-  }
-
-  return [
-    ...base,
-    t('chat.designToolbox.prompt.autoMatchIntro'),
-  ].join('\n');
-}
-
-function designToolboxSkillPrompt({
-  skill,
-  workspaceItem,
-  activeDraft,
-  resourceIndex,
-  t,
-}: {
-  skill: SkillSummary;
-  workspaceItem: WorkspaceContextItem | null;
-  activeDraft: string;
-  resourceIndex: DesignToolboxResourceIndex;
-  t: TranslateFn;
-}): string {
-  return [
-    designToolboxContextLine(workspaceItem, t),
-    t('chat.designToolbox.prompt.useSkill', { skill: skill.name }),
-    ...designToolboxResourceIndexLines(resourceIndex, t),
-    designToolboxDraftLine(activeDraft, t),
-    t('chat.designToolbox.prompt.skillInstruction'),
-  ].filter(Boolean).join('\n');
-}
-
-function designToolboxResourcePrompt({
-  resource,
-  workspaceItem,
-  activeDraft,
-  resourceIndex,
-  t,
-}: {
-  resource: Exclude<DesignToolboxResource, { kind: 'skill' }>;
-  workspaceItem: WorkspaceContextItem | null;
-  activeDraft: string;
-  resourceIndex: DesignToolboxResourceIndex;
-  t: TranslateFn;
-}): string {
-  const base = [
-    designToolboxContextLine(workspaceItem, t),
-    t('chat.designToolbox.prompt.selectedResource', {
-      kind: designToolboxResourceKindLabel(resource.kind, t),
-      title: resource.title,
-      id: resource.id,
-    }),
-    resource.subtitle ? t('chat.designToolbox.prompt.resourceDescription', { description: resource.subtitle }) : '',
-    ...designToolboxResourceIndexLines(resourceIndex, t),
-    designToolboxDraftLine(activeDraft, t),
-  ].filter(Boolean);
-
-  switch (resource.kind) {
-    case 'plugin':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.pluginResource'),
-      ].join('\n');
-    case 'mcp':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.mcpResource'),
-      ].join('\n');
-    case 'mcp-template':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.mcpTemplateResource'),
-      ].join('\n');
-    case 'connector':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.connectorResource'),
-      ].join('\n');
-    case 'file':
-      return [
-        ...base,
-        t('chat.designToolbox.prompt.fileResource'),
-      ].join('\n');
-  }
-}
-
-function designToolboxResourceIndexLines(
-  index: DesignToolboxResourceIndex,
-  t: TranslateFn,
-): string[] {
-  const files = index.projectFiles
-    .filter((file) => file.type !== 'dir')
-    .map((file) => file.path ?? file.name);
-  return [
-    t('chat.designToolbox.prompt.resourceIndex', {
-      skills: index.skills.length,
-      plugins: index.plugins.length,
-      mcpEnabled: index.mcpServers.length,
-      mcpTemplates: index.mcpTemplates.length,
-      connectors: index.connectors.length,
-      files: files.length,
-    }),
-    designToolboxCompactLine(t('chat.designToolbox.prompt.searchableSkills'), index.skills.map((skill) => skill.name), 60, t),
-    designToolboxCompactLine(t('chat.designToolbox.prompt.searchablePlugins'), index.plugins.map((plugin) => plugin.title), 40, t),
-    designToolboxCompactLine(t('chat.designToolbox.prompt.availableMcp'), [
-      ...index.mcpServers.map((server) => server.label || server.id),
-      ...index.mcpTemplates.map((template) => t('chat.designToolbox.prompt.mcpTemplateName', { name: template.label })),
-    ], 40, t),
-    designToolboxCompactLine(t('chat.designToolbox.prompt.connectedConnectors'), index.connectors.map((connector) => connector.name), 30, t),
-    designToolboxCompactLine(t('chat.designToolbox.prompt.referenceDesignFiles'), files, 40, t),
-    t('chat.designToolbox.prompt.processRule'),
-  ].filter(Boolean);
-}
-
-function designToolboxCompactLine(
-  label: string,
-  values: string[],
-  limit: number,
-  t: TranslateFn,
-): string {
-  const clean = Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
-  if (clean.length === 0) return '';
-  const shown = clean.slice(0, limit);
-  const suffix = clean.length > shown.length
-    ? t('chat.designToolbox.prompt.moreSuffix', { count: clean.length - shown.length })
-    : '';
-  return t('chat.designToolbox.prompt.compactLine', {
-    label,
-    values: shown.join(', '),
-    suffix,
-  });
-}
-
-function skillMentionRank(skill: SkillSummary, query: string): number {
-  const q = query.trim().toLowerCase();
-  if (!q) return 1;
-  const id = skill.id.toLowerCase();
-  const name = skill.name.toLowerCase();
-  if (id.startsWith(q) || name.startsWith(q)) return 0;
-  return 1;
-}
-
-function mcpServerMatchesQuery(server: McpServerConfig, query: string): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  return [
-    server.id,
-    server.label ?? '',
-    server.transport,
-    server.url ?? '',
-    server.command ?? '',
-  ]
-    .join(' ')
-    .toLowerCase()
-    .includes(q);
-}
-
-function mcpTemplateMatchesQuery(tpl: McpTemplate, query: string): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  return [
-    tpl.id,
-    tpl.label,
-    tpl.description,
-    tpl.transport,
-    tpl.category,
-    tpl.homepage ?? '',
-    tpl.example ?? '',
-  ]
-    .join(' ')
-    .toLowerCase()
-    .includes(q);
-}
-
-function pluginSourceLabel(plugin: InstalledPluginRecord, t: TranslateFn): string {
-  return plugin.sourceKind === 'bundled' ? t('chat.mentionPluginOfficial') : t('chat.mentionPluginMine');
-}
-
-function ToolsImportPanel({
-  t,
-  onLinkFolder,
-  currentDesignSystemId,
-  onSwitchDesignSystem,
-}: {
-  t: TranslateFn;
-  onLinkFolder: () => Promise<void> | void;
-  currentDesignSystemId?: string | null;
-  // When omitted (no active project) the design-system import row stays
-  // disabled with the existing "Coming soon" affordance so users aren't
-  // routed into a picker that has nothing to PATCH. Returns true on a
-  // successful PATCH so the picker can close itself; false leaves the
-  // picker open so the user can retry.
-  onSwitchDesignSystem?: (
-    designSystemId: string | null,
-    title: string | null,
-  ) => Promise<boolean>;
-}) {
-  const [view, setView] = useState<'root' | 'designSystems'>('root');
-
-  if (view === 'designSystems' && onSwitchDesignSystem) {
-    return (
-      <DesignSystemSwitchPicker
-        t={t}
-        currentDesignSystemId={currentDesignSystemId}
-        onSelect={onSwitchDesignSystem}
-        onBack={() => setView('root')}
-      />
-    );
-  }
-
-  return (
-    <div className="composer-tools-list">
-      <ImportItem icon="upload" label={t('chat.importFig')} t={t} />
-      <ImportItem icon="grid" label={t('chat.importWeb')} t={t} />
-      <ImportItem
-        icon="folder"
-        label={t('chat.importFolder')}
-        t={t}
-        enabled
-        onClick={() => void onLinkFolder()}
-      />
-      <ImportItem
-        icon="sparkles"
-        label={t('chat.importSkills')}
-        t={t}
-        enabled={!!onSwitchDesignSystem}
-        onClick={() => setView('designSystems')}
-        testId="composer-import-design-systems"
-      />
-      <ImportItem icon="file" label={t('chat.importProject')} t={t} />
-    </div>
-  );
-}
-
-function ImportItem({
-  icon,
-  label,
-  t,
-  enabled,
-  onClick,
-  testId,
-}: {
-  icon: "upload" | "link" | "grid" | "folder" | "sparkles" | "file";
-  label: string;
-  t: TranslateFn;
-  enabled?: boolean;
-  onClick?: () => void;
-  testId?: string;
-}) {
-  return (
-    <button
-      type="button"
-      className={`composer-import-item${enabled ? ' composer-import-item-enabled' : ''}`}
-      role="menuitem"
-      tabIndex={-1}
-      disabled={!enabled}
-      title={enabled ? label : t('chat.importComingSoon')}
-      onClick={enabled && onClick ? onClick : (e) => e.preventDefault()}
-      data-testid={testId}
-    >
-      <span className="ico" aria-hidden>
-        <Icon name={icon} size={14} />
-      </span>
-      <span className="composer-import-item-label">{label}</span>
-      {!enabled && <span className="composer-import-item-soon">{t('chat.importSoon')}</span>}
-    </button>
-  );
-}
-
-function SlashPopover({
-  commands,
-  activeIndex,
-  onPick,
-  onHover,
-  t,
-}: {
-  commands: SlashCommand[];
-  activeIndex: number;
-  onPick: (cmd: SlashCommand) => void;
-  onHover: (index: number) => void;
-  t: TranslateFn;
-}) {
-  return (
-    <div
-      className="slash-popover"
-      data-testid="slash-popover"
-      role="listbox"
-      aria-label={t('pet.slashPopoverAria')}
-    >
-      <div className="slash-popover-head">
-        <span>{t('pet.slashPopoverTitle')}</span>
-        <span className="slash-popover-hint">{t('pet.slashPopoverHint')}</span>
-      </div>
-      {commands.map((cmd, idx) => {
-        const active = idx === activeIndex;
-        return (
-          <button
-            key={cmd.id}
-            id={`slash-opt-${idx}`}
-            type="button"
-            role="option"
-            aria-selected={active}
-            className={`slash-item${active ? ' active' : ''}`}
-            onMouseDown={(e) => {
-              // Prevent the textarea from losing focus before the click
-              // handler fires — otherwise selectionStart resets and the
-              // pick replacement targets the wrong substring.
-              e.preventDefault();
-            }}
-            onMouseEnter={() => onHover(idx)}
-            onClick={() => onPick(cmd)}
-          >
-            <span className="slash-item-icon" aria-hidden>
-              <Icon name={cmd.icon} size={13} />
-            </span>
-            <span className="slash-item-body">
-              <span className="slash-item-row">
-                <code className="slash-item-label">{cmd.label}</code>
-                {cmd.argHint ? (
-                  <span className="slash-item-arg">{cmd.argHint}</span>
-                ) : null}
-              </span>
-              <span className="slash-item-desc">{t(cmd.descKey)}</span>
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function MentionPopover({
-  files,
-  workspaceContexts,
-  connectors,
-  plugins,
-  skills,
-  mcpServers,
-  query,
-  tab,
-  onTabChange,
-  activeIndex,
-  currentSkillId,
-  onPickFile,
-  onPickWorkspaceContext,
-  onPickPlugin,
-  onPickSkill,
-  onPickMcp,
-  onPickConnector,
-}: {
-  files: ProjectFile[];
-  workspaceContexts: WorkspaceContextItem[];
-  connectors: ConnectorDetail[];
-  plugins: InstalledPluginRecord[];
-  skills: SkillSummary[];
-  mcpServers: McpServerConfig[];
-  query: string;
-  tab: MentionTab;
-  onTabChange: (tab: MentionTab) => void;
-  activeIndex: number;
-  currentSkillId: string | null;
-  onPickFile: (path: string) => void;
-  onPickWorkspaceContext: (item: WorkspaceContextItem) => void;
-  onPickPlugin: (record: InstalledPluginRecord) => void;
-  onPickSkill: (skill: SkillSummary) => void;
-  onPickMcp: (server: McpServerConfig) => void;
-  onPickConnector: (connector: ConnectorDetail) => void;
-}) {
-  const { locale, t } = useI18n();
-  const ref = useRef<HTMLDivElement | null>(null);
-  const tabs: Array<{ id: MentionTab; label: string }> = [
-    { id: 'all', label: t('chat.mentionTabAll') },
-    { id: 'files', label: t('chat.mentionTabFiles') },
-    { id: 'tabs', label: t('chat.mentionTabTabs') },
-    { id: 'plugins', label: t('chat.mentionTabPlugins') },
-    { id: 'skills', label: t('chat.mentionTabSkills') },
-    { id: 'mcp', label: t('chat.mentionTabMcp') },
-    { id: 'connectors', label: t('chat.mentionTabConnectors') },
-  ];
-  const showTabs = tab === 'all' || tab === 'tabs';
-  const showFiles = tab === 'all' || tab === 'files';
-  const showPlugins = tab === 'all' || tab === 'plugins';
-  const showSkills = tab === 'all' || tab === 'skills';
-  const showMcp = tab === 'all' || tab === 'mcp';
-  const showConnectors = tab === 'all' || tab === 'connectors';
-  const hasVisibleResults =
-    (showFiles && files.length > 0) ||
-    (showTabs && workspaceContexts.length > 0) ||
-    (showPlugins && plugins.length > 0) ||
-    (showSkills && skills.length > 0) ||
-    (showMcp && mcpServers.length > 0) ||
-    (showConnectors && connectors.length > 0);
-  useEffect(() => {
-    if (ref.current) ref.current.scrollTop = 0;
-  }, [connectors, files, plugins, skills, mcpServers, tab, workspaceContexts]);
-  let optionIndex = 0;
-  return (
-    <div className="mention-popover" data-testid="mention-popover">
-      <div className="mention-tabs" role="tablist" aria-label={t('chat.mentionTabsAria')}>
-        {tabs.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            role="tab"
-            aria-selected={tab === item.id}
-            className={`mention-tab${tab === item.id ? ' active' : ''}`}
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={() => onTabChange(item.id)}
-          >
-            {item.label}
-          </button>
-        ))}
-      </div>
-      <div className="mention-results" ref={ref} role="listbox" id="mention-listbox">
-        {!hasVisibleResults ? (
-          <div className="mention-empty">
-            {query ? (
-              <>{t('chat.mentionNoResults', { query })}</>
-            ) : (
-              <>{t('chat.mentionSearchPrompt')}</>
-            )}
-          </div>
-        ) : null}
-        {showFiles && files.length > 0 ? (
-          <>
-            <div className="mention-section-label">{t('chat.mentionSectionFiles')}</div>
-            {files.map((f) => {
-              const key = f.path ?? f.name;
-              const flat = optionIndex;
-              optionIndex += 1;
-              const active = flat === activeIndex;
-              return (
-                <button
-                  key={`file-${key}`}
-                  id={`mention-opt-${flat}`}
-                  role="option"
-                  aria-selected={active}
-                  className={`mention-item${active ? ' is-active' : ''}`}
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => onPickFile(key)}
-                >
-                  <Icon name="file" size={12} />
-                  <span className="mention-item-body">
-                    <strong>{projectFileMentionTitle(f, key)}</strong>
-                    <span className="mention-meta mention-meta--desc mention-meta--path">
-                      {projectFileMentionDescription(f, key)}
-                    </span>
-                  </span>
-                  {f.size != null ? (
-                    <span className="mention-meta mention-item-kind">{prettySize(f.size)}</span>
-                  ) : null}
-                </button>
-              );
-            })}
-          </>
-        ) : null}
-        {showTabs && workspaceContexts.length > 0 ? (
-          <>
-            <div className="mention-section-label">{t('chat.mentionSectionTabs')}</div>
-            {workspaceContexts.map((item) => {
-              const flat = optionIndex;
-              optionIndex += 1;
-              const active = flat === activeIndex;
-              return (
-                <button
-                  key={`workspace-${item.kind}-${item.id}`}
-                  id={`mention-opt-${flat}`}
-                  role="option"
-                  aria-selected={active}
-                  className={`mention-item mention-item--workspace${active ? ' is-active' : ''}`}
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => onPickWorkspaceContext(item)}
-                  title={workspaceContextTitle(item)}
-                >
-                  <Icon name={workspaceContextIcon(item)} size={12} />
-                  <span className="mention-item-body">
-                    <strong>{item.label}</strong>
-                    <span className="mention-meta mention-meta--desc">
-                      {workspaceContextDescription(item)}
-                    </span>
-                  </span>
-                  <span className="mention-meta mention-item-kind">{workspaceContextKindLabel(item.kind)}</span>
-                </button>
-              );
-            })}
-          </>
-        ) : null}
-        {showPlugins && plugins.length > 0 ? (
-          <>
-            <div className="mention-section-label">{t('chat.mentionSectionPlugins')}</div>
-            {plugins.map((p) => {
-              const flat = optionIndex;
-              optionIndex += 1;
-              const active = flat === activeIndex;
-              const pluginTitle = localizePluginTitle(locale, p);
-              const pluginDescription = localizePluginDescription(locale, p);
-              return (
-                <button
-                  key={`plugin-${p.id}`}
-                  id={`mention-opt-${flat}`}
-                  role="option"
-                  aria-selected={active}
-                  className={`mention-item mention-item--plugin${active ? ' is-active' : ''}`}
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => onPickPlugin(p)}
-                  title={pluginDescription || pluginTitle}
-                >
-                  <Icon name="sparkles" size={12} />
-                  <span className="mention-item-body">
-                    <strong>{pluginTitle}</strong>
-                    <span className="mention-meta mention-meta--desc">
-                      {pluginDescription || p.id}
-                    </span>
-                  </span>
-                  <span className="mention-meta mention-item-kind">{pluginSourceLabel(p, t)}</span>
-                </button>
-              );
-            })}
-          </>
-        ) : null}
-        {showSkills && skills.length > 0 ? (
-          <>
-            <div className="mention-section-label">{t('chat.mentionSectionSkills')}</div>
-            {skills.map((skill) => {
-              const flat = optionIndex;
-              optionIndex += 1;
-              const rowActive = flat === activeIndex;
-              const isCurrent = skill.id === currentSkillId;
-              return (
-                <button
-                  key={`skill-${skill.id}`}
-                  id={`mention-opt-${flat}`}
-                  role="option"
-                  aria-selected={rowActive}
-                  className={`mention-item${rowActive ? ' is-active' : ''}`}
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => onPickSkill(skill)}
-                  title={localizeSkillDescription(locale, skill)}
-                >
-                  <Icon name={isCurrent ? 'check' : 'file'} size={12} />
-                  <span className="mention-item-body">
-                    <strong>{localizeSkillName(locale, skill)}</strong>
-                    <span className="mention-meta mention-meta--desc">
-                      {localizeSkillDescription(locale, skill) || skill.id}
-                    </span>
-                  </span>
-                  <span className="mention-meta mention-item-kind">{isCurrent ? t('chat.mentionActiveSkill') : skill.mode}</span>
-                </button>
-              );
-            })}
-          </>
-        ) : null}
-        {showMcp && mcpServers.length > 0 ? (
-          <>
-            <div className="mention-section-label">{t('chat.mentionSectionMcp')}</div>
-            {mcpServers.map((server) => {
-              const flat = optionIndex;
-              optionIndex += 1;
-              const active = flat === activeIndex;
-              return (
-                <button
-                  key={`mcp-${server.id}`}
-                  id={`mention-opt-${flat}`}
-                  role="option"
-                  aria-selected={active}
-                  className={`mention-item${active ? ' is-active' : ''}`}
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => onPickMcp(server)}
-                  title={t('chat.mentionUseMcpTitle', { name: server.label || server.id })}
-                >
-                  <Icon name="link" size={12} />
-                  <span className="mention-item-body">
-                    <strong>{server.label || server.id}</strong>
-                    <span className="mention-meta mention-meta--desc">
-                      {server.url || server.command || server.id}
-                    </span>
-                  </span>
-                  <span className="mention-meta mention-item-kind">{server.transport}</span>
-                </button>
-              );
-            })}
-          </>
-        ) : null}
-        {showConnectors && connectors.length > 0 ? (
-          <>
-            <div className="mention-section-label">{t('chat.mentionSectionConnectors')}</div>
-            {connectors.map((connector) => {
-              const flat = optionIndex;
-              optionIndex += 1;
-              const active = flat === activeIndex;
-              return (
-                <button
-                  key={`connector-${connector.id}`}
-                  id={`mention-opt-${flat}`}
-                  role="option"
-                  aria-selected={active}
-                  className={`mention-item${active ? ' is-active' : ''}`}
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => onPickConnector(connector)}
-                  title={t('chat.mentionUseConnectorTitle', { name: connector.name })}
-                >
-                  <Icon name="link" size={12} />
-                  <span className="mention-item-body">
-                    <strong>{connector.name}</strong>
-                    <span className="mention-meta mention-meta--desc">
-                      {connector.description || connector.provider || connector.id}
-                    </span>
-                  </span>
-                  <span className="mention-meta mention-item-kind">{connector.accountLabel ?? connector.provider}</span>
-                </button>
-              );
-            })}
-          </>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function stripInlineMentionToken(text: string, label: string): string {
-  const token = inlineMentionToken(label);
-  return text.replace(
-    new RegExp(`(^|[\\s([{"'])${escapeRegExp(token)}(?=$|\\s|[.,;:!?)}\\]"'])([^\\S\\r\\n])?`, 'g'),
-    '$1',
-  );
-}
-
-function stripInlineMentionLabels(text: string, labels: string[]): string {
-  const uniqueLabels = Array.from(new Set(labels.map((label) => label.trim()).filter(Boolean)));
-  return uniqueLabels.reduce(
-    (current, label) => stripInlineMentionToken(current, label),
-    text,
-  );
-}
-
-function loadComposerDraft(key?: string): string | null {
-  if (!key || typeof window === 'undefined') return null;
-  try {
-    return window.localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-function saveComposerDraft(key: string | undefined, draft: string) {
-  if (!key || typeof window === 'undefined') return;
-  try {
-    if (draft) {
-      window.localStorage.setItem(key, draft);
-    } else {
-      window.localStorage.removeItem(key);
-    }
-  } catch {
-    // Storage can be unavailable in privacy modes; the composer should still work.
-  }
-}
-
-function looksLikeImage(name: string): boolean {
-  return /\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i.test(name);
-}
-
-function prettySize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
-}

--- a/apps/web/src/features/chat-composer/actions.ts
+++ b/apps/web/src/features/chat-composer/actions.ts
@@ -1,0 +1,1465 @@
+// Orchestration functions for the chat-composer: real branching/side-effect
+// logic (unlike rules.ts, which stays pure) extracted out of ChatComposer.tsx
+// so the god-component shrinks without a redesign. Each function takes every
+// piece of orchestrator state/setter/callback it needs as an explicit
+// parameter (a `deps` bag) instead of closing over component scope — the
+// orchestrator keeps a thin bound wrapper for anything it needs to reference
+// elsewhere (an imperative-handle ref, a JSX callback). No React, no
+// transport, no DOM globals — only injected callbacks touch those.
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import type {
+  AppliedPluginSnapshot,
+  ChatAnalyticsEntryFrom,
+  ChatSessionMode,
+  ConnectorDetail,
+  InstalledPluginRecord,
+  McpServerConfig,
+  PluginDuplicateProjectResponse,
+  WorkspaceContextItem,
+} from '@open-design/contracts';
+import type { ComposerBarClickProps, DesignToolboxClickProps } from '@open-design/contracts/analytics';
+import type {
+  AppConfig,
+  ChatAttachment,
+  ChatCommentAttachment,
+  Project,
+  ProjectFile,
+  ProjectMetadata,
+  SkillSummary,
+} from '../../types';
+import { inlineMentionToken, mentionTokenPresent, type InlineMentionEntity } from '../../utils/inlineMentions';
+import { findDesignToolboxSkill, type DesignToolboxAction } from '../../runtime/design-toolbox';
+import { BUILT_IN_PETS, CUSTOM_PET_ID } from '../../components/pet/pets';
+import { workspaceContextLinkedDir } from '../../components/workspace-context';
+import type { ProjectReferenceSelection } from '../../components/ProjectReferenceModal';
+import type { CaretRect } from '../../components/composer/LexicalComposerInput';
+import type { PlaceholderScenario } from '../../components/home-hero/placeholderScenarios';
+import { localizePluginTitle } from '../../components/plugins-home/localization';
+import type { Locale } from '../../i18n/types';
+import type { Route } from '../../router';
+import {
+  trackComposerBarClick,
+  trackContextLinkResult,
+  trackDesignToolboxClick,
+} from '../../analytics/events';
+import {
+  currentRunContextMeta as currentRunContextMetaRule,
+  designToolboxActionPrompt,
+  designToolboxResourcePrompt,
+  designToolboxSkillPrompt,
+  dropWorkspaceLinkedDirAdds,
+  expandHatchCommand,
+  expandSearchCommand,
+  linkedDirsWithWorkspaceContext,
+  stripInlineMentionLabels,
+  workspaceContextDirStillReferenced,
+} from './rules';
+import type {
+  ChatSendMeta,
+  DesignToolboxResource,
+  DesignToolboxResourceIndex,
+  MentionTab,
+  SlashCommand,
+  TrackedWorkspaceLinkedDir,
+  TranslateFn,
+} from './types';
+
+/** Everything the composer bottom bar's/design-toolbox's click-tracking
+ *  wrappers need: the analytics sink and the project id both fill into the
+ *  fixed page/area/project context so call sites only pass event-specific
+ *  fields. */
+export interface ComposerTrackDeps {
+  track: (
+    event: string,
+    properties: Record<string, unknown>,
+    options?: { requestId?: string; insertId?: string },
+  ) => void;
+  projectId: string | null;
+}
+
+/** Fills the fixed page/area/project context for the rest of the composer
+ *  bottom bar (plus menu, design-system / working-dir switch, agent
+ *  selector, context-chip removal). */
+export function trackComposerBar(
+  fields: Omit<ComposerBarClickProps, 'page_name' | 'area' | 'project_id'>,
+  deps: ComposerTrackDeps,
+) {
+  trackComposerBarClick(deps.track, {
+    page_name: 'chat_panel',
+    area: 'chat_composer',
+    ...(deps.projectId ? { project_id: deps.projectId } : {}),
+    ...fields,
+  });
+}
+
+/** Fills the fixed page/area/project context so toolbox call sites only
+ *  pass the event-specific fields (element + ids). */
+export function trackDesignToolbox(
+  fields: Omit<DesignToolboxClickProps, 'page_name' | 'area' | 'project_id'>,
+  deps: ComposerTrackDeps,
+) {
+  trackDesignToolboxClick(deps.track, {
+    page_name: 'chat_panel',
+    area: 'chat_composer',
+    ...(deps.projectId ? { project_id: deps.projectId } : {}),
+    ...fields,
+  });
+}
+
+/** Everything the plugin-details modal's "duplicate as project" flow needs:
+ *  the transport call (injected rather than imported directly, matching the
+ *  WorkingDirActionDeps precedent), the modal setter it closes on success,
+ *  navigation to the new project, and the failure-toast fallback. No single
+ *  cluster owns this (modals + router + a one-off transport call), so it
+ *  lives here rather than any one hook. */
+export interface DuplicatePluginDeps {
+  locale: Locale;
+  t: TranslateFn;
+  duplicatePluginAsProject: (
+    pluginId: string,
+    input: { name?: string },
+  ) => Promise<PluginDuplicateProjectResponse>;
+  navigate: (route: Route) => void;
+  setDetailsRecord: (record: InstalledPluginRecord | null) => void;
+  onShowToast?: (message: string) => void;
+}
+
+/** Duplicates `record` as a new project, closes the details modal, and
+ *  navigates to the new project on success; shows a toast and leaves the
+ *  modal open on failure. */
+export async function duplicatePluginRecordAsProject(
+  record: InstalledPluginRecord,
+  deps: DuplicatePluginDeps,
+) {
+  try {
+    const result = await deps.duplicatePluginAsProject(record.id, {
+      name: localizePluginTitle(deps.locale, record),
+    });
+    deps.setDetailsRecord(null);
+    deps.navigate({
+      kind: 'project',
+      projectId: result.projectId,
+      conversationId: result.conversationId,
+      fileName: result.relPath,
+    });
+  } catch {
+    deps.onShowToast?.(deps.t('pluginCard.duplicateFailed'));
+  }
+}
+
+/** Everything the design-toolbox "apply" flow needs from the outside world. */
+export interface DesignToolboxApplyDeps {
+  skills: SkillSummary[];
+  visibleWorkspaceContext: WorkspaceContextItem | null;
+  draft: string;
+  resourceIndex: DesignToolboxResourceIndex;
+  t: TranslateFn;
+  setStagedSkills: Dispatch<SetStateAction<SkillSummary[]>>;
+  setStagedMcpServers: Dispatch<SetStateAction<McpServerConfig[]>>;
+  setStagedConnectors: Dispatch<SetStateAction<ConnectorDetail[]>>;
+  replaceEditorDraft: (text: string) => void;
+  focusEditor: () => void;
+  appendContextAttachment: (path: string) => void;
+  setInlineBackedPlugin: (value: { id: string; label: string } | null) => void;
+  applyPluginById: (id: string, record: InstalledPluginRecord) => Promise<void>;
+}
+
+/** Adds `skill` to the staged list for this turn if it isn't already there
+ *  (dedup by id). */
+export function stageSkillForCurrentTurn(
+  skill: SkillSummary,
+  deps: Pick<DesignToolboxApplyDeps, 'setStagedSkills'>,
+) {
+  deps.setStagedSkills((prev) => (prev.some((s) => s.id === skill.id) ? prev : [...prev, skill]));
+}
+
+/** Replaces the draft with `prompt` and refocuses the editor. */
+export function applyDesignToolboxDraft(
+  prompt: string,
+  deps: Pick<DesignToolboxApplyDeps, 'replaceEditorDraft' | 'focusEditor'>,
+) {
+  deps.replaceEditorDraft(prompt);
+  deps.focusEditor();
+}
+
+/** Builds the full draft (prefixed with an `@<skill>` mention token when a
+ *  skill is given) and applies it, staging the skill first so its chip is
+ *  already present when the prompt lands. */
+export function applyDesignToolboxPrompt(
+  prompt: string,
+  skill: SkillSummary | null,
+  deps: Pick<DesignToolboxApplyDeps, 'setStagedSkills' | 'replaceEditorDraft' | 'focusEditor'>,
+) {
+  const nextPrompt = skill ? `${inlineMentionToken(skill.name)}\n${prompt}` : prompt;
+  if (skill) stageSkillForCurrentTurn(skill, deps);
+  applyDesignToolboxDraft(nextPrompt, deps);
+}
+
+/** Resolves a design-toolbox quick action to its prompt text (looking up
+ *  any skill it implies) and applies it. */
+export function applyDesignToolboxAction(action: DesignToolboxAction, deps: DesignToolboxApplyDeps) {
+  const skill = findDesignToolboxSkill(action, deps.skills);
+  applyDesignToolboxPrompt(
+    designToolboxActionPrompt({
+      action,
+      skill,
+      workspaceItem: deps.visibleWorkspaceContext,
+      activeDraft: deps.draft,
+      resourceIndex: deps.resourceIndex,
+      t: deps.t,
+    }),
+    skill,
+    deps,
+  );
+}
+
+/** Builds and applies the prompt for picking a skill directly from the
+ *  design toolbox. */
+export function applyDesignToolboxSkill(skill: SkillSummary, deps: DesignToolboxApplyDeps) {
+  applyDesignToolboxPrompt(
+    designToolboxSkillPrompt({
+      skill,
+      workspaceItem: deps.visibleWorkspaceContext,
+      activeDraft: deps.draft,
+      resourceIndex: deps.resourceIndex,
+      t: deps.t,
+    }),
+    skill,
+    deps,
+  );
+}
+
+/** Applies a design-toolbox resource pick. Skills delegate to
+ *  `applyDesignToolboxSkill`; plugins bind the inline-mention bridge and
+ *  apply the plugin before seeding the prompt; MCP servers/connectors/files
+ *  each stage themselves before seeding an `@`-prefixed prompt; any other
+ *  kind falls through to a plain prompt apply. */
+export function applyDesignToolboxResource(resource: DesignToolboxResource, deps: DesignToolboxApplyDeps) {
+  if (resource.kind === 'skill') {
+    applyDesignToolboxSkill(resource.skill, deps);
+    return;
+  }
+
+  const prompt = designToolboxResourcePrompt({
+    resource,
+    workspaceItem: deps.visibleWorkspaceContext,
+    activeDraft: deps.draft,
+    resourceIndex: deps.resourceIndex,
+    t: deps.t,
+  });
+
+  if (resource.kind === 'plugin') {
+    void (async () => {
+      deps.setInlineBackedPlugin({ id: resource.plugin.id, label: resource.plugin.title });
+      await deps.applyPluginById(resource.plugin.id, resource.plugin);
+      applyDesignToolboxDraft(`${inlineMentionToken(resource.plugin.title)}\n${prompt}`, deps);
+    })();
+    return;
+  }
+
+  if (resource.kind === 'mcp') {
+    const label = resource.server.label || resource.server.id;
+    deps.setStagedMcpServers((current) =>
+      current.some((item) => item.id === resource.server.id) ? current : [...current, resource.server],
+    );
+    applyDesignToolboxDraft(`${inlineMentionToken(label)}\n${prompt}`, deps);
+    return;
+  }
+
+  if (resource.kind === 'connector') {
+    deps.setStagedConnectors((current) =>
+      current.some((item) => item.id === resource.connector.id) ? current : [...current, resource.connector],
+    );
+    applyDesignToolboxDraft(`${inlineMentionToken(resource.connector.name)}\n${prompt}`, deps);
+    return;
+  }
+
+  if (resource.kind === 'file') {
+    const path = resource.file.path ?? resource.file.name;
+    deps.appendContextAttachment(path);
+    applyDesignToolboxDraft(`${inlineMentionToken(path)}\n${prompt}`, deps);
+    return;
+  }
+
+  applyDesignToolboxDraft(prompt, deps);
+}
+
+/** Everything the staged-context "remove" handlers need from the outside world. */
+export interface StagedRemovalDeps {
+  draft: string;
+  replaceEditorDraft: (text: string) => void;
+  trackComposerBar: (fields: Omit<ComposerBarClickProps, 'page_name' | 'area' | 'project_id'>) => void;
+}
+
+/** Removes a staged skill by id, tracks the removal via analytics, and
+ *  strips its `@<name>`/`@<id>` mention token from the draft. */
+export function removeStagedSkill(
+  id: string,
+  stagedSkills: SkillSummary[],
+  setStagedSkills: Dispatch<SetStateAction<SkillSummary[]>>,
+  deps: StagedRemovalDeps,
+) {
+  deps.trackComposerBar({ element: 'context_remove', resource_kind: 'skill', resource_id: id });
+  const skill = stagedSkills.find((s) => s.id === id) ?? null;
+  setStagedSkills((prev) => prev.filter((s) => s.id !== id));
+  const labels = [id, skill?.name ?? ''];
+  deps.replaceEditorDraft(stripInlineMentionLabels(deps.draft, labels));
+}
+
+/** Removes a staged MCP server by id, tracks the removal via analytics, and
+ *  strips its `@<label>`/`@<id>` mention token from the draft. */
+export function removeStagedMcpServer(
+  id: string,
+  stagedMcpServers: McpServerConfig[],
+  setStagedMcpServers: Dispatch<SetStateAction<McpServerConfig[]>>,
+  deps: StagedRemovalDeps,
+) {
+  deps.trackComposerBar({ element: 'context_remove', resource_kind: 'mcp', resource_id: id });
+  const server = stagedMcpServers.find((item) => item.id === id) ?? null;
+  setStagedMcpServers((prev) => prev.filter((item) => item.id !== id));
+  deps.replaceEditorDraft(stripInlineMentionLabels(deps.draft, [id, server?.label ?? '']));
+}
+
+/** Removes a staged connector by id, tracks the removal via analytics, and
+ *  strips its `@<name>`/`@<id>` mention token from the draft. */
+export function removeStagedConnector(
+  id: string,
+  stagedConnectors: ConnectorDetail[],
+  setStagedConnectors: Dispatch<SetStateAction<ConnectorDetail[]>>,
+  deps: StagedRemovalDeps,
+) {
+  deps.trackComposerBar({ element: 'context_remove', resource_kind: 'connector', resource_id: id });
+  const connector = stagedConnectors.find((item) => item.id === id) ?? null;
+  setStagedConnectors((prev) => prev.filter((item) => item.id !== id));
+  deps.replaceEditorDraft(stripInlineMentionLabels(deps.draft, [id, connector?.name ?? '']));
+}
+
+/** Everything the working-directory picker's set/clear/pick flow needs from
+ *  the outside world — transport (patchProject, openFolderDialog), the
+ *  cross-cluster workspace-context state a promoted dir must reconcile
+ *  against, and the recent-dirs hook's own writer. */
+export interface WorkingDirActionDeps {
+  projectId: string | null;
+  projectMetadata: ProjectMetadata | undefined;
+  workspaceContextMetadataLinkedDirList: string[];
+  selectedWorkspaceContextDirs: string[];
+  patchProject: (id: string, patch: { metadata: ProjectMetadata }) => Promise<Project | null>;
+  openFolderDialog: () => Promise<string | null>;
+  onShowToast?: (message: string) => void;
+  onProjectMetadataChange?: (metadata: ProjectMetadata) => void;
+  setPromotedWorkspaceContextDir: Dispatch<SetStateAction<string | null>>;
+  setWorkspaceLinkedDirAdds: Dispatch<SetStateAction<Record<string, TrackedWorkspaceLinkedDir>>>;
+  rememberRecentDir: (dir: string) => Promise<void>;
+  t: TranslateFn;
+}
+
+/**
+ * The WorkingDirPicker treats the project's working directory as a single
+ * primary folder, so selecting one replaces the primary `linkedDirs` entry
+ * while preserving staged workspace-context dirs. The folder is read-only
+ * awareness for the agent (→ `--add-dir`), not a Design Files import, and
+ * `baseDir` is never touched.
+ */
+export async function setWorkingDirFolder(
+  dir: string,
+  deps: Omit<WorkingDirActionDeps, 'openFolderDialog'>,
+) {
+  if (!deps.projectId) return;
+  const base = deps.projectMetadata ?? { kind: 'prototype' as const };
+  const metadata: ProjectMetadata = {
+    ...base,
+    linkedDirs: linkedDirsWithWorkspaceContext(dir, deps.workspaceContextMetadataLinkedDirList),
+  };
+  const result = await deps.patchProject(deps.projectId, { metadata });
+  // The daemon rejects stale/inaccessible/system dirs with
+  // INVALID_LINKED_DIR (patchProject → null). Only commit the selection and
+  // promote it in recents when the project accepted it; otherwise surface
+  // the failure and leave recents untouched so a rejected path isn't
+  // re-promoted to the top of the menu.
+  if (!result?.metadata) {
+    deps.onShowToast?.(deps.t('homeWorkingDir.applyFailed'));
+    return;
+  }
+  deps.onProjectMetadataChange?.(result.metadata);
+  const promotedDir = dir.trim();
+  deps.setPromotedWorkspaceContextDir(
+    deps.selectedWorkspaceContextDirs.includes(promotedDir) ? promotedDir : null,
+  );
+  deps.setWorkspaceLinkedDirAdds((current) => dropWorkspaceLinkedDirAdds(current, promotedDir));
+  void deps.rememberRecentDir(dir);
+}
+
+/** Opens the folder-picker dialog and, if the user picked a folder, applies
+ *  it via `setWorkingDirFolder`. */
+export async function handlePickWorkingDir(deps: WorkingDirActionDeps) {
+  const selected = await deps.openFolderDialog();
+  if (selected) await setWorkingDirFolder(selected, deps);
+}
+
+/** Clears the project's working-directory selection back to no primary
+ *  linked dir. */
+export async function clearWorkingDir(
+  deps: Pick<
+    WorkingDirActionDeps,
+    | 'projectId'
+    | 'projectMetadata'
+    | 'workspaceContextMetadataLinkedDirList'
+    | 'patchProject'
+    | 'onProjectMetadataChange'
+    | 'setPromotedWorkspaceContextDir'
+  >,
+) {
+  if (!deps.projectId) return;
+  const base = deps.projectMetadata ?? { kind: 'prototype' as const };
+  const metadata: ProjectMetadata = {
+    ...base,
+    linkedDirs: linkedDirsWithWorkspaceContext(null, deps.workspaceContextMetadataLinkedDirList),
+  };
+  const result = await deps.patchProject(deps.projectId, { metadata });
+  if (result?.metadata) {
+    deps.setPromotedWorkspaceContextDir(null);
+    deps.onProjectMetadataChange?.(result.metadata);
+  }
+}
+
+/** Everything `appendWorkspacePrompt` needs to stage a workspace-context item
+ *  and insert its `@`-mention pill into the draft. */
+export interface AppendWorkspacePromptDeps {
+  setStagedWorkspaceContexts: Dispatch<SetStateAction<WorkspaceContextItem[]>>;
+  insertInlineMentionSeparator: () => void;
+  insertMention: (insert: { token: string; entity: InlineMentionEntity }) => void;
+  setMention: (value: { q: string } | null) => void;
+  setSlash: (value: { q: string } | null) => void;
+  markComposerEngaged: () => void;
+}
+
+/** Stages `item` as a workspace context (if not already staged), inserts
+ *  its `@`-mention pill into the draft, and closes the mention/slash
+ *  popovers. */
+export function appendWorkspacePrompt(item: WorkspaceContextItem, deps: AppendWorkspacePromptDeps) {
+  deps.setStagedWorkspaceContexts((current) =>
+    current.some((candidate) => candidate.id === item.id) ? current : [...current, item],
+  );
+  deps.insertInlineMentionSeparator();
+  deps.insertMention({
+    token: inlineMentionToken(item.label),
+    entity: { id: item.id, kind: 'workspace', label: item.label },
+  });
+  deps.setMention(null);
+  deps.setSlash(null);
+  deps.markComposerEngaged();
+}
+
+/** Everything `addLinkedDirs`/`addLinkedDir` need to persist new `linkedDirs`
+ *  entries onto the project and remember them in the recents list. */
+export interface LinkedDirActionDeps {
+  projectId: string | null;
+  projectMetadata: ProjectMetadata | undefined;
+  workspaceLinkedDirAdds: Record<string, TrackedWorkspaceLinkedDir>;
+  patchProject: (id: string, patch: { metadata: ProjectMetadata }) => Promise<Project | null>;
+  onShowToast?: (message: string) => void;
+  onProjectMetadataChange?: (metadata: ProjectMetadata) => void;
+  rememberRecentDir: (dir: string) => Promise<void>;
+  t: TranslateFn;
+}
+
+/**
+ * Links every (trimmed, deduped) dir in `dirs` onto the project's
+ * `linkedDirs`, skipping any already present. Returns a map from dir to its
+ * `TrackedWorkspaceLinkedDir` bookkeeping entry (or `null` when the dir was
+ * already linked by something other than a workspace-context add), or
+ * `false` if the project patch failed.
+ */
+export async function addLinkedDirs(
+  dirs: string[],
+  deps: LinkedDirActionDeps,
+): Promise<Map<string, TrackedWorkspaceLinkedDir | null> | false> {
+  if (!deps.projectId) return false;
+  const trimmedDirs = Array.from(new Set(dirs.map((dir) => dir.trim()).filter(Boolean)));
+  if (trimmedDirs.length === 0) return new Map();
+  const base = deps.projectMetadata ?? { kind: 'prototype' as const };
+  const existing = base.linkedDirs ?? [];
+  const nextLinkedDirs = [...existing];
+  const trackedByDir = new Map<string, TrackedWorkspaceLinkedDir | null>();
+  let changed = false;
+  for (const trimmed of trimmedDirs) {
+    if (nextLinkedDirs.includes(trimmed)) {
+      const ownedByWorkspaceContext = Object.values(deps.workspaceLinkedDirAdds).some(
+        (tracked) => tracked.dir === trimmed,
+      );
+      trackedByDir.set(trimmed, ownedByWorkspaceContext ? { dir: trimmed, previousLinkedDirs: existing } : null);
+      continue;
+    }
+    nextLinkedDirs.push(trimmed);
+    trackedByDir.set(trimmed, { dir: trimmed, previousLinkedDirs: existing });
+    changed = true;
+  }
+  if (changed) {
+    const metadata: ProjectMetadata = { ...base, linkedDirs: nextLinkedDirs };
+    const result = await deps.patchProject(deps.projectId, { metadata });
+    if (!result?.metadata) {
+      deps.onShowToast?.(deps.t('homeWorkingDir.applyFailed'));
+      return false;
+    }
+    deps.onProjectMetadataChange?.(result.metadata);
+    for (const trimmed of trimmedDirs) void deps.rememberRecentDir(trimmed);
+  }
+  return trackedByDir;
+}
+
+/** Single-dir convenience wrapper over `addLinkedDirs`. */
+export async function addLinkedDir(
+  dir: string,
+  deps: LinkedDirActionDeps,
+): Promise<TrackedWorkspaceLinkedDir | null | false> {
+  const trackedByDir = await addLinkedDirs([dir], deps);
+  if (trackedByDir === false) return false;
+  return trackedByDir.get(dir.trim()) ?? null;
+}
+
+/** Everything `handleReferenceProjects` needs: linking transport, staging the
+ *  picked projects as workspace-context prompts, and analytics. */
+export interface ReferenceProjectsDeps extends LinkedDirActionDeps, AppendWorkspacePromptDeps {
+  track: (
+    event: string,
+    properties: Record<string, unknown>,
+    options?: { requestId?: string; insertId?: string },
+  ) => void;
+  setProjectReferenceOpen: (open: boolean) => void;
+  setWorkspaceLinkedDirAdds: Dispatch<SetStateAction<Record<string, TrackedWorkspaceLinkedDir>>>;
+}
+
+/** Links every selected project's resolved dir, stages each as a
+ *  workspace-context prompt, closes the reference-project modal on success,
+ *  and reports the linking result via analytics. */
+export async function handleReferenceProjects(
+  selections: ProjectReferenceSelection[],
+  deps: ReferenceProjectsDeps,
+) {
+  const items = selections.map(({ project, resolvedDir }) => {
+    const path = resolvedDir.trim();
+    return {
+      id: `project:${project.id}`,
+      kind: 'project',
+      label: project.name || project.id,
+      title: project.name || project.id,
+      path: project.id,
+      ...(path ? { absolutePath: path } : {}),
+    } satisfies WorkspaceContextItem;
+  });
+  const trackedByDir = await addLinkedDirs(items.map((item) => workspaceContextLinkedDir(item) ?? ''), deps);
+  if (trackedByDir === false) {
+    trackContextLinkResult(deps.track, {
+      page_name: 'chat_panel',
+      area: 'chat_composer',
+      context_kind: 'project',
+      result: 'failed',
+      count: items.length,
+      ...(deps.projectId ? { project_id: deps.projectId } : {}),
+    });
+    return;
+  }
+  for (const item of items) {
+    appendWorkspacePrompt(item, deps);
+  }
+  deps.setProjectReferenceOpen(false);
+  trackContextLinkResult(deps.track, {
+    page_name: 'chat_panel',
+    area: 'chat_composer',
+    context_kind: 'project',
+    result: 'success',
+    count: items.length,
+    ...(deps.projectId ? { project_id: deps.projectId } : {}),
+  });
+  const trackedAdds: Record<string, TrackedWorkspaceLinkedDir> = {};
+  for (const item of items) {
+    const path = workspaceContextLinkedDir(item);
+    const trackedLinkedDir = path ? trackedByDir.get(path) ?? null : null;
+    if (trackedLinkedDir) trackedAdds[item.id] = trackedLinkedDir;
+  }
+  if (Object.keys(trackedAdds).length > 0) {
+    deps.setWorkspaceLinkedDirAdds((current) => ({ ...current, ...trackedAdds }));
+  }
+}
+
+/** Everything `handleLinkLocalCodeContext` needs: the folder-picker dialog,
+ *  linking transport, staging the picked folder, and analytics. */
+export interface LinkLocalCodeContextDeps extends LinkedDirActionDeps, AppendWorkspacePromptDeps {
+  openFolderDialog: () => Promise<string | null>;
+  track: (
+    event: string,
+    properties: Record<string, unknown>,
+    options?: { requestId?: string; insertId?: string },
+  ) => void;
+  setWorkspaceLinkedDirAdds: Dispatch<SetStateAction<Record<string, TrackedWorkspaceLinkedDir>>>;
+}
+
+/** Opens the folder picker, links the selected folder, stages it as a
+ *  workspace-context prompt, and reports the result via analytics. */
+export async function handleLinkLocalCodeContext(deps: LinkLocalCodeContextDeps) {
+  const selected = await deps.openFolderDialog();
+  if (!selected) {
+    trackContextLinkResult(deps.track, {
+      page_name: 'chat_panel',
+      area: 'chat_composer',
+      context_kind: 'local_code',
+      result: 'cancelled',
+      ...(deps.projectId ? { project_id: deps.projectId } : {}),
+    });
+    return;
+  }
+  const trackedLinkedDir = await addLinkedDir(selected, deps);
+  if (trackedLinkedDir === false) {
+    trackContextLinkResult(deps.track, {
+      page_name: 'chat_panel',
+      area: 'chat_composer',
+      context_kind: 'local_code',
+      result: 'failed',
+      ...(deps.projectId ? { project_id: deps.projectId } : {}),
+    });
+    return;
+  }
+  const label = selected.split(/[/\\]/).filter(Boolean).pop() || selected;
+  const item: WorkspaceContextItem = {
+    id: `local-code:${selected}`,
+    kind: 'local-code',
+    label,
+    title: label,
+    absolutePath: selected,
+  };
+  appendWorkspacePrompt(item, deps);
+  if (trackedLinkedDir) {
+    deps.setWorkspaceLinkedDirAdds((current) => ({ ...current, [item.id]: trackedLinkedDir }));
+  }
+  trackContextLinkResult(deps.track, {
+    page_name: 'chat_panel',
+    area: 'chat_composer',
+    context_kind: 'local_code',
+    result: 'success',
+    count: 1,
+    ...(deps.projectId ? { project_id: deps.projectId } : {}),
+  });
+}
+
+/**
+ * Currently unreferenced from the orchestrator's JSX (the WorkingDirPicker's
+ * own pick/recent flows cover folder-linking today) but preserved verbatim
+ * from the pre-extraction component rather than dropped, since removing dead
+ * code is a cleanup out of scope for this behavior-preserving move.
+ */
+export async function handleLinkFolder(
+  deps: LinkedDirActionDeps & { openFolderDialog: () => Promise<string | null> },
+) {
+  if (!deps.projectId) return;
+  const selected = await deps.openFolderDialog();
+  if (!selected) return;
+  await addLinkedDir(selected, deps);
+}
+
+/** Everything the staged workspace-context "remove" flow needs: transport to
+ *  unlink a promoted dir, the cross-cluster staged/dismissed state it
+ *  reconciles, and the editor-draft mention cleanup. */
+export interface RemoveWorkspaceContextDeps {
+  projectId: string | null;
+  projectMetadata: ProjectMetadata | undefined;
+  patchProject: (id: string, patch: { metadata: ProjectMetadata }) => Promise<Project | null>;
+  onShowToast?: (message: string) => void;
+  onProjectMetadataChange?: (metadata: ProjectMetadata) => void;
+  t: TranslateFn;
+  workspaceLinkedDirAdds: Record<string, TrackedWorkspaceLinkedDir>;
+  setWorkspaceLinkedDirAdds: Dispatch<SetStateAction<Record<string, TrackedWorkspaceLinkedDir>>>;
+  selectedWorkspaceContexts: WorkspaceContextItem[];
+  workingDir: string | null;
+  visibleWorkspaceContext: WorkspaceContextItem | null;
+  setDismissedWorkspaceContextId: Dispatch<SetStateAction<string | null>>;
+  setStagedWorkspaceContexts: Dispatch<SetStateAction<WorkspaceContextItem[]>>;
+  draftRef: MutableRefObject<string>;
+  replaceEditorDraft: (text: string) => void;
+  trackComposerBar: (fields: Omit<ComposerBarClickProps, 'page_name' | 'area' | 'project_id'>) => void;
+}
+
+/** Unlinks a workspace-context-added dir from the project, unless something
+ *  else (another staged workspace context, or the active working dir) still
+ *  references it — in which case only the local tracking entry is dropped
+ *  and the project's `linkedDirs` is left untouched. Returns false only when
+ *  the project patch itself failed. */
+export async function removeTrackedWorkspaceLinkedDir(
+  id: string,
+  tracked: TrackedWorkspaceLinkedDir,
+  deps: Pick<
+    RemoveWorkspaceContextDeps,
+    | 'projectId'
+    | 'projectMetadata'
+    | 'patchProject'
+    | 'onShowToast'
+    | 'onProjectMetadataChange'
+    | 't'
+    | 'workspaceLinkedDirAdds'
+    | 'setWorkspaceLinkedDirAdds'
+    | 'selectedWorkspaceContexts'
+    | 'workingDir'
+  >,
+): Promise<boolean> {
+  if (!deps.projectId) return true;
+  if (
+    workspaceContextDirStillReferenced(
+      id,
+      tracked.dir,
+      deps.workspaceLinkedDirAdds,
+      deps.selectedWorkspaceContexts,
+      deps.workingDir,
+    )
+  ) {
+    deps.setWorkspaceLinkedDirAdds((current) => {
+      const { [id]: _removed, ...rest } = current;
+      return rest;
+    });
+    return true;
+  }
+  const base = deps.projectMetadata ?? { kind: 'prototype' as const };
+  const currentLinkedDirs = base.linkedDirs ?? [...tracked.previousLinkedDirs, tracked.dir];
+  const nextLinkedDirs = currentLinkedDirs.filter((dir) => dir !== tracked.dir);
+  const metadata: ProjectMetadata = { ...base, linkedDirs: nextLinkedDirs };
+  const result = await deps.patchProject(deps.projectId, { metadata });
+  if (!result?.metadata) {
+    deps.onShowToast?.(deps.t('homeWorkingDir.applyFailed'));
+    return false;
+  }
+  deps.onProjectMetadataChange?.(result.metadata);
+  deps.setWorkspaceLinkedDirAdds((current) => {
+    const { [id]: _removed, ...rest } = current;
+    return rest;
+  });
+  return true;
+}
+
+/** Removes a staged/selected workspace context: unlinks its tracked dir (if
+ *  any, subject to the still-referenced check in
+ *  `removeTrackedWorkspaceLinkedDir`), clears it from the dismissed/staged
+ *  lists, and strips its mention labels from the draft. */
+export async function removeWorkspaceContext(id: string, deps: RemoveWorkspaceContextDeps) {
+  deps.trackComposerBar({ element: 'context_remove', resource_kind: 'workspace', resource_id: id });
+  const workspaceItem = deps.selectedWorkspaceContexts.find((item) => item.id === id) ?? null;
+  const trackedLinkedDir = deps.workspaceLinkedDirAdds[id] ?? null;
+  if (trackedLinkedDir && !(await removeTrackedWorkspaceLinkedDir(id, trackedLinkedDir, deps))) {
+    return;
+  }
+  if (deps.visibleWorkspaceContext?.id === id) deps.setDismissedWorkspaceContextId(id);
+  deps.setStagedWorkspaceContexts((prev) => prev.filter((item) => item.id !== id));
+  if (!trackedLinkedDir) {
+    deps.setWorkspaceLinkedDirAdds((current) => {
+      const { [id]: _removed, ...rest } = current;
+      return rest;
+    });
+  }
+  if (workspaceItem) {
+    deps.replaceEditorDraft(stripInlineMentionLabels(deps.draftRef.current, [
+      workspaceItem.label,
+      workspaceItem.id,
+      workspaceItem.title ?? '',
+      workspaceItem.path ?? '',
+      workspaceItem.absolutePath ?? '',
+      workspaceItem.url ?? '',
+    ]));
+  }
+}
+
+/** Everything `pickSlash` needs from the outside world: the popover state it
+ *  clears and the Lexical editor operations (shared across every cluster, so
+ *  they stay orchestrator-owned) it drives. */
+export interface PickSlashDeps {
+  slash: { q: string } | null;
+  setSlash: (value: { q: string } | null) => void;
+  replaceActiveTrigger: (text: string) => void;
+  focusEditor: () => void;
+}
+
+/** Replaces the in-flight `/<query>` trigger with the picked command's
+ *  canonical insertion text and closes the slash popover. */
+export function pickSlash(cmd: SlashCommand, deps: PickSlashDeps) {
+  if (!deps.slash) return;
+  // Replace the in-flight `/<query>` trigger with the picked command's
+  // canonical insertion text. Lexical owns the caret afterwards.
+  deps.replaceActiveTrigger(cmd.insert);
+  deps.focusEditor();
+  deps.setSlash(null);
+}
+
+/** Everything `tryHandleMcpSlash` needs: the draft it inspects and clears,
+ *  and the settings-open callback it defers to. */
+export interface McpSlashDeps {
+  draft: string;
+  onOpenMcpSettings?: () => void;
+  clearDraft: () => void;
+}
+
+/**
+ * `/mcp` (no arg) opens settings on the External MCP tab — pure UX hook,
+ * never sent to the agent. `/mcp <id>` is intentionally NOT intercepted
+ * here: the slash palette already replaces it with a natural-language hint
+ * sentence ("Use the `<id>` MCP server tools."), and the user is expected to
+ * keep typing the rest of the prompt before sending.
+ */
+export function tryHandleMcpSlash(deps: McpSlashDeps): boolean {
+  if (!deps.onOpenMcpSettings) return false;
+  const trimmed = deps.draft.trim();
+  if (!/^\/mcp\s*$/i.test(trimmed)) return false;
+  deps.onOpenMcpSettings();
+  deps.clearDraft();
+  return true;
+}
+
+/** Everything `tryHandlePetSlash` needs: the draft it inspects and clears,
+ *  pet state/config, and the pet action callbacks it defers to. */
+export interface PetSlashDeps {
+  petEnabled: boolean;
+  draft: string;
+  petConfig?: AppConfig['pet'];
+  onTogglePet?: () => void;
+  onOpenPetSettings?: () => void;
+  onAdoptPet?: (petId: string) => void;
+  clearDraft: () => void;
+}
+
+/**
+ * Parse a `/pet [arg]` slash command out of the draft. Recognized forms:
+ * `/pet` (toggle wake/tuck), `/pet wake`, `/pet tuck`, `/pet adopt` (open
+ * settings), or `/pet <id>` to adopt a built-in by id. The slash is stripped
+ * from the draft on a successful match so the user does not accidentally
+ * send the command to the agent.
+ */
+export function tryHandlePetSlash(deps: PetSlashDeps): boolean {
+  if (!deps.petEnabled) return false;
+  const trimmed = deps.draft.trim();
+  const match = /^\/pet(?:\s+(\S+))?$/i.exec(trimmed);
+  if (!match) return false;
+  const arg = match[1]?.toLowerCase();
+  if (!arg || arg === 'toggle') {
+    deps.onTogglePet?.();
+  } else if (arg === 'wake' || arg === 'show') {
+    if (deps.petConfig?.adopted) {
+      if (!deps.petConfig.enabled) deps.onTogglePet?.();
+    } else {
+      deps.onOpenPetSettings?.();
+    }
+  } else if (arg === 'tuck' || arg === 'hide') {
+    if (deps.petConfig?.enabled) deps.onTogglePet?.();
+  } else if (arg === 'adopt' || arg === 'settings' || arg === 'change') {
+    deps.onOpenPetSettings?.();
+  } else if (arg === CUSTOM_PET_ID) {
+    deps.onAdoptPet?.(CUSTOM_PET_ID);
+  } else {
+    const pet = BUILT_IN_PETS.find((p) => p.id === arg);
+    if (pet) {
+      deps.onAdoptPet?.(pet.id);
+    } else {
+      return false;
+    }
+  }
+  deps.clearDraft();
+  return true;
+}
+
+/** Everything the `@`-mention popover's trigger-detection, keyboard-nav, and
+ *  pick handlers need from the outside world: the mention/slash popover
+ *  state (slash is another cluster's, read/written here since a single
+ *  Lexical callback drives both popovers' keyboard nav), the filtered
+ *  candidate lists, the Lexical editor's mention-insert primitive, and every
+ *  staging setter a pick can touch. */
+export interface MentionActionDeps {
+  setCaretRect: Dispatch<SetStateAction<CaretRect | null>>;
+  mention: { q: string } | null;
+  setMention: Dispatch<SetStateAction<{ q: string } | null>>;
+  mentionIndex: number;
+  setMentionIndex: Dispatch<SetStateAction<number>>;
+  mentionTab: MentionTab;
+  setMentionTab: Dispatch<SetStateAction<MentionTab>>;
+  slash: { q: string } | null;
+  setSlash: (value: { q: string } | null) => void;
+  slashIndex: number;
+  setSlashIndex: Dispatch<SetStateAction<number>>;
+  filteredSlash: SlashCommand[];
+  pickSlash: (cmd: SlashCommand) => void;
+  filteredFiles: ProjectFile[];
+  filteredWorkspaceContexts: WorkspaceContextItem[];
+  filteredPlugins: InstalledPluginRecord[];
+  filteredSkills: SkillSummary[];
+  filteredMcpServers: McpServerConfig[];
+  filteredConnectors: ConnectorDetail[];
+  insertEditorMention: (insert: { token: string; entity: InlineMentionEntity }) => void;
+  staged: ChatAttachment[];
+  appendContextAttachment: (path: string) => void;
+  setStagedSkills: Dispatch<SetStateAction<SkillSummary[]>>;
+  setStagedMcpServers: Dispatch<SetStateAction<McpServerConfig[]>>;
+  setStagedConnectors: Dispatch<SetStateAction<ConnectorDetail[]>>;
+  setStagedWorkspaceContexts: Dispatch<SetStateAction<WorkspaceContextItem[]>>;
+  setInlineBackedPlugin: (value: { id: string; label: string } | null) => void;
+  applyPluginById: (id: string, record: InstalledPluginRecord) => Promise<void>;
+  projectId: string | null;
+  patchProject: (id: string, patch: { skillId: string }) => Promise<Project | null>;
+  onProjectSkillChange?: (skillId: string | null) => void;
+}
+
+/**
+ * Lexical reports the active @/slash trigger derived from the caret. The
+ * mention popover state collapses to `{ q }`; the slash state replicates the
+ * old detection effect (reset the keyboard index on open).
+ */
+export function handleEditorTrigger(
+  {
+    mention: nextMention,
+    slash: nextSlash,
+    anchorRect,
+  }: {
+    mention: { q: string } | null;
+    slash: { q: string } | null;
+    anchorRect: CaretRect | null;
+  },
+  deps: Pick<
+    MentionActionDeps,
+    'setCaretRect' | 'mention' | 'setMentionTab' | 'setMention' | 'setMentionIndex' | 'setSlash' | 'setSlashIndex'
+  >,
+) {
+  deps.setCaretRect(anchorRect);
+  if (nextMention && !deps.mention) {
+    deps.setMentionTab('all');
+  } else if (!nextMention) {
+    deps.setMentionTab('all');
+  }
+  deps.setMention((prev) => {
+    // Reset the active row only when the query identity changes (mirror of
+    // the slash reset) so re-renders from unrelated state don't snap it.
+    if (nextMention && (!prev || prev.q !== nextMention.q)) deps.setMentionIndex(0);
+    return nextMention;
+  });
+  if (nextSlash) {
+    deps.setSlash(nextSlash);
+    deps.setSlashIndex(0);
+  } else {
+    deps.setSlash(null);
+  }
+}
+
+/**
+ * Routes popover navigation keys lifted verbatim from the old textarea
+ * onKeyDown. Returns true when the key was consumed so the editor can
+ * preventDefault; false lets the editor handle it normally (e.g. plain arrow
+ * keys when no popover is open).
+ */
+export function handlePopoverKey(
+  key: 'ArrowDown' | 'ArrowUp' | 'Tab' | 'Enter' | 'Escape',
+  deps: MentionActionDeps,
+): boolean {
+  if (deps.slash && deps.filteredSlash.length > 0) {
+    if (key === 'ArrowDown') {
+      deps.setSlashIndex((i) => (i + 1) % deps.filteredSlash.length);
+      return true;
+    }
+    if (key === 'ArrowUp') {
+      deps.setSlashIndex((i) => (i - 1 + deps.filteredSlash.length) % deps.filteredSlash.length);
+      return true;
+    }
+    if (key === 'Tab' || key === 'Enter') {
+      const safe = Math.min(deps.slashIndex, deps.filteredSlash.length - 1);
+      deps.pickSlash(deps.filteredSlash[safe]!);
+      return true;
+    }
+    if (key === 'Escape') {
+      deps.setSlash(null);
+      return true;
+    }
+  }
+  if (deps.mention && key === 'Escape') {
+    deps.setMention(null);
+    return true;
+  }
+  if (deps.mention) {
+    // Drive a single index over the visible section union. MentionPopover
+    // renders the same files-first section order and highlights the
+    // matching row from activeIndex.
+    const showFiles = deps.mentionTab === 'all' || deps.mentionTab === 'files';
+    const showTabs = deps.mentionTab === 'all' || deps.mentionTab === 'tabs';
+    const showPlugins = deps.mentionTab === 'all' || deps.mentionTab === 'plugins';
+    const showSkills = deps.mentionTab === 'all' || deps.mentionTab === 'skills';
+    const showMcp = deps.mentionTab === 'all' || deps.mentionTab === 'mcp';
+    const showConnectors = deps.mentionTab === 'all' || deps.mentionTab === 'connectors';
+    const total =
+      (showFiles ? deps.filteredFiles.length : 0) +
+      (showTabs ? deps.filteredWorkspaceContexts.length : 0) +
+      (showPlugins ? deps.filteredPlugins.length : 0) +
+      (showSkills ? deps.filteredSkills.length : 0) +
+      (showMcp ? deps.filteredMcpServers.length : 0) +
+      (showConnectors ? deps.filteredConnectors.length : 0);
+    if (total > 0) {
+      if (key === 'ArrowDown') {
+        deps.setMentionIndex((i) => (i + 1) % total);
+        return true;
+      }
+      if (key === 'ArrowUp') {
+        deps.setMentionIndex((i) => (i - 1 + total) % total);
+        return true;
+      }
+      if (key === 'Tab' || key === 'Enter') {
+        pickMentionByFlatIndex(Math.min(deps.mentionIndex, total - 1), deps);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolves a flat visible-section index to the right insert call. Section
+ * order MUST match MentionPopover's render order (files→tabs→plugins→skills
+ * →mcp→connectors); the activeIndex highlight and Enter target stay in
+ * lockstep across "All" and individual tabs.
+ */
+export function pickMentionByFlatIndex(flat: number, deps: MentionActionDeps) {
+  let i = flat;
+  if (deps.mentionTab === 'all' || deps.mentionTab === 'files') {
+    if (i < deps.filteredFiles.length) {
+      insertMention(deps.filteredFiles[i]!.path ?? deps.filteredFiles[i]!.name, deps);
+      return;
+    }
+    i -= deps.filteredFiles.length;
+  }
+  if (deps.mentionTab === 'all' || deps.mentionTab === 'tabs') {
+    if (i < deps.filteredWorkspaceContexts.length) {
+      insertWorkspaceMention(deps.filteredWorkspaceContexts[i]!, deps);
+      return;
+    }
+    i -= deps.filteredWorkspaceContexts.length;
+  }
+  if (deps.mentionTab === 'all' || deps.mentionTab === 'plugins') {
+    if (i < deps.filteredPlugins.length) {
+      void insertPluginMention(deps.filteredPlugins[i]!, deps);
+      return;
+    }
+    i -= deps.filteredPlugins.length;
+  }
+  if (deps.mentionTab === 'all' || deps.mentionTab === 'skills') {
+    if (i < deps.filteredSkills.length) {
+      void insertSkillMention(deps.filteredSkills[i]!, deps);
+      return;
+    }
+    i -= deps.filteredSkills.length;
+  }
+  if (deps.mentionTab === 'all' || deps.mentionTab === 'mcp') {
+    if (i < deps.filteredMcpServers.length) {
+      insertMcpMention(deps.filteredMcpServers[i]!, deps);
+      return;
+    }
+    i -= deps.filteredMcpServers.length;
+  }
+  if (deps.mentionTab === 'all' || deps.mentionTab === 'connectors') {
+    if (i < deps.filteredConnectors.length) {
+      insertConnectorMention(deps.filteredConnectors[i]!, deps);
+      return;
+    }
+  }
+}
+
+/** Inserts a file's `@<path>` mention pill and stages the file as an
+ *  attachment if it isn't already staged. */
+export function insertMention(
+  filePath: string,
+  deps: Pick<MentionActionDeps, 'insertEditorMention' | 'staged' | 'appendContextAttachment' | 'setMention'>,
+) {
+  deps.insertEditorMention({
+    token: inlineMentionToken(filePath),
+    entity: { id: filePath, kind: 'file', label: filePath },
+  });
+  if (!deps.staged.some((s) => s.path === filePath)) {
+    deps.appendContextAttachment(filePath);
+  }
+  deps.setMention(null);
+}
+
+/** Inserts a plugin's `@<title>` mention pill, binds the inline-mention
+ *  bridge to it, and applies the plugin. */
+export async function insertPluginMention(
+  record: InstalledPluginRecord,
+  deps: Pick<MentionActionDeps, 'insertEditorMention' | 'setMention' | 'setInlineBackedPlugin' | 'applyPluginById'>,
+) {
+  deps.insertEditorMention({
+    token: inlineMentionToken(record.title),
+    entity: { id: record.id, kind: 'plugin', label: record.title },
+  });
+  deps.setMention(null);
+  deps.setInlineBackedPlugin({ id: record.id, label: record.title });
+  await deps.applyPluginById(record.id, record);
+}
+
+/** Stages an MCP server (if not already staged) and inserts its `@<label>`
+ *  mention pill. */
+export function insertMcpMention(
+  server: McpServerConfig,
+  deps: Pick<MentionActionDeps, 'setStagedMcpServers' | 'insertEditorMention' | 'setMention'>,
+) {
+  deps.setStagedMcpServers((current) => (
+    current.some((item) => item.id === server.id) ? current : [...current, server]
+  ));
+  deps.insertEditorMention({
+    token: inlineMentionToken(server.label || server.id),
+    entity: { id: server.id, kind: 'mcp', label: server.label || server.id },
+  });
+  deps.setMention(null);
+}
+
+/** Stages a connector (if not already staged) and inserts its `@<name>`
+ *  mention pill. */
+export function insertConnectorMention(
+  connector: ConnectorDetail,
+  deps: Pick<MentionActionDeps, 'setStagedConnectors' | 'insertEditorMention' | 'setMention'>,
+) {
+  deps.setStagedConnectors((current) => (
+    current.some((item) => item.id === connector.id) ? current : [...current, connector]
+  ));
+  deps.insertEditorMention({
+    token: inlineMentionToken(connector.name),
+    entity: { id: connector.id, kind: 'connector', label: connector.name },
+  });
+  deps.setMention(null);
+}
+
+/** Stages a workspace context (if not already staged) and inserts its
+ *  `@<label>` mention pill. */
+export function insertWorkspaceMention(
+  item: WorkspaceContextItem,
+  deps: Pick<MentionActionDeps, 'setStagedWorkspaceContexts' | 'insertEditorMention' | 'setMention'>,
+) {
+  deps.setStagedWorkspaceContexts((current) =>
+    current.some((candidate) => candidate.id === item.id)
+      ? current
+      : [...current, item],
+  );
+  deps.insertEditorMention({
+    token: inlineMentionToken(item.label),
+    entity: { id: item.id, kind: 'workspace', label: item.label },
+  });
+  deps.setMention(null);
+}
+
+/** Patches the project's `skillId` to `skill.id` and reports the change
+ *  upstream. Returns false when there's no active project or the patch
+ *  fails. */
+export async function applyProjectSkill(
+  skill: SkillSummary,
+  deps: Pick<MentionActionDeps, 'projectId' | 'patchProject' | 'onProjectSkillChange'>,
+): Promise<boolean> {
+  if (!deps.projectId) return false;
+  const result = await deps.patchProject(deps.projectId, { skillId: skill.id });
+  if (!result) return false;
+  deps.onProjectSkillChange?.(result.skillId ?? skill.id);
+  return true;
+}
+
+/** Applies the skill as the project's active skill, then (if that
+ *  succeeded) stages it and inserts its `@<name>` mention pill. */
+export async function insertSkillMention(
+  skill: SkillSummary,
+  deps: Pick<
+    MentionActionDeps,
+    'projectId' | 'patchProject' | 'onProjectSkillChange' | 'setStagedSkills' | 'insertEditorMention' | 'setMention'
+  >,
+) {
+  const applied = await applyProjectSkill(skill, deps);
+  if (!applied) return;
+  // Stage the skill so it rides this turn's skillIds, then insert an atomic
+  // `@<name>` pill carrying the skill's real id. The onChange prune keys on
+  // `skill:<id>` being present in the editor text, so the chip survives
+  // until the user deletes the pill.
+  deps.setStagedSkills((prev) =>
+    prev.some((s) => s.id === skill.id) ? prev : [...prev, skill],
+  );
+  deps.insertEditorMention({
+    token: inlineMentionToken(skill.name),
+    entity: { id: skill.id, kind: 'skill', label: skill.name },
+  });
+  deps.setMention(null);
+}
+
+/** Everything the Lexical editor's onChange needs. `present` is the entity
+ *  list the editor's text currently references (MentionNodes plus plain
+ *  `@token`s matched against composerMentionEntities, deduped by kind:id).
+ *  Spans four clusters (draft, applied-plugin, staged run-context,
+ *  workspace-context) with no single owning hook, so per the escalation
+ *  order this stays a deps-bag action rather than moving into any one of
+ *  them. */
+export interface EditorChangeDeps {
+  draftRef: MutableRefObject<string>;
+  setDraft: Dispatch<SetStateAction<string>>;
+  activeAppliedPlugin: AppliedPluginSnapshot | null;
+  inlineBackedPluginRef: MutableRefObject<{ id: string; label: string } | null>;
+  clearPluginsSection: () => void;
+  setStagedSkills: Dispatch<SetStateAction<SkillSummary[]>>;
+  setStagedMcpServers: Dispatch<SetStateAction<McpServerConfig[]>>;
+  setStagedConnectors: Dispatch<SetStateAction<ConnectorDetail[]>>;
+  stagedWorkspaceContexts: WorkspaceContextItem[];
+  setStagedWorkspaceContexts: Dispatch<SetStateAction<WorkspaceContextItem[]>>;
+  workspaceLinkedDirAdds: Record<string, TrackedWorkspaceLinkedDir>;
+}
+
+/** Syncs the draft off the editor's onChange, then prunes every staged
+ *  skill/mcp/connector/workspace-context chip to whatever `present` still
+ *  references, dropping the applied-plugin inline-mention bridge if its own
+ *  token was hand-deleted. */
+export function handleEditorChange(
+  text: string,
+  present: InlineMentionEntity[],
+  deps: EditorChangeDeps,
+) {
+  deps.draftRef.current = text;
+  deps.setDraft(text);
+  const set = new Set(present.map((e) => `${e.kind}:${e.id}`));
+  // We prune the staged skill/mcp/connector chips to whatever the text still
+  // references — generalizing the old skill-only regex prune so a
+  // hand-deleted token also drops its chip and never leaks into the run
+  // context. Workspace contexts that added linked dirs are kept visible
+  // until the chip remove button clears the matching metadata access.
+  // `staged` (files) is intentionally NOT pruned: users attach files via the
+  // upload button without leaving an `@<path>` token.
+  if (
+    deps.activeAppliedPlugin
+    && deps.inlineBackedPluginRef.current?.id === deps.activeAppliedPlugin.pluginId
+    && !set.has(`plugin:${deps.activeAppliedPlugin.pluginId}`)
+    && !mentionTokenPresent(text, deps.inlineBackedPluginRef.current.label)
+  ) {
+    deps.inlineBackedPluginRef.current = null;
+    deps.clearPluginsSection();
+  }
+  deps.setStagedSkills((prev) => prev.filter((s) => set.has(`skill:${s.id}`)));
+  deps.setStagedMcpServers((prev) => prev.filter((m) => set.has(`mcp:${m.id}`)));
+  deps.setStagedConnectors((prev) => prev.filter((c) => set.has(`connector:${c.id}`)));
+  deps.setStagedWorkspaceContexts((prev) =>
+    prev.filter((item) => set.has(`workspace:${item.id}`) || Boolean(deps.workspaceLinkedDirAdds[item.id])),
+  );
+}
+
+/** Everything `reset`/`sendComposedTurn`/`submit` need from the outside
+ *  world: every staging setter reset() clears, the Next-step pending refs
+ *  both reset() and sendComposedTurn() consume, the Lexical editor/plugins-
+ *  section primitives, `onSend` itself, and everything `currentRunContextMeta`
+ *  needs to build the run-context selection for the turn about to send. */
+export interface SendActionDeps {
+  pendingEntryFromRef: MutableRefObject<ChatAnalyticsEntryFrom | null>;
+  pendingSessionModeRef: MutableRefObject<ChatSessionMode | null>;
+  nextAttachmentOrderRef: MutableRefObject<number>;
+  stagedWorkspaceContexts: WorkspaceContextItem[];
+  workspaceLinkedDirAdds: Record<string, TrackedWorkspaceLinkedDir>;
+  setWorkspaceLinkedDirAdds: Dispatch<SetStateAction<Record<string, TrackedWorkspaceLinkedDir>>>;
+  setStagedWorkspaceContexts: Dispatch<SetStateAction<WorkspaceContextItem[]>>;
+  promotedWorkspaceContextDir: string | null;
+  setPromotedWorkspaceContextDir: Dispatch<SetStateAction<string | null>>;
+  setDraft: (text: string) => void;
+  setStaged: Dispatch<SetStateAction<ChatAttachment[]>>;
+  setStagedVisualComments: Dispatch<SetStateAction<ChatCommentAttachment[]>>;
+  setStagedSkills: Dispatch<SetStateAction<SkillSummary[]>>;
+  setStagedMcpServers: Dispatch<SetStateAction<McpServerConfig[]>>;
+  setStagedConnectors: Dispatch<SetStateAction<ConnectorDetail[]>>;
+  clearPluginsSection: () => void;
+  setInlineBackedPlugin: (value: { id: string; label: string } | null) => void;
+  inlineBackedPluginRef: MutableRefObject<{ id: string; label: string } | null>;
+  setActiveAppliedPlugin: Dispatch<SetStateAction<AppliedPluginSnapshot | null>>;
+  activeAppliedPlugin: AppliedPluginSnapshot | null;
+  setUploadError: (value: string | null) => void;
+  setMention: (value: { q: string } | null) => void;
+  setMentionTab: Dispatch<SetStateAction<MentionTab>>;
+  setSlash: (value: { q: string } | null) => void;
+  clearEditor: () => void;
+  setStreamingAnnotationSendPending: (value: boolean) => void;
+  activeFileContext: string | null;
+  activeFileDisplayName: string | null;
+  onSend: (
+    prompt: string,
+    attachments: ChatAttachment[],
+    commentAttachments: ChatCommentAttachment[],
+    meta?: ChatSendMeta,
+  ) => void;
+  draft: string;
+  sendDisabled: boolean;
+  petEnabled: boolean;
+  petConfig?: AppConfig['pet'];
+  onTogglePet?: () => void;
+  onOpenPetSettings?: () => void;
+  onAdoptPet?: (petId: string) => void;
+  onOpenMcpSettings?: () => void;
+  clearDraft: () => void;
+  streaming: boolean;
+  staged: ChatAttachment[];
+  currentCommentAttachments: (extra?: ChatCommentAttachment[]) => ChatCommentAttachment[];
+  researchAvailable: boolean;
+  placeholderSubmittable: boolean;
+  placeholderScenario: PlaceholderScenario | null;
+  stagedSkills: SkillSummary[];
+  stagedMcpServers: McpServerConfig[];
+  stagedConnectors: ConnectorDetail[];
+  selectedWorkspaceContexts: WorkspaceContextItem[];
+}
+
+/** Reads the current run's staged context (skills/plugin/mcp/connectors/
+ *  workspace items) into a `ChatSendMeta`, via the pure `currentRunContextMeta`
+ *  rule — this wrapper only unwraps the inline-backed-plugin ref so the rule
+ *  itself stays pure. */
+export function currentRunContextMeta(
+  deps: Pick<
+    SendActionDeps,
+    | 'stagedSkills'
+    | 'activeAppliedPlugin'
+    | 'stagedMcpServers'
+    | 'stagedConnectors'
+    | 'selectedWorkspaceContexts'
+    | 'inlineBackedPluginRef'
+  >,
+): ChatSendMeta | undefined {
+  return currentRunContextMetaRule({
+    stagedSkills: deps.stagedSkills,
+    activeAppliedPlugin: deps.activeAppliedPlugin,
+    stagedMcpServers: deps.stagedMcpServers,
+    stagedConnectors: deps.stagedConnectors,
+    selectedWorkspaceContexts: deps.selectedWorkspaceContexts,
+    inlineBackedPlugin: deps.inlineBackedPluginRef.current,
+  });
+}
+
+/**
+ * Clears the composer back to its empty state after a send: draft,
+ * attachments (files + visual comments + skill/mcp/connector chips), the
+ * applied-plugin snapshot, and the mention/slash popovers. Workspace
+ * contexts that are still linked-dir-tracked survive the reset (they
+ * represent a durable project link, not per-turn staging) — only contexts
+ * whose linked dir was never tracked (or has since been dropped) are
+ * cleared alongside everything else.
+ */
+export function reset(deps: SendActionDeps) {
+  deps.pendingEntryFromRef.current = null;
+  deps.pendingSessionModeRef.current = null;
+  const linkedWorkspaceContexts = deps.stagedWorkspaceContexts.filter((item) => (
+    Boolean(item.absolutePath?.trim()) && Boolean(deps.workspaceLinkedDirAdds[item.id])
+  ));
+  const linkedWorkspaceContextIds = new Set(linkedWorkspaceContexts.map((item) => item.id));
+  const nextWorkspaceLinkedDirAdds = Object.fromEntries(
+    Object.entries(deps.workspaceLinkedDirAdds).filter(([id]) => linkedWorkspaceContextIds.has(id)),
+  );
+  deps.setDraft("");
+  deps.setStaged([]);
+  deps.nextAttachmentOrderRef.current = 0;
+  deps.setStagedVisualComments([]);
+  deps.setStagedSkills([]);
+  deps.setStagedMcpServers([]);
+  deps.setStagedConnectors([]);
+  deps.setStagedWorkspaceContexts(linkedWorkspaceContexts);
+  deps.setWorkspaceLinkedDirAdds(nextWorkspaceLinkedDirAdds);
+  if (
+    deps.promotedWorkspaceContextDir &&
+    !linkedWorkspaceContexts.some((item) => item.absolutePath?.trim() === deps.promotedWorkspaceContextDir)
+  ) {
+    deps.setPromotedWorkspaceContextDir(null);
+  }
+  deps.clearPluginsSection();
+  deps.setInlineBackedPlugin(null);
+  deps.setActiveAppliedPlugin(null);
+  deps.setUploadError(null);
+  deps.setMention(null);
+  deps.setMentionTab('all');
+  deps.setSlash(null);
+  deps.clearEditor();
+}
+
+/** Sends a composed turn: seeds in the active-file attachment if it isn't
+ *  already included, folds in any pending Next-step `entryFrom`/
+ *  `sessionMode` tags (then clears them so they only color the immediate
+ *  send), calls `onSend`, and resets the composer. Returns false (a no-op)
+ *  when there is nothing to send. */
+export function sendComposedTurn(
+  prompt: string,
+  attachments: ChatAttachment[],
+  nextCommentAttachments: ChatCommentAttachment[],
+  meta: ChatSendMeta | undefined,
+  deps: SendActionDeps,
+): boolean {
+  deps.setStreamingAnnotationSendPending(false);
+  if (!prompt && attachments.length === 0 && nextCommentAttachments.length === 0) return false;
+  const nextAttachments =
+    deps.activeFileContext && !attachments.some((attachment) => attachment.path === deps.activeFileContext)
+      ? [
+          {
+            path: deps.activeFileContext,
+            name: deps.activeFileDisplayName ?? deps.activeFileContext,
+            kind: 'file' as const,
+          },
+          ...attachments,
+        ]
+      : attachments;
+  // Apply pending Next-step metadata if the caller didn't set its own
+  // fields, then clear it so it only colors the immediate next send.
+  const pendingEntryFrom = deps.pendingEntryFromRef.current;
+  const pendingSessionMode = deps.pendingSessionModeRef.current;
+  deps.pendingEntryFromRef.current = null;
+  deps.pendingSessionModeRef.current = null;
+  const effectiveMetaShape: ChatSendMeta = {
+    ...(meta ?? {}),
+    ...(pendingEntryFrom && !meta?.entryFrom ? { entryFrom: pendingEntryFrom } : {}),
+    ...(pendingSessionMode && !meta?.sessionMode ? { sessionMode: pendingSessionMode } : {}),
+  };
+  const effectiveMeta =
+    Object.keys(effectiveMetaShape).length > 0 ? effectiveMetaShape : undefined;
+  deps.onSend(prompt, nextAttachments, nextCommentAttachments, effectiveMeta);
+  reset(deps);
+  return true;
+}
+
+/** The composer's Send-button/Enter handler. Intercepts `/pet`/`/mcp` slash
+ *  commands before they'd reach the agent, expands `/hatch`/search shorthand
+ *  into their canonical prompts, falls back to a placeholder-carousel prompt
+ *  when the draft and every attachment list are empty, and otherwise sends
+ *  the typed prompt via `sendComposedTurn`. */
+export async function submit(deps: SendActionDeps) {
+  const prompt = deps.draft.trim();
+  if (deps.sendDisabled) return;
+  // Intercept `/pet …` and `/mcp` before sending so the slash command
+  // never hits the agent — these are local UX hooks, not model prompts.
+  if (tryHandlePetSlash(deps)) return;
+  if (tryHandleMcpSlash(deps)) return;
+  // `/hatch <concept>` expands into the canonical hatch-pet skill prompt and
+  // *is* sent to the agent — the agent runs the skill, packages a Codex pet
+  // under `~/.codex/pets/`, and the user adopts it from "Recently hatched"
+  // in pet settings afterwards.
+  const contextMeta = currentRunContextMeta(deps);
+  const hatched = expandHatchCommand(prompt);
+  const nextCommentAttachments = deps.currentCommentAttachments();
+  if (hatched) {
+    if (deps.streaming) return;
+    deps.setStreamingAnnotationSendPending(false);
+    deps.onSend(hatched, deps.staged, nextCommentAttachments, contextMeta);
+    reset(deps);
+    return;
+  }
+  const search = deps.researchAvailable ? expandSearchCommand(prompt) : null;
+  if (search) {
+    if (deps.streaming) return;
+    deps.setStreamingAnnotationSendPending(false);
+    deps.onSend(search.prompt, deps.staged, nextCommentAttachments, {
+      ...contextMeta,
+      research: { enabled: true, query: search.query },
+    });
+    reset(deps);
+    return;
+  }
+  if (!prompt && deps.staged.length === 0 && nextCommentAttachments.length === 0) {
+    const placeholderPrompt = deps.placeholderSubmittable && deps.placeholderScenario
+      ? deps.placeholderScenario.text.trim()
+      : '';
+    if (!placeholderPrompt) return;
+    const placeholderMeta: ChatSendMeta | undefined = deps.placeholderScenario?.sessionMode
+      ? {
+          ...(contextMeta ?? {}),
+          sessionMode: deps.placeholderScenario.sessionMode,
+          entryFrom: contextMeta?.entryFrom ?? 'next_step',
+        }
+      : contextMeta;
+    sendComposedTurn(placeholderPrompt, [], [], placeholderMeta, deps);
+    return;
+  }
+  sendComposedTurn(prompt, deps.staged, nextCommentAttachments, contextMeta, deps);
+}

--- a/apps/web/src/features/chat-composer/attachment-actions.ts
+++ b/apps/web/src/features/chat-composer/attachment-actions.ts
@@ -1,0 +1,542 @@
+// Orchestration functions for the chat-composer's staged-attachment /
+// upload flows: attachment-order bookkeeping, the project-files and
+// library-asset upload transports, clipboard-paste and drag-drop handlers,
+// and per-attachment removal. Split out of actions.ts (Phase 6, cluster 7)
+// because the combined file would exceed the slice's size budget — same
+// deps-bag convention as actions.ts (each function takes every piece of
+// orchestrator state/setter/callback it needs as an explicit parameter
+// object instead of closing over component scope). No React, no transport,
+// no DOM globals — only injected callbacks touch those.
+import type { Dispatch, DragEvent, MutableRefObject, SetStateAction } from 'react';
+import type { ChatAnalyticsEntryFrom, LibraryApplyResponse, LibraryAsset } from '@open-design/contracts';
+import type { ComposerBarClickProps } from '@open-design/contracts/analytics';
+import type { ChatAttachment, ChatCommentAttachment } from '../../types';
+import { assetTitle, elementMetaOf } from '../../components/LibraryAssetMeta';
+import { deriveUploadCohort } from '../../analytics/upload-tracking';
+import { trackFileUploadResult } from '../../analytics/events';
+import { buildVisualAnnotationAttachment } from '../../comments';
+import type { AnnotationEventDetail } from '../../components/PreviewDrawOverlay';
+import { looksLikeImage } from './formatters';
+import {
+  assignChatAttachmentOrders,
+  formatElementHtmlBlock,
+  isFiniteAttachmentOrder,
+  nextChatAttachmentOrder,
+  queueMeta,
+  sortChatAttachmentsByOrder,
+  stripInlineMentionToken,
+} from './rules';
+import { currentRunContextMeta, sendComposedTurn, type SendActionDeps } from './actions';
+import type { ChatSendMeta, TranslateFn, UploadFilesResult } from './types';
+
+/** Everything the attachment/upload cluster needs from the outside world:
+ *  the staged-attachment list + its order-assignment ref, the already-landed
+ *  upload UI-feedback hook's setters (`useComposerUpload`), the project
+ *  lifecycle + transport calls (sourced from the orchestrator's own existing
+ *  `providers/registry` imports, passed straight through — not wrapped in a
+ *  new port, matching the `WorkingDirActionDeps` precedent), analytics, the
+ *  Lexical editor operations these functions drive, and the cross-cluster
+ *  visual-comment state `removeStaged` also clears. */
+export interface UploadActionDeps {
+  staged: ChatAttachment[];
+  setStaged: Dispatch<SetStateAction<ChatAttachment[]>>;
+  nextAttachmentOrderRef: MutableRefObject<number>;
+  setUploading: (value: boolean) => void;
+  setUploadError: (value: string | null) => void;
+  setDragActive: (value: boolean) => void;
+  projectId: string | null;
+  onEnsureProject: () => Promise<string | null>;
+  uploadProjectFiles: (projectId: string, files: File[]) => Promise<UploadFilesResult>;
+  applyLibraryAsset: (assetId: string, projectId: string) => Promise<LibraryApplyResponse | null>;
+  fetchLibraryAssetElementHtml: (assetId: string) => Promise<string | null>;
+  track: (
+    event: string,
+    properties: Record<string, unknown>,
+    options?: { requestId?: string; insertId?: string },
+  ) => void;
+  getEditorText: () => string;
+  insertEditorText: (text: string) => void;
+  focusEditor: () => void;
+  replaceEditorDraft: (text: string) => void;
+  draft: string;
+  setStagedVisualComments: Dispatch<SetStateAction<ChatCommentAttachment[]>>;
+  trackComposerBar: (fields: Omit<ComposerBarClickProps, 'page_name' | 'area' | 'project_id'>) => void;
+}
+
+/**
+ * Reserves `count` sequential attachment orders starting after both the
+ * ref's high-water mark and the current staged list's own max order, so
+ * concurrent staging paths (upload + library add + annotation) never
+ * collide. Returns the first reserved order.
+ */
+export function reserveAttachmentOrders(
+  count: number,
+  deps: Pick<UploadActionDeps, 'staged' | 'nextAttachmentOrderRef'>,
+): number {
+  const orderStart = Math.max(deps.nextAttachmentOrderRef.current, nextChatAttachmentOrder(deps.staged));
+  deps.nextAttachmentOrderRef.current = orderStart + count;
+  return orderStart;
+}
+
+export function appendOrderedStagedAttachments(
+  attachments: ChatAttachment[],
+  deps: Pick<UploadActionDeps, 'setStaged' | 'nextAttachmentOrderRef'>,
+) {
+  if (attachments.length === 0) return;
+  deps.setStaged((current) => {
+    const knownPaths = new Set(current.map((attachment) => attachment.path));
+    const nextAttachments = attachments.filter((attachment) => !knownPaths.has(attachment.path));
+    if (nextAttachments.length === 0) return current;
+    const next = sortChatAttachmentsByOrder([...current, ...nextAttachments]);
+    deps.nextAttachmentOrderRef.current = Math.max(
+      deps.nextAttachmentOrderRef.current,
+      nextChatAttachmentOrder(next),
+    );
+    return next;
+  });
+}
+
+export function appendContextAttachment(
+  filePath: string,
+  deps: Pick<UploadActionDeps, 'setStaged' | 'nextAttachmentOrderRef'>,
+) {
+  deps.setStaged((current) => {
+    if (current.some((item) => item.path === filePath)) return current;
+    const order = Math.max(deps.nextAttachmentOrderRef.current, nextChatAttachmentOrder(current));
+    deps.nextAttachmentOrderRef.current = order + 1;
+    return sortChatAttachmentsByOrder([
+      ...current,
+      {
+        path: filePath,
+        name: filePath.split('/').pop() || filePath,
+        kind: looksLikeImage(filePath) ? 'image' : 'file',
+        order,
+      },
+    ]);
+  });
+}
+
+export async function ensureProject(
+  deps: Pick<UploadActionDeps, 'projectId' | 'onEnsureProject'>,
+): Promise<string | null> {
+  if (deps.projectId) return deps.projectId;
+  return deps.onEnsureProject();
+}
+
+type UploadTransportDeps = Pick<
+  UploadActionDeps,
+  | 'staged'
+  | 'nextAttachmentOrderRef'
+  | 'setStaged'
+  | 'setUploading'
+  | 'setUploadError'
+  | 'projectId'
+  | 'onEnsureProject'
+  | 'uploadProjectFiles'
+  | 'track'
+>;
+
+export async function uploadFiles(files: File[], deps: UploadTransportDeps) {
+  if (files.length === 0) return;
+  const id = await ensureProject(deps);
+  if (!id) return;
+  deps.setUploading(true);
+  deps.setUploadError(null);
+  // Cohort math is identical to the Design Files Upload button; see
+  // `analytics/upload-tracking.ts`. v2 doc fires one
+  // file_upload_result per surface so this path reports
+  // `page_name='chat_panel'` / `area='chat_composer'`.
+  const cohort = deriveUploadCohort(files);
+  const orderStart = reserveAttachmentOrders(files.length, deps);
+  try {
+    const result = await deps.uploadProjectFiles(id, files);
+    if (result.uploaded.length > 0) {
+      const orderedUploaded = assignChatAttachmentOrders(result.uploaded, orderStart);
+      appendOrderedStagedAttachments(orderedUploaded, deps);
+    }
+    const partial = result.failed.length > 0;
+    if (partial) {
+      const failedCount = result.failed.length;
+      const uploadedCount = result.uploaded.length;
+      const detail = result.error ? ` (${result.error})` : '';
+      deps.setUploadError(
+        uploadedCount > 0
+          ? `Attached ${uploadedCount} file(s), but ${failedCount} failed${detail}.`
+          : `Attachment upload failed for ${failedCount} file(s)${detail}.`,
+      );
+      console.warn('Some attachments failed to upload', result.failed);
+    }
+    trackFileUploadResult(deps.track, {
+      page_name: 'chat_panel',
+      area: 'chat_composer',
+      project_id: id,
+      ...cohort,
+      result: partial ? 'failed' : 'success',
+      ...(partial && result.error ? { error_code: result.error } : {}),
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    deps.setUploadError(`Attachment upload failed (${detail}).`);
+    trackFileUploadResult(deps.track, {
+      page_name: 'chat_panel',
+      area: 'chat_composer',
+      project_id: id,
+      ...cohort,
+      result: 'failed',
+      error_code: detail,
+    });
+  } finally {
+    deps.setUploading(false);
+  }
+}
+
+// "Select from library" (资源库): copy each chosen asset into the project's
+// design files and stage it as an attachment chip, mirroring how the native
+// file picker materializes uploads into the project on attach. The apply
+// call records a provenance back-link so the registry knows the asset was
+// consumed.
+export async function addAssetsFromLibrary(
+  assets: LibraryAsset[],
+  deps: Pick<
+    UploadActionDeps,
+    | 'staged'
+    | 'nextAttachmentOrderRef'
+    | 'setStaged'
+    | 'setUploading'
+    | 'setUploadError'
+    | 'projectId'
+    | 'onEnsureProject'
+    | 'applyLibraryAsset'
+    | 'fetchLibraryAssetElementHtml'
+    | 'getEditorText'
+    | 'insertEditorText'
+    | 'focusEditor'
+  >,
+) {
+  if (assets.length === 0) return;
+  const id = await ensureProject(deps);
+  if (!id) return;
+  deps.setUploading(true);
+  deps.setUploadError(null);
+  const orderStart = reserveAttachmentOrders(assets.length, deps);
+  try {
+    const applied: ChatAttachment[] = [];
+    // Element-pick captures carry their picked node's markup; collect it so
+    // we can drop the HTML straight into the composer input (the image still
+    // attaches as a normal reference).
+    const elementBlocks: string[] = [];
+    let failed = 0;
+    for (const asset of assets) {
+      const res = await deps.applyLibraryAsset(asset.id, id);
+      if (!res?.relPath) {
+        failed += 1;
+        continue;
+      }
+      applied.push({
+        path: res.relPath,
+        name: assetTitle(asset),
+        kind: asset.kind === 'image' ? 'image' : 'file',
+      });
+      const element = elementMetaOf(asset);
+      if (element?.hasHtml) {
+        const html = await deps.fetchLibraryAssetElementHtml(asset.id);
+        if (html) elementBlocks.push(formatElementHtmlBlock(asset, element, html));
+      }
+    }
+    if (applied.length > 0) {
+      appendOrderedStagedAttachments(assignChatAttachmentOrders(applied, orderStart), deps);
+    }
+    if (elementBlocks.length > 0) {
+      const existing = deps.getEditorText();
+      deps.insertEditorText((existing.trim() ? '\n\n' : '') + elementBlocks.join('\n\n'));
+      deps.focusEditor();
+    }
+    if (failed > 0) {
+      deps.setUploadError(
+        applied.length > 0
+          ? `Added ${applied.length} item(s), but ${failed} failed.`
+          : `Could not add ${failed} item(s) from the library.`,
+      );
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    deps.setUploadError(`Could not add from library (${detail}).`);
+  } finally {
+    deps.setUploading(false);
+  }
+}
+
+export async function uploadClipboardImagesFromAsyncClipboard(
+  deps: UploadTransportDeps,
+): Promise<boolean> {
+  if (!navigator.clipboard?.read) return false;
+  try {
+    const items = await navigator.clipboard.read();
+    const files: File[] = [];
+    const stamp = Date.now();
+    for (const item of items) {
+      const imageType = item.types.find((type) => type.startsWith('image/'));
+      if (!imageType) continue;
+      const blob = await item.getType(imageType);
+      const extension = imageType.split('/')[1]?.replace('jpeg', 'jpg') || 'png';
+      files.push(new File([blob], `clipboard-screenshot-${stamp}.${extension}`, { type: imageType }));
+    }
+    if (files.length === 0) return false;
+    await uploadFiles(files, deps);
+    return true;
+  } catch (err) {
+    console.warn('Could not read image from clipboard', err);
+    return false;
+  }
+}
+
+// Paste handler invoked by the editor's PastePlugin. `files` are the items
+// the clipboard exposed synchronously; when empty we fall back to the async
+// Clipboard API to recover pasted screenshots that some browsers only
+// surface through `navigator.clipboard.read()`.
+export function handlePasteFiles(files: File[], deps: UploadTransportDeps) {
+  if (files.length > 0) {
+    void uploadFiles(files, deps);
+    return;
+  }
+  void uploadClipboardImagesFromAsyncClipboard(deps);
+}
+
+export function handleDrop(
+  e: DragEvent<HTMLDivElement>,
+  deps: UploadTransportDeps & Pick<UploadActionDeps, 'setDragActive'>,
+) {
+  e.preventDefault();
+  deps.setDragActive(false);
+  const files = Array.from(e.dataTransfer.files ?? []);
+  if (files.length > 0) void uploadFiles(files, deps);
+}
+
+export function removeStaged(
+  path: string,
+  deps: Pick<
+    UploadActionDeps,
+    'setStaged' | 'setStagedVisualComments' | 'draft' | 'replaceEditorDraft' | 'trackComposerBar'
+  >,
+) {
+  deps.trackComposerBar({ element: 'context_remove', resource_kind: 'attachment', resource_id: path });
+  deps.setStaged((s) => s.filter((a) => a.path !== path));
+  deps.setStagedVisualComments((current) => current.filter((attachment) => attachment.screenshotPath !== path));
+  // Strip the `@<path>` token from the draft and push the result back into
+  // the editor so the pill disappears in lockstep with the chip.
+  deps.replaceEditorDraft(stripInlineMentionToken(deps.draft, path));
+}
+
+/** Everything the Mark draw-overlay's `ANNOTATION_EVENT` handler needs: the
+ *  upload cluster's own deps bag (nested rather than re-flattened — every
+ *  field is already `UploadActionDeps`-shaped), the send cluster's deps bag
+ *  (ditto), i18n, and the streaming-deferred-send bookkeeping this handler
+ *  shares with the deferred-send-flush effect. */
+export interface AnnotationActionDeps {
+  t: TranslateFn;
+  uploadActionDeps: UploadActionDeps;
+  sendActionDeps: SendActionDeps;
+  draftRef: MutableRefObject<string>;
+  setDraft: (text: string) => void;
+  setEditorText: (text: string) => void;
+  focusEditor: () => void;
+  draft: string;
+  staged: ChatAttachment[];
+  currentCommentAttachments: (extra?: ChatCommentAttachment[]) => ChatCommentAttachment[];
+  streaming: boolean;
+  streamingAnnotationSendEntryFromRef: MutableRefObject<ChatAnalyticsEntryFrom | undefined>;
+  setStreamingAnnotationSendPending: (value: boolean) => void;
+}
+
+/**
+ * Handles one `ANNOTATION_EVENT` (the Mark draw-overlay's queue/send/draft
+ * actions): uploads the screenshot + any attached images, builds the visual-
+ * comment attachment when the mark has bounds, then either stages it into
+ * the draft (`draft` action), composes + sends immediately (`send`, or
+ * defers to the streaming-flush effect if a run is already in flight), or
+ * composes + queues (`queue`, tagged `queueOnly`). `entry_from: 'mark'` on
+ * every send/queue path separates Mark-driven runs from plain composer
+ * sends on the analytics dashboard.
+ */
+export async function handleAnnotationEvent(
+  detail: AnnotationEventDetail,
+  deps: AnnotationActionDeps,
+): Promise<void> {
+  let acked = false;
+  const ack = (result: { ok: boolean; message?: string }) => {
+    if (acked) return;
+    acked = true;
+    detail.ack?.(result);
+  };
+  let uploaded: ChatAttachment[] = [];
+  let visualAttachmentInput: Parameters<typeof buildVisualAnnotationAttachment>[0] | null = null;
+  let visualAttachment: ChatCommentAttachment | null = null;
+  try {
+    // Upload the annotation screenshot together with any images the user
+    // attached in the markup composer. The screenshot (when present) is
+    // first so it keeps backing the structured visual comment; the rest ride
+    // along as ordinary chat attachments.
+    const annotationFiles = [detail.file, ...(detail.extraFiles ?? [])].filter(
+      (f): f is File => Boolean(f),
+    );
+    if (annotationFiles.length > 0) {
+      const orderStart = reserveAttachmentOrders(annotationFiles.length, deps.uploadActionDeps);
+      const id = await ensureProject(deps.uploadActionDeps);
+      if (!id) {
+        ack({ ok: false, message: deps.t('chat.annotationProjectCreateFailed') });
+        return;
+      }
+      deps.uploadActionDeps.setUploading(true);
+      const result = await deps.uploadActionDeps.uploadProjectFiles(id, annotationFiles);
+      if (result.uploaded.length > 0) {
+        uploaded = assignChatAttachmentOrders(result.uploaded, orderStart);
+        const screenshot = detail.file ? uploaded[0] : null;
+        if (screenshot && detail.markKind && detail.bounds) {
+          visualAttachmentInput = {
+            order: isFiniteAttachmentOrder(screenshot.order) ? screenshot.order : orderStart,
+            idSeed: screenshot.path,
+            screenshotPath: screenshot.path,
+            markKind: detail.markKind,
+            note: detail.note,
+            bounds: detail.bounds,
+            target: detail.target
+              ? {
+                  filePath: detail.target.filePath || detail.filePath || screenshot.path,
+                  elementId: detail.target.elementId,
+                  selector: detail.target.selector,
+                  label: detail.target.label,
+                  text: detail.target.text,
+                  position: detail.target.position,
+                  htmlHint: detail.target.htmlHint,
+                }
+              : {
+                  filePath: detail.filePath || screenshot.path,
+                  position: detail.bounds,
+                },
+          };
+        }
+      }
+      if (result.failed.length > 0) {
+        const detailText = result.error ? ` (${result.error})` : '';
+        deps.uploadActionDeps.setUploadError(`Attachment upload failed for ${result.failed.length} file(s)${detailText}.`);
+        if (uploaded.length === 0) {
+          ack({ ok: false, message: deps.t('chat.annotationUploadFailed') });
+          return;
+        }
+      }
+    }
+    deps.uploadActionDeps.setUploading(false);
+
+    const appendAnnotationToComposer = () => {
+      if (uploaded.length > 0) {
+        appendOrderedStagedAttachments(uploaded, deps.uploadActionDeps);
+      }
+      if (visualAttachmentInput) {
+        deps.uploadActionDeps.setStagedVisualComments((current) => [
+          ...current,
+          buildVisualAnnotationAttachment({ ...visualAttachmentInput! }),
+        ]);
+      }
+      if (detail.note) {
+        // Accumulate through draftRef so two annotations resolving
+        // concurrently compose (each reads the other's write) instead of
+        // both starting from the same stale closure. Mirror the result into
+        // the editor with setText so the now-non-empty editor does not fire
+        // an onChange('') that would clobber the accumulated draft back to
+        // empty.
+        const nextDraft = deps.draftRef.current
+          ? `${deps.draftRef.current}\n${detail.note}`
+          : detail.note;
+        deps.draftRef.current = nextDraft;
+        deps.setDraft(nextDraft);
+        deps.setEditorText(nextDraft);
+      }
+      deps.focusEditor();
+    };
+
+    if (detail.action === 'queue') {
+      if (visualAttachmentInput) {
+        visualAttachment = buildVisualAnnotationAttachment({ ...visualAttachmentInput });
+      }
+      const prompt = [deps.draft.trim(), detail.note].filter(Boolean).join('\n');
+      const attachments = sortChatAttachmentsByOrder([...deps.staged, ...uploaded]);
+      const nextCommentAttachments = deps.currentCommentAttachments(visualAttachment ? [visualAttachment] : []);
+      const meta: ChatSendMeta = { ...queueMeta(currentRunContextMeta(deps.sendActionDeps)), entryFrom: 'mark' };
+      sendComposedTurn(prompt, attachments, nextCommentAttachments, meta, deps.sendActionDeps);
+      ack({ ok: true });
+      return;
+    }
+
+    if (detail.action === 'send') {
+      if (deps.streaming) {
+        appendAnnotationToComposer();
+        // Carry entry_from='mark' through the deferred send so the flush
+        // effect reports the run as a Mark annotation rather than the
+        // default composer entry.
+        deps.streamingAnnotationSendEntryFromRef.current = 'mark';
+        deps.setStreamingAnnotationSendPending(true);
+        ack({ ok: true });
+        return;
+      }
+      if (visualAttachmentInput) {
+        visualAttachment = buildVisualAnnotationAttachment({ ...visualAttachmentInput });
+      }
+      const prompt = [deps.draft.trim(), detail.note].filter(Boolean).join('\n');
+      const attachments = sortChatAttachmentsByOrder([...deps.staged, ...uploaded]);
+      const nextCommentAttachments = deps.currentCommentAttachments(visualAttachment ? [visualAttachment] : []);
+      const meta: ChatSendMeta = { ...currentRunContextMeta(deps.sendActionDeps), entryFrom: 'mark' };
+      sendComposedTurn(prompt, attachments, nextCommentAttachments, meta, deps.sendActionDeps);
+      ack({ ok: true });
+      return;
+    }
+
+    if (detail.action === 'draft') {
+      appendAnnotationToComposer();
+      ack({ ok: true });
+      return;
+    }
+
+    ack({ ok: false, message: deps.t('chat.annotationFailed') });
+  } catch (err) {
+    console.warn('Could not send annotation', err);
+    deps.uploadActionDeps.setUploadError(err instanceof Error ? err.message : deps.t('chat.annotationFailed'));
+    ack({ ok: false, message: deps.t('chat.annotationFailed') });
+  } finally {
+    deps.uploadActionDeps.setUploading(false);
+  }
+}
+
+/** Everything the deferred-send-flush effect needs: the "a Mark send arrived
+ *  mid-stream" latch (state + its authoritative ref pair from
+ *  `useCommentAttachments`), the entry_from carried through the deferral, and
+ *  the send cluster's own deps bag. */
+export interface DeferredAnnotationSendDeps {
+  streamingAnnotationSendPending: boolean;
+  streamingAnnotationSendPendingRef: MutableRefObject<boolean>;
+  streaming: boolean;
+  sendDisabled: boolean;
+  draftRef: MutableRefObject<string>;
+  streamingAnnotationSendEntryFromRef: MutableRefObject<ChatAnalyticsEntryFrom | undefined>;
+  staged: ChatAttachment[];
+  currentCommentAttachments: (extra?: ChatCommentAttachment[]) => ChatCommentAttachment[];
+  sendActionDeps: SendActionDeps;
+}
+
+/**
+ * Flushes a Mark draw-overlay send that arrived while a run was already
+ * streaming, once that run finishes: reads `draftRef` (not a closed-over
+ * `draft`) since the accumulating annotation handler writes it synchronously
+ * and the ref stays authoritative even if this effect's render closure
+ * predates the last accumulation, and restores the deferred send's
+ * `entry_from: 'mark'` tag.
+ */
+export function flushDeferredAnnotationSend(deps: DeferredAnnotationSendDeps): void {
+  if (!deps.streamingAnnotationSendPending || !deps.streamingAnnotationSendPendingRef.current) return;
+  if (deps.streaming || deps.sendDisabled) return;
+  const prompt = deps.draftRef.current.trim();
+  const pendingEntryFrom = deps.streamingAnnotationSendEntryFromRef.current;
+  deps.streamingAnnotationSendEntryFromRef.current = undefined;
+  const baseMeta = currentRunContextMeta(deps.sendActionDeps);
+  const meta = pendingEntryFrom ? { ...baseMeta, entryFrom: pendingEntryFrom } : baseMeta;
+  sendComposedTurn(prompt, deps.staged, deps.currentCommentAttachments(), meta, deps.sendActionDeps);
+}

--- a/apps/web/src/features/chat-composer/components/DesignToolboxPanel.tsx
+++ b/apps/web/src/features/chat-composer/components/DesignToolboxPanel.tsx
@@ -1,0 +1,259 @@
+// The "+" → design-toolbox flyout: follow-up actions plus searchable
+// skill/plugin/mcp/connector/file resources. Hover-detail positioning is
+// owned by `useWiredDesignToolboxDetail` (a feature-local hook injected with
+// the viewport port); the portal target is passed in as `modalHost` (the
+// orchestrator resolves `document.body`, matching the
+// `MemoryAdvancedModal` canary) so this component stays DOM-free. Otherwise
+// props-in/JSX-out aside from its own search-query state and the one-time
+// `onOpened` mount effect.
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useI18n } from '../../../i18n';
+import { Icon } from '../../../components/Icon';
+import { ComposerPluginPreview } from '../../../components/ComposerPluginPreview';
+import {
+  designToolboxActionBadge,
+  designToolboxActionDescription,
+  designToolboxActionMatchesQuery,
+  designToolboxActionTitle,
+  findDesignToolboxSkill,
+  type DesignToolboxAction,
+} from '../../../runtime/design-toolbox';
+import type {
+  ConnectorDetail,
+  InstalledPluginRecord,
+  McpServerConfig,
+  McpTemplate,
+} from '@open-design/contracts';
+import type { ProjectFile, SkillSummary } from '../../../types';
+import { localizeSkillDescription, localizeSkillName } from '../../../i18n/content';
+import {
+  buildDesignToolboxResources,
+  designToolboxDefaultResources,
+  designToolboxResourceIsActive,
+  designToolboxResourceKindLabel,
+  designToolboxResourceMatchesQuery,
+} from '../rules';
+import type { DesignToolboxResource } from '../types';
+import { ToolboxItemRow } from './ToolboxItemRow';
+import { useWiredDesignToolboxDetail } from '../hooks/useDesignToolboxDetail.hooks';
+
+export function DesignToolboxPanel({
+  actions,
+  skills,
+  plugins,
+  mcpServers,
+  mcpTemplates,
+  connectors,
+  projectFiles,
+  activeSkillIds,
+  activePluginId,
+  activeMcpServerIds,
+  activeConnectorIds,
+  activeFilePaths,
+  modalHost,
+  onPickAction,
+  onPickSkill,
+  onPickResource,
+  onOpened,
+}: {
+  actions: DesignToolboxAction[];
+  skills: SkillSummary[];
+  plugins: InstalledPluginRecord[];
+  mcpServers: McpServerConfig[];
+  mcpTemplates: McpTemplate[];
+  connectors: ConnectorDetail[];
+  projectFiles: ProjectFile[];
+  activeSkillIds: string[];
+  activePluginId: string | null;
+  activeMcpServerIds: string[];
+  activeConnectorIds: string[];
+  activeFilePaths: string[];
+  modalHost: HTMLElement | null;
+  onPickAction: (action: DesignToolboxAction) => void;
+  onPickSkill: (skill: SkillSummary) => void;
+  onPickResource: (resource: DesignToolboxResource) => void;
+  onOpened?: () => void;
+}) {
+  const { locale, t } = useI18n();
+  const [query, setQuery] = useState('');
+  // Fire once when the toolbox panel mounts (i.e. the user opened it).
+  useEffect(() => {
+    onOpened?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const activeSkillSet = useMemo(() => new Set(activeSkillIds), [activeSkillIds]);
+  const activeMcpServerSet = useMemo(() => new Set(activeMcpServerIds), [activeMcpServerIds]);
+  const activeConnectorSet = useMemo(() => new Set(activeConnectorIds), [activeConnectorIds]);
+  const activeFileSet = useMemo(() => new Set(activeFilePaths), [activeFilePaths]);
+  const resources = useMemo(
+    () =>
+      buildDesignToolboxResources({
+        skills,
+        plugins,
+        mcpServers,
+        mcpTemplates,
+        connectors,
+        projectFiles,
+        locale,
+        t,
+      }),
+    [connectors, locale, mcpServers, mcpTemplates, plugins, projectFiles, skills, t],
+  );
+  const visibleActions = useMemo(
+    () =>
+      actions.filter((action) => {
+        const skill = findDesignToolboxSkill(action, skills);
+        return designToolboxActionMatchesQuery(
+          action,
+          query,
+          skill,
+          t,
+          skill ? [localizeSkillName(locale, skill), localizeSkillDescription(locale, skill)] : [],
+        );
+      }),
+    [actions, query, skills, locale, t],
+  );
+  const visibleResources = useMemo(
+    () => {
+      const source = query
+        ? resources.filter((resource) => designToolboxResourceMatchesQuery(resource, query))
+        : designToolboxDefaultResources(actions, resources);
+      return source.slice(0, query ? 14 : 8);
+    },
+    [actions, query, resources],
+  );
+
+  const { toolboxDetail, showToolboxDetail, cancelDetailClose, scheduleToolboxDetailClose } =
+    useWiredDesignToolboxDetail();
+
+  return (
+    <>
+      <div className="composer-design-toolbox-head">
+        <div className="composer-design-toolbox-title">
+          <Icon name="lightbulb" size={14} />
+          <span>{t('chat.designToolbox.title')}</span>
+        </div>
+      </div>
+      <div className="plus-menu__search">
+        <Icon name="search" size={13} />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+          placeholder={t('chat.designToolbox.searchPlaceholder')}
+          aria-label={t('chat.designToolbox.searchAria')}
+        />
+      </div>
+      {visibleActions.length > 0 || visibleResources.length > 0 ? (
+        <div className="plus-menu__list">
+          {visibleActions.length > 0 ? (
+            <div className="plus-menu__section-label">
+              {t('chat.designToolbox.followupSection')}
+            </div>
+          ) : null}
+          {visibleActions.map((action) => {
+            const skill = findDesignToolboxSkill(action, skills);
+            const actionTitle = designToolboxActionTitle(action, t);
+            const actionDescription = designToolboxActionDescription(action, t);
+            const skillName = skill ? localizeSkillName(locale, skill) : null;
+            return (
+              <ToolboxItemRow
+                key={action.id}
+                detailKey={action.id}
+                icon={action.icon}
+                name={actionTitle}
+                onHover={showToolboxDetail}
+                onLeave={scheduleToolboxDetailClose}
+                onPick={() => onPickAction(action)}
+                detail={
+                  <>
+                    <div className="plus-menu__detail-title">{actionTitle}</div>
+                    {actionDescription ? (
+                      <div className="plus-menu__detail-desc">{actionDescription}</div>
+                    ) : null}
+                    {skillName ? (
+                      <div className="plus-menu__detail-skill">@{skillName}</div>
+                    ) : null}
+                    <div className="plus-menu__detail-badge">
+                      {designToolboxActionBadge(action, t)}
+                    </div>
+                  </>
+                }
+              />
+            );
+          })}
+          {visibleResources.length > 0 ? (
+            <div className="plus-menu__section-label">
+              {t('chat.designToolbox.resourcesSection')}
+            </div>
+          ) : null}
+          {visibleResources.map((resource) => {
+            const active = designToolboxResourceIsActive(resource, {
+              skillIds: activeSkillSet,
+              pluginId: activePluginId,
+              mcpServerIds: activeMcpServerSet,
+              connectorIds: activeConnectorSet,
+              filePaths: activeFileSet,
+            });
+            return (
+              <ToolboxItemRow
+                key={resource.key}
+                detailKey={resource.key}
+                icon={resource.icon}
+                name={resource.title}
+                active={active}
+                onHover={showToolboxDetail}
+                onLeave={scheduleToolboxDetailClose}
+                onPick={() => {
+                  if (resource.kind === 'skill') {
+                    onPickSkill(resource.skill);
+                  } else {
+                    onPickResource(resource);
+                  }
+                }}
+                detail={
+                  // Plugin rows reuse the rich visual preview (poster /
+                  // sandboxed example iframe + meta); every other kind keeps
+                  // the compact text detail since it has no preview asset.
+                  resource.kind === 'plugin' ? (
+                    <ComposerPluginPreview record={resource.plugin} locale={locale} />
+                  ) : (
+                    <>
+                      <div className="plus-menu__detail-title">{resource.title}</div>
+                      {resource.subtitle ? (
+                        <div className="plus-menu__detail-desc">{resource.subtitle}</div>
+                      ) : null}
+                      <div className="plus-menu__detail-skill">
+                        {designToolboxResourceKindLabel(resource.kind, t)}
+                      </div>
+                      <div className="plus-menu__detail-badge">
+                        {active ? t('chat.designToolbox.selected') : resource.badge}
+                      </div>
+                    </>
+                  )
+                }
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className="plus-menu__empty">
+          {t('chat.designToolbox.noResources', { query })}
+        </div>
+      )}
+      {toolboxDetail && modalHost
+        ? createPortal(
+            <div
+              className="plus-menu__detail"
+              style={{ left: toolboxDetail.left, top: toolboxDetail.top }}
+              onMouseEnter={cancelDetailClose}
+              onMouseLeave={() => scheduleToolboxDetailClose(toolboxDetail.key)}
+            >
+              {toolboxDetail.node}
+            </div>,
+            modalHost,
+          )
+        : null}
+    </>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/ImportItem.tsx
+++ b/apps/web/src/features/chat-composer/components/ImportItem.tsx
@@ -1,0 +1,37 @@
+import { Icon } from '../../../components/Icon';
+import type { TranslateFn } from '../types';
+
+export function ImportItem({
+  icon,
+  label,
+  t,
+  enabled,
+  onClick,
+  testId,
+}: {
+  icon: "upload" | "link" | "grid" | "folder" | "sparkles" | "file";
+  label: string;
+  t: TranslateFn;
+  enabled?: boolean;
+  onClick?: () => void;
+  testId?: string;
+}) {
+  return (
+    <button
+      type="button"
+      className={`composer-import-item${enabled ? ' composer-import-item-enabled' : ''}`}
+      role="menuitem"
+      tabIndex={-1}
+      disabled={!enabled}
+      title={enabled ? label : t('chat.importComingSoon')}
+      onClick={enabled && onClick ? onClick : (e) => e.preventDefault()}
+      data-testid={testId}
+    >
+      <span className="ico" aria-hidden>
+        <Icon name={icon} size={14} />
+      </span>
+      <span className="composer-import-item-label">{label}</span>
+      {!enabled && <span className="composer-import-item-soon">{t('chat.importSoon')}</span>}
+    </button>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/MentionPopover.tsx
+++ b/apps/web/src/features/chat-composer/components/MentionPopover.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useRef } from 'react';
+import type { ConnectorDetail, InstalledPluginRecord, McpServerConfig, WorkspaceContextItem } from '@open-design/contracts';
+import { useI18n } from '../../../i18n';
+import { localizePluginDescription, localizePluginTitle } from '../../../components/plugins-home/localization';
+import { localizeSkillDescription, localizeSkillName } from '../../../i18n/content';
+import { Icon } from '../../../components/Icon';
+import type { ProjectFile, SkillSummary } from '../../../types';
+import type { MentionTab } from '../types';
+import {
+  workspaceContextDescription,
+  workspaceContextIcon,
+  workspaceContextKindLabel,
+  workspaceContextTitle,
+  projectFileMentionDescription,
+  projectFileMentionTitle,
+  pluginSourceLabel,
+} from '../rules';
+import { prettySize } from '../formatters';
+
+export function MentionPopover({
+  files,
+  workspaceContexts,
+  connectors,
+  plugins,
+  skills,
+  mcpServers,
+  query,
+  tab,
+  onTabChange,
+  activeIndex,
+  currentSkillId,
+  onPickFile,
+  onPickWorkspaceContext,
+  onPickPlugin,
+  onPickSkill,
+  onPickMcp,
+  onPickConnector,
+}: {
+  files: ProjectFile[];
+  workspaceContexts: WorkspaceContextItem[];
+  connectors: ConnectorDetail[];
+  plugins: InstalledPluginRecord[];
+  skills: SkillSummary[];
+  mcpServers: McpServerConfig[];
+  query: string;
+  tab: MentionTab;
+  onTabChange: (tab: MentionTab) => void;
+  activeIndex: number;
+  currentSkillId: string | null;
+  onPickFile: (path: string) => void;
+  onPickWorkspaceContext: (item: WorkspaceContextItem) => void;
+  onPickPlugin: (record: InstalledPluginRecord) => void;
+  onPickSkill: (skill: SkillSummary) => void;
+  onPickMcp: (server: McpServerConfig) => void;
+  onPickConnector: (connector: ConnectorDetail) => void;
+}) {
+  const { locale, t } = useI18n();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const tabs: Array<{ id: MentionTab; label: string }> = [
+    { id: 'all', label: t('chat.mentionTabAll') },
+    { id: 'files', label: t('chat.mentionTabFiles') },
+    { id: 'tabs', label: t('chat.mentionTabTabs') },
+    { id: 'plugins', label: t('chat.mentionTabPlugins') },
+    { id: 'skills', label: t('chat.mentionTabSkills') },
+    { id: 'mcp', label: t('chat.mentionTabMcp') },
+    { id: 'connectors', label: t('chat.mentionTabConnectors') },
+  ];
+  const showTabs = tab === 'all' || tab === 'tabs';
+  const showFiles = tab === 'all' || tab === 'files';
+  const showPlugins = tab === 'all' || tab === 'plugins';
+  const showSkills = tab === 'all' || tab === 'skills';
+  const showMcp = tab === 'all' || tab === 'mcp';
+  const showConnectors = tab === 'all' || tab === 'connectors';
+  const hasVisibleResults =
+    (showFiles && files.length > 0) ||
+    (showTabs && workspaceContexts.length > 0) ||
+    (showPlugins && plugins.length > 0) ||
+    (showSkills && skills.length > 0) ||
+    (showMcp && mcpServers.length > 0) ||
+    (showConnectors && connectors.length > 0);
+  useEffect(() => {
+    if (ref.current) ref.current.scrollTop = 0;
+  }, [connectors, files, plugins, skills, mcpServers, tab, workspaceContexts]);
+  let optionIndex = 0;
+  return (
+    <div className="mention-popover" data-testid="mention-popover">
+      <div className="mention-tabs" role="tablist" aria-label={t('chat.mentionTabsAria')}>
+        {tabs.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={tab === item.id}
+            className={`mention-tab${tab === item.id ? ' active' : ''}`}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => onTabChange(item.id)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div className="mention-results" ref={ref} role="listbox" id="mention-listbox">
+        {!hasVisibleResults ? (
+          <div className="mention-empty">
+            {query ? (
+              <>{t('chat.mentionNoResults', { query })}</>
+            ) : (
+              <>{t('chat.mentionSearchPrompt')}</>
+            )}
+          </div>
+        ) : null}
+        {showFiles && files.length > 0 ? (
+          <>
+            <div className="mention-section-label">{t('chat.mentionSectionFiles')}</div>
+            {files.map((f) => {
+              const key = f.path ?? f.name;
+              const flat = optionIndex;
+              optionIndex += 1;
+              const active = flat === activeIndex;
+              return (
+                <button
+                  key={`file-${key}`}
+                  id={`mention-opt-${flat}`}
+                  role="option"
+                  aria-selected={active}
+                  className={`mention-item${active ? ' is-active' : ''}`}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onPickFile(key)}
+                >
+                  <Icon name="file" size={12} />
+                  <span className="mention-item-body">
+                    <strong>{projectFileMentionTitle(f, key)}</strong>
+                    <span className="mention-meta mention-meta--desc mention-meta--path">
+                      {projectFileMentionDescription(f, key)}
+                    </span>
+                  </span>
+                  {f.size != null ? (
+                    <span className="mention-meta mention-item-kind">{prettySize(f.size)}</span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </>
+        ) : null}
+        {showTabs && workspaceContexts.length > 0 ? (
+          <>
+            <div className="mention-section-label">{t('chat.mentionSectionTabs')}</div>
+            {workspaceContexts.map((item) => {
+              const flat = optionIndex;
+              optionIndex += 1;
+              const active = flat === activeIndex;
+              return (
+                <button
+                  key={`workspace-${item.kind}-${item.id}`}
+                  id={`mention-opt-${flat}`}
+                  role="option"
+                  aria-selected={active}
+                  className={`mention-item mention-item--workspace${active ? ' is-active' : ''}`}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onPickWorkspaceContext(item)}
+                  title={workspaceContextTitle(item)}
+                >
+                  <Icon name={workspaceContextIcon(item)} size={12} />
+                  <span className="mention-item-body">
+                    <strong>{item.label}</strong>
+                    <span className="mention-meta mention-meta--desc">
+                      {workspaceContextDescription(item)}
+                    </span>
+                  </span>
+                  <span className="mention-meta mention-item-kind">{workspaceContextKindLabel(item.kind)}</span>
+                </button>
+              );
+            })}
+          </>
+        ) : null}
+        {showPlugins && plugins.length > 0 ? (
+          <>
+            <div className="mention-section-label">{t('chat.mentionSectionPlugins')}</div>
+            {plugins.map((p) => {
+              const flat = optionIndex;
+              optionIndex += 1;
+              const active = flat === activeIndex;
+              const pluginTitle = localizePluginTitle(locale, p);
+              const pluginDescription = localizePluginDescription(locale, p);
+              return (
+                <button
+                  key={`plugin-${p.id}`}
+                  id={`mention-opt-${flat}`}
+                  role="option"
+                  aria-selected={active}
+                  className={`mention-item mention-item--plugin${active ? ' is-active' : ''}`}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onPickPlugin(p)}
+                  title={pluginDescription || pluginTitle}
+                >
+                  <Icon name="sparkles" size={12} />
+                  <span className="mention-item-body">
+                    <strong>{pluginTitle}</strong>
+                    <span className="mention-meta mention-meta--desc">
+                      {pluginDescription || p.id}
+                    </span>
+                  </span>
+                  <span className="mention-meta mention-item-kind">{pluginSourceLabel(p, t)}</span>
+                </button>
+              );
+            })}
+          </>
+        ) : null}
+        {showSkills && skills.length > 0 ? (
+          <>
+            <div className="mention-section-label">{t('chat.mentionSectionSkills')}</div>
+            {skills.map((skill) => {
+              const flat = optionIndex;
+              optionIndex += 1;
+              const rowActive = flat === activeIndex;
+              const isCurrent = skill.id === currentSkillId;
+              return (
+                <button
+                  key={`skill-${skill.id}`}
+                  id={`mention-opt-${flat}`}
+                  role="option"
+                  aria-selected={rowActive}
+                  className={`mention-item${rowActive ? ' is-active' : ''}`}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onPickSkill(skill)}
+                  title={localizeSkillDescription(locale, skill)}
+                >
+                  <Icon name={isCurrent ? 'check' : 'file'} size={12} />
+                  <span className="mention-item-body">
+                    <strong>{localizeSkillName(locale, skill)}</strong>
+                    <span className="mention-meta mention-meta--desc">
+                      {localizeSkillDescription(locale, skill) || skill.id}
+                    </span>
+                  </span>
+                  <span className="mention-meta mention-item-kind">{isCurrent ? t('chat.mentionActiveSkill') : skill.mode}</span>
+                </button>
+              );
+            })}
+          </>
+        ) : null}
+        {showMcp && mcpServers.length > 0 ? (
+          <>
+            <div className="mention-section-label">{t('chat.mentionSectionMcp')}</div>
+            {mcpServers.map((server) => {
+              const flat = optionIndex;
+              optionIndex += 1;
+              const active = flat === activeIndex;
+              return (
+                <button
+                  key={`mcp-${server.id}`}
+                  id={`mention-opt-${flat}`}
+                  role="option"
+                  aria-selected={active}
+                  className={`mention-item${active ? ' is-active' : ''}`}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onPickMcp(server)}
+                  title={t('chat.mentionUseMcpTitle', { name: server.label || server.id })}
+                >
+                  <Icon name="link" size={12} />
+                  <span className="mention-item-body">
+                    <strong>{server.label || server.id}</strong>
+                    <span className="mention-meta mention-meta--desc">
+                      {server.url || server.command || server.id}
+                    </span>
+                  </span>
+                  <span className="mention-meta mention-item-kind">{server.transport}</span>
+                </button>
+              );
+            })}
+          </>
+        ) : null}
+        {showConnectors && connectors.length > 0 ? (
+          <>
+            <div className="mention-section-label">{t('chat.mentionSectionConnectors')}</div>
+            {connectors.map((connector) => {
+              const flat = optionIndex;
+              optionIndex += 1;
+              const active = flat === activeIndex;
+              return (
+                <button
+                  key={`connector-${connector.id}`}
+                  id={`mention-opt-${flat}`}
+                  role="option"
+                  aria-selected={active}
+                  className={`mention-item${active ? ' is-active' : ''}`}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onPickConnector(connector)}
+                  title={t('chat.mentionUseConnectorTitle', { name: connector.name })}
+                >
+                  <Icon name="link" size={12} />
+                  <span className="mention-item-body">
+                    <strong>{connector.name}</strong>
+                    <span className="mention-meta mention-meta--desc">
+                      {connector.description || connector.provider || connector.id}
+                    </span>
+                  </span>
+                  <span className="mention-meta mention-item-kind">{connector.accountLabel ?? connector.provider}</span>
+                </button>
+              );
+            })}
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/SlashPopover.tsx
+++ b/apps/web/src/features/chat-composer/components/SlashPopover.tsx
@@ -1,0 +1,64 @@
+import { Icon } from '../../../components/Icon';
+import type { SlashCommand, TranslateFn } from '../types';
+
+export function SlashPopover({
+  commands,
+  activeIndex,
+  onPick,
+  onHover,
+  t,
+}: {
+  commands: SlashCommand[];
+  activeIndex: number;
+  onPick: (cmd: SlashCommand) => void;
+  onHover: (index: number) => void;
+  t: TranslateFn;
+}) {
+  return (
+    <div
+      className="slash-popover"
+      data-testid="slash-popover"
+      role="listbox"
+      aria-label={t('pet.slashPopoverAria')}
+    >
+      <div className="slash-popover-head">
+        <span>{t('pet.slashPopoverTitle')}</span>
+        <span className="slash-popover-hint">{t('pet.slashPopoverHint')}</span>
+      </div>
+      {commands.map((cmd, idx) => {
+        const active = idx === activeIndex;
+        return (
+          <button
+            key={cmd.id}
+            id={`slash-opt-${idx}`}
+            type="button"
+            role="option"
+            aria-selected={active}
+            className={`slash-item${active ? ' active' : ''}`}
+            onMouseDown={(e) => {
+              // Prevent the textarea from losing focus before the click
+              // handler fires — otherwise selectionStart resets and the
+              // pick replacement targets the wrong substring.
+              e.preventDefault();
+            }}
+            onMouseEnter={() => onHover(idx)}
+            onClick={() => onPick(cmd)}
+          >
+            <span className="slash-item-icon" aria-hidden>
+              <Icon name={cmd.icon} size={13} />
+            </span>
+            <span className="slash-item-body">
+              <span className="slash-item-row">
+                <code className="slash-item-label">{cmd.label}</code>
+                {cmd.argHint ? (
+                  <span className="slash-item-arg">{cmd.argHint}</span>
+                ) : null}
+              </span>
+              <span className="slash-item-desc">{t(cmd.descKey)}</span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/StagedCommentAttachments.tsx
+++ b/apps/web/src/features/chat-composer/components/StagedCommentAttachments.tsx
@@ -1,0 +1,42 @@
+import type { ChatCommentAttachment } from '../../../types';
+import { commentTargetDisplayName } from '../../../comments';
+import { Icon } from '../../../components/Icon';
+import type { TranslateFn } from '../types';
+
+export function StagedCommentAttachments({
+  attachments,
+  onRemove,
+  t,
+}: {
+  attachments: ChatCommentAttachment[];
+  onRemove: (id: string) => void;
+  t: TranslateFn;
+}) {
+  const visibleAttachments = attachments.filter((attachment) => attachment.selectionKind !== 'visual');
+  if (visibleAttachments.length === 0) return null;
+  return (
+    <div className="staged-row comment-staged-row" data-testid="staged-comment-attachments">
+      {visibleAttachments.map((a) => (
+        <div key={a.id} className="staged-chip staged-comment">
+          <span
+            className="staged-name"
+            title={`${a.screenshotPath ? `${a.screenshotPath}: ` : ''}${commentTargetDisplayName(a)}${a.comment ? `: ${a.comment}` : ''}`}
+          >
+            <strong>{commentTargetDisplayName(a)}</strong>
+            {a.comment ? <span>{a.comment}</span> : null}
+          </span>
+          <button
+            type="button"
+            className="staged-remove od-tooltip"
+            onClick={() => onRemove(a.id)}
+            title={t('chat.comments.removeAttachment')}
+            data-tooltip={t('chat.comments.removeAttachment')}
+            aria-label={t('chat.comments.removeAttachmentAria', { name: a.elementId })}
+          >
+            <Icon name="close" size={11} />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/StagedRunContexts.tsx
+++ b/apps/web/src/features/chat-composer/components/StagedRunContexts.tsx
@@ -1,0 +1,299 @@
+// The wrap row of chips above the composer input: the active design-system
+// picker, the applied-plugin chip, staged workspace/skill/mcp/connector
+// context, and staged file attachments (with an image-preview trigger).
+//
+// The attachment preview modal's `preview` state and its
+// `window.addEventListener('keydown', …)` Escape-to-close subscription are
+// owned by the ORCHESTRATOR, not a feature hook — an accumulating browser
+// subscription belongs to the single-instance orchestrator so it isn't
+// re-subscribed per slice-hook instance. This component just renders what
+// it's given and reports picks via callbacks, staying props-in/JSX-out.
+// `previewUrl`/`resolveImageUrl` are passed in rather than computed here so
+// the slice never imports `providers/registry`'s `projectRawUrl` directly.
+import type { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import type { ConnectorDetail, McpServerConfig, WorkspaceContextItem } from '@open-design/contracts';
+import type { ChatAttachment, SkillSummary } from '../../../types';
+import { Icon } from '../../../components/Icon';
+import {
+  workspaceContextIcon,
+  workspaceContextKindLabel,
+  workspaceContextTitle,
+} from '../rules';
+import type { TranslateFn } from '../types';
+
+export function StagedRunContexts({
+  designSystemPicker,
+  workspaceItems,
+  currentWorkspaceContextId,
+  skills,
+  mcpServers,
+  connectors,
+  attachments,
+  pluginChip,
+  projectId,
+  preview,
+  previewUrl,
+  modalHost,
+  onPreviewAttachment,
+  onClosePreview,
+  resolveImageUrl,
+  onRemoveWorkspace,
+  onRemoveSkill,
+  onRemoveMcp,
+  onRemoveConnector,
+  onRemoveAttachment,
+  onRemovePlugin,
+  onPluginDetails,
+  onSkillDetails,
+  t,
+}: {
+  designSystemPicker?: ReactNode;
+  workspaceItems: WorkspaceContextItem[];
+  currentWorkspaceContextId: string | null;
+  skills: SkillSummary[];
+  mcpServers: McpServerConfig[];
+  connectors: ConnectorDetail[];
+  attachments: ChatAttachment[];
+  pluginChip?: { id: string; title: string } | null;
+  projectId: string | null;
+  preview: ChatAttachment | null;
+  previewUrl: string | null;
+  modalHost: HTMLElement | null;
+  onPreviewAttachment: (attachment: ChatAttachment) => void;
+  onClosePreview: () => void;
+  resolveImageUrl: (path: string) => string | null;
+  onRemoveWorkspace: (id: string) => void;
+  onRemoveSkill: (id: string) => void;
+  onRemoveMcp: (id: string) => void;
+  onRemoveConnector: (id: string) => void;
+  onRemoveAttachment: (path: string) => void;
+  onRemovePlugin?: () => void;
+  onPluginDetails?: (id: string) => void;
+  onSkillDetails?: (id: string) => void;
+  t: TranslateFn;
+}) {
+  return (
+    <>
+    <div
+      className="staged-row staged-context-row"
+      data-testid="staged-contexts"
+    >
+      {designSystemPicker ? (
+        <div className="staged-context-picker staged-context-picker--design-system">
+          {designSystemPicker}
+        </div>
+      ) : null}
+      {pluginChip ? (
+        <div className="staged-chip staged-context staged-context--plugin">
+          {/* Two sibling controls — a details button (icon + name) and the
+              remove button — rather than a role=button wrapper containing the
+              remove button. Nested interactive controls break focus order and
+              assistive-tech announcements. */}
+          <button
+            type="button"
+            className="staged-context-open"
+            onClick={() => onPluginDetails?.(pluginChip.id)}
+            title={pluginChip.title}
+            aria-label={pluginChip.title}
+          >
+            <span className="staged-icon" aria-hidden>
+              <Icon name="sparkles" size={12} />
+            </span>
+            <span className="staged-name">{pluginChip.title}</span>
+          </button>
+          <button
+            type="button"
+            className="staged-remove od-tooltip"
+            onClick={() => onRemovePlugin?.()}
+            title={t('common.delete')}
+            data-tooltip={t('common.delete')}
+            aria-label={t('chat.removeAria', { name: pluginChip.title })}
+          >
+            <Icon name="close" size={11} />
+          </button>
+        </div>
+      ) : null}
+      {workspaceItems.map((workspaceItem) => {
+        const kindLabel =
+          workspaceItem.id === currentWorkspaceContextId
+            ? 'Current'
+            : workspaceContextKindLabel(workspaceItem.kind);
+        return (
+          <div
+            key={workspaceItem.id}
+            className={`staged-chip staged-context staged-context--workspace staged-context--workspace-${workspaceItem.kind}`}
+          >
+            <span className="staged-icon" aria-hidden>
+              <Icon name={workspaceContextIcon(workspaceItem)} size={12} />
+            </span>
+            <span className="staged-name" title={workspaceContextTitle(workspaceItem)}>
+              <span className="staged-context-kind">{kindLabel}</span>
+              {workspaceItem.label}
+            </span>
+            <button
+              type="button"
+              className="staged-remove od-tooltip"
+              onClick={() => onRemoveWorkspace(workspaceItem.id)}
+              title={t('common.delete')}
+              data-tooltip={t('common.delete')}
+              aria-label={t('chat.removeAria', { name: workspaceItem.label })}
+            >
+              <Icon name="close" size={11} />
+            </button>
+          </div>
+        );
+      })}
+      {skills.map((s) => (
+        <div
+          key={s.id}
+          className={`staged-chip staged-context staged-context--skill staged-skill-${s.source ?? 'built-in'}`}
+        >
+          <button
+            type="button"
+            className="staged-context-open"
+            onClick={() => onSkillDetails?.(s.id)}
+            title={s.description || s.name}
+            aria-label={s.name}
+          >
+            <span className="staged-icon" aria-hidden>
+              <Icon name="sparkles" size={12} />
+            </span>
+            <span className="staged-name">@{s.name}</span>
+          </button>
+          <button
+            type="button"
+            className="staged-remove od-tooltip"
+            onClick={() => onRemoveSkill(s.id)}
+            title={t('common.delete')}
+            data-tooltip={t('common.delete')}
+            aria-label={t('chat.removeAria', { name: s.name })}
+          >
+            <Icon name="close" size={11} />
+          </button>
+        </div>
+      ))}
+      {mcpServers.map((server) => {
+        const label = server.label || server.id;
+        return (
+          <div
+            key={server.id}
+            className="staged-chip staged-context staged-context--mcp"
+          >
+            <span className="staged-icon" aria-hidden>
+              <Icon name="link" size={12} />
+            </span>
+            <span className="staged-name" title={server.command || server.url || server.id}>
+              @{label}
+            </span>
+            <button
+              type="button"
+              className="staged-remove od-tooltip"
+              onClick={() => onRemoveMcp(server.id)}
+              title={t('common.delete')}
+              data-tooltip={t('common.delete')}
+              aria-label={t('chat.removeAria', { name: label })}
+            >
+              <Icon name="close" size={11} />
+            </button>
+          </div>
+        );
+      })}
+      {connectors.map((connector) => (
+        <div
+          key={connector.id}
+          className="staged-chip staged-context staged-context--connector"
+        >
+          <span className="staged-icon" aria-hidden>
+            <Icon name="link" size={12} />
+          </span>
+          <span className="staged-name" title={connector.accountLabel ?? connector.provider}>
+            @{connector.name}
+          </span>
+          <button
+            type="button"
+            className="staged-remove od-tooltip"
+            onClick={() => onRemoveConnector(connector.id)}
+            title={t('common.delete')}
+            data-tooltip={t('common.delete')}
+            aria-label={t('chat.removeAria', { name: connector.name })}
+          >
+            <Icon name="close" size={11} />
+          </button>
+        </div>
+      ))}
+      {attachments.map((a, index) => {
+        const canPreview = a.kind === 'image' && Boolean(projectId);
+        const imageUrl = canPreview ? resolveImageUrl(a.path) : null;
+        return (
+          <div key={a.path} className={`staged-chip staged-${a.kind}`}>
+            <span className="staged-order" aria-label={`Attachment ${index + 1}`}>
+              {index + 1}
+            </span>
+            {canPreview && imageUrl ? (
+              <button
+                type="button"
+                className="staged-preview-trigger"
+                onClick={() => onPreviewAttachment(a)}
+                title={a.path}
+                aria-label={`Preview ${a.name}`}
+              >
+                <img src={imageUrl} alt="" aria-hidden />
+                <span className="staged-name">{a.name}</span>
+              </button>
+            ) : (
+              <>
+                <span className="staged-icon" aria-hidden>
+                  <Icon name="file" size={13} />
+                </span>
+                <span className="staged-name" title={a.path}>
+                  {a.name}
+                </span>
+              </>
+            )}
+            <button
+              type="button"
+              className="staged-remove od-tooltip"
+              onClick={() => onRemoveAttachment(a.path)}
+              title={t('common.delete')}
+              data-tooltip={t('common.delete')}
+              aria-label={t('chat.removeAria', { name: a.name })}
+            >
+              <Icon name="close" size={11} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+    {preview && previewUrl && modalHost ? createPortal(
+      <div
+        className="staged-preview-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={preview.name}
+        onMouseDown={(e) => {
+          if (e.target === e.currentTarget) onClosePreview();
+        }}
+      >
+        <div className="staged-preview-card">
+          <div className="staged-preview-head">
+            <span title={preview.path}>{preview.name}</span>
+            <button
+              type="button"
+              className="icon-only od-tooltip"
+              onClick={onClosePreview}
+              aria-label={t('common.close')}
+              title={t('common.close')}
+              data-tooltip={t('common.close')}
+            >
+              <Icon name="close" size={14} />
+            </button>
+          </div>
+          <img src={previewUrl} alt={preview.name} />
+        </div>
+      </div>,
+      modalHost
+    ) : null}
+    </>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/ToolboxItemRow.tsx
+++ b/apps/web/src/features/chat-composer/components/ToolboxItemRow.tsx
@@ -1,0 +1,57 @@
+import { useRef, type ReactNode } from 'react';
+import { Icon, type IconName } from '../../../components/Icon';
+
+// A single toolbox row, styled like the Connectors/Plugins submenu rows
+// (single line: icon + name). Clicking applies the entry; hovering shows a
+// third-level detail panel (title / description / @skill / badge). The detail
+// panel is PORTALED to <body> because the parent flyout uses `overflow-y: auto`
+// (height-capped scroll) which would otherwise clip a nested panel.
+// The hover detail panel is owned by the PARENT
+// (DesignToolboxPanel) as ONE shared panel — not per-row — so sweeping across
+// rows swaps the single panel in place instead of stacking several portaled
+// panels that briefly coexist (the close delay would otherwise leave 2-4 of
+// them on screen at once, reading as ghosting). The row just reports hover
+// enter/leave with its rect + detail node.
+export function ToolboxItemRow({
+  icon,
+  name,
+  active,
+  detailKey,
+  detail,
+  onHover,
+  onLeave,
+  onPick,
+}: {
+  icon: IconName;
+  name: string;
+  active?: boolean;
+  detailKey: string;
+  detail: ReactNode;
+  onHover: (key: string, rect: DOMRect, detail: ReactNode) => void;
+  onLeave: (key: string) => void;
+  onPick: () => void;
+}) {
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div
+      ref={rowRef}
+      className="plus-menu__subitem"
+      onMouseEnter={() => {
+        const r = rowRef.current?.getBoundingClientRect();
+        if (r) onHover(detailKey, r, detail);
+      }}
+      onMouseLeave={() => onLeave(detailKey)}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        className={`plus-menu__item${active ? ' is-active' : ''}`}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onPick}
+      >
+        <Icon name={icon} size={14} className="plus-menu__item-icon" />
+        <span>{name}</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/ToolsImportPanel.tsx
+++ b/apps/web/src/features/chat-composer/components/ToolsImportPanel.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { DesignSystemSwitchPicker } from '../../../components/DesignSystemSwitchPicker';
+import type { TranslateFn } from '../types';
+import { ImportItem } from './ImportItem';
+
+export function ToolsImportPanel({
+  t,
+  onLinkFolder,
+  currentDesignSystemId,
+  onSwitchDesignSystem,
+}: {
+  t: TranslateFn;
+  onLinkFolder: () => Promise<void> | void;
+  currentDesignSystemId?: string | null;
+  // When omitted (no active project) the design-system import row stays
+  // disabled with the existing "Coming soon" affordance so users aren't
+  // routed into a picker that has nothing to PATCH. Returns true on a
+  // successful PATCH so the picker can close itself; false leaves the
+  // picker open so the user can retry.
+  onSwitchDesignSystem?: (
+    designSystemId: string | null,
+    title: string | null,
+  ) => Promise<boolean>;
+}) {
+  const [view, setView] = useState<'root' | 'designSystems'>('root');
+
+  if (view === 'designSystems' && onSwitchDesignSystem) {
+    return (
+      <DesignSystemSwitchPicker
+        t={t}
+        currentDesignSystemId={currentDesignSystemId}
+        onSelect={onSwitchDesignSystem}
+        onBack={() => setView('root')}
+      />
+    );
+  }
+
+  return (
+    <div className="composer-tools-list">
+      <ImportItem icon="upload" label={t('chat.importFig')} t={t} />
+      <ImportItem icon="grid" label={t('chat.importWeb')} t={t} />
+      <ImportItem
+        icon="folder"
+        label={t('chat.importFolder')}
+        t={t}
+        enabled
+        onClick={() => void onLinkFolder()}
+      />
+      <ImportItem
+        icon="sparkles"
+        label={t('chat.importSkills')}
+        t={t}
+        enabled={!!onSwitchDesignSystem}
+        onClick={() => setView('designSystems')}
+        testId="composer-import-design-systems"
+      />
+      <ImportItem icon="file" label={t('chat.importProject')} t={t} />
+    </div>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/ToolsMcpPanel.tsx
+++ b/apps/web/src/features/chat-composer/components/ToolsMcpPanel.tsx
@@ -1,0 +1,103 @@
+import { useMemo, useState } from 'react';
+import type { McpServerConfig, McpTemplate } from '@open-design/contracts';
+import { Icon } from '../../../components/Icon';
+import { mcpServerMatchesQuery, mcpTemplateMatchesQuery } from '../rules';
+
+export function ToolsMcpPanel({
+  servers,
+  templates,
+  onInsert,
+  onManage,
+}: {
+  servers: McpServerConfig[];
+  templates: McpTemplate[];
+  onInsert: (serverId: string) => void;
+  onManage: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const visibleServers = useMemo(
+    () => servers.filter((s) => mcpServerMatchesQuery(s, query)),
+    [servers, query],
+  );
+  const visibleTemplates = useMemo(
+    () => templates.filter((tpl) => mcpTemplateMatchesQuery(tpl, query)).slice(0, 8),
+    [templates, query],
+  );
+
+  return (
+    <>
+      <div className="composer-tools-filter">
+        <input
+          className="composer-tools-search"
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+          placeholder="Search MCP…"
+          aria-label="Search MCP servers and templates"
+        />
+      </div>
+      {visibleServers.length === 0 ? (
+        <div className="composer-tools-empty">
+          {servers.length === 0
+            ? 'No enabled MCP servers configured yet.'
+            : `No configured MCP results for “${query}”.`}
+        </div>
+      ) : (
+        <div className="composer-tools-list">
+          <div className="composer-tools-section-label">Configured</div>
+          {visibleServers.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              role="menuitem"
+              className="composer-tools-row"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => onInsert(s.id)}
+              title={`Insert a hint that nudges the model to use ${s.label || s.id}`}
+            >
+              <Icon name="link" size={12} />
+              <span className="composer-tools-row-body">
+                <strong>{s.label || s.id}</strong>
+                <span className="composer-tools-row-meta">{s.transport}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+      {visibleTemplates.length > 0 ? (
+        <div className="composer-tools-list">
+          <div className="composer-tools-section-label">Templates</div>
+          {visibleTemplates.map((tpl) => (
+            <button
+              key={tpl.id}
+              type="button"
+              role="menuitem"
+              className="composer-tools-row"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={onManage}
+              title={`Add ${tpl.label} from Settings`}
+            >
+              <Icon name="plus" size={12} />
+              <span className="composer-tools-row-body">
+                <strong>{tpl.label}</strong>
+                <span className="composer-tools-row-meta">
+                  {tpl.transport}
+                  {tpl.category ? ` · ${tpl.category}` : ''}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        role="menuitem"
+        className="composer-tools-row composer-tools-row-action"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onManage}
+      >
+        <Icon name="settings" size={12} />
+        <span>Manage MCP servers…</span>
+      </button>
+    </>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/ToolsPluginsPanel.tsx
+++ b/apps/web/src/features/chat-composer/components/ToolsPluginsPanel.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from 'react';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+import { useI18n } from '../../../i18n';
+import { localizePluginDescription, localizePluginTitle } from '../../../components/plugins-home/localization';
+import { Icon } from '../../../components/Icon';
+import { USER_PLUGIN_SOURCE_KINDS } from '../constants';
+import { pluginMatchesQuery } from '../rules';
+
+export function ToolsPluginsPanel({
+  plugins,
+  activePluginId,
+  onApply,
+  onShowDetails,
+}: {
+  plugins: InstalledPluginRecord[];
+  activePluginId: string | null;
+  onApply: (record: InstalledPluginRecord) => void | Promise<void>;
+  onShowDetails: (record: InstalledPluginRecord) => void;
+}) {
+  const { locale } = useI18n();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [source, setSource] = useState<'community' | 'mine'>('community');
+  const [query, setQuery] = useState('');
+  const communityPlugins = useMemo(
+    () => plugins.filter((p) => p.sourceKind === 'bundled'),
+    [plugins],
+  );
+  const userPlugins = useMemo(
+    () => plugins.filter((p) => USER_PLUGIN_SOURCE_KINDS.has(p.sourceKind)),
+    [plugins],
+  );
+  const scopedPlugins = source === 'community' ? communityPlugins : userPlugins;
+  const visiblePlugins = useMemo(
+    () => scopedPlugins.filter((p) => pluginMatchesQuery(p, query)),
+    [scopedPlugins, query],
+  );
+
+  return (
+    <>
+      <div className="composer-tools-filter">
+        <div className="composer-tools-segments" role="tablist" aria-label="Plugin source">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={source === 'community'}
+            className={`composer-tools-segment${source === 'community' ? ' active' : ''}`}
+            onClick={() => setSource('community')}
+            title={`${communityPlugins.length} installed official plugins`}
+          >
+            Official
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={source === 'mine'}
+            className={`composer-tools-segment${source === 'mine' ? ' active' : ''}`}
+            onClick={() => setSource('mine')}
+            title={`${userPlugins.length} installed user plugins`}
+          >
+            My plugins
+          </button>
+        </div>
+        <input
+          className="composer-tools-search"
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+          placeholder="Search plugins…"
+          aria-label="Search plugins"
+        />
+      </div>
+      {visiblePlugins.length === 0 ? (
+        <div className="composer-tools-empty">
+          {plugins.length === 0 ? (
+            <>
+              No plugins installed yet. Browse Official or add your own with{' '}
+              <code>od plugin install &lt;source&gt;</code>.
+            </>
+          ) : query ? (
+            <>No {source === 'community' ? 'Official' : 'My plugins'} results for “{query}”.</>
+          ) : (
+            <>No {source === 'community' ? 'Official' : 'My plugins'} plugins available.</>
+          )}
+        </div>
+      ) : (
+        <div className="composer-tools-list">
+          {visiblePlugins.map((p) => {
+            const pluginTitle = localizePluginTitle(locale, p);
+            const pluginDescription = localizePluginDescription(locale, p);
+            return (
+            <div
+              key={p.id}
+              className={`composer-tools-row composer-tools-row--plugin${
+                p.id === activePluginId ? ' active' : ''
+              }`}
+            >
+              <button
+                type="button"
+                className="composer-tools-row-main"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={async () => {
+                  setPendingId(p.id);
+                  try {
+                    await onApply(p);
+                  } finally {
+                    setPendingId(null);
+                  }
+                }}
+                disabled={pendingId !== null}
+                aria-busy={pendingId === p.id ? 'true' : undefined}
+                title={pluginDescription || pluginTitle}
+              >
+                <Icon name="sparkles" size={12} />
+                <span className="composer-tools-row-body">
+                  <strong>{pluginTitle}</strong>
+                  {pluginDescription ? (
+                    <span className="composer-tools-row-meta">
+                      {pluginDescription}
+                    </span>
+                  ) : (
+                    <span className="composer-tools-row-meta">{p.id}</span>
+                  )}
+                </span>
+                {pendingId === p.id ? (
+                  <span className="composer-tools-row-pending">Applying…</span>
+                ) : null}
+              </button>
+              <button
+                type="button"
+                className="composer-tools-row-side"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => onShowDetails(p)}
+                title={`View details for ${pluginTitle}`}
+                aria-label={`View details for ${pluginTitle}`}
+              >
+                <Icon name="eye" size={12} />
+              </button>
+            </div>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/chat-composer/components/ToolsSkillsPanel.tsx
+++ b/apps/web/src/features/chat-composer/components/ToolsSkillsPanel.tsx
@@ -1,0 +1,79 @@
+import { useMemo, useState } from 'react';
+import { useI18n } from '../../../i18n';
+import { localizeSkillDescription, localizeSkillName } from '../../../i18n/content';
+import { skillMatchesQuery } from '../../../runtime/design-toolbox';
+import { Icon } from '../../../components/Icon';
+import type { SkillSummary } from '../../../types';
+
+export function ToolsSkillsPanel({
+  skills,
+  currentSkillId,
+  onPick,
+}: {
+  skills: SkillSummary[];
+  currentSkillId: string | null;
+  onPick: (skill: SkillSummary) => void | Promise<void>;
+}) {
+  const { locale } = useI18n();
+  const [query, setQuery] = useState('');
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const visibleSkills = useMemo(
+    () => skills.filter((s) => skillMatchesQuery(s, query)).slice(0, 24),
+    [skills, query],
+  );
+  return (
+    <>
+      <div className="composer-tools-filter">
+        <input
+          className="composer-tools-search"
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+          placeholder="Search skills…"
+          aria-label="Search skills"
+        />
+      </div>
+      {visibleSkills.length === 0 ? (
+        <div className="composer-tools-empty">
+          {skills.length === 0 ? 'No skills available yet.' : `No skills found for “${query}”.`}
+        </div>
+      ) : (
+        <div className="composer-tools-list">
+          {visibleSkills.map((skill) => {
+            const active = skill.id === currentSkillId;
+            return (
+              <button
+                key={skill.id}
+                type="button"
+                role="menuitem"
+                className={`composer-tools-row${active ? ' active' : ''}`}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={async () => {
+                  setPendingId(skill.id);
+                  try {
+                    await onPick(skill);
+                  } finally {
+                    setPendingId(null);
+                  }
+                }}
+                disabled={pendingId !== null}
+                title={localizeSkillDescription(locale, skill)}
+              >
+                <Icon name={active ? 'check' : 'file'} size={12} />
+                <span className="composer-tools-row-body">
+                  <strong>{localizeSkillName(locale, skill)}</strong>
+                  <span className="composer-tools-row-meta">
+                    {skill.mode}
+                    {skill.surface ? ` · ${skill.surface}` : ''}
+                  </span>
+                </span>
+                {pendingId === skill.id ? (
+                  <span className="composer-tools-row-pending">Applying…</span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/chat-composer/constants.ts
+++ b/apps/web/src/features/chat-composer/constants.ts
@@ -1,0 +1,24 @@
+// Slice-wide constants for the chat-composer feature. No React, no transport.
+import type { PluginSourceKind } from '@open-design/contracts';
+import type { DetailPositionOptions } from './rules';
+
+/** `sourceKind`s the tools panel's "My plugins" tab groups together. */
+export const USER_PLUGIN_SOURCE_KINDS = new Set<PluginSourceKind>([
+  'user',
+  'project',
+  'marketplace',
+  'github',
+  'url',
+  'local',
+]);
+
+/** Sizing the design-toolbox hover-detail panel clamps against. */
+export const DESIGN_TOOLBOX_DETAIL_OPTIONS: DetailPositionOptions = {
+  detailWidth: 264,
+  gap: 8,
+  margin: 8,
+  estimatedHeight: 340,
+};
+
+/** Hover-out grace period before the design-toolbox detail panel closes. */
+export const DESIGN_TOOLBOX_DETAIL_CLOSE_DELAY_MS = 160;

--- a/apps/web/src/features/chat-composer/dependencies.ts
+++ b/apps/web/src/features/chat-composer/dependencies.ts
@@ -1,0 +1,40 @@
+// Composition root for the chat-composer slice: binds a concrete transport/DOM
+// adapter to the slice's port. This is the ONE feature file allowed to import
+// `providers/` — everything else in the slice depends on the port, so swapping
+// the adapter (or a fake in tests) touches only this file.
+import { getViewportSize, readComposerDraft, writeComposerDraft } from '../../providers/dom';
+import {
+  dirExists,
+  fetchRecentLinkedDirs,
+  pushRecentLinkedDir,
+} from '../../providers/registry';
+// `fetchMcpServers`/`listPlugins` live in `state/`, not `providers/`, but are
+// bound here anyway (like the two providers/ adapters above) so the catalogue
+// hook stays port-only — nothing else in the orchestrator calls them directly.
+import { fetchMcpServers } from '../../state/mcp';
+import { listPlugins } from '../../state/projects';
+import type { ComposerCataloguePort, ComposerDraftPort, ViewportPort, WorkingDirPort } from './ports';
+
+/** Default binding: the real browser viewport. */
+export const viewportPort: ViewportPort = {
+  getViewportSize,
+};
+
+/** Default binding: the real localStorage-backed draft persistence. */
+export const composerDraftPort: ComposerDraftPort = {
+  readComposerDraft,
+  writeComposerDraft,
+};
+
+/** Default binding: the real registry provider. */
+export const workingDirPort: WorkingDirPort = {
+  dirExists,
+  fetchRecentLinkedDirs,
+  pushRecentLinkedDir,
+};
+
+/** Default binding: the real MCP + plugins providers. */
+export const composerCataloguePort: ComposerCataloguePort = {
+  fetchMcpServers,
+  listInstalledPlugins: () => listPlugins(),
+};

--- a/apps/web/src/features/chat-composer/formatters.ts
+++ b/apps/web/src/features/chat-composer/formatters.ts
@@ -1,0 +1,13 @@
+// Pure display formatters for the chat-composer slice: file-name/size
+// presentation used by the mention picker and attachment chips. No React, no
+// transport, no DOM (ADR 0002).
+
+export function looksLikeImage(name: string): boolean {
+  return /\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i.test(name);
+}
+
+export function prettySize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}

--- a/apps/web/src/features/chat-composer/hooks/useAppliedPlugin.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useAppliedPlugin.hooks.ts
@@ -1,0 +1,98 @@
+// Feature-local hook for the composer's currently-applied plugin: the
+// snapshot shown as a chip in the staged-context bar, plus the
+// inline-mention "backed by an applied plugin" bridge ref that lets the
+// auto-clear effect below tell an inline `@<plugin>` token apart from a
+// plugin the user applied through the tools panel. Genuinely cross-cutting
+// state (read/written by the design-toolbox-apply functions, the
+// mention-insert family, `handleEditorChange`, `reset`, and the
+// `PluginsSection`/`StagedRunContexts` JSX handlers) that previously sat
+// bare in the orchestrator with no owning hook.
+//
+// Owns its own deps-bag callbacks (Phase 6 "a hook should own its own
+// deps-bag callbacks" pattern): `handlePluginApplied` and the auto-clear
+// effect need `setDraft`/`clearPluginsSection`, cross-cluster pieces this
+// hook takes as params rather than requiring the orchestrator to assemble
+// them itself.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import type { AppliedPluginSnapshot, ApplyResult } from '@open-design/contracts';
+import { mentionTokenPresent } from '../../../utils/inlineMentions';
+
+export type InlineBackedPlugin = { id: string; label: string } | null;
+
+export interface AppliedPluginParams {
+  draft: string;
+  setDraft: Dispatch<SetStateAction<string>>;
+  clearPluginsSection: () => void;
+}
+
+export interface AppliedPluginController {
+  activeAppliedPlugin: AppliedPluginSnapshot | null;
+  setActiveAppliedPlugin: Dispatch<SetStateAction<AppliedPluginSnapshot | null>>;
+  inlineBackedPluginRef: MutableRefObject<InlineBackedPlugin>;
+  setInlineBackedPlugin: (value: InlineBackedPlugin) => void;
+  handlePluginApplied: (brief: string, applied: ApplyResult) => void;
+  handlePluginCleared: () => void;
+  removeAppliedPlugin: () => void;
+}
+
+export function useAppliedPlugin({
+  draft,
+  setDraft,
+  clearPluginsSection,
+}: AppliedPluginParams): AppliedPluginController {
+  const [activeAppliedPlugin, setActiveAppliedPlugin] = useState<AppliedPluginSnapshot | null>(null);
+  const inlineBackedPluginRef = useRef<InlineBackedPlugin>(null);
+
+  const setInlineBackedPlugin = useCallback((value: InlineBackedPlugin) => {
+    inlineBackedPluginRef.current = value;
+  }, []);
+
+  // Fired by PluginsSection.onApplied every time its own brief changes.
+  // Functional setState so a stale closure from the @-mention flow (which
+  // awaits applyById after setDraft) still sees the latest draft value
+  // before deciding whether to seed.
+  const handlePluginApplied = useCallback((brief: string, applied: ApplyResult) => {
+    setActiveAppliedPlugin(applied.appliedPlugin);
+    if (typeof brief === 'string' && brief.length > 0) {
+      setDraft((cur) => (cur.trim().length === 0 ? brief : cur));
+    }
+  }, [setDraft]);
+
+  // Fired by PluginsSection.onCleared when the section clears itself (e.g.
+  // the user removed its last context chip) — must NOT call
+  // `clearPluginsSection` back, that would re-enter the section that just
+  // told us it cleared.
+  const handlePluginCleared = useCallback(() => {
+    inlineBackedPluginRef.current = null;
+    setActiveAppliedPlugin(null);
+  }, []);
+
+  // Fired by StagedRunContexts.onRemovePlugin when the user removes the
+  // plugin chip from the staged-context bar (external to PluginsSection),
+  // so this DOES need to actively tell the section to clear itself.
+  const removeAppliedPlugin = useCallback(() => {
+    clearPluginsSection();
+    setActiveAppliedPlugin(null);
+  }, [clearPluginsSection]);
+
+  // Drops the inline-mention bridge (and clears the section) once the
+  // applied plugin's `@<label>` token is hand-deleted from the draft.
+  useEffect(() => {
+    const inlinePlugin = inlineBackedPluginRef.current;
+    if (!activeAppliedPlugin || inlinePlugin?.id !== activeAppliedPlugin.pluginId) return;
+    if (mentionTokenPresent(draft, inlinePlugin.label)) return;
+    inlineBackedPluginRef.current = null;
+    clearPluginsSection();
+  }, [activeAppliedPlugin, draft, clearPluginsSection]);
+
+  return {
+    activeAppliedPlugin,
+    setActiveAppliedPlugin,
+    inlineBackedPluginRef,
+    setInlineBackedPlugin,
+    handlePluginApplied,
+    handlePluginCleared,
+    removeAppliedPlugin,
+  };
+}

--- a/apps/web/src/features/chat-composer/hooks/useCommentAttachments.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useCommentAttachments.hooks.ts
@@ -1,0 +1,80 @@
+// Feature-local hook for the composer's comment/annotation attachments: the
+// visual-comment chips staged locally (Mark draw-overlay annotations) merged
+// with the `commentAttachments` prop (comments staged upstream, e.g. from a
+// file-viewer selection), the "streaming annotation send is pending" latch
+// used when an annotation arrives mid-stream and must wait for the current
+// run to finish before it can send, and the entry_from tag that deferred send
+// must carry once it flushes (the Mark draw-overlay tags 'mark' synchronously;
+// without this the flush effect would report the run as the default composer
+// entry). Pure UI state — no port, no transport — matching the memory
+// canary's no-port `useMemoryFlash` and this slice's
+// `useComposerModals`/`useComposerUpload`.
+//
+// The `ANNOTATION_EVENT` window listener (and its paired "flush the deferred
+// send" effect) stay in the orchestrator: both are heavily entangled with
+// other clusters' state (`draft`/`draftRef`, `staged`, `streaming`,
+// `sendDisabled`, `sendComposedTurn`, `currentRunContextMeta`) that hasn't
+// been extracted yet, so this hook only exposes the state/functions that are
+// genuinely this cluster's own for those orchestrator-owned effects to call.
+import { useCallback, useRef, useState } from 'react';
+import type { ChatAnalyticsEntryFrom } from '@open-design/contracts';
+import type { ChatCommentAttachment } from '../../../types';
+import { sortChatCommentAttachmentsByOrder } from '../rules';
+
+export interface CommentAttachmentsParams {
+  commentAttachments: ChatCommentAttachment[];
+  onRemoveCommentAttachment?: (id: string) => void;
+}
+
+export interface CommentAttachmentsController {
+  stagedVisualComments: ChatCommentAttachment[];
+  setStagedVisualComments: React.Dispatch<React.SetStateAction<ChatCommentAttachment[]>>;
+  streamingAnnotationSendPending: boolean;
+  streamingAnnotationSendPendingRef: React.MutableRefObject<boolean>;
+  setStreamingAnnotationSendPending: (value: boolean) => void;
+  streamingAnnotationSendEntryFromRef: React.MutableRefObject<ChatAnalyticsEntryFrom | undefined>;
+  currentCommentAttachments: (extra?: ChatCommentAttachment[]) => ChatCommentAttachment[];
+  removeCommentAttachment: (id: string) => void;
+}
+
+export function useCommentAttachments({
+  commentAttachments,
+  onRemoveCommentAttachment,
+}: CommentAttachmentsParams): CommentAttachmentsController {
+  const [stagedVisualComments, setStagedVisualComments] = useState<ChatCommentAttachment[]>([]);
+  const streamingAnnotationSendPendingRef = useRef(false);
+  const [streamingAnnotationSendPending, setStreamingAnnotationSendPendingState] = useState(false);
+  const streamingAnnotationSendEntryFromRef = useRef<ChatAnalyticsEntryFrom | undefined>(undefined);
+
+  const setStreamingAnnotationSendPending = useCallback((value: boolean) => {
+    streamingAnnotationSendPendingRef.current = value;
+    setStreamingAnnotationSendPendingState(value);
+  }, []);
+
+  const currentCommentAttachments = useCallback(
+    (extra: ChatCommentAttachment[] = []): ChatCommentAttachment[] =>
+      sortChatCommentAttachmentsByOrder([...commentAttachments, ...stagedVisualComments, ...extra]),
+    [commentAttachments, stagedVisualComments],
+  );
+
+  const removeCommentAttachment = useCallback(
+    (id: string) => {
+      setStagedVisualComments((current) => current.filter((attachment) => attachment.id !== id));
+      if (!stagedVisualComments.some((attachment) => attachment.id === id)) {
+        onRemoveCommentAttachment?.(id);
+      }
+    },
+    [onRemoveCommentAttachment, stagedVisualComments],
+  );
+
+  return {
+    stagedVisualComments,
+    setStagedVisualComments,
+    streamingAnnotationSendPending,
+    streamingAnnotationSendPendingRef,
+    setStreamingAnnotationSendPending,
+    streamingAnnotationSendEntryFromRef,
+    currentCommentAttachments,
+    removeCommentAttachment,
+  };
+}

--- a/apps/web/src/features/chat-composer/hooks/useComposerCatalogue.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useComposerCatalogue.hooks.ts
@@ -1,0 +1,165 @@
+// Feature-local hook for the MCP servers / MCP templates / connectors /
+// installed-plugins catalogue, and the `composerEngaged` latch that gates
+// fetching all four. `composerEngaged` starts false and flips true (never
+// back) on the composer's first real interaction, so an untouched empty
+// composer never pays for the plugin/MCP/connector fetches.
+//
+// `fetchMcpServers` and `listPlugins` are real transport calls used ONLY by
+// this hook's fetch effects (verified: nothing else in the orchestrator
+// calls either), so — unlike `patchProject`/`openFolderDialog`, which stay
+// plain deps-bag callbacks because other clusters also use them — they are
+// routed through a dedicated port (`ComposerCataloguePort`), following the
+// `WorkingDirPort` pattern exactly. `fetchConnectorCatalogSnapshot` lives in
+// `components/connectors-state.ts`, which is shared with `EntryView.tsx`
+// (not slice-exclusive); moving it into `providers/` is a separate, later
+// cleanup, so this hook imports it directly from `components/` — the guard
+// only blocks `providers/` imports outside `dependencies.ts`, not
+// `components/` imports.
+//
+// The connectors-changed subscription (`listenForConnectorsChanged`, from
+// `components/connectors-events.ts`) is an ACCUMULATING `window`/event
+// listener, so per the slice's effect-placement rule it stays in the
+// orchestrator (a guaranteed single instance) instead of this hook. This
+// hook only exposes `refreshConnectors` for that orchestrator-owned effect
+// to call, mirroring how `useWorkingDirStatus` exposes `checkWorkingDir` for
+// the orchestrator's focus/visibilitychange listener.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  ConnectorDetail,
+  InstalledPluginRecord,
+  McpServerConfig,
+  McpTemplate,
+} from '@open-design/contracts';
+import { fetchConnectorCatalogSnapshot } from '../../../components/connectors-state';
+import { composerCataloguePort } from '../dependencies';
+import type { ComposerCataloguePort } from '../ports';
+
+export interface ComposerCatalogueParams {
+  projectId: string | null;
+  /**
+   * Seeds the `composerEngaged` latch. The orchestrator passes
+   * `(draft ?? '').trim().length > 0` (the pre-extraction initializer) so a
+   * composer that starts with content still fetches immediately. Only
+   * consulted on mount — like the `useState` initializer it replaces, React
+   * ignores this value on later renders.
+   */
+  initialEngaged: boolean;
+}
+
+export interface ComposerCatalogueController {
+  mcpServers: McpServerConfig[];
+  mcpTemplates: McpTemplate[];
+  connectors: ConnectorDetail[];
+  installedPlugins: InstalledPluginRecord[];
+  composerEngaged: boolean;
+  /** Latches `composerEngaged` true. Idempotent (a no-op once already
+   *  engaged) — safe to call from every existing trigger: first focus, the
+   *  tools/plus-menu opening, an @/slash trigger, a pre-seeded draft, or the
+   *  imperative `openDesignToolbox` handle. */
+  markComposerEngaged: () => void;
+  /** Re-fetches the connector catalogue with discovery refreshed. Exposed so
+   *  the orchestrator's connectors-changed listener effect (kept out of this
+   *  hook — see module header) can trigger a reload. */
+  refreshConnectors: () => Promise<void>;
+}
+
+export function useComposerCatalogue(
+  { projectId, initialEngaged }: ComposerCatalogueParams,
+  port: ComposerCataloguePort,
+): ComposerCatalogueController {
+  const [mcpServers, setMcpServers] = useState<McpServerConfig[]>([]);
+  const [mcpTemplates, setMcpTemplates] = useState<McpTemplate[]>([]);
+  const [connectors, setConnectors] = useState<ConnectorDetail[]>([]);
+  const [installedPlugins, setInstalledPlugins] = useState<InstalledPluginRecord[]>([]);
+  const [composerEngaged, setComposerEngaged] = useState(initialEngaged);
+
+  const markComposerEngaged = useCallback(() => {
+    setComposerEngaged(true);
+  }, []);
+
+  // Tracks component lifetime (not a per-effect flag) so `refreshConnectors`
+  // — called imperatively from the orchestrator's own listener effect,
+  // outside any effect this hook owns — can still skip a state update after
+  // unmount, matching the cancellation guard the original inline effect had.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
+
+  // Lazy-fetch the user's external MCP servers list (once engaged) so the
+  // `/mcp …` slash palette and the composer's MCP button popover have
+  // something to render. We deliberately do not reactively re-fetch when
+  // the user toggles servers from Settings — the dialog refreshes itself,
+  // and the chat composer rehydrates next time the user re-opens it. A
+  // background poll would be cheap but unnecessary for the typical
+  // edit-once-then-chat workflow.
+  useEffect(() => {
+    if (!composerEngaged) return;
+    let cancelled = false;
+    void (async () => {
+      const data = await port.fetchMcpServers();
+      if (cancelled || !data) return;
+      setMcpServers(data.servers);
+      setMcpTemplates(data.templates);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [composerEngaged, port]);
+
+  // Lazy-fetch installed plugins once on mount; the tools-menu Plugins
+  // tab and the @-mention picker both consume this list.
+  useEffect(() => {
+    if (!projectId || !composerEngaged) return;
+    let cancelled = false;
+    void port.listInstalledPlugins().then((rows) => {
+      if (cancelled) return;
+      setInstalledPlugins(rows);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, composerEngaged, port]);
+
+  useEffect(() => {
+    if (!composerEngaged) return;
+    let cancelled = false;
+    void fetchConnectorCatalogSnapshot().then((rows) => {
+      if (cancelled) return;
+      setConnectors(rows.filter((connector) => connector.status === 'connected'));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [composerEngaged]);
+
+  const refreshConnectors = useCallback(async () => {
+    const rows = await fetchConnectorCatalogSnapshot({ refreshDiscovery: true });
+    if (!mountedRef.current) return;
+    setConnectors(rows.filter((connector) => connector.status === 'connected'));
+  }, []);
+
+  return {
+    mcpServers,
+    mcpTemplates,
+    connectors,
+    installedPlugins,
+    composerEngaged,
+    markComposerEngaged,
+    refreshConnectors,
+  };
+}
+
+/**
+ * Wirer: binds the real MCP + plugins providers. This is the default the
+ * orchestrator injects; tests call `useComposerCatalogue` directly with a
+ * hand-written fake port instead.
+ */
+export function useWiredComposerCatalogue(
+  params: ComposerCatalogueParams,
+): ComposerCatalogueController {
+  return useComposerCatalogue(params, composerCataloguePort);
+}

--- a/apps/web/src/features/chat-composer/hooks/useComposerDraft.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useComposerDraft.hooks.ts
@@ -1,0 +1,118 @@
+// Feature-local hook for the composer's draft text: the `draft` state (seeded
+// from `initialDraft` or a persisted localStorage value), a synchronous
+// `draftRef` mirror event handlers off a stale closure read/write (notably
+// the annotation listener, where two uploads can resolve concurrently), the
+// placeholder-carousel scenario selection, and the seed-once/persist effects.
+// Transport (localStorage) is INJECTED as the slice port so the hook holds no
+// import to a provider — see `dependencies.ts`.
+//
+// Both effects below are internal state management (reacting to a prop and
+// this hook's own state, not an external `window`/`document`/`EventSource`
+// subscription), so they stay in the hook per the accumulating-subscription
+// rule.
+//
+// `replaceEditorDraft`/`insertInlineMentionSeparator` need the Lexical editor
+// ref, which is shared across every popover/cluster and stays orchestrator-
+// owned — so it's taken as a hook param (a plain React ref, not a
+// `providers/` import) rather than imported.
+import { useEffect, useRef, useState } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import type { LexicalComposerInputHandle } from '../../../components/composer/LexicalComposerInput';
+import type { PlaceholderScenario } from '../../../components/home-hero/placeholderScenarios';
+import { composerDraftPort } from '../dependencies';
+import type { ComposerDraftPort } from '../ports';
+
+export interface ComposerDraftParams {
+  initialDraft?: string;
+  draftStorageKey?: string;
+  editorRef: MutableRefObject<LexicalComposerInputHandle | null>;
+}
+
+export interface ComposerDraftController {
+  draft: string;
+  setDraft: Dispatch<SetStateAction<string>>;
+  draftRef: MutableRefObject<string>;
+  seededRef: MutableRefObject<boolean>;
+  placeholderScenario: PlaceholderScenario | null;
+  setPlaceholderScenario: Dispatch<SetStateAction<PlaceholderScenario | null>>;
+  replaceEditorDraft: (text: string) => void;
+  insertInlineMentionSeparator: () => void;
+  clearDraft: () => void;
+}
+
+export function useComposerDraft(
+  { initialDraft, draftStorageKey, editorRef }: ComposerDraftParams,
+  port: ComposerDraftPort,
+): ComposerDraftController {
+  const [draft, setDraft] = useState(() => initialDraft ?? port.readComposerDraft(draftStorageKey) ?? "");
+  const [placeholderScenario, setPlaceholderScenario] = useState<PlaceholderScenario | null>(null);
+  // Synchronous mirror of `draft`. Kept in lockstep with `draft` by
+  // `handleEditorChange` (the editor is the single source for typing) and by
+  // the programmatic-set paths below.
+  const draftRef = useRef(draft);
+
+  // initialDraft is only honored on the first non-empty value the parent
+  // hands us. After we seed once, the composer is fully under user control —
+  // re-renders that pass the same prompt back must not reseed. If the
+  // initial useState above already consumed a non-empty initialDraft we mark
+  // it seeded immediately, so an early clear by the user (typing or
+  // backspace before the parent stops passing initialDraft) does not get
+  // overwritten by the effect.
+  const seededRef = useRef(Boolean(initialDraft));
+
+  useEffect(() => {
+    if (seededRef.current) return;
+    if (initialDraft && initialDraft !== draft) {
+      setDraft(initialDraft);
+      seededRef.current = true;
+    } else if (initialDraft === undefined) {
+      seededRef.current = true;
+    }
+  }, [initialDraft, draft]);
+
+  useEffect(() => {
+    port.writeComposerDraft(draftStorageKey, draft);
+  }, [port, draftStorageKey, draft]);
+
+  function replaceEditorDraft(text: string) {
+    draftRef.current = text;
+    setDraft(text);
+    editorRef.current?.setText(text);
+  }
+
+  function insertInlineMentionSeparator() {
+    const current = editorRef.current?.getText() ?? draftRef.current;
+    if (current.trim() && !/\s$/.test(current)) {
+      editorRef.current?.insertText(' ');
+    }
+  }
+
+  // Shared by the draft-clearing slash actions (mcp/pet) and reset/submit:
+  // stops a slash command or a sent turn from reaching the agent by wiping
+  // the draft in lockstep with the Lexical editor.
+  function clearDraft() {
+    setDraft('');
+    editorRef.current?.clear();
+  }
+
+  return {
+    draft,
+    setDraft,
+    draftRef,
+    seededRef,
+    placeholderScenario,
+    setPlaceholderScenario,
+    replaceEditorDraft,
+    insertInlineMentionSeparator,
+    clearDraft,
+  };
+}
+
+/**
+ * Wirer: binds the real localStorage-backed port. This is the default the
+ * orchestrator injects; tests call `useComposerDraft` directly with a
+ * hand-written fake port instead.
+ */
+export function useWiredComposerDraft(params: ComposerDraftParams): ComposerDraftController {
+  return useComposerDraft(params, composerDraftPort);
+}

--- a/apps/web/src/features/chat-composer/hooks/useComposerModals.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useComposerModals.hooks.ts
@@ -1,0 +1,52 @@
+// Feature-local hook for the composer's simple modal/detail-panel visibility
+// state: the plugin/skill details panels, and the library/Figma-import/
+// Figma-help/project-reference modal toggles. Pure UI state — no transport,
+// no DOM — so there is no port and no `useWiredX` wirer, matching the
+// memory canary's `useMemoryFlash` (also a no-port hook).
+import { useState } from 'react';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+import type { SkillSummary } from '../../../types';
+
+export interface ComposerDetailsSkill {
+  id: string;
+  summary?: SkillSummary | null;
+}
+
+export interface ComposerModalsController {
+  detailsRecord: InstalledPluginRecord | null;
+  setDetailsRecord: (record: InstalledPluginRecord | null) => void;
+  detailsSkill: ComposerDetailsSkill | null;
+  setDetailsSkill: (detail: ComposerDetailsSkill | null) => void;
+  libraryPickerOpen: boolean;
+  setLibraryPickerOpen: (open: boolean) => void;
+  figmaModalOpen: boolean;
+  setFigmaModalOpen: (open: boolean) => void;
+  figmaHelpOpen: boolean;
+  setFigmaHelpOpen: (open: boolean) => void;
+  projectReferenceOpen: boolean;
+  setProjectReferenceOpen: (open: boolean) => void;
+}
+
+export function useComposerModals(): ComposerModalsController {
+  const [detailsRecord, setDetailsRecord] = useState<InstalledPluginRecord | null>(null);
+  const [detailsSkill, setDetailsSkill] = useState<ComposerDetailsSkill | null>(null);
+  const [libraryPickerOpen, setLibraryPickerOpen] = useState(false);
+  const [figmaModalOpen, setFigmaModalOpen] = useState(false);
+  const [figmaHelpOpen, setFigmaHelpOpen] = useState(false);
+  const [projectReferenceOpen, setProjectReferenceOpen] = useState(false);
+
+  return {
+    detailsRecord,
+    setDetailsRecord,
+    detailsSkill,
+    setDetailsSkill,
+    libraryPickerOpen,
+    setLibraryPickerOpen,
+    figmaModalOpen,
+    setFigmaModalOpen,
+    figmaHelpOpen,
+    setFigmaHelpOpen,
+    projectReferenceOpen,
+    setProjectReferenceOpen,
+  };
+}

--- a/apps/web/src/features/chat-composer/hooks/useComposerUpload.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useComposerUpload.hooks.ts
@@ -1,0 +1,46 @@
+// Feature-local hook for the composer's attachment/upload cluster: the
+// in-flight flag, the last error message, the drag-over highlight, AND the
+// staged-attachment list + its order-assignment ref. The list lives here
+// (rather than its own hook) because every consumer already treats it as
+// part of this same cluster — see `UploadActionDeps` in attachment-actions.ts,
+// whose own docblock calls this "the attachment/upload cluster's deps bag"
+// and bundles `staged`/`setStaged`/`nextAttachmentOrderRef` with these
+// setters as one unit. Pure UI/list state - no port, no transport - the
+// actual upload transport calls stay in the orchestrator
+// (uploadProjectFiles / applyLibraryAsset) and just call the setters this
+// hook returns, same shape as useComposerModals.
+import { useRef, useState } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import type { ChatAttachment } from '../../../types';
+
+export interface ComposerUploadController {
+  uploading: boolean;
+  setUploading: (value: boolean) => void;
+  uploadError: string | null;
+  setUploadError: (value: string | null) => void;
+  dragActive: boolean;
+  setDragActive: (value: boolean) => void;
+  staged: ChatAttachment[];
+  setStaged: Dispatch<SetStateAction<ChatAttachment[]>>;
+  nextAttachmentOrderRef: MutableRefObject<number>;
+}
+
+export function useComposerUpload(): ComposerUploadController {
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const [staged, setStaged] = useState<ChatAttachment[]>([]);
+  const nextAttachmentOrderRef = useRef(0);
+
+  return {
+    uploading,
+    setUploading,
+    uploadError,
+    setUploadError,
+    dragActive,
+    setDragActive,
+    staged,
+    setStaged,
+    nextAttachmentOrderRef,
+  };
+}

--- a/apps/web/src/features/chat-composer/hooks/useDesignToolboxDetail.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useDesignToolboxDetail.hooks.ts
@@ -1,0 +1,85 @@
+// Feature-local hook for the design-toolbox hover-detail panel: one shared
+// portaled panel swapped as the cursor sweeps the resource list (a per-row
+// panel ghosted — the close delay left several stacked on screen at once).
+//
+// `useDesignToolboxDetail(port)` is the real hook; its viewport read is
+// INJECTED as the slice port so it holds no import to a provider and
+// unit-tests against a hand-written fake `ViewportPort`.
+// `useWiredDesignToolboxDetail()` (bottom of file) binds the real provider
+// port and is the default the orchestrator/panel injects.
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import type { ViewportPort } from '../ports';
+import { viewportPort } from '../dependencies';
+import { computeToolboxDetailPosition } from '../rules';
+import {
+  DESIGN_TOOLBOX_DETAIL_CLOSE_DELAY_MS,
+  DESIGN_TOOLBOX_DETAIL_OPTIONS,
+} from '../constants';
+
+export interface DesignToolboxDetailState {
+  key: string;
+  left: number;
+  top: number;
+  node: ReactNode;
+}
+
+export interface DesignToolboxDetailController {
+  toolboxDetail: DesignToolboxDetailState | null;
+  /** Cancel any pending close and show the detail panel for `key`. */
+  showToolboxDetail: (key: string, rect: DOMRect, node: ReactNode) => void;
+  /** Cancel any pending close (e.g. the pointer re-enters the panel itself). */
+  cancelDetailClose: () => void;
+  /** Schedule `key`'s panel to close after a short grace period. */
+  scheduleToolboxDetailClose: (key: string) => void;
+}
+
+export function useDesignToolboxDetail(port: ViewportPort): DesignToolboxDetailController {
+  const [toolboxDetail, setToolboxDetail] = useState<DesignToolboxDetailState | null>(null);
+  const detailCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelDetailClose = useCallback(() => {
+    if (detailCloseTimer.current) {
+      clearTimeout(detailCloseTimer.current);
+      detailCloseTimer.current = null;
+    }
+  }, []);
+
+  const showToolboxDetail = useCallback(
+    (key: string, rect: DOMRect, node: ReactNode) => {
+      cancelDetailClose();
+      // Plugin rows render a tall visual preview; the helper clamps both axes
+      // into the viewport so the fixed panel never lands off-screen on a
+      // narrow pane (see computeToolboxDetailPosition).
+      const { left, top } = computeToolboxDetailPosition(
+        rect,
+        port.getViewportSize(),
+        DESIGN_TOOLBOX_DETAIL_OPTIONS,
+      );
+      setToolboxDetail({ key, left, top, node });
+    },
+    [cancelDetailClose, port],
+  );
+
+  const scheduleToolboxDetailClose = useCallback(
+    (key: string) => {
+      cancelDetailClose();
+      detailCloseTimer.current = setTimeout(() => {
+        setToolboxDetail((cur) => (cur?.key === key ? null : cur));
+        detailCloseTimer.current = null;
+      }, DESIGN_TOOLBOX_DETAIL_CLOSE_DELAY_MS);
+    },
+    [cancelDetailClose],
+  );
+
+  useEffect(() => () => cancelDetailClose(), [cancelDetailClose]);
+
+  return { toolboxDetail, showToolboxDetail, cancelDetailClose, scheduleToolboxDetailClose };
+}
+
+/**
+ * Wirer: binds the real viewport port and returns a ready-to-call hook. This
+ * is the default the panel injects; swap it via the component prop in tests.
+ */
+export function useWiredDesignToolboxDetail(): DesignToolboxDetailController {
+  return useDesignToolboxDetail(viewportPort);
+}

--- a/apps/web/src/features/chat-composer/hooks/useMentionPopover.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useMentionPopover.hooks.ts
@@ -1,0 +1,389 @@
+// Feature-local hook for the `@`-mention popover: the open/query/tab state,
+// the caret box the popover anchors against, the per-source filtered
+// candidate lists (files, workspace tabs, plugins, skills, MCP servers,
+// connectors), the "known entities" list the Lexical editor uses to detect
+// existing `@token`s in the draft, and the bound trigger-detection/keyboard-
+// nav/pick action functions (via `actions.ts`, deps-bag internally).
+//
+// Picking a result needs pieces several OTHER clusters own (the slash-
+// popover's state/pick callback, the Lexical editor's mention-insert
+// primitive, every staging setter a pick can touch, project skill patching)
+// — this hook takes those as params (mirroring `MemorySection.tsx`'s
+// `useEntries({ fireFlash, hydrateConfig, openEditor, closeEditor })`, which
+// takes other hooks' outputs as params rather than pushing the composition
+// back onto the orchestrator) and returns the already-bound callbacks, so
+// the orchestrator itself never builds a deps bag or wraps a `useCallback`.
+import { useCallback, useMemo, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type {
+  ConnectorDetail,
+  InstalledPluginRecord,
+  McpServerConfig,
+  WorkspaceContextItem,
+} from '@open-design/contracts';
+import type { ChatAttachment, Project, ProjectFile, SkillSummary } from '../../../types';
+import type { CaretRect } from '../../../components/composer/LexicalComposerInput';
+import { workspaceContextSearchText, skillMentionRank, buildComposerMentionEntities } from '../rules';
+import { skillMatchesQuery } from '../../../runtime/design-toolbox';
+import type { InlineMentionEntity } from '../../../utils/inlineMentions';
+import type { MentionTab, SlashCommand } from '../types';
+import {
+  handleEditorTrigger as handleEditorTriggerAction,
+  handlePopoverKey as handlePopoverKeyAction,
+  insertMention as insertMentionAction,
+  insertPluginMention as insertPluginMentionAction,
+  insertMcpMention as insertMcpMentionAction,
+  insertConnectorMention as insertConnectorMentionAction,
+  insertWorkspaceMention as insertWorkspaceMentionAction,
+  insertSkillMention as insertSkillMentionAction,
+  type MentionActionDeps,
+} from '../actions';
+
+export interface MentionPopoverParams {
+  projectFiles: ProjectFile[];
+  /** The full set of workspace-context "tabs" the @-picker can offer (a
+   *  prop), distinct from the staged/selected subset another cluster owns. */
+  workspaceContexts: WorkspaceContextItem[];
+  pluginsForComposer: InstalledPluginRecord[];
+  enabledMcpServers: McpServerConfig[];
+  connectors: ConnectorDetail[];
+  skills: SkillSummary[];
+  stagedSkills: SkillSummary[];
+  staged: ChatAttachment[];
+  /** The visible + staged workspace contexts (from the workspace-context
+   *  linking cluster) that feed the editor's known-mention-entities list. */
+  selectedWorkspaceContexts: WorkspaceContextItem[];
+  // The slash-popover cluster's state + pick callback — `handlePopoverKey`
+  // drives both popovers' keyboard nav from one Lexical callback.
+  slash: { q: string } | null;
+  setSlash: (value: { q: string } | null) => void;
+  slashIndex: number;
+  setSlashIndex: Dispatch<SetStateAction<number>>;
+  filteredSlash: SlashCommand[];
+  pickSlash: (cmd: SlashCommand) => void;
+  // The Lexical editor's mention-insert primitive (shared across every
+  // popover/cluster, orchestrator-owned) and the upload cluster's
+  // context-attachment appender a file pick also needs.
+  insertEditorMention: (insert: { token: string; entity: InlineMentionEntity }) => void;
+  appendContextAttachment: (path: string) => void;
+  // Staging setters a pick can touch (each cluster's own).
+  setStagedSkills: Dispatch<SetStateAction<SkillSummary[]>>;
+  setStagedMcpServers: Dispatch<SetStateAction<McpServerConfig[]>>;
+  setStagedConnectors: Dispatch<SetStateAction<ConnectorDetail[]>>;
+  setStagedWorkspaceContexts: Dispatch<SetStateAction<WorkspaceContextItem[]>>;
+  // The inline-backed-plugin ref bridge + plugins-section apply, shared with
+  // the design-toolbox cluster's own binding of the same primitives.
+  setInlineBackedPlugin: (value: { id: string; label: string } | null) => void;
+  applyPluginById: (id: string, record: InstalledPluginRecord) => Promise<void>;
+  projectId: string | null;
+  patchProject: (id: string, patch: { skillId: string }) => Promise<Project | null>;
+  onProjectSkillChange?: (skillId: string | null) => void;
+}
+
+export interface MentionPopoverController {
+  mention: { q: string } | null;
+  setMention: Dispatch<SetStateAction<{ q: string } | null>>;
+  mentionIndex: number;
+  setMentionIndex: Dispatch<SetStateAction<number>>;
+  mentionTab: MentionTab;
+  setMentionTab: Dispatch<SetStateAction<MentionTab>>;
+  caretRect: CaretRect | null;
+  setCaretRect: Dispatch<SetStateAction<CaretRect | null>>;
+  mentionQuery: string;
+  composerMentionEntities: InlineMentionEntity[];
+  filteredFiles: ProjectFile[];
+  filteredWorkspaceContexts: WorkspaceContextItem[];
+  filteredPlugins: InstalledPluginRecord[];
+  filteredMcpServers: McpServerConfig[];
+  filteredConnectors: ConnectorDetail[];
+  filteredSkills: SkillSummary[];
+  handleEditorTrigger: (params: {
+    mention: { q: string } | null;
+    slash: { q: string } | null;
+    anchorRect: CaretRect | null;
+  }) => void;
+  handlePopoverKey: (key: 'ArrowDown' | 'ArrowUp' | 'Tab' | 'Enter' | 'Escape') => boolean;
+  insertMention: (filePath: string) => void;
+  insertPluginMention: (record: InstalledPluginRecord) => Promise<void>;
+  insertMcpMention: (server: McpServerConfig) => void;
+  insertConnectorMention: (connector: ConnectorDetail) => void;
+  insertWorkspaceMention: (item: WorkspaceContextItem) => void;
+  insertSkillMention: (skill: SkillSummary) => Promise<void>;
+  handleMentionTabChange: (nextTab: MentionTab) => void;
+}
+
+export function useMentionPopover({
+  projectFiles,
+  workspaceContexts,
+  pluginsForComposer,
+  enabledMcpServers,
+  connectors,
+  skills,
+  stagedSkills,
+  staged,
+  selectedWorkspaceContexts,
+  slash,
+  setSlash,
+  slashIndex,
+  setSlashIndex,
+  filteredSlash,
+  pickSlash,
+  insertEditorMention,
+  appendContextAttachment,
+  setStagedSkills,
+  setStagedMcpServers,
+  setStagedConnectors,
+  setStagedWorkspaceContexts,
+  setInlineBackedPlugin,
+  applyPluginById,
+  projectId,
+  patchProject,
+  onProjectSkillChange,
+}: MentionPopoverParams): MentionPopoverController {
+  // Lexical owns the caret, so the mention trigger state only carries the
+  // typed query — no cursor offset.
+  const [mention, setMention] = useState<{ q: string } | null>(null);
+  // Active-row index for the @-popover's visible union (files → tabs →
+  // plugins → skills → mcp → connectors). Resets to 0 whenever the query
+  // identity or tab changes; drives the visual highlight + Enter/Tab target.
+  const [mentionIndex, setMentionIndex] = useState(0);
+  const [mentionTab, setMentionTab] = useState<MentionTab>('all');
+  // Viewport caret box the floating popover anchors against. Sampled by the
+  // editor at trigger-detection time; null when no trigger is live.
+  const [caretRect, setCaretRect] = useState<CaretRect | null>(null);
+
+  const composerMentionEntities = useMemo(
+    () =>
+      buildComposerMentionEntities({
+        connectors,
+        files: projectFiles,
+        mcpServers: enabledMcpServers,
+        plugins: pluginsForComposer,
+        skills,
+        staged,
+        workspaceContexts: selectedWorkspaceContexts,
+      }),
+    [connectors, enabledMcpServers, pluginsForComposer, projectFiles, selectedWorkspaceContexts, skills, staged],
+  );
+
+  // The @-picker offers a unified search across context surfaces: workspace
+  // tabs first, then project files, plugins, skills, active MCP servers, and
+  // connectors. The suggestion lists below only matter while the @-popover is
+  // open (each is `[]` otherwise). Memoize them on `[mention, mentionQuery,
+  // <source>]` so the filter/sort passes run only when the query or the
+  // backing list actually changes — not on every unrelated composer render
+  // (streaming flips, draft typing routed through Lexical, staged-chip
+  // churn). `mention` is in the deps (not just `mentionQuery`) so the
+  // open/close gate re-evaluates: a null→{q:''} transition keeps the query ''
+  // but must flip the list from `[]` to live results.
+  const mentionQuery = mention ? mention.q.toLowerCase() : '';
+
+  const filteredWorkspaceContexts = useMemo(
+    () =>
+      mention
+        ? workspaceContexts
+            .filter((item) => {
+              if (!mentionQuery) return true;
+              return workspaceContextSearchText(item).toLowerCase().includes(mentionQuery);
+            })
+            .slice(0, 12)
+        : [],
+    [mention, mentionQuery, workspaceContexts],
+  );
+  const filteredFiles = useMemo(
+    () =>
+      mention
+        ? projectFiles
+            .filter((f) => f.type === undefined || f.type === "file")
+            .filter((f) => {
+              const key = f.path ?? f.name;
+              return key.toLowerCase().includes(mentionQuery);
+            })
+            .slice(0, 12)
+        : [],
+    [mention, mentionQuery, projectFiles],
+  );
+  const filteredPlugins = useMemo(
+    () =>
+      mention
+        ? pluginsForComposer
+            .filter((p) => {
+              if (!mentionQuery) return true;
+              return (
+                p.title.toLowerCase().includes(mentionQuery) ||
+                p.id.toLowerCase().includes(mentionQuery) ||
+                (p.manifest?.description ?? '').toLowerCase().includes(mentionQuery) ||
+                (p.manifest?.tags ?? []).join(' ').toLowerCase().includes(mentionQuery)
+              );
+            })
+            .slice(0, 8)
+        : [],
+    [mention, mentionQuery, pluginsForComposer],
+  );
+  const filteredMcpServers = useMemo(
+    () =>
+      mention
+        ? enabledMcpServers
+            .filter((s) => {
+              if (!mentionQuery) return true;
+              return [
+                s.id,
+                s.label ?? '',
+                s.transport,
+                s.url ?? '',
+                s.command ?? '',
+              ]
+                .join(' ')
+                .toLowerCase()
+                .includes(mentionQuery);
+            })
+            .slice(0, 8)
+        : [],
+    [mention, mentionQuery, enabledMcpServers],
+  );
+  const filteredConnectors = useMemo(
+    () =>
+      mention
+        ? connectors
+            .filter((connector) => {
+              if (!mentionQuery) return true;
+              return [
+                connector.id,
+                connector.name,
+                connector.provider,
+                connector.category,
+                connector.description ?? '',
+                connector.accountLabel ?? '',
+              ]
+                .join(' ')
+                .toLowerCase()
+                .includes(mentionQuery);
+            })
+            .slice(0, 8)
+        : [],
+    [mention, mentionQuery, connectors],
+  );
+  // Already-staged skills drop out of the suggestion list (carried over from
+  // main) so the @-popover keeps moving forward as the user picks.
+  const filteredSkills = useMemo(() => {
+    if (!mention) return [];
+    const stagedSkillIds = new Set(stagedSkills.map((s) => s.id));
+    return skills
+      .filter((s) => !stagedSkillIds.has(s.id))
+      .filter((s) => skillMatchesQuery(s, mentionQuery))
+      .sort((a, b) => skillMentionRank(a, mentionQuery) - skillMentionRank(b, mentionQuery));
+  }, [mention, mentionQuery, skills, stagedSkills]);
+
+  // Recreated each render (every field below either comes straight from a
+  // prop/other-hook value or is itself recreated each render), so the
+  // callbacks below always close over the latest state — matching the
+  // pre-hook-extraction orchestrator's "recreated each render" deps-bag
+  // convention exactly, just assembled here instead of in the orchestrator.
+  const mentionActionDeps: MentionActionDeps = {
+    setCaretRect,
+    mention,
+    setMention,
+    mentionIndex,
+    setMentionIndex,
+    mentionTab,
+    setMentionTab,
+    slash,
+    setSlash,
+    slashIndex,
+    setSlashIndex,
+    filteredSlash,
+    pickSlash,
+    filteredFiles,
+    filteredWorkspaceContexts,
+    filteredPlugins,
+    filteredSkills,
+    filteredMcpServers,
+    filteredConnectors,
+    insertEditorMention,
+    staged,
+    appendContextAttachment,
+    setStagedSkills,
+    setStagedMcpServers,
+    setStagedConnectors,
+    setStagedWorkspaceContexts,
+    setInlineBackedPlugin,
+    applyPluginById,
+    projectId,
+    patchProject,
+    onProjectSkillChange,
+  };
+
+  const handleEditorTrigger = useCallback((params: {
+    mention: { q: string } | null;
+    slash: { q: string } | null;
+    anchorRect: CaretRect | null;
+  }) => {
+    handleEditorTriggerAction(params, mentionActionDeps);
+  }, [mentionActionDeps]);
+
+  const handlePopoverKey = useCallback(
+    (key: 'ArrowDown' | 'ArrowUp' | 'Tab' | 'Enter' | 'Escape'): boolean =>
+      handlePopoverKeyAction(key, mentionActionDeps),
+    [mentionActionDeps],
+  );
+
+  const insertMention = useCallback((filePath: string) => {
+    insertMentionAction(filePath, mentionActionDeps);
+  }, [mentionActionDeps]);
+
+  const insertPluginMention = useCallback(async (record: InstalledPluginRecord) => {
+    await insertPluginMentionAction(record, mentionActionDeps);
+  }, [mentionActionDeps]);
+
+  const insertMcpMention = useCallback((server: McpServerConfig) => {
+    insertMcpMentionAction(server, mentionActionDeps);
+  }, [mentionActionDeps]);
+
+  const insertConnectorMention = useCallback((connector: ConnectorDetail) => {
+    insertConnectorMentionAction(connector, mentionActionDeps);
+  }, [mentionActionDeps]);
+
+  const insertWorkspaceMention = useCallback((item: WorkspaceContextItem) => {
+    insertWorkspaceMentionAction(item, mentionActionDeps);
+  }, [mentionActionDeps]);
+
+  const insertSkillMention = useCallback(async (skill: SkillSummary) => {
+    await insertSkillMentionAction(skill, mentionActionDeps);
+  }, [mentionActionDeps]);
+
+  // Both mentionTab and mentionIndex are this hook's own state — switching
+  // tabs also resets the active index so the previous tab's selection
+  // doesn't carry over as an out-of-range highlight on the new list.
+  const handleMentionTabChange = useCallback((nextTab: MentionTab) => {
+    setMentionTab(nextTab);
+    setMentionIndex(0);
+  }, []);
+
+  return {
+    mention,
+    setMention,
+    mentionIndex,
+    setMentionIndex,
+    mentionTab,
+    setMentionTab,
+    caretRect,
+    setCaretRect,
+    mentionQuery,
+    composerMentionEntities,
+    filteredFiles,
+    filteredWorkspaceContexts,
+    filteredPlugins,
+    filteredMcpServers,
+    filteredConnectors,
+    filteredSkills,
+    handleEditorTrigger,
+    handlePopoverKey,
+    insertMention,
+    insertPluginMention,
+    insertMcpMention,
+    insertConnectorMention,
+    insertWorkspaceMention,
+    insertSkillMention,
+    handleMentionTabChange,
+  };
+}

--- a/apps/web/src/features/chat-composer/hooks/useSlashPopover.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useSlashPopover.hooks.ts
@@ -1,0 +1,101 @@
+// Feature-local hook for the `/`-command popover: the open/query state, the
+// active-index for keyboard nav, and the catalogue of available slash
+// commands (external MCP servers + `/search` when research is available).
+// Pure UI state - no port, no transport. The catalogue depends on values the
+// orchestrator owns (research availability, i18n, the MCP catalogue), so
+// they're taken as hook inputs rather than closed over.
+//
+// Picking a command still needs the Lexical editor ref, which is shared
+// across every popover/cluster and stays orchestrator-owned — so `pickSlash`
+// itself lives in actions.ts (deps-bag), not here; this hook only exposes
+// the state that action needs.
+import { useMemo, useState } from 'react';
+import type { McpServerConfig } from '@open-design/contracts';
+import type { SlashCommand, TranslateFn } from '../types';
+
+export interface SlashPopoverParams {
+  researchAvailable?: boolean;
+  t: TranslateFn;
+  // Raw MCP server list (filtered to enabled internally) rather than an
+  // orchestrator-memoized `enabledMcpServers`, so this hook can be called
+  // early in the orchestrator's render — before the state that memo is
+  // itself derived from other clusters' data is available.
+  mcpServers: McpServerConfig[];
+  onOpenMcpSettings?: () => void;
+}
+
+export interface SlashPopoverController {
+  slash: { q: string } | null;
+  setSlash: (value: { q: string } | null) => void;
+  slashIndex: number;
+  setSlashIndex: React.Dispatch<React.SetStateAction<number>>;
+  slashCommands: SlashCommand[];
+  filteredSlash: SlashCommand[];
+}
+
+export function useSlashPopover({
+  researchAvailable,
+  t,
+  mcpServers,
+  onOpenMcpSettings,
+}: SlashPopoverParams): SlashPopoverController {
+  const [slash, setSlash] = useState<{ q: string } | null>(null);
+  const [slashIndex, setSlashIndex] = useState(0);
+
+  const enabledMcpServers = useMemo(
+    () => mcpServers.filter((s) => s.enabled),
+    [mcpServers],
+  );
+
+  // Catalog of supported slash commands. Each entry shows up in the popover
+  // when the user types `/` in the composer. The `insert` value is what we
+  // drop into the draft when the user picks the entry — usually the
+  // canonical command form with a trailing space ready for an argument.
+  const slashCommands = useMemo<SlashCommand[]>(() => {
+    const list: SlashCommand[] = [];
+    // External MCP servers — `/mcp` opens settings, `/mcp <id>` inserts a
+    // prompt-side hint nudging the model to use that server's tools. The
+    // hint flows through to the agent verbatim; the daemon already wired the
+    // MCP config into the agent's launch so the tools are callable.
+    if (onOpenMcpSettings) {
+      list.push({
+        id: 'mcp',
+        label: '/mcp',
+        insert: '/mcp ',
+        descKey: 'pet.slashPet',
+        icon: 'sliders',
+        argHint: 'open settings · <server-id> to insert hint',
+      });
+    }
+    for (const s of enabledMcpServers) {
+      list.push({
+        id: `mcp-${s.id}`,
+        label: `/mcp ${s.id}`,
+        insert: `Use the \`${s.id}\` MCP server tools. `,
+        descKey: 'pet.slashPet',
+        icon: 'sparkles',
+        argHint: s.label || s.transport,
+      });
+    }
+    if (researchAvailable) {
+      list.push({
+        id: 'search',
+        label: '/search',
+        insert: '/search ',
+        descKey: 'pet.slashSearch',
+        icon: 'sparkles',
+        argHint: t('pet.slashSearchArg'),
+      });
+    }
+    return list;
+  }, [researchAvailable, t, enabledMcpServers, onOpenMcpSettings]);
+
+  const filteredSlash = useMemo(() => {
+    if (!slash) return [] as SlashCommand[];
+    const q = slash.q.toLowerCase();
+    if (!q) return slashCommands;
+    return slashCommands.filter((c) => c.label.toLowerCase().includes(q));
+  }, [slash, slashCommands]);
+
+  return { slash, setSlash, slashIndex, setSlashIndex, slashCommands, filteredSlash };
+}

--- a/apps/web/src/features/chat-composer/hooks/useStagedRunContext.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useStagedRunContext.hooks.ts
@@ -1,0 +1,82 @@
+// Feature-local hook for the composer's staged run-context chips: the
+// skills/MCP-servers/connectors the user has @-mentioned or applied for this
+// turn, plus their bound remove callbacks. Genuinely cross-cutting state
+// (read/written by the design-toolbox-apply functions, the mention-insert
+// family, `handleEditorChange`, `reset`, and each remove handler) that
+// previously sat bare in the orchestrator with no owning hook — the exact
+// situation `stagedWorkspaceContexts` was in before it got
+// `useWorkspaceContextLinking`. Pure UI/list state — no port, no transport.
+//
+// Owns its own deps-bag callbacks (Phase 6 "a hook should own its own
+// deps-bag callbacks" pattern, same shape as `useMentionPopover`): each
+// remove function is too entangled with the draft/editor/analytics cluster
+// to be a pure rule, but this hook is its one natural owner, so it takes
+// those cross-cluster pieces as params and returns the bound callbacks ready
+// to wire directly into JSX.
+import { useCallback, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { ConnectorDetail, McpServerConfig } from '@open-design/contracts';
+import type { ComposerBarClickProps } from '@open-design/contracts/analytics';
+import type { SkillSummary } from '../../../types';
+import {
+  removeStagedConnector as removeStagedConnectorImpl,
+  removeStagedMcpServer as removeStagedMcpServerImpl,
+  removeStagedSkill as removeStagedSkillImpl,
+  type StagedRemovalDeps,
+} from '../actions';
+
+export interface StagedRunContextParams {
+  draft: string;
+  replaceEditorDraft: (text: string) => void;
+  trackComposerBar: (fields: Omit<ComposerBarClickProps, 'page_name' | 'area' | 'project_id'>) => void;
+}
+
+export interface StagedRunContextController {
+  stagedSkills: SkillSummary[];
+  setStagedSkills: Dispatch<SetStateAction<SkillSummary[]>>;
+  stagedMcpServers: McpServerConfig[];
+  setStagedMcpServers: Dispatch<SetStateAction<McpServerConfig[]>>;
+  stagedConnectors: ConnectorDetail[];
+  setStagedConnectors: Dispatch<SetStateAction<ConnectorDetail[]>>;
+  removeStagedSkill: (id: string) => void;
+  removeStagedMcpServer: (id: string) => void;
+  removeStagedConnector: (id: string) => void;
+}
+
+export function useStagedRunContext({
+  draft,
+  replaceEditorDraft,
+  trackComposerBar,
+}: StagedRunContextParams): StagedRunContextController {
+  const [stagedSkills, setStagedSkills] = useState<SkillSummary[]>([]);
+  const [stagedMcpServers, setStagedMcpServers] = useState<McpServerConfig[]>([]);
+  const [stagedConnectors, setStagedConnectors] = useState<ConnectorDetail[]>([]);
+
+  // Recreated each render so it always closes over the latest draft — matches
+  // the orchestrator's existing deps-bag convention (see `uploadActionDeps`).
+  const stagedRemovalDeps: StagedRemovalDeps = { draft, replaceEditorDraft, trackComposerBar };
+
+  const removeStagedSkill = useCallback((id: string) => {
+    removeStagedSkillImpl(id, stagedSkills, setStagedSkills, stagedRemovalDeps);
+  }, [stagedSkills, stagedRemovalDeps]);
+
+  const removeStagedMcpServer = useCallback((id: string) => {
+    removeStagedMcpServerImpl(id, stagedMcpServers, setStagedMcpServers, stagedRemovalDeps);
+  }, [stagedMcpServers, stagedRemovalDeps]);
+
+  const removeStagedConnector = useCallback((id: string) => {
+    removeStagedConnectorImpl(id, stagedConnectors, setStagedConnectors, stagedRemovalDeps);
+  }, [stagedConnectors, stagedRemovalDeps]);
+
+  return {
+    stagedSkills,
+    setStagedSkills,
+    stagedMcpServers,
+    setStagedMcpServers,
+    stagedConnectors,
+    setStagedConnectors,
+    removeStagedSkill,
+    removeStagedMcpServer,
+    removeStagedConnector,
+  };
+}

--- a/apps/web/src/features/chat-composer/hooks/useWorkingDirStatus.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useWorkingDirStatus.hooks.ts
@@ -1,0 +1,71 @@
+// Feature-local hook for the working-directory status: the recent-dirs list
+// (fetched once on mount) and the live existence check for the project's
+// current working dir. Transport is INJECTED as the slice port so the hook
+// holds no import to a provider.
+//
+// The mount-fetch effect below is internal state management (a bounded
+// one-shot promise with a cancellation guard, not an accumulating
+// subscription) so it stays in the hook. The focus/visibilitychange re-check
+// subscription is different — it's an external `window`/`document` listener
+// pair — and stays in the orchestrator (a guaranteed single instance) per
+// the accumulating-subscription rule; this hook only exposes
+// `checkWorkingDir` for that orchestrator effect to call.
+import { useCallback, useEffect, useState } from 'react';
+import { workingDirPort } from '../dependencies';
+import type { WorkingDirPort } from '../ports';
+
+export interface WorkingDirStatusController {
+  recentDirs: string[];
+  workingDirMissing: boolean;
+  rememberRecentDir: (dir: string) => Promise<void>;
+  checkWorkingDir: (workingDir: string | null) => Promise<void>;
+}
+
+export function useWorkingDirStatus(port: WorkingDirPort): WorkingDirStatusController {
+  const [recentDirs, setRecentDirs] = useState<string[]>([]);
+  const [workingDirMissing, setWorkingDirMissing] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void port.fetchRecentLinkedDirs().then((dirs) => {
+      if (!cancelled) setRecentDirs(dirs);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [port]);
+
+  const rememberRecentDir = useCallback(
+    async (dir: string) => {
+      setRecentDirs((prev) => [dir, ...prev.filter((d) => d !== dir)].slice(0, 5));
+      const persisted = await port.pushRecentLinkedDir(dir);
+      setRecentDirs(persisted);
+    },
+    [port],
+  );
+
+  // Live-checks whether the selected working directory still exists, so a
+  // folder deleted from disk turns the picker red without a page reload.
+  const checkWorkingDir = useCallback(
+    async (workingDir: string | null) => {
+      if (!workingDir) {
+        setWorkingDirMissing(false);
+        return;
+      }
+      const ok = await port.dirExists(workingDir);
+      setWorkingDirMissing(!ok);
+    },
+    [port],
+  );
+
+  return { recentDirs, workingDirMissing, rememberRecentDir, checkWorkingDir };
+}
+
+/**
+ * Wirer: binds the real registry provider. This is the default the
+ * orchestrator injects; tests call `useWorkingDirStatus` directly with a
+ * hand-written fake port instead.
+ */
+export function useWiredWorkingDirStatus(): WorkingDirStatusController {
+  return useWorkingDirStatus(workingDirPort);
+}

--- a/apps/web/src/features/chat-composer/hooks/useWorkspaceContextLinking.hooks.ts
+++ b/apps/web/src/features/chat-composer/hooks/useWorkspaceContextLinking.hooks.ts
@@ -1,0 +1,136 @@
+// Feature-local hook for the composer's staged workspace-context chips
+// (referenced projects, linked local-code folders) and the bookkeeping that
+// reconciles them against the project's `linkedDirs`. Pure UI + derived state
+// — no port, no transport — matching this slice's other no-port hooks
+// (`useComposerModals`/`useComposerUpload`/`useCommentAttachments`). The
+// actual link/unlink transport calls (`patchProject`) live in `actions.ts`'s
+// deps-bag functions, which read this hook's state/setters as explicit
+// parameters.
+//
+// The `activeWorkspaceContextId` reset effect below reacts only to a prop
+// (the parent's currently-active context, e.g. a switched conversation) and
+// this hook's own refs/state — it is internal state management, not an
+// external subscription, so it stays in the hook per the
+// accumulating-subscription rule (that rule only pulls `window`/`document`/
+// `EventSource` listeners out into the orchestrator).
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { WorkspaceContextItem } from '@open-design/contracts';
+import { workspaceContextLinkedDirs } from '../../../components/workspace-context';
+import {
+  dedupeWorkspaceContextItems,
+  trackedWorkspaceLinkedDirsForContexts,
+} from '../rules';
+import type { TrackedWorkspaceLinkedDir } from '../types';
+
+export interface WorkspaceContextLinkingParams {
+  activeWorkspaceContext: WorkspaceContextItem | null;
+  initialWorkspaceContexts: WorkspaceContextItem[];
+  linkedDirs: string[];
+}
+
+export interface WorkspaceContextLinkingController {
+  stagedWorkspaceContexts: WorkspaceContextItem[];
+  setStagedWorkspaceContexts: Dispatch<SetStateAction<WorkspaceContextItem[]>>;
+  workspaceLinkedDirAdds: Record<string, TrackedWorkspaceLinkedDir>;
+  setWorkspaceLinkedDirAdds: Dispatch<SetStateAction<Record<string, TrackedWorkspaceLinkedDir>>>;
+  promotedWorkspaceContextDir: string | null;
+  setPromotedWorkspaceContextDir: Dispatch<SetStateAction<string | null>>;
+  dismissedWorkspaceContextId: string | null;
+  setDismissedWorkspaceContextId: Dispatch<SetStateAction<string | null>>;
+  /** The active context, unless the user dismissed its chip this session. */
+  visibleWorkspaceContext: WorkspaceContextItem | null;
+  /** `visibleWorkspaceContext` + every staged item, deduped. */
+  selectedWorkspaceContexts: WorkspaceContextItem[];
+  selectedWorkspaceContextDirs: string[];
+  workspaceContextMetadataLinkedDirList: string[];
+  /** The project's primary working dir: the first `linkedDirs` entry NOT
+   *  claimed by a workspace-context item. */
+  workingDir: string | null;
+}
+
+export function useWorkspaceContextLinking({
+  activeWorkspaceContext,
+  initialWorkspaceContexts,
+  linkedDirs,
+}: WorkspaceContextLinkingParams): WorkspaceContextLinkingController {
+  const [stagedWorkspaceContexts, setStagedWorkspaceContexts] = useState<WorkspaceContextItem[]>(
+    () => dedupeWorkspaceContextItems(initialWorkspaceContexts),
+  );
+  const [workspaceLinkedDirAdds, setWorkspaceLinkedDirAdds] = useState<Record<string, TrackedWorkspaceLinkedDir>>(
+    () => trackedWorkspaceLinkedDirsForContexts(initialWorkspaceContexts, linkedDirs),
+  );
+  const [promotedWorkspaceContextDir, setPromotedWorkspaceContextDir] = useState<string | null>(null);
+  const [dismissedWorkspaceContextId, setDismissedWorkspaceContextId] = useState<string | null>(null);
+
+  const activeWorkspaceContextId = activeWorkspaceContext?.id ?? null;
+  const previousWorkspaceContextIdRef = useRef<string | null>(activeWorkspaceContextId);
+  useEffect(() => {
+    if (previousWorkspaceContextIdRef.current === activeWorkspaceContextId) return;
+    previousWorkspaceContextIdRef.current = activeWorkspaceContextId;
+    setDismissedWorkspaceContextId(null);
+    setPromotedWorkspaceContextDir(null);
+  }, [activeWorkspaceContextId]);
+
+  const visibleWorkspaceContext =
+    activeWorkspaceContext && activeWorkspaceContext.id !== dismissedWorkspaceContextId
+      ? activeWorkspaceContext
+      : null;
+
+  const selectedWorkspaceContexts = useMemo(() => {
+    const out: WorkspaceContextItem[] = [];
+    const seen = new Set<string>();
+    const push = (item: WorkspaceContextItem | null | undefined) => {
+      if (!item) return;
+      const key = `${item.kind}:${item.id}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push(item);
+    };
+    push(visibleWorkspaceContext);
+    for (const item of stagedWorkspaceContexts) push(item);
+    return out;
+  }, [stagedWorkspaceContexts, visibleWorkspaceContext]);
+
+  const selectedWorkspaceContextDirs = useMemo<string[]>(
+    () => workspaceContextLinkedDirs(selectedWorkspaceContexts),
+    [selectedWorkspaceContexts],
+  );
+
+  const workspaceContextMetadataLinkedDirList = useMemo<string[]>(
+    () =>
+      Array.from(new Set([
+        ...Object.values(workspaceLinkedDirAdds).map((tracked) => tracked.dir),
+        ...selectedWorkspaceContextDirs,
+      ])),
+    [selectedWorkspaceContextDirs, workspaceLinkedDirAdds],
+  );
+
+  const workspaceContextLinkedDirList = useMemo<string[]>(
+    () =>
+      workspaceContextMetadataLinkedDirList.filter((dir) => dir !== promotedWorkspaceContextDir),
+    [promotedWorkspaceContextDir, workspaceContextMetadataLinkedDirList],
+  );
+  const workspaceContextLinkedDirSet = useMemo<Set<string>>(
+    () => new Set(workspaceContextLinkedDirList),
+    [workspaceContextLinkedDirList],
+  );
+
+  const workingDir = linkedDirs.find((dir) => !workspaceContextLinkedDirSet.has(dir)) ?? null;
+
+  return {
+    stagedWorkspaceContexts,
+    setStagedWorkspaceContexts,
+    workspaceLinkedDirAdds,
+    setWorkspaceLinkedDirAdds,
+    promotedWorkspaceContextDir,
+    setPromotedWorkspaceContextDir,
+    dismissedWorkspaceContextId,
+    setDismissedWorkspaceContextId,
+    visibleWorkspaceContext,
+    selectedWorkspaceContexts,
+    selectedWorkspaceContextDirs,
+    workspaceContextMetadataLinkedDirList,
+    workingDir,
+  };
+}

--- a/apps/web/src/features/chat-composer/index.ts
+++ b/apps/web/src/features/chat-composer/index.ts
@@ -1,0 +1,244 @@
+// Public API of the chat-composer slice. Consumers (the ChatComposer
+// orchestrator, which lives outside the slice at components/ChatComposer.tsx)
+// import ONLY from here — never from the slice's internal files.
+// `scripts/check-web-slice-boundaries.ts` fails any outside-in deep import that
+// reaches past this barrel (ADR 0002).
+
+// Pure rules the orchestrator (and future hooks/components) read.
+export {
+  isFiniteAttachmentOrder,
+  formatElementHtmlBlock,
+  normalizeChatAttachmentOrders,
+  assignChatAttachmentOrders,
+  nextChatAttachmentOrder,
+  sortChatAttachmentsByOrder,
+  sortChatCommentAttachmentsByOrder,
+  workspaceContextIcon,
+  workspaceContextTitle,
+  workspaceContextDescription,
+  lastPathSegment,
+  projectFileMentionTitle,
+  projectFileMentionDescription,
+  workspaceContextSearchText,
+  workspaceContextKindLabel,
+  escapeRegExp,
+  stripInlineMentionToken,
+  stripInlineMentionLabels,
+  pluginMatchesQuery,
+  buildDesignToolboxResources,
+  designToolboxResourceMatchesQuery,
+  designToolboxDefaultResources,
+  designToolboxResourceKindLabel,
+  designToolboxResourceIsActive,
+  designToolboxSkillBadge,
+  designToolboxSkillIcon,
+  designToolboxContextLine,
+  designToolboxDraftLine,
+  designToolboxWorkspaceKindLabel,
+  designToolboxActionPrompt,
+  designToolboxSkillPrompt,
+  designToolboxResourcePrompt,
+  designToolboxResourceIndexLines,
+  designToolboxCompactLine,
+  skillMentionRank,
+  mcpServerMatchesQuery,
+  mcpTemplateMatchesQuery,
+  pluginSourceLabel,
+  pluginsAllowedForComposer,
+  computeToolboxDetailPosition,
+  designToolboxResourceTracking,
+  linkedDirsWithWorkspaceContext,
+  dropWorkspaceLinkedDirAdds,
+  dedupeWorkspaceContextItems,
+  trackedWorkspaceLinkedDirsForContexts,
+  workspaceContextDirStillReferenced,
+  buildComposerMentionEntities,
+  inlineBackedPluginFromRestoredDraft,
+  queueMeta,
+  composerSendGate,
+  expandHatchCommand,
+  expandSearchCommand,
+} from './rules';
+
+export type {
+  DetailAnchorRect,
+  DetailViewport,
+  DetailPositionOptions,
+  ComposerSendGateInput,
+  ComposerSendGate,
+} from './rules';
+
+// Pure display formatters.
+export { looksLikeImage, prettySize } from './formatters';
+
+// UI-facing types the orchestrator (and rules) share.
+export type {
+  TranslateFn,
+  DesignToolboxResourceKind,
+  DesignToolboxResourceIndex,
+  DesignToolboxResourceBase,
+  DesignToolboxResource,
+  MentionTab,
+  SlashCommand,
+  TrackedWorkspaceLinkedDir,
+  ChatSendMeta,
+} from './types';
+
+// Dumb components the orchestrator composes.
+export { StagedCommentAttachments } from './components/StagedCommentAttachments';
+export { ToolsPluginsPanel } from './components/ToolsPluginsPanel';
+export { ToolsMcpPanel } from './components/ToolsMcpPanel';
+export { ToolboxItemRow } from './components/ToolboxItemRow';
+export { ToolsSkillsPanel } from './components/ToolsSkillsPanel';
+export { ToolsImportPanel } from './components/ToolsImportPanel';
+export { ImportItem } from './components/ImportItem';
+export { SlashPopover } from './components/SlashPopover';
+export { MentionPopover } from './components/MentionPopover';
+export { DesignToolboxPanel } from './components/DesignToolboxPanel';
+export { StagedRunContexts } from './components/StagedRunContexts';
+
+// Feature-local hooks the orchestrator wires directly.
+export { useComposerModals } from './hooks/useComposerModals.hooks';
+export type { ComposerDetailsSkill, ComposerModalsController } from './hooks/useComposerModals.hooks';
+export { useComposerUpload } from './hooks/useComposerUpload.hooks';
+export type { ComposerUploadController } from './hooks/useComposerUpload.hooks';
+export {
+  useWorkingDirStatus,
+  useWiredWorkingDirStatus,
+} from './hooks/useWorkingDirStatus.hooks';
+export type { WorkingDirStatusController } from './hooks/useWorkingDirStatus.hooks';
+export type { WorkingDirPort } from './ports';
+export { useSlashPopover } from './hooks/useSlashPopover.hooks';
+export type { SlashPopoverParams, SlashPopoverController } from './hooks/useSlashPopover.hooks';
+export { useCommentAttachments } from './hooks/useCommentAttachments.hooks';
+export type {
+  CommentAttachmentsParams,
+  CommentAttachmentsController,
+} from './hooks/useCommentAttachments.hooks';
+export {
+  useComposerCatalogue,
+  useWiredComposerCatalogue,
+} from './hooks/useComposerCatalogue.hooks';
+export type {
+  ComposerCatalogueParams,
+  ComposerCatalogueController,
+} from './hooks/useComposerCatalogue.hooks';
+export type { ComposerCataloguePort } from './ports';
+export { useWorkspaceContextLinking } from './hooks/useWorkspaceContextLinking.hooks';
+export type {
+  WorkspaceContextLinkingParams,
+  WorkspaceContextLinkingController,
+} from './hooks/useWorkspaceContextLinking.hooks';
+export { useMentionPopover } from './hooks/useMentionPopover.hooks';
+export type {
+  MentionPopoverParams,
+  MentionPopoverController,
+} from './hooks/useMentionPopover.hooks';
+export { useStagedRunContext } from './hooks/useStagedRunContext.hooks';
+export type {
+  StagedRunContextParams,
+  StagedRunContextController,
+} from './hooks/useStagedRunContext.hooks';
+export { useAppliedPlugin } from './hooks/useAppliedPlugin.hooks';
+export type {
+  InlineBackedPlugin,
+  AppliedPluginParams,
+  AppliedPluginController,
+} from './hooks/useAppliedPlugin.hooks';
+export {
+  useComposerDraft,
+  useWiredComposerDraft,
+} from './hooks/useComposerDraft.hooks';
+export type {
+  ComposerDraftParams,
+  ComposerDraftController,
+} from './hooks/useComposerDraft.hooks';
+export type { ComposerDraftPort } from './ports';
+
+// Orchestration functions with injected deps (real branching/side-effect
+// logic; unlike rules.ts, these are not pure).
+export {
+  trackComposerBar,
+  trackDesignToolbox,
+  duplicatePluginRecordAsProject,
+  stageSkillForCurrentTurn,
+  applyDesignToolboxDraft,
+  applyDesignToolboxPrompt,
+  applyDesignToolboxAction,
+  applyDesignToolboxSkill,
+  applyDesignToolboxResource,
+  removeStagedSkill,
+  removeStagedMcpServer,
+  removeStagedConnector,
+  setWorkingDirFolder,
+  handlePickWorkingDir,
+  clearWorkingDir,
+  pickSlash,
+  tryHandleMcpSlash,
+  tryHandlePetSlash,
+  appendWorkspacePrompt,
+  addLinkedDirs,
+  addLinkedDir,
+  handleReferenceProjects,
+  handleLinkLocalCodeContext,
+  handleLinkFolder,
+  removeTrackedWorkspaceLinkedDir,
+  removeWorkspaceContext,
+  handleEditorTrigger,
+  handlePopoverKey,
+  pickMentionByFlatIndex,
+  insertMention,
+  insertPluginMention,
+  insertMcpMention,
+  insertConnectorMention,
+  insertWorkspaceMention,
+  applyProjectSkill,
+  insertSkillMention,
+  handleEditorChange,
+  currentRunContextMeta,
+  reset,
+  sendComposedTurn,
+  submit,
+} from './actions';
+export type {
+  ComposerTrackDeps,
+  DuplicatePluginDeps,
+  DesignToolboxApplyDeps,
+  StagedRemovalDeps,
+  WorkingDirActionDeps,
+  PickSlashDeps,
+  McpSlashDeps,
+  PetSlashDeps,
+  AppendWorkspacePromptDeps,
+  LinkedDirActionDeps,
+  ReferenceProjectsDeps,
+  LinkLocalCodeContextDeps,
+  RemoveWorkspaceContextDeps,
+  MentionActionDeps,
+  EditorChangeDeps,
+  SendActionDeps,
+} from './actions';
+
+// Staged-attachment / upload orchestration functions (Phase 6, cluster 7) —
+// split into their own file since combining with actions.ts would exceed
+// the slice's size budget; same deps-bag convention.
+export {
+  reserveAttachmentOrders,
+  appendOrderedStagedAttachments,
+  appendContextAttachment,
+  ensureProject,
+  uploadFiles,
+  addAssetsFromLibrary,
+  uploadClipboardImagesFromAsyncClipboard,
+  handlePasteFiles,
+  handleDrop,
+  removeStaged,
+  handleAnnotationEvent,
+  flushDeferredAnnotationSend,
+} from './attachment-actions';
+export type {
+  UploadActionDeps,
+  AnnotationActionDeps,
+  DeferredAnnotationSendDeps,
+} from './attachment-actions';
+export type { UploadFilesFailure, UploadFilesResult } from './types';

--- a/apps/web/src/features/chat-composer/ports.ts
+++ b/apps/web/src/features/chat-composer/ports.ts
@@ -1,0 +1,35 @@
+// The chat-composer slice's dependency on transport/DOM globals, expressed as
+// an interface it owns. The slice depends on this port, never on `providers/`
+// directly; a provider is bound to it in `dependencies.ts`. Tests supply a
+// hand-written fake — no global mocking.
+import type { InstalledPluginRecord, McpServersResponse } from '@open-design/contracts';
+import type { ViewportSize } from './types';
+
+/** Viewport reads the design-toolbox hover-detail positioning needs. */
+export interface ViewportPort {
+  getViewportSize(): ViewportSize;
+}
+
+/** localStorage reads/writes the composer-draft persistence hook needs. */
+export interface ComposerDraftPort {
+  readComposerDraft(key: string | undefined): string | null;
+  writeComposerDraft(key: string | undefined, draft: string): void;
+}
+
+/** Transport the working-directory status hook needs: an existence probe for
+ *  the live "still there?" check, plus the recent-dirs list read/write. */
+export interface WorkingDirPort {
+  dirExists(path: string): Promise<boolean>;
+  fetchRecentLinkedDirs(): Promise<string[]>;
+  pushRecentLinkedDir(dir: string): Promise<string[]>;
+}
+
+/** Transport the composer-catalogue hook needs: the external MCP servers +
+ *  templates list, and the installed-plugins list. Both routes are read by
+ *  ONLY this hook's fetch effects (unlike `patchProject`/`openFolderDialog`,
+ *  which stay plain deps-bag callbacks because other clusters also call
+ *  them), so each gets a dedicated port method here rather than a bag entry. */
+export interface ComposerCataloguePort {
+  fetchMcpServers(): Promise<McpServersResponse | null>;
+  listInstalledPlugins(): Promise<InstalledPluginRecord[]>;
+}

--- a/apps/web/src/features/chat-composer/rules.ts
+++ b/apps/web/src/features/chat-composer/rules.ts
@@ -1,0 +1,1546 @@
+// Pure rules for the chat-composer slice: attachment-order normalization/sort,
+// captured-element markup formatting, and workspace-context display/search
+// helpers. No React, no transport, no DOM — they test against `contracts` +
+// app types with zero doubles (ADR 0002).
+import type {
+  AppliedPluginSnapshot,
+  ConnectorDetail,
+  InstalledPluginRecord,
+  LibraryAsset,
+  LibraryElementMeta,
+  McpServerConfig,
+  McpTemplate,
+  RunContextSelection,
+  WorkspaceContextItem,
+} from '@open-design/contracts';
+import type { ChatAttachment, ChatCommentAttachment, ProjectFile, SkillSummary } from '../../types';
+import type { PlaceholderScenario } from '../../components/home-hero/placeholderScenarios';
+import type { DesignToolboxClickProps } from '@open-design/contracts/analytics';
+import type { IconName } from '../../components/Icon';
+import { assetTitle } from '../../components/LibraryAssetMeta';
+import { inlineMentionToken, mentionTokenPresent, type InlineMentionEntity } from '../../utils/inlineMentions';
+import { localizePluginDescription, localizePluginTitle } from '../../components/plugins-home/localization';
+import { localizeSkillDescription, localizeSkillName } from '../../i18n/content';
+import type { Locale } from '../../i18n/types';
+import {
+  findDesignToolboxSkill,
+  skillMatchesQuery,
+  type DesignToolboxAction,
+} from '../../runtime/design-toolbox';
+import { looksLikeImage } from './formatters';
+import { workspaceContextLinkedDir } from '../../components/workspace-context';
+import type {
+  ChatSendMeta,
+  DesignToolboxResource,
+  DesignToolboxResourceIndex,
+  DesignToolboxResourceKind,
+  TrackedWorkspaceLinkedDir,
+  TranslateFn,
+} from './types';
+
+/** True for a finite, non-negative attachment `order` value — anything else
+ *  (missing, negative, `NaN`) needs a fallback order assigned. */
+export function isFiniteAttachmentOrder(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+// Upper bound on element markup folded into the composer input so a huge node's
+// outerHTML can't swamp the prompt; the screenshot still attaches in full.
+const MAX_ELEMENT_HTML_CHARS = 8000;
+
+/**
+ * Render a captured element's markup as a composer-input block: a one-line
+ * descriptor (selector + rendered size) followed by a fenced HTML code block.
+ * Used when an element-pick library asset is pulled into the chat so the user
+ * sees — and can edit — the element's HTML inline before sending.
+ */
+export function formatElementHtmlBlock(
+  asset: LibraryAsset,
+  element: LibraryElementMeta,
+  html: string,
+): string {
+  const descriptor = element.selector || element.tag || assetTitle(asset);
+  const size = element.width && element.height ? ` · ${element.width}×${element.height}` : '';
+  const trimmed = html.trim();
+  const body =
+    trimmed.length > MAX_ELEMENT_HTML_CHARS
+      ? `${trimmed.slice(0, MAX_ELEMENT_HTML_CHARS)}\n<!-- …truncated -->`
+      : trimmed;
+  return `Captured element ${descriptor}${size}\n\n\`\`\`html\n${body}\n\`\`\``;
+}
+
+/** Assigns every attachment a finite integer `order`, preserving existing
+ *  finite orders and back-filling the rest sequentially after the highest
+ *  existing order — used to sanitize a restored/queued attachment list. */
+export function normalizeChatAttachmentOrders(attachments: ChatAttachment[]): ChatAttachment[] {
+  let fallbackOrder = 0;
+  return attachments.map((attachment) => {
+    if (isFiniteAttachmentOrder(attachment.order)) {
+      fallbackOrder = Math.max(fallbackOrder, Math.floor(attachment.order) + 1);
+      return { ...attachment, order: Math.floor(attachment.order) };
+    }
+    const order = fallbackOrder;
+    fallbackOrder += 1;
+    return { ...attachment, order };
+  });
+}
+
+/** Reassigns `attachments` sequential orders starting at `orderStart`, in
+ *  their current array order. */
+export function assignChatAttachmentOrders(
+  attachments: ChatAttachment[],
+  orderStart: number,
+): ChatAttachment[] {
+  return attachments.map((attachment, index) => ({
+    ...attachment,
+    order: orderStart + index,
+  }));
+}
+
+/** The next free order after every existing (or index-fallback) order in
+ *  `attachments` — the high-water mark a new attachment should start from. */
+export function nextChatAttachmentOrder(attachments: ChatAttachment[]): number {
+  return attachments.reduce(
+    (max, attachment, index) =>
+      Math.max(max, isFiniteAttachmentOrder(attachment.order) ? Math.floor(attachment.order) + 1 : index + 1),
+    0,
+  );
+}
+
+/** Sorts by `order` (falling back to array index for attachments with no
+ *  finite order), stable on ties. */
+export function sortChatAttachmentsByOrder(attachments: ChatAttachment[]): ChatAttachment[] {
+  return attachments
+    .map((attachment, index) => ({ attachment, index }))
+    .sort((a, b) => {
+      const aOrder = isFiniteAttachmentOrder(a.attachment.order) ? a.attachment.order : a.index;
+      const bOrder = isFiniteAttachmentOrder(b.attachment.order) ? b.attachment.order : b.index;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.attachment);
+}
+
+/** Same ordering rule as `sortChatAttachmentsByOrder`, for comment
+ *  attachments (visual/screenshot annotations rather than uploaded files). */
+export function sortChatCommentAttachmentsByOrder(attachments: ChatCommentAttachment[]): ChatCommentAttachment[] {
+  return attachments
+    .map((attachment, index) => ({ attachment, index }))
+    .sort((a, b) => {
+      const aOrder = isFiniteAttachmentOrder(a.attachment.order) ? a.attachment.order : a.index;
+      const bOrder = isFiniteAttachmentOrder(b.attachment.order) ? b.attachment.order : b.index;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.attachment);
+}
+
+/** The chip/row icon for a workspace-context item, by kind. */
+export function workspaceContextIcon(item: WorkspaceContextItem): IconName {
+  if (item.kind === 'browser') return 'globe';
+  if (item.kind === 'folder' || item.kind === 'design-files') return 'folder';
+  if (item.kind === 'project') return 'folder';
+  if (item.kind === 'local-code') return 'terminal';
+  if (item.kind === 'terminal') return 'terminal';
+  if (item.kind === 'side-chat') return 'comment';
+  if (item.kind === 'design-system') return 'blocks';
+  return 'file';
+}
+
+/** A tooltip-style title stringing together the item's kind label plus
+ *  whichever path/url/title fields it has — pipe-joined so every present
+ *  field is visible at once. */
+export function workspaceContextTitle(item: WorkspaceContextItem): string {
+  return [
+    workspaceContextKindLabel(item.kind),
+    item.path ? `path: ${item.path}` : null,
+    item.absolutePath ? `absolute: ${item.absolutePath}` : null,
+    item.url ? `url: ${item.url}` : null,
+    item.title ? `title: ${item.title}` : null,
+  ].filter(Boolean).join(' | ');
+}
+
+/** The one-line subtitle shown under a workspace-context chip/row: the most
+ *  identifying field for its kind (path for design files, absolute path for
+ *  local code/project, etc.), falling back through the rest. */
+export function workspaceContextDescription(item: WorkspaceContextItem): string {
+  if (item.kind === 'design-files') return item.path || 'Project files';
+  if (item.kind === 'project') return item.absolutePath || item.path || item.title || item.id;
+  if (item.kind === 'local-code') return item.absolutePath || item.path || item.title || item.id;
+  if (item.kind === 'terminal') return item.title || 'Terminal session';
+  return item.url || item.path || item.absolutePath || item.title || item.tabId || item.id;
+}
+
+/** The final path segment (filename or folder name), normalizing Windows
+ *  backslashes and trailing slashes first; falls back to the whole path if
+ *  it has no separators. */
+export function lastPathSegment(path: string): string {
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
+  return normalized.split('/').filter(Boolean).pop() || path;
+}
+
+/** The display title for a project-file mention: the file's own `name` if
+ *  known, otherwise the last segment of `fallback` (the raw path string). */
+export function projectFileMentionTitle(file: ProjectFile, fallback: string): string {
+  return file.name || lastPathSegment(fallback);
+}
+
+/** The subtitle for a project-file mention: the fallback path itself when it
+ *  differs from the title (so the full path stays visible), otherwise the
+ *  file's kind/mime. */
+export function projectFileMentionDescription(file: ProjectFile, fallback: string): string {
+  const label = projectFileMentionTitle(file, fallback);
+  if (fallback && fallback !== label) return fallback;
+  return [file.kind, file.mime].filter(Boolean).join(' · ');
+}
+
+/** Every searchable field on a workspace-context item, space-joined, for the
+ *  mention popover's plain-text filter. */
+export function workspaceContextSearchText(item: WorkspaceContextItem): string {
+  return [
+    item.id,
+    item.kind,
+    item.label,
+    item.tabId ?? '',
+    item.path ?? '',
+    item.absolutePath ?? '',
+    item.url ?? '',
+    item.title ?? '',
+  ].join(' ');
+}
+
+/** The human-readable label for a workspace-context kind. */
+export function workspaceContextKindLabel(kind: WorkspaceContextItem['kind']): string {
+  switch (kind) {
+    case 'browser':
+      return 'Browser';
+    case 'design-files':
+      return 'Design files';
+    case 'design-system':
+      return 'Design system';
+    case 'folder':
+      return 'Folder';
+    case 'project':
+      return 'Project';
+    case 'local-code':
+      return 'Local code';
+    case 'terminal':
+      return 'Terminal';
+    case 'side-chat':
+      return 'Side chat';
+    case 'live-artifact':
+      return 'Live artifact';
+    case 'file':
+    default:
+      return 'File';
+  }
+}
+
+/** Escapes every regex-special character in `value` so it can be embedded
+ *  literally in a `RegExp`. */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Removes the `@<label>` inline-mention token for `label` from `text`
+ *  (plus one trailing space, if any), so deleting a chip's mention pill
+ *  cleanly drops its token from the draft too. */
+export function stripInlineMentionToken(text: string, label: string): string {
+  const token = inlineMentionToken(label);
+  return text.replace(
+    new RegExp(`(^|[\\s([{"'])${escapeRegExp(token)}(?=$|\\s|[.,;:!?)}\\]"'])([^\\S\\r\\n])?`, 'g'),
+    '$1',
+  );
+}
+
+/** Strips every (deduped, trimmed) label's mention token from `text` in
+ *  turn — used when a removed chip could be referenced by more than one
+ *  label (e.g. a skill's name AND its id). */
+export function stripInlineMentionLabels(text: string, labels: string[]): string {
+  const uniqueLabels = Array.from(new Set(labels.map((label) => label.trim()).filter(Boolean)));
+  return uniqueLabels.reduce(
+    (current, label) => stripInlineMentionToken(current, label),
+    text,
+  );
+}
+
+/** True when `query` (case-insensitive, empty always matches) is found in
+ *  the plugin's title, id, source, description, or manifest tags. */
+export function pluginMatchesQuery(plugin: InstalledPluginRecord, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return [
+    plugin.title,
+    plugin.id,
+    plugin.sourceKind,
+    plugin.source,
+    plugin.manifest?.description ?? '',
+    ...(plugin.manifest?.tags ?? []),
+  ]
+    .join(' ')
+    .toLowerCase()
+    .includes(q);
+}
+
+/** Projects every mentionable source (skills, plugins, MCP servers/
+ *  templates, connectors, project files) into one flat, uniformly-shaped
+ *  `DesignToolboxResource[]` list — each entry carries its own search text,
+ *  badge, and icon so the toolbox panel and the mention popover can render
+ *  and filter them identically regardless of source kind. */
+export function buildDesignToolboxResources({
+  skills,
+  plugins,
+  mcpServers,
+  mcpTemplates,
+  connectors,
+  projectFiles,
+  locale,
+  t,
+}: DesignToolboxResourceIndex & { locale: Locale; t: TranslateFn }): DesignToolboxResource[] {
+  const resources: DesignToolboxResource[] = [];
+
+  for (const skill of skills) {
+    const title = localizeSkillName(locale, skill);
+    const subtitle = localizeSkillDescription(locale, skill);
+    resources.push({
+      key: `skill:${skill.id}`,
+      kind: 'skill',
+      id: skill.id,
+      title,
+      subtitle,
+      badge: designToolboxSkillBadge(skill, t),
+      icon: designToolboxSkillIcon(skill),
+      searchText: [
+        'skill',
+        skill.id,
+        skill.name,
+        title,
+        subtitle,
+        skill.mode,
+        skill.surface ?? '',
+        skill.category ?? '',
+        ...skill.triggers,
+      ].join(' '),
+      skill,
+    });
+  }
+
+  for (const plugin of plugins) {
+    const subtitle = localizePluginDescription(locale, plugin) || plugin.id;
+    resources.push({
+      key: `plugin:${plugin.id}`,
+      kind: 'plugin',
+      id: plugin.id,
+      title: localizePluginTitle(locale, plugin),
+      subtitle,
+      badge: plugin.manifest?.od?.kind ?? 'plugin',
+      icon: 'sparkles',
+      searchText: [
+        'plugin',
+        plugin.id,
+        plugin.title,
+        plugin.sourceKind,
+        plugin.source,
+        subtitle,
+        ...(plugin.manifest?.tags ?? []),
+        plugin.manifest?.od?.kind ?? '',
+        plugin.manifest?.od?.scenario ?? '',
+        plugin.manifest?.od?.mode ?? '',
+      ].join(' '),
+      plugin,
+    });
+  }
+
+  for (const server of mcpServers) {
+    const title = server.label || server.id;
+    const subtitle = server.command || server.url || server.transport;
+    resources.push({
+      key: `mcp:${server.id}`,
+      kind: 'mcp',
+      id: server.id,
+      title,
+      subtitle,
+      badge: 'MCP',
+      icon: 'link',
+      searchText: [
+        'mcp',
+        server.id,
+        title,
+        subtitle,
+        server.transport,
+        server.templateId ?? '',
+      ].join(' '),
+      server,
+    });
+  }
+
+  for (const template of mcpTemplates) {
+    resources.push({
+      key: `mcp-template:${template.id}`,
+      kind: 'mcp-template',
+      id: template.id,
+      title: template.label,
+      subtitle: template.description,
+      badge: template.category,
+      icon: 'plus',
+      searchText: [
+        'mcp template',
+        template.id,
+        template.label,
+        template.description,
+        template.transport,
+        template.category,
+        template.homepage ?? '',
+        template.example ?? '',
+      ].join(' '),
+      template,
+    });
+  }
+
+  for (const connector of connectors) {
+    const toolCount = connector.toolCount ?? connector.tools.length;
+    resources.push({
+      key: `connector:${connector.id}`,
+      kind: 'connector',
+      id: connector.id,
+      title: connector.name,
+      subtitle: [
+        connector.description ?? connector.provider,
+        toolCount > 0 ? `${toolCount} tools` : null,
+        connector.accountLabel ?? null,
+      ].filter(Boolean).join(' · '),
+      badge: connector.category || 'connector',
+      icon: 'link',
+      searchText: [
+        'connector',
+        connector.id,
+        connector.name,
+        connector.provider,
+        connector.category,
+        connector.description ?? '',
+        connector.accountLabel ?? '',
+        ...(connector.featuredToolNames ?? []),
+        ...(connector.allowedToolNames ?? []),
+        ...connector.tools.slice(0, 20).flatMap((tool) => [tool.name, tool.title, tool.description ?? '']),
+      ].join(' '),
+      connector,
+    });
+  }
+
+  const seenFiles = new Set<string>();
+  for (const file of projectFiles) {
+    if (file.type === 'dir') continue;
+    const path = file.path ?? file.name;
+    if (!path || seenFiles.has(path)) continue;
+    seenFiles.add(path);
+    resources.push({
+      key: `file:${path}`,
+      kind: 'file',
+      id: path,
+      title: path,
+      subtitle: [file.kind, file.mime, file.artifactKind ?? ''].filter(Boolean).join(' · '),
+      badge: file.artifactKind ?? file.kind,
+      icon: looksLikeImage(path) ? 'image' : 'file',
+      searchText: [
+        'file',
+        'design file',
+        path,
+        file.name,
+        file.kind,
+        file.mime,
+        file.artifactKind ?? '',
+      ].join(' '),
+      file,
+    });
+  }
+
+  return resources;
+}
+
+/** True when `query` (case-insensitive, empty always matches) is found in
+ *  the resource's precomputed `searchText`. */
+export function designToolboxResourceMatchesQuery(
+  resource: DesignToolboxResource,
+  query: string,
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return resource.searchText.toLowerCase().includes(q);
+}
+
+/** The design toolbox's default (no-query) resource list: the
+ *  "creative-director" skill first, then each quick action's preferred
+ *  skill, then up to 8 total resources matching a curated set of design-
+ *  flavored search terms (skills excluded from this second pass since
+ *  they're already covered above). Deduped by resource key throughout. */
+export function designToolboxDefaultResources(
+  actions: DesignToolboxAction[],
+  resources: DesignToolboxResource[],
+): DesignToolboxResource[] {
+  const out: DesignToolboxResource[] = [];
+  const seen = new Set<string>();
+  function add(resource: DesignToolboxResource | null | undefined) {
+    if (!resource || seen.has(resource.key)) return;
+    seen.add(resource.key);
+    out.push(resource);
+  }
+  function addByKindId(kind: DesignToolboxResourceKind, id: string) {
+    add(resources.find((resource) => resource.kind === kind && resource.id === id));
+  }
+
+  addByKindId('skill', 'creative-director');
+  for (const action of actions) {
+    const skill = resources.find((resource) =>
+      resource.kind === 'skill'
+      && action.preferredSkillIds.some((id) => resource.skill.id === id || resource.skill.name === id),
+    );
+    add(skill);
+  }
+  for (const term of ['design', 'image', 'video', 'motion', 'figma']) {
+    for (const resource of resources) {
+      if (out.length >= 8) return out;
+      if (resource.kind !== 'skill' && designToolboxResourceMatchesQuery(resource, term)) {
+        add(resource);
+      }
+    }
+  }
+  return out;
+}
+
+/** The human-readable label for a design-toolbox resource kind. */
+export function designToolboxResourceKindLabel(
+  kind: DesignToolboxResourceKind,
+  t: TranslateFn,
+): string {
+  switch (kind) {
+    case 'skill':
+      return t('chat.designToolbox.kind.skill');
+    case 'plugin':
+      return t('chat.designToolbox.kind.plugin');
+    case 'mcp':
+      return t('chat.designToolbox.kind.mcp');
+    case 'mcp-template':
+      return t('chat.designToolbox.kind.mcpTemplate');
+    case 'connector':
+      return t('chat.designToolbox.kind.connector');
+    case 'file':
+      return t('chat.designToolbox.kind.designFile');
+  }
+}
+
+/** True when `resource` matches one of the caller's already-active
+ *  skill/plugin/mcp/connector/file selections — drives the toolbox's active
+ *  checkmark. `mcp-template` resources are never "active" (a template isn't
+ *  itself a staged server). */
+export function designToolboxResourceIsActive(
+  resource: DesignToolboxResource,
+  active: {
+    skillIds: Set<string>;
+    pluginId: string | null;
+    mcpServerIds: Set<string>;
+    connectorIds: Set<string>;
+    filePaths: Set<string>;
+  },
+): boolean {
+  switch (resource.kind) {
+    case 'skill':
+      return active.skillIds.has(resource.skill.id);
+    case 'plugin':
+      return active.pluginId === resource.plugin.id;
+    case 'mcp':
+      return active.mcpServerIds.has(resource.server.id);
+    case 'connector':
+      return active.connectorIds.has(resource.connector.id);
+    case 'file':
+      return active.filePaths.has(resource.file.path ?? resource.file.name);
+    case 'mcp-template':
+      return false;
+  }
+}
+
+/** True for a skill the design toolbox should surface: either its category
+ *  is on the curated design-flavored allowlist, or it matches one of a
+ *  curated set of design/motion/asset-related search terms. */
+export function isDesignToolboxSkill(skill: SkillSummary): boolean {
+  const category = skill.category ?? '';
+  if (
+    [
+      'animation-motion',
+      'creative-direction',
+      'image-generation',
+      'video-generation',
+      'web-artifacts',
+    ].includes(category)
+  ) {
+    return true;
+  }
+  return [
+    'animation',
+    'motion',
+    'gsap',
+    'polish',
+    'critique',
+    'taste',
+    'anti slop',
+    'anti ai',
+    'image',
+    'asset',
+    'reference',
+    'icon',
+    'logo',
+    'chart',
+    'diagram',
+    'echarts',
+    'three',
+    'spline',
+    'rive',
+    'lottie',
+    'mapbox',
+    'deck.gl',
+    'video',
+    'frontend',
+    'beautify',
+  ].some((term) => skillMatchesQuery(skill, term));
+}
+
+/** The design toolbox's default skill list: each quick action's own
+ *  matched skill first, then each action's `preferredSkillIds` (matched by
+ *  id or name), deduped by skill id throughout. */
+export function designToolboxDefaultSkills(
+  actions: DesignToolboxAction[],
+  skills: SkillSummary[],
+): SkillSummary[] {
+  const out: SkillSummary[] = [];
+  const seen = new Set<string>();
+  function add(skill: SkillSummary | null | undefined) {
+    if (!skill || seen.has(skill.id)) return;
+    seen.add(skill.id);
+    out.push(skill);
+  }
+  for (const action of actions) {
+    add(findDesignToolboxSkill(action, skills));
+  }
+  for (const action of actions) {
+    for (const id of action.preferredSkillIds) {
+      add(skills.find((skill) => skill.id === id || skill.name === id));
+    }
+  }
+  return out;
+}
+
+/** The chip badge label for a skill in the design toolbox, by its
+ *  mode/category (video, image, motion, polish, or the raw mode string). */
+export function designToolboxSkillBadge(skill: SkillSummary, t: TranslateFn): string {
+  if (skill.mode === 'video' || skill.category === 'video-generation') return t('chat.designToolbox.badge.video');
+  if (skill.mode === 'image' || skill.category === 'image-generation') return t('chat.designToolbox.badge.image');
+  if (skill.category === 'animation-motion') return t('chat.designToolbox.badge.motion');
+  if (skill.category === 'creative-direction') return t('chat.designToolbox.badge.polish');
+  return skill.mode;
+}
+
+/** The chip icon for a skill in the design toolbox, mirroring
+ *  `designToolboxSkillBadge`'s mode/category branching. */
+export function designToolboxSkillIcon(skill: SkillSummary): IconName {
+  if (skill.mode === 'video' || skill.category === 'video-generation') return 'play';
+  if (skill.mode === 'image' || skill.category === 'image-generation') return 'image';
+  if (skill.category === 'animation-motion') return 'sliders';
+  if (skill.category === 'creative-direction') return 'sparkles';
+  return 'file';
+}
+
+/** The prompt line naming the active workspace context ("Using <kind>:
+ *  <label>"), or a generic fallback line when no context is active. */
+export function designToolboxContextLine(
+  workspaceItem: WorkspaceContextItem | null,
+  t: TranslateFn,
+): string {
+  if (!workspaceItem) {
+    return t('chat.designToolbox.prompt.contextGeneric');
+  }
+  const label = workspaceItem.label || workspaceItem.path || workspaceItem.title || workspaceItem.id;
+  return t('chat.designToolbox.prompt.contextSpecific', {
+    kind: designToolboxWorkspaceKindLabel(workspaceItem.kind, t),
+    label,
+  });
+}
+
+/** The prompt line preserving the user's existing draft text, or an empty
+ *  string when there's nothing to preserve. */
+export function designToolboxDraftLine(activeDraft: string, t: TranslateFn): string {
+  const trimmed = activeDraft.trim();
+  if (!trimmed) return '';
+  return t('chat.designToolbox.prompt.preserveDraft', { draft: trimmed });
+}
+
+/** The human-readable workspace-kind label used inside design-toolbox
+ *  prompt text (distinct wording from `workspaceContextKindLabel`, which
+ *  labels UI chips). */
+export function designToolboxWorkspaceKindLabel(
+  kind: WorkspaceContextItem['kind'],
+  t: TranslateFn,
+): string {
+  switch (kind) {
+    case 'browser':
+      return t('chat.designToolbox.context.browser');
+    case 'design-files':
+      return t('chat.designToolbox.context.designFiles');
+    case 'design-system':
+      return t('chat.designToolbox.context.designSystem');
+    case 'folder':
+    case 'project':
+    case 'local-code':
+      return t('chat.designToolbox.context.folder');
+    case 'terminal':
+      return t('chat.designToolbox.context.terminal');
+    case 'side-chat':
+      return t('chat.designToolbox.context.sideChat');
+    case 'live-artifact':
+      return t('chat.designToolbox.context.liveArtifact');
+    case 'file':
+    default:
+      return t('chat.designToolbox.context.file');
+  }
+}
+
+/** Builds the full agent-facing prompt for a design-toolbox quick action:
+ *  the shared context/skill/resource-index/draft-preservation lines, plus
+ *  an action-specific instruction block keyed by `action.id` (falls back to
+ *  the auto-match intro for any action id without its own case). */
+export function designToolboxActionPrompt({
+  action,
+  skill,
+  workspaceItem,
+  activeDraft,
+  resourceIndex,
+  t,
+}: {
+  action: DesignToolboxAction;
+  skill: SkillSummary | null;
+  workspaceItem: WorkspaceContextItem | null;
+  activeDraft: string;
+  resourceIndex: DesignToolboxResourceIndex;
+  t: TranslateFn;
+}): string {
+  const skillLine = skill
+    ? t('chat.designToolbox.prompt.selectedSkill', { skill: skill.name })
+    : t('chat.designToolbox.prompt.noSkill');
+  const resourceLines = designToolboxResourceIndexLines(resourceIndex, t);
+  const draftLine = designToolboxDraftLine(activeDraft, t);
+  const base = [
+    designToolboxContextLine(workspaceItem, t),
+    skillLine,
+    ...resourceLines,
+    draftLine,
+  ].filter(Boolean);
+
+  switch (action.id) {
+    case 'auto-match':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.autoMatchIntro'),
+        t('chat.designToolbox.prompt.autoMatchStep1'),
+        t('chat.designToolbox.prompt.autoMatchStep2'),
+        t('chat.designToolbox.prompt.autoMatchStep3'),
+        t('chat.designToolbox.prompt.autoMatchStep4'),
+      ].join('\n');
+    case 'asset-search':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.assetSearch'),
+      ].join('\n');
+    case 'icon-workflow':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.iconWorkflow'),
+      ].join('\n');
+    case 'image-replace':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.imageReplace'),
+      ].join('\n');
+    case 'reference-extract':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.referenceExtract'),
+      ].join('\n');
+    case 'motion':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.motion'),
+      ].join('\n');
+    case 'motion-polish':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.motionPolish'),
+      ].join('\n');
+    case 'transition-motion':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.transitionMotion'),
+      ].join('\n');
+    case 'plan-outline':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.planOutline'),
+      ].join('\n');
+    case 'threejs-scene':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.threejsScene'),
+      ].join('\n');
+    case 'anti-ai-polish':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.antiAiPolish'),
+      ].join('\n');
+    case 'visual-polish':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.visualPolish'),
+      ].join('\n');
+    case 'image-gen':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.imageGen'),
+      ].join('\n');
+    case 'chart-gen':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.chartGen'),
+      ].join('\n');
+    case 'logo-gen':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.logoGen'),
+      ].join('\n');
+    case 'video-gen':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.videoGen'),
+      ].join('\n');
+  }
+
+  return [
+    ...base,
+    t('chat.designToolbox.prompt.autoMatchIntro'),
+  ].join('\n');
+}
+
+/** Builds the agent-facing prompt for picking a skill directly from the
+ *  design toolbox (rather than via a quick action). */
+export function designToolboxSkillPrompt({
+  skill,
+  workspaceItem,
+  activeDraft,
+  resourceIndex,
+  t,
+}: {
+  skill: SkillSummary;
+  workspaceItem: WorkspaceContextItem | null;
+  activeDraft: string;
+  resourceIndex: DesignToolboxResourceIndex;
+  t: TranslateFn;
+}): string {
+  return [
+    designToolboxContextLine(workspaceItem, t),
+    t('chat.designToolbox.prompt.useSkill', { skill: skill.name }),
+    ...designToolboxResourceIndexLines(resourceIndex, t),
+    designToolboxDraftLine(activeDraft, t),
+    t('chat.designToolbox.prompt.skillInstruction'),
+  ].filter(Boolean).join('\n');
+}
+
+/** Builds the agent-facing prompt for picking a non-skill design-toolbox
+ *  resource (plugin/mcp/mcp-template/connector/file), with a
+ *  resource-kind-specific instruction block. */
+export function designToolboxResourcePrompt({
+  resource,
+  workspaceItem,
+  activeDraft,
+  resourceIndex,
+  t,
+}: {
+  resource: Exclude<DesignToolboxResource, { kind: 'skill' }>;
+  workspaceItem: WorkspaceContextItem | null;
+  activeDraft: string;
+  resourceIndex: DesignToolboxResourceIndex;
+  t: TranslateFn;
+}): string {
+  const base = [
+    designToolboxContextLine(workspaceItem, t),
+    t('chat.designToolbox.prompt.selectedResource', {
+      kind: designToolboxResourceKindLabel(resource.kind, t),
+      title: resource.title,
+      id: resource.id,
+    }),
+    resource.subtitle ? t('chat.designToolbox.prompt.resourceDescription', { description: resource.subtitle }) : '',
+    ...designToolboxResourceIndexLines(resourceIndex, t),
+    designToolboxDraftLine(activeDraft, t),
+  ].filter(Boolean);
+
+  switch (resource.kind) {
+    case 'plugin':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.pluginResource'),
+      ].join('\n');
+    case 'mcp':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.mcpResource'),
+      ].join('\n');
+    case 'mcp-template':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.mcpTemplateResource'),
+      ].join('\n');
+    case 'connector':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.connectorResource'),
+      ].join('\n');
+    case 'file':
+      return [
+        ...base,
+        t('chat.designToolbox.prompt.fileResource'),
+      ].join('\n');
+  }
+}
+
+/** The prompt lines summarizing everything available to the agent (counts
+ *  plus a compact, truncated list per source), so a design-toolbox prompt
+ *  tells the agent what else it could reach for beyond the one resource the
+ *  user picked. */
+export function designToolboxResourceIndexLines(
+  index: DesignToolboxResourceIndex,
+  t: TranslateFn,
+): string[] {
+  const files = index.projectFiles
+    .filter((file) => file.type !== 'dir')
+    .map((file) => file.path ?? file.name);
+  return [
+    t('chat.designToolbox.prompt.resourceIndex', {
+      skills: index.skills.length,
+      plugins: index.plugins.length,
+      mcpEnabled: index.mcpServers.length,
+      mcpTemplates: index.mcpTemplates.length,
+      connectors: index.connectors.length,
+      files: files.length,
+    }),
+    designToolboxCompactLine(t('chat.designToolbox.prompt.searchableSkills'), index.skills.map((skill) => skill.name), 60, t),
+    designToolboxCompactLine(t('chat.designToolbox.prompt.searchablePlugins'), index.plugins.map((plugin) => plugin.title), 40, t),
+    designToolboxCompactLine(t('chat.designToolbox.prompt.availableMcp'), [
+      ...index.mcpServers.map((server) => server.label || server.id),
+      ...index.mcpTemplates.map((template) => t('chat.designToolbox.prompt.mcpTemplateName', { name: template.label })),
+    ], 40, t),
+    designToolboxCompactLine(t('chat.designToolbox.prompt.connectedConnectors'), index.connectors.map((connector) => connector.name), 30, t),
+    designToolboxCompactLine(t('chat.designToolbox.prompt.referenceDesignFiles'), files, 40, t),
+    t('chat.designToolbox.prompt.processRule'),
+  ].filter(Boolean);
+}
+
+/** Formats a labeled, comma-joined, deduped list capped at `limit` entries,
+ *  with a "+N more" suffix for anything past the cap. Returns an empty
+ *  string when `values` has nothing usable, so callers can `.filter(Boolean)`
+ *  it out of a line list. */
+export function designToolboxCompactLine(
+  label: string,
+  values: string[],
+  limit: number,
+  t: TranslateFn,
+): string {
+  const clean = Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+  if (clean.length === 0) return '';
+  const shown = clean.slice(0, limit);
+  const suffix = clean.length > shown.length
+    ? t('chat.designToolbox.prompt.moreSuffix', { count: clean.length - shown.length })
+    : '';
+  return t('chat.designToolbox.prompt.compactLine', {
+    label,
+    values: shown.join(', '),
+    suffix,
+  });
+}
+
+/** 0 when the skill's id or name starts with `query` (a prefix match sorts
+ *  first in the mention popover), 1 otherwise; an empty query ranks every
+ *  skill 1 (no preferred ordering). */
+export function skillMentionRank(skill: SkillSummary, query: string): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 1;
+  const id = skill.id.toLowerCase();
+  const name = skill.name.toLowerCase();
+  if (id.startsWith(q) || name.startsWith(q)) return 0;
+  return 1;
+}
+
+/**
+ * Builds the flat entity list the Lexical editor uses to detect existing
+ * `@token`s already present in the draft (MentionNodes plus plain `@token`
+ * text), across every mentionable source: workspace-context tabs, plugins,
+ * skills (indexed under both name and id, since either can appear in the
+ * token), MCP servers (name and id), connectors (name and id), project files,
+ * and staged file attachments.
+ */
+export function buildComposerMentionEntities({
+  connectors,
+  files,
+  mcpServers,
+  plugins,
+  skills,
+  staged,
+  workspaceContexts,
+}: {
+  connectors: ConnectorDetail[];
+  files: ProjectFile[];
+  mcpServers: McpServerConfig[];
+  plugins: InstalledPluginRecord[];
+  skills: SkillSummary[];
+  staged: ChatAttachment[];
+  workspaceContexts: WorkspaceContextItem[];
+}): InlineMentionEntity[] {
+  const entities: InlineMentionEntity[] = [];
+  const workspaceSeen = new Set<string>();
+  for (const item of workspaceContexts) {
+    if (!item.id || !item.label) continue;
+    const key = `workspace:${item.id}`;
+    if (workspaceSeen.has(key)) continue;
+    workspaceSeen.add(key);
+    entities.push({
+      id: item.id,
+      kind: 'workspace',
+      label: item.label,
+      token: inlineMentionToken(item.label),
+      title: `Workspace: ${item.label}`,
+    });
+  }
+  for (const plugin of plugins) {
+    entities.push({
+      id: plugin.id,
+      kind: 'plugin',
+      label: plugin.title,
+      token: inlineMentionToken(plugin.title),
+      title: `Plugin: ${plugin.title}`,
+    });
+  }
+  for (const skill of skills) {
+    entities.push({
+      id: skill.id,
+      kind: 'skill',
+      label: skill.name,
+      token: inlineMentionToken(skill.name),
+      title: `Skill: ${skill.name}`,
+    });
+    if (skill.id !== skill.name) {
+      entities.push({
+        id: skill.id,
+        kind: 'skill',
+        label: skill.id,
+        token: inlineMentionToken(skill.id),
+        title: `Skill: ${skill.name}`,
+      });
+    }
+  }
+  for (const server of mcpServers) {
+    const label = server.label || server.id;
+    entities.push({
+      id: server.id,
+      kind: 'mcp',
+      label,
+      token: inlineMentionToken(label),
+      title: `MCP: ${label}`,
+    });
+    if (server.id !== label) {
+      entities.push({
+        id: server.id,
+        kind: 'mcp',
+        label: server.id,
+        token: inlineMentionToken(server.id),
+        title: `MCP: ${label}`,
+      });
+    }
+  }
+  for (const connector of connectors) {
+    entities.push({
+      id: connector.id,
+      kind: 'connector',
+      label: connector.name,
+      token: inlineMentionToken(connector.name),
+      title: `Connector: ${connector.name}`,
+    });
+    if (connector.id !== connector.name) {
+      entities.push({
+        id: connector.id,
+        kind: 'connector',
+        label: connector.id,
+        token: inlineMentionToken(connector.id),
+        title: `Connector: ${connector.name}`,
+      });
+    }
+  }
+  const filePaths = new Set<string>();
+  for (const file of files) {
+    const path = file.path ?? file.name;
+    if (!path || filePaths.has(path)) continue;
+    filePaths.add(path);
+    entities.push({
+      id: path,
+      kind: 'file',
+      label: path,
+      token: inlineMentionToken(path),
+      title: `File: ${path}`,
+    });
+  }
+  for (const attachment of staged) {
+    if (!attachment.path || filePaths.has(attachment.path)) continue;
+    filePaths.add(attachment.path);
+    entities.push({
+      id: attachment.path,
+      kind: 'file',
+      label: attachment.path,
+      token: inlineMentionToken(attachment.path),
+      title: `File: ${attachment.path}`,
+    });
+  }
+  return entities;
+}
+
+/** True when `query` (case-insensitive, empty always matches) is found in
+ *  the server's id, label, transport, url, or command. */
+export function mcpServerMatchesQuery(server: McpServerConfig, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return [
+    server.id,
+    server.label ?? '',
+    server.transport,
+    server.url ?? '',
+    server.command ?? '',
+  ]
+    .join(' ')
+    .toLowerCase()
+    .includes(q);
+}
+
+/** True when `query` (case-insensitive, empty always matches) is found in
+ *  the template's id, label, description, transport, category, homepage, or
+ *  example. */
+export function mcpTemplateMatchesQuery(tpl: McpTemplate, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return [
+    tpl.id,
+    tpl.label,
+    tpl.description,
+    tpl.transport,
+    tpl.category,
+    tpl.homepage ?? '',
+    tpl.example ?? '',
+  ]
+    .join(' ')
+    .toLowerCase()
+    .includes(q);
+}
+
+/** "Official" for a bundled plugin, "Mine" for anything user-installed. */
+export function pluginSourceLabel(plugin: InstalledPluginRecord, t: TranslateFn): string {
+  return plugin.sourceKind === 'bundled' ? t('chat.mentionPluginOfficial') : t('chat.mentionPluginMine');
+}
+
+// The composer-side plugin list hides bundled atoms (pipeline-only, not
+// meant to be applied directly from chat) while keeping the full installed
+// list available even when the project was created from a pinned plugin, so
+// users can switch or layer different plugin context from the tools menu
+// and @ picker. A plugin with no `od.kind` at all predates the manifest
+// field and is treated as allowed.
+const COMPOSER_ALLOWED_PLUGIN_KINDS = new Set(['skill', 'scenario', 'bundle']);
+
+/** Filters `installedPlugins` down to the kinds the composer's plugin list
+ *  may show — see `COMPOSER_ALLOWED_PLUGIN_KINDS` above for the why. */
+export function pluginsAllowedForComposer(
+  installedPlugins: InstalledPluginRecord[],
+): InstalledPluginRecord[] {
+  return installedPlugins.filter((p) => {
+    const kind = p.manifest?.od?.kind;
+    return !kind || COMPOSER_ALLOWED_PLUGIN_KINDS.has(kind);
+  });
+}
+
+// Every toolbox resource carries a common `kind` + `id`, and the tracking
+// enum mirrors `DesignToolboxResourceKind` exactly, so this is a direct
+// projection.
+export function designToolboxResourceTracking(resource: DesignToolboxResource): {
+  resource_kind: NonNullable<DesignToolboxClickProps['resource_kind']>;
+  resource_id: string;
+} {
+  return { resource_kind: resource.kind, resource_id: resource.id };
+}
+
+// Pure positioning for the design-toolbox hover-detail / preview panel.
+//
+// The panel is `position: fixed`, so its left/top are viewport coordinates.
+// Extracted from ChatComposer's showToolboxDetail closure so the narrow-pane
+// clamp is unit-testable without a DOM: a row near the left edge (or a
+// viewport narrower than detailWidth + gap*2) must NOT produce a negative
+// left that pushes the panel off-screen — it must clamp back into view.
+
+/** The hovered row's bounding box (viewport coordinates), the anchor the
+ *  detail panel positions itself against. */
+export interface DetailAnchorRect {
+  left: number;
+  right: number;
+  top: number;
+}
+
+/** The current viewport size, for clamping the detail panel on-screen. */
+export interface DetailViewport {
+  width: number;
+  height: number;
+}
+
+/** Sizing constants for `computeToolboxDetailPosition`. */
+export interface DetailPositionOptions {
+  /** Panel width (px). */
+  detailWidth: number;
+  /** Gap between the row and the panel (px). */
+  gap: number;
+  /** Min distance kept from every viewport edge (px). */
+  margin: number;
+  /** Assumed panel height for the vertical clamp (px). */
+  estimatedHeight: number;
+}
+
+/**
+ * Place the detail panel beside the hovered row: to the right when it fits,
+ * otherwise to the left — then clamp both axes into the viewport so the
+ * fixed-positioned panel always stays reachable.
+ */
+export function computeToolboxDetailPosition(
+  rect: DetailAnchorRect,
+  viewport: DetailViewport,
+  { detailWidth, gap, margin, estimatedHeight }: DetailPositionOptions,
+): { left: number; top: number } {
+  const toRight = rect.right + gap;
+  const preferredLeft =
+    toRight + detailWidth > viewport.width - margin
+      ? rect.left - gap - detailWidth
+      : toRight;
+  const left = Math.max(
+    margin,
+    Math.min(preferredLeft, viewport.width - margin - detailWidth),
+  );
+  const top = Math.max(
+    margin,
+    Math.min(rect.top, viewport.height - margin - estimatedHeight),
+  );
+  return { left, top };
+}
+
+/**
+ * The WorkingDirPicker treats the project's working directory as a single
+ * primary folder, so setting or clearing it recomputes the full `linkedDirs`
+ * list to persist: the primary dir (if any) first, followed by every staged/
+ * linked workspace-context dir (deduped against a primary-dir collision).
+ */
+export function linkedDirsWithWorkspaceContext(
+  primaryDir: string | null,
+  workspaceContextMetadataLinkedDirList: string[],
+): string[] {
+  const primary = primaryDir?.trim();
+  const contextDirs = primary
+    ? workspaceContextMetadataLinkedDirList.filter((dir) => dir !== primary)
+    : workspaceContextMetadataLinkedDirList;
+  return Array.from(new Set([
+    ...(primary ? [primary] : []),
+    ...contextDirs,
+  ]));
+}
+
+/**
+ * Drop any `workspaceLinkedDirAdds` tracking entry pointing at `dir` — its
+ * promotion to the project's primary working dir is complete, so the
+ * context-linked-dir bookkeeping for it is no longer needed.
+ */
+export function dropWorkspaceLinkedDirAdds(
+  current: Record<string, TrackedWorkspaceLinkedDir>,
+  dir: string,
+): Record<string, TrackedWorkspaceLinkedDir> {
+  const nextEntries = Object.entries(current).filter(([, tracked]) => tracked.dir !== dir);
+  return nextEntries.length === Object.keys(current).length
+    ? current
+    : Object.fromEntries(nextEntries);
+}
+
+/**
+ * Dedupe a workspace-context item list on `kind:id`, keeping the first
+ * occurrence. Used to sanitize the `initialWorkspaceContexts` prop once on
+ * mount (a parent-supplied list is not guaranteed unique).
+ */
+export function dedupeWorkspaceContextItems(items: WorkspaceContextItem[]): WorkspaceContextItem[] {
+  const out: WorkspaceContextItem[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const key = `${item.kind}:${item.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+/**
+ * Seeds the "dirs this workspace-context item is responsible for linking"
+ * tracking map from a parent-supplied initial context list: only items whose
+ * linked dir is already present in `linkedDirs` count as tracked (anything
+ * else was linked by some other means and this item shouldn't claim credit
+ * for un-linking it later).
+ */
+export function trackedWorkspaceLinkedDirsForContexts(
+  items: WorkspaceContextItem[],
+  linkedDirs: string[],
+): Record<string, TrackedWorkspaceLinkedDir> {
+  const out: Record<string, TrackedWorkspaceLinkedDir> = {};
+  for (const item of items) {
+    const dir = workspaceContextLinkedDir(item) ?? '';
+    if (!dir || !linkedDirs.includes(dir)) continue;
+    out[item.id] = {
+      dir,
+      previousLinkedDirs: linkedDirs.filter((linkedDir) => linkedDir !== dir),
+    };
+  }
+  return out;
+}
+
+/**
+ * True when some OTHER workspace-context item (or the project's own primary
+ * working dir) still needs `dir` linked, so removing `id`'s claim on it must
+ * not unlink the directory itself — only drop `id`'s own tracking entry.
+ */
+export function workspaceContextDirStillReferenced(
+  id: string,
+  dir: string,
+  workspaceLinkedDirAdds: Record<string, TrackedWorkspaceLinkedDir>,
+  selectedWorkspaceContexts: WorkspaceContextItem[],
+  workingDir: string | null,
+): boolean {
+  return Object.entries(workspaceLinkedDirAdds).some(
+    ([candidateId, candidate]) => candidateId !== id && candidate.dir === dir,
+  ) || selectedWorkspaceContexts.some((item) => (
+    item.id !== id && workspaceContextLinkedDir(item) === dir
+  )) || workingDir === dir;
+}
+
+/**
+ * Expand a `/hatch <concept>` draft into the canonical hatch-pet skill
+ * prompt before sending. Returns null when the draft is not a hatch command
+ * so the caller can fall through to the regular submit path.
+ */
+export function expandHatchCommand(input: string): string | null {
+  const m = /^\/hatch(?:\s+([\s\S]*))?$/i.exec(input.trim());
+  if (!m) return null;
+  const concept = m[1]?.trim() ?? '';
+  const intro = concept
+    ? `Hatch a Codex-compatible animated pet for me. Concept: ${concept}.`
+    : 'Hatch a Codex-compatible animated pet for me.';
+  return [
+    intro,
+    '',
+    'Use the @hatch-pet skill end-to-end:',
+    '1. Generate the base look with $imagegen.',
+    '2. Generate every row strip (idle, running-right, waving, jumping, failed, waiting, running, review).',
+    '3. Mirror running-left from running-right only when the design is symmetric.',
+    '4. Run the deterministic scripts (extract / compose / validate / contact-sheet / videos).',
+    '5. Package the result into ${CODEX_HOME:-$HOME/.codex}/pets/<pet-name>/ with pet.json + spritesheet.webp.',
+    '',
+    'When the spritesheet is saved, tell me the absolute path and the pet folder name. I will adopt it from Settings → Pets → Recently hatched.',
+  ].join('\n');
+}
+
+/**
+ * Expand a `/search <query>` draft into the canonical research-tool prompt.
+ * Returns null when the draft is not a search command (or has no query).
+ */
+export function expandSearchCommand(input: string): { prompt: string; query: string } | null {
+  const m = /^\/search(?:\s+([\s\S]*))?$/i.exec(input.trim());
+  if (!m) return null;
+  const query = m[1]?.trim() ?? '';
+  if (!query) return null;
+  return {
+    query,
+    prompt: [
+      `Search for: ${query}`,
+      '',
+      'Before answering, your first tool action must be the OD research command for your shell.',
+      'POSIX: "$OD_NODE_BIN" "$OD_BIN" research search --query "<search query>" --max-sources 5',
+      'PowerShell: & $env:OD_NODE_BIN $env:OD_BIN research search --query "<search query>" --max-sources 5',
+      'cmd.exe: "%OD_NODE_BIN%" "%OD_BIN%" research search --query "<search query>" --max-sources 5',
+      'Use the canonical query below as the exact search query, with safe quoting for your shell.',
+      '',
+      'Canonical query:',
+      '',
+      '```text',
+      query.replace(/```/g, '`\u200b`\u200b`'),
+      '```',
+      'If the OD command fails because Tavily is not configured or unavailable, report that error, then use your own search capability as fallback and label the fallback clearly.',
+      'After the command returns JSON or fallback search results, write a reusable Markdown report into Design Files at `research/<safe-query-slug>.md` or another fresh project-relative path.',
+      'The report must include the query, fetched time, short summary, key findings, source list with [1], [2] citations, and a note that source content is external untrusted evidence.',
+      'Then summarize the findings with citations by source index and mention the Markdown report path.',
+    ].join('\n'),
+  };
+}
+
+/**
+ * Resolves the inline-backed-plugin ref value a restored/queued draft should
+ * seed: the plugin snapshot was "inline-backed" only if the restored meta's
+ * `inlineAppliedPlugin` still matches the applied plugin AND its label
+ * token is still present in the restored text (the user may have deleted the
+ * `@<plugin>` pill before the draft was queued).
+ */
+export function inlineBackedPluginFromRestoredDraft(
+  text: string,
+  appliedPlugin: AppliedPluginSnapshot | null | undefined,
+  meta: ChatSendMeta | undefined,
+): { id: string; label: string } | null {
+  if (!appliedPlugin) return null;
+  const restoredInline = meta?.inlineAppliedPlugin;
+  if (restoredInline?.pluginId !== appliedPlugin.pluginId) return null;
+  return mentionTokenPresent(text, restoredInline.label)
+    ? { id: appliedPlugin.pluginId, label: restoredInline.label }
+    : null;
+}
+
+/** Marks a send meta as queue-only (staged for later rather than sent now). */
+export function queueMeta(meta?: ChatSendMeta): ChatSendMeta {
+  return { ...(meta ?? {}), queueOnly: true };
+}
+
+/**
+ * Builds the run-context selection + send meta for the turn about to be
+ * composed, from every staged/applied context source: staged skills, the
+ * applied plugin snapshot (and whether it's still inline-backed by an
+ * `@<plugin>` pill in the draft), staged MCP servers, staged connectors, and
+ * the visible + staged workspace contexts. Returns `undefined` when nothing
+ * is staged, so callers can spread it into `onSend`/`sendComposedTurn`
+ * without special-casing the empty case.
+ */
+export function currentRunContextMeta({
+  stagedSkills,
+  activeAppliedPlugin,
+  stagedMcpServers,
+  stagedConnectors,
+  selectedWorkspaceContexts,
+  inlineBackedPlugin,
+}: {
+  stagedSkills: SkillSummary[];
+  activeAppliedPlugin: AppliedPluginSnapshot | null;
+  stagedMcpServers: McpServerConfig[];
+  stagedConnectors: ConnectorDetail[];
+  selectedWorkspaceContexts: WorkspaceContextItem[];
+  inlineBackedPlugin: { id: string; label: string } | null;
+}): ChatSendMeta | undefined {
+  const skillIds = stagedSkills.map((s) => s.id);
+  const pluginIds = activeAppliedPlugin ? [activeAppliedPlugin.pluginId] : [];
+  const mcpServerIds = stagedMcpServers.map((s) => s.id);
+  const connectorIds = stagedConnectors.map((c) => c.id);
+  const workspaceItems = selectedWorkspaceContexts;
+  const context: RunContextSelection = {
+    ...(skillIds.length > 0 ? { skillIds } : {}),
+    ...(pluginIds.length > 0 ? { pluginIds } : {}),
+    ...(mcpServerIds.length > 0 ? { mcpServerIds } : {}),
+    ...(connectorIds.length > 0 ? { connectorIds } : {}),
+    ...(workspaceItems.length > 0 ? { workspaceItems } : {}),
+  };
+  const meta: ChatSendMeta = {
+    ...(skillIds.length > 0 ? { skillIds } : {}),
+    ...(activeAppliedPlugin
+      ? {
+          appliedPluginSnapshot: activeAppliedPlugin,
+          appliedPluginSnapshotId: activeAppliedPlugin.snapshotId,
+          ...(inlineBackedPlugin?.id === activeAppliedPlugin.pluginId
+            ? {
+                inlineAppliedPlugin: {
+                  pluginId: activeAppliedPlugin.pluginId,
+                  label: inlineBackedPlugin.label,
+                },
+              }
+            : {}),
+        }
+      : {}),
+    ...(Object.keys(context).length > 0 ? { context } : {}),
+  };
+  return Object.keys(meta).length > 0 ? meta : undefined;
+}
+
+/** The composer's send/stop-button and placeholder-carousel gating. Pure
+ *  derivation from the composer's current input state — no transport, no
+ *  DOM — so it's directly unit-testable without rendering the component. */
+export interface ComposerSendGateInput {
+  streaming: boolean;
+  sendDisabled: boolean;
+  activeFileContext: string | null;
+  placeholderScenarios: ReadonlyArray<PlaceholderScenario>;
+  draft: string;
+  staged: ChatAttachment[];
+  commentAttachmentCount: number;
+  mention: { q: string } | null;
+  slash: { q: string } | null;
+  placeholderScenario: PlaceholderScenario | null;
+}
+
+/** Output of `composerSendGate` — see each field's own doc below. */
+export interface ComposerSendGate {
+  /** True when the placeholder carousel should be shown instead of the
+   *  empty-composer state (no active file, no draft/attachments/popovers, at
+   *  least one scenario available). */
+  placeholderCarouselActive: boolean;
+  /** True when the carousel is active AND its current scenario has real text
+   *  to submit — the fallback prompt `submit()` uses when the composer is
+   *  otherwise empty. */
+  placeholderSubmittable: boolean;
+  /** True when there's anything a send would actually transmit: typed text,
+   *  staged attachments/comments, or a submittable placeholder. */
+  hasComposerPayload: boolean;
+  showStopButton: boolean;
+  showSendButton: boolean;
+}
+
+/** Computes the composer's send/stop-button visibility and the placeholder
+ *  carousel's active/submittable state, per the field docs on
+ *  `ComposerSendGate`. */
+export function composerSendGate({
+  streaming,
+  sendDisabled,
+  activeFileContext,
+  placeholderScenarios,
+  draft,
+  staged,
+  commentAttachmentCount,
+  mention,
+  slash,
+  placeholderScenario,
+}: ComposerSendGateInput): ComposerSendGate {
+  const placeholderCarouselActive =
+    !streaming
+    && !sendDisabled
+    && !activeFileContext
+    && placeholderScenarios.length > 0
+    && draft.trim().length === 0
+    && staged.length === 0
+    && commentAttachmentCount === 0
+    && !mention
+    && !slash;
+  const placeholderSubmittable =
+    placeholderCarouselActive && Boolean(placeholderScenario?.text.trim());
+  const hasComposerPayload =
+    draft.trim().length > 0
+    || staged.length > 0
+    || commentAttachmentCount > 0
+    || placeholderSubmittable;
+  return {
+    placeholderCarouselActive,
+    placeholderSubmittable,
+    hasComposerPayload,
+    showStopButton: streaming && !hasComposerPayload,
+    showSendButton: !streaming || hasComposerPayload,
+  };
+}

--- a/apps/web/src/features/chat-composer/types.ts
+++ b/apps/web/src/features/chat-composer/types.ts
@@ -1,0 +1,153 @@
+// UI-facing types for the chat-composer slice: the design-toolbox resource
+// index/union the composer searches over, and the i18n translate-function
+// shape the pure rules take as a parameter (never read from a closure). No
+// React, no transport (ADR 0002).
+import type {
+  AppliedPluginSnapshot,
+  ChatAnalyticsEntryFrom,
+  ChatSessionMode,
+  ConnectorDetail,
+  InstalledPluginRecord,
+  McpServerConfig,
+  McpTemplate,
+  ResearchOptions,
+  RunContextSelection,
+} from '@open-design/contracts';
+import type { Dict } from '../../i18n/types';
+import type { IconName } from '../../components/Icon';
+import type { ChatAttachment, ProjectFile, SkillSummary } from '../../types';
+
+export type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
+
+/**
+ * Per-send metadata the orchestrator's `onSend`/`restoreDraft`/imperative
+ * handle carry alongside a prompt: run-context selection (skills/plugins/
+ * mcp/connectors/workspace items picked for the turn), the applied-plugin
+ * snapshot, analytics entry-from tagging, and a one-shot session-mode
+ * override. Defined here (not in the orchestrator) so `rules.ts`/`actions.ts`
+ * can reference it too; the orchestrator re-exports this type from its own
+ * module (`export type { ChatSendMeta } from '../features/chat-composer'`)
+ * so its existing external consumers (ProjectView, SideChatTab) are
+ * unaffected.
+ */
+export interface ChatSendMeta {
+  queueOnly?: boolean;
+  research?: ResearchOptions;
+  context?: RunContextSelection;
+  appliedPluginSnapshot?: AppliedPluginSnapshot;
+  appliedPluginSnapshotId?: string;
+  inlineAppliedPlugin?: {
+    pluginId: string;
+    label: string;
+  };
+  // Per-turn skill ids picked via the @-mention popover. The chat layer
+  // forwards these to the daemon's `skillIds` field so the system prompt
+  // for this run only is composed with the extra skill bodies, without
+  // touching the project's persistent `skillId`.
+  skillIds?: string[];
+  /** Overrides the run_created / run_finished `entry_from` analytics prop for
+   *  this send (e.g. 'mark' when the turn is sent from the Mark draw overlay).
+   *  Behavior never depends on it; it only shapes PostHog props. */
+  entryFrom?: ChatAnalyticsEntryFrom;
+  /** One-shot run mode override for seeded follow-ups before parent state catches up. */
+  sessionMode?: ChatSessionMode;
+}
+
+export type DesignToolboxResourceKind =
+  | 'skill'
+  | 'plugin'
+  | 'mcp'
+  | 'mcp-template'
+  | 'connector'
+  | 'file';
+
+export interface DesignToolboxResourceIndex {
+  skills: SkillSummary[];
+  plugins: InstalledPluginRecord[];
+  mcpServers: McpServerConfig[];
+  mcpTemplates: McpTemplate[];
+  connectors: ConnectorDetail[];
+  projectFiles: ProjectFile[];
+}
+
+export type DesignToolboxResourceBase = {
+  key: string;
+  kind: DesignToolboxResourceKind;
+  id: string;
+  title: string;
+  subtitle: string;
+  badge: string;
+  icon: IconName;
+  searchText: string;
+};
+
+export type DesignToolboxResource =
+  | (DesignToolboxResourceBase & { kind: 'skill'; skill: SkillSummary })
+  | (DesignToolboxResourceBase & { kind: 'plugin'; plugin: InstalledPluginRecord })
+  | (DesignToolboxResourceBase & { kind: 'mcp'; server: McpServerConfig })
+  | (DesignToolboxResourceBase & { kind: 'mcp-template'; template: McpTemplate })
+  | (DesignToolboxResourceBase & { kind: 'connector'; connector: ConnectorDetail })
+  | (DesignToolboxResourceBase & { kind: 'file'; file: ProjectFile });
+
+/** The `@`-mention popover's tab filter. */
+export type MentionTab = 'all' | 'tabs' | 'files' | 'plugins' | 'skills' | 'mcp' | 'connectors';
+
+/** One `/`-command entry in the slash popover. */
+export interface SlashCommand {
+  id: string;
+  /** Visible label, e.g. `/hatch`. Shown in the popover row. */
+  label: string;
+  /**
+   * Text inserted into the draft when the user picks the entry. The cursor is
+   * positioned at the end of `insert`, so a trailing space is the difference
+   * between a "ready for argument" command and a "submit immediately" one.
+   */
+  insert: string;
+  /** i18n key of the short description shown next to the label. */
+  descKey: keyof Dict;
+  /** Optional argument hint shown after the description. */
+  argHint?: string;
+  /** Icon glyph from the project Icon set. */
+  icon: 'sparkles' | 'eye' | 'sliders';
+}
+
+/**
+ * Viewport size the design-toolbox hover-detail positioning needs. Defined
+ * in-slice (not imported from `providers/dom`) because the boundary guard is
+ * AST-level and rejects a `providers/` import from any feature file other
+ * than `dependencies.ts` — including `import type`. `dependencies.ts` binds
+ * the real provider's return value structurally against this shape.
+ */
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+/** Tracks a workspace-context dir that was added to `linkedDirs` on the
+ *  context's behalf, so it can be dropped again if the dir is later promoted
+ *  to the project's primary working dir. */
+export interface TrackedWorkspaceLinkedDir {
+  dir: string;
+  previousLinkedDirs: string[];
+}
+
+/**
+ * Per-file failure reported by the project-files upload transport. Defined
+ * in-slice (not imported from `providers/registry`) because the boundary
+ * guard is AST-level and rejects a `providers/` import from any feature file
+ * other than `dependencies.ts` — including `import type`. The attachment
+ * cluster's `UploadActionDeps.uploadProjectFiles` binds the real provider's
+ * return value against this shape structurally.
+ */
+export interface UploadFilesFailure {
+  name: string;
+  code?: string;
+  error?: string;
+}
+
+/** Result of a project-files upload batch; see {@link UploadFilesFailure}. */
+export interface UploadFilesResult {
+  uploaded: ChatAttachment[];
+  failed: UploadFilesFailure[];
+  error?: string;
+}

--- a/apps/web/src/providers/dom.ts
+++ b/apps/web/src/providers/dom.ts
@@ -1,0 +1,61 @@
+// Thin browser-global reads shared across slices. Kept as a provider (not
+// inlined in a feature) so `features/**` stays DOM-free per the
+// `check-web-slice-boundaries` guard — a slice reaches this only through its
+// own port + `dependencies.ts`.
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+/** The current viewport size, or a zero-size fallback outside the browser (SSR). */
+export function getViewportSize(): ViewportSize {
+  if (typeof window === 'undefined') return { width: 0, height: 0 };
+  return { width: window.innerWidth, height: window.innerHeight };
+}
+
+/** Reads a localStorage-persisted draft; `null` outside the browser (SSR),
+ *  with no key, or when storage throws (privacy modes). */
+export function readComposerDraft(key: string | undefined): string | null {
+  if (!key || typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** Persists (or clears, for an empty value) a draft to localStorage; a no-op
+ *  outside the browser (SSR), with no key, or when storage throws (privacy
+ *  modes) — the composer should still work without persistence. */
+export function writeComposerDraft(key: string | undefined, draft: string): void {
+  if (!key || typeof window === 'undefined') return;
+  try {
+    if (draft) {
+      window.localStorage.setItem(key, draft);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // Storage can be unavailable in privacy modes; the composer should still work.
+  }
+}
+
+/**
+ * Opens the mid-chat design-system picker by finding its trigger button
+ * inside `container` and clicking/focusing it — the picker itself owns no
+ * open state the composer can call directly, so this drives the trigger's
+ * own click handler instead. A no-op when the trigger is missing or
+ * disabled (composer-specific selector, so this only makes sense scoped to
+ * a `ChatComposer` root).
+ */
+export function openDesignSystemPickerTrigger(container: HTMLElement | null): void {
+  const trigger = container?.querySelector<HTMLButtonElement>(
+    '[data-testid="project-ds-picker-trigger"]',
+  );
+  if (!trigger || trigger.disabled) return;
+  window.requestAnimationFrame(() => {
+    if (trigger.getAttribute('aria-expanded') !== 'true') trigger.click();
+    trigger.focus({ preventScroll: true });
+  });
+}


### PR DESCRIPTION
## Why

Decomposing the `ChatComposer.tsx` god-component into a `features/chat-composer/` vertical slice (ports, pure rules, feature-local hooks, dumb components), following the same shape as the `MemorySection.tsx`/`McpClientSection.tsx`/`ChatPane.tsx` (#5461) canaries.

`ChatComposer.tsx` had grown to 5,569 lines with no unit-testable seams. This is also the first concrete step toward turning the composer into more of an agentic control plane for the project as a whole (see issue #5398) — clean ports/hooks are the prerequisite groundwork that a future capability registry and inbound tool-execution bridge would attach to. No such capability is added in this PR; it is a pure internal refactor.

This branch is rebuilt directly against current `main` (not carried over from the prior unmerged canary lineage), so it is deliberately **standalone**: it does not depend on `docs/adr/0002-frontend-vertical-slice-decomposition.md`, `dev-skills/fixing-open-design-web/SKILL.md`, or the `check-web-slice-boundaries` guard script, none of which exist on `main` yet.

This is a **draft PR opened to run CI against the real GitHub Actions pipeline** (Playwright visual diffs, the full validation matrix, etc.) — not requesting review or merge yet.

## What users will see

Nothing. Pure internal refactor — same component, same props, same rendered markup.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] **None** — internal refactor only

## What this does

`ChatComposer.tsx`: 5,569 → 1,774 lines.

- **Mechanical moves**: mention popover, slash popover, design-toolbox panel + detail hook, staged run contexts, staged comment attachments, tools import/MCP/plugins/skills panels, and the pure formatter/rules helpers — moved into `features/chat-composer/components/`, `rules.ts`, `formatters.ts`, `constants.ts` unchanged.
- **Feature-local hooks**, each an independent orchestrator cluster: `useComposerDraft`, `useComposerModals`, `useComposerUpload`, `useCommentAttachments`, `useAppliedPlugin`, `useMentionPopover`, `useSlashPopover`, `useDesignToolboxDetail`, `useStagedRunContext`, `useWorkingDirStatus`, `useWorkspaceContextLinking`, `useComposerCatalogue`.
- **`actions.ts`/`attachment-actions.ts`**: the composer's send/attach/upload action bodies, extracted out of inline JSX handlers so the orchestrator stays declarative.

`ChatComposer.tsx` itself has zero drift against current `main` (byte-identical at this branch's fork point), so no behavior needed folding in. Two residual direct provider imports were repointed to their current `main` locations rather than the not-yet-landed paths the original lineage introduced: `McpServerConfig` now imports from `@open-design/contracts` directly, and `fetchMcpServers` from `state/mcp` (the `providers/mcp` barrel move is separate unmerged work).

New additions to `providers/dom.ts` (the slice's only file allowed to import `providers/`): `getViewportSize`, `readComposerDraft`, `writeComposerDraft`, `openDesignSystemPickerTrigger` — 4 SSR-guarded browser bridges replacing the bare `window`/`document`/`localStorage` access this logic needed once it moved into `features/**`.

Note: `apps/web/src/providers/dom.ts` is a **new file** also being added independently by the `ChatPane.tsx` decomposition (#5461), with a different (non-overlapping) subset of functions. Landing both PRs will need the second one to reconcile the union of both function sets in that file — flagging here so it isn't a surprise at merge time.

## Validation

- `pnpm --filter @open-design/web typecheck` — clean
- Full `@open-design/web` suite — green (410 files / 4,290 tests, 7 pre-existing skips)
- `pnpm guard` — clean (78/78 checks)
