### PR TITLE
skills: add character visual interactions

### DIFF
--- a/skills/add-character-visual-interactions/README.md
+++ b/skills/add-character-visual-interactions/README.md
@@ -1,0 +1,69 @@
+# Add Character Visual Interactions
+
+Add page-local 2D or 3D character motion to an existing web page while preserving its business behavior. Typical effects include gaze following, pointer tracking, blinking, hovering, head turns, and independently animated wings or other local parts.
+
+This package is a functional Skill for Open Design and a portable Agent Skill for compatible coding agents.
+
+## Open Design placement
+
+- Directory: `skills/add-character-visual-interactions/`
+- Mode: `prototype`
+- Surface: `web`
+- Category: `animation-motion`
+- Scenario: `design`
+
+Although the skill works on visual prototypes, it is not a design template. It enhances an existing page and does not create a new page from scratch.
+
+Open Design's current `skills/AGENTS.md` describes `utility` as the functional-skill mode, while the current daemon mode normalizer does not recognize it. With `utility`, this skill is incorrectly inferred as an image skill from its 2D asset language. This package therefore declares the supported `prototype` mode with `surface: web` so the current runtime classifies it correctly. Disclose this compatibility exception during review without expanding the Skill-only contribution into a parser change.
+
+## What it does
+
+- Inspects the existing page, stack, assets, dependencies, tests, and uncommitted changes.
+- Preserves APIs, authentication, routing, stores, permissions, validation, submission, and analytics behavior.
+- Selects a layered 2D route for image parts or a Three.js route for supplied GLB/GLTF/FBX assets.
+- Separates target tracking, pure motion math, and rendering.
+- Adds responsive and reduced-motion fallbacks.
+- Verifies lifecycle cleanup, browser layout, functional controls, and failure paths.
+
+## What it does not do
+
+- Create a new page or redesign the product from scratch.
+- Replace business logic, application state, routes, or API contracts.
+- Invent anatomical pivots or pretend whole-model shaking is local character motion.
+- Download or redistribute character assets without confirmed licensing.
+- Guarantee compatibility with an untested framework version or build configuration.
+
+## Example prompts
+
+```text
+Add gaze-following eyes, randomized blinking, and subtle head tracking to the supplied character on the existing login page. Preserve authentication, validation, routing, keyboard behavior, and form submission exactly as they are.
+```
+
+```text
+为现有首页中的 2D 分层角色添加视线跟随和随机眨眼。不要修改导航、埋点、按钮事件或页面路由，并为窄屏和减少动态效果设置提供降级方案。
+```
+
+## Resource map
+
+- `SKILL.md`: trigger metadata, boundaries, and core workflow.
+- `references/motion-core.md`: target signal, bounded mapping, damping, and lifecycle ownership.
+- `references/2d-layered.md`: layered raster/vector asset route.
+- `references/3d-models.md`: GLB/GLTF/FBX inspection, pivots, rendering, and failure behavior.
+- `references/framework-adapters.md`: lifecycle adaptation guidance for common frontend stacks.
+- `references/checklist.md`: P0/P1/P2 validation gates and completion reporting.
+- `agents/openai.yaml`: Codex-facing display metadata; Open Design reads the `od:` metadata in `SKILL.md` instead.
+
+## Compatibility policy
+
+The framework reference covers React, Vue, Next.js, Nuxt, Svelte, Angular, vanilla JavaScript, and comparable component systems. These are adaptation targets, not a claim that every framework version has already been tested. Each implementation must report the exact stack, version, route, build, and browser checks verified with fresh evidence.
+
+## Differentiation from nearby Open Design skills
+
+- `emilkowalski-motion` provides general interface motion polish; this skill focuses on character anatomy, target tracking, layered 2D, and model-local 3D motion.
+- `threejs` covers general browser 3D scenes; this skill adds existing-page isolation, business-behavior protection, local-part validation, and a layered 2D alternative.
+- `redesign-existing-projects` performs broad visual redesign; this skill explicitly prohibits business and structural redesign.
+- GSAP skills are library-specific; this skill reuses the existing stack and prefers CSS or platform APIs when they are sufficient.
+
+## License
+
+Apache-2.0. User-supplied and project-owned character assets retain their original licenses and are not relicensed by this skill.

