### PR TITLE
fix: wrap composer placeholder text instead of clipping

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -1260,8 +1260,6 @@
   font-size: 13.5px;
   line-height: 1.6;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   max-width: calc(100% - 8px);
 }
 .composer-input-wrap .home-hero__carousel {

--- a/apps/web/tests/styles/composer-input-placeholder.test.ts
+++ b/apps/web/tests/styles/composer-input-placeholder.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const chatCss = readFileSync(
+  new URL('../../src/styles/chat.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = chatCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('composer input placeholder', () => {
+  it('does not force the placeholder onto a single clipped line', () => {
+    const placeholder = cssDeclarations('.composer-input-placeholder');
+
+    // Regression guard for #5370: white-space: nowrap forced ellipsis-clipping
+    // after just a few words. It must stay wrap-friendly so it can rely on
+    // the shared .composer-input-editor scroll container instead.
+    expect(() => ruleValue(placeholder, 'white-space')).toThrow();
+  });
+
+  it('keeps the placeholder horizontally contained within the editor', () => {
+    const placeholder = cssDeclarations('.composer-input-placeholder');
+
+    expect(ruleValue(placeholder, 'overflow')).toBe('hidden');
+    expect(ruleValue(placeholder, 'max-width')).toBe('calc(100% - 8px)');
+  });
+});


### PR DESCRIPTION
Fixes #5370

## Why

I picked this up as a CodePath AI301 contribution — claimed the issue and worked through root-causing it with the maintainer (lefarcen) in the issue thread. The reported pain: the composer input doesn't show the full prompt text — longer text gets visually truncated instead of wrapping/scrolling, making it hard to review before sending.

Worth noting how the scope narrowed as I investigated: the original report could plausibly have pointed at several different pieces of composer text — real typed content, suggestion-card seeded content, or the empty-state placeholder hint. Testing confirmed real typed/seeded content already wraps and scrolls correctly (`.composer-editable`'s existing `white-space: pre-wrap` handles that fine). The actual bug was isolated specifically to `.composer-input-placeholder` — the empty-state hint text — which had `white-space: nowrap` forcing single-line ellipsis clipping. This PR is scoped to just that.

## What users will see

- **Short placeholder text** — unchanged in practice. Note: some placeholder strings intentionally end with a literal "…" character baked into the copy itself (e.g. `'Describe what you want to generate…'`), which is a content/copy choice, not CSS truncation — that's expected and not part of this bug.
- **Long placeholder text** — previously got cut off after just a few words with a hard ellipsis; now wraps across multiple lines and scrolls within the composer's existing bounds, matching how real typed content already behaves.
- The rotating example-prompt typewriter (`PlaceholderCarousel`, used on the Home page and reused in the project chat sidebar) is unchanged — it's intentionally single-line for its typing/caret animation, reviewed and deliberately left out of scope (see note below).

## Surface area

- [x] **UI** — behavior fix to the chat composer's placeholder text in `apps/web`
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

No screenshots attached. This is a CSS-only fix to an element (`.composer-input-placeholder`) that is genuinely hard to capture meaningfully in a static image: the default placeholder strings rarely reach wrapping length in English, and the element is normally superseded almost immediately by an animated carousel overlay (`PlaceholderCarousel`), so any screenshot would require artificially lengthening the string via DevTools rather than showing real, organic behavior. The change is instead verified via the regression test (`composer-input-placeholder.test.ts`, confirmed red on `main` / green on this branch) and manual testing described above. Happy to add screenshots if a reviewer would find them useful.


## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/composer-input-placeholder.test.ts`
- Did the test go red on `main` and green on this branch? **Yes** — confirmed by temporarily re-adding `white-space: nowrap` to `.composer-input-placeholder` (test fails), then removing it to restore the committed fix (test passes).

## Validation

- `pnpm guard` — pass (78/78 tests)
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web build` — pass
- `pnpm --filter @open-design/web test` (styles + composer tests) — pass

## Additional observations (not part of this fix)

While testing, I noticed two related things in `PlaceholderCarousel` worth flagging for a possible follow-up, but out of scope here:
1. The typewriter's hold duration is quite brief — can be hard to read before it cycles to the next prompt.
2. Its fully-typed state is still single-line/ellipsis-clipped for long prompts, similar in shape to this bug — but its single-line design looks intentional (preserves the typing/caret animation), so I didn't change it without checking first.

Happy to open a follow-up issue for either if useful.