### PR TITLE
fix(frontmatter): parse flush-left YAML sequences, quoted inline arrays, and deep block scalars

### DIFF
--- a/apps/daemon/src/design-systems/frontmatter.ts
+++ b/apps/daemon/src/design-systems/frontmatter.ts
@@ -36,13 +36,29 @@ function parseYamlSubset(src: string): FrontmatterObject {
       continue;
     }
     const indent = raw.match(/^\s*/)?.[0].length ?? 0;
+    const line = raw.slice(indent);
 
+    // A block sequence may sit at the SAME indentation as its parent mapping
+    // key (the flush-left `key:` / `- item` style). Such a `- ` item belongs
+    // to the pending key placeholder at its own indent, so don't pop that
+    // placeholder the way a normal dedent would — it is either the empty
+    // object still awaiting a value or the array we already started for it.
+    const isSeqItem = line.startsWith('- ');
     while (stack.length > 1 && indent <= (stack[stack.length - 1]?.indent ?? -1)) {
+      const entry = stack[stack.length - 1];
+      if (
+        entry &&
+        isSeqItem &&
+        indent === entry.indent &&
+        entry.key !== null &&
+        (Array.isArray(entry.container) || Object.keys(entry.container).length === 0)
+      ) {
+        break;
+      }
       stack.pop();
     }
     const top = stack[stack.length - 1];
     if (!top) throw new Error('frontmatter parser stack invariant violated');
