### PR TITLE
fix(daemon): cancel active runs when deleting a conversation or project (#5468)

### DIFF
--- a/apps/daemon/src/routes/project/cancel-owned-runs.ts
+++ b/apps/daemon/src/routes/project/cancel-owned-runs.ts
@@ -1,0 +1,33 @@
+// The slice of the run service this helper needs. Kept structural so it is
+// satisfied by the real `design.runs` without depending on the daemon's loose
+// `ServerContext.design: any` type.
+interface RunCancellationService {
+  list: (filter: { projectId?: string; conversationId?: string; status?: string }) => unknown[];
+  cancel: (run: unknown) => Promise<unknown>;
+}
+
+/**
+ * Terminate every still-active agent run owned by a conversation or project
+ * before its row is deleted.
+ *
+ * Deleting a conversation or project must not orphan a live agent CLI
+ * subprocess: without this the child keeps consuming provider quota, the run
+ * stays non-terminal in `GET /api/runs` with no UI trace, and for a project
+ * delete the process keeps writing into a directory that has been removed out
+ * from under it (#5468). The run service already knows how to stop a run —
+ * `cancel` terminates the child and marks it `canceled` — so the delete
+ * handlers just have to call it for the runs they would otherwise strand.
+ *
+ * `list({ status: 'active' })` already filters to non-terminal runs, and
+ * `cancel` is a no-op on an already-terminal run, so this is safe to call
+ * unconditionally and races with a naturally-finishing run harmlessly. A
+ * cancellation failure is swallowed per-run so it can never block the delete
+ * the user asked for.
+ */
+export async function cancelRunsOwnedBy(
+  runs: RunCancellationService,
+  scope: { conversationId?: string; projectId?: string },
+): Promise<void> {
+  const active = runs.list({ ...scope, status: 'active' });
+  await Promise.all(active.map((run) => runs.cancel(run).catch(() => {})));
+}

--- a/apps/daemon/src/routes/project/conversations.ts
+++ b/apps/daemon/src/routes/project/conversations.ts
@@ -4,8 +4,9 @@ import { readAnalyticsContext } from '../../analytics.js';
 import { backfillBrandExtractionTranscriptForProject } from '../../brands/index.js';
 import type { RouteDeps } from '../../server-context.js';
 import { registerProjectCommentRoutes } from './comments.js';
+import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
 
-export interface RegisterProjectConversationRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'projectStore' | 'conversations' | 'ids' | 'telemetry' | 'appConfig' | 'agents'> {}
+export interface RegisterProjectConversationRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'conversations' | 'ids' | 'telemetry' | 'appConfig' | 'agents'> {}
 
 function normalizeChatSessionMode(value: unknown): ChatSessionMode {
   return value === 'chat' || value === 'plan' ? value : 'design';
@@ -16,7 +17,7 @@ function isChatSessionMode(value: unknown): value is ChatSessionMode {
 }
 
 export function registerProjectConversationRoutes(app: Express, ctx: RegisterProjectConversationRoutesDeps): void {
-  const { db } = ctx;
+  const { db, design } = ctx;
   const { sendApiError } = ctx.http;
   const { getProject, updateProject } = ctx.projectStore;
   const {
@@ -148,11 +149,14 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
     res.json({ conversation: updated });
   });
 
-  app.delete('/api/projects/:id/conversations/:cid', (req, res) => {
+  app.delete('/api/projects/:id/conversations/:cid', async (req, res) => {
     const conv = getConversation(db, req.params.cid);
     if (!conv || conv.projectId !== req.params.id) {
       return res.status(404).json({ error: 'not found' });
     }
+    // Stop any live agent run for this conversation before the row is gone,
+    // otherwise the CLI subprocess is orphaned and keeps billing (#5468).
+    await cancelRunsOwnedBy(design.runs, { conversationId: req.params.cid });
     deleteConversation(db, req.params.cid);
     res.json({ ok: true });
   });

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -56,6 +56,7 @@ import {
 import { auditDesignSystemPackage } from '../../tools-connectors-cli.js';
 import { parseOrchestratorWorkspace } from '../../workspace-contract.js';
 import { registerProjectConversationRoutes } from './conversations.js';
+import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
 
 export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'appConfig' | 'agents' | 'validation'> {}
 
@@ -2177,6 +2178,10 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
 
   app.delete('/api/projects/:id', async (req, res) => {
     try {
+      // Stop any live agent run in this project before its row and directory
+      // are removed, otherwise the CLI subprocess is orphaned — it keeps
+      // billing and writes into a directory that no longer exists (#5468).
+      await cancelRunsOwnedBy(design.runs, { projectId: req.params.id });
       dbDeleteProject(db, req.params.id);
       await removeProjectDir(PROJECTS_DIR, req.params.id).catch(() => {});
       /** @type {import('@open-design/contracts').OkResponse} */

--- a/apps/daemon/tests/cancel-owned-runs.test.ts
+++ b/apps/daemon/tests/cancel-owned-runs.test.ts
@@ -1,0 +1,56 @@
+// Unit coverage for the shared invariant behind #5468: cancelRunsOwnedBy must
+// terminate exactly the still-active runs owned by a scope (project or
+// conversation) and leave everything else alone. The conversation DELETE path
+// is exercised end-to-end in delete-cancels-active-runs.test.ts; this locks the
+// project scope and the terminal/foreign-scope edges against a real run service.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { cancelRunsOwnedBy } from '../src/routes/project/cancel-owned-runs.js';
+import { createChatRunService } from '../src/runtimes/runs.js';
+
+function makeRunService() {
+  return createChatRunService({
+    createSseResponse: () => ({ send: vi.fn(() => true), end: vi.fn(), cleanup: vi.fn() }),
+    createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+    shutdownGraceMs: 10,
+    ttlMs: 60_000,
+  });
+}
+
+describe('cancelRunsOwnedBy (#5468)', () => {
+  it('cancels active runs owned by a project and leaves other projects alone', async () => {
+    const runs = makeRunService();
+    const mine = runs.create({ projectId: 'p1', conversationId: 'c1' });
+    const other = runs.create({ projectId: 'p2', conversationId: 'c2' });
+
+    await cancelRunsOwnedBy(runs, { projectId: 'p1' });
+
+    expect(mine.status).toBe('canceled');
+    expect(other.status).not.toBe('canceled');
+    expect(runs.list({ projectId: 'p1', status: 'active' })).toEqual([]);
+    expect(runs.list({ projectId: 'p2', status: 'active' })).toHaveLength(1);
+  });
+
+  it('cancels active runs owned by a conversation only', async () => {
+    const runs = makeRunService();
+    const mine = runs.create({ projectId: 'p1', conversationId: 'c1' });
+    const sibling = runs.create({ projectId: 'p1', conversationId: 'c2' });
+
+    await cancelRunsOwnedBy(runs, { conversationId: 'c1' });
+
+    expect(mine.status).toBe('canceled');
+    expect(sibling.status).not.toBe('canceled');
+  });
+
+  it('is a no-op when the scope owns no active runs', async () => {
+    const runs = makeRunService();
+    const already = runs.create({ projectId: 'p1', conversationId: 'c1' });
+    await runs.cancel(already);
+    expect(already.status).toBe('canceled');
+
+    // Should not throw and should not resurrect or re-cancel anything.
+    await expect(cancelRunsOwnedBy(runs, { projectId: 'p1' })).resolves.toBeUndefined();
+    expect(runs.list({ projectId: 'p1', status: 'active' })).toEqual([]);
+  });
+});

--- a/apps/daemon/tests/delete-cancels-active-runs.test.ts
+++ b/apps/daemon/tests/delete-cancels-active-runs.test.ts
@@ -1,0 +1,170 @@
+// Regression for #5468: deleting a conversation (or project) must terminate
+// any still-active agent run it owns. Before the fix the DELETE handler only
+// removed the row, leaving the run's CLI subprocess alive — it kept burning
+// provider quota, stayed `running` in GET /api/runs with no UI trace, and for
+// a project delete kept writing into a directory that had been rm'd out from
+// under it.
+//
+// This exercises the real HTTP boundary: a bare Express app with the actual
+// conversation route registrar and a real run service, so the assertion is on
+// observable behavior (the run ends `canceled`) rather than on source shape.
+
+import express from 'express';
+import type { Response } from 'express';
+import type { AddressInfo } from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  closeDatabase,
+  deleteConversation,
+  getConversation,
+  getProject,
+  insertConversation,
+  insertProject,
+  listConversations,
+  listMessages,
+  openDatabase,
+  updateConversation,
+  updateProject,
+  upsertMessage,
+} from '../src/db.js';
+import { createChatRunService } from '../src/runtimes/runs.js';
+import {
+  registerProjectConversationRoutes,
+  type RegisterProjectConversationRoutesDeps,
+} from '../src/routes/project/conversations.js';
+
+type Db = ReturnType<typeof openDatabase>;
+
+function makeRunService() {
+  return createChatRunService({
+    createSseResponse: () => ({ send: vi.fn(() => true), end: vi.fn(), cleanup: vi.fn() }),
+    createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+    shutdownGraceMs: 10,
+    ttlMs: 60_000,
+  });
+}
+
+async function mountConversationApp(
+  db: Db,
+  runs: ReturnType<typeof createChatRunService>,
+  tempDir: string,
+) {
+  const app = express();
+  app.use(express.json());
+  registerProjectConversationRoutes(app, {
+    db,
+    http: {
+      sendApiError: (res: Response, status: number, code: string, message: string) =>
+        res.status(status).json({ error: { code, message } }),
+    },
+    paths: { BRANDS_DIR: tempDir, PROJECTS_DIR: tempDir, RUNTIME_DATA_DIR: tempDir },
+    projectStore: { getProject, updateProject },
+    conversations: {
+      insertConversation,
+      getConversation,
+      listConversations,
+      updateConversation,
+      deleteConversation,
+      listMessages,
+      upsertMessage,
+    },
+    ids: { randomId: () => 'rid-' + Math.random().toString(36).slice(2) },
+    appConfig: { readAppConfig: async () => ({}) },
+    agents: { getAgentDef: () => null },
+    design: { runs },
+  } as unknown as RegisterProjectConversationRoutesDeps);
+
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  return {
+    base,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe('DELETE conversation cancels its active runs (#5468)', () => {
+  let tempDir: string;
+  let db: Db;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-5468-'));
+    db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, { id: 'p1', name: 'Project', createdAt: now, updatedAt: now });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('terminates a still-active run owned by the deleted conversation', async () => {
+    const now = Date.now();
+    insertConversation(db, {
+      id: 'c1',
+      projectId: 'p1',
+      title: null,
+      sessionMode: 'design',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const runs = makeRunService();
+    const run = runs.create({ projectId: 'p1', conversationId: 'c1' });
+    expect(runs.isTerminal(run.status)).toBe(false);
+
+    const app = await mountConversationApp(db, runs, tempDir);
+    try {
+      const res = await fetch(`${app.base}/api/projects/p1/conversations/c1`, {
+        method: 'DELETE',
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      await app.close();
+    }
+
+    expect(run.status).toBe('canceled');
+    expect(runs.list({ conversationId: 'c1', status: 'active' })).toEqual([]);
+  });
+
+  it('leaves runs owned by other conversations untouched', async () => {
+    const now = Date.now();
+    insertConversation(db, {
+      id: 'c1',
+      projectId: 'p1',
+      title: null,
+      sessionMode: 'design',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'c2',
+      projectId: 'p1',
+      title: null,
+      sessionMode: 'design',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const runs = makeRunService();
+    const doomed = runs.create({ projectId: 'p1', conversationId: 'c1' });
+    const bystander = runs.create({ projectId: 'p1', conversationId: 'c2' });
+
+    const app = await mountConversationApp(db, runs, tempDir);
+    try {
+      const res = await fetch(`${app.base}/api/projects/p1/conversations/c1`, { method: 'DELETE' });
+      expect(res.status).toBe(200);
+    } finally {
+      await app.close();
+    }
+
+    expect(doomed.status).toBe('canceled');
+    expect(bystander.status).not.toBe('canceled');
+    expect(runs.list({ conversationId: 'c2', status: 'active' })).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #5468

## Why

A common way to stop an agent that has gone off the rails is to delete the conversation — or the whole project — it is running in. Today that does not actually stop it: the two DELETE handlers only remove the row (and, for a project, the directory), and never cancel the run they own. The agent CLI subprocess keeps running the full turn, so it keeps consuming provider quota for a conversation/project that no longer exists, the run stays non-terminal in `GET /api/runs/:id` with no UI trace, and for a project delete the process keeps writing into a directory that has just been `rm`'d out from under it.

The daemon already knows how to stop a run cleanly — `design.runs.cancel(run)` terminates the child and marks it `canceled` — the delete handlers just never called it. This wires that existing capability into both delete paths so "delete to stop it" behaves the way users expect.

## What users will see

Deleting a conversation or project now actually stops its in-flight agent run instead of leaving it running in the background. No more silent provider billing after you delete a conversation to abort a runaway generation, and no more orphaned process writing into a project directory you just deleted. The delete controls themselves look and behave the same — they just also stop the work now.

## How it works

A small shared helper, `cancelRunsOwnedBy(design.runs, { conversationId } | { projectId })`, lists the non-terminal runs owned by that scope (`design.runs.list({ ...scope, status: 'active' })`) and awaits `cancel` on each before the row/directory is removed. It is safe to call unconditionally: `list({ status: 'active' })` already excludes terminal runs, `cancel` is a no-op on an already-terminal run, and a per-run cancellation failure is swallowed so it can never block the delete the user asked for. The conversation DELETE handler becomes `async` and gains the existing `design` dependency (its registrar is already handed the project route context, which carries `design`).

These two HTTP handlers are the only user-facing paths that can strand a live run: the other `deleteConversation` / `deleteProject` callers in the daemon are create-then-rollback cleanup paths (`if (insertedProject) …`) that run before any agent has started, so they have nothing to cancel. The project scope cancels by `projectId`, which every run carries, so it covers all of a project's runs directly without walking its conversations.

## Surface area

- Daemon HTTP routes: `DELETE /api/projects/:id/conversations/:cid` and `DELETE /api/projects/:id` — behavior change only, no new endpoint, no request/response shape change.
- UI/CLI dual-track: both the web delete controls and `od` drive the same `/api/*` DELETE endpoints, so both surfaces get the fix with no new surface to add.
- No `packages/contracts` change, no i18n keys, no new dependencies, no migrations.

## Bug fix verification

Red spec: `apps/daemon/tests/delete-cancels-active-runs.test.ts` mounts the real conversation route registrar with a real run service, creates a still-active run for a conversation, and DELETEs the conversation over HTTP. It went **red on `main`** (`expected 'queued' to be 'canceled'` — the run was left running) and is **green on this branch**. A second case asserts a run owned by a different conversation is left untouched.

`apps/daemon/tests/cancel-owned-runs.test.ts` locks the shared helper for the project scope and the edges (foreign scope untouched, terminal runs skipped, no-op when nothing is active).

## Validation

- `pnpm --filter @open-design/daemon typecheck` — clean.
- `pnpm guard` — 78/78.
- `pnpm --filter @open-design/daemon exec vitest run tests/delete-cancels-active-runs.test.ts tests/cancel-owned-runs.test.ts tests/server-startup-smoke.test.ts tests/mcp-spawn.test.ts` — 24/24 passing (the two new specs plus the existing full-app delete-path suites, no regression).