--- a/skills/add-character-visual-interactions/SKILL.md
+++ b/skills/add-character-visual-interactions/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: add-character-visual-interactions
+en_name: "Character Visual Interactions"
+zh_name: "角色视觉交互"
+description: |
+  Add isolated mouse-responsive, gaze-following, blinking, hovering, and localized
+  2D/3D character motion to an existing web page without changing APIs, routing,
+  authentication, forms, analytics, or other business behavior. Use when a supplied
+  character asset should react to a pointer or another page-local target.
+en_description: "Add safe, page-local 2D or 3D character interactions to an existing web page without changing business behavior."
+zh_description: "在不改变业务行为的前提下，为现有网页添加页面内隔离的 2D 或 3D 角色交互。"
+triggers:
+  - "add character interaction"
+  - "character visual interaction"
+  - "mouse-following character"
+  - "gaze-following eyes"
+  - "2d character animation"
+  - "3d character interaction"
+  - "角色跟随鼠标"
+  - "角色视线跟随"
+  - "角色交互动效"
+license: Apache-2.0
+od:
+  mode: prototype
+  surface: web
+  scenario: design
+  category: animation-motion
+  preview:
+    type: markdown
+  design_system:
+    requires: false
+  craft:
+    requires:
+      - animation-discipline
+      - accessibility-baseline
+  example_prompt: |
+    Add gaze-following eyes, randomized blinking, and subtle head tracking to the
+    supplied character on the existing login page. Preserve authentication,
+    validation, routing, keyboard behavior, and form submission exactly as they are.
+  example_prompt_i18n:
+    zh-CN: |
+      为现有登录页中的角色添加视线跟随、随机眨眼和轻微头部转动，保持认证、
+      校验、路由、键盘操作和表单提交行为完全不变。
+  capabilities_required:
+    - file_write
+---
+
+# Add Character Visual Interactions
+
+## Purpose
+
+Add character-driven visual motion to an existing page without changing what the page does. Adapt to the detected frontend stack and choose layered 2D or GLB/GLTF/FBX 3D from project-owned or user-supplied assets. Treat framework entries as lifecycle guidance, not blanket compatibility guarantees; verify the actual target project before claiming support.
+
+## Non-Negotiable Boundaries
+
+- Work only on an existing page named by the user, such as a home or login page.
+- Do not create a new page from scratch.
+- Do not change APIs, authentication, routing, stores, permissions, validation, submissions, analytics, or other business behavior.
+- Preserve existing functional elements and event bindings. Visual layout changes are allowed only when behavior remains intact.
+- Mount the interaction only on the requested page and clean it up when that page unmounts.
+- Use only assets already in the project or supplied by the user. Do not download or redistribute character models, images, fonts, or textures without confirmed licensing.
+- If the requested effect cannot be isolated from business logic, stop and explain the conflict before editing.
+
+## Workflow
+
+1. Inspect the target page, package manifest, framework conventions, assets, dependencies, tests, and uncommitted changes.
+2. Record the functional surface that must remain unchanged and define desktop and mobile visual acceptance criteria.
+3. Choose the smallest viable route:
+   - Use layered 2D for images, transparent parts, or an image that can be safely cropped into independent visual regions.
+   - Use 3D only when GLB/GLTF/FBX assets are supplied or explicitly requested.
+4. Isolate target tracking, motion math, and rendering. Keep motion calculations pure and testable.
+5. Implement with existing component, styling, test, and lifecycle patterns. Reuse installed dependencies; add no animation library when CSS and platform APIs are enough.
+6. Read the validation checklist, then verify original page behavior, focused motion tests, production build, live browser layout, cleanup, and console output.
+
+## Route References
+
+- Read references/motion-core.md for shared tracking and motion rules.
+- Read references/2d-layered.md when using layered raster or vector artwork.
+- Read references/3d-models.md when using GLB/GLTF/FBX models.
+- Read references/framework-adapters.md for framework lifecycle patterns and compatibility reporting.
+- Always read references/checklist.md before claiming completion.
+
+## Implementation Rules
+
+- Keep the system pointer visible unless the user explicitly asks to replace it.
+- Normalize target coordinates, clamp rotation, damp movement, and avoid cumulative rotation.
+- Drive local parts independently. Do not shake an entire image or model to imitate eye, head, or wing movement.
+- Respect prefers-reduced-motion and provide a responsive fallback where the effect would obstruct the page.
+- Keep decorative surfaces out of the interaction path with pointer-events and stacking rules unless direct character interaction was explicitly requested.
+- Prefer deletion and reuse over new abstractions. A page-local component plus pure motion functions is usually enough.

