### PR TITLE
fix: preserve dark-first brand canvases in derived themes

### DIFF
--- a/apps/daemon/src/brands/engine/build.ts
+++ b/apps/daemon/src/brands/engine/build.ts
@@ -29,7 +29,7 @@ import type { Brand, AssetKind } from "../schema.js";
 import { injectFontFaces, type FontFile } from "../fonts.js";
 import { prefetchBrand, type PrefetchResult } from "../prefetch.js";
 import type { BrandSystem, DesignTokens, SeedToken, ThemeAlgorithm } from "./types.js";
-import { deriveTokens } from "./derive.js";
+import { deriveTokens, defaultThemeAlgorithm } from "./derive.js";
 import { seedFromBrand, seedFromMaterial } from "./seed.js";
 import { tokensToJson, tokensToCssVars, tokensToThemeJson } from "./export.js";
 import { renderKitPage } from "./kit.js";
@@ -198,7 +198,10 @@ function assemble({ slug, brand, seed, extraFiles, fontFiles, fontsBase = "../" 
   files["scripts/apply-design-tokens.mjs"] = applyDesignTokensScript();
 
   // ── antd ConfigProvider theme ──
-  files["theme.json"] = tokensToThemeJson(seed, "default");
+  // Route through defaultThemeAlgorithm so a dark-first seed exports
+  // algorithm:"dark" here too, matching the dark math already baked into
+  // tokens.default.json / variables.css / kit.html.
+  files["theme.json"] = tokensToThemeJson(seed, defaultThemeAlgorithm(seed));
 
   // kit/index sit at the bundle root, artifacts one level deeper — each doc's
   // @font-face urls are relative to its own location.

--- a/apps/daemon/src/brands/engine/derive.ts
+++ b/apps/daemon/src/brands/engine/derive.ts
@@ -91,12 +91,23 @@ function lightThemeTextBase(input: string | undefined): string {
 }
 
 /**
- * A seed whose bg base is confidently dark marks a dark-first brand — seed
- * synthesis only lets a dark canvas through deliberately (see neutralBases in
- * seed.ts), so honoring it here keeps the default theme on-brand.
+ * A seed marks a dark-first brand only when it carries BOTH a confidently dark
+ * canvas AND a light foreground — the exact gate `neutralBases()` in seed.ts
+ * uses (dark bg + light fg → keep the dark canvas). Both must be checked here:
+ * the seed-override path (`rebuildSystem` → `sanitizeSeedOverrides`) can merge a
+ * background-only override such as `{ colorBgBase: "#050505" }` onto an
+ * otherwise light brand. Keying off `colorBgBase` alone would flip derivation to
+ * the dark ladder (forcing a white text base) while the seed still carried a
+ * dark `colorTextBase`, and `tokensToThemeJson(seed, defaultThemeAlgorithm(seed))`
+ * would then export `algorithm:"dark"` over that dark text — the very
+ * ConfigProvider mismatch this predicate exists to prevent. Thresholds mirror
+ * seed.ts (dark ≤ 0.3, light ≥ 0.6).
  */
 function seedPrefersDark(seed: SeedToken): boolean {
-  return luminance(parseHex(seed.colorBgBase || "#ffffff")) <= 0.3;
+  return (
+    luminance(parseHex(seed.colorBgBase || "#ffffff")) <= 0.3 &&
+    luminance(parseHex(seed.colorTextBase || "#000000")) >= 0.6
+  );
 }
 
 /**

--- a/apps/daemon/src/brands/engine/derive.ts
+++ b/apps/daemon/src/brands/engine/derive.ts
@@ -99,6 +99,19 @@ function seedPrefersDark(seed: SeedToken): boolean {
   return luminance(parseHex(seed.colorBgBase || "#ffffff")) <= 0.3;
 }
 
+/**
+ * The effective ConfigProvider algorithm for a seed's DEFAULT theme. A
+ * dark-first seed derives its default `tokens.default.json`, `variables.css`,
+ * and `kit.html` with dark palette + neutral math (see `deriveTokens` below),
+ * so the exported `theme.json` must carry `"dark"` to stay consistent with
+ * them — otherwise a ConfigProvider consumer applies the light algorithm to a
+ * dark canvas. Light and ambiguous seeds stay `"default"`. This is the single
+ * shared decision every `theme.json` producer must route through.
+ */
+export function defaultThemeAlgorithm(seed: SeedToken): ThemeAlgorithm {
+  return seedPrefersDark(seed) ? "dark" : "default";
+}
+
 function darkThemeTextBase(input: string | undefined): string {
   const hex = input || "#ffffff";
   return luminance(parseHex(hex)) >= 0.6 ? hex : "#ffffff";

--- a/apps/daemon/src/brands/engine/derive.ts
+++ b/apps/daemon/src/brands/engine/derive.ts
@@ -90,6 +90,20 @@ function lightThemeTextBase(input: string | undefined): string {
   return luminance(parseHex(hex)) <= 0.45 ? hex : "#000000";
 }
 
+/**
+ * A seed whose bg base is confidently dark marks a dark-first brand — seed
+ * synthesis only lets a dark canvas through deliberately (see neutralBases in
+ * seed.ts), so honoring it here keeps the default theme on-brand.
+ */
+function seedPrefersDark(seed: SeedToken): boolean {
+  return luminance(parseHex(seed.colorBgBase || "#ffffff")) <= 0.3;
+}
+
+function darkThemeTextBase(input: string | undefined): string {
+  const hex = input || "#ffffff";
+  return luminance(parseHex(hex)) >= 0.6 ? hex : "#ffffff";
+}
+
 // ─────────────────────────── color ladder mapping ───────────────────────────
 
 /** A semantic color's full interaction-state set, mapped off a 10-step ramp. */
@@ -225,35 +239,48 @@ export function deriveTokens(seed: SeedToken, algorithm: ThemeAlgorithm = "defau
   const isCompact = algorithm === "compact";
 
   // --- resolve the light/dark base canvas ------------------------------------
-  // Light and compact themes must stay visually light even when the source site
-  // is dark-native and the extractor records black as the observed background.
-  // Dark mode owns the near-black canvas; default/compact keep a light base and
-  // only preserve brand-provided neutral bases when they are already light/dark
-  // enough for readable light-mode contrast.
-  const textBaseHex = isDark ? "#ffffff" : lightThemeTextBase(seed.colorTextBase);
-  const bgBaseHex = isDark ? "#141414" : lightThemeBgBase(seed.colorBgBase);
+  // Default/compact stay visually light for ambiguous sources (a dark-native
+  // site whose extractor merely records black), but a seed that deliberately
+  // carries a dark canvas (dark-first brand, see seedPrefersDark) keeps it in
+  // every algorithm so the derived kit matches the brand. The dark algorithm
+  // owns the #141414 near-black only as the fallback for light-first brands.
+  const darkFirst = seedPrefersDark(seed);
+  const canvasDark = isDark || darkFirst;
+  const textBaseHex = canvasDark
+    ? darkThemeTextBase(darkFirst ? seed.colorTextBase : undefined)
+    : lightThemeTextBase(seed.colorTextBase);
+  const bgBaseHex = darkFirst
+    ? seed.colorBgBase
+    : isDark
+      ? "#141414"
+      : lightThemeBgBase(seed.colorBgBase);
   const textBase = parseHex(textBaseHex);
   const bgBase = parseHex(bgBaseHex);
 
-  const paletteOpts = isDark
+  // Color-state mapping and neutral alphas follow the canvas, not the
+  // algorithm label: a dark-first brand needs dark-legible states in its
+  // default theme too.
+  const stateAlgorithm: ThemeAlgorithm = canvasDark ? "dark" : algorithm;
+
+  const paletteOpts = canvasDark
     ? ({ theme: "dark", backgroundColor: bgBaseHex } as const)
     : undefined;
 
   // --- color palettes (primary + functional) ---------------------------------
   const primaryPalette = generate(seed.colorPrimary, paletteOpts);
-  const primary = statesFromPalette(primaryPalette, algorithm);
+  const primary = statesFromPalette(primaryPalette, stateAlgorithm);
 
-  const successStates = statesFromPalette(generate(seed.colorSuccess, paletteOpts), algorithm);
-  const warningStates = statesFromPalette(generate(seed.colorWarning, paletteOpts), algorithm);
-  const errorStates = statesFromPalette(generate(seed.colorError, paletteOpts), algorithm);
-  const infoStates = statesFromPalette(generate(seed.colorInfo, paletteOpts), algorithm);
+  const successStates = statesFromPalette(generate(seed.colorSuccess, paletteOpts), stateAlgorithm);
+  const warningStates = statesFromPalette(generate(seed.colorWarning, paletteOpts), stateAlgorithm);
+  const errorStates = statesFromPalette(generate(seed.colorError, paletteOpts), stateAlgorithm);
+  const infoStates = statesFromPalette(generate(seed.colorInfo, paletteOpts), stateAlgorithm);
 
   // colorLink falls back to colorInfo when empty (per SeedToken contract).
   const linkSeed = seed.colorLink && seed.colorLink.length > 0 ? seed.colorLink : seed.colorInfo;
-  const linkStates = statesFromPalette(generate(linkSeed, paletteOpts), algorithm);
+  const linkStates = statesFromPalette(generate(linkSeed, paletteOpts), stateAlgorithm);
 
   // --- neutral text / fill / bg / border via alpha over the base canvas -------
-  const na = neutralAlphas(algorithm);
+  const na = neutralAlphas(stateAlgorithm);
   const text = (a: number) => alphaOver(textBase, bgBase, a);
 
   const colorText = text(na.text[0]);
@@ -273,7 +300,7 @@ export function deriveTokens(seed: SeedToken, algorithm: ThemeAlgorithm = "defau
   // sit on the pure base. In dark mode elevated is lifted one notch lighter.
   const colorBgLayout = text(na.layout);
   const colorBgContainer = bgBaseHex;
-  const colorBgElevated = isDark ? alphaOver(textBase, bgBase, 0.08) : bgBaseHex;
+  const colorBgElevated = canvasDark ? alphaOver(textBase, bgBase, 0.08) : bgBaseHex;
 
   // --- typography -------------------------------------------------------------
   const fontSize = seed.fontSize;

--- a/apps/daemon/src/brands/engine/index.ts
+++ b/apps/daemon/src/brands/engine/index.ts
@@ -26,7 +26,7 @@ export { generate, presets } from "./palette.js";
 export { defaultSeed, seedFromBrand, seedFromMaterial } from "./seed.js";
 
 // ── derive: Seed → full DesignTokens for an algorithm ──
-export { deriveTokens } from "./derive.js";
+export { deriveTokens, defaultThemeAlgorithm } from "./derive.js";
 
 // ── export: serializers ──
 export { tokensToJson, tokensToCssVars, tokensToThemeJson } from "./export.js";

--- a/apps/daemon/src/brands/engine/seed.ts
+++ b/apps/daemon/src/brands/engine/seed.ts
@@ -158,6 +158,41 @@ function lightThemeForeground(raw: string | undefined): string {
   return hex && luminance(hex) <= 0.45 ? hex : defaultSeed.colorTextBase;
 }
 
+/** Canvas at or below this luminance reads as a deliberate dark background. */
+const DARK_CANVAS_MAX_LUMINANCE = 0.3;
+/** Foreground at or above this luminance reads as light text. */
+const LIGHT_FOREGROUND_MIN_LUMINANCE = 0.6;
+
+/**
+ * Resolve the seed's neutral bases from the brand's explicit neutral roles.
+ *
+ * A brand that carries BOTH a confidently dark background (or surface) AND a
+ * light foreground is dark-first: its canvas is preserved so the derived
+ * default theme stays on-brand instead of clamping to the light Ant baseline.
+ * Anything ambiguous (mid-gray canvas, missing roles, dark-on-dark) falls back
+ * to the light baseline exactly as before.
+ */
+function neutralBases(
+  background: string | undefined,
+  surface: string | undefined,
+  foreground: string | undefined,
+): { colorTextBase: string; colorBgBase: string } {
+  const bgHex = normalizeHex(background ?? "") ?? normalizeHex(surface ?? "");
+  const fgHex = normalizeHex(foreground ?? "");
+  const darkFirst =
+    bgHex !== null &&
+    fgHex !== null &&
+    luminance(bgHex) <= DARK_CANVAS_MAX_LUMINANCE &&
+    luminance(fgHex) >= LIGHT_FOREGROUND_MIN_LUMINANCE;
+  if (darkFirst) {
+    return { colorTextBase: fgHex, colorBgBase: bgHex };
+  }
+  return {
+    colorTextBase: lightThemeForeground(foreground),
+    colorBgBase: lightThemeBackground(background, surface),
+  };
+}
+
 // ─────────────────────────── Brand → Seed ───────────────────────────────────
 
 function findRole(colors: BrandColor[], role: BrandColor["role"]): BrandColor | undefined {
@@ -190,8 +225,10 @@ function fontStack(primaryFamily: string | undefined, fallbacks: string[]): stri
  *  - colorInfo     ← same as primary
  *  - colorLink     ← role "accent-secondary" (else "")
  *  - colorSuccess  ← accent-secondary if it reads green, else default
- *  - colorTextBase ← dark role "foreground"; light foregrounds fall back to black
- *  - colorBgBase   ← light role "background" / "surface"; dark canvases fall back to white
+ *  - colorTextBase / colorBgBase ← neutralBases(): dark-first brands (dark
+ *                    background + light foreground) keep their true canvas;
+ *                    otherwise light foregrounds fall back to black and dark
+ *                    canvases fall back to white as before
  *  - fontFamily    ← body face + fallbacks + system tail
  *  - borderRadius  ← parseInt(layout.radius) || 6
  *  - everything else ← defaultSeed
@@ -229,8 +266,7 @@ export function seedFromBrand(brand: Brand): SeedToken {
     colorInfo: primaryHex,
     colorLink: linkHex ?? "",
     colorSuccess: successHex,
-    colorTextBase: lightThemeForeground(foreground?.hex),
-    colorBgBase: lightThemeBackground(background?.hex, surface?.hex),
+    ...neutralBases(background?.hex, surface?.hex, foreground?.hex),
     fontFamily: fontStack(brand.typography?.body?.family, brand.typography?.body?.fallbacks ?? []),
     borderRadius: Number.isFinite(radius) && radius > 0 ? radius : defaultSeed.borderRadius,
   };

--- a/apps/daemon/src/brands/system.ts
+++ b/apps/daemon/src/brands/system.ts
@@ -8,6 +8,7 @@ import { sanitizeSeedOverrides } from './schema.js';
 import {
   brandFontAssets,
   buildBrandSystem,
+  defaultThemeAlgorithm,
   deriveTokens,
   renderArtifact,
   renderArtifactGallery,
@@ -67,7 +68,7 @@ function reassembleWithSeed(
     tokensToCssVars(themes.default, ':root') + '\n' + tokensToCssVars(themes.dark, '.dark');
   files['variables.dark.css'] = tokensToCssVars(themes.dark, ':root');
   files['scripts/apply-design-tokens.mjs'] = applyDesignTokensScript();
-  files['theme.json'] = tokensToThemeJson(seed, 'default');
+  files['theme.json'] = tokensToThemeJson(seed, defaultThemeAlgorithm(seed));
   const fonts = brandFontAssets(brand);
   files['kit.html'] = withFonts(
     renderKitPage(themes.default, {

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -29,7 +29,15 @@ import { patchMeta } from '../src/brands/store.js';
 import { ensureLogoFallback } from '../src/brands/logo-fallback.js';
 import { brandFromMaterial } from '../src/brands/provisional.js';
 import { listDesignSystems } from '../src/design-systems/index.js';
-import { buildBrandSystem, deriveTokens, seedFromMaterial } from '../src/brands/engine/index.js';
+import {
+  buildBrandSystem,
+  defaultSeed,
+  defaultThemeAlgorithm,
+  deriveTokens,
+  seedFromMaterial,
+  tokensToThemeJson,
+} from '../src/brands/engine/index.js';
+import type { SeedToken } from '../src/brands/engine/types.js';
 import {
   adoptExistingImagery,
   findImageRefs,
@@ -250,6 +258,27 @@ describe('agent-driven brand extraction engine', () => {
     expect(system.themes.dark.colorBgContainer).toBe('#141414');
     // ...and the exported ConfigProvider artifact stays on the light algorithm.
     expect(JSON.parse(system.files['theme.json'] ?? '').algorithm).toBe('default');
+  });
+
+  it('keeps theme.json algorithm consistent with the derived theme under a background-only seed override', () => {
+    // Locks the rebuildSystem seed-override path (sanitizeSeedOverrides →
+    // reassembleWithSeed → tokensToThemeJson(seed, defaultThemeAlgorithm(seed))):
+    // a background-only override on an otherwise light brand must NOT be treated
+    // as dark-first, or theme.json would export algorithm:"dark" while the seed
+    // still carries a dark colorTextBase — the ConfigProvider mismatch.
+    const bgOnlyDark: SeedToken = { ...defaultSeed, colorBgBase: '#050505' }; // colorTextBase stays #000000
+    expect(defaultThemeAlgorithm(bgOnlyDark)).toBe('default');
+    // The derived default theme clamps back to the light canvas...
+    expect(deriveTokens(bgOnlyDark, 'default').colorBgContainer).toBe('#ffffff');
+    // ...and the exported ConfigProvider algorithm matches it (no dark/light split).
+    expect(JSON.parse(tokensToThemeJson(bgOnlyDark, defaultThemeAlgorithm(bgOnlyDark))).algorithm).toBe('default');
+
+    // A full override supplying BOTH a dark canvas and a light foreground DOES
+    // opt into dark-first — consistently across the derived theme and export.
+    const fullDark: SeedToken = { ...defaultSeed, colorBgBase: '#050505', colorTextBase: '#f4f4f4' };
+    expect(defaultThemeAlgorithm(fullDark)).toBe('dark');
+    expect(deriveTokens(fullDark, 'default').colorBgContainer).toBe('#050505');
+    expect(JSON.parse(tokensToThemeJson(fullDark, defaultThemeAlgorithm(fullDark))).algorithm).toBe('dark');
   });
 
   it('keeps programmatic dark-site material on a light default seed', () => {

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -225,6 +225,10 @@ describe('agent-driven brand extraction engine', () => {
     expect(system.files['kit.html']).toContain('--brand-color-bg-container: #050505;');
     expect(system.files['kit.html']).not.toContain('--brand-color-bg-container: #ffffff;');
     expect(system.files['kit.dark.html']).toContain('--brand-color-bg-container: #050505;');
+    // The exported ConfigProvider artifact must carry the SAME effective
+    // algorithm as the tokens/CSS/kit above — otherwise a consumer applies the
+    // light algorithm to a dark canvas.
+    expect(JSON.parse(system.files['theme.json'] ?? '').algorithm).toBe('dark');
   });
 
   it('still falls back to the light default theme when brand neutrals are ambiguous', () => {
@@ -244,6 +248,8 @@ describe('agent-driven brand extraction engine', () => {
     // baseline exactly as before.
     expect(system.themes.default.colorBgContainer).toBe('#ffffff');
     expect(system.themes.dark.colorBgContainer).toBe('#141414');
+    // ...and the exported ConfigProvider artifact stays on the light algorithm.
+    expect(JSON.parse(system.files['theme.json'] ?? '').algorithm).toBe('default');
   });
 
   it('keeps programmatic dark-site material on a light default seed', () => {

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -200,7 +200,7 @@ describe('agent-driven brand extraction engine', () => {
   let projectsRoot: string;
   let userDesignSystemsRoot: string;
 
-  it('keeps the generated default theme light even when the source canvas is dark', () => {
+  it('adopts the brand canvas for the default theme when the brand is explicitly dark-first', () => {
     const darkCanvasBrand: Brand = {
       ...VALID_BRAND,
       name: 'Open Design',
@@ -214,14 +214,36 @@ describe('agent-driven brand extraction engine', () => {
 
     const system = buildBrandSystem(darkCanvasBrand);
 
+    // A brand that explicitly carries a dark background role plus a light
+    // foreground role is dark-first: the default theme keeps its canvas
+    // instead of clamping to the light Ant baseline.
+    expect(system.themes.default.colorBgContainer).toBe('#050505');
+    expect(system.themes.dark.colorBgContainer).toBe('#050505');
+    // Neutral text derives from the brand foreground over the dark canvas —
+    // it must read light, not the light-theme #1f1f1f.
+    expect(parseInt(system.themes.default.colorText.slice(1, 3), 16)).toBeGreaterThan(180);
+    expect(system.files['kit.html']).toContain('--brand-color-bg-container: #050505;');
+    expect(system.files['kit.html']).not.toContain('--brand-color-bg-container: #ffffff;');
+    expect(system.files['kit.dark.html']).toContain('--brand-color-bg-container: #050505;');
+  });
+
+  it('still falls back to the light default theme when brand neutrals are ambiguous', () => {
+    const midGrayBrand: Brand = {
+      ...VALID_BRAND,
+      name: 'Open Design',
+      colors: [
+        { role: 'background', hex: '#808080', oklch: 'oklch(60% 0 0)', name: 'Gray', usage: 'source background' },
+        { role: 'foreground', hex: '#f4f4f4', oklch: 'oklch(96% 0 0)', name: 'White', usage: 'source text' },
+        { role: 'accent', hex: '#56fe13', oklch: 'oklch(86% 0.29 142)', name: 'Signal Green', usage: 'primary actions' },
+      ],
+    };
+
+    const system = buildBrandSystem(midGrayBrand);
+
+    // A mid-gray canvas is not a confident dark-first signal; keep the light
+    // baseline exactly as before.
     expect(system.themes.default.colorBgContainer).toBe('#ffffff');
-    expect(system.themes.default.colorText).toBe('#1f1f1f');
     expect(system.themes.dark.colorBgContainer).toBe('#141414');
-    expect(system.themes.dark.colorText).toBe('#dcdcdc');
-    expect(system.files['kit.html']).toContain('--brand-color-bg-container: #ffffff;');
-    expect(system.files['kit.html']).toContain('--brand-color-text: #1f1f1f;');
-    expect(system.files['kit.html']).not.toContain('--brand-color-bg-container: #141414;');
-    expect(system.files['kit.dark.html']).toContain('--brand-color-bg-container: #141414;');
   });
 
   it('keeps programmatic dark-site material on a light default seed', () => {


### PR DESCRIPTION
Fixes #5500

## Why

Hit this while extracting design systems from dark-first sources (a near-black mobile-app case study on Behance, and a screenshot-based brand): the extraction itself captured the right palette in `brand.json`, but every derived kit rendered white. `seedFromBrand` clamps any background below 0.72 luminance to `#ffffff`, and `deriveTokens` re-clamps plus hardcodes `#141414`/`#ffffff` for the dark algorithm — so a dark-first brand's default theme looks nothing like the brand, and re-running finalize reverts any manual dark retheme the refine agent made. The pain is user-facing: "I gave it four dark screenshots and got a white design system."

## What users will see

Extracting a brand whose evidence carries an explicitly dark background + light foreground now yields a default theme on that brand's own canvas (and a dark theme on the brand's near-black instead of generic `#141414`). Light-first and ambiguous brands (mid-gray canvas, missing roles) derive exactly as before, and the programmatic URL fast pass intentionally still starts light.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — dark-first brands (explicit dark background role + light foreground role) now derive dark default kits; previously they were forced light. No schema or setting changes.
- [ ] **None**

## Screenshots

No new UI surface — the change is in derived token values. (Before: dark-first brand → white kit with `#1f1f1f` text. After: same brand → its own near-black canvas, light neutral ladder, dark palette math for interaction states.)

## Bug fix verification

- Test path: `apps/daemon/tests/brand-extraction-engine.test.ts` — `adopts the brand canvas for the default theme when the brand is explicitly dark-first`, plus `still falls back to the light default theme when brand neutrals are ambiguous` guarding the old behavior for ambiguous brands.
- Red on `main`, green on this branch? **yes** (the previous spec froze the clamp-to-white behavior; it has been replaced by the two specs above).
- Also ran: full `brand-extraction-engine` suite (47), `brand-routes`, `finalize-design`, design-system suites (231 tests total), `pnpm guard`, `pnpm typecheck` — all green. Verified end-to-end by re-running `POST /api/brands/:id/finalize` on a dark-first brand and confirming `system/variables.css` / `kit.html` regenerate on the brand canvas.

## Notes for review

The old "keep default light even when the source canvas is dark" behavior was deliberate (it had its own spec), so this PR deliberately narrows the change: dark derivation only triggers when the brand carries BOTH a confidently dark background/surface role (luminance ≤ 0.3) AND a light foreground role (luminance ≥ 0.6) — i.e. the extractor affirmatively measured a dark-first design. `seedFromMaterial` (no role evidence) is untouched. If you'd rather gate this behind a brand-level flag instead of the luminance heuristic, happy to rework.


## Validation

Commands run on this branch (all green):

- `pnpm --filter @open-design/daemon test tests/brand-extraction-engine.test.ts` — 47 passed (includes the dark-first / ambiguous specs **and** the new `theme.json` algorithm assertions for both cases).
- `pnpm --filter @open-design/daemon test tests/finalize-design.test.ts tests/brand-routes.test.ts` — 63 passed (exercises the `system.ts` finalize path that also emits `theme.json`).
- `pnpm --filter @open-design/daemon typecheck` — clean.
- `pnpm guard` — clean.
- End-to-end: restarted the daemon and re-ran `POST /api/brands/:id/finalize` on a dark-first brand; `system/variables.css`, `kit.html`, and `theme.json` all regenerate on the brand's near-black canvas with `algorithm: "dark"`.

## Update — review follow-up (@nettee)

Addressed the blocking `theme.json` consistency issue in a follow-up commit: added `defaultThemeAlgorithm(seed)` as the single shared decision (dark-first → `"dark"`, light/ambiguous → `"default"`) and routed **both** `theme.json` producers (`engine/build.ts` and `system.ts`) through it, so the exported ConfigProvider artifact carries the same effective algorithm as the tokens/CSS/kit. Added assertions for both the dark-first and ambiguous cases so the export can't drift again.

## Update 2 — second review follow-up (@nettee)

Fixed a deeper case the re-review caught: `seedPrefersDark()` keyed only off `colorBgBase`, but the real dark-first gate (`neutralBases()`) requires a dark background **and** a light foreground. Via the `rebuildSystem` seed-override path, a `{ colorBgBase: "#050505" }` override on an otherwise light brand flipped derivation to the dark ladder while `theme.json` kept the seed's dark `colorTextBase` — the same mismatch, via overrides. `seedPrefersDark` now mirrors `neutralBases` exactly (dark ≤ 0.3 **and** light ≥ 0.6), so a background-only override stays on the light/default path consistently across `deriveTokens`, `defaultThemeAlgorithm`, and `theme.json`. Added a regression locking the override seed both ways (bg-only → `default`, bg + light-fg → `dark`). 48 engine tests + 63 finalize/routes tests + `pnpm guard` green.
