### PR TITLE
fix: defuse script tags in stored prefetch captures

### DIFF
--- a/apps/daemon/src/brands/prefetch.ts
+++ b/apps/daemon/src/brands/prefetch.ts
@@ -216,9 +216,22 @@ export function isChallengePage(html: string): boolean {
   return false;
 }
 
+/**
+ * Captured pages are stored as READ-ONLY source evidence. Defuse every script
+ * tag so previewing a capture can never run the source site's live code —
+ * auth widgets (Google One Tap sign-in bubbles), analytics beacons, consent
+ * SDKs. The markup stays readable: only execution is disabled, by leading the
+ * tag with a non-JS type attribute (on duplicate attributes the HTML parser
+ * keeps the first, so an original type="module" further right is inert).
+ */
+function defuseScripts(html: string): string {
+  return html.replace(/<script\b/gi, '<script type="text/od-defused-script"');
+}
+
 export function previewablePrefetchHtml(html: string, cap = HTML_CAP): string {
-  const out = html.slice(0, cap);
-  if (/<body\b/i.test(out) || out.length < cap) return out;
+  const raw = html.slice(0, cap);
+  const out = defuseScripts(raw);
+  if (/<body\b/i.test(out) || raw.length < cap) return out;
   const title = decodeEntities(/<title[^>]*>([\s\S]*?)<\/title>/i.exec(out)?.[1] ?? "").trim();
   return [
     "<!doctype html>",

--- a/apps/daemon/tests/brand-prefetch.test.ts
+++ b/apps/daemon/tests/brand-prefetch.test.ts
@@ -39,6 +39,25 @@ describe('brand prefetch artifacts', () => {
     expect(preview).toBe(html.slice(0, 72));
     expect(preview).toContain('<body>');
   });
+
+  it('defuses script execution in stored captures so previews never run source-site code', () => {
+    const html =
+      '<!doctype html><html><head>' +
+      '<script src="https://accounts.google.com/gsi/client" async></script>' +
+      '<SCRIPT type="module">initOneTap();</SCRIPT>' +
+      '</head><body>page</body></html>';
+
+    const preview = previewablePrefetchHtml(html);
+
+    // The markup stays readable as evidence, but no script tag may remain
+    // executable: every opening tag must lead with the defused type attribute
+    // (first attribute wins on duplicates), covering both external-src and
+    // inline scripts regardless of original casing.
+    expect(preview).toContain('accounts.google.com/gsi/client');
+    expect(preview).not.toMatch(/<script\s+(?!type="text\/od-defused-script")/i);
+    expect(preview.match(/<script type="text\/od-defused-script"/gi)).toHaveLength(2);
+    expect(preview).toContain('page');
+  });
 });
 
 describe('prefetchFromHtml (extract from already-rendered DOM)', () => {


### PR DESCRIPTION
Fixes #5501

## Why

Hit this personally after extracting a design system from a Behance case study: Chrome kept popping a native "127.0.0.1 — Sign in with Google" bubble in the studio, with no visible connection to the extraction that caused it. Root cause: `prefetch/page.html` is stored verbatim, so previewing a capture executes the source site's live JavaScript from the local origin — Behance/Medium/LinkedIn ship Google One Tap on every page, and analytics beacons and consent SDKs replay the same way. Captures are read-only extraction evidence; running another site's auth widgets inside the user's local preview is pure downside.

## What users will see

No more surprise sign-in prompts (or analytics/consent popups) when viewing `prefetch/page.html` or files derived from it. The capture still renders and stays fully readable as evidence — script tags, srcs, and inline bodies are preserved as text — they just no longer execute.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — stored captures no longer execute source-site scripts when previewed. Existing captures on disk are unaffected until re-captured.
- [ ] **None**

## Screenshots

No new UI. Symptom before the fix: Chrome's FedCM "Sign in with Google" bubble anchored to 127.0.0.1 whenever a Behance capture rendered; after: no requests to accounts.google.com at all (verified via the network log).

## Bug fix verification

- Test path: `apps/daemon/tests/brand-prefetch.test.ts` — `defuses script execution in stored captures so previews never run source-site code`.
- Red on `main`, green on this branch? **yes**.
- Full `brand-prefetch` suite green (13 tests). Verified live by re-rendering a defused Behance capture in the studio and confirming zero requests to any Google host.

## Notes for review

Mechanism: every `<script` opening tag gets a leading `type="text/od-defused-script"` attribute. On duplicate attributes the HTML parser keeps the first, so an original `type="module"` further right is inert, and both external-src and inline scripts are covered regardless of casing. This keeps the capture byte-for-byte readable (nothing is stripped) while making execution impossible. Truncation detection unchanged — it is computed on the raw slice before defusing so the added attribute bytes can't flip the truncated-head diagnostic.


## Validation

Commands run on this branch (all green):

- `pnpm --filter @open-design/daemon test tests/brand-prefetch.test.ts` — 13 passed, including the new `defuses script execution in stored captures so previews never run source-site code` spec (covers external `src` scripts, inline scripts, mixed casing, duplicate-`type` behavior, and preserved-readable-evidence).
- Red on `main`, green on this branch for that spec.
- `pnpm guard` — clean.
- End-to-end: re-rendered a defused Behance capture (`prefetch/page.html`) in the studio and confirmed **zero** requests to any Google host in the network log — the localhost One Tap prompt no longer fires.