--- a/skills/add-character-visual-interactions/agents/openai.yaml
+++ b/skills/add-character-visual-interactions/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Character Visual Interactions"
+  short_description: "Add safe, page-local 2D and 3D character motion"
+  default_prompt: "Use $add-character-visual-interactions to add isolated character-driven visual interactions to an existing web page without changing its business behavior."

--- a/skills/add-character-visual-interactions/references/2d-layered.md
+++ b/skills/add-character-visual-interactions/references/2d-layered.md
@@ -1,0 +1,31 @@
+# Layered 2D Route
+
+## Asset Contract
+
+Prefer transparent, independently positioned assets for body, head, face, eyes, eyelids, and moving appendages. Record each part visual anchor and transform origin.
+
+A single source image may be reused through CSS clipping when separate assets are unavailable, but treat this as page-specific. For reusable production work, request transparent layers rather than building a generic image segmentation system.
+
+## Layering
+
+Use a stable relative container and absolutely positioned visual parts. Keep page layout outside the character component so moving the character never changes form or navigation geometry.
+
+Recommended order:
+
+1. Body
+2. Head mask or background repair layer
+3. Head and face
+4. Eyes and pupils
+5. Eyelids and foreground details
+
+Move pupils faster than the head. Move the head with smaller angles and stronger damping. Set transform origins at anatomical pivots, not element centers by default.
+
+## Micro-Animation
+
+Use CSS keyframes for blink closure and a page-local timer for randomized intervals. A typical blink lasts 120 to 180 milliseconds with several seconds between blinks. Clear every timer on unmount.
+
+Do not move the full character to fake blinking, breathing, or wing motion. Animate the relevant layer. Add idle breathing only when requested and keep it below the threshold that shifts surrounding layout.
+
+## Responsive Behavior
+
+Scale from a constrained aspect ratio. At narrow widths, reduce opacity or hide the decorative character before allowing it to cover functional controls. Verify that long labels, validation messages, and loading states still fit.

--- a/skills/add-character-visual-interactions/references/3d-models.md
+++ b/skills/add-character-visual-interactions/references/3d-models.md
@@ -1,0 +1,33 @@
+# 3D Model Route
+
+## Supported Formats
+
+Prefer GLB/GLTF. Support FBX when supplied. Do not claim OBJ support in the first version because it lacks a reliable animation and hierarchy contract.
+
+Use Three.js only for the 3D route. Reuse the installed version when present; add it only when the requested model requires it and the user accepts the dependency.
+
+## Inspect Before Animating
+
+Load the model and traverse its hierarchy. Record meshes, groups, bones, animation clips, material warnings, bounds, and component names. Confirm whether body, eyes, wings, or other parts are independently controllable.
+
+When parts are welded but geometrically separable, split only when geometry provides an unambiguous boundary. Otherwise report the asset limitation instead of guessing.
+
+If the requested local motion needs a head, eye, wing, or other pivot that the asset cannot provide, stop before implementation. Ask for a corrected asset or explicit approval for a reduced effect such as whole-character target following. Never present whole-model shaking as local animation.
+
+## Normalize the Asset
+
+Use model bounds to compute center and scale. Place the visible subject around a stable root group and keep camera framing independent from source-unit scale. Cap renderer pixel ratio.
+
+Create rotation pivots at anatomical roots. For wings, pivot at each wing root and animate left and right parts with mirrored motion. Small and large wings may use a slight phase offset. Never shake the whole model to imitate local animation.
+
+## Motion Constraints
+
+Apply yaw to the stable root, allow only a small bounded pitch, and keep roll at zero unless explicitly required. Prevent flips and continuous rotation. Use shortest-path interpolation for turns.
+
+## Failure Fallback
+
+Model loading, unsupported materials, missing WebGL, or renderer creation must never block the page. Remove or hide the failed visual surface, preserve all functional content, and report the visual limitation. Do not redirect, disable controls, or change authentication behavior because a decorative asset failed.
+
+## Cleanup
+
+On unmount, cancel animation frames, disconnect observers, remove listeners, dispose geometries, materials, textures, and the renderer, then detach the canvas. The 3D code and assets must not load on unrelated routes.

