### PR TITLE
fix(daemon): preserve user files when updating a design system

### DIFF
--- a/apps/daemon/src/design-systems/index.ts
+++ b/apps/daemon/src/design-systems/index.ts
@@ -1988,6 +1988,89 @@ function classifyDesignSystemFile(
   return 'asset';
 }
 
+// Hidden fingerprint manifest recording the content the generator last wrote for
+// each derived file. `collectDesignSystemFiles` skips dot-prefixed entries, so it
+// is excluded from file listings and ZIP archives; the pull/static allowlists are
+// default-deny, so it is never served either.
+const GENERATED_MANIFEST_FILENAME = '.od-generated.json';
+
+// Manifest keys are posix-relative paths under the design-system root, matching
+// the `collectDesignSystemFiles` relative-path convention.
+function generatedManifestKey(dir: string, targetPath: string): string {
+  return path.relative(dir, targetPath).split(path.sep).join('/');
+}
+
+function hashGeneratedContent(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function serializeGeneratedManifest(manifest: Record<string, string>): string {
+  const sorted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(manifest).sort(([a], [b]) => a.localeCompare(b))) {
+    sorted[key] = value;
+  }
+  return `${JSON.stringify(sorted, null, 2)}\n`;
+}
+
+// Reading the manifest is fault-tolerant: a missing, malformed, or user-authored
+// same-named file all degrade to "no manifest" (an empty record). That routes the
+// caller into the conservative legacy path (write-if-missing) instead of ever
+// trusting an untrusted file as a source of overwrite decisions.
+async function readGeneratedManifest(dir: string): Promise<Record<string, string>> {
+  const raw = await readFileOptional(path.join(dir, GENERATED_MANIFEST_FILENAME));
+  if (raw === undefined) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value === 'string') out[key] = value;
+  }
+  return out;
+}
+
+// Regeneration must never discard files a user has customized (issue #323). A
+// generated file is only overwritten when it is still byte-identical to what the
+// generator last wrote (recorded in `.od-generated.json`). Anything the user
+// edited — or any pre-existing file with no recorded fingerprint (legacy systems)
+// — is preserved. Files that are absent are written and fingerprinted. The
+// returned `nextManifest` records fingerprints for every path that will be
+// written/refreshed, preserves the prior fingerprint for kept-but-skipped paths,
+// and drops manifest keys the generator no longer produces.
+async function filterGeneratedWritesPreservingUserEdits(
+  dir: string,
+  writes: AtomicTextFileWrite[],
+  manifest: Record<string, string>,
+): Promise<{ writes: AtomicTextFileWrite[]; nextManifest: Record<string, string> }> {
+  const kept: AtomicTextFileWrite[] = [];
+  const nextManifest: Record<string, string> = {};
+  for (const write of writes) {
+    const key = generatedManifestKey(dir, write.targetPath);
+    const current = await readFileOptional(write.targetPath);
+    if (current === undefined) {
+      // Absent → safe to write.
+      kept.push(write);
+      nextManifest[key] = hashGeneratedContent(write.content);
+      continue;
+    }
+    const recorded = manifest[key];
+    if (recorded !== undefined && hashGeneratedContent(current) === recorded) {
+      // Untouched since the last generation → refresh to the new content.
+      kept.push(write);
+      nextManifest[key] = hashGeneratedContent(write.content);
+      continue;
+    }
+    // User-owned (edited, or a legacy file with no fingerprint) → preserve as-is.
+    // Retain any prior fingerprint so future updates can still compare.
+    if (recorded !== undefined) nextManifest[key] = recorded;
+  }
+  return { writes: kept, nextManifest };
+}
+
 async function writeGeneratedDesignSystemFiles(
   root: string,
   id: string,
@@ -2012,10 +2095,19 @@ async function writeGeneratedDesignSystemFiles(
     mkdir(path.join(dir, 'ui_kits', 'app', 'components'), { recursive: true }),
   ]);
 
+  const manifest = await readGeneratedManifest(dir);
+  const { writes, nextManifest } = await filterGeneratedWritesPreservingUserEdits(
+    dir,
+    generatedDesignSystemFileWrites(dir, input),
+    manifest,
+  );
   await Promise.all(
-    generatedDesignSystemFileWrites(dir, input).map((write) =>
-      writeFile(write.targetPath, write.content, 'utf8')
-    ),
+    writes.map((write) => writeFile(write.targetPath, write.content, 'utf8')),
+  );
+  await writeFile(
+    path.join(dir, GENERATED_MANIFEST_FILENAME),
+    serializeGeneratedManifest(nextManifest),
+    'utf8',
   );
 }
 