-    const line = raw.slice(indent);
 
     // Array item
     if (line.startsWith('- ')) {
@@ -99,7 +115,12 @@ function parseYamlSubset(src: string): FrontmatterObject {
 
     if (val === '|' || val === '|-' || val === '>' || val === '>-') {
       const collected = [];
-      const childIndent = indent + 2;
+      // YAML derives a block scalar's indentation from its first non-empty
+      // content line, not a fixed key+2, so content indented deeper than
+      // key+2 is stripped to its own base instead of keeping spurious
+      // leading whitespace. Relative indentation deeper than the base is
+      // preserved.
+      let blockIndent = -1;
       i++;
       while (i < lines.length) {
         const next = lines[i] ?? '';
@@ -109,8 +130,10 @@ function parseYamlSubset(src: string): FrontmatterObject {
           continue;
         }
         const nIndent = next.match(/^\s*/)?.[0].length ?? 0;
-        if (nIndent < childIndent) break;
-        collected.push(next.slice(childIndent));
+        if (nIndent <= indent) break;
+        if (blockIndent === -1) blockIndent = nIndent;
+        if (nIndent < blockIndent) break;
+        collected.push(next.slice(blockIndent));
         i++;
       }
       if (Array.isArray(top.container)) throw new Error('frontmatter object container expected');
@@ -127,9 +150,7 @@ function parseYamlSubset(src: string): FrontmatterObject {
 
     if (val.startsWith('[') && val.endsWith(']')) {
       if (Array.isArray(top.container)) throw new Error('frontmatter object container expected');
-      top.container[key] = val
-        .slice(1, -1)
-        .split(',')
+      top.container[key] = splitInlineArrayItems(val.slice(1, -1))
         .map((s) => coerce(s.trim()))
         .filter((v) => v !== '');
       i++;
@@ -142,6 +163,34 @@ function parseYamlSubset(src: string): FrontmatterObject {
   }
 
   return root;
+}
+
+// Split an inline-array body (`a, "b,c", 'd'`) on top-level commas only, so a
+// comma inside a quoted element is not treated as a separator. A quote only
+// opens a quoted element when it is that element's first non-whitespace
+// character; a quote mid-token (e.g. the apostrophe in `don't`) is a literal
+// plain-scalar character. Escaping inside quotes is out of scope, matching the
+// rest of this minimal parser.
+function splitInlineArrayItems(inner: string): string[] {
+  const items: string[] = [];
+  let buf = '';
+  let quote: '"' | "'" | null = null;
+  for (const ch of inner) {
+    if (quote) {
+      buf += ch;
+      if (ch === quote) quote = null;
+    } else if ((ch === '"' || ch === "'") && buf.trim() === '') {
+      quote = ch;
+      buf += ch;
+    } else if (ch === ',') {
+      items.push(buf);
+      buf = '';
+    } else {
+      buf += ch;
+    }
+  }
+  items.push(buf);
+  return items;
 }
 
 function coerce(raw: string | undefined): FrontmatterValue {

--- a/apps/daemon/tests/frontmatter.test.ts
+++ b/apps/daemon/tests/frontmatter.test.ts
@@ -57,3 +57,54 @@ describe('parseFrontmatter scalar coercion', () => {
     expect(data("a: '").a).toBe("'");
   });
 });
+
+describe('parseFrontmatter block sequences and arrays', () => {
+  // A block sequence may sit at the same indentation as its mapping key (the
+  // common flush-left `tags:` / `- item` YAML style). These items must attach
+  // to the key rather than being dropped.
+  it('parses a flush-left (zero-indent) block sequence', () => {
+    expect(data('tags:\n- a\n- b').tags).toEqual(['a', 'b']);
+  });
+
+  it('parses a nested flush-left sequence without dropping enclosing keys', () => {
+    expect(data('od:\n  craft:\n    requires:\n    - alpha\n    - beta').od).toEqual({
+      craft: { requires: ['alpha', 'beta'] },
+    });
+  });
+
+  it('parses a flush-left sequence of single-line objects', () => {
+    expect(data('items:\n- k: 1\n  v: 2\n- k: 3').items).toEqual([{ k: 1, v: 2 }, { k: 3 }]);
+  });
+
+  it('returns to the parent level for a key following a flush-left sequence', () => {
+    expect(data('tags:\n- a\n- b\nname: foo')).toEqual({ tags: ['a', 'b'], name: 'foo' });
+  });
+
+  it('still parses an indented block sequence', () => {
+    expect(data('tags:\n  - a\n  - b').tags).toEqual(['a', 'b']);
+  });
+
+  it('does not split inline-array elements on commas inside quotes', () => {
+    expect(data('a: ["a,b", "c"]').a).toEqual(['a,b', 'c']);
+    expect(data("a: ['x, y', z]").a).toEqual(['x, y', 'z']);
+  });
+
+  it('treats an apostrophe inside an unquoted inline-array element as literal', () => {
+    expect(data("tags: [don't, stop]").tags).toEqual(["don't", 'stop']);
+  });
+
+  it('still splits plain inline arrays on commas', () => {
+    expect(data('a: [x, y, z]').a).toEqual(['x', 'y', 'z']);
+  });
+
+  // A block scalar's indentation is derived from its first content line, not a
+  // fixed key+2, so content indented deeper is not left with leading spaces
+  // while relative indentation deeper than that base is preserved.
+  it('strips a block scalar to its own base indentation', () => {
+    expect(data('text: |\n    line one\n    line two').text).toBe('line one\nline two');
+  });
+
+  it('preserves relative indentation inside a block scalar', () => {
+    expect(data('text: |\n  a\n    b').text).toBe('a\n  b');
+  });
+});

--- a/packages/plugin-runtime/src/parsers/frontmatter.ts
+++ b/packages/plugin-runtime/src/parsers/frontmatter.ts
@@ -78,13 +78,29 @@ function parseYamlSubset(src: string): FrontmatterObject {
       continue;
     }
     const indent = raw.match(/^\s*/)?.[0].length ?? 0;
+    const line = raw.slice(indent);
 
+    // A block sequence may sit at the SAME indentation as its parent mapping
+    // key (the flush-left `key:` / `- item` style). Such a `- ` item belongs
+    // to the pending key placeholder at its own indent, so don't pop that
+    // placeholder the way a normal dedent would — it is either the empty
+    // object still awaiting a value or the array we already started for it.
+    const isSeqItem = line.startsWith('- ');
     while (stack.length > 1 && indent <= (stack[stack.length - 1]?.indent ?? -1)) {
+      const entry = stack[stack.length - 1];
+      if (
+        entry &&
+        isSeqItem &&
+        indent === entry.indent &&
+        entry.key !== null &&
+        (Array.isArray(entry.container) || Object.keys(entry.container).length === 0)
+      ) {
+        break;
+      }
       stack.pop();
     }
     const top = stack[stack.length - 1];
     if (!top) throw new Error('frontmatter parser stack invariant violated');
-    const line = raw.slice(indent);
 
     if (line.startsWith('- ')) {
       const value = line.slice(2).trim();
@@ -138,7 +154,12 @@ function parseYamlSubset(src: string): FrontmatterObject {
 
     if (val === '|' || val === '|-' || val === '>' || val === '>-') {
       const collected: string[] = [];
-      const childIndent = indent + 2;
+      // YAML derives a block scalar's indentation from its first non-empty
+      // content line, not a fixed key+2, so content indented deeper than
+      // key+2 is stripped to its own base instead of keeping spurious
+      // leading whitespace. Relative indentation deeper than the base is
+      // preserved.
+      let blockIndent = -1;
       i++;
       while (i < lines.length) {
         const next = lines[i] ?? '';
@@ -148,8 +169,10 @@ function parseYamlSubset(src: string): FrontmatterObject {
           continue;
         }
         const nIndent = next.match(/^\s*/)?.[0].length ?? 0;
-        if (nIndent < childIndent) break;
-        collected.push(next.slice(childIndent));
+        if (nIndent <= indent) break;
+        if (blockIndent === -1) blockIndent = nIndent;
+        if (nIndent < blockIndent) break;
+        collected.push(next.slice(blockIndent));
         i++;
       }
       if (Array.isArray(top.container)) throw new Error('frontmatter object container expected');
@@ -166,9 +189,7 @@ function parseYamlSubset(src: string): FrontmatterObject {
 
     if (val.startsWith('[') && val.endsWith(']')) {
       if (Array.isArray(top.container)) throw new Error('frontmatter object container expected');
-      top.container[key] = val
-        .slice(1, -1)
-        .split(',')
+      top.container[key] = splitInlineArrayItems(val.slice(1, -1))
         .map((s) => coerce(s.trim()))
         .filter((v): v is FrontmatterValue => v !== '');
       i++;
@@ -181,6 +202,34 @@ function parseYamlSubset(src: string): FrontmatterObject {
   }
 
   return root;
+}
+
+// Split an inline-array body (`a, "b,c", 'd'`) on top-level commas only, so a
+// comma inside a quoted element is not treated as a separator. A quote only
+// opens a quoted element when it is that element's first non-whitespace
+// character; a quote mid-token (e.g. the apostrophe in `don't`) is a literal
+// plain-scalar character. Escaping inside quotes is out of scope, matching the
+// rest of this minimal parser.
+function splitInlineArrayItems(inner: string): string[] {
+  const items: string[] = [];
+  let buf = '';
+  let quote: '"' | "'" | null = null;
+  for (const ch of inner) {
+    if (quote) {
+      buf += ch;
+      if (ch === quote) quote = null;
+    } else if ((ch === '"' || ch === "'") && buf.trim() === '') {
+      quote = ch;
+      buf += ch;
+    } else if (ch === ',') {
+      items.push(buf);
+      buf = '';
+    } else {
+      buf += ch;
+    }
+  }
+  items.push(buf);
+  return items;
 }
 
 function coerce(raw: string | undefined): FrontmatterValue {

--- a/packages/plugin-runtime/tests/parsers.test.ts
+++ b/packages/plugin-runtime/tests/parsers.test.ts
@@ -148,4 +148,61 @@ describe('parseFrontmatter', () => {
     const { data } = parseFrontmatter('---\na: "\n---\n');
     expect(data['a']).toBe('"');
   });
+
+  // A block sequence may sit at the same indentation as its mapping key (the
+  // common flush-left `tags:` / `- item` YAML style). These items must attach
+  // to the key rather than being dropped.
+  it('parses a flush-left (zero-indent) block sequence', () => {
+    const { data } = parseFrontmatter('---\ntags:\n- a\n- b\n---\n');
+    expect(data['tags']).toEqual(['a', 'b']);
+  });
+
+  it('parses a nested flush-left sequence without dropping enclosing keys', () => {
+    const { data } = parseFrontmatter('---\nod:\n  craft:\n    requires:\n    - alpha\n    - beta\n---\n');
+    expect(data['od']).toEqual({ craft: { requires: ['alpha', 'beta'] } });
+  });
+
+  it('parses a flush-left sequence of single-line objects', () => {
+    const { data } = parseFrontmatter('---\nitems:\n- k: 1\n  v: 2\n- k: 3\n---\n');
+    expect(data['items']).toEqual([{ k: 1, v: 2 }, { k: 3 }]);
+  });
+
+  it('returns to the parent level for a key following a flush-left sequence', () => {
+    const { data } = parseFrontmatter('---\ntags:\n- a\n- b\nname: foo\n---\n');
+    expect(data).toEqual({ tags: ['a', 'b'], name: 'foo' });
+  });
+
+  it('still parses an indented block sequence', () => {
+    const { data } = parseFrontmatter('---\ntags:\n  - a\n  - b\n---\n');
+    expect(data['tags']).toEqual(['a', 'b']);
+  });
+
+  it('does not split inline-array elements on commas inside quotes', () => {
+    const { data } = parseFrontmatter('---\na: ["a,b", "c"]\nb: [\'x, y\', z]\n---\n');
+    expect(data['a']).toEqual(['a,b', 'c']);
+    expect(data['b']).toEqual(['x, y', 'z']);
+  });
+
+  it('treats an apostrophe inside an unquoted inline-array element as literal', () => {
+    const { data } = parseFrontmatter("---\ntags: [don't, stop]\n---\n");
+    expect(data['tags']).toEqual(["don't", 'stop']);
+  });
+
+  it('still splits plain inline arrays on commas', () => {
+    const { data } = parseFrontmatter('---\na: [x, y, z]\n---\n');
+    expect(data['a']).toEqual(['x', 'y', 'z']);
+  });
+
+  // A block scalar's indentation is derived from its first content line, not a
+  // fixed key+2, so content indented deeper is not left with leading spaces
+  // while relative indentation deeper than that base is preserved.
+  it('strips a block scalar to its own base indentation', () => {
+    const { data } = parseFrontmatter('---\ntext: |\n    line one\n    line two\n---\n');
+    expect(data['text']).toBe('line one\nline two');
+  });
+
+  it('preserves relative indentation inside a block scalar', () => {
+    const { data } = parseFrontmatter('---\ntext: |\n  a\n    b\n---\n');
+    expect(data['text']).toBe('a\n  b');
+  });
 });


### PR DESCRIPTION
## Why

Scratching an itch found while auditing the SKILL.md / design-system frontmatter parser. Three common YAML shapes were mis-parsed, and because `skills.ts` and `adaptAgentSkill` parse every installed SKILL.md, plugin metadata authored in the affected styles was being silently lost or corrupted.

## What users will see

Skills and design systems whose frontmatter uses standard YAML that the parser previously mishandled now load their metadata correctly — flush-left `tags:` lists, inline arrays containing quoted commas or apostrophes (e.g. `[don't, stop]`), and block scalars indented deeper than key+2 — instead of dropping or corrupting those values.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test paths: `packages/plugin-runtime/tests/parsers.test.ts` and `apps/daemon/tests/frontmatter.test.ts` (new `parseFrontmatter` cases).
- Did the tests go red on `main` and green on this branch? **yes** — the seven new cases fail on `main` (items dropped / arrays split inside quotes / block scalars keep leading whitespace) and pass on this branch; existing cases stay green.

## Validation

- Ran both parsers' committed test suites against the fixed sources (all green) plus `tsc` on the changed files. Full `pnpm guard` / `pnpm typecheck` left to CI (workspace deps only partially installed locally).

---

The SKILL.md / design-system frontmatter parser mishandled three common YAML shapes. open-design ships two near-identical copies of this parser — `packages/plugin-runtime/src/parsers/frontmatter.ts` (used by `adaptAgentSkill`) and `apps/daemon/src/design-systems/frontmatter.ts` (imported directly by the daemon's `skills.ts`, `memory.ts`, and design-system loader) — and both had all three bugs, so both are fixed identically with red→green tests. No dependency or API change.

**1. Flush-left block sequences were silently dropped (primary).** A mapping whose block sequence sits at the same indentation as its key — the standard YAML style — was mis-parsed: `tags:` followed by flush-left `- a` / `- b` produced `{ tags: {} }` (every item discarded), and the nested form overwrote the enclosing object with the array, losing the real key name. The stack-pop loop popped the key's placeholder on equal indent before the `- ` branch ran; a `- ` item at its key's indent now attaches to that key.

**2. Inline arrays split inside quotes / on apostrophes.** `["a,b", "c"]` parsed to `['"a', 'b"', 'c']`. Splitting now treats a `,` as a separator only at top level, and a quote opens a quoted element only when it is that element's first non-whitespace character — so `[don't, stop]` stays `["don't", "stop"]`.

**3. Block scalars kept spurious indentation.** `|` blocks stripped a fixed key+2 columns, so content indented deeper kept leading whitespace. The block's base indent is now taken from its first content line (matching YAML), and relative indentation deeper than the base is preserved.

Note: the two parser copies are intentionally left as parallel copies rather than deduplicated — their outer `parseFrontmatter` delimiter handling differs, so unifying them would change daemon behavior and is better left as a separate refactor.