--- a/skills/add-character-visual-interactions/references/checklist.md
+++ b/skills/add-character-visual-interactions/references/checklist.md
@@ -1,0 +1,38 @@
+# Validation Checklist
+
+Do not claim completion until every applicable P0 gate has fresh evidence. Report pre-existing failures separately from failures introduced by the visual change.
+
+## P0 — Required Gates
+
+- Review the diff and confirm APIs, authentication, routing, stores, permissions, validation, submissions, and analytics are unchanged.
+- Confirm existing uncommitted user changes were preserved.
+- Confirm the visual component mounts only on the requested page.
+- Confirm decorative layers do not intercept pointer input unless direct character interaction was requested.
+- Verify original clicks, keyboard focus order, validation, and submission behavior.
+- Verify listeners, observers, timers, animation frames, canvases, and renderer resources are released on unmount.
+- Verify prefers-reduced-motion and the narrow-screen fallback.
+- Run the production build or equivalent compile check.
+- Check the browser console for new errors and asset-loader warnings.
+- Record the source and license status of every newly added image, model, texture, font, or audio asset.
+
+## P1 — Motion and Layout
+
+- Add one focused test for non-trivial normalization, clamping, damping, direction, or recovery math; observe it fail before implementation when practical.
+- Run focused motion tests after implementation.
+- Verify desktop and mobile viewports.
+- Confirm no horizontal or accidental vertical overflow.
+- Confirm functional controls remain visible and correctly layered.
+- Confirm target tracking, bounded rotation, blink or local-part motion, and neutral recovery.
+- Confirm the native pointer remains visible unless replacement was requested.
+
+## P2 — Performance and Failure Paths
+
+- Confirm motion uses bounded transform or renderer updates without unnecessary layout work.
+- Confirm off-screen or inactive animation work is paused when the project pattern supports it.
+- For 3D, confirm the canvas is nonblank, the model is framed, pixel ratio is capped, and unrelated routes do not load the model.
+- For 3D, test missing WebGL, model-load failure, and unsupported-material paths; the functional page must remain usable.
+- Record residual asset, browser, rendering, and performance warnings.
+
+## Completion Report
+
+State the files changed, target page, framework and version actually verified, checks run, browser viewports inspected, asset provenance, and remaining warnings. Do not describe an unverified framework, asset route, or visual effect as working.

--- a/skills/add-character-visual-interactions/references/framework-adapters.md
+++ b/skills/add-character-visual-interactions/references/framework-adapters.md
@@ -1,0 +1,37 @@
+# Framework Adapters
+
+## Compatibility Scope
+
+Treat these entries as adaptation guidance, not as proof that every version, renderer, router, or build configuration is supported. Detect the actual stack and version first. In the completion report, name only the frameworks and routes verified with fresh build and browser evidence.
+
+## General Rule
+
+Detect the stack from the package manifest and existing source. Match existing component style and build tooling. Do not migrate APIs, rewrite the page, or introduce a new state pattern for a visual-only change.
+
+## Vue
+
+Use the existing Options API or Composition API style. Keep DOM and Three.js handles in refs. Register browser work in onMounted and remove it in onBeforeUnmount. A page-local component and a small pure motion module are normally sufficient.
+
+## React
+
+Keep renderer and DOM handles in refs. Start listeners, timers, and animation frames inside an effect and return complete cleanup. Make initialization idempotent because development Strict Mode may mount effects twice.
+
+## Next.js and Nuxt
+
+Keep browser-only rendering on the client. Dynamically load heavy 3D code when SSR would evaluate browser globals. Do not make the whole application client-only for one visual component.
+
+## Svelte
+
+Use bound element references and start browser work in onMount. Return or register complete cleanup in onDestroy. Keep motion math outside the component when it needs unit tests.
+
+## Angular
+
+Start DOM or renderer work after the view is initialized and release it in OnDestroy. Keep handles on the component instance. Run continuous animation outside Angular change detection when the existing project pattern supports it.
+
+## Vanilla and Other Stacks
+
+Use a module-scoped initializer that returns a cleanup function. Follow the same target, motion, renderer separation. For another framework, map initialization and cleanup onto native lifecycle primitives before writing code.
+
+## Styling
+
+Reuse existing CSS conventions, whether scoped CSS, CSS Modules, Tailwind, styled components, or another established system. Keep page positioning in the page layout and character internals in the visual component.