@@ -2622,6 +2714,7 @@ async function writeAcceptedUserDesignSystemRevision(
     updatedAt,
     ...(provenance ? { provenance } : {}),
   };
+  const fileChangeWrites = revisionFileChangeWrites(root, dirId, revision.fileChanges);
   const writes: AtomicTextFileWrite[] = [
     { targetPath: designPath, content: revision.proposedBody },
     {
@@ -2631,17 +2724,37 @@ async function writeAcceptedUserDesignSystemRevision(
   ];
   if (artifactMode !== 'agent-managed') {
     const sourceNotes = provenanceToNotes(provenance);
-    writes.push(...generatedDesignSystemFileWrites(base, {
-      title,
-      category,
-      surface,
-      summary: summarize(revision.proposedBody),
-      ...(provenance ? { provenance } : {}),
-      ...(sourceNotes ? { sourceNotes } : {}),
-      body: revision.proposedBody,
-    }));
+    const manifest = await readGeneratedManifest(base);
+    const filtered = await filterGeneratedWritesPreservingUserEdits(
+      base,
+      generatedDesignSystemFileWrites(base, {
+        title,
+        category,
+        surface,
+        summary: summarize(revision.proposedBody),
+        ...(provenance ? { provenance } : {}),
+        ...(sourceNotes ? { sourceNotes } : {}),
+        body: revision.proposedBody,
+      }),
+      manifest,
+    );
+    // Generated writes precede fileChanges; writeTextFilesAtomically keeps the
+    // last write per path, so an explicit fileChange wins over a same-named
+    // derived write. Drop those paths from the manifest so the hand-authored
+    // content is treated as user-owned (preserved) on the next regeneration.
+    const nextManifest = { ...filtered.nextManifest };
+    for (const change of fileChangeWrites) {
+      delete nextManifest[generatedManifestKey(base, change.targetPath)];
+    }
+    writes.push(...filtered.writes);
+    writes.push(...fileChangeWrites);
+    writes.push({
+      targetPath: path.join(base, GENERATED_MANIFEST_FILENAME),
+      content: serializeGeneratedManifest(nextManifest),
+    });
+  } else {
+    writes.push(...fileChangeWrites);
   }
-  writes.push(...revisionFileChangeWrites(root, dirId, revision.fileChanges));
   writes.push({
     targetPath: path.join(base, 'revisions', `${acceptedRevision.id}.json`),
     content: `${JSON.stringify(acceptedRevision, null, 2)}\n`,

--- a/apps/daemon/tests/design-systems/index.test.ts
+++ b/apps/daemon/tests/design-systems/index.test.ts
@@ -11,6 +11,7 @@ import {
   listDesignSystems,
   listUserDesignSystemFiles,
   readDesignSystem,
+  readDesignSystemStaticFile,
   readUserDesignSystemFile,
   readUserDesignSystemRevision,
   updateUserDesignSystem,
@@ -405,5 +406,198 @@ describe('design systems registry', () => {
       ]),
     );
     expect(generatedFiles?.map((file) => file.path)).not.toEqual(expect.arrayContaining(['README.md']));
+  });
+
+  // Regression #556 (issue #323): updating a generated design system used to
+  // unconditionally rewrite every derived file, clobbering user-authored
+  // components/docs and forcing users to redo work. Regeneration must now only
+  // refresh files the user has not customized.
+  const dirOf = (id: string): string => path.join(root, id.slice('user:'.length));
+
+  const seedUserEdits = async (dir: string): Promise<void> => {
+    await writeFile(
+      path.join(dir, 'ui_kits', 'app', 'components', 'App.jsx'),
+      'MY CUSTOM APP',
+      'utf8',
+    );
+    await mkdir(path.join(dir, 'src', 'components'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'src', 'components', 'MyButton.tsx'),
+      'export const MyButton = () => null;\n',
+      'utf8',
+    );
+    await mkdir(path.join(dir, 'ui_kits', 'app', 'custom'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'ui_kits', 'app', 'custom', 'Panel.jsx'),
+      'CUSTOM PANEL',
+      'utf8',
+    );
+  };
+
+  it('preserves user-created files and edits when updating a generated design system', async () => {
+    const created = await createUserDesignSystem(root, {
+      title: 'Retention Kit',
+      category: 'Custom',
+      status: 'draft',
+      body: '# Retention Kit\n\n> Category: Custom\n> Surface: web\n\nOriginal.\n',
+    });
+    const dir = dirOf(created.id);
+    await seedUserEdits(dir);
+
+    const updated = await updateUserDesignSystem(root, created.id, { title: 'Retention Kit Pro' });
+    expect(updated?.title).toBe('Retention Kit Pro');
+
+    await expect(readFile(path.join(dir, 'ui_kits', 'app', 'components', 'App.jsx'), 'utf8'))
+      .resolves
+      .toBe('MY CUSTOM APP');
+    await expect(readFile(path.join(dir, 'src', 'components', 'MyButton.tsx'), 'utf8'))
+      .resolves
+      .toBe('export const MyButton = () => null;\n');
+    await expect(readFile(path.join(dir, 'ui_kits', 'app', 'custom', 'Panel.jsx'), 'utf8'))
+      .resolves
+      .toBe('CUSTOM PANEL');
+  });
+
+  it('preserves user edits when accepting a design-system revision', async () => {
+    const created = await createUserDesignSystem(root, {
+      title: 'Revision Kit',
+      body: '# Revision Kit\n\n> Category: Custom\n> Surface: web\n\nBase.\n',
+    });
+    const dir = dirOf(created.id);
+    await seedUserEdits(dir);
+
+    const baseBody = await readDesignSystem(root, created.id, { idPrefix: 'user:' });
+    const revision = await createUserDesignSystemRevision(root, created.id, {
+      feedback: 'Tighten guidance from source evidence.',
+      baseBody: baseBody ?? '',
+      proposedBody: '# Revision Kit\n\n> Category: Custom\n> Surface: web\n\nRevised guidance.\n',
+    });
+    await updateUserDesignSystemRevisionStatus(root, created.id, revision?.id ?? '', 'accepted');
+
+    await expect(readDesignSystem(root, created.id, { idPrefix: 'user:' }))
+      .resolves
+      .toContain('Revised guidance.');
+    await expect(readFile(path.join(dir, 'ui_kits', 'app', 'components', 'App.jsx'), 'utf8'))
+      .resolves
+      .toBe('MY CUSTOM APP');
+    await expect(readFile(path.join(dir, 'src', 'components', 'MyButton.tsx'), 'utf8'))
+      .resolves
+      .toBe('export const MyButton = () => null;\n');
+  });
+
+  it('still refreshes untouched generated docs when the title changes', async () => {
+    const created = await createUserDesignSystem(root, {
+      title: 'Refresh Kit',
+      body: '# Refresh Kit\n\n> Category: Custom\n> Surface: web\n\nOriginal.\n',
+    });
+    const dir = dirOf(created.id);
+    await expect(readFile(path.join(dir, 'README.md'), 'utf8')).resolves.toContain('Refresh Kit');
+
+    await updateUserDesignSystem(root, created.id, { title: 'Polished System' });
+
+    // README was never user-edited, so regeneration must still refresh it.
+    await expect(readFile(path.join(dir, 'README.md'), 'utf8')).resolves.toContain('Polished System');
+  });
+
+  it('does not generate derived files for agent-managed systems on update', async () => {
+    const created = await createUserDesignSystem(root, {
+      title: 'Agent Managed Kit',
+      artifactMode: 'agent-managed',
+      body: '# Agent Managed Kit\n\n> Category: Custom\n> Surface: web\n\nBase.\n',
+    });
+
+    await updateUserDesignSystem(root, created.id, { title: 'Agent Managed Renamed' });
+
+    const files = await listUserDesignSystemFiles(root, created.id);
+    expect(files?.map((file) => file.path)).toEqual(['DESIGN.md']);
+  });
+
+  it('preserves user edits when regenerating after README deletion (read path)', async () => {
+    const created = await createUserDesignSystem(root, {
+      title: 'Read Path Kit',
+      body: '# Read Path Kit\n\n> Category: Custom\n> Surface: web\n\nBase.\n',
+    });
+    const dir = dirOf(created.id);
+    await writeFile(
+      path.join(dir, 'ui_kits', 'app', 'components', 'App.jsx'),
+      'MY CUSTOM APP',
+      'utf8',
+    );
+    await rm(path.join(dir, 'README.md'), { force: true });
+
+    // Listing files triggers ensureGeneratedDesignSystemFiles, which regenerates
+    // when README is missing. The missing README must be restored without
+    // clobbering the user's edited App.jsx.
+    const files = await listUserDesignSystemFiles(root, created.id);
+    expect(files?.map((file) => file.path)).toEqual(expect.arrayContaining(['README.md']));
+    await expect(readFile(path.join(dir, 'ui_kits', 'app', 'components', 'App.jsx'), 'utf8'))
+      .resolves
+      .toBe('MY CUSTOM APP');
+  });
+
+  it('keeps a revision file-change to a generated doc across later updates', async () => {
+    const created = await createUserDesignSystem(root, {
+      title: 'FileChange Kit',
+      body: '# FileChange Kit\n\n> Category: Custom\n> Surface: web\n\nBase.\n',
+    });
+    const dir = dirOf(created.id);
+    const baseBody = await readDesignSystem(root, created.id, { idPrefix: 'user:' });
+    const revision = await createUserDesignSystemRevision(root, created.id, {
+      feedback: 'Hand-author the README in this revision.',
+      baseBody: baseBody ?? '',
+      proposedBody: baseBody ?? '',
+      fileChanges: [{
+        path: 'README.md',
+        baseContent: '',
+        proposedContent: '# Hand-authored README\n\nCustom.\n',
+      }],
+    });
+    await updateUserDesignSystemRevisionStatus(root, created.id, revision?.id ?? '', 'accepted');
+    await expect(readFile(path.join(dir, 'README.md'), 'utf8'))
+      .resolves
+      .toBe('# Hand-authored README\n\nCustom.\n');
+
+    // A later metadata-only update must not overwrite the revision's README.
+    await updateUserDesignSystem(root, created.id, { title: 'FileChange Kit Renamed' });
+    await expect(readFile(path.join(dir, 'README.md'), 'utf8'))
+      .resolves
+      .toBe('# Hand-authored README\n\nCustom.\n');
+  });
+
+  it('preserves edits and backfills gaps for legacy systems without a manifest', async () => {
+    // Simulate an older generated system: derived files exist on disk but there
+    // is no .od-generated.json fingerprint manifest yet.
+    await mkdir(path.join(root, 'legacy', 'ui_kits', 'app', 'components'), { recursive: true });
+    await writeFile(
+      path.join(root, 'legacy', 'DESIGN.md'),
+      '# Legacy\n\n> Category: Custom\n> Surface: web\n\nBody.\n',
+      'utf8',
+    );
+    await writeFile(path.join(root, 'legacy', 'README.md'), 'USER EDITED README', 'utf8');
+
+    const updated = await updateUserDesignSystem(root, 'user:legacy', { title: 'Legacy Renamed' });
+    expect(updated?.title).toBe('Legacy Renamed');
+
+    const dir = path.join(root, 'legacy');
+    // Pre-existing (possibly user-edited) file with no fingerprint is preserved.
+    await expect(readFile(path.join(dir, 'README.md'), 'utf8')).resolves.toBe('USER EDITED README');
+    // Missing derived files are still backfilled.
+    await expect(readFile(path.join(dir, 'SKILL.md'), 'utf8')).resolves.toContain('Legacy Renamed');
+  });
+
+  it('does not expose the generated-fingerprint manifest through file surfaces', async () => {
+    const created = await createUserDesignSystem(root, {
+      title: 'Manifest Privacy Kit',
+      body: '# Manifest Privacy Kit\n\n> Category: Custom\n> Surface: web\n\nBase.\n',
+    });
+    const dir = dirOf(created.id);
+    // The manifest exists on disk after generation.
+    await expect(readFile(path.join(dir, '.od-generated.json'), 'utf8')).resolves.toContain('README.md');
+
+    const files = await listUserDesignSystemFiles(root, created.id);
+    expect(files?.map((file) => file.path)).not.toContain('.od-generated.json');
+    await expect(
+      readDesignSystemStaticFile(root, created.id, '.od-generated.json', { idPrefix: 'user:' }),
+    ).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Why

**Use case.** Dispatched to fix a paid-insight retention bug from the external demand pool (#556 → issue tracker item [50579eb2](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/50579eb2-c64b-4a2d-8fda-d10f4d4af626)). It's a **KANO must-have / P2** defect on the retention funnel: users who build up a generated-mode user design system as a workspace (custom `ui_kits/app/components/*`, `src/components/*`, hand-made folders) lose all of that work the moment they *update* the design system.

**The pain.** Every "update" path — editing the title/category/body (`PATCH /api/design-systems/:id`), the CLI `od design-systems rename`, accepting an AI revision, a brand re-extract upsert, and even the read-path regeneration when `README.md` is missing — funnels into `writeGeneratedDesignSystemFiles`, which **unconditionally `writeFile`d all ~28 derived files**. Nothing deleted user data; the scaffold values silently overwrote the user's edited/created files, which reads to the user as "my directory was wiped." Data loss on a basic flow makes the feature untrustworthy.

## What users will see

Updating a generated design system (rename, edit `DESIGN.md`, accept a revision, re-extract a brand) **no longer clobbers files you created or edited**. Your custom components under `ui_kits/app/` and `src/`, your hand-made folders, and any generated doc you've since edited are all preserved. Derived docs you *haven't* touched still refresh normally (e.g. `README.md` picks up a new title), so renaming still visibly "takes." No new UI or CLI surface — the fix is in the shared daemon function, so both the web update flow and the `od` CLI benefit automatically.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — updating a generated design system now preserves user-customized files instead of overwriting them, and each generated system gains a hidden `.od-generated.json` fingerprint file in its directory.

> This is a **shared daemon-logic bug fix**. It does not add or change any HTTP endpoint, contract DTO, UI page, or `od` subcommand — the existing update entry points (web edit/rename, `od design-systems rename`, revision accept) all call the same `/api/design-systems/*` and the same daemon function, so both the UI and CLI tracks are fixed simultaneously with no new surface (per tech spec §5).

## Screenshots

N/A — no UI change (daemon logic + tests only).

## Bug fix verification

Followed AGENTS.md → "Bug follow-up workflow" (red spec first).

- **Test path:** `apps/daemon/tests/design-systems/index.test.ts`
- **Red on `main`, green on this branch:** **yes.** With the test file present but the source reverted to `main`, 6 specs go red — the two core paths (`updateUserDesignSystem`, revision accept), the README-missing read path, the revision-`fileChange` retention case, the legacy-no-manifest first run, and the manifest-privacy assertion. All 17 specs (11 pre-existing + 8 new — some cover multiple guarantees) are green on this branch.
- Guard/固化 specs (untouched docs still refresh; agent-managed unchanged) pass on both, proving the fix didn't regress into "never regenerate."

## Validation

- `pnpm --filter @open-design/daemon test` → `tests/design-systems/index.test.ts` **17 passed**; related suites `generation-jobs`, `routes/design-system-showcase-assets`, `server-bootstrap-regression` **14 passed** (no new failures vs. baseline).
- `pnpm --filter @open-design/daemon typecheck` → exit 0.
- `pnpm guard` → 78/78 pass.

## How the fix works

The invariant: **regeneration may only replace a file that is still byte-identical to what the generator last wrote.**

- A hidden `.od-generated.json` manifest in each design-system directory records `sha256` of the generator's last write per derived file. It's a dot-file, so `collectDesignSystemFiles` already excludes it from listings/ZIP archives, and the pull/static allowlists are default-deny, so it's never served (asserted by a regression test).
- A shared pure helper `filterGeneratedWritesPreservingUserEdits(dir, writes, manifest)` implements the three-state decision: absent → write + fingerprint; on-disk hash == recorded → refresh + re-fingerprint; hash mismatch **or** no recorded fingerprint → preserve (user-owned). Uncertain cases always fall to the safe "preserve" side, so the worst case is "an update doesn't refresh a doc," never data loss.
- The filter lives *inside* `writeGeneratedDesignSystemFiles`, so all three callers (`create` / `update` / `ensure`-on-read) inherit non-destructive semantics automatically. The revision-accept atomic-write path is filtered separately and drops any `fileChange`-owned path from the manifest so hand-authored revision content is treated as user-owned on the next regeneration.
- **Legacy systems** without a manifest degrade to conservative write-if-missing on first update (backfill gaps, never overwrite existing files), then behave normally once the manifest exists.

Open question OQ1 in the spec (whether to preserve *edited generated docs* too, or only user-*created* files) is resolved to the conservative option A — preserve anything the user has touched — because it's the data-safe default and narrowing to option B later only shrinks the preserved set. Flagged here so a maintainer can course-correct in review.

## Adjacent issues

None found. The import-local/github/shadcn paths operate on `.tmp-*` staging clones, not the user's live directory, and are out of scope per spec §2.2.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>