### PR TITLE
fix(web): unwrap false-positive question-form open tag in prose

### DIFF
--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -145,7 +145,22 @@ export function splitOnQuestionForms(input: string): FormSegment[] {
     const openEnd = openStart + m[0].length;
     const closeIdx = findCloseTag(input, openEnd, closeTag);
     if (closeIdx === -1) {
-      // Unterminated — leave the rest as prose so we don't swallow it.
+      // No matching close tag found for this open tag name. The body may
+      // contain an open tag of the other name (e.g. prose mentioned
+      // <ask-question> but the real form uses <question-form>). Try to
+      // unwind to an inner open before giving up.
+      const remainder = input.slice(openEnd);
+      const nestedOpen = OPEN_RE.exec(remainder);
+      if (nestedOpen) {
+        const resumeAt = openEnd + nestedOpen.index;
+        if (openStart > cursor) {
+          out.push({ kind: 'text', text: input.slice(cursor, openStart) });
+        }
+        out.push({ kind: 'text', text: input.slice(openStart, resumeAt) });
+        cursor = resumeAt;
+        continue;
+      }
+      // Genuinely unterminated — leave the rest as prose.
       out.push({ kind: 'text', text: slice });
       break;
     }
@@ -164,17 +179,14 @@ export function splitOnQuestionForms(input: string): FormSegment[] {
       // JSON. If the body itself contains another question-form / ask-question
       // open tag, the outer match was a false positive (e.g. the model
       // mentioned the tag name inside backtick-quoted prose). Unwind to the
-      // inner open so it gets a clean parse on the next iteration.
-      const inner = OPEN_RE.exec(body);
-      if (inner) {
-        const resumeAt = openEnd + inner.index;
-        // Push only the text between the false-positive open tag and the
-        // inner open tag (the prose between lines 152-153 already handled
-        // the text before the false-positive tag). Slicing from openStart
-        // avoids duplicating the leading prose already in the output.
-        if (resumeAt > openStart) {
-          out.push({ kind: 'text', text: input.slice(openStart, resumeAt) });
-        }
+      // nested open so it gets a clean parse on the next iteration.
+      const nestedOpen = OPEN_RE.exec(body);
+      if (nestedOpen) {
+        const resumeAt = openEnd + nestedOpen.index;
+        // Text before the false-positive tag was already emitted above.
+        // Slice from openStart so only the tag and the gap up to the
+        // nested open are emitted — no duplication.
+        out.push({ kind: 'text', text: input.slice(openStart, resumeAt) });
         cursor = resumeAt;
       } else {
         out.push({ kind: 'text', text: input.slice(openStart, blockEnd) });

--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -158,11 +158,25 @@ export function splitOnQuestionForms(input: string): FormSegment[] {
     const blockEnd = closeIdx + closeTag.length;
     if (form) {
       out.push({ kind: 'form', form, raw: input.slice(openStart, blockEnd) });
+      cursor = blockEnd;
     } else {
-      // Malformed — keep raw text so the user can still see it.
-      out.push({ kind: 'text', text: input.slice(openStart, blockEnd) });
+      // The body between this open tag and the matched close tag isn't valid
+      // JSON. If the body itself contains another question-form / ask-question
+      // open tag, the outer match was a false positive (e.g. the model
+      // mentioned the tag name inside backtick-quoted prose). Unwind to the
+      // inner open so it gets a clean parse on the next iteration.
+      const inner = OPEN_RE.exec(body);
+      if (inner) {
+        const resumeAt = openEnd + inner.index;
+        if (resumeAt > cursor) {
+          out.push({ kind: 'text', text: input.slice(cursor, resumeAt) });
+        }
+        cursor = resumeAt;
+      } else {
+        out.push({ kind: 'text', text: input.slice(openStart, blockEnd) });
+        cursor = blockEnd;
+      }
     }
-    cursor = blockEnd;
   }
   return out;
 }

--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -168,8 +168,12 @@ export function splitOnQuestionForms(input: string): FormSegment[] {
       const inner = OPEN_RE.exec(body);
       if (inner) {
         const resumeAt = openEnd + inner.index;
-        if (resumeAt > cursor) {
-          out.push({ kind: 'text', text: input.slice(cursor, resumeAt) });
+        // Push only the text between the false-positive open tag and the
+        // inner open tag (the prose between lines 152-153 already handled
+        // the text before the false-positive tag). Slicing from openStart
+        // avoids duplicating the leading prose already in the output.
+        if (resumeAt > openStart) {
+          out.push({ kind: 'text', text: input.slice(openStart, resumeAt) });
         }
         cursor = resumeAt;
       } else {

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -164,6 +164,23 @@ describe('splitOnQuestionForms', () => {
       expect(out[1].form.id).toBe('x');
     }
   });
+
+  it('unwinds a false-positive open tag mentioned in prose and re-parses the real form', () => {
+    // Model mentioned the tag name inside backtick-quoted prose before
+    // emitting the real form — the first open match must not consume the real
+    // close tag, or the real form is lost.
+    const out = splitOnQuestionForms(
+      `my first output should be \`<question-form id="discovery">\`.\n\n` +
+      `Let me write a custom form:\n\n` +
+      `<question-form id="discovery" title="Quick brief">${VALID_BODY}</question-form>\n\n` +
+      `Now I'll proceed.`,
+    );
+    expect(out.map((s) => s.kind)).toEqual(['text', 'text', 'form', 'text']);
+    if (out[2]?.kind === 'form') {
+      expect(out[2].form.id).toBe('discovery');
+      expect(out[2].form.questions).toHaveLength(1);
+    }
+  });
 });
 
 describe('parsePartialQuestionForm (true token-by-token streaming)', () => {

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -186,6 +186,23 @@ describe('splitOnQuestionForms', () => {
       .join('');
     expect(reconstructed).toBe(input);
   });
+
+  it('unwinds a tag-name mismatch — prose mentions <ask-question> but the real form is <question-form>', () => {
+    const input =
+      `In your output you'll see \`<ask-question>\` tags.\n\n` +
+      `<question-form id="real" title="Brief">${VALID_BODY}</question-form>\n\n` +
+      `Done.`;
+    const out = splitOnQuestionForms(input);
+    expect(out.map((s) => s.kind)).toEqual(['text', 'text', 'form', 'text']);
+    if (out[2]?.kind === 'form') {
+      expect(out[2].form.id).toBe('real');
+      expect(out[2].form.questions).toHaveLength(1);
+    }
+    const reconstructed = out
+      .map((s) => (s.kind === 'form' ? (s as { raw: string }).raw : (s as { text: string }).text))
+      .join('');
+    expect(reconstructed).toBe(input);
+  });
 });
 
 describe('parsePartialQuestionForm (true token-by-token streaming)', () => {

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -169,17 +169,22 @@ describe('splitOnQuestionForms', () => {
     // Model mentioned the tag name inside backtick-quoted prose before
     // emitting the real form — the first open match must not consume the real
     // close tag, or the real form is lost.
-    const out = splitOnQuestionForms(
+    const input =
       `my first output should be \`<question-form id="discovery">\`.\n\n` +
       `Let me write a custom form:\n\n` +
       `<question-form id="discovery" title="Quick brief">${VALID_BODY}</question-form>\n\n` +
-      `Now I'll proceed.`,
-    );
+      `Now I'll proceed.`;
+    const out = splitOnQuestionForms(input);
     expect(out.map((s) => s.kind)).toEqual(['text', 'text', 'form', 'text']);
     if (out[2]?.kind === 'form') {
       expect(out[2].form.id).toBe('discovery');
       expect(out[2].form.questions).toHaveLength(1);
     }
+    // Segments must reconstruct the input without gaps or duplication.
+    const reconstructed = out
+      .map((s) => (s.kind === 'form' ? (s as { raw: string }).raw : (s as { text: string }).text))
+      .join('');
+    expect(reconstructed).toBe(input);
   });
 });
 


### PR DESCRIPTION
## Why

The model sometimes mentions the `<question-form>` tag name inside backtick-quoted prose while reasoning aloud before emitting the real form. `splitOnQuestionForms` matched the first open tag (inside prose) against the real form's close tag. The body between them wasn't valid JSON, so the parse failed and the real form was swallowed as plain text. `findFirstQuestionForm` returned null, clicking the Questions banner fell through to the manual/historical path which forces `interactive=false`, locking all inputs.

The trigger is narrow: the model must mention the tag name in prose right before emitting a real form. Most conversations don't hit this.

## What users will see

The chat still shows the "Mind if I ask a couple of quick questions?" banner. Clicking it now opens an interactive Questions panel where options can be selected, instead of a locked form with all inputs disabled.

## Surface area

- [x] **None** — internal refactor, tests only

## Bug fix verification

- Test path: `apps/web/tests/artifacts/question-form.test.ts` — `splitOnQuestionForms > unwinds a false-positive open tag mentioned in prose and re-parses the real form`
- Test went red on `main` and green on this branch: yes

## Validation

- `pnpm --filter @open-design/web test` — 411 test files, 4292 tests passed
- `pnpm guard` + `pnpm typecheck` — passed