--- a/skills/add-character-visual-interactions/references/motion-core.md
+++ b/skills/add-character-visual-interactions/references/motion-core.md
@@ -1,0 +1,32 @@
+# Motion Core
+
+## Target Signal
+
+Represent the visual target with page-local data containing x, y, visible, velocityX, and velocityY.
+
+x and y are viewport CSS pixels. Velocity is optional unless direction or catch-up speed depends on it. Use a local event, hook, composable, or callback; do not introduce global state for a page-only effect.
+
+## Mapping
+
+1. Measure the observer center from rendered bounds.
+2. Normalize each target offset into the range from -1 to 1 using an explicit tracking range.
+3. Map normalized values to bounded yaw, pitch, and eye displacement.
+4. Smooth current values toward targets with frame-rate-independent damping.
+
+Keep horizontal turning around the vertical axis. Vertical movement may produce a small bounded pitch. Never add roll for ordinary pointer tracking, and never accumulate angles across frames.
+
+Use shortest-path turning when a 3D subject changes left or right direction. Catch-up speed may increase with distance, but cap it so a fast pointer does not create teleporting or oscillation.
+
+## Ownership
+
+Separate three responsibilities:
+
+- Target producer: pointer, follower object, or another animated subject.
+- Motion calculation: pure functions for normalization, clamping, damping, and direction.
+- Renderer: CSS transforms, canvas, or Three.js objects.
+
+Test motion calculation without mounting the framework component.
+
+## Lifecycle
+
+Register pointer listeners and animation frames only while the target page is mounted. On cleanup, remove listeners, cancel animation frames, clear blink timers, and publish an invisible target state when observers need to return to neutral.


### PR DESCRIPTION
## Why

Character motion work on an existing product page has different constraints from general interface animation, broad redesign, or building a standalone Three.js scene. It needs to preserve authentication, routing, forms, analytics, and other business behavior while adding asset-aware, page-local 2D or 3D motion with cleanup and accessibility fallbacks.

This contribution packages that workflow as a reusable Open Design Skill for teams adding gaze following, pointer tracking, blinking, hovering, head turns, wings, or other localized character motion to an existing web page.

## What users will see

Settings → Skills can discover **Character Visual Interactions**. When invoked, the Skill guides an agent to inspect the existing page and supplied assets, choose a layered 2D or GLB/GLTF/FBX 3D route, isolate motion from business logic, and verify responsive, reduced-motion, lifecycle, and functional-behavior requirements.

The Skill complements nearby entries rather than replacing them:

- `emilkowalski-motion` covers general interface motion polish; this Skill focuses on character anatomy, target tracking, layered 2D, and model-local 3D motion.
- `threejs` covers general browser 3D scenes; this Skill adds existing-page isolation, business-behavior protection, local-part validation, and a layered 2D alternative.
- `redesign-existing-projects` supports broad redesign; this Skill explicitly prohibits business and structural redesign.

The repository guidance describes `utility` as the functional-Skill mode, but the current daemon mode normalizer does not recognize it and inferred this Skill as `image` from its 2D asset language. The contribution therefore uses the supported `prototype` mode with `surface: web`, which registers it correctly in the current runtime. This PR intentionally stays Skill-only and does not expand into a parser change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This is a non-featured Skill with a Markdown preview and does not add or change an application UI entry point.

## Bug fix verification

Not applicable; this is a new extension-point contribution.

## Validation

- `pnpm guard` — 78/78 checks passed
- `pnpm typecheck` — passed
- `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` — 4/4 passed
- `pnpm --filter @open-design/web test` — 411 test files passed; 4291 tests passed; 7 skipped
- Verified through the local daemon registry as `add-character-visual-interactions`, mode `prototype`, surface `web`, scenario `design`, category `animation-motion`, preview `markdown`, with required craft references resolved
- `git diff --cached --check` — passed

No real character-asset prompt execution was performed because this contribution does not include a target page or a licensed 2D/3D character asset.
